### PR TITLE
r/batch_compute_environment: Randomize tests

### DIFF
--- a/aws/resource_aws_batch_compute_environment_test.go
+++ b/aws/resource_aws_batch_compute_environment_test.go
@@ -7,18 +7,21 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/batch"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccAWSBatchComputeEnvironment_createEc2(t *testing.T) {
+	rInt := acctest.RandInt()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSBatchComputeEnvironmentConfigEC2,
+				Config: testAccAWSBatchComputeEnvironmentConfigEC2(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsBatchComputeEnvironmentExists(),
 				),
@@ -28,13 +31,15 @@ func TestAccAWSBatchComputeEnvironment_createEc2(t *testing.T) {
 }
 
 func TestAccAWSBatchComputeEnvironment_createEc2WithTags(t *testing.T) {
+	rInt := acctest.RandInt()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSBatchComputeEnvironmentConfigEC2WithTags,
+				Config: testAccAWSBatchComputeEnvironmentConfigEC2WithTags(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsBatchComputeEnvironmentExists(),
 					resource.TestCheckResourceAttr("aws_batch_compute_environment.ec2", "compute_resources.0.tags.%", "1"),
@@ -46,13 +51,15 @@ func TestAccAWSBatchComputeEnvironment_createEc2WithTags(t *testing.T) {
 }
 
 func TestAccAWSBatchComputeEnvironment_createSpot(t *testing.T) {
+	rInt := acctest.RandInt()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSBatchComputeEnvironmentConfigSpot,
+				Config: testAccAWSBatchComputeEnvironmentConfigSpot(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsBatchComputeEnvironmentExists(),
 				),
@@ -62,13 +69,15 @@ func TestAccAWSBatchComputeEnvironment_createSpot(t *testing.T) {
 }
 
 func TestAccAWSBatchComputeEnvironment_createUnmanaged(t *testing.T) {
+	rInt := acctest.RandInt()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSBatchComputeEnvironmentConfigUnmanaged,
+				Config: testAccAWSBatchComputeEnvironmentConfigUnmanaged(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsBatchComputeEnvironmentExists(),
 				),
@@ -78,20 +87,22 @@ func TestAccAWSBatchComputeEnvironment_createUnmanaged(t *testing.T) {
 }
 
 func TestAccAWSBatchComputeEnvironment_updateMaxvCpus(t *testing.T) {
+	rInt := acctest.RandInt()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSBatchComputeEnvironmentConfigEC2,
+				Config: testAccAWSBatchComputeEnvironmentConfigEC2(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsBatchComputeEnvironmentExists(),
 					resource.TestCheckResourceAttr("aws_batch_compute_environment.ec2", "compute_resources.0.max_vcpus", "16"),
 				),
 			},
 			{
-				Config: testAccAWSBatchComputeEnvironmentConfigEC2UpdateMaxvCpus,
+				Config: testAccAWSBatchComputeEnvironmentConfigEC2UpdateMaxvCpus(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsBatchComputeEnvironmentExists(),
 					resource.TestCheckResourceAttr("aws_batch_compute_environment.ec2", "compute_resources.0.max_vcpus", "32"),
@@ -102,20 +113,22 @@ func TestAccAWSBatchComputeEnvironment_updateMaxvCpus(t *testing.T) {
 }
 
 func TestAccAWSBatchComputeEnvironment_updateInstanceType(t *testing.T) {
+	rInt := acctest.RandInt()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSBatchComputeEnvironmentConfigEC2,
+				Config: testAccAWSBatchComputeEnvironmentConfigEC2(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsBatchComputeEnvironmentExists(),
 					resource.TestCheckResourceAttr("aws_batch_compute_environment.ec2", "compute_resources.0.instance_type.#", "1"),
 				),
 			},
 			{
-				Config: testAccAWSBatchComputeEnvironmentConfigEC2UpdateInstanceType,
+				Config: testAccAWSBatchComputeEnvironmentConfigEC2UpdateInstanceType(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsBatchComputeEnvironmentExists(),
 					resource.TestCheckResourceAttr("aws_batch_compute_environment.ec2", "compute_resources.0.instance_type.#", "2"),
@@ -126,23 +139,27 @@ func TestAccAWSBatchComputeEnvironment_updateInstanceType(t *testing.T) {
 }
 
 func TestAccAWSBatchComputeEnvironment_updateComputeEnvironmentName(t *testing.T) {
+	rInt := acctest.RandInt()
+	expectedName := fmt.Sprintf("tf_acc_test_%d", rInt)
+	expectedUpdatedName := fmt.Sprintf("tf_acc_test_updated_%d", rInt)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSBatchComputeEnvironmentConfigEC2,
+				Config: testAccAWSBatchComputeEnvironmentConfigEC2(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsBatchComputeEnvironmentExists(),
-					resource.TestCheckResourceAttr("aws_batch_compute_environment.ec2", "compute_environment_name", "sample"),
+					resource.TestCheckResourceAttr("aws_batch_compute_environment.ec2", "compute_environment_name", expectedName),
 				),
 			},
 			{
-				Config: testAccAWSBatchComputeEnvironmentConfigEC2UpdateComputeEnvironmentName,
+				Config: testAccAWSBatchComputeEnvironmentConfigEC2UpdateComputeEnvironmentName(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsBatchComputeEnvironmentExists(),
-					resource.TestCheckResourceAttr("aws_batch_compute_environment.ec2", "compute_environment_name", "sample_updated"),
+					resource.TestCheckResourceAttr("aws_batch_compute_environment.ec2", "compute_environment_name", expectedUpdatedName),
 				),
 			},
 		},
@@ -150,13 +167,15 @@ func TestAccAWSBatchComputeEnvironment_updateComputeEnvironmentName(t *testing.T
 }
 
 func TestAccAWSBatchComputeEnvironment_createEc2WithoutComputeResources(t *testing.T) {
+	rInt := acctest.RandInt()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccAWSBatchComputeEnvironmentConfigEC2WithoutComputeResources,
+				Config:      testAccAWSBatchComputeEnvironmentConfigEC2WithoutComputeResources(rInt),
 				ExpectError: regexp.MustCompile(`One compute environment is expected, but no compute environments are set`),
 			},
 		},
@@ -164,13 +183,15 @@ func TestAccAWSBatchComputeEnvironment_createEc2WithoutComputeResources(t *testi
 }
 
 func TestAccAWSBatchComputeEnvironment_createUnmanagedWithComputeResources(t *testing.T) {
+	rInt := acctest.RandInt()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSBatchComputeEnvironmentConfigUnmanagedWithComputeResources,
+				Config: testAccAWSBatchComputeEnvironmentConfigUnmanagedWithComputeResources(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsBatchComputeEnvironmentExists(),
 					resource.TestCheckResourceAttr("aws_batch_compute_environment.unmanaged", "type", "UNMANAGED"),
@@ -181,13 +202,15 @@ func TestAccAWSBatchComputeEnvironment_createUnmanagedWithComputeResources(t *te
 }
 
 func TestAccAWSBatchComputeEnvironment_createSpotWithoutBidPercentage(t *testing.T) {
+	rInt := acctest.RandInt()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccAWSBatchComputeEnvironmentConfigSpotWithoutBidPercentage,
+				Config:      testAccAWSBatchComputeEnvironmentConfigSpotWithoutBidPercentage(rInt),
 				ExpectError: regexp.MustCompile(`ComputeResources.spotIamFleetRole cannot not be null or empty`),
 			},
 		},
@@ -249,12 +272,13 @@ func testAccCheckAwsBatchComputeEnvironmentExists() resource.TestCheckFunc {
 	}
 }
 
-const testAccAWSBatchComputeEnvironmentConfigBase = `
+func testAccAWSBatchComputeEnvironmentConfigBase(rInt int) string {
+	return fmt.Sprintf(`
 
 ########## ecs_instance_role ##########
 
 resource "aws_iam_role" "ecs_instance_role" {
-  name = "ecs_instance_role"
+  name = "tf_acc_test_batch_inst_role_%d"
   assume_role_policy = <<EOF
 {
     "Version": "2012-10-17",
@@ -277,14 +301,14 @@ resource "aws_iam_role_policy_attachment" "ecs_instance_role" {
 }
 
 resource "aws_iam_instance_profile" "ecs_instance_role" {
-  name  = "ecs_instance_role"
+  name  = "tf_acc_test_batch_ip_%d"
   role = "${aws_iam_role.ecs_instance_role.name}"
 }
 
 ########## aws_batch_service_role ##########
 
 resource "aws_iam_role" "aws_batch_service_role" {
-  name = "aws_batch_service_role"
+  name = "tf_acc_test_batch_svc_role_%d"
   assume_role_policy = <<EOF
 {
     "Version": "2012-10-17",
@@ -309,7 +333,7 @@ resource "aws_iam_role_policy_attachment" "aws_batch_service_role" {
 ########## aws_ec2_spot_fleet_role ##########
 
 resource "aws_iam_role" "aws_ec2_spot_fleet_role" {
-  name = "aws_ec2_spot_fleet_role"
+  name = "tf_acc_test_batch_spot_fleet_role_%d"
   assume_role_policy = <<EOF
 {
     "Version": "2012-10-17",
@@ -334,7 +358,7 @@ resource "aws_iam_role_policy_attachment" "aws_ec2_spot_fleet_role" {
 ########## security group ##########
 
 resource "aws_security_group" "test_acc" {
-  name = "aws_batch_compute_environment_security_group"
+  name = "tf_acc_test_batch_sg_%d"
 }
 
 ########## subnets ##########
@@ -347,11 +371,13 @@ resource "aws_subnet" "test_acc" {
   vpc_id = "${aws_vpc.test_acc.id}"
   cidr_block = "10.1.1.0/24"
 }
-`
+`, rInt, rInt, rInt, rInt, rInt)
+}
 
-const testAccAWSBatchComputeEnvironmentConfigEC2 = testAccAWSBatchComputeEnvironmentConfigBase + `
+func testAccAWSBatchComputeEnvironmentConfigEC2(rInt int) string {
+	return testAccAWSBatchComputeEnvironmentConfigBase(rInt) + fmt.Sprintf(`
 resource "aws_batch_compute_environment" "ec2" {
-  compute_environment_name = "sample"
+  compute_environment_name = "tf_acc_test_%d"
   compute_resources {
     instance_role = "${aws_iam_instance_profile.ecs_instance_role.arn}"
     instance_type = [
@@ -370,11 +396,13 @@ resource "aws_batch_compute_environment" "ec2" {
   service_role = "${aws_iam_role.aws_batch_service_role.arn}"
   type = "MANAGED"
 }
-`
+`, rInt)
+}
 
-const testAccAWSBatchComputeEnvironmentConfigEC2WithTags = testAccAWSBatchComputeEnvironmentConfigBase + `
+func testAccAWSBatchComputeEnvironmentConfigEC2WithTags(rInt int) string {
+	return testAccAWSBatchComputeEnvironmentConfigBase(rInt) + fmt.Sprintf(`
 resource "aws_batch_compute_environment" "ec2" {
-  compute_environment_name = "sample"
+  compute_environment_name = "tf_acc_test_%d"
   compute_resources {
     instance_role = "${aws_iam_instance_profile.ecs_instance_role.arn}"
     instance_type = [
@@ -396,11 +424,13 @@ resource "aws_batch_compute_environment" "ec2" {
   service_role = "${aws_iam_role.aws_batch_service_role.arn}"
   type = "MANAGED"
 }
-`
+`, rInt)
+}
 
-const testAccAWSBatchComputeEnvironmentConfigSpot = testAccAWSBatchComputeEnvironmentConfigBase + `
+func testAccAWSBatchComputeEnvironmentConfigSpot(rInt int) string {
+	return testAccAWSBatchComputeEnvironmentConfigBase(rInt) + fmt.Sprintf(`
 resource "aws_batch_compute_environment" "spot" {
-  compute_environment_name = "sample"
+  compute_environment_name = "tf_acc_test_%d"
   compute_resources {
     bid_percentage = 100
     instance_role = "${aws_iam_instance_profile.ecs_instance_role.arn}"
@@ -421,19 +451,23 @@ resource "aws_batch_compute_environment" "spot" {
   service_role = "${aws_iam_role.aws_batch_service_role.arn}"
   type = "MANAGED"
 }
-`
+`, rInt)
+}
 
-const testAccAWSBatchComputeEnvironmentConfigUnmanaged = testAccAWSBatchComputeEnvironmentConfigBase + `
+func testAccAWSBatchComputeEnvironmentConfigUnmanaged(rInt int) string {
+	return testAccAWSBatchComputeEnvironmentConfigBase(rInt) + fmt.Sprintf(`
 resource "aws_batch_compute_environment" "unmanaged" {
-  compute_environment_name = "sample"
+  compute_environment_name = "tf_acc_test_%d"
   service_role = "${aws_iam_role.aws_batch_service_role.arn}"
   type = "UNMANAGED"
 }
-`
+`, rInt)
+}
 
-const testAccAWSBatchComputeEnvironmentConfigEC2UpdateMaxvCpus = testAccAWSBatchComputeEnvironmentConfigBase + `
+func testAccAWSBatchComputeEnvironmentConfigEC2UpdateMaxvCpus(rInt int) string {
+	return testAccAWSBatchComputeEnvironmentConfigBase(rInt) + fmt.Sprintf(`
 resource "aws_batch_compute_environment" "ec2" {
-  compute_environment_name = "sample"
+  compute_environment_name = "tf_acc_test_%d"
   compute_resources {
     instance_role = "${aws_iam_instance_profile.ecs_instance_role.arn}"
     instance_type = [
@@ -452,11 +486,13 @@ resource "aws_batch_compute_environment" "ec2" {
   service_role = "${aws_iam_role.aws_batch_service_role.arn}"
   type = "MANAGED"
 }
-`
+`, rInt)
+}
 
-const testAccAWSBatchComputeEnvironmentConfigEC2UpdateInstanceType = testAccAWSBatchComputeEnvironmentConfigBase + `
+func testAccAWSBatchComputeEnvironmentConfigEC2UpdateInstanceType(rInt int) string {
+	return testAccAWSBatchComputeEnvironmentConfigBase(rInt) + fmt.Sprintf(`
 resource "aws_batch_compute_environment" "ec2" {
-  compute_environment_name = "sample"
+  compute_environment_name = "tf_acc_test_%d"
   compute_resources {
     instance_role = "${aws_iam_instance_profile.ecs_instance_role.arn}"
     instance_type = [
@@ -476,11 +512,13 @@ resource "aws_batch_compute_environment" "ec2" {
   service_role = "${aws_iam_role.aws_batch_service_role.arn}"
   type = "MANAGED"
 }
-`
+`, rInt)
+}
 
-const testAccAWSBatchComputeEnvironmentConfigEC2UpdateComputeEnvironmentName = testAccAWSBatchComputeEnvironmentConfigBase + `
+func testAccAWSBatchComputeEnvironmentConfigEC2UpdateComputeEnvironmentName(rInt int) string {
+	return testAccAWSBatchComputeEnvironmentConfigBase(rInt) + fmt.Sprintf(`
 resource "aws_batch_compute_environment" "ec2" {
-  compute_environment_name = "sample_updated"
+  compute_environment_name = "tf_acc_test_updated_%d"
   compute_resources {
     instance_role = "${aws_iam_instance_profile.ecs_instance_role.arn}"
     instance_type = [
@@ -499,19 +537,23 @@ resource "aws_batch_compute_environment" "ec2" {
   service_role = "${aws_iam_role.aws_batch_service_role.arn}"
   type = "MANAGED"
 }
-`
+`, rInt)
+}
 
-const testAccAWSBatchComputeEnvironmentConfigEC2WithoutComputeResources = testAccAWSBatchComputeEnvironmentConfigBase + `
+func testAccAWSBatchComputeEnvironmentConfigEC2WithoutComputeResources(rInt int) string {
+	return testAccAWSBatchComputeEnvironmentConfigBase(rInt) + fmt.Sprintf(`
 resource "aws_batch_compute_environment" "ec2" {
-  compute_environment_name = "sample"
+  compute_environment_name = "tf_acc_test_%d"
   service_role = "${aws_iam_role.aws_batch_service_role.arn}"
   type = "MANAGED"
 }
-`
+`, rInt)
+}
 
-const testAccAWSBatchComputeEnvironmentConfigUnmanagedWithComputeResources = testAccAWSBatchComputeEnvironmentConfigBase + `
+func testAccAWSBatchComputeEnvironmentConfigUnmanagedWithComputeResources(rInt int) string {
+	return testAccAWSBatchComputeEnvironmentConfigBase(rInt) + fmt.Sprintf(`
 resource "aws_batch_compute_environment" "unmanaged" {
-  compute_environment_name = "sample"
+  compute_environment_name = "tf_acc_test_%d"
   compute_resources {
     instance_role = "${aws_iam_instance_profile.ecs_instance_role.arn}"
     instance_type = [
@@ -530,11 +572,13 @@ resource "aws_batch_compute_environment" "unmanaged" {
   service_role = "${aws_iam_role.aws_batch_service_role.arn}"
   type = "UNMANAGED"
 }
-`
+`, rInt)
+}
 
-const testAccAWSBatchComputeEnvironmentConfigSpotWithoutBidPercentage = testAccAWSBatchComputeEnvironmentConfigBase + `
+func testAccAWSBatchComputeEnvironmentConfigSpotWithoutBidPercentage(rInt int) string {
+	return testAccAWSBatchComputeEnvironmentConfigBase(rInt) + fmt.Sprintf(`
 resource "aws_batch_compute_environment" "ec2" {
-  compute_environment_name = "sample"
+  compute_environment_name = "tf_acc_test_%d"
   compute_resources {
     instance_role = "${aws_iam_instance_profile.ecs_instance_role.arn}"
     instance_type = [
@@ -553,4 +597,5 @@ resource "aws_batch_compute_environment" "ec2" {
   service_role = "${aws_iam_role.aws_batch_service_role.arn}"
   type = "MANAGED"
 }
-`
+`, rInt)
+}


### PR DESCRIPTION
This is to address the following test failures:

```
=== RUN   TestAccAWSBatchComputeEnvironment_createEc2WithTags
--- FAIL: TestAccAWSBatchComputeEnvironment_createEc2WithTags (5.53s)
    testing.go:434: Step 0 error: Error applying: 4 error(s) occurred:
        
        * aws_security_group.test_acc: 1 error(s) occurred:
        
        * aws_security_group.test_acc: Error creating Security Group: InvalidGroup.Duplicate: The security group 'aws_batch_compute_environment_security_group' already exists for VPC 'vpc-6290a707'
            status code: 400, request id: 3559c525-b574-458b-986d-450027307a87
        * aws_iam_role.aws_ec2_spot_fleet_role: 1 error(s) occurred:
        
        * aws_iam_role.aws_ec2_spot_fleet_role: Error creating IAM Role aws_ec2_spot_fleet_role: EntityAlreadyExists: Role with name aws_ec2_spot_fleet_role already exists.
            status code: 409, request id: 0deddd66-a346-11e7-98e3-5590d271096c
        * aws_iam_role.aws_batch_service_role: 1 error(s) occurred:
        
        * aws_iam_role.aws_batch_service_role: Error creating IAM Role aws_batch_service_role: EntityAlreadyExists: Role with name aws_batch_service_role already exists.
            status code: 409, request id: 0df026d2-a346-11e7-9056-91d962458027
        * aws_iam_role.ecs_instance_role: 1 error(s) occurred:
        
        * aws_iam_role.ecs_instance_role: Error creating IAM Role ecs_instance_role: EntityAlreadyExists: Role with name ecs_instance_role already exists.
            status code: 409, request id: 0df249d3-a346-11e7-af75-a595d609b797
=== RUN   TestAccAWSBatchComputeEnvironment_createEc2WithoutComputeResources
--- FAIL: TestAccAWSBatchComputeEnvironment_createEc2WithoutComputeResources (5.81s)
    testing.go:427: Step 0, expected error:
        
        Error applying: 4 error(s) occurred:
        
        * aws_iam_role.aws_ec2_spot_fleet_role: 1 error(s) occurred:
        
        * aws_iam_role.aws_ec2_spot_fleet_role: Error creating IAM Role aws_ec2_spot_fleet_role: EntityAlreadyExists: Role with name aws_ec2_spot_fleet_role already exists.
            status code: 409, request id: 1e7d0f99-a346-11e7-af75-a595d609b797
        * aws_iam_role.ecs_instance_role: 1 error(s) occurred:
        
        * aws_iam_role.ecs_instance_role: Error creating IAM Role ecs_instance_role: EntityAlreadyExists: Role with name ecs_instance_role already exists.
            status code: 409, request id: 1e79db81-a346-11e7-9056-91d962458027
        * aws_iam_role.aws_batch_service_role: 1 error(s) occurred:
        
        * aws_iam_role.aws_batch_service_role: Error creating IAM Role aws_batch_service_role: EntityAlreadyExists: Role with name aws_batch_service_role already exists.
            status code: 409, request id: 1e7b6219-a346-11e7-aa1a-cf97ecad991b
        * aws_security_group.test_acc: 1 error(s) occurred:
        
        * aws_security_group.test_acc: Error creating Security Group: InvalidGroup.Duplicate: The security group 'aws_batch_compute_environment_security_group' already exists for VPC 'vpc-6290a707'
            status code: 400, request id: 6bffd07a-90d6-494b-bbca-626ee0ab68e1
=== RUN   TestAccAWSBatchComputeEnvironment_createSpot
--- FAIL: TestAccAWSBatchComputeEnvironment_createSpot (5.85s)
    testing.go:434: Step 0 error: Error applying: 4 error(s) occurred:
        
        * aws_iam_role.ecs_instance_role: 1 error(s) occurred:
        
        * aws_iam_role.ecs_instance_role: Error creating IAM Role ecs_instance_role: EntityAlreadyExists: Role with name ecs_instance_role already exists.
            status code: 409, request id: 11437116-a346-11e7-9521-4d5e35bb3b0c
        * aws_iam_role.aws_batch_service_role: 1 error(s) occurred:
        
        * aws_iam_role.aws_batch_service_role: Error creating IAM Role aws_batch_service_role: EntityAlreadyExists: Role with name aws_batch_service_role already exists.
            status code: 409, request id: 1144a8e5-a346-11e7-98e3-5590d271096c
        * aws_security_group.test_acc: 1 error(s) occurred:
        
        * aws_security_group.test_acc: Error creating Security Group: InvalidGroup.Duplicate: The security group 'aws_batch_compute_environment_security_group' already exists for VPC 'vpc-6290a707'
            status code: 400, request id: 40407bf7-a0af-4148-86cb-0bff1a7f67de
        * aws_iam_role.aws_ec2_spot_fleet_role: 1 error(s) occurred:
        
        * aws_iam_role.aws_ec2_spot_fleet_role: Error creating IAM Role aws_ec2_spot_fleet_role: EntityAlreadyExists: Role with name aws_ec2_spot_fleet_role already exists.
            status code: 409, request id: 114bd56a-a346-11e7-b17e-5985c30173ad
=== RUN   TestAccAWSBatchComputeEnvironment_createSpotWithoutBidPercentage
--- FAIL: TestAccAWSBatchComputeEnvironment_createSpotWithoutBidPercentage (14.58s)
    testing.go:427: Step 0, expected error:
        
        Error applying: 3 error(s) occurred:
        
        * aws_iam_role.aws_ec2_spot_fleet_role: 1 error(s) occurred:
        
        * aws_iam_role.aws_ec2_spot_fleet_role: Error creating IAM Role aws_ec2_spot_fleet_role: EntityAlreadyExists: Role with name aws_ec2_spot_fleet_role already exists.
            status code: 409, request id: 216d51e2-a346-11e7-b17e-5985c30173ad
        * aws_iam_role.ecs_instance_role: 1 error(s) occurred:
        
        * aws_iam_role.ecs_instance_role: Error creating IAM Role ecs_instance_role: EntityAlreadyExists: Role with name ecs_instance_role already exists.
            status code: 409, request id: 216c18e0-a346-11e7-af75-a595d609b797
        * aws_iam_role.aws_batch_service_role: 1 error(s) occurred:
        
        * aws_iam_role.aws_batch_service_role: Error creating IAM Role aws_batch_service_role: EntityAlreadyExists: Role with name aws_batch_service_role already exists.
            status code: 409, request id: 21725a90-a346-11e7-aa1a-cf97ecad991b
        
        To match:
        
        ComputeResources.spotIamFleetRole cannot not be null or empty
=== RUN   TestAccAWSBatchComputeEnvironment_createUnmanaged
--- FAIL: TestAccAWSBatchComputeEnvironment_createUnmanaged (5.88s)
    testing.go:434: Step 0 error: Error applying: 4 error(s) occurred:
        
        * aws_security_group.test_acc: 1 error(s) occurred:
        
        * aws_security_group.test_acc: Error creating Security Group: InvalidGroup.Duplicate: The security group 'aws_batch_compute_environment_security_group' already exists for VPC 'vpc-6290a707'
            status code: 400, request id: bcb527fa-70cf-4583-b7a3-5ddb801a0b07
        * aws_iam_role.ecs_instance_role: 1 error(s) occurred:
        
        * aws_iam_role.ecs_instance_role: Error creating IAM Role ecs_instance_role: EntityAlreadyExists: Role with name ecs_instance_role already exists.
            status code: 409, request id: 14b93629-a346-11e7-af75-a595d609b797
        * aws_iam_role.aws_ec2_spot_fleet_role: 1 error(s) occurred:
        
        * aws_iam_role.aws_ec2_spot_fleet_role: Error creating IAM Role aws_ec2_spot_fleet_role: EntityAlreadyExists: Role with name aws_ec2_spot_fleet_role already exists.
            status code: 409, request id: 14b9ab4f-a346-11e7-b17e-5985c30173ad
        * aws_iam_role.aws_batch_service_role: 1 error(s) occurred:
        
        * aws_iam_role.aws_batch_service_role: Error creating IAM Role aws_batch_service_role: EntityAlreadyExists: Role with name aws_batch_service_role already exists.
            status code: 409, request id: 14b9abba-a346-11e7-aa1a-cf97ecad991b
=== RUN   TestAccAWSBatchComputeEnvironment_createUnmanagedWithComputeResources
--- FAIL: TestAccAWSBatchComputeEnvironment_createUnmanagedWithComputeResources (12.45s)
    testing.go:434: Step 0 error: Error applying: 3 error(s) occurred:
        
        * aws_security_group.test_acc: 1 error(s) occurred:
        
        * aws_security_group.test_acc: Error creating Security Group: InvalidGroup.Duplicate: The security group 'aws_batch_compute_environment_security_group' already exists for VPC 'vpc-6290a707'
            status code: 400, request id: 08adaf81-3d75-4b7c-b99a-66921595be1b
        * aws_iam_role.ecs_instance_role: 1 error(s) occurred:
        
        * aws_iam_role.ecs_instance_role: Error creating IAM Role ecs_instance_role: EntityAlreadyExists: Role with name ecs_instance_role already exists.
            status code: 409, request id: 20ecfe00-a346-11e7-98e3-5590d271096c
        * aws_iam_role.aws_batch_service_role: 1 error(s) occurred:
        
        * aws_iam_role.aws_batch_service_role: Error creating IAM Role aws_batch_service_role: EntityAlreadyExists: Role with name aws_batch_service_role already exists.
            status code: 409, request id: 20f11cdf-a346-11e7-af75-a595d609b797
=== RUN   TestAccAWSBatchComputeEnvironment_updateComputeEnvironmentName
--- FAIL: TestAccAWSBatchComputeEnvironment_updateComputeEnvironmentName (6.06s)
    testing.go:434: Step 0 error: Error applying: 4 error(s) occurred:
        
        * aws_security_group.test_acc: 1 error(s) occurred:
        
        * aws_security_group.test_acc: Error creating Security Group: InvalidGroup.Duplicate: The security group 'aws_batch_compute_environment_security_group' already exists for VPC 'vpc-6290a707'
            status code: 400, request id: e9fc1709-01f7-44c3-a6ce-b29d23ae0b07
        * aws_iam_role.aws_ec2_spot_fleet_role: 1 error(s) occurred:
        
        * aws_iam_role.aws_ec2_spot_fleet_role: Error creating IAM Role aws_ec2_spot_fleet_role: EntityAlreadyExists: Role with name aws_ec2_spot_fleet_role already exists.
            status code: 409, request id: 1da3ed93-a346-11e7-9521-4d5e35bb3b0c
        * aws_iam_role.ecs_instance_role: 1 error(s) occurred:
        
        * aws_iam_role.ecs_instance_role: Error creating IAM Role ecs_instance_role: EntityAlreadyExists: Role with name ecs_instance_role already exists.
            status code: 409, request id: 1da7224c-a346-11e7-af75-a595d609b797
        * aws_iam_role.aws_batch_service_role: 1 error(s) occurred:
        
        * aws_iam_role.aws_batch_service_role: Error creating IAM Role aws_batch_service_role: EntityAlreadyExists: Role with name aws_batch_service_role already exists.
            status code: 409, request id: 1da59b22-a346-11e7-9056-91d962458027
=== RUN   TestAccAWSBatchComputeEnvironment_updateInstanceType
--- FAIL: TestAccAWSBatchComputeEnvironment_updateInstanceType (7.79s)
    testing.go:434: Step 0 error: Error applying: 3 error(s) occurred:
        
        * aws_security_group.test_acc: 1 error(s) occurred:
        
        * aws_security_group.test_acc: Error creating Security Group: InvalidGroup.Duplicate: The security group 'aws_batch_compute_environment_security_group' already exists for VPC 'vpc-6290a707'
            status code: 400, request id: ae4834f7-d0ae-436d-8d33-b68c0873cb71
        * aws_iam_role.aws_batch_service_role: 1 error(s) occurred:
        
        * aws_iam_role.aws_batch_service_role: Error creating IAM Role aws_batch_service_role: EntityAlreadyExists: Role with name aws_batch_service_role already exists.
            status code: 409, request id: 1c4017d5-a346-11e7-9056-91d962458027
        * aws_iam_role.ecs_instance_role: 1 error(s) occurred:
        
        * aws_iam_role.ecs_instance_role: Error creating IAM Role ecs_instance_role: EntityAlreadyExists: Role with name ecs_instance_role already exists.
            status code: 409, request id: 1c3f05f0-a346-11e7-aa1a-cf97ecad991b
=== RUN   TestAccAWSBatchComputeEnvironment_updateMaxvCpus
--- FAIL: TestAccAWSBatchComputeEnvironment_updateMaxvCpus (6.59s)
    testing.go:434: Step 0 error: Error applying: 4 error(s) occurred:
        
        * aws_iam_role.ecs_instance_role: 1 error(s) occurred:
        
        * aws_iam_role.ecs_instance_role: Error creating IAM Role ecs_instance_role: EntityAlreadyExists: Role with name ecs_instance_role already exists.
            status code: 409, request id: 185a78cf-a346-11e7-aa1a-cf97ecad991b
        * aws_iam_role.aws_ec2_spot_fleet_role: 1 error(s) occurred:
        
        * aws_iam_role.aws_ec2_spot_fleet_role: Error creating IAM Role aws_ec2_spot_fleet_role: EntityAlreadyExists: Role with name aws_ec2_spot_fleet_role already exists.
            status code: 409, request id: 185a51be-a346-11e7-aa1a-cf97ecad991b
        * aws_iam_role.aws_batch_service_role: 1 error(s) occurred:
        
        * aws_iam_role.aws_batch_service_role: Error creating IAM Role aws_batch_service_role: EntityAlreadyExists: Role with name aws_batch_service_role already exists.
            status code: 409, request id: 18626822-a346-11e7-aa1a-cf97ecad991b
        * aws_security_group.test_acc: 1 error(s) occurred:
        
        * aws_security_group.test_acc: Error creating Security Group: InvalidGroup.Duplicate: The security group 'aws_batch_compute_environment_security_group' already exists for VPC 'vpc-6290a707'
            status code: 400, request id: 468d4e94-29c5-4efb-b57c-65bc924975be
```

## Test results

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSBatchComputeEnvironment'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSBatchComputeEnvironment -timeout 120m
=== RUN   TestAccAWSBatchComputeEnvironment_createEc2
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2 (79.16s)
=== RUN   TestAccAWSBatchComputeEnvironment_createEc2WithTags
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2WithTags (73.04s)
=== RUN   TestAccAWSBatchComputeEnvironment_createSpot
--- PASS: TestAccAWSBatchComputeEnvironment_createSpot (79.95s)
=== RUN   TestAccAWSBatchComputeEnvironment_createUnmanaged
--- PASS: TestAccAWSBatchComputeEnvironment_createUnmanaged (129.91s)
=== RUN   TestAccAWSBatchComputeEnvironment_updateMaxvCpus
--- PASS: TestAccAWSBatchComputeEnvironment_updateMaxvCpus (148.77s)
=== RUN   TestAccAWSBatchComputeEnvironment_updateInstanceType
--- PASS: TestAccAWSBatchComputeEnvironment_updateInstanceType (163.36s)
=== RUN   TestAccAWSBatchComputeEnvironment_updateComputeEnvironmentName
--- PASS: TestAccAWSBatchComputeEnvironment_updateComputeEnvironmentName (134.25s)
=== RUN   TestAccAWSBatchComputeEnvironment_createEc2WithoutComputeResources
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2WithoutComputeResources (42.09s)
=== RUN   TestAccAWSBatchComputeEnvironment_createUnmanagedWithComputeResources
--- PASS: TestAccAWSBatchComputeEnvironment_createUnmanagedWithComputeResources (75.29s)
=== RUN   TestAccAWSBatchComputeEnvironment_createSpotWithoutBidPercentage
--- PASS: TestAccAWSBatchComputeEnvironment_createSpotWithoutBidPercentage (40.80s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	966.666s
```