### PR TITLE
Added missing attribute in the API Gateway Resource documentation

### DIFF
--- a/aws/resource_aws_api_gateway_resource.go
+++ b/aws/resource_aws_api_gateway_resource.go
@@ -60,9 +60,8 @@ func resourceAwsApiGatewayResourceCreate(d *schema.ResourceData, meta interface{
 	}
 
 	d.SetId(*resource.Id)
-	d.Set("path", resource.Path)
 
-	return nil
+	return resourceAwsApiGatewayResourceRead(d, meta)
 }
 
 func resourceAwsApiGatewayResourceRead(d *schema.ResourceData, meta interface{}) error {
@@ -76,6 +75,7 @@ func resourceAwsApiGatewayResourceRead(d *schema.ResourceData, meta interface{})
 
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NotFoundException" {
+			log.Printf("[WARN] API Gateway Resource (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}

--- a/website/docs/r/api_gateway_resource.html.markdown
+++ b/website/docs/r/api_gateway_resource.html.markdown
@@ -37,5 +37,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `id` - The ID of the API resource
-* `path` - The complete path for this API resource, including all parent paths
+* `id` - The resource's identifier.
+* `parent_id` - The parent resource's identifier.
+* `path` - The complete path for this API resource, including all parent paths.
+* `path_parth` - The last path segment for this resource.

--- a/website/docs/r/api_gateway_resource.html.markdown
+++ b/website/docs/r/api_gateway_resource.html.markdown
@@ -35,9 +35,7 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource's identifier.
-* `parent_id` - The parent resource's identifier.
 * `path` - The complete path for this API resource, including all parent paths.
-* `path_parth` - The last path segment for this resource.


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/1229

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAPIGatewayResource_'                               
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSAPIGatewayResource_ -timeout 120m
=== RUN   TestAccAWSAPIGatewayResource_basic
--- PASS: TestAccAWSAPIGatewayResource_basic (15.40s)
=== RUN   TestAccAWSAPIGatewayResource_update
--- PASS: TestAccAWSAPIGatewayResource_update (46.89s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	62.323s
```