### PR TITLE
resource/network_interface: Fix device idx in acc test

### DIFF
--- a/aws/resource_aws_network_interface_test.go
+++ b/aws/resource_aws_network_interface_test.go
@@ -275,7 +275,7 @@ func testAccCheckAWSENIMakeExternalAttachment(n string, conf *ec2.NetworkInterfa
 			return fmt.Errorf("Not found: %s", n)
 		}
 		attach_request := &ec2.AttachNetworkInterfaceInput{
-			DeviceIndex:        aws.Int64(2),
+			DeviceIndex:        aws.Int64(1),
 			InstanceId:         aws.String(rs.Primary.ID),
 			NetworkInterfaceId: conf.NetworkInterfaceId,
 		}


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSENI_ignoreExternalAttachment
--- FAIL: TestAccAWSENI_ignoreExternalAttachment (218.89s)
    testing.go:428: Step 0 error: Check failed: Check 3/3 error: Error attaching ENI: InvalidParameterValue: Instance 'i-0372136987572ce5f' already has an interface attached at device index '2'.
            status code: 400, request id: a54391fa-1a49-482c-95a0-ff2456b8712a
```
The test started failing on the 16th May when Amazon apparently released some breaking changes to their API. The issue was acked by the support, they promised investigation by the API team, but so far we've not heard back from the API team (after ~1 month) and there's no point of waiting any longer and keeping this test red.

### Test results
```
make testacc TESTARGS='-run=TestAccAWSENI_ignoreExternalAttachment'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccAWSENI_ignoreExternalAttachment -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSENI_ignoreExternalAttachment
--- PASS: TestAccAWSENI_ignoreExternalAttachment (226.63s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	226.666s
```