### PR TITLE
Fixing the example two tier application. It no longer applies.

### DIFF
--- a/examples/two-tier/main.tf
+++ b/examples/two-tier/main.tf
@@ -112,7 +112,7 @@ resource "aws_instance" "web" {
     # The connection will use the local SSH agent for authentication.
   }
 
-  instance_type = "m1.small"
+  instance_type = "t2.micro"
 
   # Lookup the correct AMI based on the region
   # we specified

--- a/examples/two-tier/variables.tf
+++ b/examples/two-tier/variables.tf
@@ -20,9 +20,9 @@ variable "aws_region" {
 # Ubuntu Precise 12.04 LTS (x64)
 variable "aws_amis" {
   default = {
-    eu-west-1 = "ami-b1cf19c6"
-    us-east-1 = "ami-de7ab6b6"
-    us-west-1 = "ami-3f75767a"
-    us-west-2 = "ami-21f78e11"
+    eu-west-1 = "ami-674cbc1e"
+    us-east-1 = "ami-1d4e7a66"
+    us-west-1 = "ami-969ab1f6"
+    us-west-2 = "ami-8803e0f0"
   }
 }


### PR DESCRIPTION
The two tier example no longer applies. The instance type and AMI are too old. This resolves it.