### PR TITLE
Add precendence for aws_cloudfront_distribution cache behaviors

### DIFF
--- a/aws/cloudfront_distribution_configuration_structure.go
+++ b/aws/cloudfront_distribution_configuration_structure.go
@@ -42,7 +42,7 @@ func (p StringPtrSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 // Used by the aws_cloudfront_distribution Create and Update functions.
 func expandDistributionConfig(d *schema.ResourceData) *cloudfront.DistributionConfig {
 	distributionConfig := &cloudfront.DistributionConfig{
-		CacheBehaviors:       expandCacheBehaviors(d.Get("cache_behavior").(*schema.Set)),
+		CacheBehaviors:       expandCacheBehaviors(d.Get("cache_behavior").([]interface{})),
 		CustomErrorResponses: expandCustomErrorResponses(d.Get("custom_error_response").(*schema.Set)),
 		DefaultCacheBehavior: expandDefaultCacheBehavior(d.Get("default_cache_behavior").(*schema.Set).List()[0].(map[string]interface{})),
 		Enabled:              aws.Bool(d.Get("enabled").(bool)),
@@ -219,12 +219,12 @@ func defaultCacheBehaviorHash(v interface{}) int {
 		buf.WriteString(fmt.Sprintf("%d-", d.(int)))
 	}
 	if d, ok := m["allowed_methods"]; ok {
-		for _, e := range sortInterfaceSlice(d.([]interface{})) {
+		for _, e := range sortInterfaceSlice(d.(*schema.Set).List()) {
 			buf.WriteString(fmt.Sprintf("%s-", e.(string)))
 		}
 	}
 	if d, ok := m["cached_methods"]; ok {
-		for _, e := range sortInterfaceSlice(d.([]interface{})) {
+		for _, e := range sortInterfaceSlice(d.(*schema.Set).List()) {
 			buf.WriteString(fmt.Sprintf("%s-", e.(string)))
 		}
 	}
@@ -243,10 +243,10 @@ func defaultCacheBehaviorHash(v interface{}) int {
 	return hashcode.String(buf.String())
 }
 
-func expandCacheBehaviors(s *schema.Set) *cloudfront.CacheBehaviors {
+func expandCacheBehaviors(lst []interface{}) *cloudfront.CacheBehaviors {
 	var qty int64
 	var items []*cloudfront.CacheBehavior
-	for _, v := range s.List() {
+	for _, v := range lst {
 		items = append(items, expandCacheBehavior(v.(map[string]interface{})))
 		qty++
 	}
@@ -256,12 +256,12 @@ func expandCacheBehaviors(s *schema.Set) *cloudfront.CacheBehaviors {
 	}
 }
 
-func flattenCacheBehaviors(cbs *cloudfront.CacheBehaviors) *schema.Set {
-	s := []interface{}{}
+func flattenCacheBehaviors(cbs *cloudfront.CacheBehaviors) []interface{} {
+	lst := []interface{}{}
 	for _, v := range cbs.Items {
-		s = append(s, flattenCacheBehavior(v))
+		lst = append(lst, flattenCacheBehavior(v))
 	}
-	return schema.NewSet(cacheBehaviorHash, s)
+	return lst
 }
 
 func expandCacheBehavior(m map[string]interface{}) *cloudfront.CacheBehavior {
@@ -288,10 +288,10 @@ func expandCacheBehavior(m map[string]interface{}) *cloudfront.CacheBehavior {
 		cb.SmoothStreaming = aws.Bool(v.(bool))
 	}
 	if v, ok := m["allowed_methods"]; ok {
-		cb.AllowedMethods = expandAllowedMethods(v.([]interface{}))
+		cb.AllowedMethods = expandAllowedMethods(v.(*schema.Set))
 	}
 	if v, ok := m["cached_methods"]; ok {
-		cb.AllowedMethods.CachedMethods = expandCachedMethods(v.([]interface{}))
+		cb.AllowedMethods.CachedMethods = expandCachedMethods(v.(*schema.Set))
 	}
 	if v, ok := m["path_pattern"]; ok {
 		cb.PathPattern = aws.String(v.(string))
@@ -333,58 +333,6 @@ func flattenCacheBehavior(cb *cloudfront.CacheBehavior) map[string]interface{} {
 		m["path_pattern"] = *cb.PathPattern
 	}
 	return m
-}
-
-// Assemble the hash for the aws_cloudfront_distribution cache_behavior
-// TypeSet attribute.
-func cacheBehaviorHash(v interface{}) int {
-	var buf bytes.Buffer
-	m := v.(map[string]interface{})
-	buf.WriteString(fmt.Sprintf("%t-", m["compress"].(bool)))
-	buf.WriteString(fmt.Sprintf("%s-", m["viewer_protocol_policy"].(string)))
-	buf.WriteString(fmt.Sprintf("%s-", m["target_origin_id"].(string)))
-	buf.WriteString(fmt.Sprintf("%d-", forwardedValuesHash(m["forwarded_values"].(*schema.Set).List()[0].(map[string]interface{}))))
-	buf.WriteString(fmt.Sprintf("%d-", m["min_ttl"].(int)))
-	if d, ok := m["trusted_signers"]; ok {
-		for _, e := range sortInterfaceSlice(d.([]interface{})) {
-			buf.WriteString(fmt.Sprintf("%s-", e.(string)))
-		}
-	}
-	if d, ok := m["max_ttl"]; ok {
-		buf.WriteString(fmt.Sprintf("%d-", d.(int)))
-	}
-	if d, ok := m["smooth_streaming"]; ok {
-		buf.WriteString(fmt.Sprintf("%t-", d.(bool)))
-	}
-	if d, ok := m["default_ttl"]; ok {
-		buf.WriteString(fmt.Sprintf("%d-", d.(int)))
-	}
-	if d, ok := m["allowed_methods"]; ok {
-		for _, e := range sortInterfaceSlice(d.([]interface{})) {
-			buf.WriteString(fmt.Sprintf("%s-", e.(string)))
-		}
-	}
-	if d, ok := m["cached_methods"]; ok {
-		for _, e := range sortInterfaceSlice(d.([]interface{})) {
-			buf.WriteString(fmt.Sprintf("%s-", e.(string)))
-		}
-	}
-	if d, ok := m["path_pattern"]; ok {
-		buf.WriteString(fmt.Sprintf("%s-", d))
-	}
-	if d, ok := m["lambda_function_association"]; ok {
-		var associations []interface{}
-		switch d.(type) {
-		case *schema.Set:
-			associations = d.(*schema.Set).List()
-		default:
-			associations = d.([]interface{})
-		}
-		for _, lfa := range associations {
-			buf.WriteString(fmt.Sprintf("%d-", lambdaFunctionAssociationHash(lfa.(map[string]interface{}))))
-		}
-	}
-	return hashcode.String(buf.String())
 }
 
 func expandTrustedSigners(s []interface{}) *cloudfront.TrustedSigners {
@@ -588,32 +536,32 @@ func flattenCookieNames(cn *cloudfront.CookieNames) []interface{} {
 	return []interface{}{}
 }
 
-func expandAllowedMethods(s []interface{}) *cloudfront.AllowedMethods {
+func expandAllowedMethods(s *schema.Set) *cloudfront.AllowedMethods {
 	return &cloudfront.AllowedMethods{
-		Quantity: aws.Int64(int64(len(s))),
-		Items:    expandStringList(s),
+		Quantity: aws.Int64(int64(s.Len())),
+		Items:    expandStringList(s.List()),
 	}
 }
 
-func flattenAllowedMethods(am *cloudfront.AllowedMethods) []interface{} {
+func flattenAllowedMethods(am *cloudfront.AllowedMethods) *schema.Set {
 	if am.Items != nil {
-		return flattenStringList(am.Items)
+		return schema.NewSet(schema.HashString, flattenStringList(am.Items))
 	}
-	return []interface{}{}
+	return nil
 }
 
-func expandCachedMethods(s []interface{}) *cloudfront.CachedMethods {
+func expandCachedMethods(s *schema.Set) *cloudfront.CachedMethods {
 	return &cloudfront.CachedMethods{
-		Quantity: aws.Int64(int64(len(s))),
-		Items:    expandStringList(s),
+		Quantity: aws.Int64(int64(s.Len())),
+		Items:    expandStringList(s.List()),
 	}
 }
 
-func flattenCachedMethods(cm *cloudfront.CachedMethods) []interface{} {
+func flattenCachedMethods(cm *cloudfront.CachedMethods) *schema.Set {
 	if cm.Items != nil {
-		return flattenStringList(cm.Items)
+		return schema.NewSet(schema.HashString, flattenStringList(cm.Items))
 	}
-	return []interface{}{}
+	return nil
 }
 
 func expandOrigins(s *schema.Set) *cloudfront.Origins {

--- a/aws/resource_aws_cloudfront_distribution.go
+++ b/aws/resource_aws_cloudfront_distribution.go
@@ -35,18 +35,17 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 				Set:      aliasesHash,
 			},
 			"cache_behavior": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Optional: true,
-				Set:      cacheBehaviorHash,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"allowed_methods": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Required: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 						"cached_methods": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Required: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
@@ -189,12 +188,12 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"allowed_methods": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Required: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 						"cached_methods": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Required: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -76,6 +76,49 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     max_ttl                = 86400
   }
 
+  # Cache behavior with precedence 0
+  cache_behavior {
+    path_pattern     = "/content/immutable/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = "myS3Origin"
+
+    forwarded_values {
+      query_string = false
+      headers = ["Origin"]
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  # Cache behavior with precedence 1
+  cache_behavior {
+    path_pattern     = "/content/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "myS3Origin"
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
   price_class = "PriceClass_200"
 
   restrictions {
@@ -106,7 +149,8 @@ of several sub-resources - these resources are laid out below.
     this distribution.
 
   * `cache_behavior` (Optional) - A [cache behavior](#cache-behavior-arguments)
-    resource for this distribution (multiples allowed).
+    resource for this distribution (multiples allowed). List from top to bottom
+    in order of precedence. The topmost cache behavior will have precedence 0.
 
   * `comment` (Optional) - Any comments you want to include about the
     distribution.


### PR DESCRIPTION
The goal of this PR is to address #188.

This PR changes `cache_behavior` of the `aws_cloudfront_distribution` resource from a `TypeSet` to a `TypeList`. By making this a list, we can set the precedence of cache behaviors in CloudFront.

Tested against AWS using `Terraform v0.10.0-dev` local build.