### PR TITLE
provider/aws: Add support for iam_role tp force_detach_policies

### DIFF
--- a/aws/resource_aws_iam_role.go
+++ b/aws/resource_aws_iam_role.go
@@ -273,7 +273,7 @@ func resourceAwsIamRoleDelete(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			return fmt.Errorf("Error listing Policies for IAM Role (%s) when trying to delete: %s", d.Id(), err)
 		}
-		// Loop and remove this Role from any Profiles
+		// Loop and remove the Policies from the Role
 		if len(policiesResp.AttachedPolicies) > 0 {
 			for _, i := range policiesResp.AttachedPolicies {
 				_, err := iamconn.DetachRolePolicy(&iam.DetachRolePolicyInput{

--- a/aws/resource_aws_iam_role.go
+++ b/aws/resource_aws_iam_role.go
@@ -21,7 +21,7 @@ func resourceAwsIamRole() *schema.Resource {
 		Update: resourceAwsIamRoleUpdate,
 		Delete: resourceAwsIamRoleDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: resourceAwsIamRoleImport,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -95,12 +95,24 @@ func resourceAwsIamRole() *schema.Resource {
 				ValidateFunc:     validateJsonString,
 			},
 
+			"force_detach_policies": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"create_date": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 		},
 	}
+}
+
+func resourceAwsIamRoleImport(
+	d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	d.Set("force_detach_policies", false)
+	return []*schema.ResourceData{d}, nil
 }
 
 func resourceAwsIamRoleCreate(d *schema.ResourceData, meta interface{}) error {
@@ -250,6 +262,27 @@ func resourceAwsIamRoleDelete(d *schema.ResourceData, meta interface{}) error {
 			})
 			if err != nil {
 				return fmt.Errorf("Error deleting IAM Role %s: %s", d.Id(), err)
+			}
+		}
+	}
+
+	if d.Get("force_detach_policies").(bool) {
+		policiesResp, err := iamconn.ListAttachedRolePolicies(&iam.ListAttachedRolePoliciesInput{
+			RoleName: aws.String(d.Id()),
+		})
+		if err != nil {
+			return fmt.Errorf("Error listing Policies for IAM Role (%s) when trying to delete: %s", d.Id(), err)
+		}
+		// Loop and remove this Role from any Profiles
+		if len(policiesResp.AttachedPolicies) > 0 {
+			for _, i := range policiesResp.AttachedPolicies {
+				_, err := iamconn.DetachRolePolicy(&iam.DetachRolePolicyInput{
+					PolicyArn: i.PolicyArn,
+					RoleName:  aws.String(d.Id()),
+				})
+				if err != nil {
+					return fmt.Errorf("Error deleting IAM Role %s: %s", d.Id(), err)
+				}
 			}
 		}
 	}

--- a/website/docs/r/iam_role.html.markdown
+++ b/website/docs/r/iam_role.html.markdown
@@ -41,6 +41,7 @@ The following arguments are supported:
 * `name` - (Optional, Forces new resource) The name of the role. If omitted, Terraform will assign a random, unique name.
 * `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `assume_role_policy` - (Required) The policy that grants an entity permission to assume the role.
+* `force_detach_policies` - (Optional) Specifies to force detaching any policies the role has before destroying it. Defaults to `false`.
 
 ~> **NOTE:** This `assume_role_policy` is very similar but slightly different than just a standard IAM policy and cannot use an `aws_iam_policy` resource.  It _can_ however, use an `aws_iam_policy_document` [data source](https://www.terraform.io/docs/providers/aws/d/iam_policy_document.html), see example below for how this could work.
 


### PR DESCRIPTION
Fixes: #883

```
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSIAMRole_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSIAMRole_ -timeout 120m
=== RUN   TestAccAWSIAMRole_importBasic
--- PASS: TestAccAWSIAMRole_importBasic (90.60s)
=== RUN   TestAccAWSIAMRole_basic
--- PASS: TestAccAWSIAMRole_basic (63.38s)
=== RUN   TestAccAWSIAMRole_basicWithDescription
--- PASS: TestAccAWSIAMRole_basicWithDescription (160.94s)
=== RUN   TestAccAWSIAMRole_namePrefix
--- PASS: TestAccAWSIAMRole_namePrefix (82.85s)
=== RUN   TestAccAWSIAMRole_testNameChange
--- PASS: TestAccAWSIAMRole_testNameChange (104.43s)
=== RUN   TestAccAWSIAMRole_badJSON
--- PASS: TestAccAWSIAMRole_badJSON (5.03s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	507.244s
```