### PR TITLE
provider/aws: Add support for name_prefix to aws_sqs_queue

### DIFF
--- a/website/docs/r/sqs_queue.html.markdown
+++ b/website/docs/r/sqs_queue.html.markdown
@@ -35,7 +35,8 @@ resource "aws_sqs_queue" "terraform_queue" {
 
 The following arguments are supported:
 
-* `name` - (Required) This is the human-readable name of the queue
+* `name` - (Optional) This is the human-readable name of the queue. If omitted, Terraform will assign a random name.
+* `name_prefix` - (Optional) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `visibility_timeout_seconds` - (Optional) The visibility timeout for the queue. An integer from 0 to 43200 (12 hours). The default for this attribute is 30. For more information about visibility timeout, see [AWS docs](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/AboutVT.html).
 * `message_retention_seconds` - (Optional) The number of seconds Amazon SQS retains a message. Integer representing seconds, from 60 (1 minute) to 1209600 (14 days). The default for this attribute is 345600 (4 days).
 * `max_message_size` - (Optional) The limit of how many bytes a message can contain before Amazon SQS rejects it. An integer from 1024 bytes (1 KiB) up to 262144 bytes (256 KiB). The default for this attribute is 262144 (256 KiB).


### PR DESCRIPTION
```
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSSQSQueue'                                                                           130 ↵ ✹
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSSQSQueue -timeout 120m
=== RUN   TestAccAWSSQSQueue_importBasic
--- PASS: TestAccAWSSQSQueue_importBasic (64.06s)
=== RUN   TestAccAWSSQSQueue_importFifo
--- PASS: TestAccAWSSQSQueue_importFifo (57.57s)
=== RUN   TestAccAWSSQSQueuePolicy_basic
--- PASS: TestAccAWSSQSQueuePolicy_basic (63.44s)
=== RUN   TestAccAWSSQSQueue_basic
--- PASS: TestAccAWSSQSQueue_basic (127.25s)
=== RUN   TestAccAWSSQSQueue_namePrefix
--- PASS: TestAccAWSSQSQueue_namePrefix (50.10s)
=== RUN   TestAccAWSSQSQueue_policy
--- PASS: TestAccAWSSQSQueue_policy (72.06s)
=== RUN   TestAccAWSSQSQueue_redrivePolicy
--- PASS: TestAccAWSSQSQueue_redrivePolicy (64.35s)
=== RUN   TestAccAWSSQSQueue_Policybasic
--- PASS: TestAccAWSSQSQueue_Policybasic (83.56s)
=== RUN   TestAccAWSSQSQueue_FIFO
--- PASS: TestAccAWSSQSQueue_FIFO (37.44s)
=== RUN   TestAccAWSSQSQueue_FIFOExpectNameError
--- PASS: TestAccAWSSQSQueue_FIFOExpectNameError (13.06s)
=== RUN   TestAccAWSSQSQueue_FIFOWithContentBasedDeduplication
--- PASS: TestAccAWSSQSQueue_FIFOWithContentBasedDeduplication (49.01s)
=== RUN   TestAccAWSSQSQueue_ExpectContentBasedDeduplicationError
--- PASS: TestAccAWSSQSQueue_ExpectContentBasedDeduplicationError (15.86s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	697.786s
```