### PR TITLE
docs/aws_redshift_cluster: Fix default value of skip_final_snapshot

### DIFF
--- a/website/docs/r/redshift_cluster.html.markdown
+++ b/website/docs/r/redshift_cluster.html.markdown
@@ -61,7 +61,7 @@ string.
 * `enhanced_vpc_routing` - (Optional) If true , enhanced VPC routing is enabled.
 * `kms_key_id` - (Optional) The ARN for the KMS encryption key. When specifying `kms_key_id`, `encrypted` needs to be set to true.
 * `elastic_ip` - (Optional) The Elastic IP (EIP) address for the cluster.
-* `skip_final_snapshot` - (Optional) Determines whether a final snapshot of the cluster is created before Amazon Redshift deletes the cluster. If true , a final cluster snapshot is not created. If false , a final cluster snapshot is created before the cluster is deleted. Default is true.
+* `skip_final_snapshot` - (Optional) Determines whether a final snapshot of the cluster is created before Amazon Redshift deletes the cluster. If true , a final cluster snapshot is not created. If false , a final cluster snapshot is created before the cluster is deleted. Default is false.
 * `final_snapshot_identifier` - (Optional) The identifier of the final snapshot that is to be created immediately before deleting the cluster. If this parameter is provided, `skip_final_snapshot` must be false.
 * `snapshot_identifier` - (Optional) The name of the snapshot from which to create the new cluster.
 * `snapshot_cluster_identifier` - (Optional) The name of the cluster the source snapshot was created from.


### PR DESCRIPTION
The default value of `skip_final_snapshot` was changed to `false`
with the following change, but the document was not updated.
https://github.com/hashicorp/terraform/pull/11695