### PR TITLE
provider: Remove assumeRoleHash

### DIFF
--- a/aws/data_source_aws_caller_identity_test.go
+++ b/aws/data_source_aws_caller_identity_test.go
@@ -23,6 +23,23 @@ func TestAccAWSCallerIdentity_basic(t *testing.T) {
 	})
 }
 
+// Protects against a panic in the AWS Provider configuration.
+// See https://github.com/terraform-providers/terraform-provider-aws/pull/1227
+func TestAccAWSCallerIdentity_basic_panic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAwsCallerIdentityConfig_basic_panic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsCallerIdentityAccountId("data.aws_caller_identity.current"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAwsCallerIdentityAccountId(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -53,4 +70,13 @@ func testAccCheckAwsCallerIdentityAccountId(n string) resource.TestCheckFunc {
 
 const testAccCheckAwsCallerIdentityConfig_basic = `
 data "aws_caller_identity" "current" { }
+`
+
+const testAccCheckAwsCallerIdentityConfig_basic_panic = `
+provider "aws" {
+  assume_role {
+  }
+}
+
+data "aws_caller_identity" "current" {}
 `

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -683,18 +683,7 @@ func assumeRoleSchema() *schema.Schema {
 				},
 			},
 		},
-		Set: assumeRoleToHash,
 	}
-}
-
-func assumeRoleToHash(v interface{}) int {
-	var buf bytes.Buffer
-	m := v.(map[string]interface{})
-	buf.WriteString(fmt.Sprintf("%s-", m["role_arn"].(string)))
-	buf.WriteString(fmt.Sprintf("%s-", m["session_name"].(string)))
-	buf.WriteString(fmt.Sprintf("%s-", m["external_id"].(string)))
-	buf.WriteString(fmt.Sprintf("%s-", m["policy"].(string)))
-	return hashcode.String(buf.String())
 }
 
 func endpointsSchema() *schema.Schema {


### PR DESCRIPTION
The default hash function is good enough to use for the `assume_role` schema,
previously the custom hash function was causing a panic in the provider if the
`assume_role` configuration block was present but empty.

Fixes: #1213 