### PR TITLE
Kinesis concurrent CreateStream backoff

### DIFF
--- a/aws/resource_aws_kinesis_stream.go
+++ b/aws/resource_aws_kinesis_stream.go
@@ -111,6 +111,11 @@ func resourceAwsKinesisStreamCreate(d *schema.ResourceData, meta interface{}) er
 		if isAWSErr(err, "LimitExceededException", "simultaneously be in CREATING or DELETING") {
 			return resource.RetryableError(err)
 		}
+		// AWS (un)helpfully raises LimitExceededException
+		// rather than ThrottlingException here
+		if isAWSErr(err, "LimitExceededException", "Rate exceeded for stream") {
+			return resource.RetryableError(err)
+		}
 		return resource.NonRetryableError(err)
 	})
 

--- a/aws/resource_aws_kinesis_stream_test.go
+++ b/aws/resource_aws_kinesis_stream_test.go
@@ -36,6 +36,45 @@ func TestAccAWSKinesisStream_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSKinesisStream_createMultipleConcurrentStreams(t *testing.T) {
+	var stream kinesis.StreamDescription
+
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKinesisStreamDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKinesisStreamConfigConcurrent(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisStreamExists("aws_kinesis_stream.test_stream.0", &stream),
+					testAccCheckKinesisStreamExists("aws_kinesis_stream.test_stream.1", &stream),
+					testAccCheckKinesisStreamExists("aws_kinesis_stream.test_stream.2", &stream),
+					testAccCheckKinesisStreamExists("aws_kinesis_stream.test_stream.3", &stream),
+					testAccCheckKinesisStreamExists("aws_kinesis_stream.test_stream.4", &stream),
+					testAccCheckKinesisStreamExists("aws_kinesis_stream.test_stream.5", &stream),
+					testAccCheckKinesisStreamExists("aws_kinesis_stream.test_stream.6", &stream),
+					testAccCheckKinesisStreamExists("aws_kinesis_stream.test_stream.7", &stream),
+					testAccCheckKinesisStreamExists("aws_kinesis_stream.test_stream.8", &stream),
+					testAccCheckKinesisStreamExists("aws_kinesis_stream.test_stream.9", &stream),
+					testAccCheckKinesisStreamExists("aws_kinesis_stream.test_stream.10", &stream),
+					testAccCheckKinesisStreamExists("aws_kinesis_stream.test_stream.11", &stream),
+					testAccCheckKinesisStreamExists("aws_kinesis_stream.test_stream.12", &stream),
+					testAccCheckKinesisStreamExists("aws_kinesis_stream.test_stream.13", &stream),
+					testAccCheckKinesisStreamExists("aws_kinesis_stream.test_stream.14", &stream),
+					testAccCheckKinesisStreamExists("aws_kinesis_stream.test_stream.15", &stream),
+					testAccCheckKinesisStreamExists("aws_kinesis_stream.test_stream.16", &stream),
+					testAccCheckKinesisStreamExists("aws_kinesis_stream.test_stream.17", &stream),
+					testAccCheckKinesisStreamExists("aws_kinesis_stream.test_stream.18", &stream),
+					testAccCheckKinesisStreamExists("aws_kinesis_stream.test_stream.19", &stream),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSKinesisStream_encryptionWithoutKmsKeyThrowsError(t *testing.T) {
 	rInt := acctest.RandInt()
 
@@ -317,6 +356,18 @@ func testAccKinesisStreamConfig(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_kinesis_stream" "test_stream" {
 	name = "terraform-kinesis-test-%d"
+	shard_count = 2
+	tags {
+		Name = "tf-test"
+	}
+}`, rInt)
+}
+
+func testAccKinesisStreamConfigConcurrent(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_kinesis_stream" "test_stream" {
+        count = 20
+	name = "terraform-kinesis-test-%d-${count.index}"
 	shard_count = 2
 	tags {
 		Name = "tf-test"


### PR DESCRIPTION
See: http://docs.aws.amazon.com/kinesis/latest/APIReference/API_CreateStream.html

Similar to DynamoDB, only up to 5 kinesis streams are able to be in the 
CREATING state simultaneously otherwise a LimitExceededException is
thrown as can be seen below:

```
	* aws_kinesis_stream.test_stream.6: [WARN] Error creating Kinesis Stream: "This request would have exceed the limit on the number  of streams that can simultaneously be in CREATING or DELETING for the account XXXX. Limit: 5.", code: "LimitExceededException"
		* aws_kinesis_stream.test_stream[1]: 1 error(s) occurred
```

We create about 20 streams per environment (read: single Terraform run) 
and had been seeing these errors frequently, having to do several 
`terraform apply` to get a clean run. After speaking with AWS support, 
this is a hard limit (5) and they have no way of tuning per account.