### PR TITLE
Update api_gateway_domain_name.html.markdown

### DIFF
--- a/website/docs/r/api_gateway_domain_name.html.markdown
+++ b/website/docs/r/api_gateway_domain_name.html.markdown
@@ -59,7 +59,7 @@ The following arguments are supported:
 
 * `domain_name` - (Required) The fully-qualified domain name to register
 * `certificate_name` - (Optional) The unique name to use when registering this
-  cert as an IAM server certificate. Conflicts with `certificate_arn`.
+  cert as an IAM server certificate. Conflicts with `certificate_arn`. Required if `certificate_arn` is not set.
 * `certificate_body` - (Optional) The certificate issued for the domain name
   being registered, in PEM format. Conflicts with `certificate_arn`.
 * `certificate_chain` - (Optional) The certificate for the CA that issued the


### PR DESCRIPTION
Fixes #802

What about adding a guard in the code, like if the certificate name & certificate arn are unset, throwing an error about the name / arn being required?