### PR TITLE
emr_cluster/instance: force emr connection argument for refresh func

### DIFF
--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -360,7 +360,7 @@ func resourceAwsEMRClusterRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("cluster_state", cluster.Status.State)
 	}
 
-	instanceGroups, err := fetchAllEMRInstanceGroups(meta, d.Id())
+	instanceGroups, err := fetchAllEMRInstanceGroups(emrconn, d.Id())
 	if err == nil {
 		coreGroup := findGroup(instanceGroups, "CORE")
 		if coreGroup != nil {
@@ -414,7 +414,7 @@ func resourceAwsEMRClusterUpdate(d *schema.ResourceData, meta interface{}) error
 	if d.HasChange("core_instance_count") {
 		d.SetPartial("core_instance_count")
 		log.Printf("[DEBUG] Modify EMR cluster")
-		groups, err := fetchAllEMRInstanceGroups(meta, d.Id())
+		groups, err := fetchAllEMRInstanceGroups(conn, d.Id())
 		if err != nil {
 			log.Printf("[DEBUG] Error finding all instance groups: %s", err)
 			return err

--- a/aws/resource_aws_emr_instance_group.go
+++ b/aws/resource_aws_emr_instance_group.go
@@ -155,7 +155,8 @@ func resourceAwsEMRInstanceGroupCreate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceAwsEMRInstanceGroupRead(d *schema.ResourceData, meta interface{}) error {
-	group, err := fetchEMRInstanceGroup(meta, d.Get("cluster_id").(string), d.Id())
+	conn := meta.(*AWSClient).emrconn
+	group, err := fetchEMRInstanceGroup(conn, d.Get("cluster_id").(string), d.Id())
 	if err != nil {
 		switch err {
 		case emrInstanceGroupNotFound:
@@ -186,8 +187,7 @@ func resourceAwsEMRInstanceGroupRead(d *schema.ResourceData, meta interface{}) e
 	return nil
 }
 
-func fetchAllEMRInstanceGroups(meta interface{}, clusterId string) ([]*emr.InstanceGroup, error) {
-	conn := meta.(*AWSClient).emrconn
+func fetchAllEMRInstanceGroups(conn *emr.EMR, clusterId string) ([]*emr.InstanceGroup, error) {
 	req := &emr.ListInstanceGroupsInput{
 		ClusterId: aws.String(clusterId),
 	}
@@ -221,8 +221,8 @@ func fetchAllEMRInstanceGroups(meta interface{}, clusterId string) ([]*emr.Insta
 	return groups, nil
 }
 
-func fetchEMRInstanceGroup(meta interface{}, clusterId, groupId string) (*emr.InstanceGroup, error) {
-	groups, err := fetchAllEMRInstanceGroups(meta, clusterId)
+func fetchEMRInstanceGroup(conn *emr.EMR, clusterId, groupId string) (*emr.InstanceGroup, error) {
+	groups, err := fetchAllEMRInstanceGroups(conn, clusterId)
 	if err != nil {
 		return nil, err
 	}
@@ -280,9 +280,9 @@ func resourceAwsEMRInstanceGroupUpdate(d *schema.ResourceData, meta interface{})
 	return resourceAwsEMRInstanceGroupRead(d, meta)
 }
 
-func instanceGroupStateRefresh(meta interface{}, clusterID, igID string) resource.StateRefreshFunc {
+func instanceGroupStateRefresh(conn *emr.EMR, clusterID, igID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		group, err := fetchEMRInstanceGroup(meta, clusterID, igID)
+		group, err := fetchEMRInstanceGroup(conn, clusterID, igID)
 		if err != nil {
 			return nil, "Not Found", err
 		}


### PR DESCRIPTION
#1264 crashes because of a wrong type assertion. Here I change the method signature `instanceGroupStateRefresh` to specifically call for an `*emr.EMR` type. I did this expecting to find a complication error where we're sending an `*emr.EMR` instead of the expected `*AWSClient`, but that never happened. 

I've included a test that panics on master, but passes now. 

Fixes #1264