### PR TITLE
resource/aws_ssm_parameter: ForceNew on ssm_parameter rename

### DIFF
--- a/aws/resource_aws_ssm_parameter.go
+++ b/aws/resource_aws_ssm_parameter.go
@@ -21,6 +21,7 @@ func resourceAwsSsmParameter() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"type": {
 				Type:         schema.TypeString,


### PR DESCRIPTION
Fixes: #1008

There doesn't seem to be a way to change the name of an AWS SSM
Parameter. Therefore, it should be marked as ForceNew.

```
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSSSMParameter_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSSSMParameter_ -timeout 120m
=== RUN   TestAccAWSSSMParameter_basic
--- PASS: TestAccAWSSSMParameter_basic (25.06s)
=== RUN   TestAccAWSSSMParameter_update
--- PASS: TestAccAWSSSMParameter_update (43.21s)
=== RUN   TestAccAWSSSMParameter_changeNameForcesNew
--- PASS: TestAccAWSSSMParameter_changeNameForcesNew (40.84s)
=== RUN   TestAccAWSSSMParameter_secure
--- PASS: TestAccAWSSSMParameter_secure (37.90s)
=== RUN   TestAccAWSSSMParameter_secure_with_key
--- PASS: TestAccAWSSSMParameter_secure_with_key (73.26s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	220.297s
```