### PR TITLE
r/kms_key: Retry lookups after creation

### DIFF
--- a/aws/resource_aws_kms_key_test.go
+++ b/aws/resource_aws_kms_key_test.go
@@ -212,12 +212,15 @@ func testAccCheckAWSKmsKeyExists(name string, key *kms.KeyMetadata) resource.Tes
 
 		conn := testAccProvider.Meta().(*AWSClient).kmsconn
 
-		out, err := conn.DescribeKey(&kms.DescribeKeyInput{
-			KeyId: aws.String(rs.Primary.ID),
+		o, err := retryOnAwsCode("NotFoundException", func() (interface{}, error) {
+			return conn.DescribeKey(&kms.DescribeKeyInput{
+				KeyId: aws.String(rs.Primary.ID),
+			})
 		})
 		if err != nil {
 			return err
 		}
+		out := o.(*kms.DescribeKeyOutput)
 
 		*key = *out.KeyMetadata
 


### PR DESCRIPTION
This is to address the following test failures:

```
=== RUN   TestAccAWSKmsAlias_basic
--- FAIL: TestAccAWSKmsAlias_basic (24.96s)
    testing.go:428: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_kms_key.two: 1 error(s) occurred:
        
        * aws_kms_key.two: NotFoundException: Key 'arn:aws:kms:us-west-2:*******:key/c857a00e-1276-4e08-8e08-d5b9d0b75e41' does not exist
            status code: 400, request id: 0eba259a-5a3b-11e7-b344-c7ea9798df62

=== RUN   TestAccAWSKmsAlias_importBasic
--- FAIL: TestAccAWSKmsAlias_importBasic (25.91s)
    testing.go:428: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_kms_key.one: 1 error(s) occurred:
        
        * aws_kms_key.one: NotFoundException: Key 'arn:aws:kms:us-west-2:*******:key/118a3530-5361-4649-8536-a93f2ede591a' does not exist
            status code: 400, request id: 9898277d-5c8a-11e7-abbd-b9503fe779e7

=== RUN   TestAccAWSKmsAlias_multiple
--- FAIL: TestAccAWSKmsAlias_multiple (22.69s)
    testing.go:428: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_kms_key.single: 1 error(s) occurred:
        
        * aws_kms_key.single: Failed to get KMS key tags (key: e47b525d-38b2-4402-aee1-0be1292d9c4a): NotFoundException: Key 'arn:aws:kms:us-west-2:*******:key/e47b525d-38b2-4402-aee1-0be1292d9c4a' does not exist
            status code: 400, request id: 078d3a84-5329-11e7-a59b-71d56abfc9fc

=== RUN   TestAccAWSKmsAlias_name_prefix
--- FAIL: TestAccAWSKmsAlias_name_prefix (23.85s)
    testing.go:428: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_kms_key.two: 1 error(s) occurred:
        
        * aws_kms_key.two: NotFoundException: Key 'arn:aws:kms:us-west-2:*******:key/620c5864-ab1e-4f32-8615-a39552d0c6b8' does not exist
            status code: 400, request id: e963e5c2-50cf-11e7-9c90-87b19212a0de

=== RUN   TestAccAWSKmsAlias_no_name
--- FAIL: TestAccAWSKmsAlias_no_name (23.85s)
    testing.go:428: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_kms_key.two: 1 error(s) occurred:
        
        * aws_kms_key.two: NotFoundException: Key 'arn:aws:kms:us-west-2:*******:key/03d28cdc-f477-43d0-9605-d52de2e0ff76' does not exist
            status code: 400, request id: fb98019c-54bb-11e7-8cee-9f3a8216e097

=== RUN   TestAccAWSKmsKey_basic
--- FAIL: TestAccAWSKmsKey_basic (22.54s)
    testing.go:280: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_kms_key.foo: 1 error(s) occurred:
        
        * aws_kms_key.foo: NotFoundException: Key 'arn:aws:kms:us-west-2:*******:key/adeb6095-616a-4b50-958d-0325dac6ae4f' does not exist
            status code: 400, request id: 9fcce70a-45cc-11e7-87aa-cb3194a8108b

=== RUN   TestAccAWSKmsKey_disappears
--- FAIL: TestAccAWSKmsKey_disappears (3.09s)
    testing.go:280: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_kms_key.foo: 1 error(s) occurred:
        
        * aws_kms_key.foo: NotFoundException: Key 'arn:aws:kms:us-west-2:*******:key/2520d4af-7071-4b39-9bec-8c75e3b46032' does not exist
            status code: 400, request id: 5ec12c47-32ef-11e7-ac0c-1feea159ca97

=== RUN   TestAccAWSKmsKey_importBasic
--- FAIL: TestAccAWSKmsKey_importBasic (23.50s)
    testing.go:280: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_kms_key.foo: 1 error(s) occurred:
        
        * aws_kms_key.foo: NotFoundException: Key 'arn:aws:kms:us-west-2:*******:key/161bfac9-279f-470b-8c4d-c8eed3783c3a' does not exist
            status code: 400, request id: 6d7093c7-4a76-11e7-b6df-cb1b052b0f43

=== RUN   TestAccAWSKmsKey_isEnabled
--- FAIL: TestAccAWSKmsKey_isEnabled (21.54s)
    testing.go:265: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_kms_key.bar: 1 error(s) occurred:
        
        * aws_kms_key.bar: Failed to set key rotation for "0750e54a-1bd6-4ae8-830b-a019ad0601ec" to true: "NotFoundException: Key 'arn:aws:kms:us-west-2:*******:key/0750e54a-1bd6-4ae8-830b-a019ad0601ec' does not exist\n\tstatus code: 400, request id: 8c1c8664-f5a4-11e6-bd72-9d8ac691c38b"

=== RUN   TestAccAWSKmsKey_policy
--- FAIL: TestAccAWSKmsKey_policy (22.99s)
    testing.go:428: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_kms_key.foo: 1 error(s) occurred:
        
        * aws_kms_key.foo: NotFoundException: Key 'arn:aws:kms:us-west-2:*******:key/b0bc93e2-b846-4d38-afa0-5c41a23fd3b3' does not exist
            status code: 400, request id: eeafefd9-5f41-11e7-932d-7b4776770aa1

=== RUN   TestAccAWSKmsKey_tags
--- FAIL: TestAccAWSKmsKey_tags (23.16s)
    testing.go:428: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_kms_key.foo: 1 error(s) occurred:
        
        * aws_kms_key.foo: NotFoundException: Key 'arn:aws:kms:us-west-2:*******:key/c0468528-75cd-46a4-941d-38cbab46cda9' does not exist
            status code: 400, request id: 00e0034e-50d0-11e7-b0df-ed08666dd37a
```

this one

```
=== RUN   TestAccAWSKmsKey_isEnabled
--- FAIL: TestAccAWSKmsKey_isEnabled (100.82s)
    testing.go:428: Step 1 error: After applying this step and refreshing, the plan was not empty:
        
        DIFF:
        
        UPDATE: aws_kms_key.bar
          is_enabled: "true" => "false"
        
        STATE:
        
        aws_kms_key.bar:
          ID = 331666bc-e480-4bbd-8e94-19457be08dcc
          arn = arn:aws:kms:us-west-2:*******:key/331666bc-e480-4bbd-8e94-19457be08dcc
          deletion_window_in_days = 7
          description = Terraform acc test is_enabled Sun, 25 Jun 2017 06:53:24 UTC
          enable_key_rotation = false
          is_enabled = true
          key_id = 331666bc-e480-4bbd-8e94-19457be08dcc
          key_usage = ENCRYPT_DECRYPT
          policy = {"Id":"key-default-1","Statement":[{"Action":"kms:*","Effect":"Allow","Principal":{"AWS":"arn:aws:iam::*******:root"},"Resource":"*","Sid":"Enable IAM User Permissions"}],"Version":"2012-10-17"}
          tags.% = 0

=== RUN   TestAccAWSKmsKey_isEnabled
--- FAIL: TestAccAWSKmsKey_isEnabled (76.05s)
    testing.go:265: Step 1 error: Check failed: Check 2/4 error: aws_kms_key.bar: Attribute 'is_enabled' expected "false", got "true"
```
and this one
```
=== RUN   TestAccAWSKmsKey_isEnabled
--- FAIL: TestAccAWSKmsKey_isEnabled (229.51s)
    testing.go:280: Step 2 error: Error applying: 1 error(s) occurred:
        
        * aws_kms_key.bar: 1 error(s) occurred:
        
        * aws_kms_key.bar: Failed to set key rotation for "c98e0539-7d2a-4bdf-9380-0a5258a69b44" to true: "DisabledException: arn:aws:kms:us-west-2:*******:key/c98e0539-7d2a-4bdf-9380-0a5258a69b44 is disabled.\n\tstatus code: 400, request id: 6a240630-2b16-11e7-b764-abbc11cb3f70"
```

and maybe a some more caused by the same error code.