### PR TITLE
r/appautoscaling_policy: Add support for DynamoDB

### DIFF
--- a/aws/resource_aws_appautoscaling_policy.go
+++ b/aws/resource_aws_appautoscaling_policy.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/applicationautoscaling"
 	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -153,64 +155,94 @@ func resourceAwsAppautoscalingPolicy() *schema.Resource {
 					},
 				},
 			},
-			"customized_metric_specification": &schema.Schema{
-				Type:     schema.TypeSet,
+			"target_tracking_scaling_policy_configuration": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"dimensions": &schema.Schema{
-							Type:     schema.TypeList,
+						"customized_metric_specification": &schema.Schema{
+							Type:          schema.TypeList,
+							MaxItems:      1,
+							Optional:      true,
+							ConflictsWith: []string{"target_tracking_scaling_policy_configuration.0.predefined_metric_specification"},
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"dimensions": &schema.Schema{
+										Type:     schema.TypeSet,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"name": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+												"value": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+											},
+										},
+									},
+									"metric_name": &schema.Schema{
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"namespace": &schema.Schema{
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"statistic": &schema.Schema{
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validateAppautoscalingCustomizedMetricSpecificationStatistic,
+									},
+									"unit": &schema.Schema{
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"predefined_metric_specification": &schema.Schema{
+							Type:          schema.TypeList,
+							MaxItems:      1,
+							Optional:      true,
+							ConflictsWith: []string{"target_tracking_scaling_policy_configuration.0.customized_metric_specification"},
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"predefined_metric_type": &schema.Schema{
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validateAppautoscalingPredefinedMetricSpecification,
+									},
+									"resource_label": &schema.Schema{
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validateAppautoscalingPredefinedResourceLabel,
+									},
+								},
+							},
+						},
+						"disable_scale_in": &schema.Schema{
+							Type:     schema.TypeBool,
+							Default:  false,
 							Optional: true,
 						},
-						"metric_name": &schema.Schema{
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"namespace": &schema.Schema{
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"statistic": &schema.Schema{
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validateAppautoscalingCustomizedMetricSpecificationStatistic,
-						},
-						"unit": &schema.Schema{
+						"scale_in_cooldown": &schema.Schema{
 							Type:     schema.TypeInt,
 							Optional: true,
 						},
-					},
-				},
-			},
-			"predefined_metric_specification": &schema.Schema{
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"predefined_metric_type": &schema.Schema{
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validateAppautoscalingPredefinedMetricSpecification,
+						"scale_out_cooldown": &schema.Schema{
+							Type:     schema.TypeInt,
+							Optional: true,
 						},
-						"resource_label": &schema.Schema{
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: validateAppautoscalingPredefinedResourceLabel,
+						"target_value": &schema.Schema{
+							Type:     schema.TypeFloat,
+							Required: true,
 						},
 					},
 				},
-			},
-			"scale_in_cooldown": &schema.Schema{
-				Type:     schema.TypeInt,
-				Optional: true,
-			},
-			"scale_out_cooldown": &schema.Schema{
-				Type:     schema.TypeInt,
-				Optional: true,
-			},
-			"target_value": &schema.Schema{
-				Type:     schema.TypeFloat,
-				Required: true,
 			},
 		},
 	}
@@ -225,9 +257,20 @@ func resourceAwsAppautoscalingPolicyCreate(d *schema.ResourceData, meta interfac
 	}
 
 	log.Printf("[DEBUG] ApplicationAutoScaling PutScalingPolicy: %#v", params)
-	resp, err := conn.PutScalingPolicy(&params)
+	var resp *applicationautoscaling.PutScalingPolicyOutput
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		var err error
+		resp, err = conn.PutScalingPolicy(&params)
+		if err != nil {
+			if isAWSErr(err, "FailedResourceAccessException", "is not authorized to perform") {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(fmt.Errorf("Error putting scaling policy: %s", err))
+		}
+		return nil
+	})
 	if err != nil {
-		return fmt.Errorf("Error putting scaling policy: %s", err)
+		return err
 	}
 
 	d.Set("arn", resp.PolicyARN)
@@ -257,6 +300,8 @@ func resourceAwsAppautoscalingPolicyRead(d *schema.ResourceData, meta interface{
 	d.Set("service_namespace", p.ServiceNamespace)
 	d.Set("alarms", p.Alarms)
 	d.Set("step_scaling_policy_configuration", flattenStepScalingPolicyConfiguration(p.StepScalingPolicyConfiguration))
+	d.Set("target_tracking_scaling_policy_configuration",
+		flattenTargetTrackingScalingPolicyConfiguration(p.TargetTrackingScalingPolicyConfiguration))
 
 	return nil
 }
@@ -363,8 +408,8 @@ func expandAppautoscalingStepAdjustments(configured []interface{}) ([]*applicati
 	return adjustments, nil
 }
 
-func expandAppautoscalingCustomizedMetricSpecification(configured []interface{}) (*applicationautoscaling.CustomizedMetricSpecification, error) {
-	var spec *applicationautoscaling.CustomizedMetricSpecification
+func expandAppautoscalingCustomizedMetricSpecification(configured []interface{}) *applicationautoscaling.CustomizedMetricSpecification {
+	spec := &applicationautoscaling.CustomizedMetricSpecification{}
 
 	for _, raw := range configured {
 		data := raw.(map[string]interface{})
@@ -376,27 +421,31 @@ func expandAppautoscalingCustomizedMetricSpecification(configured []interface{})
 			spec.Namespace = aws.String(v.(string))
 		}
 
-		if v, ok := data["unit"]; ok {
-			spec.Unit = aws.String(v.(string))
+		if v, ok := data["unit"].(string); ok && v != "" {
+			spec.Unit = aws.String(v)
 		}
 
 		if v, ok := data["statistic"]; ok {
 			spec.Statistic = aws.String(v.(string))
 		}
 
-		// if v, ok := data["dimensions"]; ok {
-		// 	dimensions := make([]*applicationautoscaling.MetricDimension, 0)
-		// 	for k, v := range data["dimensions"].(map[string]interface{}) {
-		// 		dimensions[k] = v.(string)
-		// 	}
-		// 	spec.Dimensions = dimensions
-		// }
+		if s, ok := data["dimensions"].(*schema.Set); ok && s.Len() > 0 {
+			dimensions := make([]*applicationautoscaling.MetricDimension, s.Len(), s.Len())
+			for i, d := range s.List() {
+				dimension := d.(map[string]interface{})
+				dimensions[i] = &applicationautoscaling.MetricDimension{
+					Name:  aws.String(dimension["name"].(string)),
+					Value: aws.String(dimension["value"].(string)),
+				}
+			}
+			spec.Dimensions = dimensions
+		}
 	}
-	return spec, nil
+	return spec
 }
 
-func expandAppautoscalingPredefinedMetricSpecification(configured []interface{}) (*applicationautoscaling.PredefinedMetricSpecification, error) {
-	var spec *applicationautoscaling.PredefinedMetricSpecification
+func expandAppautoscalingPredefinedMetricSpecification(configured []interface{}) *applicationautoscaling.PredefinedMetricSpecification {
+	spec := &applicationautoscaling.PredefinedMetricSpecification{}
 
 	for _, raw := range configured {
 		data := raw.(map[string]interface{})
@@ -405,11 +454,11 @@ func expandAppautoscalingPredefinedMetricSpecification(configured []interface{})
 			spec.PredefinedMetricType = aws.String(v.(string))
 		}
 
-		if v, ok := data["resource_label"]; ok {
-			spec.ResourceLabel = aws.String(v.(string))
+		if v, ok := data["resource_label"].(string); ok && v != "" {
+			spec.ResourceLabel = aws.String(v)
 		}
 	}
-	return spec, nil
+	return spec
 }
 
 func getAwsAppautoscalingPutScalingPolicyInput(d *schema.ResourceData) (applicationautoscaling.PutScalingPolicyInput, error) {
@@ -471,31 +520,37 @@ func getAwsAppautoscalingPutScalingPolicyInput(d *schema.ResourceData) (applicat
 		params.StepScalingPolicyConfiguration = expandStepScalingPolicyConfiguration(v.([]interface{}))
 	}
 
-	var customizedMetricSpecs *applicationautoscaling.CustomizedMetricSpecification
-	if v, ok := d.GetOk("customized_metric_specification"); ok {
-		specs, err := expandAppautoscalingCustomizedMetricSpecification(v.(*schema.Set).List())
-		if err != nil {
-			return params, fmt.Errorf("metric_interval_lower_bound and metric_interval_upper_bound must be strings!")
+	if l, ok := d.GetOk("target_tracking_scaling_policy_configuration"); ok {
+		v := l.([]interface{})
+		if len(v) < 1 {
+			return params, fmt.Errorf("Empty target_tracking_scaling_policy_configuration block")
 		}
-		customizedMetricSpecs = specs
-	}
-
-	var predefinedMetricSpecs *applicationautoscaling.PredefinedMetricSpecification
-	if v, ok := d.GetOk("customized_metric_specification"); ok {
-		specs, err := expandAppautoscalingPredefinedMetricSpecification(v.(*schema.Set).List())
-		if err != nil {
-			return params, fmt.Errorf("metric_interval_lower_bound and metric_interval_upper_bound must be strings!")
+		ttspCfg := v[0].(map[string]interface{})
+		cfg := &applicationautoscaling.TargetTrackingScalingPolicyConfiguration{
+			TargetValue: aws.Float64(ttspCfg["target_value"].(float64)),
 		}
-		predefinedMetricSpecs = specs
-	}
 
-	// build TargetTrackingScalingPolicyConfiguration
-	params.TargetTrackingScalingPolicyConfiguration = &applicationautoscaling.TargetTrackingScalingPolicyConfiguration{
-		CustomizedMetricSpecification: customizedMetricSpecs,
-		PredefinedMetricSpecification: predefinedMetricSpecs,
-		ScaleInCooldown:               aws.Int64(int64(d.Get("scale_in_cooldown").(int))),
-		ScaleOutCooldown:              aws.Int64(int64(d.Get("scale_out_cooldown").(int))),
-		TargetValue:                   aws.Float64(d.Get("target_value").(float64)),
+		if v, ok := ttspCfg["scale_in_cooldown"]; ok {
+			cfg.ScaleInCooldown = aws.Int64(int64(v.(int)))
+		}
+
+		if v, ok := ttspCfg["scale_out_cooldown"]; ok {
+			cfg.ScaleOutCooldown = aws.Int64(int64(v.(int)))
+		}
+
+		if v, ok := ttspCfg["disable_scale_in"]; ok {
+			cfg.DisableScaleIn = aws.Bool(v.(bool))
+		}
+
+		if v, ok := ttspCfg["customized_metric_specification"].([]interface{}); ok && len(v) > 0 {
+			cfg.CustomizedMetricSpecification = expandAppautoscalingCustomizedMetricSpecification(v)
+		}
+
+		if v, ok := ttspCfg["predefined_metric_specification"].([]interface{}); ok && len(v) > 0 {
+			cfg.PredefinedMetricSpecification = expandAppautoscalingPredefinedMetricSpecification(v)
+		}
+
+		params.TargetTrackingScalingPolicyConfiguration = cfg
 	}
 
 	return params, nil
@@ -599,6 +654,78 @@ func flattenAppautoscalingStepAdjustments(adjs []*applicationautoscaling.StepAdj
 	}
 
 	return out
+}
+
+func flattenTargetTrackingScalingPolicyConfiguration(cfg *applicationautoscaling.TargetTrackingScalingPolicyConfiguration) []interface{} {
+	if cfg == nil {
+		return []interface{}{}
+	}
+
+	m := make(map[string]interface{}, 0)
+	m["target_value"] = *cfg.TargetValue
+
+	if cfg.DisableScaleIn != nil {
+		m["disable_scale_in"] = *cfg.DisableScaleIn
+	}
+	if cfg.ScaleInCooldown != nil {
+		m["scale_in_cooldown"] = *cfg.ScaleInCooldown
+	}
+	if cfg.ScaleOutCooldown != nil {
+		m["scale_out_cooldown"] = *cfg.ScaleOutCooldown
+	}
+	if cfg.CustomizedMetricSpecification != nil {
+		m["customized_metric_specification"] = flattenCustomizedMetricSpecification(cfg.CustomizedMetricSpecification)
+	}
+	if cfg.PredefinedMetricSpecification != nil {
+		m["predefined_metric_specification"] = flattenPredefinedMetricSpecification(cfg.PredefinedMetricSpecification)
+	}
+
+	return []interface{}{m}
+}
+
+func flattenCustomizedMetricSpecification(cfg *applicationautoscaling.CustomizedMetricSpecification) []interface{} {
+	if cfg == nil {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"metric_name": *cfg.MetricName,
+		"namespace":   *cfg.Namespace,
+		"statistic":   *cfg.Statistic,
+	}
+
+	if len(cfg.Dimensions) > 0 {
+		m["dimensions"] = flattenMetricDimensions(cfg.Dimensions)
+	}
+
+	if cfg.Unit != nil {
+		m["unit"] = *cfg.Unit
+	}
+	return []interface{}{m}
+}
+
+func flattenMetricDimensions(ds []*applicationautoscaling.MetricDimension) []interface{} {
+	l := make([]interface{}, len(ds), len(ds))
+	for i, d := range ds {
+		l[i] = map[string]interface{}{
+			"name":  *d.Name,
+			"value": *d.Value,
+		}
+	}
+	return l
+}
+
+func flattenPredefinedMetricSpecification(cfg *applicationautoscaling.PredefinedMetricSpecification) []interface{} {
+	if cfg == nil {
+		return []interface{}{}
+	}
+	m := map[string]interface{}{
+		"predefined_metric_type": *cfg.PredefinedMetricType,
+	}
+	if cfg.ResourceLabel != nil {
+		m["resource_label"] = *cfg.ResourceLabel
+	}
+	return []interface{}{m}
 }
 
 func resourceAwsAppautoscalingAdjustmentHash(v interface{}) int {

--- a/aws/resource_aws_appautoscaling_policy_test.go
+++ b/aws/resource_aws_appautoscaling_policy_test.go
@@ -97,6 +97,29 @@ func TestAccAWSAppautoScalingPolicy_spotFleetRequest(t *testing.T) {
 	})
 }
 
+func TestAccAWSAppautoScalingPolicy_dynamoDb(t *testing.T) {
+	var policy applicationautoscaling.ScalingPolicy
+
+	randPolicyName := fmt.Sprintf("test-appautoscaling-policy-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAppautoscalingPolicyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSAppautoscalingPolicyDynamoDB(randPolicyName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAppautoscalingPolicyExists("aws_appautoscaling_policy.dynamo_test", &policy),
+					resource.TestCheckResourceAttr("aws_appautoscaling_policy.dynamo_test", "name", randPolicyName),
+					resource.TestCheckResourceAttr("aws_appautoscaling_policy.dynamo_test", "service_namespace", "dynamodb"),
+					resource.TestCheckResourceAttr("aws_appautoscaling_policy.dynamo_test", "scalable_dimension", "dynamodb:table:WriteCapacityUnits"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSAppautoscalingPolicyExists(n string, policy *applicationautoscaling.ScalingPolicy) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -414,4 +437,97 @@ resource "aws_appautoscaling_policy" "foobar_simple" {
 	depends_on = ["aws_appautoscaling_target.tgt"]
 }
 `, randClusterName, randClusterName, randClusterName, randPolicyName)
+}
+
+func testAccAWSAppautoscalingPolicyDynamoDB(
+	randPolicyName string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "dynamodb_table_test" {
+  name           = "%s"
+  read_capacity  = 5
+  write_capacity = 5
+  hash_key       = "FooKey"
+  attribute {
+    name = "FooKey"
+    type = "S"
+  }
+}
+resource "aws_iam_role" "dynamodb_role" {
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "dynamodb.amazonaws.com"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+resource "aws_iam_role_policy_attachment" "dynamodb_role_policy" {
+  role = "${aws_iam_role.dynamodb_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonDynamoDBFullAccess"
+}
+resource "aws_iam_role" "autoscale_role" {
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "application-autoscaling.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+resource "aws_iam_role_policy_attachment" "autoscale_role_policy" {
+  role = "${aws_iam_role.autoscale_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AutoScalingFullAccess"
+}
+resource "aws_appautoscaling_target" "dynamo_test" {
+  service_namespace = "dynamodb"
+  resource_id = "${aws_dynamodb_table.dynamodb_table_test.name}"
+  scalable_dimension = "dynamodb:table:WriteCapacityUnits"
+  role_arn = "${aws_iam_role.autoscale_role.arn}"
+  min_capacity = 1
+  max_capacity = 10
+}
+resource "aws_appautoscaling_policy" "dynamo_test" {
+  name = "%s"
+  service_namespace = "dynamodb"
+  resource_id = "${aws_dynamodb_table.dynamodb_table_test.name}"
+  scalable_dimension = "dynamodb:table:WriteCapacityUnits"
+  adjustment_type = "ChangeInCapacity"
+  cooldown = 60
+  metric_aggregation_type = "Maximum"
+  step_adjustment {
+    metric_interval_lower_bound = 0
+    scaling_adjustment = 1
+  }
+  
+  customized_metric_specification = {
+    metric_name = "foo"
+    namespace = "dynamodb"
+    statistic = "Sum"
+  }
+  predefined_metric_specification = {
+    predefined_metric_type = "DynamoDBWriteCapacityUtilization"
+  }
+  
+  scale_in_cooldown = 10
+  scale_out_cooldown = 10
+  target_value = 70
+  depends_on = ["aws_appautoscaling_target.dynamo_test"]
+}
+`, randPolicyName, randPolicyName)
 }

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1026,6 +1026,11 @@ func validateAppautoscalingScalableDimension(v interface{}, k string) (ws []stri
 		"ecs:service:DesiredCount":                     true,
 		"ec2:spot-fleet-request:TargetCapacity":        true,
 		"elasticmapreduce:instancegroup:InstanceCount": true,
+		"appstream:fleet:DesiredCapacity":              true,
+		"dynamodb:table:ReadCapacityUnits":             true,
+		"dynamodb:table:WriteCapacityUnits":            true,
+		"dynamodb:index:ReadCapacityUnits":             true,
+		"dynamodb:index:WriteCapacityUnits":            true,
 	}
 
 	if !dimensions[value] {
@@ -1039,11 +1044,59 @@ func validateAppautoscalingServiceNamespace(v interface{}, k string) (ws []strin
 	namespaces := map[string]bool{
 		"ecs":              true,
 		"ec2":              true,
+		"appstream":        true,
+		"dynamodb":         true,
 		"elasticmapreduce": true,
 	}
 
 	if !namespaces[value] {
 		errors = append(errors, fmt.Errorf("%q must be a valid service namespace value: %q", k, value))
+	}
+	return
+}
+
+func validateAppautoscalingCustomizedMetricSpecificationStatistic(v interface{}, k string) (ws []string, errors []error) {
+	validStatistic := []string{
+		"Average",
+		"Minimum",
+		"Maximum",
+		"SampleCount",
+		"Sum",
+	}
+	statistic := v.(string)
+	for _, o := range validStatistic {
+		if statistic == o {
+			return
+		}
+	}
+	errors = append(errors, fmt.Errorf(
+		"%q contains an invalid statistic %q. Valid statistic are %q.",
+		k, statistic, validStatistic))
+	return
+}
+
+func validateAppautoscalingPredefinedMetricSpecification(v interface{}, k string) (ws []string, errors []error) {
+	validMetrics := []string{
+		"DynamoDBReadCapacityUtilization",
+		"DynamoDBWriteCapacityUtilization",
+	}
+	metric := v.(string)
+	for _, o := range validMetrics {
+		if metric == o {
+			return
+		}
+	}
+	errors = append(errors, fmt.Errorf(
+		"%q contains an invalid metric %q. Valid metric are %q.",
+		k, metric, validMetrics))
+	return
+}
+
+func validateAppautoscalingPredefinedResourceLabel(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if len(value) > 1023 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be greater than 1023 characters", k))
 	}
 	return
 }

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1026,7 +1026,6 @@ func validateAppautoscalingScalableDimension(v interface{}, k string) (ws []stri
 		"ecs:service:DesiredCount":                     true,
 		"ec2:spot-fleet-request:TargetCapacity":        true,
 		"elasticmapreduce:instancegroup:InstanceCount": true,
-		"appstream:fleet:DesiredCapacity":              true,
 		"dynamodb:table:ReadCapacityUnits":             true,
 		"dynamodb:table:WriteCapacityUnits":            true,
 		"dynamodb:index:ReadCapacityUnits":             true,
@@ -1044,7 +1043,6 @@ func validateAppautoscalingServiceNamespace(v interface{}, k string) (ws []strin
 	namespaces := map[string]bool{
 		"ecs":              true,
 		"ec2":              true,
-		"appstream":        true,
 		"dynamodb":         true,
 		"elasticmapreduce": true,
 	}

--- a/website/docs/r/appautoscaling_policy.html.markdown
+++ b/website/docs/r/appautoscaling_policy.html.markdown
@@ -47,9 +47,11 @@ The following arguments are supported:
 * `name` - (Required) The name of the policy.
 * `policy_type` - (Optional) Defaults to "StepScaling" because it is the only option available.
 * `resource_id` - (Required) The resource type and unique identifier string for the resource associated with the scaling policy. For Amazon ECS services, this value is the resource type, followed by the cluster name and service name, such as `service/default/sample-webapp`. For Amazon EC2 Spot fleet requests, the resource type is `spot-fleet-request`, and the identifier is the Spot fleet request ID; for example, `spot-fleet-request/sfr-73fbd2ce-aa30-494c-8788-1cee4EXAMPLE`.
+For DynamoDB tables, this value is `table/nameOfTheTable`.
 * `scalable_dimension` - (Required) The scalable dimension of the scalable target. The scalable dimension contains the service namespace,   resource  type, and scaling property, such as `ecs:service:DesiredCount` for the desired task count of an Amazon ECS service, or `ec2:spot-fleet-request:TargetCapacity` for the target capacity of an Amazon EC2 Spot fleet request.
-* `service_namespace` - (Required) The AWS service namespace of the scalable target. Valid values are `ecs` for Amazon ECS services and `ec2` Amazon EC2 Spot fleet requests.
+* `service_namespace` - (Required) The AWS service namespace of the scalable target. Valid values are `ecs` for Amazon ECS services, `ec2` for Amazon EC2 Spot fleet requests and `dynamodb` for DynamoDB tables.
 * `step_scaling_policy_configuration` - (Optional) Step scaling policy configuration, requires `policy_type = "StepScaling"` (default). See supported fields below.
+* `target_tracking_scaling_policy_configuration` - (Optional) A target tracking policy, requires `policy_type = "TargetTrackingScaling"`. See supported fields below.
 
 ## Nested fields
 
@@ -77,6 +79,28 @@ The following arguments are supported:
   * `metric_interval_lower_bound` - (Optional) The lower bound for the difference between the alarm threshold and the CloudWatch metric. Without a value, AWS will treat this bound as infinity.
   * `metric_interval_upper_bound` - (Optional) The upper bound for the difference between the alarm threshold and the CloudWatch metric. Without a value, AWS will treat this bound as infinity. The upper bound must be greater than the lower bound.
   * `scaling_adjustment` - (Required) The number of members by which to scale, when the adjustment bounds are breached. A positive value scales up. A negative value scales down.
+
+### `target_tracking_scaling_policy_configuration`
+
+* `target_value` - (Optional) The target value for the metric.
+* `disable_scale_in` - (Optional) Indicates whether scale in by the target tracking policy is disabled. If the value is true, scale in is disabled and the target tracking policy won't remove capacity from the scalable resource. Otherwise, scale in is enabled and the target tracking policy can remove capacity from the scalable resource. The default value is `false`.
+* `scale_in_cooldown` - (Optional) The amount of time, in seconds, after a scale in activity completes before another scale in activity can start.
+* `scale_out_cooldown` - (Optional) The amount of time, in seconds, after a scale out activity completes before another scale out activity can start.
+* `customized_metric_specification` - (Optional) Reserved for future use. See supported fields below.
+* `predefined_metric_specification` - (Optional) A predefined metric. See supported fields below.
+
+### `customized_metric_specification`
+
+* `dimensions` - (Optional) The dimensions of the metric.
+* `metric_name` - (Optional) The name of the metric.
+* `namespace` - (Optional) The namespace of the metric.
+* `statistic` - (Optional) The statistic of the metric.
+* `unit` - (Optional) The unit of the metric.
+
+### `predefined_metric_specification`
+
+* `predefined_metric_type` - (Required) The metric type.
+* `resource_label` - (Optional) Reserved for future use.
 
 ## Attribute Reference
 * `adjustment_type` - The scaling policy's adjustment type.

--- a/website/docs/r/dynamodb_table.html.markdown
+++ b/website/docs/r/dynamodb_table.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides a DynamoDB table resource
 
+~> **Note:** It is recommended to use `lifecycle` [`ignore_changes`](/docs/configuration/resources.html#ignore_changes) for `read_capacity` and/or `write_capacity` if there's [autoscaling policy](/docs/providers/aws/r/appautoscaling_policy.html) attached to the table.
+
 ## Example Usage
 
 The following dynamodb table description models the table and GSI shown


### PR DESCRIPTION
Closes #866
Closes #888
Closes #919
Closes #920 

I don't like squashing too many bugfixes & features into one PR, but fixing #920 was the only way to make acceptance tests pass in my case. 🤷‍♂️ 

### Test results

```
TF_ACC=1 go test ./aws -v -run=TestAccAWSAppautoScalingPolicy_ -timeout 120m
=== RUN   TestAccAWSAppautoScalingPolicy_basic
--- PASS: TestAccAWSAppautoScalingPolicy_basic (122.74s)
=== RUN   TestAccAWSAppautoScalingPolicy_nestedSchema
--- PASS: TestAccAWSAppautoScalingPolicy_nestedSchema (126.13s)
=== RUN   TestAccAWSAppautoScalingPolicy_spotFleetRequest
--- PASS: TestAccAWSAppautoScalingPolicy_spotFleetRequest (92.60s)
=== RUN   TestAccAWSAppautoScalingPolicy_dynamoDb
--- PASS: TestAccAWSAppautoScalingPolicy_dynamoDb (62.78s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	404.289s
```

----

In regards to `customized_metric_specification` - I wasn't able to find any example to test this part of the API/schema at all. It seems to be open only to an undefined small group of AWS customers.
