### PR TITLE
r/aws_cloudformation_stack: Add timeout support

### DIFF
--- a/aws/resource_aws_cloudformation_stack.go
+++ b/aws/resource_aws_cloudformation_stack.go
@@ -21,6 +21,12 @@ func resourceAwsCloudFormationStack() *schema.Resource {
 		Update: resourceAwsCloudFormationStackUpdate,
 		Delete: resourceAwsCloudFormationStackDelete,
 
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -105,7 +111,6 @@ func resourceAwsCloudFormationStack() *schema.Resource {
 }
 
 func resourceAwsCloudFormationStackCreate(d *schema.ResourceData, meta interface{}) error {
-	retryTimeout := int64(30)
 	conn := meta.(*AWSClient).cfconn
 
 	input := cloudformation.CreateStackInput{
@@ -152,10 +157,6 @@ func resourceAwsCloudFormationStackCreate(d *schema.ResourceData, meta interface
 	if v, ok := d.GetOk("timeout_in_minutes"); ok {
 		m := int64(v.(int))
 		input.TimeoutInMinutes = aws.Int64(m)
-		if m > retryTimeout {
-			retryTimeout = m + 5
-			log.Printf("[DEBUG] CloudFormation timeout: %d", retryTimeout)
-		}
 	}
 	if v, ok := d.GetOk("iam_role_arn"); ok {
 		input.RoleARN = aws.String(v.(string))
@@ -184,7 +185,7 @@ func resourceAwsCloudFormationStackCreate(d *schema.ResourceData, meta interface
 			"ROLLBACK_COMPLETE",
 			"ROLLBACK_FAILED",
 		},
-		Timeout:    time.Duration(retryTimeout) * time.Minute,
+		Timeout:    d.Timeout(schema.TimeoutCreate),
 		MinTimeout: 1 * time.Second,
 		Refresh: func() (interface{}, string, error) {
 			resp, err := conn.DescribeStacks(&cloudformation.DescribeStacksInput{
@@ -349,7 +350,6 @@ func resourceAwsCloudFormationStackRead(d *schema.ResourceData, meta interface{}
 }
 
 func resourceAwsCloudFormationStackUpdate(d *schema.ResourceData, meta interface{}) error {
-	retryTimeout := int64(30)
 	conn := meta.(*AWSClient).cfconn
 
 	input := &cloudformation.UpdateStackInput{
@@ -416,13 +416,6 @@ func resourceAwsCloudFormationStackUpdate(d *schema.ResourceData, meta interface
 		return err
 	}
 
-	if v, ok := d.GetOk("timeout_in_minutes"); ok {
-		m := int64(v.(int))
-		if m > retryTimeout {
-			retryTimeout = m + 5
-			log.Printf("[DEBUG] CloudFormation timeout: %d", retryTimeout)
-		}
-	}
 	var lastStatus string
 	var stackId string
 	wait := resource.StateChangeConf{
@@ -438,7 +431,7 @@ func resourceAwsCloudFormationStackUpdate(d *schema.ResourceData, meta interface
 			"UPDATE_ROLLBACK_COMPLETE",
 			"UPDATE_ROLLBACK_FAILED",
 		},
-		Timeout:    time.Duration(retryTimeout) * time.Minute,
+		Timeout:    d.Timeout(schema.TimeoutUpdate),
 		MinTimeout: 5 * time.Second,
 		Refresh: func() (interface{}, string, error) {
 			resp, err := conn.DescribeStacks(&cloudformation.DescribeStacksInput{
@@ -508,7 +501,7 @@ func resourceAwsCloudFormationStackDelete(d *schema.ResourceData, meta interface
 			"DELETE_COMPLETE",
 			"DELETE_FAILED",
 		},
-		Timeout:    30 * time.Minute,
+		Timeout:    d.Timeout(schema.TimeoutDelete),
 		MinTimeout: 5 * time.Second,
 		Refresh: func() (interface{}, string, error) {
 			resp, err := conn.DescribeStacks(&cloudformation.DescribeStacksInput{

--- a/website/docs/r/cloudformation_stack.html.markdown
+++ b/website/docs/r/cloudformation_stack.html.markdown
@@ -74,3 +74,14 @@ The following attributes are exported:
 
 * `id` - A unique identifier of the stack.
 * `outputs` - A map of outputs from the stack.
+
+
+<a id="timeouts"></a>
+## Timeouts
+
+`aws_cloudformation_stack` provides the following
+[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+- `create` - (Default `30 minutes`) Used for Creating Stacks
+- `update` - (Default `30 minutes`) Used for Stack modifications
+- `delete` - (Default `30 minutes`) Used for destroying stacks.


### PR DESCRIPTION
Fixes: #961

```
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSCloudFormation_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCloudFormation_ -timeout 120m
=== RUN   TestAccAWSCloudFormation_basic
--- PASS: TestAccAWSCloudFormation_basic (84.48s)
=== RUN   TestAccAWSCloudFormation_yaml
--- PASS: TestAccAWSCloudFormation_yaml (84.53s)
=== RUN   TestAccAWSCloudFormation_defaultParams
--- PASS: TestAccAWSCloudFormation_defaultParams (84.81s)
=== RUN   TestAccAWSCloudFormation_allAttributes
--- PASS: TestAccAWSCloudFormation_allAttributes (131.14s)
=== RUN   TestAccAWSCloudFormation_withParams
--- PASS: TestAccAWSCloudFormation_withParams (157.67s)
=== RUN   TestAccAWSCloudFormation_withUrl_withParams
--- PASS: TestAccAWSCloudFormation_withUrl_withParams (228.50s)
=== RUN   TestAccAWSCloudFormation_withUrl_withParams_withYaml
--- PASS: TestAccAWSCloudFormation_withUrl_withParams_withYaml (135.53s)
=== RUN   TestAccAWSCloudFormation_withUrl_withParams_noUpdate
--- PASS: TestAccAWSCloudFormation_withUrl_withParams_noUpdate (186.99s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1093.670s
```