### PR TITLE
Closes #150: EB diffs settings correctly

### DIFF
--- a/aws/resource_aws_elastic_beanstalk_environment.go
+++ b/aws/resource_aws_elastic_beanstalk_environment.go
@@ -769,6 +769,7 @@ func optionSettingValueHash(v interface{}) int {
 		resourceName = v
 	}
 	value, _ := rd["value"].(string)
+	value, _ = normalizeJsonString(value)
 	hk := fmt.Sprintf("%s:%s%s=%s", namespace, optionName, resourceName, sortValues(value))
 	log.Printf("[DEBUG] Elastic Beanstalk optionSettingValueHash(%#v): %s: hk=%s,hc=%d", v, optionName, hk, hashcode.String(hk))
 	return hashcode.String(hk)

--- a/aws/resource_aws_elastic_beanstalk_environment_test.go
+++ b/aws/resource_aws_elastic_beanstalk_environment_test.go
@@ -287,6 +287,24 @@ func TestAccAWSBeanstalkEnv_version_label(t *testing.T) {
 	})
 }
 
+func TestAccAWSBeanstalkEnv_settingWithJsonValue(t *testing.T) {
+	var app elasticbeanstalk.EnvironmentDescription
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBeanstalkEnvDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccBeanstalkEnvSettingJsonValue(acctest.RandInt()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBeanstalkEnvExists("aws_elastic_beanstalk_environment.default", &app),
+				),
+			},
+		},
+	})
+}
+
 func testAccVerifyBeanstalkConfig(env *elasticbeanstalk.EnvironmentDescription, expected []string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if env == nil {
@@ -991,4 +1009,215 @@ resource "aws_elastic_beanstalk_environment" "default" {
   solution_stack_name = "64bit Amazon Linux running Python"
 }
 `, randInt, randInt, randInt)
+}
+
+func testAccBeanstalkEnvSettingJsonValue(randInt int) string {
+	return fmt.Sprintf(`
+resource "aws_elastic_beanstalk_application" "app" {
+  name = "tf-acc-test-%d"
+  description = "This is a description"
+}
+
+resource "aws_sqs_queue" "test" {
+  name = "tf-acc-test-%d"
+}
+
+resource "aws_key_pair" "test" {
+  key_name   = "tf-acc-test-%d"
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 email@example.com"
+}
+
+resource "aws_iam_instance_profile" "app" {
+  name  = "tf-acc-test-%d"
+  role = "${aws_iam_role.test.name}"
+}
+
+resource "aws_iam_role" "test" {
+  name = "tf_acc_test_%d"
+  path = "/"
+
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": "sts:AssumeRole",
+            "Principal": {
+               "Service": "ec2.amazonaws.com"
+            },
+            "Effect": "Allow",
+            "Sid": ""
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "test" {
+  name = "test_policy"
+  role = "${aws_iam_role.test.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "dynamodb:*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_elastic_beanstalk_environment" "default" {
+  name = "tf-acc-test-%d"
+  application = "${aws_elastic_beanstalk_application.app.name}"
+  tier = "Worker"
+  solution_stack_name = "64bit Amazon Linux 2016.03 v2.1.0 running Docker 1.9.1"
+
+  setting = {
+    namespace = "aws:elasticbeanstalk:command"
+    name = "BatchSize"
+    value = "30"
+  }
+
+  setting = {
+    namespace = "aws:elasticbeanstalk:command"
+    name = "BatchSizeType"
+    value = "Percentage"
+  }
+
+  setting = {
+    namespace = "aws:elasticbeanstalk:command"
+    name = "DeploymentPolicy"
+    value = "Rolling"
+  }
+
+  setting = {
+    namespace = "aws:elasticbeanstalk:sns:topics"
+    name = "Notification Endpoint"
+    value = "example@example.com"
+  }
+
+  setting = {
+    namespace = "aws:elasticbeanstalk:sqsd"
+    name = "ErrorVisibilityTimeout"
+    value = "2"
+  }
+
+  setting = {
+    namespace = "aws:elasticbeanstalk:sqsd"
+    name = "HttpPath"
+    value = "/event-message"
+  }
+
+  setting = {
+    namespace = "aws:elasticbeanstalk:sqsd"
+    name = "WorkerQueueURL"
+    value = "${aws_sqs_queue.test.id}"
+  }
+
+  setting = {
+    namespace = "aws:elasticbeanstalk:sqsd"
+    name = "VisibilityTimeout"
+    value = "300"
+  }
+
+  setting = {
+    namespace = "aws:elasticbeanstalk:sqsd"
+    name = "HttpConnections"
+    value = "10"
+  }
+
+  setting = {
+    namespace = "aws:elasticbeanstalk:sqsd"
+    name = "InactivityTimeout"
+    value = "299"
+  }
+
+  setting = {
+    namespace = "aws:elasticbeanstalk:sqsd"
+    name = "MimeType"
+    value = "application/json"
+  }
+
+  setting = {
+    namespace = "aws:elasticbeanstalk:environment"
+    name = "ServiceRole"
+    value = "aws-elasticbeanstalk-service-role"
+  }
+
+  setting = {
+    namespace = "aws:elasticbeanstalk:environment"
+    name = "EnvironmentType"
+    value = "LoadBalanced"
+  }
+
+  setting = {
+    namespace = "aws:elasticbeanstalk:application"
+    name = "Application Healthcheck URL"
+    value = "/health"
+  }
+
+  setting = {
+    namespace = "aws:elasticbeanstalk:healthreporting:system"
+    name = "SystemType"
+    value = "enhanced"
+  }
+
+  setting = {
+    namespace = "aws:elasticbeanstalk:healthreporting:system"
+    name = "HealthCheckSuccessThreshold"
+    value = "Ok"
+  }
+
+  setting = {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name = "IamInstanceProfile"
+    value = "${aws_iam_instance_profile.app.name}"
+  }
+
+  setting = {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name = "InstanceType"
+    value = "t2.micro"
+  }
+
+  setting = {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name = "EC2KeyName"
+    value = "${aws_key_pair.test.key_name}"
+  }
+
+  setting = {
+    namespace = "aws:autoscaling:updatepolicy:rollingupdate"
+    name = "RollingUpdateEnabled"
+    value = "false"
+  }
+
+  setting = {
+    namespace = "aws:elasticbeanstalk:healthreporting:system"
+    name = "ConfigDocument"
+    value = <<EOF
+{
+	"Version": 1,
+	"CloudWatchMetrics": {
+		"Instance": {
+			"ApplicationRequestsTotal": 60
+		},
+		"Environment": {
+			"ApplicationRequests5xx": 60,
+			"ApplicationRequests4xx": 60,
+			"ApplicationRequests2xx": 60
+		}
+	}
+}
+EOF
+  }
+}
+`, randInt, randInt, randInt, randInt, randInt, randInt)
 }

--- a/aws/structure_test.go
+++ b/aws/structure_test.go
@@ -1222,7 +1222,19 @@ func TestNormalizeJsonString(t *testing.T) {
 
 	// We expect the invalid JSON to be shown back to us again.
 	if actual != invalidJson {
-		t.Fatalf("Got:\n\n%s\n\nExpected:\n\n%s\n", expected, invalidJson)
+		t.Fatalf("Got:\n\n%s\n\nExpected:\n\n%s\n", actual, invalidJson)
+	}
+
+	// Verify that it leaves strings alone
+	testString := "2016-07-28t04:07:02z\nsomething else"
+	expected = "2016-07-28t04:07:02z\nsomething else"
+	actual, err = normalizeJsonString(testString)
+	if err == nil {
+		t.Fatalf("Expected to throw an error while parsing JSON, but got: %s", err)
+	}
+
+	if actual != expected {
+		t.Fatalf("Got:\n\n%s\n\nExpected:\n\n%s\n", actual, expected)
 	}
 }
 


### PR DESCRIPTION
All this commit does is add a call to `normalizeJsonString`, so the
settings returned by the AWS API and the settings set by users in the tf
config don't indicate diffs in the tf state whenever there's extra
whitespace in the JSON. I added a case to the `structure_test.go` file, to
verify that `normalizeJsonString` treats regular strings the way I'd
expect.

I would have added an acceptance test, but the 15-20 minute feedback loop
is far too long to be practical. I tried figuring out a way to spoof the
flow instead, but had no luck.

Fixes #150