### PR TITLE
Add support for DynamoDb as an AWS DMS target

### DIFF
--- a/aws/resource_aws_dms_endpoint.go
+++ b/aws/resource_aws_dms_endpoint.go
@@ -43,6 +43,10 @@ func resourceAwsDmsEndpoint() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validateDmsEndpointId,
 			},
+			"service_access_role": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"endpoint_type": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -58,6 +62,7 @@ func resourceAwsDmsEndpoint() *schema.Resource {
 					"mysql",
 					"oracle",
 					"postgres",
+					"dynamodb",
 					"mariadb",
 					"aurora",
 					"redshift",
@@ -79,16 +84,16 @@ func resourceAwsDmsEndpoint() *schema.Resource {
 			},
 			"password": {
 				Type:      schema.TypeString,
-				Required:  true,
+				Optional:  true,
 				Sensitive: true,
 			},
 			"port": {
 				Type:     schema.TypeInt,
-				Required: true,
+				Optional: true,
 			},
 			"server_name": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"ssl_mode": {
 				Type:     schema.TypeString,
@@ -107,7 +112,7 @@ func resourceAwsDmsEndpoint() *schema.Resource {
 			},
 			"username": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 		},
 	}
@@ -120,21 +125,30 @@ func resourceAwsDmsEndpointCreate(d *schema.ResourceData, meta interface{}) erro
 		EndpointIdentifier: aws.String(d.Get("endpoint_id").(string)),
 		EndpointType:       aws.String(d.Get("endpoint_type").(string)),
 		EngineName:         aws.String(d.Get("engine_name").(string)),
-		Password:           aws.String(d.Get("password").(string)),
-		Port:               aws.Int64(int64(d.Get("port").(int))),
-		ServerName:         aws.String(d.Get("server_name").(string)),
 		Tags:               dmsTagsFromMap(d.Get("tags").(map[string]interface{})),
-		Username:           aws.String(d.Get("username").(string)),
 	}
 
-	if v, ok := d.GetOk("database_name"); ok {
-		request.DatabaseName = aws.String(v.(string))
+	// if dynamodb then add required params
+	if d.Get("engine_name").(string) == "dynamodb" {
+		request.DynamoDbSettings = &dms.DynamoDbSettings{
+			ServiceAccessRoleArn: aws.String(d.Get("service_access_role").(string)),
+		}
+	} else {
+		request.Password = aws.String(d.Get("password").(string))
+		request.Port = aws.Int64(int64(d.Get("port").(int)))
+		request.ServerName = aws.String(d.Get("server_name").(string))
+		request.Username = aws.String(d.Get("username").(string))
+
+		if v, ok := d.GetOk("database_name"); ok {
+			request.DatabaseName = aws.String(v.(string))
+		}
+		if v, ok := d.GetOk("extra_connection_attributes"); ok {
+			request.ExtraConnectionAttributes = aws.String(v.(string))
+		}
 	}
+
 	if v, ok := d.GetOk("certificate_arn"); ok {
 		request.CertificateArn = aws.String(v.(string))
-	}
-	if v, ok := d.GetOk("extra_connection_attributes"); ok {
-		request.ExtraConnectionAttributes = aws.String(v.(string))
 	}
 	if v, ok := d.GetOk("kms_key_arn"); ok {
 		request.KmsKeyId = aws.String(v.(string))
@@ -205,6 +219,13 @@ func resourceAwsDmsEndpointUpdate(d *schema.ResourceData, meta interface{}) erro
 
 	if d.HasChange("database_name") {
 		request.DatabaseName = aws.String(d.Get("database_name").(string))
+		hasChanges = true
+	}
+
+	if d.HasChange("service_access_role") {
+		request.DynamoDbSettings = &dms.DynamoDbSettings{
+			ServiceAccessRoleArn: aws.String(d.Get("service_access_role").(string)),
+		}
 		hasChanges = true
 	}
 
@@ -290,18 +311,28 @@ func resourceAwsDmsEndpointSetState(d *schema.ResourceData, endpoint *dms.Endpoi
 	d.SetId(*endpoint.EndpointIdentifier)
 
 	d.Set("certificate_arn", endpoint.CertificateArn)
-	d.Set("database_name", endpoint.DatabaseName)
 	d.Set("endpoint_arn", endpoint.EndpointArn)
 	d.Set("endpoint_id", endpoint.EndpointIdentifier)
 	// For some reason the AWS API only accepts lowercase type but returns it as uppercase
 	d.Set("endpoint_type", strings.ToLower(*endpoint.EndpointType))
 	d.Set("engine_name", endpoint.EngineName)
-	d.Set("extra_connection_attributes", endpoint.ExtraConnectionAttributes)
+
+	if *endpoint.EngineName == "dynamodb" {
+		if endpoint.DynamoDbSettings != nil {
+			d.Set("service_access_role", endpoint.DynamoDbSettings.ServiceAccessRoleArn)
+		} else {
+			d.Set("service_access_role", "")
+		}
+	} else {
+		d.Set("database_name", endpoint.DatabaseName)
+		d.Set("extra_connection_attributes", endpoint.ExtraConnectionAttributes)
+		d.Set("port", endpoint.Port)
+		d.Set("server_name", endpoint.ServerName)
+		d.Set("username", endpoint.Username)
+	}
+
 	d.Set("kms_key_arn", endpoint.KmsKeyId)
-	d.Set("port", endpoint.Port)
-	d.Set("server_name", endpoint.ServerName)
 	d.Set("ssl_mode", endpoint.SslMode)
-	d.Set("username", endpoint.Username)
 
 	return nil
 }

--- a/aws/resource_aws_dms_endpoint_test.go
+++ b/aws/resource_aws_dms_endpoint_test.go
@@ -76,8 +76,6 @@ func TestAccAwsDmsEndpointDynamoDb(t *testing.T) {
 				Config: dmsEndpointDynamoDbConfigUpdate(randId),
 				Check: resource.ComposeTestCheckFunc(
 					checkDmsEndpointExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "ssl_mode", "none"),
-					resource.TestCheckResourceAttr(resourceName, "server_name", "tftestupdate"),
 				),
 			},
 		},
@@ -182,7 +180,6 @@ resource "aws_dms_endpoint" "dms_endpoint" {
 	endpoint_id = "tf-test-dms-endpoint-%[1]s"
 	endpoint_type = "target"
 	engine_name = "dynamodb"
-	server_name = "tftest"
 	service_access_role = "${aws_iam_role.iam_role.arn}"
 	ssl_mode = "none"
 	tags {
@@ -190,6 +187,8 @@ resource "aws_dms_endpoint" "dms_endpoint" {
 		Update = "to-update"
 		Remove = "to-remove"
 	}
+
+	depends_on = ["aws_iam_role_policy.dms_dynamodb_access"]
 }
 resource "aws_iam_role" "iam_role" {
   name = "tf-test-iam-dynamodb-role-%[1]s"
@@ -244,7 +243,6 @@ resource "aws_dms_endpoint" "dms_endpoint" {
 	endpoint_id = "tf-test-dms-endpoint-%[1]s"
 	endpoint_type = "target"
 	engine_name = "dynamodb"
-	server_name = "tftestupdate"
 	service_access_role = "${aws_iam_role.iam_role.arn}"
 	ssl_mode = "none"
 	tags {

--- a/website/docs/r/dms_endpoint.html.markdown
+++ b/website/docs/r/dms_endpoint.html.markdown
@@ -53,15 +53,15 @@ The following arguments are supported:
     - Must not contain two consecutive hyphens
 
 * `endpoint_type` - (Required) The type of endpoint. Can be one of `source | target`.
-* `engine_name` - (Required) The type of engine for the endpoint. Can be one of `mysql | oracle | postgres | mariadb | aurora | redshift | sybase | sqlserver`.
+* `engine_name` - (Required) The type of engine for the endpoint. Can be one of `mysql | oracle | postgres | mariadb | aurora | redshift | sybase | sqlserver | dynamodb`.
 * `extra_connection_attributes` - (Optional) Additional attributes associated with the connection. For available attributes see [Using Extra Connection Attributes with AWS Database Migration Service](http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Introduction.ConnectionAttributes.html).
 * `kms_key_arn` - (Optional) The Amazon Resource Name (ARN) for the KMS key that will be used to encrypt the connection parameters. If you do not specify a value for `kms_key_arn`, then AWS DMS will use your default encryption key. AWS KMS creates the default encryption key for your AWS account. Your AWS account has a different default encryption key for each AWS region.
-* `password` - (Required) The password to be used to login to the endpoint database.
-* `port` - (Required) The port used by the endpoint database.
-* `server_name` - (Required) The host name of the server.
+* `password` - (Optional) The password to be used to login to the endpoint database.
+* `port` - (Optional) The port used by the endpoint database.
+* `server_name` - (Optional) The host name of the server.
 * `ssl_mode` - (Optional, Default: none) The SSL mode to use for the connection. Can be one of `none | require | verify-ca | verify-full`
 * `tags` - (Optional) A mapping of tags to assign to the resource.
-* `username` - (Required) The user name to be used to login to the endpoint database.
+* `username` - (Optional) The user name to be used to login to the endpoint database.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This is a port of @chrisjharding's work in https://github.com/hashicorp/terraform/pull/15163

Fixes: #797

I used his patch, then added the docs, and a retry on the Endpoint Create to allow for IAM Role eventual consistency

```
% make testacc TEST=./aws TESTARGS='-run=TestAccAwsDmsEndpoint'                                                           2 ↵ ✹ ✭
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAwsDmsEndpoint -timeout 120m
=== RUN   TestAccAwsDmsEndpointBasic
--- PASS: TestAccAwsDmsEndpointBasic (75.60s)
=== RUN   TestAccAwsDmsEndpointDynamoDb
--- PASS: TestAccAwsDmsEndpointDynamoDb (65.74s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	141.367s
```