### PR TITLE
r/elastic_beanstalk_application_version: Scope labels to application

### DIFF
--- a/aws/resource_aws_elastic_beanstalk_application_version.go
+++ b/aws/resource_aws_elastic_beanstalk_application_version.go
@@ -3,13 +3,12 @@ package aws
 import (
 	"fmt"
 	"log"
-
-	"github.com/hashicorp/terraform/helper/schema"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/elasticbeanstalk"
-	"time"
+	"github.com/hashicorp/terraform/helper/schema"
 )
 
 func resourceAwsElasticBeanstalkApplicationVersion() *schema.Resource {
@@ -90,9 +89,9 @@ func resourceAwsElasticBeanstalkApplicationVersionRead(d *schema.ResourceData, m
 	conn := meta.(*AWSClient).elasticbeanstalkconn
 
 	resp, err := conn.DescribeApplicationVersions(&elasticbeanstalk.DescribeApplicationVersionsInput{
-		VersionLabels: []*string{aws.String(d.Id())},
+		ApplicationName: aws.String(d.Get("application").(string)),
+		VersionLabels:   []*string{aws.String(d.Id())},
 	})
-
 	if err != nil {
 		return err
 	}
@@ -104,7 +103,8 @@ func resourceAwsElasticBeanstalkApplicationVersionRead(d *schema.ResourceData, m
 
 		return nil
 	} else if len(resp.ApplicationVersions) != 1 {
-		return fmt.Errorf("Error reading application version properties: found %d application versions, expected 1", len(resp.ApplicationVersions))
+		return fmt.Errorf("Error reading application version properties: found %d versions of label %q, expected 1",
+			len(resp.ApplicationVersions), d.Id())
 	}
 
 	if err := d.Set("description", resp.ApplicationVersions[0].Description); err != nil {


### PR DESCRIPTION
This is to prevent issues mentioned in https://github.com/terraform-providers/terraform-provider-aws/pull/954 by scoping the version lookup to the given application name.

### Test plan

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSBeanstalkApp'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSBeanstalk -timeout 120m
=== RUN   TestAccAWSBeanstalkApp_basic
--- PASS: TestAccAWSBeanstalkApp_basic (49.85s)
=== RUN   TestAccAWSBeanstalkAppVersion_basic
--- PASS: TestAccAWSBeanstalkAppVersion_basic (84.59s)
=== RUN   TestAccAWSBeanstalkAppVersion_duplicateLabels
--- PASS: TestAccAWSBeanstalkAppVersion_duplicateLabels (116.77s)
```