### PR TITLE
Fixed the documentation for ElastiCache Replication Group address

### DIFF
--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -100,8 +100,8 @@ Cluster Mode (`cluster_mode`) supports the following:
 The following attributes are exported:
 
 * `id` - The ID of the ElastiCache Replication Group.
-* `primary_endpoint_address` - The address of the endpoint for the primary node in the replication group. If Redis, only present when cluster mode is disabled.
-* `configuration_endpoint_address` - (Redis only) The address of the replication group configuration endpoint when cluster mode is enabled.
+* `configuration_endpoint_address` - The address of the endpoint for the primary node in the replication group. If Redis, only present when cluster mode is disabled.
+* `primary_endpoint_address` - (Redis only) The address of the replication group configuration endpoint when cluster mode is enabled.
 
 ## Import
 


### PR DESCRIPTION
Fixes #375

As exposed [in the code](https://github.com/terraform-providers/terraform-provider-aws/blob/master/aws/resource_aws_elasticache_replication_group.go#L304-L310), `primary_endpoint_address ` is set when there are node groups, so when in a cluster mode.
`configuration_endpoint_address` is the exact opposite.