### PR TITLE
[docs] Remove owners arg from db_snapshot data src

### DIFF
--- a/website/docs/d/db_snapshot.html.markdown
+++ b/website/docs/d/db_snapshot.html.markdown
@@ -27,7 +27,6 @@ resource "aws_db_instance" "default" {
 
 data "aws_db_snapshot" "db_snapshot" {
     most_recent = true
-    owners = ["self"]
     db_instance_identifier = "${aws_db_instance.default.identifier}"
 }
 ```

--- a/website/docs/d/db_snapshot.html.markdown
+++ b/website/docs/d/db_snapshot.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Use this data source to get information about a DB Snapshot for use when provisioning DB instances
 
+~> **NOTE:** This data source does not apply to snapshots created on Aurora DB clusters.
+
 ## Example Usage
 
 ```


### PR DESCRIPTION
This key is not used in the aws_db_snapshot data source:

```
1 error(s) occurred:

* data.aws_db_snapshot.source: : invalid or unknown key: owners
```

edit: I also added a note that this data source does not fetch details on Aurora snapshots.