### PR TITLE
r/kms_key: Retry getting rotation status

### DIFF
--- a/aws/resource_aws_kms_key.go
+++ b/aws/resource_aws_kms_key.go
@@ -179,12 +179,15 @@ func resourceAwsKmsKeyRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	d.Set("policy", policy)
 
-	krs, err := conn.GetKeyRotationStatus(&kms.GetKeyRotationStatusInput{
-		KeyId: metadata.KeyId,
+	out, err := retryOnAwsCode("NotFoundException", func() (interface{}, error) {
+		return conn.GetKeyRotationStatus(&kms.GetKeyRotationStatusInput{
+			KeyId: metadata.KeyId,
+		})
 	})
 	if err != nil {
 		return err
 	}
+	krs, _ := out.(*kms.GetKeyRotationStatusOutput)
 	d.Set("enable_key_rotation", krs.KeyRotationEnabled)
 
 	tagList, err := conn.ListResourceTags(&kms.ListResourceTagsInput{


### PR DESCRIPTION
This is to address the following test failure:
```
=== RUN   TestAccDataSourceAwsKmsCiphertext_basic
--- FAIL: TestAccDataSourceAwsKmsCiphertext_basic (31.03s)
    testing.go:434: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_kms_key.foo: 1 error(s) occurred:
        
        * aws_kms_key.foo: NotFoundException: Key 'arn:aws:kms:us-west-2:*******:key/20505b0e-764f-4ef5-8f1b-73a2686fd11b' does not exist
            status code: 400, request id: a92026f9-a994-11e7-bbbb-41668ba48bea
```

Snippet from debug log:

```
2017/10/05 06:16:00 [DEBUG] [aws-sdk-go] DEBUG: Response kms/DescribeKey Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 200 OK
Connection: close
Content-Length: 383
Content-Type: application/x-amz-json-1.1
Date: Thu, 05 Oct 2017 06:16:01 GMT
Server: Server
X-Amzn-Requestid: a91885e4-a994-11e7-9579-2da1021b9d1d


-----------------------------------------------------
2017/10/05 06:16:00 [DEBUG] [aws-sdk-go] {"KeyMetadata":{"AWSAccountId":"*REDACTED*","Arn":"arn:aws:kms:us-west-2:*REDACTED*:key/20505b0e-764f-4ef5-8f1b-73a2686fd11b","CreationDate":1.507184161473E9,"Description":"tf-test-acc-data-source-aws-kms-ciphertext-basic","Enabled":true,"KeyId":"20505b0e-764f-4ef5-8f1b-73a2686fd11b","KeyManager":"CUSTOMER","KeyState":"Enabled","KeyUsage":"ENCRYPT_DECRYPT","Origin":"AWS_KMS"}}

2017/10/05 06:16:00 [DEBUG] [aws-sdk-go] DEBUG: Response kms/GetKeyRotationStatus Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 400 Bad Request
Connection: close
Content-Length: 139
Content-Type: application/x-amz-json-1.1
Date: Thu, 05 Oct 2017 06:16:01 GMT
Server: Server
X-Amzn-Requestid: a92026f9-a994-11e7-bbbb-41668ba48bea


-----------------------------------------------------
2017/10/05 06:16:00 [DEBUG] [aws-sdk-go] {"__type":"NotFoundException","message":"Key 'arn:aws:kms:us-west-2:*REDACTED*:key/20505b0e-764f-4ef5-8f1b-73a2686fd11b' does not exist"}
```