### PR TITLE
resource/ecs_service: Fixes normalization issues in placement_strategy

### DIFF
--- a/aws/resource_aws_ecs_service.go
+++ b/aws/resource_aws_ecs_service.go
@@ -127,6 +127,20 @@ func resourceAwsEcsService() *schema.Resource {
 						},
 					},
 				},
+				Set: func(v interface{}) int {
+					var buf bytes.Buffer
+					m := v.(map[string]interface{})
+					buf.WriteString(fmt.Sprintf("%s-", m["type"].(string)))
+					if m["field"] != nil {
+						field := m["field"].(string)
+						if field == "host" {
+							buf.WriteString("instanceId-")
+						} else {
+							buf.WriteString(fmt.Sprintf("%s-", field))
+						}
+					}
+					return hashcode.String(buf.String())
+				},
 			},
 
 			"placement_constraints": {

--- a/website/docs/r/ecs_service.html.markdown
+++ b/website/docs/r/ecs_service.html.markdown
@@ -80,6 +80,8 @@ Load balancers support the following:
  For the `binpack` type, valid values are `memory` and `cpu`. For the `random` type, this attribute is not
  needed. For more information, see [Placement Strategy](http://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_PlacementStrategy.html).
 
+-> **Note:** for `spread`, `host` and `instanceId` will be normalized, by AWS, to be `instanceId`. This means the statefile will show `instanceId` but your config will differ if you use `host`.
+
 ## placement_constraints
 
 `placement_constraints` support the following:


### PR DESCRIPTION
Fixes: #938

When aws_ecs_service has a placement_strategy of type `spread`, you can
use a field of `instanceId` or `host` interchangable. BUT AWS will normalize the
field value to return `instanceId`.

We have introduced a custom Set func to manage this work so that we
understand when someone uses `host`, we won't get a diff when AWS return
`instanceId` -> if there is a diff, a ForceNew is applied

```
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSEcsService'                                                                  ✹
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSEcsService -timeout 120m
=== RUN   TestAccAWSEcsServiceWithARN
--- PASS: TestAccAWSEcsServiceWithARN (147.06s)
=== RUN   TestAccAWSEcsServiceWithUnnormalizedPlacementStrategy
--- PASS: TestAccAWSEcsServiceWithUnnormalizedPlacementStrategy (116.97s)
=== RUN   TestAccAWSEcsServiceWithFamilyAndRevision
--- PASS: TestAccAWSEcsServiceWithFamilyAndRevision (125.69s)
=== RUN   TestAccAWSEcsServiceWithRenamedCluster
--- PASS: TestAccAWSEcsServiceWithRenamedCluster (268.02s)
=== RUN   TestAccAWSEcsService_withIamRole
--- PASS: TestAccAWSEcsService_withIamRole (155.57s)
=== RUN   TestAccAWSEcsService_withDeploymentValues
--- PASS: TestAccAWSEcsService_withDeploymentValues (128.80s)
=== RUN   TestAccAWSEcsService_withLbChanges
--- PASS: TestAccAWSEcsService_withLbChanges (242.82s)
=== RUN   TestAccAWSEcsService_withEcsClusterName
--- PASS: TestAccAWSEcsService_withEcsClusterName (113.21s)
=== RUN   TestAccAWSEcsService_withAlb
--- PASS: TestAccAWSEcsService_withAlb (349.69s)
=== RUN   TestAccAWSEcsServiceWithPlacementStrategy
--- PASS: TestAccAWSEcsServiceWithPlacementStrategy (238.08s)
=== RUN   TestAccAWSEcsServiceWithPlacementConstraints
--- PASS: TestAccAWSEcsServiceWithPlacementConstraints (123.41s)
=== RUN   TestAccAWSEcsServiceWithPlacementConstraints_emptyExpression
--- PASS: TestAccAWSEcsServiceWithPlacementConstraints_emptyExpression (126.25s)
PASS
ok	github.com/terraform-providers/terraform-provider-aws/aws	2138.968s
```