### PR TITLE
r/vpn_connection: Raise timeout to 40mins

### DIFF
--- a/aws/resource_aws_vpn_connection.go
+++ b/aws/resource_aws_vpn_connection.go
@@ -274,7 +274,7 @@ func resourceAwsVpnConnectionCreate(d *schema.ResourceData, meta interface{}) er
 		Pending:    []string{"pending"},
 		Target:     []string{"available"},
 		Refresh:    vpnConnectionRefreshFunc(conn, *vpnConnection.VpnConnectionId),
-		Timeout:    30 * time.Minute,
+		Timeout:    40 * time.Minute,
 		Delay:      10 * time.Second,
 		MinTimeout: 10 * time.Second,
 	}
@@ -283,7 +283,7 @@ func resourceAwsVpnConnectionCreate(d *schema.ResourceData, meta interface{}) er
 	if stateErr != nil {
 		return fmt.Errorf(
 			"Error waiting for VPN connection (%s) to become ready: %s",
-			*vpnConnection.VpnConnectionId, err)
+			*vpnConnection.VpnConnectionId, stateErr)
 	}
 
 	// Create tags.


### PR DESCRIPTION
This is to address the following failure which came out of one of our hourly smoke tests:

```
[04:30:53]	1 error(s) occurred:
[04:30:53]	
[04:30:53]	* aws_vpn_connection.main: 1 error(s) occurred:
[04:30:53]	
[04:30:53]	* aws_vpn_connection.main: Error waiting for VPN connection (vpn-11677d03) to become ready: %!s(<nil>)
[04:30:53]
```