### PR TITLE
Fixed recreation of EIP when it does not exist anymore

### DIFF
--- a/aws/resource_aws_eip.go
+++ b/aws/resource_aws_eip.go
@@ -159,6 +159,7 @@ func resourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 			if ok && (awsErr.Code() == "InvalidAllocationID.NotFound" ||
 				awsErr.Code() == "InvalidAddress.NotFound") {
 				log.Printf("[WARN] EIP not found, removing from state: %s", req)
+				d.SetId("")
 				return nil
 			}
 			return err


### PR DESCRIPTION
Fixes #1529

This missing bit was not marking the resource as needing recreation, when it should have been.
In case the EIP was created and removed from the console, this read was simply warning in the logs, but never doing anything more.