### PR TITLE
provide automated authorization message decoding

### DIFF
--- a/aws/awserr.go
+++ b/aws/awserr.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/helper/schema"
 )
 
 func isAWSErr(err error, code string, message string) bool {
@@ -48,7 +47,7 @@ type stsDecoder interface {
 // decoded results
 func decodeAWSError(decoder stsDecoder, err error) error {
 
-	if err != nil {
+	if err != nil && decoder != nil {
 		groups := encodedFailureMessagePattern.FindStringSubmatch(err.Error())
 		if groups != nil && len(groups) > 1 {
 			result, decodeErr := decoder.DecodeAuthorizationMessage(&sts.DecodeAuthorizationMessageInput{
@@ -62,65 +61,4 @@ func decodeAWSError(decoder stsDecoder, err error) error {
 		}
 	}
 	return err
-}
-
-// makeAuthZMessageDecodingResources modifies a map of resources, replacing the individual
-// Create, Read, Delete, Exists methods with wrappers that will attempt to automatically
-// decode any encoded authorization messages
-func makeAuthZMessageDecodingResources(resources map[string]*schema.Resource) map[string]*schema.Resource {
-	for _, r := range resources {
-		decodeErrorsForResource(r)
-	}
-	return resources
-}
-
-// creates auto-decoding wrappers around the existing resource functions
-func decodeErrorsForResource(r *schema.Resource) {
-	if r.Create != nil {
-		create := r.Create
-		r.Create = func(d *schema.ResourceData, meta interface{}) error {
-			err := create(d, meta)
-			return decodeAWSError(meta.(*AWSClient).stsconn, err)
-		}
-	}
-
-	if r.Update != nil {
-		update := r.Update
-		r.Update = func(d *schema.ResourceData, meta interface{}) error {
-			err := update(d, meta)
-			return decodeAWSError(meta.(*AWSClient).stsconn, err)
-		}
-	}
-
-	if r.Read != nil {
-		read := r.Read
-		r.Read = func(d *schema.ResourceData, meta interface{}) error {
-			err := read(d, meta)
-			return decodeAWSError(meta.(*AWSClient).stsconn, err)
-		}
-	}
-
-	if r.Delete != nil {
-		delete := r.Delete
-		r.Delete = func(d *schema.ResourceData, meta interface{}) error {
-			err := delete(d, meta)
-			return decodeAWSError(meta.(*AWSClient).stsconn, err)
-		}
-	}
-
-	if r.Exists != nil {
-		exists := r.Exists
-		r.Exists = func(d *schema.ResourceData, meta interface{}) (bool, error) {
-			ok, err := exists(d, meta)
-			return ok, decodeAWSError(meta.(*AWSClient).stsconn, err)
-		}
-	}
-
-	if r.Importer != nil {
-		state := r.Importer.State
-		r.Importer.State = func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-			rd, err := state(d, meta)
-			return rd, decodeAWSError(meta.(*AWSClient).stsconn, err)
-		}
-	}
 }

--- a/aws/awserr.go
+++ b/aws/awserr.go
@@ -1,11 +1,17 @@
 package aws
 
 import (
+	"fmt"
+	"log"
+	"regexp"
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
 )
 
 func isAWSErr(err error, code string, message string) bool {
@@ -30,4 +36,91 @@ func retryOnAwsCode(code string, f func() (interface{}, error)) (interface{}, er
 		return nil
 	})
 	return resp, err
+}
+
+var encodedFailureMessagePattern = regexp.MustCompile(`(?i)(.*) Encoded authorization failure message: ([\w-]+) ?( .*)?`)
+
+type stsDecoder interface {
+	DecodeAuthorizationMessage(input *sts.DecodeAuthorizationMessageInput) (*sts.DecodeAuthorizationMessageOutput, error)
+}
+
+// decodeError replaces encoded authorization messages with the
+// decoded results
+func decodeAWSError(decoder stsDecoder, err error) error {
+
+	if err != nil {
+		groups := encodedFailureMessagePattern.FindStringSubmatch(err.Error())
+		if groups != nil && len(groups) > 1 {
+			result, decodeErr := decoder.DecodeAuthorizationMessage(&sts.DecodeAuthorizationMessageInput{
+				EncodedMessage: aws.String(groups[2]),
+			})
+			if decodeErr == nil {
+				msg := aws.StringValue(result.DecodedMessage)
+				return fmt.Errorf("%s Authorization failure message: '%s'%s", groups[1], msg, groups[3])
+			}
+			log.Printf("[WARN] Attempted to decode authorization message, but received: %v", decodeErr)
+		}
+	}
+	return err
+}
+
+// makeAuthZMessageDecodingResources modifies a map of resources, replacing the individual
+// Create, Read, Delete, Exists methods with wrappers that will attempt to automatically
+// decode any encoded authorization messages
+func makeAuthZMessageDecodingResources(resources map[string]*schema.Resource) map[string]*schema.Resource {
+	for _, r := range resources {
+		decodeErrorsForResource(r)
+	}
+	return resources
+}
+
+// creates auto-decoding wrappers around the existing resource functions
+func decodeErrorsForResource(r *schema.Resource) {
+	if r.Create != nil {
+		create := r.Create
+		r.Create = func(d *schema.ResourceData, meta interface{}) error {
+			err := create(d, meta)
+			return decodeAWSError(meta.(*AWSClient).stsconn, err)
+		}
+	}
+
+	if r.Update != nil {
+		update := r.Update
+		r.Update = func(d *schema.ResourceData, meta interface{}) error {
+			err := update(d, meta)
+			return decodeAWSError(meta.(*AWSClient).stsconn, err)
+		}
+	}
+
+	if r.Read != nil {
+		read := r.Read
+		r.Read = func(d *schema.ResourceData, meta interface{}) error {
+			err := read(d, meta)
+			return decodeAWSError(meta.(*AWSClient).stsconn, err)
+		}
+	}
+
+	if r.Delete != nil {
+		delete := r.Delete
+		r.Delete = func(d *schema.ResourceData, meta interface{}) error {
+			err := delete(d, meta)
+			return decodeAWSError(meta.(*AWSClient).stsconn, err)
+		}
+	}
+
+	if r.Exists != nil {
+		exists := r.Exists
+		r.Exists = func(d *schema.ResourceData, meta interface{}) (bool, error) {
+			ok, err := exists(d, meta)
+			return ok, decodeAWSError(meta.(*AWSClient).stsconn, err)
+		}
+	}
+
+	if r.Importer != nil {
+		state := r.Importer.State
+		r.Importer.State = func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+			rd, err := state(d, meta)
+			return rd, decodeAWSError(meta.(*AWSClient).stsconn, err)
+		}
+	}
 }

--- a/aws/awserr_test.go
+++ b/aws/awserr_test.go
@@ -1,0 +1,70 @@
+package aws
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sts"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+)
+
+type mockSTS struct {
+}
+
+func (m *mockSTS) DecodeAuthorizationMessage(input *sts.DecodeAuthorizationMessageInput) (*sts.DecodeAuthorizationMessageOutput, error) {
+	return &sts.DecodeAuthorizationMessageOutput{
+		DecodedMessage: aws.String(`{
+			"allowed": false,
+			"explicitDeny": true,
+			"matchedStatements": {}
+		}`),
+	}, nil
+}
+
+func TestErrorsParsing_RequestFailure(t *testing.T) {
+
+	ae := awserr.New("UnauthorizedOperation",
+		`You are not authorized to perform this operation. Encoded authorization failure message: D9Q7oicjOMr9l2CC-NPP1FiZXK9Ijia1k-3l0siBFCcrK3oSuMFMkBIO5TNj0HdXE-WfwnAcdycFOohfKroNO6toPJEns8RFVfy_M_IjNGmrEFJ6E62pnmBW0OLrMsXxR9FQE4gB4gJzSM0AD6cV6S3FOfqYzWBRX-sQdOT4HryGkFNRoFBr9Xbp-tRwiadwkbdHdfnV9fbRkXmnwCdULml16NBSofC4ZPepLMKmIB5rKjwk-m179UUh2XA-J5no0si6XcRo5GbHQB5QfCIwSHL4vsro2wLZUd16-8OWKyr3tVlTbQe0ERZskqRqRQ5E28QuiBCVV6XstUyo-T4lBSr75Fgnyr3wCO-dS3b_5Ns3WzA2JD4E2AJOAStXIU8IH5YuKkAg7C-dJMuBMPpmKCBEXhNoHDwCyOo5PsV3xMlc0jSb0qYGpfst_TDDtejcZfn7NssUjxVq9qkdH-OXz2gPoQB-hX8ycmZCL5UZwKc3TCLUr7TGnudHjmnMrE9cUo-yTCWfyHPLprhiYhTCKW18EikJ0O1EKI3FJ_b4F19_jFBPARjSwQc7Ut6MNCVzrPdZGYSF6acj5gPaxdy9uSkVQwWXK7Pd5MFP7EBDE1_DgYbzodgwDO2PXeVFUbSLBHKWo_ebZS9ZX2nYPcGss_sYaly0ZVSIJXp7G58B5BoFVhvVH6jYnF9XiAOjMltuP_ycu1pQP1lki500RY3baLvfeYeAsB38XZHKEgWZzq7Fei-uh89q0cjJTmlVyrfRU3q6`,
+		fmt.Errorf("You can't do it!!"))
+	rf := awserr.NewRequestFailure(ae, 400, "abc-def-123-456")
+
+	result := decodeAWSError(&mockSTS{}, rf)
+	if result == nil {
+		t.Error("Expected resulting error")
+	}
+	if !strings.Contains(result.Error(), "Authorization failure message:") {
+		t.Error("Expected authorization failure message")
+	}
+}
+
+func TestErrorsParsing_NonAuthorizationFailure(t *testing.T) {
+
+	ae := awserr.New("BadRequest",
+		`You did something wrong. Try again`,
+		fmt.Errorf("Request was no good."))
+	rf := awserr.NewRequestFailure(ae, 400, "abc-def-123-456")
+
+	result := decodeAWSError(&mockSTS{}, rf)
+	if result == nil {
+		t.Error("Expected resulting error")
+	}
+	if result != rf {
+		t.Error("Expected original error to be returned unchanged")
+	}
+}
+
+func TestErrorsParsing_NonAWSError(t *testing.T) {
+
+	err := fmt.Errorf("Random error occurred")
+
+	result := decodeAWSError(&mockSTS{}, err)
+	if result == nil {
+		t.Error("Expected resulting error")
+	}
+	if result != err {
+		t.Error("Expected original error to be returned unchanged")
+	}
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -157,9 +157,16 @@ func Provider() terraform.ResourceProvider {
 				Default:     false,
 				Description: descriptions["s3_force_path_style"],
 			},
+
+			"decode_authorization_messages": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: descriptions["decode_authorization_messages"],
+			},
 		},
 
-		DataSourcesMap: makeAuthZMessageDecodingResources(map[string]*schema.Resource{
+		DataSourcesMap: map[string]*schema.Resource{
 			"aws_acm_certificate":          dataSourceAwsAcmCertificate(),
 			"aws_alb":                      dataSourceAwsAlb(),
 			"aws_alb_listener":             dataSourceAwsAlbListener(),
@@ -219,9 +226,9 @@ func Provider() terraform.ResourceProvider {
 			"aws_vpc_endpoint_service":             dataSourceAwsVpcEndpointService(),
 			"aws_vpc_peering_connection":           dataSourceAwsVpcPeeringConnection(),
 			"aws_vpn_gateway":                      dataSourceAwsVpnGateway(),
-		}),
+		},
 
-		ResourcesMap: makeAuthZMessageDecodingResources(map[string]*schema.Resource{
+		ResourcesMap: map[string]*schema.Resource{
 			"aws_alb":                                      resourceAwsAlb(),
 			"aws_alb_listener":                             resourceAwsAlbListener(),
 			"aws_alb_listener_rule":                        resourceAwsAlbListenerRule(),
@@ -489,7 +496,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_batch_compute_environment":                resourceAwsBatchComputeEnvironment(),
 			"aws_batch_job_definition":                     resourceAwsBatchJobDefinition(),
 			"aws_batch_job_queue":                          resourceAwsBatchJobQueue(),
-		}),
+		},
 		ConfigureFunc: providerConfigure,
 	}
 }
@@ -586,24 +593,29 @@ func init() {
 		"assume_role_policy": "The permissions applied when assuming a role. You cannot use," +
 			" this policy to grant further permissions that are in excess to those of the, " +
 			" role that is being assumed.",
+
+		"decode_authorization_messages": "Attempt to automatically decode (using the" +
+			" sts:DecodeAuthorizationMessage API) any encoded authorization error messages;" +
+			" requires that the effective user/role have permission to 'sts:DecodeAuthorizationMessage'.",
 	}
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
-		AccessKey:               d.Get("access_key").(string),
-		SecretKey:               d.Get("secret_key").(string),
-		Profile:                 d.Get("profile").(string),
-		Token:                   d.Get("token").(string),
-		Region:                  d.Get("region").(string),
-		MaxRetries:              d.Get("max_retries").(int),
-		Insecure:                d.Get("insecure").(bool),
-		SkipCredsValidation:     d.Get("skip_credentials_validation").(bool),
-		SkipGetEC2Platforms:     d.Get("skip_get_ec2_platforms").(bool),
-		SkipRegionValidation:    d.Get("skip_region_validation").(bool),
-		SkipRequestingAccountId: d.Get("skip_requesting_account_id").(bool),
-		SkipMetadataApiCheck:    d.Get("skip_metadata_api_check").(bool),
-		S3ForcePathStyle:        d.Get("s3_force_path_style").(bool),
+		AccessKey:                   d.Get("access_key").(string),
+		SecretKey:                   d.Get("secret_key").(string),
+		Profile:                     d.Get("profile").(string),
+		Token:                       d.Get("token").(string),
+		Region:                      d.Get("region").(string),
+		MaxRetries:                  d.Get("max_retries").(int),
+		Insecure:                    d.Get("insecure").(bool),
+		SkipCredsValidation:         d.Get("skip_credentials_validation").(bool),
+		SkipGetEC2Platforms:         d.Get("skip_get_ec2_platforms").(bool),
+		SkipRegionValidation:        d.Get("skip_region_validation").(bool),
+		SkipRequestingAccountId:     d.Get("skip_requesting_account_id").(bool),
+		SkipMetadataApiCheck:        d.Get("skip_metadata_api_check").(bool),
+		S3ForcePathStyle:            d.Get("s3_force_path_style").(bool),
+		DecodeAuthorizationMessages: d.Get("decode_authorization_messages").(bool),
 	}
 
 	// Set CredsFilename, expanding home directory

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -159,7 +159,7 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 
-		DataSourcesMap: map[string]*schema.Resource{
+		DataSourcesMap: makeAuthZMessageDecodingResources(map[string]*schema.Resource{
 			"aws_acm_certificate":          dataSourceAwsAcmCertificate(),
 			"aws_alb":                      dataSourceAwsAlb(),
 			"aws_alb_listener":             dataSourceAwsAlbListener(),
@@ -219,9 +219,9 @@ func Provider() terraform.ResourceProvider {
 			"aws_vpc_endpoint_service":             dataSourceAwsVpcEndpointService(),
 			"aws_vpc_peering_connection":           dataSourceAwsVpcPeeringConnection(),
 			"aws_vpn_gateway":                      dataSourceAwsVpnGateway(),
-		},
+		}),
 
-		ResourcesMap: map[string]*schema.Resource{
+		ResourcesMap: makeAuthZMessageDecodingResources(map[string]*schema.Resource{
 			"aws_alb":                                      resourceAwsAlb(),
 			"aws_alb_listener":                             resourceAwsAlbListener(),
 			"aws_alb_listener_rule":                        resourceAwsAlbListenerRule(),
@@ -489,7 +489,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_batch_compute_environment":                resourceAwsBatchComputeEnvironment(),
 			"aws_batch_job_definition":                     resourceAwsBatchJobDefinition(),
 			"aws_batch_job_queue":                          resourceAwsBatchJobQueue(),
-		},
+		}),
 		ConfigureFunc: providerConfigure,
 	}
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -234,6 +234,11 @@ The following arguments are supported in the `provider` block:
   virtual hosted bucket addressing, `http://BUCKET.s3.amazonaws.com/KEY`,
   when possible. Specific to the Amazon S3 service.
 
+* `decode_authorization_messages` - (Optional) Set this to `true` to enable
+  automatic decoding of any encoded authorization message errors using the
+  `sts:DecodeAuthorizationMessage` API; requires that the effective user/role
+  has permissions to `sts:DecodeAuthorizationMessage` on resource `*`.
+
 The nested `assume_role` block supports the following:
 
 * `role_arn` - (Required) The ARN of the role to assume.


### PR DESCRIPTION
**Changes**:
Adds a new optional boolean provider attribute `decode_authorization_messages`; when enabled, any encoded authorization messages will be automatically decoded using the `sts:DecodeAuthorizationMessage` action. Decoding requires that the effective user/role has permission to `sts:DecodeAuthorizationMessage` on resource `*`.

Example:
```
provider "aws" {
   decode_authorization_messages = true
   ...
}
```

**Before**:
```
* aws_instance.example: Error launching source instance: UnauthorizedOperation: You are not authorized to perform this operation. Encoded authorization failure message: PtmmadLNbKWVfeHgApa-62p0EM9DuD4gAtc3EhbBhVy3wIGiy2mTOcuDhCpfakJisGMB9OUTCGll2zbH-hMSguO1EOBAiswlapbXU_ovWgfAqNAawrGMs-WCo3k54Y6pzcwTkGlZYDspgh18Z98GdFOb29rLilYyHvpCW1lC9H2OGnHmpq9E2NeCZHINNE6Xzfdy468JOD_Ou3jfebEHx4oxYxShrEytBEbmhD_amiwPoIMpZ6xRWjn8KRdJM8RpAfGMoY7LIN4JQwIgiZpQOJBlzWuQq-sM7OicdDopjLRxEkApfHnh8JJIjZx6As6-42oPDd594_cdfBr6R34NA6xiDsueFL8ep8S7kprIffjt0MKqsdFe5SFat1Feo23QaU9n2f_nWcBgvUCgBpvDZk9VRe48tT72lYvHJFajutopRsvR9gjdPnrFqnbTp1HCmWZ4M2esBy7cDmZUUu02eZ_OZDEIojUAE0sfzBKIyaFvSzN07NEmd0Hi4xxGEQJcFg4RSko27b-8sI05Ot3qE_5MgZsfCPdbay4i23el4MlLSH9FS4WgUmYi-jxcAj6uVI_s19m23H4v2w_dl-9OKMEjCE6fWyoGAApT2osVirSo1t-0XhrHgzhQTNNI6WkNvNuPs95T_9ttln7u8VKBYcGQC2Rca7v5mtqzyr9NElexpLPOHND1xY4taxYyTJiC7_nv4otoXr9feW1vnH_9ewEPE2e4zVyY4ep6Cbm2xugIskrXqPElJjGjUF6rliwhKN8LjaFLEg
	status code: 403, request id: 27a76565-182c-4edd-a090-351ab9cf840c
``` 

**After**:
```
* aws_instance.example: Error launching source instance: UnauthorizedOperation: You are not authorized to perform this operation. Authorization failure message: '{"allowed":false,"explicitDeny":true,"matchedStatements":{"items":[{"statementId":"","effect":"DENY","principals":{"items":[{"value":"XXXXXXXXXXXXXXXXXX"}]},"principalGroups":{"items":[]},"actions":{"items":[{"value":"ec2:RunInstances"}]},"resources":{"items":[{"value":"arn:aws:ec2:*:*:instance/*"}]},"conditions":{"items":[{"key":"aws:RequestTag/application-group","values":{"items":[{"value":"appdev-platform"}]}}]}}]},"failures":{"items":[]},"context":{"principal":{"id":"XXXXXXXXXXXXXXXXXX:000000123456789000","arn":"arn:aws:sts::123456789012:assumed-role/appdev-platform-application-deployer-doer/000000123456789000"},"action":"ec2:RunInstances","resource":"arn:aws:ec2:us-west-2:123456789012:instance/*","conditions":{"items":[{"key":"aws:Resource","values":{"items":[{"value":"instance/*"}]}},{"key":"aws:Account","values":{"items":[{"value":"123456789012"}]}},{"key":"ec2:AvailabilityZone","values":{"items":[{"value":"us-west-2b"}]}},{"key":"ec2:ebsOptimized","values":{"items":[{"value":"false"}]}},{"key":"ec2:InstanceType","values":{"items":[{"value":"t2.nano"}]}},{"key":"ec2:RootDeviceType","values":{"items":[{"value":"ebs"}]}},{"key":"aws:Region","values":{"items":[{"value":"us-west-2"}]}},{"key":"aws:Service","values":{"items":[{"value":"ec2"}]}},{"key":"ec2:InstanceID","values":{"items":[{"value":"*"}]}},{"key":"aws:Type","values":{"items":[{"value":"instance"}]}},{"key":"ec2:Tenancy","values":{"items":[{"value":"default"}]}},{"key":"ec2:Region","values":{"items":[{"value":"us-west-2"}]}},{"key":"aws:ARN","values":{"items":[{"value":"arn:aws:ec2:us-west-2:123456789012:instance/*"}]}}]}}}'
```

**Note**: There is some discussion about adding this in the upstream, but nothing solid yet:
https://github.com/aws/aws-sdk-go/issues/1536