### PR TITLE
Set availability_zone attribute on RDS cluster instance

### DIFF
--- a/aws/resource_aws_rds_cluster_instance.go
+++ b/aws/resource_aws_rds_cluster_instance.go
@@ -159,6 +159,11 @@ func resourceAwsRDSClusterInstance() *schema.Resource {
 				Default:  0,
 			},
 
+			"availability_zone": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"tags": tagsSchema(),
 		},
 	}
@@ -296,6 +301,7 @@ func resourceAwsRDSClusterInstanceRead(d *schema.ResourceData, meta interface{})
 	d.Set("promotion_tier", db.PromotionTier)
 	d.Set("preferred_backup_window", db.PreferredBackupWindow)
 	d.Set("preferred_maintenance_window", db.PreferredMaintenanceWindow)
+	d.Set("availability_zone", db.AvailabilityZone)
 
 	if db.MonitoringInterval != nil {
 		d.Set("monitoring_interval", db.MonitoringInterval)

--- a/aws/resource_aws_rds_cluster_instance_test.go
+++ b/aws/resource_aws_rds_cluster_instance_test.go
@@ -33,6 +33,7 @@ func TestAccAWSRDSClusterInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("aws_rds_cluster_instance.cluster_instances", "preferred_maintenance_window"),
 					resource.TestCheckResourceAttrSet("aws_rds_cluster_instance.cluster_instances", "preferred_backup_window"),
 					resource.TestCheckResourceAttrSet("aws_rds_cluster_instance.cluster_instances", "dbi_resource_id"),
+					resource.TestCheckResourceAttrSet("aws_rds_cluster_instance.cluster_instances", "availability_zone"),
 				),
 			},
 			{

--- a/website/docs/r/rds_cluster_instance.html.markdown
+++ b/website/docs/r/rds_cluster_instance.html.markdown
@@ -89,7 +89,7 @@ The following attributes are exported:
 * `writer` – Boolean indicating if this instance is writable. `False` indicates
 this instance is a read replica
 * `allocated_storage` - The amount of allocated storage
-* `availability_zones` - The availability zone of the instance
+* `availability_zone` - The availability zone of the instance
 * `endpoint` - The DNS address for this instance. May not be writable
 * `engine` - The database engine
 * `engine_version` - The database engine version


### PR DESCRIPTION
First PR so let me know if I'm missing anything.

Current docs state that `aws_rds_cluster_instance` returns the `availability_zones` attribute but is not the case https://www.terraform.io/docs/providers/aws/r/rds_cluster_instance.html#availability_zones 

Enhanced resource to set the attribute and remove plural from docs.