### PR TITLE
d/aws_db_snapshot: Id was being set incorrectly

### DIFF
--- a/aws/data_source_aws_db_snapshot.go
+++ b/aws/data_source_aws_db_snapshot.go
@@ -192,7 +192,7 @@ func mostRecentDbSnapshot(snapshots []*rds.DBSnapshot) *rds.DBSnapshot {
 }
 
 func dbSnapshotDescriptionAttributes(d *schema.ResourceData, snapshot *rds.DBSnapshot) error {
-	d.SetId(*snapshot.DBInstanceIdentifier)
+	d.SetId(*snapshot.DBSnapshotIdentifier)
 	d.Set("db_instance_identifier", snapshot.DBInstanceIdentifier)
 	d.Set("db_snapshot_identifier", snapshot.DBSnapshotIdentifier)
 	d.Set("snapshot_type", snapshot.SnapshotType)


### PR DESCRIPTION
Fixes #858

In this resource, the ID was (incorrectly) set as the DB Instance
Identifier and NOT the DB Snapshot Identifier