### PR TITLE
resource/aws_rds_cluster: Add support for iam_roles to rds_cluster

### DIFF
--- a/aws/resource_aws_rds_cluster_test.go
+++ b/aws/resource_aws_rds_cluster_test.go
@@ -146,6 +146,41 @@ func TestAccAWSRDSCluster_updateTags(t *testing.T) {
 	})
 }
 
+func TestAccAWSRDSCluster_updateIamRoles(t *testing.T) {
+	var v rds.DBCluster
+	ri := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSClusterConfigIncludingIamRoles(ri),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSClusterExists("aws_rds_cluster.default", &v),
+				),
+			},
+			{
+				Config: testAccAWSClusterConfigAddIamRoles(ri),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSClusterExists("aws_rds_cluster.default", &v),
+					resource.TestCheckResourceAttr(
+						"aws_rds_cluster.default", "iam_role.#", "2"),
+				),
+			},
+			{
+				Config: testAccAWSClusterConfigRemoveIamRoles(ri),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSClusterExists("aws_rds_cluster.default", &v),
+					resource.TestCheckResourceAttr(
+						"aws_rds_cluster.default", "iam_role.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSRDSCluster_kmsKey(t *testing.T) {
 	var v rds.DBCluster
 	keyRegex := regexp.MustCompile("^arn:aws:kms:")
@@ -590,4 +625,232 @@ resource "aws_rds_cluster" "default" {
   iam_database_authentication_enabled = true
   skip_final_snapshot = true
 }`, n)
+}
+
+func testAccAWSClusterConfigIncludingIamRoles(n int) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "rds_sample_role" {
+  name = "rds_sample_role_%d"
+  path = "/"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "rds.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+resource "aws_iam_role_policy" "rds_policy" {
+	name = "rds_sample_role_policy_%d"
+	role = "${aws_iam_role.rds_sample_role.name}"
+	policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Action": "*",
+    "Resource": "*"
+  }
+}
+EOF
+}
+resource "aws_iam_role" "another_rds_sample_role" {
+  name = "another_rds_sample_role_%d"
+  path = "/"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "rds.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+resource "aws_iam_role_policy" "another_rds_policy" {
+	name = "another_rds_sample_role_policy_%d"
+	role = "${aws_iam_role.another_rds_sample_role.name}"
+	policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Action": "*",
+    "Resource": "*"
+  }
+}
+EOF
+}
+resource "aws_rds_cluster" "default" {
+  cluster_identifier = "tf-aurora-cluster-%d"
+  availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
+  database_name = "mydb"
+  master_username = "foo"
+  master_password = "mustbeeightcharaters"
+  db_cluster_parameter_group_name = "default.aurora5.6"
+  skip_final_snapshot = true
+  tags {
+    Environment = "production"
+  }
+  depends_on = ["aws_iam_role.another_rds_sample_role", "aws_iam_role.rds_sample_role"]
+
+}`, n, n, n, n, n)
+}
+
+func testAccAWSClusterConfigAddIamRoles(n int) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "rds_sample_role" {
+  name = "rds_sample_role_%d"
+  path = "/"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "rds.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+resource "aws_iam_role_policy" "rds_policy" {
+	name = "rds_sample_role_policy_%d"
+	role = "${aws_iam_role.rds_sample_role.name}"
+	policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Action": "*",
+    "Resource": "*"
+  }
+}
+EOF
+}
+resource "aws_iam_role" "another_rds_sample_role" {
+  name = "another_rds_sample_role_%d"
+  path = "/"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "rds.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+resource "aws_iam_role_policy" "another_rds_policy" {
+	name = "another_rds_sample_role_policy_%d"
+	role = "${aws_iam_role.another_rds_sample_role.name}"
+	policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Action": "*",
+    "Resource": "*"
+  }
+}
+EOF
+}
+resource "aws_rds_cluster" "default" {
+  cluster_identifier = "tf-aurora-cluster-%d"
+  availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
+  database_name = "mydb"
+  master_username = "foo"
+  master_password = "mustbeeightcharaters"
+  db_cluster_parameter_group_name = "default.aurora5.6"
+  skip_final_snapshot = true
+  iam_role {
+  	role_arn = "${aws_iam_role.rds_sample_role.arn}"
+  }
+  iam_role {
+  	role_arn = "${aws_iam_role.another_rds_sample_role.arn}"
+  }
+  tags {
+    Environment = "production"
+  }
+  depends_on = ["aws_iam_role.another_rds_sample_role", "aws_iam_role.rds_sample_role"]
+
+}`, n, n, n, n, n)
+}
+
+func testAccAWSClusterConfigRemoveIamRoles(n int) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "another_rds_sample_role" {
+  name = "another_rds_sample_role_%d"
+  path = "/"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "rds.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+resource "aws_iam_role_policy" "another_rds_policy" {
+	name = "another_rds_sample_role_policy_%d"
+	role = "${aws_iam_role.another_rds_sample_role.name}"
+	policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Action": "*",
+    "Resource": "*"
+  }
+}
+EOF
+}
+resource "aws_rds_cluster" "default" {
+  cluster_identifier = "tf-aurora-cluster-%d"
+  availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
+  database_name = "mydb"
+  master_username = "foo"
+  master_password = "mustbeeightcharaters"
+  db_cluster_parameter_group_name = "default.aurora5.6"
+  skip_final_snapshot = true
+  iam_role {
+  	role_arn = "${aws_iam_role.another_rds_sample_role.arn}"
+  }
+  tags {
+    Environment = "production"
+  }
+
+  depends_on = ["aws_iam_role.another_rds_sample_role"]
+}`, n, n, n)
 }

--- a/website/docs/r/rds_cluster.html.markdown
+++ b/website/docs/r/rds_cluster.html.markdown
@@ -83,7 +83,12 @@ Default: A 30-minute window selected at random from an 8-hour block of time per 
 * `db_subnet_group_name` - (Optional) A DB subnet group to associate with this DB instance. **NOTE:** This must match the `db_subnet_group_name` specified on every [`aws_rds_cluster_instance`](/docs/providers/aws/r/rds_cluster_instance.html) in the cluster.
 * `db_cluster_parameter_group_name` - (Optional) A cluster parameter group to associate with the cluster.
 * `kms_key_id` - (Optional) The ARN for the KMS encryption key. When specifying `kms_key_id`, `storage_encrypted` needs to be set to true.
+* `iam_role` - (Optional) An `iam_role` block to associate to the cluster. As specified below.
 * `iam_database_authentication_enabled` - (Optional) Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled.
+
+`iam_role` supports the following:
+
+* `role_arn` - (Required) The Arn of the IAM Role to associate with the RDS Cluster.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fixes: #382

We store the state of the role that was added so that we can understand
if the status of the role is `invalid` and thus an error has occurred

```
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSRDSCluster_updateIamRoles'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSRDSCluster_updateIamRoles -timeout 120m
=== RUN   TestAccAWSRDSCluster_updateIamRoles
--- PASS: TestAccAWSRDSCluster_updateIamRoles (190.73s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	190.769s
```