### PR TITLE
aws_eip: dissociate EIP on update

### DIFF
--- a/aws/resource_aws_eip.go
+++ b/aws/resource_aws_eip.go
@@ -194,6 +194,14 @@ func resourceAwsEipUpdate(d *schema.ResourceData, meta interface{}) error {
 	v_instance, ok_instance := d.GetOk("instance")
 	v_interface, ok_interface := d.GetOk("network_interface")
 
+	// If we are updating an EIP that is not newly created, and we are attached to
+	// an instance or interface, detach first.
+	if (d.Get("instance").(string) != "" || d.Get("association_id").(string) != "") && !d.IsNewResource() {
+		if err := dissociateEip(d, meta); err != nil {
+			return err
+		}
+	}
+
 	if ok_instance || ok_interface {
 		instanceId := v_instance.(string)
 		networkInterfaceId := v_interface.(string)
@@ -256,30 +264,7 @@ func resourceAwsEipDelete(d *schema.ResourceData, meta interface{}) error {
 
 	// If we are attached to an instance or interface, detach first.
 	if d.Get("instance").(string) != "" || d.Get("association_id").(string) != "" {
-		log.Printf("[DEBUG] Disassociating EIP: %s", d.Id())
-		var err error
-		switch resourceAwsEipDomain(d) {
-		case "vpc":
-			_, err = ec2conn.DisassociateAddress(&ec2.DisassociateAddressInput{
-				AssociationId: aws.String(d.Get("association_id").(string)),
-			})
-		case "standard":
-			_, err = ec2conn.DisassociateAddress(&ec2.DisassociateAddressInput{
-				PublicIp: aws.String(d.Get("public_ip").(string)),
-			})
-		}
-
-		if err != nil {
-			// First check if the association ID is not found. If this
-			// is the case, then it was already disassociated somehow,
-			// and that is okay. The most commmon reason for this is that
-			// the instance or ENI it was attached it was destroyed.
-			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidAssociationID.NotFound" {
-				err = nil
-			}
-		}
-
-		if err != nil {
+		if err := dissociateEip(d, meta); err != nil {
 			return err
 		}
 	}
@@ -323,4 +308,32 @@ func resourceAwsEipDomain(d *schema.ResourceData) string {
 	}
 
 	return "standard"
+}
+
+func dissociateEip(d *schema.ResourceData, meta interface{}) error {
+	ec2conn := meta.(*AWSClient).ec2conn
+	log.Printf("[DEBUG] Disassociating EIP: %s", d.Id())
+	var err error
+	switch resourceAwsEipDomain(d) {
+	case "vpc":
+		_, err = ec2conn.dissociateAddress(&ec2.dissociateAddressInput{
+			AssociationId: aws.String(d.Get("association_id").(string)),
+		})
+	case "standard":
+		_, err = ec2conn.dissociateAddress(&ec2.dissociateAddressInput{
+			PublicIp: aws.String(d.Get("public_ip").(string)),
+		})
+	}
+
+	if err != nil {
+		// First check if the association ID is not found. If this
+		// is the case, then it was already dissociated somehow,
+		// and that is okay. The most commmon reason for this is that
+		// the instance or ENI it was attached it was destroyed.
+		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidAssociationID.NotFound" {
+			err = nil
+		}
+		return err
+	}
+	return nil
 }

--- a/aws/resource_aws_eip_test.go
+++ b/aws/resource_aws_eip_test.go
@@ -182,6 +182,40 @@ func TestAccAWSEIP_associated_user_private_ip(t *testing.T) {
 	})
 }
 
+// Regression test for https://github.com/hashicorp/terraform/issues/3429 (now
+// https://github.com/terraform-providers/terraform-provider-aws/issues/42)
+func TestAccAWSEIP_classic_disassociate(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEIPDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSEIP_classic_disassociate("ami-408c7f28"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"aws_eip.ip.0",
+						"instance"),
+					resource.TestCheckResourceAttrSet(
+						"aws_eip.ip.1",
+						"instance"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSEIP_classic_disassociate("ami-8c6ea9e4"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"aws_eip.ip.0",
+						"instance"),
+					resource.TestCheckResourceAttrSet(
+						"aws_eip.ip.1",
+						"instance"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSEIPDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).ec2conn
 
@@ -544,3 +578,70 @@ resource "aws_eip" "two" {
   associate_with_private_ip = "10.0.0.11"
 }
 `
+
+func testAccAWSEIP_classic_disassociate(ami string) string {
+	return fmt.Sprintf(`
+provider "aws" {
+  region = "us-east-1"
+}
+
+variable "server_count" {
+  default = 2
+}
+
+resource "aws_eip" "ip" {
+  count    = "${var.server_count}"
+  instance = "${element(aws_instance.example.*.id, count.index)}"
+  vpc      = true
+}
+
+resource "aws_instance" "example" {
+  count = "${var.server_count}"
+
+  ami                         = "%s"
+  instance_type               = "m1.small"
+  associate_public_ip_address = true
+  subnet_id                   = "${aws_subnet.us-east-1b-public.id}"
+  availability_zone           = "${aws_subnet.us-east-1b-public.availability_zone}"
+
+  tags {
+    Name = "testAccAWSEIP_classic_disassociate"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_vpc" "example" {
+  cidr_block = "10.0.0.0/16"
+	tags {
+		Name = "TestAccAWSEIP_classic_disassociate"
+	}
+}
+
+resource "aws_internet_gateway" "example" {
+  vpc_id = "${aws_vpc.example.id}"
+}
+
+resource "aws_subnet" "us-east-1b-public" {
+  vpc_id = "${aws_vpc.example.id}"
+
+  cidr_block        = "10.0.0.0/24"
+  availability_zone = "us-east-1b"
+}
+
+resource "aws_route_table" "us-east-1-public" {
+  vpc_id = "${aws_vpc.example.id}"
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = "${aws_internet_gateway.example.id}"
+  }
+}
+
+resource "aws_route_table_association" "us-east-1b-public" {
+  subnet_id      = "${aws_subnet.us-east-1b-public.id}"
+  route_table_id = "${aws_route_table.us-east-1-public.id}"
+}`, ami)
+}


### PR DESCRIPTION
Fixes #42 by dissociating the EIP before trying to update it. Only do this on true update and not part of the create, as there is not actual association yet. Includes regression test `TestAccAWSEIP_classic_disassociate`, which fails on `master`

Originally reported at https://github.com/hashicorp/terraform/issues/3429 

CI is running, will post update