### PR TITLE
Add retries for AppScaling policies throttling exceptions

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -399,6 +399,20 @@ func (c *Config) Client() (interface{}, error) {
 		}
 	})
 
+	// Workaround for https://github.com/aws/aws-sdk-go/issues/1472
+	client.appautoscalingconn.Handlers.Retry.PushBack(func(r *request.Request) {
+		if !strings.HasPrefix(r.Operation.Name, "Describe") && !strings.HasPrefix(r.Operation.Name, "List") {
+			return
+		}
+		err, ok := r.Error.(awserr.Error)
+		if !ok || err == nil {
+			return
+		}
+		if err.Code() == applicationautoscaling.ErrCodeFailedResourceAccessException {
+			r.Retryable = aws.Bool(true)
+		}
+	})
+
 	return &client, nil
 }
 


### PR DESCRIPTION
Fix for https://github.com/terraform-providers/terraform-provider-aws/issues/1428, allows retry on DescribeScalingPolices throttling error. 

```
TF_ACC=1 go test ./aws -v -run=TestAccAWSAppautoScalingPolicy -timeout 120m
=== RUN   TestAccAWSAppautoScalingPolicy_basic
--- PASS: TestAccAWSAppautoScalingPolicy_basic (128.68s)
=== RUN   TestAccAWSAppautoScalingPolicy_spotFleetRequest
--- PASS: TestAccAWSAppautoScalingPolicy_spotFleetRequest (84.73s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	213.435s
```
