### PR TITLE
resource/aws_cloudwatch_log_subscription_filter: Add support for ResourceNotFound

### DIFF
--- a/aws/resource_aws_cloudwatch_log_subscription_filter.go
+++ b/aws/resource_aws_cloudwatch_log_subscription_filter.go
@@ -23,27 +23,27 @@ func resourceAwsCloudwatchLogSubscriptionFilter() *schema.Resource {
 		Delete: resourceAwsCloudwatchLogSubscriptionFilterDelete,
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"destination_arn": &schema.Schema{
+			"destination_arn": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"filter_pattern": &schema.Schema{
+			"filter_pattern": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: false,
 			},
-			"log_group_name": &schema.Schema{
+			"log_group_name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"role_arn": &schema.Schema{
+			"role_arn": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
@@ -137,6 +137,11 @@ func resourceAwsCloudwatchLogSubscriptionFilterRead(d *schema.ResourceData, meta
 
 	resp, err := conn.DescribeSubscriptionFilters(req)
 	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "ResourceNotFoundException" {
+			log.Printf("[WARN] SubscriptionFilters (%q) Not Found", d.Id())
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("Error reading SubscriptionFilters for log group %s with name prefix %s: %#v", log_group_name, d.Get("name").(string), err)
 	}
 

--- a/aws/resource_aws_cloudwatch_log_subscription_filter_test.go
+++ b/aws/resource_aws_cloudwatch_log_subscription_filter_test.go
@@ -5,14 +5,14 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccAWSCloudwatchLogSubscriptionFilter_basic(t *testing.T) {
-	var conf lambda.GetFunctionOutput
+	var filter cloudwatchlogs.SubscriptionFilter
 
 	rstring := acctest.RandString(5)
 
@@ -24,8 +24,13 @@ func TestAccAWSCloudwatchLogSubscriptionFilter_basic(t *testing.T) {
 			{
 				Config: testAccAWSCloudwatchLogSubscriptionFilterConfig(rstring),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsCloudwatchLogSubscriptionFilterExists("aws_cloudwatch_log_subscription_filter.test_lambdafunction_logfilter", &conf, rstring),
-					testAccCheckAWSCloudwatchLogSubscriptionFilterAttributes(&conf, rstring),
+					testAccCheckAwsCloudwatchLogSubscriptionFilterExists("aws_cloudwatch_log_subscription_filter.test_lambdafunction_logfilter", &filter, rstring),
+					resource.TestCheckResourceAttr(
+						"aws_cloudwatch_log_subscription_filter.test_lambdafunction_logfilter", "filter_pattern", "logtype test"),
+					resource.TestCheckResourceAttr(
+						"aws_cloudwatch_log_subscription_filter.test_lambdafunction_logfilter", "name", fmt.Sprintf("test_lambdafunction_logfilter_%s", rstring)),
+					resource.TestCheckResourceAttr(
+						"aws_cloudwatch_log_subscription_filter.test_lambdafunction_logfilter", "log_group_name", fmt.Sprintf("example_lambda_name_%s", rstring)),
 				),
 			},
 		},
@@ -33,19 +38,24 @@ func TestAccAWSCloudwatchLogSubscriptionFilter_basic(t *testing.T) {
 }
 
 func testAccCheckCloudwatchLogSubscriptionFilterDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*AWSClient).lambdaconn
+	conn := testAccProvider.Meta().(*AWSClient).cloudwatchlogsconn
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_cloudwatch_log_subscription_filter" {
 			continue
 		}
 
-		_, err := conn.GetFunction(&lambda.GetFunctionInput{
-			FunctionName: aws.String(rs.Primary.ID),
-		})
+		logGroupName, _ := rs.Primary.Attributes["log_group_name"]
+		filterNamePrefix, _ := rs.Primary.Attributes["name"]
 
+		input := cloudwatchlogs.DescribeSubscriptionFiltersInput{
+			LogGroupName:     aws.String(logGroupName),
+			FilterNamePrefix: aws.String(filterNamePrefix),
+		}
+
+		_, err := conn.DescribeSubscriptionFilters(&input)
 		if err == nil {
-			return fmt.Errorf("Lambda Function still exists")
+			return fmt.Errorf("SubscriptionFilter still exists")
 		}
 
 	}
@@ -54,45 +64,41 @@ func testAccCheckCloudwatchLogSubscriptionFilterDestroy(s *terraform.State) erro
 
 }
 
-func testAccCheckAwsCloudwatchLogSubscriptionFilterExists(n string, function *lambda.GetFunctionOutput, rstring string) resource.TestCheckFunc {
+func testAccCheckAwsCloudwatchLogSubscriptionFilterExists(n string, filter *cloudwatchlogs.SubscriptionFilter, rName string) resource.TestCheckFunc {
 	// Wait for IAM role
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Lambda function not found: %s", n)
+			return fmt.Errorf("SubscriptionFilter not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("Lambda function ID not set")
+			return fmt.Errorf("SubscriptionFilter ID not set")
 		}
 
-		conn := testAccProvider.Meta().(*AWSClient).lambdaconn
+		conn := testAccProvider.Meta().(*AWSClient).cloudwatchlogsconn
 
-		params := &lambda.GetFunctionInput{
-			FunctionName: aws.String("example_lambda_name_" + rstring),
+		logGroupName, _ := rs.Primary.Attributes["log_group_name"]
+		filterNamePrefix, _ := rs.Primary.Attributes["name"]
+
+		input := cloudwatchlogs.DescribeSubscriptionFiltersInput{
+			LogGroupName:     aws.String(logGroupName),
+			FilterNamePrefix: aws.String(filterNamePrefix),
 		}
 
-		getFunction, err := conn.GetFunction(params)
-		if err != nil {
+		resp, err := conn.DescribeSubscriptionFilters(&input)
+		if err == nil {
 			return err
 		}
 
-		*function = *getFunction
-
-		return nil
-	}
-}
-
-func testAccCheckAWSCloudwatchLogSubscriptionFilterAttributes(function *lambda.GetFunctionOutput, rstring string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		c := function.Configuration
-		expectedName := fmt.Sprintf("example_lambda_name_%s", rstring)
-		if *c.FunctionName != expectedName {
-			return fmt.Errorf("Expected function name %s, got %s", expectedName, *c.FunctionName)
+		if len(resp.SubscriptionFilters) == 0 {
+			return fmt.Errorf("SubscriptionFilter not found")
 		}
 
-		if *c.FunctionArn == "" {
-			return fmt.Errorf("Could not read Lambda Function's ARN")
+		for _, i := range resp.SubscriptionFilters {
+			if *i.FilterName == fmt.Sprintf("test_lambdafunction_logfilter_%s", rName) {
+				*filter = *i
+			}
 		}
 
 		return nil


### PR DESCRIPTION
**Please can both commits be kept here! The first commit was an important change to change the way the acceptance tests work for this resource**

Fixes: #1405

```
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSCloudwatchLogSubscriptionFilter_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCloudwatchLogSubscriptionFilter_ -timeout 120m
=== RUN   TestAccAWSCloudwatchLogSubscriptionFilter_basic
--- PASS: TestAccAWSCloudwatchLogSubscriptionFilter_basic (44.98s)
=== RUN   TestAccAWSCloudwatchLogSubscriptionFilter_subscriptionFilterDisappears
--- PASS: TestAccAWSCloudwatchLogSubscriptionFilter_subscriptionFilterDisappears (46.29s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       91.297s
```

Before this patch:

```
% terraform plan
aws_iam_role.iam_for_lambda: Refreshing state... (ID: test_lambdafuntion_iam_role_dev)
aws_cloudwatch_log_group.logs: Refreshing state... (ID: example_lambda_name_dev)
aws_iam_role_policy.test_lambdafunction_iam_policy: Refreshing state... (ID: test_lambdafuntion_iam_role_dev:test_lambdafunction_iam_policy_dev)
aws_lambda_function.test_lambdafunction: Refreshing state... (ID: example_lambda_name_dev)
aws_lambda_permission.allow_cloudwatch_logs: Refreshing state... (ID: AllowExecutionFromCloudWatchLogs)
aws_cloudwatch_log_subscription_filter.test_lambdafunction_logfilter: Refreshing state... (ID: cwlsf-1141377109)
Error refreshing state: 1 error(s) occurred:

* aws_cloudwatch_log_subscription_filter.test_lambdafunction_logfilter: 1 error(s) occurred:

* aws_cloudwatch_log_subscription_filter.test_lambdafunction_logfilter: aws_cloudwatch_log_subscription_filter.test_lambdafunction_logfilter: Error reading SubscriptionFilters for log group example_lambda_name_dev with name prefix test_lambdafunction_logfilter_dev: ResourceNotFoundException: The specified log group does not exist.
	status code: 400, request id: 9fd09281-8181-11e7-9b65-4d3de36b3958
```

After this patch, we no longer get an issue when planning:

```
% terraform plan
aws_iam_role.iam_for_lambda: Refreshing state... (ID: test_lambdafuntion_iam_role_dev)
aws_iam_role_policy.test_lambdafunction_iam_policy: Refreshing state... (ID: test_lambdafuntion_iam_role_dev:test_lambdafunction_iam_policy_dev)
aws_lambda_function.test_lambdafunction: Refreshing state... (ID: example_lambda_name_dev)
aws_lambda_permission.allow_cloudwatch_logs: Refreshing state... (ID: AllowExecutionFromCloudWatchLogs)
The Terraform execution plan has been generated and is shown below.
Resources are shown in alphabetical order for quick scanning. Green resources
will be created (or destroyed and then created if an existing resource
exists), yellow resources are being changed in-place, and red resources
will be destroyed. Cyan entries are data sources to be read.

Note: You didn't specify an "-out" parameter to save this plan, so when
"apply" is called, Terraform can't guarantee this is what will execute.

  + aws_cloudwatch_log_group.logs
      arn:               "<computed>"
      name:              "example_lambda_name_dev"
      retention_in_days: "1"

  + aws_cloudwatch_log_subscription_filter.test_lambdafunction_logfilter
      destination_arn: "arn:aws:lambda:us-west-2:187416307283:function:example_lambda_name_dev"
      filter_pattern:  "logtype test"
      log_group_name:  "example_lambda_name_dev"
      name:            "test_lambdafunction_logfilter_dev"
      role_arn:        "<computed>"


Plan: 2 to add, 0 to change, 0 to destroy.
```

Also cleaned up the acceptance tests to actually test the correct resource rather than a lambda func created as part of the acceptance testing harness