### PR TITLE
resource/aws_ecs_service: Prevent destroying tasks

### DIFF
--- a/aws/resource_aws_ecs_service.go
+++ b/aws/resource_aws_ecs_service.go
@@ -47,6 +47,7 @@ func resourceAwsEcsService() *schema.Resource {
 			"desired_count": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 
 			"iam_role": {


### PR DESCRIPTION
Hi everyone,

This is a Pull request to fix an annoying issue when using `aws_ecs_service` described by @BrunoBonacci here [#9690](https://github.com/hashicorp/terraform/issues/9690). 

I already submit this PR in the past in the Terraform project (see [#11892](https://github.com/hashicorp/terraform/pull/11892))

The idea is to used `desired_count` to create or update the number of ECS service tasks, but the `desired_count` is not updated in the state when reading from the real-infrastructure (during `refresh`).

This prevents to destroy tasks  (running containers) if the number of tasks has been changed manually in AWS Console or by auto-scaling rules.