### PR TITLE
Rule number is multiple of 100

### DIFF
--- a/website/docs/r/network_acl.html.markdown
+++ b/website/docs/r/network_acl.html.markdown
@@ -19,7 +19,7 @@ resource "aws_network_acl" "main" {
 
   egress {
     protocol   = "tcp"
-    rule_no    = 2
+    rule_no    = 200
     action     = "allow"
     cidr_block = "10.3.0.0/18"
     from_port  = 443
@@ -28,7 +28,7 @@ resource "aws_network_acl" "main" {
 
   ingress {
     protocol   = "tcp"
-    rule_no    = 1
+    rule_no    = 100
     action     = "allow"
     cidr_block = "10.3.0.0/18"
     from_port  = 80


### PR DESCRIPTION
To confirm to best practice, rules should be a multiple of 100.

[AWS docs](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_ACLs.html) state:

> We recommend that you start by creating rules with rule numbers that are multiples of 100, so that you can insert new rules where you need to later on.