### PR TITLE
New Resource: aws_vpc_associate_cidr_block

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -469,6 +469,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_vpc_peering_connection_accepter":          resourceAwsVpcPeeringConnectionAccepter(),
 			"aws_default_vpc":                              resourceAwsDefaultVpc(),
 			"aws_vpc":                                      resourceAwsVpc(),
+			"aws_vpc_associate_cidr_block":                 resourceAwsVpcAssociateCidrBlock(),
 			"aws_vpc_endpoint":                             resourceAwsVpcEndpoint(),
 			"aws_vpc_endpoint_route_table_association":     resourceAwsVpcEndpointRouteTableAssociation(),
 			"aws_vpn_connection":                           resourceAwsVpnConnection(),

--- a/aws/resource_aws_vpc.go
+++ b/aws/resource_aws_vpc.go
@@ -19,7 +19,7 @@ func resourceAwsVpc() *schema.Resource {
 		Update: resourceAwsVpcUpdate,
 		Delete: resourceAwsVpcDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceAwsVpcInstanceImport,
+			State: schema.ImportStatePassthrough,
 		},
 
 		SchemaVersion: 1,
@@ -67,7 +67,13 @@ func resourceAwsVpc() *schema.Resource {
 			"assign_generated_ipv6_cidr_block": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  false,
+				Computed: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if !d.IsNewResource() && old == "false" {
+						return true
+					}
+					return false
+				},
 			},
 
 			"main_route_table_id": {
@@ -181,6 +187,10 @@ func resourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 
 	// Tags
 	d.Set("tags", tagsToMap(vpc.Tags))
+
+	if len(vpc.Ipv6CidrBlockAssociationSet) == 0 {
+		d.Set("assign_generated_ipv6_cidr_block", false)
+	}
 
 	for _, a := range vpc.Ipv6CidrBlockAssociationSet {
 		if *a.Ipv6CidrBlockState.State == "associated" { //we can only ever have 1 IPv6 block associated at once
@@ -391,65 +401,31 @@ func resourceAwsVpcUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("assign_generated_ipv6_cidr_block") && !d.IsNewResource() {
-		toAssign := d.Get("assign_generated_ipv6_cidr_block").(bool)
-
-		log.Printf("[INFO] Modifying assign_generated_ipv6_cidr_block to %#v", toAssign)
-
-		if toAssign {
-			modifyOpts := &ec2.AssociateVpcCidrBlockInput{
-				VpcId: &vpcid,
-				AmazonProvidedIpv6CidrBlock: aws.Bool(toAssign),
-			}
-			log.Printf("[INFO] Enabling assign_generated_ipv6_cidr_block vpc attribute for %s: %#v",
-				d.Id(), modifyOpts)
-			resp, err := conn.AssociateVpcCidrBlock(modifyOpts)
-			if err != nil {
-				return err
-			}
-
-			// Wait for the CIDR to become available
-			log.Printf(
-				"[DEBUG] Waiting for IPv6 CIDR (%s) to become associated",
-				d.Id())
-			stateConf := &resource.StateChangeConf{
-				Pending: []string{"associating", "disassociated"},
-				Target:  []string{"associated"},
-				Refresh: Ipv6CidrStateRefreshFunc(conn, d.Id(), *resp.Ipv6CidrBlockAssociation.AssociationId),
-				Timeout: 1 * time.Minute,
-			}
-			if _, err := stateConf.WaitForState(); err != nil {
-				return fmt.Errorf(
-					"Error waiting for IPv6 CIDR (%s) to become associated: %s",
-					d.Id(), err)
-			}
-		} else {
-			modifyOpts := &ec2.DisassociateVpcCidrBlockInput{
-				AssociationId: aws.String(d.Get("ipv6_association_id").(string)),
-			}
-			log.Printf("[INFO] Disabling assign_generated_ipv6_cidr_block vpc attribute for %s: %#v",
-				d.Id(), modifyOpts)
-			if _, err := conn.DisassociateVpcCidrBlock(modifyOpts); err != nil {
-				return err
-			}
-
-			// Wait for the CIDR to become available
-			log.Printf(
-				"[DEBUG] Waiting for IPv6 CIDR (%s) to become disassociated",
-				d.Id())
-			stateConf := &resource.StateChangeConf{
-				Pending: []string{"disassociating", "associated"},
-				Target:  []string{"disassociated"},
-				Refresh: Ipv6CidrStateRefreshFunc(conn, d.Id(), d.Get("ipv6_association_id").(string)),
-				Timeout: 1 * time.Minute,
-			}
-			if _, err := stateConf.WaitForState(); err != nil {
-				return fmt.Errorf(
-					"Error waiting for IPv6 CIDR (%s) to become disassociated: %s",
-					d.Id(), err)
-			}
+		//we know that the change is only going to be to disable IPv6 as we suppress the func for enabling
+		modifyOpts := &ec2.DisassociateVpcCidrBlockInput{
+			AssociationId: aws.String(d.Get("ipv6_association_id").(string)),
+		}
+		log.Printf("[INFO] Disabling assign_generated_ipv6_cidr_block vpc attribute for %s: %#v",
+			d.Id(), modifyOpts)
+		if _, err := conn.DisassociateVpcCidrBlock(modifyOpts); err != nil {
+			return err
 		}
 
-		d.SetPartial("assign_generated_ipv6_cidr_block")
+		// Wait for the CIDR to become available
+		log.Printf(
+			"[DEBUG] Waiting for IPv6 CIDR (%s) to become disassociated",
+			d.Id())
+		stateConf := &resource.StateChangeConf{
+			Pending: []string{"disassociating", "associated"},
+			Target:  []string{"disassociated"},
+			Refresh: Ipv6CidrStateRefreshFunc(conn, d.Id(), d.Get("ipv6_association_id").(string)),
+			Timeout: 1 * time.Minute,
+		}
+		if _, err := stateConf.WaitForState(); err != nil {
+			return fmt.Errorf(
+				"Error waiting for IPv6 CIDR (%s) to become disassociated: %s",
+				d.Id(), err)
+		}
 	}
 
 	if err := setTags(conn, d); err != nil {
@@ -630,12 +606,6 @@ func resourceAwsVpcSetDefaultRouteTable(conn *ec2.EC2, d *schema.ResourceData) e
 	d.Set("default_route_table_id", resp.RouteTables[0].RouteTableId)
 
 	return nil
-}
-
-func resourceAwsVpcInstanceImport(
-	d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	d.Set("assign_generated_ipv6_cidr_block", false)
-	return []*schema.ResourceData{d}, nil
 }
 
 func awsVpcDescribeVpcAttribute(attribute string, vpcId string, conn *ec2.EC2) (*ec2.DescribeVpcAttributeOutput, error) {

--- a/aws/resource_aws_vpc_associate_cidr_block.go
+++ b/aws/resource_aws_vpc_associate_cidr_block.go
@@ -1,0 +1,128 @@
+package aws
+
+import (
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsVpcAssociateCidrBlock() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsVpcAssociateCidrBlockCreate,
+		Read:   resourceAwsVpcAssociateCidrBlockRead,
+		Delete: resourceAwsVpcAssociateCidrBlockDelete,
+
+		Schema: map[string]*schema.Schema{
+
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"ipv4_cidr_block": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateCIDRNetworkAddress,
+			},
+
+			"assign_generated_ipv6_cidr_block": {
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Default:       false,
+				ForceNew:      true,
+				ConflictsWith: []string{"ipv4_cidr_block"},
+			},
+
+			"ipv6_cidr_block": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsVpcAssociateCidrBlockCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	params := &ec2.AssociateVpcCidrBlockInput{
+		VpcId: aws.String(d.Get("vpc_id").(string)),
+		AmazonProvidedIpv6CidrBlock: aws.Bool(d.Get("assign_generated_ipv6_cidr_block").(bool)),
+	}
+
+	if v, ok := d.GetOk("ipv4_cidr_block"); ok {
+		params.CidrBlock = aws.String(v.(string))
+	}
+
+	resp, err := conn.AssociateVpcCidrBlock(params)
+	if err != nil {
+		return err
+	}
+
+	if d.Get("assign_generated_ipv6_cidr_block").(bool) == true {
+		d.SetId(*resp.Ipv6CidrBlockAssociation.AssociationId)
+	} else {
+		d.SetId(*resp.CidrBlockAssociation.AssociationId)
+	}
+
+	return resourceAwsVpcAssociateCidrBlockRead(d, meta)
+}
+
+func resourceAwsVpcAssociateCidrBlockRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	vpcRaw, _, err := VPCStateRefreshFunc(conn, d.Get("vpc_id").(string))()
+	if err != nil {
+		return err
+	}
+
+	if vpcRaw == nil {
+		log.Printf("[INFO] No VPC Found for id %q", d.Get("vpc_id").(string))
+		d.SetId("")
+		return nil
+	}
+
+	vpc := vpcRaw.(*ec2.Vpc)
+	found := false
+
+	if d.Get("assign_generated_ipv6_cidr_block").(bool) == true {
+		for _, ipv6Association := range vpc.Ipv6CidrBlockAssociationSet {
+			if *ipv6Association.AssociationId == d.Id() {
+				found = true
+				d.Set("ipv6_cidr_block", ipv6Association.Ipv6CidrBlock)
+				break
+			}
+		}
+	} else {
+		for _, cidrAssociation := range vpc.CidrBlockAssociationSet {
+			if *cidrAssociation.AssociationId == d.Id() {
+				found = true
+				d.Set("ipv4_cidr_block", cidrAssociation.CidrBlock)
+			}
+		}
+	}
+
+	if !found {
+		log.Printf("[INFO] No VPC CIDR Association found for ID: %q", d.Id())
+	}
+
+	return nil
+}
+
+func resourceAwsVpcAssociateCidrBlockDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	params := &ec2.DisassociateVpcCidrBlockInput{
+		AssociationId: aws.String(d.Id()),
+	}
+
+	_, err := conn.DisassociateVpcCidrBlock(params)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/aws/resource_aws_vpc_associate_cidr_block_test.go
+++ b/aws/resource_aws_vpc_associate_cidr_block_test.go
@@ -1,0 +1,242 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSVpcAssociateIpv4CidrBlock(t *testing.T) {
+	var association ec2.VpcCidrBlockAssociation
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVpcAssociateCidrBlockDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcIpv4CidrAssociationConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVpcIpv4CidrAssociationExists("aws_vpc_associate_cidr_block.secondary_cidr", &association),
+					testAccCheckVpcIpv4AssociationCidr(&association, "172.2.0.0/16"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSVpcAssociateIpv6CidrBlock(t *testing.T) {
+	var association ec2.VpcIpv6CidrBlockAssociation
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVpcAssociateCidrBlockDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcIpv6CidrAssociationConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVpcIpv6CidrAssociationExists("aws_vpc_associate_cidr_block.secondary_ipv6_cidr", &association),
+					resource.TestCheckResourceAttrSet("aws_vpc_associate_cidr_block.secondary_ipv6_cidr", "ipv6_cidr_block"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSVpcAssociateIpv4AndIpv6CidrBlock(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVpcAssociateCidrBlockDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccVpcIpv4AndIpv6CidrAssociationConfig,
+				ExpectError: regexp.MustCompile(`: conflicts with`),
+			},
+		},
+	})
+}
+
+func testAccCheckVpcIpv4AssociationCidr(association *ec2.VpcCidrBlockAssociation, expected string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		CIDRBlock := association.CidrBlock
+		if *CIDRBlock != expected {
+			return fmt.Errorf("Bad cidr: %s", *association.CidrBlock)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckVpcAssociateCidrBlockDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_vpc_associate_cidr_block" {
+			continue
+		}
+
+		// Try to find the VPC
+		DescribeVpcOpts := &ec2.DescribeVpcsInput{
+			VpcIds: []*string{aws.String(rs.Primary.Attributes["vpc_id"])},
+		}
+		resp, err := conn.DescribeVpcs(DescribeVpcOpts)
+		if err == nil {
+			vpc := resp.Vpcs[0]
+
+			for _, ipv4Association := range vpc.CidrBlockAssociationSet {
+				if *ipv4Association.AssociationId == rs.Primary.ID {
+					return fmt.Errorf("VPC CIDR Association still exists.")
+				}
+			}
+
+			for _, ipv6Association := range vpc.Ipv6CidrBlockAssociationSet {
+				if *ipv6Association.AssociationId == rs.Primary.ID {
+					return fmt.Errorf("VPC CIDR Association still exists.")
+				}
+			}
+
+			return nil
+		}
+
+		// Verify the error is what we want
+		ec2err, ok := err.(awserr.Error)
+		if !ok {
+			return err
+		}
+		if ec2err.Code() != "InvalidVpcID.NotFound" {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckVpcIpv4CidrAssociationExists(n string, association *ec2.VpcCidrBlockAssociation) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No VPC ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+		DescribeVpcOpts := &ec2.DescribeVpcsInput{
+			VpcIds: []*string{aws.String(rs.Primary.Attributes["vpc_id"])},
+		}
+		resp, err := conn.DescribeVpcs(DescribeVpcOpts)
+		if err != nil {
+			return err
+		}
+		if len(resp.Vpcs) == 0 {
+			return fmt.Errorf("VPC not found")
+		}
+
+		vpc := resp.Vpcs[0]
+		found := false
+		for _, cidrAssociation := range vpc.CidrBlockAssociationSet {
+			if *cidrAssociation.AssociationId == rs.Primary.ID {
+				*association = *cidrAssociation
+				found = true
+			}
+		}
+
+		if !found {
+			return fmt.Errorf("VPC CIDR Association not found")
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckVpcIpv6CidrAssociationExists(n string, association *ec2.VpcIpv6CidrBlockAssociation) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No VPC ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+		DescribeVpcOpts := &ec2.DescribeVpcsInput{
+			VpcIds: []*string{aws.String(rs.Primary.Attributes["vpc_id"])},
+		}
+		resp, err := conn.DescribeVpcs(DescribeVpcOpts)
+		if err != nil {
+			return err
+		}
+		if len(resp.Vpcs) == 0 {
+			return fmt.Errorf("VPC not found")
+		}
+
+		vpc := resp.Vpcs[0]
+		found := false
+		for _, cidrAssociation := range vpc.Ipv6CidrBlockAssociationSet {
+			if *cidrAssociation.AssociationId == rs.Primary.ID {
+				*association = *cidrAssociation
+				found = true
+			}
+		}
+
+		if !found {
+			return fmt.Errorf("VPC CIDR Association not found")
+		}
+
+		return nil
+	}
+}
+
+const testAccVpcIpv4CidrAssociationConfig = `
+resource "aws_vpc" "foo" {
+	cidr_block = "10.1.0.0/16"
+}
+
+resource "aws_vpc_associate_cidr_block" "secondary_cidr" {
+	vpc_id = "${aws_vpc.foo.id}"
+	ipv4_cidr_block = "172.2.0.0/16"
+}
+
+resource "aws_vpc_associate_cidr_block" "tertiary_cidr" {
+	vpc_id = "${aws_vpc.foo.id}"
+	ipv4_cidr_block = "170.2.0.0/16"
+}
+`
+
+const testAccVpcIpv6CidrAssociationConfig = `
+resource "aws_vpc" "foo" {
+	cidr_block = "10.1.0.0/16"
+}
+
+resource "aws_vpc_associate_cidr_block" "secondary_ipv6_cidr" {
+	vpc_id = "${aws_vpc.foo.id}"
+	assign_generated_ipv6_cidr_block = true
+}
+`
+
+const testAccVpcIpv4AndIpv6CidrAssociationConfig = `
+resource "aws_vpc" "foo" {
+	cidr_block = "10.1.0.0/16"
+	assign_generated_ipv6_cidr_block = true
+}
+
+resource "aws_vpc_associate_cidr_block" "secondary_ipv6_cidr" {
+	vpc_id = "${aws_vpc.foo.id}"
+	ipv4_cidr_block = "172.2.0.0/16"
+	assign_generated_ipv6_cidr_block = true
+}
+`

--- a/aws/resource_aws_vpc_test.go
+++ b/aws/resource_aws_vpc_test.go
@@ -48,7 +48,6 @@ func TestAccAWSVpc_enableIpv6(t *testing.T) {
 				Config: testAccVpcConfigIpv6Enabled,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVpcExists("aws_vpc.foo", &vpc),
-					testAccCheckVpcCidr(&vpc, "10.1.0.0/16"),
 					resource.TestCheckResourceAttr(
 						"aws_vpc.foo", "cidr_block", "10.1.0.0/16"),
 					resource.TestCheckResourceAttrSet(
@@ -63,26 +62,8 @@ func TestAccAWSVpc_enableIpv6(t *testing.T) {
 				Config: testAccVpcConfigIpv6Disabled,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVpcExists("aws_vpc.foo", &vpc),
-					testAccCheckVpcCidr(&vpc, "10.1.0.0/16"),
-					resource.TestCheckResourceAttr(
-						"aws_vpc.foo", "cidr_block", "10.1.0.0/16"),
 					resource.TestCheckResourceAttr(
 						"aws_vpc.foo", "assign_generated_ipv6_cidr_block", "false"),
-				),
-			},
-			{
-				Config: testAccVpcConfigIpv6Enabled,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVpcExists("aws_vpc.foo", &vpc),
-					testAccCheckVpcCidr(&vpc, "10.1.0.0/16"),
-					resource.TestCheckResourceAttr(
-						"aws_vpc.foo", "cidr_block", "10.1.0.0/16"),
-					resource.TestCheckResourceAttrSet(
-						"aws_vpc.foo", "ipv6_association_id"),
-					resource.TestCheckResourceAttrSet(
-						"aws_vpc.foo", "ipv6_cidr_block"),
-					resource.TestCheckResourceAttr(
-						"aws_vpc.foo", "assign_generated_ipv6_cidr_block", "true"),
 				),
 			},
 		},
@@ -331,6 +312,7 @@ resource "aws_vpc" "foo" {
 const testAccVpcConfigIpv6Disabled = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
+	assign_generated_ipv6_cidr_block = false
 }
 `
 

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1487,6 +1487,10 @@
                             <a href="/docs/providers/aws/r/vpc.html">aws_vpc</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-vpc-associate-cidr-block") %>>
+                            <a href="/docs/providers/aws/r/vpc_associate_cidr_block.html">aws_vpc_associate_cidr_block</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-aws-resource-vpc-dhcp-options") %>>
                             <a href="/docs/providers/aws/r/vpc_dhcp_options.html">aws_vpc_dhcp_options</a>
                         </li>

--- a/website/docs/r/vpc.html.markdown
+++ b/website/docs/r/vpc.html.markdown
@@ -51,6 +51,10 @@ block with a /56 prefix length for the VPC. You cannot specify the range of IP a
 the size of the CIDR block. Default is `false`.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
+~> **Note:** If you create a VPC with `assign_generated_ipv6_cidr_block` set to `false` and want to
+update that to `true`, Terraform will no longer support this operation and we suggest to use `aws_vpc_associate_cidr_block` resource instead.
+The VPC won't reflect the new IPv6 values from the new resource until `terraform refresh` happens.
+
 ## Attributes Reference
 
 The following attributes are exported:

--- a/website/docs/r/vpc_associate_cidr_block.html.markdown
+++ b/website/docs/r/vpc_associate_cidr_block.html.markdown
@@ -1,0 +1,58 @@
+---
+layout: "aws"
+page_title: "AWS: aws_vpc_associate_cidr_block"
+sidebar_current: "docs-aws-resource-vpc-associate-cidr-block"
+description: |-
+  Associates a CIDR block to a VPC
+---
+
+# aws_vpc_associate_cidr_block
+
+Associates a CIDR block to a VPC
+
+## Example Usage
+
+IPv4 CIDR Block Association:
+
+```hcl
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_vpc_associate_cidr_block" "secondary_cidr" {
+  vpc_id = "${aws_vpc.main.id}"
+  ipv4_cidr_block = "172.2.0.0/16"
+}
+```
+
+IPv6 CIDR Block Association:
+
+```hcl
+resource "aws_vpc" "main" {
+  cidr_block       = "10.0.0.0/16"
+  assign_generated_ipv6_cidr_block = true
+}
+
+resource "aws_vpc_associate_cidr_block" "secondary_ipv6_cidr" {
+  vpc_id = "${aws_vpc.main.id}"
+  assign_generated_ipv6_cidr_block = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `vpc_id` - (Required) The ID of the VPC to make the association with
+* `cidr_block` - (Optional) The IPv4 CIDR block to associate to the VPC.
+* `assign_generated_ipv6_cidr_block` - (Optional) Requests an Amazon-provided IPv6 CIDR 
+block with a /56 prefix length for the VPC. You cannot specify the range of IP addresses, or 
+the size of the CIDR block. Default is `false`.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the VPC CIDR Association
+* `ipv6_cidr_block` - The IPv6 CIDR block.
+


### PR DESCRIPTION
Adds the ability to associate extra IPv4 or IPv6 CIDR Blocks with a VPC.
In order to avoid getting into the same issue as security_group and
security_group_rule, we added a diffSuppressFunc that stops people
enabling `ipv6` for an existant AWS VPC. We added a note to the
documentation to talk about this

```
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSVpc_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSVpc_ -timeout 120m
=== RUN   TestAccAWSVpc_importBasic
--- PASS: TestAccAWSVpc_importBasic (54.16s)
=== RUN   TestAccAWSVpc_basic
--- PASS: TestAccAWSVpc_basic (45.26s)
=== RUN   TestAccAWSVpc_enableIpv6
--- PASS: TestAccAWSVpc_enableIpv6 (87.40s)
=== RUN   TestAccAWSVpc_dedicatedTenancy
--- PASS: TestAccAWSVpc_dedicatedTenancy (45.51s)
=== RUN   TestAccAWSVpc_tags
--- PASS: TestAccAWSVpc_tags (84.80s)
=== RUN   TestAccAWSVpc_update
--- PASS: TestAccAWSVpc_update (97.12s)
=== RUN   TestAccAWSVpc_bothDnsOptionsSet
--- PASS: TestAccAWSVpc_bothDnsOptionsSet (19.82s)
=== RUN   TestAccAWSVpc_DisabledDnsSupport
--- PASS: TestAccAWSVpc_DisabledDnsSupport (44.93s)
=== RUN   TestAccAWSVpc_classiclinkOptionSet
--- PASS: TestAccAWSVpc_classiclinkOptionSet (46.18s)
=== RUN   TestAccAWSVpc_classiclinkDnsSupportOptionSet
--- PASS: TestAccAWSVpc_classiclinkDnsSupportOptionSet (47.51s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	572.738s
```

```
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSVpcAssociat'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSVpcAssociat -timeout 120m
=== RUN   TestAccAWSVpcAssociateIpv4CidrBlock
--- PASS: TestAccAWSVpcAssociateIpv4CidrBlock (51.48s)
=== RUN   TestAccAWSVpcAssociateIpv6CidrBlock
--- PASS: TestAccAWSVpcAssociateIpv6CidrBlock (50.16s)
=== RUN   TestAccAWSVpcAssociateIpv4AndIpv6CidrBlock
--- PASS: TestAccAWSVpcAssociateIpv4AndIpv6CidrBlock (2.13s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	103.802s
```