### PR TITLE
security_group: Raise creation timeout

### DIFF
--- a/aws/resource_aws_security_group.go
+++ b/aws/resource_aws_security_group.go
@@ -253,7 +253,7 @@ func resourceAwsSecurityGroupCreate(d *schema.ResourceData, meta interface{}) er
 		Pending: []string{""},
 		Target:  []string{"exists"},
 		Refresh: SGStateRefreshFunc(conn, d.Id()),
-		Timeout: 5 * time.Minute,
+		Timeout: 10 * time.Minute,
 	}
 
 	resp, err := stateConf.WaitForState()


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs
--- FAIL: TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs (362.92s)
    testing.go:428: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_security_group.tf_test_foo: 1 error(s) occurred:
        
        * aws_security_group.tf_test_foo: Error waiting for Security Group (sg-49784332) to become available: timeout while waiting for state to become 'exists' (timeout: 5m0s)
```