### PR TITLE
Append the info about IAM Server Certificate import

### DIFF
--- a/website/docs/r/iam_server_certificate.html.markdown
+++ b/website/docs/r/iam_server_certificate.html.markdown
@@ -121,7 +121,7 @@ The following arguments are supported:
 IAM Server Certificates can be imported using the `name`, e.g.
 
 ```
-$ terraform import aws_iam_server_certificate.sertificate example.com-certificate-until-2018
+$ terraform import aws_iam_server_certificate.certificate example.com-certificate-until-2018
 ```
 
 [1]: https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html

--- a/website/docs/r/iam_server_certificate.html.markdown
+++ b/website/docs/r/iam_server_certificate.html.markdown
@@ -116,6 +116,13 @@ The following arguments are supported:
 * `name` - The name of the Server Certificate
 * `arn` - The Amazon Resource Name (ARN) specifying the server certificate.
 
+## Import
+
+IAM Server Certificates can be imported using the `name`, e.g.
+
+```
+$ terraform import aws_iam_server_certificate.sertificate example.com-certificate-until-2018
+```
 
 [1]: https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html
 [2]: https://docs.aws.amazon.com/IAM/latest/UserGuide/ManagingServerCerts.html


### PR DESCRIPTION
I noticed that we missed an information about IAM certificates import. From the user side it looks like a Terraform cannot do this. So, I tried import by `id` and by `name` both. Only the last one succeeded.
So, please, update the docs.