### PR TITLE
docs/ecs_task_definition: clarify multiple volume blocks may be specified

### DIFF
--- a/website/docs/r/ecs_task_definition.html.markdown
+++ b/website/docs/r/ecs_task_definition.html.markdown
@@ -78,7 +78,7 @@ definition document. For a detailed description of what parameters are available
 official [Developer Guide](https://docs.aws.amazon.com/AmazonECS/latest/developerguide).
 * `task_role_arn` - (Optional) The ARN of IAM role that allows your Amazon ECS container task to make calls to other AWS services.
 * `network_mode` - (Optional) The Docker networking mode to use for the containers in the task. The valid values are `none`, `bridge`, and `host`.
-* `volume` - (Optional) A volume block. See below for details about what arguments are supported.
+* `volume` - (Optional) Can be specified multiple times for each volume. Each volume block supports fields documented below.
 * `placement_constraints` - (Optional) rules that are taken into consideration during task placement. Maximum number of
 `placement_constraints` is `10`. Defined below.
 

--- a/website/docs/r/ecs_task_definition.html.markdown
+++ b/website/docs/r/ecs_task_definition.html.markdown
@@ -67,7 +67,7 @@ contains only a small subset of the available parameters.
 
 ## Argument Reference
 
-The following arguments are supported:
+### Top-Level Arguments
 
 * `family` - (Required) A unique name for your task definition.
 * `container_definitions` - (Required) A list of valid [container definitions]
@@ -78,19 +78,16 @@ definition document. For a detailed description of what parameters are available
 official [Developer Guide](https://docs.aws.amazon.com/AmazonECS/latest/developerguide).
 * `task_role_arn` - (Optional) The ARN of IAM role that allows your Amazon ECS container task to make calls to other AWS services.
 * `network_mode` - (Optional) The Docker networking mode to use for the containers in the task. The valid values are `none`, `bridge`, and `host`.
-* `volume` - (Optional) Can be specified multiple times for each volume. Each volume block supports fields documented below.
-* `placement_constraints` - (Optional) rules that are taken into consideration during task placement. Maximum number of
-`placement_constraints` is `10`. Defined below.
+* `volume` - (Optional) A set of [volume blocks](#volume-block-arguments) that containers in your task may use.
+* `placement_constraints` - (Optional) A set of [placement constraints](#placement-constraints-arguments) rules that are taken into consideration during task placement. Maximum number of `placement_constraints` is `10`.
 
-Volume block supports the following arguments:
+#### Volume Block Arguments
 
 * `name` - (Required) The name of the volume. This name is referenced in the `sourceVolume`
 parameter of container definition in the `mountPoints` section.
 * `host_path` - (Optional) The path on the host container instance that is presented to the container. If not set, ECS will create a nonpersistent data volume that starts empty and is deleted after the task has finished.
 
-## placement_constraints
-
-`placement_constraints` support the following:
+#### Placement Constraints Arguments
 
 * `type` - (Required) The type of constraint. Use `memberOf` to restrict selection to a group of valid candidates.
 Note that `distinctInstance` is not supported in task definitions.


### PR DESCRIPTION
updated the aws_ecs_task_definition.volume to indicate that multiple volume blocks can be specified. matched the language used in [aws_security_group.ingress](https://www.terraform.io/docs/providers/aws/r/security_group.html#ingress).

**reasoning**: it is unclear/not explicit that multiple volume blocks may currently be specified. was noted by multiple people here: https://github.com/hashicorp/terraform/issues/10836

**relevant version**: next version