### PR TITLE
AssociatePublicIPs: value when false should work.

### DIFF
--- a/aws/resource_aws_launch_configuration.go
+++ b/aws/resource_aws_launch_configuration.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 	"time"
 
@@ -124,10 +125,10 @@ func resourceAwsLaunchConfiguration() *schema.Resource {
 			},
 
 			"associate_public_ip_address": {
-				Type:     schema.TypeBool,
+				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
-				Default:  false,
+				Default:  "",
 			},
 
 			"spot_price": {
@@ -311,8 +312,12 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 		createLaunchConfigurationOpts.PlacementTenancy = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("associate_public_ip_address"); ok {
-		createLaunchConfigurationOpts.AssociatePublicIpAddress = aws.Bool(v.(bool))
+	if v, ok := d.GetOk("associate_public_ip_address"); v != nil && v.(string) != "" && ok {
+		vbool, err := strconv.ParseBool(v.(string))
+		if err != nil {
+			return err
+		}
+		createLaunchConfigurationOpts.AssociatePublicIpAddress = aws.Bool(vbool)
 	}
 
 	if v, ok := d.GetOk("key_name"); ok {


### PR DESCRIPTION
PR is an attempt to resolve the issue: https://github.com/terraform-providers/terraform-provider-aws/issues/227

To summarize:
Currently the key associate_public_ip_addresses can be in three states: true, false, nil (not defined). The behavior of the provider, because of how GetOk behaves sets the value to nil when false was the value in the template. This is not the expected behavior, and the default type should NOT be boolean in the schema.

Why we need this:
When launching kubernetes nodes using a LC it will become important to disable public IPs in a production environment and not necessarily adopt the default of the vpc/subnet. 

Note to reviewer:
Please feel free to help me make this cleaner/clearer and consistent with the expectations of this repo, which I am new to. Thank you for your time!