### PR TITLE
Support > 20 parameters in rds cluster parameter groups

### DIFF
--- a/aws/resource_aws_rds_cluster_parameter_group.go
+++ b/aws/resource_aws_rds_cluster_parameter_group.go
@@ -13,6 +13,8 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
+const rdsClusterParameterGroupMaxParamsBulkEdit = 20
+
 func resourceAwsRDSClusterParameterGroup() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsRDSClusterParameterGroupCreate,
@@ -217,16 +219,16 @@ func resourceAwsRDSClusterParameterGroupUpdate(d *schema.ResourceData, meta inte
 		if len(parameters) > 0 {
 			// We can only modify 20 parameters at a time, so walk them until
 			// we've got them all.
-			maxParams := 20
 			for parameters != nil {
 				paramsToModify := make([]*rds.Parameter, 0)
-				if len(parameters) <= maxParams {
+				if len(parameters) <= rdsClusterParameterGroupMaxParamsBulkEdit {
 					paramsToModify, parameters = parameters[:], nil
 				} else {
-					paramsToModify, parameters = parameters[:maxParams], parameters[maxParams:]
+					paramsToModify, parameters = parameters[:rdsClusterParameterGroupMaxParamsBulkEdit], parameters[rdsClusterParameterGroupMaxParamsBulkEdit:]
 				}
+				parameterGroupName := d.Get("name").(string)
 				modifyOpts := rds.ModifyDBClusterParameterGroupInput{
-					DBClusterParameterGroupName: aws.String(d.Get("name").(string)),
+					DBClusterParameterGroupName: aws.String(parameterGroupName),
 					Parameters:                  paramsToModify,
 				}
 

--- a/aws/resource_aws_rds_cluster_parameter_group.go
+++ b/aws/resource_aws_rds_cluster_parameter_group.go
@@ -215,18 +215,29 @@ func resourceAwsRDSClusterParameterGroupUpdate(d *schema.ResourceData, meta inte
 		}
 
 		if len(parameters) > 0 {
-			modifyOpts := rds.ModifyDBClusterParameterGroupInput{
-				DBClusterParameterGroupName: aws.String(d.Get("name").(string)),
-				Parameters:                  parameters,
-			}
+			// We can only modify 20 parameters at a time, so walk them until
+			// we've got them all.
+			maxParams := 20
+			for parameters != nil {
+				paramsToModify := make([]*rds.Parameter, 0)
+				if len(parameters) <= maxParams {
+					paramsToModify, parameters = parameters[:], nil
+				} else {
+					paramsToModify, parameters = parameters[:maxParams], parameters[maxParams:]
+				}
+				modifyOpts := rds.ModifyDBClusterParameterGroupInput{
+					DBClusterParameterGroupName: aws.String(d.Get("name").(string)),
+					Parameters:                  paramsToModify,
+				}
 
-			log.Printf("[DEBUG] Modify DB Cluster Parameter Group: %s", modifyOpts)
-			_, err = rdsconn.ModifyDBClusterParameterGroup(&modifyOpts)
-			if err != nil {
-				return fmt.Errorf("Error modifying DB Cluster Parameter Group: %s", err)
+				log.Printf("[DEBUG] Modify DB Cluster Parameter Group: %s", modifyOpts)
+				_, err = rdsconn.ModifyDBClusterParameterGroup(&modifyOpts)
+				if err != nil {
+					return fmt.Errorf("Error modifying DB Cluster Parameter Group: %s", err)
+				}
 			}
+			d.SetPartial("parameter")
 		}
-		d.SetPartial("parameter")
 	}
 
 	if arn, err := buildRDSCPGARN(d.Id(), meta.(*AWSClient).partition, meta.(*AWSClient).accountid, meta.(*AWSClient).region); err == nil {


### PR DESCRIPTION
```
* aws_rds_cluster_parameter_group.default: Error modifying DB Cluster Parameter Group: InvalidParameterCombination: Cannot modify more than 20 parameters in a single request
	status code: 400, request id: f82dc777-76b4-11e7-8f35-1df008be969c
```
