### PR TITLE
cloudwatch_event_target: Add ecs_target

### DIFF
--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -64,9 +64,15 @@ The following arguments are supported:
 	that is used for extracting part of the matched event when passing it to the target.
 * `role_arn` - (Optional) The Amazon Resource Name (ARN) of the IAM role to be used for this target when the rule is triggered.
 * `run_command_targets` - (Optional) Parameters used when you are using the rule to invoke Amazon EC2 Run Command. Documented below. A maximum of 5 are allowed.
+* `ecs_target` - (Optional) Parameters used when you are using the rule to invoke Amazon ECS Task. Documented below. A maximum of 1 are allowed.
 
 `run_command_parameters` support the following:
 
 * `key` - (Required) Can be either `tag:tag-key` or `InstanceIds`.
 * `values` - (Required) If Key is `tag:tag-key`, Values is a list of tag values. If Key is `InstanceIds`, Values is a list of Amazon EC2 instance IDs.
+
+`ecs_target` support the following:
+
+* `task_count` - (Optional) The number of tasks to create based on the TaskDefinition. The default is 1.
+* `task_definition_arn` - (Required) The ARN of the task definition to use if the event target is an Amazon ECS cluster.
 


### PR DESCRIPTION
Add `ecs_target` parameter to `aws_cloudwatch_event_target` resource.

This feature can set run task based on CloudWatch Event Trigger.

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCloudWatchEventTarget_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCloudWatchEventTarget_ -timeout 120m
=== RUN   TestAccAWSCloudWatchEventTarget_basic
--- PASS: TestAccAWSCloudWatchEventTarget_basic (36.85s)
=== RUN   TestAccAWSCloudWatchEventTarget_missingTargetId
--- PASS: TestAccAWSCloudWatchEventTarget_missingTargetId (20.25s)
=== RUN   TestAccAWSCloudWatchEventTarget_full
--- PASS: TestAccAWSCloudWatchEventTarget_full (98.58s)
=== RUN   TestAccAWSCloudWatchEventTarget_ssmDocument
--- PASS: TestAccAWSCloudWatchEventTarget_ssmDocument (29.25s)
=== RUN   TestAccAWSCloudWatchEventTarget_ecs
--- PASS: TestAccAWSCloudWatchEventTarget_ecs (31.22s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       216.171s
```