### PR TITLE
r/aws_appautoscaling_policy: Nest step scaling policy cfg

### DIFF
--- a/aws/resource_aws_appautoscaling_policy_test.go
+++ b/aws/resource_aws_appautoscaling_policy_test.go
@@ -29,7 +29,42 @@ func TestAccAWSAppautoScalingPolicy_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_appautoscaling_policy.foobar_simple", "adjustment_type", "ChangeInCapacity"),
 					resource.TestCheckResourceAttr("aws_appautoscaling_policy.foobar_simple", "policy_type", "StepScaling"),
 					resource.TestCheckResourceAttr("aws_appautoscaling_policy.foobar_simple", "cooldown", "60"),
+					resource.TestCheckResourceAttr("aws_appautoscaling_policy.foobar_simple", "step_adjustment.#", "1"),
+					resource.TestCheckResourceAttr("aws_appautoscaling_policy.foobar_simple", "step_adjustment.2087484785.scaling_adjustment", "1"),
+					resource.TestCheckResourceAttr("aws_appautoscaling_policy.foobar_simple", "step_adjustment.2087484785.metric_interval_lower_bound", "0"),
 					resource.TestCheckResourceAttr("aws_appautoscaling_policy.foobar_simple", "name", randPolicyName),
+					resource.TestCheckResourceAttr("aws_appautoscaling_policy.foobar_simple", "resource_id", fmt.Sprintf("service/%s/foobar", randClusterName)),
+					resource.TestCheckResourceAttr("aws_appautoscaling_policy.foobar_simple", "service_namespace", "ecs"),
+					resource.TestCheckResourceAttr("aws_appautoscaling_policy.foobar_simple", "scalable_dimension", "ecs:service:DesiredCount"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAppautoScalingPolicy_nestedSchema(t *testing.T) {
+	var policy applicationautoscaling.ScalingPolicy
+
+	randClusterName := fmt.Sprintf("cluster%s", acctest.RandString(10))
+	randPolicyName := fmt.Sprintf("terraform-test-foobar-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAppautoscalingPolicyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSAppautoscalingPolicyNestedSchemaConfig(randClusterName, randPolicyName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAppautoscalingPolicyExists("aws_appautoscaling_policy.foobar_simple", &policy),
+					resource.TestCheckResourceAttr("aws_appautoscaling_policy.foobar_simple", "step_scaling_policy_configuration.0.adjustment_type", "PercentChangeInCapacity"),
+					resource.TestCheckResourceAttr("aws_appautoscaling_policy.foobar_simple", "step_scaling_policy_configuration.0.cooldown", "60"),
+					resource.TestCheckResourceAttr("aws_appautoscaling_policy.foobar_simple", "step_scaling_policy_configuration.0.step_adjustment.#", "1"),
+					resource.TestCheckResourceAttr("aws_appautoscaling_policy.foobar_simple", "step_scaling_policy_configuration.0.step_adjustment.2252990027.scaling_adjustment", "1"),
+					resource.TestCheckResourceAttr("aws_appautoscaling_policy.foobar_simple", "step_scaling_policy_configuration.0.step_adjustment.2252990027.metric_interval_lower_bound", "1"),
+					resource.TestCheckResourceAttr("aws_appautoscaling_policy.foobar_simple", "step_scaling_policy_configuration.0.step_adjustment.2252990027.metric_interval_upper_bound", "-1"),
+					resource.TestCheckResourceAttr("aws_appautoscaling_policy.foobar_simple", "name", randPolicyName),
+					resource.TestCheckResourceAttr("aws_appautoscaling_policy.foobar_simple", "policy_type", "StepScaling"),
 					resource.TestCheckResourceAttr("aws_appautoscaling_policy.foobar_simple", "resource_id", fmt.Sprintf("service/%s/foobar", randClusterName)),
 					resource.TestCheckResourceAttr("aws_appautoscaling_policy.foobar_simple", "service_namespace", "ecs"),
 					resource.TestCheckResourceAttr("aws_appautoscaling_policy.foobar_simple", "scalable_dimension", "ecs:service:DesiredCount"),
@@ -289,4 +324,94 @@ resource "aws_appautoscaling_policy" "test" {
   depends_on = ["aws_appautoscaling_target.test"]
 }
 `, randPolicyName)
+}
+
+func testAccAWSAppautoscalingPolicyNestedSchemaConfig(
+	randClusterName string,
+	randPolicyName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "autoscale_role" {
+	name = "%s"
+	path = "/"
+
+	assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Action\":[\"sts:AssumeRole\"]}]}"
+}
+
+resource "aws_iam_role_policy" "autoscale_role_policy" {
+	name = "%s"
+	role = "${aws_iam_role.autoscale_role.id}"
+
+	policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ecs:DescribeServices",
+                "ecs:UpdateService",
+				"cloudwatch:DescribeAlarms"
+            ],
+            "Resource": ["*"]
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_ecs_cluster" "foo" {
+	name = "%s"
+}
+
+resource "aws_ecs_task_definition" "task" {
+	family = "foobar"
+	container_definitions = <<EOF
+[
+	{
+		"name": "busybox",
+		"image": "busybox:latest",
+		"cpu": 10,
+		"memory": 128,
+		"essential": true
+	}
+]
+EOF
+}
+
+resource "aws_ecs_service" "service" {
+	name = "foobar"
+	cluster = "${aws_ecs_cluster.foo.id}"
+	task_definition = "${aws_ecs_task_definition.task.arn}"
+	desired_count = 1
+	deployment_maximum_percent = 200
+	deployment_minimum_healthy_percent = 50
+}
+
+resource "aws_appautoscaling_target" "tgt" {
+	service_namespace = "ecs"
+	resource_id = "service/${aws_ecs_cluster.foo.name}/${aws_ecs_service.service.name}"
+	scalable_dimension = "ecs:service:DesiredCount"
+	role_arn = "${aws_iam_role.autoscale_role.arn}"
+	min_capacity = 1
+	max_capacity = 4
+}
+
+resource "aws_appautoscaling_policy" "foobar_simple" {
+	name = "%s"
+	service_namespace = "ecs"
+	resource_id = "service/${aws_ecs_cluster.foo.name}/${aws_ecs_service.service.name}"
+	scalable_dimension = "ecs:service:DesiredCount"
+
+	step_scaling_policy_configuration {
+		adjustment_type = "PercentChangeInCapacity"
+		cooldown = 60
+		metric_aggregation_type = "Average"
+		step_adjustment {
+			metric_interval_lower_bound = 1
+			scaling_adjustment = 1
+		}
+	}
+	depends_on = ["aws_appautoscaling_target.tgt"]
+}
+`, randClusterName, randClusterName, randClusterName, randPolicyName)
 }


### PR DESCRIPTION
This is a first step towards supporting DynamoDB autoscaling as mentioned in https://github.com/terraform-providers/terraform-provider-aws/pull/919#pullrequestreview-58109291

### Test results

```
TF_ACC=1 go test ./aws -v -run=TestAccAWSAppautoScalingPolicy_ -timeout 120m
=== RUN   TestAccAWSAppautoScalingPolicy_basic
--- PASS: TestAccAWSAppautoScalingPolicy_basic (133.65s)
=== RUN   TestAccAWSAppautoScalingPolicy_nestedSchema
--- PASS: TestAccAWSAppautoScalingPolicy_nestedSchema (132.69s)
=== RUN   TestAccAWSAppautoScalingPolicy_spotFleetRequest
--- PASS: TestAccAWSAppautoScalingPolicy_spotFleetRequest (100.88s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	367.255s
```