### PR TITLE
r/ecr_repository: Randomize names in tests

### DIFF
--- a/aws/import_aws_ecr_repository_test.go
+++ b/aws/import_aws_ecr_repository_test.go
@@ -3,11 +3,13 @@ package aws
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccAWSEcrRepository_importBasic(t *testing.T) {
 	resourceName := "aws_ecr_repository.default"
+	randString := acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -15,7 +17,7 @@ func TestAccAWSEcrRepository_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSEcrRepositoryDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSEcrRepository,
+				Config: testAccAWSEcrRepository(randString),
 			},
 
 			resource.TestStep{

--- a/aws/resource_aws_ecr_repository_policy_test.go
+++ b/aws/resource_aws_ecr_repository_policy_test.go
@@ -7,18 +7,21 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccAWSEcrRepositoryPolicy_basic(t *testing.T) {
+	randString := acctest.RandString(10)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEcrRepositoryPolicyDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSEcrRepositoryPolicy,
+				Config: testAccAWSEcrRepositoryPolicy(randString),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcrRepositoryPolicyExists("aws_ecr_repository_policy.default"),
 				),
@@ -28,13 +31,15 @@ func TestAccAWSEcrRepositoryPolicy_basic(t *testing.T) {
 }
 
 func TestAccAWSEcrRepositoryPolicy_iam(t *testing.T) {
+	randString := acctest.RandString(10)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEcrRepositoryPolicyDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSEcrRepositoryPolicyWithIAMRole,
+				Config: testAccAWSEcrRepositoryPolicyWithIAMRole(randString),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcrRepositoryPolicyExists("aws_ecr_repository_policy.default"),
 				),
@@ -77,14 +82,15 @@ func testAccCheckAWSEcrRepositoryPolicyExists(name string) resource.TestCheckFun
 	}
 }
 
-var testAccAWSEcrRepositoryPolicy = `
+func testAccAWSEcrRepositoryPolicy(randString string) string {
+	return fmt.Sprintf(`
 # ECR initially only available in us-east-1
 # https://aws.amazon.com/blogs/aws/ec2-container-registry-now-generally-available/
 provider "aws" {
 	region = "us-east-1"
 }
 resource "aws_ecr_repository" "foo" {
-	name = "bar"
+	name = "tf-acc-test-ecr-%s"
 }
 
 resource "aws_ecr_repository_policy" "default" {
@@ -105,23 +111,25 @@ resource "aws_ecr_repository_policy" "default" {
 }
 EOF
 }
-`
+`, randString)
+}
 
 // testAccAWSEcrRepositoryPolicyWithIAMRole creates a new IAM Role and tries
 // to use it's ARN in an ECR Repository Policy. IAM changes need some time to
 // be propagated to other services - like ECR. So the following code should
 // exercise our retry logic, since we try to use the new resource instantly.
-var testAccAWSEcrRepositoryPolicyWithIAMRole = `
+func testAccAWSEcrRepositoryPolicyWithIAMRole(randString string) string {
+	return fmt.Sprintf(`
 provider "aws" {
 	region = "us-east-1"
 }
 
 resource "aws_ecr_repository" "foo" {
-	name = "bar"
+	name = "tf-acc-test-ecr-%s"
 }
 
 resource "aws_iam_role" "foo" {
-  name = "bar"
+  name = "tf-acc-test-ecr-%s"
 
   assume_role_policy = <<EOF
 {
@@ -159,4 +167,5 @@ resource "aws_ecr_repository_policy" "default" {
 }
 EOF
 }
-`
+`, randString, randString)
+}

--- a/aws/resource_aws_ecr_repository_test.go
+++ b/aws/resource_aws_ecr_repository_test.go
@@ -7,18 +7,21 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccAWSEcrRepository_basic(t *testing.T) {
+	randString := acctest.RandString(10)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEcrRepositoryDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEcrRepository,
+				Config: testAccAWSEcrRepository(randString),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcrRepositoryExists("aws_ecr_repository.default"),
 				),
@@ -69,8 +72,10 @@ func testAccCheckAWSEcrRepositoryExists(name string) resource.TestCheckFunc {
 	}
 }
 
-var testAccAWSEcrRepository = `
+func testAccAWSEcrRepository(randString string) string {
+	return fmt.Sprintf(`
 resource "aws_ecr_repository" "default" {
-	name = "foo-repository-terraform"
+	name = "tf-acc-test-ecr-%s"
 }
-`
+`, randString)
+}


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSEcrRepositoryPolicy_iam
--- FAIL: TestAccAWSEcrRepositoryPolicy_iam (6.93s)
    testing.go:428: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_ecr_repository.foo: 1 error(s) occurred:
        
        * aws_ecr_repository.foo: RepositoryAlreadyExistsException: The repository with name 'bar' already exists in the registry with id '*******'
            status code: 400, request id: e8abb2bb-70fe-11e7-a63d-1be4e5fc76eb
FAIL
```

### Test results after patch

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSEcrRepository'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSEcrRepository -timeout 120m
=== RUN   TestAccAWSEcrRepository_importBasic
--- PASS: TestAccAWSEcrRepository_importBasic (36.37s)
=== RUN   TestAccAWSEcrRepositoryPolicy_basic
--- PASS: TestAccAWSEcrRepositoryPolicy_basic (27.26s)
=== RUN   TestAccAWSEcrRepositoryPolicy_iam
--- PASS: TestAccAWSEcrRepositoryPolicy_iam (36.89s)
=== RUN   TestAccAWSEcrRepository_basic
--- PASS: TestAccAWSEcrRepository_basic (33.57s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	134.127s
```