### PR TITLE
resource/aws_alb_target_group: Add support for `target_type`

### DIFF
--- a/aws/resource_aws_alb_target_group_test.go
+++ b/aws/resource_aws_alb_target_group_test.go
@@ -38,7 +38,7 @@ func TestALBTargetGroupCloudwatchSuffixFromARN(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		actual := albTargetGroupSuffixFromARN(tc.arn)
+		actual := lbTargetGroupSuffixFromARN(tc.arn)
 		if actual != tc.suffix {
 			t.Fatalf("bad suffix: %q\nExpected: %s\n     Got: %s", tc.name, tc.suffix, actual)
 		}

--- a/aws/resource_aws_alb_target_group_test.go
+++ b/aws/resource_aws_alb_target_group_test.go
@@ -1,0 +1,789 @@
+package aws
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestALBTargetGroupCloudwatchSuffixFromARN(t *testing.T) {
+	cases := []struct {
+		name   string
+		arn    *string
+		suffix string
+	}{
+		{
+			name:   "valid suffix",
+			arn:    aws.String(`arn:aws:elasticloadbalancing:us-east-1:123456:targetgroup/my-targets/73e2d6bc24d8a067`),
+			suffix: `targetgroup/my-targets/73e2d6bc24d8a067`,
+		},
+		{
+			name:   "no suffix",
+			arn:    aws.String(`arn:aws:elasticloadbalancing:us-east-1:123456:targetgroup`),
+			suffix: ``,
+		},
+		{
+			name:   "nil ARN",
+			arn:    nil,
+			suffix: ``,
+		},
+	}
+
+	for _, tc := range cases {
+		actual := albTargetGroupSuffixFromARN(tc.arn)
+		if actual != tc.suffix {
+			t.Fatalf("bad suffix: %q\nExpected: %s\n     Got: %s", tc.name, tc.suffix, actual)
+		}
+	}
+}
+
+func TestAccAWSALBTargetGroup_basic(t *testing.T) {
+	var conf elbv2.TargetGroup
+	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_alb_target_group.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSALBTargetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSALBTargetGroupConfig_basic(targetGroupName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
+					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "arn"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "name", targetGroupName),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "port", "443"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "protocol", "HTTPS"),
+					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "vpc_id"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "deregistration_delay", "200"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "target_type", "instance"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.#", "1"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.0.enabled", "true"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.0.type", "lb_cookie"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.0.cookie_duration", "10000"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.#", "1"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.path", "/health"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.interval", "60"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.port", "8081"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.protocol", "HTTP"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.timeout", "3"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.healthy_threshold", "3"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.unhealthy_threshold", "3"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.matcher", "200-299"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "tags.%", "1"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "tags.TestName", "TestAccAWSALBTargetGroup_basic"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSALBTargetGroup_namePrefix(t *testing.T) {
+	var conf elbv2.TargetGroup
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_alb_target_group.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSALBTargetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSALBTargetGroupConfig_namePrefix,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
+					resource.TestMatchResourceAttr("aws_alb_target_group.test", "name", regexp.MustCompile("^tf-")),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSALBTargetGroup_generatedName(t *testing.T) {
+	var conf elbv2.TargetGroup
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_alb_target_group.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSALBTargetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSALBTargetGroupConfig_generatedName,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSALBTargetGroup_changeNameForceNew(t *testing.T) {
+	var before, after elbv2.TargetGroup
+	targetGroupNameBefore := fmt.Sprintf("test-target-group-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	targetGroupNameAfter := fmt.Sprintf("test-target-group-%s", acctest.RandStringFromCharSet(4, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_alb_target_group.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSALBTargetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSALBTargetGroupConfig_basic(targetGroupNameBefore),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &before),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "name", targetGroupNameBefore),
+				),
+			},
+			{
+				Config: testAccAWSALBTargetGroupConfig_basic(targetGroupNameAfter),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &after),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "name", targetGroupNameAfter),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSALBTargetGroup_changeProtocolForceNew(t *testing.T) {
+	var before, after elbv2.TargetGroup
+	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_alb_target_group.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSALBTargetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSALBTargetGroupConfig_basic(targetGroupName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &before),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "protocol", "HTTPS"),
+				),
+			},
+			{
+				Config: testAccAWSALBTargetGroupConfig_updatedProtocol(targetGroupName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &after),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "protocol", "HTTP"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSALBTargetGroup_changePortForceNew(t *testing.T) {
+	var before, after elbv2.TargetGroup
+	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_alb_target_group.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSALBTargetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSALBTargetGroupConfig_basic(targetGroupName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &before),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "port", "443"),
+				),
+			},
+			{
+				Config: testAccAWSALBTargetGroupConfig_updatedPort(targetGroupName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &after),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "port", "442"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSALBTargetGroup_changeVpcForceNew(t *testing.T) {
+	var before, after elbv2.TargetGroup
+	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_alb_target_group.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSALBTargetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSALBTargetGroupConfig_basic(targetGroupName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &before),
+				),
+			},
+			{
+				Config: testAccAWSALBTargetGroupConfig_updatedVpc(targetGroupName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &after),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSALBTargetGroup_tags(t *testing.T) {
+	var conf elbv2.TargetGroup
+	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_alb_target_group.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSALBTargetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSALBTargetGroupConfig_basic(targetGroupName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "tags.%", "1"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "tags.TestName", "TestAccAWSALBTargetGroup_basic"),
+				),
+			},
+			{
+				Config: testAccAWSALBTargetGroupConfig_updateTags(targetGroupName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "tags.%", "2"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "tags.Environment", "Production"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "tags.Type", "ALB Target Group"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSALBTargetGroup_updateHealthCheck(t *testing.T) {
+	var conf elbv2.TargetGroup
+	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_alb_target_group.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSALBTargetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSALBTargetGroupConfig_basic(targetGroupName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
+					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "arn"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "name", targetGroupName),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "port", "443"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "protocol", "HTTPS"),
+					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "vpc_id"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "deregistration_delay", "200"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.#", "1"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.0.type", "lb_cookie"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.0.cookie_duration", "10000"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.#", "1"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.path", "/health"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.interval", "60"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.port", "8081"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.protocol", "HTTP"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.timeout", "3"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.healthy_threshold", "3"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.unhealthy_threshold", "3"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.matcher", "200-299"),
+				),
+			},
+			{
+				Config: testAccAWSALBTargetGroupConfig_updateHealthCheck(targetGroupName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
+					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "arn"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "name", targetGroupName),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "port", "443"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "protocol", "HTTPS"),
+					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "vpc_id"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "deregistration_delay", "200"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.#", "1"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.0.type", "lb_cookie"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.0.cookie_duration", "10000"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.#", "1"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.path", "/health2"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.interval", "30"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.port", "8082"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.protocol", "HTTPS"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.timeout", "4"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.healthy_threshold", "4"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.unhealthy_threshold", "4"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.matcher", "200"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSALBTargetGroup_updateSticknessEnabled(t *testing.T) {
+	var conf elbv2.TargetGroup
+	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_alb_target_group.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSALBTargetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSALBTargetGroupConfig_stickiness(targetGroupName, false, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
+					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "arn"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "name", targetGroupName),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "port", "443"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "protocol", "HTTPS"),
+					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "vpc_id"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "deregistration_delay", "200"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.#", "1"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.path", "/health2"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.interval", "30"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.port", "8082"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.protocol", "HTTPS"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.timeout", "4"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.healthy_threshold", "4"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.unhealthy_threshold", "4"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.matcher", "200"),
+				),
+			},
+			{
+				Config: testAccAWSALBTargetGroupConfig_stickiness(targetGroupName, true, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
+					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "arn"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "name", targetGroupName),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "port", "443"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "protocol", "HTTPS"),
+					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "vpc_id"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "deregistration_delay", "200"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.#", "1"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.0.enabled", "true"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.0.type", "lb_cookie"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.0.cookie_duration", "10000"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.#", "1"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.path", "/health2"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.interval", "30"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.port", "8082"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.protocol", "HTTPS"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.timeout", "4"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.healthy_threshold", "4"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.unhealthy_threshold", "4"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.matcher", "200"),
+				),
+			},
+			{
+				Config: testAccAWSALBTargetGroupConfig_stickiness(targetGroupName, true, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
+					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "arn"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "name", targetGroupName),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "port", "443"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "protocol", "HTTPS"),
+					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "vpc_id"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "deregistration_delay", "200"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.#", "1"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.0.enabled", "false"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.0.type", "lb_cookie"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.0.cookie_duration", "10000"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.#", "1"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.path", "/health2"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.interval", "30"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.port", "8082"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.protocol", "HTTPS"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.timeout", "4"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.healthy_threshold", "4"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.unhealthy_threshold", "4"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.matcher", "200"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSALBTargetGroupExists(n string, res *elbv2.TargetGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("No Target Group ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).elbv2conn
+
+		describe, err := conn.DescribeTargetGroups(&elbv2.DescribeTargetGroupsInput{
+			TargetGroupArns: []*string{aws.String(rs.Primary.ID)},
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if len(describe.TargetGroups) != 1 ||
+			*describe.TargetGroups[0].TargetGroupArn != rs.Primary.ID {
+			return errors.New("Target Group not found")
+		}
+
+		*res = *describe.TargetGroups[0]
+		return nil
+	}
+}
+
+func testAccCheckAWSALBTargetGroupDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).elbv2conn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_alb_target_group" {
+			continue
+		}
+
+		describe, err := conn.DescribeTargetGroups(&elbv2.DescribeTargetGroupsInput{
+			TargetGroupArns: []*string{aws.String(rs.Primary.ID)},
+		})
+
+		if err == nil {
+			if len(describe.TargetGroups) != 0 &&
+				*describe.TargetGroups[0].TargetGroupArn == rs.Primary.ID {
+				return fmt.Errorf("Target Group %q still exists", rs.Primary.ID)
+			}
+		}
+
+		// Verify the error
+		if isTargetGroupNotFound(err) {
+			return nil
+		} else {
+			return errwrap.Wrapf("Unexpected error checking ALB destroyed: {{err}}", err)
+		}
+	}
+
+	return nil
+}
+
+func testAccAWSALBTargetGroupConfig_basic(targetGroupName string) string {
+	return fmt.Sprintf(`resource "aws_alb_target_group" "test" {
+  name = "%s"
+  port = 443
+  protocol = "HTTPS"
+  vpc_id = "${aws_vpc.test.id}"
+
+  deregistration_delay = 200
+
+  stickiness {
+    type = "lb_cookie"
+    cookie_duration = 10000
+  }
+
+  health_check {
+    path = "/health"
+    interval = 60
+    port = 8081
+    protocol = "HTTP"
+    timeout = 3
+    healthy_threshold = 3
+    unhealthy_threshold = 3
+    matcher = "200-299"
+  }
+
+  tags {
+    TestName = "TestAccAWSALBTargetGroup_basic"
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    TestName = "TestAccAWSALBTargetGroup_basic"
+  }
+}`, targetGroupName)
+}
+
+func testAccAWSALBTargetGroupConfig_updatedPort(targetGroupName string) string {
+	return fmt.Sprintf(`resource "aws_alb_target_group" "test" {
+  name = "%s"
+  port = 442
+  protocol = "HTTPS"
+  vpc_id = "${aws_vpc.test.id}"
+
+  deregistration_delay = 200
+
+  stickiness {
+    type = "lb_cookie"
+    cookie_duration = 10000
+  }
+
+  health_check {
+    path = "/health"
+    interval = 60
+    port = 8081
+    protocol = "HTTP"
+    timeout = 3
+    healthy_threshold = 3
+    unhealthy_threshold = 3
+    matcher = "200-299"
+  }
+
+  tags {
+    TestName = "TestAccAWSALBTargetGroup_basic"
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    TestName = "TestAccAWSALBTargetGroup_basic"
+  }
+}`, targetGroupName)
+}
+
+func testAccAWSALBTargetGroupConfig_updatedProtocol(targetGroupName string) string {
+	return fmt.Sprintf(`resource "aws_alb_target_group" "test" {
+  name = "%s"
+  port = 443
+  protocol = "HTTP"
+  vpc_id = "${aws_vpc.test2.id}"
+
+  deregistration_delay = 200
+
+  stickiness {
+    type = "lb_cookie"
+    cookie_duration = 10000
+  }
+
+  health_check {
+    path = "/health"
+    interval = 60
+    port = 8081
+    protocol = "HTTP"
+    timeout = 3
+    healthy_threshold = 3
+    unhealthy_threshold = 3
+    matcher = "200-299"
+  }
+
+  tags {
+    TestName = "TestAccAWSALBTargetGroup_basic"
+  }
+}
+
+resource "aws_vpc" "test2" {
+  cidr_block = "10.10.0.0/16"
+
+  tags {
+    TestName = "TestAccAWSALBTargetGroup_basic"
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    TestName = "TestAccAWSALBTargetGroup_basic"
+  }
+}`, targetGroupName)
+}
+
+func testAccAWSALBTargetGroupConfig_updatedVpc(targetGroupName string) string {
+	return fmt.Sprintf(`resource "aws_alb_target_group" "test" {
+  name = "%s"
+  port = 443
+  protocol = "HTTPS"
+  vpc_id = "${aws_vpc.test.id}"
+
+  deregistration_delay = 200
+
+  stickiness {
+    type = "lb_cookie"
+    cookie_duration = 10000
+  }
+
+  health_check {
+    path = "/health"
+    interval = 60
+    port = 8081
+    protocol = "HTTP"
+    timeout = 3
+    healthy_threshold = 3
+    unhealthy_threshold = 3
+    matcher = "200-299"
+  }
+
+  tags {
+    TestName = "TestAccAWSALBTargetGroup_basic"
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    TestName = "TestAccAWSALBTargetGroup_basic"
+  }
+}`, targetGroupName)
+}
+
+func testAccAWSALBTargetGroupConfig_updateTags(targetGroupName string) string {
+	return fmt.Sprintf(`resource "aws_alb_target_group" "test" {
+  name = "%s"
+  port = 443
+  protocol = "HTTPS"
+  vpc_id = "${aws_vpc.test.id}"
+
+  deregistration_delay = 200
+
+  stickiness {
+    type = "lb_cookie"
+    cookie_duration = 10000
+  }
+
+  health_check {
+    path = "/health"
+    interval = 60
+    port = 8081
+    protocol = "HTTP"
+    timeout = 3
+    healthy_threshold = 3
+    unhealthy_threshold = 3
+    matcher = "200-299"
+  }
+
+  tags {
+    Environment = "Production"
+    Type = "ALB Target Group"
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    TestName = "TestAccAWSALBTargetGroup_basic"
+  }
+}`, targetGroupName)
+}
+
+func testAccAWSALBTargetGroupConfig_updateHealthCheck(targetGroupName string) string {
+	return fmt.Sprintf(`resource "aws_alb_target_group" "test" {
+  name = "%s"
+  port = 443
+  protocol = "HTTPS"
+  vpc_id = "${aws_vpc.test.id}"
+
+  deregistration_delay = 200
+
+  stickiness {
+    type = "lb_cookie"
+    cookie_duration = 10000
+  }
+
+  health_check {
+    path = "/health2"
+    interval = 30
+    port = 8082
+    protocol = "HTTPS"
+    timeout = 4
+    healthy_threshold = 4
+    unhealthy_threshold = 4
+    matcher = "200"
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    TestName = "TestAccAWSALBTargetGroup_basic"
+  }
+}`, targetGroupName)
+}
+
+func testAccAWSALBTargetGroupConfig_stickiness(targetGroupName string, addStickinessBlock bool, enabled bool) string {
+	var stickinessBlock string
+
+	if addStickinessBlock {
+		stickinessBlock = fmt.Sprintf(`stickiness {
+	    enabled = "%t"
+	    type = "lb_cookie"
+	    cookie_duration = 10000
+	  }`, enabled)
+	}
+
+	return fmt.Sprintf(`resource "aws_alb_target_group" "test" {
+  name = "%s"
+  port = 443
+  protocol = "HTTPS"
+  vpc_id = "${aws_vpc.test.id}"
+
+  deregistration_delay = 200
+
+  %s
+
+  health_check {
+    path = "/health2"
+    interval = 30
+    port = 8082
+    protocol = "HTTPS"
+    timeout = 4
+    healthy_threshold = 4
+    unhealthy_threshold = 4
+    matcher = "200"
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    TestName = "TestAccAWSALBTargetGroup_stickiness"
+  }
+}`, targetGroupName, stickinessBlock)
+}
+
+const testAccAWSALBTargetGroupConfig_namePrefix = `
+resource "aws_alb_target_group" "test" {
+  name_prefix = "tf-"
+  port = 80
+  protocol = "HTTP"
+  vpc_id = "${aws_vpc.test.id}"
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+	tags {
+		Name = "testAccAWSALBTargetGroupConfig_namePrefix"
+	}
+}
+`
+
+const testAccAWSALBTargetGroupConfig_generatedName = `
+resource "aws_alb_target_group" "test" {
+  port = 80
+  protocol = "HTTP"
+  vpc_id = "${aws_vpc.test.id}"
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+	tags {
+		Name = "testAccAWSALBTargetGroupConfig_generatedName"
+	}
+}
+`

--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -79,6 +79,13 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 				ValidateFunc: validateAwsLbTargetGroupDeregistrationDelay,
 			},
 
+			"target_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "instance",
+				ForceNew: true,
+			},
+
 			"stickiness": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -191,10 +198,11 @@ func resourceAwsLbTargetGroupCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	params := &elbv2.CreateTargetGroupInput{
-		Name:     aws.String(groupName),
-		Port:     aws.Int64(int64(d.Get("port").(int))),
-		Protocol: aws.String(d.Get("protocol").(string)),
-		VpcId:    aws.String(d.Get("vpc_id").(string)),
+		Name:       aws.String(groupName),
+		Port:       aws.Int64(int64(d.Get("port").(int))),
+		Protocol:   aws.String(d.Get("protocol").(string)),
+		VpcId:      aws.String(d.Get("vpc_id").(string)),
+		TargetType: aws.String(d.Get("target_type").(string)),
 	}
 
 	if healthChecks := d.Get("health_check").([]interface{}); len(healthChecks) == 1 {
@@ -476,6 +484,7 @@ func flattenAwsLbTargetGroupResource(d *schema.ResourceData, meta interface{}, t
 	d.Set("port", targetGroup.Port)
 	d.Set("protocol", targetGroup.Protocol)
 	d.Set("vpc_id", targetGroup.VpcId)
+	d.Set("target_type", targetGroup.TargetType)
 
 	healthCheck := make(map[string]interface{})
 	healthCheck["interval"] = *targetGroup.HealthCheckIntervalSeconds

--- a/aws/resource_aws_lb_target_group_attachment.go
+++ b/aws/resource_aws_lb_target_group_attachment.go
@@ -36,6 +36,12 @@ func resourceAwsLbTargetGroupAttachment() *schema.Resource {
 				ForceNew: true,
 				Optional: true,
 			},
+
+			"availability_zone": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -49,6 +55,10 @@ func resourceAwsLbAttachmentCreate(d *schema.ResourceData, meta interface{}) err
 
 	if v, ok := d.GetOk("port"); ok {
 		target.Port = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("availability_zone"); ok {
+		target.AvailabilityZone = aws.String(v.(string))
 	}
 
 	params := &elbv2.RegisterTargetsInput{
@@ -80,6 +90,10 @@ func resourceAwsLbAttachmentDelete(d *schema.ResourceData, meta interface{}) err
 		target.Port = aws.Int64(int64(v.(int)))
 	}
 
+	if v, ok := d.GetOk("availability_zone"); ok {
+		target.AvailabilityZone = aws.String(v.(string))
+	}
+
 	params := &elbv2.DeregisterTargetsInput{
 		TargetGroupArn: aws.String(d.Get("target_group_arn").(string)),
 		Targets:        []*elbv2.TargetDescription{target},
@@ -106,6 +120,10 @@ func resourceAwsLbAttachmentRead(d *schema.ResourceData, meta interface{}) error
 
 	if v, ok := d.GetOk("port"); ok {
 		target.Port = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("availability_zone"); ok {
+		target.AvailabilityZone = aws.String(v.(string))
 	}
 
 	resp, err := elbconn.DescribeTargetHealth(&elbv2.DescribeTargetHealthInput{

--- a/aws/resource_aws_lb_target_group_attachment_test.go
+++ b/aws/resource_aws_lb_target_group_attachment_test.go
@@ -71,6 +71,25 @@ func TestAccAWSLBTargetGroupAttachment_withoutPort(t *testing.T) {
 	})
 }
 
+func TestAccAWSALBTargetGroupAttachment_ipAddress(t *testing.T) {
+	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_lb_target_group.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSLBTargetGroupAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLBTargetGroupAttachmentConfigWithIpAddress(targetGroupName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLBTargetGroupAttachmentExists("aws_lb_target_group_attachment.test"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSLBTargetGroupAttachmentExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -158,26 +177,21 @@ resource "aws_lb_target_group_attachment" "test" {
   target_group_arn = "${aws_lb_target_group.test.arn}"
   target_id = "${aws_instance.test.id}"
 }
-
 resource "aws_instance" "test" {
   ami = "ami-f701cb97"
   instance_type = "t2.micro"
   subnet_id = "${aws_subnet.subnet.id}"
 }
-
 resource "aws_lb_target_group" "test" {
   name = "%s"
   port = 443
   protocol = "HTTPS"
   vpc_id = "${aws_vpc.test.id}"
-
   deregistration_delay = 200
-
   stickiness {
     type = "lb_cookie"
     cookie_duration = 10000
   }
-
   health_check {
     path = "/health"
     interval = 60
@@ -189,13 +203,10 @@ resource "aws_lb_target_group" "test" {
     matcher = "200-299"
   }
 }
-
 resource "aws_subnet" "subnet" {
   cidr_block = "10.0.1.0/24"
   vpc_id = "${aws_vpc.test.id}"
-
 }
-
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 	tags {
@@ -211,26 +222,21 @@ resource "aws_lb_target_group_attachment" "test" {
   target_id = "${aws_instance.test.id}"
   port = 80
 }
-
 resource "aws_instance" "test" {
   ami = "ami-f701cb97"
   instance_type = "t2.micro"
   subnet_id = "${aws_subnet.subnet.id}"
 }
-
 resource "aws_lb_target_group" "test" {
   name = "%s"
   port = 443
   protocol = "HTTPS"
   vpc_id = "${aws_vpc.test.id}"
-
   deregistration_delay = 200
-
   stickiness {
     type = "lb_cookie"
     cookie_duration = 10000
   }
-
   health_check {
     path = "/health"
     interval = 60
@@ -242,13 +248,10 @@ resource "aws_lb_target_group" "test" {
     matcher = "200-299"
   }
 }
-
 resource "aws_subnet" "subnet" {
   cidr_block = "10.0.1.0/24"
   vpc_id = "${aws_vpc.test.id}"
-
 }
-
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 	tags {
@@ -264,26 +267,21 @@ resource "aws_alb_target_group_attachment" "test" {
   target_id = "${aws_instance.test.id}"
   port = 80
 }
-
 resource "aws_instance" "test" {
   ami = "ami-f701cb97"
   instance_type = "t2.micro"
   subnet_id = "${aws_subnet.subnet.id}"
 }
-
 resource "aws_alb_target_group" "test" {
   name = "%s"
   port = 443
   protocol = "HTTPS"
   vpc_id = "${aws_vpc.test.id}"
-
   deregistration_delay = 200
-
   stickiness {
     type = "lb_cookie"
     cookie_duration = 10000
   }
-
   health_check {
     path = "/health"
     interval = 60
@@ -295,17 +293,60 @@ resource "aws_alb_target_group" "test" {
     matcher = "200-299"
   }
 }
-
 resource "aws_subnet" "subnet" {
   cidr_block = "10.0.1.0/24"
   vpc_id = "${aws_vpc.test.id}"
-
 }
-
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 	tags {
 		Name = "testAccAWSLBTargetGroupAttachmentConfig_basic"
+	}
+}`, targetGroupName)
+}
+
+func testAccAWSLBTargetGroupAttachmentConfigWithIpAddress(targetGroupName string) string {
+	return fmt.Sprintf(`
+resource "aws_lb_target_group_attachment" "test" {
+  target_group_arn = "${aws_lb_target_group.test.arn}"
+  target_id = "${aws_instance.test.private_ip}"
+  availability_zone = "${aws_instance.test.availability_zone}"
+}
+resource "aws_instance" "test" {
+  ami = "ami-f701cb97"
+  instance_type = "t2.micro"
+  subnet_id = "${aws_subnet.subnet.id}"
+}
+resource "aws_lb_target_group" "test" {
+  name = "%s"
+  port = 443
+  protocol = "HTTPS"
+  vpc_id = "${aws_vpc.test.id}"
+  target_type = "ip"
+  deregistration_delay = 200
+  stickiness {
+    type = "lb_cookie"
+    cookie_duration = 10000
+  }
+  health_check {
+    path = "/health"
+    interval = 60
+    port = 8081
+    protocol = "HTTP"
+    timeout = 3
+    healthy_threshold = 3
+    unhealthy_threshold = 3
+    matcher = "200-299"
+  }
+}
+resource "aws_subnet" "subnet" {
+  cidr_block = "10.0.1.0/24"
+  vpc_id = "${aws_vpc.test.id}"
+}
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+	tags {
+		Name = "testAccAWSALBTargetGroupAttachmentConfigWithoutPort"
 	}
 }`, targetGroupName)
 }

--- a/website/docs/r/lb_target_group.html.markdown
+++ b/website/docs/r/lb_target_group.html.markdown
@@ -39,6 +39,12 @@ The following arguments are supported:
 * `deregistration_delay` - (Optional) The amount time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused. The range is 0-3600 seconds. The default value is 300 seconds.
 * `stickiness` - (Optional) A Stickiness block. Stickiness blocks are documented below.
 * `health_check` - (Optional) A Health Check block. Health Check blocks are documented below.
+* `target_type` - (Optional) The type of target that you must specify when registering targets with this target group.
+The possible values are `instance` (targets are specified by instance ID) or `ip` (targets are specified by IP address).
+The default is `instance`. Note that you can't specify targets for a target group using both instance IDs and IP addresses.
+If the target type is `ip`, specify IP addresses from the subnets of the virtual private cloud (VPC) for the target group,
+the RFC 1918 range (10.0.0.0/8, 172.16.0.0/12, and 192.168.0.0/16), and the RFC 6598 range (100.64.0.0/10).
+You can't specify publicly routable IP addresses.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 Stickiness Blocks (`stickiness`) support the following:

--- a/website/docs/r/lb_target_group_attachment.html.markdown
+++ b/website/docs/r/lb_target_group_attachment.html.markdown
@@ -37,8 +37,9 @@ resource "aws_instance" "test" {
 The following arguments are supported:
 
 * `target_group_arn` - (Required) The ARN of the target group with which to register targets
-* `target_id` (Required) The ID of the target. This is the Instance ID for an instance, or the container ID for an ECS container.
+* `target_id` (Required) The ID of the target. This is the Instance ID for an instance, or the container ID for an ECS container. If the target type is ip, specify an IP address.
 * `port` - (Optional) The port on which targets receive traffic.
+* `availability_zone` - (Optional) The Availability Zone where the IP address of the target is to be registered.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fixes: #1588

```
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSALBTargetGroup_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSALBTargetGroup_ -timeout 120m
=== RUN   TestAccAWSALBTargetGroup_basic
--- PASS: TestAccAWSALBTargetGroup_basic (73.55s)
=== RUN   TestAccAWSALBTargetGroup_namePrefix
--- PASS: TestAccAWSALBTargetGroup_namePrefix (72.26s)
=== RUN   TestAccAWSALBTargetGroup_generatedName
--- PASS: TestAccAWSALBTargetGroup_generatedName (74.94s)
=== RUN   TestAccAWSALBTargetGroup_changeNameForceNew
--- PASS: TestAccAWSALBTargetGroup_changeNameForceNew (129.78s)
=== RUN   TestAccAWSALBTargetGroup_changeProtocolForceNew
--- PASS: TestAccAWSALBTargetGroup_changeProtocolForceNew (151.66s)
=== RUN   TestAccAWSALBTargetGroup_changePortForceNew
--- PASS: TestAccAWSALBTargetGroup_changePortForceNew (129.73s)
=== RUN   TestAccAWSALBTargetGroup_changeVpcForceNew
--- PASS: TestAccAWSALBTargetGroup_changeVpcForceNew (112.48s)
=== RUN   TestAccAWSALBTargetGroup_tags
--- PASS: TestAccAWSALBTargetGroup_tags (124.72s)
=== RUN   TestAccAWSALBTargetGroup_updateHealthCheck
--- PASS: TestAccAWSALBTargetGroup_updateHealthCheck (122.61s)
=== RUN   TestAccAWSALBTargetGroup_updateSticknessEnabled
--- PASS: TestAccAWSALBTargetGroup_updateSticknessEnabled (170.23s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1161.982s
```