### PR TITLE
[WIP] Optional password hashing before writing to state - RDS DB

### DIFF
--- a/aws/utils.go
+++ b/aws/utils.go
@@ -1,8 +1,10 @@
 package aws
 
 import (
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"regexp"
 )
@@ -39,4 +41,12 @@ func jsonBytesEqual(b1, b2 []byte) bool {
 	}
 
 	return reflect.DeepEqual(o1, o2)
+}
+
+func hashSum(value interface{}) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(value.(string))))
+}
+
+func hashPassword(value interface{}) string {
+	return hashSum(value)
 }


### PR DESCRIPTION
In reference to existing PR: #1084

**Summary**
Gives users the option to hash their RDS master password before it's written clear text in the state file. 

**Comments**
I'm unable to utilize SchemeStateFunc since ResourceData is not available from within. This is why all the code is in the Create/Update functions. The if/else hell prevents aws change password events whenever apply runs. This could all be fixed if we had access to ResourceData inside SchemaStateFunc.

**Questions:**
-  Is it possible to get other config values from within SchemaStateFunc? 
-  I was able to get SchemaStateFunc method working with a global variable. It's A LOT less code, how do you feel about it?
-  Should I consolidate hashSum and hashPassword into one function? (plan on submitting the same PR for other resources)
