### PR TITLE
r/aws_eip_association: Avoid crash in EC2 Classic

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -402,6 +402,15 @@ func (c *Config) Client() (interface{}, error) {
 	return &client, nil
 }
 
+func hasEc2Classic(platforms []string) bool {
+	for _, p := range platforms {
+		if p == "EC2" {
+			return true
+		}
+	}
+	return false
+}
+
 // ValidateRegion returns an error if the configured region is not a
 // valid aws region and nil otherwise.
 func (c *Config) ValidateRegion() error {


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/337

### Test results

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSEIP'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSEIP -timeout 120m
=== RUN   TestAccAWSEIPAssociation_basic
--- PASS: TestAccAWSEIPAssociation_basic (159.44s)
=== RUN   TestAccAWSEIPAssociation_ec2Classic
--- PASS: TestAccAWSEIPAssociation_ec2Classic (207.69s)
=== RUN   TestAccAWSEIPAssociation_disappears
--- PASS: TestAccAWSEIPAssociation_disappears (147.68s)
=== RUN   TestAccAWSEIP_importEc2Classic
--- PASS: TestAccAWSEIP_importEc2Classic (141.03s)
=== RUN   TestAccAWSEIP_importVpc
--- PASS: TestAccAWSEIP_importVpc (94.51s)
=== RUN   TestAccAWSEIP_basic
--- PASS: TestAccAWSEIP_basic (37.61s)
=== RUN   TestAccAWSEIP_instance
--- PASS: TestAccAWSEIP_instance (234.50s)
=== RUN   TestAccAWSEIP_network_interface
--- PASS: TestAccAWSEIP_network_interface (93.46s)
=== RUN   TestAccAWSEIP_twoEIPsOneNetworkInterface
--- PASS: TestAccAWSEIP_twoEIPsOneNetworkInterface (89.93s)
=== RUN   TestAccAWSEIP_associated_user_private_ip
--- PASS: TestAccAWSEIP_associated_user_private_ip (236.41s)
=== RUN   TestAccAWSEIP_classic_disassociate
--- PASS: TestAccAWSEIP_classic_disassociate (300.25s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1742.539s
```