### PR TITLE
resource/aws_ssm_association: Migrate the schema to use association_id

### DIFF
--- a/aws/resource_aws_ssm_association.go
+++ b/aws/resource_aws_ssm_association.go
@@ -17,6 +17,9 @@ func resourceAwsSsmAssociation() *schema.Resource {
 		Update: resourceAwsSsmAssocationUpdate,
 		Delete: resourceAwsSsmAssociationDelete,
 
+		MigrateState:  resourceAwsSsmAssociationMigrateState,
+		SchemaVersion: 1,
+
 		Schema: map[string]*schema.Schema{
 			"association_id": {
 				Type:     schema.TypeString,
@@ -129,7 +132,7 @@ func resourceAwsSsmAssociationCreate(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("[ERROR] AssociationDescription was nil")
 	}
 
-	d.SetId(*resp.AssociationDescription.Name)
+	d.SetId(*resp.AssociationDescription.AssociationId)
 	d.Set("association_id", resp.AssociationDescription.AssociationId)
 
 	return resourceAwsSsmAssociationRead(d, meta)
@@ -141,7 +144,7 @@ func resourceAwsSsmAssociationRead(d *schema.ResourceData, meta interface{}) err
 	log.Printf("[DEBUG] Reading SSM Association: %s", d.Id())
 
 	params := &ssm.DescribeAssociationInput{
-		AssociationId: aws.String(d.Get("association_id").(string)),
+		AssociationId: aws.String(d.Id()),
 	}
 
 	resp, err := ssmconn.DescribeAssociation(params)

--- a/aws/resource_aws_ssm_association_migrate.go
+++ b/aws/resource_aws_ssm_association_migrate.go
@@ -1,0 +1,38 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func resourceAwsSsmAssociationMigrateState(
+	v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	switch v {
+	case 0:
+		log.Println("[INFO] Found AWS SSM Association State v0; migrating to v1")
+		return migrateSsmAssociationStateV0toV1(is)
+	default:
+		return is, fmt.Errorf("Unexpected schema version: %d", v)
+	}
+}
+
+func migrateSsmAssociationStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
+
+	if is.Empty() {
+		log.Println("[DEBUG] Empty InstanceState; nothing to migrate.")
+
+		return is, nil
+	}
+
+	log.Printf("[DEBUG] Attributes before migration: %#v", is.Attributes)
+
+	is.Attributes["id"] = is.Attributes["association_id"]
+	is.ID = is.Attributes["association_id"]
+
+	log.Printf("[DEBUG] Attributes after migration: %#v, new id: %s", is.Attributes, is.Attributes["association_id"])
+
+	return is, nil
+
+}

--- a/aws/resource_aws_ssm_association_migrate_test.go
+++ b/aws/resource_aws_ssm_association_migrate_test.go
@@ -1,0 +1,46 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAWSSsmAssociationRuleMigrateState(t *testing.T) {
+
+	cases := map[string]struct {
+		StateVersion int
+		ID           string
+		Attributes   map[string]string
+		Expected     string
+		Meta         interface{}
+	}{
+		"v0_1": {
+			StateVersion: 0,
+			ID:           "test_document_association-dev",
+			Attributes: map[string]string{
+				"association_id": "fb03b7e6-4a21-4012-965f-91a38cfeec72",
+				"instance_id":    "i-0381b34d460caf6ef",
+				"name":           "test_document_association-dev",
+			},
+			Expected: "fb03b7e6-4a21-4012-965f-91a38cfeec72",
+		},
+	}
+
+	for tn, tc := range cases {
+		is := &terraform.InstanceState{
+			ID:         tc.ID,
+			Attributes: tc.Attributes,
+		}
+		is, err := resourceAwsSsmAssociationMigrateState(
+			tc.StateVersion, is, tc.Meta)
+
+		if err != nil {
+			t.Fatalf("bad: %s, err: %#v", tn, err)
+		}
+
+		if is.ID != tc.Expected {
+			t.Fatalf("bad ssm association id: %s\n\n expected: %s", is.ID, tc.Expected)
+		}
+	}
+}


### PR DESCRIPTION
The id of `aws_ssm_association` was currently stored as name but should
have been association_id from the outside

This PR introduces a new migration to update the ssm_association state
to migrate to storing the id as the association_id rather than the name

This will make it easier to implement the import of `aws_ssm_associations`

```
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSSSMAssociation_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSSSMAssociation_ -timeout 120m
=== RUN   TestAccAWSSSMAssociation_basic
--- PASS: TestAccAWSSSMAssociation_basic (138.40s)
=== RUN   TestAccAWSSSMAssociation_withTargets
--- PASS: TestAccAWSSSMAssociation_withTargets (37.27s)
=== RUN   TestAccAWSSSMAssociation_withParameters
--- PASS: TestAccAWSSSMAssociation_withParameters (59.31s)
=== RUN   TestAccAWSSSMAssociation_withDocumentVersion
--- PASS: TestAccAWSSSMAssociation_withDocumentVersion (38.17s)
=== RUN   TestAccAWSSSMAssociation_withOutputLocation
--- PASS: TestAccAWSSSMAssociation_withOutputLocation (164.86s)
=== RUN   TestAccAWSSSMAssociation_withScheduleExpression
--- PASS: TestAccAWSSSMAssociation_withScheduleExpression (59.66s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	497.700s
```