### PR TITLE
Update data_source_aws_redshift_service_account.go

### DIFF
--- a/aws/data_source_aws_redshift_service_account.go
+++ b/aws/data_source_aws_redshift_service_account.go
@@ -20,6 +20,8 @@ var redshiftServiceAccountPerRegionMap = map[string]string{
 	"ca-central-1":   "907379612154",
 	"eu-central-1":   "053454850223",
 	"eu-west-1":      "210876761215",
+	"eu-west-2":	  "307160386991",
+	"sa-east-1":	  "075028567923",
 }
 
 func dataSourceAwsRedshiftServiceAccount() *schema.Resource {


### PR DESCRIPTION
terraform-provider-aws update required for

data_source_aws_redshift_service_account.go

The following Redshift service accounts need to be added, as Redshift is now available in these regions:

eu-west-2  307160386991
sa-east-1   075028567923