### PR TITLE
Elasticache Memcached az_mode requires ForceNew

### DIFF
--- a/aws/resource_aws_elasticache_cluster.go
+++ b/aws/resource_aws_elasticache_cluster.go
@@ -157,7 +157,6 @@ func resourceAwsElasticacheCluster() *schema.Resource {
 		Type:     schema.TypeString,
 		Optional: true,
 		Computed: true,
-		ForceNew: true,
 	}
 
 	resourceSchema["availability_zone"] = &schema.Schema{
@@ -380,6 +379,11 @@ func resourceAwsElasticacheClusterRead(d *schema.ResourceData, meta interface{})
 			}
 		}
 		d.Set("availability_zone", c.PreferredAvailabilityZone)
+		if *c.PreferredAvailabilityZone == "Multiple" {
+			d.Set("az_mode", "cross-az")
+		} else {
+			d.Set("az_mode", "single-az")
+		}
 
 		if err := setCacheNodeData(d, c); err != nil {
 			return err
@@ -470,6 +474,11 @@ func resourceAwsElasticacheClusterUpdate(d *schema.ResourceData, meta interface{
 
 	if d.HasChange("snapshot_retention_limit") {
 		req.SnapshotRetentionLimit = aws.Int64(int64(d.Get("snapshot_retention_limit").(int)))
+		requestUpdate = true
+	}
+
+	if d.HasChange("az_mode") {
+		req.AZMode = aws.String(d.Get("az_mode").(string))
 		requestUpdate = true
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/terraform-providers/terraform-provider-aws/issues/726

Due to some AWS API quirkiness, it's best to set up memcached like this:
```
resource "aws_elasticache_cluster" "memcached" {
  cluster_id             = "${format("%.16s-%.3s", lower(var.name), random_id.token.hex)}"
  (...)
  az_mode                = "${var.nodes_number == 1 ? "single-az" : "cross-az"}"
  engine                 = "memcached"
}
```
otherwise it might be hard to scale down cluster. Or just stick with `single-az` if needed.

```
=== RUN   TestAccAWSElasticacheCluster_basic
--- PASS: TestAccAWSElasticacheCluster_basic (499.00s)
=== RUN   TestAccAWSElasticacheCluster_snapshotsWithUpdates
--- PASS: TestAccAWSElasticacheCluster_snapshotsWithUpdates (1059.79s)
=== RUN   TestAccAWSElasticacheCluster_decreasingCacheNodes
--- PASS: TestAccAWSElasticacheCluster_decreasingCacheNodes (1137.61s)
=== RUN   TestAccAWSElasticacheCluster_multiAZInVpc
--- PASS: TestAccAWSElasticacheCluster_multiAZInVpc (676.54s)s
=== RUN   TestAccAWSElasticacheCluster_vpc
--- PASS: TestAccAWSElasticacheCluster_vpc (600.21s)
```