### PR TITLE
Added CloudWatch Dashboard documentation

### DIFF
--- a/website/aws.erb
+++ b/website/aws.erb
@@ -303,6 +303,10 @@
                 <li<%= sidebar_current("docs-aws-resource-cloudwatch") %>>
                     <a href="#">CloudWatch Resources</a>
                     <ul class="nav nav-visible">
+                        <li<%= sidebar_current("docs-aws-resource-cloudwatch-dashboard") %>>
+                            <a href="/docs/providers/aws/r/cloudwatch_dashboard.html">aws_cloudwatch_dashboard</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-aws-resource-cloudwatch-event-rule") %>>
                             <a href="/docs/providers/aws/r/cloudwatch_event_rule.html">aws_cloudwatch_event_rule</a>
                         </li>

--- a/website/docs/r/cloudwatch_dashboard.html.markdown
+++ b/website/docs/r/cloudwatch_dashboard.html.markdown
@@ -1,0 +1,77 @@
+---
+layout: "aws"
+page_title: "AWS: aws_cloudwatch_dashboard"
+sidebar_current: "docs-aws-resource-cloudwatch-dashboard"
+description: |-
+  Provides a CloudWatch Dashboard resource.
+---
+
+# aws_cloudwatch_dashboard
+
+Provides a CloudWatch Dashboard resource.
+
+## Example Usage
+
+```hcl
+resource "aws_cloudwatch_dashboard" "main" {
+   dashboard_name = "my-dashboard"
+   dashboard_body = <<EOF
+ {
+   "widgets": [
+       {
+          "type":"metric",
+          "x":0,
+          "y":0,
+          "width":12,
+          "height":6,
+          "properties":{
+             "metrics":[
+                [
+                   "AWS/EC2",
+                   "CPUUtilization",
+                   "InstanceId",
+                   "i-012345"
+                ]
+             ],
+             "period":300,
+             "stat":"Average",
+             "region":"us-east-1",
+             "title":"EC2 Instance CPU"
+          }
+       },
+       {
+          "type":"text",
+          "x":0,
+          "y":7,
+          "width":3,
+          "height":3,
+          "properties":{
+             "markdown":"Hello world"
+          }
+       }
+   ]
+ }
+ EOF
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `dashboard_name` - (Required) The name of the dashboard.
+* `dashboard_body` - (Required) The detailed information about the dashboard, including what widgets are included and their location on the dashboard. You can read more about the body structure in the [documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/CloudWatch-Dashboard-Body-Structure.html).
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `dashboard_arn` - The Amazon Resource Name (ARN) of the dashboard.
+
+## Import
+
+CloudWatch dashboards can be imported using the `dashboard_name`, e.g.
+
+```
+$ terraform import aws_cloudwatch_dashboard.sample <dashboard_name>
+```


### PR DESCRIPTION
This adds the missing bit when reviewing https://github.com/terraform-providers/terraform-provider-aws/pull/1172.