### PR TITLE
Add a body property to API Gateway RestAPI for Swagger import support

### DIFF
--- a/aws/resource_aws_api_gateway_rest_api_test.go
+++ b/aws/resource_aws_api_gateway_rest_api_test.go
@@ -56,6 +56,47 @@ func TestAccAWSAPIGatewayRestApi_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSAPIGatewayRestApi_openapi(t *testing.T) {
+	var conf apigateway.RestApi
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayRestAPIDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayRestAPIConfigOpenAPI,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayRestAPIExists("aws_api_gateway_rest_api.test", &conf),
+					testAccCheckAWSAPIGatewayRestAPINameAttribute(&conf, "test"),
+					testAccCheckAWSAPIGatewayRestAPIRoutes(&conf, []string{"/", "/test"}),
+					resource.TestCheckResourceAttr(
+						"aws_api_gateway_rest_api.test", "name", "test"),
+					resource.TestCheckResourceAttr(
+						"aws_api_gateway_rest_api.test", "description", ""),
+					resource.TestCheckResourceAttrSet(
+						"aws_api_gateway_rest_api.test", "created_date"),
+					resource.TestCheckNoResourceAttr(
+						"aws_api_gateway_rest_api.test", "binary_media_types"),
+				),
+			},
+
+			{
+				Config: testAccAWSAPIGatewayRestAPIUpdateConfigOpenAPI,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayRestAPIExists("aws_api_gateway_rest_api.test", &conf),
+					testAccCheckAWSAPIGatewayRestAPINameAttribute(&conf, "test"),
+					testAccCheckAWSAPIGatewayRestAPIRoutes(&conf, []string{"/", "/update"}),
+					resource.TestCheckResourceAttr(
+						"aws_api_gateway_rest_api.test", "name", "test"),
+					resource.TestCheckResourceAttrSet(
+						"aws_api_gateway_rest_api.test", "created_date"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSAPIGatewayRestAPINameAttribute(conf *apigateway.RestApi, name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if *conf.Name != name {
@@ -70,6 +111,37 @@ func testAccCheckAWSAPIGatewayRestAPIDescriptionAttribute(conf *apigateway.RestA
 	return func(s *terraform.State) error {
 		if *conf.Description != description {
 			return fmt.Errorf("Wrong Description: %q", *conf.Description)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSAPIGatewayRestAPIRoutes(conf *apigateway.RestApi, routes []string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).apigateway
+
+		resp, err := conn.GetResources(&apigateway.GetResourcesInput{
+			RestApiId: conf.Id,
+		})
+		if err != nil {
+			return err
+		}
+
+		actualRoutePaths := map[string]bool{}
+		for _, resource := range resp.Items {
+			actualRoutePaths[*resource.Path] = true
+		}
+
+		for _, route := range routes {
+			if _, ok := actualRoutePaths[route]; !ok {
+				return fmt.Errorf("Expected path %v but did not find it in %v", route, actualRoutePaths)
+			}
+			delete(actualRoutePaths, route)
+		}
+
+		if len(actualRoutePaths) > 0 {
+			return fmt.Errorf("Found unexpected paths %v", actualRoutePaths)
 		}
 
 		return nil
@@ -142,5 +214,83 @@ resource "aws_api_gateway_rest_api" "test" {
   name = "test"
   description = "test"
   binary_media_types = ["application/octet-stream"]
+}
+`
+
+const testAccAWSAPIGatewayRestAPIConfigOpenAPI = `
+resource "aws_api_gateway_rest_api" "test" {
+  name = "test"
+  body = <<EOF
+{
+	"swagger": "2.0",
+	"info": {
+		"title": "test",
+		"version": "2017-04-20T04:08:08Z"
+  },
+  "schemes": [
+    "https"
+  ],
+  "paths": {
+    "/test": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "200 response"
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "type": "HTTP",
+          "uri": "https://www.google.de",
+          "httpMethod": "GET",
+          "responses": {
+            "default": {
+              "statusCode": 200
+            }
+          }
+        }
+      }
+    }
+  }
+}
+EOF
+}
+`
+
+const testAccAWSAPIGatewayRestAPIUpdateConfigOpenAPI = `
+resource "aws_api_gateway_rest_api" "test" {
+  name = "test"
+  body = <<EOF
+{
+	"swagger": "2.0",
+	"info": {
+		"title": "test",
+		"version": "2017-04-20T04:08:08Z"
+  },
+  "schemes": [
+    "https"
+  ],
+  "paths": {
+    "/update": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "200 response"
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "type": "HTTP",
+          "uri": "https://www.google.de",
+          "httpMethod": "GET",
+          "responses": {
+            "default": {
+              "statusCode": 200
+            }
+          }
+        }
+      }
+    }
+  }
+}
+EOF
 }
 `

--- a/aws/resource_aws_api_gateway_rest_api_test.go
+++ b/aws/resource_aws_api_gateway_rest_api_test.go
@@ -222,10 +222,10 @@ resource "aws_api_gateway_rest_api" "test" {
   name = "test"
   body = <<EOF
 {
-	"swagger": "2.0",
-	"info": {
-		"title": "test",
-		"version": "2017-04-20T04:08:08Z"
+  "swagger": "2.0",
+  "info": {
+    "title": "test",
+    "version": "2017-04-20T04:08:08Z"
   },
   "schemes": [
     "https"
@@ -261,10 +261,10 @@ resource "aws_api_gateway_rest_api" "test" {
   name = "test"
   body = <<EOF
 {
-	"swagger": "2.0",
-	"info": {
-		"title": "test",
-		"version": "2017-04-20T04:08:08Z"
+  "swagger": "2.0",
+  "info": {
+    "title": "test",
+    "version": "2017-04-20T04:08:08Z"
   },
   "schemes": [
     "https"

--- a/website/docs/r/api_gateway_rest_api.html.markdown
+++ b/website/docs/r/api_gateway_rest_api.html.markdown
@@ -26,6 +26,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the REST API
 * `description` - (Optional) The description of the REST API
 * `binary_media_types` - (Optional) The list of binary media types supported by the RestApi. By default, the RestApi supports only UTF-8-encoded text payloads.
+* `body` - (Optional) An OpenAPI specification that defines the set of routes and integrations to create as part of the REST API.
 
 ## Attributes Reference
 

--- a/website/docs/r/api_gateway_rest_api.html.markdown
+++ b/website/docs/r/api_gateway_rest_api.html.markdown
@@ -28,6 +28,17 @@ The following arguments are supported:
 * `binary_media_types` - (Optional) The list of binary media types supported by the RestApi. By default, the RestApi supports only UTF-8-encoded text payloads.
 * `body` - (Optional) An OpenAPI specification that defines the set of routes and integrations to create as part of the REST API.
 
+__Note__: If the `body` argument is provided, the OpenAPI specification will be used to configure the resources, methods and integrations for the Rest API. If this argument is provided, the following resources should not be configured manually for the same REST API, as updates may cause manual resource updates to be overwritten:
+
+* `aws_api_gateway_resource`
+* `aws_api_gateway_method`
+* `aws_api_gateway_method_response`
+* `aws_api_gateway_method_settings`
+* `aws_api_gateway_integration`
+* `aws_api_gateway_integration_response`
+* `aws_api_gateway_gateway_response`
+* `aws_api_gateway_model`
+
 ## Attributes Reference
 
 The following attributes are exported:

--- a/website/docs/r/api_gateway_rest_api.html.markdown
+++ b/website/docs/r/api_gateway_rest_api.html.markdown
@@ -28,7 +28,7 @@ The following arguments are supported:
 * `binary_media_types` - (Optional) The list of binary media types supported by the RestApi. By default, the RestApi supports only UTF-8-encoded text payloads.
 * `body` - (Optional) An OpenAPI specification that defines the set of routes and integrations to create as part of the REST API.
 
-__Note__: If the `body` argument is provided, the OpenAPI specification will be used to configure the resources, methods and integrations for the Rest API. If this argument is provided, the following resources should not be configured manually for the same REST API, as updates may cause manual resource updates to be overwritten:
+__Note__: If the `body` argument is provided, the OpenAPI specification will be used to configure the resources, methods and integrations for the Rest API. If this argument is provided, the following resources should not be managed as separate ones, as updates may cause manual resource updates to be overwritten:
 
 * `aws_api_gateway_resource`
 * `aws_api_gateway_method`


### PR DESCRIPTION
## Description

The `body` property allows supplying a Swagger/OpenAPI spec to a RestAPI to create the API definition using the routes and integrations defined in the spec.

Related to https://github.com/hashicorp/terraform/issues/11034 and the work done in https://github.com/hashicorp/terraform/pull/6175.

Provides similar behaviour to what's available in CloudFormation with: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-body.

## Tests
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAPIGatewayRestApi_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSAPIGatewayRestApi_ -timeout 120m
=== RUN   TestAccAWSAPIGatewayRestApi_basic
--- PASS: TestAccAWSAPIGatewayRestApi_basic (50.66s)
=== RUN   TestAccAWSAPIGatewayRestApi_openapi
--- PASS: TestAccAWSAPIGatewayRestApi_openapi (28.66s)
PASS
ok  	github.com/pulumi/terraform-provider-aws/aws	79.354s
```


