### PR TITLE
Fix restriction on length of `name_prefix` for `aws_iam_server_certificate`

### DIFF
--- a/aws/data_source_aws_iam_server_certificate.go
+++ b/aws/data_source_aws_iam_server_certificate.go
@@ -38,9 +38,9 @@ func dataSourceAwsIAMServerCertificate() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					value := v.(string)
-					if len(value) > 30 {
+					if len(value) > 102 {
 						errors = append(errors, fmt.Errorf(
-							"%q cannot be longer than 30 characters, name is limited to 128", k))
+							"%q cannot be longer than 102 characters, name is limited to 128", k))
 					}
 					return
 				},

--- a/aws/resource_aws_iam_server_certificate.go
+++ b/aws/resource_aws_iam_server_certificate.go
@@ -76,9 +76,9 @@ func resourceAwsIAMServerCertificate() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					value := v.(string)
-					if len(value) > 30 {
+					if len(value) > 102 {
 						errors = append(errors, fmt.Errorf(
-							"%q cannot be longer than 30 characters, name is limited to 128", k))
+							"%q cannot be longer than 102 characters, name is limited to 128", k))
 					}
 					return
 				},


### PR DESCRIPTION
Currently `name_prefix` is restricted to 30 characters, which is unnecessarily prohibitive.