### PR TITLE
add primary private ip to the documentation

### DIFF
--- a/website/docs/r/network_interface.markdown
+++ b/website/docs/r/network_interface.markdown
@@ -31,6 +31,7 @@ The following arguments are supported:
 
 * `subnet_id` - (Required) Subnet ID to create the ENI in.
 * `description` - (Optional) A description for the network interface.
+* `private_ip` - (Optional) The primary private IPv4 address of the network interface.
 * `private_ips` - (Optional) List of private IPs to assign to the ENI.
 * `private_ips_count` - (Optional) Number of private IPs to assign to the ENI.
 * `security_groups` - (Optional) List of security group IDs to assign to the ENI.
@@ -49,6 +50,7 @@ The following attributes are exported:
 
 * `subnet_id` - Subnet ID the ENI is in.
 * `description` - A description for the network interface.
+* `private_ip` - (Optional) The primary private IPv4 address of the network interface.
 * `private_ips` - List of private IPs assigned to the ENI.
 * `security_groups` - List of security groups attached to the ENI.
 * `attachment` - Block defining the attachment of the ENI.


### PR DESCRIPTION
Fixing the documentation of the eni resource as I noticed that `private_ip` for primary private ip is not specified in the documentation eventhough I can see it's in the schema of the eni resource implementation. 