### PR TITLE
aws/data/subnet: Add filter example to website

### DIFF
--- a/website/docs/d/subnet.html.markdown
+++ b/website/docs/d/subnet.html.markdown
@@ -71,6 +71,14 @@ which take the following arguments:
 
 * `name` - (Required) The name of the field to filter by, as defined by
   [the underlying AWS API](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSubnets.html).
+  For example, if matching against tag `Name`, use:
+  
+  ```hcl
+  filter {
+    name = "tag:Name"
+    value = ...
+  }
+  ```
 
 * `values` - (Required) Set of values that are accepted for the given field.
   A subnet will be selected if any one of the given values matches.

--- a/website/docs/d/subnet.html.markdown
+++ b/website/docs/d/subnet.html.markdown
@@ -76,7 +76,7 @@ which take the following arguments:
   ```hcl
   filter {
     name = "tag:Name"
-    value = ...
+    values = ...
   }
   ```
 


### PR DESCRIPTION
I found the lack of an example to be extremely unfriendly... 

After consulting the API documentation, I believed the correct syntax was `tag:name=Name` vs the actually correct `tag:Name`.

It was this example which saved me: https://github.com/hashicorp/terraform/issues/10074#issuecomment-260439012