### PR TITLE
resource/aws_sfn_state_machine: Handle another NotFound exception type

### DIFF
--- a/aws/resource_aws_sfn_state_machine.go
+++ b/aws/resource_aws_sfn_state_machine.go
@@ -103,9 +103,12 @@ func resourceAwsSfnStateMachineRead(d *schema.ResourceData, meta interface{}) er
 		StateMachineArn: aws.String(d.Id()),
 	})
 	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NotFoundException" {
-			d.SetId("")
-			return nil
+
+		if awserr, ok := err.(awserr.Error); ok {
+			if awserr.Code() == "NotFoundException" || awserr.Code() == "StateMachineDoesNotExist" {
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}


### PR DESCRIPTION
Fixes: #1058

Before this:

```
% terraform refresh
aws_iam_role.iam_for_lambda: Refreshing state... (ID: iam_for_lambda_stack72)
data.aws_region.current: Refreshing state...
aws_lambda_function.lambda_function_test: Refreshing state... (ID: sfn-stack72)
aws_iam_role_policy.iam_policy_for_lambda: Refreshing state... (ID: iam_for_lambda_stack72:iam_policy_for_lambda_stack72)
aws_iam_role.iam_for_sfn: Refreshing state... (ID: iam_for_sfn_stack72)
aws_iam_role_policy.iam_policy_for_sfn: Refreshing state... (ID: iam_for_sfn_stack72:iam_policy_for_sfn_stack72)
aws_sfn_state_machine.foo: Refreshing state... (ID: arn:aws:states:us-west-2:187416307283:stateMachine:test_sfn_stack72)
Error refreshing state: 1 error(s) occurred:

* aws_sfn_state_machine.foo: 1 error(s) occurred:

* aws_sfn_state_machine.foo: aws_sfn_state_machine.foo: StateMachineDoesNotExist: State Machine Does Not Exist: 'arn:aws:states:us-west-2:187416307283:stateMachine:test_sfn_stack72'
	status code: 400, request id: 6f749392-6178-11e7-80a1-1db62a3892e8
```

After this:

```
% terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

aws_iam_role.iam_for_lambda: Refreshing state... (ID: iam_for_lambda_stack72)
data.aws_region.current: Refreshing state...
aws_iam_role_policy.iam_policy_for_lambda: Refreshing state... (ID: iam_for_lambda_stack72:iam_policy_for_lambda_stack72)
aws_lambda_function.lambda_function_test: Refreshing state... (ID: sfn-stack72)
aws_iam_role.iam_for_sfn: Refreshing state... (ID: iam_for_sfn_stack72)
aws_iam_role_policy.iam_policy_for_sfn: Refreshing state... (ID: iam_for_sfn_stack72:iam_policy_for_sfn_stack72)
The Terraform execution plan has been generated and is shown below.
Resources are shown in alphabetical order for quick scanning. Green resources
will be created (or destroyed and then created if an existing resource
exists), yellow resources are being changed in-place, and red resources
will be destroyed. Cyan entries are data sources to be read.

Note: You didn't specify an "-out" parameter to save this plan, so when
"apply" is called, Terraform can't guarantee this is what will execute.

+ aws_sfn_state_machine.foo
    creation_date: "<computed>"
    definition:    "{\n  \"Comment\": \"A Hello World example of the Amazon States Language using an AWS Lambda Function\",\n  \"StartAt\": \"HelloWorld\",\n  \"States\": {\n    \"HelloWorld\": {\n      \"Type\": \"Task\",\n      \"Resource\": \"arn:aws:lambda:us-west-2:187416307283:function:sfn-stack72\",\n      \"End\": true\n    }\n  }\n}\n"
    name:          "test_sfn_stack72"
    role_arn:      "arn:aws:iam::187416307283:role/iam_for_sfn_stack72"
    status:        "<computed>"
```