### PR TITLE
[WIP] resource/aws_dynamodb_table: Use just the name to determine hashcode of GSI

### DIFF
--- a/aws/resource_aws_dynamodb_table.go
+++ b/aws/resource_aws_dynamodb_table.go
@@ -177,6 +177,12 @@ func resourceAwsDynamoDbTable() *schema.Resource {
 						},
 					},
 				},
+				Set: func(v interface{}) int {
+					var buf bytes.Buffer
+					m := v.(map[string]interface{})
+					buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
+					return hashcode.String(buf.String())
+				},
 			},
 			"stream_enabled": {
 				Type:     schema.TypeBool,


### PR DESCRIPTION
I'm trying to make changes to DynamoDB GSI capacity ignorable. This is likely the wrong approach. #CunninghamsLaw. I picked up the idea from something that was removed in https://github.com/hashicorp/terraform/pull/13256.

The catch-22 with this approach is if something is not included in calculating the return value of the Set function then when you change said thing it's not updated. I just wanted it to not change the resource address so that I can use `ignore_changes`. For people that _do_ want to control their GSI's capacity in terraform, a change should still be applicable. 

Even if I wanted to hardcode something nasty like `ignore_changes = ["global_secondary_index.3291674533.read_capacity"]`, I can't because "3291674533" is calculated based, in part, on the read_capacity. 

Other ideas:

1) Modify ignore_changes to accept the right kind of wildcard to support this case
2) Are GSIs a bad fit for the type TypeSet, given their mutability? Would it be better to split GSIs out into their own resource?

Closes https://github.com/terraform-providers/terraform-provider-aws/issues/671