### PR TITLE
Fix ssm_parameter doc line break

### DIFF
--- a/website/docs/r/ssm_parameter.html.markdown
+++ b/website/docs/r/ssm_parameter.html.markdown
@@ -56,6 +56,7 @@ The following arguments are supported:
 * `type` - (Required) The type of the parameter. Valid types are `String`, `StringList` and `SecureString`.
 * `value` - (Required) The value of the parameter.
 * `key_id` - (Optional) The KMS key id or arn for encrypting a SecureString.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
Renders fine on GitHub without the additional linebreak, but the eventual deployed page is incorrect: https://www.terraform.io/docs/providers/aws/r/ssm_parameter.html