### PR TITLE
resource/aws_cloudwatch_log_metric_filter: Add support for DefaultValue

### DIFF
--- a/aws/resource_aws_cloudwatch_log_metric_filter.go
+++ b/aws/resource_aws_cloudwatch_log_metric_filter.go
@@ -21,14 +21,14 @@ func resourceAwsCloudWatchLogMetricFilter() *schema.Resource {
 		Delete: resourceAwsCloudWatchLogMetricFilterDelete,
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validateLogMetricFilterName,
 			},
 
-			"pattern": &schema.Schema{
+			"pattern": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validateMaxLength(512),
@@ -41,33 +41,37 @@ func resourceAwsCloudWatchLogMetricFilter() *schema.Resource {
 				},
 			},
 
-			"log_group_name": &schema.Schema{
+			"log_group_name": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validateLogGroupName,
 			},
 
-			"metric_transformation": &schema.Schema{
+			"metric_transformation": {
 				Type:     schema.TypeList,
 				Required: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"name": &schema.Schema{
+						"name": {
 							Type:         schema.TypeString,
 							Required:     true,
 							ValidateFunc: validateLogMetricFilterTransformationName,
 						},
-						"namespace": &schema.Schema{
+						"namespace": {
 							Type:         schema.TypeString,
 							Required:     true,
 							ValidateFunc: validateLogMetricFilterTransformationName,
 						},
-						"value": &schema.Schema{
+						"value": {
 							Type:         schema.TypeString,
 							Required:     true,
 							ValidateFunc: validateMaxLength(100),
+						},
+						"default_value": {
+							Type:     schema.TypeFloat,
+							Optional: true,
 						},
 					},
 				},
@@ -87,10 +91,14 @@ func resourceAwsCloudWatchLogMetricFilterUpdate(d *schema.ResourceData, meta int
 
 	transformations := d.Get("metric_transformation").([]interface{})
 	o := transformations[0].(map[string]interface{})
-	input.MetricTransformations = expandCloudWachLogMetricTransformations(o)
+	metricsTransformations, err := expandCloudWachLogMetricTransformations(o)
+	if err != nil {
+		return err
+	}
+	input.MetricTransformations = metricsTransformations
 
 	log.Printf("[DEBUG] Creating/Updating CloudWatch Log Metric Filter: %s", input)
-	_, err := conn.PutMetricFilter(&input)
+	_, err = conn.PutMetricFilter(&input)
 	if err != nil {
 		return fmt.Errorf("Creating/Updating CloudWatch Log Metric Filter failed: %s", err)
 	}

--- a/aws/resource_aws_cloudwatch_log_metric_filter_test.go
+++ b/aws/resource_aws_cloudwatch_log_metric_filter_test.go
@@ -51,6 +51,7 @@ func TestAccAWSCloudWatchLogMetricFilter_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_cloudwatch_log_metric_filter.foobar", "metric_transformation.0.name", "AccessDeniedCount"),
 					resource.TestCheckResourceAttr("aws_cloudwatch_log_metric_filter.foobar", "metric_transformation.0.namespace", "MyNamespace"),
 					resource.TestCheckResourceAttr("aws_cloudwatch_log_metric_filter.foobar", "metric_transformation.0.value", "2"),
+					resource.TestCheckResourceAttr("aws_cloudwatch_log_metric_filter.foobar", "metric_transformation.0.default_value", "1"),
 					testAccCheckCloudWatchLogMetricFilterTransformation(&mf, &cloudwatchlogs.MetricTransformation{
 						MetricName:      aws.String("AccessDeniedCount"),
 						MetricNamespace: aws.String("MyNamespace"),
@@ -181,6 +182,7 @@ PATTERN
   	name = "AccessDeniedCount"
   	namespace = "MyNamespace"
   	value = "2"
+  	default_value = "1"
   }
 }
 

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -1526,7 +1526,7 @@ func flattenCloudWachLogMetricTransformations(ts []*cloudwatchlogs.MetricTransfo
 	m["value"] = *ts[0].MetricValue
 
 	if ts[0].DefaultValue != nil {
-		m["default_value"] = strconv.FormatFloat(*ts[0].DefaultValue, 'E', -1, 64)
+		m["default_value"] = *ts[0].DefaultValue
 	}
 
 	mts = append(mts, m)

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -1503,14 +1503,18 @@ func expandApiGatewayStageKeyOperations(d *schema.ResourceData) []*apigateway.Pa
 	return operations
 }
 
-func expandCloudWachLogMetricTransformations(m map[string]interface{}) []*cloudwatchlogs.MetricTransformation {
+func expandCloudWachLogMetricTransformations(m map[string]interface{}) ([]*cloudwatchlogs.MetricTransformation, error) {
 	transformation := cloudwatchlogs.MetricTransformation{
 		MetricName:      aws.String(m["name"].(string)),
 		MetricNamespace: aws.String(m["namespace"].(string)),
 		MetricValue:     aws.String(m["value"].(string)),
 	}
 
-	return []*cloudwatchlogs.MetricTransformation{&transformation}
+	if m["default_value"] != "" {
+		transformation.DefaultValue = aws.Float64(m["default_value"].(float64))
+	}
+
+	return []*cloudwatchlogs.MetricTransformation{&transformation}, nil
 }
 
 func flattenCloudWachLogMetricTransformations(ts []*cloudwatchlogs.MetricTransformation) []interface{} {
@@ -1520,6 +1524,10 @@ func flattenCloudWachLogMetricTransformations(ts []*cloudwatchlogs.MetricTransfo
 	m["name"] = *ts[0].MetricName
 	m["namespace"] = *ts[0].MetricNamespace
 	m["value"] = *ts[0].MetricValue
+
+	if ts[0].DefaultValue != nil {
+		m["default_value"] = strconv.FormatFloat(*ts[0].DefaultValue, 'E', -1, 64)
+	}
 
 	mts = append(mts, m)
 

--- a/website/docs/r/cloudwatch_log_metric_filter.html.markdown
+++ b/website/docs/r/cloudwatch_log_metric_filter.html.markdown
@@ -46,6 +46,7 @@ The `metric_transformation` block supports the following arguments:
 * `name` - (Required) The name of the CloudWatch metric to which the monitored log information should be published (e.g. `ErrorCount`)
 * `namespace` - (Required) The destination namespace of the CloudWatch metric.
 * `value` - (Required) What to publish to the metric. For example, if you're counting the occurrences of a particular term like "Error", the value will be "1" for each occurrence. If you're counting the bytes transferred the published value will be the value in the log event.
+* `default_value` - (Optional) The value to emit when a filter pattern does not match a log event.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fixes: #1563
Fixes: #1442

```
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSCloudWatchLogMetricFilter_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCloudWatchLogMetricFilter_ -timeout 120m
=== RUN   TestAccAWSCloudWatchLogMetricFilter_basic
--- PASS: TestAccAWSCloudWatchLogMetricFilter_basic (59.02s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	59.047s
```