### PR TITLE
r/aws_instance: Fix import in EC2 Classic

### DIFF
--- a/aws/data_source_aws_instance.go
+++ b/aws/data_source_aws_instance.go
@@ -316,7 +316,7 @@ func instanceDescriptionAttributes(d *schema.ResourceData, instance *ec2.Instanc
 	d.Set("tags", dataSourceTags(instance.Tags))
 
 	// Security Groups
-	if err := readSecurityGroups(d, instance); err != nil {
+	if err := readSecurityGroups(d, instance, conn); err != nil {
 		return err
 	}
 

--- a/aws/import_aws_instance_test.go
+++ b/aws/import_aws_instance_test.go
@@ -1,8 +1,10 @@
 package aws
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
@@ -26,4 +28,116 @@ func TestAccAWSInstance_importBasic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccAWSInstance_importInDefaultVpc(t *testing.T) {
+	resourceName := "aws_instance.foo"
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccInstanceConfigInDefaultVpc(rInt),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSInstance_importInEc2Classic(t *testing.T) {
+	resourceName := "aws_instance.foo"
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccInstanceConfigInEc2Classic(rInt),
+			},
+
+			resource.TestStep{
+				Config:                  testAccInstanceConfigInEc2Classic(rInt),
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"network_interface", "source_dest_check"},
+			},
+		},
+	})
+}
+
+func testAccInstanceConfigInDefaultVpc(rInt int) string {
+	return fmt.Sprintf(`
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
+resource "aws_security_group" "sg" {
+  name = "tf_acc_test_%d"
+  description = "Test security group"
+}
+
+resource "aws_instance" "foo" {
+  ami             = "${data.aws_ami.ubuntu.id}"
+  instance_type   = "t2.micro"
+  security_groups = ["${aws_security_group.sg.name}"]
+}
+`, rInt)
+}
+
+func testAccInstanceConfigInEc2Classic(rInt int) string {
+	return fmt.Sprintf(`
+provider "aws" {
+  region = "us-east-1"
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/ubuntu-trusty-14.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["paravirtual"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
+resource "aws_security_group" "sg" {
+  name = "tf_acc_test_%d"
+  description = "Test security group"
+}
+
+resource "aws_instance" "foo" {
+  ami             = "${data.aws_ami.ubuntu.id}"
+  instance_type   = "m3.medium"
+  security_groups = ["${aws_security_group.sg.name}"]
+}
+`, rInt)
 }


### PR DESCRIPTION
## Before
```
$ terraform import aws_instance.web i-0f70463f2991f8de2
aws_instance.web: Importing from ID "i-0f70463f2991f8de2"...
aws_instance.web: Import complete!
  Imported aws_instance (ID: i-0f70463f2991f8de2)
aws_instance.web: Refreshing state... (ID: i-0f70463f2991f8de2)
```
```
$ terraform plan
...
-/+ aws_instance.web (new resource required)
      ami:                          "ami-253edd5d" => "ami-253edd5d"
      associate_public_ip_address:  "true" => "<computed>"
      availability_zone:            "us-west-2a" => "<computed>"
      ebs_block_device.#:           "0" => "<computed>"
      ephemeral_block_device.#:     "0" => "<computed>"
      instance_state:               "running" => "<computed>"
      instance_type:                "t2.micro" => "t2.micro"
      ipv6_address_count:           "" => "<computed>"
      ipv6_addresses.#:             "0" => "<computed>"
      key_name:                     "" => "<computed>"
      network_interface.#:          "0" => "<computed>"
      network_interface_id:         "eni-fe1c37c0" => "<computed>"
      placement_group:              "" => "<computed>"
      primary_network_interface_id: "eni-fe1c37c0" => "<computed>"
      private_dns:                  "ip-172-31-34-123.us-west-2.compute.internal" => "<computed>"
      private_ip:                   "172.31.34.123" => "<computed>"
      public_dns:                   "ec2-34-213-93-232.us-west-2.compute.amazonaws.com" => "<computed>"
      public_ip:                    "34.213.93.232" => "<computed>"
      root_block_device.#:          "1" => "<computed>"
      security_groups.#:            "0" => "1" (forces new resource)
      security_groups.930721592:    "" => "test_sg" (forces new resource)
      source_dest_check:            "true" => "true"
      subnet_id:                    "subnet-fea5fb89" => "<computed>"
      tenancy:                      "default" => "<computed>"
      volume_tags.%:                "0" => "<computed>"
      vpc_security_group_ids.#:     "1" => "<computed>"

```

## After

```
$ terraform plan
...
aws_instance.web: Refreshing state... (ID: i-0f70463f2991f8de2)
No changes. Infrastructure is up-to-date.
```

## Test results

```
=== RUN   TestAccAWSInstanceDataSource_blockDevices
--- PASS: TestAccAWSInstanceDataSource_blockDevices (67.90s)
=== RUN   TestAccAWSInstance_GP2IopsDevice
--- PASS: TestAccAWSInstance_GP2IopsDevice (78.55s)
=== RUN   TestAccAWSInstanceDataSource_keyPair
--- PASS: TestAccAWSInstanceDataSource_keyPair (84.90s)
=== RUN   TestAccAWSInstance_blockDevices
--- PASS: TestAccAWSInstance_blockDevices (89.77s)
=== RUN   TestAccAWSInstance_rootInstanceStore
--- PASS: TestAccAWSInstance_rootInstanceStore (94.36s)
=== RUN   TestAccAWSInstance_importInEc2Classic
--- PASS: TestAccAWSInstance_importInEc2Classic (100.47s)
=== RUN   TestAccAWSInstanceDataSource_SecurityGroups
--- PASS: TestAccAWSInstanceDataSource_SecurityGroups (111.94s)
=== RUN   TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError
--- PASS: TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError (25.51s)
=== RUN   TestAccAWSInstanceDataSource_gp2IopsDevice
--- PASS: TestAccAWSInstanceDataSource_gp2IopsDevice (122.53s)
=== RUN   TestAccAWSInstanceDataSource_rootInstanceStore
--- PASS: TestAccAWSInstanceDataSource_rootInstanceStore (131.15s)
=== RUN   TestAccAWSInstance_importBasic
--- PASS: TestAccAWSInstance_importBasic (136.98s)
=== RUN   TestAccAWSInstanceDataSource_AzUserData
--- PASS: TestAccAWSInstanceDataSource_AzUserData (158.06s)
=== RUN   TestAccAWSInstance_noAMIEphemeralDevices
--- PASS: TestAccAWSInstance_noAMIEphemeralDevices (174.65s)
=== RUN   TestAccAWSInstance_userDataBase64
--- PASS: TestAccAWSInstance_userDataBase64 (182.40s)
=== RUN   TestAccAWSInstanceDataSource_tags
--- PASS: TestAccAWSInstanceDataSource_tags (203.14s)
=== RUN   TestAccAWSInstanceDataSource_basic
--- PASS: TestAccAWSInstanceDataSource_basic (214.22s)
=== RUN   TestAccAWSInstanceDataSource_VPCSecurityGroups
--- PASS: TestAccAWSInstanceDataSource_VPCSecurityGroups (231.09s)
=== RUN   TestAccAWSInstance_ipv6_supportAddressCount
--- PASS: TestAccAWSInstance_ipv6_supportAddressCount (160.24s)
=== RUN   TestAccAWSInstance_basic
--- PASS: TestAccAWSInstance_basic (257.73s)
=== RUN   TestAccAWSInstance_tags
--- PASS: TestAccAWSInstance_tags (143.44s)
=== RUN   TestAccAWSInstance_keyPairCheck
--- PASS: TestAccAWSInstance_keyPairCheck (74.68s)
=== RUN   TestAccAWSInstance_vpc
--- PASS: TestAccAWSInstance_vpc (237.05s)
=== RUN   TestAccAWSInstance_multipleRegions
--- PASS: TestAccAWSInstance_multipleRegions (214.84s)
=== RUN   TestAccAWSInstance_NetworkInstanceSecurityGroups
--- PASS: TestAccAWSInstance_NetworkInstanceSecurityGroups (234.54s)
=== RUN   TestAccAWSInstance_withIamInstanceProfile
--- PASS: TestAccAWSInstance_withIamInstanceProfile (172.66s)
=== RUN   TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs
--- PASS: TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs (246.63s)
=== RUN   TestAccAWSInstance_ipv6_supportAddressCountWithIpv4
--- PASS: TestAccAWSInstance_ipv6_supportAddressCountWithIpv4 (291.08s)
=== RUN   TestAccAWSInstance_instanceProfileChange
--- PASS: TestAccAWSInstance_instanceProfileChange (219.34s)
=== RUN   TestAccAWSInstanceDataSource_VPC
--- PASS: TestAccAWSInstanceDataSource_VPC (413.47s)
=== RUN   TestAccAWSInstance_associatePublicIPAndPrivateIP
--- PASS: TestAccAWSInstance_associatePublicIPAndPrivateIP (217.72s)
=== RUN   TestAccAWSInstance_changeInstanceType
--- PASS: TestAccAWSInstance_changeInstanceType (181.48s)
=== RUN   TestAccAWSInstance_sourceDestCheck
--- PASS: TestAccAWSInstance_sourceDestCheck (429.52s)
=== RUN   TestAccAWSInstance_primaryNetworkInterface
--- PASS: TestAccAWSInstance_primaryNetworkInterface (208.63s)
=== RUN   TestAccAWSInstance_associatePublic_defaultPublic
--- PASS: TestAccAWSInstance_associatePublic_defaultPublic (156.21s)
=== RUN   TestAccAWSInstance_forceNewAndTagsDrift
--- PASS: TestAccAWSInstance_forceNewAndTagsDrift (268.30s)
=== RUN   TestAccAWSInstance_associatePublic_defaultPrivate
--- PASS: TestAccAWSInstance_associatePublic_defaultPrivate (172.21s)
=== RUN   TestAccAWSInstance_importInDefaultVpc
--- PASS: TestAccAWSInstance_importInDefaultVpc (532.10s)
=== RUN   TestAccAWSInstance_volumeTags
--- PASS: TestAccAWSInstance_volumeTags (396.00s)
=== RUN   TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck
--- PASS: TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck (250.65s)
=== RUN   TestAccAWSInstance_associatePublic_overridePublic
--- PASS: TestAccAWSInstance_associatePublic_overridePublic (167.20s)
=== RUN   TestAccAWSInstance_associatePublic_explicitPublic
--- PASS: TestAccAWSInstance_associatePublic_explicitPublic (189.82s)
=== RUN   TestAccAWSInstance_associatePublic_explicitPrivate
--- PASS: TestAccAWSInstance_associatePublic_explicitPrivate (203.44s)
=== RUN   TestAccAWSInstance_associatePublic_overridePrivate
--- PASS: TestAccAWSInstance_associatePublic_overridePrivate (169.57s)
=== RUN   TestAccAWSInstance_disableApiTermination
--- PASS: TestAccAWSInstance_disableApiTermination (552.54s)
=== RUN   TestAccAWSInstance_volumeTagsComputed
--- PASS: TestAccAWSInstance_volumeTagsComputed (475.81s)
=== RUN   TestAccAWSInstance_addSecondaryInterface
--- PASS: TestAccAWSInstance_addSecondaryInterface (317.62s)
=== RUN   TestAccAWSInstance_addSecurityGroupNetworkInterface
--- PASS: TestAccAWSInstance_addSecurityGroupNetworkInterface (373.97s)
=== RUN   TestAccAWSInstance_rootBlockDeviceMismatch
--- PASS: TestAccAWSInstance_rootBlockDeviceMismatch (496.85s)
=== RUN   TestAccAWSInstanceDataSource_privateIP
--- PASS: TestAccAWSInstanceDataSource_privateIP (765.80s)
=== RUN   TestAccAWSInstance_privateIP
--- PASS: TestAccAWSInstance_privateIP (577.55s)
```