### PR TITLE
[WIP] Fix assuming role via ".aws/config"

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -76,13 +76,14 @@ import (
 )
 
 type Config struct {
-	AccessKey     string
-	SecretKey     string
-	CredsFilename string
-	Profile       string
-	Token         string
-	Region        string
-	MaxRetries    int
+	AccessKey      string
+	SecretKey      string
+	CredsFilename  string
+	ConfigFilename string
+	Profile        string
+	Token          string
+	Region         string
+	MaxRetries     int
 
 	AssumeRoleARN         string
 	AssumeRoleExternalID  string

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -600,8 +600,6 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		AccessKey:               d.Get("access_key").(string),
 		SecretKey:               d.Get("secret_key").(string),
 		Profile:                 d.Get("profile").(string),
-		CredsFilename:           d.Get("shared_credentials_file").(string),
-		ConfigFilename:          d.Get("shared_config_file").(string),
 		Token:                   d.Get("token").(string),
 		Region:                  d.Get("region").(string),
 		MaxRetries:              d.Get("max_retries").(int),
@@ -620,6 +618,12 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		return nil, err
 	}
 	config.CredsFilename = credsPath
+
+	configPath, err := homedir.Expand(d.Get("shared_config_file").(string))
+	if err != nil {
+		return nil, err
+	}
+	config.ConfigFilename = configPath
 
 	assumeRoleList := d.Get("assume_role").(*schema.Set).List()
 	if len(assumeRoleList) == 1 {

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -50,6 +50,13 @@ func Provider() terraform.ResourceProvider {
 				Description: descriptions["shared_credentials_file"],
 			},
 
+			"shared_config_file": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "~/.aws/config",
+				Description: descriptions["shared_config_file"],
+			},
+
 			"token": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -509,6 +516,9 @@ func init() {
 		"shared_credentials_file": "The path to the shared credentials file. If not set\n" +
 			"this defaults to ~/.aws/credentials.",
 
+		"shared_config_file": "The path to the shared config file. If not set\n" +
+			"this defaults to ~/.aws/config.",
+
 		"token": "session token. A session token is only required if you are\n" +
 			"using temporary security credentials.",
 
@@ -590,6 +600,8 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		AccessKey:               d.Get("access_key").(string),
 		SecretKey:               d.Get("secret_key").(string),
 		Profile:                 d.Get("profile").(string),
+		CredsFilename:           d.Get("shared_credentials_file").(string),
+		ConfigFilename:          d.Get("shared_config_file").(string),
 		Token:                   d.Get("token").(string),
 		Region:                  d.Get("region").(string),
 		MaxRetries:              d.Get("max_retries").(int),

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -165,6 +165,9 @@ The following arguments are supported in the `provider` block:
 * `shared_credentials_file` = (Optional) This is the path to the shared credentials file.
   If this is not set and a profile is specified, `~/.aws/credentials` will be used.
 
+* `shared_config_file` = (Optional) This is the path to the shared config file.
+  If this is not set and a profile is specified, `~/.aws/config` will be used.
+
 * `token` - (Optional) Use this to set an MFA token. It can also be sourced
   from the `AWS_SESSION_TOKEN` environment variable.
 


### PR DESCRIPTION
> Fixes #1184

This PR allows assuming roles via shared configuration `~/.aws/config`. It still supports assuming other roles for different provider configurations afterwards.

I am somehow not fully satisfied with the code yet, so feel free to nitpick everything.

**Open Questions**

* Should I try to reduce code duplication due to assuming roles twice?
* I am not entirely sure, if MFA would work correctly, but AFAIS when using MFA one has to do the `aws sts assume-role` manually anyway, so it shouldn't be affected by this change.
