### PR TITLE
resource/aws_ssm_parameter: Refresh from state on 404

### DIFF
--- a/aws/resource_aws_ssm_parameter.go
+++ b/aws/resource_aws_ssm_parameter.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -66,8 +65,10 @@ func resourceAwsSsmParameterRead(d *schema.ResourceData, meta interface{}) error
 		return errwrap.Wrapf("[ERROR] Error describing SSM parameter: {{err}}", err)
 	}
 
-	if len(resp.InvalidParameters) > 0 {
-		return fmt.Errorf("[ERROR] SSM Parameter %s is invalid", d.Id())
+	if len(resp.Parameters) == 0 {
+		log.Printf("[INFO] SSM Param %q not found", d.Id())
+		d.SetId("")
+		return nil
 	}
 
 	param := resp.Parameters[0]

--- a/aws/resource_aws_ssm_parameter.go
+++ b/aws/resource_aws_ssm_parameter.go
@@ -66,7 +66,7 @@ func resourceAwsSsmParameterRead(d *schema.ResourceData, meta interface{}) error
 	}
 
 	if len(resp.Parameters) == 0 {
-		log.Printf("[INFO] SSM Param %q not found", d.Id())
+		log.Printf("[WARN] SSM Param %q not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}


### PR DESCRIPTION
fixes: #1007

when an SSM Parameter is manually deleted, Terraform should recreate it.
For some reason, Terraform was inspecting the `InvalidParameters` part
of the response rather than actually checking that the Parameter was
returned. By removing this and then refreshing from state on no
parameters found, a manually deleted parameter can then be recreated

As part of this PR, a lot of the acceptance tests were restructured.
Previously, each acceptance tests was making multiple API requests to
check type and value of the param. This is replaced by 1 API request now
to check the Parameter now exists. We can then check the type and value
from our statefile

```
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSSSMParameter_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSSSMParameter_ -timeout 120m
=== RUN   TestAccAWSSSMParameter_basic
--- PASS: TestAccAWSSSMParameter_basic (23.73s)
=== RUN   TestAccAWSSSMParameter_disappears
--- PASS: TestAccAWSSSMParameter_disappears (17.86s)
=== RUN   TestAccAWSSSMParameter_update
--- PASS: TestAccAWSSSMParameter_update (46.65s)
=== RUN   TestAccAWSSSMParameter_changeNameForcesNew
--- PASS: TestAccAWSSSMParameter_changeNameForcesNew (42.80s)
=== RUN   TestAccAWSSSMParameter_secure
--- PASS: TestAccAWSSSMParameter_secure (24.52s)
=== RUN   TestAccAWSSSMParameter_secure_with_key
--- PASS: TestAccAWSSSMParameter_secure_with_key (65.95s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	221.529s
```