### PR TITLE
resource/rds_db_instance: Correctly create cross-region encrypted replica

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If you wish to work on the provider, you'll first need [Go](http://www.golang.or
 To compile the provider, run `make build`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
 
 ```sh
-$ make bin
+$ make build
 ...
 $ $GOPATH/bin/terraform-provider-aws
 ...

--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -402,6 +402,13 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			opts.DBSubnetGroupName = aws.String(attr.(string))
 		}
 
+		if attr, ok := d.GetOk("kms_key_id"); ok {
+			opts.KmsKeyId = aws.String(attr.(string))
+			if arnParts := strings.Split(v.(string), ":"); len(arnParts) >= 4 {
+				opts.SourceRegion = aws.String(arnParts[3])
+			}
+		}
+
 		if attr, ok := d.GetOk("monitoring_role_arn"); ok {
 			opts.MonitoringRoleArn = aws.String(attr.(string))
 		}

--- a/vendor/github.com/aws/aws-sdk-go/LICENSE.txt
+++ b/vendor/github.com/aws/aws-sdk-go/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/aws/aws-sdk-go/NOTICE.txt
+++ b/vendor/github.com/aws/aws-sdk-go/NOTICE.txt
@@ -1,0 +1,3 @@
+AWS SDK for Go
+Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+Copyright 2014-2015 Stripe, Inc.

--- a/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
@@ -91,6 +91,7 @@ const (
 	FirehoseServiceID                     = "firehose"                     // Firehose.
 	GameliftServiceID                     = "gamelift"                     // Gamelift.
 	GlacierServiceID                      = "glacier"                      // Glacier.
+	GreengrassServiceID                   = "greengrass"                   // Greengrass.
 	HealthServiceID                       = "health"                       // Health.
 	IamServiceID                          = "iam"                          // Iam.
 	ImportexportServiceID                 = "importexport"                 // Importexport.
@@ -263,6 +264,7 @@ var awsPartition = partition{
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
+				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
 				"us-west-1":      endpoint{},
@@ -469,12 +471,16 @@ var awsPartition = partition{
 
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
+				"ap-northeast-2": endpoint{},
 				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
+				"eu-west-2":      endpoint{},
+				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
+				"us-west-1":      endpoint{},
 				"us-west-2":      endpoint{},
 			},
 		},
@@ -963,6 +969,16 @@ var awsPartition = partition{
 				"us-west-2":      endpoint{},
 			},
 		},
+		"greengrass": service{
+			IsRegionalized: boxedTrue,
+			Defaults: endpoint{
+				Protocols: []string{"https"},
+			},
+			Endpoints: endpoints{
+				"us-east-1": endpoint{},
+				"us-west-2": endpoint{},
+			},
+		},
 		"health": service{
 
 			Endpoints: endpoints{
@@ -1006,6 +1022,7 @@ var awsPartition = partition{
 				"ap-southeast-2": endpoint{},
 				"eu-west-1":      endpoint{},
 				"us-east-1":      endpoint{},
+				"us-west-1":      endpoint{},
 				"us-west-2":      endpoint{},
 			},
 		},
@@ -1085,6 +1102,7 @@ var awsPartition = partition{
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
+				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
 				"us-west-1":      endpoint{},
@@ -1534,6 +1552,7 @@ var awsPartition = partition{
 
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
+				"ap-southeast-2": endpoint{},
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
 				"us-east-1":      endpoint{},

--- a/vendor/github.com/aws/aws-sdk-go/aws/request/validation.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/request/validation.go
@@ -220,7 +220,7 @@ type ErrParamMinLen struct {
 func NewErrParamMinLen(field string, min int) *ErrParamMinLen {
 	return &ErrParamMinLen{
 		errInvalidParam: errInvalidParam{
-			code:  ParamMinValueErrCode,
+			code:  ParamMinLenErrCode,
 			field: field,
 			msg:   fmt.Sprintf("minimum field size of %v", min),
 		},

--- a/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/v4.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/v4.go
@@ -402,7 +402,7 @@ var SignRequestHandler = request.NamedHandler{
 }
 
 // SignSDKRequest signs an AWS request with the V4 signature. This
-// request handler is bested used only with the SDK's built in service client's
+// request handler should only be used with the SDK's built in service client's
 // API operation requests.
 //
 // This function should not be used on its on its own, but in conjunction with

--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.8.34"
+const SDKVersion = "1.8.41"

--- a/vendor/github.com/aws/aws-sdk-go/service/acm/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/acm/api.go
@@ -979,6 +979,8 @@ func (c *ACM) ResendValidationEmailRequest(input *ResendValidationEmailInput) (r
 // the mail be resent within 72 hours of requesting the ACM Certificate. If
 // more than 72 hours have elapsed since your original request or since your
 // last attempt to resend validation mail, you must request a new certificate.
+// For more information about setting up your contact email addresses, see Configure
+// Email for your Domain (http://docs.aws.amazon.com/acm/latest/userguide/setup-email.html).
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2181,6 +2183,20 @@ type RequestCertificateInput struct {
 	// a wildcard certificate that protects several sites in the same domain. For
 	// example, *.example.com protects www.example.com, site.example.com, and images.example.com.
 	//
+	// The maximum length of a DNS name is 253 octets. The name is made up of multiple
+	// labels separated by periods. No label can be longer than 63 octets. Consider
+	// the following examples:
+	//
+	// (63 octets).(63 octets).(63 octets).(61 octets) is legal because the total
+	// length is 253 octets (63+1+63+1+63+1+61) and no label exceeds 63 octets.
+	//
+	// (64 octets).(63 octets).(63 octets).(61 octets) is not legal because the
+	// total length exceeds 253 octets (64+1+63+1+63+1+61) and the first label exceeds
+	// 63 octets.
+	//
+	// (63 octets).(63 octets).(63 octets).(62 octets) is not legal because the
+	// total length of the DNS name (63+1+63+1+63+1+62) exceeds 253 octets.
+	//
 	// DomainName is a required field
 	DomainName *string `min:"1" type:"string" required:"true"`
 
@@ -2199,7 +2215,10 @@ type RequestCertificateInput struct {
 	// Additional FQDNs to be included in the Subject Alternative Name extension
 	// of the ACM Certificate. For example, add the name www.example.net to a certificate
 	// for which the DomainName field is www.example.com if users can reach your
-	// site by using either name.
+	// site by using either name. The maximum number of domain names that you can
+	// add to an ACM Certificate is 100. However, the initial limit is 10 domain
+	// names. If you need more than 10 names, you must request a limit increase.
+	// For more information, see Limits (http://docs.aws.amazon.com/acm/latest/userguide/acm-limits.html).
 	SubjectAlternativeNames []*string `min:"1" type:"list"`
 }
 

--- a/vendor/github.com/aws/aws-sdk-go/service/cloudfront/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/cloudfront/api.go
@@ -2809,7 +2809,56 @@ func (c *CloudFront) UpdateDistributionRequest(input *UpdateDistributionInput) (
 
 // UpdateDistribution API operation for Amazon CloudFront.
 //
-// Update a distribution.
+// Updates the configuration for a web distribution. Perform the following steps.
+//
+// For information about updating a distribution using the CloudFront console,
+// see Creating or Updating a Web Distribution Using the CloudFront Console
+//  (http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-creating-console.html)
+// in the Amazon CloudFront Developer Guide.
+//
+// To update a web distribution using the CloudFront API
+//
+// Submit a GetDistributionConfig request to get the current configuration and
+// an Etag header for the distribution.
+//
+// If you update the distribution again, you need to get a new Etag header.
+//
+// Update the XML document that was returned in the response to your GetDistributionConfig
+// request to include the desired changes. You can't change the value of CallerReference.
+// If you try to change this value, CloudFront returns an IllegalUpdate error.
+//
+// The new configuration replaces the existing configuration; the values that
+// you specify in an UpdateDistribution request are not merged into the existing
+// configuration. When you add, delete, or replace values in an element that
+// allows multiple values (for example, CNAME), you must specify all of the
+// values that you want to appear in the updated distribution. In addition,
+// you must update the corresponding Quantity element.
+//
+// Submit an UpdateDistribution request to update the configuration for your
+// distribution:
+//
+// In the request body, include the XML document that you updated in Step 2.
+// The request body must include an XML document with a DistributionConfig element.
+//
+// Set the value of the HTTP If-Match header to the value of the ETag header
+// that CloudFront returned when you submitted the GetDistributionConfig request
+// in Step 1.
+//
+// Review the response to the UpdateDistribution request to confirm that the
+// configuration was successfully updated.
+//
+// Optional: Submit a GetDistribution request to confirm that your changes have
+// propagated. When propagation is complete, the value of Status is Deployed.
+//
+// Beginning with the 2012-05-05 version of the CloudFront API, we made substantial
+// changes to the format of the XML document that you include in the request
+// body when you create or update a distribution. With previous versions of
+// the API, we discovered that it was too easy to accidentally delete one or
+// more values for an element that accepts multiple values, for example, CNAMEs
+// and trusted signers. Our changes for the 2012-05-05 release are intended
+// to prevent these accidental deletions and to notify you when there's a mismatch
+// between the number of values you say you're specifying in the Quantity element
+// and the number of values you're actually specifying.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -8696,7 +8745,7 @@ type S3OriginConfig struct {
 	// objects in an Amazon S3 bucket through CloudFront. The format of the value
 	// is:
 	//
-	// origin-access-identity/CloudFront/ID-of-origin-access-identity
+	// origin-access-identity/cloudfront/ID-of-origin-access-identity
 	//
 	// where ID-of-origin-access-identity is the value that CloudFront returned
 	// in the ID element when you created the origin access identity.

--- a/vendor/github.com/aws/aws-sdk-go/service/configservice/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/configservice/api.go
@@ -6605,4 +6605,7 @@ const (
 
 	// ResourceTypeAwsRedshiftEventSubscription is a ResourceType enum value
 	ResourceTypeAwsRedshiftEventSubscription = "AWS::Redshift::EventSubscription"
+
+	// ResourceTypeAwsCloudWatchAlarm is a ResourceType enum value
+	ResourceTypeAwsCloudWatchAlarm = "AWS::CloudWatch::Alarm"
 )

--- a/vendor/github.com/aws/aws-sdk-go/service/opsworks/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/opsworks/api.go
@@ -342,8 +342,10 @@ func (c *OpsWorks) AttachElasticLoadBalancerRequest(input *AttachElasticLoadBala
 
 // AttachElasticLoadBalancer API operation for AWS OpsWorks.
 //
-// Attaches an Elastic Load Balancing load balancer to a specified layer. For
-// more information, see Elastic Load Balancing (http://docs.aws.amazon.com/opsworks/latest/userguide/load-balancer-elb.html).
+// Attaches an Elastic Load Balancing load balancer to a specified layer. AWS
+// OpsWorks Stacks does not support Application Load Balancer. You can only
+// use Classic Load Balancer with AWS OpsWorks Stacks. For more information,
+// see Elastic Load Balancing (http://docs.aws.amazon.com/opsworks/latest/userguide/layers-elb.html).
 //
 // You must create the Elastic Load Balancing instance separately, by using
 // the Elastic Load Balancing console, API, or CLI. For more information, see
@@ -4197,6 +4199,89 @@ func (c *OpsWorks) GrantAccessWithContext(ctx aws.Context, input *GrantAccessInp
 	return out, req.Send()
 }
 
+const opListTags = "ListTags"
+
+// ListTagsRequest generates a "aws/request.Request" representing the
+// client's request for the ListTags operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See ListTags for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the ListTags method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the ListTagsRequest method.
+//    req, resp := client.ListTagsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/opsworks-2013-02-18/ListTags
+func (c *OpsWorks) ListTagsRequest(input *ListTagsInput) (req *request.Request, output *ListTagsOutput) {
+	op := &request.Operation{
+		Name:       opListTags,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &ListTagsInput{}
+	}
+
+	output = &ListTagsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListTags API operation for AWS OpsWorks.
+//
+// Returns a list of tags that are applied to the specified stack or layer.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS OpsWorks's
+// API operation ListTags for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeValidationException "ValidationException"
+//   Indicates that a request was not valid.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   Indicates that a resource was not found.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/opsworks-2013-02-18/ListTags
+func (c *OpsWorks) ListTags(input *ListTagsInput) (*ListTagsOutput, error) {
+	req, out := c.ListTagsRequest(input)
+	return out, req.Send()
+}
+
+// ListTagsWithContext is the same as ListTags with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListTags for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *OpsWorks) ListTagsWithContext(ctx aws.Context, input *ListTagsInput, opts ...request.Option) (*ListTagsOutput, error) {
+	req, out := c.ListTagsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opRebootInstance = "RebootInstance"
 
 // RebootInstanceRequest generates a "aws/request.Request" representing the
@@ -5396,6 +5481,93 @@ func (c *OpsWorks) StopStackWithContext(ctx aws.Context, input *StopStackInput, 
 	return out, req.Send()
 }
 
+const opTagResource = "TagResource"
+
+// TagResourceRequest generates a "aws/request.Request" representing the
+// client's request for the TagResource operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See TagResource for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the TagResource method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the TagResourceRequest method.
+//    req, resp := client.TagResourceRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/opsworks-2013-02-18/TagResource
+func (c *OpsWorks) TagResourceRequest(input *TagResourceInput) (req *request.Request, output *TagResourceOutput) {
+	op := &request.Operation{
+		Name:       opTagResource,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &TagResourceInput{}
+	}
+
+	output = &TagResourceOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(jsonrpc.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// TagResource API operation for AWS OpsWorks.
+//
+// Apply cost-allocation tags to a specified stack or layer in AWS OpsWorks
+// Stacks. For more information about how tagging works, see Tags (http://docs.aws.amazon.com/opsworks/latest/userguide/tagging.html)
+// in the AWS OpsWorks User Guide.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS OpsWorks's
+// API operation TagResource for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeValidationException "ValidationException"
+//   Indicates that a request was not valid.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   Indicates that a resource was not found.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/opsworks-2013-02-18/TagResource
+func (c *OpsWorks) TagResource(input *TagResourceInput) (*TagResourceOutput, error) {
+	req, out := c.TagResourceRequest(input)
+	return out, req.Send()
+}
+
+// TagResourceWithContext is the same as TagResource with the addition of
+// the ability to pass a context and additional request options.
+//
+// See TagResource for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *OpsWorks) TagResourceWithContext(ctx aws.Context, input *TagResourceInput, opts ...request.Option) (*TagResourceOutput, error) {
+	req, out := c.TagResourceRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opUnassignInstance = "UnassignInstance"
 
 // UnassignInstanceRequest generates a "aws/request.Request" representing the
@@ -5575,6 +5747,91 @@ func (c *OpsWorks) UnassignVolume(input *UnassignVolumeInput) (*UnassignVolumeOu
 // for more information on using Contexts.
 func (c *OpsWorks) UnassignVolumeWithContext(ctx aws.Context, input *UnassignVolumeInput, opts ...request.Option) (*UnassignVolumeOutput, error) {
 	req, out := c.UnassignVolumeRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opUntagResource = "UntagResource"
+
+// UntagResourceRequest generates a "aws/request.Request" representing the
+// client's request for the UntagResource operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See UntagResource for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the UntagResource method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the UntagResourceRequest method.
+//    req, resp := client.UntagResourceRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/opsworks-2013-02-18/UntagResource
+func (c *OpsWorks) UntagResourceRequest(input *UntagResourceInput) (req *request.Request, output *UntagResourceOutput) {
+	op := &request.Operation{
+		Name:       opUntagResource,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &UntagResourceInput{}
+	}
+
+	output = &UntagResourceOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(jsonrpc.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// UntagResource API operation for AWS OpsWorks.
+//
+// Removes tags from a specified stack or layer.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS OpsWorks's
+// API operation UntagResource for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeValidationException "ValidationException"
+//   Indicates that a request was not valid.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   Indicates that a resource was not found.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/opsworks-2013-02-18/UntagResource
+func (c *OpsWorks) UntagResource(input *UntagResourceInput) (*UntagResourceOutput, error) {
+	req, out := c.UntagResourceRequest(input)
+	return out, req.Send()
+}
+
+// UntagResourceWithContext is the same as UntagResource with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UntagResource for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *OpsWorks) UntagResourceWithContext(ctx aws.Context, input *UntagResourceInput, opts ...request.Option) (*UntagResourceOutput, error) {
+	req, out := c.UntagResourceRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -7117,8 +7374,8 @@ type CloneStackInput struct {
 	// The stack's operating system, which must be set to one of the following.
 	//
 	//    * A supported Linux operating system: An Amazon Linux version, such as
-	//    Amazon Linux 2016.09, Amazon Linux 2016.03, Amazon Linux 2015.09, or Amazon
-	//    Linux 2015.03.
+	//    Amazon Linux 2017.03, Amazon Linux 2016.09, Amazon Linux 2016.03, Amazon
+	//    Linux 2015.09, or Amazon Linux 2015.03.
 	//
 	//    * A supported Ubuntu operating system, such as Ubuntu 16.04 LTS, Ubuntu
 	//    14.04 LTS, or Ubuntu 12.04 LTS.
@@ -7682,25 +7939,29 @@ type Command struct {
 
 	// The command type:
 	//
+	//    * configure
+	//
 	//    * deploy
 	//
+	//    * execute_recipes
+	//
+	//    * install_dependencies
+	//
+	//    * restart
+	//
 	//    * rollback
+	//
+	//    * setup
 	//
 	//    * start
 	//
 	//    * stop
 	//
-	//    * restart
-	//
 	//    * undeploy
-	//
-	//    * update_dependencies
-	//
-	//    * install_dependencies
 	//
 	//    * update_custom_cookbooks
 	//
-	//    * execute_recipes
+	//    * update_dependencies
 	Type *string `type:"string"`
 }
 
@@ -8197,8 +8458,8 @@ type CreateInstanceInput struct {
 	// The instance's operating system, which must be set to one of the following.
 	//
 	//    * A supported Linux operating system: An Amazon Linux version, such as
-	//    Amazon Linux 2016.09, Amazon Linux 2016.03, Amazon Linux 2015.09, or Amazon
-	//    Linux 2015.03.
+	//    Amazon Linux 2017.03, Amazon Linux 2016.09, Amazon Linux 2016.03, Amazon
+	//    Linux 2015.09, or Amazon Linux 2015.03.
 	//
 	//    * A supported Ubuntu operating system, such as Ubuntu 16.04 LTS, Ubuntu
 	//    14.04 LTS, or Ubuntu 12.04 LTS.
@@ -8763,8 +9024,8 @@ type CreateStackInput struct {
 	// You can specify one of the following.
 	//
 	//    * A supported Linux operating system: An Amazon Linux version, such as
-	//    Amazon Linux 2016.09, Amazon Linux 2016.03, Amazon Linux 2015.09, or Amazon
-	//    Linux 2015.03.
+	//    Amazon Linux 2017.03, Amazon Linux 2016.09, Amazon Linux 2016.03, Amazon
+	//    Linux 2015.09, or Amazon Linux 2015.03.
 	//
 	//    * A supported Ubuntu operating system, such as Ubuntu 16.04 LTS, Ubuntu
 	//    14.04 LTS, or Ubuntu 12.04 LTS.
@@ -9665,17 +9926,17 @@ type DeploymentCommand struct {
 	// The update_dependencies command takes two arguments:
 	//
 	//    * upgrade_os_to - Specifies the desired Amazon Linux version for instances
-	//    whose OS you want to upgrade, such as Amazon Linux 2014.09. You must also
+	//    whose OS you want to upgrade, such as Amazon Linux 2016.09. You must also
 	//    set the allow_reboot argument to true.
 	//
 	//    * allow_reboot - Specifies whether to allow AWS OpsWorks Stacks to reboot
 	//    the instances if necessary, after installing the updates. This argument
 	//    can be set to either true or false. The default value is false.
 	//
-	// For example, to upgrade an instance to Amazon Linux 2014.09, set Args to
+	// For example, to upgrade an instance to Amazon Linux 2016.09, set Args to
 	// the following.
 	//
-	// { "upgrade_os_to":["Amazon Linux 2014.09"], "allow_reboot":["true"] }
+	// { "upgrade_os_to":["Amazon Linux 2016.09"], "allow_reboot":["true"] }
 	Args map[string][]*string `type:"map"`
 
 	// Specifies the operation. You can specify only one command.
@@ -12057,6 +12318,8 @@ type Instance struct {
 	// The instance architecture: "i386" or "x86_64".
 	Architecture *string `type:"string" enum:"Architecture"`
 
+	Arn *string `type:"string"`
+
 	// For load-based or time-based instances, the type.
 	AutoScalingType *string `type:"string" enum:"AutoScalingType"`
 
@@ -12124,7 +12387,7 @@ type Instance struct {
 	// The instance's platform.
 	Platform *string `type:"string"`
 
-	// The The instance's private DNS name.
+	// The instance's private DNS name.
 	PrivateDns *string `type:"string"`
 
 	// The instance's private IP address.
@@ -12235,6 +12498,12 @@ func (s *Instance) SetAmiId(v string) *Instance {
 // SetArchitecture sets the Architecture field's value.
 func (s *Instance) SetArchitecture(v string) *Instance {
 	s.Architecture = &v
+	return s
+}
+
+// SetArn sets the Arn field's value.
+func (s *Instance) SetArn(v string) *Instance {
+	s.Arn = &v
 	return s
 }
 
@@ -12687,6 +12956,8 @@ func (s *InstancesCount) SetUnassigning(v int64) *InstancesCount {
 type Layer struct {
 	_ struct{} `type:"structure"`
 
+	Arn *string `type:"string"`
+
 	// The layer attributes.
 	//
 	// For the HaproxyStatsPassword, MysqlRootPassword, and GangliaPassword attributes,
@@ -12791,6 +13062,12 @@ func (s Layer) String() string {
 // GoString returns the string representation
 func (s Layer) GoString() string {
 	return s.String()
+}
+
+// SetArn sets the Arn field's value.
+func (s *Layer) SetArn(v string) *Layer {
+	s.Arn = &v
+	return s
 }
 
 // SetAttributes sets the Attributes field's value.
@@ -12947,6 +13224,103 @@ func (s LifecycleEventConfiguration) GoString() string {
 // SetShutdown sets the Shutdown field's value.
 func (s *LifecycleEventConfiguration) SetShutdown(v *ShutdownEventConfiguration) *LifecycleEventConfiguration {
 	s.Shutdown = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/opsworks-2013-02-18/ListTagsRequest
+type ListTagsInput struct {
+	_ struct{} `type:"structure"`
+
+	// Do not use. A validation exception occurs if you add a MaxResults parameter
+	// to a ListTagsRequest call.
+	MaxResults *int64 `type:"integer"`
+
+	// Do not use. A validation exception occurs if you add a NextToken parameter
+	// to a ListTagsRequest call.
+	NextToken *string `type:"string"`
+
+	// The stack or layer's Amazon Resource Number (ARN).
+	//
+	// ResourceArn is a required field
+	ResourceArn *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s ListTagsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListTagsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListTagsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListTagsInput"}
+	if s.ResourceArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListTagsInput) SetMaxResults(v int64) *ListTagsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListTagsInput) SetNextToken(v string) *ListTagsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetResourceArn sets the ResourceArn field's value.
+func (s *ListTagsInput) SetResourceArn(v string) *ListTagsInput {
+	s.ResourceArn = &v
+	return s
+}
+
+// Contains the response to a ListTags request.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/opsworks-2013-02-18/ListTagsResult
+type ListTagsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// If a paginated request does not return all of the remaining results, this
+	// parameter is set to a token that you can assign to the request object's NextToken
+	// parameter to get the next set of results. If the previous paginated request
+	// returned all of the remaining results, this parameter is set to null.
+	NextToken *string `type:"string"`
+
+	// A set of key-value pairs that contain tag keys and tag values that are attached
+	// to a stack or layer.
+	Tags map[string]*string `type:"map"`
+}
+
+// String returns the string representation
+func (s ListTagsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListTagsOutput) GoString() string {
+	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListTagsOutput) SetNextToken(v string) *ListTagsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *ListTagsOutput) SetTags(v map[string]*string) *ListTagsOutput {
+	s.Tags = v
 	return s
 }
 
@@ -14387,7 +14761,7 @@ type Source struct {
 	// The repository type.
 	Type *string `type:"string" enum:"SourceType"`
 
-	// The source URL.
+	// The source URL. The following is an example of an Amazon S3 source URL: https://s3.amazonaws.com/opsworks-demo-bucket/opsworks_cookbook_demo.tar.gz.
 	Url *string `type:"string"`
 
 	// This parameter depends on the repository type.
@@ -15066,6 +15440,90 @@ func (s StopStackOutput) GoString() string {
 	return s.String()
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/opsworks-2013-02-18/TagResourceRequest
+type TagResourceInput struct {
+	_ struct{} `type:"structure"`
+
+	// The stack or layer's Amazon Resource Number (ARN).
+	//
+	// ResourceArn is a required field
+	ResourceArn *string `type:"string" required:"true"`
+
+	// A map that contains tag keys and tag values that are attached to a stack
+	// or layer.
+	//
+	//    * The key cannot be empty.
+	//
+	//    * The key can be a maximum of 127 characters, and can contain only Unicode
+	//    letters, numbers, or separators, or the following special characters:
+	//    + - = . _ : /
+	//
+	//    * The value can be a maximum 255 characters, and contain only Unicode
+	//    letters, numbers, or separators, or the following special characters:
+	//    + - = . _ : /
+	//
+	//    * Leading and trailing white spaces are trimmed from both the key and
+	//    value.
+	//
+	//    * A maximum of 40 tags is allowed for any resource.
+	//
+	// Tags is a required field
+	Tags map[string]*string `type:"map" required:"true"`
+}
+
+// String returns the string representation
+func (s TagResourceInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TagResourceInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TagResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TagResourceInput"}
+	if s.ResourceArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceArn"))
+	}
+	if s.Tags == nil {
+		invalidParams.Add(request.NewErrParamRequired("Tags"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetResourceArn sets the ResourceArn field's value.
+func (s *TagResourceInput) SetResourceArn(v string) *TagResourceInput {
+	s.ResourceArn = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *TagResourceInput) SetTags(v map[string]*string) *TagResourceInput {
+	s.Tags = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/opsworks-2013-02-18/TagResourceOutput
+type TagResourceOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s TagResourceOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TagResourceOutput) GoString() string {
+	return s.String()
+}
+
 // Contains the data needed by RDP clients such as the Microsoft Remote Desktop
 // Connection to log in to the instance.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/opsworks-2013-02-18/TemporaryCredential
@@ -15261,6 +15719,74 @@ func (s UnassignVolumeOutput) String() string {
 
 // GoString returns the string representation
 func (s UnassignVolumeOutput) GoString() string {
+	return s.String()
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/opsworks-2013-02-18/UntagResourceRequest
+type UntagResourceInput struct {
+	_ struct{} `type:"structure"`
+
+	// The stack or layer's Amazon Resource Number (ARN).
+	//
+	// ResourceArn is a required field
+	ResourceArn *string `type:"string" required:"true"`
+
+	// A list of the keys of tags to be removed from a stack or layer.
+	//
+	// TagKeys is a required field
+	TagKeys []*string `type:"list" required:"true"`
+}
+
+// String returns the string representation
+func (s UntagResourceInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UntagResourceInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UntagResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UntagResourceInput"}
+	if s.ResourceArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceArn"))
+	}
+	if s.TagKeys == nil {
+		invalidParams.Add(request.NewErrParamRequired("TagKeys"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetResourceArn sets the ResourceArn field's value.
+func (s *UntagResourceInput) SetResourceArn(v string) *UntagResourceInput {
+	s.ResourceArn = &v
+	return s
+}
+
+// SetTagKeys sets the TagKeys field's value.
+func (s *UntagResourceInput) SetTagKeys(v []*string) *UntagResourceInput {
+	s.TagKeys = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/opsworks-2013-02-18/UntagResourceOutput
+type UntagResourceOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s UntagResourceOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UntagResourceOutput) GoString() string {
 	return s.String()
 }
 
@@ -15571,8 +16097,8 @@ type UpdateInstanceInput struct {
 	// You cannot update an instance that is using a custom AMI.
 	//
 	//    * A supported Linux operating system: An Amazon Linux version, such as
-	//    Amazon Linux 2016.09, Amazon Linux 2016.03, Amazon Linux 2015.09, or Amazon
-	//    Linux 2015.03.
+	//    Amazon Linux 2017.03, Amazon Linux 2016.09, Amazon Linux 2016.03, Amazon
+	//    Linux 2015.09, or Amazon Linux 2015.03.
 	//
 	//    * A supported Ubuntu operating system, such as Ubuntu 16.04 LTS, Ubuntu
 	//    14.04 LTS, or Ubuntu 12.04 LTS.
@@ -16121,8 +16647,8 @@ type UpdateStackInput struct {
 	// The stack's operating system, which must be set to one of the following:
 	//
 	//    * A supported Linux operating system: An Amazon Linux version, such as
-	//    Amazon Linux 2016.09, Amazon Linux 2016.03, Amazon Linux 2015.09, or Amazon
-	//    Linux 2015.03.
+	//    Amazon Linux 2017.03, Amazon Linux 2016.09, Amazon Linux 2016.03, Amazon
+	//    Linux 2015.09, or Amazon Linux 2015.03.
 	//
 	//    * A supported Ubuntu operating system, such as Ubuntu 16.04 LTS, Ubuntu
 	//    14.04 LTS, or Ubuntu 12.04 LTS.

--- a/vendor/github.com/aws/aws-sdk-go/service/rds/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/rds/api.go
@@ -845,61 +845,13 @@ func (c *RDS) CopyDBSnapshotRequest(input *CopyDBSnapshotInput) (req *request.Re
 // Copies the specified DB snapshot. The source DB snapshot must be in the "available"
 // state.
 //
-// To copy a DB snapshot from a shared manual DB snapshot, SourceDBSnapshotIdentifier
-// must be the Amazon Resource Name (ARN) of the shared DB snapshot.
+// You can copy a snapshot from one AWS region to another. In that case, the
+// region where you call the CopyDBSnapshot action is the destination region
+// for the DB snapshot copy.
 //
-// You can copy an encrypted DB snapshot from another AWS region. In that case,
-// the region where you call the CopyDBSnapshot action is the destination region
-// for the encrypted DB snapshot to be copied to. To copy an encrypted DB snapshot
-// from another region, you must provide the following values:
+// You cannot copy an encrypted, shared DB snapshot from one AWS region to another.
 //
-//    * KmsKeyId - The AWS Key Management System (KMS) key identifier for the
-//    key to use to encrypt the copy of the DB snapshot in the destination region.
-//
-//    * PreSignedUrl - A URL that contains a Signature Version 4 signed request
-//    for the CopyDBSnapshot action to be called in the source region where
-//    the DB snapshot will be copied from. The presigned URL must be a valid
-//    request for the CopyDBSnapshot API action that can be executed in the
-//    source region that contains the encrypted DB snapshot to be copied.
-//
-// The presigned URL request must contain the following parameter values:
-//
-// DestinationRegion - The AWS Region that the encrypted DB snapshot will be
-//    copied to. This region is the same one where the CopyDBSnapshot action
-//    is called that contains this presigned URL.
-//
-// For example, if you copy an encrypted DB snapshot from the us-west-2 region
-//    to the us-east-1 region, then you will call the CopyDBSnapshot action
-//    in the us-east-1 region and provide a presigned URL that contains a call
-//    to the CopyDBSnapshot action in the us-west-2 region. For this example,
-//    the DestinationRegion in the presigned URL must be set to the us-east-1
-//    region.
-//
-// KmsKeyId - The KMS key identifier for the key to use to encrypt the copy
-//    of the DB snapshot in the destination region. This identifier is the same
-//    for both the CopyDBSnapshot action that is called in the destination region,
-//    and the action contained in the presigned URL.
-//
-// SourceDBSnapshotIdentifier - The DB snapshot identifier for the encrypted
-//    snapshot to be copied. This identifier must be in the Amazon Resource
-//    Name (ARN) format for the source region. For example, if you copy an encrypted
-//    DB snapshot from the us-west-2 region, then your SourceDBSnapshotIdentifier
-//    looks like this example: arn:aws:rds:us-west-2:123456789012:snapshot:mysql-instance1-snapshot-20161115.
-//
-// To learn how to generate a Signature Version 4 signed request, see  Authenticating
-//    Requests: Using Query Parameters (AWS Signature Version 4) (http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html)
-//    and  Signature Version 4 Signing Process (http://docs.aws.amazon.com/general/latest/gr/signature-version-4.html).
-//
-//    * TargetDBSnapshotIdentifier - The identifier for the new copy of the
-//    DB snapshot in the destination region.
-//
-//    * SourceDBSnapshotIdentifier - The DB snapshot identifier for the encrypted
-//    snapshot to be copied. This identifier must be in the ARN format for the
-//    source region and is the same value as the SourceDBSnapshotIdentifier
-//    in the presigned URL.
-//
-// For more information on copying encrypted snapshots from one region to another,
-// see  Copying a DB Snapshot (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_CopySnapshot.html#USER_CopyDBSnapshot)
+// For more information about copying snapshots, see Copying a DB Snapshot (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_CopyDBSnapshot.html)
 // in the Amazon RDS User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -10695,31 +10647,40 @@ type CopyDBSnapshotInput struct {
 	// Resource Name (ARN), KMS key identifier, or the KMS key alias for the KMS
 	// encryption key.
 	//
-	// If you copy an unencrypted DB snapshot and specify a value for the KmsKeyId
-	// parameter, Amazon RDS encrypts the target DB snapshot using the specified
-	// KMS encryption key.
-	//
 	// If you copy an encrypted DB snapshot from your AWS account, you can specify
-	// a value for KmsKeyId to encrypt the copy with a new KMS encryption key. If
-	// you don't specify a value for KmsKeyId, then the copy of the DB snapshot
-	// is encrypted with the same KMS key as the source DB snapshot.
-	//
-	// If you copy an encrypted snapshot to a different AWS region, then you must
-	// specify a KMS key for the destination AWS region.
+	// a value for this parameter to encrypt the copy with a new KMS encryption
+	// key. If you don't specify a value for this parameter, then the copy of the
+	// DB snapshot is encrypted with the same KMS key as the source DB snapshot.
 	//
 	// If you copy an encrypted DB snapshot that is shared from another AWS account,
-	// then you must specify a value for KmsKeyId.
+	// then you must specify a value for this parameter.
 	//
-	// To copy an encrypted DB snapshot to another region, you must set KmsKeyId
-	// to the KMS key ID used to encrypt the copy of the DB snapshot in the destination
-	// region. KMS encryption keys are specific to the region that they are created
-	// in, and you cannot use encryption keys from one region in another region.
+	// If you specify this parameter when you copy an unencrypted snapshot, the
+	// copy is encrypted.
+	//
+	// If you copy an encrypted snapshot to a different AWS region, then you must
+	// specify a KMS key for the destination AWS region. KMS encryption keys are
+	// specific to the region that they are created in, and you cannot use encryption
+	// keys from one region in another region.
 	KmsKeyId *string `type:"string"`
 
+	// The name of an option group to associate with the copy.
+	//
+	// Specify this option if you are copying a snapshot from one AWS region to
+	// another, and your DB instance uses a non-default option group. If your source
+	// DB instance uses Transparent Data Encryption for Oracle or Microsoft SQL
+	// Server, you must specify this option when copying across regions. For more
+	// information, see Option Group Considerations (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_CopySnapshot.html#USER_CopySnapshot.Options).
+	OptionGroupName *string `type:"string"`
+
 	// The URL that contains a Signature Version 4 signed request for the CopyDBSnapshot
-	// API action in the AWS region that contains the source DB snapshot to copy.
-	// The PreSignedUrl parameter must be used when copying an encrypted DB snapshot
-	// from another AWS region.
+	// API action in the source AWS region that contains the source DB snapshot
+	// to copy.
+	//
+	// You must specify this parameter when you copy an encrypted DB snapshot from
+	// another AWS region by using the Amazon RDS API. You can specify the source
+	// region option instead of this parameter when you copy an encrypted DB snapshot
+	// from another AWS region by using the AWS CLI.
 	//
 	// The presigned URL must be a valid request for the CopyDBSnapshot API action
 	// that can be executed in the source region that contains the encrypted DB
@@ -10748,28 +10709,30 @@ type CopyDBSnapshotInput struct {
 	//    an encrypted DB snapshot from the us-west-2 region, then your SourceDBSnapshotIdentifier
 	//    looks like the following example: arn:aws:rds:us-west-2:123456789012:snapshot:mysql-instance1-snapshot-20161115.
 	//
-	// To learn how to generate a Signature Version 4 signed request, see  Authenticating
+	//
+	// To learn how to generate a Signature Version 4 signed request, see Authenticating
 	// Requests: Using Query Parameters (AWS Signature Version 4) (http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html)
-	// and  Signature Version 4 Signing Process (http://docs.aws.amazon.com/general/latest/gr/signature-version-4.html).
+	// and Signature Version 4 Signing Process (http://docs.aws.amazon.com/general/latest/gr/signature-version-4.html).
 	PreSignedUrl *string `type:"string"`
 
 	// The identifier for the source DB snapshot.
 	//
-	// If you are copying from a shared manual DB snapshot, this must be the ARN
-	// of the shared DB snapshot.
+	// If the source snapshot is in the same region as the copy, specify a valid
+	// DB snapshot identifier. For example, rds:mysql-instance1-snapshot-20130805.
 	//
-	// You cannot copy an encrypted, shared DB snapshot from one AWS region to another.
+	// If the source snapshot is in a different region than the copy, specify a
+	// valid DB snapshot ARN. For example, arn:aws:rds:us-west-2:123456789012:snapshot:mysql-instance1-snapshot-20130805.
+	//
+	// If you are copying from a shared manual DB snapshot, this parameter must
+	// be the Amazon Resource Name (ARN) of the shared DB snapshot.
+	//
+	// If you are copying an encrypted snapshot this parameter must be in the ARN
+	// format for the source region, and must match the SourceDBSnapshotIdentifier
+	// in the PreSignedUrl parameter.
 	//
 	// Constraints:
 	//
 	//    * Must specify a valid system snapshot in the "available" state.
-	//
-	//    * If the source snapshot is in the same region as the copy, specify a
-	//    valid DB snapshot identifier.
-	//
-	//    * If the source snapshot is in a different region than the copy, specify
-	//    a valid DB snapshot ARN. For more information, go to  Copying a DB Snapshot
-	//    or DB Cluster Snapshot (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_CopySnapshot.html).
 	//
 	// Example: rds:mydb-2012-04-02-00-01
 	//
@@ -10786,7 +10749,7 @@ type CopyDBSnapshotInput struct {
 	// A list of tags.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 
-	// The identifier for the copied snapshot.
+	// The identifier for the copy of the snapshot.
 	//
 	// Constraints:
 	//
@@ -10845,6 +10808,12 @@ func (s *CopyDBSnapshotInput) SetDestinationRegion(v string) *CopyDBSnapshotInpu
 // SetKmsKeyId sets the KmsKeyId field's value.
 func (s *CopyDBSnapshotInput) SetKmsKeyId(v string) *CopyDBSnapshotInput {
 	s.KmsKeyId = &v
+	return s
+}
+
+// SetOptionGroupName sets the OptionGroupName field's value.
+func (s *CopyDBSnapshotInput) SetOptionGroupName(v string) *CopyDBSnapshotInput {
+	s.OptionGroupName = &v
 	return s
 }
 
@@ -11904,7 +11873,7 @@ type CreateDBInstanceInput struct {
 	// True to enable mapping of AWS Identity and Access Management (IAM) accounts
 	// to database accounts; otherwise false.
 	//
-	// You can enable IAM database authentication for the following database engines
+	// You can enable IAM database authentication for the following database engines:
 	//
 	//    * For MySQL 5.6, minor version 5.6.34 or higher
 	//
@@ -11915,11 +11884,33 @@ type CreateDBInstanceInput struct {
 
 	// The name of the database engine to be used for this instance.
 	//
-	// Valid Values: mysql | mariadb | oracle-se1 | oracle-se2 | oracle-se | oracle-ee
-	// | sqlserver-ee | sqlserver-se | sqlserver-ex | sqlserver-web | postgres |
-	// aurora
-	//
 	// Not every database engine is available for every AWS region.
+	//
+	// Valid Values:
+	//
+	//    * aurora
+	//
+	//    * mariadb
+	//
+	//    * mysql
+	//
+	//    * oracle-ee
+	//
+	//    * oracle-se2
+	//
+	//    * oracle-se1
+	//
+	//    * oracle-se
+	//
+	//    * postgres
+	//
+	//    * sqlserver-ee
+	//
+	//    * sqlserver-se
+	//
+	//    * sqlserver-ex
+	//
+	//    * sqlserver-web
 	//
 	// Engine is a required field
 	Engine *string `type:"string" required:"true"`
@@ -11934,142 +11925,151 @@ type CreateDBInstanceInput struct {
 	//
 	//    * Version 5.6 (available in these AWS regions: ap-northeast-1, ap-northeast-2,
 	//    ap-south-1, ap-southeast-2, eu-west-1, us-east-1, us-east-2, us-west-2):
-	//    5.6.10a
+	//     5.6.10a
 	//
 	// MariaDB
 	//
-	//    * Version 10.1 (available in these AWS regions: us-east-2): 10.1.16
+	//    * 10.1.19 (supported in all AWS regions)
 	//
-	//    * Version 10.1 (available in these AWS regions: ap-northeast-1, ap-northeast-2,
-	//    ap-south-1, ap-southeast-1, ap-southeast-2, eu-central-1, eu-west-1, sa-east-1,
-	//    us-east-1, us-west-1, us-west-2): 10.1.14
+	//    * 10.1.14 (supported in all regions except us-east-2)
 	//
-	//    * Version 10.0 (available in all AWS regions): 10.0.24
+	// 10.0.28 (supported in all AWS regions)
 	//
-	//    * Version 10.0 (available in these AWS regions: ap-northeast-1, ap-northeast-2,
-	//    ap-south-1, ap-southeast-1, ap-southeast-2, eu-central-1, eu-west-1, sa-east-1,
-	//    us-east-1, us-gov-west-1, us-west-1, us-west-2): 10.0.17
+	//    * 10.0.24 (supported in all AWS regions)
+	//
+	//    * 10.0.17 (supported in all regions except us-east-2, ca-central-1, eu-west-2)
 	//
 	// Microsoft SQL Server 2016
 	//
-	//    * 13.00.2164.0.v1 (supported for all editions, and all AWS regions except
-	//    sa-east-1)
+	// 13.00.4422.0.v1 (supported for all editions, and all AWS regions)
+	//
+	//    * 13.00.2164.0.v1 (supported for all editions, and all AWS regions)
 	//
 	// Microsoft SQL Server 2014
+	//
+	// 12.00.5546.0.v1 (supported for all editions, and all AWS regions)
 	//
 	//    * 12.00.5000.0.v1 (supported for all editions, and all AWS regions)
 	//
 	//    * 12.00.4422.0.v1 (supported for all editions except Enterprise Edition,
-	//    and all AWS regions except us-east-2)
+	//    and all AWS regions except ca-central-1 and eu-west-2)
 	//
 	// Microsoft SQL Server 2012
+	//
+	// 11.00.6594.0.v1 (supported for all editions, and all AWS regions)
 	//
 	//    * 11.00.6020.0.v1 (supported for all editions, and all AWS regions)
 	//
 	//    * 11.00.5058.0.v1 (supported for all editions, and all AWS regions except
-	//    us-east-2)
+	//    us-east-2, ca-central-1, and eu-west-2)
 	//
 	//    * 11.00.2100.60.v1 (supported for all editions, and all AWS regions except
-	//    us-east-2)
+	//    us-east-2, ca-central-1, and eu-west-2)
 	//
 	// Microsoft SQL Server 2008 R2
 	//
-	//    * 10.50.6529.0.v1 (supported for all editions, and all AWS regions except
-	//    us-east-2)
+	// 10.50.6529.0.v1 (supported for all editions, and all AWS regions except us-east-2,
+	// ca-central-1, and eu-west-2)
 	//
 	//    * 10.50.6000.34.v1 (supported for all editions, and all AWS regions except
-	//    us-east-2)
+	//    us-east-2, ca-central-1, and eu-west-2)
 	//
 	//    * 10.50.2789.0.v1 (supported for all editions, and all AWS regions except
-	//    us-east-2)
+	//    us-east-2, ca-central-1, and eu-west-2)
 	//
 	// MySQL
 	//
-	//    * Version 5.7 (available in all AWS regions): 5.7.11
+	// 5.7.17 (supported in all AWS regions)
 	//
-	//    * Version 5.7 (available in these AWS regions: ap-northeast-1, ap-northeast-2,
-	//    ap-south-1, ap-southeast-1, ap-southeast-2, eu-central-1, eu-west-1, sa-east-1,
-	//    us-east-1, us-gov-west-1, us-west-1, us-west-2): 5.7.10
+	//    * 5.7.16 (supported in all AWS regions)
 	//
-	//    * Version 5.6 (available in all AWS regions): 5.6.29
+	//    * 5.7.11 (supported in all AWS regions)
 	//
-	//    * Version 5.6 (available in these AWS regions: ap-northeast-1, ap-northeast-2,
-	//    ap-south-1, ap-southeast-1, ap-southeast-2, eu-central-1, eu-west-1, sa-east-1,
-	//    us-east-1, us-gov-west-1, us-west-1, us-west-2): 5.6.27
+	//    * 5.7.10 (supported in all regions except us-east-2, ca-central-1, eu-west-2)
 	//
-	//    * Version 5.6 (available in these AWS regions: ap-northeast-1, ap-northeast-2,
-	//    ap-southeast-1, ap-southeast-2, eu-central-1, eu-west-1, sa-east-1, us-east-1,
-	//    us-gov-west-1, us-west-1, us-west-2): 5.6.23
+	//    * 5.6.35 (supported in all AWS regions)
 	//
-	//    * Version 5.6 (available in these AWS regions: ap-northeast-1, ap-southeast-1,
-	//    ap-southeast-2, eu-central-1, eu-west-1, sa-east-1, us-east-1, us-gov-west-1,
-	//    us-west-1, us-west-2): 5.6.19a | 5.6.19b | 5.6.21 | 5.6.21b | 5.6.22
+	//    * 5.6.34 (supported in all AWS regions)
 	//
-	//    * Version 5.5 (available in all AWS regions): 5.5.46
+	//    * 5.6.29 (supported in all AWS regions)
 	//
-	//    * Version 5.1 (only available in AWS regions ap-northeast-1, ap-southeast-1,
-	//    ap-southeast-2, eu-west-1, sa-east-1, us-east-1, us-gov-west-1, us-west-1,
-	//    us-west-2): 5.1.73a | 5.1.73b
+	//    * 5.6.27 (supported in all regions except us-east-2, ca-central-1, eu-west-2)
+	//
+	//    * 5.6.23 (supported in all regions except us-east-2, ap-south-1, ca-central-1,
+	//    eu-west-2)
+	//
+	//    * 5.6.22 (supported in all regions except us-east-2, ap-south-1, ap-northeast-2,
+	//    ca-central-1, eu-west-2)
+	//
+	//    * 5.6.21b (supported in all regions except us-east-2, ap-south-1, ap-northeast-2,
+	//    ca-central-1, eu-west-2)
+	//
+	//    * 5.6.21 (supported in all regions except us-east-2, ap-south-1, ap-northeast-2,
+	//    ca-central-1, eu-west-2)
+	//
+	//    * 5.6.19b (supported in all regions except us-east-2, ap-south-1, ap-northeast-2,
+	//    ca-central-1, eu-west-2)
+	//
+	//    * 5.6.19a (supported in all regions except us-east-2, ap-south-1, ap-northeast-2,
+	//    ca-central-1, eu-west-2)
+	//
+	// 5.5.54(supported in all AWS regions)
+	//
+	// 5.5.53(supported in all AWS regions)
+	//
+	// 5.5.46(supported in all AWS regions)
 	//
 	// Oracle 12c
 	//
-	//    * 12.1.0.2.v8 (supported for EE in all AWS regions, and SE2 in all AWS
-	//    regions except us-gov-west-1)
+	// 12.1.0.2.v8(supported for EE in all AWS regions, and SE2 in all AWS regions except us-gov-west-1)
 	//
-	//    * 12.1.0.2.v7 (supported for EE in all AWS regions, and SE2 in all AWS
-	//    regions except us-gov-west-1)
+	// 12.1.0.2.v7(supported for EE in all AWS regions, and SE2 in all AWS regions except us-gov-west-1)
 	//
-	//    * 12.1.0.2.v6 (supported for EE in all AWS regions, and SE2 in all AWS
-	//    regions except us-gov-west-1)
+	// 12.1.0.2.v6(supported for EE in all AWS regions, and SE2 in all AWS regions except us-gov-west-1)
 	//
-	//    * 12.1.0.2.v5 (supported for EE in all AWS regions, and SE2 in all AWS
-	//    regions except us-gov-west-1)
+	// 12.1.0.2.v5(supported for EE in all AWS regions, and SE2 in all AWS regions except us-gov-west-1)
 	//
-	//    * 12.1.0.2.v4 (supported for EE in all AWS regions, and SE2 in all AWS
-	//    regions except us-gov-west-1)
+	// 12.1.0.2.v4(supported for EE in all AWS regions, and SE2 in all AWS regions except us-gov-west-1)
 	//
-	//    * 12.1.0.2.v3 (supported for EE in all AWS regions, and SE2 in all AWS
-	//    regions except us-gov-west-1)
+	// 12.1.0.2.v3(supported for EE in all AWS regions, and SE2 in all AWS regions except us-gov-west-1)
 	//
-	//    * 12.1.0.2.v2 (supported for EE in all AWS regions, and SE2 in all AWS
-	//    regions except us-gov-west-1)
+	// 12.1.0.2.v2(supported for EE in all AWS regions, and SE2 in all AWS regions except us-gov-west-1)
 	//
-	//    * 12.1.0.2.v1 (supported for EE in all AWS regions, and SE2 in all AWS
-	//    regions except us-gov-west-1)
+	// 12.1.0.2.v1(supported for EE in all AWS regions, and SE2 in all AWS regions except us-gov-west-1)
 	//
 	// Oracle 11g
 	//
-	//    * 11.2.0.4.v12 (supported for EE, SE1, and SE, in all AWS regions)
+	// 11.2.0.4.v12(supported for EE, SE1, and SE, in all AWS regions)
 	//
-	//    * 11.2.0.4.v11 (supported for EE, SE1, and SE, in all AWS regions)
+	// 11.2.0.4.v11(supported for EE, SE1, and SE, in all AWS regions)
 	//
-	//    * 11.2.0.4.v10 (supported for EE, SE1, and SE, in all AWS regions)
+	// 11.2.0.4.v10(supported for EE, SE1, and SE, in all AWS regions)
 	//
-	//    * 11.2.0.4.v9 (supported for EE, SE1, and SE, in all AWS regions)
+	// 11.2.0.4.v9(supported for EE, SE1, and SE, in all AWS regions)
 	//
-	//    * 11.2.0.4.v8 (supported for EE, SE1, and SE, in all AWS regions)
+	// 11.2.0.4.v8(supported for EE, SE1, and SE, in all AWS regions)
 	//
-	//    * 11.2.0.4.v7 (supported for EE, SE1, and SE, in all AWS regions)
+	// 11.2.0.4.v7(supported for EE, SE1, and SE, in all AWS regions)
 	//
-	//    * 11.2.0.4.v6 (supported for EE, SE1, and SE, in all AWS regions)
+	// 11.2.0.4.v6(supported for EE, SE1, and SE, in all AWS regions)
 	//
-	//    * 11.2.0.4.v5 (supported for EE, SE1, and SE, in all AWS regions)
+	// 11.2.0.4.v5(supported for EE, SE1, and SE, in all AWS regions)
 	//
-	//    * 11.2.0.4.v4 (supported for EE, SE1, and SE, in all AWS regions)
+	// 11.2.0.4.v4(supported for EE, SE1, and SE, in all AWS regions)
 	//
-	//    * 11.2.0.4.v3 (supported for EE, SE1, and SE, in all AWS regions)
+	// 11.2.0.4.v3(supported for EE, SE1, and SE, in all AWS regions)
 	//
-	//    * 11.2.0.4.v1 (supported for EE, SE1, and SE, in all AWS regions)
+	// 11.2.0.4.v1(supported for EE, SE1, and SE, in all AWS regions)
 	//
 	// PostgreSQL
 	//
-	//    * Version 9.6.x: 9.6.1 | 9.6.2
+	// Version 9.6.x: 9.6.1 | 9.6.2
 	//
-	//    * Version 9.5.x:9.5.6 | 9.5.4 | 9.5.2
+	// Version 9.5.x:9.5.6 | 9.5.4 | 9.5.2
 	//
-	//    * Version 9.4.x:9.4.11 | 9.4.9 | 9.4.7
+	// Version 9.4.x:9.4.11 | 9.4.9 | 9.4.7
 	//
-	//    * Version 9.3.x:9.3.16 | 9.3.14 | 9.3.12
+	// Version 9.3.x:9.3.16 | 9.3.14 | 9.3.12
 	EngineVersion *string `type:"string"`
 
 	// The amount of Provisioned IOPS (input/output operations per second) to be
@@ -12634,6 +12634,10 @@ type CreateDBInstanceOutput struct {
 	//
 	//    * ModifyDBInstance
 	//
+	//    * StopDBInstance
+	//
+	//    * StartDBInstance
+	//
 	// This data type is used as a response element in the DescribeDBInstances action.
 	DBInstance *DBInstance `type:"structure"`
 }
@@ -13047,6 +13051,10 @@ type CreateDBInstanceReadReplicaOutput struct {
 	//    * DeleteDBInstance
 	//
 	//    * ModifyDBInstance
+	//
+	//    * StopDBInstance
+	//
+	//    * StartDBInstance
 	//
 	// This data type is used as a response element in the DescribeDBInstances action.
 	DBInstance *DBInstance `type:"structure"`
@@ -13846,6 +13854,9 @@ type DBCluster struct {
 	// associated with.
 	CharacterSetName *string `type:"string"`
 
+	// Identifies the clone group to which the DB cluster is associated.
+	CloneGroupId *string `type:"string"`
+
 	// Specifies the time when the DB cluster was created, in Universal Coordinated
 	// Time (UTC).
 	ClusterCreateTime *time.Time `type:"timestamp" timestampFormat:"iso8601"`
@@ -13996,6 +14007,12 @@ func (s *DBCluster) SetBackupRetentionPeriod(v int64) *DBCluster {
 // SetCharacterSetName sets the CharacterSetName field's value.
 func (s *DBCluster) SetCharacterSetName(v string) *DBCluster {
 	s.CharacterSetName = &v
+	return s
+}
+
+// SetCloneGroupId sets the CloneGroupId field's value.
+func (s *DBCluster) SetCloneGroupId(v string) *DBCluster {
+	s.CloneGroupId = &v
 	return s
 }
 
@@ -14810,6 +14827,10 @@ func (s *DBEngineVersion) SetValidUpgradeTarget(v []*UpgradeTarget) *DBEngineVer
 //    * DeleteDBInstance
 //
 //    * ModifyDBInstance
+//
+//    * StopDBInstance
+//
+//    * StartDBInstance
 //
 // This data type is used as a response element in the DescribeDBInstances action.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/DBInstance
@@ -16450,6 +16471,10 @@ type DeleteDBInstanceOutput struct {
 	//    * DeleteDBInstance
 	//
 	//    * ModifyDBInstance
+	//
+	//    * StopDBInstance
+	//
+	//    * StartDBInstance
 	//
 	// This data type is used as a response element in the DescribeDBInstances action.
 	DBInstance *DBInstance `type:"structure"`
@@ -22601,6 +22626,10 @@ type ModifyDBInstanceOutput struct {
 	//
 	//    * ModifyDBInstance
 	//
+	//    * StopDBInstance
+	//
+	//    * StartDBInstance
+	//
 	// This data type is used as a response element in the DescribeDBInstances action.
 	DBInstance *DBInstance `type:"structure"`
 }
@@ -24527,6 +24556,10 @@ type PromoteReadReplicaOutput struct {
 	//
 	//    * ModifyDBInstance
 	//
+	//    * StopDBInstance
+	//
+	//    * StartDBInstance
+	//
 	// This data type is used as a response element in the DescribeDBInstances action.
 	DBInstance *DBInstance `type:"structure"`
 }
@@ -24714,6 +24747,10 @@ type RebootDBInstanceOutput struct {
 	//    * DeleteDBInstance
 	//
 	//    * ModifyDBInstance
+	//
+	//    * StopDBInstance
+	//
+	//    * StartDBInstance
 	//
 	// This data type is used as a response element in the DescribeDBInstances action.
 	DBInstance *DBInstance `type:"structure"`
@@ -26175,7 +26212,7 @@ type RestoreDBClusterToPointInTimeInput struct {
 	//    * If the DB cluster is not encrypted, then the restored DB cluster is
 	//    not encrypted.
 	//
-	// If DBClusterIdentifier refers to a DB cluster that is note encrypted, then
+	// If DBClusterIdentifier refers to a DB cluster that is not encrypted, then
 	// the restore request is rejected.
 	KmsKeyId *string `type:"string"`
 
@@ -26197,10 +26234,30 @@ type RestoreDBClusterToPointInTimeInput struct {
 	//
 	//    * Must be before the latest restorable time for the DB instance
 	//
+	//    * Must be specified if UseLatestRestorableTime parameter is not provided
+	//
 	//    * Cannot be specified if UseLatestRestorableTime parameter is true
+	//
+	//    * Cannot be specified if RestoreType parameter is copy-on-write
 	//
 	// Example: 2015-03-07T23:45:00Z
 	RestoreToTime *time.Time `type:"timestamp" timestampFormat:"iso8601"`
+
+	// The type of restore to be performed. You can specify one of the following
+	// values:
+	//
+	//    * full-copy - The new DB cluster is restored as a full copy of the source
+	//    DB cluster.
+	//
+	//    * copy-on-write - The new DB cluster is restored as a clone of the source
+	//    DB cluster.
+	//
+	// Constraints: You cannot specify copy-on-write if the engine version of the
+	// source DB cluster is earlier than 1.11.
+	//
+	// If you don't specify a RestoreType value, then the new DB cluster is restored
+	// as a full copy of the source DB cluster.
+	RestoreType *string `type:"string"`
 
 	// The identifier of the source DB cluster from which to restore.
 	//
@@ -26228,7 +26285,7 @@ type RestoreDBClusterToPointInTimeInput struct {
 	// Constraints: Cannot be specified if RestoreToTime parameter is provided.
 	UseLatestRestorableTime *bool `type:"boolean"`
 
-	// A lst of VPC security groups that the new DB cluster belongs to.
+	// A list of VPC security groups that the new DB cluster belongs to.
 	VpcSecurityGroupIds []*string `locationNameList:"VpcSecurityGroupId" type:"list"`
 }
 
@@ -26297,6 +26354,12 @@ func (s *RestoreDBClusterToPointInTimeInput) SetPort(v int64) *RestoreDBClusterT
 // SetRestoreToTime sets the RestoreToTime field's value.
 func (s *RestoreDBClusterToPointInTimeInput) SetRestoreToTime(v time.Time) *RestoreDBClusterToPointInTimeInput {
 	s.RestoreToTime = &v
+	return s
+}
+
+// SetRestoreType sets the RestoreType field's value.
+func (s *RestoreDBClusterToPointInTimeInput) SetRestoreType(v string) *RestoreDBClusterToPointInTimeInput {
+	s.RestoreType = &v
 	return s
 }
 
@@ -26720,6 +26783,10 @@ type RestoreDBInstanceFromDBSnapshotOutput struct {
 	//
 	//    * ModifyDBInstance
 	//
+	//    * StopDBInstance
+	//
+	//    * StartDBInstance
+	//
 	// This data type is used as a response element in the DescribeDBInstances action.
 	DBInstance *DBInstance `type:"structure"`
 }
@@ -27123,6 +27190,10 @@ type RestoreDBInstanceToPointInTimeOutput struct {
 	//
 	//    * ModifyDBInstance
 	//
+	//    * StopDBInstance
+	//
+	//    * StartDBInstance
+	//
 	// This data type is used as a response element in the DescribeDBInstances action.
 	DBInstance *DBInstance `type:"structure"`
 }
@@ -27358,6 +27429,10 @@ type StartDBInstanceOutput struct {
 	//
 	//    * ModifyDBInstance
 	//
+	//    * StopDBInstance
+	//
+	//    * StartDBInstance
+	//
 	// This data type is used as a response element in the DescribeDBInstances action.
 	DBInstance *DBInstance `type:"structure"`
 }
@@ -27438,6 +27513,10 @@ type StopDBInstanceOutput struct {
 	//    * DeleteDBInstance
 	//
 	//    * ModifyDBInstance
+	//
+	//    * StopDBInstance
+	//
+	//    * StartDBInstance
 	//
 	// This data type is used as a response element in the DescribeDBInstances action.
 	DBInstance *DBInstance `type:"structure"`

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -27,652 +27,652 @@
 			"revisionTime": "2016-08-26T14:30:32Z"
 		},
 		{
-			"checksumSHA1": "fFU9OeM0pKWGL3D+Fa3PmHSjjLg=",
+			"checksumSHA1": "JSL29KvKDlNHbphDhOviia5hJeg=",
 			"path": "github.com/aws/aws-sdk-go/aws",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "Y9W+4GimK4Fuxq+vyIskVYFRnX4=",
 			"path": "github.com/aws/aws-sdk-go/aws/awserr",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "yyYr41HZ1Aq0hWc3J5ijXwYEcac=",
 			"path": "github.com/aws/aws-sdk-go/aws/awsutil",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "gcA6wFbLBJLLO/6g+AH9QoQQX1U=",
 			"path": "github.com/aws/aws-sdk-go/aws/client",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "ieAJ+Cvp/PKv1LpUEnUXpc3OI6E=",
 			"path": "github.com/aws/aws-sdk-go/aws/client/metadata",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "7/8j/q0TWtOgXyvEcv4B2Dhl00o=",
 			"path": "github.com/aws/aws-sdk-go/aws/corehandlers",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "Y+cPwQL0dZMyqp3wI+KJWmA9KQ8=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "u3GOAJLmdvbuNUeUEcZSEAOeL/0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "NUJUTWlc1sV8b7WjfiYc4JZbXl0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/endpointcreds",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "JEYqmF83O5n5bHkupAzA6STm0no=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "ZdtYh3ZHSgP/WEIaqwJHTEhpkbs=",
 			"path": "github.com/aws/aws-sdk-go/aws/defaults",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "/EXbk/z2TWjWc1Hvb4QYs3Wmhb8=",
 			"path": "github.com/aws/aws-sdk-go/aws/ec2metadata",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
-			"checksumSHA1": "vaHB7ND2ZMMwBwrdT0KJUKT1VaM=",
+			"checksumSHA1": "1xyL+7LjrKyigf5bWQSUgUB3TJ0=",
 			"path": "github.com/aws/aws-sdk-go/aws/endpoints",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
-			"checksumSHA1": "Utpqcq3J2hqoaKEsjI7kDF9bUkg=",
+			"checksumSHA1": "8eN3YdBuWsN8bTC7/OGuzREf+oA=",
 			"path": "github.com/aws/aws-sdk-go/aws/request",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "Y20DEtMtbfE9qTtmoi2NYV1x7aA=",
 			"path": "github.com/aws/aws-sdk-go/aws/session",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
-			"checksumSHA1": "SvIsunO8D9MEKbetMENA4WRnyeE=",
+			"checksumSHA1": "oyNzdFI344f4sAT3xAp7ulNseXc=",
 			"path": "github.com/aws/aws-sdk-go/aws/signer/v4",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "04ypv4x12l4q0TksA1zEVsmgpvw=",
 			"path": "github.com/aws/aws-sdk-go/internal/shareddefaults",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "wk7EyvDaHwb5qqoOP/4d3cV0708=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "1QmQ3FqV37w0Zi44qv8pA1GeR0A=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/ec2query",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "O6hcK24yI6w7FA+g4Pbr+eQ7pys=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/json/jsonutil",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "R00RL5jJXRYq1iiK1+PGvMfvXyM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/jsonrpc",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "ZqY5RWavBLWTo6j9xqdyBEaNFRk=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "Drt1JfLMa0DQEZLWrnMlTWaIcC8=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "VCTh+dEaqqhog5ncy/WTt9+/gFM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/rest",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "Rpu8KBtHZgvhkwHxUfaky+qW+G4=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restjson",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "ODo+ko8D6unAxZuN1jGzMcN4QCc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restxml",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "0qYPUga28aQVkxZgBR3Z86AbGUQ=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "F6mth+G7dXN1GI+nktaGo8Lx8aE=",
 			"path": "github.com/aws/aws-sdk-go/private/signer/v2",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
-			"checksumSHA1": "RihpzjL86Zqrq7caZqddkGmpS/U=",
+			"checksumSHA1": "ByXfXvSQCvkb9iJ44fDWUP6h+Nk=",
 			"path": "github.com/aws/aws-sdk-go/service/acm",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "Vty8Iim26/C2eW4v5ID75vXoQj0=",
 			"path": "github.com/aws/aws-sdk-go/service/apigateway",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "kq7a1zUsytCRQV+Q9KZf5Tzkv4s=",
 			"path": "github.com/aws/aws-sdk-go/service/applicationautoscaling",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "y1rEAHCCFNKFXtzGeNTuSkxdxnw=",
 			"path": "github.com/aws/aws-sdk-go/service/autoscaling",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "H36nvtC7Uxl6I3NlRbgSYHqIhyQ=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudformation",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
-			"checksumSHA1": "Xa4HENUzQxHSsx5HoabaxdUpVrg=",
+			"checksumSHA1": "Jta0N8UpREoBZJ1n2n8Y0hh6AxY=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudfront",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "hj0mJrjPfyAc8kHGDcXnMuMVozg=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudtrail",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "dqRrfGewSrIfajRNmsx1ugEYSuw=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatch",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "uQXi6iOpIf22Hz1VP4qLb3jfAqw=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchevents",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "eJJjXlK7MLOlZhu8741//GZj0ZQ=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
-			"checksumSHA1": "fkA9YVQMcsQ0qQlGSUw3iN/BhR4=",
+			"checksumSHA1": "9HEcT7rmgDmH6cz/w70mUyu62jQ=",
 			"path": "github.com/aws/aws-sdk-go/service/codebuild",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "BsfbsSZlJdNvYlM/ykGHTZVoLY0=",
 			"path": "github.com/aws/aws-sdk-go/service/codecommit",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "tK1JfJ1vPlusBWvmnhi/IEOS1BQ=",
 			"path": "github.com/aws/aws-sdk-go/service/codedeploy",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "bZ5Dg5Pww7RsjVhgKqmGIzoFkug=",
 			"path": "github.com/aws/aws-sdk-go/service/codepipeline",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "W+yGe3hYhzKMlRE/0jR4B6FpDJY=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentity",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
-			"checksumSHA1": "eSqx7hsdmEMqD9K2l36FE/PlgHM=",
+			"checksumSHA1": "8e/a7xOBlUIwwitOO92ivARo5FY=",
 			"path": "github.com/aws/aws-sdk-go/service/configservice",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "S+tUbNOE99Ok1ppIxF82/JcI4Gk=",
 			"path": "github.com/aws/aws-sdk-go/service/databasemigrationservice",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "JsCuHtHM4ql9lVjpCJ869L7irZk=",
 			"path": "github.com/aws/aws-sdk-go/service/devicefarm",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "nZ0ZiiZ29v0HiVleXACY3m6bXgI=",
 			"path": "github.com/aws/aws-sdk-go/service/directoryservice",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "dcUwKQHxD9+ap+/MP9gZ6kT/lXI=",
 			"path": "github.com/aws/aws-sdk-go/service/dynamodb",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "RGW6Tn0SO0m9m0pNQAY9OhdJ3tI=",
 			"path": "github.com/aws/aws-sdk-go/service/ec2",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "Lwqoi9aWc+j6dzkgt06LLR7i1XA=",
 			"path": "github.com/aws/aws-sdk-go/service/ecr",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "xK333jTw5R1dnr9mt+yxsEHg3/A=",
 			"path": "github.com/aws/aws-sdk-go/service/ecs",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "WJ0qqKev5awu3aOPmYEmLz2B7Tw=",
 			"path": "github.com/aws/aws-sdk-go/service/efs",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "aO69igvJSXy8Hw3zCP2g9d/icv4=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticache",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "bnl0q1BLkaBD6rD7n1tWemceVzI=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticbeanstalk",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "omf+Wesp5JG8FrhzLXJgItIYAHk=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticsearchservice",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "VWn6yZTaOgD0daNMBAQWnc5tOp4=",
 			"path": "github.com/aws/aws-sdk-go/service/elastictranscoder",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "i/ykCvWenrw5U3O3xb9hJ9tfFa8=",
 			"path": "github.com/aws/aws-sdk-go/service/elb",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "P0SzxhcZ8vFMDys3qIWQW7MhD8k=",
 			"path": "github.com/aws/aws-sdk-go/service/elbv2",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "TJDUTql/Ls5Ds86pLO1F2b/DqdA=",
 			"path": "github.com/aws/aws-sdk-go/service/emr",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "FCPGPaaFgN9iWup3dVCDVt0Yqp0=",
 			"path": "github.com/aws/aws-sdk-go/service/firehose",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "g/B0cturzQMWZN+VJwm9izYoQ5Q=",
 			"path": "github.com/aws/aws-sdk-go/service/glacier",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "sUTXkrAohDlfGKgkLEYh9UawmL0=",
 			"path": "github.com/aws/aws-sdk-go/service/iam",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "oYVrMzwK3o8fi9ejIhN9R5h4KRc=",
 			"path": "github.com/aws/aws-sdk-go/service/inspector",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "KJuPA/SLv0fLME23SmxVP4410BE=",
 			"path": "github.com/aws/aws-sdk-go/service/kinesis",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "DlyhlgQf94WXnPSpGy1WlzdNkkE=",
 			"path": "github.com/aws/aws-sdk-go/service/kms",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "qnpJf/YILf+JOxp4vM8oOgQAQ28=",
 			"path": "github.com/aws/aws-sdk-go/service/lambda",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "GcreyMFdl0U8K+3oaf052AepgNI=",
 			"path": "github.com/aws/aws-sdk-go/service/lightsail",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
-			"checksumSHA1": "O2MqFCP7z1x6cC59NxiXVOZiUfY=",
+			"checksumSHA1": "y16WbkNBVJcuU5NcBJIMYAdJjdE=",
 			"path": "github.com/aws/aws-sdk-go/service/opsworks",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
-			"checksumSHA1": "nKMjGqakuQZpROgbXGfL9uP+N68=",
+			"checksumSHA1": "gCTZVPwRzFgt+Ve9KKtp7SAgzx4=",
 			"path": "github.com/aws/aws-sdk-go/service/rds",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "Q8CPmpN6L73bkhA7rEy1ciy6izo=",
 			"path": "github.com/aws/aws-sdk-go/service/redshift",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "g/d8eqqotx1ITOpxwyk4PWDXiVk=",
 			"path": "github.com/aws/aws-sdk-go/service/route53",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "krqUUMDYRN2ohYcumxZl8BTR5EQ=",
 			"path": "github.com/aws/aws-sdk-go/service/s3",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "wCql3QDkXRHDY6Cm6GSUijoeDcg=",
 			"path": "github.com/aws/aws-sdk-go/service/ses",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "EPVYa41c+FwHj5as9Px5zCZmxlQ=",
 			"path": "github.com/aws/aws-sdk-go/service/sfn",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "qbJgxyoq6VmwEtQR5uT9KVYqV6I=",
 			"path": "github.com/aws/aws-sdk-go/service/simpledb",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "vP/0ADSA7kkW5CCadIpV3Q6s+DQ=",
 			"path": "github.com/aws/aws-sdk-go/service/sns",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "/2BKYAF4iJKOIiOixgXWb0tVclE=",
 			"path": "github.com/aws/aws-sdk-go/service/sqs",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "TUxh01D/FrlX+12NTF5M8f+tYYA=",
 			"path": "github.com/aws/aws-sdk-go/service/ssm",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "VH5y62f+SDyEIqnTibiPtQ687i8=",
 			"path": "github.com/aws/aws-sdk-go/service/sts",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "MXy2G+JW109dosdS5rhbWj7X1Dg=",
 			"path": "github.com/aws/aws-sdk-go/service/waf",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "s5N7qUhc2Zs1Nj2bwpZCy4QQRlo=",
 			"path": "github.com/aws/aws-sdk-go/service/wafregional",
-			"revision": "be4fa13e47938e4801fada8c8ca3d1867ad3dcb3",
-			"revisionTime": "2017-06-02T18:54:01Z",
-			"version": "v1.8.34",
-			"versionExact": "v1.8.34"
+			"revision": "47ba3b0518c83189f3a1c95d20fc22f267e02ed3",
+			"revisionTime": "2017-06-13T17:42:44Z",
+			"version": "v1.8.41",
+			"versionExact": "v1.8.41"
 		},
 		{
 			"checksumSHA1": "nqw2Qn5xUklssHTubS5HDvEL9L4=",

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -109,7 +109,7 @@ database, and to use this value as the source database. This correlates to the
 enhanced monitoring metrics to CloudWatch Logs. You can find more information on the [AWS Documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.html)
 what IAM permissions are needed to allow Enhanced Monitoring for RDS Instances.
 * `monitoring_interval` - (Optional) The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60.
-* `kms_key_id` - (Optional) The ARN for the KMS encryption key.
+* `kms_key_id` - (Optional) The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN.
 * `character_set_name` - (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed.
 [Oracle Character Sets Supported in Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.OracleCharacterSets.html)
 * `iam_database_authentication_enabled` - (Optional) Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled.


### PR DESCRIPTION
* Bumped AWS SDK to v1.8.41

The AWS SDK generates and sets the `rds.CreateDBInstanceReadReplicaInput.PreSignedUrl` for you if you [set the `.SourceRegion`](https://github.com/aws/aws-sdk-go/blob/v1.8.41/service/rds/customizations.go#L58-L60). 

Closes #864