### PR TITLE
r/resource_aws_subnet: increase deletion timeout

### DIFF
--- a/aws/resource_aws_subnet.go
+++ b/aws/resource_aws_subnet.go
@@ -294,7 +294,7 @@ func resourceAwsSubnetDelete(d *schema.ResourceData, meta interface{}) error {
 	wait := resource.StateChangeConf{
 		Pending:    []string{"pending"},
 		Target:     []string{"destroyed"},
-		Timeout:    10 * time.Minute,
+		Timeout:    30 * time.Minute,
 		MinTimeout: 1 * time.Second,
 		Refresh: func() (interface{}, string, error) {
 			_, err := conn.DeleteSubnet(req)


### PR DESCRIPTION
This adds a bump in the timeout for removing subnets as we experienced a high flake count upon cluster destruction. Introducing this timeout reduces flakes significantly

This is a stop-gap solution until resource providers get timeout override support.

Fixes https://github.com/coreos/tectonic-installer/issues/1245

/cc @radeksimko @jasminSPC