### PR TITLE
resource/vpc: Increase deletion timeout to 10mins

### DIFF
--- a/aws/resource_aws_vpc.go
+++ b/aws/resource_aws_vpc.go
@@ -423,7 +423,7 @@ func resourceAwsVpcDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 	log.Printf("[INFO] Deleting VPC: %s", d.Id())
 
-	return resource.Retry(5*time.Minute, func() *resource.RetryError {
+	return resource.Retry(10*time.Minute, func() *resource.RetryError {
 		_, err := conn.DeleteVpc(DeleteVpcOpts)
 		if err == nil {
 			return nil


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccDataSourceAwsVpcEndpoint_basic
--- FAIL: TestAccDataSourceAwsVpcEndpoint_basic (421.86s)
    testing.go:428: Step 0 error: Check failed: Check 1/1 error: can't find aws_vpc_endpoint.s3 in state
    testing.go:492: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Error applying: 1 error(s) occurred:
        
        * aws_vpc.foo (destroy): 1 error(s) occurred:
        
        * aws_vpc.foo: DependencyViolation: The vpc 'vpc-70977a16' has dependencies and cannot be deleted.
            status code: 400, request id: 0c3a8064-3d43-4f90-9a7d-e5be4f005d3f
        
```