### PR TITLE
fix typo for "Associates" in ssm_association

### DIFF
--- a/website/docs/r/ssm_association.html.markdown
+++ b/website/docs/r/ssm_association.html.markdown
@@ -3,12 +3,12 @@ layout: "aws"
 page_title: "AWS: aws_ssm_association"
 sidebar_current: "docs-aws-resource-ssm-association"
 description: |-
-  Assosciates an SSM Document to an instance.
+  Associates an SSM Document to an instance.
 ---
 
 # aws_ssm_association
 
-Assosciates an SSM Document to an instance.
+Associates an SSM Document to an instance.
 
 ## Example Usage
 


### PR DESCRIPTION
I found a typo, and have fix it in my branch. Appreciate if it can be merged.

Thanks.