### PR TITLE
resource/aws_cloudformation_stack: Add support for Import

### DIFF
--- a/aws/resource_aws_cloudformation_stack.go
+++ b/aws/resource_aws_cloudformation_stack.go
@@ -21,6 +21,10 @@ func resourceAwsCloudFormationStack() *schema.Resource {
 		Update: resourceAwsCloudFormationStackUpdate,
 		Delete: resourceAwsCloudFormationStackDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),
 			Update: schema.DefaultTimeout(30 * time.Minute),

--- a/aws/resource_aws_cloudformation_stack_test.go
+++ b/aws/resource_aws_cloudformation_stack_test.go
@@ -11,6 +11,28 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestAccAWSCloudFormation_importBasic(t *testing.T) {
+	stackName := fmt.Sprintf("tf-acc-test-basic-%s", acctest.RandString(10))
+
+	resourceName := "aws_cloudformation_stack.network"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudFormationConfig(stackName),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSCloudFormation_basic(t *testing.T) {
 	var stack cloudformation.Stack
 	stackName := fmt.Sprintf("tf-acc-test-basic-%s", acctest.RandString(10))

--- a/website/docs/r/cloudformation_stack.html.markdown
+++ b/website/docs/r/cloudformation_stack.html.markdown
@@ -76,6 +76,15 @@ The following attributes are exported:
 * `outputs` - A map of outputs from the stack.
 
 
+## Import
+
+Cloudformation Stacks can be imported using the `name`, e.g.
+
+```
+$ terraform import aws_cloudformation_stack.stack networking-stack
+```
+
+
 <a id="timeouts"></a>
 ## Timeouts
 


### PR DESCRIPTION
Fixes: #1331

```
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSCloudFormation_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCloudFormation_ -timeout 120m
=== RUN   TestAccAWSCloudFormation_importBasic
--- PASS: TestAccAWSCloudFormation_importBasic (89.21s)
=== RUN   TestAccAWSCloudFormation_basic
--- PASS: TestAccAWSCloudFormation_basic (85.71s)
=== RUN   TestAccAWSCloudFormation_yaml
--- PASS: TestAccAWSCloudFormation_yaml (85.08s)
=== RUN   TestAccAWSCloudFormation_defaultParams
--- PASS: TestAccAWSCloudFormation_defaultParams (86.75s)
=== RUN   TestAccAWSCloudFormation_allAttributes
--- PASS: TestAccAWSCloudFormation_allAttributes (154.23s)
=== RUN   TestAccAWSCloudFormation_withParams
--- PASS: TestAccAWSCloudFormation_withParams (158.42s)
```