### PR TITLE
data_source aws_kms_secret: Trim whitespace characters from decrypted values

### DIFF
--- a/aws/data_source_aws_kms_secret.go
+++ b/aws/data_source_aws_kms_secret.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -92,7 +93,8 @@ func dataSourceAwsKmsSecretRead(d *schema.ResourceData, meta interface{}) error 
 
 		// Set the secret via the name
 		log.Printf("[DEBUG] aws_kms_secret - successfully decrypted secret: %s", secret["name"].(string))
-		d.UnsafeSetFieldRaw(secret["name"].(string), string(resp.Plaintext))
+		SecretPlaintext := strings.TrimSpace(string(resp.Plaintext))
+		d.UnsafeSetFieldRaw(secret["name"].(string), SecretPlaintext)
 	}
 
 	return nil


### PR DESCRIPTION
fixes #685 

as described in https://github.com/hashicorp/terraform/issues/13533#issuecomment-300719325 the output of `data.aws_kms_secret.decrypt.value` always contains a newline `\n` character at the end of the output making invalid when used as input in other resources, or setting a secret different from the expected secret.

This patch trims the whitespace before and after the decrypted value.