### PR TITLE
r/elasticache_parameter_group: Retry resetting group on pending changes

### DIFF
--- a/aws/resource_aws_elasticache_parameter_group.go
+++ b/aws/resource_aws_elasticache_parameter_group.go
@@ -174,7 +174,16 @@ func resourceAwsElasticacheParameterGroupUpdate(d *schema.ResourceData, meta int
 			}
 
 			log.Printf("[DEBUG] Reset Cache Parameter Group: %s", resetOpts)
-			_, err = conn.ResetCacheParameterGroup(&resetOpts)
+			err := resource.Retry(15*time.Second, func() *resource.RetryError {
+				_, err = conn.ResetCacheParameterGroup(&resetOpts)
+				if err != nil {
+					if isAWSErr(err, "InvalidCacheParameterGroupState", " has pending changes") {
+						resource.RetryableError(err)
+					}
+					return resource.NonRetryableError(err)
+				}
+				return nil
+			})
 			if err != nil {
 				return fmt.Errorf("Error resetting Cache Parameter Group: %s", err)
 			}


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSElasticacheParameterGroup_removeParam
--- FAIL: TestAccAWSElasticacheParameterGroup_removeParam (8.71s)
    testing.go:434: Step 1 error: Error applying: 1 error(s) occurred:
        
        * aws_elasticache_parameter_group.bar: 1 error(s) occurred:
        
        * aws_elasticache_parameter_group.bar: Error resetting Cache Parameter Group: InvalidCacheParameterGroupState: Cannot reset the parameter group because the parameter appendfsync has pending changes.
            status code: 400, request id: 32179f6e-a73a-11e7-85aa-c99861294b17
```

I picked an arbitrary value of 15 seconds to start with and we'll see if it needs raising based on test results and failures in the future.

## Test results

```
TF_ACC=1 go test ./aws -v -run=TestAccAWSElasticacheParameterGroup_removeParam -timeout 120m
=== RUN   TestAccAWSElasticacheParameterGroup_removeParam
--- PASS: TestAccAWSElasticacheParameterGroup_removeParam (59.93s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	59.977s
```