### PR TITLE
resource/aws_ssm_document: Added name validation

### DIFF
--- a/aws/resource_aws_ssm_document.go
+++ b/aws/resource_aws_ssm_document.go
@@ -32,8 +32,9 @@ func resourceAwsSsmDocument() *schema.Resource {
 				Computed: true,
 			},
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateAwsSSMName,
 			},
 			"content": {
 				Type:     schema.TypeString,

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1393,6 +1393,18 @@ func validateIamRoleDescription(v interface{}, k string) (ws []string, errors []
 	return
 }
 
+func validateAwsSSMName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+
+	if !regexp.MustCompile(`^[a-zA-Z0-9_\-.]{3,128}$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"Only alphanumeric characters, hyphens, dots & underscores allowed in %q: %q (Must satisfy regular expression pattern: ^[a-zA-Z0-9_\\-.]{3,128}$)",
+			k, value))
+	}
+
+	return
+}
+
 func validateSsmParameterType(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	types := map[string]bool{

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1394,6 +1394,7 @@ func validateIamRoleDescription(v interface{}, k string) (ws []string, errors []
 }
 
 func validateAwsSSMName(v interface{}, k string) (ws []string, errors []error) {
+	// http://docs.aws.amazon.com/systems-manager/latest/APIReference/API_CreateDocument.html#EC2-CreateDocument-request-Name
 	value := v.(string)
 
 	if !regexp.MustCompile(`^[a-zA-Z0-9_\-.]{3,128}$`).MatchString(value) {

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -2375,6 +2375,31 @@ func TestValidateIamRoleDescription(t *testing.T) {
 	}
 }
 
+func TestValidateAwsSSMName(t *testing.T) {
+	validNames := []string{
+		".foo-bar_123",
+		strings.Repeat("W", 128),
+	}
+	for _, v := range validNames {
+		_, errors := validateAwsSSMName(v, "name")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid SSM Name: %q", v, errors)
+		}
+	}
+
+	invalidNames := []string{
+		"foo+bar",
+		"tf",
+		strings.Repeat("W", 129), // > 128
+	}
+	for _, v := range invalidNames {
+		_, errors := validateAwsSSMName(v, "name")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be an invalid SSM Name: %q", v, errors)
+		}
+	}
+}
+
 func TestValidateSsmParameterType(t *testing.T) {
 	validTypes := []string{
 		"String",


### PR DESCRIPTION
Previously, the SSM document name was not even validated, thus potentially bringing issues at apply time.

Related Documentation: http://docs.aws.amazon.com/systems-manager/latest/APIReference/API_CreateDocument.html#API_CreateDocument_RequestSyntax