### PR TITLE
Add support for Task Roles when running on ECS or CodeBuild

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -101,6 +101,13 @@ provider "aws" {
 }
 ```
 
+### ECS and CodeBuild Task Roles
+
+If you're running Terraform on ECS or CodeBuild and you have configured an [IAM Task Role](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html),
+Terraform will use the container's Task Role. Terraform looks for the presence of the `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`
+environment variable that AWS injects when a Task Role is configured. If you have not defined a Task Role for your container
+or CodeBuild job, Terraform will continue to use the [EC2 Role](#ec2-role).
+
 ### EC2 Role
 
 If you're running Terraform from an EC2 instance with IAM Instance Profile
@@ -112,7 +119,7 @@ This is a preferred approach over any other when running in EC2 as you can avoid
 hard coding credentials. Instead these are leased on-the-fly by Terraform
 which reduces the chance of leakage.
 
-You can provide the custom metadata API endpoint via the `AWS_METADATA_ENDPOINT` variable
+You can provide the custom metadata API endpoint via the `AWS_METADATA_URL` variable
 which expects the endpoint URL, including the version, and defaults to `http://169.254.169.254:80/latest`.
 
 The default deadline for the EC2 metadata API endpoint is 100 milliseconds,


### PR DESCRIPTION
This is a port of my original PR [#14199](https://github.com/hashicorp/terraform/pull/14199) from the terraform repo, before the provider spin-off in 0.10+. It addresses #259.

Here's the comment from the original PR:
> [This PR] adds the RemoteCredProvider from the AWS SDK if the AWS_CONTAINER_CREDENTIALS_RELATIVE_URI environment variable is set. The RemoteCredProvider uses the value of that environment variable and appends it to the hard-coded URL http://169.254.170.2, and uses the resulting URL to obtain Task Role credentials.

The benefit of this approach is that it falls back to the default AWS SDK to obtain ECS credentials. It may be valuable to always fall back to the default SDK unless specific terraform overrides are configured, rather than providing a custom credentials bootstrap or mimicking the SDK behavior, so that terraform is able to automatically take advantage of future updates to the SDK's credential-finding behavior.