### PR TITLE
AWS_METADATA_TIMEOUT configuration environment variable

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -113,6 +113,14 @@ which reduces the chance of leakage.
 You can provide the custom metadata API endpoint via the `AWS_METADATA_ENDPOINT` variable
 which expects the endpoint URL, including the version, and defaults to `http://169.254.169.254:80/latest`.
 
+The default deadline for the EC2 metadata API endpoint is 100 milliseconds,
+which can be overidden by setting the `AWS_METADATA_TIMEOUT` environment
+variable. The variable expects a positive golang Time.Duration string, which is
+a sequence of decimal numbers and a unit suffix; valid suffixes are `ns`
+(nanoseconds), `us` (microseconds), `ms` (milliseconds), `s` (seconds), `m`
+(minutes), and `h` (hours). Examples of valid inputs: `100ms`, `250ms`, `1s`,
+`2.5s`, `2.5m`, `1m30s`.
+
 ### Assume role
 
 If provided with a role ARN, Terraform will attempt to assume this role


### PR DESCRIPTION
We have a custom Terraform authentication server which impersonates the EC2 metadata API endpoint, but our use and implementation would benefit from being able to boost the 100ms API endpoint timeout in our environment.