### PR TITLE
Fix a panic

### DIFF
--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -784,21 +784,24 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 				rule["id"] = *lifecycleRule.ID
 			}
 			filter := lifecycleRule.Filter
-			if filter.And != nil {
-				// Prefix
-				if filter.And.Prefix != nil && *filter.And.Prefix != "" {
-					rule["prefix"] = *filter.And.Prefix
-				}
-				// Tag
-				if len(filter.And.Tags) > 0 {
-					rule["tags"] = tagsToMapS3(filter.And.Tags)
-				}
-			} else {
-				// Prefix
-				if filter.Prefix != nil && *filter.Prefix != "" {
-					rule["prefix"] = *filter.Prefix
+			if filter != nil {
+				if filter.And != nil {
+					// Prefix
+					if filter.And.Prefix != nil && *filter.And.Prefix != "" {
+						rule["prefix"] = *filter.And.Prefix
+					}
+					// Tag
+					if len(filter.And.Tags) > 0 {
+						rule["tags"] = tagsToMapS3(filter.And.Tags)
+					}
+				} else {
+					// Prefix
+					if filter.Prefix != nil && *filter.Prefix != "" {
+						rule["prefix"] = *filter.Prefix
+					}
 				}
 			}
+
 			// Enabled
 			if lifecycleRule.Status != nil {
 				if *lifecycleRule.Status == s3.ExpirationStatusEnabled {


### PR DESCRIPTION
Fixes hashicorp/terraform#15706. Fixes #1314. A recent pull request #899) accessed `lifecycleRule.Filter` without first ensuring that it is not a `nil` pointer.