### PR TITLE
resource/elastic_beanstalk_configuration_template: Handle missing platform

### DIFF
--- a/aws/resource_aws_elastic_beanstalk_configuration_template.go
+++ b/aws/resource_aws_elastic_beanstalk_configuration_template.go
@@ -108,6 +108,10 @@ func resourceAwsElasticBeanstalkConfigurationTemplateRead(d *schema.ResourceData
 				log.Printf("[WARN] No Configuration Template named (%s) found", d.Id())
 				d.SetId("")
 				return nil
+			} else if awsErr.Code() == "InvalidParameterValue" && strings.Contains(awsErr.Message(), "No Platform named") {
+				log.Printf("[WARN] No Platform named (%s) found", d.Get("solution_stack_name").(string))
+				d.SetId("")
+				return nil
 			}
 		}
 		return err


### PR DESCRIPTION
When a platform was removed by AWS, Terraform failed in the following
manner:

```
Error refreshing state: 1 error(s) occurred:
* aws_elastic_beanstalk_configuration_template.my_app: aws_elastic_beanstalk_configuration_template.my_app: InvalidParameterValue: No Platform named 'arn:aws:elasticbeanstalk:us-east-1::platform/Multi-container Docker running on 64bit Amazon Linux/2.7.1' found.
    status code: 400
```

Terraform should handle the missing platform error in the same way it handles the missing config template error - it will plan to remove it from state and then readd it

This was reported in `HangOps` - https://hangops.slack.com/archives/C0Z93TPFX/p1500904037044893