### PR TITLE
S3 bucket policy html markdown update

### DIFF
--- a/website/docs/r/s3_bucket_policy.html.markdown
+++ b/website/docs/r/s3_bucket_policy.html.markdown
@@ -12,20 +12,37 @@ Attaches a policy to an S3 bucket resource.
 
 ## Example Usage
 
-### Using versioning
+### Creating a custom policy and adding to the bucket
 
 ```hcl
 resource "aws_s3_bucket" "b" {
-  # Arguments
+  bucket = "my_tf_test_bucket"
 }
 
-data "aws_iam_policy_document" "b" {
-  # Policy statements
+variable "my_bucket_policy" {
+  default = <<EOF
+{
+  "Version": "2012-10-17",
+  "Id": "MYBUCKETPOLICY",
+  "Statement": [
+    {
+      "Sid": "IPAllow",
+      "Effect": "Deny",
+      "Principal": "*",
+      "Action": "s3:*",
+      "Resource": "arn:aws:s3:::my_tf_test_bucket/*",
+      "Condition": {
+         "IpAddress": {"aws:SourceIp": "8.8.8.8/32"}
+      } 
+    } 
+  ]
+}
+EOF
 }
 
 resource "aws_s3_bucket_policy" "b" {
   bucket = "${aws_s3_bucket.b.id}"
-  policy = "${data.aws_iam_policy_document.b.json}"
+  policy = "${var.my_bucket_policy}"
 }
 ```
 

--- a/website/docs/r/s3_bucket_policy.html.markdown
+++ b/website/docs/r/s3_bucket_policy.html.markdown
@@ -12,6 +12,8 @@ Attaches a policy to an S3 bucket resource.
 
 ## Example Usage
 
+### Basic Usage
+
 ```hcl
 resource "aws_s3_bucket" "b" {
   bucket = "my_tf_test_bucket"

--- a/website/docs/r/s3_bucket_policy.html.markdown
+++ b/website/docs/r/s3_bucket_policy.html.markdown
@@ -12,15 +12,14 @@ Attaches a policy to an S3 bucket resource.
 
 ## Example Usage
 
-### Creating a custom policy and adding to the bucket
-
 ```hcl
 resource "aws_s3_bucket" "b" {
   bucket = "my_tf_test_bucket"
 }
 
-variable "my_bucket_policy" {
-  default = <<EOF
+resource "aws_s3_bucket_policy" "b" {
+  bucket = "${aws_s3_bucket.b.id}"
+  policy =<<POLICY
 {
   "Version": "2012-10-17",
   "Id": "MYBUCKETPOLICY",
@@ -37,12 +36,7 @@ variable "my_bucket_policy" {
     } 
   ]
 }
-EOF
-}
-
-resource "aws_s3_bucket_policy" "b" {
-  bucket = "${aws_s3_bucket.b.id}"
-  policy = "${var.my_bucket_policy}"
+POLICY
 }
 ```
 


### PR DESCRIPTION
Second try.

Fixes [#1410](https://github.com/terraform-providers/terraform-provider-aws/issues/1410#issuecomment-322566852). Provides a working example for the aws_s3_bucket_policy resource and removes confusing reference to "Versioning" that was likely a copy paste error from somewhere else.