### PR TITLE
r/aws_elb: Cleanup ENIs after deleting ELB

### DIFF
--- a/aws/resource_aws_elb.go
+++ b/aws/resource_aws_elb.go
@@ -792,6 +792,13 @@ func resourceAwsElbDelete(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error deleting ELB: %s", err)
 	}
 
+	name := d.Get("name").(string)
+
+	err := cleanupELBNetworkInterfaces(meta.(*AWSClient).ec2conn, name)
+	if err != nil {
+		log.Printf("[WARN] Failed to cleanup ENIs for ELB %q: %#v", name, err)
+	}
+
 	return nil
 }
 
@@ -973,4 +980,104 @@ func isValidProtocol(s string) bool {
 	}
 
 	return true
+}
+
+// ELB automatically creates ENI(s) on creation
+// but the cleanup is asynchronous and may take time
+// which then blocks IGW or VPC on deletion
+// So we make the cleanup "synchronous" here
+func cleanupELBNetworkInterfaces(conn *ec2.EC2, name string) error {
+	out, err := conn.DescribeNetworkInterfaces(&ec2.DescribeNetworkInterfacesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("attachment.instance-owner-id"),
+				Values: []*string{aws.String("amazon-elb")},
+			},
+			{
+				Name:   aws.String("description"),
+				Values: []*string{aws.String("ELB " + name)},
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] Found %d ENIs to cleanup for ELB %q",
+		len(out.NetworkInterfaces), name)
+
+	if len(out.NetworkInterfaces) == 0 {
+		// Nothing to cleanup
+		return nil
+	}
+
+	err = detachNetworkInterfaces(conn, out.NetworkInterfaces)
+	if err != nil {
+		return err
+	}
+
+	err = deleteNetworkInterfaces(conn, out.NetworkInterfaces)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func detachNetworkInterfaces(conn *ec2.EC2, nis []*ec2.NetworkInterface) error {
+	log.Printf("[DEBUG] Trying to detach %d leftover ENIs", len(nis))
+	for _, ni := range nis {
+		if ni.Attachment == nil {
+			log.Printf("[DEBUG] ENI %s is already detached", *ni.NetworkInterfaceId)
+			continue
+		}
+		_, err := conn.DetachNetworkInterface(&ec2.DetachNetworkInterfaceInput{
+			AttachmentId: ni.Attachment.AttachmentId,
+			Force:        aws.Bool(true),
+		})
+		if err != nil {
+			awsErr, ok := err.(awserr.Error)
+			if ok && awsErr.Code() == "InvalidAttachmentID.NotFound" {
+				log.Printf("[DEBUG] ENI %s is already detached", *ni.NetworkInterfaceId)
+				continue
+			}
+			return err
+		}
+
+		log.Printf("[DEBUG] Waiting for ENI (%s) to become detached", *ni.NetworkInterfaceId)
+		stateConf := &resource.StateChangeConf{
+			Pending: []string{"true"},
+			Target:  []string{"false"},
+			Refresh: networkInterfaceAttachmentRefreshFunc(conn, *ni.NetworkInterfaceId),
+			Timeout: 10 * time.Minute,
+		}
+
+		if _, err := stateConf.WaitForState(); err != nil {
+			awsErr, ok := err.(awserr.Error)
+			if ok && awsErr.Code() == "InvalidNetworkInterfaceID.NotFound" {
+				continue
+			}
+			return fmt.Errorf(
+				"Error waiting for ENI (%s) to become detached: %s", *ni.NetworkInterfaceId, err)
+		}
+	}
+	return nil
+}
+
+func deleteNetworkInterfaces(conn *ec2.EC2, nis []*ec2.NetworkInterface) error {
+	log.Printf("[DEBUG] Trying to delete %d leftover ENIs", len(nis))
+	for _, ni := range nis {
+		_, err := conn.DeleteNetworkInterface(&ec2.DeleteNetworkInterfaceInput{
+			NetworkInterfaceId: ni.NetworkInterfaceId,
+		})
+		if err != nil {
+			awsErr, ok := err.(awserr.Error)
+			if ok && awsErr.Code() == "InvalidNetworkInterfaceID.NotFound" {
+				log.Printf("[DEBUG] ENI %s is already deleted", *ni.NetworkInterfaceId)
+				continue
+			}
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
This is a continuation of https://github.com/terraform-providers/terraform-provider-aws/pull/1021

cc @s-urbaniak

The aim is to reduce the chance of hitting `DependencyViolation` when deleting IGW, subnet or VPC generally and speed up the deletion of infrastructure when there are ELBs involved.

Here's an example of ENI left around by ELB based on which I cobbled the filter:

```
{
  Association: {
    IpOwnerId: "amazon-elb",
    PublicDnsName: "ec2-35-177-221-5.eu-west-2.compute.amazonaws.com",
    PublicIp: "35.177.221.5"
  },
  Attachment: {
    AttachTime: 2017-06-30 12:40:12 +0000 UTC,
    AttachmentId: "eni-attach-b0ff53d0",
    DeleteOnTermination: false,
    DeviceIndex: 1,
    InstanceOwnerId: "amazon-elb",
    Status: "attached"
  },
  AvailabilityZone: "eu-west-2a",
  Description: "ELB sur-con",
  Groups: [{
      GroupId: "sg-20793c49",
      GroupName: "terraform-00b5732b378e3e1af7ae523317"
    }],
  MacAddress: "06:be:07:24:55:b7",
  NetworkInterfaceId: "eni-38a80942",
  OwnerId: "187416307283",
  PrivateDnsName: "ip-10-0-1-33.eu-west-2.compute.internal",
  PrivateIpAddress: "10.0.1.33",
  PrivateIpAddresses: [{
      Association: {
        IpOwnerId: "amazon-elb",
        PublicDnsName: "ec2-35-177-221-5.eu-west-2.compute.amazonaws.com",
        PublicIp: "35.177.221.5"
      },
      Primary: true,
      PrivateDnsName: "ip-10-0-1-33.eu-west-2.compute.internal",
      PrivateIpAddress: "10.0.1.33"
    }],
  RequesterId: "amazon-elb",
  RequesterManaged: true,
  SourceDestCheck: true,
  Status: "in-use",
  SubnetId: "subnet-2118ae5a",
  VpcId: "vpc-1fa72476"
}
```

### Test results

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSELB'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSELB -timeout 120m
=== RUN   TestAccAWSELB_importBasic
--- PASS: TestAccAWSELB_importBasic (55.48s)
=== RUN   TestAccAWSELBAttachment_basic
--- PASS: TestAccAWSELBAttachment_basic (287.73s)
=== RUN   TestAccAWSELBAttachment_drift
--- PASS: TestAccAWSELBAttachment_drift (179.94s)
=== RUN   TestAccAWSELB_basic
--- PASS: TestAccAWSELB_basic (48.33s)
=== RUN   TestAccAWSELB_fullCharacterRange
--- PASS: TestAccAWSELB_fullCharacterRange (49.15s)
=== RUN   TestAccAWSELB_AccessLogs_enabled
--- PASS: TestAccAWSELB_AccessLogs_enabled (188.42s)
=== RUN   TestAccAWSELB_AccessLogs_disabled
--- PASS: TestAccAWSELB_AccessLogs_disabled (196.72s)
=== RUN   TestAccAWSELB_namePrefix
--- PASS: TestAccAWSELB_namePrefix (47.65s)
=== RUN   TestAccAWSELB_generatedName
--- PASS: TestAccAWSELB_generatedName (78.70s)
=== RUN   TestAccAWSELB_generatesNameForZeroValue
--- PASS: TestAccAWSELB_generatesNameForZeroValue (46.59s)
=== RUN   TestAccAWSELB_availabilityZones
--- PASS: TestAccAWSELB_availabilityZones (131.99s)
=== RUN   TestAccAWSELB_tags
--- PASS: TestAccAWSELB_tags (83.11s)
=== RUN   TestAccAWSELB_iam_server_cert
--- PASS: TestAccAWSELB_iam_server_cert (67.93s)
=== RUN   TestAccAWSELB_swap_subnets
--- PASS: TestAccAWSELB_swap_subnets (268.53s)
=== RUN   TestAccAWSELB_InstanceAttaching
--- PASS: TestAccAWSELB_InstanceAttaching (232.62s)
=== RUN   TestAccAWSELBUpdate_Listener
--- PASS: TestAccAWSELBUpdate_Listener (144.79s)
=== RUN   TestAccAWSELB_HealthCheck
--- PASS: TestAccAWSELB_HealthCheck (57.45s)
=== RUN   TestAccAWSELBUpdate_HealthCheck
--- PASS: TestAccAWSELBUpdate_HealthCheck (87.36s)
=== RUN   TestAccAWSELB_Timeout
--- PASS: TestAccAWSELB_Timeout (53.88s)
=== RUN   TestAccAWSELBUpdate_Timeout
--- PASS: TestAccAWSELBUpdate_Timeout (98.38s)
=== RUN   TestAccAWSELB_ConnectionDraining
--- PASS: TestAccAWSELB_ConnectionDraining (50.38s)
=== RUN   TestAccAWSELBUpdate_ConnectionDraining
--- PASS: TestAccAWSELBUpdate_ConnectionDraining (170.50s)
=== RUN   TestAccAWSELB_SecurityGroups
--- PASS: TestAccAWSELB_SecurityGroups (136.36s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2762.009s
```
Here's a snippet from log to prove that it's actually working:
```
$ tail -f ~/tf.log | grep 'ENIs to cleanup for ELB '
2017/07/02 12:08:46 [DEBUG] Found 0 ENIs to cleanup for ELB "tf-lb-00085d58eac7f62f3ed38e8e9f"
2017/07/02 12:13:08 [DEBUG] Found 2 ENIs to cleanup for ELB "tf-lb-00085d58eac7f62f3ed38e8ea0"
2017/07/02 12:15:26 [DEBUG] Found 1 ENIs to cleanup for ELB "tf-lb-00085d58eac7f62f3ed38e8ea5"
2017/07/02 12:17:22 [DEBUG] Found 0 ENIs to cleanup for ELB "tf-lb-00085d58eac7f62f3ed38e8ea8"
2017/07/02 12:18:11 [DEBUG] Found 0 ENIs to cleanup for ELB "Tf-7935718592059225879"
2017/07/02 12:20:45 [DEBUG] Found 1 ENIs to cleanup for ELB "tf-lb-00085d58eac7f62f3ed38e8ea9"
2017/07/02 12:23:51 [DEBUG] Found 1 ENIs to cleanup for ELB "tf-lb-00085d58eac7f62f3ed38e8eaa"
2017/07/02 12:25:24 [DEBUG] Found 0 ENIs to cleanup for ELB "test-00085d58eac7f62f3ed38e8eab"
2017/07/02 12:26:42 [DEBUG] Found 0 ENIs to cleanup for ELB "tf-lb-00085d58eac7f62f3ed38e8eac"
2017/07/02 12:27:29 [DEBUG] Found 0 ENIs to cleanup for ELB "tf-lb-00085d58eac7f62f3ed38e8ead"
2017/07/02 12:28:57 [DEBUG] Found 1 ENIs to cleanup for ELB "tf-lb-00085d58eac7f62f3ed38e8eae"
2017/07/02 12:31:04 [DEBUG] Found 0 ENIs to cleanup for ELB "tf-lb-00085d58eac7f62f3ed38e8eaf"
2017/07/02 12:32:10 [DEBUG] Found 0 ENIs to cleanup for ELB "tf-lb-00085d58eac7f62f3ed38e8eb0"
2017/07/02 12:35:17 [DEBUG] Found 1 ENIs to cleanup for ELB "terraform-asg-deployment-example"
2017/07/02 12:39:00 [DEBUG] Found 1 ENIs to cleanup for ELB "tf-lb-00085d58eac7f62f3ed38e8eb1"
2017/07/02 12:42:11 [DEBUG] Found 1 ENIs to cleanup for ELB "tf-lb-00085d58eac7f62f3ed38e8eb2"
2017/07/02 12:43:55 [DEBUG] Found 0 ENIs to cleanup for ELB "tf-lb-00085d58eac7f62f3ed38e8eb3"
2017/07/02 12:45:23 [DEBUG] Found 0 ENIs to cleanup for ELB "tf-lb-00085d58eac7f62f3ed38e8eb4"
2017/07/02 12:46:17 [DEBUG] Found 0 ENIs to cleanup for ELB "tf-lb-00085d58eac7f62f3ed38e8eb5"
2017/07/02 12:47:43 [DEBUG] Found 1 ENIs to cleanup for ELB "tf-lb-00085d58eac7f62f3ed38e8eb6"
2017/07/02 12:48:44 [DEBUG] Found 0 ENIs to cleanup for ELB "tf-lb-00085d58eac7f62f3ed38e8eb7"
2017/07/02 12:50:50 [DEBUG] Found 1 ENIs to cleanup for ELB "tf-lb-00085d58eac7f62f3ed38e8eb8"
2017/07/02 12:53:16 [DEBUG] Found 1 ENIs to cleanup for ELB "tf-lb-00085d58eac7f62f3ed38e8eb9"
```