### PR TITLE
Implement aws_acm_certificate flag to query for most recent certificate

### DIFF
--- a/aws/data_source_aws_acm_certificate.go
+++ b/aws/data_source_aws_acm_certificate.go
@@ -124,6 +124,14 @@ func dataSourceAwsAcmCertificateRead(d *schema.ResourceData, meta interface{}) e
 	_, ok = d.GetOk("most_recent")
 	if ok {
 		mr := arns[0]
+		if mr.notBefore == nil {
+			description, err := describeCertificate(mr, conn)
+			if err != nil {
+				return errwrap.Wrapf("Error describing certificates: {{err}}", err)
+			}
+
+			mr.notBefore = description.Certificate.NotBefore
+		}
 		for _, arn := range arns[1:] {
 			if arn.notBefore == nil {
 				description, err := describeCertificate(arn, conn)

--- a/aws/data_source_aws_acm_certificate_test.go
+++ b/aws/data_source_aws_acm_certificate_test.go
@@ -2,18 +2,151 @@ package aws
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/service/acm"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccAwsAcmCertificateDataSource_noMatchReturnsError(t *testing.T) {
-	domain := "hashicorp.com"
+const ACMCertificateRe = `^arn:[^:]+:acm:[^:]+:[^:]+:certificate/.+$`
+
+func TestAccAwsAcmCertificateDataSource_singleIssued(t *testing.T) {
+	if os.Getenv("ACM_CERTIFICATE_ROOT_DOMAIN") == "" {
+		t.Skip("Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set")
+	}
+
+	var arnRe *regexp.Regexp
+	var domain string
+
+	if os.Getenv("ACM_CERTIFICATE_SINGLE_ISSUED_MOST_RECENT_ARN") != "" {
+		arnRe = regexp.MustCompile(fmt.Sprintf("^%s$", os.Getenv("ACM_CERTIFICATE_SINGLE_ISSUED_MOST_RECENT_ARN")))
+	} else {
+		arnRe = regexp.MustCompile(ACMCertificateRe)
+	}
+
+	if os.Getenv("ACM_CERTIFICATE_SINGLE_ISSUED_DOMAIN") != "" {
+		domain = os.Getenv("ACM_CERTIFICATE_SINGLE_ISSUED_DOMAIN")
+	} else {
+		domain = fmt.Sprintf("tf-acc-single-issued.%s", os.Getenv("ACM_CERTIFICATE_ROOT_DOMAIN"))
+	}
+
+	resourceName := "data.aws_acm_certificate.test"
+
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAwsAcmCertificateDataSourceConfig(domain),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(resourceName, "arn", arnRe),
+				),
+			},
+			{
+				Config: testAccCheckAwsAcmCertificateDataSourceConfigWithStatus(domain, acm.CertificateStatusIssued),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(resourceName, "arn", arnRe),
+				),
+			},
+			{
+				Config: testAccCheckAwsAcmCertificateDataSourceConfigWithTypes(domain, acm.CertificateTypeAmazonIssued),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(resourceName, "arn", arnRe),
+				),
+			},
+			{
+				Config: testAccCheckAwsAcmCertificateDataSourceConfigWithMostRecent(domain, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(resourceName, "arn", arnRe),
+				),
+			},
+			{
+				Config: testAccCheckAwsAcmCertificateDataSourceConfigWithMostRecentAndStatus(domain, acm.CertificateStatusIssued, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(resourceName, "arn", arnRe),
+				),
+			},
+			{
+				Config: testAccCheckAwsAcmCertificateDataSourceConfigWithMostRecentAndTypes(domain, acm.CertificateTypeAmazonIssued, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(resourceName, "arn", arnRe),
+				),
+			},
 		},
+	})
+}
+
+func TestAccAwsAcmCertificateDataSource_multipleIssued(t *testing.T) {
+	if os.Getenv("ACM_CERTIFICATE_ROOT_DOMAIN") == "" {
+		t.Skip("Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set")
+	}
+
+	var arnRe *regexp.Regexp
+	var domain string
+
+	if os.Getenv("ACM_CERTIFICATE_MULTIPLE_ISSUED_MOST_RECENT_ARN") != "" {
+		arnRe = regexp.MustCompile(fmt.Sprintf("^%s$", os.Getenv("ACM_CERTIFICATE_MULTIPLE_ISSUED_MOST_RECENT_ARN")))
+	} else {
+		arnRe = regexp.MustCompile(ACMCertificateRe)
+	}
+
+	if os.Getenv("ACM_CERTIFICATE_MULTIPLE_ISSUED_DOMAIN") != "" {
+		domain = os.Getenv("ACM_CERTIFICATE_MULTIPLE_ISSUED_DOMAIN")
+	} else {
+		domain = fmt.Sprintf("tf-acc-multiple-issued.%s", os.Getenv("ACM_CERTIFICATE_ROOT_DOMAIN"))
+	}
+
+	resourceName := "data.aws_acm_certificate.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckAwsAcmCertificateDataSourceConfig(domain),
+				ExpectError: regexp.MustCompile(`Multiple certificates for domain`),
+			},
+			{
+				Config:      testAccCheckAwsAcmCertificateDataSourceConfigWithStatus(domain, acm.CertificateStatusIssued),
+				ExpectError: regexp.MustCompile(`Multiple certificates for domain`),
+			},
+			{
+				Config:      testAccCheckAwsAcmCertificateDataSourceConfigWithTypes(domain, acm.CertificateTypeAmazonIssued),
+				ExpectError: regexp.MustCompile(`Multiple certificates for domain`),
+			},
+			{
+				Config: testAccCheckAwsAcmCertificateDataSourceConfigWithMostRecent(domain, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(resourceName, "arn", arnRe),
+				),
+			},
+			{
+				Config: testAccCheckAwsAcmCertificateDataSourceConfigWithMostRecentAndStatus(domain, acm.CertificateStatusIssued, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(resourceName, "arn", arnRe),
+				),
+			},
+			{
+				Config: testAccCheckAwsAcmCertificateDataSourceConfigWithMostRecentAndTypes(domain, acm.CertificateTypeAmazonIssued, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(resourceName, "arn", arnRe),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAwsAcmCertificateDataSource_noMatchReturnsError(t *testing.T) {
+	if os.Getenv("ACM_CERTIFICATE_ROOT_DOMAIN") == "" {
+		t.Skip("Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set")
+	}
+
+	domain := fmt.Sprintf("tf-acc-nonexistent.%s", os.Getenv("ACM_CERTIFICATE_ROOT_DOMAIN"))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -21,23 +154,23 @@ func TestAccAwsAcmCertificateDataSource_noMatchReturnsError(t *testing.T) {
 				ExpectError: regexp.MustCompile(`No certificate for domain`),
 			},
 			{
-				Config:      testAccCheckAwsAcmCertificateDataSourceConfigWithStatus(domain),
+				Config:      testAccCheckAwsAcmCertificateDataSourceConfigWithStatus(domain, acm.CertificateStatusIssued),
 				ExpectError: regexp.MustCompile(`No certificate for domain`),
 			},
 			{
-				Config:      testAccCheckAwsAcmCertificateDataSourceConfigWithTypes(domain),
+				Config:      testAccCheckAwsAcmCertificateDataSourceConfigWithTypes(domain, acm.CertificateTypeAmazonIssued),
 				ExpectError: regexp.MustCompile(`No certificate for domain`),
 			},
 			{
-				Config:      testAccCheckAwsAcmCertificateDataSourceConfigWithMostRecent(domain),
+				Config:      testAccCheckAwsAcmCertificateDataSourceConfigWithMostRecent(domain, true),
 				ExpectError: regexp.MustCompile(`No certificate for domain`),
 			},
 			{
-				Config:      testAccCheckAwsAcmCertificateDataSourceConfigWithMostRecentAndStatus(domain),
+				Config:      testAccCheckAwsAcmCertificateDataSourceConfigWithMostRecentAndStatus(domain, acm.CertificateStatusIssued, true),
 				ExpectError: regexp.MustCompile(`No certificate for domain`),
 			},
 			{
-				Config:      testAccCheckAwsAcmCertificateDataSourceConfigWithMostRecentAndTypes(domain),
+				Config:      testAccCheckAwsAcmCertificateDataSourceConfigWithMostRecentAndTypes(domain, acm.CertificateTypeAmazonIssued, true),
 				ExpectError: regexp.MustCompile(`No certificate for domain`),
 			},
 		},
@@ -52,49 +185,49 @@ data "aws_acm_certificate" "test" {
 `, domain)
 }
 
-func testAccCheckAwsAcmCertificateDataSourceConfigWithStatus(domain string) string {
+func testAccCheckAwsAcmCertificateDataSourceConfigWithStatus(domain, status string) string {
 	return fmt.Sprintf(`
 data "aws_acm_certificate" "test" {
 	domain = "%s"
-	statuses = ["ISSUED"]
+	statuses = ["%s"]
 }
-`, domain)
+`, domain, status)
 }
 
-func testAccCheckAwsAcmCertificateDataSourceConfigWithTypes(domain string) string {
+func testAccCheckAwsAcmCertificateDataSourceConfigWithTypes(domain, certType string) string {
 	return fmt.Sprintf(`
 data "aws_acm_certificate" "test" {
 	domain = "%s"
-	types = ["IMPORTED"]
+	types = ["%s"]
 }
-`, domain)
+`, domain, certType)
 }
 
-func testAccCheckAwsAcmCertificateDataSourceConfigWithMostRecent(domain string) string {
+func testAccCheckAwsAcmCertificateDataSourceConfigWithMostRecent(domain string, mostRecent bool) string {
 	return fmt.Sprintf(`
 data "aws_acm_certificate" "test" {
 	domain = "%s"
-	most_recent = true
+	most_recent = %v
 }
-`, domain)
+`, domain, mostRecent)
 }
 
-func testAccCheckAwsAcmCertificateDataSourceConfigWithMostRecentAndStatus(domain string) string {
+func testAccCheckAwsAcmCertificateDataSourceConfigWithMostRecentAndStatus(domain, status string, mostRecent bool) string {
 	return fmt.Sprintf(`
 data "aws_acm_certificate" "test" {
 	domain = "%s"
-	statuses = ["ISSUED"]
-	most_recent = true
+	statuses = ["%s"]
+	most_recent = %v
 }
-`, domain)
+`, domain, status, mostRecent)
 }
 
-func testAccCheckAwsAcmCertificateDataSourceConfigWithMostRecentAndTypes(domain string) string {
+func testAccCheckAwsAcmCertificateDataSourceConfigWithMostRecentAndTypes(domain, certType string, mostRecent bool) string {
 	return fmt.Sprintf(`
 data "aws_acm_certificate" "test" {
 	domain = "%s"
-	types = ["IMPORTED"]
-	most_recent = true
+	types = ["%s"]
+	most_recent = %v
 }
-`, domain)
+`, domain, certType, mostRecent)
 }

--- a/aws/data_source_aws_acm_certificate_test.go
+++ b/aws/data_source_aws_acm_certificate_test.go
@@ -28,6 +28,18 @@ func TestAccAwsAcmCertificateDataSource_noMatchReturnsError(t *testing.T) {
 				Config:      testAccCheckAwsAcmCertificateDataSourceConfigWithTypes(domain),
 				ExpectError: regexp.MustCompile(`No certificate for domain`),
 			},
+			{
+				Config:      testAccCheckAwsAcmCertificateDataSourceConfigWithMostRecent(domain),
+				ExpectError: regexp.MustCompile(`No certificate for domain`),
+			},
+			{
+				Config:      testAccCheckAwsAcmCertificateDataSourceConfigWithMostRecentAndStatus(domain),
+				ExpectError: regexp.MustCompile(`No certificate for domain`),
+			},
+			{
+				Config:      testAccCheckAwsAcmCertificateDataSourceConfigWithMostRecentAndTypes(domain),
+				ExpectError: regexp.MustCompile(`No certificate for domain`),
+			},
 		},
 	})
 }
@@ -54,6 +66,35 @@ func testAccCheckAwsAcmCertificateDataSourceConfigWithTypes(domain string) strin
 data "aws_acm_certificate" "test" {
 	domain = "%s"
 	types = ["IMPORTED"]
+}
+`, domain)
+}
+
+func testAccCheckAwsAcmCertificateDataSourceConfigWithMostRecent(domain string) string {
+	return fmt.Sprintf(`
+data "aws_acm_certificate" "test" {
+	domain = "%s"
+	most_recent = true
+}
+`, domain)
+}
+
+func testAccCheckAwsAcmCertificateDataSourceConfigWithMostRecentAndStatus(domain string) string {
+	return fmt.Sprintf(`
+data "aws_acm_certificate" "test" {
+	domain = "%s"
+	statuses = ["ISSUED"]
+	most_recent = true
+}
+`, domain)
+}
+
+func testAccCheckAwsAcmCertificateDataSourceConfigWithMostRecentAndTypes(domain string) string {
+	return fmt.Sprintf(`
+data "aws_acm_certificate" "test" {
+	domain = "%s"
+	types = ["IMPORTED"]
+	most_recent = true
 }
 `, domain)
 }

--- a/website/docs/d/acm_certificate.html.markdown
+++ b/website/docs/d/acm_certificate.html.markdown
@@ -29,7 +29,7 @@ data "aws_acm_certificate" "example" {
  * `statuses` - (Optional) A list of statuses on which to filter the returned list. Valid values are `PENDING_VALIDATION`, `ISSUED`,
    `INACTIVE`, `EXPIRED`, `VALIDATION_TIMED_OUT`, `REVOKED` and `FAILED`. If no value is specified, only certificates in the `ISSUED` state
    are returned.
-
+ * `types` - (Optional) A list of types on which to filter the returned list. Valid values are `AMAZON_ISSUED` and `IMPORTED`
 ## Attributes Reference
 
  * `arn` - Set to the ARN of the found certificate, suitable for referencing in other resources that support ACM certificates.

--- a/website/docs/d/acm_certificate.html.markdown
+++ b/website/docs/d/acm_certificate.html.markdown
@@ -20,6 +20,7 @@ them by domain without having to hard code the ARNs as input.
 data "aws_acm_certificate" "example" {
   domain   = "tf.example.com"
   statuses = ["ISSUED"]
+  most_recent = true
 }
 ```
 
@@ -30,6 +31,7 @@ data "aws_acm_certificate" "example" {
    `INACTIVE`, `EXPIRED`, `VALIDATION_TIMED_OUT`, `REVOKED` and `FAILED`. If no value is specified, only certificates in the `ISSUED` state
    are returned.
  * `types` - (Optional) A list of types on which to filter the returned list. Valid values are `AMAZON_ISSUED` and `IMPORTED`
+ * `most_recent` - (Optional) If set to true, it sorts certificates matched by previous criterias by the NotBefore field, returning only the most recent one. If set to false, it returns an error if more than one certificates are found. Defaults to false.
 ## Attributes Reference
 
  * `arn` - Set to the ARN of the found certificate, suitable for referencing in other resources that support ACM certificates.

--- a/website/docs/d/acm_certificate.html.markdown
+++ b/website/docs/d/acm_certificate.html.markdown
@@ -20,6 +20,11 @@ them by domain without having to hard code the ARNs as input.
 data "aws_acm_certificate" "example" {
   domain   = "tf.example.com"
   statuses = ["ISSUED"]
+}
+
+data "aws_acm_certificate" "example" {
+  domain   = "tf.example.com"
+  types = ["AMAZON_ISSUED"]
   most_recent = true
 }
 ```
@@ -30,8 +35,9 @@ data "aws_acm_certificate" "example" {
  * `statuses` - (Optional) A list of statuses on which to filter the returned list. Valid values are `PENDING_VALIDATION`, `ISSUED`,
    `INACTIVE`, `EXPIRED`, `VALIDATION_TIMED_OUT`, `REVOKED` and `FAILED`. If no value is specified, only certificates in the `ISSUED` state
    are returned.
- * `types` - (Optional) A list of types on which to filter the returned list. Valid values are `AMAZON_ISSUED` and `IMPORTED`
- * `most_recent` - (Optional) If set to true, it sorts certificates matched by previous criterias by the NotBefore field, returning only the most recent one. If set to false, it returns an error if more than one certificates are found. Defaults to false.
+ * `types` - (Optional) A list of types on which to filter the returned list. Valid values are `AMAZON_ISSUED` and `IMPORTED`.
+ * `most_recent` - (Optional) If set to true, it sorts the certificates matched by previous criteria by the NotBefore field, returning only the most recent one. If set to false, it returns an error if more than one certificate is found. Defaults to false.
+
 ## Attributes Reference
 
  * `arn` - Set to the ARN of the found certificate, suitable for referencing in other resources that support ACM certificates.


### PR DESCRIPTION
Fixes: #546

When the flag is set to true, it returns only one certificate when several are found, the most recent based on NotBefore field in the certificate.

```
make testacc TEST=./aws TESTARGS='-run=TestAccAwsAcmCertificateDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAwsAcmCertificateDataSource_ -timeout 120m
=== RUN   TestAccAwsAcmCertificateDataSource_noMatchReturnsError
--- PASS: TestAccAwsAcmCertificateDataSource_noMatchReturnsError (19.56s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	19.597s
```

Updated: fix documentation after review by @fertapric (thanks!). Also include a more efficient way to avoid unneeded api calls.