### PR TITLE
resource/aws_vpc: Add support for classiclink_dns_support

### DIFF
--- a/aws/resource_aws_vpc_test.go
+++ b/aws/resource_aws_vpc_test.go
@@ -298,6 +298,23 @@ func TestAccAWSVpc_classiclinkOptionSet(t *testing.T) {
 	})
 }
 
+func TestAccAWSVpc_classiclinkDnsSupportOptionSet(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVpcDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcConfig_ClassiclinkDnsSupportOption,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"aws_vpc.bar", "enable_classiclink_dns_support", "true"),
+				),
+			},
+		},
+	})
+}
+
 const testAccVpcConfig = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
@@ -381,5 +398,14 @@ resource "aws_vpc" "bar" {
 	cidr_block = "172.2.0.0/16"
 
 	enable_classiclink = true
+}
+`
+
+const testAccVpcConfig_ClassiclinkDnsSupportOption = `
+resource "aws_vpc" "bar" {
+	cidr_block = "172.2.0.0/16"
+
+	enable_classiclink = true
+	enable_classiclink_dns_support = true
 }
 `

--- a/website/docs/r/vpc.html.markdown
+++ b/website/docs/r/vpc.html.markdown
@@ -44,6 +44,8 @@ The following arguments are supported:
 * `enable_classiclink` - (Optional) A boolean flag to enable/disable ClassicLink
   for the VPC. Only valid in regions and accounts that support EC2 Classic.
   See the [ClassicLink documentation][1] for more information. Defaults false.
+* `enable_classiclink_dns_support` - (Optional) A boolean flag to enable/disable ClassicLink DNS Support for the VPC.
+  Only valid in regions and accounts that support EC2 Classic.
 * `assign_generated_ipv6_cidr_block` - (Optional) Requests an Amazon-provided IPv6 CIDR 
 block with a /56 prefix length for the VPC. You cannot specify the range of IP addresses, or 
 the size of the CIDR block. Default is `false`.


### PR DESCRIPTION
Fixes: #1076

```
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSVpc'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSVpc -timeout 120m
=== RUN   TestAccAWSVpcEndpoint_importBasic
--- PASS: TestAccAWSVpcEndpoint_importBasic (68.54s)
=== RUN   TestAccAWSVpc_importBasic
--- PASS: TestAccAWSVpc_importBasic (53.29s)
=== RUN   TestAccAWSVpcEndpointRouteTableAssociation_basic
--- PASS: TestAccAWSVpcEndpointRouteTableAssociation_basic (59.57s)
=== RUN   TestAccAWSVpcEndpoint_basic
--- PASS: TestAccAWSVpcEndpoint_basic (58.48s)
=== RUN   TestAccAWSVpcEndpoint_withRouteTableAndPolicy
--- PASS: TestAccAWSVpcEndpoint_withRouteTableAndPolicy (117.51s)
=== RUN   TestAccAWSVpcEndpoint_WithoutRouteTableOrPolicyConfig
--- PASS: TestAccAWSVpcEndpoint_WithoutRouteTableOrPolicyConfig (53.33s)
=== RUN   TestAccAWSVpcEndpoint_removed
--- PASS: TestAccAWSVpcEndpoint_removed (49.14s)
=== RUN   TestAccAWSVpc_basic
--- PASS: TestAccAWSVpc_basic (45.19s)
=== RUN   TestAccAWSVpc_enableIpv6
--- PASS: TestAccAWSVpc_enableIpv6 (132.93s)
=== RUN   TestAccAWSVpc_dedicatedTenancy
--- PASS: TestAccAWSVpc_dedicatedTenancy (46.52s)
=== RUN   TestAccAWSVpc_tags
--- PASS: TestAccAWSVpc_tags (87.11s)
=== RUN   TestAccAWSVpc_update
--- PASS: TestAccAWSVpc_update (85.61s)
=== RUN   TestAccAWSVpc_DisabledDnsSupport
--- PASS: TestAccAWSVpc_DisabledDnsSupport (43.34s)
=== RUN   TestAccAWSVpc_classiclinkOptionSet
--- PASS: TestAccAWSVpc_classiclinkOptionSet (45.99s)
=== RUN   TestAccAWSVpc_classiclinkDnsSupportOptionSet
--- PASS: TestAccAWSVpc_classiclinkDnsSupportOptionSet (52.46s)
PASS
ok	github.com/terraform-providers/terraform-provider-aws/aws	1009.082s
```