### PR TITLE
resource/aws_ssm_activation: Export ssm activation activation_code

### DIFF
--- a/aws/resource_aws_ssm_activation.go
+++ b/aws/resource_aws_ssm_activation.go
@@ -29,27 +29,31 @@ func resourceAwsSsmActivation() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
-			"expired": &schema.Schema{
+			"expired": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"expiration_date": &schema.Schema{
+			"expiration_date": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
-			"iam_role": &schema.Schema{
+			"iam_role": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"registration_limit": &schema.Schema{
+			"registration_limit": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				ForceNew: true,
 			},
-			"registration_count": &schema.Schema{
+			"registration_count": {
 				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"activation_code": {
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 		},
@@ -107,6 +111,7 @@ func resourceAwsSsmActivationCreate(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("[ERROR] ActivationId was nil")
 	}
 	d.SetId(*resp.ActivationId)
+	d.Set("activation_code", resp.ActivationCode)
 
 	return resourceAwsSsmActivationRead(d, meta)
 }

--- a/aws/resource_aws_ssm_activation_test.go
+++ b/aws/resource_aws_ssm_activation_test.go
@@ -18,10 +18,11 @@ func TestAccAWSSSMActivation_basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSSMActivationDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSSSMActivationBasicConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMActivationExists("aws_ssm_activation.foo"),
+					resource.TestCheckResourceAttrSet("aws_ssm_activation.foo", "activation_code"),
 				),
 			},
 		},

--- a/website/docs/r/ssm_activation.html.markdown
+++ b/website/docs/r/ssm_activation.html.markdown
@@ -56,6 +56,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
+* `activation_code` - The code the system generates when it processes the activation.
 * `name` - The default name of the registerd managed instance.
 * `description` - The description of the resource that was registered.
 * `expired` - If the current activation has expired.


### PR DESCRIPTION
Fixes: #1565

```
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSSSMActivation'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSSSMActivation -timeout 120m
=== RUN   TestAccAWSSSMActivation_basic
--- PASS: TestAccAWSSSMActivation_basic (41.97s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	41.999s
```