### PR TITLE
data_source/aws_vpc_endpoint: Exposing prefix_list_id in datasource

### DIFF
--- a/aws/data_source_aws_vpc_endpoint.go
+++ b/aws/data_source_aws_vpc_endpoint.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -39,11 +40,15 @@ func dataSourceAwsVpcEndpoint() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"route_table_ids": &schema.Schema{
+			"route_table_ids": {
 				Type:     schema.TypeSet,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
+			},
+			"prefix_list_id": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 		},
 	}
@@ -89,12 +94,36 @@ func dataSourceAwsVpcEndpointRead(d *schema.ResourceData, meta interface{}) erro
 		return errwrap.Wrapf("policy contains an invalid JSON: {{err}}", err)
 	}
 
+	prefixListServiceName := *vpce.ServiceName
+	prefixListInput := &ec2.DescribePrefixListsInput{
+		Filters: []*ec2.Filter{
+			{Name: aws.String("prefix-list-name"), Values: []*string{aws.String(prefixListServiceName)}},
+		},
+	}
+	log.Printf("[DEBUG] Reading VPC Endpoint prefix list: %s", prefixListServiceName)
+	prefixListsOutput, err := conn.DescribePrefixLists(prefixListInput)
+
+	if err != nil {
+		_, ok := err.(awserr.Error)
+		if !ok {
+			return fmt.Errorf("Error reading VPC Endpoint prefix list: %s", err.Error())
+		}
+	}
+
+	if len(prefixListsOutput.PrefixLists) != 1 {
+		return fmt.Errorf("There are multiple prefix lists associated with the service name '%s'. Unexpected", prefixListServiceName)
+	}
+
 	d.SetId(aws.StringValue(vpce.VpcEndpointId))
 	d.Set("id", vpce.VpcEndpointId)
 	d.Set("state", vpce.State)
 	d.Set("vpc_id", vpce.VpcId)
 	d.Set("service_name", vpce.ServiceName)
 	d.Set("policy", policy)
+
+	pl := prefixListsOutput.PrefixLists[0]
+	d.Set("prefix_list_id", pl.PrefixListId)
+
 	if err := d.Set("route_table_ids", aws.StringValueSlice(vpce.RouteTableIds)); err != nil {
 		return err
 	}

--- a/aws/data_source_aws_vpc_endpoint_test.go
+++ b/aws/data_source_aws_vpc_endpoint_test.go
@@ -13,10 +13,11 @@ func TestAccDataSourceAwsVpcEndpoint_basic(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccDataSourceAwsVpcEndpointConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceAwsVpcEndpointCheckExists("data.aws_vpc_endpoint.s3"),
+					resource.TestCheckResourceAttrSet("data.aws_vpc_endpoint.s3", "prefix_list_id"),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -29,7 +30,7 @@ func TestAccDataSourceAwsVpcEndpoint_withRouteTable(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccDataSourceAwsVpcEndpointWithRouteTableConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceAwsVpcEndpointCheckExists("data.aws_vpc_endpoint.s3"),

--- a/website/docs/d/vpc_endpoint.html.markdown
+++ b/website/docs/d/vpc_endpoint.html.markdown
@@ -44,5 +44,5 @@ The given filters must match exactly one VPC endpoint whose data will be exporte
 All of the argument attributes are also exported as result attributes.
 
 * `policy` - The policy document associated with the VPC Endpoint.
-
 * `route_table_ids` - One or more route tables associated with the VPC Endpoint.
+* `prefix_list_id` - The prefix list ID of the exposed service.


### PR DESCRIPTION
Fixes: #1691

```
terraform-provider-aws [b-aws-vpce-ds-1691●] % acctests aws TestAccDataSourceAwsVpcEndpoint_
=== RUN   TestAccDataSourceAwsVpcEndpoint_basic
--- PASS: TestAccDataSourceAwsVpcEndpoint_basic (60.06s)
=== RUN   TestAccDataSourceAwsVpcEndpoint_withRouteTable
--- PASS: TestAccDataSourceAwsVpcEndpoint_withRouteTable (64.76s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	124.860s
```