### PR TITLE
IAM: Allowed user-defined password for login profiles

### DIFF
--- a/aws/resource_aws_iam_user_login_profile_test.go
+++ b/aws/resource_aws_iam_user_login_profile_test.go
@@ -110,6 +110,14 @@ func TestAccAWSUserLoginProfile_customPassword(t *testing.T) {
 				Config: testAccAWSUserLoginProfileConfigCustomPassword(username, "/", "MyP@ssw0rd@#$!@#$^&*()_+-=[]{}|'%"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSUserLoginProfileExists("aws_iam_user_login_profile.user", &conf),
+					resource.TestCheckResourceAttr("aws_iam_user_login_profile.user", "password", "MyP@ssw0rd@#$!@#$^&*()_+-=[]{}|'%"),
+				),
+			},
+			{
+				Config: testAccAWSUserLoginProfileConfigCustomPassword(username, "/", "MyNewP@ssw0rd"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSUserLoginProfileExists("aws_iam_user_login_profile.user", &conf),
+					resource.TestCheckResourceAttr("aws_iam_user_login_profile.user", "password", "MyNewP@ssw0rd"),
 				),
 			},
 		},

--- a/aws/resource_aws_iam_user_login_profile_test.go
+++ b/aws/resource_aws_iam_user_login_profile_test.go
@@ -96,6 +96,26 @@ func TestAccAWSUserLoginProfile_notAKey(t *testing.T) {
 	})
 }
 
+func TestAccAWSUserLoginProfile_customPassword(t *testing.T) {
+	var conf iam.GetLoginProfileOutput
+
+	username := fmt.Sprintf("test-user-%d", acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSUserLoginProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSUserLoginProfileConfigCustomPassword(username, "/", "MyP@ssw0rd@#$!@#$^&*()_+-=[]{}|'%"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSUserLoginProfileExists("aws_iam_user_login_profile.user", &conf),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSUserLoginProfileDestroy(s *terraform.State) error {
 	iamconn := testAccProvider.Meta().(*AWSClient).iamconn
 
@@ -169,7 +189,7 @@ func testDecryptPasswordAndTest(nProfile, nAccessKey, key string) resource.TestC
 				NewPassword: aws.String(generatePassword(20)),
 			})
 			if err != nil {
-				if awserr, ok := err.(awserr.Error); ok && awserr.Code() == "InvalidClientTokenId" {
+				if awserr, ok := err.(awserr.Error); ok && (awserr.Code() == "InvalidClientTokenId" || awserr.Code() == "EntityTemporarilyUnmodifiable") {
 					return resource.RetryableError(err)
 				}
 
@@ -206,45 +226,56 @@ func testAccCheckAWSUserLoginProfileExists(n string, res *iam.GetLoginProfileOut
 	}
 }
 
-func testAccAWSUserLoginProfileConfig(r, p, key string) string {
-	return fmt.Sprintf(`
+const testAccAWSUserLoginProfileBaseConfig = `
 resource "aws_iam_user" "user" {
-	name = "%s"
-	path = "%s"
-	force_destroy = true
+    name = "%s"
+    path = "%s"
+    force_destroy = true
 }
 
 data "aws_caller_identity" "current" {}
 
 data "aws_iam_policy_document" "user" {
-	statement {
-		effect = "Allow"
-		actions = ["iam:GetAccountPasswordPolicy"]
-		resources = ["*"]
-	}
-	statement {
-		effect = "Allow"
-		actions = ["iam:ChangePassword"]
-		resources = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/&{aws:username}"]
-	}
+    statement {
+        effect = "Allow"
+        actions = ["iam:GetAccountPasswordPolicy"]
+        resources = ["*"]
+    }
+    statement {
+        effect = "Allow"
+        actions = ["iam:ChangePassword"]
+        resources = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/&{aws:username}"]
+    }
 }
 
 resource "aws_iam_user_policy" "user" {
-	name = "AllowChangeOwnPassword"
-	user = "${aws_iam_user.user.name}"
-	policy = "${data.aws_iam_policy_document.user.json}"
+    name = "AllowChangeOwnPassword"
+    user = "${aws_iam_user.user.name}"
+    policy = "${data.aws_iam_policy_document.user.json}"
 }
 
 resource "aws_iam_access_key" "user" {
-	user = "${aws_iam_user.user.name}"
+    user = "${aws_iam_user.user.name}"
 }
+`
 
+func testAccAWSUserLoginProfileConfig(r, p, key string) string {
+	return fmt.Sprintf(testAccAWSUserLoginProfileBaseConfig+`
 resource "aws_iam_user_login_profile" "user" {
         user = "${aws_iam_user.user.name}"
         pgp_key = <<EOF
 %sEOF
 }
 `, r, p, key)
+}
+
+func testAccAWSUserLoginProfileConfigCustomPassword(r, p, password string) string {
+	return fmt.Sprintf(testAccAWSUserLoginProfileBaseConfig+`
+resource "aws_iam_user_login_profile" "user" {
+        user = "${aws_iam_user.user.name}"
+        password = "%s"
+}
+`, r, p, password)
 }
 
 const testPubKey1 = `mQENBFXbjPUBCADjNjCUQwfxKL+RR2GA6pv/1K+zJZ8UWIF9S0lk7cVIEfJiprzzwiMwBS5cD0da

--- a/website/docs/r/iam_user_login_profile.html.markdown
+++ b/website/docs/r/iam_user_login_profile.html.markdown
@@ -12,36 +12,58 @@ Provides one-time creation of a IAM user login profile, and uses PGP to
 encrypt the password for safe transport to the user. PGP keys can be
 obtained from Keybase.
 
-## Example Usage
+## Example usage
 
-```hcl
+```
 resource "aws_iam_user" "u" {
-  name          = "auser"
-  path          = "/"
-  force_destroy = true
+        name = "auser"
+        path = "/"
+        force_destroy = true
 }
 
 resource "aws_iam_user_login_profile" "u" {
-  user    = "${aws_iam_user.u.name}"
-  pgp_key = "keybase:some_person_that_exists"
+        user = "${aws_iam_user.u.name}"
+        password = "MyP@ssw0rd"
 }
 
 output "password" {
-  value = "${aws_iam_user_login_profile.u.encrypted_password}"
+        value = "${aws_iam_user_login_profile.u.password}"
 }
 ```
+
+## PGP Key Example
+
+```
+resource "aws_iam_user" "u" {
+        name = "auser"
+        path = "/"
+        force_destroy = true
+}
+
+resource "aws_iam_user_login_profile" "u" {
+        user = "${aws_iam_user.u.name}"
+        pgp_key = "keybase:some_person_that_exists"
+}
+
+output "password" {
+        value = "${aws_iam_user_login_profile.u.encrypted_password}"
+}
+```
+
 
 ## Argument Reference
 
 The following arguments are supported:
 
 * `user` - (Required) The IAM user's name.
-* `pgp_key` - (Required) Either a base-64 encoded PGP public key, or a
+* `password` - (Optional) The password you want to set. It not specified,
+  one will be generated.
+* `pgp_key` - (Optional) Either a base-64 encoded PGP public key, or a
   keybase username in the form `keybase:username`.
+* `password_length` - (Optional, default 20) The length of the generated
+  password. Used when the password is auto-generated.
 * `password_reset_required` - (Optional, default "true") Whether the
   user should be forced to reset the generated password on first login.
-* `password_length` - (Optional, default 20) The length of the generated
-  password.
 
 ## Attributes Reference
 
@@ -49,7 +71,7 @@ The following attributes are exported:
 
 * `key_fingerprint` - The fingerprint of the PGP key used to encrypt
   the password
-* `encrypted_password` - The encrypted password, base64 encoded.
+* `encrypted_password` - The encrypted password when using PGP **only**, base64 encoded.
 
 ~> **NOTE:** The encrypted password may be decrypted using the command line,
    for example: `terraform output password | base64 --decode | keybase pgp decrypt`.


### PR DESCRIPTION
#### Reasoning for this change
This is the continuation of https://github.com/hashicorp/terraform/pull/9605.

The previous PR introduced PGP-based keys, encrypting and decrypting using keybase.io.
As the login_profile password was generated, it was missing the ability to generate a custom password. 
This allows to set it, making this even more flexible.

(Migrated from https://github.com/hashicorp/terraform/pull/10734)

#### Real Configuration
```hcl
 resource "aws_iam_user" "user" {
     name = "demo"
     path = "/"
     force_destroy = true
 }
 
 data "aws_caller_identity" "current" {}
 
 data "aws_iam_policy_document" "user" {
     statement {
         effect = "Allow"
         actions = ["iam:GetAccountPasswordPolicy"]
         resources = ["*"]
     }
     statement {
         effect = "Allow"
         actions = ["iam:ChangePassword"]
         resources = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/&{aws:username}"]
     }
 }
 
 resource "aws_iam_user_policy" "user" {
     name = "AllowChangeOwnPassword"
     user = "${aws_iam_user.user.name}"
     policy = "${data.aws_iam_policy_document.user.json}"
 }
 
 resource "aws_iam_access_key" "user" {
     user = "${aws_iam_user.user.name}"
 }
 
 resource "aws_iam_user_login_profile" "user" {
     user = "${aws_iam_user.user.name}"
     password = "test"
 }
```

#### Use cases
Demos, trainings or handsons.

#### Acceptance tests
```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSUserLoginProfile_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/12/14 21:58:25 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSUserLoginProfile_ -timeout 120m
=== RUN   TestAccAWSUserLoginProfile_basic
--- PASS: TestAccAWSUserLoginProfile_basic (22.11s)
=== RUN   TestAccAWSUserLoginProfile_keybase
--- PASS: TestAccAWSUserLoginProfile_keybase (20.71s)
=== RUN   TestAccAWSUserLoginProfile_keybaseDoesntExist
--- PASS: TestAccAWSUserLoginProfile_keybaseDoesntExist (12.11s)
=== RUN   TestAccAWSUserLoginProfile_notAKey
--- PASS: TestAccAWSUserLoginProfile_notAKey (14.28s)
=== RUN   TestAccAWSUserLoginProfile_customPassword
--- PASS: TestAccAWSUserLoginProfile_customPassword (19.61s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	88.850s
```