### PR TITLE
aws_instance: allow providing user data as base64

### DIFF
--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -317,7 +317,7 @@ func TestAccAWSInstance_rootInstanceStore(t *testing.T) {
 	})
 }
 
-func TestAcctABSInstance_noAMIEphemeralDevices(t *testing.T) {
+func TestAccAWSInstance_noAMIEphemeralDevices(t *testing.T) {
 	var v ec2.Instance
 
 	testCheck := func() resource.TestCheckFunc {

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -74,7 +74,8 @@ instances. See [Shutdown Behavior](https://docs.aws.amazon.com/AWSEC2/latest/Use
      instance in a VPC.
 * `source_dest_check` - (Optional) Controls if traffic is routed to the instance when
   the destination address does not match the instance. Used for NAT or VPNs. Defaults true.
-* `user_data` - (Optional) The user data to provide when launching the instance.
+* `user_data` - (Optional) The user data to provide when launching the instance. Do not pass gzip-compressed data via this argument; see `user_data_base64` instead.
+* `user_data_base64` - (Optional) Can be used instead of `user_data` to pass base64-encoded binary data directly. Use this instead of `user_data` whenever the value is not a valid UTF-8 string. For example, gzip-encoded user data must be base64-encoded and passed via this argument to avoid corruption.
 * `iam_instance_profile` - (Optional) The IAM Instance Profile to
   launch the instance with. Specified as the name of the Instance Profile.
 * `ipv6_address_count`- (Optional) A number of IPv6 addresses to associate with the primary network interface. Amazon EC2 chooses the IPv6 addresses from the range of your subnet.


### PR DESCRIPTION
Providing base64 directly is convenient when it must be set to something that isn't valid UTF-8, such as the gzipped payloads often passed to cloud-init for more complex setups.

Passing binary data directly via Terraform attributes is not safe because only UTF-8 strings can be stored in the state file. This is therefore intended for use in conjunction with the base64 encoding mode of `template_cloudinit_config` to enable gzip data to be passed safely to the EC2 data without corruption as it passes through Terraform.

For more information, see the discussion at hashicorp/terraform#14314, which was later migrated to #754.

This first change deals only with `aws_instance`. Similar changes will be needed for `aws_launch_configuration` and `aws_lightsail_instance` later, for the same reasons.
