### PR TITLE
aws_s3_bucket: Fix can not use days = 0 with lifecycle transition.

### DIFF
--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -240,8 +240,9 @@ func resourceAwsS3Bucket() *schema.Resource {
 										ValidateFunc: validateS3BucketLifecycleTimestamp,
 									},
 									"days": {
-										Type:     schema.TypeInt,
-										Optional: true,
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validateS3BucketLifecycleExpirationDays,
 									},
 									"expired_object_delete_marker": {
 										Type:     schema.TypeBool,
@@ -257,8 +258,9 @@ func resourceAwsS3Bucket() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"days": {
-										Type:     schema.TypeInt,
-										Optional: true,
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validateS3BucketLifecycleExpirationDays,
 									},
 								},
 							},
@@ -275,8 +277,9 @@ func resourceAwsS3Bucket() *schema.Resource {
 										ValidateFunc: validateS3BucketLifecycleTimestamp,
 									},
 									"days": {
-										Type:     schema.TypeInt,
-										Optional: true,
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validateS3BucketLifecycleTransitionDays,
 									},
 									"storage_class": {
 										Type:         schema.TypeString,
@@ -293,8 +296,9 @@ func resourceAwsS3Bucket() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"days": {
-										Type:     schema.TypeInt,
-										Optional: true,
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validateS3BucketLifecycleTransitionDays,
 									},
 									"storage_class": {
 										Type:         schema.TypeString,
@@ -1580,7 +1584,7 @@ func resourceAwsS3BucketLifecycleUpdate(s3conn *s3.S3, d *schema.ResourceData) e
 						return fmt.Errorf("Error Parsing AWS S3 Bucket Lifecycle Expiration Date: %s", err.Error())
 					}
 					i.Date = aws.Time(t)
-				} else if val, ok := transition["days"].(int); ok && val > 0 {
+				} else if val, ok := transition["days"].(int); ok && val >= 0 {
 					i.Days = aws.Int64(int64(val))
 				}
 				if val, ok := transition["storage_class"].(string); ok && val != "" {
@@ -1597,7 +1601,7 @@ func resourceAwsS3BucketLifecycleUpdate(s3conn *s3.S3, d *schema.ResourceData) e
 			for _, transition := range nc_transitions {
 				transition := transition.(map[string]interface{})
 				i := &s3.NoncurrentVersionTransition{}
-				if val, ok := transition["days"].(int); ok && val > 0 {
+				if val, ok := transition["days"].(int); ok && val >= 0 {
 					i.NoncurrentDays = aws.Int64(int64(val))
 				}
 				if val, ok := transition["storage_class"].(string); ok && val != "" {

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -594,6 +594,12 @@ func TestAccAWSS3Bucket_Lifecycle(t *testing.T) {
 						"aws_s3_bucket.bucket", "lifecycle_rule.1.expiration.2855832418.days", "0"),
 					resource.TestCheckResourceAttr(
 						"aws_s3_bucket.bucket", "lifecycle_rule.1.expiration.2855832418.expired_object_delete_marker", "false"),
+					resource.TestCheckResourceAttr(
+						"aws_s3_bucket.bucket", "lifecycle_rule.2.id", "id3"),
+					resource.TestCheckResourceAttr(
+						"aws_s3_bucket.bucket", "lifecycle_rule.2.prefix", "path3/"),
+					resource.TestCheckResourceAttr(
+						"aws_s3_bucket.bucket", "lifecycle_rule.2.transition.460947558.days", "0"),
 				),
 			},
 			{
@@ -624,6 +630,14 @@ func TestAccAWSS3Bucket_Lifecycle(t *testing.T) {
 						"aws_s3_bucket.bucket", "lifecycle_rule.1.enabled", "false"),
 					resource.TestCheckResourceAttr(
 						"aws_s3_bucket.bucket", "lifecycle_rule.1.noncurrent_version_expiration.80908210.days", "365"),
+					resource.TestCheckResourceAttr(
+						"aws_s3_bucket.bucket", "lifecycle_rule.2.id", "id3"),
+					resource.TestCheckResourceAttr(
+						"aws_s3_bucket.bucket", "lifecycle_rule.2.prefix", "path3/"),
+					resource.TestCheckResourceAttr(
+						"aws_s3_bucket.bucket", "lifecycle_rule.2.noncurrent_version_transition.3732708140.days", "0"),
+					resource.TestCheckResourceAttr(
+						"aws_s3_bucket.bucket", "lifecycle_rule.2.noncurrent_version_transition.3732708140.storage_class", "GLACIER"),
 				),
 			},
 			{
@@ -1430,6 +1444,16 @@ resource "aws_s3_bucket" "bucket" {
 			date = "2016-01-12"
 		}
 	}
+	lifecycle_rule {
+		id = "id3"
+		prefix = "path3/"
+		enabled = true
+
+		transition {
+			days = 0
+			storage_class = "GLACIER"
+		}
+	}
 }
 `, randInt)
 }
@@ -1466,6 +1490,16 @@ resource "aws_s3_bucket" "bucket" {
 
 		noncurrent_version_expiration {
 			days = 365
+		}
+	}
+	lifecycle_rule {
+		id = "id3"
+		prefix = "path3/"
+		enabled = true
+
+		noncurrent_version_transition {
+			days = 0
+			storage_class = "GLACIER"
 		}
 	}
 }

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -516,6 +516,24 @@ func validateS3BucketLifecycleTimestamp(v interface{}, k string) (ws []string, e
 	return
 }
 
+func validateS3BucketLifecycleExpirationDays(v interface{}, k string) (ws []string, errors []error) {
+	if v.(int) <= 0 {
+		errors = append(errors, fmt.Errorf(
+			"%q must be greater than 0", k))
+	}
+
+	return
+}
+
+func validateS3BucketLifecycleTransitionDays(v interface{}, k string) (ws []string, errors []error) {
+	if v.(int) < 0 {
+		errors = append(errors, fmt.Errorf(
+			"%q must be greater than 0", k))
+	}
+
+	return
+}
+
 func validateS3BucketLifecycleStorageClass(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if value != s3.TransitionStorageClassStandardIa && value != s3.TransitionStorageClassGlacier {

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -495,6 +495,60 @@ func TestValidateS3BucketLifecycleTimestamp(t *testing.T) {
 	}
 }
 
+func TestValidateS3BucketLifecycleExpirationDays(t *testing.T) {
+	validDays := []int{
+		1,
+		31,
+		1024,
+	}
+
+	for _, v := range validDays {
+		_, errors := validateS3BucketLifecycleExpirationDays(v, "days")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be valid days: %q", v, errors)
+		}
+	}
+
+	invalidDays := []int{
+		-1,
+		0,
+	}
+
+	for _, v := range invalidDays {
+		_, errors := validateS3BucketLifecycleExpirationDays(v, "date")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be invalid days", v)
+		}
+	}
+}
+
+func TestValidateS3BucketLifecycleTransitionDays(t *testing.T) {
+	validDays := []int{
+		0,
+		1,
+		31,
+		1024,
+	}
+
+	for _, v := range validDays {
+		_, errors := validateS3BucketLifecycleTransitionDays(v, "days")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be valid days: %q", v, errors)
+		}
+	}
+
+	invalidDays := []int{
+		-1,
+	}
+
+	for _, v := range invalidDays {
+		_, errors := validateS3BucketLifecycleTransitionDays(v, "date")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be invalid days", v)
+		}
+	}
+}
+
 func TestValidateS3BucketLifecycleStorageClass(t *testing.T) {
 	validStorageClass := []string{
 		"STANDARD_IA",


### PR DESCRIPTION
Add validate function in S3 bucket lifecycle's days attributes.

[Put Bucket lifecycle](http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTlifecycle.html)
> Type: Nonnegative Integer when used with Transition, Positive Integer when used with Expiration.

### Test
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSS3Bucket_Lifecycle'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSS3Bucket_Lifecycle -timeout 120m
=== RUN   TestAccAWSS3Bucket_Lifecycle
--- PASS: TestAccAWSS3Bucket_Lifecycle (74.01s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       74.026s
```

Fixes: #952 
