### PR TITLE
r/aws_alb: Cleanup ENIs after deleting ALB

### DIFF
--- a/aws/resource_aws_elb.go
+++ b/aws/resource_aws_elb.go
@@ -984,7 +984,7 @@ func isValidProtocol(s string) bool {
 
 // ELB automatically creates ENI(s) on creation
 // but the cleanup is asynchronous and may take time
-// which then blocks IGW or VPC on deletion
+// which then blocks IGW, SG or VPC on deletion
 // So we make the cleanup "synchronous" here
 func cleanupELBNetworkInterfaces(conn *ec2.EC2, name string) error {
 	out, err := conn.DescribeNetworkInterfaces(&ec2.DescribeNetworkInterfacesInput{


### PR DESCRIPTION
Similar to https://github.com/terraform-providers/terraform-provider-aws/pull/1036 - just for ALBs.

Closes #40

## Test results

```
=== RUN   TestAccAWSALB_generatesNameForZeroValue
--- FAIL: TestAccAWSALB_generatesNameForZeroValue (370.87s)
	testing.go:435: Step 0 error: Error applying: 1 error(s) occurred:
		
		* aws_internet_gateway.gw: 1 error(s) occurred:
		
		* aws_internet_gateway.gw: Error waiting for internet gateway (igw-2444de43) to attach: timeout while waiting for state to become 'available' (timeout: 4m0s)
=== RUN   TestAccAWSALB_noSecurityGroup
--- PASS: TestAccAWSALB_noSecurityGroup (404.35s)
=== RUN   TestAccAWSALB_updatedSecurityGroups
--- PASS: TestAccAWSALB_updatedSecurityGroups (409.52s)
=== RUN   TestAccAWSALB_updatedIpAddressType
--- PASS: TestAccAWSALB_updatedIpAddressType (449.90s)
=== RUN   TestAccAWSALB_updatedSubnets
--- PASS: TestAccAWSALB_updatedSubnets (561.85s)
=== RUN   TestAccAWSALB_accesslogs
--- PASS: TestAccAWSALB_accesslogs (600.44s)
=== RUN   TestAccAWSALB_generatedName
--- PASS: TestAccAWSALB_generatedName (622.92s)
=== RUN   TestAccAWSALB_tags
--- PASS: TestAccAWSALB_tags (703.79s)
=== RUN   TestAccAWSALB_namePrefix
--- PASS: TestAccAWSALB_namePrefix (821.56s)
=== RUN   TestAccAWSALB_basic
--- PASS: TestAccAWSALB_basic (892.93s)
```

## Debug log snippet

```
$ grep -h 'ENIs to cleanup for ALB' ./debug-aws-28606e1.log
```
```
2017/08/16 07:42:22 [DEBUG] Found 1 ENIs to cleanup for ALB "app/tf-lb-20170816073921274100000001/6a9f323951898014"
2017/08/16 07:43:18 [DEBUG] Found 1 ENIs to cleanup for ALB "app/testaccawsalb-nosg-hp2qc6z17j/818406808994a98d"
2017/08/16 07:43:18 [DEBUG] Found 1 ENIs to cleanup for ALB "app/testaccawsalb-basic-k492r98v1c/34a06520d7aaa53b"
2017/08/16 07:43:42 [DEBUG] Found 1 ENIs to cleanup for ALB "app/testaccawsalb-basic-fq7wg2u2te/27c06f719526bfb3"
2017/08/16 07:45:03 [DEBUG] Found 1 ENIs to cleanup for ALB "app/tf-lb-20170816073833572000000001/8d1f8af0fca15c9c"
2017/08/16 07:45:21 [DEBUG] Found 1 ENIs to cleanup for ALB "app/testaccawsalb-basic-rds8vieupa/648e743cf9994057"
2017/08/16 07:46:25 [DEBUG] Found 1 ENIs to cleanup for ALB "app/testaccawsalbaccesslog-zeig/640f4f8ceaf31c63"
2017/08/16 07:47:56 [DEBUG] Found 1 ENIs to cleanup for ALB "app/testaccawsalb-basic-enrf9z3i7h/79b4a339bc39c0f6"
2017/08/16 07:50:05 [DEBUG] Found 1 ENIs to cleanup for ALB "app/tf-lb-20170816074724825300000001/20bcce6886165959"
2017/08/16 07:51:47 [DEBUG] Found 0 ENIs to cleanup for ALB "app/testaccawsalb-basic-0rd642ipo2/a68685c31921dfa6"
```