### PR TITLE
If default cloudfront certificate is used, ignore minimum_protocol_version

### DIFF
--- a/aws/cloudfront_distribution_configuration_structure.go
+++ b/aws/cloudfront_distribution_configuration_structure.go
@@ -1096,8 +1096,12 @@ func viewerCertificateHash(v interface{}) int {
 	} else {
 		buf.WriteString(fmt.Sprintf("%t-", m["cloudfront_default_certificate"].(bool)))
 	}
-	if v, ok := m["minimum_protocol_version"]; ok && v.(string) != "" {
-		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+	// if minimum_protocol_version is not specified and we use cloudfront_default_certificate,
+	// ignore current value of minimum_protocol_version
+	if c, ok := m["cloudfront_default_certificate"]; !(ok && c.(bool)) {
+		if v, ok := m["minimum_protocol_version"]; ok && v.(string) != "" {
+			buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+		}
 	}
 	return hashcode.String(buf.String())
 }


### PR DESCRIPTION
According to the Amazon documentation http://docs.aws.amazon.com/cloudfront/latest/APIReference/API_ViewerCertificate.html,
MinimumProtocolVersion is ignored when default Cloudfront certificate is used.

It is currently set by Amazon as TLSv1, whereas default value for this in terraform is SSLv3. It causes terraform to update resources every time.

Fixes #407