### PR TITLE
resource/waf: Only set FieldToMatch.Data if not empty

### DIFF
--- a/aws/resource_aws_waf_byte_match_set.go
+++ b/aws/resource_aws_waf_byte_match_set.go
@@ -192,24 +192,6 @@ func flattenWafByteMatchTuples(bmt []*waf.ByteMatchTuple) []interface{} {
 	return out
 }
 
-func expandFieldToMatch(d map[string]interface{}) *waf.FieldToMatch {
-	return &waf.FieldToMatch{
-		Type: aws.String(d["type"].(string)),
-		Data: aws.String(d["data"].(string)),
-	}
-}
-
-func flattenFieldToMatch(fm *waf.FieldToMatch) []interface{} {
-	m := make(map[string]interface{})
-	if fm.Data != nil {
-		m["data"] = *fm.Data
-	}
-	if fm.Type != nil {
-		m["type"] = *fm.Type
-	}
-	return []interface{}{m}
-}
-
 func diffWafByteMatchSetTuples(oldT, newT []interface{}) []*waf.ByteMatchSetUpdate {
 	updates := make([]*waf.ByteMatchSetUpdate, 0)
 

--- a/aws/resource_aws_wafregional_byte_match_set.go
+++ b/aws/resource_aws_wafregional_byte_match_set.go
@@ -213,20 +213,6 @@ func updateByteMatchSetResourceWR(d *schema.ResourceData, oldT, newT []interface
 	return nil
 }
 
-func expandFieldToMatchWR(d map[string]interface{}) *waf.FieldToMatch {
-	return &waf.FieldToMatch{
-		Type: aws.String(d["type"].(string)),
-		Data: aws.String(d["data"].(string)),
-	}
-}
-
-func flattenFieldToMatchWR(fm *waf.FieldToMatch) map[string]interface{} {
-	m := make(map[string]interface{})
-	m["data"] = *fm.Data
-	m["type"] = *fm.Type
-	return m
-}
-
 func diffByteMatchSetTuple(oldT, newT []interface{}) []*waf.ByteMatchSetUpdate {
 	updates := make([]*waf.ByteMatchSetUpdate, 0)
 

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -29,6 +29,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/redshift"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/aws/aws-sdk-go/service/ssm"
+	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/hashicorp/terraform/helper/schema"
 	"gopkg.in/yaml.v2"
 )
@@ -2124,4 +2125,25 @@ func flattenAwsSsmTargets(targets []*ssm.Target) []map[string]interface{} {
 	result = append(result, t)
 
 	return result
+}
+
+func expandFieldToMatch(d map[string]interface{}) *waf.FieldToMatch {
+	ftm := &waf.FieldToMatch{
+		Type: aws.String(d["type"].(string)),
+	}
+	if data, ok := d["data"].(string); ok && data != "" {
+		ftm.Data = aws.String(data)
+	}
+	return ftm
+}
+
+func flattenFieldToMatch(fm *waf.FieldToMatch) []interface{} {
+	m := make(map[string]interface{})
+	if fm.Data != nil {
+		m["data"] = *fm.Data
+	}
+	if fm.Type != nil {
+		m["type"] = *fm.Type
+	}
+	return []interface{}{m}
 }


### PR DESCRIPTION
This is to address the following test failures:

```
=== RUN   TestAccAWSWafSizeConstraintSet_basic
--- FAIL: TestAccAWSWafSizeConstraintSet_basic (9.62s)
    testing.go:428: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_waf_size_constraint_set.size_constraint_set: 1 error(s) occurred:
        
        * aws_waf_size_constraint_set.size_constraint_set: [ERROR] Error updating SizeConstraintSet: [ERROR] Error updating SizeConstraintSet: ValidationException: 1 validation error detected: Value '' at 'updates.1.member.sizeConstraint.field.data' failed to satisfy constraint: Member must have length greater than or equal to 1
            status code: 400, request id: 10c5ea86-57e6-11e7-b001-5f2ac51ee968

=== RUN   TestAccAWSWafSizeConstraintSet_changeConstraints
--- FAIL: TestAccAWSWafSizeConstraintSet_changeConstraints (62.47s)
    testing.go:428: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_waf_size_constraint_set.size_constraint_set: 1 error(s) occurred:
        
        * aws_waf_size_constraint_set.size_constraint_set: [ERROR] Error updating SizeConstraintSet: [ERROR] Error updating SizeConstraintSet: ValidationException: 1 validation error detected: Value '' at 'updates.1.member.sizeConstraint.field.data' failed to satisfy constraint: Member must have length greater than or equal to 1
            status code: 400, request id: 392107d1-57e6-11e7-a49b-c961ff3735fd

=== RUN   TestAccAWSWafSizeConstraintSet_changeNameForceNew
--- FAIL: TestAccAWSWafSizeConstraintSet_changeNameForceNew (13.07s)
    testing.go:428: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_waf_size_constraint_set.size_constraint_set: 1 error(s) occurred:
        
        * aws_waf_size_constraint_set.size_constraint_set: [ERROR] Error updating SizeConstraintSet: [ERROR] Error updating SizeConstraintSet: ValidationException: 1 validation error detected: Value '' at 'updates.1.member.sizeConstraint.field.data' failed to satisfy constraint: Member must have length greater than or equal to 1
            status code: 400, request id: 19896a4c-57e6-11e7-b92a-0706c39b2685

=== RUN   TestAccAWSWafSizeConstraintSet_disappears
--- FAIL: TestAccAWSWafSizeConstraintSet_disappears (15.92s)
    testing.go:428: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_waf_size_constraint_set.size_constraint_set: 1 error(s) occurred:
        
        * aws_waf_size_constraint_set.size_constraint_set: [ERROR] Error updating SizeConstraintSet: [ERROR] Error updating SizeConstraintSet: ValidationException: 1 validation error detected: Value '' at 'updates.1.member.sizeConstraint.field.data' failed to satisfy constraint: Member must have length greater than or equal to 1
            status code: 400, request id: 1b1bc9ba-57e6-11e7-b001-5f2ac51ee968

=== RUN   TestAccAWSWafSqlInjectionMatchSet_basic
--- FAIL: TestAccAWSWafSqlInjectionMatchSet_basic (49.71s)
    testing.go:428: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_waf_sql_injection_match_set.sql_injection_match_set: 1 error(s) occurred:
        
        * aws_waf_sql_injection_match_set.sql_injection_match_set: [ERROR] Error updating SqlInjectionMatchSet: [ERROR] Error updating SqlInjectionMatchSet: ValidationException: 1 validation error detected: Value '' at 'updates.1.member.matchTuple.field.data' failed to satisfy constraint: Member must have length greater than or equal to 1
            status code: 400, request id: 28453c72-57e6-11e7-a49b-c961ff3735fd

=== RUN   TestAccAWSWafSqlInjectionMatchSet_changeNameForceNew
--- FAIL: TestAccAWSWafSqlInjectionMatchSet_changeNameForceNew (75.89s)
    testing.go:428: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_waf_sql_injection_match_set.sql_injection_match_set: 1 error(s) occurred:
        
        * aws_waf_sql_injection_match_set.sql_injection_match_set: [ERROR] Error updating SqlInjectionMatchSet: [ERROR] Error updating SqlInjectionMatchSet: ValidationException: 1 validation error detected: Value '' at 'updates.1.member.matchTuple.field.data' failed to satisfy constraint: Member must have length greater than or equal to 1
            status code: 400, request id: 25a9f874-57e6-11e7-84ae-b3e05f29fbe4

=== RUN   TestAccAWSWafSqlInjectionMatchSet_changeTuples
--- FAIL: TestAccAWSWafSqlInjectionMatchSet_changeTuples (13.34s)
    testing.go:428: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_waf_sql_injection_match_set.sql_injection_match_set: 1 error(s) occurred:
        
        * aws_waf_sql_injection_match_set.sql_injection_match_set: [ERROR] Error updating SqlInjectionMatchSet: [ERROR] Error updating SqlInjectionMatchSet: ValidationException: 1 validation error detected: Value '' at 'updates.1.member.matchTuple.field.data' failed to satisfy constraint: Member must have length greater than or equal to 1
            status code: 400, request id: 30d7e8bc-57e6-11e7-a49b-c961ff3735fd

=== RUN   TestAccAWSWafSqlInjectionMatchSet_disappears
--- FAIL: TestAccAWSWafSqlInjectionMatchSet_disappears (96.60s)
    testing.go:428: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_waf_sql_injection_match_set.sql_injection_match_set: 1 error(s) occurred:
        
        * aws_waf_sql_injection_match_set.sql_injection_match_set: [ERROR] Error updating SqlInjectionMatchSet: [ERROR] Error updating SqlInjectionMatchSet: ValidationException: 1 validation error detected: Value '' at 'updates.1.member.matchTuple.field.data' failed to satisfy constraint: Member must have length greater than or equal to 1
            status code: 400, request id: 526191e8-57e6-11e7-9b2f-d9137289936f

=== RUN   TestAccAWSWafXssMatchSet_basic
--- FAIL: TestAccAWSWafXssMatchSet_basic (72.48s)
    testing.go:428: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_waf_xss_match_set.xss_match_set: 1 error(s) occurred:
        
        * aws_waf_xss_match_set.xss_match_set: [ERROR] Error updating XssMatchSet: [ERROR] Error updating XssMatchSet: ValidationException: 2 validation errors detected: Value '' at 'updates.1.member.matchTuple.field.data' failed to satisfy constraint: Member must have length greater than or equal to 1; Value '' at 'updates.2.member.matchTuple.field.data' failed to satisfy constraint: Member must have length greater than or equal to 1
            status code: 400, request id: 6632a868-57e6-11e7-9b2f-d9137289936f

=== RUN   TestAccAWSWafXssMatchSet_changeNameForceNew
--- FAIL: TestAccAWSWafXssMatchSet_changeNameForceNew (104.10s)
    testing.go:428: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_waf_xss_match_set.xss_match_set: 1 error(s) occurred:
        
        * aws_waf_xss_match_set.xss_match_set: [ERROR] Error updating XssMatchSet: [ERROR] Error updating XssMatchSet: ValidationException: 2 validation errors detected: Value '' at 'updates.1.member.matchTuple.field.data' failed to satisfy constraint: Member must have length greater than or equal to 1; Value '' at 'updates.2.member.matchTuple.field.data' failed to satisfy constraint: Member must have length greater than or equal to 1
            status code: 400, request id: 40aeee9d-57e6-11e7-84ae-b3e05f29fbe4

=== RUN   TestAccAWSWafXssMatchSet_changeTuples
--- FAIL: TestAccAWSWafXssMatchSet_changeTuples (9.17s)
    testing.go:428: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_waf_xss_match_set.xss_match_set: 1 error(s) occurred:
        
        * aws_waf_xss_match_set.xss_match_set: [ERROR] Error updating XssMatchSet: [ERROR] Error updating XssMatchSet: ValidationException: 2 validation errors detected: Value '' at 'updates.1.member.matchTuple.field.data' failed to satisfy constraint: Member must have length greater than or equal to 1; Value '' at 'updates.2.member.matchTuple.field.data' failed to satisfy constraint: Member must have length greater than or equal to 1
            status code: 400, request id: 435492e4-57e6-11e7-a49b-c961ff3735fd

=== RUN   TestAccAWSWafXssMatchSet_disappears
--- FAIL: TestAccAWSWafXssMatchSet_disappears (11.62s)
    testing.go:428: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_waf_xss_match_set.xss_match_set: 1 error(s) occurred:
        
        * aws_waf_xss_match_set.xss_match_set: [ERROR] Error updating XssMatchSet: [ERROR] Error updating XssMatchSet: ValidationException: 2 validation errors detected: Value '' at 'updates.1.member.matchTuple.field.data' failed to satisfy constraint: Member must have length greater than or equal to 1; Value '' at 'updates.2.member.matchTuple.field.data' failed to satisfy constraint: Member must have length greater than or equal to 1
            status code: 400, request id: 440b5f47-57e6-11e7-9c8b-d54fc63c81ce
```
most likely caused by an API change introduced between yesterday (22nd June) and today which includes more strict validation.

### Test results after patch

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSWaf'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSWaf -timeout 120m
=== RUN   TestAccAWSWafByteMatchSet_basic
--- PASS: TestAccAWSWafByteMatchSet_basic (28.58s)
=== RUN   TestAccAWSWafByteMatchSet_changeNameForceNew
--- PASS: TestAccAWSWafByteMatchSet_changeNameForceNew (52.01s)
=== RUN   TestAccAWSWafByteMatchSet_changeTuples
--- PASS: TestAccAWSWafByteMatchSet_changeTuples (44.68s)
=== RUN   TestAccAWSWafByteMatchSet_noTuples
--- PASS: TestAccAWSWafByteMatchSet_noTuples (24.06s)
=== RUN   TestAccAWSWafByteMatchSet_disappears
--- PASS: TestAccAWSWafByteMatchSet_disappears (22.74s)
=== RUN   TestAccAWSWafIPSet_basic
--- PASS: TestAccAWSWafIPSet_basic (28.07s)
=== RUN   TestAccAWSWafIPSet_disappears
--- PASS: TestAccAWSWafIPSet_disappears (21.87s)
=== RUN   TestAccAWSWafIPSet_changeNameForceNew
--- PASS: TestAccAWSWafIPSet_changeNameForceNew (51.60s)
=== RUN   TestAccAWSWafIPSet_changeDescriptors
--- PASS: TestAccAWSWafIPSet_changeDescriptors (46.37s)
=== RUN   TestAccAWSWafIPSet_noDescriptors
--- PASS: TestAccAWSWafIPSet_noDescriptors (25.33s)
=== RUN   TestAccAWSWafRule_basic
--- PASS: TestAccAWSWafRule_basic (38.37s)
=== RUN   TestAccAWSWafRule_changeNameForceNew
--- PASS: TestAccAWSWafRule_changeNameForceNew (69.79s)
=== RUN   TestAccAWSWafRule_disappears
--- PASS: TestAccAWSWafRule_disappears (36.48s)
=== RUN   TestAccAWSWafRule_changePredicates
--- PASS: TestAccAWSWafRule_changePredicates (63.79s)
=== RUN   TestAccAWSWafRule_noPredicates
--- PASS: TestAccAWSWafRule_noPredicates (24.45s)
=== RUN   TestAccAWSWafSizeConstraintSet_basic
--- PASS: TestAccAWSWafSizeConstraintSet_basic (28.08s)
=== RUN   TestAccAWSWafSizeConstraintSet_changeNameForceNew
--- PASS: TestAccAWSWafSizeConstraintSet_changeNameForceNew (54.42s)
=== RUN   TestAccAWSWafSizeConstraintSet_disappears
--- PASS: TestAccAWSWafSizeConstraintSet_disappears (22.61s)
=== RUN   TestAccAWSWafSizeConstraintSet_changeConstraints
--- PASS: TestAccAWSWafSizeConstraintSet_changeConstraints (45.48s)
=== RUN   TestAccAWSWafSizeConstraintSet_noConstraints
--- PASS: TestAccAWSWafSizeConstraintSet_noConstraints (22.98s)
=== RUN   TestAccAWSWafSqlInjectionMatchSet_basic
--- PASS: TestAccAWSWafSqlInjectionMatchSet_basic (25.90s)
=== RUN   TestAccAWSWafSqlInjectionMatchSet_changeNameForceNew
--- PASS: TestAccAWSWafSqlInjectionMatchSet_changeNameForceNew (48.67s)
=== RUN   TestAccAWSWafSqlInjectionMatchSet_disappears
--- PASS: TestAccAWSWafSqlInjectionMatchSet_disappears (21.94s)
=== RUN   TestAccAWSWafSqlInjectionMatchSet_changeTuples
--- PASS: TestAccAWSWafSqlInjectionMatchSet_changeTuples (46.16s)
=== RUN   TestAccAWSWafSqlInjectionMatchSet_noTuples
--- PASS: TestAccAWSWafSqlInjectionMatchSet_noTuples (24.23s)
=== RUN   TestAccAWSWafWebAcl_basic
--- PASS: TestAccAWSWafWebAcl_basic (43.87s)
=== RUN   TestAccAWSWafWebAcl_changeNameForceNew
--- PASS: TestAccAWSWafWebAcl_changeNameForceNew (86.08s)
=== RUN   TestAccAWSWafWebAcl_changeDefaultAction
--- PASS: TestAccAWSWafWebAcl_changeDefaultAction (86.48s)
=== RUN   TestAccAWSWafWebAcl_disappears
--- PASS: TestAccAWSWafWebAcl_disappears (45.32s)
=== RUN   TestAccAWSWafXssMatchSet_basic
--- PASS: TestAccAWSWafXssMatchSet_basic (28.62s)
=== RUN   TestAccAWSWafXssMatchSet_changeNameForceNew
--- PASS: TestAccAWSWafXssMatchSet_changeNameForceNew (51.81s)
=== RUN   TestAccAWSWafXssMatchSet_disappears
--- PASS: TestAccAWSWafXssMatchSet_disappears (22.57s)
=== RUN   TestAccAWSWafXssMatchSet_changeTuples
--- PASS: TestAccAWSWafXssMatchSet_changeTuples (46.51s)
=== RUN   TestAccAWSWafXssMatchSet_noTuples
--- PASS: TestAccAWSWafXssMatchSet_noTuples (24.63s)
=== RUN   TestAccAWSWafRegionalByteMatchSet_basic
--- PASS: TestAccAWSWafRegionalByteMatchSet_basic (31.85s)
=== RUN   TestAccAWSWafRegionalByteMatchSet_changeNameForceNew
--- PASS: TestAccAWSWafRegionalByteMatchSet_changeNameForceNew (60.15s)
=== RUN   TestAccAWSWafRegionalByteMatchSet_changeByteMatchTuple
--- PASS: TestAccAWSWafRegionalByteMatchSet_changeByteMatchTuple (54.52s)
=== RUN   TestAccAWSWafRegionalByteMatchSet_noByteMatchTuples
--- PASS: TestAccAWSWafRegionalByteMatchSet_noByteMatchTuples (28.97s)
=== RUN   TestAccAWSWafRegionalByteMatchSet_disappears
--- PASS: TestAccAWSWafRegionalByteMatchSet_disappears (26.40s)
=== RUN   TestAccAWSWafRegionalIPSet_basic
--- PASS: TestAccAWSWafRegionalIPSet_basic (31.53s)
=== RUN   TestAccAWSWafRegionalIPSet_disappears
--- PASS: TestAccAWSWafRegionalIPSet_disappears (25.89s)
=== RUN   TestAccAWSWafRegionalIPSet_changeNameForceNew
--- PASS: TestAccAWSWafRegionalIPSet_changeNameForceNew (56.84s)
=== RUN   TestAccAWSWafRegionalIPSet_changeDescriptors
--- PASS: TestAccAWSWafRegionalIPSet_changeDescriptors (52.43s)
=== RUN   TestAccAWSWafRegionalIPSet_noDescriptors
--- PASS: TestAccAWSWafRegionalIPSet_noDescriptors (27.99s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1751.166s
```