### PR TITLE
Support updates for aws_ssm_association & aws_ssm_patch_baseline resources

### DIFF
--- a/aws/resource_aws_ssm_association.go
+++ b/aws/resource_aws_ssm_association.go
@@ -40,7 +40,6 @@ func resourceAwsSsmAssociation() *schema.Resource {
 			"parameters": {
 				Type:     schema.TypeMap,
 				Optional: true,
-				ForceNew: true,
 				Computed: true,
 			},
 			"schedule_expression": {
@@ -188,6 +187,10 @@ func resourceAwsSsmAssocationUpdate(d *schema.ResourceData, meta interface{}) er
 
 	if d.HasChange("document_version") {
 		associationInput.DocumentVersion = aws.String(d.Get("document_version").(string))
+	}
+
+	if d.HasChange("parameters") {
+		associationInput.Parameters = expandSSMDocumentParameters(d.Get("parameters").(map[string]interface{}))
 	}
 
 	if d.HasChange("output_location") {

--- a/aws/resource_aws_ssm_association.go
+++ b/aws/resource_aws_ssm_association.go
@@ -27,6 +27,11 @@ func resourceAwsSsmAssociation() *schema.Resource {
 				ForceNew: true,
 				Optional: true,
 			},
+			"document_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				ForceNew: true,
@@ -96,6 +101,10 @@ func resourceAwsSsmAssociationCreate(d *schema.ResourceData, meta interface{}) e
 		assosciationInput.InstanceId = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("document_version"); ok {
+		assosciationInput.DocumentVersion = aws.String(v.(string))
+	}
+
 	if v, ok := d.GetOk("schedule_expression"); ok {
 		assosciationInput.ScheduleExpression = aws.String(v.(string))
 	}
@@ -151,6 +160,7 @@ func resourceAwsSsmAssociationRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("parameters", association.Parameters)
 	d.Set("association_id", association.AssociationId)
 	d.Set("schedule_expression", association.ScheduleExpression)
+	d.Set("document_version", association.DocumentVersion)
 
 	if err := d.Set("targets", flattenAwsSsmTargets(association.Targets)); err != nil {
 		return fmt.Errorf("[DEBUG] Error setting targets error: %#v", err)
@@ -174,6 +184,10 @@ func resourceAwsSsmAssocationUpdate(d *schema.ResourceData, meta interface{}) er
 
 	if d.HasChange("schedule_expression") {
 		associationInput.ScheduleExpression = aws.String(d.Get("schedule_expression").(string))
+	}
+
+	if d.HasChange("document_version") {
+		associationInput.DocumentVersion = aws.String(d.Get("document_version").(string))
 	}
 
 	if d.HasChange("output_location") {

--- a/aws/resource_aws_ssm_association_test.go
+++ b/aws/resource_aws_ssm_association_test.go
@@ -46,6 +46,25 @@ func TestAccAWSSSMAssociation_withTargets(t *testing.T) {
 	})
 }
 
+func TestAccAWSSSMAssociation_withDocumentVersion(t *testing.T) {
+	name := acctest.RandString(10)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSSMAssociationBasicConfigWithDocumentVersion(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMAssociationExists("aws_ssm_association.foo"),
+					resource.TestCheckResourceAttr(
+						"aws_ssm_association.foo", "document_version", "1"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSSSMAssociation_withOutputLocation(t *testing.T) {
 	name := acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
@@ -251,6 +270,54 @@ DOC
 resource "aws_ssm_association" "foo" {
   name        = "test_document_association-%s",
   instance_id = "${aws_instance.foo.id}"
+}
+`, rName, rName, rName)
+}
+
+func testAccAWSSSMAssociationBasicConfigWithDocumentVersion(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_security_group" "tf_test_foo" {
+  name = "tf_test_foo-%s"
+  description = "foo"
+  ingress {
+    protocol = "icmp"
+    from_port = -1
+    to_port = -1
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_ssm_document" "foo_document" {
+  name    = "test_document_association-%s",
+	document_type = "Command"
+  content = <<DOC
+  {
+    "schemaVersion": "1.2",
+    "description": "Check ip configuration of a Linux instance.",
+    "parameters": {
+
+    },
+    "runtimeConfig": {
+      "aws:runShellScript": {
+        "properties": [
+          {
+            "id": "0.aws:runShellScript",
+            "runCommand": ["ifconfig"]
+          }
+        ]
+      }
+    }
+  }
+DOC
+}
+
+resource "aws_ssm_association" "foo" {
+  name        = "test_document_association-%s",
+  document_version = "${aws_ssm_document.foo_document.latest_version}"
+  targets {
+    key = "tag:Name"
+    values = ["acceptanceTest"]
+  }
 }
 `, rName, rName, rName)
 }

--- a/aws/resource_aws_ssm_association_test.go
+++ b/aws/resource_aws_ssm_association_test.go
@@ -82,6 +82,14 @@ func TestAccAWSSSMAssociation_withScheduleExpression(t *testing.T) {
 						"aws_ssm_association.foo", "schedule_expression", "cron(0 16 ? * TUE *)"),
 				),
 			},
+			{
+				Config: testAccAWSSSMAssociationBasicConfigWithScheduleExpressionUpdated(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMAssociationExists("aws_ssm_association.foo"),
+					resource.TestCheckResourceAttr(
+						"aws_ssm_association.foo", "schedule_expression", "cron(0 16 ? * WED *)"),
+				),
+			},
 		},
 	})
 }
@@ -256,6 +264,42 @@ DOC
 resource "aws_ssm_association" "foo" {
   name = "${aws_ssm_document.foo_document.name}",
   schedule_expression = "cron(0 16 ? * TUE *)"
+  targets {
+    key = "tag:Name"
+    values = ["acceptanceTest"]
+  }
+}`, rName)
+}
+
+func testAccAWSSSMAssociationBasicConfigWithScheduleExpressionUpdated(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ssm_document" "foo_document" {
+  name = "test_document_association-%s",
+  document_type = "Command"
+  content = <<DOC
+  {
+    "schemaVersion": "1.2",
+    "description": "Check ip configuration of a Linux instance.",
+    "parameters": {
+
+    },
+    "runtimeConfig": {
+      "aws:runShellScript": {
+        "properties": [
+          {
+            "id": "0.aws:runShellScript",
+            "runCommand": ["ifconfig"]
+          }
+        ]
+      }
+    }
+  }
+DOC
+}
+
+resource "aws_ssm_association" "foo" {
+  name = "${aws_ssm_document.foo_document.name}",
+  schedule_expression = "cron(0 16 ? * WED *)"
   targets {
     key = "tag:Name"
     values = ["acceptanceTest"]

--- a/aws/resource_aws_ssm_association_test.go
+++ b/aws/resource_aws_ssm_association_test.go
@@ -63,6 +63,26 @@ func TestAccAWSSSMAssociation_withOutputLocation(t *testing.T) {
 						"aws_ssm_association.foo", "output_location.0.s3_key_prefix", "SSMAssociation"),
 				),
 			},
+			{
+				Config: testAccAWSSSMAssociationBasicConfigWithOutPutLocationUpdateBucketName(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMAssociationExists("aws_ssm_association.foo"),
+					resource.TestCheckResourceAttr(
+						"aws_ssm_association.foo", "output_location.0.s3_bucket_name", fmt.Sprintf("tf-acc-test-ssmoutput-updated-%s", name)),
+					resource.TestCheckResourceAttr(
+						"aws_ssm_association.foo", "output_location.0.s3_key_prefix", "SSMAssociation"),
+				),
+			},
+			{
+				Config: testAccAWSSSMAssociationBasicConfigWithOutPutLocationUpdateKeyPrefix(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMAssociationExists("aws_ssm_association.foo"),
+					resource.TestCheckResourceAttr(
+						"aws_ssm_association.foo", "output_location.0.s3_bucket_name", fmt.Sprintf("tf-acc-test-ssmoutput-updated-%s", name)),
+					resource.TestCheckResourceAttr(
+						"aws_ssm_association.foo", "output_location.0.s3_key_prefix", "UpdatedAssociation"),
+				),
+			},
 		},
 	})
 }
@@ -349,4 +369,102 @@ resource "aws_ssm_association" "foo" {
     s3_key_prefix = "SSMAssociation"
   }
 }`, rName, rName)
+}
+
+func testAccAWSSSMAssociationBasicConfigWithOutPutLocationUpdateBucketName(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "output_location" {
+  bucket = "tf-acc-test-ssmoutput-%s"
+  force_destroy = true
+}
+
+resource "aws_s3_bucket" "output_location_updated" {
+  bucket = "tf-acc-test-ssmoutput-updated-%s"
+  force_destroy = true
+}
+
+resource "aws_ssm_document" "foo_document" {
+  name = "test_document_association-%s",
+  document_type = "Command"
+  content = <<DOC
+  {
+    "schemaVersion": "1.2",
+    "description": "Check ip configuration of a Linux instance.",
+    "parameters": {
+
+    },
+    "runtimeConfig": {
+      "aws:runShellScript": {
+        "properties": [
+          {
+            "id": "0.aws:runShellScript",
+            "runCommand": ["ifconfig"]
+          }
+        ]
+      }
+    }
+  }
+DOC
+}
+
+resource "aws_ssm_association" "foo" {
+  name = "${aws_ssm_document.foo_document.name}",
+  targets {
+    key = "tag:Name"
+    values = ["acceptanceTest"]
+  }
+  output_location {
+    s3_bucket_name = "${aws_s3_bucket.output_location_updated.id}"
+    s3_key_prefix = "SSMAssociation"
+  }
+}`, rName, rName, rName)
+}
+
+func testAccAWSSSMAssociationBasicConfigWithOutPutLocationUpdateKeyPrefix(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "output_location" {
+  bucket = "tf-acc-test-ssmoutput-%s"
+  force_destroy = true
+}
+
+resource "aws_s3_bucket" "output_location_updated" {
+  bucket = "tf-acc-test-ssmoutput-updated-%s"
+  force_destroy = true
+}
+
+resource "aws_ssm_document" "foo_document" {
+  name = "test_document_association-%s",
+  document_type = "Command"
+  content = <<DOC
+  {
+    "schemaVersion": "1.2",
+    "description": "Check ip configuration of a Linux instance.",
+    "parameters": {
+
+    },
+    "runtimeConfig": {
+      "aws:runShellScript": {
+        "properties": [
+          {
+            "id": "0.aws:runShellScript",
+            "runCommand": ["ifconfig"]
+          }
+        ]
+      }
+    }
+  }
+DOC
+}
+
+resource "aws_ssm_association" "foo" {
+  name = "${aws_ssm_document.foo_document.name}",
+  targets {
+    key = "tag:Name"
+    values = ["acceptanceTest"]
+  }
+  output_location {
+    s3_bucket_name = "${aws_s3_bucket.output_location_updated.id}"
+    s3_key_prefix = "UpdatedAssociation"
+  }
+}`, rName, rName, rName)
 }

--- a/aws/resource_aws_ssm_patch_baseline_test.go
+++ b/aws/resource_aws_ssm_patch_baseline_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestAccAWSSSMPatchBaseline_basic(t *testing.T) {
+	var before, after ssm.PatchBaselineIdentity
 	name := acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -21,19 +22,23 @@ func TestAccAWSSSMPatchBaseline_basic(t *testing.T) {
 			{
 				Config: testAccAWSSSMPatchBaselineBasicConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMPatchBaselineExists("aws_ssm_patch_baseline.foo"),
+					testAccCheckAWSSSMPatchBaselineExists("aws_ssm_patch_baseline.foo", &before),
 					resource.TestCheckResourceAttr(
 						"aws_ssm_patch_baseline.foo", "approved_patches.#", "1"),
 					resource.TestCheckResourceAttr(
 						"aws_ssm_patch_baseline.foo", "approved_patches.2062620480", "KB123456"),
 					resource.TestCheckResourceAttr(
 						"aws_ssm_patch_baseline.foo", "name", fmt.Sprintf("patch-baseline-%s", name)),
+					resource.TestCheckResourceAttr(
+						"aws_ssm_patch_baseline.foo", "approved_patches_compliance_level", "CRITICAL"),
+					resource.TestCheckResourceAttr(
+						"aws_ssm_patch_baseline.foo", "description", "Baseline containing all updates approved for production systems"),
 				),
 			},
 			{
 				Config: testAccAWSSSMPatchBaselineBasicConfigUpdated(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMPatchBaselineExists("aws_ssm_patch_baseline.foo"),
+					testAccCheckAWSSSMPatchBaselineExists("aws_ssm_patch_baseline.foo", &after),
 					resource.TestCheckResourceAttr(
 						"aws_ssm_patch_baseline.foo", "approved_patches.#", "2"),
 					resource.TestCheckResourceAttr(
@@ -42,6 +47,16 @@ func TestAccAWSSSMPatchBaseline_basic(t *testing.T) {
 						"aws_ssm_patch_baseline.foo", "approved_patches.2291496788", "KB456789"),
 					resource.TestCheckResourceAttr(
 						"aws_ssm_patch_baseline.foo", "name", fmt.Sprintf("updated-patch-baseline-%s", name)),
+					resource.TestCheckResourceAttr(
+						"aws_ssm_patch_baseline.foo", "approved_patches_compliance_level", "HIGH"),
+					resource.TestCheckResourceAttr(
+						"aws_ssm_patch_baseline.foo", "description", "Baseline containing all updates approved for production systems - August 2017"),
+					func(*terraform.State) error {
+						if *before.BaselineId != *after.BaselineId {
+							t.Fatal("Baseline IDs changed unexpectedly")
+						}
+						return nil
+					},
 				),
 			},
 		},
@@ -49,6 +64,7 @@ func TestAccAWSSSMPatchBaseline_basic(t *testing.T) {
 }
 
 func TestAccAWSSSMPatchBaselineWithOperatingSystem(t *testing.T) {
+	var before, after ssm.PatchBaselineIdentity
 	name := acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -58,7 +74,7 @@ func TestAccAWSSSMPatchBaselineWithOperatingSystem(t *testing.T) {
 			{
 				Config: testAccAWSSSMPatchBaselineConfigWithOperatingSystem(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMPatchBaselineExists("aws_ssm_patch_baseline.foo"),
+					testAccCheckAWSSSMPatchBaselineExists("aws_ssm_patch_baseline.foo", &before),
 					resource.TestCheckResourceAttr(
 						"aws_ssm_patch_baseline.foo", "approval_rule.#", "1"),
 					resource.TestCheckResourceAttr(
@@ -69,11 +85,36 @@ func TestAccAWSSSMPatchBaselineWithOperatingSystem(t *testing.T) {
 						"aws_ssm_patch_baseline.foo", "operating_system", "AMAZON_LINUX"),
 				),
 			},
+			{
+				Config: testAccAWSSSMPatchBaselineConfigWithOperatingSystemUpdated(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMPatchBaselineExists("aws_ssm_patch_baseline.foo", &after),
+					resource.TestCheckResourceAttr(
+						"aws_ssm_patch_baseline.foo", "approval_rule.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_ssm_patch_baseline.foo", "approval_rule.0.approve_after_days", "7"),
+					resource.TestCheckResourceAttr(
+						"aws_ssm_patch_baseline.foo", "approval_rule.0.patch_filter.#", "2"),
+					resource.TestCheckResourceAttr(
+						"aws_ssm_patch_baseline.foo", "operating_system", "WINDOWS"),
+					testAccCheckAwsSsmPatchBaselineRecreated(t, &before, &after),
+				),
+			},
 		},
 	})
 }
 
-func testAccCheckAWSSSMPatchBaselineExists(n string) resource.TestCheckFunc {
+func testAccCheckAwsSsmPatchBaselineRecreated(t *testing.T,
+	before, after *ssm.PatchBaselineIdentity) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if *before.BaselineId == *after.BaselineId {
+			t.Fatalf("Expected change of SSM Patch Baseline IDs, but both were %v", *before.BaselineId)
+		}
+		return nil
+	}
+}
+
+func testAccCheckAWSSSMPatchBaselineExists(n string, patch *ssm.PatchBaselineIdentity) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -97,6 +138,7 @@ func testAccCheckAWSSSMPatchBaselineExists(n string) resource.TestCheckFunc {
 
 		for _, i := range resp.BaselineIdentities {
 			if *i.BaselineId == rs.Primary.ID {
+				*patch = *i
 				return nil
 			}
 		}
@@ -144,7 +186,9 @@ func testAccAWSSSMPatchBaselineBasicConfig(rName string) string {
 
 resource "aws_ssm_patch_baseline" "foo" {
   name  = "patch-baseline-%s"
+  description = "Baseline containing all updates approved for production systems"
   approved_patches = ["KB123456"]
+  approved_patches_compliance_level = "CRITICAL"
 }
 
 `, rName)
@@ -155,7 +199,9 @@ func testAccAWSSSMPatchBaselineBasicConfigUpdated(rName string) string {
 
 resource "aws_ssm_patch_baseline" "foo" {
   name  = "updated-patch-baseline-%s"
+  description = "Baseline containing all updates approved for production systems - August 2017"
   approved_patches = ["KB123456","KB456789"]
+  approved_patches_compliance_level = "HIGH"
 }
 
 `, rName)
@@ -178,6 +224,31 @@ resource "aws_ssm_patch_baseline" "foo" {
 
   	patch_filter {
 		key = "SEVERITY"
+		values = ["Critical","Important"]
+  	}
+  }
+}
+
+`, rName)
+}
+
+func testAccAWSSSMPatchBaselineConfigWithOperatingSystemUpdated(rName string) string {
+	return fmt.Sprintf(`
+
+resource "aws_ssm_patch_baseline" "foo" {
+  name  = "patch-baseline-%s"
+  operating_system = "WINDOWS"
+  description = "Baseline containing all updates approved for production systems"
+  approval_rule {
+  	approve_after_days = 7
+
+  	patch_filter {
+		key = "PRODUCT"
+		values = ["WindowsServer2012R2"]
+  	}
+
+  	patch_filter {
+		key = "MSRC_SEVERITY"
 		values = ["Critical","Important"]
   	}
   }

--- a/website/docs/r/ssm_association.html.markdown
+++ b/website/docs/r/ssm_association.html.markdown
@@ -73,6 +73,7 @@ The following arguments are supported:
 * `targets` - (Optional) The targets (either instances or tags). Instances are specified using Key=instanceids,Values=instanceid1,instanceid2. Tags are specified using Key=tag name,Values=tag value. Only 1 target is currently supported by AWS.
 * `schedule_expression` - (Optional) A cron expression when the association will be applied to the target(s).
 * `output_location` - (Optional) An output location block. OutputLocation documented below.
+* `document_version` - (Optional) The document version you want to associate with the target(s). Can be a specific version or the default version.
 
 Output Location (`output_location`) is an S3 bucket where you want to store the results of this association:
 


### PR DESCRIPTION
Fixes: #1296

**aws_ssm_association:**
- [x] parameters
- [x] schedule_expression
- [x] output_location

```
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSSSMAssociation_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSSSMAssociation_ -timeout 120m
=== RUN   TestAccAWSSSMAssociation_basic
--- PASS: TestAccAWSSSMAssociation_basic (128.55s)
=== RUN   TestAccAWSSSMAssociation_withTargets
--- PASS: TestAccAWSSSMAssociation_withTargets (34.77s)
=== RUN   TestAccAWSSSMAssociation_withParameters
--- PASS: TestAccAWSSSMAssociation_withParameters (57.27s)
=== RUN   TestAccAWSSSMAssociation_withDocumentVersion
--- PASS: TestAccAWSSSMAssociation_withDocumentVersion (43.08s)
=== RUN   TestAccAWSSSMAssociation_withOutputLocation
--- PASS: TestAccAWSSSMAssociation_withOutputLocation (153.91s)
=== RUN   TestAccAWSSSMAssociation_withScheduleExpression
--- PASS: TestAccAWSSSMAssociation_withScheduleExpression (59.03s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	476.632s
```

**aws_ssm_patch_baseline**
- [x] name
- [x] description
- [x] global_filter
- [x] approval_rule
- [x] approved_patches
- [x] rejected_patches
- [x] approved_patches_compliance_level

```
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSSSMPatchBaseline'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSSSMPatchBaseline -timeout 120m
=== RUN   TestAccAWSSSMPatchBaseline_basic
--- PASS: TestAccAWSSSMPatchBaseline_basic (42.98s)
=== RUN   TestAccAWSSSMPatchBaselineWithOperatingSystem
--- PASS: TestAccAWSSSMPatchBaselineWithOperatingSystem (44.24s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	87.247s
```
