### PR TITLE
New Data Source: aws_efs_mount_target

### DIFF
--- a/aws/data_source_aws_efs_mount_target.go
+++ b/aws/data_source_aws_efs_mount_target.go
@@ -1,0 +1,95 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/efs"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsEfsMountTarget() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsEfsMountTargetRead,
+
+		Schema: map[string]*schema.Schema{
+			"mount_target_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"file_system_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ip_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"security_groups": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+				Computed: true,
+			},
+			"subnet_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"network_interface_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"dns_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsEfsMountTargetRead(d *schema.ResourceData, meta interface{}) error {
+	efsconn := meta.(*AWSClient).efsconn
+
+	describeEfsOpts := &efs.DescribeMountTargetsInput{
+		MountTargetId: aws.String(d.Get("mount_target_id").(string)),
+	}
+
+	resp, err := efsconn.DescribeMountTargets(describeEfsOpts)
+	if err != nil {
+		return errwrap.Wrapf("Error retrieving EFS Mount Target: {{err}}", err)
+	}
+	if len(resp.MountTargets) != 1 {
+		return fmt.Errorf("Search returned %d results, please revise so only one is returned", len(resp.MountTargets))
+	}
+
+	mt := resp.MountTargets[0]
+
+	log.Printf("[DEBUG] Found EFS mount target: %#v", mt)
+
+	d.SetId(*mt.MountTargetId)
+	d.Set("file_system_id", mt.FileSystemId)
+	d.Set("ip_address", mt.IpAddress)
+	d.Set("subnet_id", mt.SubnetId)
+	d.Set("network_interface_id", mt.NetworkInterfaceId)
+
+	sgResp, err := efsconn.DescribeMountTargetSecurityGroups(&efs.DescribeMountTargetSecurityGroupsInput{
+		MountTargetId: aws.String(d.Id()),
+	})
+	if err != nil {
+		return err
+	}
+	err = d.Set("security_groups", schema.NewSet(schema.HashString, flattenStringList(sgResp.SecurityGroups)))
+	if err != nil {
+		return err
+	}
+
+	if err := d.Set("dns_name", resourceAwsEfsMountTargetDnsName(*mt.FileSystemId, meta.(*AWSClient).region)); err != nil {
+		return fmt.Errorf("[DEBUG] Error setting dns_name error: %#v", err)
+	}
+
+	return nil
+}

--- a/aws/data_source_aws_efs_mount_target_test.go
+++ b/aws/data_source_aws_efs_mount_target_test.go
@@ -1,0 +1,59 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceAwsEfsMountTargetByMountTargetId(t *testing.T) {
+	rName := acctest.RandString(10)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsEfsMountTargetConfigByMountTargetId(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.aws_efs_mount_target.by_mount_target_id", "file_system_id"),
+					resource.TestCheckResourceAttrSet("data.aws_efs_mount_target.by_mount_target_id", "ip_address"),
+					resource.TestCheckResourceAttrSet("data.aws_efs_mount_target.by_mount_target_id", "subnet_id"),
+					resource.TestCheckResourceAttrSet("data.aws_efs_mount_target.by_mount_target_id", "network_interface_id"),
+					resource.TestCheckResourceAttrSet("data.aws_efs_mount_target.by_mount_target_id", "dns_name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAwsEfsMountTargetConfigByMountTargetId(ct string) string {
+	return fmt.Sprintf(`
+resource "aws_efs_file_system" "foo" {
+	creation_token = "%s"
+}
+
+resource "aws_efs_mount_target" "alpha" {
+	file_system_id = "${aws_efs_file_system.foo.id}"
+	subnet_id = "${aws_subnet.alpha.id}"
+}
+
+resource "aws_vpc" "foo" {
+	cidr_block = "10.0.0.0/16"
+	tags {
+		Name = "testAccAWSEFSMountTargetConfig"
+	}
+}
+
+resource "aws_subnet" "alpha" {
+	vpc_id = "${aws_vpc.foo.id}"
+	availability_zone = "us-west-2a"
+	cidr_block = "10.0.1.0/24"
+}
+
+data "aws_efs_mount_target" "by_mount_target_id" {
+	mount_target_id = "${aws_efs_mount_target.alpha.id}"
+}
+`, ct)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -182,6 +182,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_ecs_container_definition": dataSourceAwsEcsContainerDefinition(),
 			"aws_ecs_task_definition":      dataSourceAwsEcsTaskDefinition(),
 			"aws_efs_file_system":          dataSourceAwsEfsFileSystem(),
+			"aws_efs_mount_target":         dataSourceAwsEfsMountTarget(),
 			"aws_eip":                      dataSourceAwsEip(),
 			"aws_elastic_beanstalk_solution_stack": dataSourceAwsElasticBeanstalkSolutionStack(),
 			"aws_elasticache_cluster":              dataSourceAwsElastiCacheCluster(),

--- a/aws/resource_aws_efs_mount_target.go
+++ b/aws/resource_aws_efs_mount_target.go
@@ -25,20 +25,20 @@ func resourceAwsEfsMountTarget() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"file_system_id": &schema.Schema{
+			"file_system_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"ip_address": &schema.Schema{
+			"ip_address": {
 				Type:     schema.TypeString,
 				Computed: true,
 				Optional: true,
 				ForceNew: true,
 			},
 
-			"security_groups": &schema.Schema{
+			"security_groups": {
 				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
@@ -46,17 +46,17 @@ func resourceAwsEfsMountTarget() *schema.Resource {
 				Optional: true,
 			},
 
-			"subnet_id": &schema.Schema{
+			"subnet_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"network_interface_id": &schema.Schema{
+			"network_interface_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"dns_name": &schema.Schema{
+			"dns_name": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -83,6 +83,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-efs-file-system") %>>
                             <a href="/docs/providers/aws/d/efs_file_system.html">aws_efs_file_system</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-efs-mount-target") %>>
+                            <a href="/docs/providers/aws/d/efs_mount_target.html">aws_efs_mount_target</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-eip") %>>
                             <a href="/docs/providers/aws/d/eip.html">aws_eip</a>
                         </li>

--- a/website/docs/d/efs_mount_target.html.markdown
+++ b/website/docs/d/efs_mount_target.html.markdown
@@ -1,0 +1,42 @@
+---
+layout: "aws"
+page_title: "AWS: efs_file_system"
+sidebar_current: "docs-aws-datasource-efs-file-system"
+description: |-
+  Provides an Elastic File System Mount Target (EFS) data source.
+---
+
+# aws_efs_file_system
+
+Provides information about an Elastic File System Mount Target (EFS).
+
+## Example Usage
+
+```hcl
+variable "mount_target_id" {
+  type = "string"
+  default = ""
+}
+
+data "aws_efs_mount_target" "by_id" {
+  mount_target_id = "${var.mount_target_id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `mount_target_id` - (Required) ID of the mount target that you want to have described
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `file_system_id` - ID of the file system for which the mount target is intended.
+* `subnet_id` - ID of the mount target's subnet.
+* `ip_address` - Address at which the file system may be mounted via the mount target.
+* `security_groups` - List of VPC security group IDs attached to the mount target.
+* `dns_name` - The DNS name for the given subnet/AZ per [documented convention](http://docs.aws.amazon.com/efs/latest/ug/mounting-fs-mount-cmd-dns-name.html).
+* `network_interface_id` - The ID of the network interface that Amazon EFS created when it created the mount target.
+


### PR DESCRIPTION
Fixes: #1207

```
% make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsEfsMountTarget'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccDataSourceAwsEfsMountTarget -timeout 120m
=== RUN   TestAccDataSourceAwsEfsMountTargetByMountTargetId
--- PASS: TestAccDataSourceAwsEfsMountTargetByMountTargetId (253.06s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	253.094s
```