### PR TITLE
correct reference to nonexistent resource

### DIFF
--- a/website/docs/r/lambda_permission.html.markdown
+++ b/website/docs/r/lambda_permission.html.markdown
@@ -66,7 +66,7 @@ EOF
 resource "aws_lambda_permission" "with_sns" {
   statement_id  = "AllowExecutionFromSNS"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.my-func.function_name}"
+  function_name = "${aws_lambda_function.func.function_name}"
   principal     = "sns.amazonaws.com"
   source_arn    = "${aws_sns_topic.default.arn}"
 }


### PR DESCRIPTION
Corrects a documentation example reference to a nonexistent
`aws_lambda_function.my-func` resource; the documentation
example should reference a `aws_lambda_function.func` resource.