### PR TITLE
resource/default_network_acl: Add support for ipv6_cidr_block

### DIFF
--- a/aws/resource_aws_default_network_acl.go
+++ b/aws/resource_aws_default_network_acl.go
@@ -27,11 +27,11 @@ func resourceAwsDefaultNetworkAcl() *schema.Resource {
 		Update: resourceAwsDefaultNetworkAclUpdate,
 
 		Schema: map[string]*schema.Schema{
-			"vpc_id": &schema.Schema{
+			"vpc_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"default_network_acl_id": &schema.Schema{
+			"default_network_acl_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
@@ -43,7 +43,7 @@ func resourceAwsDefaultNetworkAcl() *schema.Resource {
 			// can't actually remove them, this will be a continual plan until the
 			// Subnets are themselves destroyed or reassigned to a different Network
 			// ACL
-			"subnet_ids": &schema.Schema{
+			"subnet_ids": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
@@ -52,41 +52,45 @@ func resourceAwsDefaultNetworkAcl() *schema.Resource {
 			// We want explicit management of Rules here, so we do not allow them to be
 			// computed. Instead, an empty config will enforce just that; removal of the
 			// rules
-			"ingress": &schema.Schema{
+			"ingress": {
 				Type:     schema.TypeSet,
 				Required: false,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"from_port": &schema.Schema{
+						"from_port": {
 							Type:     schema.TypeInt,
 							Required: true,
 						},
-						"to_port": &schema.Schema{
+						"to_port": {
 							Type:     schema.TypeInt,
 							Required: true,
 						},
-						"rule_no": &schema.Schema{
+						"rule_no": {
 							Type:     schema.TypeInt,
 							Required: true,
 						},
-						"action": &schema.Schema{
+						"action": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
-						"protocol": &schema.Schema{
+						"protocol": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
-						"cidr_block": &schema.Schema{
+						"cidr_block": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
-						"icmp_type": &schema.Schema{
+						"ipv6_cidr_block": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"icmp_type": {
 							Type:     schema.TypeInt,
 							Optional: true,
 						},
-						"icmp_code": &schema.Schema{
+						"icmp_code": {
 							Type:     schema.TypeInt,
 							Optional: true,
 						},
@@ -94,41 +98,45 @@ func resourceAwsDefaultNetworkAcl() *schema.Resource {
 				},
 				Set: resourceAwsNetworkAclEntryHash,
 			},
-			"egress": &schema.Schema{
+			"egress": {
 				Type:     schema.TypeSet,
 				Required: false,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"from_port": &schema.Schema{
+						"from_port": {
 							Type:     schema.TypeInt,
 							Required: true,
 						},
-						"to_port": &schema.Schema{
+						"to_port": {
 							Type:     schema.TypeInt,
 							Required: true,
 						},
-						"rule_no": &schema.Schema{
+						"rule_no": {
 							Type:     schema.TypeInt,
 							Required: true,
 						},
-						"action": &schema.Schema{
+						"action": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
-						"protocol": &schema.Schema{
+						"protocol": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
-						"cidr_block": &schema.Schema{
+						"cidr_block": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
-						"icmp_type": &schema.Schema{
+						"ipv6_cidr_block": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"icmp_type": {
 							Type:     schema.TypeInt,
 							Optional: true,
 						},
-						"icmp_code": &schema.Schema{
+						"icmp_code": {
 							Type:     schema.TypeInt,
 							Optional: true,
 						},

--- a/website/docs/r/default_network_acl.html.markdown
+++ b/website/docs/r/default_network_acl.html.markdown
@@ -131,6 +131,7 @@ Both `egress` and `ingress` support the following keys:
 protocol, you must specify a from and to port of 0.
 * `cidr_block` - (Optional) The CIDR block to match. This must be a
 valid network mask.
+* `ipv6_cidr_block` - (Optional) The IPv6 CIDR block.
 * `icmp_type` - (Optional) The ICMP type to be used. Default 0.
 * `icmp_code` - (Optional) The ICMP type code to be used. Default 0.
 


### PR DESCRIPTION
Fixes: #1096

default_security_group already has support for ipv6_cidr_block.

```
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSDefaultNetworkAcl_withIpv6Ingress'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSDefaultNetworkAcl_withIpv6Ingress -timeout 120m
=== RUN   TestAccAWSDefaultNetworkAcl_withIpv6Ingress
--- PASS: TestAccAWSDefaultNetworkAcl_withIpv6Ingress (53.45s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	53.511s
```

<img width="768" alt="screen shot 2017-07-11 at 13 35 15" src="https://user-images.githubusercontent.com/227823/28065469-5b87210c-6641-11e7-91f9-01e022420a1b.png">

<img width="830" alt="screen shot 2017-07-11 at 13 36 52" src="https://user-images.githubusercontent.com/227823/28065477-5fd727de-6641-11e7-8158-28415d444650.png">
