### PR TITLE
Support SMS in SNS Topic Subscription protocols

### DIFF
--- a/aws/validators.go
+++ b/aws/validators.go
@@ -761,7 +761,7 @@ func validateSQSFifoQueueName(v interface{}, k string) (errors []error) {
 
 func validateSNSSubscriptionProtocol(v interface{}, k string) (ws []string, errors []error) {
 	value := strings.ToLower(v.(string))
-	forbidden := []string{"email", "sms"}
+	forbidden := []string{"email"}
 	for _, f := range forbidden {
 		if strings.Contains(value, f) {
 			errors = append(

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -1104,6 +1104,7 @@ func TestValidateSNSSubscriptionProtocol(t *testing.T) {
 		"application",
 		"http",
 		"https",
+		"sms",
 	}
 	for _, v := range validProtocols {
 		if _, errors := validateSNSSubscriptionProtocol(v, "protocol"); len(errors) > 0 {
@@ -1116,8 +1117,6 @@ func TestValidateSNSSubscriptionProtocol(t *testing.T) {
 		"email",
 		"Email-JSON",
 		"email-json",
-		"SMS",
-		"sms",
 	}
 	for _, v := range invalidProtocols {
 		if _, errors := validateSNSSubscriptionProtocol(v, "protocol"); len(errors) == 0 {

--- a/website/docs/r/sns_topic_subscription.html.markdown
+++ b/website/docs/r/sns_topic_subscription.html.markdown
@@ -237,7 +237,7 @@ resource "aws_sns_topic_subscription" "sns-topic" {
 The following arguments are supported:
 
 * `topic_arn` - (Required) The ARN of the SNS topic to subscribe to
-* `protocol` - (Required) The protocol to use. The possible values for this are: `sqs`,  `lambda`, `application`. (`http` or `https` are partially supported, see below) (`email`, `sms`, are options but unsupported, see below).
+* `protocol` - (Required) The protocol to use. The possible values for this are: `sqs`, `sms`, `lambda`, `application`. (`http` or `https` are partially supported, see below) (`email` is option but unsupported, see below).
 * `endpoint` - (Required) The endpoint to send data to, the contents will vary with the protocol. (see below for more information)
 * `endpoint_auto_confirms` - (Optional) Boolean indicating whether the end point is capable of [auto confirming subscription](http://docs.aws.amazon.com/sns/latest/dg/SendMessageToHttp.html#SendMessageToHttp.prepare) e.g., PagerDuty (default is false)
 * `confirmation_timeout_in_minutes` - (Optional) Integer indicating number of minutes to wait in retying mode for fetching subscription arn before marking it as failure. Only applicable for http and https protocols (default is 1 minute).
@@ -250,6 +250,7 @@ Supported SNS protocols include:
 * `lambda` -- delivery of JSON-encoded message to a lambda function
 * `sqs` -- delivery of JSON-encoded message to an Amazon SQS queue
 * `application` -- delivery of JSON-encoded message to an EndpointArn for a mobile app and device
+* `sms` -- delivery text message
 
 Partially supported SNS protocols include:
 
@@ -260,7 +261,6 @@ Unsupported protocols include the following:
 
 * `email` -- delivery of message via SMTP
 * `email-json` -- delivery of JSON-encoded message via SMTP
-* `sms` -- delivery text message
 
 These are unsupported because the endpoint needs to be authorized and does not
 generate an ARN until the target email address has been validated. This breaks


### PR DESCRIPTION
Since June 2016 SMS recipients no longer need to opt-in to SNS. See also

https://aws.amazon.com/blogs/aws/new-worldwide-delivery-of-amazon-sns-messages-via-sms/