### PR TITLE
docs/aws_autoscaling_policy: AutoScalingGroupName shouldn't mention ARN

### DIFF
--- a/website/docs/r/autoscaling_policy.html.markdown
+++ b/website/docs/r/autoscaling_policy.html.markdown
@@ -44,7 +44,7 @@ resource "aws_autoscaling_group" "bar" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the policy.
-* `autoscaling_group_name` - (Required) The name or ARN of the group.
+* `autoscaling_group_name` - (Required) The name of the autoscaling group.
 * `adjustment_type` - (Required) Specifies whether the adjustment is an absolute number or a percentage of the current capacity. Valid values are `ChangeInCapacity`, `ExactCapacity`, and `PercentChangeInCapacity`.
 * `policy_type` - (Optional) The policy type, either "SimpleScaling" or "StepScaling". If this value isn't provided, AWS will default to "SimpleScaling."
 


### PR DESCRIPTION
Fixes: #1180

The SDK doesn't accept ARN for the AutoScalingGroupName. I raised this
as a documentation bug on the SDK here

https://github.com/aws/aws-sdk-go/issues/1474