### PR TITLE
Support for ECS credentials provider

### DIFF
--- a/aws/auth_helpers.go
+++ b/aws/auth_helpers.go
@@ -134,7 +134,7 @@ func GetCredentials(c *Config) (*awsCredentials.Credentials, error) {
 	// The ECS credential provider is higher priority than EC2RoleProvider
 	if uri := os.Getenv(ecsCredentialsRelativeUri); len(uri) > 0 {
 		u := fmt.Sprintf("http://169.254.170.2%s", uri)
-		if uriOverride := os.Getenv(ecsCredentialsAbsoluteUriOverride); len(ecsCredentialsAbsoluteUriOverride) > 0 { // for unit tests
+		if uriOverride := os.Getenv(ecsCredentialsAbsoluteUriOverride); len(uriOverride) > 0 { // for unit tests
 			u = uriOverride
 		}
 		containerCredsProvider := endpointcreds.NewProviderClient(*defaults.Config(), defaults.Handlers(), u)


### PR DESCRIPTION
This addresses issue https://github.com/terraform-providers/terraform-provider-aws/issues/259

Adds the ECS credentials provider to the credentials chain before the EC2RoleProvider when AWS_CREDENTIALS_RELATIVE_UR environment variable is defined.

The code introduced merely mimics aws' defaults: https://github.com/aws/aws-sdk-go/blob/master/aws/defaults/defaults.go#L114

Added 1 new unit test.
I did not find acceptance tests for functions in auth_helpers.go so I believe I don't need to write any for this change...

Instructions to build a fully working terraform binary with this plugin would be appreciated. 

I do not know how to point my local terraform checkout to use my locally built terraform-provider-aws. Everything is in my ~/go dir and my GOPATH is configured to point ~/go/bin as instructed. govendor faq didn't help. So far, I've tested the new terraform binary by manually copying auth_helpers.go to the terraform project. I ran the new binary in a container on ECS and it did work:

    2017/07/01 21:13:11 [INFO] AWS EC2 instance detected via default metadata API endpoint, EC2RoleProvider added to the auth chain
    2017/07/01 21:13:11 [INFO] AWS Auth provider used: "CredentialsEndpointProvider"

and got me through making calls to dynamodb and run most of terraform plan (which failed before this change because the instance-profile hasn't enough permissions). But later in the execution, terraform seems to using an older version of the plugin and therefore falls back to the instance-profile role: 

    2017/07/02 18:12:03 [DEBUG] plugin: terraform-provider-aws_v0.1.2_x4: 2017/07/02 18:12:03 [INFO] No assume_role block read from configuration
    2017/07/02 18:12:03 [DEBUG] plugin: terraform-provider-aws_v0.1.2_x4: 2017/07/02 18:12:03 [INFO] Building AWS region structure
    2017/07/02 18:12:03 [DEBUG] plugin: terraform-provider-aws_v0.1.2_x4: 2017/07/02 18:12:03 [INFO] Building AWS auth structure
    2017/07/02 18:12:03 [DEBUG] plugin: terraform-provider-aws_v0.1.2_x4: 2017/07/02 18:12:03 [INFO] Setting AWS metadata API timeout to 100ms
    2017/07/02 18:12:03 [DEBUG] root.ecs_service- [...]
    2017/07/02 18:12:03 [DEBUG] plugin: terraform-provider-aws_v0.1.2_x4: 2017/07/02 18:12:03 [INFO] AWS EC2 instance detected via default metadata API endpoint, EC2RoleProvider added to the auth chain

Feel free to take over this change.