### PR TITLE
Print whole container_definitions in aws_ecs_task_definition instead of checksum in the plan

### DIFF
--- a/aws/ecs_task_definition_equivalency.go
+++ b/aws/ecs_task_definition_equivalency.go
@@ -1,0 +1,80 @@
+package aws
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+
+	"github.com/aws/aws-sdk-go/private/protocol/json/jsonutil"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/mitchellh/copystructure"
+)
+
+func ecsContainerDefinitionsAreEquivalent(def1, def2 string) (bool, error) {
+	var obj1 containerDefinitions
+	err := json.Unmarshal([]byte(def1), &obj1)
+	if err != nil {
+		return false, err
+	}
+	err = obj1.Reduce()
+	if err != nil {
+		return false, err
+	}
+	canonicalJson1, err := jsonutil.BuildJSON(obj1)
+	if err != nil {
+		return false, err
+	}
+
+	var obj2 containerDefinitions
+	err = json.Unmarshal([]byte(def2), &obj2)
+	if err != nil {
+		return false, err
+	}
+	err = obj2.Reduce()
+	if err != nil {
+		return false, err
+	}
+	canonicalJson2, err := jsonutil.BuildJSON(obj2)
+	if err != nil {
+		return false, err
+	}
+
+	return bytes.Compare(canonicalJson1, canonicalJson2) == 0, nil
+}
+
+type containerDefinitions []*ecs.ContainerDefinition
+
+func (cd containerDefinitions) Reduce() error {
+	for i, def := range cd {
+		// Deal with special fields which have defaults
+		for j, pm := range def.PortMappings {
+			if pm.Protocol != nil && *pm.Protocol == "tcp" {
+				cd[i].PortMappings[j].Protocol = nil
+			}
+			if pm.HostPort != nil && *pm.HostPort == 0 {
+				cd[i].PortMappings[j].HostPort = nil
+			}
+		}
+
+		// Create a mutable copy
+		defCopy, err := copystructure.Copy(def)
+		if err != nil {
+			return err
+		}
+
+		definition := reflect.ValueOf(defCopy).Elem()
+		for i := 0; i < definition.NumField(); i++ {
+			sf := definition.Field(i)
+
+			// Set all empty slices to nil
+			if sf.Kind() == reflect.Slice {
+				if sf.IsValid() && !sf.IsNil() && sf.Len() == 0 {
+					sf.Set(reflect.Zero(sf.Type()))
+				}
+			}
+		}
+		iface := definition.Interface().(ecs.ContainerDefinition)
+		cd[i] = &iface
+	}
+	return nil
+}

--- a/aws/ecs_task_definition_equivalency_test.go
+++ b/aws/ecs_task_definition_equivalency_test.go
@@ -1,0 +1,173 @@
+package aws
+
+import (
+	"testing"
+)
+
+func TestAwsEcsContainerDefinitionsAreEquivalent_basic(t *testing.T) {
+	cfgRepresention := `
+[
+    {
+      "name": "wordpress",
+      "links": [
+        "mysql"
+      ],
+      "image": "wordpress",
+      "essential": true,
+      "portMappings": [
+        {
+          "containerPort": 80,
+          "hostPort": 80
+        }
+      ],
+      "memory": 500,
+      "cpu": 10
+    },
+    {
+      "environment": [
+        {
+          "name": "MYSQL_ROOT_PASSWORD",
+          "value": "password"
+        }
+      ],
+      "name": "mysql",
+      "image": "mysql",
+      "cpu": 10,
+      "memory": 500,
+      "essential": true
+    }
+]`
+
+	apiRepresentation := `
+[
+    {
+        "name": "wordpress",
+        "image": "wordpress",
+        "cpu": 10,
+        "memory": 500,
+        "links": [
+            "mysql"
+        ],
+        "portMappings": [
+            {
+                "containerPort": 80,
+                "hostPort": 80,
+                "protocol": "tcp"
+            }
+        ],
+        "essential": true,
+        "environment": [],
+        "mountPoints": [],
+        "volumesFrom": []
+    },
+    {
+        "name": "mysql",
+        "image": "mysql",
+        "cpu": 10,
+        "memory": 500,
+        "portMappings": [],
+        "essential": true,
+        "environment": [
+            {
+                "name": "MYSQL_ROOT_PASSWORD",
+                "value": "password"
+            }
+        ],
+        "mountPoints": [],
+        "volumesFrom": []
+    }
+]`
+
+	equal, err := ecsContainerDefinitionsAreEquivalent(cfgRepresention, apiRepresentation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !equal {
+		t.Fatal("Expected definitions to be equal.")
+	}
+}
+
+func TestAwsEcsContainerDefinitionsAreEquivalent_portMappings(t *testing.T) {
+	cfgRepresention := `
+[
+    {
+      "name": "wordpress",
+      "image": "wordpress",
+      "essential": true,
+      "portMappings": [
+        {
+          "containerPort": 80
+        }
+      ],
+      "memory": 500,
+      "cpu": 10
+    }
+]`
+
+	apiRepresentation := `
+[
+    {
+        "name": "wordpress",
+        "image": "wordpress",
+        "cpu": 10,
+        "memory": 500,
+        "portMappings": [
+            {
+                "containerPort": 80,
+                "hostPort": 0,
+                "protocol": "tcp"
+            }
+        ],
+        "essential": true,
+        "environment": [],
+        "mountPoints": [],
+        "volumesFrom": []
+    }
+]`
+
+	equal, err := ecsContainerDefinitionsAreEquivalent(cfgRepresention, apiRepresentation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !equal {
+		t.Fatal("Expected definitions to be equal.")
+	}
+}
+
+func TestAwsEcsContainerDefinitionsAreEquivalent_negative(t *testing.T) {
+	cfgRepresention := `
+[
+    {
+      "name": "wordpress",
+      "image": "wordpress",
+      "essential": true,
+      "memory": 500,
+      "cpu": 10,
+      "environment": [
+        {"name": "EXAMPLE_NAME", "value": "foobar"}
+      ]
+    }
+]`
+
+	apiRepresentation := `
+[
+    {
+        "name": "wordpress",
+        "image": "wordpress",
+        "cpu": 10,
+        "memory": 500,
+        "essential": true,
+        "environment": [],
+        "mountPoints": [],
+        "volumesFrom": []
+    }
+]`
+
+	equal, err := ecsContainerDefinitionsAreEquivalent(cfgRepresention, apiRepresentation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if equal {
+		t.Fatal("Expected definitions to differ.")
+	}
+}

--- a/aws/resource_aws_ecs_task_definition.go
+++ b/aws/resource_aws_ecs_task_definition.go
@@ -2,8 +2,6 @@ package aws
 
 import (
 	"bytes"
-	"crypto/sha1"
-	"encoding/hex"
 	"fmt"
 	"log"
 	"strings"
@@ -38,13 +36,9 @@ func resourceAwsEcsTaskDefinition() *schema.Resource {
 			},
 
 			"container_definitions": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				StateFunc: func(v interface{}) string {
-					hash := sha1.Sum([]byte(v.(string)))
-					return hex.EncodeToString(hash[:])
-				},
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: validateAwsEcsTaskDefinitionContainerDefinitions,
 			},
 

--- a/aws/resource_aws_ecs_task_definition.go
+++ b/aws/resource_aws_ecs_task_definition.go
@@ -219,7 +219,16 @@ func resourceAwsEcsTaskDefinitionRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("arn", taskDefinition.TaskDefinitionArn)
 	d.Set("family", taskDefinition.Family)
 	d.Set("revision", taskDefinition.Revision)
-	d.Set("container_definitions", taskDefinition.ContainerDefinitions)
+
+	defs, err := flattenEcsContainerDefinitions(taskDefinition.ContainerDefinitions)
+	if err != nil {
+		return err
+	}
+	err = d.Set("container_definitions", defs)
+	if err != nil {
+		return err
+	}
+
 	d.Set("task_role_arn", taskDefinition.TaskRoleArn)
 	d.Set("network_mode", taskDefinition.NetworkMode)
 	d.Set("volumes", flattenEcsVolumes(taskDefinition.Volumes))

--- a/aws/resource_aws_ecs_task_definition.go
+++ b/aws/resource_aws_ecs_task_definition.go
@@ -46,6 +46,10 @@ func resourceAwsEcsTaskDefinition() *schema.Resource {
 					json, _ := normalizeJsonString(v)
 					return json
 				},
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					equal, _ := ecsContainerDefinitionsAreEquivalent(old, new)
+					return equal
+				},
 				ValidateFunc: validateAwsEcsTaskDefinitionContainerDefinitions,
 			},
 

--- a/aws/resource_aws_ecs_task_definition.go
+++ b/aws/resource_aws_ecs_task_definition.go
@@ -18,6 +18,9 @@ func resourceAwsEcsTaskDefinition() *schema.Resource {
 		Read:   resourceAwsEcsTaskDefinitionRead,
 		Delete: resourceAwsEcsTaskDefinitionDelete,
 
+		SchemaVersion: 1,
+		MigrateState:  resourceAwsEcsTaskDefinitionMigrateState,
+
 		Schema: map[string]*schema.Schema{
 			"arn": {
 				Type:     schema.TypeString,
@@ -36,9 +39,13 @@ func resourceAwsEcsTaskDefinition() *schema.Resource {
 			},
 
 			"container_definitions": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				StateFunc: func(v interface{}) string {
+					json, _ := normalizeJsonString(v)
+					return json
+				},
 				ValidateFunc: validateAwsEcsTaskDefinitionContainerDefinitions,
 			},
 

--- a/aws/resource_aws_ecs_task_definition_migrate.go
+++ b/aws/resource_aws_ecs_task_definition_migrate.go
@@ -1,0 +1,44 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/private/protocol/json/jsonutil"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func resourceAwsEcsTaskDefinitionMigrateState(v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	conn := meta.(*AWSClient).ecsconn
+
+	switch v {
+	case 0:
+		log.Println("[INFO] Found AWS ECS Task Definition State v0; migrating to v1")
+		return migrateEcsTaskDefinitionStateV0toV1(is, conn)
+	default:
+		return is, fmt.Errorf("Unexpected schema version: %d", v)
+	}
+}
+
+func migrateEcsTaskDefinitionStateV0toV1(is *terraform.InstanceState, conn *ecs.ECS) (*terraform.InstanceState, error) {
+	arn := is.Attributes["arn"]
+
+	// We need to pull definitions from the API b/c they're unrecoverable from the checksum
+	td, err := conn.DescribeTaskDefinition(&ecs.DescribeTaskDefinitionInput{
+		TaskDefinition: aws.String(arn),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	b, err := jsonutil.BuildJSON(td.TaskDefinition.ContainerDefinitions)
+	if err != nil {
+		return nil, err
+	}
+
+	is.Attributes["container_definitions"] = string(b)
+
+	return is, nil
+}

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -10,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/private/protocol/json/jsonutil"
 	"github.com/aws/aws-sdk-go/service/apigateway"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
@@ -595,13 +595,12 @@ func flattenEcsLoadBalancers(list []*ecs.LoadBalancer) []map[string]interface{} 
 
 // Encodes an array of ecs.ContainerDefinitions into a JSON string
 func flattenEcsContainerDefinitions(definitions []*ecs.ContainerDefinition) (string, error) {
-	byteArray, err := json.Marshal(definitions)
+	b, err := jsonutil.BuildJSON(definitions)
 	if err != nil {
-		return "", fmt.Errorf("Error encoding to JSON: %s", err)
+		return "", err
 	}
 
-	n := bytes.Index(byteArray, []byte{0})
-	return string(byteArray[:n]), nil
+	return string(b), nil
 }
 
 // Flattens an array of Options into a []map[string]interface{}


### PR DESCRIPTION
Currently, when aws_ecs_task_definition is updated, people can see only container_definitions checksum in the plan. There is no visibility what exactly is being pushed to ECS and I think this quite confusing. In other resources, like aws_iam_policy, old version of policy and new version policy is visible in the plan. Also, this change would allow to utilize terraform-landspace to produce a pretty plan for ECS tasks ([screenshot](http://imgur.com/a/KVXKu)).

Tests:
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSEcsTaskDefinition'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSEcsTaskDefinition -timeout 120m
=== RUN   TestAccAWSEcsTaskDefinition_basic
--- PASS: TestAccAWSEcsTaskDefinition_basic (19.93s)
=== RUN   TestAccAWSEcsTaskDefinition_withScratchVolume
--- PASS: TestAccAWSEcsTaskDefinition_withScratchVolume (12.85s)
=== RUN   TestAccAWSEcsTaskDefinition_withEcsService
--- PASS: TestAccAWSEcsTaskDefinition_withEcsService (138.14s)
=== RUN   TestAccAWSEcsTaskDefinition_withTaskRoleArn
--- PASS: TestAccAWSEcsTaskDefinition_withTaskRoleArn (19.50s)
=== RUN   TestAccAWSEcsTaskDefinition_withNetworkMode
--- PASS: TestAccAWSEcsTaskDefinition_withNetworkMode (21.53s)
=== RUN   TestAccAWSEcsTaskDefinition_constraint
--- PASS: TestAccAWSEcsTaskDefinition_constraint (10.78s)
=== RUN   TestAccAWSEcsTaskDefinition_changeVolumesForcesNewResource
--- PASS: TestAccAWSEcsTaskDefinition_changeVolumesForcesNewResource (19.44s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	242.187s
```