### PR TITLE
resource/aws_instance: Added acceptance test when using encrypted volume & IOPS

### DIFF
--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -189,8 +189,26 @@ func TestAccAWSInstance_GP2IopsDevice(t *testing.T) {
 					testCheck(),
 				),
 			},
+		},
+	})
+}
+
+func TestAccAWSInstance_GP2WithIopsValue(t *testing.T) {
+	var v ec2.Instance
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_instance.foo",
+		IDRefreshIgnore: []string{
+			"ephemeral_block_device", "user_data", "security_groups", "vpc_security_groups"},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
 			{
-				Config:             testAccInstanceGP2IopsDeviceExplicit,
+				Config: testAccInstanceGP2WithIopsValue,
+				Check:  testAccCheckInstanceExists("aws_instance.foo", &v),
+			},
+			{
+				Config:             testAccInstanceGP2WithIopsValue,
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},
@@ -1518,7 +1536,7 @@ resource "aws_instance" "foo" {
 }
 `
 
-const testAccInstanceGP2IopsDeviceExplicit = `
+const testAccInstanceGP2WithIopsValue = `
 resource "aws_instance" "foo" {
 	# us-west-2
 	ami = "ami-55a7ea65"
@@ -1531,7 +1549,7 @@ resource "aws_instance" "foo" {
 	root_block_device {
 		volume_type = "gp2"
 		volume_size = 11
-        # demo a test scenario
+        # configured explicitly
 		iops        = 10
 	}
 }

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -189,6 +189,11 @@ func TestAccAWSInstance_GP2IopsDevice(t *testing.T) {
 					testCheck(),
 				),
 			},
+			{
+				Config:             testAccInstanceGP2IopsDeviceExplicit,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
 		},
 	})
 }
@@ -1509,6 +1514,25 @@ resource "aws_instance" "foo" {
 	root_block_device {
 		volume_type = "gp2"
 		volume_size = 11
+	}
+}
+`
+
+const testAccInstanceGP2IopsDeviceExplicit = `
+resource "aws_instance" "foo" {
+	# us-west-2
+	ami = "ami-55a7ea65"
+
+	# In order to attach an encrypted volume to an instance you need to have an
+	# m3.medium or larger. See "Supported Instance Types" in:
+	# http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html
+	instance_type = "m3.medium"
+
+	root_block_device {
+		volume_type = "gp2"
+		volume_size = 11
+        # demo a test scenario
+		iops        = 10
 	}
 }
 `


### PR DESCRIPTION
Before PR#1573: failing

After PR#1573:

```
$ make testacc TESTARGS="-run=TestAccAWSInstance_GP2WithIopsValue"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccAWSInstance_GP2WithIopsValue -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSInstance_GP2WithIopsValue
--- PASS: TestAccAWSInstance_GP2WithIopsValue (80.04s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	80.071s
```
