### PR TITLE
resource/aws_route53_health_check: add support for health_check regions

### DIFF
--- a/aws/resource_aws_route53_health_check_test.go
+++ b/aws/resource_aws_route53_health_check_test.go
@@ -17,7 +17,7 @@ func TestAccAWSRoute53HealthCheck_basic(t *testing.T) {
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53HealthCheckDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccRoute53HealthCheckConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53HealthCheckExists("aws_route53_health_check.foo"),
@@ -27,7 +27,7 @@ func TestAccAWSRoute53HealthCheck_basic(t *testing.T) {
 						"aws_route53_health_check.foo", "invert_healthcheck", "true"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccRoute53HealthCheckConfigUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53HealthCheckExists("aws_route53_health_check.foo"),
@@ -48,7 +48,7 @@ func TestAccAWSRoute53HealthCheck_withSearchString(t *testing.T) {
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53HealthCheckDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccRoute53HealthCheckConfigWithSearchString,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53HealthCheckExists("aws_route53_health_check.foo"),
@@ -58,7 +58,7 @@ func TestAccAWSRoute53HealthCheck_withSearchString(t *testing.T) {
 						"aws_route53_health_check.foo", "search_string", "OK"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccRoute53HealthCheckConfigWithSearchStringUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53HealthCheckExists("aws_route53_health_check.foo"),
@@ -78,10 +78,28 @@ func TestAccAWSRoute53HealthCheck_withChildHealthChecks(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53HealthCheckDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccRoute53HealthCheckConfig_withChildHealthChecks,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53HealthCheckExists("aws_route53_health_check.foo"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute53HealthCheck_withHealthCheckRegions(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53HealthCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53HealthCheckConfig_withHealthCheckRegions,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53HealthCheckExists("aws_route53_health_check.foo"),
+					resource.TestCheckResourceAttr(
+						"aws_route53_health_check.foo", "regions.#", "3"),
 				),
 			},
 		},
@@ -94,7 +112,7 @@ func TestAccAWSRoute53HealthCheck_IpConfig(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53HealthCheckDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccRoute53HealthCheckIpConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53HealthCheckExists("aws_route53_health_check.bar"),
@@ -110,7 +128,7 @@ func TestAccAWSRoute53HealthCheck_CloudWatchAlarmCheck(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53HealthCheckDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccRoute53HealthCheckCloudWatchAlarm,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53HealthCheckExists("aws_route53_health_check.foo"),
@@ -129,7 +147,7 @@ func TestAccAWSRoute53HealthCheck_withSNI(t *testing.T) {
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRoute53HealthCheckDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccRoute53HealthCheckConfigWithoutSNI,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53HealthCheckExists("aws_route53_health_check.foo"),
@@ -137,7 +155,7 @@ func TestAccAWSRoute53HealthCheck_withSNI(t *testing.T) {
 						"aws_route53_health_check.foo", "enable_sni", "true"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccRoute53HealthCheckConfigWithSNIDisabled,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53HealthCheckExists("aws_route53_health_check.foo"),
@@ -145,7 +163,7 @@ func TestAccAWSRoute53HealthCheck_withSNI(t *testing.T) {
 						"aws_route53_health_check.foo", "enable_sni", "false"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccRoute53HealthCheckConfigWithSNI,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53HealthCheckExists("aws_route53_health_check.foo"),
@@ -289,6 +307,23 @@ resource "aws_route53_health_check" "foo" {
 
   tags = {
     Name = "tf-test-calculated-health-check"
+   }
+}
+`
+
+const testAccRoute53HealthCheckConfig_withHealthCheckRegions = `
+resource "aws_route53_health_check" "foo" {
+  ip_address = "1.2.3.4"
+  port = 80
+  type = "HTTP"
+  resource_path = "/"
+  failure_threshold = "2"
+  request_interval = "30"
+
+  regions = ["us-west-1","us-east-1","eu-west-1"]
+
+  tags = {
+    Name = "tf-test-check-with-regions"
    }
 }
 `

--- a/website/docs/r/route53_health_check.html.markdown
+++ b/website/docs/r/route53_health_check.html.markdown
@@ -81,6 +81,7 @@ The following arguments are supported:
 * `cloudwatch_alarm_name` - (Optional) The name of the CloudWatch alarm.
 * `cloudwatch_alarm_region` - (Optional) The CloudWatchRegion that the CloudWatch alarm was created in.
 * `insufficient_data_health_status` - (Optional) The status of the health check when CloudWatch has insufficient data about the state of associated alarm. Valid values are `Healthy` , `Unhealthy` and `LastKnownStatus`.
+* `regions` - (Optional) A list of AWS regions that you want Amazon Route 53 health checkers to check the specified endpoint from.
 
 * `tags` - (Optional) A mapping of tags to assign to the health check.
 


### PR DESCRIPTION
Fixes: #784

```
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSRoute53HealthCheck_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSRoute53HealthCheck_ -timeout 120m
=== RUN   TestAccAWSRoute53HealthCheck_importBasic
--- PASS: TestAccAWSRoute53HealthCheck_importBasic (29.04s)
=== RUN   TestAccAWSRoute53HealthCheck_basic
--- PASS: TestAccAWSRoute53HealthCheck_basic (50.80s)
=== RUN   TestAccAWSRoute53HealthCheck_withSearchString
--- PASS: TestAccAWSRoute53HealthCheck_withSearchString (45.29s)
=== RUN   TestAccAWSRoute53HealthCheck_withChildHealthChecks
--- PASS: TestAccAWSRoute53HealthCheck_withChildHealthChecks (40.46s)
=== RUN   TestAccAWSRoute53HealthCheck_withHealthCheckRegions
--- PASS: TestAccAWSRoute53HealthCheck_withHealthCheckRegions (25.17s)
=== RUN   TestAccAWSRoute53HealthCheck_IpConfig
--- PASS: TestAccAWSRoute53HealthCheck_IpConfig (24.83s)
=== RUN   TestAccAWSRoute53HealthCheck_CloudWatchAlarmCheck
--- PASS: TestAccAWSRoute53HealthCheck_CloudWatchAlarmCheck (28.50s)
=== RUN   TestAccAWSRoute53HealthCheck_withSNI
--- PASS: TestAccAWSRoute53HealthCheck_withSNI (63.41s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	307.522s
```