### PR TITLE
r/emr_cluster: Avoid spurious diff of log_uri

### DIFF
--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -58,6 +58,13 @@ func resourceAwsEMRCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				ForceNew: true,
 				Optional: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					// EMR uses a proprietary filesystem called EMRFS
+					// and both s3n & s3 protocols are mapped to that FS
+					// so they're equvivalent in this context (confirmed by AWS support)
+					old = strings.Replace(old, "s3n://", "s3://", -1)
+					return old == new
+				},
 			},
 			"master_public_dns": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
Fixes #1356

### Test results

```
=== RUN   TestAccAWSEMRCluster_visibleToAllUsers
--- FAIL: TestAccAWSEMRCluster_visibleToAllUsers (435.08s)
	testing.go:435: Step 0 error: After applying this step, the plan was not empty:
		
		DIFF:
		
		UPDATE: aws_route_table.r
		  route.#:                                    "0" => "1"
		  route.3310190312.cidr_block:                "" => "0.0.0.0/0"
		  route.3310190312.egress_only_gateway_id:    "" => ""
		  route.3310190312.gateway_id:                "" => "igw-bf138ed8"
		  route.3310190312.instance_id:               "" => ""
		  route.3310190312.ipv6_cidr_block:           "" => ""
		  route.3310190312.nat_gateway_id:            "" => ""
		  route.3310190312.network_interface_id:      "" => ""
		  route.3310190312.vpc_peering_connection_id: "" => ""
		...
=== RUN   TestAccAWSEMRCluster_bootstrap_ordering
--- PASS: TestAccAWSEMRCluster_bootstrap_ordering (444.84s)
=== RUN   TestAccAWSEMRCluster_tags
--- PASS: TestAccAWSEMRCluster_tags (445.07s)
=== RUN   TestAccAWSEMRCluster_security_config
--- PASS: TestAccAWSEMRCluster_security_config (461.40s)
=== RUN   TestAccAWSEMRCluster_terminationProtected
--- PASS: TestAccAWSEMRCluster_terminationProtected (464.73s)
=== RUN   TestAccAWSEMRCluster_basic
--- PASS: TestAccAWSEMRCluster_basic (471.66s)
=== RUN   TestAccAWSEMRCluster_s3Logging
--- PASS: TestAccAWSEMRCluster_s3Logging (884.87s)
```

That one failure is intermittent and unrelated to this PR.