### PR TITLE
data/aws_iam_user: Add a data source for IAM user

### DIFF
--- a/aws/data_source_aws_iam_user.go
+++ b/aws/data_source_aws_iam_user.go
@@ -1,0 +1,54 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsIAMUser() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsIAMUserRead,
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"path": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"user_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"user_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsIAMUserRead(d *schema.ResourceData, meta interface{}) error {
+	iamconn := meta.(*AWSClient).iamconn
+	userName := d.Get("user_name").(string)
+	req := &iam.GetUserInput{
+		UserName: aws.String(userName),
+	}
+
+	resp, err := iamconn.GetUser(req)
+	if err != nil {
+		return errwrap.Wrapf("error getting user: {{err}}", err)
+	}
+
+	user := resp.User
+	d.SetId(*user.UserId)
+	d.Set("arn", user.Arn)
+	d.Set("path", user.Path)
+	d.Set("user_id", user.UserId)
+
+	return nil
+}

--- a/aws/data_source_aws_iam_user_test.go
+++ b/aws/data_source_aws_iam_user_test.go
@@ -20,14 +20,6 @@ func TestAccAWSDataSourceIAMUser_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.aws_iam_user.test", "user_name", "test-datasource-user"),
 					resource.TestMatchResourceAttr("data.aws_iam_user.test", "arn", regexp.MustCompile("^arn:aws:iam::[0-9]{12}:user/test-datasource-user")),
 				),
-			}, {
-				Config: testAccAwsDataSourceIAMUserUnknownConfig,
-				// Should fail with an error that looks like this:
-				//   Error refreshing: 1 error(s) occurred:
-				//   * data.aws_iam_user.test: 1 error(s) occurred:
-				//   * data.aws_iam_user.test: data.aws_iam_user.test: error getting user: NoSuchEntity: The user with name test-datasource-user-unknown cannot be found.
-				//           status code: 404, request id: 16760dec-a88d-11e7-afb8-bbe194fb2bc8
-				ExpectError: regexp.MustCompile("(?s)\\berror getting user\\b.*\\btest-datasource-user-unknown\\b.*\\b404\\b"),
 			},
 		},
 	})
@@ -41,11 +33,5 @@ resource "aws_iam_user" "user" {
 
 data "aws_iam_user" "test" {
 	  user_name = "${aws_iam_user.user.name}"
-}
-`
-
-const testAccAwsDataSourceIAMUserUnknownConfig = `
-data "aws_iam_user" "test" {
-	  user_name = "test-datasource-user-unknown"
 }
 `

--- a/aws/data_source_aws_iam_user_test.go
+++ b/aws/data_source_aws_iam_user_test.go
@@ -1,0 +1,51 @@
+package aws
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSDataSourceIAMUser_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsDataSourceIAMUserConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.aws_iam_user.test", "user_id"),
+					resource.TestCheckResourceAttr("data.aws_iam_user.test", "path", "/"),
+					resource.TestCheckResourceAttr("data.aws_iam_user.test", "user_name", "test-datasource-user"),
+					resource.TestMatchResourceAttr("data.aws_iam_user.test", "arn", regexp.MustCompile("^arn:aws:iam::[0-9]{12}:user/test-datasource-user")),
+				),
+			}, {
+				Config: testAccAwsDataSourceIAMUserUnknownConfig,
+				// Should fail with an error that looks like this:
+				//   Error refreshing: 1 error(s) occurred:
+				//   * data.aws_iam_user.test: 1 error(s) occurred:
+				//   * data.aws_iam_user.test: data.aws_iam_user.test: error getting user: NoSuchEntity: The user with name test-datasource-user-unknown cannot be found.
+				//           status code: 404, request id: 16760dec-a88d-11e7-afb8-bbe194fb2bc8
+				ExpectError: regexp.MustCompile("(?s)\\berror getting user\\b.*\\btest-datasource-user-unknown\\b.*\\b404\\b"),
+			},
+		},
+	})
+}
+
+const testAccAwsDataSourceIAMUserConfig = `
+resource "aws_iam_user" "user" {
+	name = "test-datasource-user"
+	path = "/"
+}
+
+data "aws_iam_user" "test" {
+	  user_name = "${aws_iam_user.user.name}"
+}
+`
+
+const testAccAwsDataSourceIAMUserUnknownConfig = `
+data "aws_iam_user" "test" {
+	  user_name = "test-datasource-user-unknown"
+}
+`

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -195,6 +195,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_iam_policy_document":              dataSourceAwsIamPolicyDocument(),
 			"aws_iam_role":                         dataSourceAwsIAMRole(),
 			"aws_iam_server_certificate":           dataSourceAwsIAMServerCertificate(),
+			"aws_iam_user":                         dataSourceAwsIAMUser(),
 			"aws_internet_gateway":                 dataSourceAwsInternetGateway(),
 			"aws_instance":                         dataSourceAwsInstance(),
 			"aws_ip_ranges":                        dataSourceAwsIPRanges(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -119,6 +119,9 @@
                         <li<%= sidebar_current("docs-aws-iam-server-certificate") %>>
                           <a href="/docs/providers/aws/d/iam_server_certificate.html">aws_iam_server_certificate</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-iam-user") %>>
+                            <a href="/docs/providers/aws/d/iam_user.html">aws_iam_user</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-instance") %>>
                           <a href="/docs/providers/aws/d/instance.html">aws_instance</a>
                         </li>

--- a/website/docs/d/iam_user.html.markdown
+++ b/website/docs/d/iam_user.html.markdown
@@ -1,0 +1,33 @@
+---
+layout: "aws"
+page_title: "AWS: aws_iam_user"
+sidebar_current: "docs-aws-datasource-iam-user"
+description: |-
+  Get information on a Amazon IAM user
+---
+
+# aws_iam_user
+
+This data source can be used to fetch information about a specific
+IAM user. By using this data source, you can reference IAM user
+properties without having to hard code ARNs or unique IDs as input.
+
+## Example Usage
+
+```hcl
+data "aws_iam_user" "example" {
+  user_name = "an_example_user_name"
+}
+```
+
+## Argument Reference
+
+* `user_name` - (Required) The friendly IAM user name to match.
+
+## Attributes Reference
+
+* `arn` - The Amazon Resource Name (ARN) assigned by AWS for this user.
+
+* `path` - Path in which this user was created.
+
+* `user_id` - The unique ID assigned by AWS for this user.


### PR DESCRIPTION
# New feature
This data source can be used to fetch information about a specific IAM user.
By using this data source, you can reference IAM user properties without having to hard code ARNs or unique IDs as input (e.g. referencing a user `aws:userId` when creating an IAM policy).

# Code change
- adding `aws_iam_user` data source
- adding acceptance test cases (existing user and non existing user)
- adding documentation for the new data source

# Testing done
```
TF_ACC=1 go test -run=TestAccAWSDataSourceIAMUser_basic -v
=== RUN   TestAccAWSDataSourceIAMUser_basic
--- PASS: TestAccAWSDataSourceIAMUser_basic (11.09s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	11.118s
```

# Misc
The code of this contribution was based a lot on #1140, thanks @stack72.