### PR TITLE
fix incorrect Lambda GovCloud regexes

### DIFF
--- a/aws/resource_aws_lambda_permission.go
+++ b/aws/resource_aws_lambda_permission.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
-var LambdaFunctionRegexp = `^(arn:[\w-]+:lambda:)?([a-z]{2}-[a-z]+-\d{1}:)?(\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\$LATEST|[a-zA-Z0-9-_]+))?$`
+var LambdaFunctionRegexp = `^(arn:[\w-]+:lambda:)?([a-z]{2}-(?:[a-z]+-){1,2}\d{1}:)?(\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\$LATEST|[a-zA-Z0-9-_]+))?$`
 
 func resourceAwsLambdaPermission() *schema.Resource {
 	return &schema.Resource{

--- a/aws/resource_aws_lambda_permission_test.go
+++ b/aws/resource_aws_lambda_permission_test.go
@@ -62,9 +62,8 @@ func TestLambdaPermissionGetQualifierFromLambdaAliasOrVersionArn_alias(t *testin
 		t.Fatalf("Expected qualifier to match (%q != %q)", qualifier, expectedQualifier)
 	}
 }
-
 func TestLambdaPermissionGetQualifierFromLambdaAliasOrVersionArn_govcloud(t *testing.T) {
-	arnWithAlias := "arn:aws-us-gov:lambda:us-west-2:187636751137:function:lambda_function_name:testalias"
+	arnWithAlias := "arn:aws-us-gov:lambda:us-gov-west-1:187636751137:function:lambda_function_name:testalias"
 	expectedQualifier := "testalias"
 	qualifier, err := getQualifierFromLambdaAliasOrVersionArn(arnWithAlias)
 	if err != nil {
@@ -138,6 +137,19 @@ func TestLambdaPermissionGetFunctionNameFromLambdaArn_valid(t *testing.T) {
 		t.Fatalf("Expected no error (%q): %q", validArn, err)
 	}
 	expectedFunctionname = "lambda_function_name"
+	if fn != expectedFunctionname {
+		t.Fatalf("Expected Lambda function name to match (%q != %q)",
+			validArn, expectedFunctionname)
+	}
+}
+
+func TestLambdaPermissionGetFunctionNameFromGovCloudLambdaArn(t *testing.T) {
+	validArn := "arn:aws-us-gov:lambda:us-gov-west-1:187636751137:function:lambda_function_name"
+	fn, err := getFunctionNameFromLambdaArn(validArn)
+	if err != nil {
+		t.Fatalf("Expected no error (%q): %q", validArn, err)
+	}
+	expectedFunctionname := "lambda_function_name"
 	if fn != expectedFunctionname {
 		t.Fatalf("Expected Lambda function name to match (%q != %q)",
 			validArn, expectedFunctionname)

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -293,7 +293,7 @@ func validateLambdaFunctionName(v interface{}, k string) (ws []string, errors []
 			"%q cannot be longer than 140 characters: %q", k, value))
 	}
 	// http://docs.aws.amazon.com/lambda/latest/dg/API_AddPermission.html
-	pattern := `^(arn:[\w-]+:lambda:)?([a-z]{2}-[a-z]+-\d{1}:)?(\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\$LATEST|[a-zA-Z0-9-_]+))?$`
+	pattern := `^(arn:[\w-]+:lambda:)?([a-z]{2}-(?:[a-z]+-){1,2}\d{1}:)?(\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\$LATEST|[a-zA-Z0-9-_]+))?$`
 	if !regexp.MustCompile(pattern).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
 			"%q doesn't comply with restrictions (%q): %q",

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -79,6 +79,7 @@ func TestValidateLambdaFunctionName(t *testing.T) {
 	validNames := []string{
 		"arn:aws:lambda:us-west-2:123456789012:function:ThumbNail",
 		"arn:aws-us-gov:lambda:us-west-2:123456789012:function:ThumbNail",
+		"arn:aws-us-gov:lambda:us-gov-west-1:123456789012:function:ThumbNail",
 		"FunctionName",
 		"function-name",
 	}


### PR DESCRIPTION
This is a replacement for hashicorp/terraform#14850.

This addresses several regexes used for matching Lambda ARNs to account for the extra section in the GovCloud region name.  It also updates tests to match.