### PR TITLE
Update cloudwatch_event_target.html.markdown

### DIFF
--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -17,6 +17,16 @@ resource "aws_cloudwatch_event_target" "yada" {
   target_id = "Yada"
   rule      = "${aws_cloudwatch_event_rule.console.name}"
   arn       = "${aws_kinesis_stream.test_stream.arn}"
+
+  run_command_targets {
+    key = "tag:Name"
+    values = ["FooBar"]
+  }
+
+  run_command_targets {
+    key = "InstanceIds"
+    values = ["i-162058cd308bffec2"]
+  }
 }
 
 resource "aws_cloudwatch_event_rule" "console" {


### PR DESCRIPTION
This augment the documentation on how `run_command_targets` should be defined.
Fixes #1304