### PR TITLE
provider/aws: Add ARN as an exported param for aws_ecs_cluster

### DIFF
--- a/aws/data_source_aws_ecs_cluster.go
+++ b/aws/data_source_aws_ecs_cluster.go
@@ -63,6 +63,7 @@ func dataSourceAwsEcsClusterRead(d *schema.ResourceData, meta interface{}) error
 			continue
 		}
 		d.SetId(aws.StringValue(cluster.ClusterArn))
+		d.Set("arn", cluster.ClusterArn)
 		d.Set("status", cluster.Status)
 		d.Set("pending_tasks_count", cluster.PendingTasksCount)
 		d.Set("running_tasks_count", cluster.RunningTasksCount)

--- a/aws/data_source_aws_ecs_cluster_test.go
+++ b/aws/data_source_aws_ecs_cluster_test.go
@@ -20,6 +20,7 @@ func TestAccAWSEcsDataSource_ecsCluster(t *testing.T) {
 					resource.TestCheckResourceAttr("data.aws_ecs_cluster.default", "pending_tasks_count", "0"),
 					resource.TestCheckResourceAttr("data.aws_ecs_cluster.default", "running_tasks_count", "0"),
 					resource.TestCheckResourceAttr("data.aws_ecs_cluster.default", "registered_container_instances_count", "0"),
+					resource.TestCheckResourceAttrSet("data.aws_ecs_cluster.default", "arn"),
 				),
 			},
 		},


### PR DESCRIPTION
Fixes: #988

```
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSEcsDataSource'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSEcsDataSource -timeout 120m
=== RUN   TestAccAWSEcsDataSource_ecsCluster
--- PASS: TestAccAWSEcsDataSource_ecsCluster (116.89s)
=== RUN   TestAccAWSEcsDataSource_ecsContainerDefinition
--- PASS: TestAccAWSEcsDataSource_ecsContainerDefinition (116.93s)
=== RUN   TestAccAWSEcsDataSource_ecsTaskDefinition
--- PASS: TestAccAWSEcsDataSource_ecsTaskDefinition (30.72s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	264.579s
```