### PR TITLE
Fix OpsWorks 'set permissions' failing to set ssh access.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ FEATURES:
 BUG FIXES:
 
 * resource/ecs_service: Fixes normalization issues in placement_strategy [GH-1025]
+* resource/aws_opsworks_permission: Fix for failure to change Sudo or SSH permissions for current user.
 
 ## 0.1.2 (June 30, 2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ FEATURES:
 BUG FIXES:
 
 * resource/ecs_service: Fixes normalization issues in placement_strategy [GH-1025]
-* resource/aws_opsworks_permission: Fix for failure to change Sudo or SSH permissions for current user.
+* resource/aws_opsworks_permission: Fix for failure to change Sudo or SSH permissions for current user [GH-458]
 
 ## 0.1.2 (June 30, 2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ FEATURES:
 BUG FIXES:
 
 * resource/ecs_service: Fixes normalization issues in placement_strategy [GH-1025]
-* resource/aws_opsworks_permission: Fix for failure to change Sudo or SSH permissions for current user [GH-458]
 
 ## 0.1.2 (June 30, 2017)
 

--- a/aws/resource_aws_opsworks_permission.go
+++ b/aws/resource_aws_opsworks_permission.go
@@ -125,19 +125,15 @@ func resourceAwsOpsworksPermissionRead(d *schema.ResourceData, meta interface{})
 func resourceAwsOpsworksSetPermission(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*AWSClient).opsworksconn
 
-	/* Level must be supplied as 'nil' if we are not changing it */
-	level_string := d.Get("level").(string)
-	level_aws := aws.String(level_string)
-	if level_string == "" {
-		level_aws = nil
-	}
-
 	req := &opsworks.SetPermissionInput{
 		AllowSudo:  aws.Bool(d.Get("allow_sudo").(bool)),
 		AllowSsh:   aws.Bool(d.Get("allow_ssh").(bool)),
-		Level:      level_aws,
 		IamUserArn: aws.String(d.Get("user_arn").(string)),
 		StackId:    aws.String(d.Get("stack_id").(string)),
+	}
+
+	if v, ok := d.GetOk("level"); ok {
+		req.Level = aws.String(v.(string))
 	}
 
 	err := resource.Retry(2*time.Minute, func() *resource.RetryError {

--- a/aws/resource_aws_opsworks_permission.go
+++ b/aws/resource_aws_opsworks_permission.go
@@ -125,10 +125,17 @@ func resourceAwsOpsworksPermissionRead(d *schema.ResourceData, meta interface{})
 func resourceAwsOpsworksSetPermission(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*AWSClient).opsworksconn
 
+	/* Level must be supplied as 'nil' if we are not changing it */
+	level_string := d.Get("level").(string)
+	level_aws := aws.String(level_string)
+	if level_string == "" {
+		level_aws = nil
+	}
+
 	req := &opsworks.SetPermissionInput{
 		AllowSudo:  aws.Bool(d.Get("allow_sudo").(bool)),
 		AllowSsh:   aws.Bool(d.Get("allow_ssh").(bool)),
-		Level:      aws.String(d.Get("level").(string)),
+		Level:      level_aws,
 		IamUserArn: aws.String(d.Get("user_arn").(string)),
 		StackId:    aws.String(d.Get("stack_id").(string)),
 	}


### PR DESCRIPTION
When the permissions being changed in OpsWorks were only the flags
for the sudo and ssh permissions of the current user, terraform
would send a 'level' parameter containing an empty string. This is
not valid, and AWS will respond to the request saying you cannot
change your own privilege level. Clearly an empty string ("") is
not taken as being 'unchanged', but nil is.

This change detects that an empty string would be sent to AWS and
if so, sends 'nil' in its place (which makes the parameter unset,
and allows the operation). Consequently, this allows the OpsWorks
SetPermissions operation to complete, changing the Sudo or SSH
permissions.

Fixes: https://github.com/terraform-providers/terraform-provider-aws/issues/458