### PR TITLE
r/aws_eip: Remove from state on deletion

### DIFF
--- a/aws/resource_aws_eip.go
+++ b/aws/resource_aws_eip.go
@@ -159,6 +159,7 @@ func resourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 			if ok && (awsErr.Code() == "InvalidAllocationID.NotFound" ||
 				awsErr.Code() == "InvalidAddress.NotFound") {
 				log.Printf("[WARN] EIP not found, removing from state: %s", req)
+				d.SetId("")
 				return nil
 			}
 			return err


### PR DESCRIPTION
As mentioned in https://github.com/terraform-providers/terraform-provider-aws/commit/e4244f8b481f2796f06e443a413510468fa765ec#commitcomment-23945540

cc @ksperling

Fixes #1529

```
TF_ACC=1 go test ./aws -v -run=TestAccAWSEIP_ -timeout 120m
=== RUN   TestAccAWSEIP_importEc2Classic
--- PASS: TestAccAWSEIP_importEc2Classic (138.46s)
=== RUN   TestAccAWSEIP_importVpc
--- PASS: TestAccAWSEIP_importVpc (86.02s)
=== RUN   TestAccAWSEIP_basic
--- PASS: TestAccAWSEIP_basic (27.44s)
=== RUN   TestAccAWSEIP_instance
--- PASS: TestAccAWSEIP_instance (234.09s)
=== RUN   TestAccAWSEIP_network_interface
--- PASS: TestAccAWSEIP_network_interface (83.02s)
=== RUN   TestAccAWSEIP_twoEIPsOneNetworkInterface
--- PASS: TestAccAWSEIP_twoEIPsOneNetworkInterface (82.75s)
=== RUN   TestAccAWSEIP_associated_user_private_ip
--- PASS: TestAccAWSEIP_associated_user_private_ip (230.20s)
=== RUN   TestAccAWSEIP_classic_disassociate
--- PASS: TestAccAWSEIP_classic_disassociate (285.29s)
=== RUN   TestAccAWSEIP_disappears
--- PASS: TestAccAWSEIP_disappears (20.59s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1187.911s
```