### PR TITLE
tests: Replace db.t1 (deprecated) w/ db.t2 (VPC) & db.r3 (non-VPC)

### DIFF
--- a/aws/data_source_aws_db_snapshot_test.go
+++ b/aws/data_source_aws_db_snapshot_test.go
@@ -45,7 +45,7 @@ resource "aws_db_instance" "bar" {
 	allocated_storage = 10
 	engine = "MySQL"
 	engine_version = "5.6.35"
-	instance_class = "db.t1.micro"
+	instance_class = "db.t2.micro"
 	name = "baz"
 	password = "barbarbarbar"
 	username = "foo"

--- a/aws/resource_aws_db_snapshot_test.go
+++ b/aws/resource_aws_db_snapshot_test.go
@@ -62,7 +62,7 @@ resource "aws_db_instance" "bar" {
 	allocated_storage = 10
 	engine = "MySQL"
 	engine_version = "5.6.35"
-	instance_class = "db.t1.micro"
+	instance_class = "db.t2.micro"
 	name = "baz"
 	password = "barbarbarbar"
 	username = "foo"

--- a/aws/resource_aws_opsworks_rds_db_instance_test.go
+++ b/aws/resource_aws_opsworks_rds_db_instance_test.go
@@ -178,7 +178,7 @@ resource "aws_db_instance" "foo" {
   allocated_storage    = 10
   engine               = "MySQL"
   engine_version       = "5.6.35"
-  instance_class       = "db.t1.micro"
+  instance_class       = "db.t2.micro"
   name                 = "baz"
   password             = "foofoofoofoo"
   username             = "foo"


### PR DESCRIPTION
This is to address the following test failures:

```
=== RUN   TestAccAWSDBInstanceNoSnapshot
--- FAIL: TestAccAWSDBInstanceNoSnapshot (5.22s)
    testing.go:434: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_db_instance.snapshot: 1 error(s) occurred:
        
        * aws_db_instance.snapshot: Error creating DB Instance: InvalidParameterCombination: RDS does not support creating a DB instance with the following combination: DBInstanceClass=db.t1.micro, Engine=mysql, EngineVersion=5.6.35, LicenseModel=general-public-license. For supported combinations of instance class and database engine version, see the documentation.
            status code: 400, request id: 07000e9b-9910-11e7-9713-a5c2f229a9dc
FAIL
```

I had to pick smallest available `r3` for the non-VPC tests as nothing smaller is supported there anymore

```
=== RUN   TestAccAWSDBInstanceNoSnapshot
--- FAIL: TestAccAWSDBInstanceNoSnapshot (8.13s)
    testing.go:434: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_db_instance.snapshot: 1 error(s) occurred:
        
        * aws_db_instance.snapshot: Error creating DB Instance: InsufficientDBInstanceCapacity: Cannot create a db.t2.micro database instance because there are no availability zones with sufficient capacity for non-VPC and storage type : standard for db.t2.micro. Please try the request again at a later time.
            status code: 400, request id: ec3346b4-99f5-11e7-bab1-373347f6da3d
FAIL
```

## Test results

```
=== RUN   TestAccAWSDBInstance_MinorVersion
--- PASS: TestAccAWSDBInstance_MinorVersion (406.33s)
=== RUN   TestAccAWSDBInstance_iamAuth
--- PASS: TestAccAWSDBInstance_iamAuth (406.36s)
=== RUN   TestAccAWSDBInstance_namePrefix
--- PASS: TestAccAWSDBInstance_namePrefix (406.59s)
=== RUN   TestAccAWSDBInstance_basic
--- PASS: TestAccAWSDBInstance_basic (406.69s)
=== RUN   TestAccAWSDBInstance_importBasic
--- PASS: TestAccAWSDBInstance_importBasic (407.81s)
=== RUN   TestAccAWSDBInstance_generatedName
--- PASS: TestAccAWSDBInstance_generatedName (438.18s)
=== RUN   TestAccAWSDBInstance_diffSuppressInitialState
--- PASS: TestAccAWSDBInstance_diffSuppressInitialState (458.08s)
=== RUN   TestAccAWSDBInstance_kmsKey
--- PASS: TestAccAWSDBInstance_kmsKey (486.91s)
=== RUN   TestAccAWSDBInstance_portUpdate
--- PASS: TestAccAWSDBInstance_portUpdate (573.64s)
=== RUN   TestAccAWSDBInstance_optionGroup
--- PASS: TestAccAWSDBInstance_optionGroup (630.01s)
=== RUN   TestAccAWSDBInstanceSnapshot
--- PASS: TestAccAWSDBInstanceSnapshot (720.44s)
=== RUN   TestAccAWSDBInstanceNoSnapshot
--- PASS: TestAccAWSDBInstanceNoSnapshot (739.98s)
=== RUN   TestAccAWSDBInstance_enhancedMonitoring
--- FAIL: TestAccAWSDBInstance_enhancedMonitoring (810.50s)
	testing.go:434: Step 0 error: After applying this step, the plan was not empty:
		
		DIFF:
		
		UPDATE: aws_iam_policy_attachment.test-attach
		  roles.#:          "2" => "1"
		  roles.1875389679: "enhanced-monitoring-role-743ab" => "enhanced-monitoring-role-743ab"
		  roles.578215501:  "enhanced-monitoring-role-kve84" => ""
		
...
FAIL
=== RUN   TestAccAWSDBInstance_subnetGroup
--- PASS: TestAccAWSDBInstance_subnetGroup (983.55s)
=== RUN   TestAccAWSDBInstanceReplica
--- PASS: TestAccAWSDBInstanceReplica (1339.67s)
=== RUN   TestAccAWSDBInstance_MSSQL_TZ
--- PASS: TestAccAWSDBInstance_MSSQL_TZ (1996.03s)
```
The single failure is unrelated to this PR and most likely intermittent.