### PR TITLE
resource/aws_ssm_patch_baseline: Update support for Operating System

### DIFF
--- a/website/docs/r/ssm_patch_baseline.html.markdown
+++ b/website/docs/r/ssm_patch_baseline.html.markdown
@@ -77,6 +77,8 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the patch baseline.
 * `description` - (Optional) The description of the patch baseline.
+* `operating_system` - (Optional) Defines the operating system the patch baseline applies to. Supported operating systems include `WINDOWS`, `AMAZON_LINUX`, `UBUNTU` and `REDHAT_ENTERPRISE_LINUX`. The Default value is `WINDOWS`.
+* `approved_patches_compliance_level` - (Optional) Defines the compliance level for approved patches. This means that if an approved patch is reported as missing, this is the severity of the compliance violation. Valid compliance severity levels include the following: `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, `INFORMATIONAL`, `UNSPECIFIED`. The default value is `UNSPECIFIED`.
 * `approved_patches` - (Optional) A list of explicitly approved patches for the baseline.
 * `rejected_patches` - (Optional) A list of rejected patches.
 * `global_filter` - (Optional) A set of global filters used to exclude patches from the baseline. Up to 4 global filters can be specified using Key/Value pairs. Valid Keys are `PRODUCT | CLASSIFICATION | MSRC_SEVERITY | PATCH_ID`.


### PR DESCRIPTION
Fixes: #1257

I am going to add `operating_system` and
`approved_patches_compliance_level` only in this PR - I believe that an
overhaul of SSM to remove ForceNew from all of SSM resources can be
added in a follow up PR if that suffices

```
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSSSMPatchBaseline'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSSSMPatchBaseline -timeout 120m
=== RUN   TestAccAWSSSMPatchBaseline_basic
--- PASS: TestAccAWSSSMPatchBaseline_basic (43.22s)
=== RUN   TestAccAWSSSMPatchBaselineWithOperatingSystem
--- PASS: TestAccAWSSSMPatchBaselineWithOperatingSystem (23.45s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	66.691s
```