### PR TITLE
Fix insecure aws_sns_topic_policy example

### DIFF
--- a/website/docs/r/sns_topic_policy.html.markdown
+++ b/website/docs/r/sns_topic_policy.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides an SNS topic policy resource
 
+~> **NOTE:** If a Principal is specified as just an AWS account ID rather than an ARN, AWS silently converts it to the ARN for the root user, causing future terraform plans to differ. To avoid this problem, just specify the full ARN, e.g. `arn:aws:iam::123456789012:root`
+
 ## Example Usage
 
 ```hcl
@@ -17,29 +19,50 @@ resource "aws_sns_topic" "test" {
   name = "my-topic-with-policy"
 }
 
-resource "aws_sns_topic_policy" "custom" {
+resource "aws_sns_topic_policy" "default" {
   arn = "${aws_sns_topic.test.arn}"
 
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Id": "default",
-  "Statement":[{
-    "Sid": "default",
-    "Effect": "Allow",
-    "Principal": {"AWS":"*"},
-    "Action": [
-      "SNS:GetTopicAttributes",
+  policy = "${data.aws_iam_policy_document.sns-topic-policy.json}"
+}
+
+data "aws_iam_policy_document" "sns-topic-policy" {
+  policy_id = "__default_policy_ID"
+
+  statement {
+    actions = [
+      "SNS:Subscribe",
       "SNS:SetTopicAttributes",
-      "SNS:AddPermission",
       "SNS:RemovePermission",
-      "SNS:DeleteTopic"
-    ],
-    "Resource": "${aws_sns_topic.test.arn}"
-  }]
-}
-POLICY
-}
+      "SNS:Receive",
+      "SNS:Publish",
+      "SNS:ListSubscriptionsByTopic",
+      "SNS:GetTopicAttributes",
+      "SNS:DeleteTopic",
+      "SNS:AddPermission",
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceOwner"
+
+      values = [
+        "${var.account-id}",
+      ]
+    }
+
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    resources = [
+      "${aws_sns_topic.test.arn}",
+    ]
+
+    sid = "__default_statement_ID"
+  }
 ```
 
 ## Argument Reference


### PR DESCRIPTION
Fixes #1545

Also add note to clarify AWS's behaviour when setting a principal of just an account ID, causing terraform to always see a diff.