### PR TITLE
Add 'arn' attribute to 'aws_redshift_service_account' data source

### DIFF
--- a/aws/arn.go
+++ b/aws/arn.go
@@ -1,0 +1,26 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/iam"
+)
+
+func arnString(partition, region, service, accountId, resource string) string {
+	return arn.ARN{
+		Partition: partition,
+		Region:    region,
+		Service:   service,
+		AccountID: accountId,
+		Resource:  resource,
+	}.String()
+}
+
+// See http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-iam
+func iamArnString(partition, accountId, resource string) string {
+	return arnString(
+		partition,
+		"",
+		iam.ServiceName,
+		accountId,
+		resource)
+}

--- a/aws/arn_test.go
+++ b/aws/arn_test.go
@@ -1,0 +1,13 @@
+package aws
+
+import (
+	"testing"
+)
+
+func TestArn_iamRootUser(t *testing.T) {
+	arn := iamArnString("aws", "1234567890", "root")
+	expectedArn := "arn:aws:iam::1234567890:root"
+	if arn != expectedArn {
+		t.Fatalf("Expected ARN: %s, got: %s", expectedArn, arn)
+	}
+}

--- a/aws/data_source_aws_redshift_service_account.go
+++ b/aws/data_source_aws_redshift_service_account.go
@@ -49,7 +49,7 @@ func dataSourceAwsRedshiftServiceAccountRead(d *schema.ResourceData, meta interf
 
 	if accid, ok := redshiftServiceAccountPerRegionMap[region]; ok {
 		d.SetId(accid)
-		d.Set("arn", fmt.Sprintf("arn:%s:iam::%s:user/logs", meta.(*AWSClient).partition, accid))
+		d.Set("arn", iamArnString(meta.(*AWSClient).partition, accid, "user/logs"))
 		return nil
 	}
 

--- a/aws/data_source_aws_redshift_service_account.go
+++ b/aws/data_source_aws_redshift_service_account.go
@@ -33,6 +33,10 @@ func dataSourceAwsRedshiftServiceAccount() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -45,6 +49,7 @@ func dataSourceAwsRedshiftServiceAccountRead(d *schema.ResourceData, meta interf
 
 	if accid, ok := redshiftServiceAccountPerRegionMap[region]; ok {
 		d.SetId(accid)
+		d.Set("arn", fmt.Sprintf("arn:%s:iam::%s:user/logs", meta.(*AWSClient).partition, accid))
 		return nil
 	}
 

--- a/aws/data_source_aws_redshift_service_account_test.go
+++ b/aws/data_source_aws_redshift_service_account_test.go
@@ -15,12 +15,14 @@ func TestAccAWSRedshiftServiceAccount_basic(t *testing.T) {
 				Config: testAccCheckAwsRedshiftServiceAccountConfig,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.aws_redshift_service_account.main", "id", "902366379725"),
+					resource.TestCheckResourceAttr("data.aws_redshift_service_account.main", "arn", "arn:aws:iam::902366379725:user/logs"),
 				),
 			},
 			resource.TestStep{
 				Config: testAccCheckAwsRedshiftServiceAccountExplicitRegionConfig,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.aws_redshift_service_account.regional", "id", "307160386991"),
+					resource.TestCheckResourceAttr("data.aws_redshift_service_account.regional", "arn", "arn:aws:iam::307160386991:user/logs"),
 				),
 			},
 		},

--- a/website/docs/d/redshift_service_account.html.markdown
+++ b/website/docs/d/redshift_service_account.html.markdown
@@ -3,12 +3,12 @@ layout: "aws"
 page_title: "AWS: aws_redshift_service_account"
 sidebar_current: "docs-aws-datasource-redshift-service-account"
 description: |-
-  Get AWS Redshift Service Account ID for storing audit data in S3.
+  Get AWS Redshift Service Account for storing audit data in S3.
 ---
 
 # aws\_redshift\_service\_account
 
-Use this data source to get the Service Account ID of the [AWS Redshift Account](http://docs.aws.amazon.com/redshift/latest/mgmt/db-auditing.html#db-auditing-enable-logging)
+Use this data source to get the Account ID of the [AWS Redshift Service Account](http://docs.aws.amazon.com/redshift/latest/mgmt/db-auditing.html#db-auditing-enable-logging)
 in a given region for the purpose of allowing Redshift to store audit data in S3.
 
 ## Example Usage
@@ -28,7 +28,7 @@ resource "aws_s3_bucket" "bucket" {
         			"Sid": "Put bucket policy needed for audit logging",
         			"Effect": "Allow",
         			"Principal": {
-        				"AWS": "arn:aws:iam::${data.aws_redshift_service_account.main.id}:user/logs"
+						"AWS": "${data.aws_redshift_service_account.main.arn}"
         			},
         			"Action": "s3:PutObject",
         			"Resource": "arn:aws:s3:::tf-redshift-logging-test-bucket/*"
@@ -37,7 +37,7 @@ resource "aws_s3_bucket" "bucket" {
         			"Sid": "Get bucket policy needed for audit logging ",
         			"Effect": "Allow",
         			"Principal": {
-        				"AWS": "arn:aws:iam::${data.aws_redshift_service_account.main.id}:user/logs"
+						"AWS": "${data.aws_redshift_service_account.main.arn}"
         			},
         			"Action": "s3:GetBucketAcl",
         			"Resource": "arn:aws:s3:::tf-redshift-logging-test-bucket"
@@ -50,9 +50,10 @@ EOF
 
 ## Argument Reference
 
-* `region` - (Optional) Name of the Region whose Redshift account id is desired. If not specified, default's to the region from the AWS provider configuration.
-
+* `region` - (Optional) Name of the region whose AWS Redshift account ID is desired.
+Defaults to the region from the AWS provider configuration.
 
 ## Attributes Reference
 
-* `id` - The ID of the Redshift service Account in the selected region.
+* `id` - The ID of the AWS Redshift service account in the selected region.
+* `arn` - The ARN of the AWS Redshift service account in the selected region.


### PR DESCRIPTION
Similar to https://github.com/hashicorp/terraform/pull/8700 for the `aws_elb_service_account` data source, add the `arn` attribute to the `aws_redshift_service_account` data source.
Acceptance tests:
```
make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSRedshiftServiceAccount_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAWSRedshiftServiceAccount_ -timeout 120m
=== RUN   TestAccAWSRedshiftServiceAccount_basic
--- PASS: TestAccAWSRedshiftServiceAccount_basic (31.19s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	32.215s
```