### PR TITLE
Populate listener_arn for aws_alb_listener_rule

### DIFF
--- a/aws/resource_aws_alb_listener_rule_test.go
+++ b/aws/resource_aws_alb_listener_rule_test.go
@@ -14,6 +14,47 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestALBListenerARNFromRuleARN(t *testing.T) {
+	cases := []struct {
+		name     string
+		arn      string
+		expected string
+	}{
+		{
+			name:     "valid listener rule arn",
+			arn:      "arn:aws:elasticloadbalancing:us-east-1:012345678912:listener-rule/app/name/0123456789abcdef/abcdef0123456789/456789abcedf1234",
+			expected: "arn:aws:elasticloadbalancing:us-east-1:012345678912:listener/app/name/0123456789abcdef/abcdef0123456789",
+		},
+		{
+			name:     "listener arn",
+			arn:      "arn:aws:elasticloadbalancing:us-east-1:012345678912:listener/app/name/0123456789abcdef/abcdef0123456789",
+			expected: "",
+		},
+		{
+			name:     "some other arn",
+			arn:      "arn:aws:elasticloadbalancing:us-east-1:123456:targetgroup/my-targets/73e2d6bc24d8a067",
+			expected: "",
+		},
+		{
+			name:     "not an arn",
+			arn:      "blah blah blah",
+			expected: "",
+		},
+		{
+			name:     "empty arn",
+			arn:      "",
+			expected: "",
+		},
+	}
+
+	for _, tc := range cases {
+		actual := albListenerARNFromRuleARN(tc.arn)
+		if actual != tc.expected {
+			t.Fatalf("incorrect arn returned: %q\nExpected: %s\n     Got: %s", tc.name, tc.expected, actual)
+		}
+	}
+}
+
 func TestAccAWSALBListenerRule_basic(t *testing.T) {
 	var conf elbv2.Rule
 	albName := fmt.Sprintf("testrule-basic-%s", acctest.RandStringFromCharSet(13, acctest.CharSetAlphaNum))
@@ -30,6 +71,7 @@ func TestAccAWSALBListenerRule_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSALBListenerRuleExists("aws_alb_listener_rule.static", &conf),
 					resource.TestCheckResourceAttrSet("aws_alb_listener_rule.static", "arn"),
+					resource.TestCheckResourceAttrSet("aws_alb_listener_rule.static", "listener_arn"),
 					resource.TestCheckResourceAttr("aws_alb_listener_rule.static", "priority", "100"),
 					resource.TestCheckResourceAttr("aws_alb_listener_rule.static", "action.#", "1"),
 					resource.TestCheckResourceAttr("aws_alb_listener_rule.static", "action.0.type", "forward"),


### PR DESCRIPTION
Importing a listener rule currently doesn't populate the listener_arn so the next plan attempts to recreate the rule. The AWS API doesn't return the listener arn when describing listener rules. But the listener arn can be inferred from the listener rule arn.

Closes #779