### PR TITLE
resource/aws_network_acl: Make action in ingress / egress case insensitive

### DIFF
--- a/aws/resource_aws_network_acl.go
+++ b/aws/resource_aws_network_acl.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -71,6 +72,12 @@ func resourceAwsNetworkAcl() *schema.Resource {
 						"action": {
 							Type:     schema.TypeString,
 							Required: true,
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								if strings.ToLower(old) == strings.ToLower(new) {
+									return true
+								}
+								return false
+							},
 						},
 						"protocol": {
 							Type:     schema.TypeString,
@@ -118,6 +125,12 @@ func resourceAwsNetworkAcl() *schema.Resource {
 						"action": {
 							Type:     schema.TypeString,
 							Required: true,
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								if strings.ToLower(old) == strings.ToLower(new) {
+									return true
+								}
+								return false
+							},
 						},
 						"protocol": {
 							Type:     schema.TypeString,
@@ -528,7 +541,7 @@ func resourceAwsNetworkAclEntryHash(v interface{}) int {
 	buf.WriteString(fmt.Sprintf("%d-", m["from_port"].(int)))
 	buf.WriteString(fmt.Sprintf("%d-", m["to_port"].(int)))
 	buf.WriteString(fmt.Sprintf("%d-", m["rule_no"].(int)))
-	buf.WriteString(fmt.Sprintf("%s-", m["action"].(string)))
+	buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(m["action"].(string))))
 
 	// The AWS network ACL API only speaks protocol numbers, and that's
 	// all we store. Never hash a protocol name.


### PR DESCRIPTION
Fixes: #918

Add a diff suppress func to stop case sensitivity issues on the Action
param of ingress and egress. To do this, I had to make sure that the
hash always used the lowercase version (this will mean that users who do
not see a perpetual diff are not affected)

```
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSNetworkAcl_'                                                               ✹ ✭
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSNetworkAcl_ -timeout 120m
=== RUN   TestAccAWSNetworkAcl_importBasic
--- PASS: TestAccAWSNetworkAcl_importBasic (51.69s)
=== RUN   TestAccAWSNetworkAcl_EgressAndIngressRules
--- PASS: TestAccAWSNetworkAcl_EgressAndIngressRules (49.22s)
=== RUN   TestAccAWSNetworkAcl_OnlyIngressRules_basic
--- PASS: TestAccAWSNetworkAcl_OnlyIngressRules_basic (61.61s)
=== RUN   TestAccAWSNetworkAcl_OnlyIngressRules_update
--- PASS: TestAccAWSNetworkAcl_OnlyIngressRules_update (91.95s)
=== RUN   TestAccAWSNetworkAcl_CaseSensitivityNoChanges
--- PASS: TestAccAWSNetworkAcl_CaseSensitivityNoChanges (57.69s)
=== RUN   TestAccAWSNetworkAcl_OnlyEgressRules
--- PASS: TestAccAWSNetworkAcl_OnlyEgressRules (60.46s)
=== RUN   TestAccAWSNetworkAcl_SubnetChange
--- PASS: TestAccAWSNetworkAcl_SubnetChange (92.92s)
=== RUN   TestAccAWSNetworkAcl_Subnets
--- PASS: TestAccAWSNetworkAcl_Subnets (108.76s)
=== RUN   TestAccAWSNetworkAcl_ipv6Rules
--- PASS: TestAccAWSNetworkAcl_ipv6Rules (99.07s)
=== RUN   TestAccAWSNetworkAcl_ipv6VpcRules
--- PASS: TestAccAWSNetworkAcl_ipv6VpcRules (37.64s)
=== RUN   TestAccAWSNetworkAcl_espProtocol
--- PASS: TestAccAWSNetworkAcl_espProtocol (57.23s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	768.271s
```