### PR TITLE
Fix SNS subscription sub/unsub/sub bug.

### DIFF
--- a/aws/resource_aws_sns_topic_subscription.go
+++ b/aws/resource_aws_sns_topic_subscription.go
@@ -105,7 +105,7 @@ func resourceAwsSnsTopicSubscriptionUpdate(d *schema.ResourceData, meta interfac
 	snsconn := meta.(*AWSClient).snsconn
 
 	// If any changes happened, un-subscribe and re-subscribe
-	if d.HasChange("protocol") || d.HasChange("endpoint") || d.HasChange("topic_arn") {
+	if !d.IsNewResource() && (d.HasChange("protocol") || d.HasChange("endpoint") || d.HasChange("topic_arn")) {
 		log.Printf("[DEBUG] Updating subscription %s", d.Id())
 		// Unsubscribe
 		_, err := snsconn.Unsubscribe(&sns.UnsubscribeInput{


### PR DESCRIPTION
The Terraform SNS subscriptions implementation has a bug where it:

- creates a new subscription
- verifies the subscription as created
- evaluates the newly created subscription object
- sees that some of the fields of the object have "changed" (this is technically correct, strings have changed from their initial empty value of "" to the values configured by the Terraform configuration)
- decides that the subscription configuration has been "updated"
- **destroys the subscription and recreates it!**

I noticed this when implementing SNS subscription auto-confirmation in our servers; when I created a new SNS subscription via Terraform, my server got two SNS subscription confirmation requests when I only expected one.

With `TF_LOG=debug`, the AWS provider at `HEAD` shows these outgoing requests:

```
[DEBUG] [aws-sdk-go] DEBUG: Request sns/Subscribe Details:
[DEBUG] [aws-sdk-go] DEBUG: Request sns/ListSubscriptionsByTopic Details:
[DEBUG] [aws-sdk-go] DEBUG: Request sns/Unsubscribe Details:
[DEBUG] [aws-sdk-go] DEBUG: Request sns/Subscribe Details:
[DEBUG] [aws-sdk-go] DEBUG: Request sns/ListSubscriptionsByTopic Details:
[DEBUG] [aws-sdk-go] DEBUG: Request sns/GetSubscriptionAttributes Details:  
```

I instrumented the AWS provider to show what it thought was happening with the `protocol`, `endpoint`, and `topic_arn` fields:

```
[DEBUG] protocol original , new https
[DEBUG] endpoint original , new https://<mydomain>/<myurl>
[DEBUG] topic_arn original , new arn:aws:sns:<region>:<account_id>:<topic_name>
```

With my PR, these are the outgoing requests I see:

```
[DEBUG] [aws-sdk-go] DEBUG: Request sns/Subscribe Details:
[DEBUG] [aws-sdk-go] DEBUG: Request sns/ListSubscriptionsByTopic Details:
[DEBUG] [aws-sdk-go] DEBUG: Request sns/ListSubscriptionsByTopic Details:
[DEBUG] [aws-sdk-go] DEBUG: Request sns/GetSubscriptionAttributes Details:
``` 

It's arguable that something like wasSetAndHasChange belongs upstream in https://github.com/hashicorp/terraform/blob/master/helper/schema/resource_data.go but I'd rather get this fixed here first, and then we can assess whether that is worth trying to uplift to main Terraform.