### PR TITLE
Add support for configurable timeouts in AWS OpsWorks Instances.

### DIFF
--- a/aws/resource_aws_opsworks_instance_test.go
+++ b/aws/resource_aws_opsworks_instance_test.go
@@ -389,6 +389,10 @@ resource "aws_opsworks_instance" "tf-acc" {
   state = "stopped"
   hostname = "tf-acc1"
   os = "Amazon Linux 2015.09"
+
+  timeouts {
+    update = "15s"
+  }
 }
 
 %s

--- a/website/docs/r/opsworks_instance.html.markdown
+++ b/website/docs/r/opsworks_instance.html.markdown
@@ -132,6 +132,15 @@ The following attributes are exported:
 * `tenancy` - The Instance tenancy
 * `security_group_ids` - The associated security groups.
 
+## Timeouts
+
+`aws_opsworks_instance` provides the following
+[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+- `create` - (Default `10 minutes`) Used when the instance is created. It should cover the time needed for the instance to start successfully.
+- `delete` - (Default `10 minutes`) Used when the instance is deleted. It should cover the time needed for the instance to stop successfully.
+- `update` - (Default `10 minutes`) Used when the instance is changed. It should cover the time needed to either start or stop the instance.
+
 ## Import
 
 Opsworks Instances can be imported using the `instance id`, e.g.


### PR DESCRIPTION
We have found that the creation and update of the OpsWorks Instances often
times out with the default 10 minute timeout. This change introduces a
configuration for 'Create', 'Delete' and 'Update' timeouts. The actual
implementation is required to start or stop the instance, which is the
operation which times out, and which of these is performed (particularly
for the 'Update' operation) is dependant on the change needed.

The change introduces the timeouts, adds a simple test that the format
is parsed, and provides documentation for these new parameters.