### PR TITLE
Fix the sample policy for redshift_service_account

### DIFF
--- a/website/docs/d/redshift_service_account.html.markdown
+++ b/website/docs/d/redshift_service_account.html.markdown
@@ -28,7 +28,7 @@ resource "aws_s3_bucket" "bucket" {
         			"Sid": "Put bucket policy needed for audit logging",
         			"Effect": "Allow",
         			"Principal": {
-        				"AWS": "arn:aws:iam:${data.aws_redshift_service_account.main.id}:user/logs"
+        				"AWS": "arn:aws:iam::${data.aws_redshift_service_account.main.id}:user/logs"
         			},
         			"Action": "s3:PutObject",
         			"Resource": "arn:aws:s3:::tf-redshift-logging-test-bucket/*"
@@ -37,7 +37,7 @@ resource "aws_s3_bucket" "bucket" {
         			"Sid": "Get bucket policy needed for audit logging ",
         			"Effect": "Allow",
         			"Principal": {
-        				"AWS": "arn:aws:iam:${data.aws_redshift_service_account.main.id}:user/logs"
+        				"AWS": "arn:aws:iam::${data.aws_redshift_service_account.main.id}:user/logs"
         			},
         			"Action": "s3:GetBucketAcl",
         			"Resource": "arn:aws:s3:::tf-redshift-logging-test-bucket"


### PR DESCRIPTION
Missing `:` causes invalid principle error. Policy is now aligned with: https://docs.aws.amazon.com/redshift/latest/mgmt/db-auditing.html.