### PR TITLE
data/aws_vpc: Expose enable_dns_* in aws_vpc data_source

### DIFF
--- a/aws/data_source_aws_vpc.go
+++ b/aws/data_source_aws_vpc.go
@@ -61,6 +61,16 @@ func dataSourceAwsVpc() *schema.Resource {
 				Computed: true,
 			},
 
+			"enable_dns_hostnames": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"enable_dns_support": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
 			"tags": tagsSchemaComputed(),
 		},
 	}
@@ -131,6 +141,18 @@ func dataSourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("ipv6_association_id", vpc.Ipv6CidrBlockAssociationSet[0].AssociationId)
 		d.Set("ipv6_cidr_block", vpc.Ipv6CidrBlockAssociationSet[0].Ipv6CidrBlock)
 	}
+
+	attResp, err := awsVpcDescribeVpcAttribute("enableDnsSupport", *vpc.VpcId, conn)
+	if err != nil {
+		return err
+	}
+	d.Set("enable_dns_support", attResp.EnableDnsSupport.Value)
+
+	attResp, err = awsVpcDescribeVpcAttribute("enableDnsHostnames", *vpc.VpcId, conn)
+	if err != nil {
+		return err
+	}
+	d.Set("enable_dns_hostnames", attResp.EnableDnsHostnames.Value)
 
 	return nil
 }

--- a/aws/data_source_aws_vpc_test.go
+++ b/aws/data_source_aws_vpc_test.go
@@ -26,6 +26,10 @@ func TestAccDataSourceAwsVpc_basic(t *testing.T) {
 					testAccDataSourceAwsVpcCheck("data.aws_vpc.by_cidr", cidr, tag),
 					testAccDataSourceAwsVpcCheck("data.aws_vpc.by_tag", cidr, tag),
 					testAccDataSourceAwsVpcCheck("data.aws_vpc.by_filter", cidr, tag),
+					resource.TestCheckResourceAttr(
+						"data.aws_vpc.by_id", "enable_dns_support", "true"),
+					resource.TestCheckResourceAttr(
+						"data.aws_vpc.by_id", "enable_dns_hostnames", "false"),
 				),
 			},
 		},

--- a/aws/resource_aws_vpc.go
+++ b/aws/resource_aws_vpc.go
@@ -194,27 +194,17 @@ func resourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	// Attributes
-	attribute := "enableDnsSupport"
-	describeAttrOpts := &ec2.DescribeVpcAttributeInput{
-		Attribute: aws.String(attribute),
-		VpcId:     aws.String(vpcid),
-	}
-	resp, err := conn.DescribeVpcAttribute(describeAttrOpts)
+	resp, err := awsVpcDescribeVpcAttribute("enableDnsSupport", vpcid, conn)
 	if err != nil {
 		return err
 	}
-	d.Set("enable_dns_support", *resp.EnableDnsSupport.Value)
-	attribute = "enableDnsHostnames"
-	describeAttrOpts = &ec2.DescribeVpcAttributeInput{
-		Attribute: &attribute,
-		VpcId:     &vpcid,
-	}
-	resp, err = conn.DescribeVpcAttribute(describeAttrOpts)
+	d.Set("enable_dns_support", resp.EnableDnsSupport.Value)
+
+	resp, err = awsVpcDescribeVpcAttribute("enableDnsHostnames", vpcid, conn)
 	if err != nil {
 		return err
 	}
-	d.Set("enable_dns_hostnames", *resp.EnableDnsHostnames.Value)
+	d.Set("enable_dns_hostnames", resp.EnableDnsHostnames.Value)
 
 	describeClassiclinkOpts := &ec2.DescribeVpcClassicLinkInput{
 		VpcIds: []*string{&vpcid},
@@ -646,4 +636,17 @@ func resourceAwsVpcInstanceImport(
 	d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	d.Set("assign_generated_ipv6_cidr_block", false)
 	return []*schema.ResourceData{d}, nil
+}
+
+func awsVpcDescribeVpcAttribute(attribute string, vpcId string, conn *ec2.EC2) (*ec2.DescribeVpcAttributeOutput, error) {
+	describeAttrOpts := &ec2.DescribeVpcAttributeInput{
+		Attribute: aws.String(attribute),
+		VpcId:     aws.String(vpcId),
+	}
+	resp, err := conn.DescribeVpcAttribute(describeAttrOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
 }

--- a/website/docs/d/vpc.html.markdown
+++ b/website/docs/d/vpc.html.markdown
@@ -77,7 +77,7 @@ The following attribute is additionally exported:
 
 * `instance_tenancy` - The allowed tenancy of instances launched into the
   selected VPC. May be any of `"default"`, `"dedicated"`, or `"host"`.
-
 * `ipv6_association_id` - The association ID for the IPv6 CIDR block.
-
 * `ipv6_cidr_block` - The IPv6 CIDR block.
+* `enable_dns_support` - Whether or not the VPC has DNS support
+* `enable_dns_hostnames` - Whether or not the VPC has DNS hostname support


### PR DESCRIPTION
Fixes: #1310

```
% make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsVpc_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccDataSourceAwsVpc_ -timeout 120m
=== RUN   TestAccDataSourceAwsVpc_basic
--- PASS: TestAccDataSourceAwsVpc_basic (57.65s)
=== RUN   TestAccDataSourceAwsVpc_ipv6Associated
--- PASS: TestAccDataSourceAwsVpc_ipv6Associated (56.97s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	114.644s
```

```
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSVpc_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSVpc_ -timeout 120m
=== RUN   TestAccAWSVpc_importBasic
--- PASS: TestAccAWSVpc_importBasic (55.77s)
=== RUN   TestAccAWSVpc_basic
--- PASS: TestAccAWSVpc_basic (45.39s)
=== RUN   TestAccAWSVpc_enableIpv6
--- PASS: TestAccAWSVpc_enableIpv6 (122.24s)
=== RUN   TestAccAWSVpc_dedicatedTenancy
--- PASS: TestAccAWSVpc_dedicatedTenancy (47.45s)
=== RUN   TestAccAWSVpc_tags
--- PASS: TestAccAWSVpc_tags (84.16s)
=== RUN   TestAccAWSVpc_update
--- PASS: TestAccAWSVpc_update (83.19s)
=== RUN   TestAccAWSVpc_bothDnsOptionsSet
--- PASS: TestAccAWSVpc_bothDnsOptionsSet (19.69s)
=== RUN   TestAccAWSVpc_DisabledDnsSupport
--- PASS: TestAccAWSVpc_DisabledDnsSupport (44.98s)
=== RUN   TestAccAWSVpc_classiclinkOptionSet
--- PASS: TestAccAWSVpc_classiclinkOptionSet (45.00s)
=== RUN   TestAccAWSVpc_classiclinkDnsSupportOptionSet
--- PASS: TestAccAWSVpc_classiclinkDnsSupportOptionSet (46.06s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	593.935s
```