### PR TITLE
r/api_gateway_authorizer: Fix wrong ARN (missing region)

### DIFF
--- a/aws/resource_aws_api_gateway_authorizer_test.go
+++ b/aws/resource_aws_api_gateway_authorizer_test.go
@@ -15,7 +15,7 @@ import (
 func TestAccAWSAPIGatewayAuthorizer_basic(t *testing.T) {
 	var conf apigateway.Authorizer
 
-	expectedAuthUri := regexp.MustCompile("arn:aws:apigateway:region:lambda:path/2015-03-31/functions/" +
+	expectedAuthUri := regexp.MustCompile("arn:aws:apigateway:[a-z0-9-]+:lambda:path/2015-03-31/functions/" +
 		"arn:aws:lambda:[a-z0-9-]+:[0-9]{12}:function:tf_acc_api_gateway_authorizer/invocations")
 	expectedCreds := regexp.MustCompile("arn:aws:iam::[0-9]{12}:role/tf_acc_api_gateway_auth_invocation_role")
 
@@ -303,7 +303,7 @@ const testAccAWSAPIGatewayAuthorizerConfig = testAccAWSAPIGatewayAuthorizerConfi
 resource "aws_api_gateway_authorizer" "test" {
   name = "tf-acc-test-authorizer"
   rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  authorizer_uri = "arn:aws:apigateway:region:lambda:path/2015-03-31/functions/${aws_lambda_function.authorizer.arn}/invocations"
+  authorizer_uri = "${aws_lambda_function.authorizer.invoke_arn}"
   authorizer_credentials = "${aws_iam_role.invocation_role.arn}"
 }
 `
@@ -312,7 +312,7 @@ const testAccAWSAPIGatewayAuthorizerUpdatedConfig = testAccAWSAPIGatewayAuthoriz
 resource "aws_api_gateway_authorizer" "test" {
   name = "tf-acc-test-authorizer_modified"
   rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  authorizer_uri = "arn:aws:apigateway:region:lambda:path/2015-03-31/functions/${aws_lambda_function.authorizer.arn}/invocations"
+  authorizer_uri = "${aws_lambda_function.authorizer.invoke_arn}"
   authorizer_credentials = "${aws_iam_role.invocation_role.arn}"
   authorizer_result_ttl_in_seconds = 360
   identity_validation_expression = ".*"

--- a/aws/resource_aws_api_gateway_method_test.go
+++ b/aws/resource_aws_api_gateway_method_test.go
@@ -309,7 +309,7 @@ resource "aws_lambda_function" "authorizer" {
 resource "aws_api_gateway_authorizer" "test" {
   name = "tf-acc-test-authorizer"
   rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  authorizer_uri = "arn:aws:apigateway:region:lambda:path/2015-03-31/functions/${aws_lambda_function.authorizer.arn}/invocations"
+  authorizer_uri = "${aws_lambda_function.authorizer.invoke_arn}"
   authorizer_credentials = "${aws_iam_role.invocation_role.arn}"
 }
 


### PR DESCRIPTION
The validation of ARNs has gotten tighter recently, so here I'm addressing the following two test failures:

```
=== RUN   TestAccAWSAPIGatewayAuthorizer_basic
--- FAIL: TestAccAWSAPIGatewayAuthorizer_basic (88.62s)
    testing.go:434: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_api_gateway_authorizer.test: 1 error(s) occurred:
        
        * aws_api_gateway_authorizer.test: Error creating API Gateway Authorizer: BadRequestException: Invalid Authorizer URI: arn:aws:apigateway:region:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:*******:function:tf_acc_api_gateway_authorizer/invocations. Authorizer URI should be a valid API Gateway ARN that represents a Lambda function invocation.

=== RUN   TestAccAWSAPIGatewayMethod_customauthorizer
--- FAIL: TestAccAWSAPIGatewayMethod_customauthorizer (220.80s)
    testing.go:434: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_api_gateway_authorizer.test: 1 error(s) occurred:
        
        * aws_api_gateway_authorizer.test: Error creating API Gateway Authorizer: BadRequestException: Invalid Authorizer URI: arn:aws:apigateway:region:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:*******:function:tf_acc_api_gateway_authorizer_4236506781091424971/invocations. Authorizer URI should be a valid API Gateway ARN that represents a Lambda function invocation.
```