### PR TITLE
Make aws_iam_policy_attachment warning less opaque

### DIFF
--- a/website/docs/r/iam_policy_attachment.html.markdown
+++ b/website/docs/r/iam_policy_attachment.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Attaches a Managed IAM Policy to user(s), role(s), and/or group(s)
 
-~> **NOTE:** The aws_iam_policy_attachment resource is only meant to be used once for each managed policy. All of the users/roles/groups that a single policy is being attached to should be declared by a single aws_iam_policy_attachment resource.
+!> **WARNING:** The aws_iam_policy_attachment resource creates **exclusive** attachments of IAM policies. Across the entire AWS account, all of the users/roles/groups to which a single policy is attached must be declared by a single aws_iam_policy_attachment resource. This means that even any users/roles/groups that have the attached policy via some mechanism other than Terraform will have that attached policy revoked by Terraform. Consider `aws_iam_role_policy_attachment`, `iam_user_policy_attachment`, or `iam_group_policy_attachment` instead. These resources do not enforce exclusive attachment of an IAM policy. 
 
 ```hcl
 resource "aws_iam_user" "user" {


### PR DESCRIPTION
The current note on aws_iam_policy_attachment is well intentioned but too subtle. I managed to revoke an execution role from 7 lambdas over this. I'm not alone. Consider https://github.com/terraform-providers/terraform-provider-aws/issues/94, and https://github.com/terraform-providers/terraform-provider-aws/issues/133, which feature gems like:

"aws_iam_policy_attachment as it is implemented today is insanely dangerous" and
"this is hugely disruptive and downright dangerous to use in a live environment. Folks should probably stick with using aws_iam_role_policy_attachment instead of aws_iam_policy_attachment"

I actually think aws_iam_policy_attachment ought to be removed from Terraform because no one expects the Terraform inquisition, but at the very least we can make the docs clearer. 

This update is worth deploying to the site immediately.
