### PR TITLE
r/aws_sns_topic: Provider now errors with fake iam role

### DIFF
--- a/aws/resource_aws_sns_topic.go
+++ b/aws/resource_aws_sns_topic.go
@@ -147,7 +147,7 @@ func resourceAwsSNSUpdateRefreshFunc(
 				// if the error contains the PrincipalNotFound message, we can retry
 				if strings.Contains(awsErr.Message(), "PrincipalNotFound") {
 					log.Printf("[DEBUG] Retrying AWS SNS Topic Update: %s", params)
-					return nil, "retrying", nil
+					return nil, "retrying", err
 				}
 			}
 			return nil, "failed", err

--- a/aws/resource_aws_sns_topic.go
+++ b/aws/resource_aws_sns_topic.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/hashicorp/errwrap"
-	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -126,25 +125,6 @@ func resourceAwsSnsTopicUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	return resourceAwsSnsTopicRead(d, meta)
-}
-
-func resourceAwsSNSUpdateRefreshFunc(
-	meta interface{}, params sns.SetTopicAttributesInput) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		snsconn := meta.(*AWSClient).snsconn
-		if _, err := snsconn.SetTopicAttributes(&params); err != nil {
-			log.Printf("[WARN] Erroring updating topic attributes: %s", err)
-			if awsErr, ok := err.(awserr.Error); ok {
-				// if the error contains the PrincipalNotFound message, we can retry
-				if strings.Contains(awsErr.Message(), "PrincipalNotFound") {
-					log.Printf("[DEBUG] Retrying AWS SNS Topic Update: %s", params)
-					return nil, "retrying", nil
-				}
-			}
-			return nil, "failed", err
-		}
-		return 42, "success", nil
-	}
 }
 
 func resourceAwsSnsTopicRead(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_sns_topic.go
+++ b/aws/resource_aws_sns_topic.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -113,22 +112,14 @@ func resourceAwsSnsTopicUpdate(d *schema.ResourceData, meta interface{}) error {
 						AttributeName:  aws.String(attrKey),
 						AttributeValue: aws.String(n.(string)),
 					}
-
+					conn := meta.(*AWSClient).snsconn
 					// Retry the update in the event of an eventually consistent style of
 					// error, where say an IAM resource is successfully created but not
 					// actually available. See https://github.com/hashicorp/terraform/issues/3660
-					log.Printf("[DEBUG] Updating SNS Topic (%s) attributes request: %s", d.Id(), req)
-					stateConf := &resource.StateChangeConf{
-						Pending:    []string{"retrying"},
-						Target:     []string{"success"},
-						Refresh:    resourceAwsSNSUpdateRefreshFunc(meta, req),
-						Timeout:    1 * time.Minute,
-						MinTimeout: 3 * time.Second,
-					}
-					_, err := stateConf.WaitForState()
-					if err != nil {
-						return err
-					}
+					_, err := retryOnAwsCode("InvalidParameter", func() (interface{}, error) {
+						return conn.SetTopicAttributes(&req)
+					})
+					return err
 				}
 			}
 		}
@@ -147,7 +138,7 @@ func resourceAwsSNSUpdateRefreshFunc(
 				// if the error contains the PrincipalNotFound message, we can retry
 				if strings.Contains(awsErr.Message(), "PrincipalNotFound") {
 					log.Printf("[DEBUG] Retrying AWS SNS Topic Update: %s", params)
-					return nil, "retrying", err
+					return nil, "retrying", nil
 				}
 			}
 			return nil, "failed", err

--- a/aws/resource_aws_sns_topic_policy.go
+++ b/aws/resource_aws_sns_topic_policy.go
@@ -4,9 +4,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"time"
 
-	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -50,15 +48,10 @@ func resourceAwsSnsTopicPolicyUpsert(d *schema.ResourceData, meta interface{}) e
 	// Retry the update in the event of an eventually consistent style of
 	// error, where say an IAM resource is successfully created but not
 	// actually available. See https://github.com/hashicorp/terraform/issues/3660
-	log.Printf("[DEBUG] Updating SNS Topic Policy: %s", req)
-	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"retrying"},
-		Target:     []string{"success"},
-		Refresh:    resourceAwsSNSUpdateRefreshFunc(meta, req),
-		Timeout:    3 * time.Minute,
-		MinTimeout: 3 * time.Second,
-	}
-	_, err := stateConf.WaitForState()
+	conn := meta.(*AWSClient).snsconn
+	_, err := retryOnAwsCode("InvalidParameter", func() (interface{}, error) {
+		return conn.SetTopicAttributes(&req)
+	})
 	if err != nil {
 		return err
 	}
@@ -120,18 +113,11 @@ func resourceAwsSnsTopicPolicyDelete(d *schema.ResourceData, meta interface{}) e
 	// error, where say an IAM resource is successfully created but not
 	// actually available. See https://github.com/hashicorp/terraform/issues/3660
 	log.Printf("[DEBUG] Resetting SNS Topic Policy to default: %s", req)
-	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"retrying"},
-		Target:     []string{"success"},
-		Refresh:    resourceAwsSNSUpdateRefreshFunc(meta, req),
-		Timeout:    3 * time.Minute,
-		MinTimeout: 3 * time.Second,
-	}
-	_, err = stateConf.WaitForState()
-	if err != nil {
-		return err
-	}
-	return nil
+	conn := meta.(*AWSClient).snsconn
+	_, err = retryOnAwsCode("InvalidParameter", func() (interface{}, error) {
+		return conn.SetTopicAttributes(&req)
+	})
+	return err
 }
 
 func getAccountIdFromSnsTopicArn(arn, partition string) (string, error) {


### PR DESCRIPTION
This PR is a migration from https://github.com/hashicorp/terraform/pull/14226 and fixes https://github.com/terraform-providers/terraform-provider-aws/issues/738. 

```
make testacc TEST=./aws TESTARGS="-run=TestAccAWSSNSTopic_withFakeIAMRole"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSSNSTopic_withFakeIAMRole -timeout 120m
=== RUN   TestAccAWSSNSTopic_withFakeIAMRole
--- PASS: TestAccAWSSNSTopic_withFakeIAMRole (8.34s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	8.375s
```