### PR TITLE
[WIP][NeedHelp] Bugfix for scaling elasticache cluster with memcached

### DIFF
--- a/aws/resource_aws_elasticache_cluster.go
+++ b/aws/resource_aws_elasticache_cluster.go
@@ -523,8 +523,8 @@ func resourceAwsElasticacheClusterUpdate(d *schema.ResourceData, meta interface{
 
 	if requestRecreate {
 		log.Printf("[DEBUG] Recreating ElastiCache Cluster (%s), opts:\n%s", d.Id(), req)
-		resourceAwsElasticacheClusterDelete(d,meta)
-		resourceAwsElasticacheClusterCreate(d,meta)
+		resourceAwsElasticacheClusterDelete(d, meta)
+		resourceAwsElasticacheClusterCreate(d, meta)
 	}
 
 	return resourceAwsElasticacheClusterRead(d, meta)

--- a/aws/resource_aws_elasticache_cluster.go
+++ b/aws/resource_aws_elasticache_cluster.go
@@ -426,6 +426,7 @@ func resourceAwsElasticacheClusterUpdate(d *schema.ResourceData, meta interface{
 	}
 
 	requestUpdate := false
+	requestRecreate := false
 	if d.HasChange("security_group_ids") {
 		if attr := d.Get("security_group_ids").(*schema.Set); attr.Len() > 0 {
 			req.SecurityGroupIds = expandStringList(attr.List())
@@ -464,8 +465,13 @@ func resourceAwsElasticacheClusterUpdate(d *schema.ResourceData, meta interface{
 	}
 
 	if d.HasChange("node_type") {
-		req.CacheNodeType = aws.String(d.Get("node_type").(string))
-		requestUpdate = true
+		if d.Get("engine").(string) == "memcached" {
+			req.CacheNodeType = aws.String(d.Get("node_type").(string))
+			requestRecreate = true
+		} else {
+			req.CacheNodeType = aws.String(d.Get("node_type").(string))
+			requestUpdate = true
+		}
 	}
 
 	if d.HasChange("snapshot_retention_limit") {
@@ -513,6 +519,12 @@ func resourceAwsElasticacheClusterUpdate(d *schema.ResourceData, meta interface{
 		if sterr != nil {
 			return fmt.Errorf("Error waiting for elasticache (%s) to update: %s", d.Id(), sterr)
 		}
+	}
+
+	if requestRecreate {
+		log.Printf("[DEBUG] Recreating ElastiCache Cluster (%s), opts:\n%s", d.Id(), req)
+		resourceAwsElasticacheClusterDelete(d,meta)
+		resourceAwsElasticacheClusterCreate(d,meta)
 	}
 
 	return resourceAwsElasticacheClusterRead(d, meta)


### PR DESCRIPTION
This PR aims to fix #272. When an elasticache cluster is scaled up or down terraform apply fails when the engine is memcached. This can be avoided by destroying the cluster and recreating it with the new node size.

I'm new to terraform and golang, I have one other PR but it has not been approved yet.

I did not change the docs as I believe this should work as intended and the docs don't mention scaling doesn't work with memcached.

I didn't write a unit test but should.