### PR TITLE
Update AWS Docs link text

### DIFF
--- a/website/docs/d/ebs_snapshot.html.markdown
+++ b/website/docs/d/ebs_snapshot.html.markdown
@@ -43,7 +43,7 @@ The following arguments are supported:
 
 * `filter` - (Optional) One or more name/value pairs to filter off of. There are
 several valid keys, for a full reference, check out
-[describe-volumes in the AWS CLI reference][1].
+[describe-snapshots in the AWS CLI reference][1].
 
 
 ## Attributes Reference


### PR DESCRIPTION
Fix the link text to reflect the target page in the AWS docs correctly