### PR TITLE
resource/aws_directory_service_directory: Support Import functionality

### DIFF
--- a/aws/resource_aws_directory_service_directory.go
+++ b/aws/resource_aws_directory_service_directory.go
@@ -25,57 +25,60 @@ func resourceAwsDirectoryServiceDirectory() *schema.Resource {
 		Read:   resourceAwsDirectoryServiceDirectoryRead,
 		Update: resourceAwsDirectoryServiceDirectoryUpdate,
 		Delete: resourceAwsDirectoryServiceDirectoryDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"password": &schema.Schema{
+			"password": {
 				Type:      schema.TypeString,
 				Required:  true,
 				ForceNew:  true,
 				Sensitive: true,
 			},
-			"size": &schema.Schema{
+			"size": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "Large",
 				ForceNew: true,
 			},
-			"alias": &schema.Schema{
+			"alias": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
-			"short_name": &schema.Schema{
+			"short_name": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
 			},
 			"tags": tagsSchema(),
-			"vpc_settings": &schema.Schema{
+			"vpc_settings": {
 				Type:     schema.TypeList,
 				Optional: true,
 				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"subnet_ids": &schema.Schema{
+						"subnet_ids": {
 							Type:     schema.TypeSet,
 							Required: true,
 							ForceNew: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 							Set:      schema.HashString,
 						},
-						"vpc_id": &schema.Schema{
+						"vpc_id": {
 							Type:     schema.TypeString,
 							Required: true,
 							ForceNew: true,
@@ -83,32 +86,32 @@ func resourceAwsDirectoryServiceDirectory() *schema.Resource {
 					},
 				},
 			},
-			"connect_settings": &schema.Schema{
+			"connect_settings": {
 				Type:     schema.TypeList,
 				Optional: true,
 				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"customer_username": &schema.Schema{
+						"customer_username": {
 							Type:     schema.TypeString,
 							Required: true,
 							ForceNew: true,
 						},
-						"customer_dns_ips": &schema.Schema{
+						"customer_dns_ips": {
 							Type:     schema.TypeSet,
 							Required: true,
 							ForceNew: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 							Set:      schema.HashString,
 						},
-						"subnet_ids": &schema.Schema{
+						"subnet_ids": {
 							Type:     schema.TypeSet,
 							Required: true,
 							ForceNew: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 							Set:      schema.HashString,
 						},
-						"vpc_id": &schema.Schema{
+						"vpc_id": {
 							Type:     schema.TypeString,
 							Required: true,
 							ForceNew: true,
@@ -116,22 +119,22 @@ func resourceAwsDirectoryServiceDirectory() *schema.Resource {
 					},
 				},
 			},
-			"enable_sso": &schema.Schema{
+			"enable_sso": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
 			},
-			"access_url": &schema.Schema{
+			"access_url": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"dns_ip_addresses": &schema.Schema{
+			"dns_ip_addresses": {
 				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 				Computed: true,
 			},
-			"type": &schema.Schema{
+			"type": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "SimpleAD",

--- a/aws/resource_aws_directory_service_directory_test.go
+++ b/aws/resource_aws_directory_service_directory_test.go
@@ -65,13 +65,36 @@ func TestDiffTagsDirectoryService(t *testing.T) {
 	}
 }
 
+func TestAccAWSDirectoryServiceDirectory_importBasic(t *testing.T) {
+	resourceName := "aws_directory_service_directory.bar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDirectoryServiceDirectoryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDirectoryServiceDirectoryConfig,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"password",
+				},
+			},
+		},
+	})
+}
+
 func TestAccAWSDirectoryServiceDirectory_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDirectoryServiceDirectoryDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccDirectoryServiceDirectoryConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceDirectoryExists("aws_directory_service_directory.bar"),
@@ -87,7 +110,7 @@ func TestAccAWSDirectoryServiceDirectory_tags(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDirectoryServiceDirectoryDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccDirectoryServiceDirectoryTagsConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceDirectoryExists("aws_directory_service_directory.bar"),
@@ -104,7 +127,7 @@ func TestAccAWSDirectoryServiceDirectory_microsoft(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDirectoryServiceDirectoryDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccDirectoryServiceDirectoryConfig_microsoft,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceDirectoryExists("aws_directory_service_directory.bar"),
@@ -120,7 +143,7 @@ func TestAccAWSDirectoryServiceDirectory_connector(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDirectoryServiceDirectoryDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccDirectoryServiceDirectoryConfig_connector,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceDirectoryExists("aws_directory_service_directory.connector"),
@@ -136,7 +159,7 @@ func TestAccAWSDirectoryServiceDirectory_withAliasAndSso(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDirectoryServiceDirectoryDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccDirectoryServiceDirectoryConfig_withAlias,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceDirectoryExists("aws_directory_service_directory.bar_a"),
@@ -145,7 +168,7 @@ func TestAccAWSDirectoryServiceDirectory_withAliasAndSso(t *testing.T) {
 					testAccCheckServiceDirectorySso("aws_directory_service_directory.bar_a", false),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccDirectoryServiceDirectoryConfig_withSso,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceDirectoryExists("aws_directory_service_directory.bar_a"),
@@ -154,7 +177,7 @@ func TestAccAWSDirectoryServiceDirectory_withAliasAndSso(t *testing.T) {
 					testAccCheckServiceDirectorySso("aws_directory_service_directory.bar_a", true),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccDirectoryServiceDirectoryConfig_withSso_modified,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceDirectoryExists("aws_directory_service_directory.bar_a"),

--- a/website/docs/r/directory_service_directory.html.markdown
+++ b/website/docs/r/directory_service_directory.html.markdown
@@ -83,3 +83,12 @@ The following attributes are exported:
 * `id` - The directory identifier.
 * `access_url` - The access URL for the directory, such as `http://alias.awsapps.com`.
 * `dns_ip_addresses` - A list of IP addresses of the DNS servers for the directory or connector.
+
+
+## Import
+
+DirectoryService directories can be imported using the directory `id`, e.g.
+
+```
+$ terraform import aws_directory_service_directory.sample d-926724cf57
+```


### PR DESCRIPTION
Fixes: #1709

```
terraform-provider-aws [b-aws-ds-import-1709●●] % acctests aws TestAccAWSDirectoryServiceDirectory_importBasic
=== RUN   TestAccAWSDirectoryServiceDirectory_importBasic
--- PASS: TestAccAWSDirectoryServiceDirectory_importBasic (589.56s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	589.594s
```