### PR TITLE
Add support for security group rule description

### DIFF
--- a/aws/resource_aws_security_group.go
+++ b/aws/resource_aws_security_group.go
@@ -132,6 +132,12 @@ func resourceAwsSecurityGroup() *schema.Resource {
 							Optional: true,
 							Default:  false,
 						},
+
+						"description": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validateSecurityGroupRuleDescription,
+						},
 					},
 				},
 				Set: resourceAwsSecurityGroupRuleHash,
@@ -194,6 +200,12 @@ func resourceAwsSecurityGroup() *schema.Resource {
 							Type:     schema.TypeBool,
 							Optional: true,
 							Default:  false,
+						},
+
+						"description": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validateSecurityGroupRuleDescription,
 						},
 					},
 				},
@@ -500,6 +512,9 @@ func resourceAwsSecurityGroupRuleHash(v interface{}) int {
 			buf.WriteString(fmt.Sprintf("%s-", v))
 		}
 	}
+	if m["description"].(string) != "" {
+		buf.WriteString(fmt.Sprintf("%s-", m["description"].(string)))
+	}
 
 	return hashcode.String(buf.String())
 }
@@ -526,6 +541,8 @@ func resourceAwsSecurityGroupIPPermGather(groupId string, permissions []*ec2.IpP
 		m["to_port"] = toPort
 		m["protocol"] = *perm.IpProtocol
 
+		var description string
+
 		if len(perm.IpRanges) > 0 {
 			raw, ok := m["cidr_blocks"]
 			if !ok {
@@ -535,6 +552,11 @@ func resourceAwsSecurityGroupIPPermGather(groupId string, permissions []*ec2.IpP
 
 			for _, ip := range perm.IpRanges {
 				list = append(list, *ip.CidrIp)
+
+				desc := aws.StringValue(ip.Description)
+				if desc != "" {
+					description = desc
+				}
 			}
 
 			m["cidr_blocks"] = list
@@ -549,6 +571,11 @@ func resourceAwsSecurityGroupIPPermGather(groupId string, permissions []*ec2.IpP
 
 			for _, ip := range perm.Ipv6Ranges {
 				list = append(list, *ip.CidrIpv6)
+
+				desc := aws.StringValue(ip.Description)
+				if desc != "" {
+					description = desc
+				}
 			}
 
 			m["ipv6_cidr_blocks"] = list
@@ -563,6 +590,11 @@ func resourceAwsSecurityGroupIPPermGather(groupId string, permissions []*ec2.IpP
 
 			for _, pl := range perm.PrefixListIds {
 				list = append(list, *pl.PrefixListId)
+
+				desc := aws.StringValue(pl.Description)
+				if desc != "" {
+					description = desc
+				}
 			}
 
 			m["prefix_list_ids"] = list
@@ -573,6 +605,11 @@ func resourceAwsSecurityGroupIPPermGather(groupId string, permissions []*ec2.IpP
 			if *g.GroupId == groupId {
 				groups[i], groups = groups[len(groups)-1], groups[:len(groups)-1]
 				m["self"] = true
+
+				desc := aws.StringValue(g.Description)
+				if desc != "" {
+					description = desc
+				}
 			}
 		}
 
@@ -589,10 +626,17 @@ func resourceAwsSecurityGroupIPPermGather(groupId string, permissions []*ec2.IpP
 				} else {
 					list.Add(*g.GroupId)
 				}
+
+				desc := aws.StringValue(g.Description)
+				if desc != "" {
+					description = desc
+				}
 			}
 
 			m["security_groups"] = list
 		}
+
+		m["description"] = description
 	}
 	rules := make([]map[string]interface{}, 0, len(ruleMap))
 	for _, m := range ruleMap {
@@ -1007,6 +1051,11 @@ func matchRules(rType string, local []interface{}, remote []map[string]interface
 										r["security_groups"] = diffSGs
 									} else {
 										delete(r, "security_groups")
+									}
+
+									// copy over any remote rule description
+									if _, ok := r["description"]; ok {
+										l["description"] = r["description"]
 									}
 
 									saves = append(saves, l)

--- a/aws/resource_aws_security_group_rule_test.go
+++ b/aws/resource_aws_security_group_rule_test.go
@@ -404,7 +404,7 @@ func TestAccAWSSecurityGroupRule_PartialMatching_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSecurityGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSecurityGroupRulePartialMatching(rInt),
+				Config: testAccAWSSecurityGroupRulePartialMatchingConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.web", &group),
 					testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.ingress", &group, &p, "ingress"),
@@ -448,7 +448,7 @@ func TestAccAWSSecurityGroupRule_PartialMatching_Source(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSecurityGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSecurityGroupRulePartialMatching_Source(rInt),
+				Config: testAccAWSSecurityGroupRulePartialMatching_SourceConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.web", &group),
 					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.nat", &nat),
@@ -568,6 +568,108 @@ func TestAccAWSSecurityGroupRule_PrefixListEgress(t *testing.T) {
 					testAccCheckVpcEndpointExists("aws_vpc_endpoint.s3-us-west-2", &endpoint),
 					setupSG,
 					testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.egress_1", &group, &p, "egress"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSecurityGroupRule_IngressDescription(t *testing.T) {
+	var group ec2.SecurityGroup
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityGroupRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSecurityGroupRuleIngressDescriptionConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.web", &group),
+					testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.ingress_1", &group, nil, "ingress"),
+					resource.TestCheckResourceAttr("aws_security_group_rule.ingress_1", "description", "TF acceptance test ingress rule"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSecurityGroupRule_EgressDescription(t *testing.T) {
+	var group ec2.SecurityGroup
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityGroupRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSecurityGroupRuleEgressDescriptionConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.web", &group),
+					testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.egress_1", &group, nil, "egress"),
+					resource.TestCheckResourceAttr("aws_security_group_rule.egress_1", "description", "TF acceptance test egress rule"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSecurityGroupRule_IngressDescription_updates(t *testing.T) {
+	var group ec2.SecurityGroup
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityGroupRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSecurityGroupRuleIngressDescriptionConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.web", &group),
+					testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.ingress_1", &group, nil, "ingress"),
+					resource.TestCheckResourceAttr("aws_security_group_rule.ingress_1", "description", "TF acceptance test ingress rule"),
+				),
+			},
+
+			{
+				Config: testAccAWSSecurityGroupRuleIngress_updateDescriptionConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.web", &group),
+					testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.ingress_1", &group, nil, "ingress"),
+					resource.TestCheckResourceAttr("aws_security_group_rule.ingress_1", "description", "TF acceptance test ingress rule updated"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSecurityGroupRule_EgressDescription_updates(t *testing.T) {
+	var group ec2.SecurityGroup
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityGroupRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSecurityGroupRuleEgressDescriptionConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.web", &group),
+					testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.egress_1", &group, nil, "egress"),
+					resource.TestCheckResourceAttr("aws_security_group_rule.egress_1", "description", "TF acceptance test egress rule"),
+				),
+			},
+
+			{
+				Config: testAccAWSSecurityGroupRuleEgress_updateDescriptionConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.web", &group),
+					testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.egress_1", &group, nil, "egress"),
+					resource.TestCheckResourceAttr("aws_security_group_rule.egress_1", "description", "TF acceptance test egress rule updated"),
 				),
 			},
 		},
@@ -944,7 +1046,7 @@ resource "aws_security_group_rule" "self" {
 }
 `
 
-func testAccAWSSecurityGroupRulePartialMatching(rInt int) string {
+func testAccAWSSecurityGroupRulePartialMatchingConfig(rInt int) string {
 	return fmt.Sprintf(`
 	resource "aws_vpc" "default" {
 		cidr_block = "10.0.0.0/16"
@@ -1001,7 +1103,7 @@ func testAccAWSSecurityGroupRulePartialMatching(rInt int) string {
 	}`, rInt, rInt)
 }
 
-func testAccAWSSecurityGroupRulePartialMatching_Source(rInt int) string {
+func testAccAWSSecurityGroupRulePartialMatching_SourceConfig(rInt int) string {
 	return fmt.Sprintf(`
 	resource "aws_vpc" "default" {
 		cidr_block = "10.0.0.0/16"
@@ -1046,44 +1148,6 @@ func testAccAWSSecurityGroupRulePartialMatching_Source(rInt int) string {
 		 security_group_id = "${aws_security_group.web.id}"
 	}`, rInt, rInt)
 }
-
-var testAccAWSSecurityGroupRuleRace = func() string {
-	var b bytes.Buffer
-	iterations := 50
-	b.WriteString(fmt.Sprintf(`
-		resource "aws_vpc" "default" {
-			cidr_block = "10.0.0.0/16"
-			tags { Name = "tf-sg-rule-race" }
-		}
-
-		resource "aws_security_group" "race" {
-			name   = "tf-sg-rule-race-group-%d"
-			vpc_id = "${aws_vpc.default.id}"
-		}
-	`, acctest.RandInt()))
-	for i := 1; i < iterations; i++ {
-		b.WriteString(fmt.Sprintf(`
-			resource "aws_security_group_rule" "ingress%d" {
-				security_group_id = "${aws_security_group.race.id}"
-				type              = "ingress"
-				from_port         = %d
-				to_port           = %d
-				protocol          = "tcp"
-				cidr_blocks       = ["10.0.0.%d/32"]
-			}
-
-			resource "aws_security_group_rule" "egress%d" {
-				security_group_id = "${aws_security_group.race.id}"
-				type              = "egress"
-				from_port         = %d
-				to_port           = %d
-				protocol          = "tcp"
-				cidr_blocks       = ["10.0.0.%d/32"]
-			}
-		`, i, i, i, i, i, i, i, i))
-	}
-	return b.String()
-}()
 
 const testAccAWSSecurityGroupRulePrefixListEgressConfig = `
 
@@ -1133,6 +1197,136 @@ resource "aws_security_group_rule" "egress_1" {
 	security_group_id = "${aws_security_group.egress.id}"
 }
 `
+
+func testAccAWSSecurityGroupRuleIngressDescriptionConfig(rInt int) string {
+	return fmt.Sprintf(`
+	resource "aws_security_group" "web" {
+		name = "terraform_test_%d"
+		description = "Used in the terraform acceptance tests"
+
+					tags {
+									Name = "tf-acc-test"
+					}
+	}
+
+	resource "aws_security_group_rule" "ingress_1" {
+		type = "ingress"
+		protocol = "tcp"
+		from_port = 80
+		to_port = 8000
+		cidr_blocks = ["10.0.0.0/8"]
+		description = "TF acceptance test ingress rule"
+
+		security_group_id = "${aws_security_group.web.id}"
+	}`, rInt)
+}
+
+func testAccAWSSecurityGroupRuleIngress_updateDescriptionConfig(rInt int) string {
+	return fmt.Sprintf(`
+	resource "aws_security_group" "web" {
+		name = "terraform_test_%d"
+		description = "Used in the terraform acceptance tests"
+
+					tags {
+									Name = "tf-acc-test"
+					}
+	}
+
+	resource "aws_security_group_rule" "ingress_1" {
+		type = "ingress"
+		protocol = "tcp"
+		from_port = 80
+		to_port = 8000
+		cidr_blocks = ["10.0.0.0/8"]
+		description = "TF acceptance test ingress rule updated"
+
+		security_group_id = "${aws_security_group.web.id}"
+	}`, rInt)
+}
+
+func testAccAWSSecurityGroupRuleEgressDescriptionConfig(rInt int) string {
+	return fmt.Sprintf(`
+	resource "aws_security_group" "web" {
+		name = "terraform_test_%d"
+		description = "Used in the terraform acceptance tests"
+
+					tags {
+									Name = "tf-acc-test"
+					}
+	}
+
+	resource "aws_security_group_rule" "egress_1" {
+		type = "egress"
+		protocol = "tcp"
+		from_port = 80
+		to_port = 8000
+		cidr_blocks = ["10.0.0.0/8"]
+		description = "TF acceptance test egress rule"
+
+		security_group_id = "${aws_security_group.web.id}"
+	}`, rInt)
+}
+
+func testAccAWSSecurityGroupRuleEgress_updateDescriptionConfig(rInt int) string {
+	return fmt.Sprintf(`
+	resource "aws_security_group" "web" {
+		name = "terraform_test_%d"
+		description = "Used in the terraform acceptance tests"
+
+					tags {
+									Name = "tf-acc-test"
+					}
+	}
+
+	resource "aws_security_group_rule" "egress_1" {
+		type = "egress"
+		protocol = "tcp"
+		from_port = 80
+		to_port = 8000
+		cidr_blocks = ["10.0.0.0/8"]
+		description = "TF acceptance test egress rule updated"
+
+		security_group_id = "${aws_security_group.web.id}"
+	}`, rInt)
+}
+
+var testAccAWSSecurityGroupRuleRace = func() string {
+	var b bytes.Buffer
+	iterations := 50
+	b.WriteString(fmt.Sprintf(`
+		resource "aws_vpc" "default" {
+			cidr_block = "10.0.0.0/16"
+			tags { Name = "tf-sg-rule-race" }
+		}
+
+		resource "aws_security_group" "race" {
+			name   = "tf-sg-rule-race-group-%d"
+			vpc_id = "${aws_vpc.default.id}"
+		}
+	`, acctest.RandInt()))
+	for i := 1; i < iterations; i++ {
+		b.WriteString(fmt.Sprintf(`
+			resource "aws_security_group_rule" "ingress%d" {
+				security_group_id = "${aws_security_group.race.id}"
+				type              = "ingress"
+				from_port         = %d
+				to_port           = %d
+				protocol          = "tcp"
+				cidr_blocks       = ["10.0.0.%d/32"]
+			}
+
+			resource "aws_security_group_rule" "egress%d" {
+				security_group_id = "${aws_security_group.race.id}"
+				type              = "egress"
+				from_port         = %d
+				to_port           = %d
+				protocol          = "tcp"
+				cidr_blocks       = ["10.0.0.%d/32"]
+			}
+		`, i, i, i, i, i, i, i, i))
+	}
+	return b.String()
+}()
 
 func testAccAWSSecurityGroupRuleSelfInSource(rInt int) string {
 	return fmt.Sprintf(`

--- a/aws/structure_test.go
+++ b/aws/structure_test.go
@@ -55,6 +55,7 @@ func TestExpandIPPerms(t *testing.T) {
 				"sg-11111",
 				"foo/sg-22222",
 			}),
+			"description": "desc",
 		},
 		map[string]interface{}{
 			"protocol":  "icmp",
@@ -77,14 +78,21 @@ func TestExpandIPPerms(t *testing.T) {
 			IpProtocol: aws.String("icmp"),
 			FromPort:   aws.Int64(int64(1)),
 			ToPort:     aws.Int64(int64(-1)),
-			IpRanges:   []*ec2.IpRange{&ec2.IpRange{CidrIp: aws.String("0.0.0.0/0")}},
+			IpRanges: []*ec2.IpRange{
+				&ec2.IpRange{
+					CidrIp:      aws.String("0.0.0.0/0"),
+					Description: aws.String("desc"),
+				},
+			},
 			UserIdGroupPairs: []*ec2.UserIdGroupPair{
 				&ec2.UserIdGroupPair{
-					UserId:  aws.String("foo"),
-					GroupId: aws.String("sg-22222"),
+					UserId:      aws.String("foo"),
+					GroupId:     aws.String("sg-22222"),
+					Description: aws.String("desc"),
 				},
 				&ec2.UserIdGroupPair{
-					GroupId: aws.String("sg-11111"),
+					GroupId:     aws.String("sg-11111"),
+					Description: aws.String("desc"),
 				},
 			},
 		},
@@ -922,7 +930,7 @@ func TestFlattenSecurityGroups(t *testing.T) {
 	cases := []struct {
 		ownerId  *string
 		pairs    []*ec2.UserIdGroupPair
-		expected []*ec2.GroupIdentifier
+		expected []*GroupIdentifier
 	}{
 		// simple, no user id included (we ignore it mostly)
 		{
@@ -932,8 +940,8 @@ func TestFlattenSecurityGroups(t *testing.T) {
 					GroupId: aws.String("sg-12345"),
 				},
 			},
-			expected: []*ec2.GroupIdentifier{
-				&ec2.GroupIdentifier{
+			expected: []*GroupIdentifier{
+				&GroupIdentifier{
 					GroupId: aws.String("sg-12345"),
 				},
 			},
@@ -948,8 +956,8 @@ func TestFlattenSecurityGroups(t *testing.T) {
 					UserId:  aws.String("user1234"),
 				},
 			},
-			expected: []*ec2.GroupIdentifier{
-				&ec2.GroupIdentifier{
+			expected: []*GroupIdentifier{
+				&GroupIdentifier{
 					GroupId: aws.String("sg-12345"),
 				},
 			},
@@ -966,8 +974,8 @@ func TestFlattenSecurityGroups(t *testing.T) {
 					UserId:    aws.String("user4321"),
 				},
 			},
-			expected: []*ec2.GroupIdentifier{
-				&ec2.GroupIdentifier{
+			expected: []*GroupIdentifier{
+				&GroupIdentifier{
 					GroupId:   aws.String("sg-12345"),
 					GroupName: aws.String("user4321/somegroup"),
 				},
@@ -984,9 +992,26 @@ func TestFlattenSecurityGroups(t *testing.T) {
 					UserId:  aws.String("user4321"),
 				},
 			},
-			expected: []*ec2.GroupIdentifier{
-				&ec2.GroupIdentifier{
+			expected: []*GroupIdentifier{
+				&GroupIdentifier{
 					GroupId: aws.String("user4321/sg-12345"),
+				},
+			},
+		},
+
+		// include description
+		{
+			ownerId: aws.String("user1234"),
+			pairs: []*ec2.UserIdGroupPair{
+				&ec2.UserIdGroupPair{
+					GroupId:     aws.String("sg-12345"),
+					Description: aws.String("desc"),
+				},
+			},
+			expected: []*GroupIdentifier{
+				&GroupIdentifier{
+					GroupId:     aws.String("sg-12345"),
+					Description: aws.String("desc"),
 				},
 			},
 		},

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1494,3 +1494,20 @@ func validateBatchName(v interface{}, k string) (ws []string, errors []error) {
 	}
 	return
 }
+
+func validateSecurityGroupRuleDescription(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if len(value) > 255 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be longer than 255 characters: %q", k, value))
+	}
+
+	// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IpRange.html
+	pattern := `^[A-Za-z0-9 \.\_\-\:\/\(\)\#\,\@\[\]\+\=\;\{\}\!\$\*]+$`
+	if !regexp.MustCompile(pattern).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q doesn't comply with restrictions (%q): %q",
+			k, pattern, value))
+	}
+	return
+}

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -2448,3 +2448,29 @@ func TestValidateBatchName(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateSecurityGroupRuleDescription(t *testing.T) {
+	validDescriptions := []string{
+		"testrule",
+		"testRule",
+		"testRule 123",
+		`testRule 123 ._-:/()#,@[]+=;{}!$*`,
+	}
+	for _, v := range validDescriptions {
+		_, errors := validateSecurityGroupRuleDescription(v, "description")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid security group rule description: %q", v, errors)
+		}
+	}
+
+	invalidDescriptions := []string{
+		"`",
+		"%%",
+	}
+	for _, v := range invalidDescriptions {
+		_, errors := validateSecurityGroupRuleDescription(v, "description")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be an invalid security group rule description", v)
+		}
+	}
+}

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -94,6 +94,7 @@ The `ingress` block supports:
 * `self` - (Optional) If true, the security group itself will be added as
      a source to this ingress rule.
 * `to_port` - (Required) The end range port (or ICMP code if protocol is "icmp").
+* `description` - (Optional) Description of this ingress rule.
 
 The `egress` block supports:
 
@@ -108,6 +109,7 @@ The `egress` block supports:
 * `self` - (Optional) If true, the security group itself will be added as
      a source to this egress rule.
 * `to_port` - (Required) The end range port (or ICMP code if protocol is "icmp").
+* `description` - (Optional) Description of this egress rule.
 
 ~> **NOTE on Egress rules:** By default, AWS creates an `ALLOW ALL` egress rule when creating a
 new Security Group inside of a VPC. When creating a new Security

--- a/website/docs/r/security_group_rule.html.markdown
+++ b/website/docs/r/security_group_rule.html.markdown
@@ -53,6 +53,7 @@ Only valid with `egress`.
 * `self` - (Optional) If true, the security group itself will be added as
      a source to this ingress rule.
 * `to_port` - (Required) The end port (or ICMP code if protocol is "icmp").
+* `description` - (Optional) Description of the rule.
 
 ## Usage with prefix list IDs
 
@@ -85,3 +86,4 @@ The following attributes are exported:
 * `from_port` - The start port (or ICMP type number if protocol is "icmp")
 * `to_port` - The end port (or ICMP code if protocol is "icmp")
 * `protocol` – The protocol used
+* `description` – Description of the rule


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/1554.
For backwards compatibility and simplicity I am going with one description per rule resource.
I can justify this to myself as saying it's a description of the rule as a whole rather than one per CIDR range/PL/peer SG.
The same description is set on each CIDR/PL/peer SG and on Read the last non-empty description will be the value for the rule.
Still TODO - Inline rules.