### PR TITLE
resource/aws_ssm_parameter: Add support for ssm parameter overwrite

### DIFF
--- a/aws/resource_aws_ssm_parameter.go
+++ b/aws/resource_aws_ssm_parameter.go
@@ -12,9 +12,9 @@ import (
 
 func resourceAwsSsmParameter() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceAwsSsmParameterCreate,
+		Create: resourceAwsSsmParameterPut,
 		Read:   resourceAwsSsmParameterRead,
-		Update: resourceAwsSsmParameterUpdate,
+		Update: resourceAwsSsmParameterPut,
 		Delete: resourceAwsSsmParameterDelete,
 
 		Schema: map[string]*schema.Schema{
@@ -38,12 +38,13 @@ func resourceAwsSsmParameter() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"overwrite": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 	}
-}
-
-func resourceAwsSsmParameterCreate(d *schema.ResourceData, meta interface{}) error {
-	return putAwsSSMParameter(d, meta)
 }
 
 func resourceAwsSsmParameterRead(d *schema.ResourceData, meta interface{}) error {
@@ -76,10 +77,6 @@ func resourceAwsSsmParameterRead(d *schema.ResourceData, meta interface{}) error
 	return nil
 }
 
-func resourceAwsSsmParameterUpdate(d *schema.ResourceData, meta interface{}) error {
-	return putAwsSSMParameter(d, meta)
-}
-
 func resourceAwsSsmParameterDelete(d *schema.ResourceData, meta interface{}) error {
 	ssmconn := meta.(*AWSClient).ssmconn
 
@@ -99,7 +96,7 @@ func resourceAwsSsmParameterDelete(d *schema.ResourceData, meta interface{}) err
 	return nil
 }
 
-func putAwsSSMParameter(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsSsmParameterPut(d *schema.ResourceData, meta interface{}) error {
 	ssmconn := meta.(*AWSClient).ssmconn
 
 	log.Printf("[INFO] Creating SSM Parameter: %s", d.Get("name").(string))
@@ -108,7 +105,7 @@ func putAwsSSMParameter(d *schema.ResourceData, meta interface{}) error {
 		Name:      aws.String(d.Get("name").(string)),
 		Type:      aws.String(d.Get("type").(string)),
 		Value:     aws.String(d.Get("value").(string)),
-		Overwrite: aws.Bool(!d.IsNewResource()),
+		Overwrite: aws.Bool(d.Get("overwrite").(bool)),
 	}
 	if keyID, ok := d.GetOk("key_id"); ok {
 		log.Printf("[DEBUG] Setting key_id for SSM Parameter %s: %s", d.Get("name").(string), keyID.(string))

--- a/aws/resource_aws_ssm_parameter_test.go
+++ b/aws/resource_aws_ssm_parameter_test.go
@@ -40,9 +40,9 @@ func TestAccAWSSSMParameter_update(t *testing.T) {
 				Config: testAccAWSSSMParameterBasicConfig(name, "bar"),
 			},
 			{
-				Config: testAccAWSSSMParameterBasicConfig(name, "baz"),
+				Config: testAccAWSSSMParameterBasicConfigOverwrite(name, "baz1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMParameterHasValue("aws_ssm_parameter.foo", "baz"),
+					testAccCheckAWSSSMParameterHasValue("aws_ssm_parameter.foo", "baz1"),
 					testAccCheckAWSSSMParameterType("aws_ssm_parameter.foo", "String"),
 				),
 			},
@@ -179,6 +179,17 @@ resource "aws_ssm_parameter" "foo" {
   name  = "test_parameter-%s"
   type  = "String"
   value = "%s"
+}
+`, rName, value)
+}
+
+func testAccAWSSSMParameterBasicConfigOverwrite(rName string, value string) string {
+	return fmt.Sprintf(`
+resource "aws_ssm_parameter" "foo" {
+  name  = "test_parameter-%s"
+  type  = "String"
+  value = "%s"
+  overwrite = true
 }
 `, rName, value)
 }

--- a/website/docs/r/ssm_parameter.html.markdown
+++ b/website/docs/r/ssm_parameter.html.markdown
@@ -56,6 +56,7 @@ The following arguments are supported:
 * `type` - (Required) The type of the parameter. Valid types are `String`, `StringList` and `SecureString`.
 * `value` - (Required) The value of the parameter.
 * `key_id` - (Optional) The KMS key id or arn for encrypting a SecureString.
+* `overwrite` - (Optional) Overwrite an existing parameter. If not specified, will default to `false`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fixes: #1004

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSSSMParameter_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSSSMParameter_ -timeout 120m
=== RUN   TestAccAWSSSMParameter_basic
--- PASS: TestAccAWSSSMParameter_basic (68.88s)
=== RUN   TestAccAWSSSMParameter_update
--- PASS: TestAccAWSSSMParameter_update (90.39s)
=== RUN   TestAccAWSSSMParameter_secure
--- PASS: TestAccAWSSSMParameter_secure (50.50s)
=== RUN   TestAccAWSSSMParameter_secure_with_key
--- PASS: TestAccAWSSSMParameter_secure_with_key (125.95s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	335.743s
```