### PR TITLE
Fixing malformed ARN attribute for aws_security_group data source

### DIFF
--- a/aws/data_source_aws_security_group.go
+++ b/aws/data_source_aws_security_group.go
@@ -87,7 +87,7 @@ func dataSourceAwsSecurityGroupRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("description", sg.Description)
 	d.Set("vpc_id", sg.VpcId)
 	d.Set("tags", tagsToMap(sg.Tags))
-	d.Set("arn", fmt.Sprintf("arn:%s:ec2:%s:%s/security-group/%s",
+	d.Set("arn", fmt.Sprintf("arn:%s:ec2:%s:%s:security-group/%s",
 		meta.(*AWSClient).partition, meta.(*AWSClient).region, *sg.OwnerId, *sg.GroupId))
 
 	return nil


### PR DESCRIPTION
As per the docs:
http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-ec2

`arn:aws:ec2:region:account-id:security-group/security-group-id`