### PR TITLE
Log error when failing to delete log subscription filter.

### DIFF
--- a/aws/resource_aws_cloudwatch_log_subscription_filter.go
+++ b/aws/resource_aws_cloudwatch_log_subscription_filter.go
@@ -165,7 +165,7 @@ func resourceAwsCloudwatchLogSubscriptionFilterDelete(d *schema.ResourceData, me
 	_, err := conn.DeleteSubscriptionFilter(params)
 	if err != nil {
 		return fmt.Errorf(
-			"Error deleting Subscription Filter from log group: %s with name filter name %s", log_group_name, name)
+			"Error deleting Subscription Filter from log group: %s with name filter name %s: %+v", log_group_name, name, err)
 	}
 	d.SetId("")
 	return nil


### PR DESCRIPTION
We were swallowing the error being returned when a
cloudwatch_log_subscription_filter resource's Delete method failed. This
just includes the error in the log message.