### PR TITLE
enlarge origin_read_timeout validation

### DIFF
--- a/aws/resource_aws_cloudfront_distribution.go
+++ b/aws/resource_aws_cloudfront_distribution.go
@@ -367,7 +367,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 										Type:         schema.TypeInt,
 										Optional:     true,
 										Default:      30,
-										ValidateFunc: validation.IntBetween(4, 60),
+										ValidateFunc: validation.IntBetween(4, 160),
 									},
 									"origin_protocol_policy": {
 										Type:     schema.TypeString,


### PR DESCRIPTION
We asked to AWS to increase the limitation of the parameter origin_read_timeout of cloudfront distribution to 150 seconds (default is 60) and they granted it us.
When we tried to apply these 150 seconds in this parameter with terraform the bellow message appear:

`* module.cloudfront_es.aws_cloudfront_distribution.web: expected origin.1.custom_origin_config.0.origin_read_timeout to be in the range (4 - 60), got 150. `

So we need to increase (or remove) this limitation in terraform too.