### PR TITLE
Update data_source_aws_redshift_service_account.go  #1610

### DIFF
--- a/aws/data_source_aws_redshift_service_account.go
+++ b/aws/data_source_aws_redshift_service_account.go
@@ -20,6 +20,8 @@ var redshiftServiceAccountPerRegionMap = map[string]string{
 	"ca-central-1":   "907379612154",
 	"eu-central-1":   "053454850223",
 	"eu-west-1":      "210876761215",
+	"eu-west-2":	  "307160386991",
+	"sa-east-1":	  "075028567923",
 }
 
 func dataSourceAwsRedshiftServiceAccount() *schema.Resource {

--- a/aws/data_source_aws_redshift_service_account_test.go
+++ b/aws/data_source_aws_redshift_service_account_test.go
@@ -20,7 +20,13 @@ func TestAccAWSRedshiftServiceAccount_basic(t *testing.T) {
 			resource.TestStep{
 				Config: testAccCheckAwsRedshiftServiceAccountExplicitRegionConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_redshift_service_account.regional", "id", "210876761215"),
+					resource.TestCheckResourceAttr("data.aws_redshift_service_account.regional", "id", "307160386991"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckAwsRedshiftServiceAccountExplicitRegionConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_redshift_service_account.regional", "id", "075028567923"),
 				),
 			},
 		},
@@ -33,6 +39,12 @@ data "aws_redshift_service_account" "main" { }
 
 const testAccCheckAwsRedshiftServiceAccountExplicitRegionConfig = `
 data "aws_redshift_service_account" "regional" {
-	region = "eu-west-1"
+	region = "eu-west-2"
+}
+`
+
+const testAccCheckAwsRedshiftServiceAccountExplicitRegionConfig = `
+data "aws_redshift_service_account" "regional" {
+	region = "sa-east-1"
 }
 `


### PR DESCRIPTION
terraform-provider-aws update required for

data_source_aws_redshift_service_account.go

The following Redshift service accounts need to be added, as Redshift is now available in these regions:

eu-west-2 307160386991
sa-east-1 075028567923
