### PR TITLE
Fix data IAM group copy paste

### DIFF
--- a/website/docs/d/iam_group.html.markdown
+++ b/website/docs/d/iam_group.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "aws"
-page_title: "AWS: aws_iam_role"
-sidebar_current: "docs-aws-datasource-iam-role"
+page_title: "AWS: aws_iam_group"
+sidebar_current: "docs-aws-datasource-iam-group"
 description: |-
   Get information on a Amazon IAM group
 ---
@@ -28,6 +28,6 @@ data "aws_iam_group" "example" {
 
 * `arn` - The Amazon Resource Name (ARN) specifying the group.
 
-* `path` - The path to the role.
+* `path` - The path to the group.
 
 * `group_id` - The stable and unique string identifying the group.


### PR DESCRIPTION
When reading the documentation for `data "aws_iam_group"` the page title as well as the position in the left sidebar is wrong:
https://www.terraform.io/docs/providers/aws/d/iam_group.html

Change:
- fix `page_title` and `sidebar_current ` layout attributes
- fix `path` attribute