### PR TITLE
CodeDeploy: Blue/Green deployments and In-Place deployments with traffic control.

### DIFF
--- a/aws/resource_aws_codedeploy_deployment_group.go
+++ b/aws/resource_aws_codedeploy_deployment_group.go
@@ -716,12 +716,13 @@ func buildAlarmConfig(configured []interface{}) *codedeploy.AlarmConfiguration {
 // expandDeploymentStyle converts a raw schema list containing a map[string]interface{}
 // into a single codedeploy.DeploymentStyle object
 func expandDeploymentStyle(list []interface{}) *codedeploy.DeploymentStyle {
-	result := &codedeploy.DeploymentStyle{}
 	if len(list) == 0 || list[0] == nil {
-		return result
+		return nil
 	}
 
 	style := list[0].(map[string]interface{})
+	result := &codedeploy.DeploymentStyle{}
+
 	if v, ok := style["deployment_option"]; ok {
 		result.DeploymentOption = aws.String(v.(string))
 	}
@@ -739,9 +740,8 @@ func expandLoadBalancerInfo(list []interface{}) *codedeploy.LoadBalancerInfo {
 		return nil
 	}
 
-	loadBalancerInfo := &codedeploy.LoadBalancerInfo{}
-
 	lbInfo := list[0].(map[string]interface{})
+	loadBalancerInfo := &codedeploy.LoadBalancerInfo{}
 
 	if attr, ok := lbInfo["elb_info"]; ok {
 		elbs := attr.(*schema.Set).List()
@@ -773,12 +773,12 @@ func expandLoadBalancerInfo(list []interface{}) *codedeploy.LoadBalancerInfo {
 // expandBlueGreenDeploymentConfig converts a raw schema list containing a map[string]interface{}
 // into a single codedeploy.BlueGreenDeploymentConfiguration object
 func expandBlueGreenDeploymentConfig(list []interface{}) *codedeploy.BlueGreenDeploymentConfiguration {
-	blueGreenDeploymentConfig := &codedeploy.BlueGreenDeploymentConfiguration{}
 	if len(list) == 0 || list[0] == nil {
-		return blueGreenDeploymentConfig
+		return nil
 	}
 
 	config := list[0].(map[string]interface{})
+	blueGreenDeploymentConfig := &codedeploy.BlueGreenDeploymentConfiguration{}
 
 	if attr, ok := config["deployment_ready_option"]; ok {
 		a := attr.([]interface{})
@@ -926,10 +926,8 @@ func alarmConfigToMap(config *codedeploy.AlarmConfiguration) []map[string]interf
 // flattenDeploymentStyle converts a codedeploy.DeploymentStyle object
 // into a []map[string]interface{} list containing a single item
 func flattenDeploymentStyle(style *codedeploy.DeploymentStyle) []map[string]interface{} {
-	result := make([]map[string]interface{}, 0, 1)
-
 	if style == nil {
-		return result
+		return nil
 	}
 
 	item := make(map[string]interface{})
@@ -939,6 +937,8 @@ func flattenDeploymentStyle(style *codedeploy.DeploymentStyle) []map[string]inte
 	if style.DeploymentType != nil {
 		item["deployment_type"] = *style.DeploymentType
 	}
+
+	result := make([]map[string]interface{}, 0, 1)
 	result = append(result, item)
 	return result
 }
@@ -946,10 +946,8 @@ func flattenDeploymentStyle(style *codedeploy.DeploymentStyle) []map[string]inte
 // flattenLoadBalancerInfo converts a codedeploy.LoadBalancerInfo object
 // into a []map[string]interface{} list containing a single item
 func flattenLoadBalancerInfo(loadBalancerInfo *codedeploy.LoadBalancerInfo) []map[string]interface{} {
-	result := make([]map[string]interface{}, 0, 1)
-
 	if loadBalancerInfo == nil {
-		return result
+		return nil
 	}
 
 	elbs := make([]interface{}, 0, len(loadBalancerInfo.ElbInfoList))
@@ -969,18 +967,18 @@ func flattenLoadBalancerInfo(loadBalancerInfo *codedeploy.LoadBalancerInfo) []ma
 	lbInfo := make(map[string]interface{})
 	lbInfo["elb_info"] = schema.NewSet(loadBalancerInfoHash, elbs)
 	lbInfo["target_group_info"] = schema.NewSet(loadBalancerInfoHash, targetGroups)
-	result = append(result, lbInfo)
 
+	result := make([]map[string]interface{}, 0, 1)
+	result = append(result, lbInfo)
 	return result
 }
 
 // flattenBlueGreenDeploymentConfig converts a codedeploy.BlueGreenDeploymentConfiguration object
 // into a []map[string]interface{} list containing a single item
 func flattenBlueGreenDeploymentConfig(config *codedeploy.BlueGreenDeploymentConfiguration) []map[string]interface{} {
-	list := make([]map[string]interface{}, 0)
 
 	if config == nil {
-		return list
+		return nil
 	}
 
 	m := make(map[string]interface{})
@@ -1024,6 +1022,7 @@ func flattenBlueGreenDeploymentConfig(config *codedeploy.BlueGreenDeploymentConf
 		m["terminate_blue_instances_on_deployment_success"] = append(c, blueInstanceTerminationOption)
 	}
 
+	list := make([]map[string]interface{}, 0)
 	list = append(list, m)
 	return list
 }

--- a/aws/resource_aws_codedeploy_deployment_group.go
+++ b/aws/resource_aws_codedeploy_deployment_group.go
@@ -749,8 +749,13 @@ func expandLoadBalancerInfo(list []interface{}) *codedeploy.LoadBalancerInfo {
 
 		for _, v := range elbs {
 			elb := v.(map[string]interface{})
+			name, ok := elb["name"].(string)
+			if !ok {
+				continue
+			}
+
 			loadBalancerInfo.ElbInfoList = append(loadBalancerInfo.ElbInfoList, &codedeploy.ELBInfo{
-				Name: aws.String(elb["name"].(string)),
+				Name: aws.String(name),
 			})
 		}
 	}
@@ -761,8 +766,13 @@ func expandLoadBalancerInfo(list []interface{}) *codedeploy.LoadBalancerInfo {
 
 		for _, v := range targetGroups {
 			targetGroup := v.(map[string]interface{})
+			name, ok := targetGroup["name"].(string)
+			if !ok {
+				continue
+			}
+
 			loadBalancerInfo.TargetGroupInfoList = append(loadBalancerInfo.TargetGroupInfoList, &codedeploy.TargetGroupInfo{
-				Name: aws.String(targetGroup["name"].(string)),
+				Name: aws.String(name),
 			})
 		}
 	}
@@ -952,6 +962,9 @@ func flattenLoadBalancerInfo(loadBalancerInfo *codedeploy.LoadBalancerInfo) []ma
 
 	elbs := make([]interface{}, 0, len(loadBalancerInfo.ElbInfoList))
 	for _, elb := range loadBalancerInfo.ElbInfoList {
+		if elb.Name == nil {
+			continue
+		}
 		item := make(map[string]interface{})
 		item["name"] = *elb.Name
 		elbs = append(elbs, item)
@@ -959,6 +972,9 @@ func flattenLoadBalancerInfo(loadBalancerInfo *codedeploy.LoadBalancerInfo) []ma
 
 	targetGroups := make([]interface{}, 0, len(loadBalancerInfo.TargetGroupInfoList))
 	for _, targetGroup := range loadBalancerInfo.TargetGroupInfoList {
+		if targetGroup.Name == nil {
+			continue
+		}
 		item := make(map[string]interface{})
 		item["name"] = *targetGroup.Name
 		targetGroups = append(targetGroups, item)

--- a/aws/resource_aws_codedeploy_deployment_group.go
+++ b/aws/resource_aws_codedeploy_deployment_group.go
@@ -346,7 +346,7 @@ func resourceAwsCodeDeployDeploymentGroupCreate(d *schema.ResourceData, meta int
 	}
 
 	if attr, ok := d.GetOk("deployment_style"); ok {
-		input.DeploymentStyle = buildDeploymentStyle(attr.([]interface{}))
+		input.DeploymentStyle = expandDeploymentStyle(attr.([]interface{}))
 	}
 
 	if attr, ok := d.GetOk("deployment_config_name"); ok {
@@ -381,11 +381,11 @@ func resourceAwsCodeDeployDeploymentGroupCreate(d *schema.ResourceData, meta int
 	}
 
 	if attr, ok := d.GetOk("load_balancer_info"); ok {
-		input.LoadBalancerInfo = buildLoadBalancerInfo(attr.([]interface{}))
+		input.LoadBalancerInfo = expandLoadBalancerInfo(attr.([]interface{}))
 	}
 
 	if attr, ok := d.GetOk("blue_green_deployment_config"); ok {
-		input.BlueGreenDeploymentConfiguration = buildBlueGreenDeploymentConfig(attr.([]interface{}))
+		input.BlueGreenDeploymentConfiguration = expandBlueGreenDeploymentConfig(attr.([]interface{}))
 	}
 
 	// Retry to handle IAM role eventual consistency.
@@ -451,7 +451,7 @@ func resourceAwsCodeDeployDeploymentGroupRead(d *schema.ResourceData, meta inter
 	d.Set("deployment_group_name", resp.DeploymentGroupInfo.DeploymentGroupName)
 	d.Set("service_role_arn", resp.DeploymentGroupInfo.ServiceRoleArn)
 
-	if err := d.Set("deployment_style", deploymentStyleToMap(resp.DeploymentGroupInfo.DeploymentStyle)); err != nil {
+	if err := d.Set("deployment_style", flattenDeploymentStyle(resp.DeploymentGroupInfo.DeploymentStyle)); err != nil {
 		return err
 	}
 
@@ -475,11 +475,11 @@ func resourceAwsCodeDeployDeploymentGroupRead(d *schema.ResourceData, meta inter
 		return err
 	}
 
-	if err := d.Set("load_balancer_info", loadBalancerInfoToMap(resp.DeploymentGroupInfo.LoadBalancerInfo)); err != nil {
+	if err := d.Set("load_balancer_info", flattenLoadBalancerInfo(resp.DeploymentGroupInfo.LoadBalancerInfo)); err != nil {
 		return err
 	}
 
-	if err := d.Set("blue_green_deployment_config", blueGreenDeploymentConfigToMap(resp.DeploymentGroupInfo.BlueGreenDeploymentConfiguration)); err != nil {
+	if err := d.Set("blue_green_deployment_config", flattenBlueGreenDeploymentConfig(resp.DeploymentGroupInfo.BlueGreenDeploymentConfiguration)); err != nil {
 		return err
 	}
 
@@ -512,7 +512,7 @@ func resourceAwsCodeDeployDeploymentGroupUpdate(d *schema.ResourceData, meta int
 
 	if d.HasChange("deployment_style") {
 		_, n := d.GetChange("deployment_style")
-		input.DeploymentStyle = buildDeploymentStyle(n.([]interface{}))
+		input.DeploymentStyle = expandDeploymentStyle(n.([]interface{}))
 	}
 
 	// TagFilters aren't like tags. They don't append. They simply replace.
@@ -546,12 +546,12 @@ func resourceAwsCodeDeployDeploymentGroupUpdate(d *schema.ResourceData, meta int
 
 	if d.HasChange("load_balancer_info") {
 		_, n := d.GetChange("load_balancer_info")
-		input.LoadBalancerInfo = buildLoadBalancerInfo(n.([]interface{}))
+		input.LoadBalancerInfo = expandLoadBalancerInfo(n.([]interface{}))
 	}
 
 	if d.HasChange("blue_green_deployment_config") {
 		_, n := d.GetChange("blue_green_deployment_config")
-		input.BlueGreenDeploymentConfiguration = buildBlueGreenDeploymentConfig(n.([]interface{}))
+		input.BlueGreenDeploymentConfiguration = expandBlueGreenDeploymentConfig(n.([]interface{}))
 	}
 
 	log.Printf("[DEBUG] Updating CodeDeploy DeploymentGroup %s", d.Id())
@@ -713,9 +713,9 @@ func buildAlarmConfig(configured []interface{}) *codedeploy.AlarmConfiguration {
 	return result
 }
 
-// buildDeploymentStyle converts a raw schema list containing a map[string]interface{}
+// expandDeploymentStyle converts a raw schema list containing a map[string]interface{}
 // into a single codedeploy.DeploymentStyle object
-func buildDeploymentStyle(list []interface{}) *codedeploy.DeploymentStyle {
+func expandDeploymentStyle(list []interface{}) *codedeploy.DeploymentStyle {
 	result := &codedeploy.DeploymentStyle{}
 	if len(list) == 0 || list[0] == nil {
 		return result
@@ -732,9 +732,9 @@ func buildDeploymentStyle(list []interface{}) *codedeploy.DeploymentStyle {
 	return result
 }
 
-// buildLoadBalancerInfo converts a raw schema list containing a map[string]interface{}
+// expandLoadBalancerInfo converts a raw schema list containing a map[string]interface{}
 // into a single codedeploy.LoadBalancerInfo object
-func buildLoadBalancerInfo(list []interface{}) *codedeploy.LoadBalancerInfo {
+func expandLoadBalancerInfo(list []interface{}) *codedeploy.LoadBalancerInfo {
 	if len(list) == 0 || list[0] == nil {
 		return nil
 	}
@@ -770,9 +770,9 @@ func buildLoadBalancerInfo(list []interface{}) *codedeploy.LoadBalancerInfo {
 	return loadBalancerInfo
 }
 
-// buildBlueGreenDeploymentConfig converts a raw schema list containing a map[string]interface{}
+// expandBlueGreenDeploymentConfig converts a raw schema list containing a map[string]interface{}
 // into a single codedeploy.BlueGreenDeploymentConfiguration object
-func buildBlueGreenDeploymentConfig(list []interface{}) *codedeploy.BlueGreenDeploymentConfiguration {
+func expandBlueGreenDeploymentConfig(list []interface{}) *codedeploy.BlueGreenDeploymentConfiguration {
 	blueGreenDeploymentConfig := &codedeploy.BlueGreenDeploymentConfiguration{}
 	if len(list) == 0 || list[0] == nil {
 		return blueGreenDeploymentConfig
@@ -923,9 +923,9 @@ func alarmConfigToMap(config *codedeploy.AlarmConfiguration) []map[string]interf
 	return result
 }
 
-// deploymentStyleToMap converts a codedeploy.DeploymentStyle object
+// flattenDeploymentStyle converts a codedeploy.DeploymentStyle object
 // into a []map[string]interface{} list containing a single item
-func deploymentStyleToMap(style *codedeploy.DeploymentStyle) []map[string]interface{} {
+func flattenDeploymentStyle(style *codedeploy.DeploymentStyle) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0, 1)
 
 	if style == nil {
@@ -943,9 +943,9 @@ func deploymentStyleToMap(style *codedeploy.DeploymentStyle) []map[string]interf
 	return result
 }
 
-// loadBalancerInfoToMap converts a codedeploy.LoadBalancerInfo object
+// flattenLoadBalancerInfo converts a codedeploy.LoadBalancerInfo object
 // into a []map[string]interface{} list containing a single item
-func loadBalancerInfoToMap(loadBalancerInfo *codedeploy.LoadBalancerInfo) []map[string]interface{} {
+func flattenLoadBalancerInfo(loadBalancerInfo *codedeploy.LoadBalancerInfo) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0, 1)
 
 	if loadBalancerInfo == nil {
@@ -974,9 +974,9 @@ func loadBalancerInfoToMap(loadBalancerInfo *codedeploy.LoadBalancerInfo) []map[
 	return result
 }
 
-// blueGreenDeploymentConfigToMap converts a codedeploy.BlueGreenDeploymentConfiguration object
+// flattenBlueGreenDeploymentConfig converts a codedeploy.BlueGreenDeploymentConfiguration object
 // into a []map[string]interface{} list containing a single item
-func blueGreenDeploymentConfigToMap(config *codedeploy.BlueGreenDeploymentConfiguration) []map[string]interface{} {
+func flattenBlueGreenDeploymentConfig(config *codedeploy.BlueGreenDeploymentConfiguration) []map[string]interface{} {
 	list := make([]map[string]interface{}, 0)
 
 	if config == nil {

--- a/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -1403,7 +1403,7 @@ func TestAWSCodeDeployDeploymentGroup_autoRollbackConfigToMap(t *testing.T) {
 	}
 }
 
-func TestAWSCodeDeployDeploymentGroup_buildDeploymentStyle(t *testing.T) {
+func TestAWSCodeDeployDeploymentGroup_expandDeploymentStyle(t *testing.T) {
 	input := []interface{}{
 		map[string]interface{}{
 			"deployment_option": "WITH_TRAFFIC_CONTROL",
@@ -1416,15 +1416,15 @@ func TestAWSCodeDeployDeploymentGroup_buildDeploymentStyle(t *testing.T) {
 		DeploymentType:   aws.String("BLUE_GREEN"),
 	}
 
-	actual := buildDeploymentStyle(input)
+	actual := expandDeploymentStyle(input)
 
 	if !reflect.DeepEqual(actual, expected) {
-		t.Fatalf("buildDeploymentStyle output is not correct.\nGot:\n%#v\nExpected:\n%#v\n",
+		t.Fatalf("expandDeploymentStyle output is not correct.\nGot:\n%#v\nExpected:\n%#v\n",
 			actual, expected)
 	}
 }
 
-func TestAWSCodeDeployDeploymentGroup_deploymentStyleToMap(t *testing.T) {
+func TestAWSCodeDeployDeploymentGroup_flattenDeploymentStyle(t *testing.T) {
 	expected := map[string]interface{}{
 		"deployment_option": "WITHOUT_TRAFFIC_CONTROL",
 		"deployment_type":   "IN_PLACE",
@@ -1435,7 +1435,7 @@ func TestAWSCodeDeployDeploymentGroup_deploymentStyleToMap(t *testing.T) {
 		DeploymentType:   aws.String("IN_PLACE"),
 	}
 
-	actual := deploymentStyleToMap(input)[0]
+	actual := flattenDeploymentStyle(input)[0]
 
 	fatal := false
 
@@ -1448,12 +1448,12 @@ func TestAWSCodeDeployDeploymentGroup_deploymentStyleToMap(t *testing.T) {
 	}
 
 	if fatal {
-		t.Fatalf("deploymentStyleToMap output is not correct.\nGot:\n%#v\nExpected:\n%#v\n",
+		t.Fatalf("flattenDeploymentStyle output is not correct.\nGot:\n%#v\nExpected:\n%#v\n",
 			actual, expected)
 	}
 }
 
-func TestAWSCodeDeployDeploymentGroup_buildLoadBalancerInfo(t *testing.T) {
+func TestAWSCodeDeployDeploymentGroup_expandLoadBalancerInfo(t *testing.T) {
 	input := []interface{}{
 		map[string]interface{}{
 			"elb_info": schema.NewSet(loadBalancerInfoHash, []interface{}{
@@ -1478,15 +1478,15 @@ func TestAWSCodeDeployDeploymentGroup_buildLoadBalancerInfo(t *testing.T) {
 		},
 	}
 
-	actual := buildLoadBalancerInfo(input)
+	actual := expandLoadBalancerInfo(input)
 
 	if !reflect.DeepEqual(actual, expected) {
-		t.Fatalf("buildLoadBalancerInfo output is not correct.\nGot:\n%#v\nExpected:\n%#v\n",
+		t.Fatalf("expandLoadBalancerInfo output is not correct.\nGot:\n%#v\nExpected:\n%#v\n",
 			actual, expected)
 	}
 }
 
-func TestAWSCodeDeployDeploymentGroup_loadBalancerInfoToMap(t *testing.T) {
+func TestAWSCodeDeployDeploymentGroup_flattenLoadBalancerInfo(t *testing.T) {
 	input := &codedeploy.LoadBalancerInfo{
 		TargetGroupInfoList: []*codedeploy.TargetGroupInfo{
 			{
@@ -1509,7 +1509,7 @@ func TestAWSCodeDeployDeploymentGroup_loadBalancerInfoToMap(t *testing.T) {
 		}),
 	}
 
-	actual := loadBalancerInfoToMap(input)[0]
+	actual := flattenLoadBalancerInfo(input)[0]
 
 	fatal := false
 
@@ -1520,12 +1520,12 @@ func TestAWSCodeDeployDeploymentGroup_loadBalancerInfoToMap(t *testing.T) {
 	}
 
 	if fatal {
-		t.Fatalf("loadBalancerInfoToMap output is not correct.\nGot:\n%#v\nExpected:\n%#v\n",
+		t.Fatalf("flattenLoadBalancerInfo output is not correct.\nGot:\n%#v\nExpected:\n%#v\n",
 			actual, expected)
 	}
 }
 
-func TestAWSCodeDeployDeploymentGroup_buildBlueGreenDeploymentConfig(t *testing.T) {
+func TestAWSCodeDeployDeploymentGroup_expandBlueGreenDeploymentConfig(t *testing.T) {
 	input := []interface{}{
 		map[string]interface{}{
 			"deployment_ready_option": []interface{}{
@@ -1566,15 +1566,15 @@ func TestAWSCodeDeployDeploymentGroup_buildBlueGreenDeploymentConfig(t *testing.
 		},
 	}
 
-	actual := buildBlueGreenDeploymentConfig(input)
+	actual := expandBlueGreenDeploymentConfig(input)
 
 	if !reflect.DeepEqual(actual, expected) {
-		t.Fatalf("buildBlueGreenDeploymentConfig output is not correct.\nGot:\n%#v\nExpected:\n%#v\n",
+		t.Fatalf("expandBlueGreenDeploymentConfig output is not correct.\nGot:\n%#v\nExpected:\n%#v\n",
 			actual, expected)
 	}
 }
 
-func TestAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfigToMap(t *testing.T) {
+func TestAWSCodeDeployDeploymentGroup_flattenBlueGreenDeploymentConfig(t *testing.T) {
 	input := &codedeploy.BlueGreenDeploymentConfiguration{
 		DeploymentReadyOption: &codedeploy.DeploymentReadyOption{
 			ActionOnTimeout:   aws.String("STOP_DEPLOYMENT"),
@@ -1613,7 +1613,7 @@ func TestAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfigToMap(t *testing.
 		},
 	}
 
-	actual := blueGreenDeploymentConfigToMap(input)[0]
+	actual := flattenBlueGreenDeploymentConfig(input)[0]
 
 	fatal := false
 
@@ -1641,7 +1641,7 @@ func TestAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfigToMap(t *testing.
 	}
 
 	if fatal {
-		t.Fatalf("blueGreenDeploymentConfigToMap output is not correct.\nGot:\n%#v\nExpected:\n%#v\n",
+		t.Fatalf("flattenBlueGreenDeploymentConfig output is not correct.\nGot:\n%#v\nExpected:\n%#v\n",
 			actual, expected)
 	}
 }

--- a/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -571,7 +571,485 @@ func TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_disable(t *testing.T
 	})
 }
 
-func TestValidateAWSCodeDeployTriggerEvent(t *testing.T) {
+// When no configuration is provided, a deploymentStyle object with default values is computed
+func TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_default(t *testing.T) {
+	var group codedeploy.DeploymentGroupInfo
+
+	rName := acctest.RandString(5)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: test_config_deployment_style_default(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_style.#", "1"),
+					resource.TestCheckResourceAttrSet(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_option"),
+					resource.TestCheckResourceAttrSet(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_create(t *testing.T) {
+	var group codedeploy.DeploymentGroupInfo
+
+	rName := acctest.RandString(5)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: test_config_deployment_style_default(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_style.#", "1"),
+					resource.TestCheckResourceAttrSet(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_option"),
+					resource.TestCheckResourceAttrSet(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type"),
+				),
+			},
+			resource.TestStep{
+				Config: test_config_deployment_style_create(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_style.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type", "BLUE_GREEN"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.2441772102.name", "foo-elb"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_update(t *testing.T) {
+	var group codedeploy.DeploymentGroupInfo
+
+	rName := acctest.RandString(5)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: test_config_deployment_style_create(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_style.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type", "BLUE_GREEN"),
+				),
+			},
+			resource.TestStep{
+				Config: test_config_deployment_style_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_style.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_option", "WITHOUT_TRAFFIC_CONTROL"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type", "IN_PLACE"),
+				),
+			},
+		},
+	})
+}
+
+// Removing deployment_style from configuration does not trigger an update
+// to the default state, but the previous state is instead retained...
+func TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_delete(t *testing.T) {
+	var group codedeploy.DeploymentGroupInfo
+
+	rName := acctest.RandString(5)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: test_config_deployment_style_create(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_style.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type", "BLUE_GREEN"),
+				),
+			},
+			resource.TestStep{
+				Config: test_config_deployment_style_default(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_style.#", "1"),
+					resource.TestCheckResourceAttrSet(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_option"),
+					resource.TestCheckResourceAttrSet(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_create(t *testing.T) {
+	var group codedeploy.DeploymentGroupInfo
+
+	rName := acctest.RandString(5)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: test_config_load_balancer_info_default(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.#", "0"),
+				),
+			},
+			resource.TestStep{
+				Config: test_config_load_balancer_info_create(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.2441772102.name", "foo-elb"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_update(t *testing.T) {
+	var group codedeploy.DeploymentGroupInfo
+
+	rName := acctest.RandString(5)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: test_config_load_balancer_info_create(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.2441772102.name", "foo-elb"),
+				),
+			},
+			resource.TestStep{
+				Config: test_config_load_balancer_info_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.4206303396.name", "bar-elb"),
+				),
+			},
+		},
+	})
+}
+
+// Without "Computed: true" on load_balancer_info, removing the resource
+// from configuration causes an error, becuase the remote resource still exists.
+func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_delete(t *testing.T) {
+	var group codedeploy.DeploymentGroupInfo
+
+	rName := acctest.RandString(5)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: test_config_load_balancer_info_create(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.2441772102.name", "foo-elb"),
+				),
+			},
+			resource.TestStep{
+				Config: test_config_load_balancer_info_delete(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_create(t *testing.T) {
+	var group codedeploy.DeploymentGroupInfo
+
+	rName := acctest.RandString(5)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: test_config_blue_green_deployment_config_default(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.#", "0"),
+				),
+			},
+			resource.TestStep{
+				Config: test_config_blue_green_deployment_config_create_with_asg(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.#", "1"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "STOP_DEPLOYMENT"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.0.wait_time_in_minutes", "60"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "COPY_AUTO_SCALING_GROUP"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "TERMINATE"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.termination_wait_time_in_minutes", "120"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update(t *testing.T) {
+	var group codedeploy.DeploymentGroupInfo
+
+	rName := acctest.RandString(5)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: test_config_blue_green_deployment_config_create_no_asg(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.#", "1"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "STOP_DEPLOYMENT"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.0.wait_time_in_minutes", "60"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "DISCOVER_EXISTING"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "TERMINATE"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.termination_wait_time_in_minutes", "120"),
+				),
+			},
+			resource.TestStep{
+				Config: test_config_blue_green_deployment_config_update_no_asg(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.#", "1"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "CONTINUE_DEPLOYMENT"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "DISCOVER_EXISTING"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "KEEP_ALIVE"),
+				),
+			},
+		},
+	})
+}
+
+// Without "Computed: true" on blue_green_deployment_config, removing the resource
+// from configuration causes an error, becuase the remote resource still exists.
+func TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_delete(t *testing.T) {
+	var group codedeploy.DeploymentGroupInfo
+
+	rName := acctest.RandString(5)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: test_config_blue_green_deployment_config_create_no_asg(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.#", "1"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "STOP_DEPLOYMENT"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.0.wait_time_in_minutes", "60"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "DISCOVER_EXISTING"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "TERMINATE"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.termination_wait_time_in_minutes", "120"),
+				),
+			},
+			resource.TestStep{
+				Config: test_config_blue_green_deployment_config_default(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeDeployDeploymentGroup_blueGreenDeployment_complete(t *testing.T) {
+	var group codedeploy.DeploymentGroupInfo
+
+	rName := acctest.RandString(5)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: test_config_blue_green_deployment_complete(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_style.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type", "BLUE_GREEN"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.2441772102.name", "foo-elb"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.#", "1"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "STOP_DEPLOYMENT"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.0.wait_time_in_minutes", "60"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "DISCOVER_EXISTING"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "KEEP_ALIVE"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.termination_wait_time_in_minutes", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAWSCodeDeployDeploymentGroup_validateAWSCodeDeployTriggerEvent(t *testing.T) {
 	cases := []struct {
 		Value    string
 		ErrCount int
@@ -634,7 +1112,7 @@ func TestValidateAWSCodeDeployTriggerEvent(t *testing.T) {
 	}
 }
 
-func TestBuildTriggerConfigs(t *testing.T) {
+func TestAWSCodeDeployDeploymentGroup_buildTriggerConfigs(t *testing.T) {
 	input := []interface{}{
 		map[string]interface{}{
 			"trigger_events": schema.NewSet(schema.HashString, []interface{}{
@@ -663,7 +1141,7 @@ func TestBuildTriggerConfigs(t *testing.T) {
 	}
 }
 
-func TestTriggerConfigsToMap(t *testing.T) {
+func TestAWSCodeDeployDeploymentGroup_triggerConfigsToMap(t *testing.T) {
 	input := []*codedeploy.TriggerConfig{
 		&codedeploy.TriggerConfig{
 			TriggerEvents: []*string{
@@ -708,7 +1186,7 @@ func TestTriggerConfigsToMap(t *testing.T) {
 	}
 }
 
-func TestBuildAutoRollbackConfig(t *testing.T) {
+func TestAWSCodeDeployDeploymentGroup_buildAutoRollbackConfig(t *testing.T) {
 	input := []interface{}{
 		map[string]interface{}{
 			"events": schema.NewSet(schema.HashString, []interface{}{
@@ -733,7 +1211,7 @@ func TestBuildAutoRollbackConfig(t *testing.T) {
 	}
 }
 
-func TestAutoRollbackConfigToMap(t *testing.T) {
+func TestAWSCodeDeployDeploymentGroup_autoRollbackConfigToMap(t *testing.T) {
 	input := &codedeploy.AutoRollbackConfiguration{
 		Events: []*string{
 			aws.String("DEPLOYMENT_FAILURE"),
@@ -770,7 +1248,250 @@ func TestAutoRollbackConfigToMap(t *testing.T) {
 	}
 }
 
-func TestBuildAlarmConfig(t *testing.T) {
+func TestAWSCodeDeployDeploymentGroup_buildDeploymentStyle(t *testing.T) {
+	input := []interface{}{
+		map[string]interface{}{
+			"deployment_option": "WITH_TRAFFIC_CONTROL",
+			"deployment_type":   "BLUE_GREEN",
+		},
+	}
+
+	expected := &codedeploy.DeploymentStyle{
+		DeploymentOption: aws.String("WITH_TRAFFIC_CONTROL"),
+		DeploymentType:   aws.String("BLUE_GREEN"),
+	}
+
+	actual := buildDeploymentStyle(input)
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("buildDeploymentStyle output is not correct.\nGot:\n%#v\nExpected:\n%#v\n",
+			actual, expected)
+	}
+}
+
+func TestAWSCodeDeployDeploymentGroup_deploymentStyleToMap(t *testing.T) {
+	expected := map[string]interface{}{
+		"deployment_option": "WITHOUT_TRAFFIC_CONTROL",
+		"deployment_type":   "IN_PLACE",
+	}
+
+	input := &codedeploy.DeploymentStyle{
+		DeploymentOption: aws.String("WITHOUT_TRAFFIC_CONTROL"),
+		DeploymentType:   aws.String("IN_PLACE"),
+	}
+
+	actual := deploymentStyleToMap(input)[0]
+
+	fatal := false
+
+	if actual["deployment_option"] != expected["deployment_option"] {
+		fatal = true
+	}
+
+	if actual["deployment_type"] != expected["deployment_type"] {
+		fatal = true
+	}
+
+	if fatal {
+		t.Fatalf("deploymentStyleToMap output is not correct.\nGot:\n%#v\nExpected:\n%#v\n",
+			actual, expected)
+	}
+}
+
+func TestAWSCodeDeployDeploymentGroup_buildLoadBalancerInfo(t *testing.T) {
+	input := []interface{}{
+		map[string]interface{}{
+			"elb_info": schema.NewSet(elbInfoHash, []interface{}{
+				map[string]interface{}{
+					"name": "foo-elb",
+				},
+				map[string]interface{}{
+					"name": "bar-elb",
+				},
+			}),
+		},
+	}
+
+	expected := &codedeploy.LoadBalancerInfo{
+		ElbInfoList: []*codedeploy.ELBInfo{
+			{
+				Name: aws.String("foo-elb"),
+			},
+			{
+				Name: aws.String("bar-elb"),
+			},
+		},
+	}
+
+	actual := buildLoadBalancerInfo(input)
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("buildLoadBalancerInfo output is not correct.\nGot:\n%#v\nExpected:\n%#v\n",
+			actual, expected)
+	}
+}
+
+func TestAWSCodeDeployDeploymentGroup_loadBalancerInfoToMap(t *testing.T) {
+	input := &codedeploy.LoadBalancerInfo{
+		ElbInfoList: []*codedeploy.ELBInfo{
+			{
+				Name: aws.String("abc-elb"),
+			},
+			{
+				Name: aws.String("xyz-elb"),
+			},
+		},
+	}
+
+	expected := map[string]interface{}{
+		"elb_info": schema.NewSet(elbInfoHash, []interface{}{
+			map[string]interface{}{
+				"name": "abc-elb",
+			},
+			map[string]interface{}{
+				"name": "xyz-elb",
+			},
+		}),
+	}
+
+	actual := loadBalancerInfoToMap(input)[0]
+
+	fatal := false
+
+	a := actual["elb_info"].(*schema.Set)
+	e := expected["elb_info"].(*schema.Set)
+	if !a.Equal(e) {
+		fatal = true
+	}
+
+	if fatal {
+		t.Fatalf("loadBalancerInfoToMap output is not correct.\nGot:\n%#v\nExpected:\n%#v\n",
+			actual, expected)
+	}
+}
+
+func TestAWSCodeDeployDeploymentGroup_buildBlueGreenDeploymentConfig(t *testing.T) {
+	input := []interface{}{
+		map[string]interface{}{
+			"deployment_ready_option": []interface{}{
+				map[string]interface{}{
+					"action_on_timeout":    "CONTINUE_DEPLOYMENT",
+					"wait_time_in_minutes": 60,
+				},
+			},
+
+			"green_fleet_provisioning_option": []interface{}{
+				map[string]interface{}{
+					"action": "COPY_AUTO_SCALING_GROUP",
+				},
+			},
+
+			"terminate_blue_instances_on_deployment_success": []interface{}{
+				map[string]interface{}{
+					"action": "TERMINATE",
+					"termination_wait_time_in_minutes": 90,
+				},
+			},
+		},
+	}
+
+	expected := &codedeploy.BlueGreenDeploymentConfiguration{
+		DeploymentReadyOption: &codedeploy.DeploymentReadyOption{
+			ActionOnTimeout:   aws.String("CONTINUE_DEPLOYMENT"),
+			WaitTimeInMinutes: aws.Int64(60),
+		},
+
+		GreenFleetProvisioningOption: &codedeploy.GreenFleetProvisioningOption{
+			Action: aws.String("COPY_AUTO_SCALING_GROUP"),
+		},
+
+		TerminateBlueInstancesOnDeploymentSuccess: &codedeploy.BlueInstanceTerminationOption{
+			Action: aws.String("TERMINATE"),
+			TerminationWaitTimeInMinutes: aws.Int64(90),
+		},
+	}
+
+	actual := buildBlueGreenDeploymentConfig(input)
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("buildBlueGreenDeploymentConfig output is not correct.\nGot:\n%#v\nExpected:\n%#v\n",
+			actual, expected)
+	}
+}
+
+func TestAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfigToMap(t *testing.T) {
+	input := &codedeploy.BlueGreenDeploymentConfiguration{
+		DeploymentReadyOption: &codedeploy.DeploymentReadyOption{
+			ActionOnTimeout:   aws.String("STOP_DEPLOYMENT"),
+			WaitTimeInMinutes: aws.Int64(120),
+		},
+
+		GreenFleetProvisioningOption: &codedeploy.GreenFleetProvisioningOption{
+			Action: aws.String("DISCOVER_EXISTING"),
+		},
+
+		TerminateBlueInstancesOnDeploymentSuccess: &codedeploy.BlueInstanceTerminationOption{
+			Action: aws.String("KEEP_ALIVE"),
+			TerminationWaitTimeInMinutes: aws.Int64(90),
+		},
+	}
+
+	expected := map[string]interface{}{
+		"deployment_ready_option": []map[string]interface{}{
+			map[string]interface{}{
+				"action_on_timeout":    "STOP_DEPLOYMENT",
+				"wait_time_in_minutes": 120,
+			},
+		},
+
+		"green_fleet_provisioning_option": []map[string]interface{}{
+			map[string]interface{}{
+				"action": "DISCOVER_EXISTING",
+			},
+		},
+
+		"terminate_blue_instances_on_deployment_success": []map[string]interface{}{
+			map[string]interface{}{
+				"action": "KEEP_ALIVE",
+				"termination_wait_time_in_minutes": 90,
+			},
+		},
+	}
+
+	actual := blueGreenDeploymentConfigToMap(input)[0]
+
+	fatal := false
+
+	a := actual["deployment_ready_option"].([]map[string]interface{})[0]
+	if a["action_on_timeout"].(string) != "STOP_DEPLOYMENT" {
+		fatal = true
+	}
+
+	if a["wait_time_in_minutes"].(int64) != 120 {
+		fatal = true
+	}
+
+	b := actual["green_fleet_provisioning_option"].([]map[string]interface{})[0]
+	if b["action"].(string) != "DISCOVER_EXISTING" {
+		fatal = true
+	}
+
+	c := actual["terminate_blue_instances_on_deployment_success"].([]map[string]interface{})[0]
+	if c["action"].(string) != "KEEP_ALIVE" {
+		fatal = true
+	}
+
+	if c["termination_wait_time_in_minutes"].(int64) != 90 {
+		fatal = true
+	}
+
+	if fatal {
+		t.Fatalf("blueGreenDeploymentConfigToMap output is not correct.\nGot:\n%#v\nExpected:\n%#v\n",
+			actual, expected)
+	}
+}
+
+func TestAWSCodeDeployDeploymentGroup_buildAlarmConfig(t *testing.T) {
 	input := []interface{}{
 		map[string]interface{}{
 			"alarms": schema.NewSet(schema.HashString, []interface{}{
@@ -799,7 +1520,7 @@ func TestBuildAlarmConfig(t *testing.T) {
 	}
 }
 
-func TestAlarmConfigToMap(t *testing.T) {
+func TestAWSCodeDeployDeploymentGroup_alarmConfigToMap(t *testing.T) {
 	input := &codedeploy.AlarmConfiguration{
 		Alarms: []*codedeploy.Alarm{
 			{
@@ -843,6 +1564,173 @@ func TestAlarmConfigToMap(t *testing.T) {
 	if fatal {
 		t.Fatalf("alarmConfigToMap output is not correct.\nGot:\n%#v\nExpected:\n%#v\n",
 			actual, expected)
+	}
+}
+
+func TestAWSCodeDeployDeploymentGroup_validateDeploymentOption(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "WITH_TRAFFIC_CONTROL",
+			ErrCount: 0,
+		},
+		{
+			Value:    "WITHOUT_TRAFFIC_CONTROL",
+			ErrCount: 0,
+		},
+		{
+			Value:    "NOT_A_VALID_OPTION",
+			ErrCount: 1,
+		},
+		{
+			Value:    "",
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateDeploymentOption(tc.Value, "deployment_option")
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("deployment_option validation failed for value %q: %q", tc.Value, errors)
+		}
+	}
+}
+
+func TestAWSCodeDeployDeploymentGroup_validateDeploymentType(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "IN_PLACE",
+			ErrCount: 0,
+		},
+		{
+			Value:    "BLUE_GREEN",
+			ErrCount: 0,
+		},
+		{
+			Value:    "GREEN_BLUE",
+			ErrCount: 1,
+		},
+		{
+			Value:    "NOT_A_VALID_TYPE",
+			ErrCount: 1,
+		},
+		{
+			Value:    "",
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateDeploymentType(tc.Value, "deployment_type")
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("deployment_type validation failed for value %q: %q", tc.Value, errors)
+		}
+	}
+}
+
+func TestAWSCodeDeployDeploymentGroup_validateDeploymentReadyOption(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "CONTINUE_DEPLOYMENT",
+			ErrCount: 0,
+		},
+		{
+			Value:    "STOP_DEPLOYMENT",
+			ErrCount: 0,
+		},
+		{
+			Value:    "NOT_A_VALID_OPTION",
+			ErrCount: 1,
+		},
+		{
+			Value:    "",
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateDeploymentReadyOption(tc.Value, "action_on_timeout")
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("action_on_timeout validation failed for value %q: %q", tc.Value, errors)
+		}
+	}
+}
+
+func TestAWSCodeDeployDeploymentGroup_validateGreenFleetProvisioningOption(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "DISCOVER_EXISTING",
+			ErrCount: 0,
+		},
+		{
+			Value:    "COPY_AUTO_SCALING_GROUP",
+			ErrCount: 0,
+		},
+		{
+			Value:    "DISCOVER_AUTO_SCALING_GROUP",
+			ErrCount: 1,
+		},
+		{
+			Value:    "COPY_EXISTING_INSTANCES",
+			ErrCount: 1,
+		},
+		{
+			Value:    "",
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateGreenFleetProvisioningOption(tc.Value, "action")
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("action validation failed for value %q: %q", tc.Value, errors)
+		}
+	}
+}
+
+func TestAWSCodeDeployDeploymentGroup_validateBlueInstanceTerminationOption(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "KEEP_ALIVE",
+			ErrCount: 0,
+		},
+		{
+			Value:    "TERMINATE",
+			ErrCount: 0,
+		},
+		{
+			Value:    "KEEP",
+			ErrCount: 1,
+		},
+		{
+			Value:    "STOP",
+			ErrCount: 1,
+		},
+		{
+			Value:    "",
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateBlueInstanceTerminationOption(tc.Value, "action")
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("action validation failed for value %q: %q", tc.Value, errors)
+		}
 	}
 }
 
@@ -976,357 +1864,357 @@ func testAccCheckAWSCodeDeployDeploymentGroupExists(name string, group *codedepl
 func testAccAWSCodeDeployDeploymentGroup(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codedeploy_app" "foo_app" {
-	name = "foo_app_%s"
+  name = "foo_app_%s"
 }
 
 resource "aws_iam_role_policy" "foo_policy" {
-	name = "foo_policy_%s"
-	role = "${aws_iam_role.foo_role.id}"
-	policy = <<EOF
+  name = "foo_policy_%s"
+  role = "${aws_iam_role.foo_role.id}"
+  policy = <<EOF
 {
-	"Version": "2012-10-17",
-	"Statement": [
-		{
-			"Effect": "Allow",
-			"Action": [
-				"autoscaling:CompleteLifecycleAction",
-				"autoscaling:DeleteLifecycleHook",
-				"autoscaling:DescribeAutoScalingGroups",
-				"autoscaling:DescribeLifecycleHooks",
-				"autoscaling:PutLifecycleHook",
-				"autoscaling:RecordLifecycleActionHeartbeat",
-				"ec2:DescribeInstances",
-				"ec2:DescribeInstanceStatus",
-				"tag:GetTags",
-				"tag:GetResources"
-			],
-			"Resource": "*"
-		}
-	]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DeleteLifecycleHook",
+        "autoscaling:DescribeAutoScalingGroups",
+        "autoscaling:DescribeLifecycleHooks",
+        "autoscaling:PutLifecycleHook",
+        "autoscaling:RecordLifecycleActionHeartbeat",
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceStatus",
+        "tag:GetTags",
+        "tag:GetResources"
+      ],
+      "Resource": "*"
+    }
+  ]
 }
 EOF
 }
 
 resource "aws_iam_role" "foo_role" {
-	name = "foo_role_%s"
-	assume_role_policy = <<EOF
+  name = "foo_role_%s"
+  assume_role_policy = <<EOF
 {
-	"Version": "2012-10-17",
-	"Statement": [
-		{
-			"Sid": "",
-			"Effect": "Allow",
-			"Principal": {
-				"Service": [
-					"codedeploy.amazonaws.com"
-				]
-			},
-			"Action": "sts:AssumeRole"
-		}
-	]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "codedeploy.amazonaws.com"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
 }
 EOF
 }
 
 resource "aws_codedeploy_deployment_group" "foo" {
-	app_name = "${aws_codedeploy_app.foo_app.name}"
-	deployment_group_name = "foo_%s"
-	service_role_arn = "${aws_iam_role.foo_role.arn}"
-	ec2_tag_filter {
-		key = "filterkey"
-		type = "KEY_AND_VALUE"
-		value = "filtervalue"
-	}
+  app_name = "${aws_codedeploy_app.foo_app.name}"
+  deployment_group_name = "foo_%s"
+  service_role_arn = "${aws_iam_role.foo_role.arn}"
+  ec2_tag_filter {
+    key = "filterkey"
+    type = "KEY_AND_VALUE"
+    value = "filtervalue"
+  }
 }`, rName, rName, rName, rName)
 }
 
 func testAccAWSCodeDeployDeploymentGroupModified(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codedeploy_app" "foo_app" {
-	name = "foo_app_%s"
+  name = "foo_app_%s"
 }
 
 resource "aws_iam_role_policy" "foo_policy" {
-	name = "foo_policy_%s"
-	role = "${aws_iam_role.bar_role.id}"
-	policy = <<EOF
+  name = "foo_policy_%s"
+  role = "${aws_iam_role.bar_role.id}"
+  policy = <<EOF
 {
-	"Version": "2012-10-17",
-	"Statement": [
-		{
-			"Effect": "Allow",
-			"Action": [
-				"autoscaling:CompleteLifecycleAction",
-				"autoscaling:DeleteLifecycleHook",
-				"autoscaling:DescribeAutoScalingGroups",
-				"autoscaling:DescribeLifecycleHooks",
-				"autoscaling:PutLifecycleHook",
-				"autoscaling:RecordLifecycleActionHeartbeat",
-				"ec2:DescribeInstances",
-				"ec2:DescribeInstanceStatus",
-				"tag:GetTags",
-				"tag:GetResources"
-			],
-			"Resource": "*"
-		}
-	]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DeleteLifecycleHook",
+        "autoscaling:DescribeAutoScalingGroups",
+        "autoscaling:DescribeLifecycleHooks",
+        "autoscaling:PutLifecycleHook",
+        "autoscaling:RecordLifecycleActionHeartbeat",
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceStatus",
+        "tag:GetTags",
+        "tag:GetResources"
+      ],
+      "Resource": "*"
+    }
+  ]
 }
 EOF
 }
 
 resource "aws_iam_role" "bar_role" {
-	name = "bar_role_%s"
-	assume_role_policy = <<EOF
+  name = "bar_role_%s"
+  assume_role_policy = <<EOF
 {
-	"Version": "2012-10-17",
-	"Statement": [
-		{
-			"Sid": "",
-			"Effect": "Allow",
-			"Principal": {
-				"Service": [
-					"codedeploy.amazonaws.com"
-				]
-			},
-			"Action": "sts:AssumeRole"
-		}
-	]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "codedeploy.amazonaws.com"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
 }
 EOF
 }
 
 resource "aws_codedeploy_deployment_group" "foo" {
-	app_name = "${aws_codedeploy_app.foo_app.name}"
-	deployment_group_name = "bar_%s"
-	service_role_arn = "${aws_iam_role.bar_role.arn}"
-	ec2_tag_filter {
-		key = "filterkey"
-		type = "KEY_AND_VALUE"
-		value = "anotherfiltervalue"
-	}
+  app_name = "${aws_codedeploy_app.foo_app.name}"
+  deployment_group_name = "bar_%s"
+  service_role_arn = "${aws_iam_role.bar_role.arn}"
+  ec2_tag_filter {
+    key = "filterkey"
+    type = "KEY_AND_VALUE"
+    value = "anotherfiltervalue"
+  }
 }`, rName, rName, rName, rName)
 }
 
 func testAccAWSCodeDeployDeploymentGroupOnPremiseTags(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codedeploy_app" "foo_app" {
-	name = "foo_app_%s"
+  name = "foo_app_%s"
 }
 
 resource "aws_iam_role_policy" "foo_policy" {
-	name = "foo_policy_%s"
-	role = "${aws_iam_role.foo_role.id}"
-	policy = <<EOF
+  name = "foo_policy_%s"
+  role = "${aws_iam_role.foo_role.id}"
+  policy = <<EOF
 {
-	"Version": "2012-10-17",
-	"Statement": [
-		{
-			"Effect": "Allow",
-			"Action": [
-				"autoscaling:CompleteLifecycleAction",
-				"autoscaling:DeleteLifecycleHook",
-				"autoscaling:DescribeAutoScalingGroups",
-				"autoscaling:DescribeLifecycleHooks",
-				"autoscaling:PutLifecycleHook",
-				"autoscaling:RecordLifecycleActionHeartbeat",
-				"ec2:DescribeInstances",
-				"ec2:DescribeInstanceStatus",
-				"tag:GetTags",
-				"tag:GetResources"
-			],
-			"Resource": "*"
-		}
-	]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DeleteLifecycleHook",
+        "autoscaling:DescribeAutoScalingGroups",
+        "autoscaling:DescribeLifecycleHooks",
+        "autoscaling:PutLifecycleHook",
+        "autoscaling:RecordLifecycleActionHeartbeat",
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceStatus",
+        "tag:GetTags",
+        "tag:GetResources"
+      ],
+      "Resource": "*"
+    }
+  ]
 }
 EOF
 }
 
 resource "aws_iam_role" "foo_role" {
-	name = "foo_role_%s"
-	assume_role_policy = <<EOF
+  name = "foo_role_%s"
+  assume_role_policy = <<EOF
 {
-	"Version": "2012-10-17",
-	"Statement": [
-		{
-			"Sid": "",
-			"Effect": "Allow",
-			"Principal": {
-				"Service": [
-					"codedeploy.amazonaws.com"
-				]
-			},
-			"Action": "sts:AssumeRole"
-		}
-	]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "codedeploy.amazonaws.com"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
 }
 EOF
 }
 
 resource "aws_codedeploy_deployment_group" "foo" {
-	app_name = "${aws_codedeploy_app.foo_app.name}"
-	deployment_group_name = "foo_%s"
-	service_role_arn = "${aws_iam_role.foo_role.arn}"
-	on_premises_instance_tag_filter {
-		key = "filterkey"
-		type = "KEY_AND_VALUE"
-		value = "filtervalue"
-	}
+  app_name = "${aws_codedeploy_app.foo_app.name}"
+  deployment_group_name = "foo_%s"
+  service_role_arn = "${aws_iam_role.foo_role.arn}"
+  on_premises_instance_tag_filter {
+    key = "filterkey"
+    type = "KEY_AND_VALUE"
+    value = "filtervalue"
+  }
 }`, rName, rName, rName, rName)
 }
 
 func baseCodeDeployConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codedeploy_app" "foo_app" {
-	name = "foo-app-%s"
+  name = "foo-app-%s"
 }
 
 resource "aws_iam_role_policy" "foo_policy" {
-	name = "foo-policy-%s"
-	role = "${aws_iam_role.foo_role.id}"
-	policy = <<EOF
+  name = "foo-policy-%s"
+  role = "${aws_iam_role.foo_role.id}"
+  policy = <<EOF
 {
-	"Version": "2012-10-17",
-	"Statement": [
-		{
-			"Effect": "Allow",
-			"Action": [
-				"autoscaling:CompleteLifecycleAction",
-				"autoscaling:DeleteLifecycleHook",
-				"autoscaling:DescribeAutoScalingGroups",
-				"autoscaling:DescribeLifecycleHooks",
-				"autoscaling:PutLifecycleHook",
-				"autoscaling:RecordLifecycleActionHeartbeat",
-				"codedeploy:*",
-				"ec2:DescribeInstances",
-				"ec2:DescribeInstanceStatus",
-				"tag:GetTags",
-				"tag:GetResources",
-				"sns:Publish"
-			],
-			"Resource": "*"
-		}
-	]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DeleteLifecycleHook",
+        "autoscaling:DescribeAutoScalingGroups",
+        "autoscaling:DescribeLifecycleHooks",
+        "autoscaling:PutLifecycleHook",
+        "autoscaling:RecordLifecycleActionHeartbeat",
+        "codedeploy:*",
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceStatus",
+        "tag:GetTags",
+        "tag:GetResources",
+        "sns:Publish"
+      ],
+      "Resource": "*"
+    }
+  ]
 }
 EOF
 }
 
 resource "aws_iam_role" "foo_role" {
-	name = "foo-role-%s"
-	assume_role_policy = <<EOF
+  name = "foo-role-%s"
+  assume_role_policy = <<EOF
 {
-	"Version": "2012-10-17",
-	"Statement": [
-		{
-			"Sid": "",
-			"Effect": "Allow",
-			"Principal": {
-				"Service": "codedeploy.amazonaws.com"
-			},
-			"Action": "sts:AssumeRole"
-		}
-	]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "codedeploy.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
 }
 EOF
 }
 
 resource "aws_sns_topic" "foo_topic" {
-	name = "foo-topic-%s"
+  name = "foo-topic-%s"
 }`, rName, rName, rName, rName)
 }
 
 func testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_create(rName string) string {
 	return fmt.Sprintf(`
 
-	%s
+  %s
 
 resource "aws_codedeploy_deployment_group" "foo_group" {
-	app_name = "${aws_codedeploy_app.foo_app.name}"
-	deployment_group_name = "foo-group-%s"
-	service_role_arn = "${aws_iam_role.foo_role.arn}"
+  app_name = "${aws_codedeploy_app.foo_app.name}"
+  deployment_group_name = "foo-group-%s"
+  service_role_arn = "${aws_iam_role.foo_role.arn}"
 
-	trigger_configuration {
-		trigger_events = ["DeploymentFailure"]
-		trigger_name = "foo-trigger"
-		trigger_target_arn = "${aws_sns_topic.foo_topic.arn}"
-	}
+  trigger_configuration {
+    trigger_events = ["DeploymentFailure"]
+    trigger_name = "foo-trigger"
+    trigger_target_arn = "${aws_sns_topic.foo_topic.arn}"
+  }
 }`, baseCodeDeployConfig(rName), rName)
 }
 
 func testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_update(rName string) string {
 	return fmt.Sprintf(`
 
-	%s
+  %s
 
 resource "aws_codedeploy_deployment_group" "foo_group" {
-	app_name = "${aws_codedeploy_app.foo_app.name}"
-	deployment_group_name = "foo-group-%s"
-	service_role_arn = "${aws_iam_role.foo_role.arn}"
+  app_name = "${aws_codedeploy_app.foo_app.name}"
+  deployment_group_name = "foo-group-%s"
+  service_role_arn = "${aws_iam_role.foo_role.arn}"
 
-	trigger_configuration {
-		trigger_events = ["DeploymentSuccess", "DeploymentFailure"]
-		trigger_name = "foo-trigger"
-		trigger_target_arn = "${aws_sns_topic.foo_topic.arn}"
-	}
+  trigger_configuration {
+    trigger_events = ["DeploymentSuccess", "DeploymentFailure"]
+    trigger_name = "foo-trigger"
+    trigger_target_arn = "${aws_sns_topic.foo_topic.arn}"
+  }
 }`, baseCodeDeployConfig(rName), rName)
 }
 
 func testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_createMultiple(rName string) string {
 	return fmt.Sprintf(`
 
-	%s
+  %s
 
 resource "aws_sns_topic" "bar_topic" {
-	name = "bar-topic-%s"
+  name = "bar-topic-%s"
 }
 
 resource "aws_codedeploy_deployment_group" "foo_group" {
-	app_name = "${aws_codedeploy_app.foo_app.name}"
-	deployment_group_name = "foo-group-%s"
-	service_role_arn = "${aws_iam_role.foo_role.arn}"
+  app_name = "${aws_codedeploy_app.foo_app.name}"
+  deployment_group_name = "foo-group-%s"
+  service_role_arn = "${aws_iam_role.foo_role.arn}"
 
-	trigger_configuration {
-		trigger_events = ["DeploymentFailure"]
-		trigger_name = "foo-trigger"
-		trigger_target_arn = "${aws_sns_topic.foo_topic.arn}"
-	}
+  trigger_configuration {
+    trigger_events = ["DeploymentFailure"]
+    trigger_name = "foo-trigger"
+    trigger_target_arn = "${aws_sns_topic.foo_topic.arn}"
+  }
 
-	trigger_configuration {
-		trigger_events = ["InstanceFailure"]
-		trigger_name = "bar-trigger"
-		trigger_target_arn = "${aws_sns_topic.bar_topic.arn}"
-	}
+  trigger_configuration {
+    trigger_events = ["InstanceFailure"]
+    trigger_name = "bar-trigger"
+    trigger_target_arn = "${aws_sns_topic.bar_topic.arn}"
+  }
 }`, baseCodeDeployConfig(rName), rName, rName)
 }
 
 func testAccAWSCodeDeployDeploymentGroup_triggerConfiguration_updateMultiple(rName string) string {
 	return fmt.Sprintf(`
 
-	%s
+  %s
 
 resource "aws_sns_topic" "bar_topic" {
-	name = "bar-topic-%s"
+  name = "bar-topic-%s"
 }
 
 resource "aws_sns_topic" "baz_topic" {
-	name = "baz-topic-%s"
+  name = "baz-topic-%s"
 }
 
 resource "aws_codedeploy_deployment_group" "foo_group" {
-	app_name = "${aws_codedeploy_app.foo_app.name}"
-	deployment_group_name = "foo-group-%s"
-	service_role_arn = "${aws_iam_role.foo_role.arn}"
+  app_name = "${aws_codedeploy_app.foo_app.name}"
+  deployment_group_name = "foo-group-%s"
+  service_role_arn = "${aws_iam_role.foo_role.arn}"
 
-	trigger_configuration {
-		trigger_events = ["DeploymentStart", "DeploymentSuccess", "DeploymentFailure", "DeploymentStop"]
-		trigger_name = "foo-trigger"
-		trigger_target_arn = "${aws_sns_topic.foo_topic.arn}"
-	}
+  trigger_configuration {
+    trigger_events = ["DeploymentStart", "DeploymentSuccess", "DeploymentFailure", "DeploymentStop"]
+    trigger_name = "foo-trigger"
+    trigger_target_arn = "${aws_sns_topic.foo_topic.arn}"
+  }
 
-	trigger_configuration {
-		trigger_events = ["InstanceFailure"]
-		trigger_name = "bar-trigger"
-		trigger_target_arn = "${aws_sns_topic.baz_topic.arn}"
-	}
+  trigger_configuration {
+    trigger_events = ["InstanceFailure"]
+    trigger_name = "bar-trigger"
+    trigger_target_arn = "${aws_sns_topic.baz_topic.arn}"
+  }
 }`, baseCodeDeployConfig(rName), rName, rName, rName)
 }
 
@@ -1453,6 +2341,277 @@ resource "aws_codedeploy_deployment_group" "foo_group" {
   alarm_configuration {
     alarms = ["foo"]
     enabled = false
+  }
+}`, baseCodeDeployConfig(rName), rName)
+}
+
+func test_config_deployment_style_default(rName string) string {
+	return fmt.Sprintf(`
+
+  %s
+
+resource "aws_codedeploy_deployment_group" "foo_group" {
+  app_name = "${aws_codedeploy_app.foo_app.name}"
+  deployment_group_name = "foo-group-%s"
+  service_role_arn = "${aws_iam_role.foo_role.arn}"
+}`, baseCodeDeployConfig(rName), rName)
+}
+
+func test_config_deployment_style_create(rName string) string {
+	return fmt.Sprintf(`
+
+  %s
+
+resource "aws_codedeploy_deployment_group" "foo_group" {
+  app_name = "${aws_codedeploy_app.foo_app.name}"
+  deployment_group_name = "foo-group-%s"
+  service_role_arn = "${aws_iam_role.foo_role.arn}"
+
+  deployment_style {
+    deployment_option = "WITH_TRAFFIC_CONTROL"
+    deployment_type = "BLUE_GREEN"
+  }
+
+  load_balancer_info {
+    elb_info {
+      name = "foo-elb"
+    }
+  }
+}`, baseCodeDeployConfig(rName), rName)
+}
+
+func test_config_deployment_style_update(rName string) string {
+	return fmt.Sprintf(`
+
+  %s
+
+resource "aws_codedeploy_deployment_group" "foo_group" {
+  app_name = "${aws_codedeploy_app.foo_app.name}"
+  deployment_group_name = "foo-group-%s"
+  service_role_arn = "${aws_iam_role.foo_role.arn}"
+
+  deployment_style {
+    deployment_option = "WITHOUT_TRAFFIC_CONTROL"
+    deployment_type = "IN_PLACE"
+  }
+}`, baseCodeDeployConfig(rName), rName)
+}
+
+func test_config_load_balancer_info_default(rName string) string {
+	return fmt.Sprintf(`
+
+  %s
+
+resource "aws_codedeploy_deployment_group" "foo_group" {
+  app_name = "${aws_codedeploy_app.foo_app.name}"
+  deployment_group_name = "foo-group-%s"
+  service_role_arn = "${aws_iam_role.foo_role.arn}"
+}`, baseCodeDeployConfig(rName), rName)
+}
+
+func test_config_load_balancer_info_create(rName string) string {
+	return fmt.Sprintf(`
+
+  %s
+
+resource "aws_codedeploy_deployment_group" "foo_group" {
+  app_name = "${aws_codedeploy_app.foo_app.name}"
+  deployment_group_name = "foo-group-%s"
+  service_role_arn = "${aws_iam_role.foo_role.arn}"
+
+  load_balancer_info {
+    elb_info {
+      name = "foo-elb"
+    }
+  }
+}`, baseCodeDeployConfig(rName), rName)
+}
+
+func test_config_load_balancer_info_update(rName string) string {
+	return fmt.Sprintf(`
+
+  %s
+
+resource "aws_codedeploy_deployment_group" "foo_group" {
+  app_name = "${aws_codedeploy_app.foo_app.name}"
+  deployment_group_name = "foo-group-%s"
+  service_role_arn = "${aws_iam_role.foo_role.arn}"
+
+  load_balancer_info {
+    elb_info {
+      name = "bar-elb"
+    }
+  }
+}`, baseCodeDeployConfig(rName), rName)
+}
+
+func test_config_load_balancer_info_delete(rName string) string {
+	return fmt.Sprintf(`
+
+  %s
+
+resource "aws_codedeploy_deployment_group" "foo_group" {
+  app_name = "${aws_codedeploy_app.foo_app.name}"
+  deployment_group_name = "foo-group-%s"
+  service_role_arn = "${aws_iam_role.foo_role.arn}"
+}`, baseCodeDeployConfig(rName), rName)
+}
+
+func test_config_blue_green_deployment_config_default(rName string) string {
+	return fmt.Sprintf(`
+
+  %s
+
+resource "aws_codedeploy_deployment_group" "foo_group" {
+  app_name = "${aws_codedeploy_app.foo_app.name}"
+  deployment_group_name = "foo-group-%s"
+  service_role_arn = "${aws_iam_role.foo_role.arn}"
+}`, baseCodeDeployConfig(rName), rName)
+}
+
+func test_config_blue_green_deployment_config_create_with_asg(rName string) string {
+	return fmt.Sprintf(`
+
+  %s
+
+resource "aws_launch_configuration" "foo_lc" {
+  image_id = "ami-21f78e11"
+  instance_type = "t1.micro"
+  "name_prefix" = "foo-lc-"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_autoscaling_group" "foo_asg" {
+  name = "foo-asg-%s"
+  max_size = 2
+  min_size = 0
+  desired_capacity = 1
+
+  availability_zones = ["us-west-2a"]
+
+  launch_configuration = "${aws_launch_configuration.foo_lc.name}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_codedeploy_deployment_group" "foo_group" {
+  app_name = "${aws_codedeploy_app.foo_app.name}"
+  deployment_group_name = "foo-group-%s"
+  service_role_arn = "${aws_iam_role.foo_role.arn}"
+
+  autoscaling_groups = ["${aws_autoscaling_group.foo_asg.name}"]
+
+  blue_green_deployment_config {
+    deployment_ready_option {
+      action_on_timeout = "STOP_DEPLOYMENT"
+      wait_time_in_minutes = 60
+    }
+
+    green_fleet_provisioning_option {
+      action = "COPY_AUTO_SCALING_GROUP"
+    }
+
+    terminate_blue_instances_on_deployment_success {
+      action = "TERMINATE"
+      termination_wait_time_in_minutes = 120
+    }
+  }
+}`, baseCodeDeployConfig(rName), rName, rName)
+}
+
+func test_config_blue_green_deployment_config_create_no_asg(rName string) string {
+	return fmt.Sprintf(`
+
+  %s
+
+resource "aws_codedeploy_deployment_group" "foo_group" {
+  app_name = "${aws_codedeploy_app.foo_app.name}"
+  deployment_group_name = "foo-group-%s"
+  service_role_arn = "${aws_iam_role.foo_role.arn}"
+
+  blue_green_deployment_config {
+    deployment_ready_option {
+      action_on_timeout = "STOP_DEPLOYMENT"
+      wait_time_in_minutes = 60
+    }
+
+    green_fleet_provisioning_option {
+      action = "DISCOVER_EXISTING"
+    }
+
+    terminate_blue_instances_on_deployment_success {
+      action = "TERMINATE"
+      termination_wait_time_in_minutes = 120
+    }
+  }
+}`, baseCodeDeployConfig(rName), rName)
+}
+
+func test_config_blue_green_deployment_config_update_no_asg(rName string) string {
+	return fmt.Sprintf(`
+
+  %s
+
+resource "aws_codedeploy_deployment_group" "foo_group" {
+  app_name = "${aws_codedeploy_app.foo_app.name}"
+  deployment_group_name = "foo-group-%s"
+  service_role_arn = "${aws_iam_role.foo_role.arn}"
+
+  blue_green_deployment_config {
+    deployment_ready_option {
+      action_on_timeout = "CONTINUE_DEPLOYMENT"
+    }
+
+    green_fleet_provisioning_option {
+      action = "DISCOVER_EXISTING"
+    }
+
+    terminate_blue_instances_on_deployment_success {
+      action = "KEEP_ALIVE"
+    }
+  }
+}`, baseCodeDeployConfig(rName), rName)
+}
+
+func test_config_blue_green_deployment_complete(rName string) string {
+	return fmt.Sprintf(`
+
+  %s
+
+resource "aws_codedeploy_deployment_group" "foo_group" {
+  app_name = "${aws_codedeploy_app.foo_app.name}"
+  deployment_group_name = "foo-group-%s"
+  service_role_arn = "${aws_iam_role.foo_role.arn}"
+
+  deployment_style {
+    deployment_option = "WITH_TRAFFIC_CONTROL"
+    deployment_type = "BLUE_GREEN"
+  }
+
+  load_balancer_info {
+    elb_info {
+      name = "foo-elb"
+    }
+  }
+
+  blue_green_deployment_config {
+    deployment_ready_option {
+      action_on_timeout = "STOP_DEPLOYMENT"
+      wait_time_in_minutes = 60
+    }
+
+    green_fleet_provisioning_option {
+      action = "DISCOVER_EXISTING"
+    }
+
+    terminate_blue_instances_on_deployment_success {
+      action = "KEEP_ALIVE"
+    }
   }
 }`, baseCodeDeployConfig(rName), rName)
 }

--- a/website/docs/r/codedeploy_deployment_group.html.markdown
+++ b/website/docs/r/codedeploy_deployment_group.html.markdown
@@ -8,46 +8,13 @@ description: |-
 
 # aws\_codedeploy\_deployment\_group
 
-Provides a CodeDeploy deployment group for an application
+Provides a CodeDeploy Deployment Group for a CodeDeploy Application
 
 ## Example Usage
 
 ```hcl
-resource "aws_codedeploy_app" "foo_app" {
-  name = "foo_app"
-}
-
-resource "aws_iam_role_policy" "foo_policy" {
-  name = "foo_policy"
-  role = "${aws_iam_role.foo_role.id}"
-
-  policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "autoscaling:CompleteLifecycleAction",
-                "autoscaling:DeleteLifecycleHook",
-                "autoscaling:DescribeAutoScalingGroups",
-                "autoscaling:DescribeLifecycleHooks",
-                "autoscaling:PutLifecycleHook",
-                "autoscaling:RecordLifecycleActionHeartbeat",
-                "ec2:DescribeInstances",
-                "ec2:DescribeInstanceStatus",
-                "tag:GetTags",
-                "tag:GetResources"
-            ],
-            "Resource": "*"
-        }
-    ]
-}
-EOF
-}
-
-resource "aws_iam_role" "foo_role" {
-  name = "foo_role"
+resource "aws_iam_role" "example" {
+  name = "example-role"
 
   assume_role_policy = <<EOF
 {
@@ -57,9 +24,7 @@ resource "aws_iam_role" "foo_role" {
       "Sid": "",
       "Effect": "Allow",
       "Principal": {
-        "Service": [
-          "codedeploy.amazonaws.com"
-        ]
+        "Service": "codedeploy.amazonaws.com"
       },
       "Action": "sts:AssumeRole"
     }
@@ -68,10 +33,49 @@ resource "aws_iam_role" "foo_role" {
 EOF
 }
 
-resource "aws_codedeploy_deployment_group" "foo" {
-  app_name              = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "bar"
-  service_role_arn      = "${aws_iam_role.foo_role.arn}"
+resource "aws_iam_role_policy" "example" {
+  name = "example-policy"
+  role = "${aws_iam_role.example.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DeleteLifecycleHook",
+        "autoscaling:DescribeAutoScalingGroups",
+        "autoscaling:DescribeLifecycleHooks",
+        "autoscaling:PutLifecycleHook",
+        "autoscaling:RecordLifecycleActionHeartbeat",
+        "codedeploy:*",
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceStatus",
+        "tag:GetTags",
+        "tag:GetResources",
+        "sns:Publish"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_codedeploy_app" "example" {
+  name = "example-app"
+}
+
+resource "aws_sns_topic" "example" {
+  name = "example-topic"
+}
+
+resource "aws_codedeploy_deployment_group" "example" {
+  app_name              = "${aws_codedeploy_app.example.name}"
+  deployment_group_name = "example-group"
+  service_role_arn      = "${aws_iam_role.example.arn}"
 
   ec2_tag_filter {
     key   = "filterkey"
@@ -81,8 +85,8 @@ resource "aws_codedeploy_deployment_group" "foo" {
 
   trigger_configuration {
     trigger_events     = ["DeploymentFailure"]
-    trigger_name       = "foo-trigger"
-    trigger_target_arn = "foo-topic-arn"
+    trigger_name       = "example-trigger"
+    trigger_target_arn = "${aws_sns_topic.example.arn}"
   }
 
   auto_rollback_configuration {
@@ -93,6 +97,46 @@ resource "aws_codedeploy_deployment_group" "foo" {
   alarm_configuration {
     alarms  = ["my-alarm-name"]
     enabled = true
+  }
+}
+```
+
+### Using Blue Green Deployments
+
+```hcl
+resource "aws_codedeploy_app" "example" {
+  name = "example-app"
+}
+
+resource "aws_codedeploy_deployment_group" "example" {
+  app_name              = "${aws_codedeploy_app.example.name}"
+  deployment_group_name = "example-group"
+  service_role_arn      = "${aws_iam_role.example.arn}"
+
+  deployment_style {
+    deployment_option = "WITH_TRAFFIC_CONTROL"
+    deployment_type   = "BLUE_GREEN"
+  }
+
+  load_balancer_info {
+    elb_info {
+      name = "example-elb"
+    }
+  }
+
+  blue_green_deployment_config {
+    deployment_ready_option {
+      action_on_timeout    = "STOP_DEPLOYMENT"
+      wait_time_in_minutes = 60
+    }
+
+    green_fleet_provisioning_option {
+      action = "DISCOVER_EXISTING"
+    }
+
+    terminate_blue_instances_on_deployment_success {
+      action = "KEEP_ALIVE"
+    }
   }
 }
 ```
@@ -108,34 +152,107 @@ The following arguments are supported:
 * `deployment_config_name` - (Optional) The name of the group's deployment config. The default is "CodeDeployDefault.OneAtATime".
 * `ec2_tag_filter` - (Optional) Tag filters associated with the group. See the AWS docs for details.
 * `on_premises_instance_tag_filter` - (Optional) On premise tag filters associated with the group. See the AWS docs for details.
-* `trigger_configuration` - (Optional) A Trigger Configuration block. Trigger Configurations are documented below.
-* `auto_rollback_configuration` - (Optional) The automatic rollback configuration associated with the deployment group, documented below.
-* `alarm_configuration` - (Optional) A list of alarms associated with the deployment group, documented below.
+* `trigger_configuration` - (Optional) A Trigger Configuration block (documented below).
+* `auto_rollback_configuration` - (Optional) The automatic rollback configuration associated with the deployment group (documented below).
+* `alarm_configuration` - (Optional) Information about alarms associated with the deployment group (documented below).
+* `deployment_style` - (Optional) Information about the type of deployment, either standard or blue/green, you want to run and whether to route deployment traffic behind a load balancer (documented below).
+* `load_balancer_info` - (Optional) Information about the load balancer to use in a blue/green deployment (documented below).
+* `blue_green_deployment_config` - (Optional) Information about blue/green deployment options for a deployment group (documented below).
 
-Both ec2_tag_filter and on_premises_tag_filter blocks support the following:
+### Tag Filters
+Both `ec2_tag_filter` and `on_premises_tag_filter` support the following:
 
 * `key` - (Optional) The key of the tag filter.
-* `type` - (Optional) The type of the tag filter, either KEY_ONLY, VALUE_ONLY, or KEY_AND_VALUE.
+* `type` - (Optional) The type of the tag filter, either `KEY_ONLY`, `VALUE_ONLY`, or `KEY_AND_VALUE`.
 * `value` - (Optional) The value of the tag filter.
 
-Add triggers to a Deployment Group to receive notifications about events related to deployments or instances in the group. Notifications are sent to subscribers of the SNS topic associated with the trigger. CodeDeploy must have permission to publish to the topic from this deployment group. Trigger Configurations support the following:
+### Trigger Configuration
+Add triggers to a Deployment Group to receive notifications about events related to deployments or instances in the group. Notifications are sent to subscribers of the **SNS** topic associated with the trigger. _CodeDeploy must have permission to publish to the topic from this deployment group_. `trigger_configuration` supports the following:
 
- * `trigger_events` - (Required) The event type or types for which notifications are triggered. Some values that are supported: `DeploymentStart`, `DeploymentSuccess`, `DeploymentFailure`, `InstanceStart`, `InstanceSuccess`, `InstanceFailure`.  See [the CodeDeploy documentation][1] for all possible values.
+ * `trigger_events` - (Required) The event type or types for which notifications are triggered. Some values that are supported: `DeploymentStart`, `DeploymentSuccess`, `DeploymentFailure`, `DeploymentStop`, `DeploymentRollback`, `InstanceStart`, `InstanceSuccess`, `InstanceFailure`.  See [the CodeDeploy documentation][1] for all possible values.
  * `trigger_name` - (Required) The name of the notification trigger.
  * `trigger_target_arn` - (Required) The ARN of the SNS topic through which notifications are sent.
 
-You can configure a deployment group to automatically rollback when a deployment fails or when a monitoring threshold you specify is met. In this case, the last known good version of an application revision is deployed. Only one rollback configuration block is allowed.
+### Auto Rollback Configuration
+You can configure a deployment group to automatically rollback when a deployment fails or when a monitoring threshold you specify is met. In this case, the last known good version of an application revision is deployed. `auto_rollback_configuration` supports the following:
 
  * `enabled` - (Optional) Indicates whether a defined automatic rollback configuration is currently enabled for this Deployment Group. If you enable automatic rollback, you must specify at least one event type.
  * `events` - (Optional) The event type or types that trigger a rollback. Supported types are `DEPLOYMENT_FAILURE` and `DEPLOYMENT_STOP_ON_ALARM`.
 
-You can configure a deployment to stop when a CloudWatch alarm detects that a metric has fallen below or exceeded a defined threshold. Only one alarm configuration block is allowed.
+_Only one `auto_rollback_ configuration` block is allowed_.
 
- * `alarms` - (Optional) A list of alarms configured for the deployment group. A maximum of 10 alarms can be added to a deployment group.
+### Alarm Configuration
+You can configure a deployment to stop when a **CloudWatch** alarm detects that a metric has fallen below or exceeded a defined threshold. `alarm_configuration` supports the following:
+
+ * `alarms` - (Optional) A list of alarms configured for the deployment group. _A maximum of 10 alarms can be added to a deployment group_.
  * `enabled` - (Optional) Indicates whether the alarm configuration is enabled. This option is useful when you want to temporarily deactivate alarm monitoring for a deployment group without having to add the same alarms again later.
  * `ignore_poll_alarm_failure` - (Optional) Indicates whether a deployment should continue if information about the current state of alarms cannot be retrieved from CloudWatch. The default value is `false`.
     * `true`: The deployment will proceed even if alarm status information can't be retrieved.
     * `false`: The deployment will stop if alarm status information can't be retrieved.
+
+_Only one `alarm_configuration` block is allowed_.
+
+### Deployment Style
+You can configure the type of deployment, either standard or blue/green, you want to run and whether to route deployment traffic behind a load balancer. `deployment_style` supports the following:
+
+* `deployment_option` - (Optional) Indicates whether to route deployment traffic behind a load balancer. Valid Values are `WITH_TRAFFIC_CONTROL` or `WITHOUT_TRAFFIC_CONTROL`.
+
+* `deployment_type` - (Optional) Indicates whether to run a standard deployment or a blue/green deployment. Valid Values are `IN_PLACE` or `BLUE_GREEN`.
+
+  * `IN_PLACE` deployment type is not supported with the `WITH_TRAFFIC_CONTROL` deployment option.
+  * `BLUE_GREEN` deployment type is not supported with the `WITHOUT_TRAFFIC_CONTROL` deployment option.
+
+_Only one `deployment_style` block is allowed_.
+
+### Load Balancer Info
+You can configure the **Elastic Load Balancer** to use in a blue/green deployment. `load_balancer_info` supports the following:
+
+* `elb_info_list` - (Optional) The load balancers to use in a blue/green deployment.
+
+_Only one `load_balancer_info` block is allowed_.
+
+`elb_info_list` is a list of `elb_info`. `elb_info` supports the following:
+
+* `name` - (Optional) The name of the load balancer that will be used to route traffic from original instances to replacement instances in a blue/green deployment.
+
+_Only one `elb_info` block is supported at this time._
+
+### Blue Green Deployment Configuration
+You can configure options for a blue/green deployment. `blue_green_deployment_config` supports the following:
+
+* `deployment_ready_option` - (Optional) Information about the action to take when newly provisioned instances are ready to receive traffic in a blue/green deployment (documented below).
+
+* `green_fleet_provisioning_option` - (Optional) Information about how instances are provisioned for a replacement environment in a blue/green deployment (documented below).
+
+* `terminate_blue_instances_on_deployment_success` - (Optional) Information about whether to terminate instances in the original fleet during a blue/green deployment (documented below).
+
+_Only one `blue_green_deployment_config` block is allowed_.
+
+You can configure how traffic is rerouted to instances in a replacement environment in a blue/green deployment. `deployment_ready_option` supports the following:
+
+* `action_on_timeout` - (Optional) When to reroute traffic from an original environment to a replacement environment in a blue/green deployment.
+
+  * `CONTINUE_DEPLOYMENT`: Register new instances with the load balancer immediately after the new application revision is installed on the instances in the replacement environment.
+  * `STOP_DEPLOYMENT`: Do not register new instances with load balancer unless traffic is rerouted manually. If traffic is not rerouted manually before the end of the specified wait period, the deployment status is changed to Stopped.
+
+* `wait_time_in_minutes` - (Optional) The number of minutes to wait before the status of a blue/green deployment changed to Stopped if rerouting is not started manually. Applies only to the `STOP_DEPLOYMENT` option for `action_on_timeout`.
+
+You can configure how instances will be added to the replacement environment in a blue/green deployment. `green_fleet_provisioning_option` supports the following:
+
+* `action` - (Optional) The method used to add instances to a replacement environment.
+
+  * `DISCOVER_EXISTING`: Use instances that already exist or will be created manually.
+  * `COPY_AUTO_SCALING_GROUP`: Use settings from a specified **Auto Scaling** group to define and create instances in a new Auto Scaling group. _Exactly one Auto Scaling group must be specifed_ when selecting `COPY_AUTO_SCALING_GROUP`. Use `autoscaling_groups` to specify the Auto Scaling group.
+
+You can configure how instances in the original environment are terminated when a blue/green deployment is successful. `terminate_blue_instances_on_deployment_success` supports the following:
+
+* `action` - (Optional) The action to take on instances in the original environment after a successful blue/green deployment.
+
+  * `TERMINATE`: Instances are terminated after a specified wait time.
+
+  * `KEEP_ALIVE`: Instances are left running after they are deregistered from the load balancer and removed from the deployment group.
+
+* `termination_wait_time_in_minutes` - (Optional) The number of minutes to wait after a successful blue/green deployment before terminating instances from the original environment.
 
 ## Attributes Reference
 

--- a/website/docs/r/codedeploy_deployment_group.html.markdown
+++ b/website/docs/r/codedeploy_deployment_group.html.markdown
@@ -152,7 +152,7 @@ The following arguments are supported:
 * `deployment_config_name` - (Optional) The name of the group's deployment config. The default is "CodeDeployDefault.OneAtATime".
 * `ec2_tag_filter` - (Optional) Tag filters associated with the group. See the AWS docs for details.
 * `on_premises_instance_tag_filter` - (Optional) On premise tag filters associated with the group. See the AWS docs for details.
-* `trigger_configuration` - (Optional) A Trigger Configuration block (documented below).
+* `trigger_configuration` - (Optional) Trigger Configurations for the deployment group (documented below).
 * `auto_rollback_configuration` - (Optional) The automatic rollback configuration associated with the deployment group (documented below).
 * `alarm_configuration` - (Optional) Information about alarms associated with the deployment group (documented below).
 * `deployment_style` - (Optional) Information about the type of deployment, either in-place or blue/green, you want to run and whether to route deployment traffic behind a load balancer (documented below).
@@ -179,7 +179,7 @@ You can configure a deployment group to automatically rollback when a deployment
  * `enabled` - (Optional) Indicates whether a defined automatic rollback configuration is currently enabled for this Deployment Group. If you enable automatic rollback, you must specify at least one event type.
  * `events` - (Optional) The event type or types that trigger a rollback. Supported types are `DEPLOYMENT_FAILURE` and `DEPLOYMENT_STOP_ON_ALARM`.
 
-_Only one `auto_rollback_ configuration` block is allowed_.
+_Only one `auto_rollback_ configuration` is allowed_.
 
 ### Alarm Configuration
 You can configure a deployment to stop when a **CloudWatch** alarm detects that a metric has fallen below or exceeded a defined threshold. `alarm_configuration` supports the following:
@@ -190,7 +190,7 @@ You can configure a deployment to stop when a **CloudWatch** alarm detects that 
     * `true`: The deployment will proceed even if alarm status information can't be retrieved.
     * `false`: The deployment will stop if alarm status information can't be retrieved.
 
-_Only one `alarm_configuration` block is allowed_.
+_Only one `alarm_configuration` is allowed_.
 
 ### Deployment Style
 You can configure the type of deployment, either in-place` or blue/green, you want to run and whether to route deployment traffic behind a load balancer. `deployment_style` supports the following:
@@ -199,20 +199,25 @@ You can configure the type of deployment, either in-place` or blue/green, you wa
 
 * `deployment_type` - (Optional) Indicates whether to run an in-place deployment or a blue/green deployment. Valid Values are `IN_PLACE` or `BLUE_GREEN`.
 
-_Only one `deployment_style` block is allowed_.
+_Only one `deployment_style` is allowed_.
 
 ### Load Balancer Info
-You can configure the **Elastic Load Balancer** to use in a deployment. `load_balancer_info` supports the following:
+You can configure the **Load Balancer** to use in a deployment. `load_balancer_info` supports the following:
 
-* `elb_info_list` - (Optional) The load balancers to use in a deployment.
+* `elb_info` - (Optional) The load balancer to use in a deployment.
+* `target_group_info` - (Optional) The target group to use in a deployment.
 
-_Only one `load_balancer_info` block is allowed_.
+_Only one `load_balancer_info` is supported per deployment group.
 
-`elb_info_list` is a list of `elb_info`. `elb_info` supports the following:
+`elb_info` supports the following:
 
 * `name` - (Optional) The name of the load balancer that will be used to route traffic from original instances to replacement instances in a blue/green deployment. For in-place deployments, the name of the load balancer that instances are deregistered from so they are not serving traffic during a deployment, and then re-registered with after the deployment completes.
 
-_Only one `elb_info` block is supported at this time._
+`target_group_info` supports the following:
+
+* `name` - (Optional) The name of the target group that instances in the original environment are deregistered from, and instances in the replacement environment registered with. For in-place deployments, the name of the target group that instances are deregistered from, so they are not serving traffic during a deployment, and then re-registered with after the deployment completes.
+
+_Only a single `elb_info` or `target_group_info` can be used in a deployment._
 
 ### Blue Green Deployment Configuration
 You can configure options for a blue/green deployment. `blue_green_deployment_config` supports the following:
@@ -223,7 +228,7 @@ You can configure options for a blue/green deployment. `blue_green_deployment_co
 
 * `terminate_blue_instances_on_deployment_success` - (Optional) Information about whether to terminate instances in the original fleet during a blue/green deployment (documented below).
 
-_Only one `blue_green_deployment_config` block is allowed_.
+_Only one `blue_green_deployment_config` is allowed_.
 
 You can configure how traffic is rerouted to instances in a replacement environment in a blue/green deployment. `deployment_ready_option` supports the following:
 

--- a/website/docs/r/codedeploy_deployment_group.html.markdown
+++ b/website/docs/r/codedeploy_deployment_group.html.markdown
@@ -205,15 +205,15 @@ You can configure the type of deployment, either standard or blue/green, you wan
 _Only one `deployment_style` block is allowed_.
 
 ### Load Balancer Info
-You can configure the **Elastic Load Balancer** to use in a blue/green deployment. `load_balancer_info` supports the following:
+You can configure the **Elastic Load Balancer** to use in a deployment. `load_balancer_info` supports the following:
 
-* `elb_info_list` - (Optional) The load balancers to use in a blue/green deployment.
+* `elb_info_list` - (Optional) The load balancers to use in a deployment.
 
 _Only one `load_balancer_info` block is allowed_.
 
 `elb_info_list` is a list of `elb_info`. `elb_info` supports the following:
 
-* `name` - (Optional) The name of the load balancer that will be used to route traffic from original instances to replacement instances in a blue/green deployment.
+* `name` - (Optional) The name of the load balancer that will be used to route traffic from original instances to replacement instances in a blue/green deployment. For in-place deployments, the name of the load balancer that instances are deregistered from so they are not serving traffic during a deployment, and then re-registered with after the deployment completes.
 
 _Only one `elb_info` block is supported at this time._
 

--- a/website/docs/r/codedeploy_deployment_group.html.markdown
+++ b/website/docs/r/codedeploy_deployment_group.html.markdown
@@ -155,7 +155,7 @@ The following arguments are supported:
 * `trigger_configuration` - (Optional) A Trigger Configuration block (documented below).
 * `auto_rollback_configuration` - (Optional) The automatic rollback configuration associated with the deployment group (documented below).
 * `alarm_configuration` - (Optional) Information about alarms associated with the deployment group (documented below).
-* `deployment_style` - (Optional) Information about the type of deployment, either standard or blue/green, you want to run and whether to route deployment traffic behind a load balancer (documented below).
+* `deployment_style` - (Optional) Information about the type of deployment, either in-place or blue/green, you want to run and whether to route deployment traffic behind a load balancer (documented below).
 * `load_balancer_info` - (Optional) Information about the load balancer to use in a blue/green deployment (documented below).
 * `blue_green_deployment_config` - (Optional) Information about blue/green deployment options for a deployment group (documented below).
 
@@ -193,14 +193,11 @@ You can configure a deployment to stop when a **CloudWatch** alarm detects that 
 _Only one `alarm_configuration` block is allowed_.
 
 ### Deployment Style
-You can configure the type of deployment, either standard or blue/green, you want to run and whether to route deployment traffic behind a load balancer. `deployment_style` supports the following:
+You can configure the type of deployment, either in-place` or blue/green, you want to run and whether to route deployment traffic behind a load balancer. `deployment_style` supports the following:
 
 * `deployment_option` - (Optional) Indicates whether to route deployment traffic behind a load balancer. Valid Values are `WITH_TRAFFIC_CONTROL` or `WITHOUT_TRAFFIC_CONTROL`.
 
-* `deployment_type` - (Optional) Indicates whether to run a standard deployment or a blue/green deployment. Valid Values are `IN_PLACE` or `BLUE_GREEN`.
-
-  * `IN_PLACE` deployment type is not supported with the `WITH_TRAFFIC_CONTROL` deployment option.
-  * `BLUE_GREEN` deployment type is not supported with the `WITHOUT_TRAFFIC_CONTROL` deployment option.
+* `deployment_type` - (Optional) Indicates whether to run an in-place deployment or a blue/green deployment. Valid Values are `IN_PLACE` or `BLUE_GREEN`.
 
 _Only one `deployment_style` block is allowed_.
 


### PR DESCRIPTION
Issue: https://github.com/terraform-providers/terraform-provider-aws/issues/504

This PR adds Blue/Green Deployment support to CodeDeploy Deployment Groups, as well as supporting In-Place deployments with Traffic Control (i.e. Load Balancer).

It was originally opened on February 4, 2017, as https://github.com/hashicorp/terraform/pull/11700.

This PR adds the following resources to a Deployment Group:

* DeploymentStyle
* LoadBalancerInfo
* BlueGreenDeploymentConfiguration

The original work is contained in a single new commit. The original PR retains all original commits and discussion.

These enhancements can also be used for in-place deployments with traffic control.

```hcl
deployment_style {
  deployment_option = "WITH_TRAFFIC_CONTROL"
  deployment_type = "IN_PLACE"
}
```

Since this scenario was not supported when the original PR was created, I created a new commit that includes a test for this specific configuration, as well as updating the documentation to reflect this recent change. No code changes were required to support this scenario.
