### PR TITLE
Add event types to ses_event_destination resource

### DIFF
--- a/aws/resource_aws_ses_event_destination.go
+++ b/aws/resource_aws_ses_event_destination.go
@@ -176,6 +176,8 @@ func validateMatchingTypes(v interface{}, k string) (ws []string, errors []error
 		"bounce":    true,
 		"complaint": true,
 		"delivery":  true,
+		"open":      true,
+		"click":     true,
 	}
 
 	if !matchingTypes[value] {

--- a/website/docs/r/ses_event_destination.markdown
+++ b/website/docs/r/ses_event_destination.markdown
@@ -48,7 +48,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the event destination
 * `configuration_set_name` - (Required) The name of the configuration set
 * `enabled` - (Optional) If true, the event destination will be enabled
-* `matching_types` - (Required) A list of matching types. May be any of `"send"`, `"reject"`, `"bounce"`, `"complaint"`, or `"delivery"`.
+* `matching_types` - (Required) A list of matching types. May be any of `"send"`, `"reject"`, `"bounce"`, `"complaint"`, `"delivery"`, `"open"`, or `"click"`.
 * `cloudwatch_destination` - (Optional) CloudWatch destination for the events
 * `kinesis_destination` - (Optional) Send the events to a kinesis firehose destination
 


### PR DESCRIPTION
Added `open` and `click` event types per AWS api:
http://docs.aws.amazon.com/ses/latest/APIReference/API_EventDestination.html