### PR TITLE
Fix spelling in error message for aws_db_snapshot data source

### DIFF
--- a/aws/data_source_aws_db_snapshot.go
+++ b/aws/data_source_aws_db_snapshot.go
@@ -135,7 +135,7 @@ func dataSourceAwsDbSnapshotRead(d *schema.ResourceData, meta interface{}) error
 	snapshotIdentifier, snapshotIdentifierOk := d.GetOk("db_snapshot_identifier")
 
 	if !instanceIdentifierOk && !snapshotIdentifierOk {
-		return fmt.Errorf("One of db_snapshot_indentifier or db_instance_identifier must be assigned")
+		return fmt.Errorf("One of db_snapshot_identifier or db_instance_identifier must be assigned")
 	}
 
 	params := &rds.DescribeDBSnapshotsInput{


### PR DESCRIPTION
When working with the aws_db_snapshot data source, I found this spelling error by copying a portion of the message then pasting it into my .tf file. The following error occurred:
```
1 error(s) occurred:

* data.aws_db_snapshot.db_snapshot: : invalid or unknown key: db_snapshot_indentifier
```
This updates the spelling for anyone else that copy pastes from the error message like I did.

I read through the contributing.md document but it didn't look like a lot of it applied to such a small change. Let me know if I need to update anything though.