### PR TITLE
r/appautoscaling_*: Use dimension to uniquely identify target/policy

### DIFF
--- a/aws/resource_aws_appautoscaling_policy.go
+++ b/aws/resource_aws_appautoscaling_policy.go
@@ -571,9 +571,10 @@ func getAwsAppautoscalingPolicy(d *schema.ResourceData, meta interface{}) (*appl
 	}
 
 	// find scaling policy
-	name := d.Get("name")
+	name := d.Get("name").(string)
+	dimension := d.Get("scalable_dimension").(string)
 	for idx, sp := range resp.ScalingPolicies {
-		if *sp.PolicyName == name {
+		if *sp.PolicyName == name && *sp.ScalableDimension == dimension {
 			return resp.ScalingPolicies[idx], nil
 		}
 	}

--- a/aws/resource_aws_appautoscaling_policy.go
+++ b/aws/resource_aws_appautoscaling_policy.go
@@ -270,7 +270,7 @@ func resourceAwsAppautoscalingPolicyCreate(d *schema.ResourceData, meta interfac
 		return nil
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("Failed to create scaling policy: %s", err)
 	}
 
 	d.Set("arn", resp.PolicyARN)
@@ -317,7 +317,7 @@ func resourceAwsAppautoscalingPolicyUpdate(d *schema.ResourceData, meta interfac
 	log.Printf("[DEBUG] Application Autoscaling Update Scaling Policy: %#v", params)
 	_, err := conn.PutScalingPolicy(&params)
 	if err != nil {
-		return err
+		return fmt.Errorf("Failed to update scaling policy: %s", err)
 	}
 
 	return resourceAwsAppautoscalingPolicyRead(d, meta)
@@ -341,7 +341,7 @@ func resourceAwsAppautoscalingPolicyDelete(d *schema.ResourceData, meta interfac
 	}
 	log.Printf("[DEBUG] Deleting Application AutoScaling Policy opts: %#v", params)
 	if _, err := conn.DeleteScalingPolicy(&params); err != nil {
-		return fmt.Errorf("Application AutoScaling Policy: %s", err)
+		return fmt.Errorf("Failed to delete autoscaling policy: %s", err)
 	}
 
 	d.SetId("")
@@ -578,7 +578,6 @@ func getAwsAppautoscalingPolicy(d *schema.ResourceData, meta interface{}) (*appl
 		}
 	}
 
-	// policy not found
 	return nil, nil
 }
 

--- a/aws/resource_aws_appautoscaling_target.go
+++ b/aws/resource_aws_appautoscaling_target.go
@@ -96,7 +96,8 @@ func resourceAwsAppautoscalingTargetCreate(d *schema.ResourceData, meta interfac
 func resourceAwsAppautoscalingTargetRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).appautoscalingconn
 
-	t, err := getAwsAppautoscalingTarget(d, conn)
+	namespace := d.Get("service_namespace").(string)
+	t, err := getAwsAppautoscalingTarget(d.Id(), namespace, conn)
 	if err != nil {
 		return err
 	}
@@ -119,7 +120,9 @@ func resourceAwsAppautoscalingTargetRead(d *schema.ResourceData, meta interface{
 func resourceAwsAppautoscalingTargetDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).appautoscalingconn
 
-	t, err := getAwsAppautoscalingTarget(d, conn)
+	namespace := d.Get("service_namespace").(string)
+
+	t, err := getAwsAppautoscalingTarget(d.Id(), namespace, conn)
 	if err != nil {
 		return err
 	}
@@ -153,7 +156,7 @@ func resourceAwsAppautoscalingTargetDelete(d *schema.ResourceData, meta interfac
 	}
 
 	return resource.Retry(5*time.Minute, func() *resource.RetryError {
-		if t, _ = getAwsAppautoscalingTarget(d, conn); t != nil {
+		if t, _ = getAwsAppautoscalingTarget(d.Id(), namespace, conn); t != nil {
 			return resource.RetryableError(
 				fmt.Errorf("Application AutoScaling Target still exists"))
 		}
@@ -161,14 +164,12 @@ func resourceAwsAppautoscalingTargetDelete(d *schema.ResourceData, meta interfac
 	})
 }
 
-func getAwsAppautoscalingTarget(
-	d *schema.ResourceData,
+func getAwsAppautoscalingTarget(resourceId, namespace string,
 	conn *applicationautoscaling.ApplicationAutoScaling) (*applicationautoscaling.ScalableTarget, error) {
 
-	tgtName := d.Id()
 	describeOpts := applicationautoscaling.DescribeScalableTargetsInput{
-		ResourceIds:      []*string{aws.String(tgtName)},
-		ServiceNamespace: aws.String(d.Get("service_namespace").(string)),
+		ResourceIds:      []*string{aws.String(resourceId)},
+		ServiceNamespace: aws.String(namespace),
 	}
 
 	log.Printf("[DEBUG] Application AutoScaling Target describe configuration: %#v", describeOpts)
@@ -181,7 +182,7 @@ func getAwsAppautoscalingTarget(
 	}
 
 	for idx, tgt := range describeTargets.ScalableTargets {
-		if *tgt.ResourceId == tgtName {
+		if *tgt.ResourceId == resourceId {
 			return describeTargets.ScalableTargets[idx], nil
 		}
 	}


### PR DESCRIPTION
Fixes #1765

I also bumped into another error while testing this PR: https://github.com/aws/aws-sdk-go/pull/1570

## Test results

```
=== RUN   TestAccAWSAppautoScalingPolicy_basic
--- PASS: TestAccAWSAppautoScalingPolicy_basic (119.58s)
=== RUN   TestAccAWSAppautoScalingPolicy_nestedSchema
--- PASS: TestAccAWSAppautoScalingPolicy_nestedSchema (123.51s)
=== RUN   TestAccAWSAppautoScalingPolicy_spotFleetRequest
--- PASS: TestAccAWSAppautoScalingPolicy_spotFleetRequest (93.15s)
=== RUN   TestAccAWSAppautoScalingPolicy_dynamoDb
--- PASS: TestAccAWSAppautoScalingPolicy_dynamoDb (65.88s)
=== RUN   TestAccAWSAppautoScalingPolicy_multiplePolicies
--- PASS: TestAccAWSAppautoScalingPolicy_multiplePolicies (71.65s)
=== RUN   TestAccAWSAppautoScalingTarget_basic
--- PASS: TestAccAWSAppautoScalingTarget_basic (115.50s)
=== RUN   TestAccAWSAppautoScalingTarget_spotFleetRequest
--- PASS: TestAccAWSAppautoScalingTarget_spotFleetRequest (80.70s)
=== RUN   TestAccAWSAppautoScalingTarget_emrCluster
--- PASS: TestAccAWSAppautoScalingTarget_emrCluster (531.79s)
=== RUN   TestAccAWSAppautoScalingTarget_multipleTargets
--- PASS: TestAccAWSAppautoScalingTarget_multipleTargets (60.92s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1262.713s
```