### PR TITLE
r/cloudtrail: Raise update retry timeout

### DIFF
--- a/aws/resource_aws_cloudtrail.go
+++ b/aws/resource_aws_cloudtrail.go
@@ -267,7 +267,7 @@ func resourceAwsCloudTrailUpdate(d *schema.ResourceData, meta interface{}) error
 
 	log.Printf("[DEBUG] Updating CloudTrail: %s", input)
 	var t *cloudtrail.UpdateTrailOutput
-	err := resource.Retry(15*time.Second, func() *resource.RetryError {
+	err := resource.Retry(30*time.Second, func() *resource.RetryError {
 		var err error
 		t, err = conn.UpdateTrail(&input)
 		if err != nil {


### PR DESCRIPTION
This is to address the following test failure:

```
--- FAIL: TestAccAWSCloudTrail (229.64s)
    --- FAIL: TestAccAWSCloudTrail/Trail (229.64s)
        --- FAIL: TestAccAWSCloudTrail/Trail/cloudwatch (44.90s)
            testing.go:434: Step 1 error: Error applying: 1 error(s) occurred:
                
                * aws_cloudtrail.test: 1 error(s) occurred:
                
                * aws_cloudtrail.test: InvalidCloudWatchLogsLogGroupArnException: Access denied. Check the permissions for your role.
                    status code: 400, request id: 17502cea-a999-11e7-85ea-f93e059cd270
```

Snippet from the debug log:
```
2017/10/05 06:47:43 [DEBUG] [aws-sdk-go] DEBUG: Response cloudtrail/UpdateTrail Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 400 Bad Request
Connection: close
Content-Length: 118
Content-Type: application/x-amz-json-1.1
Date: Thu, 05 Oct 2017 06:47:43 GMT
X-Amzn-Requestid: 17502cea-a999-11e7-85ea-f93e059cd270


-----------------------------------------------------
2017/10/05 06:47:43 [DEBUG] [aws-sdk-go] {"__type":"InvalidCloudWatchLogsLogGroupArnException","Message":"Access denied. Check the permissions for your role."}
```