### PR TITLE
resource/dynamodb_table: Expose stream_label attribute

### DIFF
--- a/aws/resource_aws_dynamodb_table.go
+++ b/aws/resource_aws_dynamodb_table.go
@@ -197,6 +197,10 @@ func resourceAwsDynamoDbTable() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"stream_label": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"tags": tagsSchema(),
 		},
 	}
@@ -788,6 +792,7 @@ func resourceAwsDynamoDbTableRead(d *schema.ResourceData, meta interface{}) erro
 		d.Set("stream_view_type", table.StreamSpecification.StreamViewType)
 		d.Set("stream_enabled", table.StreamSpecification.StreamEnabled)
 		d.Set("stream_arn", table.LatestStreamArn)
+		d.Set("stream_label", table.LatestStreamLabel)
 	}
 
 	err = d.Set("global_secondary_index", gsiList)

--- a/aws/resource_aws_dynamodb_table_test.go
+++ b/aws/resource_aws_dynamodb_table_test.go
@@ -57,6 +57,8 @@ func TestAccAWSDynamoDbTable_streamSpecification(t *testing.T) {
 						"aws_dynamodb_table.basic-dynamodb-table", "stream_enabled", "true"),
 					resource.TestCheckResourceAttr(
 						"aws_dynamodb_table.basic-dynamodb-table", "stream_view_type", "KEYS_ONLY"),
+					resource.TestCheckResourceAttrSet("aws_dynamodb_table.basic-dynamodb-table", "stream_arn"),
+					resource.TestCheckResourceAttrSet("aws_dynamodb_table.basic-dynamodb-table", "stream_label"),
 				),
 			},
 		},

--- a/website/docs/r/dynamodb_table.html.markdown
+++ b/website/docs/r/dynamodb_table.html.markdown
@@ -133,7 +133,10 @@ The following attributes are exported:
 * `arn` - The arn of the table
 * `id` - The name of the table
 * `stream_arn` - The ARN of the Table Stream. Only available when `stream_enabled = true`
-
+* `stream_label` - A timestamp, in ISO 8601 format, for this stream. Note that this timestamp is not
+  a unique identifier for the stream on its own. However, the combination of AWS customer ID,
+  table name and this field is guaranteed to be unique.
+  It can be used for creating CloudWatch Alarms. Only available when `stream_enabled = true`
 
 ## Import
 


### PR DESCRIPTION
### Test results

```
make testacc TESTARGS='-run=TestAccAWSDynamoDbTable_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccAWSDynamoDbTable_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSDynamoDbTable_importBasic
--- PASS: TestAccAWSDynamoDbTable_importBasic (55.86s)
=== RUN   TestAccAWSDynamoDbTable_importTags
--- PASS: TestAccAWSDynamoDbTable_importTags (48.39s)
=== RUN   TestAccAWSDynamoDbTable_basic
--- PASS: TestAccAWSDynamoDbTable_basic (172.18s)
=== RUN   TestAccAWSDynamoDbTable_streamSpecification
--- PASS: TestAccAWSDynamoDbTable_streamSpecification (65.92s)
=== RUN   TestAccAWSDynamoDbTable_tags
--- PASS: TestAccAWSDynamoDbTable_tags (54.65s)
=== RUN   TestAccAWSDynamoDbTable_gsiUpdate
--- PASS: TestAccAWSDynamoDbTable_gsiUpdate (134.71s)
=== RUN   TestAccAWSDynamoDbTable_ttl
--- PASS: TestAccAWSDynamoDbTable_ttl (81.72s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	613.465s
```