### PR TITLE
Fix typo in aws_security_group data source example

### DIFF
--- a/website/docs/d/security_group.html.markdown
+++ b/website/docs/d/security_group.html.markdown
@@ -23,7 +23,7 @@ and use this data source to obtain the data necessary to create a subnet.
 variable "security_group_id" {}
 
 data "aws_security_group" "selected" {
-  id = "${var.security_group}"
+  id = "${var.security_group_id}"
 }
 
 resource "aws_subnet" "subnet" {


### PR DESCRIPTION
Variable used in the website documentation aws_security_group data source should be security_group_id as it is declared.