### PR TITLE
Add support for aws_batch_compute_environment

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/apigateway"
 	"github.com/aws/aws-sdk-go/service/applicationautoscaling"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/aws/aws-sdk-go/service/batch"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/cloudfront"
 	"github.com/aws/aws-sdk-go/service/cloudtrail"
@@ -176,6 +177,7 @@ type AWSClient struct {
 	wafconn               *waf.WAF
 	wafregionalconn       *wafregional.WAFRegional
 	iotconn               *iot.IoT
+	batchconn             *batch.Batch
 }
 
 func (c *AWSClient) S3() *s3.S3 {
@@ -384,6 +386,7 @@ func (c *Config) Client() (interface{}, error) {
 	client.ssmconn = ssm.New(sess)
 	client.wafconn = waf.New(sess)
 	client.wafregionalconn = wafregional.New(sess)
+	client.batchconn = batch.New(sess)
 
 	// Workaround for https://github.com/aws/aws-sdk-go/issues/1376
 	client.kinesisconn.Handlers.Retry.PushBack(func(r *request.Request) {

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -484,6 +484,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_waf_sql_injection_match_set":              resourceAwsWafSqlInjectionMatchSet(),
 			"aws_wafregional_byte_match_set":               resourceAwsWafRegionalByteMatchSet(),
 			"aws_wafregional_ipset":                        resourceAwsWafRegionalIPSet(),
+			"aws_batch_compute_environment":                resourceAwsBatchComputeEnvironment(),
 		},
 		ConfigureFunc: providerConfigure,
 	}

--- a/aws/resource_aws_batch_compute_environment.go
+++ b/aws/resource_aws_batch_compute_environment.go
@@ -14,8 +14,6 @@ import (
 )
 
 var reComputeEnvironmentName = regexp.MustCompile(`^[A-Za-z0-9_]*$`)
-var reArnOfIamRole = regexp.MustCompile(`^arn:aws:iam::[0-9]{12}:role/.*$`)
-var reArnOfIamInstanceProfile = regexp.MustCompile(`^arn:aws:iam::[0-9]{12}:instance-profile/.*$`)
 
 func resourceAwsBatchComputeEnvironment() *schema.Resource {
 	return &schema.Resource{
@@ -61,7 +59,7 @@ func resourceAwsBatchComputeEnvironment() *schema.Resource {
 							Type:         schema.TypeString,
 							Required:     true,
 							ForceNew:     true,
-							ValidateFunc: isArnOfIamInstanceProfile,
+							ValidateFunc: validateArn,
 						},
 						"instance_type": {
 							Type:     schema.TypeSet,
@@ -87,7 +85,7 @@ func resourceAwsBatchComputeEnvironment() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ForceNew:     true,
-							ValidateFunc: isArnOfIamRole,
+							ValidateFunc: validateArn,
 						},
 						"subnets": {
 							Type:     schema.TypeSet,
@@ -108,7 +106,7 @@ func resourceAwsBatchComputeEnvironment() *schema.Resource {
 			"service_role": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: isArnOfIamRole,
+				ValidateFunc: validateArn,
 			},
 			"state": {
 				Type:         schema.TypeString,
@@ -443,38 +441,6 @@ func isCorrentComputeEnvironmentName(i interface{}, k string) (s []string, es []
 	if !(reComputeEnvironmentName.MatchString(v) && len(v) <= 128) {
 		es = append(es, fmt.Errorf("computeEnvironmentName must be up to 128 letters (uppercase and lowercase), numbers, and underscores."))
 		return
-	}
-
-	return
-}
-
-func isArnOfIamRole(i interface{}, k string) (s []string, es []error) {
-	v, ok := i.(string)
-	if !ok {
-		es = append(es, fmt.Errorf("expected type of %s to be string", k))
-		return
-	}
-
-	if !reArnOfIamRole.MatchString(v) {
-		es = append(es, fmt.Errorf("expected arn of iam role, got %s", v))
-		return
-
-	}
-
-	return
-}
-
-func isArnOfIamInstanceProfile(i interface{}, k string) (s []string, es []error) {
-	v, ok := i.(string)
-	if !ok {
-		es = append(es, fmt.Errorf("expected type of %s to be string", k))
-		return
-	}
-
-	if !reArnOfIamInstanceProfile.MatchString(v) {
-		es = append(es, fmt.Errorf("expected arn of iam instance profile, got %s", v))
-		return
-
 	}
 
 	return

--- a/aws/resource_aws_batch_compute_environment.go
+++ b/aws/resource_aws_batch_compute_environment.go
@@ -262,25 +262,7 @@ func resourceAwsBatchComputeEnvironmentRead(d *schema.ResourceData, meta interfa
 	d.Set("type", computeEnvironment.Type)
 
 	if *(computeEnvironment.Type) == "MANAGED" {
-		computeResource := computeEnvironment.ComputeResources
-
-		d.Set("compute_resources", []interface{}{
-			map[string]interface{}{
-				"bid_percentage":      computeResource.BidPercentage,
-				"desired_vcpus":       computeResource.DesiredvCpus,
-				"ec2_key_pair":        computeResource.Ec2KeyPair,
-				"image_id":            computeResource.ImageId,
-				"instance_role":       computeResource.InstanceRole,
-				"instance_type":       schema.NewSet(schema.HashString, flattenStringList(computeResource.InstanceTypes)),
-				"max_vcpus":           computeResource.MaxvCpus,
-				"min_vcpus":           computeResource.MinvCpus,
-				"security_group_ids":  schema.NewSet(schema.HashString, flattenStringList(computeResource.SecurityGroupIds)),
-				"spot_iam_fleet_role": computeResource.SpotIamFleetRole,
-				"subnets":             schema.NewSet(schema.HashString, flattenStringList(computeResource.Subnets)),
-				"tags":                tagsToMapGeneric(computeResource.Tags),
-				"type":                computeResource.Type,
-			},
-		})
+		d.Set("compute_resources", flattenComputeResources(computeEnvironment.ComputeResources))
 	}
 
 	d.Set("arn", computeEnvironment.ComputeEnvironmentArn)
@@ -289,6 +271,28 @@ func resourceAwsBatchComputeEnvironmentRead(d *schema.ResourceData, meta interfa
 	d.Set("status_reason", computeEnvironment.StatusReason)
 
 	return nil
+}
+
+func flattenComputeResources(computeResource *batch.ComputeResource) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0)
+	m := make(map[string]interface{})
+
+	m["bid_percentage"] = computeResource.BidPercentage
+	m["desired_vcpus"] = computeResource.DesiredvCpus
+	m["ec2_key_pair"] = computeResource.Ec2KeyPair
+	m["image_id"] = computeResource.ImageId
+	m["instance_role"] = computeResource.InstanceRole
+	m["instance_type"] = schema.NewSet(schema.HashString, flattenStringList(computeResource.InstanceTypes))
+	m["max_vcpus"] = computeResource.MaxvCpus
+	m["min_vcpus"] = computeResource.MinvCpus
+	m["security_group_ids"] = schema.NewSet(schema.HashString, flattenStringList(computeResource.SecurityGroupIds))
+	m["spot_iam_fleet_role"] = computeResource.SpotIamFleetRole
+	m["subnets"] = schema.NewSet(schema.HashString, flattenStringList(computeResource.Subnets))
+	m["tags"] = tagsToMapGeneric(computeResource.Tags)
+	m["type"] = computeResource.Type
+
+	result = append(result, m)
+	return result
 }
 
 func resourceAwsBatchComputeEnvironmentDelete(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_batch_compute_environment.go
+++ b/aws/resource_aws_batch_compute_environment.go
@@ -150,8 +150,6 @@ func resourceAwsBatchComputeEnvironmentCreate(d *schema.ResourceData, meta inter
 
 	computeEnvironmentName := d.Get("compute_environment_name").(string)
 
-	log.Printf("[DEBUG] Create compute environment \"%s\".\n", computeEnvironmentName)
-
 	serviceRole := d.Get("service_role").(string)
 	computeEnvironmentType := d.Get("type").(string)
 
@@ -222,6 +220,8 @@ func resourceAwsBatchComputeEnvironmentCreate(d *schema.ResourceData, meta inter
 		}
 	}
 
+	log.Printf("[DEBUG] Create compute environment %s.\n", input)
+
 	if _, err := conn.CreateComputeEnvironment(input); err != nil {
 		return err
 	}
@@ -245,6 +245,8 @@ func resourceAwsBatchComputeEnvironmentRead(d *schema.ResourceData, meta interfa
 			aws.String(computeEnvironmentName),
 		},
 	}
+
+	log.Printf("[DEBUG] Read compute environment %s.\n", input)
 
 	result, err := conn.DescribeComputeEnvironments(input)
 	if err != nil {
@@ -297,12 +299,12 @@ func resourceAwsBatchComputeEnvironmentDelete(d *schema.ResourceData, meta inter
 
 	computeEnvironmentName := d.Get("compute_environment_name").(string)
 
-	log.Printf("[DEBUG] Delete compute environment \"%s\".\n", computeEnvironmentName)
-
 	updateInput := &batch.UpdateComputeEnvironmentInput{
 		ComputeEnvironment: aws.String(computeEnvironmentName),
 		State:              aws.String(DISABLED),
 	}
+
+	log.Printf("[DEBUG] Delete compute environment %s.\n", updateInput)
 
 	if _, err := conn.UpdateComputeEnvironment(updateInput); err != nil {
 		return err
@@ -333,8 +335,6 @@ func resourceAwsBatchComputeEnvironmentUpdate(d *schema.ResourceData, meta inter
 	conn := meta.(*AWSClient).batchconn
 
 	computeEnvironmentName := d.Get("compute_environment_name").(string)
-
-	log.Printf("[DEBUG] Update compute environment \"%s\".\n", computeEnvironmentName)
 
 	input := &batch.UpdateComputeEnvironmentInput{
 		ComputeEnvironment: aws.String(computeEnvironmentName),
@@ -371,6 +371,8 @@ func resourceAwsBatchComputeEnvironmentUpdate(d *schema.ResourceData, meta inter
 			input.ComputeResources.MinvCpus = aws.Int64(int64(computeResource["min_vcpus"].(int)))
 		}
 	}
+
+	log.Printf("[DEBUG] Update compute environment %s.\n", input)
 
 	if _, err := conn.UpdateComputeEnvironment(input); err != nil {
 		return err

--- a/aws/resource_aws_batch_compute_environment.go
+++ b/aws/resource_aws_batch_compute_environment.go
@@ -11,6 +11,15 @@ import (
 	"github.com/hashicorp/terraform/helper/validation"
 )
 
+const (
+	MANAGED   = "MANAGED"
+	UNMANAGED = "UNMANAGED"
+	EC2       = "EC2"
+	SPOT      = "SPOT"
+	ENABLED   = "ENABLED"
+	DISABLED  = "DISABLED"
+)
+
 func resourceAwsBatchComputeEnvironment() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsBatchComputeEnvironmentCreate,
@@ -94,7 +103,7 @@ func resourceAwsBatchComputeEnvironment() *schema.Resource {
 							Type:         schema.TypeString,
 							Required:     true,
 							ForceNew:     true,
-							ValidateFunc: validation.StringInSlice([]string{"EC2", "SPOT"}, true),
+							ValidateFunc: validation.StringInSlice([]string{EC2, SPOT}, true),
 						},
 					},
 				},
@@ -106,14 +115,14 @@ func resourceAwsBatchComputeEnvironment() *schema.Resource {
 			"state": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringInSlice([]string{"ENABLED", "DISABLED"}, true),
+				ValidateFunc: validation.StringInSlice([]string{ENABLED, DISABLED}, true),
 				Default:      "ENABLED",
 			},
 			"type": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{"MANAGED", "UNMANAGED"}, true),
+				ValidateFunc: validation.StringInSlice([]string{MANAGED, UNMANAGED}, true),
 			},
 			"arn": {
 				Type:     schema.TypeString,
@@ -155,7 +164,7 @@ func resourceAwsBatchComputeEnvironmentCreate(d *schema.ResourceData, meta inter
 		input.State = aws.String(v.(string))
 	}
 
-	if computeEnvironmentType == "MANAGED" {
+	if computeEnvironmentType == MANAGED {
 		computeResources := d.Get("compute_resources").([]interface{})
 		if len(computeResources) == 0 {
 			return fmt.Errorf("One compute environment is expected, but no compute environments are set")
@@ -291,7 +300,7 @@ func resourceAwsBatchComputeEnvironmentDelete(d *schema.ResourceData, meta inter
 
 	updateInput := &batch.UpdateComputeEnvironmentInput{
 		ComputeEnvironment: aws.String(computeEnvironmentName),
-		State:              aws.String("DISABLED"),
+		State:              aws.String(DISABLED),
 	}
 
 	if _, err := conn.UpdateComputeEnvironment(updateInput); err != nil {

--- a/aws/resource_aws_batch_compute_environment.go
+++ b/aws/resource_aws_batch_compute_environment.go
@@ -274,8 +274,6 @@ func resourceAwsBatchComputeEnvironmentRead(d *schema.ResourceData, meta interfa
 
 	if len(result.ComputeEnvironments) == 0 {
 		return fmt.Errorf("One compute environment is expected, but AWS return no compute environment")
-	} else if len(result.ComputeEnvironments) >= 2 {
-		return fmt.Errorf("One compute environment is expected, but AWS return too many compute environment")
 	}
 	computeEnvironment := result.ComputeEnvironments[0]
 

--- a/aws/resource_aws_batch_compute_environment.go
+++ b/aws/resource_aws_batch_compute_environment.go
@@ -1,0 +1,428 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/batch"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func resourceAwsBatchComputeEnvironment() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsBatchComputeEnvironmentCreate,
+		Read:   resourceAwsBatchComputeEnvironmentRead,
+		Update: resourceAwsBatchComputeEnvironmentUpdate,
+		Delete: resourceAwsBatchComputeEnvironmentDelete,
+
+		Schema: map[string]*schema.Schema{
+			"compute_environment_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"compute_resources": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MinItems: 0,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"bid_percentage": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							ForceNew: true,
+						},
+						"desired_vcpus": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"ec2_key_pair": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"image_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"instance_role": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"instance_type": {
+							Type:     schema.TypeSet,
+							Required: true,
+							ForceNew: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
+						},
+						"max_vcpus": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"min_vcpus": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"security_group_ids": {
+							Type:     schema.TypeSet,
+							Required: true,
+							ForceNew: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
+						},
+						"spot_iam_fleet_role": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"subnets": {
+							Type:     schema.TypeSet,
+							Required: true,
+							ForceNew: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
+						},
+						"tags": tagsSchema(),
+						"type": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringInSlice([]string{"EC2", "SPOT"}, true),
+						},
+					},
+				},
+			},
+			"service_role": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"state": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"ENABLED", "DISABLED"}, true),
+				Default:      "ENABLED",
+			},
+			"type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice([]string{"MANAGED", "UNMANAGED"}, true),
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ecc_cluster_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status_reason": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsBatchComputeEnvironmentCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).batchconn
+
+	computeEnvironmentName := d.Get("compute_environment_name").(string)
+
+	log.Printf("[DEBUG] Create compute environment \"%s\".\n", computeEnvironmentName)
+
+	serviceRole := d.Get("service_role").(string)
+	computeEnvironmentType := d.Get("type").(string)
+
+	input := &batch.CreateComputeEnvironmentInput{
+		ComputeEnvironmentName: aws.String(computeEnvironmentName),
+		ServiceRole:            aws.String(serviceRole),
+		Type:                   aws.String(computeEnvironmentType),
+	}
+
+	if v, ok := d.GetOk("state"); ok {
+		input.State = aws.String(v.(string))
+	}
+
+	if computeEnvironmentType == "MANAGED" {
+		computeResources := d.Get("compute_resources").([]interface{})
+		if len(computeResources) == 0 {
+			return fmt.Errorf("One compute environment is expected, but no compute environments are set")
+		}
+		computeResource := computeResources[0].(map[string]interface{})
+
+		instanceRole := computeResource["instance_role"].(string)
+		maxvCpus := int64(computeResource["max_vcpus"].(int))
+		minvCpus := int64(computeResource["min_vcpus"].(int))
+		computeResourceType := computeResource["type"].(string)
+
+		var instanceTypes []*string
+		for _, v := range computeResource["instance_type"].(*schema.Set).List() {
+			instanceTypes = append(instanceTypes, aws.String(v.(string)))
+		}
+
+		var securityGroupIds []*string
+		for _, v := range computeResource["security_group_ids"].(*schema.Set).List() {
+			securityGroupIds = append(securityGroupIds, aws.String(v.(string)))
+		}
+
+		var subnets []*string
+		for _, v := range computeResource["subnets"].(*schema.Set).List() {
+			subnets = append(subnets, aws.String(v.(string)))
+		}
+
+		input.ComputeResources = &batch.ComputeResource{
+			InstanceRole:     aws.String(instanceRole),
+			InstanceTypes:    instanceTypes,
+			MaxvCpus:         aws.Int64(maxvCpus),
+			MinvCpus:         aws.Int64(minvCpus),
+			SecurityGroupIds: securityGroupIds,
+			Subnets:          subnets,
+			Type:             aws.String(computeResourceType),
+		}
+
+		if v, ok := computeResource["bid_percentage"]; ok {
+			input.ComputeResources.BidPercentage = aws.Int64(int64(v.(int)))
+		}
+		if v, ok := computeResource["desired_vcpus"]; ok {
+			input.ComputeResources.DesiredvCpus = aws.Int64(int64(v.(int)))
+		}
+		if v, ok := computeResource["ec2_key_pair"]; ok {
+			input.ComputeResources.Ec2KeyPair = aws.String(v.(string))
+		}
+		if v, ok := computeResource["image_id"]; ok {
+			input.ComputeResources.ImageId = aws.String(v.(string))
+		}
+		if v, ok := computeResource["spot_iam_fleet_role"]; ok {
+			input.ComputeResources.SpotIamFleetRole = aws.String(v.(string))
+		}
+		if v, ok := computeResource["tags"]; ok {
+			input.ComputeResources.Tags = tagsFromMapGeneric(v.(map[string]interface{}))
+		}
+	}
+
+	if _, err := conn.CreateComputeEnvironment(input); err != nil {
+		return err
+	}
+
+	d.SetId(computeEnvironmentName)
+
+	if err := waitComputeEnvironmentValid(d, meta); err != nil {
+		return err
+	}
+
+	return resourceAwsBatchComputeEnvironmentRead(d, meta)
+}
+
+func resourceAwsBatchComputeEnvironmentRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).batchconn
+
+	computeEnvironmentName := d.Get("compute_environment_name").(string)
+
+	input := &batch.DescribeComputeEnvironmentsInput{
+		ComputeEnvironments: []*string{
+			aws.String(computeEnvironmentName),
+		},
+	}
+
+	result, err := conn.DescribeComputeEnvironments(input)
+	if err != nil {
+		return err
+	}
+
+	if len(result.ComputeEnvironments) == 0 {
+		return fmt.Errorf("One compute environment is expected, but AWS return no compute environment")
+	} else if len(result.ComputeEnvironments) >= 2 {
+		return fmt.Errorf("One compute environment is expected, but AWS return too many compute environment")
+	}
+	computeEnvironment := result.ComputeEnvironments[0]
+
+	d.Set("service_role", computeEnvironment.ServiceRole)
+	d.Set("state", computeEnvironment.State)
+	d.Set("type", computeEnvironment.Type)
+
+	if *(computeEnvironment.Type) == "MANAGED" {
+		computeResource := computeEnvironment.ComputeResources
+
+		d.Set("compute_resources", []interface{}{
+			map[string]interface{}{
+				"bid_percentage":      computeResource.BidPercentage,
+				"desired_vcpus":       computeResource.DesiredvCpus,
+				"ec2_key_pair":        computeResource.Ec2KeyPair,
+				"image_id":            computeResource.ImageId,
+				"instance_role":       computeResource.InstanceRole,
+				"instance_type":       schema.NewSet(schema.HashString, flattenStringList(computeResource.InstanceTypes)),
+				"max_vcpus":           computeResource.MaxvCpus,
+				"min_vcpus":           computeResource.MinvCpus,
+				"security_group_ids":  schema.NewSet(schema.HashString, flattenStringList(computeResource.SecurityGroupIds)),
+				"spot_iam_fleet_role": computeResource.SpotIamFleetRole,
+				"subnets":             schema.NewSet(schema.HashString, flattenStringList(computeResource.Subnets)),
+				"tags":                tagsToMapGeneric(computeResource.Tags),
+				"type":                computeResource.Type,
+			},
+		})
+	}
+
+	d.Set("arn", computeEnvironment.ComputeEnvironmentArn)
+	d.Set("ecc_cluster_arn", computeEnvironment.ComputeEnvironmentArn)
+	d.Set("status", computeEnvironment.Status)
+	d.Set("status_reason", computeEnvironment.StatusReason)
+
+	return nil
+}
+
+func resourceAwsBatchComputeEnvironmentDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).batchconn
+
+	computeEnvironmentName := d.Get("compute_environment_name").(string)
+
+	log.Printf("[DEBUG] Delete compute environment \"%s\".\n", computeEnvironmentName)
+
+	updateInput := &batch.UpdateComputeEnvironmentInput{
+		ComputeEnvironment: aws.String(computeEnvironmentName),
+		State:              aws.String("DISABLED"),
+	}
+
+	if _, err := conn.UpdateComputeEnvironment(updateInput); err != nil {
+		return err
+	}
+
+	if err := waitComputeEnvironmentValid(d, meta); err != nil {
+		return err
+	}
+
+	input := &batch.DeleteComputeEnvironmentInput{
+		ComputeEnvironment: aws.String(computeEnvironmentName),
+	}
+
+	if _, err := conn.DeleteComputeEnvironment(input); err != nil {
+		return err
+	}
+
+	if err := waitComputeEnvironmentDeleted(d, meta); err != nil {
+		return err
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+func resourceAwsBatchComputeEnvironmentUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).batchconn
+
+	computeEnvironmentName := d.Get("compute_environment_name").(string)
+
+	log.Printf("[DEBUG] Update compute environment \"%s\".\n", computeEnvironmentName)
+
+	input := &batch.UpdateComputeEnvironmentInput{
+		ComputeEnvironment: aws.String(computeEnvironmentName),
+		ComputeResources:   &batch.ComputeResourceUpdate{},
+	}
+
+	if d.HasChange("service_role") {
+		log.Printf("[DEBUG] Service role of \"%s\" has change.\n", computeEnvironmentName)
+		input.ServiceRole = aws.String(d.Get("service_role").(string))
+	}
+	if d.HasChange("state") {
+		log.Printf("[DEBUG] State of \"%s\" has change.\n", computeEnvironmentName)
+		input.ServiceRole = aws.String(d.Get("state").(string))
+	}
+
+	if d.HasChange("compute_resources") {
+		log.Printf("[DEBUG] Compute resources of \"%s\" has change.\n", computeEnvironmentName)
+		computeResources := d.Get("compute_resources").([]interface{})
+		if len(computeResources) == 0 {
+			return fmt.Errorf("One compute environment is expected, but no compute environments are set")
+		}
+		computeResource := computeResources[0].(map[string]interface{})
+
+		if d.HasChange("compute_resources.0.desired_vcpus") {
+			log.Printf("[DEBUG] Desired vCpus of \"%s\" has change.\n", computeEnvironmentName)
+			input.ComputeResources.DesiredvCpus = aws.Int64(int64(computeResource["desired_vcpus"].(int)))
+		}
+		if d.HasChange("compute_resources.0.max_vcpus") {
+			log.Printf("[DEBUG] Max vCpus of \"%s\" has change.\n", computeEnvironmentName)
+			input.ComputeResources.MaxvCpus = aws.Int64(int64(computeResource["max_vcpus"].(int)))
+		}
+		if d.HasChange("compute_resources.0.min_vcpus") {
+			log.Printf("[DEBUG] Min vCpus of \"%s\" has change.\n", computeEnvironmentName)
+			input.ComputeResources.MinvCpus = aws.Int64(int64(computeResource["min_vcpus"].(int)))
+		}
+	}
+
+	if _, err := conn.UpdateComputeEnvironment(input); err != nil {
+		return err
+	}
+
+	return resourceAwsBatchComputeEnvironmentRead(d, meta)
+}
+
+func waitComputeEnvironmentValid(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).batchconn
+
+	computeEnvironmentName := d.Get("compute_environment_name").(string)
+
+	for {
+		result, err := conn.DescribeComputeEnvironments(&batch.DescribeComputeEnvironmentsInput{
+			ComputeEnvironments: []*string{
+				aws.String(computeEnvironmentName),
+			},
+		})
+		if err != nil {
+			return err
+		}
+
+		if len(result.ComputeEnvironments) == 0 {
+			return fmt.Errorf("One compute environment is expected, but AWS return no compute environment")
+		} else if len(result.ComputeEnvironments) >= 2 {
+			return fmt.Errorf("One compute environment is expected, but AWS return too many compute environment")
+		}
+		computeEnvironment := result.ComputeEnvironments[0]
+		if *(computeEnvironment.Status) == "VALID" {
+			break
+		} else {
+			time.Sleep(1 * time.Second)
+		}
+	}
+
+	log.Printf("[DEBUG] Status of compute environment \"%s\" get VALID.\n", computeEnvironmentName)
+	return nil
+}
+
+func waitComputeEnvironmentDeleted(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).batchconn
+
+	computeEnvironmentName := d.Get("compute_environment_name").(string)
+
+	for {
+		result, err := conn.DescribeComputeEnvironments(&batch.DescribeComputeEnvironmentsInput{
+			ComputeEnvironments: []*string{
+				aws.String(computeEnvironmentName),
+			},
+		})
+		if err != nil {
+			return err
+		}
+
+		if len(result.ComputeEnvironments) == 0 {
+			break
+		} else {
+			time.Sleep(1 * time.Second)
+		}
+	}
+
+	log.Printf("[DEBUG] Compute environment \"%s\" deleted.\n", computeEnvironmentName)
+	return nil
+}

--- a/aws/resource_aws_batch_compute_environment.go
+++ b/aws/resource_aws_batch_compute_environment.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"regexp"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -12,8 +11,6 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 )
-
-var reComputeEnvironmentName = regexp.MustCompile(`^[A-Za-z0-9_]*$`)
 
 func resourceAwsBatchComputeEnvironment() *schema.Resource {
 	return &schema.Resource{
@@ -27,7 +24,7 @@ func resourceAwsBatchComputeEnvironment() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: isCorrentComputeEnvironmentName,
+				ValidateFunc: validateBatchComputeEnvironmentName,
 			},
 			"compute_resources": {
 				Type:     schema.TypeList,
@@ -429,19 +426,4 @@ func resourceAwsBatchComputeEnvironmentDeleteRefreshFunc(d *schema.ResourceData,
 		computeEnvironment := result.ComputeEnvironments[0]
 		return result, *(computeEnvironment.Status), nil
 	}
-}
-
-func isCorrentComputeEnvironmentName(i interface{}, k string) (s []string, es []error) {
-	v, ok := i.(string)
-	if !ok {
-		es = append(es, fmt.Errorf("expected type of %s to be string", k))
-		return
-	}
-
-	if !(reComputeEnvironmentName.MatchString(v) && len(v) <= 128) {
-		es = append(es, fmt.Errorf("computeEnvironmentName must be up to 128 letters (uppercase and lowercase), numbers, and underscores."))
-		return
-	}
-
-	return
 }

--- a/aws/resource_aws_batch_compute_environment.go
+++ b/aws/resource_aws_batch_compute_environment.go
@@ -386,15 +386,9 @@ func resourceAwsBatchComputeEnvironmentUpdate(d *schema.ResourceData, meta inter
 		}
 		computeResource := computeResources[0].(map[string]interface{})
 
-		if d.HasChange("compute_resources.0.desired_vcpus") {
-			input.ComputeResources.DesiredvCpus = aws.Int64(int64(computeResource["desired_vcpus"].(int)))
-		}
-		if d.HasChange("compute_resources.0.max_vcpus") {
-			input.ComputeResources.MaxvCpus = aws.Int64(int64(computeResource["max_vcpus"].(int)))
-		}
-		if d.HasChange("compute_resources.0.min_vcpus") {
-			input.ComputeResources.MinvCpus = aws.Int64(int64(computeResource["min_vcpus"].(int)))
-		}
+		input.ComputeResources.DesiredvCpus = aws.Int64(int64(computeResource["desired_vcpus"].(int)))
+		input.ComputeResources.MaxvCpus = aws.Int64(int64(computeResource["max_vcpus"].(int)))
+		input.ComputeResources.MinvCpus = aws.Int64(int64(computeResource["min_vcpus"].(int)))
 	}
 
 	log.Printf("[DEBUG] Update compute environment %s.\n", input)

--- a/aws/resource_aws_batch_compute_environment.go
+++ b/aws/resource_aws_batch_compute_environment.go
@@ -342,16 +342,13 @@ func resourceAwsBatchComputeEnvironmentUpdate(d *schema.ResourceData, meta inter
 	}
 
 	if d.HasChange("service_role") {
-		log.Printf("[DEBUG] Service role of \"%s\" has change.\n", computeEnvironmentName)
 		input.ServiceRole = aws.String(d.Get("service_role").(string))
 	}
 	if d.HasChange("state") {
-		log.Printf("[DEBUG] State of \"%s\" has change.\n", computeEnvironmentName)
 		input.ServiceRole = aws.String(d.Get("state").(string))
 	}
 
 	if d.HasChange("compute_resources") {
-		log.Printf("[DEBUG] Compute resources of \"%s\" has change.\n", computeEnvironmentName)
 		computeResources := d.Get("compute_resources").([]interface{})
 		if len(computeResources) == 0 {
 			return fmt.Errorf("One compute environment is expected, but no compute environments are set")
@@ -359,15 +356,12 @@ func resourceAwsBatchComputeEnvironmentUpdate(d *schema.ResourceData, meta inter
 		computeResource := computeResources[0].(map[string]interface{})
 
 		if d.HasChange("compute_resources.0.desired_vcpus") {
-			log.Printf("[DEBUG] Desired vCpus of \"%s\" has change.\n", computeEnvironmentName)
 			input.ComputeResources.DesiredvCpus = aws.Int64(int64(computeResource["desired_vcpus"].(int)))
 		}
 		if d.HasChange("compute_resources.0.max_vcpus") {
-			log.Printf("[DEBUG] Max vCpus of \"%s\" has change.\n", computeEnvironmentName)
 			input.ComputeResources.MaxvCpus = aws.Int64(int64(computeResource["max_vcpus"].(int)))
 		}
 		if d.HasChange("compute_resources.0.min_vcpus") {
-			log.Printf("[DEBUG] Min vCpus of \"%s\" has change.\n", computeEnvironmentName)
 			input.ComputeResources.MinvCpus = aws.Int64(int64(computeResource["min_vcpus"].(int)))
 		}
 	}

--- a/aws/resource_aws_batch_compute_environment.go
+++ b/aws/resource_aws_batch_compute_environment.go
@@ -69,7 +69,6 @@ func resourceAwsBatchComputeEnvironment() *schema.Resource {
 							Required: true,
 							ForceNew: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
-							Set:      schema.HashString,
 						},
 						"max_vcpus": {
 							Type:     schema.TypeInt,
@@ -84,7 +83,6 @@ func resourceAwsBatchComputeEnvironment() *schema.Resource {
 							Required: true,
 							ForceNew: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
-							Set:      schema.HashString,
 						},
 						"spot_iam_fleet_role": {
 							Type:     schema.TypeString,
@@ -96,7 +94,6 @@ func resourceAwsBatchComputeEnvironment() *schema.Resource {
 							Required: true,
 							ForceNew: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
-							Set:      schema.HashString,
 						},
 						"tags": tagsSchema(),
 						"type": {

--- a/aws/resource_aws_batch_compute_environment_test.go
+++ b/aws/resource_aws_batch_compute_environment_test.go
@@ -237,35 +237,6 @@ func TestAccAWSBatchComputeEnvironment_createEc2WithBadComputeEnvironmentName2(t
 		},
 	})
 }
-
-func TestAccAWSBatchComputeEnvironment_createEc2WithBadIamInstanceProfileArn(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccAWSBatchComputeEnvironmentConfigEC2WithBadIamInstanceProfileArn,
-				ExpectError: regexp.MustCompile(`expected arn of iam instance profile, got bad_iam_instance_profile_arn`),
-			},
-		},
-	})
-}
-
-func TestAccAWSBatchComputeEnvironment_createEc2WithBadIamRoleArn(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccAWSBatchComputeEnvironmentConfigEC2WithBadIamRoleArn,
-				ExpectError: regexp.MustCompile(`expected arn of iam role, got bad_iam_role_arn`),
-			},
-		},
-	})
-}
-
 func testAccCheckBatchComputeEnvironmentDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).batchconn
 
@@ -692,52 +663,6 @@ resource "aws_batch_compute_environment" "ec2" {
     type = "EC2"
   }
   service_role = "${aws_iam_role.aws_batch_service_role.arn}"
-  type = "MANAGED"
-}
-`
-
-const testAccAWSBatchComputeEnvironmentConfigEC2WithBadIamInstanceProfileArn = testAccAWSBatchComputeEnvironmentConfigBase + `
-resource "aws_batch_compute_environment" "ec2" {
-  compute_environment_name = "sample"
-  compute_resources {
-    instance_role = "bad_iam_instance_profile_arn"
-    instance_type = [
-      "c4.large",
-    ]
-    max_vcpus = 16
-    min_vcpus = 0
-    security_group_ids = [
-      "${aws_security_group.test_acc.id}"
-    ]
-    subnets = [
-      "${aws_subnet.test_acc.id}"
-    ]
-    type = "EC2"
-  }
-  service_role = "${aws_iam_role.aws_batch_service_role.arn}"
-  type = "MANAGED"
-}
-`
-
-const testAccAWSBatchComputeEnvironmentConfigEC2WithBadIamRoleArn = testAccAWSBatchComputeEnvironmentConfigBase + `
-resource "aws_batch_compute_environment" "ec2" {
-  compute_environment_name = "sample"
-  compute_resources {
-    instance_role = "${aws_iam_instance_profile.ecs_instance_role.arn}"
-    instance_type = [
-      "c4.large",
-    ]
-    max_vcpus = 16
-    min_vcpus = 0
-    security_group_ids = [
-      "${aws_security_group.test_acc.id}"
-    ]
-    subnets = [
-      "${aws_subnet.test_acc.id}"
-    ]
-    type = "EC2"
-  }
-  service_role = "bad_iam_role_arn"
   type = "MANAGED"
 }
 `

--- a/aws/resource_aws_batch_compute_environment_test.go
+++ b/aws/resource_aws_batch_compute_environment_test.go
@@ -503,29 +503,6 @@ resource "aws_batch_compute_environment" "unmanaged" {
 }
 `
 
-const testAccAWSBatchComputeEnvironmentConfigUpdatevCpus = testAccAWSBatchComputeEnvironmentConfigBase + `
-resource "aws_batch_compute_environment" "ec2" {
-  compute_environment_name = "sample"
-  compute_resources {
-    instance_role = "${aws_iam_instance_profile.ecs_instance_role.arn}"
-    instance_type = [
-      "c4.large",
-    ]
-    max_vcpus = 32
-    min_vcpus = 0
-    security_group_ids = [
-      "${aws_security_group.test_acc.id}"
-    ]
-    subnets = [
-      "${aws_subnet.test_acc.id}"
-    ]
-    type = "EC2"
-  }
-  service_role = "${aws_iam_role.aws_batch_service_role.arn}"
-  type = "MANAGED"
-}
-`
-
 const testAccAWSBatchComputeEnvironmentConfigEC2UpdateMaxvCpus = testAccAWSBatchComputeEnvironmentConfigBase + `
 resource "aws_batch_compute_environment" "ec2" {
   compute_environment_name = "sample"

--- a/aws/resource_aws_batch_compute_environment_test.go
+++ b/aws/resource_aws_batch_compute_environment_test.go
@@ -194,6 +194,50 @@ func TestAccAWSBatchComputeEnvironment_createSpotWithoutBidPercentage(t *testing
 	})
 }
 
+func TestAccAWSBatchComputeEnvironment_createEc2WithGoodComputeEnvironmentName(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSBatchComputeEnvironmentConfigEC2WithGoodComputeEnvironmentName,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBatchComputeEnvironmentExists(),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSBatchComputeEnvironment_createEc2WithBadComputeEnvironmentName1(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSBatchComputeEnvironmentConfigEC2WithBadComputeEnvironmentName1,
+				ExpectError: regexp.MustCompile(`computeEnvironmentName must be up to 128 letters \(uppercase and lowercase\), numbers, and underscores.`),
+			},
+		},
+	})
+}
+
+func TestAccAWSBatchComputeEnvironment_createEc2WithBadComputeEnvironmentName2(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSBatchComputeEnvironmentConfigEC2WithBadComputeEnvironmentName2,
+				ExpectError: regexp.MustCompile(`computeEnvironmentName must be up to 128 letters \(uppercase and lowercase\), numbers, and underscores.`),
+			},
+		},
+	})
+}
+
 func testAccCheckBatchComputeEnvironmentDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).batchconn
 
@@ -572,6 +616,75 @@ resource "aws_batch_compute_environment" "ec2" {
       "${aws_subnet.test_acc.id}"
     ]
     type = "SPOT"
+  }
+  service_role = "${aws_iam_role.aws_batch_service_role.arn}"
+  type = "MANAGED"
+}
+`
+
+const testAccAWSBatchComputeEnvironmentConfigEC2WithGoodComputeEnvironmentName = testAccAWSBatchComputeEnvironmentConfigBase + `
+resource "aws_batch_compute_environment" "ec2" {
+  compute_environment_name = "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678"
+  compute_resources {
+    instance_role = "${aws_iam_instance_profile.ecs_instance_role.arn}"
+    instance_type = [
+      "c4.large",
+    ]
+    max_vcpus = 16
+    min_vcpus = 0
+    security_group_ids = [
+      "${aws_security_group.test_acc.id}"
+    ]
+    subnets = [
+      "${aws_subnet.test_acc.id}"
+    ]
+    type = "EC2"
+  }
+  service_role = "${aws_iam_role.aws_batch_service_role.arn}"
+  type = "MANAGED"
+}
+`
+
+const testAccAWSBatchComputeEnvironmentConfigEC2WithBadComputeEnvironmentName1 = testAccAWSBatchComputeEnvironmentConfigBase + `
+resource "aws_batch_compute_environment" "ec2" {
+  compute_environment_name = "sam@ple"
+  compute_resources {
+    instance_role = "${aws_iam_instance_profile.ecs_instance_role.arn}"
+    instance_type = [
+      "c4.large",
+    ]
+    max_vcpus = 16
+    min_vcpus = 0
+    security_group_ids = [
+      "${aws_security_group.test_acc.id}"
+    ]
+    subnets = [
+      "${aws_subnet.test_acc.id}"
+    ]
+    type = "EC2"
+  }
+  service_role = "${aws_iam_role.aws_batch_service_role.arn}"
+  type = "MANAGED"
+}
+`
+
+const testAccAWSBatchComputeEnvironmentConfigEC2WithBadComputeEnvironmentName2 = testAccAWSBatchComputeEnvironmentConfigBase + `
+resource "aws_batch_compute_environment" "ec2" {
+  compute_environment_name = "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"
+  compute_resources {
+    instance_role = "${aws_iam_instance_profile.ecs_instance_role.arn}"
+    instance_type = [
+      "c4.large",
+    ]
+    max_vcpus = 16
+    min_vcpus = 0
+    security_group_ids = [
+      "${aws_security_group.test_acc.id}"
+    ]
+    subnets = [
+      "${aws_subnet.test_acc.id}"
+    ]
+    type = "EC2"
   }
   service_role = "${aws_iam_role.aws_batch_service_role.arn}"
   type = "MANAGED"

--- a/aws/resource_aws_batch_compute_environment_test.go
+++ b/aws/resource_aws_batch_compute_environment_test.go
@@ -194,49 +194,6 @@ func TestAccAWSBatchComputeEnvironment_createSpotWithoutBidPercentage(t *testing
 	})
 }
 
-func TestAccAWSBatchComputeEnvironment_createEc2WithGoodComputeEnvironmentName(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSBatchComputeEnvironmentConfigEC2WithGoodComputeEnvironmentName,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsBatchComputeEnvironmentExists(),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSBatchComputeEnvironment_createEc2WithBadComputeEnvironmentName1(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccAWSBatchComputeEnvironmentConfigEC2WithBadComputeEnvironmentName1,
-				ExpectError: regexp.MustCompile(`computeEnvironmentName must be up to 128 letters \(uppercase and lowercase\), numbers, and underscores.`),
-			},
-		},
-	})
-}
-
-func TestAccAWSBatchComputeEnvironment_createEc2WithBadComputeEnvironmentName2(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccAWSBatchComputeEnvironmentConfigEC2WithBadComputeEnvironmentName2,
-				ExpectError: regexp.MustCompile(`computeEnvironmentName must be up to 128 letters \(uppercase and lowercase\), numbers, and underscores.`),
-			},
-		},
-	})
-}
 func testAccCheckBatchComputeEnvironmentDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).batchconn
 
@@ -592,75 +549,6 @@ resource "aws_batch_compute_environment" "ec2" {
       "${aws_subnet.test_acc.id}"
     ]
     type = "SPOT"
-  }
-  service_role = "${aws_iam_role.aws_batch_service_role.arn}"
-  type = "MANAGED"
-}
-`
-
-const testAccAWSBatchComputeEnvironmentConfigEC2WithGoodComputeEnvironmentName = testAccAWSBatchComputeEnvironmentConfigBase + `
-resource "aws_batch_compute_environment" "ec2" {
-  compute_environment_name = "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678"
-  compute_resources {
-    instance_role = "${aws_iam_instance_profile.ecs_instance_role.arn}"
-    instance_type = [
-      "c4.large",
-    ]
-    max_vcpus = 16
-    min_vcpus = 0
-    security_group_ids = [
-      "${aws_security_group.test_acc.id}"
-    ]
-    subnets = [
-      "${aws_subnet.test_acc.id}"
-    ]
-    type = "EC2"
-  }
-  service_role = "${aws_iam_role.aws_batch_service_role.arn}"
-  type = "MANAGED"
-}
-`
-
-const testAccAWSBatchComputeEnvironmentConfigEC2WithBadComputeEnvironmentName1 = testAccAWSBatchComputeEnvironmentConfigBase + `
-resource "aws_batch_compute_environment" "ec2" {
-  compute_environment_name = "sam@ple"
-  compute_resources {
-    instance_role = "${aws_iam_instance_profile.ecs_instance_role.arn}"
-    instance_type = [
-      "c4.large",
-    ]
-    max_vcpus = 16
-    min_vcpus = 0
-    security_group_ids = [
-      "${aws_security_group.test_acc.id}"
-    ]
-    subnets = [
-      "${aws_subnet.test_acc.id}"
-    ]
-    type = "EC2"
-  }
-  service_role = "${aws_iam_role.aws_batch_service_role.arn}"
-  type = "MANAGED"
-}
-`
-
-const testAccAWSBatchComputeEnvironmentConfigEC2WithBadComputeEnvironmentName2 = testAccAWSBatchComputeEnvironmentConfigBase + `
-resource "aws_batch_compute_environment" "ec2" {
-  compute_environment_name = "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"
-  compute_resources {
-    instance_role = "${aws_iam_instance_profile.ecs_instance_role.arn}"
-    instance_type = [
-      "c4.large",
-    ]
-    max_vcpus = 16
-    min_vcpus = 0
-    security_group_ids = [
-      "${aws_security_group.test_acc.id}"
-    ]
-    subnets = [
-      "${aws_subnet.test_acc.id}"
-    ]
-    type = "EC2"
   }
   service_role = "${aws_iam_role.aws_batch_service_role.arn}"
   type = "MANAGED"

--- a/aws/resource_aws_batch_compute_environment_test.go
+++ b/aws/resource_aws_batch_compute_environment_test.go
@@ -238,6 +238,34 @@ func TestAccAWSBatchComputeEnvironment_createEc2WithBadComputeEnvironmentName2(t
 	})
 }
 
+func TestAccAWSBatchComputeEnvironment_createEc2WithBadIamInstanceProfileArn(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSBatchComputeEnvironmentConfigEC2WithBadIamInstanceProfileArn,
+				ExpectError: regexp.MustCompile(`expected arn of iam instance profile, got bad_iam_instance_profile_arn`),
+			},
+		},
+	})
+}
+
+func TestAccAWSBatchComputeEnvironment_createEc2WithBadIamRoleArn(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSBatchComputeEnvironmentConfigEC2WithBadIamRoleArn,
+				ExpectError: regexp.MustCompile(`expected arn of iam role, got bad_iam_role_arn`),
+			},
+		},
+	})
+}
+
 func testAccCheckBatchComputeEnvironmentDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).batchconn
 
@@ -687,6 +715,52 @@ resource "aws_batch_compute_environment" "ec2" {
     type = "EC2"
   }
   service_role = "${aws_iam_role.aws_batch_service_role.arn}"
+  type = "MANAGED"
+}
+`
+
+const testAccAWSBatchComputeEnvironmentConfigEC2WithBadIamInstanceProfileArn = testAccAWSBatchComputeEnvironmentConfigBase + `
+resource "aws_batch_compute_environment" "ec2" {
+  compute_environment_name = "sample"
+  compute_resources {
+    instance_role = "bad_iam_instance_profile_arn"
+    instance_type = [
+      "c4.large",
+    ]
+    max_vcpus = 16
+    min_vcpus = 0
+    security_group_ids = [
+      "${aws_security_group.test_acc.id}"
+    ]
+    subnets = [
+      "${aws_subnet.test_acc.id}"
+    ]
+    type = "EC2"
+  }
+  service_role = "${aws_iam_role.aws_batch_service_role.arn}"
+  type = "MANAGED"
+}
+`
+
+const testAccAWSBatchComputeEnvironmentConfigEC2WithBadIamRoleArn = testAccAWSBatchComputeEnvironmentConfigBase + `
+resource "aws_batch_compute_environment" "ec2" {
+  compute_environment_name = "sample"
+  compute_resources {
+    instance_role = "${aws_iam_instance_profile.ecs_instance_role.arn}"
+    instance_type = [
+      "c4.large",
+    ]
+    max_vcpus = 16
+    min_vcpus = 0
+    security_group_ids = [
+      "${aws_security_group.test_acc.id}"
+    ]
+    subnets = [
+      "${aws_subnet.test_acc.id}"
+    ]
+    type = "EC2"
+  }
+  service_role = "bad_iam_role_arn"
   type = "MANAGED"
 }
 `

--- a/aws/resource_aws_batch_compute_environment_test.go
+++ b/aws/resource_aws_batch_compute_environment_test.go
@@ -1,0 +1,579 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/batch"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSBatchComputeEnvironment_createEc2(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSBatchComputeEnvironmentConfigEC2,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBatchComputeEnvironmentExists(),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSBatchComputeEnvironment_createEc2WithTags(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSBatchComputeEnvironmentConfigEC2WithTags,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBatchComputeEnvironmentExists(),
+					resource.TestCheckResourceAttr("aws_batch_compute_environment.ec2", "compute_resources.0.tags.%", "1"),
+					resource.TestCheckResourceAttr("aws_batch_compute_environment.ec2", "compute_resources.0.tags.Key1", "Value1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSBatchComputeEnvironment_createSpot(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSBatchComputeEnvironmentConfigSpot,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBatchComputeEnvironmentExists(),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSBatchComputeEnvironment_createUnmanaged(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSBatchComputeEnvironmentConfigUnmanaged,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBatchComputeEnvironmentExists(),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSBatchComputeEnvironment_updateMaxvCpus(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSBatchComputeEnvironmentConfigEC2,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBatchComputeEnvironmentExists(),
+					resource.TestCheckResourceAttr("aws_batch_compute_environment.ec2", "compute_resources.0.max_vcpus", "16"),
+				),
+			},
+			{
+				Config: testAccAWSBatchComputeEnvironmentConfigEC2UpdateMaxvCpus,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBatchComputeEnvironmentExists(),
+					resource.TestCheckResourceAttr("aws_batch_compute_environment.ec2", "compute_resources.0.max_vcpus", "32"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSBatchComputeEnvironment_updateInstanceType(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSBatchComputeEnvironmentConfigEC2,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBatchComputeEnvironmentExists(),
+					resource.TestCheckResourceAttr("aws_batch_compute_environment.ec2", "compute_resources.0.instance_type.#", "1"),
+				),
+			},
+			{
+				Config: testAccAWSBatchComputeEnvironmentConfigEC2UpdateInstanceType,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBatchComputeEnvironmentExists(),
+					resource.TestCheckResourceAttr("aws_batch_compute_environment.ec2", "compute_resources.0.instance_type.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSBatchComputeEnvironment_updateComputeEnvironmentName(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSBatchComputeEnvironmentConfigEC2,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBatchComputeEnvironmentExists(),
+					resource.TestCheckResourceAttr("aws_batch_compute_environment.ec2", "compute_environment_name", "sample"),
+				),
+			},
+			{
+				Config: testAccAWSBatchComputeEnvironmentConfigEC2UpdateComputeEnvironmentName,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBatchComputeEnvironmentExists(),
+					resource.TestCheckResourceAttr("aws_batch_compute_environment.ec2", "compute_environment_name", "sample_updated"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSBatchComputeEnvironment_createEc2WithoutComputeResources(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSBatchComputeEnvironmentConfigEC2WithoutComputeResources,
+				ExpectError: regexp.MustCompile(`One compute environment is expected, but no compute environments are set`),
+			},
+		},
+	})
+}
+
+func TestAccAWSBatchComputeEnvironment_createUnmanagedWithComputeResources(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSBatchComputeEnvironmentConfigUnmanagedWithComputeResources,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBatchComputeEnvironmentExists(),
+					resource.TestCheckResourceAttr("aws_batch_compute_environment.unmanaged", "type", "UNMANAGED"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSBatchComputeEnvironment_createSpotWithoutBidPercentage(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSBatchComputeEnvironmentConfigSpotWithoutBidPercentage,
+				ExpectError: regexp.MustCompile(`ComputeResources.spotIamFleetRole cannot not be null or empty`),
+			},
+		},
+	})
+}
+
+func testAccCheckBatchComputeEnvironmentDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).batchconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_batch_compute_environment" {
+			continue
+		}
+
+		result, err := conn.DescribeComputeEnvironments(&batch.DescribeComputeEnvironmentsInput{
+			ComputeEnvironments: []*string{
+				aws.String(rs.Primary.ID),
+			},
+		})
+
+		if err != nil {
+			return fmt.Errorf("Error occured when get compute environment information.")
+		}
+		if len(result.ComputeEnvironments) == 1 {
+			return fmt.Errorf("Compute environment still exists.")
+		}
+
+	}
+
+	return nil
+}
+
+func testAccCheckAwsBatchComputeEnvironmentExists() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).batchconn
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_batch_compute_environment" {
+				continue
+			}
+
+			result, err := conn.DescribeComputeEnvironments(&batch.DescribeComputeEnvironmentsInput{
+				ComputeEnvironments: []*string{
+					aws.String(rs.Primary.ID),
+				},
+			})
+
+			if err != nil {
+				return fmt.Errorf("Error occured when get compute environment information.")
+			}
+			if len(result.ComputeEnvironments) == 0 {
+				return fmt.Errorf("Compute environment doesn't exists.")
+			} else if len(result.ComputeEnvironments) >= 2 {
+				return fmt.Errorf("Too many compute environments exist.")
+			}
+		}
+
+		return nil
+	}
+}
+
+const testAccAWSBatchComputeEnvironmentConfigBase = `
+
+########## ecs_instance_role ##########
+
+resource "aws_iam_role" "ecs_instance_role" {
+  name = "ecs_instance_role"
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+	{
+	    "Action": "sts:AssumeRole",
+	    "Effect": "Allow",
+	    "Principal": {
+		"Service": "ec2.amazonaws.com"
+	    }
+	}
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_instance_role" {
+  role       = "${aws_iam_role.ecs_instance_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+}
+
+resource "aws_iam_instance_profile" "ecs_instance_role" {
+  name  = "ecs_instance_role"
+  role = "${aws_iam_role.ecs_instance_role.name}"
+}
+
+########## aws_batch_service_role ##########
+
+resource "aws_iam_role" "aws_batch_service_role" {
+  name = "aws_batch_service_role"
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+	{
+	    "Action": "sts:AssumeRole",
+	    "Effect": "Allow",
+	    "Principal": {
+		"Service": "batch.amazonaws.com"
+	    }
+	}
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "aws_batch_service_role" {
+  role       = "${aws_iam_role.aws_batch_service_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole"
+}
+
+########## aws_ec2_spot_fleet_role ##########
+
+resource "aws_iam_role" "aws_ec2_spot_fleet_role" {
+  name = "aws_ec2_spot_fleet_role"
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+	{
+	    "Action": "sts:AssumeRole",
+	    "Effect": "Allow",
+	    "Principal": {
+		"Service": "spotfleet.amazonaws.com"
+	    }
+	}
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "aws_ec2_spot_fleet_role" {
+  role       = "${aws_iam_role.aws_ec2_spot_fleet_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole"
+}
+
+########## security group ##########
+
+resource "aws_security_group" "test_acc" {
+  name = "aws_batch_compute_environment_security_group"
+}
+
+########## subnets ##########
+
+resource "aws_vpc" "test_acc" {
+  cidr_block = "10.1.0.0/16"
+}
+
+resource "aws_subnet" "test_acc" {
+  vpc_id = "${aws_vpc.test_acc.id}"
+  cidr_block = "10.1.1.0/24"
+}
+`
+
+const testAccAWSBatchComputeEnvironmentConfigEC2 = testAccAWSBatchComputeEnvironmentConfigBase + `
+resource "aws_batch_compute_environment" "ec2" {
+  compute_environment_name = "sample"
+  compute_resources {
+    instance_role = "${aws_iam_instance_profile.ecs_instance_role.arn}"
+    instance_type = [
+      "c4.large",
+    ]
+    max_vcpus = 16
+    min_vcpus = 0
+    security_group_ids = [
+      "${aws_security_group.test_acc.id}"
+    ]
+    subnets = [
+      "${aws_subnet.test_acc.id}"
+    ]
+    type = "EC2"
+  }
+  service_role = "${aws_iam_role.aws_batch_service_role.arn}"
+  type = "MANAGED"
+}
+`
+
+const testAccAWSBatchComputeEnvironmentConfigEC2WithTags = testAccAWSBatchComputeEnvironmentConfigBase + `
+resource "aws_batch_compute_environment" "ec2" {
+  compute_environment_name = "sample"
+  compute_resources {
+    instance_role = "${aws_iam_instance_profile.ecs_instance_role.arn}"
+    instance_type = [
+      "c4.large",
+    ]
+    max_vcpus = 16
+    min_vcpus = 0
+    security_group_ids = [
+      "${aws_security_group.test_acc.id}"
+    ]
+    subnets = [
+      "${aws_subnet.test_acc.id}"
+    ]
+    type = "EC2"
+    tags {
+      Key1 = "Value1"
+    }
+  }
+  service_role = "${aws_iam_role.aws_batch_service_role.arn}"
+  type = "MANAGED"
+}
+`
+
+const testAccAWSBatchComputeEnvironmentConfigSpot = testAccAWSBatchComputeEnvironmentConfigBase + `
+resource "aws_batch_compute_environment" "spot" {
+  compute_environment_name = "sample"
+  compute_resources {
+    bid_percentage = 100
+    instance_role = "${aws_iam_instance_profile.ecs_instance_role.arn}"
+    instance_type = [
+      "c4.large",
+    ]
+    max_vcpus = 16
+    min_vcpus = 0
+    security_group_ids = [
+      "${aws_security_group.test_acc.id}"
+    ]
+    spot_iam_fleet_role = "${aws_iam_role.aws_ec2_spot_fleet_role.arn}"
+    subnets = [
+      "${aws_subnet.test_acc.id}"
+    ]
+    type = "SPOT"
+  }
+  service_role = "${aws_iam_role.aws_batch_service_role.arn}"
+  type = "MANAGED"
+}
+`
+
+const testAccAWSBatchComputeEnvironmentConfigUnmanaged = testAccAWSBatchComputeEnvironmentConfigBase + `
+resource "aws_batch_compute_environment" "unmanaged" {
+  compute_environment_name = "sample"
+  service_role = "${aws_iam_role.aws_batch_service_role.arn}"
+  type = "UNMANAGED"
+}
+`
+
+const testAccAWSBatchComputeEnvironmentConfigUpdatevCpus = testAccAWSBatchComputeEnvironmentConfigBase + `
+resource "aws_batch_compute_environment" "ec2" {
+  compute_environment_name = "sample"
+  compute_resources {
+    instance_role = "${aws_iam_instance_profile.ecs_instance_role.arn}"
+    instance_type = [
+      "c4.large",
+    ]
+    max_vcpus = 32
+    min_vcpus = 0
+    security_group_ids = [
+      "${aws_security_group.test_acc.id}"
+    ]
+    subnets = [
+      "${aws_subnet.test_acc.id}"
+    ]
+    type = "EC2"
+  }
+  service_role = "${aws_iam_role.aws_batch_service_role.arn}"
+  type = "MANAGED"
+}
+`
+
+const testAccAWSBatchComputeEnvironmentConfigEC2UpdateMaxvCpus = testAccAWSBatchComputeEnvironmentConfigBase + `
+resource "aws_batch_compute_environment" "ec2" {
+  compute_environment_name = "sample"
+  compute_resources {
+    instance_role = "${aws_iam_instance_profile.ecs_instance_role.arn}"
+    instance_type = [
+      "c4.large",
+    ]
+    max_vcpus = 32
+    min_vcpus = 0
+    security_group_ids = [
+      "${aws_security_group.test_acc.id}"
+    ]
+    subnets = [
+      "${aws_subnet.test_acc.id}"
+    ]
+    type = "EC2"
+  }
+  service_role = "${aws_iam_role.aws_batch_service_role.arn}"
+  type = "MANAGED"
+}
+`
+
+const testAccAWSBatchComputeEnvironmentConfigEC2UpdateInstanceType = testAccAWSBatchComputeEnvironmentConfigBase + `
+resource "aws_batch_compute_environment" "ec2" {
+  compute_environment_name = "sample"
+  compute_resources {
+    instance_role = "${aws_iam_instance_profile.ecs_instance_role.arn}"
+    instance_type = [
+      "c4.large",
+      "c4.xlarge",
+    ]
+    max_vcpus = 16
+    min_vcpus = 0
+    security_group_ids = [
+      "${aws_security_group.test_acc.id}"
+    ]
+    subnets = [
+      "${aws_subnet.test_acc.id}"
+    ]
+    type = "EC2"
+  }
+  service_role = "${aws_iam_role.aws_batch_service_role.arn}"
+  type = "MANAGED"
+}
+`
+
+const testAccAWSBatchComputeEnvironmentConfigEC2UpdateComputeEnvironmentName = testAccAWSBatchComputeEnvironmentConfigBase + `
+resource "aws_batch_compute_environment" "ec2" {
+  compute_environment_name = "sample_updated"
+  compute_resources {
+    instance_role = "${aws_iam_instance_profile.ecs_instance_role.arn}"
+    instance_type = [
+      "c4.large",
+    ]
+    max_vcpus = 16
+    min_vcpus = 0
+    security_group_ids = [
+      "${aws_security_group.test_acc.id}"
+    ]
+    subnets = [
+      "${aws_subnet.test_acc.id}"
+    ]
+    type = "EC2"
+  }
+  service_role = "${aws_iam_role.aws_batch_service_role.arn}"
+  type = "MANAGED"
+}
+`
+
+const testAccAWSBatchComputeEnvironmentConfigEC2WithoutComputeResources = testAccAWSBatchComputeEnvironmentConfigBase + `
+resource "aws_batch_compute_environment" "ec2" {
+  compute_environment_name = "sample"
+  service_role = "${aws_iam_role.aws_batch_service_role.arn}"
+  type = "MANAGED"
+}
+`
+
+const testAccAWSBatchComputeEnvironmentConfigUnmanagedWithComputeResources = testAccAWSBatchComputeEnvironmentConfigBase + `
+resource "aws_batch_compute_environment" "unmanaged" {
+  compute_environment_name = "sample"
+  compute_resources {
+    instance_role = "${aws_iam_instance_profile.ecs_instance_role.arn}"
+    instance_type = [
+      "c4.large",
+    ]
+    max_vcpus = 16
+    min_vcpus = 0
+    security_group_ids = [
+      "${aws_security_group.test_acc.id}"
+    ]
+    subnets = [
+      "${aws_subnet.test_acc.id}"
+    ]
+    type = "EC2"
+  }
+  service_role = "${aws_iam_role.aws_batch_service_role.arn}"
+  type = "UNMANAGED"
+}
+`
+
+const testAccAWSBatchComputeEnvironmentConfigSpotWithoutBidPercentage = testAccAWSBatchComputeEnvironmentConfigBase + `
+resource "aws_batch_compute_environment" "ec2" {
+  compute_environment_name = "sample"
+  compute_resources {
+    instance_role = "${aws_iam_instance_profile.ecs_instance_role.arn}"
+    instance_type = [
+      "c4.large",
+    ]
+    max_vcpus = 16
+    min_vcpus = 0
+    security_group_ids = [
+      "${aws_security_group.test_acc.id}"
+    ]
+    subnets = [
+      "${aws_subnet.test_acc.id}"
+    ]
+    type = "SPOT"
+  }
+  service_role = "${aws_iam_role.aws_batch_service_role.arn}"
+  type = "MANAGED"
+}
+`

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1385,3 +1385,11 @@ func validateSsmParameterType(v interface{}, k string) (ws []string, errors []er
 	}
 	return
 }
+
+func validateBatchComputeEnvironmentName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !(regexp.MustCompile(`^[A-Za-z0-9_]*$`).MatchString(value) && len(value) <= 128) {
+		errors = append(errors, fmt.Errorf("computeEnvironmentName must be up to 128 letters (uppercase and lowercase), numbers, and underscores."))
+	}
+	return
+}

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -2399,3 +2399,26 @@ func TestValidateSsmParameterType(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateBatchComputeEnvironmentName(t *testing.T) {
+	validNames := []string{
+		strings.Repeat("W", 128), // <= 128
+	}
+	for _, v := range validNames {
+		_, errors := validateBatchComputeEnvironmentName(v, "name")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid Batch compute environment name: %q", v, errors)
+		}
+	}
+
+	invalidNames := []string{
+		"s@mple",
+		strings.Repeat("W", 129), // >= 129
+	}
+	for _, v := range invalidNames {
+		_, errors := validateBatchComputeEnvironmentName(v, "name")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be a invalid Batch compute environment name: %q", v, errors)
+		}
+	}
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -270,7 +270,7 @@
                     </ul>
                 </li>
 
-                <li<%= sidebar_current("docs-aws-resource-batch-compute-environment") %>>
+                <li<%= sidebar_current("docs-aws-resource-batch") %>>
                     <a href="#">Batch</a>
                     <ul class="nav nav-visible">
                         <li<%= sidebar_current("docs-aws-resource-batch-compute-environment") %>>

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -270,6 +270,15 @@
                     </ul>
                 </li>
 
+                <li<%= sidebar_current("docs-aws-resource-batch-compute-environment") %>>
+                    <a href="#">Batch</a>
+                    <ul class="nav nav-visible">
+                        <li<%= sidebar_current("docs-aws-resource-batch-compute-environment") %>>
+                            <a href="/docs/providers/aws/r/batch_compute_environment.html">aws_batch_compute_environment</a>
+                        </li>
+                    </ul>
+                </li>
+
                 <li<%= sidebar_current("docs-aws-resource-cloudformation") %>>
                     <a href="#">CloudFormation Resources</a>
                     <ul class="nav nav-visible">

--- a/website/docs/r/batch_compute_environment.html.markdown
+++ b/website/docs/r/batch_compute_environment.html.markdown
@@ -1,0 +1,140 @@
+---
+layout: "aws"
+page_title: "AWS: aws_batch_compute_environment"
+sidebar_current: "docs-aws-resource-batch-compute-environment"
+description: |-
+  Creates a AWS Batch compute environment.
+---
+
+# aws\_batch\_compute\_environment
+
+Creates a AWS Batch compute environment. Compute environments contain the Amazon ECS container instances that are used to run containerized batch jobs.
+
+For information about AWS Batch, see [What is AWS Batch?][1] .
+For information about compute environment, see [Compute Environments][2] .
+
+## Example Usage
+
+```hcl
+resource "aws_iam_role" "ecs_instance_role" {
+  name = "ecs_instance_role"
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+	{
+	    "Action": "sts:AssumeRole",
+	    "Effect": "Allow",
+	    "Principal": {
+		"Service": "ec2.amazonaws.com"
+	    }
+	}
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_instance_role" {
+  role       = "${aws_iam_role.ecs_instance_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+}
+
+resource "aws_iam_instance_profile" "ecs_instance_role" {
+  name  = "ecs_instance_role"
+  role = "${aws_iam_role.ecs_instance_role.name}"
+}
+
+resource "aws_iam_role" "aws_batch_service_role" {
+  name = "aws_batch_service_role"
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+	{
+	    "Action": "sts:AssumeRole",
+	    "Effect": "Allow",
+	    "Principal": {
+		"Service": "batch.amazonaws.com"
+	    }
+	}
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "aws_batch_service_role" {
+  role       = "${aws_iam_role.aws_batch_service_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole"
+}
+
+resource "aws_security_group" "sample" {
+  name = "aws_batch_compute_environment_security_group"
+}
+
+resource "aws_vpc" "sample" {
+  cidr_block = "10.1.0.0/16"
+}
+
+resource "aws_subnet" "sample" {
+  vpc_id = "${aws_vpc.sample.id}"
+  cidr_block = "10.1.1.0/24"
+}
+
+resource "aws_batch_compute_environment" "sample" {
+  compute_environment_name = "sample"
+  compute_resources {
+    instance_role = "${aws_iam_instance_profile.ecs_instance_role.arn}"
+    instance_type = [
+      "c4.large",
+    ]
+    max_vcpus = 16
+    min_vcpus = 0
+    security_group_ids = [
+      "${aws_security_group.sample.id}"
+    ]
+    subnets = [
+      "${aws_subnet.sample.id}"
+    ]
+    type = "EC2"
+  }
+  service_role = "${aws_iam_role.aws_batch_service_role.arn}"
+  type = "MANAGED"
+}
+```
+
+## Argument Reference
+
+* `compute_environment_name` - (Required) The name for your compute environment. Up to 128 letters (uppercase and lowercase), numbers, and underscores are allowed.
+* `compute_resources` - (Optional) Details of the compute resources managed by the compute environment. This parameter is required for managed compute environments.
+* `service_role` - (Required) The full Amazon Resource Name (ARN) of the IAM role that allows AWS Batch to make calls to other AWS services on your behalf.
+* `state` - (Optional) The state of the compute environment. If the state is `ENABLED`, then the compute environment accepts jobs from a queue and can scale out automatically based on queues. Valid items are `ENABLED` or `DISABLED`. Defaults to `ENABLED`.
+* `type` - (Required) The type of the compute environment. Valid items are `MANAGED` or `UNMANAGED`.
+
+**compute_resources** is a child block with a single argument:
+
+* `bid_percentage` - (Optional) The minimum percentage that a Spot Instance price must be when compared with the On-Demand price for that instance type before instances are launched. 
+  For example, if your bid percentage is 20%, then the Spot price must be below 20% of the current On-Demand price for that EC2 instance.
+  This parameter is required for SPOT compute environments.
+* `desired_vcpus` - (Optional) The desired number of EC2 vCPUS in the compute environment.
+* `ec2_key_pair` - (Optional) The EC2 key pair that is used for instances launched in the compute environment.
+* `image_id` - (Optional) The Amazon Machine Image (AMI) ID used for instances launched in the compute environment.
+* `instance_role` - (Required) The Amazon ECS instance role applied to Amazon EC2 instances in a compute environment.
+* `instance_type` - (Required) The instances types that may launched.
+* `max_vcpus` - (Required) The maximum number of EC2 vCPUs that an environment can reach.
+* `min_vcpus` - (Required) The minimum number of EC2 vCPUs that an environment should maintain.
+* `security_group_ids` - (Required) The EC2 security group that is associated with instances launched in the compute environment.
+* `spot_iam_fleet_role` - (Optional) The Amazon Resource Name (ARN) of the Amazon EC2 Spot Fleet IAM role applied to a SPOT compute environment.
+  This parameter is required for SPOT compute environments.
+* `subnets` - (Required) The VPC subnets into which the compute resources are launched.
+* `tags` - (Optional) Key-value pair tags to be applied to resources that are launched in the compute environment.
+* `type` - (Required) The type of compute environment. Valid items are `EC2` or `SPOT`.
+
+## Attributes Reference
+
+* `arn` - The Amazon Resource Name (ARN) of the compute environment.
+* `ecc_cluster_arn` - The Amazon Resource Name (ARN) of the underlying Amazon ECS cluster used by the compute environment.
+* `status` - The current status of the compute environment (for example, CREATING or VALID).
+* `status_reason` - A short, human-readable string to provide additional details about the current status of the compute environment.
+
+[1]: http://docs.aws.amazon.com/batch/latest/userguide/what-is-batch.html
+[2]: http://docs.aws.amazon.com/batch/latest/userguide/compute_environments.html

--- a/website/docs/r/batch_compute_environment.html.markdown
+++ b/website/docs/r/batch_compute_environment.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Creates a AWS Batch compute environment.
 ---
 
-# aws\_batch\_compute\_environment
+# aws_batch_compute_environment
 
 Creates a AWS Batch compute environment. Compute environments contain the Amazon ECS container instances that are used to run containerized batch jobs.
 

--- a/website/docs/r/batch_compute_environment.html.markdown
+++ b/website/docs/r/batch_compute_environment.html.markdown
@@ -105,27 +105,24 @@ resource "aws_batch_compute_environment" "sample" {
 ## Argument Reference
 
 * `compute_environment_name` - (Required) The name for your compute environment. Up to 128 letters (uppercase and lowercase), numbers, and underscores are allowed.
-* `compute_resources` - (Optional) Details of the compute resources managed by the compute environment. This parameter is required for managed compute environments.
+* `compute_resources` - (Optional) Details of the compute resources managed by the compute environment. This parameter is required for managed compute environments. See details below.
 * `service_role` - (Required) The full Amazon Resource Name (ARN) of the IAM role that allows AWS Batch to make calls to other AWS services on your behalf.
 * `state` - (Optional) The state of the compute environment. If the state is `ENABLED`, then the compute environment accepts jobs from a queue and can scale out automatically based on queues. Valid items are `ENABLED` or `DISABLED`. Defaults to `ENABLED`.
 * `type` - (Required) The type of the compute environment. Valid items are `MANAGED` or `UNMANAGED`.
 
 **compute_resources** is a child block with a single argument:
 
-* `bid_percentage` - (Optional) The minimum percentage that a Spot Instance price must be when compared with the On-Demand price for that instance type before instances are launched. 
-  For example, if your bid percentage is 20%, then the Spot price must be below 20% of the current On-Demand price for that EC2 instance.
-  This parameter is required for SPOT compute environments.
+* `bid_percentage` - (Optional) The minimum percentage that a Spot Instance price must be when compared with the On-Demand price for that instance type before instances are launched. For example, if your bid percentage is 20%, then the Spot price must be below 20% of the current On-Demand price for that EC2 instance. This parameter is required for SPOT compute environments.
 * `desired_vcpus` - (Optional) The desired number of EC2 vCPUS in the compute environment.
 * `ec2_key_pair` - (Optional) The EC2 key pair that is used for instances launched in the compute environment.
 * `image_id` - (Optional) The Amazon Machine Image (AMI) ID used for instances launched in the compute environment.
 * `instance_role` - (Required) The Amazon ECS instance role applied to Amazon EC2 instances in a compute environment.
-* `instance_type` - (Required) The instances types that may launched.
+* `instance_type` - (Required) A list of instance types that may be launched.
 * `max_vcpus` - (Required) The maximum number of EC2 vCPUs that an environment can reach.
 * `min_vcpus` - (Required) The minimum number of EC2 vCPUs that an environment should maintain.
-* `security_group_ids` - (Required) The EC2 security group that is associated with instances launched in the compute environment.
-* `spot_iam_fleet_role` - (Optional) The Amazon Resource Name (ARN) of the Amazon EC2 Spot Fleet IAM role applied to a SPOT compute environment.
-  This parameter is required for SPOT compute environments.
-* `subnets` - (Required) The VPC subnets into which the compute resources are launched.
+* `security_group_ids` - (Required) A list of EC2 security group that are associated with instances launched in the compute environment.
+* `spot_iam_fleet_role` - (Optional) The Amazon Resource Name (ARN) of the Amazon EC2 Spot Fleet IAM role applied to a SPOT compute environment. This parameter is required for SPOT compute environments.
+* `subnets` - (Required) A list of VPC subnets into which the compute resources are launched.
 * `tags` - (Optional) Key-value pair tags to be applied to resources that are launched in the compute environment.
 * `type` - (Required) The type of compute environment. Valid items are `EC2` or `SPOT`.
 


### PR DESCRIPTION
## Description
Add support for `aws_batch_compute_environment` to creates a AWS Batch compute environment.

## Tests
```
$ make testacc TESTARGS='-run=TestAccAWSBatchComputeEnvironment'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccAWSBatchComputeEnvironment -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSBatchComputeEnvironment_createEc2
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2 (53.54s)
=== RUN   TestAccAWSBatchComputeEnvironment_createEc2WithTags
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2WithTags (40.32s)
=== RUN   TestAccAWSBatchComputeEnvironment_createSpot
--- PASS: TestAccAWSBatchComputeEnvironment_createSpot (44.21s)
=== RUN   TestAccAWSBatchComputeEnvironment_createUnmanaged
--- PASS: TestAccAWSBatchComputeEnvironment_createUnmanaged (51.36s)
=== RUN   TestAccAWSBatchComputeEnvironment_updateMaxvCpus
--- PASS: TestAccAWSBatchComputeEnvironment_updateMaxvCpus (74.04s)
=== RUN   TestAccAWSBatchComputeEnvironment_updateInstanceType
--- PASS: TestAccAWSBatchComputeEnvironment_updateInstanceType (91.76s)
=== RUN   TestAccAWSBatchComputeEnvironment_updateComputeEnvironmentName
--- PASS: TestAccAWSBatchComputeEnvironment_updateComputeEnvironmentName (78.01s)
=== RUN   TestAccAWSBatchComputeEnvironment_createEc2WithoutComputeResources
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2WithoutComputeResources (22.59s)
=== RUN   TestAccAWSBatchComputeEnvironment_createUnmanagedWithComputeResources
--- PASS: TestAccAWSBatchComputeEnvironment_createUnmanagedWithComputeResources (49.45s)
=== RUN   TestAccAWSBatchComputeEnvironment_createSpotWithoutBidPercentage
--- PASS: TestAccAWSBatchComputeEnvironment_createSpotWithoutBidPercentage (25.54s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	530.836s
```
