### PR TITLE
dependencies: Bump SDK version to 1.10.28

### DIFF
--- a/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
@@ -92,6 +92,7 @@ const (
 	FirehoseServiceID                     = "firehose"                     // Firehose.
 	GameliftServiceID                     = "gamelift"                     // Gamelift.
 	GlacierServiceID                      = "glacier"                      // Glacier.
+	GlueServiceID                         = "glue"                         // Glue.
 	GreengrassServiceID                   = "greengrass"                   // Greengrass.
 	HealthServiceID                       = "health"                       // Health.
 	IamServiceID                          = "iam"                          // Iam.
@@ -107,6 +108,7 @@ const (
 	MachinelearningServiceID              = "machinelearning"              // Machinelearning.
 	MarketplacecommerceanalyticsServiceID = "marketplacecommerceanalytics" // Marketplacecommerceanalytics.
 	MeteringMarketplaceServiceID          = "metering.marketplace"         // MeteringMarketplace.
+	MghServiceID                          = "mgh"                          // Mgh.
 	MobileanalyticsServiceID              = "mobileanalytics"              // Mobileanalytics.
 	ModelsLexServiceID                    = "models.lex"                   // ModelsLex.
 	MonitoringServiceID                   = "monitoring"                   // Monitoring.
@@ -348,6 +350,7 @@ var awsPartition = partition{
 
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
+				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
@@ -531,6 +534,8 @@ var awsPartition = partition{
 
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
+				"ap-northeast-2": endpoint{},
+				"ap-south-1":     endpoint{},
 				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
 				"ca-central-1":   endpoint{},
@@ -551,8 +556,10 @@ var awsPartition = partition{
 				"ap-southeast-2": endpoint{},
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
+				"eu-west-2":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
+				"us-west-1":      endpoint{},
 				"us-west-2":      endpoint{},
 			},
 		},
@@ -562,6 +569,7 @@ var awsPartition = partition{
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
 				"ap-south-1":     endpoint{},
+				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
@@ -577,6 +585,7 @@ var awsPartition = partition{
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
 				"ap-south-1":     endpoint{},
+				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
@@ -592,6 +601,7 @@ var awsPartition = partition{
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
 				"ap-south-1":     endpoint{},
+				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
@@ -697,6 +707,7 @@ var awsPartition = partition{
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
+				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
 				"us-west-2":      endpoint{},
@@ -1000,6 +1011,12 @@ var awsPartition = partition{
 				"us-west-2":      endpoint{},
 			},
 		},
+		"glue": service{
+
+			Endpoints: endpoints{
+				"us-east-1": endpoint{},
+			},
+		},
 		"greengrass": service{
 			IsRegionalized: boxedTrue,
 			Defaults: endpoint{
@@ -1211,6 +1228,12 @@ var awsPartition = partition{
 				"us-east-2":      endpoint{},
 				"us-west-1":      endpoint{},
 				"us-west-2":      endpoint{},
+			},
+		},
+		"mgh": service{
+
+			Endpoints: endpoints{
+				"us-west-2": endpoint{},
 			},
 		},
 		"mobileanalytics": service{
@@ -1503,7 +1526,6 @@ var awsPartition = partition{
 				"ap-northeast-2": endpoint{},
 				"ap-south-1":     endpoint{},
 				"ap-southeast-2": endpoint{},
-				"ca-central-1":   endpoint{},
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
 				"us-east-1":      endpoint{},
@@ -1519,6 +1541,7 @@ var awsPartition = partition{
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
+				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
 				"us-west-1":      endpoint{},
@@ -1769,6 +1792,7 @@ var awsPartition = partition{
 				"ap-northeast-1": endpoint{},
 				"eu-west-1":      endpoint{},
 				"us-east-1":      endpoint{},
+				"us-west-1":      endpoint{},
 				"us-west-2":      endpoint{},
 			},
 		},
@@ -1843,6 +1867,18 @@ var awscnPartition = partition{
 		},
 	},
 	Services: services{
+		"application-autoscaling": service{
+			Defaults: endpoint{
+				Hostname:  "autoscaling.{region}.amazonaws.com",
+				Protocols: []string{"http", "https"},
+				CredentialScope: credentialScope{
+					Service: "application-autoscaling",
+				},
+			},
+			Endpoints: endpoints{
+				"cn-north-1": endpoint{},
+			},
+		},
 		"autoscaling": service{
 			Defaults: endpoint{
 				Protocols: []string{"http", "https"},
@@ -1975,6 +2011,16 @@ var awscnPartition = partition{
 				},
 			},
 		},
+		"iot": service{
+			Defaults: endpoint{
+				CredentialScope: credentialScope{
+					Service: "execute-api",
+				},
+			},
+			Endpoints: endpoints{
+				"cn-north-1": endpoint{},
+			},
+		},
 		"kinesis": service{
 
 			Endpoints: endpoints{
@@ -2103,6 +2149,18 @@ var awsusgovPartition = partition{
 		},
 	},
 	Services: services{
+		"acm": service{
+
+			Endpoints: endpoints{
+				"us-gov-west-1": endpoint{},
+			},
+		},
+		"apigateway": service{
+
+			Endpoints: endpoints{
+				"us-gov-west-1": endpoint{},
+			},
+		},
 		"autoscaling": service{
 
 			Endpoints: endpoints{

--- a/vendor/github.com/aws/aws-sdk-go/aws/request/request.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/request/request.go
@@ -269,11 +269,17 @@ func (r *Request) Presign(expireTime time.Duration) (string, error) {
 	return r.HTTPRequest.URL.String(), nil
 }
 
-// PresignRequest behaves just like presign, but hoists all headers and signs them.
-// Also returns the signed hash back to the user
+// PresignRequest behaves just like presign, with the addition of returning a
+// set of headers that were signed.
+//
+// Returns the URL string for the API operation with signature in the query string,
+// and the HTTP headers that were included in the signature. These headers must
+// be included in any HTTP request made with the presigned URL.
+//
+// To prevent hoisting any headers to the query string set NotHoist to true on
+// this Request value prior to calling PresignRequest.
 func (r *Request) PresignRequest(expireTime time.Duration) (string, http.Header, error) {
 	r.ExpireTime = expireTime
-	r.NotHoist = true
 	r.Sign()
 	if r.Error != nil {
 		return "", nil, r.Error

--- a/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/v4.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/v4.go
@@ -502,6 +502,8 @@ func (ctx *signingCtx) build(disableHeaderHoisting bool) {
 	ctx.buildTime()             // no depends
 	ctx.buildCredentialString() // no depends
 
+	ctx.buildBodyDigest()
+
 	unsignedHeaders := ctx.Request.Header
 	if ctx.isPresign {
 		if !disableHeaderHoisting {
@@ -513,7 +515,6 @@ func (ctx *signingCtx) build(disableHeaderHoisting bool) {
 		}
 	}
 
-	ctx.buildBodyDigest()
 	ctx.buildCanonicalHeaders(ignoredHeaders, unsignedHeaders)
 	ctx.buildCanonicalString() // depends on canon headers / signed headers
 	ctx.buildStringToSign()    // depends on canon string

--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.10.25"
+const SDKVersion = "1.10.28"

--- a/vendor/github.com/aws/aws-sdk-go/service/ec2/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ec2/api.go
@@ -30293,7 +30293,7 @@ type DescribeHostReservationsOutput struct {
 	_ struct{} `type:"structure"`
 
 	// Details about the reservation's configuration.
-	HostReservationSet []*HostReservation `locationName:"hostReservationSet" type:"list"`
+	HostReservationSet []*HostReservation `locationName:"hostReservationSet" locationNameList:"item" type:"list"`
 
 	// The token to use to retrieve the next page of results. This value is null
 	// when there are no more results to return.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -45,684 +45,684 @@
 			"revisionTime": "2017-07-27T15:54:43Z"
 		},
 		{
-			"checksumSHA1": "CdfUIQEOt4lGvofORCUhlNxxhh0=",
+			"checksumSHA1": "t5IKbMCzTgSfWZizgrsy4dIZr7o=",
 			"path": "github.com/aws/aws-sdk-go/aws",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "Y9W+4GimK4Fuxq+vyIskVYFRnX4=",
 			"path": "github.com/aws/aws-sdk-go/aws/awserr",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "yyYr41HZ1Aq0hWc3J5ijXwYEcac=",
 			"path": "github.com/aws/aws-sdk-go/aws/awsutil",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "n98FANpNeRT5kf6pizdpI7nm6Sw=",
 			"path": "github.com/aws/aws-sdk-go/aws/client",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "ieAJ+Cvp/PKv1LpUEnUXpc3OI6E=",
 			"path": "github.com/aws/aws-sdk-go/aws/client/metadata",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "7/8j/q0TWtOgXyvEcv4B2Dhl00o=",
 			"path": "github.com/aws/aws-sdk-go/aws/corehandlers",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "Y+cPwQL0dZMyqp3wI+KJWmA9KQ8=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "u3GOAJLmdvbuNUeUEcZSEAOeL/0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "NUJUTWlc1sV8b7WjfiYc4JZbXl0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/endpointcreds",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "JEYqmF83O5n5bHkupAzA6STm0no=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "ZdtYh3ZHSgP/WEIaqwJHTEhpkbs=",
 			"path": "github.com/aws/aws-sdk-go/aws/defaults",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "/EXbk/z2TWjWc1Hvb4QYs3Wmhb8=",
 			"path": "github.com/aws/aws-sdk-go/aws/ec2metadata",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
-			"checksumSHA1": "OW1b+bx0P5HaSKyESyEHqa+jqGw=",
+			"checksumSHA1": "VnCzTRUnuUKQ4Vxb8nOfusTePk8=",
 			"path": "github.com/aws/aws-sdk-go/aws/endpoints",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
-			"checksumSHA1": "zhO4REZnumWpIaIlT+Wn9aqZCn0=",
+			"checksumSHA1": "n/tgGgh0wICYu+VDYSqlsRy4w9s=",
 			"path": "github.com/aws/aws-sdk-go/aws/request",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "SK5Mn4Ga9+equOQTYA1DTSb3LWY=",
 			"path": "github.com/aws/aws-sdk-go/aws/session",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
-			"checksumSHA1": "1+ZxEwzc1Vz8X2l+kXkS2iATtas=",
+			"checksumSHA1": "iywvraxbXf3A/FOzFWjKfBBEQRA=",
 			"path": "github.com/aws/aws-sdk-go/aws/signer/v4",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "04ypv4x12l4q0TksA1zEVsmgpvw=",
 			"path": "github.com/aws/aws-sdk-go/internal/shareddefaults",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "wk7EyvDaHwb5qqoOP/4d3cV0708=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "1QmQ3FqV37w0Zi44qv8pA1GeR0A=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/ec2query",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "O6hcK24yI6w7FA+g4Pbr+eQ7pys=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/json/jsonutil",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "R00RL5jJXRYq1iiK1+PGvMfvXyM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/jsonrpc",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "ZqY5RWavBLWTo6j9xqdyBEaNFRk=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "Drt1JfLMa0DQEZLWrnMlTWaIcC8=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "VCTh+dEaqqhog5ncy/WTt9+/gFM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/rest",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "Rpu8KBtHZgvhkwHxUfaky+qW+G4=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restjson",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "ODo+ko8D6unAxZuN1jGzMcN4QCc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restxml",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "0qYPUga28aQVkxZgBR3Z86AbGUQ=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "F6mth+G7dXN1GI+nktaGo8Lx8aE=",
 			"path": "github.com/aws/aws-sdk-go/private/signer/v2",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "BXuQo73qo4WLmc+TdE5pAwalLUQ=",
 			"path": "github.com/aws/aws-sdk-go/service/acm",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "yKXkhhDv9rWmn8GofXPBoN6k730=",
 			"path": "github.com/aws/aws-sdk-go/service/apigateway",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "gT6mD+yVXS+z0z1skK90jLGeMgA=",
 			"path": "github.com/aws/aws-sdk-go/service/applicationautoscaling",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "/C4QDOmEP7t8vawBcB7a2ygaXuI=",
 			"path": "github.com/aws/aws-sdk-go/service/athena",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "Tl/cvRil/SnTPh7HymTSgOp38/U=",
 			"path": "github.com/aws/aws-sdk-go/service/autoscaling",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "oPNv+5p2pAZlqSv8SmxbNt2gxYI=",
 			"path": "github.com/aws/aws-sdk-go/service/batch",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "bhafhKK+lQbYk/Z3O+PdrQ5zDY4=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudformation",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "rjq4ZWRUGvQDjnXeflafkCWYsFU=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudfront",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "59kV70/8PuutX4eFkGfCCtdunIA=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudtrail",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "zm2qDEBdcJSJI3PGcE2UVr6Cxmc=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatch",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "puxztE1Umuw+w1CTBmo3hsRItGE=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchevents",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "0w5/i4GBC7HxyvMXax/8oiTjLQE=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "tMhsAUxecX9Juqg8KVG0THAvaJI=",
 			"path": "github.com/aws/aws-sdk-go/service/codebuild",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "XkyZPfxHxB3ohK+/qdF54nvMS0o=",
 			"path": "github.com/aws/aws-sdk-go/service/codecommit",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "QJYewZzcmPbuN27AWiQ6XKQ9Vrw=",
 			"path": "github.com/aws/aws-sdk-go/service/codedeploy",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "pL/7qVyn6qVry1uJ0Nw4/8tkGLM=",
 			"path": "github.com/aws/aws-sdk-go/service/codepipeline",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "7bm1eOY2oKYSesmEOd1qXvTRH2s=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentity",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "ouZ4H9foNRBFaElXZbpi5C3pqDQ=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentityprovider",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "=v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "V3QpE1495nFtpAOw24WY6AsVT1w=",
 			"path": "github.com/aws/aws-sdk-go/service/configservice",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "8UoYKgC9u/gjExZe4a6ZZf4dDl8=",
 			"path": "github.com/aws/aws-sdk-go/service/databasemigrationservice",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "HfaX42uqVu9hosilU6JwEQhgI/o=",
 			"path": "github.com/aws/aws-sdk-go/service/devicefarm",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "1O8BtYGfkXglIqgl/uxunrq3Djs=",
 			"path": "github.com/aws/aws-sdk-go/service/directoryservice",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "Qk98eGaCDibYSf0u3E2q7fAGnbY=",
 			"path": "github.com/aws/aws-sdk-go/service/dynamodb",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
-			"checksumSHA1": "g6NwckDd5WRjQOF8TVY/eLUnkAk=",
+			"checksumSHA1": "i3wKTdYhkc5emW8NLyZpaXwrF0s=",
 			"path": "github.com/aws/aws-sdk-go/service/ec2",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "YNq7YhasHn9ceelWX2aG0Cg0Ga0=",
 			"path": "github.com/aws/aws-sdk-go/service/ecr",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "ybOZuEwB/cI6Ga3mjLFUGmE7qF8=",
 			"path": "github.com/aws/aws-sdk-go/service/ecs",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "pBkeSL8bCEbz/6ub0Jr6NsjQPSc=",
 			"path": "github.com/aws/aws-sdk-go/service/efs",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "4a4FO9D6RQluAwyYEW5H6p0Nz7I=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticache",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "RzBRmfKefl+oBHDzrtsuxv8ycKE=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticbeanstalk",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "wca8VaMOBpTBJUjVlfceB+RI/aw=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticsearchservice",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "zMFn+iotI5JIiB9HFRo6BiX6CZE=",
 			"path": "github.com/aws/aws-sdk-go/service/elastictranscoder",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "sp5ZmzFBI5z1+kLkRoFjfm2GWuY=",
 			"path": "github.com/aws/aws-sdk-go/service/elb",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "hRO54p0axKFEvpO9dh4oodC/sPM=",
 			"path": "github.com/aws/aws-sdk-go/service/elbv2",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "EEj7cYvIK+F25RIynBVArzedyPQ=",
 			"path": "github.com/aws/aws-sdk-go/service/emr",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "wDZwsQurOYqUHNYoFF8+lF+01h8=",
 			"path": "github.com/aws/aws-sdk-go/service/firehose",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "Ewp675B6bZe/eWipwJl7OXqCJRo=",
 			"path": "github.com/aws/aws-sdk-go/service/glacier",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "H41YeQoLzuR1gQvBytlaL/gql+A=",
 			"path": "github.com/aws/aws-sdk-go/service/iam",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "v0OUl6sTwF7EOmXyzk9ppc5ljLw=",
 			"path": "github.com/aws/aws-sdk-go/service/inspector",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "D92k3ymegRbjpgnuAy9rWjgV7vs=",
 			"path": "github.com/aws/aws-sdk-go/service/iot",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "fE6Lygzxvif/yfo9bncKyRUCqs8=",
 			"path": "github.com/aws/aws-sdk-go/service/kinesis",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "wwFYsrpInh4Tow/vTI7bD+r5gBU=",
 			"path": "github.com/aws/aws-sdk-go/service/kms",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "I9kIOQqqkoWjqYSrYixJpSDWqM8=",
 			"path": "github.com/aws/aws-sdk-go/service/lambda",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "eHMwitdHY0uOEA5kkmJ1nGHe0z0=",
 			"path": "github.com/aws/aws-sdk-go/service/lightsail",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "84rKGr+RvT8tjOalWGPKuNPC4T4=",
 			"path": "github.com/aws/aws-sdk-go/service/opsworks",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "v/arRy3FlJhSWWugs8tRqEkz1qs=",
 			"path": "github.com/aws/aws-sdk-go/service/rds",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "QTc65yhur4smpQrn9Zq2c0UboIo=",
 			"path": "github.com/aws/aws-sdk-go/service/redshift",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "P+biqKJwS4zYtMdwteW6rGwP+OA=",
 			"path": "github.com/aws/aws-sdk-go/service/route53",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "SEKg+cGyOj6dKdK5ltUHsoL4R4Y=",
 			"path": "github.com/aws/aws-sdk-go/service/s3",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "rIBHXHWyTmY/vsqECa2PB0xT2HU=",
 			"path": "github.com/aws/aws-sdk-go/service/ses",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "u8xk+JtK/HwIKB2ume3or9Sstp8=",
 			"path": "github.com/aws/aws-sdk-go/service/sfn",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "hOcVb1zJiDUmafXSJQhkEascWwA=",
 			"path": "github.com/aws/aws-sdk-go/service/simpledb",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "1jN0ZDW5c9QEGSQIQ+KrbTACvm8=",
 			"path": "github.com/aws/aws-sdk-go/service/sns",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "SXH7QxrUFaor3KaNX0xPCV3eOhU=",
 			"path": "github.com/aws/aws-sdk-go/service/sqs",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "pxNexa5JWo6tPeiNd9UvRwuRIrE=",
 			"path": "github.com/aws/aws-sdk-go/service/ssm",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "MerduaV3PxtZAWvOGpgoBIglo38=",
 			"path": "github.com/aws/aws-sdk-go/service/sts",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "vFinPalK+r0kaIbPMaHhFbTi2QQ=",
 			"path": "github.com/aws/aws-sdk-go/service/waf",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "qe7HsjfCked/MaRvH2c0uJndWdM=",
 			"path": "github.com/aws/aws-sdk-go/service/wafregional",
-			"revision": "77c204059e353965728c1898f9755d4970294da0",
-			"revisionTime": "2017-08-14T16:38:10Z",
-			"version": "v1.10.25",
-			"versionExact": "v1.10.25"
+			"revision": "3546c9128687af50e4bcedac5b1ffdd593db0c83",
+			"revisionTime": "2017-08-18T18:08:53Z",
+			"version": "v1.10.28",
+			"versionExact": "v1.10.28"
 		},
 		{
 			"checksumSHA1": "nqw2Qn5xUklssHTubS5HDvEL9L4=",


### PR DESCRIPTION
This now includes a package to help build ARNs. This will mean that a
lot of old Terraform code that manually create ARNs can be replaced:

https://github.com/aws/aws-sdk-go/pull/1463