### PR TITLE
resource/aws_ebs_volume: Not setting the state for ebs_volume correctly

### DIFF
--- a/aws/resource_aws_ebs_volume.go
+++ b/aws/resource_aws_ebs_volume.go
@@ -140,7 +140,7 @@ func resourceAwsEbsVolumeCreate(d *schema.ResourceData, meta interface{}) error 
 		}
 	}
 
-	return readVolume(d, result)
+	return resourceAwsEbsVolumeRead(d, meta)
 }
 
 func resourceAWSEbsVolumeUpdate(d *schema.ResourceData, meta interface{}) error {
@@ -297,9 +297,7 @@ func readVolume(d *schema.ResourceData, volume *ec2.Volume) error {
 		}
 	}
 
-	if volume.Tags != nil {
-		d.Set("tags", tagsToMap(volume.Tags))
-	}
+	d.Set("tags", tagsToMap(volume.Tags))
 
 	return nil
 }


### PR DESCRIPTION
Fixes: #927

When we ran the create, we didn't make a call to the API to Describe the
volume, therefore, we were not actually setting the values to state
based on what the API returned. We also only set the Tags to state if
they were not nil. Therefore, the scenario of someone creating a tag
with Terraform, then removing that tag (and thus no tags are left on the
resource) would mean that Terraform didn't see the state drift:

```
[stacko@Pauls-MBP:~/Code/terraform-org/terraform-recreations/current-working]
% terraform apply
aws_ebs_volume.hashi-test: Creating...
  availability_zone: "" => "eu-central-1a"
  encrypted:         "" => "<computed>"
  iops:              "" => "<computed>"
  kms_key_id:        "" => "<computed>"
  size:              "" => "5"
  snapshot_id:       "" => "<computed>"
  tags.%:            "" => "1"
  tags.Name:         "" => "hashi-test"
  type:              "" => "<computed>"
aws_ebs_volume.hashi-test: Still creating... (10s elapsed)
aws_ebs_volume.hashi-test: Creation complete (ID: vol-01133d4a2d74aa55b)

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

The state of your infrastructure has been saved to the path
below. This state is required to modify and destroy your
infrastructure, so keep it safe. To inspect the complete state
use the `terraform show` command.

State path:
[stacko@Pauls-MBP:~/Code/terraform-org/terraform-recreations/current-working]
% terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

aws_ebs_volume.hashi-test: Refreshing state... (ID: vol-01133d4a2d74aa55b)
No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, Terraform
doesn't need to do anything.
```

This commit takes care of that but always setting the tags - d.Set handles the empty API response so we should use that:

```
% terraform apply
aws_ebs_volume.hashi-test: Creating...
  availability_zone: "" => "eu-central-1a"
  encrypted:         "" => "<computed>"
  iops:              "" => "<computed>"
  kms_key_id:        "" => "<computed>"
  size:              "" => "5"
  snapshot_id:       "" => "<computed>"
  tags.%:            "" => "1"
  tags.Name:         "" => "hashi-test"
  type:              "" => "<computed>"
aws_ebs_volume.hashi-test: Still creating... (10s elapsed)
aws_ebs_volume.hashi-test: Creation complete (ID: vol-0746b8a7d4f6ac0b5)

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

The state of your infrastructure has been saved to the path
below. This state is required to modify and destroy your
infrastructure, so keep it safe. To inspect the complete state
use the `terraform show` command.

State path:
[stacko@Pauls-MBP:~/Code/terraform-org/terraform-recreations/current-working]
% terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

aws_ebs_volume.hashi-test: Refreshing state... (ID: vol-0746b8a7d4f6ac0b5)
The Terraform execution plan has been generated and is shown below.
Resources are shown in alphabetical order for quick scanning. Green resources
will be created (or destroyed and then created if an existing resource
exists), yellow resources are being changed in-place, and red resources
will be destroyed. Cyan entries are data sources to be read.

Note: You didn't specify an "-out" parameter to save this plan, so when
"apply" is called, Terraform can't guarantee this is what will execute.

~ aws_ebs_volume.hashi-test
    tags.%:    "0" => "1"
    tags.Name: "" => "hashi-test"

Plan: 0 to add, 1 to change, 0 to destroy.
```