### PR TITLE
Add TLS + Template providers from new location

### DIFF
--- a/vendor/github.com/terraform-providers/terraform-provider-template/LICENSE
+++ b/vendor/github.com/terraform-providers/terraform-provider-template/LICENSE
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/vendor/github.com/terraform-providers/terraform-provider-template/template/datasource_cloudinit_config.go
+++ b/vendor/github.com/terraform-providers/terraform-provider-template/template/datasource_cloudinit_config.go
@@ -1,0 +1,185 @@
+package template
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/textproto"
+	"strconv"
+
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceCloudinitConfig() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceCloudinitConfigRead,
+
+		Schema: map[string]*schema.Schema{
+			"part": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"content_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"content": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"filename": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"merge_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"gzip": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"base64_encode": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"rendered": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "rendered cloudinit configuration",
+			},
+		},
+	}
+}
+
+func dataSourceCloudinitConfigRead(d *schema.ResourceData, meta interface{}) error {
+	rendered, err := renderCloudinitConfig(d)
+	if err != nil {
+		return err
+	}
+
+	d.Set("rendered", rendered)
+	d.SetId(strconv.Itoa(hashcode.String(rendered)))
+	return nil
+}
+
+func renderCloudinitConfig(d *schema.ResourceData) (string, error) {
+	gzipOutput := d.Get("gzip").(bool)
+	base64Output := d.Get("base64_encode").(bool)
+
+	partsValue, hasParts := d.GetOk("part")
+	if !hasParts {
+		return "", fmt.Errorf("No parts found in the cloudinit resource declaration")
+	}
+
+	cloudInitParts := make(cloudInitParts, len(partsValue.([]interface{})))
+	for i, v := range partsValue.([]interface{}) {
+		p, castOk := v.(map[string]interface{})
+		if !castOk {
+			return "", fmt.Errorf("Unable to parse parts in cloudinit resource declaration")
+		}
+
+		part := cloudInitPart{}
+		if p, ok := p["content_type"]; ok {
+			part.ContentType = p.(string)
+		}
+		if p, ok := p["content"]; ok {
+			part.Content = p.(string)
+		}
+		if p, ok := p["merge_type"]; ok {
+			part.MergeType = p.(string)
+		}
+		if p, ok := p["filename"]; ok {
+			part.Filename = p.(string)
+		}
+		cloudInitParts[i] = part
+	}
+
+	var buffer bytes.Buffer
+
+	var err error
+	if gzipOutput {
+		gzipWriter := gzip.NewWriter(&buffer)
+		err = renderPartsToWriter(cloudInitParts, gzipWriter)
+		gzipWriter.Close()
+	} else {
+		err = renderPartsToWriter(cloudInitParts, &buffer)
+	}
+	if err != nil {
+		return "", err
+	}
+
+	output := ""
+	if base64Output {
+		output = base64.StdEncoding.EncodeToString(buffer.Bytes())
+	} else {
+		output = buffer.String()
+	}
+
+	return output, nil
+}
+
+func renderPartsToWriter(parts cloudInitParts, writer io.Writer) error {
+	mimeWriter := multipart.NewWriter(writer)
+	defer mimeWriter.Close()
+
+	// we need to set the boundary explictly, otherwise the boundary is random
+	// and this causes terraform to complain about the resource being different
+	if err := mimeWriter.SetBoundary("MIMEBOUNDARY"); err != nil {
+		return err
+	}
+
+	writer.Write([]byte(fmt.Sprintf("Content-Type: multipart/mixed; boundary=\"%s\"\n", mimeWriter.Boundary())))
+	writer.Write([]byte("MIME-Version: 1.0\r\n\r\n"))
+
+	for _, part := range parts {
+		header := textproto.MIMEHeader{}
+		if part.ContentType == "" {
+			header.Set("Content-Type", "text/plain")
+		} else {
+			header.Set("Content-Type", part.ContentType)
+		}
+
+		header.Set("MIME-Version", "1.0")
+		header.Set("Content-Transfer-Encoding", "7bit")
+
+		if part.Filename != "" {
+			header.Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, part.Filename))
+		}
+
+		if part.MergeType != "" {
+			header.Set("X-Merge-Type", part.MergeType)
+		}
+
+		partWriter, err := mimeWriter.CreatePart(header)
+		if err != nil {
+			return err
+		}
+
+		_, err = partWriter.Write([]byte(part.Content))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type cloudInitPart struct {
+	ContentType string
+	MergeType   string
+	Filename    string
+	Content     string
+}
+
+type cloudInitParts []cloudInitPart

--- a/vendor/github.com/terraform-providers/terraform-provider-template/template/datasource_template_file.go
+++ b/vendor/github.com/terraform-providers/terraform-provider-template/template/datasource_template_file.go
@@ -1,0 +1,165 @@
+package template
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/hashicorp/hil"
+	"github.com/hashicorp/hil/ast"
+	"github.com/hashicorp/terraform/config"
+	"github.com/hashicorp/terraform/helper/pathorcontents"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceFile() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceFileRead,
+
+		Schema: map[string]*schema.Schema{
+			"template": &schema.Schema{
+				Type:          schema.TypeString,
+				Optional:      true,
+				Description:   "Contents of the template",
+				ConflictsWith: []string{"filename"},
+			},
+			"filename": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "file to read template from",
+				// Make a "best effort" attempt to relativize the file path.
+				StateFunc: func(v interface{}) string {
+					if v == nil || v.(string) == "" {
+						return ""
+					}
+					pwd, err := os.Getwd()
+					if err != nil {
+						return v.(string)
+					}
+					rel, err := filepath.Rel(pwd, v.(string))
+					if err != nil {
+						return v.(string)
+					}
+					return rel
+				},
+				Deprecated:    "Use the 'template' attribute instead.",
+				ConflictsWith: []string{"template"},
+			},
+			"vars": &schema.Schema{
+				Type:         schema.TypeMap,
+				Optional:     true,
+				Default:      make(map[string]interface{}),
+				Description:  "variables to substitute",
+				ValidateFunc: validateVarsAttribute,
+			},
+			"rendered": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "rendered template",
+			},
+		},
+	}
+}
+
+func dataSourceFileRead(d *schema.ResourceData, meta interface{}) error {
+	rendered, err := renderFile(d)
+	if err != nil {
+		return err
+	}
+	d.Set("rendered", rendered)
+	d.SetId(hash(rendered))
+	return nil
+}
+
+type templateRenderError error
+
+func renderFile(d *schema.ResourceData) (string, error) {
+	template := d.Get("template").(string)
+	filename := d.Get("filename").(string)
+	vars := d.Get("vars").(map[string]interface{})
+
+	contents := template
+	if template == "" && filename != "" {
+		data, _, err := pathorcontents.Read(filename)
+		if err != nil {
+			return "", err
+		}
+
+		contents = data
+	}
+
+	rendered, err := execute(contents, vars)
+	if err != nil {
+		return "", templateRenderError(
+			fmt.Errorf("failed to render %v: %v", filename, err),
+		)
+	}
+
+	return rendered, nil
+}
+
+// execute parses and executes a template using vars.
+func execute(s string, vars map[string]interface{}) (string, error) {
+	root, err := hil.Parse(s)
+	if err != nil {
+		return "", err
+	}
+
+	varmap := make(map[string]ast.Variable)
+	for k, v := range vars {
+		// As far as I can tell, v is always a string.
+		// If it's not, tell the user gracefully.
+		s, ok := v.(string)
+		if !ok {
+			return "", fmt.Errorf("unexpected type for variable %q: %T", k, v)
+		}
+		varmap[k] = ast.Variable{
+			Value: s,
+			Type:  ast.TypeString,
+		}
+	}
+
+	cfg := hil.EvalConfig{
+		GlobalScope: &ast.BasicScope{
+			VarMap:  varmap,
+			FuncMap: config.Funcs(),
+		},
+	}
+
+	result, err := hil.Eval(root, &cfg)
+	if err != nil {
+		return "", err
+	}
+	if result.Type != hil.TypeString {
+		return "", fmt.Errorf("unexpected output hil.Type: %v", result.Type)
+	}
+
+	return result.Value.(string), nil
+}
+
+func hash(s string) string {
+	sha := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sha[:])
+}
+
+func validateVarsAttribute(v interface{}, key string) (ws []string, es []error) {
+	// vars can only be primitives right now
+	var badVars []string
+	for k, v := range v.(map[string]interface{}) {
+		switch v.(type) {
+		case []interface{}:
+			badVars = append(badVars, fmt.Sprintf("%s (list)", k))
+		case map[string]interface{}:
+			badVars = append(badVars, fmt.Sprintf("%s (map)", k))
+		}
+	}
+	if len(badVars) > 0 {
+		es = append(es, fmt.Errorf(
+			"%s: cannot contain non-primitives; bad keys: %s",
+			key, strings.Join(badVars, ", ")))
+	}
+	return
+}

--- a/vendor/github.com/terraform-providers/terraform-provider-template/template/provider.go
+++ b/vendor/github.com/terraform-providers/terraform-provider-template/template/provider.go
@@ -1,0 +1,26 @@
+package template
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func Provider() terraform.ResourceProvider {
+	return &schema.Provider{
+		DataSourcesMap: map[string]*schema.Resource{
+			"template_file":             dataSourceFile(),
+			"template_cloudinit_config": dataSourceCloudinitConfig(),
+		},
+		ResourcesMap: map[string]*schema.Resource{
+			"template_file": schema.DataSourceResourceShim(
+				"template_file",
+				dataSourceFile(),
+			),
+			"template_cloudinit_config": schema.DataSourceResourceShim(
+				"template_cloudinit_config",
+				dataSourceCloudinitConfig(),
+			),
+			"template_dir": resourceDir(),
+		},
+	}
+}

--- a/vendor/github.com/terraform-providers/terraform-provider-template/template/resource_template_dir.go
+++ b/vendor/github.com/terraform-providers/terraform-provider-template/template/resource_template_dir.go
@@ -1,0 +1,234 @@
+package template
+
+import (
+	"archive/tar"
+	"bytes"
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/hashicorp/terraform/helper/pathorcontents"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceDir() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceTemplateDirCreate,
+		Read:   resourceTemplateDirRead,
+		Delete: resourceTemplateDirDelete,
+
+		Schema: map[string]*schema.Schema{
+			"source_dir": {
+				Type:        schema.TypeString,
+				Description: "Path to the directory where the files to template reside",
+				Required:    true,
+				ForceNew:    true,
+			},
+			"vars": {
+				Type:         schema.TypeMap,
+				Optional:     true,
+				Default:      make(map[string]interface{}),
+				Description:  "Variables to substitute",
+				ValidateFunc: validateVarsAttribute,
+				ForceNew:     true,
+			},
+			"destination_dir": {
+				Type:        schema.TypeString,
+				Description: "Path to the directory where the templated files will be written",
+				Required:    true,
+				ForceNew:    true,
+			},
+		},
+	}
+}
+
+func resourceTemplateDirRead(d *schema.ResourceData, meta interface{}) error {
+	sourceDir := d.Get("source_dir").(string)
+	destinationDir := d.Get("destination_dir").(string)
+
+	// If the output doesn't exist, mark the resource for creation.
+	if _, err := os.Stat(destinationDir); os.IsNotExist(err) {
+		d.SetId("")
+		return nil
+	}
+
+	// If the combined hash of the input and output directories is different from
+	// the stored one, mark the resource for re-creation.
+	//
+	// The output directory is technically enough for the general case, but by
+	// hashing the input directory as well, we make development much easier: when
+	// a developer modifies one of the input files, the generation is
+	// re-triggered.
+	hash, err := generateID(sourceDir, destinationDir)
+	if err != nil {
+		return err
+	}
+	if hash != d.Id() {
+		d.SetId("")
+		return nil
+	}
+
+	return nil
+}
+
+func resourceTemplateDirCreate(d *schema.ResourceData, meta interface{}) error {
+	sourceDir := d.Get("source_dir").(string)
+	destinationDir := d.Get("destination_dir").(string)
+	vars := d.Get("vars").(map[string]interface{})
+
+	// Always delete the output first, otherwise files that got deleted from the
+	// input directory might still be present in the output afterwards.
+	if err := resourceTemplateDirDelete(d, meta); err != nil {
+		return err
+	}
+
+	// Create the destination directory and any other intermediate directories
+	// leading to it.
+	if _, err := os.Stat(destinationDir); err != nil {
+		if err := os.MkdirAll(destinationDir, 0777); err != nil {
+			return err
+		}
+	}
+
+	// Recursively crawl the input files/directories and generate the output ones.
+	err := filepath.Walk(sourceDir, func(p string, f os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if f.IsDir() {
+			return nil
+		}
+
+		relPath, _ := filepath.Rel(sourceDir, p)
+		return generateDirFile(p, path.Join(destinationDir, relPath), f, vars)
+	})
+	if err != nil {
+		return err
+	}
+
+	// Compute ID.
+	hash, err := generateID(sourceDir, destinationDir)
+	if err != nil {
+		return err
+	}
+	d.SetId(hash)
+
+	return nil
+}
+
+func resourceTemplateDirDelete(d *schema.ResourceData, _ interface{}) error {
+	d.SetId("")
+
+	destinationDir := d.Get("destination_dir").(string)
+	if _, err := os.Stat(destinationDir); os.IsNotExist(err) {
+		return nil
+	}
+
+	if err := os.RemoveAll(destinationDir); err != nil {
+		return fmt.Errorf("could not delete directory %q: %s", destinationDir, err)
+	}
+
+	return nil
+}
+
+func generateDirFile(sourceDir, destinationDir string, f os.FileInfo, vars map[string]interface{}) error {
+	inputContent, _, err := pathorcontents.Read(sourceDir)
+	if err != nil {
+		return err
+	}
+
+	outputContent, err := execute(inputContent, vars)
+	if err != nil {
+		return templateRenderError(fmt.Errorf("failed to render %v: %v", sourceDir, err))
+	}
+
+	outputDir := path.Dir(destinationDir)
+	if _, err := os.Stat(outputDir); err != nil {
+		if err := os.MkdirAll(outputDir, 0777); err != nil {
+			return err
+		}
+	}
+
+	err = ioutil.WriteFile(destinationDir, []byte(outputContent), f.Mode())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func generateID(sourceDir, destinationDir string) (string, error) {
+	inputHash, err := generateDirHash(sourceDir)
+	if err != nil {
+		return "", err
+	}
+	outputHash, err := generateDirHash(destinationDir)
+	if err != nil {
+		return "", err
+	}
+	checksum := sha1.Sum([]byte(inputHash + outputHash))
+	return hex.EncodeToString(checksum[:]), nil
+}
+
+func generateDirHash(directoryPath string) (string, error) {
+	tarData, err := tarDir(directoryPath)
+	if err != nil {
+		return "", fmt.Errorf("could not generate output checksum: %s", err)
+	}
+
+	checksum := sha1.Sum(tarData)
+	return hex.EncodeToString(checksum[:]), nil
+}
+
+func tarDir(directoryPath string) ([]byte, error) {
+	buf := new(bytes.Buffer)
+	tw := tar.NewWriter(buf)
+
+	writeFile := func(p string, f os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		var header *tar.Header
+		var file *os.File
+
+		header, err = tar.FileInfoHeader(f, f.Name())
+		if err != nil {
+			return err
+		}
+		relPath, _ := filepath.Rel(directoryPath, p)
+		header.Name = relPath
+
+		if err := tw.WriteHeader(header); err != nil {
+			return err
+		}
+
+		if f.IsDir() {
+			return nil
+		}
+
+		file, err = os.Open(p)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
+		_, err = io.Copy(tw, file)
+		return err
+	}
+
+	if err := filepath.Walk(directoryPath, writeFile); err != nil {
+		return []byte{}, err
+	}
+	if err := tw.Flush(); err != nil {
+		return []byte{}, err
+	}
+
+	return buf.Bytes(), nil
+}

--- a/vendor/github.com/terraform-providers/terraform-provider-tls/LICENSE
+++ b/vendor/github.com/terraform-providers/terraform-provider-tls/LICENSE
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/vendor/github.com/terraform-providers/terraform-provider-tls/tls/provider.go
+++ b/vendor/github.com/terraform-providers/terraform-provider-tls/tls/provider.go
@@ -1,0 +1,112 @@
+package tls
+
+import (
+	"crypto/sha1"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func Provider() terraform.ResourceProvider {
+	return &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"tls_private_key":         resourcePrivateKey(),
+			"tls_locally_signed_cert": resourceLocallySignedCert(),
+			"tls_self_signed_cert":    resourceSelfSignedCert(),
+			"tls_cert_request":        resourceCertRequest(),
+		},
+	}
+}
+
+func hashForState(value string) string {
+	if value == "" {
+		return ""
+	}
+	hash := sha1.Sum([]byte(strings.TrimSpace(value)))
+	return hex.EncodeToString(hash[:])
+}
+
+func nameFromResourceData(nameMap map[string]interface{}) (*pkix.Name, error) {
+	result := &pkix.Name{}
+
+	if value := nameMap["common_name"]; value != nil {
+		result.CommonName = value.(string)
+	}
+	if value := nameMap["organization"]; value != nil {
+		result.Organization = []string{value.(string)}
+	}
+	if value := nameMap["organizational_unit"]; value != nil {
+		result.OrganizationalUnit = []string{value.(string)}
+	}
+	if value := nameMap["street_address"]; value != nil {
+		valueI := value.([]interface{})
+		result.StreetAddress = make([]string, len(valueI))
+		for i, vi := range valueI {
+			result.StreetAddress[i] = vi.(string)
+		}
+	}
+	if value := nameMap["locality"]; value != nil {
+		result.Locality = []string{value.(string)}
+	}
+	if value := nameMap["province"]; value != nil {
+		result.Province = []string{value.(string)}
+	}
+	if value := nameMap["country"]; value != nil {
+		result.Country = []string{value.(string)}
+	}
+	if value := nameMap["postal_code"]; value != nil {
+		result.PostalCode = []string{value.(string)}
+	}
+	if value := nameMap["serial_number"]; value != nil {
+		result.SerialNumber = value.(string)
+	}
+
+	return result, nil
+}
+
+var nameSchema *schema.Resource = &schema.Resource{
+	Schema: map[string]*schema.Schema{
+		"organization": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"common_name": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"organizational_unit": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"street_address": &schema.Schema{
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		"locality": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"province": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"country": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"postal_code": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"serial_number": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+	},
+}

--- a/vendor/github.com/terraform-providers/terraform-provider-tls/tls/resource_cert_request.go
+++ b/vendor/github.com/terraform-providers/terraform-provider-tls/tls/resource_cert_request.go
@@ -1,0 +1,127 @@
+package tls
+
+import (
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"net"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+const pemCertReqType = "CERTIFICATE REQUEST"
+
+func resourceCertRequest() *schema.Resource {
+	return &schema.Resource{
+		Create: CreateCertRequest,
+		Delete: DeleteCertRequest,
+		Read:   ReadCertRequest,
+
+		Schema: map[string]*schema.Schema{
+
+			"dns_names": &schema.Schema{
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "List of DNS names to use as subjects of the certificate",
+				ForceNew:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"ip_addresses": &schema.Schema{
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "List of IP addresses to use as subjects of the certificate",
+				ForceNew:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"key_algorithm": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of the algorithm to use to generate the certificate's private key",
+				ForceNew:    true,
+			},
+
+			"private_key_pem": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "PEM-encoded private key that the certificate will belong to",
+				ForceNew:    true,
+				StateFunc: func(v interface{}) string {
+					return hashForState(v.(string))
+				},
+			},
+
+			"subject": &schema.Schema{
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     nameSchema,
+				ForceNew: true,
+			},
+
+			"cert_request_pem": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func CreateCertRequest(d *schema.ResourceData, meta interface{}) error {
+	key, err := parsePrivateKey(d, "private_key_pem", "key_algorithm")
+	if err != nil {
+		return err
+	}
+
+	subjectConfs := d.Get("subject").([]interface{})
+	if len(subjectConfs) != 1 {
+		return fmt.Errorf("must have exactly one 'subject' block")
+	}
+	subjectConf := subjectConfs[0].(map[string]interface{})
+	subject, err := nameFromResourceData(subjectConf)
+	if err != nil {
+		return fmt.Errorf("invalid subject block: %s", err)
+	}
+
+	certReq := x509.CertificateRequest{
+		Subject: *subject,
+	}
+
+	dnsNamesI := d.Get("dns_names").([]interface{})
+	for _, nameI := range dnsNamesI {
+		certReq.DNSNames = append(certReq.DNSNames, nameI.(string))
+	}
+	ipAddressesI := d.Get("ip_addresses").([]interface{})
+	for _, ipStrI := range ipAddressesI {
+		ip := net.ParseIP(ipStrI.(string))
+		if ip == nil {
+			return fmt.Errorf("invalid IP address %#v", ipStrI.(string))
+		}
+		certReq.IPAddresses = append(certReq.IPAddresses, ip)
+	}
+
+	certReqBytes, err := x509.CreateCertificateRequest(rand.Reader, &certReq, key)
+	if err != nil {
+		return fmt.Errorf("Error creating certificate request: %s", err)
+	}
+	certReqPem := string(pem.EncodeToMemory(&pem.Block{Type: pemCertReqType, Bytes: certReqBytes}))
+
+	d.SetId(hashForState(string(certReqBytes)))
+	d.Set("cert_request_pem", certReqPem)
+
+	return nil
+}
+
+func DeleteCertRequest(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("")
+	return nil
+}
+
+func ReadCertRequest(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}

--- a/vendor/github.com/terraform-providers/terraform-provider-tls/tls/resource_certificate.go
+++ b/vendor/github.com/terraform-providers/terraform-provider-tls/tls/resource_certificate.go
@@ -1,0 +1,210 @@
+package tls
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha1"
+	"crypto/x509"
+	"encoding/asn1"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+const pemCertType = "CERTIFICATE"
+
+var keyUsages map[string]x509.KeyUsage = map[string]x509.KeyUsage{
+	"digital_signature":  x509.KeyUsageDigitalSignature,
+	"content_commitment": x509.KeyUsageContentCommitment,
+	"key_encipherment":   x509.KeyUsageKeyEncipherment,
+	"data_encipherment":  x509.KeyUsageDataEncipherment,
+	"key_agreement":      x509.KeyUsageKeyAgreement,
+	"cert_signing":       x509.KeyUsageCertSign,
+	"crl_signing":        x509.KeyUsageCRLSign,
+	"encipher_only":      x509.KeyUsageEncipherOnly,
+	"decipher_only":      x509.KeyUsageDecipherOnly,
+}
+
+var extKeyUsages map[string]x509.ExtKeyUsage = map[string]x509.ExtKeyUsage{
+	"any_extended":                  x509.ExtKeyUsageAny,
+	"server_auth":                   x509.ExtKeyUsageServerAuth,
+	"client_auth":                   x509.ExtKeyUsageClientAuth,
+	"code_signing":                  x509.ExtKeyUsageCodeSigning,
+	"email_protection":              x509.ExtKeyUsageEmailProtection,
+	"ipsec_end_system":              x509.ExtKeyUsageIPSECEndSystem,
+	"ipsec_tunnel":                  x509.ExtKeyUsageIPSECTunnel,
+	"ipsec_user":                    x509.ExtKeyUsageIPSECUser,
+	"timestamping":                  x509.ExtKeyUsageTimeStamping,
+	"ocsp_signing":                  x509.ExtKeyUsageOCSPSigning,
+	"microsoft_server_gated_crypto": x509.ExtKeyUsageMicrosoftServerGatedCrypto,
+	"netscape_server_gated_crypto":  x509.ExtKeyUsageNetscapeServerGatedCrypto,
+}
+
+// rsaPublicKey reflects the ASN.1 structure of a PKCS#1 public key.
+type rsaPublicKey struct {
+	N *big.Int
+	E int
+}
+
+// generateSubjectKeyID generates a SHA-1 hash of the subject public key.
+func generateSubjectKeyID(pub crypto.PublicKey) ([]byte, error) {
+	var publicKeyBytes []byte
+	var err error
+
+	switch pub := pub.(type) {
+	case *rsa.PublicKey:
+		publicKeyBytes, err = asn1.Marshal(rsaPublicKey{N: pub.N, E: pub.E})
+		if err != nil {
+			return nil, err
+		}
+	case *ecdsa.PublicKey:
+		publicKeyBytes = elliptic.Marshal(pub.Curve, pub.X, pub.Y)
+	default:
+		return nil, errors.New("only RSA and ECDSA public keys supported")
+	}
+
+	hash := sha1.Sum(publicKeyBytes)
+	return hash[:], nil
+}
+
+func resourceCertificateCommonSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"validity_period_hours": &schema.Schema{
+			Type:        schema.TypeInt,
+			Required:    true,
+			Description: "Number of hours that the certificate will remain valid for",
+			ForceNew:    true,
+		},
+
+		"early_renewal_hours": &schema.Schema{
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Default:     0,
+			Description: "Number of hours before the certificates expiry when a new certificate will be generated",
+			ForceNew:    true,
+		},
+
+		"is_ca_certificate": &schema.Schema{
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Whether the generated certificate will be usable as a CA certificate",
+			ForceNew:    true,
+		},
+
+		"allowed_uses": &schema.Schema{
+			Type:        schema.TypeList,
+			Required:    true,
+			Description: "Uses that are allowed for the certificate",
+			ForceNew:    true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+
+		"cert_pem": &schema.Schema{
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+
+		"validity_start_time": &schema.Schema{
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+
+		"validity_end_time": &schema.Schema{
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+	}
+}
+
+func createCertificate(d *schema.ResourceData, template, parent *x509.Certificate, pub crypto.PublicKey, priv interface{}) error {
+	var err error
+
+	template.NotBefore = time.Now()
+	template.NotAfter = template.NotBefore.Add(time.Duration(d.Get("validity_period_hours").(int)) * time.Hour)
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	template.SerialNumber, err = rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return fmt.Errorf("failed to generate serial number: %s", err)
+	}
+
+	keyUsesI := d.Get("allowed_uses").([]interface{})
+	for _, keyUseI := range keyUsesI {
+		keyUse := keyUseI.(string)
+		if usage, ok := keyUsages[keyUse]; ok {
+			template.KeyUsage |= usage
+		}
+		if usage, ok := extKeyUsages[keyUse]; ok {
+			template.ExtKeyUsage = append(template.ExtKeyUsage, usage)
+		}
+	}
+
+	if d.Get("is_ca_certificate").(bool) {
+		template.IsCA = true
+
+		template.SubjectKeyId, err = generateSubjectKeyID(pub)
+		if err != nil {
+			return fmt.Errorf("failed to set subject key identifier: %s", err)
+		}
+	}
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, template, parent, pub, priv)
+	if err != nil {
+		return fmt.Errorf("error creating certificate: %s", err)
+	}
+	certPem := string(pem.EncodeToMemory(&pem.Block{Type: pemCertType, Bytes: certBytes}))
+
+	validFromBytes, err := template.NotBefore.MarshalText()
+	if err != nil {
+		return fmt.Errorf("error serializing validity_start_time: %s", err)
+	}
+	validToBytes, err := template.NotAfter.MarshalText()
+	if err != nil {
+		return fmt.Errorf("error serializing validity_end_time: %s", err)
+	}
+
+	d.SetId(template.SerialNumber.String())
+	d.Set("cert_pem", certPem)
+	d.Set("validity_start_time", string(validFromBytes))
+	d.Set("validity_end_time", string(validToBytes))
+
+	return nil
+}
+
+func DeleteCertificate(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("")
+	return nil
+}
+
+func ReadCertificate(d *schema.ResourceData, meta interface{}) error {
+
+	endTimeStr := d.Get("validity_end_time").(string)
+	endTime := time.Now()
+	err := endTime.UnmarshalText([]byte(endTimeStr))
+	if err != nil {
+		// If end time is invalid then we'll just throw away the whole
+		// thing so we can generate a new one.
+		d.SetId("")
+		return nil
+	}
+
+	earlyRenewalPeriod := time.Duration(-d.Get("early_renewal_hours").(int)) * time.Hour
+	endTime = endTime.Add(earlyRenewalPeriod)
+
+	if time.Now().After(endTime) {
+		// Treat an expired certificate as not existing, so we'll generate
+		// a new one with the next plan.
+		d.SetId("")
+	}
+
+	return nil
+}

--- a/vendor/github.com/terraform-providers/terraform-provider-tls/tls/resource_locally_signed_cert.go
+++ b/vendor/github.com/terraform-providers/terraform-provider-tls/tls/resource_locally_signed_cert.go
@@ -1,0 +1,79 @@
+package tls
+
+import (
+	"crypto/x509"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceLocallySignedCert() *schema.Resource {
+	s := resourceCertificateCommonSchema()
+
+	s["cert_request_pem"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "PEM-encoded certificate request",
+		ForceNew:    true,
+		StateFunc: func(v interface{}) string {
+			return hashForState(v.(string))
+		},
+	}
+
+	s["ca_key_algorithm"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "Name of the algorithm used to generate the certificate's private key",
+		ForceNew:    true,
+	}
+
+	s["ca_private_key_pem"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "PEM-encoded CA private key used to sign the certificate",
+		ForceNew:    true,
+		StateFunc: func(v interface{}) string {
+			return hashForState(v.(string))
+		},
+	}
+
+	s["ca_cert_pem"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "PEM-encoded CA certificate",
+		ForceNew:    true,
+		StateFunc: func(v interface{}) string {
+			return hashForState(v.(string))
+		},
+	}
+
+	return &schema.Resource{
+		Create: CreateLocallySignedCert,
+		Delete: DeleteCertificate,
+		Read:   ReadCertificate,
+		Schema: s,
+	}
+}
+
+func CreateLocallySignedCert(d *schema.ResourceData, meta interface{}) error {
+	certReq, err := parseCertificateRequest(d, "cert_request_pem")
+	if err != nil {
+		return err
+	}
+	caKey, err := parsePrivateKey(d, "ca_private_key_pem", "ca_key_algorithm")
+	if err != nil {
+		return err
+	}
+	caCert, err := parseCertificate(d, "ca_cert_pem")
+	if err != nil {
+		return err
+	}
+
+	cert := x509.Certificate{
+		Subject:               certReq.Subject,
+		DNSNames:              certReq.DNSNames,
+		IPAddresses:           certReq.IPAddresses,
+		BasicConstraintsValid: true,
+	}
+
+	return createCertificate(d, &cert, caCert, certReq.PublicKey, caKey)
+}

--- a/vendor/github.com/terraform-providers/terraform-provider-tls/tls/resource_private_key.go
+++ b/vendor/github.com/terraform-providers/terraform-provider-tls/tls/resource_private_key.go
@@ -1,0 +1,178 @@
+package tls
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+type keyAlgo func(d *schema.ResourceData) (interface{}, error)
+type keyParser func([]byte) (interface{}, error)
+
+var keyAlgos map[string]keyAlgo = map[string]keyAlgo{
+	"RSA": func(d *schema.ResourceData) (interface{}, error) {
+		rsaBits := d.Get("rsa_bits").(int)
+		return rsa.GenerateKey(rand.Reader, rsaBits)
+	},
+	"ECDSA": func(d *schema.ResourceData) (interface{}, error) {
+		curve := d.Get("ecdsa_curve").(string)
+		switch curve {
+		case "P224":
+			return ecdsa.GenerateKey(elliptic.P224(), rand.Reader)
+		case "P256":
+			return ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		case "P384":
+			return ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+		case "P521":
+			return ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+		default:
+			return nil, fmt.Errorf("invalid ecdsa_curve; must be P224, P256, P384 or P521")
+		}
+	},
+}
+
+var keyParsers map[string]keyParser = map[string]keyParser{
+	"RSA": func(der []byte) (interface{}, error) {
+		return x509.ParsePKCS1PrivateKey(der)
+	},
+	"ECDSA": func(der []byte) (interface{}, error) {
+		return x509.ParseECPrivateKey(der)
+	},
+}
+
+func resourcePrivateKey() *schema.Resource {
+	return &schema.Resource{
+		Create: CreatePrivateKey,
+		Delete: DeletePrivateKey,
+		Read:   ReadPrivateKey,
+
+		Schema: map[string]*schema.Schema{
+			"algorithm": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of the algorithm to use to generate the private key",
+				ForceNew:    true,
+			},
+
+			"rsa_bits": &schema.Schema{
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Number of bits to use when generating an RSA key",
+				ForceNew:    true,
+				Default:     2048,
+			},
+
+			"ecdsa_curve": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "ECDSA curve to use when generating a key",
+				ForceNew:    true,
+				Default:     "P224",
+			},
+
+			"private_key_pem": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"public_key_pem": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"public_key_openssh": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func CreatePrivateKey(d *schema.ResourceData, meta interface{}) error {
+	keyAlgoName := d.Get("algorithm").(string)
+	var keyFunc keyAlgo
+	var ok bool
+	if keyFunc, ok = keyAlgos[keyAlgoName]; !ok {
+		return fmt.Errorf("invalid key_algorithm %#v", keyAlgoName)
+	}
+
+	key, err := keyFunc(d)
+	if err != nil {
+		return err
+	}
+
+	var keyPemBlock *pem.Block
+	switch k := key.(type) {
+	case *rsa.PrivateKey:
+		keyPemBlock = &pem.Block{
+			Type:  "RSA PRIVATE KEY",
+			Bytes: x509.MarshalPKCS1PrivateKey(k),
+		}
+	case *ecdsa.PrivateKey:
+		keyBytes, err := x509.MarshalECPrivateKey(k)
+		if err != nil {
+			return fmt.Errorf("error encoding key to PEM: %s", err)
+		}
+		keyPemBlock = &pem.Block{
+			Type:  "EC PRIVATE KEY",
+			Bytes: keyBytes,
+		}
+	default:
+		return fmt.Errorf("unsupported private key type")
+	}
+	keyPem := string(pem.EncodeToMemory(keyPemBlock))
+
+	pubKey := publicKey(key)
+	pubKeyBytes, err := x509.MarshalPKIXPublicKey(pubKey)
+	if err != nil {
+		return fmt.Errorf("failed to marshal public key: %s", err)
+	}
+	pubKeyPemBlock := &pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: pubKeyBytes,
+	}
+
+	d.SetId(hashForState(string((pubKeyBytes))))
+	d.Set("private_key_pem", keyPem)
+	d.Set("public_key_pem", string(pem.EncodeToMemory(pubKeyPemBlock)))
+
+	sshPubKey, err := ssh.NewPublicKey(pubKey)
+	if err == nil {
+		// Not all EC types can be SSH keys, so we'll produce this only
+		// if an appropriate type was selected.
+		sshPubKeyBytes := ssh.MarshalAuthorizedKey(sshPubKey)
+		d.Set("public_key_openssh", string(sshPubKeyBytes))
+	} else {
+		d.Set("public_key_openssh", "")
+	}
+
+	return nil
+}
+
+func DeletePrivateKey(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("")
+	return nil
+}
+
+func ReadPrivateKey(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func publicKey(priv interface{}) interface{} {
+	switch k := priv.(type) {
+	case *rsa.PrivateKey:
+		return &k.PublicKey
+	case *ecdsa.PrivateKey:
+		return &k.PublicKey
+	default:
+		return nil
+	}
+}

--- a/vendor/github.com/terraform-providers/terraform-provider-tls/tls/resource_self_signed_cert.go
+++ b/vendor/github.com/terraform-providers/terraform-provider-tls/tls/resource_self_signed_cert.go
@@ -1,0 +1,101 @@
+package tls
+
+import (
+	"crypto/x509"
+	"fmt"
+	"net"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceSelfSignedCert() *schema.Resource {
+	s := resourceCertificateCommonSchema()
+
+	s["subject"] = &schema.Schema{
+		Type:     schema.TypeList,
+		Required: true,
+		Elem:     nameSchema,
+		ForceNew: true,
+	}
+
+	s["dns_names"] = &schema.Schema{
+		Type:        schema.TypeList,
+		Optional:    true,
+		Description: "List of DNS names to use as subjects of the certificate",
+		ForceNew:    true,
+		Elem: &schema.Schema{
+			Type: schema.TypeString,
+		},
+	}
+
+	s["ip_addresses"] = &schema.Schema{
+		Type:        schema.TypeList,
+		Optional:    true,
+		Description: "List of IP addresses to use as subjects of the certificate",
+		ForceNew:    true,
+		Elem: &schema.Schema{
+			Type: schema.TypeString,
+		},
+	}
+
+	s["key_algorithm"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "Name of the algorithm to use to generate the certificate's private key",
+		ForceNew:    true,
+	}
+
+	s["private_key_pem"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "PEM-encoded private key that the certificate will belong to",
+		ForceNew:    true,
+		StateFunc: func(v interface{}) string {
+			return hashForState(v.(string))
+		},
+	}
+
+	return &schema.Resource{
+		Create: CreateSelfSignedCert,
+		Delete: DeleteCertificate,
+		Read:   ReadCertificate,
+		Schema: s,
+	}
+}
+
+func CreateSelfSignedCert(d *schema.ResourceData, meta interface{}) error {
+	key, err := parsePrivateKey(d, "private_key_pem", "key_algorithm")
+	if err != nil {
+		return err
+	}
+
+	subjectConfs := d.Get("subject").([]interface{})
+	if len(subjectConfs) != 1 {
+		return fmt.Errorf("must have exactly one 'subject' block")
+	}
+	subjectConf := subjectConfs[0].(map[string]interface{})
+	subject, err := nameFromResourceData(subjectConf)
+	if err != nil {
+		return fmt.Errorf("invalid subject block: %s", err)
+	}
+
+	cert := x509.Certificate{
+		Subject:               *subject,
+		BasicConstraintsValid: true,
+	}
+
+	dnsNamesI := d.Get("dns_names").([]interface{})
+	for _, nameI := range dnsNamesI {
+		cert.DNSNames = append(cert.DNSNames, nameI.(string))
+	}
+	ipAddressesI := d.Get("ip_addresses").([]interface{})
+	for _, ipStrI := range ipAddressesI {
+		ip := net.ParseIP(ipStrI.(string))
+		if ip == nil {
+			return fmt.Errorf("invalid IP address %#v", ipStrI.(string))
+		}
+		cert.IPAddresses = append(cert.IPAddresses, ip)
+	}
+
+	return createCertificate(d, &cert, &cert, publicKey(key), key)
+}

--- a/vendor/github.com/terraform-providers/terraform-provider-tls/tls/util.go
+++ b/vendor/github.com/terraform-providers/terraform-provider-tls/tls/util.go
@@ -1,0 +1,76 @@
+package tls
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func decodePEM(d *schema.ResourceData, pemKey, pemType string) (*pem.Block, error) {
+	block, _ := pem.Decode([]byte(d.Get(pemKey).(string)))
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block found in %s", pemKey)
+	}
+	if pemType != "" && block.Type != pemType {
+		return nil, fmt.Errorf("invalid PEM type in %s: %s", pemKey, block.Type)
+	}
+
+	return block, nil
+}
+
+func parsePrivateKey(d *schema.ResourceData, pemKey, algoKey string) (interface{}, error) {
+	algoName := d.Get(algoKey).(string)
+
+	keyFunc, ok := keyParsers[algoName]
+	if !ok {
+		return nil, fmt.Errorf("invalid %s: %#v", algoKey, algoName)
+	}
+
+	block, err := decodePEM(d, pemKey, "")
+	if err != nil {
+		return nil, err
+	}
+
+	key, err := keyFunc(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode %s: %s", pemKey, err)
+	}
+
+	return key, nil
+}
+
+func parseCertificate(d *schema.ResourceData, pemKey string) (*x509.Certificate, error) {
+	block, err := decodePEM(d, pemKey, "")
+	if err != nil {
+		return nil, err
+	}
+
+	certs, err := x509.ParseCertificates(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse %s: %s", pemKey, err)
+	}
+	if len(certs) < 1 {
+		return nil, fmt.Errorf("no certificates found in %s", pemKey)
+	}
+	if len(certs) > 1 {
+		return nil, fmt.Errorf("multiple certificates found in %s", pemKey)
+	}
+
+	return certs[0], nil
+}
+
+func parseCertificateRequest(d *schema.ResourceData, pemKey string) (*x509.CertificateRequest, error) {
+	block, err := decodePEM(d, pemKey, pemCertReqType)
+	if err != nil {
+		return nil, err
+	}
+
+	certReq, err := x509.ParseCertificateRequest(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse %s: %s", pemKey, err)
+	}
+
+	return certReq, nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1144,6 +1144,14 @@
 			"revisionTime": "2016-09-27T10:08:44Z"
 		},
 		{
+			"checksumSHA1": "EUR26b2t3XDPxiEMwDBtn8Ajp8A=",
+			"path": "github.com/terraform-providers/terraform-provider-template/template",
+			"revision": "38db8c17785b8a21666fe6c784682186f0c172ed",
+			"revisionTime": "2017-06-21T15:27:00Z",
+			"version": "v0.1.1",
+			"versionExact": "v0.1.1"
+		},
+		{
 			"checksumSHA1": "vE43s37+4CJ2CDU6TlOUOYE0K9c=",
 			"path": "golang.org/x/crypto/bcrypt",
 			"revision": "9477e0b78b9ac3d0b03822fd95422e2fe07627cd",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1152,6 +1152,14 @@
 			"versionExact": "v0.1.1"
 		},
 		{
+			"checksumSHA1": "519bsJW8eD/VZN/d1AfLYziNT3w=",
+			"path": "github.com/terraform-providers/terraform-provider-tls/tls",
+			"revision": "ce653893fc49a0459f8f8e7f59295d5c81d5f1ef",
+			"revisionTime": "2017-06-21T10:02:45Z",
+			"version": "v0.1.0",
+			"versionExact": "v0.1.0"
+		},
+		{
 			"checksumSHA1": "vE43s37+4CJ2CDU6TlOUOYE0K9c=",
 			"path": "golang.org/x/crypto/bcrypt",
 			"revision": "9477e0b78b9ac3d0b03822fd95422e2fe07627cd",


### PR DESCRIPTION
After the 0.10 split providers have new import path but the codebase still contains references to the old one:

```
$ grep -R 'builtin/' ./* | wc -l
      19
```
so this is the first step in addressing it.

I'll submit another PR to update the references and remove old packages once this is merged.