### PR TITLE
resource/aws_kinesis_firehose_delivery_stream: Fix crash in processing_configuration

### DIFF
--- a/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -480,7 +480,10 @@ func createExtendedS3Config(d *schema.ResourceData) *firehose.ExtendedS3Destinat
 		Prefix:                  extractPrefixConfiguration(s3),
 		CompressionFormat:       aws.String(s3["compression_format"].(string)),
 		EncryptionConfiguration: extractEncryptionConfiguration(s3),
-		ProcessingConfiguration: extractProcessingConfiguration(s3),
+	}
+
+	if _, ok := s3["processing_configuration"]; ok {
+		configuration.ProcessingConfiguration = extractProcessingConfiguration(s3)
 	}
 
 	if _, ok := s3["cloudwatch_logging_options"]; ok {
@@ -538,7 +541,12 @@ func updateExtendedS3Config(d *schema.ResourceData) *firehose.ExtendedS3Destinat
 }
 
 func extractProcessingConfiguration(s3 map[string]interface{}) *firehose.ProcessingConfiguration {
-	processingConfiguration := s3["processing_configuration"].([]interface{})[0].(map[string]interface{})
+	config := s3["processing_configuration"].([]interface{})
+	if len(config) == 0 {
+		return nil
+	}
+
+	processingConfiguration := config[0].(map[string]interface{})
 
 	return &firehose.ProcessingConfiguration{
 		Enabled:    aws.Bool(processingConfiguration["enabled"].(bool)),

--- a/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
@@ -99,7 +99,6 @@ func TestAccAWSKinesisFirehoseDeliveryStream_s3ConfigUpdates(t *testing.T) {
 }
 
 func TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3basic(t *testing.T) {
-
 	rSt := acctest.RandString(5)
 	rName := fmt.Sprintf("aws_kinesis_firehose_delivery_stream_test_%s", rSt)
 
@@ -302,6 +301,27 @@ func TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigUpdates(t *testi
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKinesisFirehoseDeliveryStreamExists("aws_kinesis_firehose_delivery_stream.test_stream_es", &stream),
 					testAccCheckAWSKinesisFirehoseDeliveryStreamAttributes(&stream, nil, nil, nil, updatedElasticSearchConfig),
+				),
+			},
+		},
+	})
+}
+
+// Regression test for https://github.com/terraform-providers/terraform-provider-aws/issues/1657
+func TestAccAWSKinesisFirehoseDeliveryStream_missingProcessingConfiguration(t *testing.T) {
+	var stream firehose.DeliveryStreamDescription
+	ri := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     testAccKinesisFirehosePreCheck(t),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKinesisFirehoseDeliveryStreamDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKinesisFirehoseDeliveryStreamConfig_missingProcessingConfiguration(ri),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisFirehoseDeliveryStreamExists("aws_kinesis_firehose_delivery_stream.test_stream", &stream),
+					testAccCheckAWSKinesisFirehoseDeliveryStreamAttributes(&stream, nil, nil, nil, nil),
 				),
 			},
 		},
@@ -934,3 +954,82 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream_es" {
     buffering_interval = 500
   }
 }`
+
+func testAccKinesisFirehoseDeliveryStreamConfig_missingProcessingConfiguration(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "firehose" {
+  name = "tf_acctest_firehose_delivery_role_%d"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "firehose.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "firehose" {
+  name = "tf_acctest_firehose_delivery_policy_%d"
+  role = "${aws_iam_role.firehose.id}"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": [
+        "s3:AbortMultipartUpload",
+        "s3:GetBucketLocation",
+        "s3:GetObject",
+        "s3:ListBucket",
+        "s3:ListBucketMultipartUploads",
+        "s3:PutObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${aws_s3_bucket.bucket.id}",
+        "arn:aws:s3:::${aws_s3_bucket.bucket.id}/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:putLogEvents"
+      ],
+      "Resource": [
+        "arn:aws:logs::log-group:/aws/kinesisfirehose/*"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_s3_bucket" "bucket" {
+  bucket = "tf-test-bucket-%d"
+  acl = "private"
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
+  name        = "terraform-kinesis-firehose-mpc-%d"
+  destination = "extended_s3"
+
+  extended_s3_configuration {
+    role_arn           = "${aws_iam_role.firehose.arn}"
+    prefix             = "tracking/autocomplete_stream/"
+    buffer_interval    = 300
+    buffer_size        = 5
+    compression_format = "GZIP"
+    bucket_arn         = "${aws_s3_bucket.bucket.arn}"
+  }
+}
+`, rInt, rInt, rInt, rInt)
+}


### PR DESCRIPTION
Fixes: #1657

Before this patch:

```
2017-09-12T11:56:41.138-0600 [DEBUG] plugin.terraform-provider-aws_v0.1.4_x4: panic: runtime error: index out of range
2017-09-12T11:56:41.138-0600 [DEBUG] plugin.terraform-provider-aws_v0.1.4_x4:
2017-09-12T11:56:41.138-0600 [DEBUG] plugin.terraform-provider-aws_v0.1.4_x4: goroutine 2687 [running]:
2017-09-12T11:56:41.138-0600 [DEBUG] plugin.terraform-provider-aws_v0.1.4_x4: github.com/terraform-providers/terraform-provider-aws/aws.extractProcessingConfiguration(0xc420c8f650, 0xc42080b710)
2017-09-12T11:56:41.138-0600 [DEBUG] plugin.terraform-provider-aws_v0.1.4_x4:   /opt/teamcity-agent/work/222ea50a1b4f75f4/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_kinesis_firehose_delivery_stream.go:541 +0x2ad
2017-09-12T11:56:41.138-0600 [DEBUG] plugin.terraform-provider-aws_v0.1.4_x4: github.com/terraform-providers/terraform-provider-aws/aws.createExtendedS3Config(0xc4203ecc40, 0xb)
2017-09-12T11:56:41.138-0600 [DEBUG] plugin.terraform-provider-aws_v0.1.4_x4:   /opt/teamcity-agent/work/222ea50a1b4f75f4/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_kinesis_firehose_delivery_stream.go:483 +0x479
2017-09-12T11:56:41.138-0600 [DEBUG] plugin.terraform-provider-aws_v0.1.4_x4: github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsKinesisFirehoseDeliveryStreamCreate(0xc4203ecc40, 0x29c5ec0, 0xc421689a00, 0x24, 0x40555c0)
2017-09-12T11:56:41.138-0600 [DEBUG] plugin.terraform-provider-aws_v0.1.4_x4:   /opt/teamcity-agent/work/222ea50a1b4f75f4/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_kinesis_firehose_delivery_stream.go:808 +0xbc5
2017-09-12T11:56:41.138-0600 [DEBUG] plugin.terraform-provider-aws_v0.1.4_x4: github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema.(*Resource).Apply(0xc421937ec0, 0xc420c4a820, 0xc420816140, 0x29c5ec0, 0xc421689a00, 0x1
, 0x28, 0xc420c8edb0)
```

After this patch:

```
terraform-testing % terraform apply
aws_s3_bucket.bucket: Refreshing state... (ID: tf-test-bucket-72)
aws_iam_role.firehose: Refreshing state... (ID: tf_acctest_firehose_delivery_role_72)
aws_kinesis_firehose_delivery_stream.broken_tracking_autocomplete_stream: Creating...
  arn:                                                      "" => "<computed>"
  destination:                                              "" => "extended_s3"
  destination_id:                                           "" => "<computed>"
  extended_s3_configuration.#:                              "" => "1"
  extended_s3_configuration.0.bucket_arn:                   "" => "arn:aws:s3:::tf-test-bucket-72"
  extended_s3_configuration.0.buffer_interval:              "" => "300"
  extended_s3_configuration.0.buffer_size:                  "" => "5"
  extended_s3_configuration.0.cloudwatch_logging_options.#: "" => "<computed>"
  extended_s3_configuration.0.compression_format:           "" => "GZIP"
  extended_s3_configuration.0.prefix:                       "" => "tracking/autocomplete_stream/"
  extended_s3_configuration.0.role_arn:                     "" => "arn:aws:iam::187416307283:role/tf_acctest_firehose_delivery_role_72"
  name:                                                     "" => "tracking_autocomplete_stream"
  version_id:                                               "" => "<computed>"
aws_kinesis_firehose_delivery_stream.broken_tracking_autocomplete_stream: Still creating... (10s elapsed)
aws_kinesis_firehose_delivery_stream.broken_tracking_autocomplete_stream: Still creating... (2m0s elapsed)
aws_kinesis_firehose_delivery_stream.broken_tracking_autocomplete_stream: Still creating... (3m30s elapsed)
aws_kinesis_firehose_delivery_stream.broken_tracking_autocomplete_stream: Creation complete after 3m38s (ID: arn:aws:firehose:us-west-2:187416307283...erystream/tracking_autocomplete_stream)

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

Test Output:

```
terraform-provider-aws [b-aws-kfhd-crash-1657●] % acctests aws TestAccAWSKinesisFirehoseDeliveryStream_
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_s3basic
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basic (142.95s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_s3WithCloudwatchLogging
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3WithCloudwatchLogging (153.92s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_s3ConfigUpdates
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3ConfigUpdates (266.77s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3basic
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3basic (282.11s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidProcessorType
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidProcessorType (2.86s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidParameterName
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidParameterName (2.49s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3Updates
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3Updates (182.25s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_RedshiftConfigUpdates
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_RedshiftConfigUpdates (902.22s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigUpdates
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigUpdates (1236.74s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	3172.372s
```