### PR TITLE
Updated DMS docs for creating a dynamodb endpoint.

### DIFF
--- a/website/docs/r/dms_endpoint.html.markdown
+++ b/website/docs/r/dms_endpoint.html.markdown
@@ -62,6 +62,7 @@ The following arguments are supported:
 * `ssl_mode` - (Optional, Default: none) The SSL mode to use for the connection. Can be one of `none | require | verify-ca | verify-full`
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 * `username` - (Optional) The user name to be used to login to the endpoint database.
+* `service_access_role` (Optional) The Amazon Resource Name (ARN) used by the service access IAM role for dynamodb endpoints.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This refers to https://github.com/terraform-providers/terraform-provider-aws/pull/1002. The docs are missing an argument for this endpoint. As part of this PR, the `service_access_role` param was added.
It should probably be deployed soon but it's not critical.
