### PR TITLE
Updating documentation

### DIFF
--- a/website/docs/r/vpc_peering.html.markdown
+++ b/website/docs/r/vpc_peering.html.markdown
@@ -74,7 +74,7 @@ more information.
 
 The following arguments are supported:
 
-* `peer_owner_id` - (Required) The AWS account ID of the owner of the peer VPC.
+* `peer_owner_id` - (Optional) The AWS account ID of the owner of the peer VPC.
    Defaults to the account ID the [AWS provider][1] is currently connected to.
 * `peer_vpc_id` - (Required) The ID of the VPC with which you are creating the VPC Peering Connection.
 * `vpc_id` - (Required) The ID of the requester VPC.


### PR DESCRIPTION
**Contribution Guidelines**
This is an update to the documentation. Reasoning is explained in the below paragraph. This is for the current version of Terraform and should have no issues being deployed immediately AFAIK.

---


In the `aws_vpc_peering_connection` resource the `peer_owner_id` is actually optional.

This can be seen here: https://github.com/terraform-providers/terraform-provider-aws/blob/master/aws/resource_aws_vpc_peering_connection.go#L30

The documentation after commit already explains what it defaults to (The current account ID).