### PR TITLE
Add BGP related information on aws_vpn_connection

### DIFF
--- a/aws/resource_aws_vpn_connection.go
+++ b/aws/resource_aws_vpn_connection.go
@@ -24,6 +24,8 @@ type XmlVpnConnectionConfig struct {
 
 type XmlIpsecTunnel struct {
 	OutsideAddress   string `xml:"vpn_gateway>tunnel_outside_address>ip_address"`
+	BGPASN           string `xml:"vpn_gateway>bgp>asn"`
+	BGPHoldTime      int    `xml:"vpn_gateway>bgp>hold_time"`
 	PreSharedKey     string `xml:"ike>pre_shared_key"`
 	CgwInsideAddress string `xml:"customer_gateway>tunnel_inside_address>ip_address"`
 	VgwInsideAddress string `xml:"vpn_gateway>tunnel_inside_address>ip_address"`
@@ -34,10 +36,14 @@ type TunnelInfo struct {
 	Tunnel1CgwInsideAddress string
 	Tunnel1VgwInsideAddress string
 	Tunnel1PreSharedKey     string
+	Tunnel1BGPASN           string
+	Tunnel1BGPHoldTime      int
 	Tunnel2Address          string
 	Tunnel2CgwInsideAddress string
 	Tunnel2VgwInsideAddress string
 	Tunnel2PreSharedKey     string
+	Tunnel2BGPASN           string
+	Tunnel2BGPHoldTime      int
 }
 
 func (slice XmlVpnConnectionConfig) Len() int {
@@ -116,7 +122,14 @@ func resourceAwsVpnConnection() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
+			"tunnel1_bgp_asn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tunnel1_bgp_holdtime": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 			"tunnel2_address": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -136,7 +149,14 @@ func resourceAwsVpnConnection() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
+			"tunnel2_bgp_asn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tunnel2_bgp_holdtime": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 			"routes": {
 				Type:     schema.TypeSet,
 				Computed: true,
@@ -352,10 +372,14 @@ func resourceAwsVpnConnectionRead(d *schema.ResourceData, meta interface{}) erro
 			d.Set("tunnel1_cgw_inside_address", tunnelInfo.Tunnel1CgwInsideAddress)
 			d.Set("tunnel1_vgw_inside_address", tunnelInfo.Tunnel1VgwInsideAddress)
 			d.Set("tunnel1_preshared_key", tunnelInfo.Tunnel1PreSharedKey)
+			d.Set("tunnel1_bgp_asn", tunnelInfo.Tunnel1BGPASN)
+			d.Set("tunnel1_bgp_holdtime", tunnelInfo.Tunnel1BGPHoldTime)
 			d.Set("tunnel2_address", tunnelInfo.Tunnel2Address)
 			d.Set("tunnel2_preshared_key", tunnelInfo.Tunnel2PreSharedKey)
 			d.Set("tunnel2_cgw_inside_address", tunnelInfo.Tunnel2CgwInsideAddress)
 			d.Set("tunnel2_vgw_inside_address", tunnelInfo.Tunnel2VgwInsideAddress)
+			d.Set("tunnel2_bgp_asn", tunnelInfo.Tunnel2BGPASN)
+			d.Set("tunnel2_bgp_holdtime", tunnelInfo.Tunnel2BGPHoldTime)
 		}
 	}
 
@@ -473,11 +497,14 @@ func xmlConfigToTunnelInfo(xmlConfig string) (*TunnelInfo, error) {
 		Tunnel1PreSharedKey:     vpnConfig.Tunnels[0].PreSharedKey,
 		Tunnel1CgwInsideAddress: vpnConfig.Tunnels[0].CgwInsideAddress,
 		Tunnel1VgwInsideAddress: vpnConfig.Tunnels[0].VgwInsideAddress,
-
+		Tunnel1BGPASN:           vpnConfig.Tunnels[0].BGPASN,
+		Tunnel1BGPHoldTime:      vpnConfig.Tunnels[0].BGPHoldTime,
 		Tunnel2Address:          vpnConfig.Tunnels[1].OutsideAddress,
 		Tunnel2PreSharedKey:     vpnConfig.Tunnels[1].PreSharedKey,
 		Tunnel2CgwInsideAddress: vpnConfig.Tunnels[1].CgwInsideAddress,
 		Tunnel2VgwInsideAddress: vpnConfig.Tunnels[1].VgwInsideAddress,
+		Tunnel2BGPASN:           vpnConfig.Tunnels[1].BGPASN,
+		Tunnel2BGPHoldTime:      vpnConfig.Tunnels[1].BGPHoldTime,
 	}
 
 	return &tunnelInfo, nil

--- a/aws/resource_aws_vpn_connection_test.go
+++ b/aws/resource_aws_vpn_connection_test.go
@@ -244,6 +244,12 @@ func TestAWSVpnConnection_xmlconfig(t *testing.T) {
 	if tunnelInfo.Tunnel1PreSharedKey != "FIRST_KEY" {
 		t.Fatalf("First key from tunnel XML was incorrect.")
 	}
+	if tunnelInfo.Tunnel1BGPASN != "FIRST_BGP_ASN" {
+		t.Fatalf("First bgp asn from tunnel XML was incorrect.")
+	}
+	if tunnelInfo.Tunnel1BGPHoldTime != 31 {
+		t.Fatalf("First bgp holdtime from tunnel XML was incorrect.")
+	}
 	if tunnelInfo.Tunnel2Address != "SECOND_ADDRESS" {
 		t.Fatalf("Second address from tunnel XML was incorrect.")
 	}
@@ -257,6 +263,12 @@ func TestAWSVpnConnection_xmlconfig(t *testing.T) {
 	}
 	if tunnelInfo.Tunnel2PreSharedKey != "SECOND_KEY" {
 		t.Fatalf("Second key from tunnel XML was incorrect.")
+	}
+	if tunnelInfo.Tunnel2BGPASN != "SECOND_BGP_ASN" {
+		t.Fatalf("Second bgp asn from tunnel XML was incorrect.")
+	}
+	if tunnelInfo.Tunnel2BGPHoldTime != 32 {
+		t.Fatalf("Second bgp holdtime from tunnel XML was incorrect.")
 	}
 }
 
@@ -336,6 +348,10 @@ const testAccAwsVpnTunnelInfoXML = `
         <network_mask>255.255.255.252</network_mask>
         <network_cidr>30</network_cidr>
       </tunnel_inside_address>
+      <bgp>
+        <asn>SECOND_BGP_ASN</asn>
+        <hold_time>32</hold_time>
+      </bgp>
     </vpn_gateway>
     <ike>
       <pre_shared_key>SECOND_KEY</pre_shared_key>
@@ -361,6 +377,10 @@ const testAccAwsVpnTunnelInfoXML = `
         <network_mask>255.255.255.252</network_mask>
         <network_cidr>30</network_cidr>
       </tunnel_inside_address>
+      <bgp>
+        <asn>FIRST_BGP_ASN</asn>
+        <hold_time>31</hold_time>
+      </bgp>
     </vpn_gateway>
     <ike>
       <pre_shared_key>FIRST_KEY</pre_shared_key>

--- a/website/docs/r/vpn_connection.html.markdown
+++ b/website/docs/r/vpn_connection.html.markdown
@@ -59,10 +59,14 @@ The following attributes are exported:
 * `tunnel1_cgw_inside_address` - The RFC 6890 link-local address of the first VPN tunnel (Customer Gateway Side).
 * `tunnel1_vgw_inside_address` - The RFC 6890 link-local address of the first VPN tunnel (VPN Gateway Side).
 * `tunnel1_preshared_key` - The preshared key of the first VPN tunnel.
+* `tunnel1_bgp_asn` - The bgp asn number of the first VPN tunnel.
+* `tunnel1_bgp_holdtime` - The bgp holdtime of the first VPN tunnel.
 * `tunnel2_address` - The public IP address of the second VPN tunnel.
 * `tunnel2_cgw_inside_address` - The RFC 6890 link-local address of the second VPN tunnel (Customer Gateway Side).
 * `tunnel2_vgw_inside_address` - The RFC 6890 link-local address of the second VPN tunnel (VPN Gateway Side).
 * `tunnel2_preshared_key` - The preshared key of the second VPN tunnel.
+* `tunnel2_bgp_asn` - The bgp asn number of the second VPN tunnel.
+* `tunnel2_bgp_holdtime` - The bgp holdtime of the second VPN tunnel.
 * `type` - The type of VPN connection.
 * `vpn_gateway_id` - The ID of the virtual private gateway to which the connection is attached.
 


### PR DESCRIPTION
In this commit, we add tunnel1_bgp_asn, tunnel1_bgp_holdtime,
 tunnel2_bgp_asn and tunnel2_bgp_hold time for aws_vpn_connection.
These values are needed to automate dynamic bgp vpn configuraion for
multi cloud provider such as interconnecting GCP and AWS.