### PR TITLE
Allow to set WebsiteRedirect on S3 object

### DIFF
--- a/aws/resource_aws_s3_bucket_object.go
+++ b/aws/resource_aws_s3_bucket_object.go
@@ -120,6 +120,11 @@ func resourceAwsS3BucketObject() *schema.Resource {
 			},
 
 			"tags": tagsSchema(),
+
+			"website_redirect": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -206,6 +211,10 @@ func resourceAwsS3BucketObjectPut(d *schema.ResourceData, meta interface{}) erro
 		putInput.Tagging = aws.String(values.Encode())
 	}
 
+	if v, ok := d.GetOk("website_redirect"); ok {
+		putInput.WebsiteRedirectLocation = aws.String(v.(string))
+	}
+
 	resp, err := s3conn.PutObject(putInput)
 	if err != nil {
 		return fmt.Errorf("Error putting object in S3 bucket (%s): %s", bucket, err)
@@ -251,6 +260,7 @@ func resourceAwsS3BucketObjectRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("content_type", resp.ContentType)
 	d.Set("version_id", resp.VersionId)
 	d.Set("server_side_encryption", resp.ServerSideEncryption)
+	d.Set("website_redirect", resp.WebsiteRedirectLocation)
 
 	// Only set non-default KMS key ID (one that doesn't match default)
 	if resp.SSEKMSKeyId != nil {

--- a/aws/resource_aws_s3_bucket_object_test.go
+++ b/aws/resource_aws_s3_bucket_object_test.go
@@ -90,6 +90,8 @@ func TestAccAWSS3BucketObject_withContentCharacteristics(t *testing.T) {
 					testAccCheckAWSS3BucketObjectExists("aws_s3_bucket_object.object", &obj),
 					resource.TestCheckResourceAttr(
 						"aws_s3_bucket_object.object", "content_type", "binary/octet-stream"),
+					resource.TestCheckResourceAttr(
+						"aws_s3_bucket_object.object", "website_redirect", "http://google.com"),
 				),
 			},
 		},
@@ -580,6 +582,7 @@ resource "aws_s3_bucket_object" "object" {
 	source = "%s"
 	content_language = "en"
 	content_type = "binary/octet-stream"
+	website_redirect = "http://google.com"
 }
 `, randInt, source)
 }

--- a/website/docs/r/s3_bucket_object.html.markdown
+++ b/website/docs/r/s3_bucket_object.html.markdown
@@ -76,6 +76,7 @@ The following arguments are supported:
 * `content_encoding` - (Optional) Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field. Read [w3c content encoding](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11) for further information.
 * `content_language` - (Optional) The language the content is in e.g. en-US or en-GB.
 * `content_type` - (Optional) A standard MIME type describing the format of the object data, e.g. application/octet-stream. All Valid MIME Types are valid for this input.
+* `website_redirect` - (Optional) Specifies a target URL for [website redirect](http://docs.aws.amazon.com/AmazonS3/latest/dev/how-to-page-redirect.html).
 * `storage_class` - (Optional) Specifies the desired [Storage Class](http://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html)
 for the object. Can be either "`STANDARD`", "`REDUCED_REDUNDANCY`", or "`STANDARD_IA`". Defaults to "`STANDARD`".
 * `etag` - (Optional) Used to trigger updates. The only meaningful value is `${md5(file("path/to/file"))}`.


### PR DESCRIPTION
The PR introduces support [website redirect](http://docs.aws.amazon.com/AmazonS3/latest/dev/how-to-page-redirect.html) property of S3 bucket object. 