### PR TITLE
resource/aws_spot_instance_request: Add support for instance_interruption_behaviour

### DIFF
--- a/aws/resource_aws_spot_instance_request.go
+++ b/aws/resource_aws_spot_instance_request.go
@@ -78,7 +78,12 @@ func resourceAwsSpotInstanceRequest() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			}
-
+			s["instance_interruption_behaviour"] = &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "terminate",
+				ForceNew: true,
+			}
 			return s
 		}(),
 	}
@@ -95,6 +100,7 @@ func resourceAwsSpotInstanceRequestCreate(d *schema.ResourceData, meta interface
 	spotOpts := &ec2.RequestSpotInstancesInput{
 		SpotPrice: aws.String(d.Get("spot_price").(string)),
 		Type:      aws.String(d.Get("spot_type").(string)),
+		InstanceInterruptionBehavior: aws.String(d.Get("instance_interruption_behaviour").(string)),
 
 		// Though the AWS API supports creating spot instance requests for multiple
 		// instances, for TF purposes we fix this to one instance per request.
@@ -229,6 +235,7 @@ func resourceAwsSpotInstanceRequestRead(d *schema.ResourceData, meta interface{}
 	d.Set("launch_group", request.LaunchGroup)
 	d.Set("block_duration_minutes", request.BlockDurationMinutes)
 	d.Set("tags", tagsToMap(request.Tags))
+	d.Set("instance_interruption_behaviour", request.InstanceInterruptionBehavior)
 
 	return nil
 }

--- a/aws/resource_aws_spot_instance_request_test.go
+++ b/aws/resource_aws_spot_instance_request_test.go
@@ -32,6 +32,8 @@ func TestAccAWSSpotInstanceRequest_basic(t *testing.T) {
 						"aws_spot_instance_request.foo", "spot_bid_status", "fulfilled"),
 					resource.TestCheckResourceAttr(
 						"aws_spot_instance_request.foo", "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(
+						"aws_spot_instance_request.foo", "instance_interruption_behaviour", "terminate"),
 				),
 			},
 		},

--- a/website/docs/r/spot_instance_request.html.markdown
+++ b/website/docs/r/spot_instance_request.html.markdown
@@ -60,6 +60,7 @@ Spot Instance Requests support all the same arguments as
 * `block_duration_minutes` - (Optional) The required duration for the Spot instances, in minutes. This value must be a multiple of 60 (60, 120, 180, 240, 300, or 360).
   The duration period starts as soon as your Spot instance receives its instance ID. At the end of the duration period, Amazon EC2 marks the Spot instance for termination and provides a Spot instance termination notice, which gives the instance a two-minute warning before it terminates.
   Note that you can't specify an Availability Zone group or a launch group if you specify a duration.
+* `instance_interruption_behavior` - (Optional) Indicates whether a Spot instance stops or terminates when it is interrupted. Default is `terminate` as this is the current AWS behaviour.
 
 ### Timeouts
 


### PR DESCRIPTION
Fixes: #1719

```
terraform-provider-aws [f-aws-spot-instance-instance-interuption-1719●] % acctests aws TestAccAWSSpotInstanceRequest_
=== RUN   TestAccAWSSpotInstanceRequest_basic
--- PASS: TestAccAWSSpotInstanceRequest_basic (87.41s)
=== RUN   TestAccAWSSpotInstanceRequest_withLaunchGroup
--- PASS: TestAccAWSSpotInstanceRequest_withLaunchGroup (86.44s)
=== RUN   TestAccAWSSpotInstanceRequest_withBlockDuration
--- PASS: TestAccAWSSpotInstanceRequest_withBlockDuration (98.23s)
=== RUN   TestAccAWSSpotInstanceRequest_vpc
--- FAIL: TestAccAWSSpotInstanceRequest_vpc (109.52s)
	testing.go:434: Step 0 error: Check failed: Check 4/6 error: SubnetID was not passed, but should have been for this instance to belong to a VPC
=== RUN   TestAccAWSSpotInstanceRequest_SubnetAndSGAndPublicIpAddress
--- PASS: TestAccAWSSpotInstanceRequest_SubnetAndSGAndPublicIpAddress (241.27s)
=== RUN   TestAccAWSSpotInstanceRequest_NetworkInterfaceAttributes
--- PASS: TestAccAWSSpotInstanceRequest_NetworkInterfaceAttributes (121.28s)
FAIL
exit status 1
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	744.186s
```

I believe the acceptance test failure above is unrelated