### PR TITLE
Set AWS Config Configuration recorder & Delivery channel names as ForceNew

### DIFF
--- a/aws/resource_aws_config_configuration_recorder.go
+++ b/aws/resource_aws_config_configuration_recorder.go
@@ -26,6 +26,7 @@ func resourceAwsConfigConfigurationRecorder() *schema.Resource {
 			"name": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				ForceNew:     true,
 				Default:      "default",
 				ValidateFunc: validateMaxLength(256),
 			},

--- a/aws/resource_aws_config_delivery_channel.go
+++ b/aws/resource_aws_config_delivery_channel.go
@@ -28,6 +28,7 @@ func resourceAwsConfigDeliveryChannel() *schema.Resource {
 			"name": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				ForceNew:     true,
 				Default:      "default",
 				ValidateFunc: validateMaxLength(256),
 			},

--- a/website/docs/r/config_configuration_recorder.html.markdown
+++ b/website/docs/r/config_configuration_recorder.html.markdown
@@ -45,8 +45,8 @@ POLICY
 
 The following arguments are supported:
 
-* `name` - (Optional) The name of the recorder. Defaults to `default`
-* `role_arn` - (Required) Amazon Resource Name (ARN) of the IAM role
+* `name` - (Optional) The name of the recorder. Defaults to `default`. Changing it recreates the resource.
+* `role_arn` - (Required) Amazon Resource Name (ARN) of the IAM role.
 	used to make read or write requests to the delivery channel and to describe the AWS resources associated with the account.
 	See [AWS Docs](http://docs.aws.amazon.com/config/latest/developerguide/iamrole-permissions.html) for more details.
 * `recording_group` - (Optional) Recording group - see below.

--- a/website/docs/r/config_delivery_channel.html.markdown
+++ b/website/docs/r/config_delivery_channel.html.markdown
@@ -79,7 +79,7 @@ POLICY
 
 The following arguments are supported:
 
-* `name` - (Optional) The name of the delivery channel. Defaults to `default`.
+* `name` - (Optional) The name of the delivery channel. Defaults to `default`. Changing it recreates the resource.
 * `s3_bucket_name` - (Required) The name of the S3 bucket used to store the configuration history.
 * `s3_key_prefix` - (Optional) The prefix for the specified S3 bucket.
 * `sns_topic_arn` - (Optional) The ARN of the SNS topic that AWS Config delivers notifications to.


### PR DESCRIPTION
As per the documentation, AWS Config Delivery channel & Configuration recorder name attributes cannot be changed once set.

*AWS Config Delivery Channel quote* ([documentation](http://docs.aws.amazon.com/config/latest/APIReference/API_DeliveryChannel.html#config-Type-DeliveryChannel-name))
> By default, AWS Config assigns the name "default" when creating the delivery channel. To change the delivery channel name, you must use the DeleteDeliveryChannel action to delete your current delivery channel, and then you must use the PutDeliveryChannel command to create a delivery channel that has the desired name.

*Config Configuration Recorder quote* ([documentation](http://docs.aws.amazon.com/config/latest/APIReference/API_ConfigurationRecorder.html#config-Type-ConfigurationRecorder-name))
> By default, AWS Config automatically assigns the name "default" when creating the configuration recorder. You cannot change the assigned name.

Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/1244

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSConfig'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSConfig -timeout 120m
=== RUN   TestAccAWSConfig
=== RUN   TestAccAWSConfig/Config
=== RUN   TestAccAWSConfig/Config/basic
=== RUN   TestAccAWSConfig/Config/ownerAws
=== RUN   TestAccAWSConfig/Config/customlambda
=== RUN   TestAccAWSConfig/Config/importAws
=== RUN   TestAccAWSConfig/Config/importLambda
=== RUN   TestAccAWSConfig/ConfigurationRecorderStatus
=== RUN   TestAccAWSConfig/ConfigurationRecorderStatus/basic
=== RUN   TestAccAWSConfig/ConfigurationRecorderStatus/startEnabled
=== RUN   TestAccAWSConfig/ConfigurationRecorderStatus/importBasic
=== RUN   TestAccAWSConfig/ConfigurationRecorder
=== RUN   TestAccAWSConfig/ConfigurationRecorder/importBasic
=== RUN   TestAccAWSConfig/ConfigurationRecorder/basic
=== RUN   TestAccAWSConfig/ConfigurationRecorder/allParams
=== RUN   TestAccAWSConfig/DeliveryChannel
=== RUN   TestAccAWSConfig/DeliveryChannel/allParams
=== RUN   TestAccAWSConfig/DeliveryChannel/importBasic
=== RUN   TestAccAWSConfig/DeliveryChannel/basic
--- PASS: TestAccAWSConfig (1471.07s)
    --- PASS: TestAccAWSConfig/Config (689.47s)
        --- PASS: TestAccAWSConfig/Config/basic (117.88s)
        --- PASS: TestAccAWSConfig/Config/ownerAws (123.45s)
        --- PASS: TestAccAWSConfig/Config/customlambda (161.84s)
        --- PASS: TestAccAWSConfig/Config/importAws (118.49s)
        --- PASS: TestAccAWSConfig/Config/importLambda (167.82s)
    --- PASS: TestAccAWSConfig/ConfigurationRecorderStatus (276.61s)
        --- PASS: TestAccAWSConfig/ConfigurationRecorderStatus/basic (70.03s)
        --- PASS: TestAccAWSConfig/ConfigurationRecorderStatus/startEnabled (141.84s)
        --- PASS: TestAccAWSConfig/ConfigurationRecorderStatus/importBasic (64.75s)
    --- PASS: TestAccAWSConfig/ConfigurationRecorder (209.10s)
        --- PASS: TestAccAWSConfig/ConfigurationRecorder/importBasic (64.31s)
        --- PASS: TestAccAWSConfig/ConfigurationRecorder/basic (72.20s)
        --- PASS: TestAccAWSConfig/ConfigurationRecorder/allParams (72.59s)
    --- PASS: TestAccAWSConfig/DeliveryChannel (295.89s)
        --- PASS: TestAccAWSConfig/DeliveryChannel/allParams (105.68s)
        --- PASS: TestAccAWSConfig/DeliveryChannel/importBasic (107.22s)
        --- PASS: TestAccAWSConfig/DeliveryChannel/basic (82.99s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1471.097s
```