### PR TITLE
r/resource_aws_security_group: increase deletion timeout

### DIFF
--- a/aws/resource_aws_security_group.go
+++ b/aws/resource_aws_security_group.go
@@ -415,7 +415,7 @@ func resourceAwsSecurityGroupDelete(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Failed to delete Lambda ENIs: %s", err)
 	}
 
-	return resource.Retry(5*time.Minute, func() *resource.RetryError {
+	return resource.Retry(30*time.Minute, func() *resource.RetryError {
 		_, err := conn.DeleteSecurityGroup(&ec2.DeleteSecurityGroupInput{
 			GroupId: aws.String(d.Id()),
 		})


### PR DESCRIPTION
This adds a bump in the timeout for removing security groups as we experienced a high flake count upon cluster destruction. Introducing this timeout reduces flakes significantly

This is a stop-gap solution until resource providers get timeout override support.

Fixes https://github.com/coreos/tectonic-installer/issues/1242

/cc @radeksimko @jasminSPC