### PR TITLE
Updated the Data Source Tags structure

### DIFF
--- a/aws/data_source_aws_ami.go
+++ b/aws/data_source_aws_ami.go
@@ -165,7 +165,7 @@ func dataSourceAwsAmi() *schema.Resource {
 				Type:     schema.TypeMap,
 				Computed: true,
 			},
-			"tags": dataSourceTagsSchema(),
+			"tags": tagsSchemaComputed(),
 		},
 	}
 }
@@ -299,7 +299,7 @@ func amiDescriptionAttributes(d *schema.ResourceData, image *ec2.Image) error {
 	if err := d.Set("state_reason", amiStateReason(image.StateReason)); err != nil {
 		return err
 	}
-	if err := d.Set("tags", dataSourceTags(image.Tags)); err != nil {
+	if err := d.Set("tags", tagsToMap(image.Tags)); err != nil {
 		return err
 	}
 	return nil

--- a/aws/data_source_aws_ami_ids.go
+++ b/aws/data_source_aws_ami_ids.go
@@ -34,7 +34,6 @@ func dataSourceAwsAmiIds() *schema.Resource {
 				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"tags": dataSourceTagsSchema(),
 			"ids": &schema.Schema{
 				Type:     schema.TypeList,
 				Computed: true,

--- a/aws/data_source_aws_ami_test.go
+++ b/aws/data_source_aws_ami_test.go
@@ -45,7 +45,7 @@ func TestAccAWSAmiDataSource_natInstance(t *testing.T) {
 					resource.TestCheckResourceAttr("data.aws_ami.nat_ami", "state", "available"),
 					resource.TestCheckResourceAttr("data.aws_ami.nat_ami", "state_reason.code", "UNSET"),
 					resource.TestCheckResourceAttr("data.aws_ami.nat_ami", "state_reason.message", "UNSET"),
-					resource.TestCheckResourceAttr("data.aws_ami.nat_ami", "tags.#", "0"),
+					resource.TestCheckResourceAttr("data.aws_ami.nat_ami", "tags.%", "0"),
 					resource.TestCheckResourceAttr("data.aws_ami.nat_ami", "virtualization_type", "hvm"),
 				),
 			},
@@ -82,7 +82,7 @@ func TestAccAWSAmiDataSource_windowsInstance(t *testing.T) {
 					resource.TestCheckResourceAttr("data.aws_ami.windows_ami", "state", "available"),
 					resource.TestCheckResourceAttr("data.aws_ami.windows_ami", "state_reason.code", "UNSET"),
 					resource.TestCheckResourceAttr("data.aws_ami.windows_ami", "state_reason.message", "UNSET"),
-					resource.TestCheckResourceAttr("data.aws_ami.windows_ami", "tags.#", "0"),
+					resource.TestCheckResourceAttr("data.aws_ami.windows_ami", "tags.%", "0"),
 					resource.TestCheckResourceAttr("data.aws_ami.windows_ami", "virtualization_type", "hvm"),
 				),
 			},
@@ -116,7 +116,7 @@ func TestAccAWSAmiDataSource_instanceStore(t *testing.T) {
 					resource.TestCheckResourceAttr("data.aws_ami.instance_store_ami", "state", "available"),
 					resource.TestCheckResourceAttr("data.aws_ami.instance_store_ami", "state_reason.code", "UNSET"),
 					resource.TestCheckResourceAttr("data.aws_ami.instance_store_ami", "state_reason.message", "UNSET"),
-					resource.TestCheckResourceAttr("data.aws_ami.instance_store_ami", "tags.#", "0"),
+					resource.TestCheckResourceAttr("data.aws_ami.instance_store_ami", "tags.%", "0"),
 					resource.TestCheckResourceAttr("data.aws_ami.instance_store_ami", "virtualization_type", "hvm"),
 				),
 			},
@@ -247,104 +247,104 @@ func testAccCheckAwsAmiDataSourceID(n string) resource.TestCheckFunc {
 // Amazon Linux AMIs.
 const testAccCheckAwsAmiDataSourceConfig = `
 data "aws_ami" "nat_ami" {
-	most_recent = true
-	filter {
-		name = "owner-alias"
-		values = ["amazon"]
-	}
-	filter {
-		name = "name"
-		values = ["amzn-ami-vpc-nat*"]
-	}
-	filter {
-		name = "virtualization-type"
-		values = ["hvm"]
-	}
-	filter {
-		name = "root-device-type"
-		values = ["ebs"]
-	}
-	filter {
-		name = "block-device-mapping.volume-type"
-		values = ["standard"]
-	}
+  most_recent = true
+  filter {
+    name = "owner-alias"
+    values = ["amazon"]
+  }
+  filter {
+    name = "name"
+    values = ["amzn-ami-vpc-nat*"]
+  }
+  filter {
+    name = "virtualization-type"
+    values = ["hvm"]
+  }
+  filter {
+    name = "root-device-type"
+    values = ["ebs"]
+  }
+  filter {
+    name = "block-device-mapping.volume-type"
+    values = ["standard"]
+  }
 }
 `
 
 // Windows image test.
 const testAccCheckAwsAmiDataSourceWindowsConfig = `
 data "aws_ami" "windows_ami" {
-	most_recent = true
-	filter {
-		name = "owner-alias"
-		values = ["amazon"]
-	}
-	filter {
-		name = "name"
-		values = ["Windows_Server-2012-R2*"]
-	}
-	filter {
-		name = "virtualization-type"
-		values = ["hvm"]
-	}
-	filter {
-		name = "root-device-type"
-		values = ["ebs"]
-	}
-	filter {
-		name = "block-device-mapping.volume-type"
-		values = ["gp2"]
-	}
+  most_recent = true
+  filter {
+    name = "owner-alias"
+    values = ["amazon"]
+  }
+  filter {
+    name = "name"
+    values = ["Windows_Server-2012-R2*"]
+  }
+  filter {
+    name = "virtualization-type"
+    values = ["hvm"]
+  }
+  filter {
+    name = "root-device-type"
+    values = ["ebs"]
+  }
+  filter {
+    name = "block-device-mapping.volume-type"
+    values = ["gp2"]
+  }
 }
 `
 
 // Instance store test - using Ubuntu images
 const testAccCheckAwsAmiDataSourceInstanceStoreConfig = `
 data "aws_ami" "instance_store_ami" {
-	most_recent = true
-	filter {
-		name = "owner-id"
-		values = ["099720109477"]
-	}
-	filter {
-		name = "name"
-		values = ["ubuntu/images/hvm-instance/ubuntu-trusty-14.04-amd64-server*"]
-	}
-	filter {
-		name = "virtualization-type"
-		values = ["hvm"]
-	}
-	filter {
-		name = "root-device-type"
-		values = ["instance-store"]
-	}
+  most_recent = true
+  filter {
+    name = "owner-id"
+    values = ["099720109477"]
+  }
+  filter {
+    name = "name"
+    values = ["ubuntu/images/hvm-instance/ubuntu-trusty-14.04-amd64-server*"]
+  }
+  filter {
+    name = "virtualization-type"
+    values = ["hvm"]
+  }
+  filter {
+    name = "root-device-type"
+    values = ["instance-store"]
+  }
 }
 `
 
 // Testing owner parameter
 const testAccCheckAwsAmiDataSourceOwnersConfig = `
 data "aws_ami" "amazon_ami" {
-	most_recent = true
-	owners = ["amazon"]
+  most_recent = true
+  owners = ["amazon"]
 }
 `
 
 const testAccCheckAwsAmiDataSourceEmptyOwnersConfig = `
 data "aws_ami" "amazon_ami" {
-	most_recent = true
-	owners = [""]
+  most_recent = true
+  owners = [""]
 }
 `
 
 // Testing name_regex parameter
 const testAccCheckAwsAmiDataSourceNameRegexConfig = `
 data "aws_ami" "name_regex_filtered_ami" {
-	most_recent = true
-	owners = ["amazon"]
-	filter {
-		name = "name"
-		values = ["amzn-ami-*"]
-	}
-	name_regex = "^amzn-ami-\\d{3}[5].*-ecs-optimized"
+  most_recent = true
+  owners = ["amazon"]
+  filter {
+    name = "name"
+    values = ["amzn-ami-*"]
+  }
+  name_regex = "^amzn-ami-\\d{3}[5].*-ecs-optimized"
 }
 `

--- a/aws/data_source_aws_common_schema.go
+++ b/aws/data_source_aws_common_schema.go
@@ -1,36 +1,10 @@
 package aws
 
 import (
-	"bytes"
-	"fmt"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
 )
-
-func dataSourceTagsHash(v interface{}) int {
-	var buf bytes.Buffer
-	m := v.(map[string]interface{})
-	buf.WriteString(fmt.Sprintf("%s-", m["key"].(string)))
-	buf.WriteString(fmt.Sprintf("%s-", m["value"].(string)))
-	return hashcode.String(buf.String())
-}
-
-func dataSourceTags(m []*ec2.Tag) *schema.Set {
-	s := &schema.Set{
-		F: dataSourceTagsHash,
-	}
-	for _, v := range m {
-		tag := map[string]interface{}{
-			"key":   *v.Key,
-			"value": *v.Value,
-		}
-		s.Add(tag)
-	}
-	return s
-}
 
 func buildAwsDataSourceFilters(set *schema.Set) []*ec2.Filter {
 	var filters []*ec2.Filter
@@ -64,26 +38,6 @@ func dataSourceFiltersSchema() *schema.Schema {
 					Type:     schema.TypeList,
 					Required: true,
 					Elem:     &schema.Schema{Type: schema.TypeString},
-				},
-			},
-		},
-	}
-}
-
-func dataSourceTagsSchema() *schema.Schema {
-	return &schema.Schema{
-		Type:     schema.TypeSet,
-		Computed: true,
-		Set:      dataSourceTagsHash,
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"key": {
-					Type:     schema.TypeString,
-					Computed: true,
-				},
-				"value": {
-					Type:     schema.TypeString,
-					Computed: true,
 				},
 			},
 		},

--- a/aws/data_source_aws_ebs_snapshot.go
+++ b/aws/data_source_aws_ebs_snapshot.go
@@ -80,7 +80,7 @@ func dataSourceAwsEbsSnapshot() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags": dataSourceTagsSchema(),
+			"tags": tagsSchemaComputed(),
 		},
 	}
 }
@@ -154,7 +154,7 @@ func snapshotDescriptionAttributes(d *schema.ResourceData, snapshot *ec2.Snapsho
 	d.Set("owner_id", snapshot.OwnerId)
 	d.Set("owner_alias", snapshot.OwnerAlias)
 
-	if err := d.Set("tags", dataSourceTags(snapshot.Tags)); err != nil {
+	if err := d.Set("tags", tagsToMap(snapshot.Tags)); err != nil {
 		return err
 	}
 

--- a/aws/data_source_aws_ebs_snapshot_ids.go
+++ b/aws/data_source_aws_ebs_snapshot_ids.go
@@ -26,7 +26,6 @@ func dataSourceAwsEbsSnapshotIds() *schema.Resource {
 				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"tags": dataSourceTagsSchema(),
 			"ids": &schema.Schema{
 				Type:     schema.TypeList,
 				Computed: true,

--- a/aws/data_source_aws_ebs_snapshot_test.go
+++ b/aws/data_source_aws_ebs_snapshot_test.go
@@ -18,6 +18,7 @@ func TestAccAWSEbsSnapshotDataSource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsEbsSnapshotDataSourceID("data.aws_ebs_snapshot.snapshot"),
 					resource.TestCheckResourceAttr("data.aws_ebs_snapshot.snapshot", "volume_size", "40"),
+					resource.TestCheckResourceAttr("data.aws_ebs_snapshot.snapshot", "tags.%", "0"),
 				),
 			},
 		},
@@ -34,6 +35,8 @@ func TestAccAWSEbsSnapshotDataSource_multipleFilters(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsEbsSnapshotDataSourceID("data.aws_ebs_snapshot.snapshot"),
 					resource.TestCheckResourceAttr("data.aws_ebs_snapshot.snapshot", "volume_size", "10"),
+					resource.TestCheckResourceAttr("data.aws_ebs_snapshot.snapshot", "tags.%", "1"),
+					resource.TestCheckResourceAttr("data.aws_ebs_snapshot.snapshot", "tags.Name", "TF ACC Snapshot"),
 				),
 			},
 		},
@@ -56,44 +59,47 @@ func testAccCheckAwsEbsSnapshotDataSourceID(n string) resource.TestCheckFunc {
 
 const testAccCheckAwsEbsSnapshotDataSourceConfig = `
 resource "aws_ebs_volume" "example" {
-    availability_zone = "us-west-2a"
-    type = "gp2"
-    size = 40
-    tags {
-        Name = "External Volume"
-    }
+  availability_zone = "us-west-2a"
+  type = "gp2"
+  size = 40
+  tags {
+    Name = "External Volume"
+  }
 }
 
 resource "aws_ebs_snapshot" "snapshot" {
-    volume_id = "${aws_ebs_volume.example.id}"
+  volume_id = "${aws_ebs_volume.example.id}"
 }
 
 data "aws_ebs_snapshot" "snapshot" {
-    most_recent = true
-    snapshot_ids = ["${aws_ebs_snapshot.snapshot.id}"]
+  most_recent = true
+  snapshot_ids = ["${aws_ebs_snapshot.snapshot.id}"]
 }
 `
 
 const testAccCheckAwsEbsSnapshotDataSourceConfigWithMultipleFilters = `
 resource "aws_ebs_volume" "external1" {
-    availability_zone = "us-west-2a"
-    type = "gp2"
-    size = 10
-    tags {
-        Name = "External Volume 1"
-    }
+  availability_zone = "us-west-2a"
+  type = "gp2"
+  size = 10
+  tags {
+    Name = "External Volume 1"
+  }
 }
 
 resource "aws_ebs_snapshot" "snapshot" {
-    volume_id = "${aws_ebs_volume.external1.id}"
+  volume_id = "${aws_ebs_volume.external1.id}"
+  tags {
+    Name = "TF ACC Snapshot"
+  }
 }
 
 data "aws_ebs_snapshot" "snapshot" {
-    most_recent = true
-    snapshot_ids = ["${aws_ebs_snapshot.snapshot.id}"]
-    filter {
-	name = "volume-size"
-	values = ["10"]
-    }
+  most_recent = true
+  snapshot_ids = ["${aws_ebs_snapshot.snapshot.id}"]
+  filter {
+    name = "volume-size"
+    values = ["10"]
+  }
 }
 `

--- a/aws/data_source_aws_ebs_volume.go
+++ b/aws/data_source_aws_ebs_volume.go
@@ -54,7 +54,7 @@ func dataSourceAwsEbsVolume() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags": dataSourceTagsSchema(),
+			"tags": tagsSchemaComputed(),
 		},
 	}
 }
@@ -128,7 +128,7 @@ func volumeDescriptionAttributes(d *schema.ResourceData, volume *ec2.Volume) err
 	d.Set("snapshot_id", volume.SnapshotId)
 	d.Set("volume_type", volume.VolumeType)
 
-	if err := d.Set("tags", dataSourceTags(volume.Tags)); err != nil {
+	if err := d.Set("tags", tagsToMap(volume.Tags)); err != nil {
 		return err
 	}
 

--- a/aws/data_source_aws_ebs_volume_test.go
+++ b/aws/data_source_aws_ebs_volume_test.go
@@ -18,6 +18,8 @@ func TestAccAWSEbsVolumeDataSource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsEbsVolumeDataSourceID("data.aws_ebs_volume.ebs_volume"),
 					resource.TestCheckResourceAttr("data.aws_ebs_volume.ebs_volume", "size", "40"),
+					resource.TestCheckResourceAttr("data.aws_ebs_volume.ebs_volume", "tags.%", "1"),
+					resource.TestCheckResourceAttr("data.aws_ebs_volume.ebs_volume", "tags.Name", "External Volume"),
 				),
 			},
 		},
@@ -35,6 +37,8 @@ func TestAccAWSEbsVolumeDataSource_multipleFilters(t *testing.T) {
 					testAccCheckAwsEbsVolumeDataSourceID("data.aws_ebs_volume.ebs_volume"),
 					resource.TestCheckResourceAttr("data.aws_ebs_volume.ebs_volume", "size", "10"),
 					resource.TestCheckResourceAttr("data.aws_ebs_volume.ebs_volume", "volume_type", "gp2"),
+					resource.TestCheckResourceAttr("data.aws_ebs_volume.ebs_volume", "tags.%", "1"),
+					resource.TestCheckResourceAttr("data.aws_ebs_volume.ebs_volume", "tags.Name", "External Volume 1"),
 				),
 			},
 		},
@@ -57,50 +61,50 @@ func testAccCheckAwsEbsVolumeDataSourceID(n string) resource.TestCheckFunc {
 
 const testAccCheckAwsEbsVolumeDataSourceConfig = `
 resource "aws_ebs_volume" "example" {
-    availability_zone = "us-west-2a"
-    type = "gp2"
-    size = 40
-    tags {
-        Name = "External Volume"
-    }
+  availability_zone = "us-west-2a"
+  type = "gp2"
+  size = 40
+  tags {
+    Name = "External Volume"
+  }
 }
 
 data "aws_ebs_volume" "ebs_volume" {
-    most_recent = true
-    filter {
-	name = "tag:Name"
-	values = ["External Volume"]
-    }
-    filter {
-	name = "volume-type"
-	values = ["${aws_ebs_volume.example.type}"]
-    }
+  most_recent = true
+  filter {
+    name = "tag:Name"
+    values = ["External Volume"]
+  }
+  filter {
+    name = "volume-type"
+    values = ["${aws_ebs_volume.example.type}"]
+  }
 }
 `
 
 const testAccCheckAwsEbsVolumeDataSourceConfigWithMultipleFilters = `
 resource "aws_ebs_volume" "external1" {
-    availability_zone = "us-west-2a"
-    type = "gp2"
-    size = 10
-    tags {
-        Name = "External Volume 1"
-    }
+  availability_zone = "us-west-2a"
+  type = "gp2"
+  size = 10
+  tags {
+    Name = "External Volume 1"
+  }
 }
 
 data "aws_ebs_volume" "ebs_volume" {
-    most_recent = true
-    filter {
-	name = "tag:Name"
-	values = ["External Volume 1"]
-    }
-    filter {
-	name = "size"
-	values = ["${aws_ebs_volume.external1.size}"]
-    }
-    filter {
-	name = "volume-type"
-	values = ["${aws_ebs_volume.external1.type}"]
-    }
+  most_recent = true
+  filter {
+    name = "tag:Name"
+    values = ["External Volume 1"]
+  }
+  filter {
+    name = "size"
+    values = ["${aws_ebs_volume.external1.size}"]
+  }
+  filter {
+    name = "volume-type"
+    values = ["${aws_ebs_volume.external1.type}"]
+  }
 }
 `

--- a/aws/data_source_aws_instance.go
+++ b/aws/data_source_aws_instance.go
@@ -15,7 +15,7 @@ func dataSourceAwsInstance() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"filter":        dataSourceFiltersSchema(),
-			"tags":          dataSourceTagsSchema(),
+			"tags":          tagsSchemaComputed(),
 			"instance_tags": tagsSchemaComputed(),
 			"instance_id": {
 				Type:     schema.TypeString,
@@ -313,7 +313,7 @@ func instanceDescriptionAttributes(d *schema.ResourceData, instance *ec2.Instanc
 		d.Set("monitoring", monitoringState == "enabled" || monitoringState == "pending")
 	}
 
-	d.Set("tags", dataSourceTags(instance.Tags))
+	d.Set("tags", tagsToMap(instance.Tags))
 
 	// Security Groups
 	if err := readSecurityGroups(d, instance, conn); err != nil {

--- a/aws/data_source_aws_instance_test.go
+++ b/aws/data_source_aws_instance_test.go
@@ -17,12 +17,9 @@ func TestAccAWSInstanceDataSource_basic(t *testing.T) {
 			{
 				Config: testAccInstanceDataSourceConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.web-instance", "ami", "ami-4fccb37f"),
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.web-instance", "tags.#", "1"),
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.web-instance", "instance_type", "m1.small"),
+					resource.TestCheckResourceAttr("data.aws_instance.web-instance", "ami", "ami-4fccb37f"),
+					resource.TestCheckResourceAttr("data.aws_instance.web-instance", "tags.%", "1"),
+					resource.TestCheckResourceAttr("data.aws_instance.web-instance", "instance_type", "m1.small"),
 				),
 			},
 		},
@@ -38,12 +35,9 @@ func TestAccAWSInstanceDataSource_tags(t *testing.T) {
 			{
 				Config: testAccInstanceDataSourceConfig_Tags(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.web-instance", "ami", "ami-4fccb37f"),
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.web-instance", "tags.#", "2"),
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.web-instance", "instance_type", "m1.small"),
+					resource.TestCheckResourceAttr("data.aws_instance.web-instance", "ami", "ami-4fccb37f"),
+					resource.TestCheckResourceAttr("data.aws_instance.web-instance", "tags.%", "2"),
+					resource.TestCheckResourceAttr("data.aws_instance.web-instance", "instance_type", "m1.small"),
 				),
 			},
 		},
@@ -58,16 +52,11 @@ func TestAccAWSInstanceDataSource_AzUserData(t *testing.T) {
 			{
 				Config: testAccInstanceDataSourceConfig_AzUserData,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.foo", "ami", "ami-4fccb37f"),
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.foo", "tags.#", "1"),
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.foo", "instance_type", "m1.small"),
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.foo", "availability_zone", "us-west-2a"),
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.foo", "user_data", "3dc39dda39be1205215e776bad998da361a5955d"),
+					resource.TestCheckResourceAttr("data.aws_instance.foo", "ami", "ami-4fccb37f"),
+					resource.TestCheckResourceAttr("data.aws_instance.foo", "tags.%", "1"),
+					resource.TestCheckResourceAttr("data.aws_instance.foo", "instance_type", "m1.small"),
+					resource.TestCheckResourceAttr("data.aws_instance.foo", "availability_zone", "us-west-2a"),
+					resource.TestCheckResourceAttr("data.aws_instance.foo", "user_data", "3dc39dda39be1205215e776bad998da361a5955d"),
 				),
 			},
 		},
@@ -82,18 +71,12 @@ func TestAccAWSInstanceDataSource_gp2IopsDevice(t *testing.T) {
 			{
 				Config: testAccInstanceDataSourceConfig_gp2IopsDevice,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.foo", "ami", "ami-55a7ea65"),
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.foo", "instance_type", "m3.medium"),
-					resource.TestCheckResourceAttr(
-						"aws_instance.foo", "root_block_device.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_instance.foo", "root_block_device.0.volume_size", "11"),
-					resource.TestCheckResourceAttr(
-						"aws_instance.foo", "root_block_device.0.volume_type", "gp2"),
-					resource.TestCheckResourceAttr(
-						"aws_instance.foo", "root_block_device.0.iops", "100"),
+					resource.TestCheckResourceAttr("data.aws_instance.foo", "ami", "ami-55a7ea65"),
+					resource.TestCheckResourceAttr("data.aws_instance.foo", "instance_type", "m3.medium"),
+					resource.TestCheckResourceAttr("aws_instance.foo", "root_block_device.#", "1"),
+					resource.TestCheckResourceAttr("aws_instance.foo", "root_block_device.0.volume_size", "11"),
+					resource.TestCheckResourceAttr("aws_instance.foo", "root_block_device.0.volume_type", "gp2"),
+					resource.TestCheckResourceAttr("aws_instance.foo", "root_block_device.0.iops", "100"),
 				),
 			},
 		},
@@ -108,20 +91,13 @@ func TestAccAWSInstanceDataSource_blockDevices(t *testing.T) {
 			{
 				Config: testAccInstanceDataSourceConfig_blockDevices,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.foo", "ami", "ami-55a7ea65"),
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.foo", "instance_type", "m3.medium"),
-					resource.TestCheckResourceAttr(
-						"aws_instance.foo", "root_block_device.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_instance.foo", "root_block_device.0.volume_size", "11"),
-					resource.TestCheckResourceAttr(
-						"aws_instance.foo", "root_block_device.0.volume_type", "gp2"),
-					resource.TestCheckResourceAttr(
-						"aws_instance.foo", "ebs_block_device.#", "3"),
-					resource.TestCheckResourceAttr(
-						"aws_instance.foo", "ephemeral_block_device.#", "1"),
+					resource.TestCheckResourceAttr("data.aws_instance.foo", "ami", "ami-55a7ea65"),
+					resource.TestCheckResourceAttr("data.aws_instance.foo", "instance_type", "m3.medium"),
+					resource.TestCheckResourceAttr("aws_instance.foo", "root_block_device.#", "1"),
+					resource.TestCheckResourceAttr("aws_instance.foo", "root_block_device.0.volume_size", "11"),
+					resource.TestCheckResourceAttr("aws_instance.foo", "root_block_device.0.volume_type", "gp2"),
+					resource.TestCheckResourceAttr("aws_instance.foo", "ebs_block_device.#", "3"),
+					resource.TestCheckResourceAttr("aws_instance.foo", "ephemeral_block_device.#", "1"),
 				),
 			},
 		},
@@ -136,16 +112,11 @@ func TestAccAWSInstanceDataSource_rootInstanceStore(t *testing.T) {
 			{
 				Config: testAccInstanceDataSourceConfig_rootInstanceStore,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.foo", "ami", "ami-44c36524"),
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.foo", "instance_type", "m3.medium"),
-					resource.TestCheckResourceAttr(
-						"aws_instance.foo", "ebs_block_device.#", "0"),
-					resource.TestCheckResourceAttr(
-						"aws_instance.foo", "ebs_optimized", "false"),
-					resource.TestCheckResourceAttr(
-						"aws_instance.foo", "root_block_device.#", "0"),
+					resource.TestCheckResourceAttr("data.aws_instance.foo", "ami", "ami-44c36524"),
+					resource.TestCheckResourceAttr("data.aws_instance.foo", "instance_type", "m3.medium"),
+					resource.TestCheckResourceAttr("aws_instance.foo", "ebs_block_device.#", "0"),
+					resource.TestCheckResourceAttr("aws_instance.foo", "ebs_optimized", "false"),
+					resource.TestCheckResourceAttr("aws_instance.foo", "root_block_device.#", "0"),
 				),
 			},
 		},
@@ -160,12 +131,9 @@ func TestAccAWSInstanceDataSource_privateIP(t *testing.T) {
 			{
 				Config: testAccInstanceDataSourceConfig_privateIP,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.foo", "ami", "ami-c5eabbf5"),
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.foo", "instance_type", "t2.micro"),
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.foo", "private_ip", "10.1.1.42"),
+					resource.TestCheckResourceAttr("data.aws_instance.foo", "ami", "ami-c5eabbf5"),
+					resource.TestCheckResourceAttr("data.aws_instance.foo", "instance_type", "t2.micro"),
+					resource.TestCheckResourceAttr("data.aws_instance.foo", "private_ip", "10.1.1.42"),
 				),
 			},
 		},
@@ -181,14 +149,10 @@ func TestAccAWSInstanceDataSource_keyPair(t *testing.T) {
 			{
 				Config: testAccInstanceDataSourceConfig_keyPair(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.foo", "ami", "ami-408c7f28"),
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.foo", "instance_type", "t1.micro"),
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.foo", "tags.#", "1"),
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.foo", "key_name", rName),
+					resource.TestCheckResourceAttr("data.aws_instance.foo", "ami", "ami-408c7f28"),
+					resource.TestCheckResourceAttr("data.aws_instance.foo", "instance_type", "t1.micro"),
+					resource.TestCheckResourceAttr("data.aws_instance.foo", "tags.%", "1"),
+					resource.TestCheckResourceAttr("data.aws_instance.foo", "key_name", rName),
 				),
 			},
 		},
@@ -203,16 +167,11 @@ func TestAccAWSInstanceDataSource_VPC(t *testing.T) {
 			{
 				Config: testAccInstanceDataSourceConfig_VPC,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.foo", "ami", "ami-4fccb37f"),
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.foo", "instance_type", "m1.small"),
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.foo", "user_data", "562a3e32810edf6ff09994f050f12e799452379d"),
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.foo", "associate_public_ip_address", "true"),
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.foo", "tenancy", "dedicated"),
+					resource.TestCheckResourceAttr("data.aws_instance.foo", "ami", "ami-4fccb37f"),
+					resource.TestCheckResourceAttr("data.aws_instance.foo", "instance_type", "m1.small"),
+					resource.TestCheckResourceAttr("data.aws_instance.foo", "user_data", "562a3e32810edf6ff09994f050f12e799452379d"),
+					resource.TestCheckResourceAttr("data.aws_instance.foo", "associate_public_ip_address", "true"),
+					resource.TestCheckResourceAttr("data.aws_instance.foo", "tenancy", "dedicated"),
 				),
 			},
 		},
@@ -228,16 +187,11 @@ func TestAccAWSInstanceDataSource_SecurityGroups(t *testing.T) {
 			{
 				Config: testAccInstanceDataSourceConfig_SecurityGroups(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.foo", "ami", "ami-408c7f28"),
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.foo", "instance_type", "m1.small"),
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.foo", "vpc_security_group_ids.#", "0"),
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.foo", "security_groups.#", "1"),
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.foo", "user_data", "3dc39dda39be1205215e776bad998da361a5955d"),
+					resource.TestCheckResourceAttr("data.aws_instance.foo", "ami", "ami-408c7f28"),
+					resource.TestCheckResourceAttr("data.aws_instance.foo", "instance_type", "m1.small"),
+					resource.TestCheckResourceAttr("data.aws_instance.foo", "vpc_security_group_ids.#", "0"),
+					resource.TestCheckResourceAttr("data.aws_instance.foo", "security_groups.#", "1"),
+					resource.TestCheckResourceAttr("data.aws_instance.foo", "user_data", "3dc39dda39be1205215e776bad998da361a5955d"),
 				),
 			},
 		},
@@ -252,14 +206,10 @@ func TestAccAWSInstanceDataSource_VPCSecurityGroups(t *testing.T) {
 			{
 				Config: testAccInstanceDataSourceConfig_VPCSecurityGroups,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.foo", "ami", "ami-21f78e11"),
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.foo", "instance_type", "t1.micro"),
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.foo", "security_groups.#", "0"),
-					resource.TestCheckResourceAttr(
-						"data.aws_instance.foo", "vpc_security_group_ids.#", "1"),
+					resource.TestCheckResourceAttr("data.aws_instance.foo", "ami", "ami-21f78e11"),
+					resource.TestCheckResourceAttr("data.aws_instance.foo", "instance_type", "t1.micro"),
+					resource.TestCheckResourceAttr("data.aws_instance.foo", "security_groups.#", "0"),
+					resource.TestCheckResourceAttr("data.aws_instance.foo", "vpc_security_group_ids.#", "1"),
 				),
 			},
 		},
@@ -269,7 +219,7 @@ func TestAccAWSInstanceDataSource_VPCSecurityGroups(t *testing.T) {
 // Lookup based on InstanceID
 const testAccInstanceDataSourceConfig = `
 resource "aws_instance" "web" {
-	# us-west-2
+  # us-west-2
   ami = "ami-4fccb37f"
   instance_type = "m1.small"
   tags {
@@ -289,7 +239,7 @@ data "aws_instance" "web-instance" {
 func testAccInstanceDataSourceConfig_Tags(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_instance" "web" {
-	# us-west-2
+  # us-west-2
   ami = "ami-4fccb37f"
   instance_type = "m1.small"
   tags {
@@ -310,15 +260,15 @@ data "aws_instance" "web-instance" {
 // filter on tag, populate more attributes
 const testAccInstanceDataSourceConfig_AzUserData = `
 resource "aws_instance" "foo" {
-	# us-west-2
-	ami = "ami-4fccb37f"
-	availability_zone = "us-west-2a"
+  # us-west-2
+  ami = "ami-4fccb37f"
+  availability_zone = "us-west-2a"
 
-	instance_type = "m1.small"
-	user_data = "foo:-with-character's"
-	tags {
-	  TFAccTest = "YesThisIsATest"
-	}
+  instance_type = "m1.small"
+  user_data = "foo:-with-character's"
+  tags {
+    TFAccTest = "YesThisIsATest"
+  }
 }
 
 data "aws_instance" "foo" {
@@ -329,13 +279,13 @@ data "aws_instance" "foo" {
 // GP2IopsDevice
 const testAccInstanceDataSourceConfig_gp2IopsDevice = `
 resource "aws_instance" "foo" {
-	# us-west-2
-	ami = "ami-55a7ea65"
-	instance_type = "m3.medium"
-	root_block_device {
-		volume_type = "gp2"
-		volume_size = 11
-	}
+  # us-west-2
+  ami = "ami-55a7ea65"
+  instance_type = "m3.medium"
+  root_block_device {
+    volume_type = "gp2"
+    volume_size = 11
+  }
 }
 
 data "aws_instance" "foo" {
@@ -346,36 +296,36 @@ data "aws_instance" "foo" {
 // Block Device
 const testAccInstanceDataSourceConfig_blockDevices = `
 resource "aws_instance" "foo" {
-	# us-west-2
-	ami = "ami-55a7ea65"
-	instance_type = "m3.medium"
+  # us-west-2
+  ami = "ami-55a7ea65"
+  instance_type = "m3.medium"
 
-	root_block_device {
-		volume_type = "gp2"
-		volume_size = 11
-	}
-	ebs_block_device {
-		device_name = "/dev/sdb"
-		volume_size = 9
-	}
-	ebs_block_device {
-		device_name = "/dev/sdc"
-		volume_size = 10
-		volume_type = "io1"
-		iops = 100
-	}
+  root_block_device {
+    volume_type = "gp2"
+    volume_size = 11
+  }
+  ebs_block_device {
+    device_name = "/dev/sdb"
+    volume_size = 9
+  }
+  ebs_block_device {
+    device_name = "/dev/sdc"
+    volume_size = 10
+    volume_type = "io1"
+    iops = 100
+  }
 
-	# Encrypted ebs block device
-	ebs_block_device {
-		device_name = "/dev/sdd"
-		volume_size = 12
-		encrypted = true
-	}
+  # Encrypted ebs block device
+  ebs_block_device {
+    device_name = "/dev/sdd"
+    volume_size = 12
+    encrypted = true
+  }
 
-	ephemeral_block_device {
-		device_name = "/dev/sde"
-		virtual_name = "ephemeral0"
-	}
+  ephemeral_block_device {
+    device_name = "/dev/sde"
+    virtual_name = "ephemeral0"
+  }
 }
 
 data "aws_instance" "foo" {
@@ -395,22 +345,22 @@ data "aws_instance" "foo" {
 
 const testAccInstanceDataSourceConfig_privateIP = `
 resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
-	tags {
-		Name = "testAccInstanceDataSourceConfig_privateIP"
-	}
+  cidr_block = "10.1.0.0/16"
+  tags {
+    Name = "testAccInstanceDataSourceConfig_privateIP"
+  }
 }
 
 resource "aws_subnet" "foo" {
-	cidr_block = "10.1.1.0/24"
-	vpc_id = "${aws_vpc.foo.id}"
+  cidr_block = "10.1.1.0/24"
+  vpc_id = "${aws_vpc.foo.id}"
 }
 
 resource "aws_instance" "foo" {
-	ami = "ami-c5eabbf5"
-	instance_type = "t2.micro"
-	subnet_id = "${aws_subnet.foo.id}"
-	private_ip = "10.1.1.42"
+  ami = "ami-c5eabbf5"
+  instance_type = "t2.micro"
+  subnet_id = "${aws_subnet.foo.id}"
+  private_ip = "10.1.1.42"
 }
 
 data "aws_instance" "foo" {
@@ -421,21 +371,21 @@ data "aws_instance" "foo" {
 func testAccInstanceDataSourceConfig_keyPair(rName string) string {
 	return fmt.Sprintf(`
 provider "aws" {
-	region = "us-east-1"
+  region = "us-east-1"
 }
 
 resource "aws_key_pair" "debugging" {
-	key_name = "%s"
-	public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
+  key_name = "%s"
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 }
 
 resource "aws_instance" "foo" {
   ami = "ami-408c7f28"
   instance_type = "t1.micro"
   key_name = "${aws_key_pair.debugging.key_name}"
-	tags {
-		Name = "testAccInstanceDataSourceConfigKeyPair_TestAMI"
-	}
+  tags {
+    Name = "testAccInstanceDataSourceConfigKeyPair_TestAMI"
+  }
 }
 
 data "aws_instance" "foo" {
@@ -452,26 +402,26 @@ data "aws_instance" "foo" {
 
 const testAccInstanceDataSourceConfig_VPC = `
 resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
-	tags {
-		Name = "testAccInstanceDataSourceConfig_VPC"
-	}
+  cidr_block = "10.1.0.0/16"
+  tags {
+    Name = "testAccInstanceDataSourceConfig_VPC"
+  }
 }
 
 resource "aws_subnet" "foo" {
-	cidr_block = "10.1.1.0/24"
-	vpc_id = "${aws_vpc.foo.id}"
+  cidr_block = "10.1.1.0/24"
+  vpc_id = "${aws_vpc.foo.id}"
 }
 
 resource "aws_instance" "foo" {
-	# us-west-2
-	ami = "ami-4fccb37f"
-	instance_type = "m1.small"
-	subnet_id = "${aws_subnet.foo.id}"
-	associate_public_ip_address = true
-	tenancy = "dedicated"
-	# pre-encoded base64 data
-	user_data = "3dc39dda39be1205215e776bad998da361a5955d"
+  # us-west-2
+  ami = "ami-4fccb37f"
+  instance_type = "m1.small"
+  subnet_id = "${aws_subnet.foo.id}"
+  associate_public_ip_address = true
+  tenancy = "dedicated"
+  # pre-encoded base64 data
+  user_data = "3dc39dda39be1205215e776bad998da361a5955d"
 }
 
 data "aws_instance" "foo" {
@@ -482,26 +432,26 @@ data "aws_instance" "foo" {
 func testAccInstanceDataSourceConfig_SecurityGroups(rInt int) string {
 	return fmt.Sprintf(`
 provider "aws" {
-	region = "us-east-1"
+  region = "us-east-1"
 }
 
 resource "aws_security_group" "tf_test_foo" {
-	name = "tf_test_foo-%d"
-	description = "foo"
+  name = "tf_test_foo-%d"
+  description = "foo"
 
-	ingress {
-		protocol = "icmp"
-		from_port = -1
-		to_port = -1
-		cidr_blocks = ["0.0.0.0/0"]
-	}
+  ingress {
+    protocol = "icmp"
+    from_port = -1
+    to_port = -1
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 }
 
 resource "aws_instance" "foo" {
-	ami = "ami-408c7f28"
-	instance_type = "m1.small"
-	security_groups = ["${aws_security_group.tf_test_foo.name}"]
-	user_data = "foo:-with-character's"
+  ami = "ami-408c7f28"
+  instance_type = "m1.small"
+  security_groups = ["${aws_security_group.tf_test_foo.name}"]
+  user_data = "foo:-with-character's"
 }
 
 data "aws_instance" "foo" {
@@ -517,9 +467,9 @@ resource "aws_internet_gateway" "gw" {
 
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-	tags {
-		Name = "tf-network-test"
-	}
+  tags {
+    Name = "tf-network-test"
+  }
 }
 
 resource "aws_security_group" "tf_test_foo" {
@@ -545,7 +495,7 @@ resource "aws_instance" "foo_instance" {
   instance_type = "t1.micro"
   vpc_security_group_ids = ["${aws_security_group.tf_test_foo.id}"]
   subnet_id = "${aws_subnet.foo.id}"
-	depends_on = ["aws_internet_gateway.gw"]
+  depends_on = ["aws_internet_gateway.gw"]
 }
 
 data "aws_instance" "foo" {


### PR DESCRIPTION
## Issues & Context
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/853
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/1423

## Tests

#### AWS Instance
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSInstanceDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSInstanceDataSource_ -timeout 120m
=== RUN   TestAccAWSInstanceDataSource_basic
--- PASS: TestAccAWSInstanceDataSource_basic (171.58s)
=== RUN   TestAccAWSInstanceDataSource_tags
--- PASS: TestAccAWSInstanceDataSource_tags (172.30s)
=== RUN   TestAccAWSInstanceDataSource_AzUserData
--- PASS: TestAccAWSInstanceDataSource_AzUserData (171.20s)
=== RUN   TestAccAWSInstanceDataSource_gp2IopsDevice
--- PASS: TestAccAWSInstanceDataSource_gp2IopsDevice (150.83s)
=== RUN   TestAccAWSInstanceDataSource_blockDevices
--- PASS: TestAccAWSInstanceDataSource_blockDevices (157.89s)
=== RUN   TestAccAWSInstanceDataSource_rootInstanceStore
--- PASS: TestAccAWSInstanceDataSource_rootInstanceStore (145.93s)
=== RUN   TestAccAWSInstanceDataSource_privateIP
--- PASS: TestAccAWSInstanceDataSource_privateIP (200.84s)
=== RUN   TestAccAWSInstanceDataSource_keyPair
--- PASS: TestAccAWSInstanceDataSource_keyPair (126.20s)
=== RUN   TestAccAWSInstanceDataSource_VPC
--- PASS: TestAccAWSInstanceDataSource_VPC (203.34s)
=== RUN   TestAccAWSInstanceDataSource_SecurityGroups
--- PASS: TestAccAWSInstanceDataSource_SecurityGroups (158.47s)
=== RUN   TestAccAWSInstanceDataSource_VPCSecurityGroups
--- PASS: TestAccAWSInstanceDataSource_VPCSecurityGroups (222.70s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1881.28s
```

#### AWS AMI
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAmiDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSAmiDataSource_ -timeout 120m
=== RUN   TestAccAWSAmiDataSource_natInstance
--- PASS: TestAccAWSAmiDataSource_natInstance (38.85s)
=== RUN   TestAccAWSAmiDataSource_windowsInstance
--- PASS: TestAccAWSAmiDataSource_windowsInstance (41.52s)
=== RUN   TestAccAWSAmiDataSource_instanceStore
--- PASS: TestAccAWSAmiDataSource_instanceStore (37.32s)
=== RUN   TestAccAWSAmiDataSource_owners
--- PASS: TestAccAWSAmiDataSource_owners (68.84s)
=== RUN   TestAccAWSAmiDataSource_ownersEmpty
--- PASS: TestAccAWSAmiDataSource_ownersEmpty (126.56s)
=== RUN   TestAccAWSAmiDataSource_localNameFilter
--- PASS: TestAccAWSAmiDataSource_localNameFilter (62.73s)
PASS
ok	github.com/terraform-providers/terraform-provider-aws/aws	376.069s
```

#### EBS Snapshot
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSEbsSnapshotDataSource'                                             
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSEbsSnapshotDataSource -timeout 120m
=== RUN   TestAccAWSEbsSnapshotDataSource_basic
--- PASS: TestAccAWSEbsSnapshotDataSource_basic (81.23s)
=== RUN   TestAccAWSEbsSnapshotDataSource_multipleFilters
--- PASS: TestAccAWSEbsSnapshotDataSource_multipleFilters (103.58s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	184.850s
```

#### EBS Volume
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSEbsVolumeDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSEbsVolumeDataSource_ -timeout 120m
=== RUN   TestAccAWSEbsVolumeDataSource_basic
--- PASS: TestAccAWSEbsVolumeDataSource_basic (58.11s)
=== RUN   TestAccAWSEbsVolumeDataSource_multipleFilters
--- PASS: TestAccAWSEbsVolumeDataSource_multipleFilters (54.35s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	112.494s
```