### PR TITLE
data.aws_db_snapshot was not exposing 'storage_type'

### DIFF
--- a/aws/data_source_aws_db_snapshot.go
+++ b/aws/data_source_aws_db_snapshot.go
@@ -196,6 +196,7 @@ func dbSnapshotDescriptionAttributes(d *schema.ResourceData, snapshot *rds.DBSna
 	d.Set("db_instance_identifier", snapshot.DBInstanceIdentifier)
 	d.Set("db_snapshot_identifier", snapshot.DBSnapshotIdentifier)
 	d.Set("snapshot_type", snapshot.SnapshotType)
+	d.Set("storage_type", snapshot.StorageType)
 	d.Set("allocated_storage", snapshot.AllocatedStorage)
 	d.Set("availability_zone", snapshot.AvailabilityZone)
 	d.Set("db_snapshot_arn", snapshot.DBSnapshotArn)


### PR DESCRIPTION
data.aws_db_snapshot was not exposing 'storage_type'

The documentation is already fine:
https://www.terraform.io/docs/providers/aws/r/db_snapshot.html#storage_type
