### PR TITLE
s3_bucket_notification: Fix not create `bucket` field when import

### DIFF
--- a/aws/import_aws_s3_bucket_notification_test.go
+++ b/aws/import_aws_s3_bucket_notification_test.go
@@ -20,10 +20,9 @@ func TestAccAWSS3BucketNotification_importBasic(t *testing.T) {
 			},
 
 			resource.TestStep{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"bucket"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -38,10 +37,9 @@ func TestAccAWSS3BucketNotification_importBasic(t *testing.T) {
 			},
 
 			resource.TestStep{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"bucket"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -56,10 +54,9 @@ func TestAccAWSS3BucketNotification_importBasic(t *testing.T) {
 			},
 
 			resource.TestStep{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"bucket"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/aws/resource_aws_s3_bucket_notification.go
+++ b/aws/resource_aws_s3_bucket_notification.go
@@ -378,6 +378,9 @@ func resourceAwsS3BucketNotificationRead(d *schema.ResourceData, meta interface{
 		return err
 	}
 	log.Printf("[DEBUG] S3 Bucket: %s, get notification: %v", d.Id(), notificationConfigs)
+
+	d.Set("bucket", d.Id())
+
 	// Topic Notification
 	if err := d.Set("topic", flattenTopicConfigurations(notificationConfigs.TopicConfigurations)); err != nil {
 		return fmt.Errorf("error reading S3 bucket \"%s\" topic notification: %s", d.Id(), err)


### PR DESCRIPTION
Fixes #895

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSS3BucketNotification_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSS3BucketNotification_ -timeout 120m
=== RUN   TestAccAWSS3BucketNotification_importBasic
--- PASS: TestAccAWSS3BucketNotification_importBasic (117.69s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       117.704s
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSS3Bucket_Notification'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSS3Bucket_Notification -timeout 120m
=== RUN   TestAccAWSS3Bucket_Notification
--- PASS: TestAccAWSS3Bucket_Notification (190.11s)
=== RUN   TestAccAWSS3Bucket_NotificationWithoutFilter
--- PASS: TestAccAWSS3Bucket_NotificationWithoutFilter (70.96s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       261.088s
```