### PR TITLE
Add support for S3 as an AWS DMS Endpoint (target).

### DIFF
--- a/website/docs/r/dms_endpoint.html.markdown
+++ b/website/docs/r/dms_endpoint.html.markdown
@@ -53,7 +53,7 @@ The following arguments are supported:
     - Must not contain two consecutive hyphens
 
 * `endpoint_type` - (Required) The type of endpoint. Can be one of `source | target`.
-* `engine_name` - (Required) The type of engine for the endpoint. Can be one of `mysql | oracle | postgres | mariadb | aurora | redshift | sybase | sqlserver | dynamodb`.
+* `engine_name` - (Required) The type of engine for the endpoint. Can be one of `mysql | oracle | postgres | mariadb | aurora | redshift | sybase | sqlserver | dynamodb | s3`.
 * `extra_connection_attributes` - (Optional) Additional attributes associated with the connection. For available attributes see [Using Extra Connection Attributes with AWS Database Migration Service](http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Introduction.ConnectionAttributes.html).
 * `kms_key_arn` - (Optional) The Amazon Resource Name (ARN) for the KMS key that will be used to encrypt the connection parameters. If you do not specify a value for `kms_key_arn`, then AWS DMS will use your default encryption key. AWS KMS creates the default encryption key for your AWS account. Your AWS account has a different default encryption key for each AWS region.
 * `password` - (Optional) The password to be used to login to the endpoint database.
@@ -62,7 +62,9 @@ The following arguments are supported:
 * `ssl_mode` - (Optional, Default: none) The SSL mode to use for the connection. Can be one of `none | require | verify-ca | verify-full`
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 * `username` - (Optional) The user name to be used to login to the endpoint database.
-* `service_access_role` (Optional) The Amazon Resource Name (ARN) used by the service access IAM role for dynamodb endpoints.
+* `service_access_role` (Optional) The Amazon Resource Name (ARN) used by the service access IAM role for `dynamodb | s3` endpoints.
+* `bucket_name` - (Optional) The S3 bucket name.
+* `bucket_folder` - (Optional) If provided, tables are created in the path <bucket_folder>/<schema_name>/<table_name>/.
 
 ## Attributes Reference
 


### PR DESCRIPTION
* Added support for s3 as dms endpoint (with tests).

As AWS added the new feature to use a S3 DMS endpoint as a target endpoint we would be happy to have it also in terraform. We at Takeaway.com are using terraform for provisioning our AWS infrastructure. Currently we are implementing the DMS for replicating the data from production slave database to Redshift and S3 as a separate task, as we want to have a backup of the data.

The feature is already tested in our environment and working in forked project. 
Hope everything done in a proper way including the description.
Thanks in advance.