### PR TITLE
acc-tests: Skip EC2Classic tests if platform is not available

### DIFF
--- a/aws/import_aws_instance_test.go
+++ b/aws/import_aws_instance_test.go
@@ -57,7 +57,7 @@ func TestAccAWSInstance_importInEc2Classic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{

--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -60,3 +60,13 @@ func testAccPreCheck(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func testAccEC2ClassicPreCheck(t *testing.T) {
+	client := testAccProvider.Meta().(*AWSClient)
+	platforms := client.supportedplatforms
+	region := client.region
+	if !hasEc2Classic(platforms) {
+		t.Skipf("This test can only run in EC2 Classic, platforms available in %s: %q",
+			region, platforms)
+	}
+}

--- a/aws/resource_aws_eip_association_test.go
+++ b/aws/resource_aws_eip_association_test.go
@@ -48,7 +48,7 @@ func TestAccAWSEIPAssociation_ec2Classic(t *testing.T) {
 	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEIPAssociationDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_eip_test.go
+++ b/aws/resource_aws_eip_test.go
@@ -21,7 +21,7 @@ func TestAccAWSEIP_importEc2Classic(t *testing.T) {
 	resourceName := "aws_eip.bar"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEIPDestroy,
 		Steps: []resource.TestStep{
@@ -186,7 +186,7 @@ func TestAccAWSEIP_associated_user_private_ip(t *testing.T) {
 // https://github.com/terraform-providers/terraform-provider-aws/issues/42)
 func TestAccAWSEIP_classic_disassociate(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEIPDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
## Example

```
=== RUN   TestAccAWSEIP_importEc2Classic
--- SKIP: TestAccAWSEIP_importEc2Classic (2.86s)
	provider_test.go:69: This test can only run in EC2 Classic, platforms available in us-west-2: ["VPC"]
PASS
```

cc @Ninir 

Related to https://github.com/terraform-providers/terraform-provider-aws/pull/1551#issuecomment-326299353

Ideally we'd probably want to make both regions (standard + EC2Classic) configurable instead of hard-coded to us-west-2 & us-east-1, but that's a different task with slightly wider scope.