### PR TITLE
Add support for batch_job_definition and batch_job_queue

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -487,6 +487,8 @@ func Provider() terraform.ResourceProvider {
 			"aws_wafregional_byte_match_set":               resourceAwsWafRegionalByteMatchSet(),
 			"aws_wafregional_ipset":                        resourceAwsWafRegionalIPSet(),
 			"aws_batch_compute_environment":                resourceAwsBatchComputeEnvironment(),
+			"aws_batch_job_definition":                     resourceAwsBatchJobDefinition(),
+			"aws_batch_job_queue":                          resourceAwsBatchJobQueue(),
 		},
 		ConfigureFunc: providerConfigure,
 	}

--- a/aws/resource_aws_batch_compute_environment.go
+++ b/aws/resource_aws_batch_compute_environment.go
@@ -24,7 +24,7 @@ func resourceAwsBatchComputeEnvironment() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validateBatchComputeEnvironmentName,
+				ValidateFunc: validateBatchName,
 			},
 			"compute_resources": {
 				Type:     schema.TypeList,

--- a/aws/resource_aws_batch_compute_environment_test.go
+++ b/aws/resource_aws_batch_compute_environment_test.go
@@ -395,6 +395,7 @@ resource "aws_batch_compute_environment" "ec2" {
   }
   service_role = "${aws_iam_role.aws_batch_service_role.arn}"
   type = "MANAGED"
+  depends_on = ["aws_iam_role_policy_attachment.aws_batch_service_role"]
 }
 `, rInt)
 }
@@ -423,6 +424,7 @@ resource "aws_batch_compute_environment" "ec2" {
   }
   service_role = "${aws_iam_role.aws_batch_service_role.arn}"
   type = "MANAGED"
+  depends_on = ["aws_iam_role_policy_attachment.aws_batch_service_role"]
 }
 `, rInt)
 }
@@ -450,6 +452,7 @@ resource "aws_batch_compute_environment" "spot" {
   }
   service_role = "${aws_iam_role.aws_batch_service_role.arn}"
   type = "MANAGED"
+  depends_on = ["aws_iam_role_policy_attachment.aws_batch_service_role"]
 }
 `, rInt)
 }
@@ -460,6 +463,7 @@ resource "aws_batch_compute_environment" "unmanaged" {
   compute_environment_name = "tf_acc_test_%d"
   service_role = "${aws_iam_role.aws_batch_service_role.arn}"
   type = "UNMANAGED"
+  depends_on = ["aws_iam_role_policy_attachment.aws_batch_service_role"]
 }
 `, rInt)
 }
@@ -485,6 +489,7 @@ resource "aws_batch_compute_environment" "ec2" {
   }
   service_role = "${aws_iam_role.aws_batch_service_role.arn}"
   type = "MANAGED"
+  depends_on = ["aws_iam_role_policy_attachment.aws_batch_service_role"]
 }
 `, rInt)
 }
@@ -511,6 +516,7 @@ resource "aws_batch_compute_environment" "ec2" {
   }
   service_role = "${aws_iam_role.aws_batch_service_role.arn}"
   type = "MANAGED"
+  depends_on = ["aws_iam_role_policy_attachment.aws_batch_service_role"]
 }
 `, rInt)
 }
@@ -536,6 +542,7 @@ resource "aws_batch_compute_environment" "ec2" {
   }
   service_role = "${aws_iam_role.aws_batch_service_role.arn}"
   type = "MANAGED"
+  depends_on = ["aws_iam_role_policy_attachment.aws_batch_service_role"]
 }
 `, rInt)
 }
@@ -546,6 +553,7 @@ resource "aws_batch_compute_environment" "ec2" {
   compute_environment_name = "tf_acc_test_%d"
   service_role = "${aws_iam_role.aws_batch_service_role.arn}"
   type = "MANAGED"
+  depends_on = ["aws_iam_role_policy_attachment.aws_batch_service_role"]
 }
 `, rInt)
 }
@@ -571,6 +579,7 @@ resource "aws_batch_compute_environment" "unmanaged" {
   }
   service_role = "${aws_iam_role.aws_batch_service_role.arn}"
   type = "UNMANAGED"
+  depends_on = ["aws_iam_role_policy_attachment.aws_batch_service_role"]
 }
 `, rInt)
 }
@@ -596,6 +605,7 @@ resource "aws_batch_compute_environment" "ec2" {
   }
   service_role = "${aws_iam_role.aws_batch_service_role.arn}"
   type = "MANAGED"
+  depends_on = ["aws_iam_role_policy_attachment.aws_batch_service_role"]
 }
 `, rInt)
 }

--- a/aws/resource_aws_batch_job_definition.go
+++ b/aws/resource_aws_batch_job_definition.go
@@ -63,7 +63,6 @@ func resourceAwsBatchJobDefinition() *schema.Resource {
 			},
 			"revision": {
 				Type:     schema.TypeInt,
-				Optional: true,
 				Computed: true,
 			},
 			"arn": {

--- a/aws/resource_aws_batch_job_definition.go
+++ b/aws/resource_aws_batch_job_definition.go
@@ -1,0 +1,209 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/batch"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func resourceAwsBatchJobDefinition() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsBatchJobDefinitionCreate,
+		Read:   resourceAwsBatchJobDefinitionRead,
+		Delete: resourceAwsBatchJobDefinitionDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateBatchName,
+			},
+			"container_properties": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				StateFunc: func(v interface{}) string {
+					hash := sha1.Sum([]byte(v.(string)))
+					return hex.EncodeToString(hash[:])
+				},
+				ValidateFunc: validateAwsBatchJobContainerProperties,
+			},
+			"parameters": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+				Elem:     schema.TypeString,
+			},
+			"retry_strategy": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"attempts": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+					},
+				},
+			},
+			"type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice([]string{batch.JobDefinitionTypeContainer}, true),
+			},
+			"revision": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsBatchJobDefinitionCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).batchconn
+	name := d.Get("name").(string)
+
+	input := &batch.RegisterJobDefinitionInput{
+		JobDefinitionName: aws.String(name),
+		Type:              aws.String(d.Get("type").(string)),
+	}
+
+	if v, ok := d.GetOk("container_properties"); ok {
+		props, err := expandBatchJobContainerProperties(v.(string))
+		if err != nil {
+			return fmt.Errorf("%s %q", err, name)
+		}
+		input.ContainerProperties = props
+	}
+
+	if v, ok := d.GetOk("parameters"); ok {
+		input.Parameters = expandJobDefinitionParameters(v.(map[string]interface{}))
+	}
+
+	if v, ok := d.GetOk("retry_strategy"); ok {
+		input.RetryStrategy = expandJobDefinitionRetryStrategy(v.(*schema.Set))
+	}
+
+	out, err := conn.RegisterJobDefinition(input)
+	if err != nil {
+		return fmt.Errorf("%s %q", err, name)
+	}
+	d.SetId(*out.JobDefinitionArn)
+	d.Set("arn", out.JobDefinitionArn)
+	return resourceAwsBatchJobDefinitionRead(d, meta)
+}
+
+func resourceAwsBatchJobDefinitionRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).batchconn
+	arn := d.Get("arn").(string)
+	job, err := getJobDefinition(conn, arn)
+	if err != nil {
+		return fmt.Errorf("%s %q", err, arn)
+	}
+	d.Set("arn", *job.JobDefinitionArn)
+	d.Set("container_properties", *job.ContainerProperties)
+	d.Set("parameters", job.Parameters)
+	d.Set("retry_strategy", flattenRetryStrategy(job.RetryStrategy))
+	d.Set("revision", *job.Revision)
+	d.Set("type", job.Type)
+	return nil
+}
+
+func resourceAwsBatchJobDefinitionDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).batchconn
+	arn := d.Get("arn").(string)
+	_, err := conn.DeregisterJobDefinition(&batch.DeregisterJobDefinitionInput{
+		JobDefinition: aws.String(arn),
+	})
+	if err != nil {
+		return fmt.Errorf("%s %q", err, arn)
+	}
+	d.SetId("")
+	return nil
+}
+
+func getJobDefinition(conn *batch.Batch, arn string) (*batch.JobDefinition, error) {
+	describeOpts := &batch.DescribeJobDefinitionsInput{
+		JobDefinitions: []*string{aws.String(arn)},
+	}
+	resp, err := conn.DescribeJobDefinitions(describeOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	numJobDefinitions := len(resp.JobDefinitions)
+	switch {
+	case numJobDefinitions == 0:
+		log.Printf("[DEBUG] Job Definition %q is already gone", arn)
+		return nil, nil
+	case numJobDefinitions == 1:
+		return resp.JobDefinitions[0], nil
+	case numJobDefinitions > 1:
+		return nil, fmt.Errorf("Multiple Job Definitions with name %s", arn)
+	}
+	return nil, nil
+}
+
+func validateAwsBatchJobContainerProperties(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	_, err := expandBatchJobContainerProperties(value)
+	if err != nil {
+		errors = append(errors, fmt.Errorf("AWS Batch Job container_properties is invalid: %s", err))
+	}
+	return
+}
+
+func expandBatchJobContainerProperties(rawProps string) (*batch.ContainerProperties, error) {
+	var props *batch.ContainerProperties
+
+	err := json.Unmarshal([]byte(rawProps), &props)
+	if err != nil {
+		return nil, fmt.Errorf("Error decoding JSON: %s", err)
+	}
+
+	return props, nil
+}
+
+func expandJobDefinitionParameters(params map[string]interface{}) map[string]*string {
+	var jobParams = make(map[string]*string)
+	for k, v := range params {
+		jobParams[k] = aws.String(v.(string))
+	}
+
+	return jobParams
+}
+
+func expandJobDefinitionRetryStrategy(item *schema.Set) *batch.RetryStrategy {
+	data := item.List()[0].(map[string]interface{})
+	return &batch.RetryStrategy{
+		Attempts: aws.Int64(int64(data["attempts"].(int))),
+	}
+}
+
+func flattenRetryStrategy(item *batch.RetryStrategy) []map[string]interface{} {
+	data := []map[string]interface{}{}
+	if item != nil {
+		data = append(data, map[string]interface{}{
+			"attempts": item.Attempts,
+		})
+	}
+	return data
+}

--- a/aws/resource_aws_batch_job_definition_test.go
+++ b/aws/resource_aws_batch_job_definition_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"log"
 	"strings"
 	"testing"
 
@@ -97,7 +96,6 @@ func TestAccAWSBatchJobDefinitionUpdateForcesNewResource(t *testing.T) {
 func testAccCheckBatchJobDefinitionExists(n string, jd *batch.JobDefinition) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
-		log.Printf("State: %#v", s.RootModule().Resources)
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
@@ -166,8 +164,8 @@ func testAccCheckBatchJobDefinitionDestroy(s *terraform.State) error {
 		}
 		conn := testAccProvider.Meta().(*AWSClient).batchconn
 		js, err := getJobDefinition(conn, rs.Primary.Attributes["arn"])
-		if err == nil {
-			if *js.Status != "INACTIVE" {
+		if err == nil && js != nil {
+			if *js.Status == "ACTIVE" {
 				return fmt.Errorf("Error: Job Definition still active")
 			}
 		}

--- a/aws/resource_aws_batch_job_definition_test.go
+++ b/aws/resource_aws_batch_job_definition_test.go
@@ -135,10 +135,10 @@ func testAccCheckBatchJobDefinitionAttributes(jd *batch.JobDefinition, compare *
 			}
 			if compare != nil {
 				if compare.Parameters != nil && !reflect.DeepEqual(compare.Parameters, jd.Parameters) {
-					return fmt.Errorf("Bad Job Definition Params\n\t expected: %s\n\tgot: %s\n", compare.Parameters, jd.Parameters)
+					return fmt.Errorf("Bad Job Definition Params\n\t expected: %v\n\tgot: %v\n", compare.Parameters, jd.Parameters)
 				}
 				if compare.RetryStrategy != nil && *compare.RetryStrategy.Attempts != *jd.RetryStrategy.Attempts {
-					return fmt.Errorf("Bad Job Definition Retry Strategy\n\t expected: %s\n\tgot: %s\n", *compare.RetryStrategy.Attempts, *jd.RetryStrategy.Attempts)
+					return fmt.Errorf("Bad Job Definition Retry Strategy\n\t expected: %d\n\tgot: %d\n", *compare.RetryStrategy.Attempts, *jd.RetryStrategy.Attempts)
 				}
 				if compare.ContainerProperties != nil && compare.ContainerProperties.Command != nil && !reflect.DeepEqual(compare.ContainerProperties, jd.ContainerProperties) {
 					return fmt.Errorf("Bad Job Definition Container Properties\n\t expected: %s\n\tgot: %s\n", compare.ContainerProperties, jd.ContainerProperties)

--- a/aws/resource_aws_batch_job_definition_test.go
+++ b/aws/resource_aws_batch_job_definition_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSBatchJobDefinition(t *testing.T) {
+func TestAccAWSBatchJobDefinition_basic(t *testing.T) {
 	var jd batch.JobDefinition
 	compare := batch.JobDefinition{
 		Parameters: map[string]*string{
@@ -64,7 +64,7 @@ func TestAccAWSBatchJobDefinition(t *testing.T) {
 	})
 }
 
-func TestAccAWSBatchJobDefinitionUpdateForcesNewResource(t *testing.T) {
+func TestAccAWSBatchJobDefinition_updateForcesNewResource(t *testing.T) {
 	var before batch.JobDefinition
 	var after batch.JobDefinition
 	ri := acctest.RandInt()

--- a/aws/resource_aws_batch_job_definition_test.go
+++ b/aws/resource_aws_batch_job_definition_test.go
@@ -1,0 +1,264 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+
+	"reflect"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/batch"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSBatchJobDefinition(t *testing.T) {
+	var jd batch.JobDefinition
+	compare := batch.JobDefinition{
+		Parameters: map[string]*string{
+			"param1": aws.String("val1"),
+			"param2": aws.String("val2"),
+		},
+		RetryStrategy: &batch.RetryStrategy{
+			Attempts: aws.Int64(int64(1)),
+		},
+		ContainerProperties: &batch.ContainerProperties{
+			Command: []*string{aws.String("ls"), aws.String("-la")},
+			Environment: []*batch.KeyValuePair{
+				{Name: aws.String("VARNAME"), Value: aws.String("VARVAL")},
+			},
+			Image:  aws.String("busybox"),
+			Memory: aws.Int64(int64(512)),
+			MountPoints: []*batch.MountPoint{
+				{ContainerPath: aws.String("/tmp"), ReadOnly: aws.Bool(false), SourceVolume: aws.String("tmp")},
+			},
+			Ulimits: []*batch.Ulimit{
+				{HardLimit: aws.Int64(int64(1024)), Name: aws.String("nofile"), SoftLimit: aws.Int64(int64(1024))},
+			},
+			Volumes: []*batch.Volume{
+				{
+					Host: &batch.Host{SourcePath: aws.String("/tmp")},
+					Name: aws.String("tmp"),
+				},
+			},
+			Vcpus: aws.Int64(int64(1)),
+		},
+	}
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccBatchJobDefinitionBaseConfig, ri)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBatchJobDefinitionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBatchJobDefinitionExists("aws_batch_job_definition.test", &jd),
+					testAccCheckBatchJobDefinitionAttributes(&jd, &compare),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSBatchJobDefinitionUpdateForcesNewResource(t *testing.T) {
+	var before batch.JobDefinition
+	var after batch.JobDefinition
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccBatchJobDefinitionBaseConfig, ri)
+	updateConfig := fmt.Sprintf(testAccBatchJobDefinitionUpdateConfig, ri)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBatchJobDefinitionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBatchJobDefinitionExists("aws_batch_job_definition.test", &before),
+					testAccCheckBatchJobDefinitionAttributes(&before, nil),
+				),
+			},
+			{
+				Config: updateConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBatchJobDefinitionExists("aws_batch_job_definition.test", &after),
+					testAccCheckJobDefinitionRecreated(t, &before, &after),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckBatchJobDefinitionExists(n string, jd *batch.JobDefinition) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		log.Printf("State: %#v", s.RootModule().Resources)
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Batch Job Queue ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).batchconn
+		arn := rs.Primary.Attributes["arn"]
+		def, err := getJobDefinition(conn, arn)
+		if err != nil {
+			return err
+		}
+		if def == nil {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		*jd = *def
+
+		return nil
+	}
+}
+
+func testAccCheckBatchJobDefinitionAttributes(jd *batch.JobDefinition, compare *batch.JobDefinition) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if !strings.HasPrefix(*jd.JobDefinitionName, "tf_acctest_batch_job_definition") {
+			return fmt.Errorf("Bad Job Definition name: %s", *jd.JobDefinitionName)
+		}
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_batch_job_definition" {
+				continue
+			}
+			if *jd.JobDefinitionArn != rs.Primary.Attributes["arn"] {
+				return fmt.Errorf("Bad Job Definition ARN\n\t expected: %s\n\tgot: %s\n", rs.Primary.Attributes["arn"], *jd.JobDefinitionArn)
+			}
+			if compare != nil {
+				if compare.Parameters != nil && !reflect.DeepEqual(compare.Parameters, jd.Parameters) {
+					return fmt.Errorf("Bad Job Definition Params\n\t expected: %s\n\tgot: %s\n", compare.Parameters, jd.Parameters)
+				}
+				if compare.RetryStrategy != nil && *compare.RetryStrategy.Attempts != *jd.RetryStrategy.Attempts {
+					return fmt.Errorf("Bad Job Definition Retry Strategy\n\t expected: %s\n\tgot: %s\n", *compare.RetryStrategy.Attempts, *jd.RetryStrategy.Attempts)
+				}
+				if compare.ContainerProperties != nil && compare.ContainerProperties.Command != nil && !reflect.DeepEqual(compare.ContainerProperties, jd.ContainerProperties) {
+					return fmt.Errorf("Bad Job Definition Container Properties\n\t expected: %s\n\tgot: %s\n", compare.ContainerProperties, jd.ContainerProperties)
+				}
+			}
+		}
+		return nil
+	}
+}
+
+func testAccCheckJobDefinitionRecreated(t *testing.T,
+	before, after *batch.JobDefinition) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if *before.Revision == *after.Revision {
+			t.Fatalf("Expected change of JobDefinition Revisions, but both were %v", before.Revision)
+		}
+		return nil
+	}
+}
+
+func testAccCheckBatchJobDefinitionDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_batch_job_definition" {
+			continue
+		}
+		conn := testAccProvider.Meta().(*AWSClient).batchconn
+		js, err := getJobDefinition(conn, rs.Primary.Attributes["arn"])
+		if err == nil {
+			if *js.Status != "INACTIVE" {
+				return fmt.Errorf("Error: Job Definition still active")
+			}
+		}
+		return nil
+	}
+	return nil
+}
+
+const testAccBatchJobDefinitionBaseConfig = `
+resource "aws_batch_job_definition" "test" {
+	name = "tf_acctest_batch_job_definition_%[1]d"
+	type = "container"
+	parameters = {
+		param1 = "val1"
+		param2 = "val2"
+	}
+	retry_strategy = {
+		attempts = 1
+	}
+	container_properties = <<CONTAINER_PROPERTIES
+{
+	"command": ["ls", "-la"],
+	"image": "busybox",
+	"memory": 512,
+	"vcpus": 1,
+	"volumes": [
+      {
+        "host": {
+          "sourcePath": "/tmp"
+        },
+        "name": "tmp"
+      }
+    ],
+	"environment": [
+		{"name": "VARNAME", "value": "VARVAL"}
+	],
+	"mountPoints": [
+		{
+          "sourceVolume": "tmp",
+          "containerPath": "/tmp",
+          "readOnly": false
+        }
+	],
+    "ulimits": [
+      {
+        "hardLimit": 1024,
+        "name": "nofile",
+        "softLimit": 1024
+      }
+    ]
+}
+CONTAINER_PROPERTIES
+}
+`
+
+const testAccBatchJobDefinitionUpdateConfig = `
+resource "aws_batch_job_definition" "test" {
+	name = "tf_acctest_batch_job_definition_%[1]d"
+	type = "container"
+	container_properties = <<CONTAINER_PROPERTIES
+{
+	"command": ["ls", "-la"],
+	"image": "busybox",
+	"memory": 1024,
+	"vcpus": 1,
+	"volumes": [
+      {
+        "host": {
+          "sourcePath": "/tmp"
+        },
+        "name": "tmp"
+      }
+    ],
+	"environment": [
+		{"name": "VARNAME", "value": "VARVAL"}
+	],
+	"mountPoints": [
+		{
+          "sourceVolume": "tmp",
+          "containerPath": "/tmp",
+          "readOnly": false
+        }
+	],
+    "ulimits": [
+      {
+        "hardLimit": 1024,
+        "name": "nofile",
+        "softLimit": 1024
+      }
+    ]
+}
+CONTAINER_PROPERTIES
+}
+`

--- a/aws/resource_aws_batch_job_queue.go
+++ b/aws/resource_aws_batch_job_queue.go
@@ -1,0 +1,206 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/batch"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func resourceAwsBatchJobQueue() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsBatchJobQueueCreate,
+		Read:   resourceAwsBatchJobQueueRead,
+		Update: resourceAwsBatchJobQueueUpdate,
+		Delete: resourceAwsBatchJobQueueDelete,
+
+		Schema: map[string]*schema.Schema{
+			"compute_environments": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 3,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"priority": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"state": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice([]string{batch.JQStateDisabled, batch.JQStateEnabled}, true),
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsBatchJobQueueCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).batchconn
+	input := batch.CreateJobQueueInput{
+		ComputeEnvironmentOrder: createComputeEnvironmentOrder(d),
+		JobQueueName:            aws.String(d.Get("name").(string)),
+		Priority:                aws.Int64(int64(d.Get("priority").(int))),
+		State:                   aws.String(d.Get("state").(string)),
+	}
+	name := d.Get("name").(string)
+	out, err := conn.CreateJobQueue(&input)
+	if err != nil {
+		return fmt.Errorf("%s %q", err, name)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{batch.JQStatusCreating, batch.JQStatusUpdating},
+		Target:     []string{batch.JQStatusValid},
+		Refresh:    batchJobQueueRefreshFunc(conn, name),
+		Timeout:    10 * time.Minute,
+		Delay:      10 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("[WARN] Error waiting for JobQueue state to be \"VALID\": %s", err)
+	}
+
+	arn := *out.JobQueueArn
+	log.Printf("[DEBUG] JobQueue created: %s", arn)
+	d.SetId(arn)
+
+	return resourceAwsBatchJobQueueRead(d, meta)
+}
+
+func resourceAwsBatchJobQueueRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).batchconn
+
+	jq, err := getJobQueue(conn, d.Get("name").(string))
+	if err != nil {
+		return err
+	}
+	if jq == nil {
+		return fmt.Errorf("[WARN] Error reading JobQueue: \"%s\"", err)
+	}
+	d.Set("arn", jq.JobQueueArn)
+	d.Set("compute_environments", jq.ComputeEnvironmentOrder)
+	d.Set("name", jq.JobQueueName)
+	d.Set("priority", jq.Priority)
+	d.Set("state", jq.State)
+	return nil
+}
+
+func resourceAwsBatchJobQueueUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).batchconn
+
+	updateInput := &batch.UpdateJobQueueInput{
+		ComputeEnvironmentOrder: createComputeEnvironmentOrder(d),
+		JobQueue:                aws.String(d.Get("name").(string)),
+		Priority:                aws.Int64(int64(d.Get("priority").(int))),
+		State:                   aws.String(d.Get("state").(string)),
+	}
+	_, err := conn.UpdateJobQueue(updateInput)
+	if err != nil {
+		return err
+	}
+	return resourceAwsBatchJobQueueRead(d, meta)
+}
+
+func resourceAwsBatchJobQueueDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).batchconn
+	sn := d.Get("name").(string)
+	_, err := conn.UpdateJobQueue(&batch.UpdateJobQueueInput{
+		JobQueue: aws.String(sn),
+		State:    aws.String(batch.JQStateDisabled),
+	})
+	if err != nil {
+		return err
+	}
+
+	// Wait until the Job Queue is disabled
+	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+		log.Printf("[DEBUG] Trying to delete Job Queue %s", sn)
+		_, err = conn.DeleteJobQueue(&batch.DeleteJobQueueInput{
+			JobQueue: aws.String(sn),
+		})
+		if err == nil {
+			return nil
+		}
+		return resource.RetryableError(err)
+	})
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{batch.JQStatusUpdating, batch.JQStatusDeleting},
+		Target:     []string{batch.JQStatusDeleted},
+		Refresh:    batchJobQueueRefreshFunc(conn, sn),
+		Timeout:    10 * time.Minute,
+		Delay:      10 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf(
+			"Error waiting for Job Queue (%s) to be destroyed: %s",
+			sn, err)
+	}
+	d.SetId("")
+	return nil
+}
+
+func createComputeEnvironmentOrder(d *schema.ResourceData) (envs []*batch.ComputeEnvironmentOrder) {
+	data := d.Get("compute_environments").([]interface{})
+	for i, env := range data {
+		envs = append(envs, &batch.ComputeEnvironmentOrder{
+			Order:              aws.Int64(int64(i)),
+			ComputeEnvironment: aws.String(env.(string)),
+		})
+	}
+	return
+}
+
+func getJobQueue(conn *batch.Batch, sn string) (*batch.JobQueueDetail, error) {
+	describeOpts := &batch.DescribeJobQueuesInput{
+		JobQueues: []*string{aws.String(sn)},
+	}
+	resp, err := conn.DescribeJobQueues(describeOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	numJobQueues := len(resp.JobQueues)
+	switch {
+	case numJobQueues == 0:
+		log.Printf("[DEBUG] Job Queue %q is already gone", sn)
+		return nil, nil
+	case numJobQueues == 1:
+		return resp.JobQueues[0], nil
+	case numJobQueues > 1:
+		return nil, fmt.Errorf("Multiple Job Queues with name %s", sn)
+	}
+	return nil, nil
+}
+
+func batchJobQueueRefreshFunc(conn *batch.Batch, sn string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		ce, err := getJobQueue(conn, sn)
+		if err != nil {
+			return nil, "failed", err
+		}
+		if ce == nil {
+			return 42, batch.JQStatusDeleted, nil
+		}
+		return ce, *ce.Status, nil
+	}
+}

--- a/aws/resource_aws_batch_job_queue_test.go
+++ b/aws/resource_aws_batch_job_queue_test.go
@@ -108,7 +108,7 @@ func testAccCheckBatchJobQueueAttributes(jq *batch.JobQueueDetail) resource.Test
 				return err
 			}
 			if *jq.Priority != priority {
-				return fmt.Errorf("Bad Job Queue Priority\n\t expected: %s\n\tgot: %s\n", rs.Primary.Attributes["priority"], *jq.Priority)
+				return fmt.Errorf("Bad Job Queue Priority\n\t expected: %s\n\tgot: %d\n", rs.Primary.Attributes["priority"], *jq.Priority)
 			}
 		}
 		return nil

--- a/aws/resource_aws_batch_job_queue_test.go
+++ b/aws/resource_aws_batch_job_queue_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSBatchJobQueue(t *testing.T) {
+func TestAccAWSBatchJobQueue_basic(t *testing.T) {
 	var jq batch.JobQueueDetail
 	ri := acctest.RandInt()
 	config := fmt.Sprintf(testAccBatchJobQueueBasic, ri)
@@ -33,7 +33,7 @@ func TestAccAWSBatchJobQueue(t *testing.T) {
 	})
 }
 
-func TestAccAWSBatchJobQueueUpdate(t *testing.T) {
+func TestAccAWSBatchJobQueue_update(t *testing.T) {
 	var jq batch.JobQueueDetail
 	ri := acctest.RandInt()
 	config := fmt.Sprintf(testAccBatchJobQueueBasic, ri)

--- a/aws/resource_aws_batch_job_queue_test.go
+++ b/aws/resource_aws_batch_job_queue_test.go
@@ -1,0 +1,238 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/batch"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSBatchJobQueue(t *testing.T) {
+	var jq batch.JobQueueDetail
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccBatchJobQueueBasic, ri)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBatchJobQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBatchJobQueueExists("aws_batch_job_queue.test_queue", &jq),
+					testAccCheckBatchJobQueueAttributes(&jq),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSBatchJobQueueUpdate(t *testing.T) {
+	var jq batch.JobQueueDetail
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccBatchJobQueueBasic, ri)
+	updateConfig := fmt.Sprintf(testAccBatchJobQueueUpdate, ri)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBatchJobQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBatchJobQueueExists("aws_batch_job_queue.test_queue", &jq),
+					testAccCheckBatchJobQueueAttributes(&jq),
+				),
+			},
+			{
+				Config: updateConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBatchJobQueueExists("aws_batch_job_queue.test_queue", &jq),
+					testAccCheckBatchJobQueueAttributes(&jq),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckBatchJobQueueExists(n string, jq *batch.JobQueueDetail) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		log.Printf("State: %#v", s.RootModule().Resources)
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Batch Job Queue ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).batchconn
+		name := rs.Primary.Attributes["name"]
+		queue, err := getJobQueue(conn, name)
+		if err != nil {
+			return err
+		}
+		if queue == nil {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		*jq = *queue
+
+		return nil
+	}
+}
+
+func testAccCheckBatchJobQueueAttributes(jq *batch.JobQueueDetail) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if !strings.HasPrefix(*jq.JobQueueName, "tf_acctest_batch_job_queue") {
+			return fmt.Errorf("Bad Job Queue name: %s", *jq.JobQueueName)
+		}
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_batch_job_queue" {
+				continue
+			}
+			if *jq.JobQueueArn != rs.Primary.Attributes["arn"] {
+				return fmt.Errorf("Bad Job Queue ARN\n\t expected: %s\n\tgot: %s\n", rs.Primary.Attributes["arn"], *jq.JobQueueArn)
+			}
+			if *jq.State != rs.Primary.Attributes["state"] {
+				return fmt.Errorf("Bad Job Queue State\n\t expected: %s\n\tgot: %s\n", rs.Primary.Attributes["state"], *jq.State)
+			}
+			priority, err := strconv.ParseInt(rs.Primary.Attributes["priority"], 10, 64)
+			if err != nil {
+				return err
+			}
+			if *jq.Priority != priority {
+				return fmt.Errorf("Bad Job Queue Priority\n\t expected: %s\n\tgot: %s\n", rs.Primary.Attributes["priority"], *jq.Priority)
+			}
+		}
+		return nil
+	}
+}
+
+func testAccCheckBatchJobQueueDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_batch_job_queue" {
+			continue
+		}
+		conn := testAccProvider.Meta().(*AWSClient).batchconn
+		jq, err := getJobQueue(conn, rs.Primary.Attributes["name"])
+		if err == nil {
+			if jq != nil {
+				return fmt.Errorf("Error: Job Queue still exists")
+			}
+		}
+		return nil
+	}
+	return nil
+}
+
+const testAccBatchJobQueueBaseConfig = `
+########## ecs_instance_role ##########
+
+resource "aws_iam_role" "ecs_instance_role" {
+  name = "ecs_instance_role_%[1]d"
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+	{
+	    "Action": "sts:AssumeRole",
+	    "Effect": "Allow",
+	    "Principal": {
+		"Service": "ec2.amazonaws.com"
+	    }
+	}
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_instance_role" {
+  role       = "${aws_iam_role.ecs_instance_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+}
+
+resource "aws_iam_instance_profile" "ecs_instance_role" {
+  name  = "ecs_instance_role_%[1]d"
+  role = "${aws_iam_role.ecs_instance_role.name}"
+}
+
+########## aws_batch_service_role ##########
+
+resource "aws_iam_role" "aws_batch_service_role" {
+  name = "aws_batch_service_role_%[1]d"
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+	{
+	    "Action": "sts:AssumeRole",
+	    "Effect": "Allow",
+	    "Principal": {
+		"Service": "batch.amazonaws.com"
+	    }
+	}
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "aws_batch_service_role" {
+  role       = "${aws_iam_role.aws_batch_service_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole"
+}
+
+########## security group ##########
+
+resource "aws_security_group" "test_acc" {
+  name = "aws_batch_compute_environment_security_group_%[1]d"
+}
+
+########## subnets ##########
+
+resource "aws_vpc" "test_acc" {
+  cidr_block = "10.1.0.0/16"
+}
+
+resource "aws_subnet" "test_acc" {
+  vpc_id = "${aws_vpc.test_acc.id}"
+  cidr_block = "10.1.1.0/24"
+}
+
+resource "aws_batch_compute_environment" "test_environment" {
+  compute_environment_name = "tf_acctest_batch_compute_environment_%[1]d"
+  compute_resources = {
+    instance_role = "${aws_iam_role.aws_batch_service_role.arn}"
+    instance_type = ["m3.medium"]
+    max_vcpus = 1
+    min_vcpus = 0
+    security_group_ids = ["${aws_security_group.test_acc.id}"]
+    subnets = ["${aws_subnet.test_acc.id}"]
+    type = "EC2"
+  }
+  service_role = "${aws_iam_role.aws_batch_service_role.arn}"
+  type = "MANAGED"
+  depends_on = ["aws_iam_role_policy_attachment.aws_batch_service_role"]
+}`
+
+var testAccBatchJobQueueBasic = testAccBatchJobQueueBaseConfig + `
+resource "aws_batch_job_queue" "test_queue" {
+  name = "tf_acctest_batch_job_queue_%[1]d"
+  state = "ENABLED"
+  priority = 1
+  compute_environments = ["${aws_batch_compute_environment.test_environment.arn}"]
+}`
+
+var testAccBatchJobQueueUpdate = testAccBatchJobQueueBaseConfig + `
+resource "aws_batch_job_queue" "test_queue" {
+  name = "tf_acctest_batch_job_queue_%[1]d"
+  state = "DISABLED"
+  priority = 2
+  compute_environments = ["${aws_batch_compute_environment.test_environment.arn}"]
+}`

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1487,7 +1487,7 @@ func validateSsmParameterType(v interface{}, k string) (ws []string, errors []er
 	return
 }
 
-func validateBatchComputeEnvironmentName(v interface{}, k string) (ws []string, errors []error) {
+func validateBatchName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if !regexp.MustCompile(`^[A-Za-z0-9_]{1,128}$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf("%q (%q) must be up to 128 letters (uppercase and lowercase), numbers, and underscores.", k, v))

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -2426,14 +2426,14 @@ func TestValidateSsmParameterType(t *testing.T) {
 	}
 }
 
-func TestValidateBatchComputeEnvironmentName(t *testing.T) {
+func TestValidateBatchName(t *testing.T) {
 	validNames := []string{
 		strings.Repeat("W", 128), // <= 128
 	}
 	for _, v := range validNames {
-		_, errors := validateBatchComputeEnvironmentName(v, "name")
+		_, errors := validateBatchName(v, "name")
 		if len(errors) != 0 {
-			t.Fatalf("%q should be a valid Batch compute environment name: %q", v, errors)
+			t.Fatalf("%q should be a valid Batch name: %q", v, errors)
 		}
 	}
 
@@ -2442,9 +2442,9 @@ func TestValidateBatchComputeEnvironmentName(t *testing.T) {
 		strings.Repeat("W", 129), // >= 129
 	}
 	for _, v := range invalidNames {
-		_, errors := validateBatchComputeEnvironmentName(v, "name")
+		_, errors := validateBatchName(v, "name")
 		if len(errors) == 0 {
-			t.Fatalf("%q should be a invalid Batch compute environment name: %q", v, errors)
+			t.Fatalf("%q should be a invalid Batch name: %q", v, errors)
 		}
 	}
 }

--- a/examples/ecs-alb/main.tf
+++ b/examples/ecs-alb/main.tf
@@ -248,7 +248,7 @@ EOF
 }
 
 resource "aws_iam_instance_profile" "app" {
-  name  = "tf-ecs-instprofile"
+  name = "tf-ecs-instprofile"
   role = "${aws_iam_role.app_instance.name}"
 }
 

--- a/examples/networking/region/subnets.tf
+++ b/examples/networking/region/subnets.tf
@@ -1,5 +1,4 @@
-data "aws_availability_zones" "all" {
-}
+data "aws_availability_zones" "all" {}
 
 module "primary_subnet" {
   source            = "../subnet"

--- a/examples/networking/subnet/subnet.tf
+++ b/examples/networking/subnet/subnet.tf
@@ -1,6 +1,6 @@
 resource "aws_subnet" "main" {
-  cidr_block = "${cidrsubnet(data.aws_vpc.target.cidr_block, 4, lookup(var.az_numbers, data.aws_availability_zone.target.name_suffix))}"
-  vpc_id     = "${var.vpc_id}"
+  cidr_block        = "${cidrsubnet(data.aws_vpc.target.cidr_block, 4, lookup(var.az_numbers, data.aws_availability_zone.target.name_suffix))}"
+  vpc_id            = "${var.vpc_id}"
   availability_zone = "${var.availability_zone}"
 }
 

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -276,6 +276,12 @@
                         <li<%= sidebar_current("docs-aws-resource-batch-compute-environment") %>>
                             <a href="/docs/providers/aws/r/batch_compute_environment.html">aws_batch_compute_environment</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-resource-batch-job-definition") %>>
+                            <a href="/docs/providers/aws/r/batch_job_definition.html">aws_batch_job_definition</a>
+                        </li>
+                        <li<%= sidebar_current("docs-aws-resource-batch-job-queue") %>>
+                            <a href="/docs/providers/aws/r/batch_job_queue.html">aws_batch_job_queue</a>
+                        </li>
                     </ul>
                 </li>
 

--- a/website/docs/r/batch_compute_environment.html.markdown
+++ b/website/docs/r/batch_compute_environment.html.markdown
@@ -13,6 +13,9 @@ Creates a AWS Batch compute environment. Compute environments contain the Amazon
 For information about AWS Batch, see [What is AWS Batch?][1] .
 For information about compute environment, see [Compute Environments][2] .
 
+~> **Note:** To prevent a race condition during environment deletion, make sure to set `depends_on` to the related `aws_iam_role_policy_attachment`;
+   otherwise, the policy may be destroyed too soon and the compute environment will then get stuck in the `DELETING` state, see [Troubleshooting AWS Batch][3] .
+
 ## Example Usage
 
 ```hcl
@@ -99,6 +102,7 @@ resource "aws_batch_compute_environment" "sample" {
   }
   service_role = "${aws_iam_role.aws_batch_service_role.arn}"
   type = "MANAGED"
+  depends_on = ["aws_iam_role_policy_attachment.aws_batch_service_role"]
 }
 ```
 
@@ -135,3 +139,4 @@ resource "aws_batch_compute_environment" "sample" {
 
 [1]: http://docs.aws.amazon.com/batch/latest/userguide/what-is-batch.html
 [2]: http://docs.aws.amazon.com/batch/latest/userguide/compute_environments.html
+[3]: http://docs.aws.amazon.com/batch/latest/userguide/troubleshooting.html

--- a/website/docs/r/batch_job_definition.html.markdown
+++ b/website/docs/r/batch_job_definition.html.markdown
@@ -1,0 +1,78 @@
+---
+layout: "aws"
+page_title: "AWS: batch"
+sidebar_current: "docs-aws-resource-batch-job-definition"
+description: |-
+  Provides a Batch Job Definition resource.
+---
+
+# aws_batch_job_definition
+
+Provides a Batch Job Definition resource.
+
+## Example Usage
+
+```hcl
+resource "aws_batch_job_definition" "test" {
+	name = "tf-test-batch-job-definition"
+	type = "container"
+	container_properties = <<CONTAINER_PROPERTIES
+{
+	"command": ["ls", "-la"],
+	"image": "busybox",
+	"memory": 1024,
+	"vcpus": 1,
+	"volumes": [
+      {
+        "host": {
+          "sourcePath": "/tmp"
+        },
+        "name": "tmp"
+      }
+    ],
+	"environment": [
+		{"name": "VARNAME", "value": "VARVAL"}
+	],
+	"mountPoints": [
+		{
+          "sourceVolume": "tmp",
+          "containerPath": "/tmp",
+          "readOnly": false
+        }
+	],
+    "ulimits": [
+      {
+        "hardLimit": 1024,
+        "name": "nofile",
+        "softLimit": 1024
+      }
+    ]
+}
+CONTAINER_PROPERTIES
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the name of the job definition.
+* `container_properties` - (Optional) A valid [container properties](http://docs.aws.amazon.com/batch/latest/APIReference/API_RegisterJobDefinition.html)
+    provided as a single valid JSON document. This parameter is required if the `type` parameter is `container`.
+* `parameters` - (Optional) Specifies the parameter substitution placeholders to set in the job definition.
+* `retry_strategy` - (Optional) Specifies the retry strategy to use for failed jobs that are submitted with this job definition.
+    Maximum number of `retry_strategy` is `1`.  Defined below.
+* `type` - (Required) The type of job definition.  Must be `container`
+
+## retry_strategy
+
+`retry_strategy` supports the following:
+
+* `attempts` - (Required) The number of times to move a job to the `RUNNABLE` status. You may specify between `1` and `10` attempts.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `arn` - The Amazon Resource Name of the job definition.
+* `revision` - The revision of the job definition.

--- a/website/docs/r/batch_job_definition.html.markdown
+++ b/website/docs/r/batch_job_definition.html.markdown
@@ -14,7 +14,7 @@ Provides a Batch Job Definition resource.
 
 ```hcl
 resource "aws_batch_job_definition" "test" {
-	name = "tf-test-batch-job-definition"
+	name = "tf_test_batch_job_definition"
 	type = "container"
 	container_properties = <<CONTAINER_PROPERTIES
 {

--- a/website/docs/r/batch_job_queue.html.markdown
+++ b/website/docs/r/batch_job_queue.html.markdown
@@ -1,0 +1,41 @@
+---
+layout: "aws"
+page_title: "AWS: batch"
+sidebar_current: "docs-aws-resource-batch-job-queue"
+description: |-
+  Provides a Batch Job Queue resource.
+---
+
+# aws_batch_job_queue
+
+Provides a Batch Job Queue resource.
+
+## Example Usage
+
+```hcl
+resource "aws_batch_job_queue" "test_queue" {
+  name = "tf-test-batch-job-queue"
+  state = "ENABLED"
+  priority = 1
+  compute_environments = ["${aws_batch_compute_environment.test_environment_1.arn}", "${aws_batch_compute_environment.test_environment_2.arn}"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the name of the job queue.
+* `compute_environments` - (Required) Specifies the set of compute environments
+    mapped to a job queue and their order.  The position of the compute environments
+    in the list will dictate the order. You can associate up to 3 compute environments
+    with a job queue.
+* `priority` - (Required) The priority of the job queue. Job queues with a higher priority
+    are evaluated first when associated with same compute environment.
+* `state` - (Required) The state of the job queue. Must be one of: `ENABLED` or `DISABLED`
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `arn` - The Amazon Resource Name of the job queue.


### PR DESCRIPTION
## Description
Adding resources `aws_batch_job_definition` and `aws_batch_job_queue`.

Additionally, I found an issue with some of the tests for `aws_batch_compute_environment` which seems to be a condition where the `aws_iam_role_policy_attachment` gets deleted before the compute environment and causes the `aws_batch_compute_environment ` to be a dangling resource.  I have added a note in the documentation about it, and have also fixed the tests by adding a `depends_on` link in the `aws_batch_compute_environment ` to the `aws_iam_role_policy_attachment`.

## Tests
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSBatchJobDefinition'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSBatchJobDefinition -timeout 120m
=== RUN   TestAccAWSBatchJobDefinition
--- PASS: TestAccAWSBatchJobDefinition (14.26s)
=== RUN   TestAccAWSBatchJobDefinitionUpdateForcesNewResource
--- PASS: TestAccAWSBatchJobDefinitionUpdateForcesNewResource (22.15s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	36.442s
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSBatchJobQueue'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSBatchJobQueue -timeout 120m
=== RUN   TestAccAWSBatchJobQueue
--- PASS: TestAccAWSBatchJobQueue (89.57s)
=== RUN   TestAccAWSBatchJobQueueUpdate
--- PASS: TestAccAWSBatchJobQueueUpdate (104.32s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	193.919s
```