### PR TITLE
r/aws_codebuild_project: Allowed for BITBUCKET source type

### DIFF
--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -728,14 +729,21 @@ func validateAwsCodeBuildEnvironmentType(v interface{}, k string) (ws []string, 
 func validateAwsCodeBuildSourceType(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	types := map[string]bool{
-		"CODECOMMIT":   true,
-		"CODEPIPELINE": true,
-		"GITHUB":       true,
-		"S3":           true,
+		codebuild.SourceTypeBitbucket:    true,
+		codebuild.SourceTypeCodecommit:   true,
+		codebuild.SourceTypeCodepipeline: true,
+		codebuild.SourceTypeGithub:       true,
+		codebuild.SourceTypeS3:           true,
+	}
+	s := make([]string, 0, len(types))
+
+	for key, _ := range types {
+		s = append(s, key)
 	}
 
 	if !types[value] {
-		errors = append(errors, fmt.Errorf("CodeBuild: Source Type can only be CODECOMMIT / CODEPIPELINE / GITHUB / S3"))
+		strings.Join(s, ", ")
+		errors = append(errors, fmt.Errorf("CodeBuild: Source Type can only be one of: %s", strings.Join(s, ", ")))
 	}
 	return
 }

--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -212,6 +212,7 @@ func TestAWSCodeBuildProject_sourceTypeValidation(t *testing.T) {
 		{Value: "CODEPIPELINE", ErrCount: 0},
 		{Value: "GITHUB", ErrCount: 0},
 		{Value: "S3", ErrCount: 0},
+		{Value: "BITBUCKET", ErrCount: 0},
 		{Value: "GITLAB", ErrCount: 1},
 	}
 
@@ -375,21 +376,21 @@ resource "aws_codebuild_project" "foo" {
   name         = "test-project-%s"
   description  = "test_codebuild_project"
   build_timeout      = "5"
-	service_role = "${aws_iam_role.codebuild_role.arn}"
+  service_role = "${aws_iam_role.codebuild_role.arn}"
 
-	artifacts {
-		type = "NO_ARTIFACTS"
-	}
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
 
   environment {
     compute_type = "BUILD_GENERAL1_SMALL"
     image        = "2"
     type         = "LINUX_CONTAINER"
 
-		environment_variable = {
-			"name"  = "SOME_KEY"
-			"value" = "SOME_VALUE"
-		}
+    environment_variable = {
+      "name"  = "SOME_KEY"
+      "value" = "SOME_VALUE"
+    }
   }
 
   source {
@@ -458,21 +459,21 @@ resource "aws_codebuild_project" "foo" {
   name         = "test-project-%s"
   description  = "test_codebuild_project"
   build_timeout      = "50"
-	service_role = "${aws_iam_role.codebuild_role.arn}"
+  service_role = "${aws_iam_role.codebuild_role.arn}"
 
-	artifacts {
-		type = "NO_ARTIFACTS"
-	}
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
 
   environment {
     compute_type = "BUILD_GENERAL1_SMALL"
     image        = "2"
     type         = "LINUX_CONTAINER"
 
-		environment_variable = {
-			"name"  = "SOME_OTHERKEY"
-			"value" = "SOME_OTHERVALUE"
-		}
+    environment_variable = {
+      "name"  = "SOME_OTHERKEY"
+      "value" = "SOME_OTHERVALUE"
+    }
   }
 
   source {
@@ -541,21 +542,21 @@ resource "aws_codebuild_project" "foo" {
   name         = "test-project-%s"
   description  = "test_codebuild_project"
 
-	service_role = "${aws_iam_role.codebuild_role.arn}"
+  service_role = "${aws_iam_role.codebuild_role.arn}"
 
-	artifacts {
-		type = "NO_ARTIFACTS"
-	}
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
 
   environment {
     compute_type = "BUILD_GENERAL1_SMALL"
     image        = "2"
     type         = "LINUX_CONTAINER"
 
-		environment_variable = {
-			"name"  = "SOME_OTHERKEY"
-			"value" = "SOME_OTHERVALUE"
-		}
+    environment_variable = {
+      "name"  = "SOME_OTHERKEY"
+      "value" = "SOME_OTHERVALUE"
+    }
   }
 
   source {

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -137,7 +137,7 @@ The following arguments are supported:
 
 `source` supports the following:
 
-* `type` - (Required) The type of repository that contains the source code to be built. Valid values for this parameter are: `CODECOMMIT`, `CODEPIPELINE`, `GITHUB` or `S3`.
+* `type` - (Required) The type of repository that contains the source code to be built. Valid values for this parameter are: `CODECOMMIT`, `CODEPIPELINE`, `GITHUB`, `BITBUCKET` or `S3`.
 * `auth` - (Optional) Information about the authorization settings for AWS CodeBuild to access the source code to be built. Auth blocks are documented below.
 * `buildspec` - (Optional) The build spec declaration to use for this build project's related builds.
 * `location` - (Optional) The location of the source code from git or s3.


### PR DESCRIPTION
Fixes #1462

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCodeBuildProject_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCodeBuildProject_ -timeout 120m
=== RUN   TestAccAWSCodeBuildProject_basic
--- PASS: TestAccAWSCodeBuildProject_basic (58.69s)
=== RUN   TestAccAWSCodeBuildProject_default_build_timeout
--- PASS: TestAccAWSCodeBuildProject_default_build_timeout (62.17s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	120.892s
```