### PR TITLE
r/api_gateway_integration: Update integration example to clarify source_arn

### DIFF
--- a/website/docs/r/api_gateway_integration.html.markdown
+++ b/website/docs/r/api_gateway_integration.html.markdown
@@ -64,9 +64,15 @@ resource "aws_api_gateway_rest_api" "api" {
   name = "myapi"
 }
 
+resource "aws_api_gateway_resource" "resource" {
+  path_part = "resource"
+  parent_id = "${aws_api_gateway_rest_api.api.root_resource_id}"
+  rest_api_id = "${aws_api_gateway_rest_api.api.id}"
+}
+
 resource "aws_api_gateway_method" "method" {
   rest_api_id   = "${aws_api_gateway_rest_api.api.id}"
-  resource_id   = "${aws_api_gateway_rest_api.api.root_resource_id}"
+  resource_id   = "${aws_api_gateway_resource.resource.id}"
   http_method   = "GET"
   authorization = "NONE"
 }
@@ -88,7 +94,7 @@ resource "aws_lambda_permission" "apigw_lambda" {
   principal     = "apigateway.amazonaws.com"
 
   # More: http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-control-access-using-iam-policies-to-invoke-api.html
-  source_arn = "arn:aws:execute-api:${var.myregion}:${var.accountId}:${aws_api_gateway_rest_api.api.id}/*/${aws_api_gateway_method.method.http_method}/resourcepath/subresourcepath"
+  source_arn = "arn:aws:execute-api:${var.myregion}:${var.accountId}:${aws_api_gateway_rest_api.api.id}/*/${aws_api_gateway_method.method.http_method}${aws_api_gateway_resource.resource.path}"
 }
 
 resource "aws_lambda_function" "lambda" {


### PR DESCRIPTION
To clarify resource path must be specified in the Lambda permission.

I thought adding a resource, whilst complicating the example a little, made it clearer that the path at the end of the `source_arn`attribute should match that of the resource