### PR TITLE
vendor: github.com/aws/aws-sdk-go/...@v1.10.36

### DIFF
--- a/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
@@ -985,10 +985,15 @@ var awsPartition = partition{
 				"ap-northeast-2": endpoint{},
 				"ap-south-1":     endpoint{},
 				"ap-southeast-1": endpoint{},
+				"ap-southeast-2": endpoint{},
+				"ca-central-1":   endpoint{},
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
+				"eu-west-2":      endpoint{},
 				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
+				"us-east-2":      endpoint{},
+				"us-west-1":      endpoint{},
 				"us-west-2":      endpoint{},
 			},
 		},
@@ -1498,6 +1503,7 @@ var awsPartition = partition{
 
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
+				"ap-northeast-2": endpoint{},
 				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
 				"ca-central-1":   endpoint{},

--- a/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/v4.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/v4.go
@@ -324,6 +324,10 @@ func (v4 Signer) signWithBody(r *http.Request, body io.ReadSeeker, service, regi
 		unsignedPayload:        v4.UnsignedPayload,
 	}
 
+	for key := range ctx.Query {
+		sort.Strings(ctx.Query[key])
+	}
+
 	if ctx.isRequestSigned() {
 		ctx.Time = currentTimeFn()
 		ctx.handlePresignRemoval()

--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.10.34"
+const SDKVersion = "1.10.36"

--- a/vendor/github.com/aws/aws-sdk-go/service/applicationautoscaling/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/applicationautoscaling/api.go
@@ -2990,6 +2990,8 @@ type TargetTrackingScalingPolicyConfiguration struct {
 	// Reserved for future use.
 	CustomizedMetricSpecification *CustomizedMetricSpecification `type:"structure"`
 
+	DisableScaleIn *bool `type:"boolean"`
+
 	// A predefined metric.
 	PredefinedMetricSpecification *PredefinedMetricSpecification `type:"structure"`
 
@@ -3055,6 +3057,12 @@ func (s *TargetTrackingScalingPolicyConfiguration) Validate() error {
 // SetCustomizedMetricSpecification sets the CustomizedMetricSpecification field's value.
 func (s *TargetTrackingScalingPolicyConfiguration) SetCustomizedMetricSpecification(v *CustomizedMetricSpecification) *TargetTrackingScalingPolicyConfiguration {
 	s.CustomizedMetricSpecification = v
+	return s
+}
+
+// SetDisableScaleIn sets the DisableScaleIn field's value.
+func (s *TargetTrackingScalingPolicyConfiguration) SetDisableScaleIn(v bool) *TargetTrackingScalingPolicyConfiguration {
+	s.DisableScaleIn = &v
 	return s
 }
 

--- a/vendor/github.com/aws/aws-sdk-go/service/codebuild/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/codebuild/api.go
@@ -11,6 +11,85 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 )
 
+const opBatchDeleteBuilds = "BatchDeleteBuilds"
+
+// BatchDeleteBuildsRequest generates a "aws/request.Request" representing the
+// client's request for the BatchDeleteBuilds operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See BatchDeleteBuilds for more information on using the BatchDeleteBuilds
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the BatchDeleteBuildsRequest method.
+//    req, resp := client.BatchDeleteBuildsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codebuild-2016-10-06/BatchDeleteBuilds
+func (c *CodeBuild) BatchDeleteBuildsRequest(input *BatchDeleteBuildsInput) (req *request.Request, output *BatchDeleteBuildsOutput) {
+	op := &request.Operation{
+		Name:       opBatchDeleteBuilds,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &BatchDeleteBuildsInput{}
+	}
+
+	output = &BatchDeleteBuildsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// BatchDeleteBuilds API operation for AWS CodeBuild.
+//
+// Deletes one or more builds.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS CodeBuild's
+// API operation BatchDeleteBuilds for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidInputException "InvalidInputException"
+//   The input value that was provided is not valid.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codebuild-2016-10-06/BatchDeleteBuilds
+func (c *CodeBuild) BatchDeleteBuilds(input *BatchDeleteBuildsInput) (*BatchDeleteBuildsOutput, error) {
+	req, out := c.BatchDeleteBuildsRequest(input)
+	return out, req.Send()
+}
+
+// BatchDeleteBuildsWithContext is the same as BatchDeleteBuilds with the addition of
+// the ability to pass a context and additional request options.
+//
+// See BatchDeleteBuilds for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CodeBuild) BatchDeleteBuildsWithContext(ctx aws.Context, input *BatchDeleteBuildsInput, opts ...request.Option) (*BatchDeleteBuildsOutput, error) {
+	req, out := c.BatchDeleteBuildsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opBatchGetBuilds = "BatchGetBuilds"
 
 // BatchGetBuildsRequest generates a "aws/request.Request" representing the
@@ -899,6 +978,81 @@ func (c *CodeBuild) UpdateProjectWithContext(ctx aws.Context, input *UpdateProje
 	return out, req.Send()
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codebuild-2016-10-06/BatchDeleteBuildsInput
+type BatchDeleteBuildsInput struct {
+	_ struct{} `type:"structure"`
+
+	// The IDs of the builds to delete.
+	//
+	// Ids is a required field
+	Ids []*string `locationName:"ids" min:"1" type:"list" required:"true"`
+}
+
+// String returns the string representation
+func (s BatchDeleteBuildsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s BatchDeleteBuildsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *BatchDeleteBuildsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "BatchDeleteBuildsInput"}
+	if s.Ids == nil {
+		invalidParams.Add(request.NewErrParamRequired("Ids"))
+	}
+	if s.Ids != nil && len(s.Ids) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Ids", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetIds sets the Ids field's value.
+func (s *BatchDeleteBuildsInput) SetIds(v []*string) *BatchDeleteBuildsInput {
+	s.Ids = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codebuild-2016-10-06/BatchDeleteBuildsOutput
+type BatchDeleteBuildsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The IDs of the builds that were successfully deleted.
+	BuildsDeleted []*string `locationName:"buildsDeleted" min:"1" type:"list"`
+
+	// Information about any builds that could not be successfully deleted.
+	BuildsNotDeleted []*BuildNotDeleted `locationName:"buildsNotDeleted" type:"list"`
+}
+
+// String returns the string representation
+func (s BatchDeleteBuildsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s BatchDeleteBuildsOutput) GoString() string {
+	return s.String()
+}
+
+// SetBuildsDeleted sets the BuildsDeleted field's value.
+func (s *BatchDeleteBuildsOutput) SetBuildsDeleted(v []*string) *BatchDeleteBuildsOutput {
+	s.BuildsDeleted = v
+	return s
+}
+
+// SetBuildsNotDeleted sets the BuildsNotDeleted field's value.
+func (s *BatchDeleteBuildsOutput) SetBuildsNotDeleted(v []*BuildNotDeleted) *BatchDeleteBuildsOutput {
+	s.BuildsNotDeleted = v
+	return s
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/codebuild-2016-10-06/BatchGetBuildsInput
 type BatchGetBuildsInput struct {
 	_ struct{} `type:"structure"`
@@ -1284,6 +1438,40 @@ func (s *BuildArtifacts) SetMd5sum(v string) *BuildArtifacts {
 // SetSha256sum sets the Sha256sum field's value.
 func (s *BuildArtifacts) SetSha256sum(v string) *BuildArtifacts {
 	s.Sha256sum = &v
+	return s
+}
+
+// Information about a build that could not be successfully deleted.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codebuild-2016-10-06/BuildNotDeleted
+type BuildNotDeleted struct {
+	_ struct{} `type:"structure"`
+
+	// The ID of the build that could not be successfully deleted.
+	Id *string `locationName:"id" min:"1" type:"string"`
+
+	// Additional information about the build that could not be successfully deleted.
+	StatusCode *string `locationName:"statusCode" type:"string"`
+}
+
+// String returns the string representation
+func (s BuildNotDeleted) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s BuildNotDeleted) GoString() string {
+	return s.String()
+}
+
+// SetId sets the Id field's value.
+func (s *BuildNotDeleted) SetId(v string) *BuildNotDeleted {
+	s.Id = &v
+	return s
+}
+
+// SetStatusCode sets the StatusCode field's value.
+func (s *BuildNotDeleted) SetStatusCode(v string) *BuildNotDeleted {
+	s.StatusCode = &v
 	return s
 }
 
@@ -2570,8 +2758,8 @@ type ProjectEnvironment struct {
 	// with Docker support.)
 	//
 	// - nohup /usr/local/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://0.0.0.0:2375
-	// --storage-driver=vfs& - timeout -t 15 sh -c "until docker info; do echo .;
-	// sleep 1; done"
+	// --storage-driver=overlay& - timeout -t 15 sh -c "until docker info; do echo
+	// .; sleep 1; done"
 	PrivilegedMode *bool `locationName:"privilegedMode" type:"boolean"`
 
 	// The type of build environment to use for related builds.
@@ -2662,7 +2850,7 @@ type ProjectSource struct {
 	//
 	// This information is for the AWS CodeBuild console's use only. Your code should
 	// not get or set this information directly (unless the build project's source
-	// type value is GITHUB).
+	// type value is BITBUCKET or GITHUB).
 	Auth *SourceAuth `locationName:"auth" type:"structure"`
 
 	// The build spec declaration to use for the builds in this build project.
@@ -2699,10 +2887,23 @@ type ProjectSource struct {
 	//    may then leave the AWS CodeBuild console.) To instruct AWS CodeBuild to
 	//    then use this connection, in the source object, set the auth object's
 	//    type value to OAUTH.
+	//
+	//    * For source code in a Bitbucket repository, the HTTPS clone URL to the
+	//    repository that contains the source and the build spec. Also, you must
+	//    connect your AWS account to your Bitbucket account. To do this, use the
+	//    AWS CodeBuild console to begin creating a build project. When you use
+	//    the console to connect (or reconnect) with Bitbucket, on the Bitbucket
+	//    Confirm access to your account page that displays, choose Grant access.
+	//    (After you have connected to your Bitbucket account, you do not need to
+	//    finish creating the build project, and you may then leave the AWS CodeBuild
+	//    console.) To instruct AWS CodeBuild to then use this connection, in the
+	//    source object, set the auth object's type value to OAUTH.
 	Location *string `locationName:"location" type:"string"`
 
 	// The type of repository that contains the source code to be built. Valid values
 	// include:
+	//
+	//    * BITBUCKET: The source code is in a Bitbucket repository.
 	//
 	//    * CODECOMMIT: The source code is in an AWS CodeCommit repository.
 	//
@@ -2775,7 +2976,7 @@ func (s *ProjectSource) SetType(v string) *ProjectSource {
 //
 // This information is for the AWS CodeBuild console's use only. Your code should
 // not get or set this information directly (unless the build project's source
-// type value is GITHUB).
+// type value is BITBUCKET or GITHUB).
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/codebuild-2016-10-06/SourceAuth
 type SourceAuth struct {
 	_ struct{} `type:"structure"`
@@ -2849,7 +3050,19 @@ type StartBuildInput struct {
 	// A version of the build input to be built, for this build only. If not specified,
 	// the latest version will be used. If specified, must be one of:
 	//
-	//    * For AWS CodeCommit or GitHub: the commit ID to use.
+	//    * For AWS CodeCommit: the commit ID to use.
+	//
+	//    * For GitHub: the commit ID, pull request ID, branch name, or tag name
+	//    that corresponds to the version of the source code you want to build.
+	//    If a pull request ID is specified, it must use the format pr/pull-request-ID
+	//    (for example pr/25). If a branch name is specified, the branch's HEAD
+	//    commit ID will be used. If not specified, the default branch's HEAD commit
+	//    ID will be used.
+	//
+	//    * For Bitbucket: the commit ID, branch name, or tag name that corresponds
+	//    to the version of the source code you want to build. If a branch name
+	//    is specified, the branch's HEAD commit ID will be used. If not specified,
+	//    the default branch's HEAD commit ID will be used.
 	//
 	//    * For Amazon Simple Storage Service (Amazon S3): the version ID of the
 	//    object representing the build input ZIP file to use.

--- a/vendor/github.com/aws/aws-sdk-go/service/codebuild/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/codebuild/doc.go
@@ -15,6 +15,8 @@
 //
 // AWS CodeBuild supports these operations:
 //
+//    * BatchDeleteBuilds: Deletes one or more builds.
+//
 //    * BatchGetProjects: Gets information about one or more build projects.
 //    A build project defines how AWS CodeBuild will run a build. This includes
 //    information such as where to get the source code to build, the build environment

--- a/vendor/github.com/aws/aws-sdk-go/service/ec2/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ec2/api.go
@@ -1468,7 +1468,8 @@ func (c *EC2) AuthorizeSecurityGroupEgressRequest(input *AuthorizeSecurityGroupE
 // range or a source group. For the TCP and UDP protocols, you must also specify
 // the destination port or port range. For the ICMP protocol, you must also
 // specify the ICMP type and code. You can use -1 for the type or code to mean
-// all types or all codes.
+// all types or all codes. You can optionally specify a description for the
+// rule.
 //
 // Rule changes are propagated to affected instances as quickly as possible.
 // However, a small delay might occur.
@@ -1564,6 +1565,8 @@ func (c *EC2) AuthorizeSecurityGroupIngressRequest(input *AuthorizeSecurityGroup
 // group for your VPC. The security groups must all be for the same VPC or a
 // peer VPC in a VPC peering connection. For more information about VPC security
 // group limits, see Amazon VPC Limits (http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Appendix_Limits.html).
+//
+// You can optionally specify a description for the security group rule.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -18906,13 +18909,14 @@ func (c *EC2) RevokeSecurityGroupEgressRequest(input *RevokeSecurityGroupEgressI
 //
 // [EC2-VPC only] Removes one or more egress rules from a security group for
 // EC2-VPC. This action doesn't apply to security groups for use in EC2-Classic.
-// The values that you specify in the revoke request (for example, ports) must
-// match the existing rule's values for the rule to be revoked.
+// To remove a rule, the values that you specify (for example, ports) must match
+// the existing rule's values exactly.
 //
 // Each rule consists of the protocol and the IPv4 or IPv6 CIDR range or source
 // security group. For the TCP and UDP protocols, you must also specify the
 // destination port or range of ports. For the ICMP protocol, you must also
-// specify the ICMP type and code.
+// specify the ICMP type and code. If the security group rule has a description,
+// you do not have to specify the description to revoke the rule.
 //
 // Rule changes are propagated to instances within the security group as quickly
 // as possible. However, a small delay might occur.
@@ -18991,9 +18995,9 @@ func (c *EC2) RevokeSecurityGroupIngressRequest(input *RevokeSecurityGroupIngres
 
 // RevokeSecurityGroupIngress API operation for Amazon Elastic Compute Cloud.
 //
-// Removes one or more ingress rules from a security group. The values that
-// you specify in the revoke request (for example, ports) must match the existing
-// rule's values for the rule to be removed.
+// Removes one or more ingress rules from a security group. To remove a rule,
+// the values that you specify (for example, ports) must match the existing
+// rule's values exactly.
 //
 // [EC2-Classic security groups only] If the values you specify do not match
 // the existing rule's values, no error is returned. Use DescribeSecurityGroups
@@ -19002,7 +19006,8 @@ func (c *EC2) RevokeSecurityGroupIngressRequest(input *RevokeSecurityGroupIngres
 // Each rule consists of the protocol and the CIDR range or source security
 // group. For the TCP and UDP protocols, you must also specify the destination
 // port or range of ports. For the ICMP protocol, you must also specify the
-// ICMP type and code.
+// ICMP type and code. If the security group rule has a description, you do
+// not have to specify the description to revoke the rule.
 //
 // Rule changes are propagated to instances within the security group as quickly
 // as possible. However, a small delay might occur.
@@ -19755,6 +19760,166 @@ func (c *EC2) UnmonitorInstances(input *UnmonitorInstancesInput) (*UnmonitorInst
 // for more information on using Contexts.
 func (c *EC2) UnmonitorInstancesWithContext(ctx aws.Context, input *UnmonitorInstancesInput, opts ...request.Option) (*UnmonitorInstancesOutput, error) {
 	req, out := c.UnmonitorInstancesRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opUpdateSecurityGroupRuleDescriptionsEgress = "UpdateSecurityGroupRuleDescriptionsEgress"
+
+// UpdateSecurityGroupRuleDescriptionsEgressRequest generates a "aws/request.Request" representing the
+// client's request for the UpdateSecurityGroupRuleDescriptionsEgress operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See UpdateSecurityGroupRuleDescriptionsEgress for more information on using the UpdateSecurityGroupRuleDescriptionsEgress
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the UpdateSecurityGroupRuleDescriptionsEgressRequest method.
+//    req, resp := client.UpdateSecurityGroupRuleDescriptionsEgressRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/UpdateSecurityGroupRuleDescriptionsEgress
+func (c *EC2) UpdateSecurityGroupRuleDescriptionsEgressRequest(input *UpdateSecurityGroupRuleDescriptionsEgressInput) (req *request.Request, output *UpdateSecurityGroupRuleDescriptionsEgressOutput) {
+	op := &request.Operation{
+		Name:       opUpdateSecurityGroupRuleDescriptionsEgress,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &UpdateSecurityGroupRuleDescriptionsEgressInput{}
+	}
+
+	output = &UpdateSecurityGroupRuleDescriptionsEgressOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// UpdateSecurityGroupRuleDescriptionsEgress API operation for Amazon Elastic Compute Cloud.
+//
+// [EC2-VPC only] Updates the description of an egress (outbound) security group
+// rule. You can replace an existing description, or add a description to a
+// rule that did not have one previously.
+//
+// You specify the description as part of the IP permissions structure. You
+// can remove a description for a security group rule by omitting the description
+// parameter in the request.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation UpdateSecurityGroupRuleDescriptionsEgress for usage and error information.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/UpdateSecurityGroupRuleDescriptionsEgress
+func (c *EC2) UpdateSecurityGroupRuleDescriptionsEgress(input *UpdateSecurityGroupRuleDescriptionsEgressInput) (*UpdateSecurityGroupRuleDescriptionsEgressOutput, error) {
+	req, out := c.UpdateSecurityGroupRuleDescriptionsEgressRequest(input)
+	return out, req.Send()
+}
+
+// UpdateSecurityGroupRuleDescriptionsEgressWithContext is the same as UpdateSecurityGroupRuleDescriptionsEgress with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UpdateSecurityGroupRuleDescriptionsEgress for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) UpdateSecurityGroupRuleDescriptionsEgressWithContext(ctx aws.Context, input *UpdateSecurityGroupRuleDescriptionsEgressInput, opts ...request.Option) (*UpdateSecurityGroupRuleDescriptionsEgressOutput, error) {
+	req, out := c.UpdateSecurityGroupRuleDescriptionsEgressRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opUpdateSecurityGroupRuleDescriptionsIngress = "UpdateSecurityGroupRuleDescriptionsIngress"
+
+// UpdateSecurityGroupRuleDescriptionsIngressRequest generates a "aws/request.Request" representing the
+// client's request for the UpdateSecurityGroupRuleDescriptionsIngress operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See UpdateSecurityGroupRuleDescriptionsIngress for more information on using the UpdateSecurityGroupRuleDescriptionsIngress
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the UpdateSecurityGroupRuleDescriptionsIngressRequest method.
+//    req, resp := client.UpdateSecurityGroupRuleDescriptionsIngressRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/UpdateSecurityGroupRuleDescriptionsIngress
+func (c *EC2) UpdateSecurityGroupRuleDescriptionsIngressRequest(input *UpdateSecurityGroupRuleDescriptionsIngressInput) (req *request.Request, output *UpdateSecurityGroupRuleDescriptionsIngressOutput) {
+	op := &request.Operation{
+		Name:       opUpdateSecurityGroupRuleDescriptionsIngress,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &UpdateSecurityGroupRuleDescriptionsIngressInput{}
+	}
+
+	output = &UpdateSecurityGroupRuleDescriptionsIngressOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// UpdateSecurityGroupRuleDescriptionsIngress API operation for Amazon Elastic Compute Cloud.
+//
+// Updates the description of an ingress (inbound) security group rule. You
+// can replace an existing description, or add a description to a rule that
+// did not have one previously.
+//
+// You specify the description as part of the IP permissions structure. You
+// can remove a description for a security group rule by omitting the description
+// parameter in the request.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation UpdateSecurityGroupRuleDescriptionsIngress for usage and error information.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/UpdateSecurityGroupRuleDescriptionsIngress
+func (c *EC2) UpdateSecurityGroupRuleDescriptionsIngress(input *UpdateSecurityGroupRuleDescriptionsIngressInput) (*UpdateSecurityGroupRuleDescriptionsIngressOutput, error) {
+	req, out := c.UpdateSecurityGroupRuleDescriptionsIngressRequest(input)
+	return out, req.Send()
+}
+
+// UpdateSecurityGroupRuleDescriptionsIngressWithContext is the same as UpdateSecurityGroupRuleDescriptionsIngress with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UpdateSecurityGroupRuleDescriptionsIngress for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) UpdateSecurityGroupRuleDescriptionsIngressWithContext(ctx aws.Context, input *UpdateSecurityGroupRuleDescriptionsIngressInput, opts ...request.Option) (*UpdateSecurityGroupRuleDescriptionsIngressOutput, error) {
+	req, out := c.UpdateSecurityGroupRuleDescriptionsIngressRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -21745,12 +21910,16 @@ type AuthorizeSecurityGroupIngressInput struct {
 
 	// The start of port range for the TCP and UDP protocols, or an ICMP/ICMPv6
 	// type number. For the ICMP/ICMPv6 type number, use -1 to specify all types.
+	// If you specify all ICMP/ICMPv6 types, you must specify all codes.
 	FromPort *int64 `type:"integer"`
 
-	// The ID of the security group. Required for a nondefault VPC.
+	// The ID of the security group. You must specify either the security group
+	// ID or the security group name in the request. For security groups in a nondefault
+	// VPC, you must specify the security group ID.
 	GroupId *string `type:"string"`
 
-	// [EC2-Classic, default VPC] The name of the security group.
+	// [EC2-Classic, default VPC] The name of the security group. You must specify
+	// either the security group ID or the security group name in the request.
 	GroupName *string `type:"string"`
 
 	// A set of IP permissions. Can be used to specify multiple rules in a single
@@ -21783,7 +21952,8 @@ type AuthorizeSecurityGroupIngressInput struct {
 	SourceSecurityGroupOwnerId *string `type:"string"`
 
 	// The end of port range for the TCP and UDP protocols, or an ICMP/ICMPv6 code
-	// number. For the ICMP/ICMPv6 code number, use -1 to specify all codes.
+	// number. For the ICMP/ICMPv6 code number, use -1 to specify all codes. If
+	// you specify all ICMP/ICMPv6 types, you must specify all codes.
 	ToPort *int64 `type:"integer"`
 }
 
@@ -43994,7 +44164,8 @@ type IpPermission struct {
 	_ struct{} `type:"structure"`
 
 	// The start of port range for the TCP and UDP protocols, or an ICMP/ICMPv6
-	// type number. A value of -1 indicates all ICMP/ICMPv6 types.
+	// type number. A value of -1 indicates all ICMP/ICMPv6 types. If you specify
+	// all ICMP/ICMPv6 types, you must specify all codes.
 	FromPort *int64 `locationName:"fromPort" type:"integer"`
 
 	// The IP protocol name (tcp, udp, icmp) or number (see Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)).
@@ -44021,6 +44192,7 @@ type IpPermission struct {
 
 	// The end of port range for the TCP and UDP protocols, or an ICMP/ICMPv6 code.
 	// A value of -1 indicates all ICMP/ICMPv6 codes for the specified ICMP type.
+	// If you specify all ICMP/ICMPv6 types, you must specify all codes.
 	ToPort *int64 `locationName:"toPort" type:"integer"`
 
 	// One or more security group and AWS account ID pairs.
@@ -44087,6 +44259,13 @@ type IpRange struct {
 	// The IPv4 CIDR range. You can either specify a CIDR range or a source security
 	// group, not both. To specify a single IPv4 address, use the /32 prefix.
 	CidrIp *string `locationName:"cidrIp" type:"string"`
+
+	// A description for the security group rule that references this IPv4 address
+	// range.
+	//
+	// Constraints: Up to 255 characters in length. Allowed characters are a-z,
+	// A-Z, 0-9, spaces, and ._-:/()#,@[]+=;{}!$*
+	Description *string `locationName:"description" type:"string"`
 }
 
 // String returns the string representation
@@ -44102,6 +44281,12 @@ func (s IpRange) GoString() string {
 // SetCidrIp sets the CidrIp field's value.
 func (s *IpRange) SetCidrIp(v string) *IpRange {
 	s.CidrIp = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *IpRange) SetDescription(v string) *IpRange {
+	s.Description = &v
 	return s
 }
 
@@ -44138,6 +44323,13 @@ type Ipv6Range struct {
 	// The IPv6 CIDR range. You can either specify a CIDR range or a source security
 	// group, not both. To specify a single IPv6 address, use the /128 prefix.
 	CidrIpv6 *string `locationName:"cidrIpv6" type:"string"`
+
+	// A description for the security group rule that references this IPv6 address
+	// range.
+	//
+	// Constraints: Up to 255 characters in length. Allowed characters are a-z,
+	// A-Z, 0-9, spaces, and ._-:/()#,@[]+=;{}!$*
+	Description *string `locationName:"description" type:"string"`
 }
 
 // String returns the string representation
@@ -44153,6 +44345,12 @@ func (s Ipv6Range) GoString() string {
 // SetCidrIpv6 sets the CidrIpv6 field's value.
 func (s *Ipv6Range) SetCidrIpv6(v string) *Ipv6Range {
 	s.CidrIpv6 = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *Ipv6Range) SetDescription(v string) *Ipv6Range {
+	s.Description = &v
 	return s
 }
 
@@ -47669,6 +47867,13 @@ func (s *PrefixList) SetPrefixListName(v string) *PrefixList {
 type PrefixListId struct {
 	_ struct{} `type:"structure"`
 
+	// A description for the security group rule that references this prefix list
+	// ID.
+	//
+	// Constraints: Up to 255 characters in length. Allowed characters are a-z,
+	// A-Z, 0-9, spaces, and ._-:/()#,@[]+=;{}!$*
+	Description *string `locationName:"description" type:"string"`
+
 	// The ID of the prefix.
 	PrefixListId *string `locationName:"prefixListId" type:"string"`
 }
@@ -47681,6 +47886,12 @@ func (s PrefixListId) String() string {
 // GoString returns the string representation
 func (s PrefixListId) GoString() string {
 	return s.String()
+}
+
+// SetDescription sets the Description field's value.
+func (s *PrefixListId) SetDescription(v string) *PrefixListId {
+	s.Description = &v
+	return s
 }
 
 // SetPrefixListId sets the PrefixListId field's value.
@@ -56609,6 +56820,202 @@ func (s *UnsuccessfulItemError) SetMessage(v string) *UnsuccessfulItemError {
 	return s
 }
 
+// Contains the parameters for UpdateSecurityGroupRuleDescriptionsEgress.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/UpdateSecurityGroupRuleDescriptionsEgressRequest
+type UpdateSecurityGroupRuleDescriptionsEgressInput struct {
+	_ struct{} `type:"structure"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// The ID of the security group. You must specify either the security group
+	// ID or the security group name in the request. For security groups in a nondefault
+	// VPC, you must specify the security group ID.
+	GroupId *string `type:"string"`
+
+	// [Default VPC] The name of the security group. You must specify either the
+	// security group ID or the security group name in the request.
+	GroupName *string `type:"string"`
+
+	// The IP permissions for the security group rule.
+	//
+	// IpPermissions is a required field
+	IpPermissions []*IpPermission `locationNameList:"item" type:"list" required:"true"`
+}
+
+// String returns the string representation
+func (s UpdateSecurityGroupRuleDescriptionsEgressInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateSecurityGroupRuleDescriptionsEgressInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateSecurityGroupRuleDescriptionsEgressInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateSecurityGroupRuleDescriptionsEgressInput"}
+	if s.IpPermissions == nil {
+		invalidParams.Add(request.NewErrParamRequired("IpPermissions"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *UpdateSecurityGroupRuleDescriptionsEgressInput) SetDryRun(v bool) *UpdateSecurityGroupRuleDescriptionsEgressInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetGroupId sets the GroupId field's value.
+func (s *UpdateSecurityGroupRuleDescriptionsEgressInput) SetGroupId(v string) *UpdateSecurityGroupRuleDescriptionsEgressInput {
+	s.GroupId = &v
+	return s
+}
+
+// SetGroupName sets the GroupName field's value.
+func (s *UpdateSecurityGroupRuleDescriptionsEgressInput) SetGroupName(v string) *UpdateSecurityGroupRuleDescriptionsEgressInput {
+	s.GroupName = &v
+	return s
+}
+
+// SetIpPermissions sets the IpPermissions field's value.
+func (s *UpdateSecurityGroupRuleDescriptionsEgressInput) SetIpPermissions(v []*IpPermission) *UpdateSecurityGroupRuleDescriptionsEgressInput {
+	s.IpPermissions = v
+	return s
+}
+
+// Contains the output of UpdateSecurityGroupRuleDescriptionsEgress.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/UpdateSecurityGroupRuleDescriptionsEgressResult
+type UpdateSecurityGroupRuleDescriptionsEgressOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Returns true if the request succeeds; otherwise, returns an error.
+	Return *bool `locationName:"return" type:"boolean"`
+}
+
+// String returns the string representation
+func (s UpdateSecurityGroupRuleDescriptionsEgressOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateSecurityGroupRuleDescriptionsEgressOutput) GoString() string {
+	return s.String()
+}
+
+// SetReturn sets the Return field's value.
+func (s *UpdateSecurityGroupRuleDescriptionsEgressOutput) SetReturn(v bool) *UpdateSecurityGroupRuleDescriptionsEgressOutput {
+	s.Return = &v
+	return s
+}
+
+// Contains the parameters for UpdateSecurityGroupRuleDescriptionsIngress.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/UpdateSecurityGroupRuleDescriptionsIngressRequest
+type UpdateSecurityGroupRuleDescriptionsIngressInput struct {
+	_ struct{} `type:"structure"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// The ID of the security group. You must specify either the security group
+	// ID or the security group name in the request. For security groups in a nondefault
+	// VPC, you must specify the security group ID.
+	GroupId *string `type:"string"`
+
+	// [EC2-Classic, default VPC] The name of the security group. You must specify
+	// either the security group ID or the security group name in the request.
+	GroupName *string `type:"string"`
+
+	// The IP permissions for the security group rule.
+	//
+	// IpPermissions is a required field
+	IpPermissions []*IpPermission `locationNameList:"item" type:"list" required:"true"`
+}
+
+// String returns the string representation
+func (s UpdateSecurityGroupRuleDescriptionsIngressInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateSecurityGroupRuleDescriptionsIngressInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateSecurityGroupRuleDescriptionsIngressInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateSecurityGroupRuleDescriptionsIngressInput"}
+	if s.IpPermissions == nil {
+		invalidParams.Add(request.NewErrParamRequired("IpPermissions"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *UpdateSecurityGroupRuleDescriptionsIngressInput) SetDryRun(v bool) *UpdateSecurityGroupRuleDescriptionsIngressInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetGroupId sets the GroupId field's value.
+func (s *UpdateSecurityGroupRuleDescriptionsIngressInput) SetGroupId(v string) *UpdateSecurityGroupRuleDescriptionsIngressInput {
+	s.GroupId = &v
+	return s
+}
+
+// SetGroupName sets the GroupName field's value.
+func (s *UpdateSecurityGroupRuleDescriptionsIngressInput) SetGroupName(v string) *UpdateSecurityGroupRuleDescriptionsIngressInput {
+	s.GroupName = &v
+	return s
+}
+
+// SetIpPermissions sets the IpPermissions field's value.
+func (s *UpdateSecurityGroupRuleDescriptionsIngressInput) SetIpPermissions(v []*IpPermission) *UpdateSecurityGroupRuleDescriptionsIngressInput {
+	s.IpPermissions = v
+	return s
+}
+
+// Contains the output of UpdateSecurityGroupRuleDescriptionsIngress.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/UpdateSecurityGroupRuleDescriptionsIngressResult
+type UpdateSecurityGroupRuleDescriptionsIngressOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Returns true if the request succeeds; otherwise, returns an error.
+	Return *bool `locationName:"return" type:"boolean"`
+}
+
+// String returns the string representation
+func (s UpdateSecurityGroupRuleDescriptionsIngressOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateSecurityGroupRuleDescriptionsIngressOutput) GoString() string {
+	return s.String()
+}
+
+// SetReturn sets the Return field's value.
+func (s *UpdateSecurityGroupRuleDescriptionsIngressOutput) SetReturn(v bool) *UpdateSecurityGroupRuleDescriptionsIngressOutput {
+	s.Return = &v
+	return s
+}
+
 // Describes the S3 bucket for the disk image.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/UserBucket
 type UserBucket struct {
@@ -56709,6 +57116,13 @@ func (s *UserData) SetData(v string) *UserData {
 type UserIdGroupPair struct {
 	_ struct{} `type:"structure"`
 
+	// A description for the security group rule that references this user ID group
+	// pair.
+	//
+	// Constraints: Up to 255 characters in length. Allowed characters are a-z,
+	// A-Z, 0-9, spaces, and ._-:/()#,@[]+=;{}!$*
+	Description *string `locationName:"description" type:"string"`
+
 	// The ID of the security group.
 	GroupId *string `locationName:"groupId" type:"string"`
 
@@ -56742,6 +57156,12 @@ func (s UserIdGroupPair) String() string {
 // GoString returns the string representation
 func (s UserIdGroupPair) GoString() string {
 	return s.String()
+}
+
+// SetDescription sets the Description field's value.
+func (s *UserIdGroupPair) SetDescription(v string) *UserIdGroupPair {
+	s.Description = &v
+	return s
 }
 
 // SetGroupId sets the GroupId field's value.

--- a/vendor/github.com/aws/aws-sdk-go/service/elbv2/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/elbv2/api.go
@@ -3692,6 +3692,18 @@ type CreateTargetGroupInput struct {
 	// Protocol is a required field
 	Protocol *string `type:"string" required:"true" enum:"ProtocolEnum"`
 
+	// The type of target that you must specify when registering targets with this
+	// target group. The possible values are instance (targets are specified by
+	// instance ID) or ip (targets are specified by IP address). The default is
+	// instance. Note that you can't specify targets for a target group using both
+	// instance IDs and IP addresses.
+	//
+	// If the target type is ip, specify IP addresses from the subnets of the virtual
+	// private cloud (VPC) for the target group, the RFC 1918 range (10.0.0.0/8,
+	// 172.16.0.0/12, and 192.168.0.0/16), and the RFC 6598 range (100.64.0.0/10).
+	// You can't specify publicly routable IP addresses.
+	TargetType *string `type:"string" enum:"TargetTypeEnum"`
+
 	// The number of consecutive health check failures required before considering
 	// a target unhealthy. The default is 2.
 	UnhealthyThresholdCount *int64 `min:"2" type:"integer"`
@@ -3814,6 +3826,12 @@ func (s *CreateTargetGroupInput) SetPort(v int64) *CreateTargetGroupInput {
 // SetProtocol sets the Protocol field's value.
 func (s *CreateTargetGroupInput) SetProtocol(v string) *CreateTargetGroupInput {
 	s.Protocol = &v
+	return s
+}
+
+// SetTargetType sets the TargetType field's value.
+func (s *CreateTargetGroupInput) SetTargetType(v string) *CreateTargetGroupInput {
+	s.TargetType = &v
 	return s
 }
 
@@ -6671,7 +6689,19 @@ func (s *TagDescription) SetTags(v []*Tag) *TagDescription {
 type TargetDescription struct {
 	_ struct{} `type:"structure"`
 
-	// The ID of the target.
+	// The Availability Zone where the IP address is to be registered. Specify all
+	// to register an IP address outside the target group VPC with all Availability
+	// Zones that are enabled for the load balancer.
+	//
+	// If the IP address is in a subnet of the VPC for the target group, the Availability
+	// Zone is automatically detected and this parameter is optional.
+	//
+	// This parameter is not supported if the target type of the target group is
+	// instance.
+	AvailabilityZone *string `type:"string"`
+
+	// The ID of the target. If the target type of the target group is instance,
+	// specify an instance ID. If the target type is ip, specify an IP address.
 	//
 	// Id is a required field
 	Id *string `type:"string" required:"true"`
@@ -6704,6 +6734,12 @@ func (s *TargetDescription) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *TargetDescription) SetAvailabilityZone(v string) *TargetDescription {
+	s.AvailabilityZone = &v
+	return s
 }
 
 // SetId sets the Id field's value.
@@ -6762,6 +6798,11 @@ type TargetGroup struct {
 
 	// The name of the target group.
 	TargetGroupName *string `type:"string"`
+
+	// The type of target that you must specify when registering targets with this
+	// target group. The possible values are instance (targets are specified by
+	// instance ID) or ip (targets are specified by IP address).
+	TargetType *string `type:"string" enum:"TargetTypeEnum"`
 
 	// The number of consecutive health check failures required before considering
 	// the target unhealthy.
@@ -6850,6 +6891,12 @@ func (s *TargetGroup) SetTargetGroupArn(v string) *TargetGroup {
 // SetTargetGroupName sets the TargetGroupName field's value.
 func (s *TargetGroup) SetTargetGroupName(v string) *TargetGroup {
 	s.TargetGroupName = &v
+	return s
+}
+
+// SetTargetType sets the TargetType field's value.
+func (s *TargetGroup) SetTargetType(v string) *TargetGroup {
+	s.TargetType = &v
 	return s
 }
 
@@ -7116,6 +7163,9 @@ const (
 	// TargetHealthReasonEnumTargetInvalidState is a TargetHealthReasonEnum enum value
 	TargetHealthReasonEnumTargetInvalidState = "Target.InvalidState"
 
+	// TargetHealthReasonEnumTargetIpUnusable is a TargetHealthReasonEnum enum value
+	TargetHealthReasonEnumTargetIpUnusable = "Target.IpUnusable"
+
 	// TargetHealthReasonEnumElbInternalError is a TargetHealthReasonEnum enum value
 	TargetHealthReasonEnumElbInternalError = "Elb.InternalError"
 )
@@ -7135,4 +7185,12 @@ const (
 
 	// TargetHealthStateEnumDraining is a TargetHealthStateEnum enum value
 	TargetHealthStateEnumDraining = "draining"
+)
+
+const (
+	// TargetTypeEnumInstance is a TargetTypeEnum enum value
+	TargetTypeEnumInstance = "instance"
+
+	// TargetTypeEnumIp is a TargetTypeEnum enum value
+	TargetTypeEnumIp = "ip"
 )

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -45,692 +45,692 @@
 			"revisionTime": "2017-07-27T15:54:43Z"
 		},
 		{
-			"checksumSHA1": "mCbxLxIsVHhFBOXsHfvmszckEcE=",
+			"checksumSHA1": "MV3UQE73DSgDj8KP2O7OvQCatNw=",
 			"path": "github.com/aws/aws-sdk-go/aws",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "DtuTqKH29YnLjrIJkRYX0HQtXY0=",
 			"path": "github.com/aws/aws-sdk-go/aws/arn",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "Y9W+4GimK4Fuxq+vyIskVYFRnX4=",
 			"path": "github.com/aws/aws-sdk-go/aws/awserr",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "yyYr41HZ1Aq0hWc3J5ijXwYEcac=",
 			"path": "github.com/aws/aws-sdk-go/aws/awsutil",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "n98FANpNeRT5kf6pizdpI7nm6Sw=",
 			"path": "github.com/aws/aws-sdk-go/aws/client",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "ieAJ+Cvp/PKv1LpUEnUXpc3OI6E=",
 			"path": "github.com/aws/aws-sdk-go/aws/client/metadata",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "7/8j/q0TWtOgXyvEcv4B2Dhl00o=",
 			"path": "github.com/aws/aws-sdk-go/aws/corehandlers",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "Y+cPwQL0dZMyqp3wI+KJWmA9KQ8=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "u3GOAJLmdvbuNUeUEcZSEAOeL/0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "NUJUTWlc1sV8b7WjfiYc4JZbXl0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/endpointcreds",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "JEYqmF83O5n5bHkupAzA6STm0no=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "ZdtYh3ZHSgP/WEIaqwJHTEhpkbs=",
 			"path": "github.com/aws/aws-sdk-go/aws/defaults",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "/EXbk/z2TWjWc1Hvb4QYs3Wmhb8=",
 			"path": "github.com/aws/aws-sdk-go/aws/ec2metadata",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
-			"checksumSHA1": "hqLb0mWjIQQH3y+JDWxscaPnp+M=",
+			"checksumSHA1": "4nYrom/vWxOflVaFv8/E3B5jQfw=",
 			"path": "github.com/aws/aws-sdk-go/aws/endpoints",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "n/tgGgh0wICYu+VDYSqlsRy4w9s=",
 			"path": "github.com/aws/aws-sdk-go/aws/request",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "SK5Mn4Ga9+equOQTYA1DTSb3LWY=",
 			"path": "github.com/aws/aws-sdk-go/aws/session",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
-			"checksumSHA1": "KkxzzAAYtey7T6Hk4FSYY5kn3ek=",
+			"checksumSHA1": "iywvraxbXf3A/FOzFWjKfBBEQRA=",
 			"path": "github.com/aws/aws-sdk-go/aws/signer/v4",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "04ypv4x12l4q0TksA1zEVsmgpvw=",
 			"path": "github.com/aws/aws-sdk-go/internal/shareddefaults",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "wk7EyvDaHwb5qqoOP/4d3cV0708=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "1QmQ3FqV37w0Zi44qv8pA1GeR0A=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/ec2query",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "O6hcK24yI6w7FA+g4Pbr+eQ7pys=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/json/jsonutil",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "R00RL5jJXRYq1iiK1+PGvMfvXyM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/jsonrpc",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "ZqY5RWavBLWTo6j9xqdyBEaNFRk=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "Drt1JfLMa0DQEZLWrnMlTWaIcC8=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "VCTh+dEaqqhog5ncy/WTt9+/gFM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/rest",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "Rpu8KBtHZgvhkwHxUfaky+qW+G4=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restjson",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "ODo+ko8D6unAxZuN1jGzMcN4QCc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restxml",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "0qYPUga28aQVkxZgBR3Z86AbGUQ=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "F6mth+G7dXN1GI+nktaGo8Lx8aE=",
 			"path": "github.com/aws/aws-sdk-go/private/signer/v2",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "BXuQo73qo4WLmc+TdE5pAwalLUQ=",
 			"path": "github.com/aws/aws-sdk-go/service/acm",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "yKXkhhDv9rWmn8GofXPBoN6k730=",
 			"path": "github.com/aws/aws-sdk-go/service/apigateway",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
-			"checksumSHA1": "gT6mD+yVXS+z0z1skK90jLGeMgA=",
+			"checksumSHA1": "8nby/zySa8zYFPMamvrvkk5BOUE=",
 			"path": "github.com/aws/aws-sdk-go/service/applicationautoscaling",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "/C4QDOmEP7t8vawBcB7a2ygaXuI=",
 			"path": "github.com/aws/aws-sdk-go/service/athena",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "Tl/cvRil/SnTPh7HymTSgOp38/U=",
 			"path": "github.com/aws/aws-sdk-go/service/autoscaling",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "oPNv+5p2pAZlqSv8SmxbNt2gxYI=",
 			"path": "github.com/aws/aws-sdk-go/service/batch",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "Z6mv349IWcg2A8ib0BuOiCJ6X8Q=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudformation",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "rjq4ZWRUGvQDjnXeflafkCWYsFU=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudfront",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "59kV70/8PuutX4eFkGfCCtdunIA=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudtrail",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "zm2qDEBdcJSJI3PGcE2UVr6Cxmc=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatch",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "puxztE1Umuw+w1CTBmo3hsRItGE=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchevents",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "0w5/i4GBC7HxyvMXax/8oiTjLQE=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
-			"checksumSHA1": "tMhsAUxecX9Juqg8KVG0THAvaJI=",
+			"checksumSHA1": "ke7ciG4pxLLU5Ohgu9PCLtBkF7A=",
 			"path": "github.com/aws/aws-sdk-go/service/codebuild",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "XkyZPfxHxB3ohK+/qdF54nvMS0o=",
 			"path": "github.com/aws/aws-sdk-go/service/codecommit",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "QJYewZzcmPbuN27AWiQ6XKQ9Vrw=",
 			"path": "github.com/aws/aws-sdk-go/service/codedeploy",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "pL/7qVyn6qVry1uJ0Nw4/8tkGLM=",
 			"path": "github.com/aws/aws-sdk-go/service/codepipeline",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "7bm1eOY2oKYSesmEOd1qXvTRH2s=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentity",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "ouZ4H9foNRBFaElXZbpi5C3pqDQ=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentityprovider",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "V3QpE1495nFtpAOw24WY6AsVT1w=",
 			"path": "github.com/aws/aws-sdk-go/service/configservice",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "8UoYKgC9u/gjExZe4a6ZZf4dDl8=",
 			"path": "github.com/aws/aws-sdk-go/service/databasemigrationservice",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "HfaX42uqVu9hosilU6JwEQhgI/o=",
 			"path": "github.com/aws/aws-sdk-go/service/devicefarm",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "1O8BtYGfkXglIqgl/uxunrq3Djs=",
 			"path": "github.com/aws/aws-sdk-go/service/directoryservice",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "Qk98eGaCDibYSf0u3E2q7fAGnbY=",
 			"path": "github.com/aws/aws-sdk-go/service/dynamodb",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
-			"checksumSHA1": "rNdqz+dhoBfAlrJdmGVjxq2KwR4=",
+			"checksumSHA1": "MAB7R9NXK1tsvGsA0qrgvODtTKY=",
 			"path": "github.com/aws/aws-sdk-go/service/ec2",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "YNq7YhasHn9ceelWX2aG0Cg0Ga0=",
 			"path": "github.com/aws/aws-sdk-go/service/ecr",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "ybOZuEwB/cI6Ga3mjLFUGmE7qF8=",
 			"path": "github.com/aws/aws-sdk-go/service/ecs",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "pBkeSL8bCEbz/6ub0Jr6NsjQPSc=",
 			"path": "github.com/aws/aws-sdk-go/service/efs",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "4a4FO9D6RQluAwyYEW5H6p0Nz7I=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticache",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "RzBRmfKefl+oBHDzrtsuxv8ycKE=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticbeanstalk",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "wca8VaMOBpTBJUjVlfceB+RI/aw=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticsearchservice",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "zMFn+iotI5JIiB9HFRo6BiX6CZE=",
 			"path": "github.com/aws/aws-sdk-go/service/elastictranscoder",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "sp5ZmzFBI5z1+kLkRoFjfm2GWuY=",
 			"path": "github.com/aws/aws-sdk-go/service/elb",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
-			"checksumSHA1": "hRO54p0axKFEvpO9dh4oodC/sPM=",
+			"checksumSHA1": "HYqIZQYXiY8gfrOJ3cIlxo0rtEg=",
 			"path": "github.com/aws/aws-sdk-go/service/elbv2",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "EEj7cYvIK+F25RIynBVArzedyPQ=",
 			"path": "github.com/aws/aws-sdk-go/service/emr",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "tuK++zhf2K0RBocTCU1ZltzS8ko=",
 			"path": "github.com/aws/aws-sdk-go/service/firehose",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "Ewp675B6bZe/eWipwJl7OXqCJRo=",
 			"path": "github.com/aws/aws-sdk-go/service/glacier",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "H41YeQoLzuR1gQvBytlaL/gql+A=",
 			"path": "github.com/aws/aws-sdk-go/service/iam",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "v0OUl6sTwF7EOmXyzk9ppc5ljLw=",
 			"path": "github.com/aws/aws-sdk-go/service/inspector",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "D92k3ymegRbjpgnuAy9rWjgV7vs=",
 			"path": "github.com/aws/aws-sdk-go/service/iot",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "fE6Lygzxvif/yfo9bncKyRUCqs8=",
 			"path": "github.com/aws/aws-sdk-go/service/kinesis",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "wwFYsrpInh4Tow/vTI7bD+r5gBU=",
 			"path": "github.com/aws/aws-sdk-go/service/kms",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "I9kIOQqqkoWjqYSrYixJpSDWqM8=",
 			"path": "github.com/aws/aws-sdk-go/service/lambda",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "eHMwitdHY0uOEA5kkmJ1nGHe0z0=",
 			"path": "github.com/aws/aws-sdk-go/service/lightsail",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "84rKGr+RvT8tjOalWGPKuNPC4T4=",
 			"path": "github.com/aws/aws-sdk-go/service/opsworks",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "WTV47G/M/WfY7bgwmu5OBrSiwnY=",
 			"path": "github.com/aws/aws-sdk-go/service/rds",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "QTc65yhur4smpQrn9Zq2c0UboIo=",
 			"path": "github.com/aws/aws-sdk-go/service/redshift",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "BFBST8eUZJckFLTjhhmDRto0IhQ=",
 			"path": "github.com/aws/aws-sdk-go/service/route53",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "SEKg+cGyOj6dKdK5ltUHsoL4R4Y=",
 			"path": "github.com/aws/aws-sdk-go/service/s3",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "rIBHXHWyTmY/vsqECa2PB0xT2HU=",
 			"path": "github.com/aws/aws-sdk-go/service/ses",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "u8xk+JtK/HwIKB2ume3or9Sstp8=",
 			"path": "github.com/aws/aws-sdk-go/service/sfn",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "hOcVb1zJiDUmafXSJQhkEascWwA=",
 			"path": "github.com/aws/aws-sdk-go/service/simpledb",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "1jN0ZDW5c9QEGSQIQ+KrbTACvm8=",
 			"path": "github.com/aws/aws-sdk-go/service/sns",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "SXH7QxrUFaor3KaNX0xPCV3eOhU=",
 			"path": "github.com/aws/aws-sdk-go/service/sqs",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "IrubgUh1G0xLdm1ISsEGE8cN5hk=",
 			"path": "github.com/aws/aws-sdk-go/service/ssm",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "MerduaV3PxtZAWvOGpgoBIglo38=",
 			"path": "github.com/aws/aws-sdk-go/service/sts",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "vFinPalK+r0kaIbPMaHhFbTi2QQ=",
 			"path": "github.com/aws/aws-sdk-go/service/waf",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "qe7HsjfCked/MaRvH2c0uJndWdM=",
 			"path": "github.com/aws/aws-sdk-go/service/wafregional",
-			"revision": "5b4d64c21c9af31b5c870528001cd2e3ef37bfe0",
-			"revisionTime": "2017-08-29T15:29:28Z",
-			"version": "v1.10.34",
-			"versionExact": "v1.10.34"
+			"revision": "b79a722cb7aba0edd9bd2256361ae2e15e98f8ad",
+			"revisionTime": "2017-08-31T21:31:26Z",
+			"version": "v1.10.36",
+			"versionExact": "v1.10.36"
 		},
 		{
 			"checksumSHA1": "nqw2Qn5xUklssHTubS5HDvEL9L4=",


### PR DESCRIPTION
This is to get support for https://aws.amazon.com/about-aws/whats-new/2017/08/simplify-management-of-security-groups-with-security-group-rule-descriptions/ which are folks likely going to ask for.