### PR TITLE
Add ability to specify EMR instance group bid price

### DIFF
--- a/aws/resource_aws_emr_instance_group.go
+++ b/aws/resource_aws_emr_instance_group.go
@@ -55,6 +55,11 @@ func resourceAwsEMRInstanceGroup() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"bid_price": {
+				Type: schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"ebs_config": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -116,6 +121,7 @@ func readEmrEBSConfig(d *schema.ResourceData) *emr.EbsConfiguration {
 	return result
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticmapreduce-2009-03-31/AddInstanceGroups
 func resourceAwsEMRInstanceGroupCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).emrconn
 
@@ -123,6 +129,7 @@ func resourceAwsEMRInstanceGroupCreate(d *schema.ResourceData, meta interface{})
 	instanceType := d.Get("instance_type").(string)
 	instanceCount := d.Get("instance_count").(int)
 	groupName := d.Get("name").(string)
+	bidPrice := d.Get("bid_price").(string)
 
 	ebsConfig := readEmrEBSConfig(d)
 
@@ -133,6 +140,7 @@ func resourceAwsEMRInstanceGroupCreate(d *schema.ResourceData, meta interface{})
 				InstanceCount:    aws.Int64(int64(instanceCount)),
 				InstanceType:     aws.String(instanceType),
 				Name:             aws.String(groupName),
+				BidPrice:         aws.String(bidPrice),
 				EbsConfiguration: ebsConfig,
 			},
 		},

--- a/aws/resource_aws_emr_instance_group.go
+++ b/aws/resource_aws_emr_instance_group.go
@@ -59,6 +59,7 @@ func resourceAwsEMRInstanceGroup() *schema.Resource {
 				Type: schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				ValidateFunc: validateAwsEmrBidPrice,
 			},
 			"ebs_config": {
 				Type:     schema.TypeSet,

--- a/aws/resource_aws_emr_instance_group_test.go
+++ b/aws/resource_aws_emr_instance_group_test.go
@@ -29,6 +29,22 @@ func TestAccAWSEMRInstanceGroup_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSEMRInstanceGroup_spot(t *testing.T) {
+	var ig emr.InstanceGroup
+	rInt := acctest.RandInt()
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEmrInstanceGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEmrInstanceGroupConfig_bid(rInt),
+				Check:  testAccCheckAWSEmrInstanceGroupExists("aws_emr_instance_group.task", &ig),
+			},
+		},
+	})
+}
+
 // Confirm we can scale down the instance count. Regression test for https://github.com/terraform-providers/terraform-provider-aws/issues/1264
 func TestAccAWSEMRInstanceGroup_zero_count(t *testing.T) {
 	var ig emr.InstanceGroup
@@ -402,6 +418,17 @@ func testAccAWSEmrInstanceGroupConfig(r int) string {
     cluster_id     = "${aws_emr_cluster.tf-test-cluster.id}"
     instance_count = 1
     instance_type  = "m1.small"
+  }
+	`, r, r, r, r, r, r)
+}
+
+func testAccAWSEmrInstanceGroupConfig_bid(r int) string {
+	return fmt.Sprintf(testAccAWSEmrInstanceGroupBase+`
+	resource "aws_emr_instance_group" "task" {
+    cluster_id     = "${aws_emr_cluster.tf-test-cluster.id}"
+    instance_count = 1
+    instance_type  = "m1.small"
+    bid_price = "0.10"
   }
 	`, r, r, r, r, r, r)
 }

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -861,6 +861,16 @@ func validateAwsEcsPlacementStrategy(stratType, stratField string) error {
 	return nil
 }
 
+func validateAwsEmrBidPrice(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+
+	if len(value) > 256 {
+		errors = append(errors, fmt.Errorf("%q cannot be longer than 256 characters", k))
+	}
+
+	return
+}
+
 func validateAwsEmrEbsVolumeType(v interface{}, k string) (ws []string, errors []error) {
 	validTypes := map[string]struct{}{
 		"gp2":      {},

--- a/website/docs/r/emr_instance_group.html.md
+++ b/website/docs/r/emr_instance_group.html.md
@@ -41,6 +41,8 @@ The following arguments are supported:
 * `size` - (Optional) The volume size, in gibibytes (GiB). This can be a number from 1 - 1024. If the volume type is EBS-optimized, the minimum value is 10.
 * `type` - (Optional) The volume type. Valid options are 'gp2', 'io1' and 'standard'.
 * `volumes_per_instance` - (Optional) The number of EBS Volumes to attach per instance.
+* `bid_price` - (Optional) Bid price for each EC2 instance in the instance group when launching nodes as Spot Instances, expressed in USD.
+This must be a string, for exemple '0.10'. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Spot Instances in Amazon EMR provide an option for you to purchase Amazon EC2 instance capacity at a reduced cost as compared to On-Demand purchasing.

The `bid_price` for spot instances. This must be a string. To define Spot Instances in the instance group, you have to specify a single Spot Instance type and a bid price. 
Changing this forces a new resource to be created.

http://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-instance-purchasing-options.html

```hcl
resource "aws_emr_instance_group" "task" {
    cluster_id     = "${aws_emr_cluster.tf-test-cluster.id}"
    instance_count = 1
    instance_type  = "m1.small"
    bid_price = "100"
  }
```

Partially fixes https://github.com/terraform-providers/terraform-provider-aws/issues/1147