### PR TITLE
resource/aws_api_gateway_rest_api: Allowed for binary media types update

### DIFF
--- a/aws/resource_aws_api_gateway_rest_api.go
+++ b/aws/resource_aws_api_gateway_rest_api.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -176,20 +175,18 @@ func resourceAwsApiGatewayRestApiUpdateOperations(d *schema.ResourceData) []*api
 		// Remove every binary media types. Simpler to remove and add new ones,
 		// since there are no replacings.
 		for _, v := range old {
-			m := v.(string)
 			operations = append(operations, &apigateway.PatchOperation{
 				Op:   aws.String("remove"),
-				Path: aws.String(fmt.Sprintf("/%s/%s", prefix, strings.Replace(m, "/", "~1", -1))),
+				Path: aws.String(fmt.Sprintf("/%s/%s", prefix, escapeJsonPointer(v.(string)))),
 			})
 		}
 
 		// Handle additions
 		if len(new) > 0 {
 			for _, v := range new {
-				m := v.(string)
 				operations = append(operations, &apigateway.PatchOperation{
 					Op:   aws.String("add"),
-					Path: aws.String(fmt.Sprintf("/%s/%s", prefix, strings.Replace(m, "/", "~1", -1))),
+					Path: aws.String(fmt.Sprintf("/%s/%s", prefix, escapeJsonPointer(v.(string)))),
 				})
 			}
 		}

--- a/aws/resource_aws_api_gateway_rest_api_test.go
+++ b/aws/resource_aws_api_gateway_rest_api_test.go
@@ -23,14 +23,10 @@ func TestAccAWSAPIGatewayRestApi_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayRestAPIExists("aws_api_gateway_rest_api.test", &conf),
 					testAccCheckAWSAPIGatewayRestAPINameAttribute(&conf, "bar"),
-					resource.TestCheckResourceAttr(
-						"aws_api_gateway_rest_api.test", "name", "bar"),
-					resource.TestCheckResourceAttr(
-						"aws_api_gateway_rest_api.test", "description", ""),
-					resource.TestCheckResourceAttrSet(
-						"aws_api_gateway_rest_api.test", "created_date"),
-					resource.TestCheckNoResourceAttr(
-						"aws_api_gateway_rest_api.test", "binary_media_types"),
+					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "name", "bar"),
+					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "description", ""),
+					resource.TestCheckResourceAttrSet("aws_api_gateway_rest_api.test", "created_date"),
+					resource.TestCheckNoResourceAttr("aws_api_gateway_rest_api.test", "binary_media_types"),
 				),
 			},
 
@@ -40,16 +36,11 @@ func TestAccAWSAPIGatewayRestApi_basic(t *testing.T) {
 					testAccCheckAWSAPIGatewayRestAPIExists("aws_api_gateway_rest_api.test", &conf),
 					testAccCheckAWSAPIGatewayRestAPINameAttribute(&conf, "test"),
 					testAccCheckAWSAPIGatewayRestAPIDescriptionAttribute(&conf, "test"),
-					resource.TestCheckResourceAttr(
-						"aws_api_gateway_rest_api.test", "name", "test"),
-					resource.TestCheckResourceAttr(
-						"aws_api_gateway_rest_api.test", "description", "test"),
-					resource.TestCheckResourceAttrSet(
-						"aws_api_gateway_rest_api.test", "created_date"),
-					resource.TestCheckResourceAttr(
-						"aws_api_gateway_rest_api.test", "binary_media_types.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_api_gateway_rest_api.test", "binary_media_types.0", "application/octet-stream"),
+					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "name", "test"),
+					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "description", "test"),
+					resource.TestCheckResourceAttrSet("aws_api_gateway_rest_api.test", "created_date"),
+					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "binary_media_types.#", "1"),
+					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "binary_media_types.0", "application/octet-stream"),
 				),
 			},
 		},
@@ -70,14 +61,10 @@ func TestAccAWSAPIGatewayRestApi_openapi(t *testing.T) {
 					testAccCheckAWSAPIGatewayRestAPIExists("aws_api_gateway_rest_api.test", &conf),
 					testAccCheckAWSAPIGatewayRestAPINameAttribute(&conf, "test"),
 					testAccCheckAWSAPIGatewayRestAPIRoutes(&conf, []string{"/", "/test"}),
-					resource.TestCheckResourceAttr(
-						"aws_api_gateway_rest_api.test", "name", "test"),
-					resource.TestCheckResourceAttr(
-						"aws_api_gateway_rest_api.test", "description", ""),
-					resource.TestCheckResourceAttrSet(
-						"aws_api_gateway_rest_api.test", "created_date"),
-					resource.TestCheckNoResourceAttr(
-						"aws_api_gateway_rest_api.test", "binary_media_types"),
+					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "name", "test"),
+					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "description", ""),
+					resource.TestCheckResourceAttrSet("aws_api_gateway_rest_api.test", "created_date"),
+					resource.TestCheckNoResourceAttr("aws_api_gateway_rest_api.test", "binary_media_types"),
 				),
 			},
 
@@ -87,10 +74,8 @@ func TestAccAWSAPIGatewayRestApi_openapi(t *testing.T) {
 					testAccCheckAWSAPIGatewayRestAPIExists("aws_api_gateway_rest_api.test", &conf),
 					testAccCheckAWSAPIGatewayRestAPINameAttribute(&conf, "test"),
 					testAccCheckAWSAPIGatewayRestAPIRoutes(&conf, []string{"/", "/update"}),
-					resource.TestCheckResourceAttr(
-						"aws_api_gateway_rest_api.test", "name", "test"),
-					resource.TestCheckResourceAttrSet(
-						"aws_api_gateway_rest_api.test", "created_date"),
+					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "name", "test"),
+					resource.TestCheckResourceAttrSet("aws_api_gateway_rest_api.test", "created_date"),
 				),
 			},
 		},

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -2147,3 +2147,11 @@ func flattenFieldToMatch(fm *waf.FieldToMatch) []interface{} {
 	}
 	return []interface{}{m}
 }
+
+// escapeJsonPointer escapes string per RFC 6901
+// so it can be used as path in JSON patch operations
+func escapeJsonPointer(path string) string {
+	path = strings.Replace(path, "~", "~0", -1)
+	path = strings.Replace(path, "/", "~1", -1)
+	return path
+}


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/1594

### Tests
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAPIGatewayRestApi_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSAPIGatewayRestApi_ -timeout 120m
=== RUN   TestAccAWSAPIGatewayRestApi_basic
--- PASS: TestAccAWSAPIGatewayRestApi_basic (22.78s)
=== RUN   TestAccAWSAPIGatewayRestApi_openapi
--- PASS: TestAccAWSAPIGatewayRestApi_openapi (35.56s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	58.385s
```