### PR TITLE
d/aws_ami: update image_location regex

### DIFF
--- a/aws/data_source_aws_ami_test.go
+++ b/aws/data_source_aws_ami_test.go
@@ -104,7 +104,7 @@ func TestAccAWSAmiDataSource_instanceStore(t *testing.T) {
 					resource.TestMatchResourceAttr("data.aws_ami.instance_store_ami", "creation_date", regexp.MustCompile("^20[0-9]{2}-")),
 					resource.TestCheckResourceAttr("data.aws_ami.instance_store_ami", "hypervisor", "xen"),
 					resource.TestMatchResourceAttr("data.aws_ami.instance_store_ami", "image_id", regexp.MustCompile("^ami-")),
-					resource.TestMatchResourceAttr("data.aws_ami.instance_store_ami", "image_location", regexp.MustCompile("images/hvm-instance/ubuntu-trusty-14.04-amd64-server")),
+					resource.TestMatchResourceAttr("data.aws_ami.instance_store_ami", "image_location", regexp.MustCompile("ubuntu-trusty-14.04-amd64-server")),
 					resource.TestCheckResourceAttr("data.aws_ami.instance_store_ami", "image_type", "machine"),
 					resource.TestCheckResourceAttr("data.aws_ami.instance_store_ami", "most_recent", "true"),
 					resource.TestMatchResourceAttr("data.aws_ami.instance_store_ami", "name", regexp.MustCompile("^ubuntu/images/hvm-instance/ubuntu-trusty-14.04-amd64-server")),


### PR DESCRIPTION
Fix a failing test by adjusting the regex. From what I can tell, the name/format of the returned `image_location` has changed:

```
------- Stdout: -------
=== RUN   TestAccAWSAmiDataSource_instanceStore
--- FAIL: TestAccAWSAmiDataSource_instanceStore (36.78s)
    testing.go:434: Step 0 error: Check failed: Check 7/20 error: data.aws_ami.instance_store_ami: Attribute 'image_location' didn't match "images/hvm-instance/ubuntu-trusty-14.04-amd64-server", got "ubuntu-images-us-west-2-release/trusty/20170918/hvm/instance-store/ubuntu-trusty-14.04-amd64-server-20170918.manifest.xml"
FAIL
```

I've loosened the requirements of the regex here. @radeksimko does this seem sensible? 