### PR TITLE
Fix copy/paste error in data_source_aws_db_instance

### DIFF
--- a/aws/data_source_aws_db_instance.go
+++ b/aws/data_source_aws_db_instance.go
@@ -232,7 +232,7 @@ func dataSourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("availability_zone", dbInstance.AvailabilityZone)
 	d.Set("backup_retention_period", dbInstance.BackupRetentionPeriod)
 	d.Set("db_cluster_identifier", dbInstance.DBClusterIdentifier)
-	d.Set("db_instance_arn", dbInstance.DBClusterIdentifier)
+	d.Set("db_instance_arn", dbInstance.DBInstanceArn)
 	d.Set("db_instance_class", dbInstance.DBInstanceClass)
 	d.Set("db_name", dbInstance.DBName)
 


### PR DESCRIPTION
`db_instance_arn` is coming back incorrectly right now. Seems like a simple fix. I'm new to Terraform though, so I may have overlooked something.