### PR TITLE
vpc_peering_accepter correct comment syntax

### DIFF
--- a/website/docs/r/vpc_peering_accepter.html.markdown
+++ b/website/docs/r/vpc_peering_accepter.html.markdown
@@ -20,13 +20,13 @@ connection into management.
 
 ```hcl
 provider "aws" {
-  // Requester's credentials.
+  # Requester's credentials.
 }
 
 provider "aws" {
   alias = "peer"
 
-  // Accepter's credentials.
+  # Accepter's credentials.
 }
 
 resource "aws_vpc" "main" {
@@ -42,7 +42,7 @@ data "aws_caller_identity" "peer" {
   provider = "aws.peer"
 }
 
-// Requester's side of the connection.
+# Requester's side of the connection.
 resource "aws_vpc_peering_connection" "peer" {
   vpc_id        = "${aws_vpc.main.id}"
   peer_vpc_id   = "${aws_vpc.peer.id}"
@@ -54,7 +54,7 @@ resource "aws_vpc_peering_connection" "peer" {
   }
 }
 
-// Accepter's side of the connection.
+# Accepter's side of the connection.
 resource "aws_vpc_peering_connection_accepter" "peer" {
   provider                  = "aws.peer"
   vpc_peering_connection_id = "${aws_vpc_peering_connection.peer.id}"


### PR DESCRIPTION
[Website](https://www.terraform.io/docs/providers/aws/r/vpc_peering_accepter.html) syntax highlighting is wrong because of incorrect comment syntax.
- incorrect comment syntax: `//`
- correct comment syntax: `#`