### PR TITLE
r/asg: Fix TestAccAWSAutoScalingGroup_VpcUpdates

### DIFF
--- a/aws/resource_aws_autoscaling_group_test.go
+++ b/aws/resource_aws_autoscaling_group_test.go
@@ -316,7 +316,7 @@ func TestAccAWSAutoScalingGroup_VpcUpdates(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_autoscaling_group.bar", "availability_zones.2487133097", "us-west-2a"),
 					resource.TestCheckResourceAttr(
-						"aws_autoscaling_group.bar", "vpc_zone_identifier.#", "1"),
+						"aws_autoscaling_group.bar", "vpc_zone_identifier.#", "0"),
 				),
 			},
 


### PR DESCRIPTION
This was just overlooked when merging bugfix https://github.com/terraform-providers/terraform-provider-aws/pull/1191

### Before
```
=== RUN   TestAccAWSAutoScalingGroup_VpcUpdates
--- FAIL: TestAccAWSAutoScalingGroup_VpcUpdates (42.93s)
    testing.go:428: Step 0 error: Check failed: Check 4/4 error: aws_autoscaling_group.bar: Attribute 'vpc_zone_identifier.#' expected "1", got "0"
FAIL
```

### After
```
=== RUN   TestAccAWSAutoScalingGroup_VpcUpdates
--- PASS: TestAccAWSAutoScalingGroup_VpcUpdates (122.28s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	122.312s
```

cc @joshuaspence