### PR TITLE
Add Waf RateBasedRule support

### DIFF
--- a/aws/resource_aws_waf_rate_based_rule_test.go
+++ b/aws/resource_aws_waf_rate_based_rule_test.go
@@ -25,7 +25,7 @@ func TestAccAWSWafRateBasedRule_basic(t *testing.T) {
 			resource.TestStep{
 				Config: testAccAWSWafRateBasedRuleConfig(wafRuleName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRateBasedRuleExists("aws_waf_rule.wafrule", &v),
+					testAccCheckAWSWafRateBasedRuleExists("aws_waf_rate_based_rule.wafrule", &v),
 					resource.TestCheckResourceAttr(
 						"aws_waf_rate_based_rule.wafrule", "name", wafRuleName),
 					resource.TestCheckResourceAttr(
@@ -49,9 +49,9 @@ func TestAccAWSWafRateBasedRule_changeNameForceNew(t *testing.T) {
 		CheckDestroy: testAccCheckAWSWafIPSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSWafRuleConfig(wafRuleName),
+				Config: testAccAWSWafRateBasedRuleConfig(wafRuleName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRateBasedRuleExists("aws_waf_rule.wafrule", &before),
+					testAccCheckAWSWafRateBasedRuleExists("aws_waf_rate_based_rule.wafrule", &before),
 					resource.TestCheckResourceAttr(
 						"aws_waf_rate_based_rule.wafrule", "name", wafRuleName),
 					resource.TestCheckResourceAttr(
@@ -63,7 +63,7 @@ func TestAccAWSWafRateBasedRule_changeNameForceNew(t *testing.T) {
 			{
 				Config: testAccAWSWafRateBasedRuleConfigChangeName(wafRuleNewName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRateBasedRuleExists("aws_waf_rule.wafrule", &after),
+					testAccCheckAWSWafRateBasedRuleExists("aws_waf_rate_based_rule.wafrule", &after),
 					resource.TestCheckResourceAttr(
 						"aws_waf_rate_based_rule.wafrule", "name", wafRuleNewName),
 					resource.TestCheckResourceAttr(
@@ -113,24 +113,24 @@ func TestAccAWSWafRateBasedRule_changePredicates(t *testing.T) {
 				Config: testAccAWSWafRateBasedRuleConfig(ruleName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSWafIPSetExists("aws_waf_ipset.ipset", &ipset),
-					testAccCheckAWSWafRateBasedRuleExists("aws_waf_rule.wafrule", &before),
-					resource.TestCheckResourceAttr("aws_waf_rule.wafrule", "name", ruleName),
-					resource.TestCheckResourceAttr("aws_waf_rule.wafrule", "predicates.#", "1"),
+					testAccCheckAWSWafRateBasedRuleExists("aws_waf_rate_based_rule.wafrule", &before),
+					resource.TestCheckResourceAttr("aws_waf_rate_based_rule.wafrule", "name", ruleName),
+					resource.TestCheckResourceAttr("aws_waf_rate_based_rule.wafrule", "predicates.#", "1"),
 					computeWafRateBasedRulePredicateWithIpSet(&ipset, false, "IPMatch", &idx),
-					testCheckResourceAttrWithIndexesAddr("aws_waf_rule.wafrule", "predicates.%d.negated", &idx, "false"),
-					testCheckResourceAttrWithIndexesAddr("aws_waf_rule.wafrule", "predicates.%d.type", &idx, "IPMatch"),
+					testCheckResourceAttrWithIndexesAddr("aws_waf_rate_based_rule.wafrule", "predicates.%d.negated", &idx, "false"),
+					testCheckResourceAttrWithIndexesAddr("aws_waf_rate_based_rule.wafrule", "predicates.%d.type", &idx, "IPMatch"),
 				),
 			},
 			{
 				Config: testAccAWSWafRateBasedRuleConfig_changePredicates(ruleName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSWafByteMatchSetExists("aws_waf_byte_match_set.set", &byteMatchSet),
-					testAccCheckAWSWafRateBasedRuleExists("aws_waf_rule.wafrule", &after),
-					resource.TestCheckResourceAttr("aws_waf_rule.wafrule", "name", ruleName),
-					resource.TestCheckResourceAttr("aws_waf_rule.wafrule", "predicates.#", "1"),
+					testAccCheckAWSWafRateBasedRuleExists("aws_waf_rate_based_rule.wafrule", &after),
+					resource.TestCheckResourceAttr("aws_waf_rate_based_rule.wafrule", "name", ruleName),
+					resource.TestCheckResourceAttr("aws_waf_rate_based_rule.wafrule", "predicates.#", "1"),
 					computeWafRateBasedRulePredicateWithByteMatchSet(&byteMatchSet, true, "ByteMatch", &idx),
-					testCheckResourceAttrWithIndexesAddr("aws_waf_rule.wafrule", "predicates.%d.negated", &idx, "true"),
-					testCheckResourceAttrWithIndexesAddr("aws_waf_rule.wafrule", "predicates.%d.type", &idx, "ByteMatch"),
+					testCheckResourceAttrWithIndexesAddr("aws_waf_rate_based_rule.wafrule", "predicates.%d.negated", &idx, "true"),
+					testCheckResourceAttrWithIndexesAddr("aws_waf_rate_based_rule.wafrule", "predicates.%d.type", &idx, "ByteMatch"),
 				),
 			},
 		},
@@ -207,6 +207,7 @@ func testAccCheckAWSWafRateBasedRuleDisappears(v *waf.RateBasedRule) resource.Te
 			req := &waf.UpdateRateBasedRuleInput{
 				ChangeToken: token,
 				RuleId:      v.RuleId,
+				RateLimit:   v.RateLimit,
 			}
 
 			for _, Predicate := range v.MatchPredicates {

--- a/aws/resource_aws_waf_rule.go
+++ b/aws/resource_aws_waf_rule.go
@@ -40,7 +40,7 @@ func resourceAwsWafRule() *schema.Resource {
 						},
 						"data_id": &schema.Schema{
 							Type:     schema.TypeString,
-							Optional: true,
+							Required: true,
 							ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 								value := v.(string)
 								if len(value) > 128 {

--- a/aws/resource_aws_waf_web_acl.go
+++ b/aws/resource_aws_waf_web_acl.go
@@ -64,6 +64,18 @@ func resourceAwsWafWebAcl() *schema.Resource {
 							Type:     schema.TypeInt,
 							Required: true,
 						},
+						"type": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+								value := v.(string)
+								if value != waf.WafRuleTypeRegular && value != waf.WafRuleTypeRateBased {
+									errors = append(errors, fmt.Errorf(
+										"%q must be one of %s | %s", k, waf.WafRuleTypeRegular, waf.WafRuleTypeRateBased))
+								}
+								return
+							},
+						},
 						"rule_id": &schema.Schema{
 							Type:     schema.TypeString,
 							Required: true,
@@ -180,6 +192,7 @@ func updateWebAclResource(d *schema.ResourceData, meta interface{}, ChangeAction
 				ActivatedRule: &waf.ActivatedRule{
 					Priority: aws.Int64(int64(aclRule["priority"].(int))),
 					RuleId:   aws.String(aclRule["rule_id"].(string)),
+					Type:     aws.String(aclRule["type"].(string)),
 					Action:   &waf.WafAction{Type: aws.String(action["type"].(string))},
 				},
 			}

--- a/aws/resource_aws_waf_web_acl.go
+++ b/aws/resource_aws_waf_web_acl.go
@@ -66,7 +66,8 @@ func resourceAwsWafWebAcl() *schema.Resource {
 						},
 						"type": &schema.Schema{
 							Type:     schema.TypeString,
-							Required: true,
+							Optional: true,
+							Default:  waf.WafRuleTypeRegular,
 							ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 								value := v.(string)
 								if value != waf.WafRuleTypeRegular && value != waf.WafRuleTypeRateBased {

--- a/aws/resource_aws_waf_web_acl_test.go
+++ b/aws/resource_aws_waf_web_acl_test.go
@@ -288,9 +288,8 @@ resource "aws_waf_web_acl" "waf_acl" {
     action {
        type = "BLOCK"
     }
-    priority = 1
+    priority = 1 
     rule_id = "${aws_waf_rule.wafrule.id}"
-    type    = "REGULAR"
   }
 }`, name, name, name, name, name)
 }
@@ -325,9 +324,8 @@ resource "aws_waf_web_acl" "waf_acl" {
     action {
        type = "BLOCK"
     }
-    priority = 1
+    priority = 1 
     rule_id = "${aws_waf_rule.wafrule.id}"
-    type    = "REGULAR"
   }
 }`, name, name, name, name, name)
 }
@@ -362,9 +360,8 @@ resource "aws_waf_web_acl" "waf_acl" {
     action {
        type = "BLOCK"
     }
-    priority = 1
+    priority = 1 
     rule_id = "${aws_waf_rule.wafrule.id}"
-    type    = "REGULAR"
   }
 }`, name, name, name, name, name)
 }

--- a/aws/resource_aws_waf_web_acl_test.go
+++ b/aws/resource_aws_waf_web_acl_test.go
@@ -288,8 +288,9 @@ resource "aws_waf_web_acl" "waf_acl" {
     action {
        type = "BLOCK"
     }
-    priority = 1 
+    priority = 1
     rule_id = "${aws_waf_rule.wafrule.id}"
+    type    = "REGULAR"
   }
 }`, name, name, name, name, name)
 }
@@ -324,8 +325,9 @@ resource "aws_waf_web_acl" "waf_acl" {
     action {
        type = "BLOCK"
     }
-    priority = 1 
+    priority = 1
     rule_id = "${aws_waf_rule.wafrule.id}"
+    type    = "REGULAR"
   }
 }`, name, name, name, name, name)
 }
@@ -360,8 +362,9 @@ resource "aws_waf_web_acl" "waf_acl" {
     action {
        type = "BLOCK"
     }
-    priority = 1 
+    priority = 1
     rule_id = "${aws_waf_rule.wafrule.id}"
+    type    = "REGULAR"
   }
 }`, name, name, name, name, name)
 }

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -887,7 +887,7 @@
 
                     </ul>
                 </li>
-                
+
                 <li<%= sidebar_current("docs-aws-resource-iot") %>>
                   <a href="#">IoT Resources</a>
                   <ul class="nav nav-visible">
@@ -1160,6 +1160,10 @@
 
                   <li<%= sidebar_current("docs-aws-resource-waf-rule") %>>
                     <a href="/docs/providers/aws/r/waf_rule.html">aws_waf_rule</a>
+                  </li>
+
+                  <li<%= sidebar_current("docs-aws-resource-waf-rate-based-rule") %>>
+                    <a href="/docs/providers/aws/r/waf_rate_based_rule.html">aws_waf_rate_based_rule</a>
                   </li>
 
                   <li<%= sidebar_current("docs-aws-resource-waf-size-constraint-set") %>>

--- a/website/docs/r/waf_rate_based_rule.html.markdown
+++ b/website/docs/r/waf_rate_based_rule.html.markdown
@@ -58,7 +58,7 @@ The following arguments are supported:
   based on the settings in the specified `ByteMatchSet`, `IPSet`, `SqlInjectionMatchSet`, `XssMatchSet`, or `SizeConstraintSet`.
   For example, if an IPSet includes the IP address `192.0.2.44`, AWS WAF will allow or block requests based on that IP address.
   If set to `true`, AWS WAF will allow, block, or count requests based on all IP addresses _except_ `192.0.2.44`.
-* `data_id` - (Optional) A unique identifier for a predicate in the rule, such as Byte Match Set ID or IPSet ID.
+* `data_id` - (Required) A unique identifier for a predicate in the rule, such as Byte Match Set ID or IPSet ID.
 * `type` - (Required) The type of predicate in a rule, such as `ByteMatchSet` or `IPSet`
 
 ## Remarks

--- a/website/docs/r/waf_rate_based_rule.html.markdown
+++ b/website/docs/r/waf_rate_based_rule.html.markdown
@@ -1,0 +1,70 @@
+---
+layout: "aws"
+page_title: "AWS: waf_rate_based_rule"
+sidebar_current: "docs-aws-resource-waf-rate-based-rule"
+description: |-
+  Provides a AWS WAF rule resource.
+---
+
+# aws\_waf\_rate\_based\_rule
+
+Provides a WAF Rate Based Rule Resource
+
+## Example Usage
+
+```hcl
+resource "aws_waf_ipset" "ipset" {
+  name = "tfIPSet"
+
+  ip_set_descriptors {
+    type  = "IPV4"
+    value = "192.0.7.0/24"
+  }
+}
+
+resource "aws_waf_rate_based_rule" "wafrule" {
+  depends_on  = ["aws_waf_ipset.ipset"]
+  name        = "tfWAFRule"
+  metric_name = "tfWAFRule"
+
+  rate_key = "IP"
+  rate_limit = 2000
+
+  predicates {
+    data_id = "${aws_waf_ipset.ipset.id}"
+    negated = false
+    type    = "IPMatch"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `metric_name` - (Required) The name or description for the Amazon CloudWatch metric of this rule.
+* `name` - (Required) The name or description of the rule.
+* `rate_key` - (Required) Valid value is IP.
+* `rate_limit` - (Required) The maximum number of requests, which have an identical value in the field specified by the RateKey, allowed in a five-minute period. Minimum value is 2000.
+* `predicates` - (Optional) One of ByteMatchSet, IPSet, SizeConstraintSet, SqlInjectionMatchSet, or XssMatchSet objects to include in a rule.
+
+## Nested Blocks
+
+### `predicates`
+
+#### Arguments
+
+* `negated` - (Required) Set this to `false` if you want to allow, block, or count requests
+  based on the settings in the specified `ByteMatchSet`, `IPSet`, `SqlInjectionMatchSet`, `XssMatchSet`, or `SizeConstraintSet`.
+  For example, if an IPSet includes the IP address `192.0.2.44`, AWS WAF will allow or block requests based on that IP address.
+  If set to `true`, AWS WAF will allow, block, or count requests based on all IP addresses _except_ `192.0.2.44`.
+* `data_id` - (Optional) A unique identifier for a predicate in the rule, such as Byte Match Set ID or IPSet ID.
+* `type` - (Required) The type of predicate in a rule, such as `ByteMatchSet` or `IPSet`
+
+## Remarks
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the WAF rule.

--- a/website/docs/r/waf_rule.html.markdown
+++ b/website/docs/r/waf_rule.html.markdown
@@ -53,7 +53,7 @@ The following arguments are supported:
   based on the settings in the specified `ByteMatchSet`, `IPSet`, `SqlInjectionMatchSet`, `XssMatchSet`, or `SizeConstraintSet`.
   For example, if an IPSet includes the IP address `192.0.2.44`, AWS WAF will allow or block requests based on that IP address.
   If set to `true`, AWS WAF will allow, block, or count requests based on all IP addresses _except_ `192.0.2.44`.
-* `data_id` - (Optional) A unique identifier for a predicate in the rule, such as Byte Match Set ID or IPSet ID.
+* `data_id` - (Required) A unique identifier for a predicate in the rule, such as Byte Match Set ID or IPSet ID.
 * `type` - (Required) The type of predicate in a rule, such as `ByteMatchSet` or `IPSet`
 
 ## Remarks

--- a/website/docs/r/waf_web_acl.html.markdown
+++ b/website/docs/r/waf_web_acl.html.markdown
@@ -50,6 +50,7 @@ resource "aws_waf_web_acl" "waf_acl" {
 
     priority = 1
     rule_id  = "${aws_waf_rule.wafrule.id}"
+    type     = "REGULAR"
   }
 }
 ```
@@ -83,6 +84,7 @@ See [docs](http://docs.aws.amazon.com/waf/latest/APIReference/API_ActivatedRule.
 * `priority` - (Required) Specifies the order in which the rules in a WebACL are evaluated.
   Rules with a lower value are evaluated before rules with a higher value.
 * `rule_id` - (Required) ID of the associated [rule](/docs/providers/aws/r/waf_rule.html)
+* `type` - (Required) The rule type, either `REGULAR`, as defined by [Rule](http://docs.aws.amazon.com/waf/latest/APIReference/API_Rule.html), or `RATE_BASED`, as defined by [RateBasedRule](http://docs.aws.amazon.com/waf/latest/APIReference/API_RateBasedRule.html)
 
 ## Attributes Reference
 

--- a/website/docs/r/waf_web_acl.html.markdown
+++ b/website/docs/r/waf_web_acl.html.markdown
@@ -84,7 +84,7 @@ See [docs](http://docs.aws.amazon.com/waf/latest/APIReference/API_ActivatedRule.
 * `priority` - (Required) Specifies the order in which the rules in a WebACL are evaluated.
   Rules with a lower value are evaluated before rules with a higher value.
 * `rule_id` - (Required) ID of the associated [rule](/docs/providers/aws/r/waf_rule.html)
-* `type` - (Required) The rule type, either `REGULAR`, as defined by [Rule](http://docs.aws.amazon.com/waf/latest/APIReference/API_Rule.html), or `RATE_BASED`, as defined by [RateBasedRule](http://docs.aws.amazon.com/waf/latest/APIReference/API_RateBasedRule.html)
+* `type` - (Optional) The rule type, either `REGULAR`, as defined by [Rule](http://docs.aws.amazon.com/waf/latest/APIReference/API_Rule.html), or `RATE_BASED`, as defined by [RateBasedRule](http://docs.aws.amazon.com/waf/latest/APIReference/API_RateBasedRule.html). The default is REGULAR. If you add a RATE_BASED rule, you need to set `type` as `RATE_BASED`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Updated version of https://github.com/terraform-providers/terraform-provider-aws/pull/1285. 
I had to add the required `type` field to the rules block under `aws_waf_rule`. The value could be either `REGULAR` or `RATE_BASED` regarding which type of rule you are using.
The docs are updated as well.