### PR TITLE
Add 'dns_name' attribute to aws_efs_file_system resource

### DIFF
--- a/aws/resource_aws_efs_file_system.go
+++ b/aws/resource_aws_efs_file_system.go
@@ -64,6 +64,11 @@ func resourceAwsEfsFileSystem() *schema.Resource {
 				ValidateFunc: validateArn,
 			},
 
+			"dns_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"tags": tagsSchema(),
 		},
 	}
@@ -230,6 +235,12 @@ func resourceAwsEfsFileSystemRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("encrypted", fs.Encrypted)
 	d.Set("kms_key_id", fs.KmsKeyId)
 
+	region := meta.(*AWSClient).region
+	err = d.Set("dns_name", resourceAwsEfsDnsName(*fs.FileSystemId, region))
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -304,4 +315,8 @@ func hasEmptyFileSystems(fs *efs.DescribeFileSystemsOutput) bool {
 		return false
 	}
 	return true
+}
+
+func resourceAwsEfsDnsName(fileSystemId, region string) string {
+	return fmt.Sprintf("%s.efs.%s.amazonaws.com", fileSystemId, region)
 }

--- a/aws/resource_aws_efs_file_system_test.go
+++ b/aws/resource_aws_efs_file_system_test.go
@@ -103,6 +103,11 @@ func TestAccAWSEFSFileSystem_basic(t *testing.T) {
 						"aws_efs_file_system.foo",
 						"generalPurpose",
 					),
+					resource.TestMatchResourceAttr(
+						"aws_efs_file_system.foo",
+						"dns_name",
+						regexp.MustCompile("^[^.]+.efs.us-west-2.amazonaws.com$"),
+					),
 				),
 			},
 			{

--- a/website/docs/d/efs_file_system.html.markdown
+++ b/website/docs/d/efs_file_system.html.markdown
@@ -38,3 +38,4 @@ The following attributes are exported:
 * `tags` - The list of tags assigned to the file system.
 * `encrypted` - Whether EFS is encrypted.
 * `kms_key_id` - The ARN for the KMS encryption key.
+* `dns_name` - The DNS name for the filesystem per [documented convention](http://docs.aws.amazon.com/efs/latest/ug/mounting-fs-mount-cmd-dns-name.html).


### PR DESCRIPTION
This adds a 'dns_name' attribute to the aws_efs_file_system resource, reflecting the AZ-agnostic naming convention described in [AWS docs](http://docs.aws.amazon.com/efs/latest/ug/mounting-fs-mount-cmd-dns-name.html). A similar change was made to aws_efs_mount_target and this PR mimics that change at the filesystem level. Technically, I think the change to aws_efs_mount_target was incorrect, since the AZ-specific names that terraform was generating for mount targets are still valid and there is now no way to get them. I did not undo that change here, however, since I imagine some users are relying on it. In any case, getting a AZ-agnostic DNS name (useable anywhere in the VPC) seems more natural coming from the filesystem itself than from an AZ-specific mount target. 

See https://github.com/hashicorp/terraform/issues/10902 and https://github.com/hashicorp/terraform/pull/11023