### PR TITLE
resource/aws_instance: Guard check for aws_instance UserData to prevent panic

### DIFF
--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -718,7 +718,7 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			return err
 		}
-		if attr.UserData.Value != nil {
+		if attr.UserData != nil && attr.UserData.Value != nil {
 			d.Set("user_data", userDataHashSum(*attr.UserData.Value))
 		}
 	}


### PR DESCRIPTION
Fixes: #581

This is just a simple guard clause to make sure that we are checking
UserData is not nil before we check that the UserData.Value is not nil