### PR TITLE
r/aws_autoscaling_schedule: Allow empty value

### DIFF
--- a/aws/resource_aws_autoscaling_schedule_test.go
+++ b/aws/resource_aws_autoscaling_schedule_test.go
@@ -117,10 +117,31 @@ func TestAccAWSAutoscalingSchedule_zeroValues(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAutoscalingScheduleDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSAutoscalingScheduleConfig_zeroValues(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScalingScheduleExists("aws_autoscaling_schedule.foobar", &schedule),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAutoscalingSchedule_negativeOne(t *testing.T) {
+	var schedule autoscaling.ScheduledUpdateGroupAction
+
+	rName := fmt.Sprintf("tf-test-%d", acctest.RandInt())
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAutoscalingScheduleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAutoscalingScheduleConfig_negativeOne(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalingScheduleExists("aws_autoscaling_schedule.foobar", &schedule),
+					testAccCheckScalingScheduleHasNoDesiredCapacity(&schedule),
+					resource.TestCheckResourceAttr("aws_autoscaling_schedule.foobar", "desired_capacity", "-1"),
 				),
 			},
 		},
@@ -180,6 +201,17 @@ func testAccCheckAWSAutoscalingScheduleDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccCheckScalingScheduleHasNoDesiredCapacity(
+	schedule *autoscaling.ScheduledUpdateGroupAction) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if schedule.DesiredCapacity == nil {
+			return nil
+		}
+		return fmt.Errorf("Expected not to set desired capacity, got %v",
+			aws.Int64Value(schedule.DesiredCapacity))
+	}
 }
 
 func testAccAWSAutoscalingScheduleConfig(r, start, end string) string {
@@ -283,6 +315,42 @@ resource "aws_autoscaling_schedule" "foobar" {
     max_size = 0
     min_size = 0
     desired_capacity = 0
+    start_time = "2018-01-16T07:00:00Z"
+    end_time = "2018-01-16T13:00:00Z"
+    autoscaling_group_name = "${aws_autoscaling_group.foobar.name}"
+}`, r, r)
+}
+
+func testAccAWSAutoscalingScheduleConfig_negativeOne(r string) string {
+	return fmt.Sprintf(`
+resource "aws_launch_configuration" "foobar" {
+    name = "%s"
+    image_id = "ami-21f78e11"
+    instance_type = "t1.micro"
+}
+
+resource "aws_autoscaling_group" "foobar" {
+    availability_zones = ["us-west-2a"]
+    name = "%s"
+    max_size = 1
+    min_size = 1
+    health_check_grace_period = 300
+    health_check_type = "ELB"
+    force_delete = true
+    termination_policies = ["OldestInstance"]
+    launch_configuration = "${aws_launch_configuration.foobar.name}"
+    tag {
+        key = "Foo"
+        value = "foo-bar"
+        propagate_at_launch = true
+    }
+}
+
+resource "aws_autoscaling_schedule" "foobar" {
+    scheduled_action_name = "foobar"
+    max_size = 3
+    min_size = 1
+    desired_capacity = -1
     start_time = "2018-01-16T07:00:00Z"
     end_time = "2018-01-16T13:00:00Z"
     autoscaling_group_name = "${aws_autoscaling_group.foobar.name}"

--- a/website/docs/r/autoscaling_schedule.html.markdown
+++ b/website/docs/r/autoscaling_schedule.html.markdown
@@ -47,10 +47,10 @@ The following arguments are supported:
                           If you try to schedule your action in the past, Auto Scaling returns an error message.
 * `recurrence` - (Optional) The time when recurring future actions will start. Start time is specified by the user following the Unix cron syntax format.
 * `min_size` - (Optional) The minimum size for the Auto Scaling group. Default
-0.
+0. Set to -1 if you don't want to change the minimum size at the scheduled time.
 * `max_size` - (Optional) The maximum size for the Auto Scaling group. Default
-0.
-* `desired_capacity` - (Optional) The number of EC2 instances that should be running in the group. Default 0.
+0. Set to -1 if you don't want to change the maximum size at the scheduled time.
+* `desired_capacity` - (Optional) The number of EC2 instances that should be running in the group. Default 0.  Set to -1 if you don't want to change the desired capacity at the scheduled time.
 
 ~> **NOTE:** When `start_time` and `end_time` are specified with `recurrence` , they form the boundaries of when the recurring action will start and stop.
 


### PR DESCRIPTION
Initially opened in https://github.com/hashicorp/terraform/issues/9941
Migrated to the new provider repository

```
$ make testacc TEST=./aws TESTARGS="-run=TestAccAWSAutoscalingSchedule_negativeOne"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSAutoscalingSchedule_negativeOne -timeout 120m
=== RUN   TestAccAWSAutoscalingSchedule_negativeOne
--- PASS: TestAccAWSAutoscalingSchedule_negativeOne (182.68s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       182.688s
```

Initial work done by @glasser