### PR TITLE
data/aws_iam_group: Add a data source for AWS IAM Group

### DIFF
--- a/aws/data_source_aws_iam_group.go
+++ b/aws/data_source_aws_iam_group.go
@@ -1,0 +1,62 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsIAMGroup() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsIAMGroupRead,
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"path": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"group_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"group_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsIAMGroupRead(d *schema.ResourceData, meta interface{}) error {
+	iamconn := meta.(*AWSClient).iamconn
+
+	groupName := d.Get("group_name").(string)
+
+	req := &iam.GetGroupInput{
+		GroupName: aws.String(groupName),
+	}
+
+	resp, err := iamconn.GetGroup(req)
+	if err != nil {
+		return errwrap.Wrapf("Error getting group: {{err}}", err)
+	}
+	if resp == nil {
+		return fmt.Errorf("no IAM group found")
+	}
+
+	group := resp.Group
+
+	d.SetId(*group.GroupId)
+	d.Set("arn", group.Arn)
+	d.Set("path", group.Path)
+	d.Set("group_id", group.GroupId)
+
+	return nil
+}

--- a/aws/data_source_aws_iam_group_test.go
+++ b/aws/data_source_aws_iam_group_test.go
@@ -1,0 +1,37 @@
+package aws
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSDataSourceIAMGroup_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsIAMGroupConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.aws_iam_group.test", "group_id"),
+					resource.TestCheckResourceAttr("data.aws_iam_group.test", "path", "/"),
+					resource.TestCheckResourceAttr("data.aws_iam_group.test", "group_name", "test-datasource-group"),
+					resource.TestMatchResourceAttr("data.aws_iam_group.test", "arn", regexp.MustCompile("^arn:aws:iam::[0-9]{12}:group/test-datasource-group")),
+				),
+			},
+		},
+	})
+}
+
+const testAccAwsIAMGroupConfig = `
+resource "aws_iam_group" "group" {
+	name = "test-datasource-group"
+	path = "/"
+}
+
+data "aws_iam_group" "test" {
+	  group_name = "${aws_iam_group.group.name}"
+}
+`

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -188,6 +188,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_elb_hosted_zone_id":               dataSourceAwsElbHostedZoneId(),
 			"aws_elb_service_account":              dataSourceAwsElbServiceAccount(),
 			"aws_iam_account_alias":                dataSourceAwsIamAccountAlias(),
+			"aws_iam_group":                        dataSourceAwsIAMGroup(),
 			"aws_iam_instance_profile":             dataSourceAwsIAMInstanceProfile(),
 			"aws_iam_policy_document":              dataSourceAwsIamPolicyDocument(),
 			"aws_iam_role":                         dataSourceAwsIAMRole(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -101,6 +101,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-iam-account-alias") %>>
                             <a href="/docs/providers/aws/d/iam_account_alias.html">aws_iam_account_alias</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-iam-group") %>>
+                            <a href="/docs/providers/aws/d/iam_group.html">aws_iam_group</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-iam-instance-profile") %>>
                             <a href="/docs/providers/aws/d/iam_instance_profile.html">aws_iam_instance_profile</a>
                         </li>

--- a/website/docs/d/iam_group.html.markdown
+++ b/website/docs/d/iam_group.html.markdown
@@ -1,0 +1,33 @@
+---
+layout: "aws"
+page_title: "AWS: aws_iam_role"
+sidebar_current: "docs-aws-datasource-iam-role"
+description: |-
+  Get information on a Amazon IAM group
+---
+
+# aws_iam_group
+
+This data source can be used to fetch information about a specific
+IAM group. By using this data source, you can reference IAM group
+properties without having to hard code ARNs as input.
+
+## Example Usage
+
+```hcl
+data "aws_iam_group" "example" {
+  group_name = "an_example_group_name"
+}
+```
+
+## Argument Reference
+
+* `group_name` - (Required) The friendly IAM group name to match.
+
+## Attributes Reference
+
+* `arn` - The Amazon Resource Name (ARN) specifying the group.
+
+* `path` - The path to the role.
+
+* `group_id` - The stable and unique string identifying the group.


### PR DESCRIPTION
Fixes: #1138

```
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSDataSourceIAMGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSDataSourceIAMGroup -timeout 120m
=== RUN   TestAccAWSDataSourceIAMGroup_basic
--- PASS: TestAccAWSDataSourceIAMGroup_basic (31.44s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	31.464s
```