### PR TITLE
Adding second scenario where IPv6 is not supported

### DIFF
--- a/aws/resource_aws_security_group.go
+++ b/aws/resource_aws_security_group.go
@@ -316,7 +316,7 @@ func resourceAwsSecurityGroupCreate(d *schema.ResourceData, meta interface{}) er
 		if err != nil {
 			//If we have a NotFound or InvalidParameterValue, then we are trying to remove the default IPv6 egress of a non-IPv6
 			//enabled SG
-			if ec2err, ok := err.(awserr.Error); ok && (ec2err.Code() != "InvalidPermission.NotFound" || ec2err.Code() != "InvalidParameterValue: remote-ipv6-range") {
+			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() != "InvalidPermission.NotFound" && ec2err.Code() != "InvalidParameterValue" {
 				return fmt.Errorf(
 					"Error revoking default IPv6 egress rule for Security Group (%s): %s",
 					d.Id(), err)

--- a/aws/resource_aws_security_group.go
+++ b/aws/resource_aws_security_group.go
@@ -314,9 +314,9 @@ func resourceAwsSecurityGroupCreate(d *schema.ResourceData, meta interface{}) er
 
 		_, err = conn.RevokeSecurityGroupEgress(req)
 		if err != nil {
-			//If we have a NotFound, then we are trying to remove the default IPv6 egress of a non-IPv6
+			//If we have a NotFound or InvalidParameterValue, then we are trying to remove the default IPv6 egress of a non-IPv6
 			//enabled SG
-			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() != "InvalidPermission.NotFound" {
+			if ec2err, ok := err.(awserr.Error); ok && (ec2err.Code() != "InvalidPermission.NotFound" || ec2err.Code() != "InvalidParameterValue: remote-ipv6-range") {
 				return fmt.Errorf(
 					"Error revoking default IPv6 egress rule for Security Group (%s): %s",
 					d.Id(), err)

--- a/aws/resource_aws_security_group.go
+++ b/aws/resource_aws_security_group.go
@@ -316,7 +316,7 @@ func resourceAwsSecurityGroupCreate(d *schema.ResourceData, meta interface{}) er
 		if err != nil {
 			//If we have a NotFound or InvalidParameterValue, then we are trying to remove the default IPv6 egress of a non-IPv6
 			//enabled SG
-			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() != "InvalidPermission.NotFound" && ec2err.Code() != "InvalidParameterValue" {
+			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() != "InvalidPermission.NotFound" && !isAWSErr(err, "InvalidParameterValue", "remote-ipv6-range") {
 				return fmt.Errorf(
 					"Error revoking default IPv6 egress rule for Security Group (%s): %s",
 					d.Id(), err)


### PR DESCRIPTION
When trying to create a security group in AWS CN I ran into the following error:

```
* module.security_groups.aws_security_group.dev-https-in: 1 error(s) occurred:

* aws_security_group.dev-https-in: Error revoking default IPv6 egress rule for Security Group (sg-56489bc5): InvalidParameterValue: remote-ipv6-range
	status code: 400, request id: beeb90dd-7b32-4905-9b94-59e3e00f77f5
```

Added this check as another way to determine IPv6 is not supported therefore ignore the error and continue.
I already tested with the same case that gave me these errors and I no longer get them and my security groups are created.

I'm not sure the code is exactly how it should be, I'll be more than happy to modify it if needed.