### PR TITLE
Allow ipv6_cidr_block to be assigned to peering_connection

### DIFF
--- a/aws/resource_aws_route.go
+++ b/aws/resource_aws_route.go
@@ -176,12 +176,12 @@ func resourceAwsRouteCreate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if v, ok := d.GetOk("destination_cidr_block"); ok {
- 			createOpts.DestinationCidrBlock = aws.String(v.(string))
- 		}
+			createOpts.DestinationCidrBlock = aws.String(v.(string))
+		}
 
- 		if v, ok := d.GetOk("destination_ipv6_cidr_block"); ok {
- 			createOpts.DestinationIpv6CidrBlock = aws.String(v.(string))
- 		}
+		if v, ok := d.GetOk("destination_ipv6_cidr_block"); ok {
+			createOpts.DestinationIpv6CidrBlock = aws.String(v.(string))
+		}
 
 	default:
 		return fmt.Errorf("An invalid target type specified: %s", setTarget)

--- a/aws/resource_aws_route.go
+++ b/aws/resource_aws_route.go
@@ -172,9 +172,17 @@ func resourceAwsRouteCreate(d *schema.ResourceData, meta interface{}) error {
 	case "vpc_peering_connection_id":
 		createOpts = &ec2.CreateRouteInput{
 			RouteTableId:           aws.String(d.Get("route_table_id").(string)),
-			DestinationCidrBlock:   aws.String(d.Get("destination_cidr_block").(string)),
 			VpcPeeringConnectionId: aws.String(d.Get("vpc_peering_connection_id").(string)),
 		}
+
+		if v, ok := d.GetOk("destination_cidr_block"); ok {
+ 			createOpts.DestinationCidrBlock = aws.String(v.(string))
+ 		}
+
+ 		if v, ok := d.GetOk("destination_ipv6_cidr_block"); ok {
+ 			createOpts.DestinationIpv6CidrBlock = aws.String(v.(string))
+ 		}
+
 	default:
 		return fmt.Errorf("An invalid target type specified: %s", setTarget)
 	}

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -107,25 +107,24 @@ func TestAccAWSRoute_ipv6ToInternetGateway(t *testing.T) {
 }
 
 func TestAccAWSRoute_ipv6ToPeeringConnection(t *testing.T) {
- 	var route ec2.Route
+	var route ec2.Route
 
- 	resource.Test(t, resource.TestCase{
- 		PreCheck: func() {
- 			testAccPreCheck(t)
- 		},
- 		Providers:    testAccProviders,
- 		CheckDestroy: testAccCheckAWSRouteDestroy,
- 		Steps: []resource.TestStep{
- 			{
- 				Config: testAccAWSRouteConfigIpv6PeeringConnection,
- 				Check: resource.ComposeTestCheckFunc(
- 					testAccCheckAWSRouteExists("aws_route.pc", &route),
- 				),
- 			},
- 		},
- 	})
- }
-
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRouteConfigIpv6PeeringConnection,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists("aws_route.pc", &route),
+				),
+			},
+		},
+	})
+}
 
 func TestAccAWSRoute_changeCidr(t *testing.T) {
 	var route ec2.Route
@@ -383,7 +382,6 @@ resource "aws_route" "pc" {
 }
 
 `)
-
 
 var testAccAWSRouteConfigIpv6 = fmt.Sprintf(`
 resource "aws_vpc" "foo" {

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -106,6 +106,27 @@ func TestAccAWSRoute_ipv6ToInternetGateway(t *testing.T) {
 	})
 }
 
+func TestAccAWSRoute_ipv6ToPeeringConnection(t *testing.T) {
+ 	var route ec2.Route
+
+ 	resource.Test(t, resource.TestCase{
+ 		PreCheck: func() {
+ 			testAccPreCheck(t)
+ 		},
+ 		Providers:    testAccProviders,
+ 		CheckDestroy: testAccCheckAWSRouteDestroy,
+ 		Steps: []resource.TestStep{
+ 			{
+ 				Config: testAccAWSRouteConfigIpv6PeeringConnection,
+ 				Check: resource.ComposeTestCheckFunc(
+ 					testAccCheckAWSRouteExists("aws_route.pc", &route),
+ 				),
+ 			},
+ 		},
+ 	})
+ }
+
+
 func TestAccAWSRoute_changeCidr(t *testing.T) {
 	var route ec2.Route
 	var routeTable ec2.RouteTable
@@ -333,6 +354,36 @@ resource "aws_route" "igw" {
 }
 
 `)
+
+var testAccAWSRouteConfigIpv6PeeringConnection = fmt.Sprintf(`
+resource "aws_vpc" "foo" {
+	cidr_block = "10.0.0.0/16"
+	assign_generated_ipv6_cidr_block = true
+}
+
+resource "aws_vpc" "bar" {
+	cidr_block = "10.1.0.0/16"
+	assign_generated_ipv6_cidr_block = true
+}
+
+resource "aws_vpc_peering_connection" "foo" {
+	vpc_id = "${aws_vpc.foo.id}"
+	peer_vpc_id = "${aws_vpc.bar.id}"
+	auto_accept = true
+}
+
+resource "aws_route_table" "peering" {
+	vpc_id = "${aws_vpc.foo.id}"
+}
+
+resource "aws_route" "pc" {
+  route_table_id = "${aws_route_table.peering.id}"
+  destination_ipv6_cidr_block = "${aws_vpc.bar.ipv6_cidr_block}"
+  vpc_peering_connection_id = "${aws_vpc_peering_connection.foo.id}"
+}
+
+`)
+
 
 var testAccAWSRouteConfigIpv6 = fmt.Sprintf(`
 resource "aws_vpc" "foo" {


### PR DESCRIPTION
I've encountered an issue when trying to use `destination_ipv6_cidr_block` with `vpc_peering_connection_id`. I believe this fixes #778.

I'm not sure about whether `destination_ipv6_cidr_block` should be allowed together with other types (`nat_gateway_id`, `instance_id`, `network_interface_id`).

Also, I could not find any acceptance test for this functionality, so I've not added any new tests to cover this. I'm happy to add tests, however I might need guidance.

This is a migrated pull request from original repo https://github.com/hashicorp/terraform/pull/15145