### PR TITLE
r/eip: Avoid disassociating if there's no association

### DIFF
--- a/aws/resource_aws_eip.go
+++ b/aws/resource_aws_eip.go
@@ -340,8 +340,14 @@ func disassociateEip(d *schema.ResourceData, meta interface{}) error {
 	var err error
 	switch resourceAwsEipDomain(d) {
 	case "vpc":
+		associationID := d.Get("association_id").(string)
+		if associationID == "" {
+			// If assiciationID is empty, it means there's no association.
+			// Hence this disassociation can be skipped.
+			return nil
+		}
 		_, err = ec2conn.DisassociateAddress(&ec2.DisassociateAddressInput{
-			AssociationId: aws.String(d.Get("association_id").(string)),
+			AssociationId: aws.String(associationID),
 		})
 	case "standard":
 		_, err = ec2conn.DisassociateAddress(&ec2.DisassociateAddressInput{


### PR DESCRIPTION
After disassociation (due to instance termination or manual disassociation),
"association_id" becomes empty. Sending empty associationId in request
results in bad request. Skipping disassociation because we know that there's
no association.

fixes #1616 