### PR TITLE
Added private_dns_name to network_interface

### DIFF
--- a/aws/resource_aws_network_interface.go
+++ b/aws/resource_aws_network_interface.go
@@ -40,6 +40,11 @@ func resourceAwsNetworkInterface() *schema.Resource {
 				Computed: true,
 			},
 
+			"private_dns_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"private_ips": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -162,6 +167,7 @@ func resourceAwsNetworkInterfaceRead(d *schema.ResourceData, meta interface{}) e
 	eni := describeResp.NetworkInterfaces[0]
 	d.Set("subnet_id", eni.SubnetId)
 	d.Set("private_ip", eni.PrivateIpAddress)
+	d.Set("private_dns_name", eni.PrivateDnsName)
 	d.Set("private_ips", flattenNetworkInterfacesPrivateIPAddresses(eni.PrivateIpAddresses))
 	d.Set("security_groups", flattenGroupIdentifiers(eni.Groups))
 	d.Set("source_dest_check", eni.SourceDestCheck)

--- a/aws/resource_aws_network_interface_test.go
+++ b/aws/resource_aws_network_interface_test.go
@@ -27,6 +27,8 @@ func TestAccAWSENI_basic(t *testing.T) {
 					testAccCheckAWSENIAttributes(&conf),
 					resource.TestCheckResourceAttr(
 						"aws_network_interface.bar", "private_ips.#", "1"),
+					resource.TestCheckResourceAttrSet(
+						"aws_network_interface.bar", "private_dns_name"),
 					resource.TestCheckResourceAttr(
 						"aws_network_interface.bar", "tags.Name", "bar_interface"),
 					resource.TestCheckResourceAttr(
@@ -205,6 +207,10 @@ func testAccCheckAWSENIAttributes(conf *ec2.NetworkInterface) resource.TestCheck
 			return fmt.Errorf("expected private ip to be 172.16.10.100, but was %s", *conf.PrivateIpAddress)
 		}
 
+		if *conf.PrivateDnsName != "ip-172-16-10-100.us-west-2.compute.internal" {
+			return fmt.Errorf("expected private dns name to be ip-172-16-10-100.us-west-2.compute.internal, but was %s", *conf.PrivateDnsName)
+		}
+
 		if *conf.SourceDestCheck != true {
 			return fmt.Errorf("expected source_dest_check to be true, but was %t", *conf.SourceDestCheck)
 		}
@@ -238,6 +244,10 @@ func testAccCheckAWSENIAttributesWithAttachment(conf *ec2.NetworkInterface) reso
 
 		if *conf.PrivateIpAddress != "172.16.10.100" {
 			return fmt.Errorf("expected private ip to be 172.16.10.100, but was %s", *conf.PrivateIpAddress)
+		}
+
+		if *conf.PrivateDnsName != "ip-172-16-10-100.us-west-2.compute.internal" {
+			return fmt.Errorf("expected private dns name to be ip-172-16-10-100.us-west-2.compute.internal, but was %s", *conf.PrivateDnsName)
 		}
 
 		return nil
@@ -290,7 +300,8 @@ func testAccCheckAWSENIMakeExternalAttachment(n string, conf *ec2.NetworkInterfa
 
 const testAccAWSENIConfig = `
 resource "aws_vpc" "foo" {
-    cidr_block = "172.16.0.0/16"
+	cidr_block = "172.16.0.0/16"
+	enable_dns_hostnames = true
 		tags {
 			Name = "testAccAWSENIConfig"
 		}
@@ -328,7 +339,8 @@ resource "aws_network_interface" "bar" {
 
 const testAccAWSENIConfigUpdatedDescription = `
 resource "aws_vpc" "foo" {
-    cidr_block = "172.16.0.0/16"
+	cidr_block = "172.16.0.0/16"
+	enable_dns_hostnames = true
 		tags {
 			Name = "testAccAWSENIConfigUpdatedDescription"
 		}
@@ -366,7 +378,8 @@ resource "aws_network_interface" "bar" {
 
 const testAccAWSENIConfigWithSourceDestCheck = `
 resource "aws_vpc" "foo" {
-    cidr_block = "172.16.0.0/16"
+	cidr_block = "172.16.0.0/16"
+	enable_dns_hostnames = true
 		tags {
 			Name = "testAccAWSENIConfigWithSourceDestCheck"
 		}
@@ -387,7 +400,8 @@ resource "aws_network_interface" "bar" {
 
 const testAccAWSENIConfigWithNoPrivateIPs = `
 resource "aws_vpc" "foo" {
-    cidr_block = "172.16.0.0/16"
+	cidr_block = "172.16.0.0/16"
+	enable_dns_hostnames = true
 		tags {
 			Name = "testAccAWSENIConfigWithNoPrivateIPs"
 		}
@@ -407,7 +421,8 @@ resource "aws_network_interface" "bar" {
 
 const testAccAWSENIConfigWithAttachment = `
 resource "aws_vpc" "foo" {
-    cidr_block = "172.16.0.0/16"
+	cidr_block = "172.16.0.0/16"
+	enable_dns_hostnames = true
         tags {
             Name = "tf-eni-test"
         }
@@ -464,7 +479,8 @@ resource "aws_network_interface" "bar" {
 
 const testAccAWSENIConfigExternalAttachment = `
 resource "aws_vpc" "foo" {
-    cidr_block = "172.16.0.0/16"
+	cidr_block = "172.16.0.0/16"
+	enable_dns_hostnames = true
         tags {
             Name = "tf-eni-test"
         }


### PR DESCRIPTION
I added the private_dns_name field to the aws_network_interface resource as I needed it.
Changed test cases to add DNS hostnames in VPCs.

```
TF_ACC=1 go test -v gitb.com/terraform-providers/terraform-provider-aws/aws -timeout=7200s -run "TestAccAWSENI_.*"
=== RUN   TestAccAWSENI_importBasic
--- PASS: TestAccAWSENI_importBasic (68.99s)
=== RUN   TestAccAWSENI_basic
--- PASS: TestAccAWSENI_basic (65.42s)
=== RUN   TestAccAWSENI_updatedDescription
--- PASS: TestAccAWSENI_updatedDescription (106.23s)
=== RUN   TestAccAWSENI_attached
--- PASS: TestAccAWSENI_attached (296.42s)
=== RUN   TestAccAWSENI_ignoreExternalAttachment
--- PASS: TestAccAWSENI_ignoreExternalAttachment (174.64s)
=== RUN   TestAccAWSENI_sourceDestCheck
--- PASS: TestAccAWSENI_sourceDestCheck (58.91s)
=== RUN   TestAccAWSENI_computedIPs
--- PASS: TestAccAWSENI_computedIPs (64.46s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	835.092s
```