### PR TITLE
Modify RDS Cluster after restoring from snapshot, if required

### DIFF
--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -291,10 +291,19 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 			opts.Port = aws.Int64(int64(attr.(int)))
 		}
 
-		var sgUpdate bool
+		// Check if any of the parameters that require a cluster modification after creation are set
+		var clusterUpdate bool
 		if attr := d.Get("vpc_security_group_ids").(*schema.Set); attr.Len() > 0 {
-			sgUpdate = true
+			clusterUpdate = true
 			opts.VpcSecurityGroupIds = expandStringList(attr.List())
+		}
+
+		if _, ok := d.GetOk("db_cluster_parameter_group_name"); ok {
+			clusterUpdate = true
+		}
+
+		if _, ok := d.GetOk("backup_retention_period"); ok {
+			clusterUpdate = true
 		}
 
 		log.Printf("[DEBUG] RDS Cluster restore from snapshot configuration: %s", opts)
@@ -303,12 +312,13 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 			return fmt.Errorf("Error creating RDS Cluster: %s", err)
 		}
 
-		if sgUpdate {
-			log.Printf("[INFO] RDS Cluster is restoring from snapshot with default security, but custom security should be set, will now update after snapshot is restored!")
+		if clusterUpdate {
+			log.Printf("[INFO] RDS Cluster is restoring from snapshot with default db_cluster_parameter_group_name, backup_retention_period and vpc_security_group_ids" +
+				"but custom values should be set, will now update after snapshot is restored!")
 
 			d.SetId(d.Get("cluster_identifier").(string))
 
-			log.Printf("[INFO] RDS Cluster Instance ID: %s", d.Id())
+			log.Printf("[INFO] RDS Cluster ID: %s", d.Id())
 
 			log.Println("[INFO] Waiting for RDS Cluster to be available")
 
@@ -327,7 +337,7 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 				return err
 			}
 
-			err = resourceAwsRDSClusterInstanceUpdate(d, meta)
+			err = resourceAwsRDSClusterUpdate(d, meta)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This PR fixes issue [588](https://github.com/terraform-providers/terraform-provider-aws/issues/588)

That issue is visible when restoring an RDS Cluster from a snapshot. AWS will set the cluster parameter group and backup retention period to the default values and does not allow them to be overridden. This fix ensures that after restoring an RDS Cluster from a snapshot the modifyDbCluster action is executed if any of those parameters has been set to a custom value.

Since it is possible to start a cluster without any instances (omitting the database_name parameter), using 'resourceAwsRDSClusterInstanceUpdate' to update the SG could return an error for not finding any instance to update.

Since 'resourceAwsRDSClusterUpdate' is also able to update the SG across the Cluster and works with zero or more instances in the cluster it makes sense to issue a single call to update all the settings in one go, both solving the error, reducing the number of calls and speeding up the process.