### PR TITLE
website: use a more accessible example for s3 object data source

### DIFF
--- a/website/docs/d/s3_bucket_object.html.markdown
+++ b/website/docs/d/s3_bucket_object.html.markdown
@@ -15,30 +15,32 @@ _optionally_ (see below) content of an object stored inside S3 bucket.
 
 ## Example Usage
 
+The following example retrieves a text object (which must have a `Content-Type`
+value starting with `text/`) and uses it as the `user_data` for an EC2 instance:
+
+```hcl
+data "aws_s3_bucket_object" "bootstrap_script" {
+  bucket = "ourcorp-deploy-config"
+  key    = "ec2-bootstrap-script.sh"
+}
+
+resource "aws_instance" "example" {
+  instance_type = "t2.micro"
+  ami           = "ami-2757f631"
+  user_data     = "${aws_s3_bucket_object.bootstrap_script.body}"
+}
+```
+
+The following, more-complex example retrieves only the metadata for a zip
+file stored in S3, which is then used to pass the most recent `version_id`
+to AWS Lambda for use as a function implementation. More information about
+Lambda functions is available in the documentation for
+[`aws_lambda_function`](/docs/providers/aws/r/lambda_function.html).
+
 ```hcl
 data "aws_s3_bucket_object" "lambda" {
-  bucket = "my-lambda-functions"
+  bucket = "ourcorp-lambda-functions"
   key    = "hello-world.zip"
-}
-
-resource "aws_iam_role" "iam_for_lambda" {
-  name = "iam_for_lambda"
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "lambda.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
 }
 
 resource "aws_lambda_function" "test_lambda" {
@@ -46,7 +48,7 @@ resource "aws_lambda_function" "test_lambda" {
   s3_key            = "${data.aws_s3_bucket_object.lambda.key}"
   s3_object_version = "${data.aws_s3_bucket_object.lambda.version_id}"
   function_name     = "lambda_function_name"
-  role              = "${aws_iam_role.iam_for_lambda.arn}"
+  role              = "${aws_iam_role.iam_for_lambda.arn}" # (not shown)
   handler           = "exports.test"
 }
 ```


### PR DESCRIPTION
Previously our first and only example for the `aws_s3_bucket_object` data source was in terms of an AWS Lambda function. That's not an ideal first example because not all users are familiar enough with Lambda to know how to adapt the example to other use-cases.

Here we add another example that uses `aws_instance`, which results in a simpler config and assumes that hopefully more people are familiar enough with EC2 to understand how to map this approach to other problems.

This also now omits the definition of the IAM role for the lambda function in the prior example. Although it's unfortunate that this leaves the example as an incomplete config, the visual size of the config for that resource seemed to distract from the main point of this example. Instead, we link to the `aws_lambda_function` docs for more context on this usage, so that this example can focus primarily on the `aws_s3_bucket_object` part.
