### PR TITLE
fix for issue where s3 lifecycle rule prefix key value is not set corr…

### DIFF
--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -800,6 +800,10 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 						rule["prefix"] = *filter.Prefix
 					}
 				}
+			} else {
+				if lifecycleRule.Prefix != nil {
+					rule["prefix"] = *lifecycleRule.Prefix
+				}
 			}
 
 			// Enabled


### PR DESCRIPTION
…ectly if prefix is not under the filter key

On `Terraform v0.10.0`, it looks there is an issue where the `prefix` value on a s3 bucket lifecycle policy is not set when it is not under a `filter` key in the document returned from the AWS API.

Here's the DEBUG log output showing the prefix in the AWS API document:
```
2017/08/04 14:52:45 [DEBUG] plugin: terraform-provider-aws: 2017/08/04 14:52:45 [DEBUG] S3 Bucket: my-bucket, lifecycle: {
2017/08/04 14:52:45 [DEBUG] plugin: terraform-provider-aws:   Rules: [{
2017/08/04 14:52:45 [DEBUG] plugin: terraform-provider-aws:       AbortIncompleteMultipartUpload: {
2017/08/04 14:52:45 [DEBUG] plugin: terraform-provider-aws:         DaysAfterInitiation: 7
2017/08/04 14:52:45 [DEBUG] plugin: terraform-provider-aws:       },
2017/08/04 14:52:45 [DEBUG] plugin: terraform-provider-aws:       Expiration: {
2017/08/04 14:52:45 [DEBUG] plugin: terraform-provider-aws:       },
2017/08/04 14:52:45 [DEBUG] plugin: terraform-provider-aws:       ID: "<redacted-1>",
2017/08/04 14:52:45 [DEBUG] plugin: terraform-provider-aws:       NoncurrentVersionExpiration: {
2017/08/04 14:52:45 [DEBUG] plugin: terraform-provider-aws:       },
2017/08/04 14:52:45 [DEBUG] plugin: terraform-provider-aws:       Prefix: "some_prefix_1/",
2017/08/04 14:52:45 [DEBUG] plugin: terraform-provider-aws:       Status: "Enabled"
2017/08/04 14:52:45 [DEBUG] plugin: terraform-provider-aws:     },{
2017/08/04 14:52:45 [DEBUG] plugin: terraform-provider-aws:       AbortIncompleteMultipartUpload: {
2017/08/04 14:52:45 [DEBUG] plugin: terraform-provider-aws:         DaysAfterInitiation: 7
2017/08/04 14:52:45 [DEBUG] plugin: terraform-provider-aws:       },
2017/08/04 14:52:45 [DEBUG] plugin: terraform-provider-aws:       Expiration: {
2017/08/04 14:52:45 [DEBUG] plugin: terraform-provider-aws:         Days: 368
2017/08/04 14:52:45 [DEBUG] plugin: terraform-provider-aws:       },
2017/08/04 14:52:45 [DEBUG] plugin: terraform-provider-aws:       ID: "<redacted-2>",
2017/08/04 14:52:45 [DEBUG] plugin: terraform-provider-aws:       NoncurrentVersionExpiration: {
2017/08/04 14:52:45 [DEBUG] plugin: terraform-provider-aws:         NoncurrentDays: 10
2017/08/04 14:52:45 [DEBUG] plugin: terraform-provider-aws:       },
2017/08/04 14:52:45 [DEBUG] plugin: terraform-provider-aws:       Prefix: "some_prefix_2/",
2017/08/04 14:52:45 [DEBUG] plugin: terraform-provider-aws:       Status: "Enabled",
2017/08/04 14:52:45 [DEBUG] plugin: terraform-provider-aws:       Transitions: [{
2017/08/04 14:52:45 [DEBUG] plugin: terraform-provider-aws:           Days: 15,
2017/08/04 14:52:45 [DEBUG] plugin: terraform-provider-aws:           StorageClass: "GLACIER"
2017/08/04 14:52:45 [DEBUG] plugin: terraform-provider-aws:         }]
2017/08/04 14:52:45 [DEBUG] plugin: terraform-provider-aws:     }]
2017/08/04 14:52:45 [DEBUG] plugin: terraform-provider-aws: }
```
