### PR TITLE
[Help needed] New Resource: aws_ssm_document_list

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -429,6 +429,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_ssm_activation":                           resourceAwsSsmActivation(),
 			"aws_ssm_association":                          resourceAwsSsmAssociation(),
 			"aws_ssm_document":                             resourceAwsSsmDocument(),
+			"aws_ssm_document_list":                        resourceAwsSsmDocumentList(),
 			"aws_ssm_maintenance_window":                   resourceAwsSsmMaintenanceWindow(),
 			"aws_ssm_maintenance_window_target":            resourceAwsSsmMaintenanceWindowTarget(),
 			"aws_ssm_maintenance_window_task":              resourceAwsSsmMaintenanceWindowTask(),

--- a/aws/resource_aws_ssm_document_list.go
+++ b/aws/resource_aws_ssm_document_list.go
@@ -1,0 +1,584 @@
+package aws
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ssm"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsSsmDocumentList() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsSsmDocumentListCreate,
+		Read:   resourceAwsSsmDocumentListRead,
+		Update: resourceAwsSsmDocumentListUpdate,
+		Delete: resourceAwsSsmDocumentListDelete,
+
+		Schema: map[string]*schema.Schema{
+			"documents_hash": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"documents_type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateAwsSSMDocumentType,
+			},
+			"documents_permissions": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"account_ids": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"documents_list": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"arn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Optional: true,
+							DiffSuppressFunc: func(k, o, n string, d *schema.ResourceData) bool {
+								return true // id is a hash of name and content, so showing it as a diff is meaningless
+							},
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"content": {
+							Type:     schema.TypeString,
+							Optional: true,
+							StateFunc: func(v interface{}) string {
+								switch v.(type) {
+								case string:
+									return contentHashSum(v.(string))
+								default:
+									return ""
+								}
+							},
+						},
+						"schema_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"created_date": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"default_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"hash": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"hash_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"latest_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"owner": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"platform_types": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"parameter": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"default_value": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"description": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func contentHashSum(content string) string {
+	hash := sha1.Sum([]byte(content))
+	return hex.EncodeToString(hash[:])
+}
+
+func GetDocumentListItemKey(index int, name string) string {
+	return fmt.Sprintf("documents_list.%d.%s", index, name)
+}
+
+func GetDocumentListItemValue(d *schema.ResourceData, index int, name string) (interface{}, error) {
+	key := GetDocumentListItemKey(index, name)
+
+	if v, ok := d.GetOk(key); ok && v != nil {
+		return v, nil
+	} else {
+		return nil, errors.New(fmt.Sprintf("Item %q not found", key))
+	}
+}
+
+func resourceAwsSsmDocumentListCreate(d *schema.ResourceData, meta interface{}) error {
+
+	// Potentially creating a large number of documents, so use partial state
+	id := d.Get("documents_hash").(string)
+	d.SetId(id)
+	d.Partial(true) // make sure we record the id even if the rest of this gets interrupted
+	d.Set("id", id)
+	d.SetPartial("id")
+	d.SetPartial("documents_hash")
+	d.SetPartial("documents_type")
+
+	documents := d.Get("documents_list").([]interface{})
+	partialDocList := make([]interface{}, 0)
+
+	for i, v := range documents {
+		log.Printf("[INFO] SSM Document Number: %d", i)
+
+		document := v.(map[string]interface{})
+
+		name, err := GetDocumentListItemValue(d, i, "name")
+		if err != nil {
+			return errwrap.Wrapf("[ERROR] Error retrieving name for SSM document: {{err}}", err)
+		}
+
+		content, err := GetDocumentListItemValue(d, i, "content")
+		if err != nil {
+			return errwrap.Wrapf("[ERROR] Error retrieving content for SSM document: {{err}}", err)
+		}
+
+		if err := CreateSSMDocument(name.(string), content.(string), d.Get("documents_type").(string), meta); err != nil {
+			return err
+		}
+
+		// Store the hash of the content
+		document["content"] = contentHashSum(document["content"].(string))
+
+		// Document was created successfully, so save partial state
+		partialDocList = append(partialDocList, document)
+		d.Set("documents_list", partialDocList)
+		d.SetPartial("documents_list")
+
+		// if v, ok := d.GetOk("documents_permissions"); ok && v != nil {
+		// 	if err := setDocumentPermissions(d, meta); err != nil {
+		// 		return err
+		// 	}
+		// } else {
+		// 	log.Printf("[DEBUG] Not setting permissions for %q", d.Id())
+		// }
+
+	}
+	d.Partial(false)
+
+	return resourceAwsSsmDocumentListRead(d, meta)
+}
+
+func resourceAwsSsmDocumentListRead(d *schema.ResourceData, meta interface{}) error {
+	ssmconn := meta.(*AWSClient).ssmconn
+
+	docsFromState := d.Get("documents_list").([]interface{})
+	docsFromAWS := make([]interface{}, 0)
+
+	for _, v := range docsFromState {
+
+		document := v.(map[string]interface{})
+
+		log.Printf("[INFO] Reading SSM Document: %s", document["name"].(string))
+
+		docInput := &ssm.DescribeDocumentInput{
+			Name: aws.String(document["name"].(string)),
+		}
+
+		resp, err := ssmconn.DescribeDocument(docInput)
+		if err != nil {
+			if ssmErr, ok := err.(awserr.Error); ok && ssmErr.Code() == "InvalidDocument" {
+				log.Printf("[WARN] SSM Document not found so removing from state")
+			} else {
+				return errwrap.Wrapf("[ERROR] Error describing SSM document: {{err}}", err)
+			}
+
+		} else {
+			doc := resp.Document
+
+			document["created_date"] = (*doc.CreatedDate).String()
+
+			document["default_version"] = *doc.DefaultVersion
+			document["description"] = *doc.Description
+			document["schema_version"] = *doc.SchemaVersion
+
+			document["hash"] = *doc.Hash
+			document["hash_type"] = *doc.HashType
+			document["latest_version"] = *doc.LatestVersion
+			document["name"] = *doc.Name
+
+			document["owner"] = *doc.Owner
+			document["platform_types"] = flattenStringList(doc.PlatformTypes)
+			document["arn"] = flattenAwsSsmDocumentArn(meta, doc.Name)
+
+			document["status"] = *doc.Status
+
+			// gp, err := getDocumentPermissions(d, meta)
+
+			// if err != nil {
+			// 	return errwrap.Wrapf("[ERROR] Error reading SSM document permissions: {{err}}", err)
+			// }
+
+			// d.Set("documents_permissions", gp)
+
+			// params := make([]map[string]interface{}, 0)
+			// for i := 0; i < len(doc.Parameters); i++ {
+
+			// 	dp := doc.Parameters[i]
+			// 	param := make(map[string]interface{})
+
+			// 	if dp.DefaultValue != nil {
+			// 		param["default_value"] = *dp.DefaultValue
+			// 	}
+			// 	if dp.Description != nil {
+			// 		param["description"] = *dp.Description
+			// 	}
+			// 	if dp.Name != nil {
+			// 		param["name"] = *dp.Name
+			// 	}
+			// 	if dp.Type != nil {
+			// 		param["type"] = *dp.Type
+			// 	}
+			// 	params = append(params, param)
+			// }
+
+			// if len(params) == 0 {
+			// 	params = make([]map[string]interface{}, 1)
+			// }
+
+			// if err := d.Set("parameter", params); err != nil {
+			// 	return err
+			// }
+
+			docsFromAWS = append(docsFromAWS, document)
+		}
+	}
+
+	if err := d.Set("documents_list", docsFromAWS); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceAwsSsmDocumentListUpdate(d *schema.ResourceData, meta interface{}) error {
+
+	id := d.Get("documents_hash").(string)
+	d.SetId(id)
+
+	d.Partial(true) // make sure we record the id even if the rest of this gets interrupted
+	d.Set("id", id)
+	d.SetPartial("id")
+	d.SetPartial("documents_hash")
+	d.SetPartial("documents_type")
+
+	if d.HasChange("documents_list") {
+		log.Printf("[INFO] Has changes")
+
+		o, n := d.GetChange("documents_list")
+
+		os := o.([]interface{})
+		ns := n.([]interface{})
+
+		oContents := make(map[string]string)
+		oDocuments := make(map[string]map[string]interface{})
+		partialDocList := make(map[string]map[string]interface{})
+		for _, v := range os {
+			document := v.(map[string]interface{})
+			name := document["name"].(string)
+			log.Printf("[INFO] Old Docs: %s", name)
+			oContents[name] = document["content"].(string)
+			oDocuments[name] = document
+			partialDocList[name] = document
+		}
+
+		nContents := make(map[string]string)
+		nDocuments := make(map[string]map[string]interface{})
+		for _, v := range ns {
+			document := v.(map[string]interface{})
+			name := document["name"].(string)
+			log.Printf("[INFO] New Docs: %s", name)
+			nContents[name] = document["content"].(string)
+			nDocuments[name] = document
+		}
+
+		// Handle deleted documents
+		for name := range oDocuments {
+			_, ok := nDocuments[name]
+			if !ok {
+				if err := DeleteSSMDocument(name, meta); err != nil {
+					return err
+				}
+				delete(partialDocList, name)
+				d.Set("documents_list", ConvertPartialDocListMapToSlice(partialDocList))
+				d.SetPartial("documents_list")
+			}
+		}
+
+		// Handle new and updated documents
+		for name := range nDocuments {
+			log.Printf("[INFO] Processing SSM Document: %s", name)
+
+			_, ok := oDocuments[name]
+			if !ok {
+				if err := CreateSSMDocument(name, nContents[name], d.Get("documents_type").(string), meta); err != nil {
+					return err
+				}
+				nDocuments[name]["content"] = contentHashSum(nDocuments[name]["content"].(string))
+			} else {
+				if oContents[name] != nContents[name] {
+
+					doc := oDocuments[name]                      // Get the existing doc from state. This brings across the default version etc
+					doc["content"] = nDocuments[name]["content"] // Then add the new content
+					if err := UpdateSSMDocument(doc, meta); err != nil {
+						return err
+					}
+					nDocuments[name]["content"] = contentHashSum(nDocuments[name]["content"].(string))
+				}
+			}
+			partialDocList[name] = nDocuments[name]
+			d.Set("documents_list", ConvertPartialDocListMapToSlice(partialDocList))
+			d.SetPartial("documents_list")
+		}
+
+	} else {
+		log.Printf("[INFO] No changes")
+	}
+
+	// 	if _, ok := d.GetOk("permissions"); ok {
+	// 	if err := setDocumentPermissions(d, meta); err != nil {
+	// 		return err
+	// 	}
+	// } else {
+	// 	log.Printf("[DEBUG] Not setting document permissions on %q", d.Id())
+	// }
+
+	//	return nil
+	d.Partial(false)
+	d.SetId(d.Get("documents_hash").(string))
+
+	return resourceAwsSsmDocumentListRead(d, meta)
+}
+
+func resourceAwsSsmDocumentListDelete(d *schema.ResourceData, meta interface{}) error {
+
+	documents := d.Get("documents_list").([]interface{})
+
+	for i, _ := range documents {
+		log.Printf("[INFO] SSM Document Number: %d", i)
+
+		name, err := GetDocumentListItemValue(d, i, "name")
+		if err != nil {
+			return errwrap.Wrapf("[ERROR] Error retrieving name for SSM document: {{err}}", err)
+		}
+
+		// if err := deleteDocumentPermissions(d, meta); err != nil {
+		// 	return err
+		// }
+
+		if err := DeleteSSMDocument(name.(string), meta); err != nil {
+			return err
+		}
+
+	}
+	d.SetId("")
+	return nil
+}
+
+func ConvertPartialDocListMapToSlice(m map[string]map[string]interface{}) []map[string]interface{} {
+
+	v := make([]map[string]interface{}, 0, len(m))
+
+	// Sort the map to prevent constant diffs due to the order of docs in state
+	var keys []string
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		log.Printf("[INFO] Partial Docs: %s", k)
+		v = append(v, m[k])
+	}
+	return v
+}
+
+func CreateSSMDocument(name, content, docType string, meta interface{}) error {
+	ssmconn := meta.(*AWSClient).ssmconn
+
+	log.Printf("[INFO] Creating SSM Document: %q", name)
+
+	input := &ssm.CreateDocumentInput{
+		Name:         aws.String(name),
+		Content:      aws.String(content),
+		DocumentType: aws.String(docType),
+	}
+
+	log.Printf("[DEBUG] Waiting for SSM Document %q to be created", name)
+	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
+		_, err := ssmconn.CreateDocument(input)
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return errwrap.Wrapf("[ERROR] Error creating SSM document: {{err}}", err)
+	}
+	return nil
+}
+
+func UpdateSSMDocument(document map[string]interface{}, meta interface{}) error {
+	ssmconn := meta.(*AWSClient).ssmconn
+
+	name := document["name"].(string)
+
+	schemaVersion := document["schema_version"].(string)
+	schemaNumber, _ := strconv.ParseFloat(schemaVersion, 64)
+
+	if schemaNumber < MINIMUM_VERSIONED_SCHEMA {
+		log.Printf("[DEBUG] Skipping document update because schema version is not 2.0 %q", name)
+		return nil
+	}
+
+	log.Printf("[INFO] Updating SSM Document: %q", name)
+
+	newDefaultVersion := document["default_version"].(string)
+
+	updateDocInput := &ssm.UpdateDocumentInput{
+		Name:            aws.String(name),
+		Content:         aws.String(document["content"].(string)),
+		DocumentVersion: aws.String(newDefaultVersion),
+	}
+
+	updated, err := ssmconn.UpdateDocument(updateDocInput)
+
+	if isAWSErr(err, "DuplicateDocumentContent", "") {
+		log.Printf("[DEBUG] Content is a duplicate of the latest version so update is not necessary: %s", name)
+		log.Printf("[INFO] Updating the default version to the latest version %s: %s", newDefaultVersion, name)
+
+		newDefaultVersion = document["latest_version"].(string)
+	} else if err != nil {
+		return errwrap.Wrapf("Error updating SSM document: {{err}}", err)
+	} else {
+		log.Printf("[INFO] Updating the default version to the new version %s: %s", newDefaultVersion, name)
+		newDefaultVersion = *updated.DocumentDescription.DocumentVersion
+	}
+
+	updateDefaultInput := &ssm.UpdateDocumentDefaultVersionInput{
+		Name:            aws.String(name),
+		DocumentVersion: aws.String(newDefaultVersion),
+	}
+
+	_, err = ssmconn.UpdateDocumentDefaultVersion(updateDefaultInput)
+
+	if err != nil {
+		return errwrap.Wrapf("Error updating the default document version to that of the updated document: {{err}}", err)
+	}
+	return nil
+}
+
+func DeleteSSMDocument(name string, meta interface{}) error {
+	ssmconn := meta.(*AWSClient).ssmconn
+
+	log.Printf("[INFO] Deleting SSM Document: %q", name)
+
+	input := &ssm.DeleteDocumentInput{
+		Name: aws.String(name),
+	}
+
+	_, err := ssmconn.DeleteDocument(input)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] Waiting for SSM Document %q to be deleted", name)
+	err = resource.Retry(10*time.Minute, func() *resource.RetryError {
+		_, err := ssmconn.DescribeDocument(&ssm.DescribeDocumentInput{
+			Name: aws.String(name),
+		})
+
+		if err != nil {
+			awsErr, ok := err.(awserr.Error)
+			if !ok {
+				return resource.NonRetryableError(err)
+			}
+
+			if awsErr.Code() == "InvalidDocument" {
+				return nil
+			}
+
+			return resource.NonRetryableError(err)
+		}
+
+		return resource.RetryableError(
+			fmt.Errorf("%q: Timeout while waiting for the document to be deleted", input.Name))
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/aws/resource_aws_ssm_document_list_test.go
+++ b/aws/resource_aws_ssm_document_list_test.go
@@ -1,0 +1,460 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ssm"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSSSMDocumentList_basic(t *testing.T) {
+	name := acctest.RandString(10)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMDocumentListDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSSSMDocumentListBasicConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMDocumentExists("aws_ssm_document.foo"),
+				),
+			},
+		},
+	})
+}
+
+// func TestAccAWSSSMDocument_update(t *testing.T) {
+// 	name := acctest.RandString(10)
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:     func() { testAccPreCheck(t) },
+// 		Providers:    testAccProviders,
+// 		CheckDestroy: testAccCheckAWSSSMDocumentDestroy,
+// 		Steps: []resource.TestStep{
+// 			resource.TestStep{
+// 				Config: testAccAWSSSMDocument20Config(name),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					testAccCheckAWSSSMDocumentExists("aws_ssm_document.foo"),
+// 					resource.TestCheckResourceAttr(
+// 						"aws_ssm_document.foo", "schema_version", "2.0"),
+// 					resource.TestCheckResourceAttr(
+// 						"aws_ssm_document.foo", "latest_version", "1"),
+// 					resource.TestCheckResourceAttr(
+// 						"aws_ssm_document.foo", "default_version", "1"),
+// 				),
+// 			},
+// 			resource.TestStep{
+// 				Config: testAccAWSSSMDocument20UpdatedConfig(name),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					testAccCheckAWSSSMDocumentExists("aws_ssm_document.foo"),
+// 					resource.TestCheckResourceAttr(
+// 						"aws_ssm_document.foo", "latest_version", "2"),
+// 					resource.TestCheckResourceAttr(
+// 						"aws_ssm_document.foo", "default_version", "2"),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
+
+// func TestAccAWSSSMDocument_permission(t *testing.T) {
+// 	name := acctest.RandString(10)
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:     func() { testAccPreCheck(t) },
+// 		Providers:    testAccProviders,
+// 		CheckDestroy: testAccCheckAWSSSMDocumentDestroy,
+// 		Steps: []resource.TestStep{
+// 			resource.TestStep{
+// 				Config: testAccAWSSSMDocumentPermissionConfig(name),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					testAccCheckAWSSSMDocumentExists("aws_ssm_document.foo"),
+// 					resource.TestCheckResourceAttr(
+// 						"aws_ssm_document.foo", "permissions.type", "Share"),
+// 					resource.TestCheckResourceAttr(
+// 						"aws_ssm_document.foo", "permissions.account_ids", "all"),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
+
+// func TestAccAWSSSMDocument_params(t *testing.T) {
+// 	name := acctest.RandString(10)
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:     func() { testAccPreCheck(t) },
+// 		Providers:    testAccProviders,
+// 		CheckDestroy: testAccCheckAWSSSMDocumentDestroy,
+// 		Steps: []resource.TestStep{
+// 			resource.TestStep{
+// 				Config: testAccAWSSSMDocumentParamConfig(name),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					testAccCheckAWSSSMDocumentExists("aws_ssm_document.foo"),
+// 					resource.TestCheckResourceAttr(
+// 						"aws_ssm_document.foo", "parameter.0.name", "commands"),
+// 					resource.TestCheckResourceAttr(
+// 						"aws_ssm_document.foo", "parameter.0.type", "StringList"),
+// 					resource.TestCheckResourceAttr(
+// 						"aws_ssm_document.foo", "parameter.1.name", "workingDirectory"),
+// 					resource.TestCheckResourceAttr(
+// 						"aws_ssm_document.foo", "parameter.1.type", "String"),
+// 					resource.TestCheckResourceAttr(
+// 						"aws_ssm_document.foo", "parameter.2.name", "executionTimeout"),
+// 					resource.TestCheckResourceAttr(
+// 						"aws_ssm_document.foo", "parameter.2.type", "String"),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
+
+// func TestAccAWSSSMDocument_automation(t *testing.T) {
+// 	name := acctest.RandString(10)
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:     func() { testAccPreCheck(t) },
+// 		Providers:    testAccProviders,
+// 		CheckDestroy: testAccCheckAWSSSMDocumentDestroy,
+// 		Steps: []resource.TestStep{
+// 			resource.TestStep{
+// 				Config: testAccAWSSSMDocumentTypeAutomationConfig(name),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					testAccCheckAWSSSMDocumentExists("aws_ssm_document.foo"),
+// 					resource.TestCheckResourceAttr(
+// 						"aws_ssm_document.foo", "document_type", "Automation"),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
+
+// func testAccCheckAWSSSMDocumentExists(n string) resource.TestCheckFunc {
+// 	return func(s *terraform.State) error {
+// 		rs, ok := s.RootModule().Resources[n]
+// 		if !ok {
+// 			return fmt.Errorf("Not found: %s", n)
+// 		}
+
+// 		if rs.Primary.ID == "" {
+// 			return fmt.Errorf("No SSM Document ID is set")
+// 		}
+
+// 		conn := testAccProvider.Meta().(*AWSClient).ssmconn
+
+// 		_, err := conn.DescribeDocument(&ssm.DescribeDocumentInput{
+// 			Name: aws.String(rs.Primary.ID),
+// 		})
+// 		if err != nil {
+// 			return err
+// 		}
+
+// 		return nil
+// 	}
+// }
+
+func testAccCheckAWSSSMDocumentListDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).ssmconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_ssm_document_list" {
+			continue
+		}
+		return nil
+
+		// TODO: How to get the list of documents from here?
+		documents := rs.Primary.Attributes["documents_list"] //.([]interface{})
+
+		for i, v := range documents {
+			//document := v.(map[string]interface{})
+
+			out, err := conn.DescribeDocument(&ssm.DescribeDocumentInput{
+				Name: aws.String(rs.Primary.Attributes["documents_list.0.name"]),
+			})
+
+			if err != nil {
+				// InvalidDocument means it's gone, this is good
+				if wserr, ok := err.(awserr.Error); ok && wserr.Code() == "InvalidDocument" {
+					continue
+				}
+				return err
+			}
+
+			if out != nil {
+				return fmt.Errorf("Expected AWS SSM Document to be gone, but was still found")
+			}
+		}
+		return nil
+	}
+
+	return fmt.Errorf("Default error in SSM Document Test")
+}
+
+/*
+Based on examples from here: https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/create-ssm-doc.html
+*/
+
+func testAccAWSSSMDocumentListBasicConfig(rName string) string {
+	return fmt.Sprintf(`
+
+resource "aws_ssm_document_list" "list" {
+	documents_hash = "12345678"
+	documents_type = "Command"
+	documents_list {
+		name = "test_document-%s"
+		content = <<DOC
+			{
+			"schemaVersion": "1.2",
+			"description": "Check ip configuration of a Linux instance.",
+			"parameters": {},
+			"runtimeConfig": {
+				"aws:runShellScript": {
+				"properties": [
+					{
+					"id": "0.aws:runShellScript",
+					"runCommand": ["ifconfig"]
+					}
+				]
+				}
+			}
+			}
+		DOC
+	}
+}
+`, rName)
+}
+
+// func testAccAWSSSMDocument20Config(rName string) string {
+// 	return fmt.Sprintf(`
+// resource "aws_ssm_document" "foo" {
+//   name = "test_document-%s"
+//          document_type = "Command"
+
+//   content = <<DOC
+//     {
+//        "schemaVersion": "2.0",
+//        "description": "Sample version 2.0 document v2",
+//        "parameters": {
+
+//        },
+//        "mainSteps": [
+//           {
+//              "action": "aws:runPowerShellScript",
+//              "name": "runPowerShellScript",
+//              "inputs": {
+//                 "runCommand": [
+//                    "Get-Process"
+//                 ]
+//              }
+//           }
+//        ]
+//     }
+// DOC
+// }
+// `, rName)
+// }
+
+// func testAccAWSSSMDocument20UpdatedConfig(rName string) string {
+// 	return fmt.Sprintf(`
+// resource "aws_ssm_document" "foo" {
+//   name = "test_document-%s"
+//          document_type = "Command"
+
+//   content = <<DOC
+//     {
+//        "schemaVersion": "2.0",
+//        "description": "Sample version 2.0 document v2",
+//        "parameters": {
+
+//        },
+//        "mainSteps": [
+//           {
+//              "action": "aws:runPowerShellScript",
+//              "name": "runPowerShellScript",
+//              "inputs": {
+//                 "runCommand": [
+//                    "Get-Process -Verbose"
+//                 ]
+//              }
+//           }
+//        ]
+//     }
+// DOC
+// }
+// `, rName)
+// }
+
+// func testAccAWSSSMDocumentPermissionConfig(rName string) string {
+// 	return fmt.Sprintf(`
+// resource "aws_ssm_document" "foo" {
+//   name = "test_document-%s"
+// 	document_type = "Command"
+
+//   permissions = {
+//     type        = "Share"
+//     account_ids = "all"
+//   }
+
+//   content = <<DOC
+//     {
+//       "schemaVersion": "1.2",
+//       "description": "Check ip configuration of a Linux instance.",
+//       "parameters": {
+
+//       },
+//       "runtimeConfig": {
+//         "aws:runShellScript": {
+//           "properties": [
+//             {
+//               "id": "0.aws:runShellScript",
+//               "runCommand": ["ifconfig"]
+//             }
+//           ]
+//         }
+//       }
+//     }
+// DOC
+// }
+// `, rName)
+// }
+
+// func testAccAWSSSMDocumentParamConfig(rName string) string {
+// 	return fmt.Sprintf(`
+// resource "aws_ssm_document" "foo" {
+//   name = "test_document-%s"
+// 	document_type = "Command"
+
+//   content = <<DOC
+// 		{
+// 		    "schemaVersion":"1.2",
+// 		    "description":"Run a PowerShell script or specify the paths to scripts to run.",
+// 		    "parameters":{
+// 		        "commands":{
+// 		            "type":"StringList",
+// 		            "description":"(Required) Specify the commands to run or the paths to existing scripts on the instance.",
+// 		            "minItems":1,
+// 		            "displayType":"textarea"
+// 		        },
+// 		        "workingDirectory":{
+// 		            "type":"String",
+// 		            "default":"",
+// 		            "description":"(Optional) The path to the working directory on your instance.",
+// 		            "maxChars":4096
+// 		        },
+// 		        "executionTimeout":{
+// 		            "type":"String",
+// 		            "default":"3600",
+// 		            "description":"(Optional) The time in seconds for a command to be completed before it is considered to have failed. Default is 3600 (1 hour). Maximum is 28800 (8 hours).",
+// 		            "allowedPattern":"([1-9][0-9]{0,3})|(1[0-9]{1,4})|(2[0-7][0-9]{1,3})|(28[0-7][0-9]{1,2})|(28800)"
+// 		        }
+// 		    },
+// 		    "runtimeConfig":{
+// 		        "aws:runPowerShellScript":{
+// 		            "properties":[
+// 		                {
+// 		                    "id":"0.aws:runPowerShellScript",
+// 		                    "runCommand":"{{ commands }}",
+// 		                    "workingDirectory":"{{ workingDirectory }}",
+// 		                    "timeoutSeconds":"{{ executionTimeout }}"
+// 		                }
+// 		            ]
+// 		        }
+// 		    }
+// 		}
+// DOC
+// }
+
+// `, rName)
+// }
+
+// func testAccAWSSSMDocumentTypeAutomationConfig(rName string) string {
+// 	return fmt.Sprintf(`
+// data "aws_ami" "ssm_ami" {
+// 	most_recent = true
+// 	filter {
+// 		name = "name"
+// 		values = ["*hvm-ssd/ubuntu-trusty-14.04*"]
+// 	}
+// }
+
+// resource "aws_iam_instance_profile" "ssm_profile" {
+//   name = "ssm_profile-%s"
+//   roles = ["${aws_iam_role.ssm_role.name}"]
+// }
+
+// resource "aws_iam_role" "ssm_role" {
+//     name = "ssm_role-%s"
+//     path = "/"
+//     assume_role_policy = <<EOF
+// {
+//     "Version": "2012-10-17",
+//     "Statement": [
+//         {
+//             "Action": "sts:AssumeRole",
+//             "Principal": {
+//                "Service": "ec2.amazonaws.com"
+//             },
+//             "Effect": "Allow",
+//             "Sid": ""
+//         }
+//     ]
+// }
+// EOF
+// }
+
+// resource "aws_ssm_document" "foo" {
+//   name = "test_document-%s"
+// 	document_type = "Automation"
+//   content = <<DOC
+// 	{
+// 	   "description": "Systems Manager Automation Demo",
+// 	   "schemaVersion": "0.3",
+// 	   "assumeRole": "${aws_iam_role.ssm_role.arn}",
+// 	   "mainSteps": [
+// 	      {
+// 	         "name": "startInstances",
+// 	         "action": "aws:runInstances",
+// 	         "timeoutSeconds": 1200,
+// 	         "maxAttempts": 1,
+// 	         "onFailure": "Abort",
+// 	         "inputs": {
+// 	            "ImageId": "${data.aws_ami.ssm_ami.id}",
+// 	            "InstanceType": "t2.small",
+// 	            "MinInstanceCount": 1,
+// 	            "MaxInstanceCount": 1,
+// 	            "IamInstanceProfileName": "${aws_iam_instance_profile.ssm_profile.name}"
+// 	         }
+// 	      },
+// 	      {
+// 	         "name": "stopInstance",
+// 	         "action": "aws:changeInstanceState",
+// 	         "maxAttempts": 1,
+// 	         "onFailure": "Continue",
+// 	         "inputs": {
+// 	            "InstanceIds": [
+// 	               "{{ startInstances.InstanceIds }}"
+// 	            ],
+// 	            "DesiredState": "stopped"
+// 	         }
+// 	      },
+// 	      {
+// 	         "name": "terminateInstance",
+// 	         "action": "aws:changeInstanceState",
+// 	         "maxAttempts": 1,
+// 	         "onFailure": "Continue",
+// 	         "inputs": {
+// 	            "InstanceIds": [
+// 	               "{{ startInstances.InstanceIds }}"
+// 	            ],
+// 	            "DesiredState": "terminated"
+// 	         }
+// 	      }
+// 	   ]
+// 	}
+// DOC
+// }
+
+// `, rName, rName, rName)
+// }


### PR DESCRIPTION
Adding `aws_ssm_document_list`. This based on `aws_ssm_document`, but allows a list of documents to be passed in.

## Use Case

The use case for this is when dealing with many of these documents, instead of creating a `ssm_document` for every document, it's easier to get a list of documents from a folder.

Previously, I was using the powershell below to retrieve this list, and passing that to `ssm_document` as a list variable. This works initially, but has a few issues:

- If a document is added, renamed or deleted, it can affect the ordering of the list and the state file, causing terraform to try updating multiple documents
- If documents are added the statefile change causes move existing files down the list, causing terraform to try (and fail) to re-create an existing document
- The same re-ordering of the list can cause update issues because the document version in AWS, no longer matches the one held in state.

```
data "external" "doc-list" {
  program = ["powershell", "New-Object PSObject | Add-Member -PassThru NoteProperty Name ((Get-ChildItem -Path ../../docs/linux -File -Filter '*.json').Name -join ',') | ConvertTo-Json"]
}
```

And passing that output to a module as a variable:

```
variable "linux-command-doc-list" {
  type = "list"
}

resource "aws_ssm_document" "command-docs" {
  name          = "${replace(element(var.linux-command-doc-list, count.index), ".json", "")}"
  document_type = "Command"
  content       = "${file("../../docs/linux/${element(var.linux-command-doc-list, count.index)}")}"
  count         = "${length(var.linux-command-doc-list)}"
}
```

## aws_ssm_document_list
Using `aws_ssm_document_list` with [datasource_template_file_list](https://github.com/terraform-providers/terraform-provider-template/pull/13), I can write this:

```
data "template_file_list" "list" {
  source_dir = "./docs"
}

resource "aws_ssm_document_list" "docs" {
  documents_list = ["${data.template_file_list.list.files}"]
  documents_hash = "${data.template_file_list.list.id}"
  documents_type = "Command"
}
```

The `Create` action takes all documents in the list and creates them in AWS, using partial state.

The `Update` action takes care of Creating / Updating / Deleting new and existing documents that get added or removed from the folder. It also takes care of avoiding making changes to documents that haven't changed (from the statefile re-ordering issue above)

The `Delete` action takes all documents in the list and deletes them from AWS, using partial state.

## Todo / Help

- [ ] Help: How to get the list of documents from [`rs.Primary.Attributes["documents_list"]`](https://github.com/terraform-providers/terraform-provider-aws/compare/master...PaulAtkins:ssm-list?expand=1#diff-ab8ad7945fc513af542600025de74d55R167) ?
- [ ] Help: I've duplicated a lot of code from `ssm_document`, because I couldn't find a way to get a `*schema.ResourceData` type object from `d.Get("documents_list")`. Is that possible a different way?
- [ ] Todo: Finish adding tests
- [ ] Todo: Add setting of document permissions
- [ ] Todo: Website / docs 
