### PR TITLE
Add support in TF file configuration for assuming roles via profiles defined in ~/.aws/config

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -250,17 +250,16 @@ func (c *Config) Client() (interface{}, error) {
 	cp, err := creds.Get()
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NoCredentialProviders" {
-			// If a profile wasn't specifed then error out
+			// If a profile wasn't specified then error out
 			if c.Profile == "" {
 				return nil, errors.New(`No valid credential sources found for AWS Provider.
   Please see https://terraform.io/docs/providers/aws/index.html for more information on
   providing credentials for the AWS Provider`)
-			} else {
-				// add the profile and enable share config file usage
-				log.Printf("[INFO] AWS Auth using Profile: %q", c.Profile)
-				opt.Profile = c.Profile
-				opt.SharedConfigState = session.SharedConfigEnable
 			}
+			// add the profile and enable share config file usage
+			log.Printf("[INFO] AWS Auth using Profile: %q", c.Profile)
+			opt.Profile = c.Profile
+			opt.SharedConfigState = session.SharedConfigEnable
 		} else {
 			return nil, fmt.Errorf("Error loading credentials for AWS Provider: %s", err)
 		}
@@ -290,7 +289,7 @@ func (c *Config) Client() (interface{}, error) {
   Please see https://terraform.io/docs/providers/aws/index.html for more information on
   providing credentials for the AWS Provider`)
 		}
-		return nil, errwrap.Wrapf("MM: Error creating AWS session: {{err}}", err)
+		return nil, errwrap.Wrapf("Error creating AWS session: {{err}}", err)
 	}
 
 	sess.Handlers.Build.PushBackNamed(addTerraformVersionToUserAgent)

--- a/aws/config.go
+++ b/aws/config.go
@@ -232,51 +232,76 @@ func (c *Config) Client() (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// define the AWS Session options
+	// Credentials or Profile will be set in the Options below
+	// MaxRetries may be set once we validate credentials
+	var opt = session.Options{
+		Config: aws.Config{
+			Region:           aws.String(c.Region),
+			MaxRetries:       aws.Int(0),
+			HTTPClient:       cleanhttp.DefaultClient(),
+			S3ForcePathStyle: aws.Bool(c.S3ForcePathStyle),
+		},
+	}
+
 	// Call Get to check for credential provider. If nothing found, we'll get an
 	// error, and we can present it nicely to the user
 	cp, err := creds.Get()
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NoCredentialProviders" {
+			// If a profile wasn't specifed then error out
+			if c.Profile == "" {
+				return nil, errors.New(`No valid credential sources found for AWS Provider.
+  Please see https://terraform.io/docs/providers/aws/index.html for more information on
+  providing credentials for the AWS Provider`)
+			} else {
+				// add the profile and enable share config file usage
+				log.Printf("[INFO] AWS Auth using Profile: %q", c.Profile)
+				opt.Profile = c.Profile
+				opt.SharedConfigState = session.SharedConfigEnable
+			}
+		} else {
+			return nil, fmt.Errorf("Error loading credentials for AWS Provider: %s", err)
+		}
+	} else {
+		// add the validated credentials to the session options
+		log.Printf("[INFO] AWS Auth provider used: %q", cp.ProviderName)
+		opt.Config.Credentials = creds
+	}
+
+	if logging.IsDebugOrHigher() {
+		opt.Config.LogLevel = aws.LogLevel(aws.LogDebugWithHTTPBody | aws.LogDebugWithRequestRetries | aws.LogDebugWithRequestErrors)
+		opt.Config.Logger = awsLogger{}
+	}
+
+	if c.Insecure {
+		transport := opt.Config.HTTPClient.Transport.(*http.Transport)
+		transport.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
+	}
+
+	// create base session with no retries. MaxRetries will be set later
+	sess, err := session.NewSessionWithOptions(opt)
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NoCredentialProviders" {
 			return nil, errors.New(`No valid credential sources found for AWS Provider.
   Please see https://terraform.io/docs/providers/aws/index.html for more information on
   providing credentials for the AWS Provider`)
 		}
-
-		return nil, fmt.Errorf("Error loading credentials for AWS Provider: %s", err)
-	}
-
-	log.Printf("[INFO] AWS Auth provider used: %q", cp.ProviderName)
-
-	awsConfig := &aws.Config{
-		Credentials:      creds,
-		Region:           aws.String(c.Region),
-		MaxRetries:       aws.Int(c.MaxRetries),
-		HTTPClient:       cleanhttp.DefaultClient(),
-		S3ForcePathStyle: aws.Bool(c.S3ForcePathStyle),
-	}
-
-	if logging.IsDebugOrHigher() {
-		awsConfig.LogLevel = aws.LogLevel(aws.LogDebugWithHTTPBody | aws.LogDebugWithRequestRetries | aws.LogDebugWithRequestErrors)
-		awsConfig.Logger = awsLogger{}
-	}
-
-	if c.Insecure {
-		transport := awsConfig.HTTPClient.Transport.(*http.Transport)
-		transport.TLSClientConfig = &tls.Config{
-			InsecureSkipVerify: true,
-		}
-	}
-
-	// Set up base session
-	sess, err := session.NewSession(awsConfig)
-	if err != nil {
-		return nil, errwrap.Wrapf("Error creating AWS session: {{err}}", err)
+		return nil, errwrap.Wrapf("MM: Error creating AWS session: {{err}}", err)
 	}
 
 	sess.Handlers.Build.PushBackNamed(addTerraformVersionToUserAgent)
 
 	if extraDebug := os.Getenv("TERRAFORM_AWS_AUTHFAILURE_DEBUG"); extraDebug != "" {
 		sess.Handlers.UnmarshalError.PushFrontNamed(debugAuthFailure)
+	}
+
+	// if the desired number of retries is non-zero, update the session
+	if c.MaxRetries > 0 {
+		sess = sess.Copy(&aws.Config{MaxRetries: aws.Int(c.MaxRetries)})
 	}
 
 	// This restriction should only be used for Route53 sessions.


### PR DESCRIPTION
This is simply a port of https://github.com/hashicorp/terraform/pull/11734 to the new terraform-provider-aws repo. (the original PR won't be merged since the code it relates to has been moved to this repo).

This should address #1184.

This won't support assuming roles where an MFA device has been specified for the profile (in ~/.aws/config). The original PR has some discussion of this, however, Terraform seems to utilise multiple, simultaneous sessions with AWS which complicates the situation somewhat. (I certainly saw repeated prompts for MFA when testing adding this)

I can't see much in the way of test code in config_test.go so am not immediately sure where and how to test this successfuly.

Original work by @craiglink in https://github.com/hashicorp/terraform/pull/11734.