### PR TITLE
r/aws_instance: Fix associate_public_ip_address

### DIFF
--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -1235,10 +1235,9 @@ func fetchRootDeviceName(ami string, conn *ec2.EC2) (*string, error) {
 func buildNetworkInterfaceOpts(d *schema.ResourceData, groups []*string, nInterfaces interface{}) []*ec2.InstanceNetworkInterfaceSpecification {
 	networkInterfaces := []*ec2.InstanceNetworkInterfaceSpecification{}
 	// Get necessary items
-	associatePublicIPAddress := d.Get("associate_public_ip_address").(bool)
 	subnet, hasSubnet := d.GetOk("subnet_id")
 
-	if hasSubnet && associatePublicIPAddress {
+	if hasSubnet {
 		// If we have a non-default VPC / Subnet specified, we can flag
 		// AssociatePublicIpAddress to get a Public IP assigned. By default these are not provided.
 		// You cannot specify both SubnetId and the NetworkInterface.0.* parameters though, otherwise
@@ -1247,10 +1246,13 @@ func buildNetworkInterfaceOpts(d *schema.ResourceData, groups []*string, nInterf
 		// to avoid: Network interfaces and an instance-level security groups may not be specified on
 		// the same request
 		ni := &ec2.InstanceNetworkInterfaceSpecification{
-			AssociatePublicIpAddress: aws.Bool(associatePublicIPAddress),
-			DeviceIndex:              aws.Int64(int64(0)),
-			SubnetId:                 aws.String(subnet.(string)),
-			Groups:                   groups,
+			DeviceIndex: aws.Int64(int64(0)),
+			SubnetId:    aws.String(subnet.(string)),
+			Groups:      groups,
+		}
+
+		if v, ok := d.GetOkExists("associate_public_ip_address"); ok {
+			ni.AssociatePublicIpAddress = aws.Bool(v.(bool))
 		}
 
 		if v, ok := d.GetOk("private_ip"); ok {
@@ -1573,8 +1575,6 @@ func buildAwsInstanceOpts(
 		opts.Placement.Tenancy = aws.String(v)
 	}
 
-	associatePublicIPAddress := d.Get("associate_public_ip_address").(bool)
-
 	var groups []*string
 	if v := d.Get("security_groups"); v != nil {
 		// Security group names.
@@ -1593,7 +1593,7 @@ func buildAwsInstanceOpts(
 	networkInterfaces, interfacesOk := d.GetOk("network_interface")
 
 	// If setting subnet and public address, OR manual network interfaces, populate those now.
-	if hasSubnet && associatePublicIPAddress || interfacesOk {
+	if hasSubnet || interfacesOk {
 		// Otherwise we're attaching (a) network interface(s)
 		opts.NetworkInterfaces = buildNetworkInterfaceOpts(d, groups, networkInterfaces)
 	} else {

--- a/vendor/github.com/hashicorp/terraform/CHANGELOG.md
+++ b/vendor/github.com/hashicorp/terraform/CHANGELOG.md
@@ -1,96 +1,12 @@
-## 0.10.0 (August 2, 2017)
+## 0.10.0 (Unreleased)
 
-**This is the complete 0.9.11 to 0.10.0 CHANGELOG**
+BUG FIXES: 
 
-BACKWARDS INCOMPATIBILITIES / NOTES:
-
-* A new flag `-auto-approve` has been added to `terraform apply`. This flag controls whether an interactive approval is applied before
-  making the changes in the plan. For now this flag defaults to `true` to preserve previous behavior, but this will become the new default
-  in a future version. We suggest that anyone running `terraform apply` in wrapper scripts or automation refer to the upgrade guide to learn
-  how to prepare such wrapper scripts for the later breaking change.
-* The `validate` command now checks that all variables are specified by default.  The validation will fail by default if that's not the
-  case. ([#13872](https://github.com/hashicorp/terraform/issues/13872))
-* `terraform state rm` now requires at least one argument. Previously, calling it with no arguments would remove all resources from state,
-  which is consistent with the other `terraform state` commands but unlikely enough that we considered it better to be inconsistent here to
-  reduce the risk of accidentally destroying the state.
-* Terraform providers are no longer distributed as part of the main Terraform distribution. Instead, they are installed automatically as
-  part of running `terraform init`. It is therefore now mandatory to run `terraform init` before any other operations that use provider
-  plugins, to ensure that the required plugins are installed and properly initialized.
-* The `terraform env` family of commands have been renamed to `terraform workspace`, in response to feedback that the previous naming was
-  confusing due to collisions with other concepts of the same name. The commands still work the same as they did before, and the `env`
-  subcommand is still supported as an alias for backward compatibility. The `env` subcommand will be removed altogether in a future release,
-  so it's recommended to update any automation or wrapper scripts that use these commands.
-* The `terraform init` subcommand no longer takes a SOURCE argument to copy to the current directory. The behavior has been changed to match
-  that of `plan` and `apply`, so that a configuration can be provided as an argument on the commandline while initializing the current
-  directory. If a module needs to be copied into the current directory before initialization, it will have to be done manually.
-* The `-target` option available on several Terraform subcommands has changed behavior and **now matches potentially more resources**.  In
-  particular, given an option `-target=module.foo`, resources in any descendent modules of `foo` will also be targeted, where before this
-  was not true. After upgrading, be sure to look carefully at the set of changes proposed by `terraform plan` when using `-target` to ensure
-  that the target is being interpreted as expected. Note that the `-target` argument is offered for exceptional circumstances only and is
-  not intended for routine use.
-* The `import` command requires that imported resources be specified in the configuration file. Previously, users were encouraged to import
-  a resource and _then_ write the configuration block for it. This creates the risk that users could import a resource and subsequently
-  create no configuration for it, which results in Terraform deleting the resource. If the imported resource is not present in the
-  configuration file, the `import` command will fail.
-
-FEATURES:
-
-* **Separate Provider Releases:** Providers are now released independently from Terraform.
-* **Automatic Provider Installation:** The required providers will be automatically installed during `terraform init`.
-* **Provider Constraints:** Provider are now versioned, and version constraints may be declared in the configuration.
-
-PROVIDERS:
-
-* Providers now maintain their own CHANGELOGs in their respective repositories: [terraform-providers](https://github.com/terraform-providers)
+* provisioner/chef: fix panic [GH-15617]
 
 IMPROVEMENTS:
 
-* cli: Add a `-from-module` flag to `terraform init` to re-introduce the legacy `terraform init` behavior of fetching a module. ([#15666](https://github.com/hashicorp/terraform/issues/15666))
-* backend/s3: Add `workspace_key_prefix` to allow a user-configurable prefix for workspaces in the S3 Backend. ([#15370](https://github.com/hashicorp/terraform/issues/15370))
-* cli: `terraform apply` now has an option `-auto-approve=false` that produces an interactive prompt to approve the generated plan. This will become the default workflow in a future Terraform version. ([#7251](https://github.com/hashicorp/terraform/issues/7251))
-* cli: `terraform workspace show` command prints the current workspace name in a way that's more convenient for processing in wrapper scripts. ([#15157](https://github.com/hashicorp/terraform/issues/15157))
-* cli: `terraform state rm` will now generate an error if no arguments are passed, whereas before it treated it as an open resource address selecting _all_ resources ([#15283](https://github.com/hashicorp/terraform/issues/15283))
-* cli: Files in the config directory ending in `.auto.tfvars` are now loaded automatically (in lexicographical order) in addition to the single `terraform.tfvars` file that auto-loaded previously. ([#13306](https://github.com/hashicorp/terraform/issues/13306))
-* Providers no longer in the main Terraform distribution; installed automatically by init instead ([#15208](https://github.com/hashicorp/terraform/issues/15208))
-* cli: `terraform env` command renamed to `terraform workspace` ([#14952](https://github.com/hashicorp/terraform/issues/14952))
-* cli: `terraform init` command now has `-upgrade` option to download the latest versions (within specified constraints) of modules and provider plugins.
-* cli: The `-target` option to various Terraform operation can now target resources in descendent modules. ([#15314](https://github.com/hashicorp/terraform/issues/15314))
-* cli: Minor updates to `terraform plan` output: use standard resource address syntax, more visually-distinct `-/+` actions, and more ([#15362](https://github.com/hashicorp/terraform/issues/15362))
-* config: New interpolation function `contains`, to find if a given string exists in a list of strings. ([#15322](https://github.com/hashicorp/terraform/issues/15322))
-
-BUG FIXES:
-
-* provisioner/chef: fix panic ([#15617](https://github.com/hashicorp/terraform/issues/15617))
-* Don't show a message about the path to the state file if the state is remote ([#15435](https://github.com/hashicorp/terraform/issues/15435))
-* Fix crash when `terraform graph` is run with no configuration ([#15588](https://github.com/hashicorp/terraform/issues/15588))
-* Handle correctly the `.exe` suffix on locally-compiled provider plugins on Windows systems. ([#15587](https://github.com/hashicorp/terraform/issues/15587))
-* config: Fixed a parsing issue in the interpolation language HIL that was causing misinterpretation of literal strings ending with escaped backslashes ([#15415](https://github.com/hashicorp/terraform/issues/15415))
-* core: the S3 Backend was failing to remove the state file checksums from DynamoDB when deleting a workspace ([#15383](https://github.com/hashicorp/terraform/issues/15383))
-* core: Improved reslience against crashes for a certain kind of inconsistency in the representation of list values in state. ([#15390](https://github.com/hashicorp/terraform/issues/15390))
-* core: Display correct to and from backends in copy message when migrating to new remote state ([#15318](https://github.com/hashicorp/terraform/issues/15318))
-* core: Fix a regression from 0.9.6 that was causing the tally of resources to create to be double-counted sometimes in the plan output ([#15344](https://github.com/hashicorp/terraform/issues/15344))
-* cli: the state `rm` and `mv` commands were always loading a state from a Backend, and ignoring the `-state` flag ([#15388](https://github.com/hashicorp/terraform/issues/15388))
-* cli: certain prompts in `terraform init` were respecting `-input=false` but not the `TF_INPUT` environment variable ([#15391](https://github.com/hashicorp/terraform/issues/15391))
-* state: Further work, building on [#15423](https://github.com/hashicorp/terraform/issues/15423), to improve the internal design of the state managers to make this code more maintainable and reduce the risk of regressions; this may lead to slight changes to the number of times Terraform writes to remote state and how the serial is implemented with respect to those writes, which does not affect outward functionality but is worth noting if you log or inspect state updates for debugging purposes.
-* config: Interpolation function `cidrhost` was not correctly calcluating host addresses under IPv6 CIDR prefixes ([#15321](https://github.com/hashicorp/terraform/issues/15321))
-* provisioner/chef: Prevent a panic while trying to read the connection info ([#15271](https://github.com/hashicorp/terraform/issues/15271))
-* provisioner/file: Refactor the provisioner validation function to prevent false positives ([#15273](https://github.com/hashicorp/terraform/issues/15273))
-
-INTERNAL CHANGES:
-
-* helper/schema: Actively disallow reserved field names in schema ([#15522](https://github.com/hashicorp/terraform/issues/15522))
-* helper/schema: Force field names to be alphanum lowercase + underscores ([#15562](https://github.com/hashicorp/terraform/issues/15562))
-
-
-## 0.10.0-rc1 to 0.10.0 (August 2, 2017)
-
-BUG FIXES:
-
-* provisioner/chef: fix panic ([#15617](https://github.com/hashicorp/terraform/issues/15617))
-
-IMPROVEMENTS:
-
-* cli: Add a `-from-module` flag to `terraform init` to re-introduce the legacy `terraform init` behavior of fetching a module. ([#15666](https://github.com/hashicorp/terraform/issues/15666))
+* cli: Add a `-from-module` flag to `terraform init` to re-introduce the legacy `terraform init` behavior of fetching a module. [GH-15666]
 
 
 ## 0.10.0-rc1 (July 19, 2017)

--- a/vendor/github.com/hashicorp/terraform/helper/schema/resource_data.go
+++ b/vendor/github.com/hashicorp/terraform/helper/schema/resource_data.go
@@ -104,6 +104,22 @@ func (d *ResourceData) GetOk(key string) (interface{}, bool) {
 	return r.Value, exists
 }
 
+// GetOkExists returns the data for a given key and whether or not the key
+// has been set to a non-zero value. This is only useful for determining
+// if boolean attributes have been set, if they are Optional but do not
+// have a Default value.
+//
+// This is nearly the same function as GetOk, yet it does not check
+// for the zero value of the attribute's type. This allows for attributes
+// without a default, to fully check for a literal assignment, regardless
+// of the zero-value for that type.
+// This should only be used if absolutely required/needed.
+func (d *ResourceData) GetOkExists(key string) (interface{}, bool) {
+	r := d.getRaw(key, getSourceSet)
+	exists := r.Exists && !r.Computed
+	return r.Value, exists
+}
+
 func (d *ResourceData) getRaw(key string, level getSource) getResult {
 	var parts []string
 	if key != "" {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1847,10 +1847,6 @@
 			"revisionTime": "2017-06-01T21:16:37Z"
 		},
 		{
-			"path": "github.com/masterzen/winrm/winrm",
-			"revision": "1ca0ba637a877ee12b69abc73c6161fccb77b70a"
-		},
-		{
 			"checksumSHA1": "bx+egnFe0OB0BZBcgZcaqsvcmS4=",
 			"path": "github.com/masterzen/xmlpath",
 			"revision": "13f4951698adc0fa9c1dda3e275d489a24201161",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1354,420 +1354,316 @@
 			"revisionTime": "2017-08-02T19:05:30Z"
 		},
 		{
-			"checksumSHA1": "f6PIzvwe/rpiEDCqqd0hkxpY6E8=",
+			"checksumSHA1": "D0F12Q8yZNxF9cSQ/HRAVN34ZwQ=",
 			"path": "github.com/hashicorp/terraform",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "ExrDQgeh/AFUiAmwczS0O+4iv2k=",
 			"path": "github.com/hashicorp/terraform/backend",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "ZWqZhZxaT2AMNy4dzCcvMKc46GY=",
 			"path": "github.com/hashicorp/terraform/backend/atlas",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "tpENC7Upm0NCz26xgED30Wi8RwA=",
 			"path": "github.com/hashicorp/terraform/backend/init",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "ISwgLoSPkcEYAcwFoYu5FNsMDD0=",
 			"path": "github.com/hashicorp/terraform/backend/legacy",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "LxrFHRlPRk+YFnCg0XZG9j9/gEc=",
 			"path": "github.com/hashicorp/terraform/backend/local",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "dm2mPVgLkl0LEg8hnDL7agzsLtw=",
 			"path": "github.com/hashicorp/terraform/backend/remote-state",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "ckRjYzdabaVIFIHfCo9/McYi3PI=",
 			"path": "github.com/hashicorp/terraform/backend/remote-state/consul",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "2DlWhwNky9LZSRAy0LmSdPHhF2s=",
 			"path": "github.com/hashicorp/terraform/backend/remote-state/inmem",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "WgzSa5s1Gflzw5MR6KFQrIoHy64=",
 			"path": "github.com/hashicorp/terraform/backend/remote-state/s3",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "l0SZPCxWxxlYHOedkUCZUCWw4R0=",
 			"path": "github.com/hashicorp/terraform/backend/remote-state/swift",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "/x8LyJMq8kPYSRNu4xyB8zcf9DQ=",
 			"path": "github.com/hashicorp/terraform/builtin/provisioners/chef",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "EtcHzH4aXhylC1Uu8yBQis6IzfU=",
 			"path": "github.com/hashicorp/terraform/builtin/provisioners/file",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "cqsxeQ91qnrGUicLBKoDZCuozMM=",
 			"path": "github.com/hashicorp/terraform/builtin/provisioners/local-exec",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "OChAYHSZ6OJKTCQVMgpaIz5MEMA=",
 			"path": "github.com/hashicorp/terraform/builtin/provisioners/remote-exec",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "RuHDe6nFcPIhiFEsrJ+Qzzlu74U=",
 			"path": "github.com/hashicorp/terraform/command",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "HWbnuaEFdfRFeKxZdlYUWZm+DU0=",
 			"path": "github.com/hashicorp/terraform/command/clistate",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "Nf4HkguPGljvTOOXidsSLYEAMOM=",
 			"path": "github.com/hashicorp/terraform/command/format",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "Pg0fge6Fl6a34pYl2fH1eb6kgNE=",
 			"path": "github.com/hashicorp/terraform/communicator",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "zCAC53a+zRYTwnfw7vUFJmvqxQc=",
 			"path": "github.com/hashicorp/terraform/communicator/remote",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "gOdZ52GCuL8KLiqYGEVNVZyMO5U=",
 			"path": "github.com/hashicorp/terraform/communicator/shared",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "go3oS7xtI1wIdMv0XyhEt33dA0Y=",
 			"path": "github.com/hashicorp/terraform/communicator/ssh",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "OpE2PWCmoN2WCmWGGVnoeCaeOTQ=",
 			"path": "github.com/hashicorp/terraform/communicator/winrm",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "KPrCMDPNcLmO7K6xPcJSl86LwPk=",
 			"path": "github.com/hashicorp/terraform/config",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "uPCJ6seQo9kvoNSfwNWKX9KzVMk=",
 			"path": "github.com/hashicorp/terraform/config/module",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "w+l+UGTmwYNJ+L0p2vTd6+yqjok=",
 			"path": "github.com/hashicorp/terraform/dag",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "P8gNPDuOzmiK4Lz9xG7OBy4Rlm8=",
 			"path": "github.com/hashicorp/terraform/flatmap",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "zx5DLo5aV0xDqxGTzSibXg7HHAA=",
 			"path": "github.com/hashicorp/terraform/helper/acctest",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "uT6Q9RdSRAkDjyUgQlJ2XKJRab4=",
 			"path": "github.com/hashicorp/terraform/helper/config",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "FH5eOEHfHgdxPC/JnfmCeSBk66U=",
 			"path": "github.com/hashicorp/terraform/helper/encryption",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "Vbo55GDzPgG/L/+W2pcvDhxrPZc=",
 			"path": "github.com/hashicorp/terraform/helper/experiment",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "BmIPKTr0zDutSJdyq7pYXrK1I3E=",
 			"path": "github.com/hashicorp/terraform/helper/hashcode",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "B267stWNQd0/pBTXHfI/tJsxzfc=",
 			"path": "github.com/hashicorp/terraform/helper/hilmapstructure",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "2wJa9F3BGlbe2DNqH5lb5POayRI=",
 			"path": "github.com/hashicorp/terraform/helper/logging",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "twkFd4x71kBnDfrdqO5nhs8dMOY=",
 			"path": "github.com/hashicorp/terraform/helper/mutexkv",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "ImyqbHM/xe3eAT2moIjLI8ksuks=",
 			"path": "github.com/hashicorp/terraform/helper/pathorcontents",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "dhU2woQaSEI2OnbYLdkHxf7/nu8=",
 			"path": "github.com/hashicorp/terraform/helper/resource",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
-			"checksumSHA1": "0smlb90amL15c/6nWtW4DV6Lqh8=",
+			"checksumSHA1": "oaQ6rBNVs4Ae86vv3fKZU4tWETM=",
 			"path": "github.com/hashicorp/terraform/helper/schema",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "1yCGh/Wl4H4ODBBRmIRFcV025b0=",
 			"path": "github.com/hashicorp/terraform/helper/shadow",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "eQ6F8nDi/R+F/SX51xCEY8iPZOE=",
 			"path": "github.com/hashicorp/terraform/helper/slowmessage",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "Fzbv+N7hFXOtrR6E7ZcHT3jEE9s=",
 			"path": "github.com/hashicorp/terraform/helper/structure",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "qsI85GvNukAIUv+kcy8CdgP7um8=",
 			"path": "github.com/hashicorp/terraform/helper/validation",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "a1YCqJht+4G5O0UNTnOTD8vfXb0=",
 			"path": "github.com/hashicorp/terraform/helper/variables",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "ExvF2RbMeCfxuq2eASmOChEcRgQ=",
 			"path": "github.com/hashicorp/terraform/helper/wrappedreadline",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "q96i9foHLGSZ+9dFOV7jUseq7zs=",
 			"path": "github.com/hashicorp/terraform/helper/wrappedstreams",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "yFWmdS6yEJZpRJzUqd/mULqCYGk=",
 			"path": "github.com/hashicorp/terraform/moduledeps",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "4ODNVUds3lyBf7gV02X1EeYR4GA=",
 			"path": "github.com/hashicorp/terraform/plugin",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "mujz3BDg1X82ynvJncCFUT6/7XI=",
 			"path": "github.com/hashicorp/terraform/plugin/discovery",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "vW75JRFcEDJNxNCB2mrlFeYOyX4=",
 			"path": "github.com/hashicorp/terraform/repl",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "6GDMHApWhgYT4AVkhSBknxK0YyU=",
 			"path": "github.com/hashicorp/terraform/state",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "uHQBceHkR/Im5m7TLBfrRK78k8s=",
 			"path": "github.com/hashicorp/terraform/state/remote",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "ksfNQjZs/6llziARojABd6iuvdw=",
 			"path": "github.com/hashicorp/terraform/terraform",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "ft77GtqeZEeCXioGpF/s6DlGm/U=",
@@ -1949,6 +1845,10 @@
 			"path": "github.com/masterzen/winrm/soap",
 			"revision": "1ca0ba637a877ee12b69abc73c6161fccb77b70a",
 			"revisionTime": "2017-06-01T21:16:37Z"
+		},
+		{
+			"path": "github.com/masterzen/winrm/winrm",
+			"revision": "1ca0ba637a877ee12b69abc73c6161fccb77b70a"
 		},
 		{
 			"checksumSHA1": "bx+egnFe0OB0BZBcgZcaqsvcmS4=",


### PR DESCRIPTION
Previously we had no way of determining if a boolean attribute was a
literal `false` or a zero-value type of `false`. With the core enhancement
added to Terraform via https://github.com/hashicorp/terraform/pull/15723,
we can now reliably check for a zero-type value of a boolean attribute,
or a literal boolean `false` inside of schema.

This allows the `associate_public_ip_address` to work as expected,
when configuring an AWS Instance inside of a subnet that defaults to
public address assignment, with a literal `false` for the `associate_public_ip_address` attribute.

```
$ make testacc TEST=./aws TESTARGS="-run=TestAccAWSInstance_explicitAssociatePublicAddress"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSInstance_explicitAssociatePublicAddress -timeout 120m
=== RUN   TestAccAWSInstance_explicitAssociatePublicAddress
--- PASS: TestAccAWSInstance_explicitAssociatePublicAddress (113.04s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       113.045s
```

Fixes: #227 