### PR TITLE
Add support for specifying cache key parameters in API Gateway.

### DIFF
--- a/aws/resource_aws_api_gateway_integration.go
+++ b/aws/resource_aws_api_gateway_integration.go
@@ -112,6 +112,7 @@ func resourceAwsApiGatewayIntegration() *schema.Resource {
 			"cache_namespace": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 		},
 	}

--- a/aws/resource_aws_api_gateway_integration_test.go
+++ b/aws/resource_aws_api_gateway_integration_test.go
@@ -89,6 +89,28 @@ func TestAccAWSAPIGatewayIntegration_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.application/xml", "#set($inputRoot = $input.path('$'))\n{ }"),
 				),
 			},
+
+			{
+				Config: testAccAWSAPIGatewayIntegrationConfigCacheKeyParameters,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayIntegrationExists("aws_api_gateway_integration.test", &conf),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "type", "HTTP"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "integration_http_method", "GET"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "uri", "https://www.google.de"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "passthrough_behavior", "WHEN_NO_MATCH"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "content_handling", "CONVERT_TO_TEXT"),
+					resource.TestCheckNoResourceAttr("aws_api_gateway_integration.test", "credentials"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.%", "3"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.integration.request.header.X-Authorization", "'static'"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.integration.request.header.X-Foo", "'Bar'"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.integration.request.path.param", "method.request.path.param"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "cache_key_parameters.#", "1"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "cache_key_parameters.550492954", "method.request.path.param"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.%", "2"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.application/json", ""),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.application/xml", "#set($inputRoot = $input.path('$'))\n{ }"),
+				),
+			},
 		},
 	})
 }
@@ -271,6 +293,58 @@ resource "aws_api_gateway_integration" "test" {
   rest_api_id = "${aws_api_gateway_rest_api.test.id}"
   resource_id = "${aws_api_gateway_resource.test.id}"
   http_method = "${aws_api_gateway_method.test.http_method}"
+
+  type = "HTTP"
+  uri = "https://www.google.de"
+  integration_http_method = "GET"
+  passthrough_behavior = "WHEN_NO_MATCH"
+  content_handling = "CONVERT_TO_TEXT"
+}
+`
+
+const testAccAWSAPIGatewayIntegrationConfigCacheKeyParameters = `
+resource "aws_api_gateway_rest_api" "test" {
+  name = "test"
+}
+
+resource "aws_api_gateway_resource" "test" {
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  parent_id = "${aws_api_gateway_rest_api.test.root_resource_id}"
+  path_part = "{param}"
+}
+
+resource "aws_api_gateway_method" "test" {
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  resource_id = "${aws_api_gateway_resource.test.id}"
+  http_method = "GET"
+  authorization = "NONE"
+
+  request_models = {
+    "application/json" = "Error"
+  }
+
+  request_parameters = {
+    "method.request.path.param" = true
+  }
+}
+
+resource "aws_api_gateway_integration" "test" {
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  resource_id = "${aws_api_gateway_resource.test.id}"
+  http_method = "${aws_api_gateway_method.test.http_method}"
+
+  request_templates = {
+    "application/json" = ""
+    "application/xml" = "#set($inputRoot = $input.path('$'))\n{ }"
+  }
+
+  request_parameters = {
+    "integration.request.header.X-Authorization" = "'static'"
+    "integration.request.header.X-Foo" = "'Bar'"
+    "integration.request.path.param" = "method.request.path.param"
+  }
+
+  cache_key_parameters = ["method.request.path.param"]
 
   type = "HTTP"
   uri = "https://www.google.de"

--- a/aws/resource_aws_api_gateway_integration_test.go
+++ b/aws/resource_aws_api_gateway_integration_test.go
@@ -89,7 +89,18 @@ func TestAccAWSAPIGatewayIntegration_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.application/xml", "#set($inputRoot = $input.path('$'))\n{ }"),
 				),
 			},
+		},
+	})
+}
 
+func TestAccAWSAPIGatewayIntegration_cache_key_parameters(t *testing.T) {
+	var conf apigateway.Integration
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayIntegrationDestroy,
+		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSAPIGatewayIntegrationConfigCacheKeyParameters,
 				Check: resource.ComposeTestCheckFunc(
@@ -106,6 +117,7 @@ func TestAccAWSAPIGatewayIntegration_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.integration.request.path.param", "method.request.path.param"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "cache_key_parameters.#", "1"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "cache_key_parameters.550492954", "method.request.path.param"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "cache_namespace", "foobar"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.%", "2"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.application/json", ""),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.application/xml", "#set($inputRoot = $input.path('$'))\n{ }"),
@@ -345,6 +357,7 @@ resource "aws_api_gateway_integration" "test" {
   }
 
   cache_key_parameters = ["method.request.path.param"]
+  cache_namespace = "foobar"
 
   type = "HTTP"
   uri = "https://www.google.de"


### PR DESCRIPTION
Pull request to fix issue #856 

This pull request provides a way to specify cache key parameters, so that caching can take into account varying path parameters or query strings.

I have tested the changes, and I was able to effectively create, read or update cache key parameters. The following (adapted) example shows how to do so for path parameters:

```
resource "aws_api_gateway_resource" "path1" {
  rest_api_id = "${aws_api_gateway_rest_api.api.id}"
  parent_id   = "${aws_api_gateway_rest_api.api.root_resource_id}"
  path_part   = "{param1}"
}

resource "aws_api_gateway_resource" "path2" {
  rest_api_id = "${aws_api_gateway_rest_api.api.id}"
  parent_id   = "${aws_api_gateway_resource.path1.id}"
  path_part   = "{param2}"
}

resource "aws_api_gateway_method" "method" {
  rest_api_id   = "${aws_api_gateway_rest_api.api.id}"
  resource_id   = "${aws_api_gateway_resource.path2.id}"
  http_method   = "GET"
  authorization = "NONE"
  request_parameters = {
      "method.request.path.param1" = true
      "method.request.path.param2" = true
  }
}

resource "aws_api_gateway_integration" "integration" {
  rest_api_id   = "${aws_api_gateway_rest_api.api.id}"
  resource_id   = "${aws_api_gateway_resource.path2.id}"
  http_method   = "${aws_api_gateway_method.method.http_method}"
  type          = "AWS"
  uri           = "arn:aws:apigateway:${var.region}:lambda:path/2015-03-31/functions/${var.lambda_arn}/invocations"
  integration_http_method = "POST"
  request_parameters = {
      "integration.request.path.param1" = "method.request.path.param1"
      "integration.request.path.param2" = "method.request.path.param2"
  }
  cache_key_parameters = ["method.request.path.param1", "method.request.path.param2"]
}
```

The example shows how to set the new field (`cache_key_parameters`) as well as `request_parameters` (both in the method and integration resources).