### PR TITLE
resource/aws_cloudwatch_log_group: Add support for LogGroup encryption

### DIFF
--- a/aws/resource_aws_cloudwatch_log_group.go
+++ b/aws/resource_aws_cloudwatch_log_group.go
@@ -45,6 +45,11 @@ func resourceAwsCloudWatchLogGroup() *schema.Resource {
 				Default:  0,
 			},
 
+			"kms_key_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -69,9 +74,15 @@ func resourceAwsCloudWatchLogGroupCreate(d *schema.ResourceData, meta interface{
 
 	log.Printf("[DEBUG] Creating CloudWatch Log Group: %s", logGroupName)
 
-	_, err := conn.CreateLogGroup(&cloudwatchlogs.CreateLogGroupInput{
+	params := &cloudwatchlogs.CreateLogGroupInput{
 		LogGroupName: aws.String(logGroupName),
-	})
+	}
+
+	if v, ok := d.GetOk("kms_key_id"); ok {
+		params.KmsKeyId = aws.String(v.(string))
+	}
+
+	_, err := conn.CreateLogGroup(params)
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "ResourceAlreadyExistsException" {
 			return fmt.Errorf("Creating CloudWatch Log Group failed: %s:  The CloudWatch Log Group '%s' already exists.", err, d.Get("name").(string))
@@ -104,6 +115,7 @@ func resourceAwsCloudWatchLogGroupRead(d *schema.ResourceData, meta interface{})
 
 	d.Set("arn", lg.Arn)
 	d.Set("name", lg.LogGroupName)
+	d.Set("kms_key_id", lg.KmsKeyId)
 
 	if lg.RetentionInDays != nil {
 		d.Set("retention_in_days", lg.RetentionInDays)
@@ -196,6 +208,27 @@ func resourceAwsCloudWatchLogGroupUpdate(d *schema.ResourceData, meta interface{
 			_, err := conn.TagLogGroup(&cloudwatchlogs.TagLogGroupInput{
 				LogGroupName: aws.String(name),
 				Tags:         create,
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if d.HasChange("kms_key_id") && !d.IsNewResource() {
+		_, newKey := d.GetChange("kms_key_id")
+
+		if newKey.(string) == "" {
+			_, err := conn.DisassociateKmsKey(&cloudwatchlogs.DisassociateKmsKeyInput{
+				LogGroupName: aws.String(name),
+			})
+			if err != nil {
+				return err
+			}
+		} else {
+			_, err := conn.AssociateKmsKey(&cloudwatchlogs.AssociateKmsKeyInput{
+				LogGroupName: aws.String(name),
+				KmsKeyId:     aws.String(newKey.(string)),
 			})
 			if err != nil {
 				return err

--- a/website/docs/r/cloudwatch_log_group.html.markdown
+++ b/website/docs/r/cloudwatch_log_group.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides a CloudWatch Log Group resource.
 ---
 
-# aws\_cloudwatch\_log\_group
+# aws_cloudwatch_log_group
 
 Provides a CloudWatch Log Group resource.
 
@@ -31,6 +31,9 @@ The following arguments are supported:
 * `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `retention_in_days` - (Optional) Specifies the number of days
   you want to retain log events in the specified log group.
+* `kms_key_id` - (Optional) The ARN of the KMS Key to use when encrypting log data. Please note, after the AWS KMS CMK is disassociated from the log group,
+AWS CloudWatch Logs stops encrypting newly ingested data for the log group. All previously ingested data remains encrypted, and AWS CloudWatch Logs requires
+permissions for the CMK whenever the encrypted data is requested.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference


### PR DESCRIPTION
```
terraform-provider-aws [f-aws-clg-kms] % acctests aws TestAccAWSCloudWatchLogGroup_
=== RUN   TestAccAWSCloudWatchLogGroup_importBasic
--- PASS: TestAccAWSCloudWatchLogGroup_importBasic (28.88s)
=== RUN   TestAccAWSCloudWatchLogGroup_basic
--- PASS: TestAccAWSCloudWatchLogGroup_basic (36.69s)
=== RUN   TestAccAWSCloudWatchLogGroup_namePrefix
--- PASS: TestAccAWSCloudWatchLogGroup_namePrefix (24.17s)
=== RUN   TestAccAWSCloudWatchLogGroup_generatedName
--- PASS: TestAccAWSCloudWatchLogGroup_generatedName (25.37s)
=== RUN   TestAccAWSCloudWatchLogGroup_retentionPolicy
--- PASS: TestAccAWSCloudWatchLogGroup_retentionPolicy (47.64s)
=== RUN   TestAccAWSCloudWatchLogGroup_multiple
--- PASS: TestAccAWSCloudWatchLogGroup_multiple (29.25s)
=== RUN   TestAccAWSCloudWatchLogGroup_disappears
--- PASS: TestAccAWSCloudWatchLogGroup_disappears (17.67s)
=== RUN   TestAccAWSCloudWatchLogGroup_tagging
--- PASS: TestAccAWSCloudWatchLogGroup_tagging (100.67s)
=== RUN   TestAccAWSCloudWatchLogGroup_kmsKey
--- PASS: TestAccAWSCloudWatchLogGroup_kmsKey (88.46s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	398.846s
```