### PR TITLE
resource/iam_server_certificate: Increase deletion timeout

### DIFF
--- a/aws/resource_aws_iam_server_certificate.go
+++ b/aws/resource_aws_iam_server_certificate.go
@@ -172,7 +172,7 @@ func resourceAwsIAMServerCertificateRead(d *schema.ResourceData, meta interface{
 func resourceAwsIAMServerCertificateDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).iamconn
 	log.Printf("[INFO] Deleting IAM Server Certificate: %s", d.Id())
-	err := resource.Retry(10*time.Minute, func() *resource.RetryError {
+	err := resource.Retry(15*time.Minute, func() *resource.RetryError {
 		_, err := conn.DeleteServerCertificate(&iam.DeleteServerCertificateInput{
 			ServerCertificateName: aws.String(d.Get("name").(string)),
 		})


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSLBSSLNegotiationPolicy_missingLB
--- FAIL: TestAccAWSLBSSLNegotiationPolicy_missingLB (718.52s)
    testing.go:492: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Error applying: 1 error(s) occurred:
        
        * aws_iam_server_certificate.test_cert (destroy): 1 error(s) occurred:
        
        * aws_iam_server_certificate.test_cert: DeleteConflict: Certificate: ASCAJXDEAGR64DZQSW564 is currently in use by arn:aws:elasticloadbalancing:us-west-2:*******:loadbalancer/tf-test-lb-wsxm9. Please remove it first before deleting it from IAM.
            status code: 409, request id: 200c2905-53f5-11e7-a79c-5921a71de6df
        
        State: aws_iam_server_certificate.test_cert:
          ID = ASCAJXDEAGR64DZQSW564
          arn = arn:aws:iam::*******:server-certificate/tf-acctest-xdb2fjbm3b
          certificate_body = 32c8d055f078a2a9fd053c0da56307b2041a5fc8
          certificate_chain = 62d98850b90a08fe0a8fa48803099cbab71913bf
          name = tf-acctest-xdb2fjbm3b
          path = /
          private_key = ed98e97354e5d9d1ebe5b2cb595c94ae6d4c3d69
```