### PR TITLE
Allow parameters to follow standard lifecycle rules

### DIFF
--- a/aws/resource_aws_ssm_parameter.go
+++ b/aws/resource_aws_ssm_parameter.go
@@ -42,7 +42,6 @@ func resourceAwsSsmParameter() *schema.Resource {
 			"overwrite": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  false,
 			},
 		},
 	}
@@ -101,12 +100,11 @@ func resourceAwsSsmParameterPut(d *schema.ResourceData, meta interface{}) error 
 	ssmconn := meta.(*AWSClient).ssmconn
 
 	log.Printf("[INFO] Creating SSM Parameter: %s", d.Get("name").(string))
-
 	paramInput := &ssm.PutParameterInput{
 		Name:      aws.String(d.Get("name").(string)),
 		Type:      aws.String(d.Get("type").(string)),
 		Value:     aws.String(d.Get("value").(string)),
-		Overwrite: aws.Bool(d.Get("overwrite").(bool)),
+		Overwrite: aws.Bool(shouldUpdateSsmParameter(d)),
 	}
 	if keyID, ok := d.GetOk("key_id"); ok {
 		log.Printf("[DEBUG] Setting key_id for SSM Parameter %s: %s", d.Get("name").(string), keyID.(string))
@@ -123,4 +121,21 @@ func resourceAwsSsmParameterPut(d *schema.ResourceData, meta interface{}) error 
 	d.SetId(d.Get("name").(string))
 
 	return resourceAwsSsmParameterRead(d, meta)
+}
+
+func shouldUpdateSsmParameter(d *schema.ResourceData) bool {
+	// If the user has specifed a preference, return their preference
+	if value, ok := d.GetOkExists("overwrite"); ok == true {
+		return value.(bool)
+	}
+
+	// Since the user has not specified a preference, obey lifecycle rules
+	// 	Only parameters that have been created by terraform should be updated
+	if !d.IsNewResource() {
+		return true
+	}
+
+	// This is a new resource and hence the parameter should not exist and
+	// should not need to be overwritten.
+	return false
 }

--- a/aws/resource_aws_ssm_parameter_test.go
+++ b/aws/resource_aws_ssm_parameter_test.go
@@ -263,3 +263,36 @@ resource "aws_kms_key" "test_key" {
 }
 `, rName, value)
 }
+
+func TestAWSSSMParameterShouldUpdate(t *testing.T) {
+	data := resourceAwsSsmParameter().TestResourceData()
+	failure := false
+
+	if !shouldUpdateSsmParameter(data) {
+		t.Logf("Existing resources should be overwritten if the values don't match!")
+		failure = true
+	}
+
+	data.MarkNewResource()
+	if shouldUpdateSsmParameter(data) {
+		t.Logf("New resources must never be overwritten, this will overwrite parameters created outside of the system")
+		failure = true
+	}
+
+	data = resourceAwsSsmParameter().TestResourceData()
+	data.Set("overwrite", true)
+	if !shouldUpdateSsmParameter(data) {
+		t.Logf("Resources should always be overwritten if the user requests it")
+		failure = true
+	}
+
+	data.Set("overwrite", false)
+	if shouldUpdateSsmParameter(data) {
+		t.Logf("Resources should never be overwritten if the user requests it")
+		failure = true
+	}
+	if failure {
+		t.Fail()
+	}
+
+}

--- a/website/docs/r/ssm_parameter.html.markdown
+++ b/website/docs/r/ssm_parameter.html.markdown
@@ -56,7 +56,7 @@ The following arguments are supported:
 * `type` - (Required) The type of the parameter. Valid types are `String`, `StringList` and `SecureString`.
 * `value` - (Required) The value of the parameter.
 * `key_id` - (Optional) The KMS key id or arn for encrypting a SecureString.
-* `overwrite` - (Optional) Overwrite an existing parameter. If not specified, will default to `false`.
+* `overwrite` - (Optional) Overwrite an existing parameter even if it was created outside of terraform.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This pull request refines the commits that were merged in response to #1004 and #1006. When 1006 was merged it introduced a new flag which allows the user to overwrite an existing parameter. I understand that this can be helpful if the parameter already exists in your system, however the introduction of this flags has broken the update lifecycle. Specifically the way that updates interacts with overwrite is non-sensical. Under the introduced in 1006 you must have overwrite set to true if the value of that parameter needs to be updated. This creates an unsafe scenario in that a new resource will overwrite an existing value that it did not create _and_ this should throw an error unless the user decides that it should always be overwritten. 

I am proposing the following the following rules to govern update.
1. If the user has specified the overwrite flag, overwrite the parameters value.
2. If the resource is new, do not overwrite the parameters value. This will result in an error if the parameter already exists and is not managed by terraform. By default we do not want to overwrite parameters which we don't not own.
3. All other cases, allow the parameter to be overwritten.
