### PR TITLE
remove "id" fields from schema definitions

### DIFF
--- a/aws/data_source_aws_availability_zone.go
+++ b/aws/data_source_aws_availability_zone.go
@@ -79,7 +79,6 @@ func dataSourceAwsAvailabilityZoneRead(d *schema.ResourceData, meta interface{})
 	nameSuffix := (*az.ZoneName)[len(*az.RegionName):]
 
 	d.SetId(*az.ZoneName)
-	d.Set("id", az.ZoneName)
 	d.Set("name", az.ZoneName)
 	d.Set("name_suffix", nameSuffix)
 	d.Set("region", az.RegionName)

--- a/aws/data_source_aws_canonical_user_id.go
+++ b/aws/data_source_aws_canonical_user_id.go
@@ -14,10 +14,6 @@ func dataSourceAwsCanonicalUserId() *schema.Resource {
 		Read: dataSourceAwsCanonicalUserIdRead,
 
 		Schema: map[string]*schema.Schema{
-			"id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"display_name": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -41,7 +37,6 @@ func dataSourceAwsCanonicalUserIdRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	d.SetId(aws.StringValue(resp.Owner.ID))
-	d.Set("id", resp.Owner.ID)
 	d.Set("display_name", resp.Owner.DisplayName)
 
 	return nil

--- a/aws/data_source_aws_eip.go
+++ b/aws/data_source_aws_eip.go
@@ -14,6 +14,11 @@ func dataSourceAwsEip() *schema.Resource {
 		Read: dataSourceAwsEipRead,
 
 		Schema: map[string]*schema.Schema{
+			"id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"public_ip": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,

--- a/aws/data_source_aws_eip.go
+++ b/aws/data_source_aws_eip.go
@@ -14,12 +14,6 @@ func dataSourceAwsEip() *schema.Resource {
 		Read: dataSourceAwsEipRead,
 
 		Schema: map[string]*schema.Schema{
-			"id": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-
 			"public_ip": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -34,8 +28,8 @@ func dataSourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 
 	req := &ec2.DescribeAddressesInput{}
 
-	if id := d.Get("id"); id != "" {
-		req.AllocationIds = []*string{aws.String(id.(string))}
+	if id := d.Id(); id != "" {
+		req.AllocationIds = []*string{aws.String(id)}
 	}
 
 	if public_ip := d.Get("public_ip"); public_ip != "" {
@@ -57,7 +51,6 @@ func dataSourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 	eip := resp.Addresses[0]
 
 	d.SetId(*eip.AllocationId)
-	d.Set("id", eip.AllocationId)
 	d.Set("public_ip", eip.PublicIp)
 
 	return nil

--- a/aws/data_source_aws_iam_server_certificate.go
+++ b/aws/data_source_aws_iam_server_certificate.go
@@ -58,11 +58,6 @@ func dataSourceAwsIAMServerCertificate() *schema.Resource {
 				Computed: true,
 			},
 
-			"id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
 			"path": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -130,7 +125,6 @@ func dataSourceAwsIAMServerCertificateRead(d *schema.ResourceData, meta interfac
 	d.SetId(*metadata.ServerCertificateId)
 	d.Set("arn", *metadata.Arn)
 	d.Set("path", *metadata.Path)
-	d.Set("id", *metadata.ServerCertificateId)
 	d.Set("name", *metadata.ServerCertificateName)
 	if metadata.Expiration != nil {
 		d.Set("expiration_date", metadata.Expiration.Format("2006-01-02T15:04:05"))

--- a/aws/data_source_aws_prefix_list.go
+++ b/aws/data_source_aws_prefix_list.go
@@ -23,11 +23,6 @@ func dataSourceAwsPrefixList() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
-			// Computed values.
-			"id": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"cidr_blocks": &schema.Schema{
 				Type:     schema.TypeList,
 				Computed: true,
@@ -63,7 +58,6 @@ func dataSourceAwsPrefixListRead(d *schema.ResourceData, meta interface{}) error
 	pl := resp.PrefixLists[0]
 
 	d.SetId(*pl.PrefixListId)
-	d.Set("id", pl.PrefixListId)
 	d.Set("name", pl.PrefixListName)
 
 	cidrs := make([]string, len(pl.Cidrs))

--- a/aws/data_source_aws_region.go
+++ b/aws/data_source_aws_region.go
@@ -75,7 +75,6 @@ func dataSourceAwsRegionRead(d *schema.ResourceData, meta interface{}) error {
 	region := resp.Regions[0]
 
 	d.SetId(*region.RegionName)
-	d.Set("id", region.RegionName)
 	d.Set("name", region.RegionName)
 	d.Set("endpoint", region.Endpoint)
 	d.Set("current", *region.RegionName == currentRegion)

--- a/aws/data_source_aws_security_group.go
+++ b/aws/data_source_aws_security_group.go
@@ -40,8 +40,8 @@ func dataSourceAwsSecurityGroupRead(d *schema.ResourceData, meta interface{}) er
 	conn := meta.(*AWSClient).ec2conn
 	req := &ec2.DescribeSecurityGroupsInput{}
 
-	if id, idExists := d.GetOk("id"); idExists {
-		req.GroupIds = []*string{aws.String(id.(string))}
+	if id := d.Id(); id != "" {
+		req.GroupIds = []*string{aws.String(id)}
 	}
 
 	req.Filters = buildEC2AttributeFilterList(
@@ -76,7 +76,6 @@ func dataSourceAwsSecurityGroupRead(d *schema.ResourceData, meta interface{}) er
 	sg := resp.SecurityGroups[0]
 
 	d.SetId(*sg.GroupId)
-	d.Set("id", sg.VpcId)
 	d.Set("name", sg.GroupName)
 	d.Set("description", sg.Description)
 	d.Set("vpc_id", sg.VpcId)

--- a/aws/data_source_aws_security_group.go
+++ b/aws/data_source_aws_security_group.go
@@ -26,12 +26,6 @@ func dataSourceAwsSecurityGroup() *schema.Resource {
 			},
 			"filter": ec2CustomFiltersSchema(),
 
-			"id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/aws/data_source_aws_security_group.go
+++ b/aws/data_source_aws_security_group.go
@@ -26,6 +26,12 @@ func dataSourceAwsSecurityGroup() *schema.Resource {
 			},
 			"filter": ec2CustomFiltersSchema(),
 
+			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/aws/data_source_aws_subnet.go
+++ b/aws/data_source_aws_subnet.go
@@ -40,12 +40,6 @@ func dataSourceAwsSubnet() *schema.Resource {
 
 			"filter": ec2CustomFiltersSchema(),
 
-			"id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-
 			"state": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/aws/data_source_aws_subnet.go
+++ b/aws/data_source_aws_subnet.go
@@ -40,6 +40,12 @@ func dataSourceAwsSubnet() *schema.Resource {
 
 			"filter": ec2CustomFiltersSchema(),
 
+			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
 			"state": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/aws/data_source_aws_subnet.go
+++ b/aws/data_source_aws_subnet.go
@@ -77,8 +77,8 @@ func dataSourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
 
 	req := &ec2.DescribeSubnetsInput{}
 
-	if id := d.Get("id"); id != "" {
-		req.SubnetIds = []*string{aws.String(id.(string))}
+	if id := d.Id(); id != "" {
+		req.SubnetIds = []*string{aws.String(id)}
 	}
 
 	// We specify default_for_az as boolean, but EC2 filters want
@@ -133,7 +133,6 @@ func dataSourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
 	subnet := resp.Subnets[0]
 
 	d.SetId(*subnet.SubnetId)
-	d.Set("id", subnet.SubnetId)
 	d.Set("vpc_id", subnet.VpcId)
 	d.Set("availability_zone", subnet.AvailabilityZone)
 	d.Set("cidr_block", subnet.CidrBlock)

--- a/aws/data_source_aws_vpc.go
+++ b/aws/data_source_aws_vpc.go
@@ -34,12 +34,6 @@ func dataSourceAwsVpc() *schema.Resource {
 
 			"filter": ec2CustomFiltersSchema(),
 
-			"id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-
 			"instance_tenancy": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/aws/data_source_aws_vpc.go
+++ b/aws/data_source_aws_vpc.go
@@ -34,6 +34,12 @@ func dataSourceAwsVpc() *schema.Resource {
 
 			"filter": ec2CustomFiltersSchema(),
 
+			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
 			"instance_tenancy": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/aws/data_source_aws_vpc.go
+++ b/aws/data_source_aws_vpc.go
@@ -75,8 +75,8 @@ func dataSourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 
 	req := &ec2.DescribeVpcsInput{}
 
-	if id := d.Get("id"); id != "" {
-		req.VpcIds = []*string{aws.String(id.(string))}
+	if id := d.Id(); id != "" {
+		req.VpcIds = []*string{aws.String(id)}
 	}
 
 	// We specify "default" as boolean, but EC2 filters want
@@ -123,7 +123,6 @@ func dataSourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 	vpc := resp.Vpcs[0]
 
 	d.SetId(*vpc.VpcId)
-	d.Set("id", vpc.VpcId)
 	d.Set("cidr_block", vpc.CidrBlock)
 	d.Set("dhcp_options_id", vpc.DhcpOptionsId)
 	d.Set("instance_tenancy", vpc.InstanceTenancy)

--- a/aws/data_source_aws_vpc_endpoint.go
+++ b/aws/data_source_aws_vpc_endpoint.go
@@ -15,6 +15,11 @@ func dataSourceAwsVpcEndpoint() *schema.Resource {
 		Read: dataSourceAwsVpcEndpointRead,
 
 		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"state": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/aws/data_source_aws_vpc_endpoint.go
+++ b/aws/data_source_aws_vpc_endpoint.go
@@ -15,11 +15,6 @@ func dataSourceAwsVpcEndpoint() *schema.Resource {
 		Read: dataSourceAwsVpcEndpointRead,
 
 		Schema: map[string]*schema.Schema{
-			"id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
 			"state": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -56,8 +51,8 @@ func dataSourceAwsVpcEndpointRead(d *schema.ResourceData, meta interface{}) erro
 
 	req := &ec2.DescribeVpcEndpointsInput{}
 
-	if id, ok := d.GetOk("id"); ok {
-		req.VpcEndpointIds = aws.StringSlice([]string{id.(string)})
+	if id := d.Id(); id != "" {
+		req.VpcEndpointIds = aws.StringSlice([]string{id})
 	}
 
 	req.Filters = buildEC2AttributeFilterList(
@@ -90,7 +85,6 @@ func dataSourceAwsVpcEndpointRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	d.SetId(aws.StringValue(vpce.VpcEndpointId))
-	d.Set("id", vpce.VpcEndpointId)
 	d.Set("state", vpce.State)
 	d.Set("vpc_id", vpce.VpcId)
 	d.Set("service_name", vpce.ServiceName)

--- a/aws/data_source_aws_vpc_peering_connection.go
+++ b/aws/data_source_aws_vpc_peering_connection.go
@@ -14,6 +14,11 @@ func dataSourceAwsVpcPeeringConnection() *schema.Resource {
 		Read: dataSourceAwsVpcPeeringConnectionRead,
 
 		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"status": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/aws/data_source_aws_vpc_peering_connection.go
+++ b/aws/data_source_aws_vpc_peering_connection.go
@@ -72,8 +72,8 @@ func dataSourceAwsVpcPeeringConnectionRead(d *schema.ResourceData, meta interfac
 
 	req := &ec2.DescribeVpcPeeringConnectionsInput{}
 
-	if id, ok := d.GetOk("id"); ok {
-		req.VpcPeeringConnectionIds = aws.StringSlice([]string{id.(string)})
+	if id := d.Id(); id != "" {
+		req.VpcPeeringConnectionIds = aws.StringSlice([]string{id})
 	}
 
 	req.Filters = buildEC2AttributeFilterList(
@@ -112,7 +112,6 @@ func dataSourceAwsVpcPeeringConnectionRead(d *schema.ResourceData, meta interfac
 	pcx := resp.VpcPeeringConnections[0]
 
 	d.SetId(aws.StringValue(pcx.VpcPeeringConnectionId))
-	d.Set("id", pcx.VpcPeeringConnectionId)
 	d.Set("status", pcx.Status.Code)
 	d.Set("vpc_id", pcx.RequesterVpcInfo.VpcId)
 	d.Set("owner_id", pcx.RequesterVpcInfo.OwnerId)

--- a/aws/data_source_aws_vpc_peering_connection.go
+++ b/aws/data_source_aws_vpc_peering_connection.go
@@ -14,11 +14,6 @@ func dataSourceAwsVpcPeeringConnection() *schema.Resource {
 		Read: dataSourceAwsVpcPeeringConnectionRead,
 
 		Schema: map[string]*schema.Schema{
-			"id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
 			"status": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/aws/data_source_aws_vpn_gateway.go
+++ b/aws/data_source_aws_vpn_gateway.go
@@ -14,6 +14,11 @@ func dataSourceAwsVpnGateway() *schema.Resource {
 		Read: dataSourceAwsVpnGatewayRead,
 
 		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"state": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/aws/data_source_aws_vpn_gateway.go
+++ b/aws/data_source_aws_vpn_gateway.go
@@ -42,8 +42,8 @@ func dataSourceAwsVpnGatewayRead(d *schema.ResourceData, meta interface{}) error
 
 	req := &ec2.DescribeVpnGatewaysInput{}
 
-	if id, ok := d.GetOk("id"); ok {
-		req.VpnGatewayIds = aws.StringSlice([]string{id.(string)})
+	if id := d.Id(); id != "" {
+		req.VpnGatewayIds = aws.StringSlice([]string{id})
 	}
 
 	req.Filters = buildEC2AttributeFilterList(

--- a/aws/data_source_aws_vpn_gateway.go
+++ b/aws/data_source_aws_vpn_gateway.go
@@ -14,11 +14,6 @@ func dataSourceAwsVpnGateway() *schema.Resource {
 		Read: dataSourceAwsVpnGatewayRead,
 
 		Schema: map[string]*schema.Schema{
-			"id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
 			"state": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/aws/opsworks_layers.go
+++ b/aws/opsworks_layers.go
@@ -276,7 +276,7 @@ func (lt *opsworksLayerType) Read(d *schema.ResourceData, client *opsworks.OpsWo
 	}
 
 	layer := resp.Layers[0]
-	d.Set("id", layer.LayerId)
+	d.SetId(aws.StringValue(layer.LayerId))
 	d.Set("auto_assign_elastic_ips", layer.AutoAssignElasticIps)
 	d.Set("auto_assign_public_ips", layer.AutoAssignPublicIps)
 	d.Set("custom_instance_profile_arn", layer.CustomInstanceProfileArn)
@@ -365,7 +365,6 @@ func (lt *opsworksLayerType) Create(d *schema.ResourceData, client *opsworks.Ops
 
 	layerId := *resp.LayerId
 	d.SetId(layerId)
-	d.Set("id", layerId)
 
 	loadBalancer := aws.String(d.Get("elastic_load_balancer").(string))
 	if loadBalancer != nil && *loadBalancer != "" {

--- a/aws/opsworks_layers.go
+++ b/aws/opsworks_layers.go
@@ -45,11 +45,6 @@ var (
 
 func (lt *opsworksLayerType) SchemaResource() *schema.Resource {
 	resourceSchema := map[string]*schema.Schema{
-		"id": &schema.Schema{
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-
 		"auto_assign_elastic_ips": &schema.Schema{
 			Type:     schema.TypeBool,
 			Optional: true,

--- a/aws/resource_aws_ami.go
+++ b/aws/resource_aws_ami.go
@@ -110,10 +110,8 @@ func resourceAwsAmiCreate(d *schema.ResourceData, meta interface{}) error {
 
 	id := *res.ImageId
 	d.SetId(id)
-	d.Partial(true) // make sure we record the id even if the rest of this gets interrupted
-	d.Set("id", id)
+	d.Partial(true)
 	d.Set("manage_ebs_block_devices", false)
-	d.SetPartial("id")
 	d.SetPartial("manage_ebs_block_devices")
 	d.Partial(false)
 

--- a/aws/resource_aws_ami.go
+++ b/aws/resource_aws_ami.go
@@ -397,10 +397,6 @@ func resourceAwsAmiCommonSchema(computed bool) map[string]*schema.Schema {
 	}
 
 	return map[string]*schema.Schema{
-		"id": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
 		"image_location": {
 			Type:     schema.TypeString,
 			Optional: !computed,

--- a/aws/resource_aws_ami_copy.go
+++ b/aws/resource_aws_ami_copy.go
@@ -75,9 +75,7 @@ func resourceAwsAmiCopyCreate(d *schema.ResourceData, meta interface{}) error {
 	id := *res.ImageId
 	d.SetId(id)
 	d.Partial(true) // make sure we record the id even if the rest of this gets interrupted
-	d.Set("id", id)
 	d.Set("manage_ebs_snapshots", true)
-	d.SetPartial("id")
 	d.SetPartial("manage_ebs_snapshots")
 	d.Partial(false)
 

--- a/aws/resource_aws_ami_from_instance.go
+++ b/aws/resource_aws_ami_from_instance.go
@@ -55,9 +55,7 @@ func resourceAwsAmiFromInstanceCreate(d *schema.ResourceData, meta interface{}) 
 	id := *res.ImageId
 	d.SetId(id)
 	d.Partial(true) // make sure we record the id even if the rest of this gets interrupted
-	d.Set("id", id)
 	d.Set("manage_ebs_snapshots", true)
-	d.SetPartial("id")
 	d.SetPartial("manage_ebs_snapshots")
 	d.Partial(false)
 

--- a/aws/resource_aws_opsworks_application.go
+++ b/aws/resource_aws_opsworks_application.go
@@ -21,10 +21,6 @@ func resourceAwsOpsworksApplication() *schema.Resource {
 		Update: resourceAwsOpsworksApplicationUpdate,
 		Delete: resourceAwsOpsworksApplicationDelete,
 		Schema: map[string]*schema.Schema{
-			"id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/aws/resource_aws_opsworks_application.go
+++ b/aws/resource_aws_opsworks_application.go
@@ -341,7 +341,6 @@ func resourceAwsOpsworksApplicationCreate(d *schema.ResourceData, meta interface
 
 	appID := *resp.AppId
 	d.SetId(appID)
-	d.Set("id", appID)
 
 	return resourceAwsOpsworksApplicationRead(d, meta)
 }

--- a/aws/resource_aws_opsworks_instance.go
+++ b/aws/resource_aws_opsworks_instance.go
@@ -559,7 +559,6 @@ func resourceAwsOpsworksInstanceRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("hostname", instance.Hostname)
 	d.Set("infrastructure_class", instance.InfrastructureClass)
 	d.Set("install_updates_on_boot", instance.InstallUpdatesOnBoot)
-	d.Set("id", instanceId)
 	d.Set("instance_profile_arn", instance.InstanceProfileArn)
 	d.Set("instance_type", instance.InstanceType)
 	d.Set("last_service_error_id", instance.LastServiceErrorId)
@@ -780,7 +779,6 @@ func resourceAwsOpsworksInstanceCreate(d *schema.ResourceData, meta interface{})
 
 	instanceId := *resp.InstanceId
 	d.SetId(instanceId)
-	d.Set("id", instanceId)
 
 	if v, ok := d.GetOk("state"); ok && v.(string) == "running" {
 		err := startOpsworksInstance(d, meta, true, d.Timeout(schema.TimeoutCreate))
@@ -801,9 +799,9 @@ func resourceAwsOpsworksInstanceUpdate(d *schema.ResourceData, meta interface{})
 	}
 
 	req := &opsworks.UpdateInstanceInput{
+		InstanceId:           aws.String(d.Id()),
 		AgentVersion:         aws.String(d.Get("agent_version").(string)),
 		Architecture:         aws.String(d.Get("architecture").(string)),
-		InstanceId:           aws.String(d.Get("id").(string)),
 		InstallUpdatesOnBoot: aws.Bool(d.Get("install_updates_on_boot").(bool)),
 	}
 
@@ -913,7 +911,7 @@ func resourceAwsOpsworksInstanceImport(
 func startOpsworksInstance(d *schema.ResourceData, meta interface{}, wait bool, timeout time.Duration) error {
 	client := meta.(*AWSClient).opsworksconn
 
-	instanceId := d.Get("id").(string)
+	instanceId := d.Id()
 
 	req := &opsworks.StartInstanceInput{
 		InstanceId: aws.String(instanceId),
@@ -951,7 +949,7 @@ func startOpsworksInstance(d *schema.ResourceData, meta interface{}, wait bool, 
 func stopOpsworksInstance(d *schema.ResourceData, meta interface{}, wait bool, timeout time.Duration) error {
 	client := meta.(*AWSClient).opsworksconn
 
-	instanceId := d.Get("id").(string)
+	instanceId := d.Id()
 
 	req := &opsworks.StopInstanceInput{
 		InstanceId: aws.String(instanceId),

--- a/aws/resource_aws_opsworks_instance.go
+++ b/aws/resource_aws_opsworks_instance.go
@@ -32,11 +32,6 @@ func resourceAwsOpsworksInstance() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
 			"agent_version": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/aws/resource_aws_opsworks_permission.go
+++ b/aws/resource_aws_opsworks_permission.go
@@ -20,10 +20,6 @@ func resourceAwsOpsworksPermission() *schema.Resource {
 		Read:   resourceAwsOpsworksPermissionRead,
 
 		Schema: map[string]*schema.Schema{
-			"id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"allow_ssh": {
 				Type:     schema.TypeBool,
 				Computed: true,

--- a/aws/resource_aws_opsworks_permission.go
+++ b/aws/resource_aws_opsworks_permission.go
@@ -100,7 +100,6 @@ func resourceAwsOpsworksPermissionRead(d *schema.ResourceData, meta interface{})
 		if d.Get("user_arn").(string)+d.Get("stack_id").(string) == id {
 			found = true
 			d.SetId(id)
-			d.Set("id", id)
 			d.Set("allow_ssh", permission.AllowSsh)
 			d.Set("allow_sudo", permission.AllowSudo)
 			d.Set("user_arn", permission.IamUserArn)

--- a/aws/resource_aws_opsworks_rds_db_instance.go
+++ b/aws/resource_aws_opsworks_rds_db_instance.go
@@ -20,10 +20,6 @@ func resourceAwsOpsworksRdsDbInstance() *schema.Resource {
 		Read:   resourceAwsOpsworksRdsDbInstanceRead,
 
 		Schema: map[string]*schema.Schema{
-			"id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"stack_id": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/aws/resource_aws_opsworks_rds_db_instance.go
+++ b/aws/resource_aws_opsworks_rds_db_instance.go
@@ -150,7 +150,6 @@ func resourceAwsOpsworksRdsDbInstanceRead(d *schema.ResourceData, meta interface
 		if fmt.Sprintf("%s%s", d.Get("rds_db_instance_arn").(string), d.Get("stack_id").(string)) == id {
 			found = true
 			d.SetId(id)
-			d.Set("id", id)
 			d.Set("stack_id", instance.StackId)
 			d.Set("rds_db_instance_arn", instance.RdsDbInstanceArn)
 			d.Set("db_user", instance.DbUser)

--- a/aws/resource_aws_opsworks_stack.go
+++ b/aws/resource_aws_opsworks_stack.go
@@ -40,11 +40,6 @@ func resourceAwsOpsworksStack() *schema.Resource {
 				Computed: true,
 			},
 
-			"id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/aws/resource_aws_opsworks_stack.go
+++ b/aws/resource_aws_opsworks_stack.go
@@ -471,7 +471,6 @@ func resourceAwsOpsworksStackCreate(d *schema.ResourceData, meta interface{}) er
 
 	stackId := *resp.StackId
 	d.SetId(stackId)
-	d.Set("id", stackId)
 
 	if inVpc && *req.UseOpsworksSecurityGroups {
 		// For VPC-based stacks, OpsWorks asynchronously creates some default

--- a/aws/resource_aws_opsworks_user_profile.go
+++ b/aws/resource_aws_opsworks_user_profile.go
@@ -18,11 +18,6 @@ func resourceAwsOpsworksUserProfile() *schema.Resource {
 		Delete: resourceAwsOpsworksUserProfileDelete,
 
 		Schema: map[string]*schema.Schema{
-			"id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
 			"user_arn": {
 				Type:     schema.TypeString,
 				Required: true,


### PR DESCRIPTION
The "id" field is built-in and not required in the schema. Future
updates to helper/schema will cause these to fail validation.