### PR TITLE
r/aws_api_gateway_authorizer: URI must contain region name

### DIFF
--- a/website/docs/r/api_gateway_authorizer.html.markdown
+++ b/website/docs/r/api_gateway_authorizer.html.markdown
@@ -16,7 +16,7 @@ Provides an API Gateway Authorizer.
 resource "aws_api_gateway_authorizer" "demo" {
   name                   = "demo"
   rest_api_id            = "${aws_api_gateway_rest_api.demo.id}"
-  authorizer_uri         = "arn:aws:apigateway:region:lambda:path/2015-03-31/functions/${aws_lambda_function.authorizer.arn}/invocations"
+  authorizer_uri         = "arn:aws:apigateway:${var.myregion}:lambda:path/2015-03-31/functions/${aws_lambda_function.authorizer.arn}/invocations"
   authorizer_credentials = "${aws_iam_role.invocation_role.arn}"
 }
 
@@ -98,7 +98,7 @@ The following arguments are supported:
 
 * `authorizer_uri` - (Required) The authorizer's Uniform Resource Identifier (URI).
 	For `TOKEN` type, this must be a well-formed Lambda function URI in the form of
-	`arn:aws:apigateway:{region}:lambda:path/{service_api}`. e.g. `arn:aws:apigateway:region:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:012345678912:function:my-function/invocations`
+	`arn:aws:apigateway:{region}:lambda:path/{service_api}`. e.g. `arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:012345678912:function:my-function/invocations`
 * `name` - (Required) The name of the authorizer
 * `rest_api_id` - (Required) The ID of the associated REST API
 * `identity_source` - (Optional) The source of the identity in an incoming request.

--- a/website/docs/r/api_gateway_authorizer.html.markdown
+++ b/website/docs/r/api_gateway_authorizer.html.markdown
@@ -16,7 +16,7 @@ Provides an API Gateway Authorizer.
 resource "aws_api_gateway_authorizer" "demo" {
   name                   = "demo"
   rest_api_id            = "${aws_api_gateway_rest_api.demo.id}"
-  authorizer_uri         = "arn:aws:apigateway:${var.myregion}:lambda:path/2015-03-31/functions/${aws_lambda_function.authorizer.arn}/invocations"
+  authorizer_uri         = "${aws_lambda_function.authorizer.invoke_arn}"
   authorizer_credentials = "${aws_iam_role.invocation_role.arn}"
 }
 


### PR DESCRIPTION
Was having an issue with gateway authorizer permissions and it took a while to track this down but it looks like the authorizer URI needs to contain the region it's being created in. The resource will be created but it won't work properly until you go in and save it, at which point the authorizer will be able to be called properly.