### PR TITLE
Fix ECS cluster ARN attribute name/value for aws_batch_compute_environment resource

### DIFF
--- a/aws/resource_aws_batch_compute_environment.go
+++ b/aws/resource_aws_batch_compute_environment.go
@@ -121,6 +121,11 @@ func resourceAwsBatchComputeEnvironment() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"ecc_cluster_arn": {
+				Type:       schema.TypeString,
+				Computed:   true,
+				Deprecated: "Use ecs_cluster_arn instead",
+			},
 			"ecs_cluster_arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -266,6 +271,7 @@ func resourceAwsBatchComputeEnvironmentRead(d *schema.ResourceData, meta interfa
 	}
 
 	d.Set("arn", computeEnvironment.ComputeEnvironmentArn)
+	d.Set("ecc_cluster_arn", computeEnvironment.EcsClusterArn)
 	d.Set("ecs_cluster_arn", computeEnvironment.EcsClusterArn)
 	d.Set("status", computeEnvironment.Status)
 	d.Set("status_reason", computeEnvironment.StatusReason)

--- a/aws/resource_aws_batch_compute_environment.go
+++ b/aws/resource_aws_batch_compute_environment.go
@@ -121,7 +121,7 @@ func resourceAwsBatchComputeEnvironment() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"ecc_cluster_arn": {
+			"ecs_cluster_arn": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -266,7 +266,7 @@ func resourceAwsBatchComputeEnvironmentRead(d *schema.ResourceData, meta interfa
 	}
 
 	d.Set("arn", computeEnvironment.ComputeEnvironmentArn)
-	d.Set("ecc_cluster_arn", computeEnvironment.ComputeEnvironmentArn)
+	d.Set("ecs_cluster_arn", computeEnvironment.EcsClusterArn)
 	d.Set("status", computeEnvironment.Status)
 	d.Set("status_reason", computeEnvironment.StatusReason)
 

--- a/website/docs/r/batch_compute_environment.html.markdown
+++ b/website/docs/r/batch_compute_environment.html.markdown
@@ -133,7 +133,7 @@ resource "aws_batch_compute_environment" "sample" {
 ## Attributes Reference
 
 * `arn` - The Amazon Resource Name (ARN) of the compute environment.
-* `ecc_cluster_arn` - The Amazon Resource Name (ARN) of the underlying Amazon ECS cluster used by the compute environment.
+* `ecs_cluster_arn` - The Amazon Resource Name (ARN) of the underlying Amazon ECS cluster used by the compute environment.
 * `status` - The current status of the compute environment (for example, CREATING or VALID).
 * `status_reason` - A short, human-readable string to provide additional details about the current status of the compute environment.
 


### PR DESCRIPTION
## Description
Small change here, the ECS Cluster ARN attribute was named `ecc_cluster_arn` and was actually being assigned the ARN of the compute environment instead of the cluster. I have updated the code to use the ECS cluster ARN instead, as well updating the attribute name in the code/documentation to `ecs_cluster_arn`.

## Test
```
AWS_ACCESS_KEY_ID=$(aws configure get aws_access_key_id) AWS_SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key) AWS_REGION=us-east-1 make testacc TEST=./aws TESTARGS='-run=TestAccAWSBatchComputeEnvironment_createUnmanaged'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSBatchComputeEnvironment_createUnmanaged -timeout 120m
=== RUN   TestAccAWSBatchComputeEnvironment_createUnmanaged
--- PASS: TestAccAWSBatchComputeEnvironment_createUnmanaged (52.43s)
=== RUN   TestAccAWSBatchComputeEnvironment_createUnmanagedWithComputeResources
--- PASS: TestAccAWSBatchComputeEnvironment_createUnmanagedWithComputeResources (41.30s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	93.764s
```