### PR TITLE
Optional password hashing before writing to state - RDS DB

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -581,9 +581,10 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			CopyTagsToSnapshot:      aws.Bool(d.Get("copy_tags_to_snapshot").(bool)),
 		}
 
-		// If hash_password config is true, the create switch will hash the password.
-		// Otherwise no work is done.
-		managePasswordHash(d, "create")
+		// If hash_password config is true, hash the password
+		if d.Get("hash_password").(bool) {
+			d.Set("password", hashPassword(d.Get("password")))
+		}
 
 		attr := d.Get("backup_retention_period")
 		opts.BackupRetentionPeriod = aws.Int64(int64(attr.(int)))
@@ -954,7 +955,7 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 	}
 	if d.HasChange("password") || d.HasChange("hash_password") {
 		d.SetPartial("password")
-		requestUpdate, req.MasterUserPassword = managePasswordHash(d, "update")
+		requestUpdate, req.MasterUserPassword = managePasswordHashUpdate(d)
 	}
 	if d.HasChange("multi_az") {
 		d.SetPartial("multi_az")

--- a/aws/utils.go
+++ b/aws/utils.go
@@ -1,8 +1,10 @@
 package aws
 
 import (
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"regexp"
 )
@@ -39,4 +41,12 @@ func jsonBytesEqual(b1, b2 []byte) bool {
 	}
 
 	return reflect.DeepEqual(o1, o2)
+}
+
+func hashSum(value interface{}) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(value.(string))))
+}
+
+func hashPassword(value interface{}) string {
+	return hashSum(value)
 }

--- a/aws/utils.go
+++ b/aws/utils.go
@@ -55,37 +55,31 @@ func hashPassword(value interface{}) string {
 }
 
 // Manages password hashing in state file based on hash_password config value.
-// Should be called from CRUD functions. Switches on method to accomplish different
-// tasks.
-func managePasswordHash(d *schema.ResourceData, method string) (bool, *string) {
+// Should be called from the update function. Compare old password with new
+// and update RDS if no match is found. At the end, hash the password if the
+// hash_password config value is true.
+func managePasswordHashUpdate(d *schema.ResourceData) (bool, *string) {
 	var requestUpdate bool
 	var masterUserPassword *string
 	o_passwd, n_passwd := d.GetChange("password")
 	n_passwdHash := hashPassword(n_passwd)
 	hash_flag := d.Get("hash_password").(bool)
-	switch method {
-	case "create":
-		if hash_flag {
-			d.Set("password", n_passwdHash)
+	values := []string{o_passwd.(string), n_passwd.(string), n_passwdHash}
+	encounter := map[string]bool{}
+	var match bool
+	for value := range values {
+		if encounter[values[value]] {
+			match = true
+		} else {
+			encounter[values[value]] = true
 		}
-	case "update":
-		values := []string{o_passwd.(string), n_passwd.(string), n_passwdHash}
-		encounter := map[string]bool{}
-		var match bool
-		for value := range values {
-			if encounter[values[value]] {
-				match = true
-			} else {
-				encounter[values[value]] = true
-			}
-		}
-		if !match {
-			masterUserPassword = aws.String(n_passwd.(string))
-			requestUpdate = true
-		}
-		if hash_flag {
-			d.Set("password", n_passwdHash)
-		}
+	}
+	if !match {
+		masterUserPassword = aws.String(n_passwd.(string))
+		requestUpdate = true
+	}
+	if hash_flag {
+		d.Set("password", n_passwdHash)
 	}
 	return requestUpdate, masterUserPassword
 }


### PR DESCRIPTION
In reference to existing PR: #1084

**Summary**
Gives users the option to hash their RDS master password before it's written clear text in the state file. 

**Comments**
Unable to utilize SchemeStateFunc since ResourceData is not available from within. This is why all the code is in the Create/Update functions. This could all be fixed if we had access to ResourceData/context inside SchemaStateFunc.
