### PR TITLE
r/elasticache_parameter_group: Allow removing parameters

### DIFF
--- a/aws/resource_aws_elasticache_parameter_group.go
+++ b/aws/resource_aws_elasticache_parameter_group.go
@@ -44,7 +44,6 @@ func resourceAwsElasticacheParameterGroup() *schema.Resource {
 			"parameter": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
-				ForceNew: false,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": &schema.Schema{
@@ -144,36 +143,63 @@ func resourceAwsElasticacheParameterGroupUpdate(d *schema.ResourceData, meta int
 		os := o.(*schema.Set)
 		ns := n.(*schema.Set)
 
-		// Expand the "parameter" set to aws-sdk-go compat []elasticacheconn.Parameter
-		parameters, err := expandElastiCacheParameters(ns.Difference(os).List())
+		toRemove, err := expandElastiCacheParameters(os.Difference(ns).List())
 		if err != nil {
 			return err
 		}
 
-		if len(parameters) > 0 {
-			// We can only modify 20 parameters at a time, so walk them until
-			// we've got them all.
-			maxParams := 20
-			for parameters != nil {
-				paramsToModify := make([]*elasticache.ParameterNameValue, 0)
-				if len(parameters) <= maxParams {
-					paramsToModify, parameters = parameters[:], nil
-				} else {
-					paramsToModify, parameters = parameters[:maxParams], parameters[maxParams:]
-				}
-				modifyOpts := elasticache.ModifyCacheParameterGroupInput{
-					CacheParameterGroupName: aws.String(d.Get("name").(string)),
-					ParameterNameValues:     paramsToModify,
-				}
+		log.Printf("[DEBUG] Parameters to remove: %#v", toRemove)
 
-				log.Printf("[DEBUG] Modify Cache Parameter Group: %#v", modifyOpts)
-				_, err = conn.ModifyCacheParameterGroup(&modifyOpts)
-				if err != nil {
-					return fmt.Errorf("Error modifying Cache Parameter Group: %s", err)
-				}
-			}
-			d.SetPartial("parameter")
+		toAdd, err := expandElastiCacheParameters(ns.Difference(os).List())
+		if err != nil {
+			return err
 		}
+
+		log.Printf("[DEBUG] Parameters to add: %#v", toAdd)
+
+		// We can only modify 20 parameters at a time, so walk them until
+		// we've got them all.
+		maxParams := 20
+
+		for len(toRemove) > 0 {
+			paramsToModify := make([]*elasticache.ParameterNameValue, 0)
+			if len(toRemove) <= maxParams {
+				paramsToModify, toRemove = toRemove[:], nil
+			} else {
+				paramsToModify, toRemove = toRemove[:maxParams], toRemove[maxParams:]
+			}
+			resetOpts := elasticache.ResetCacheParameterGroupInput{
+				CacheParameterGroupName: aws.String(d.Get("name").(string)),
+				ParameterNameValues:     paramsToModify,
+			}
+
+			log.Printf("[DEBUG] Reset Cache Parameter Group: %s", resetOpts)
+			_, err = conn.ResetCacheParameterGroup(&resetOpts)
+			if err != nil {
+				return fmt.Errorf("Error resetting Cache Parameter Group: %s", err)
+			}
+		}
+
+		for len(toAdd) > 0 {
+			paramsToModify := make([]*elasticache.ParameterNameValue, 0)
+			if len(toAdd) <= maxParams {
+				paramsToModify, toAdd = toAdd[:], nil
+			} else {
+				paramsToModify, toAdd = toAdd[:maxParams], toAdd[maxParams:]
+			}
+			modifyOpts := elasticache.ModifyCacheParameterGroupInput{
+				CacheParameterGroupName: aws.String(d.Get("name").(string)),
+				ParameterNameValues:     paramsToModify,
+			}
+
+			log.Printf("[DEBUG] Modify Cache Parameter Group: %s", modifyOpts)
+			_, err = conn.ModifyCacheParameterGroup(&modifyOpts)
+			if err != nil {
+				return fmt.Errorf("Error modifying Cache Parameter Group: %s", err)
+			}
+		}
+
+		d.SetPartial("parameter")
 	}
 
 	d.Partial(false)

--- a/aws/resource_aws_elasticache_parameter_group_test.go
+++ b/aws/resource_aws_elasticache_parameter_group_test.go
@@ -63,7 +63,7 @@ func TestAccAWSElasticacheParameterGroup_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSElasticacheParameterGroupOnly(t *testing.T) {
+func TestAccAWSElasticacheParameterGroup_only(t *testing.T) {
 	var v elasticache.CacheParameterGroup
 	rName := fmt.Sprintf("parameter-group-test-terraform-%d", acctest.RandInt())
 
@@ -73,6 +73,42 @@ func TestAccAWSElasticacheParameterGroupOnly(t *testing.T) {
 		CheckDestroy: testAccCheckAWSElasticacheParameterGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
+				Config: testAccAWSElasticacheParameterGroupOnlyConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheParameterGroupExists("aws_elasticache_parameter_group.bar", &v),
+					testAccCheckAWSElasticacheParameterGroupAttributes(&v, rName),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_parameter_group.bar", "name", rName),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_parameter_group.bar", "family", "redis2.8"),
+				),
+			},
+		},
+	})
+}
+
+// Regression for https://github.com/terraform-providers/terraform-provider-aws/issues/116
+func TestAccAWSElasticacheParameterGroup_removeParam(t *testing.T) {
+	var v elasticache.CacheParameterGroup
+	rName := fmt.Sprintf("parameter-group-test-terraform-%d", acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheParameterGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSElasticacheParameterGroupAddParametersConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheParameterGroupExists("aws_elasticache_parameter_group.bar", &v),
+					testAccCheckAWSElasticacheParameterGroupAttributes(&v, rName),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_parameter_group.bar", "name", rName),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_parameter_group.bar", "family", "redis2.8"),
+				),
+			},
+			{
 				Config: testAccAWSElasticacheParameterGroupOnlyConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheParameterGroupExists("aws_elasticache_parameter_group.bar", &v),


### PR DESCRIPTION
Closes #116

```
=== RUN   TestAccAWSElasticacheParameterGroup_importBasic
--- PASS: TestAccAWSElasticacheParameterGroup_importBasic (14.88s)
=== RUN   TestAccAWSElasticacheParameterGroup_only
--- PASS: TestAccAWSElasticacheParameterGroup_only (18.41s)
=== RUN   TestAccAWSElasticacheSubnetGroup_importBasic
--- PASS: TestAccAWSElasticacheSubnetGroup_importBasic (18.67s)
=== RUN   TestAccAWSElasticacheParameterGroup_basic
--- PASS: TestAccAWSElasticacheParameterGroup_basic (18.89s)
=== RUN   TestAccAWSElasticacheReplicationGroup_clusteringAndCacheNodesCausesError
--- PASS: TestAccAWSElasticacheReplicationGroup_clusteringAndCacheNodesCausesError (11.01s)
=== RUN   TestAccAWSElasticacheSecurityGroup_basic
--- PASS: TestAccAWSElasticacheSecurityGroup_basic (14.38s)
=== RUN   TestAccAWSElasticacheParameterGroup_removeParam
--- PASS: TestAccAWSElasticacheParameterGroup_removeParam (36.25s)
=== RUN   TestAccAWSElasticacheSubnetGroup_basic
--- PASS: TestAccAWSElasticacheSubnetGroup_basic (11.61s)
=== RUN   TestAccAWSElasticacheSubnetGroup_update
--- PASS: TestAccAWSElasticacheSubnetGroup_update (20.03s)
=== RUN   TestAccAWSElasticacheCluster_basic
--- PASS: TestAccAWSElasticacheCluster_basic (475.80s)
=== RUN   TestAccAWSElasticacheCluster_importBasic
--- PASS: TestAccAWSElasticacheCluster_importBasic (501.54s)
=== RUN   TestAccAWSElasticacheCluster_vpc
--- PASS: TestAccAWSElasticacheCluster_vpc (815.85s)
=== RUN   TestAccAWSElasticacheCluster_multiAZInVpc
--- PASS: TestAccAWSElasticacheCluster_multiAZInVpc (846.11s)
=== RUN   TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow
--- PASS: TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow (899.87s)
=== RUN   TestAccAWSElasticacheReplicationGroup_vpc
--- PASS: TestAccAWSElasticacheReplicationGroup_vpc (900.68s)
=== RUN   TestAccAWSElasticacheReplicationGroup_importBasic
--- PASS: TestAccAWSElasticacheReplicationGroup_importBasic (954.23s)
=== RUN   TestAccAWSElasticacheReplicationGroup_basic
--- PASS: TestAccAWSElasticacheReplicationGroup_basic (962.40s)
=== RUN   TestAccAWSElasticacheCluster_decreasingCacheNodes
--- PASS: TestAccAWSElasticacheCluster_decreasingCacheNodes (983.90s)
=== RUN   TestAccAWSElasticacheReplicationGroup_updateDescription
--- PASS: TestAccAWSElasticacheReplicationGroup_updateDescription (1003.99s)
=== RUN   TestAccAWSElasticacheReplicationGroup_updateParameterGroup
--- PASS: TestAccAWSElasticacheReplicationGroup_updateParameterGroup (1005.43s)
=== RUN   TestAccAWSElasticacheReplicationGroup_enableSnapshotting
--- PASS: TestAccAWSElasticacheReplicationGroup_enableSnapshotting (1004.29s)
=== RUN   TestAccAWSElasticacheCluster_snapshotsWithUpdates
--- PASS: TestAccAWSElasticacheCluster_snapshotsWithUpdates (1078.01s)
=== RUN   TestAccAWSElasticacheReplicationGroup_nativeRedisCluster
--- PASS: TestAccAWSElasticacheReplicationGroup_nativeRedisCluster (1221.85s)
=== RUN   TestAccAWSElasticacheReplicationGroup_multiAzInVpc
--- PASS: TestAccAWSElasticacheReplicationGroup_multiAzInVpc (1327.93s)
=== RUN   TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2
--- PASS: TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2 (1358.07s)
=== RUN   TestAccAWSElasticacheReplicationGroup_updateNodeSize
--- PASS: TestAccAWSElasticacheReplicationGroup_updateNodeSize (1857.41s)
```