### PR TITLE
Update docs to include old AWS env vars

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -60,9 +60,10 @@ provider "aws" {
 
 You can provide your credentials via the `AWS_ACCESS_KEY_ID` and
 `AWS_SECRET_ACCESS_KEY`, environment variables, representing your AWS
-Access Key and AWS Secret Key, respectively.  The `AWS_DEFAULT_REGION`
-and `AWS_SESSION_TOKEN` environment variables are also used, if
-applicable:
+Access Key and AWS Secret Key, respectively.  Note that the `AWS_ACCESS_KEY`
+and `AWS_SECRET_KEY` environment variables are also still respected. The
+`AWS_DEFAULT_REGION` and `AWS_SESSION_TOKEN` environment variables are
+also used, if applicable:
 
 ```hcl
 provider "aws" {}


### PR DESCRIPTION
Looks like the old AWS env vars are still used. This is relevant as in order to make use of `AWS_SHARED_CREDENTIALS_FILE` / `AWS_PROFILE` you must unset _all_ other AWS vars.