### PR TITLE
spot_instance_request: fixed network interfaces configuration

### DIFF
--- a/aws/resource_aws_spot_instance_request.go
+++ b/aws/resource_aws_spot_instance_request.go
@@ -109,19 +109,12 @@ func resourceAwsSpotInstanceRequestCreate(d *schema.ResourceData, meta interface
 			SecurityGroups:      instanceOpts.SecurityGroups,
 			SubnetId:            instanceOpts.SubnetID,
 			UserData:            instanceOpts.UserData64,
+			NetworkInterfaces:   instanceOpts.NetworkInterfaces,
 		},
 	}
 
 	if v, ok := d.GetOk("block_duration_minutes"); ok {
 		spotOpts.BlockDurationMinutes = aws.Int64(int64(v.(int)))
-	}
-
-	// If the instance is configured with a Network Interface (a subnet, has
-	// public IP, etc), then the instanceOpts.SecurityGroupIds and SubnetId will
-	// be nil
-	if len(instanceOpts.NetworkInterfaces) > 0 {
-		spotOpts.LaunchSpecification.SecurityGroupIds = instanceOpts.NetworkInterfaces[0].Groups
-		spotOpts.LaunchSpecification.SubnetId = instanceOpts.NetworkInterfaces[0].SubnetId
 	}
 
 	// Make the spot instance request

--- a/aws/resource_aws_spot_instance_request_test.go
+++ b/aws/resource_aws_spot_instance_request_test.go
@@ -93,7 +93,7 @@ func TestAccAWSSpotInstanceRequest_vpc(t *testing.T) {
 	})
 }
 
-func TestAccAWSSpotInstanceRequest_SubnetAndSG(t *testing.T) {
+func TestAccAWSSpotInstanceRequest_SubnetAndSGAndPublicIpAddress(t *testing.T) {
 	var sir ec2.SpotInstanceRequest
 	rInt := acctest.RandInt()
 
@@ -103,11 +103,13 @@ func TestAccAWSSpotInstanceRequest_SubnetAndSG(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotInstanceRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotInstanceRequestConfig_SubnetAndSG(rInt),
+				Config: testAccAWSSpotInstanceRequestConfig_SubnetAndSGAndPublicIpAddress(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSpotInstanceRequestExists(
 						"aws_spot_instance_request.foo", &sir),
 					testAccCheckAWSSpotInstanceRequest_InstanceAttributes(&sir, rInt),
+					resource.TestCheckResourceAttr(
+						"aws_spot_instance_request.foo", "associate_public_ip_address", "true"),
 				),
 			},
 		},
@@ -384,7 +386,7 @@ func testAccAWSSpotInstanceRequestConfigVPC(rInt int) string {
 	}`, rInt)
 }
 
-func testAccAWSSpotInstanceRequestConfig_SubnetAndSG(rInt int) string {
+func testAccAWSSpotInstanceRequestConfig_SubnetAndSGAndPublicIpAddress(rInt int) string {
 	return fmt.Sprintf(`
 	resource "aws_spot_instance_request" "foo" {
 		ami                         = "ami-4fccb37f"


### PR DESCRIPTION
Fixes configuration public ip for spot_instance_request. Originally hashicorp/terraform#13736 & bug hashicorp/terraform#9575.