### PR TITLE
aws_route53_record alias name documentation (must be all in lowercase letters)

### DIFF
--- a/website/docs/r/route53_record.html.markdown
+++ b/website/docs/r/route53_record.html.markdown
@@ -113,7 +113,7 @@ Exactly one of `records` or `alias` must be specified: this determines whether i
 
 Alias records support the following:
 
-* `name` - (Required) DNS domain name for a CloudFront distribution, S3 bucket, ELB, or another resource record set in this hosted zone.
+* `name` - (Required) DNS domain name for a CloudFront distribution, S3 bucket, ELB, or another resource record set in this hosted zone. Must entirely be in lowercase letters to prevent the plan from detecting false changes (consider wrapping a dynamic resource name with the `lower` function).
 * `zone_id` - (Required) Hosted zone ID for a CloudFront distribution, S3 bucket, ELB, or Route 53 hosted zone. See [`resource_elb.zone_id`](/docs/providers/aws/r/elb.html#zone_id) for example.
 * `evaluate_target_health` - (Required) Set to `true` if you want Route 53 to determine whether to respond to DNS queries using this resource record set by checking the health of the resource record set. Some resources have special requirements, see [related part of documentation](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-values.html#rrsets-values-alias-evaluate-target-health).
 


### PR DESCRIPTION
This PR is a response to an issue I faced when working with the`aws_route53_record` resource, similar to what was described in https://github.com/hashicorp/terraform/issues/10004.

The problem for me was that my ELB had a name containing some uppercase letters. This meant that this route53 record's alias name contained uppercase letters and thus semantically violated the constraints of a domain name (must be in lowercase letters).

My hope is that this small additional bit of documentation can help a Terraform developer who faces this problem to more quickly find a possible solution (ie, use the `lower` function) instead of having to spend additional time Google-ing around for a solution.

I hope this helps. Happy Hacktoberfest ;)