### PR TITLE
resource/aws_spot_fleet_request: Add support for instance_interruption_behaviour

### DIFF
--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -278,6 +278,12 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 				Default:  "Default",
 				ForceNew: false,
 			},
+			"instance_interruption_behaviour": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "terminate",
+				ForceNew: true,
+			},
 			"spot_price": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -552,6 +558,7 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 		ClientToken:                      aws.String(resource.UniqueId()),
 		TerminateInstancesWithExpiration: aws.Bool(d.Get("terminate_instances_with_expiration").(bool)),
 		ReplaceUnhealthyInstances:        aws.Bool(d.Get("replace_unhealthy_instances").(bool)),
+		InstanceInterruptionBehavior:     aws.String(d.Get("instance_interruption_behaviour").(string)),
 	}
 
 	if v, ok := d.GetOk("excess_capacity_termination_policy"); ok {
@@ -788,6 +795,7 @@ func resourceAwsSpotFleetRequestRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	d.Set("replace_unhealthy_instances", config.ReplaceUnhealthyInstances)
+	d.Set("instance_interruption_behaviour", config.InstanceInterruptionBehavior)
 	d.Set("launch_specification", launchSpecsToSet(config.LaunchSpecifications, conn))
 
 	return nil

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -41,6 +41,31 @@ func TestAccAWSSpotFleetRequest_associatePublicIpAddress(t *testing.T) {
 	})
 }
 
+func TestAccAWSSpotFleetRequest_instanceInterruptionBehavior(t *testing.T) {
+	var sfr ec2.SpotFleetRequestConfig
+	rName := acctest.RandString(10)
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSpotFleetRequestConfig(rName, rInt),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSSpotFleetRequestExists(
+						"aws_spot_fleet_request.foo", &sfr),
+					resource.TestCheckResourceAttr(
+						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(
+						"aws_spot_fleet_request.foo", "instance_interruption_behaviour", "stop"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSSpotFleetRequest_changePriceForcesNewRequest(t *testing.T) {
 	var before, after ec2.SpotFleetRequestConfig
 	rName := acctest.RandString(10)
@@ -534,6 +559,7 @@ resource "aws_spot_fleet_request" "foo" {
     target_capacity = 2
     valid_until = "2019-11-04T20:44:20Z"
     terminate_instances_with_expiration = true
+    instance_interruption_behaviour = "stop"
     wait_for_fulfillment = true
     launch_specification {
         instance_type = "m1.small"

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -559,7 +559,6 @@ resource "aws_spot_fleet_request" "foo" {
     target_capacity = 2
     valid_until = "2019-11-04T20:44:20Z"
     terminate_instances_with_expiration = true
-    instance_interruption_behaviour = "stop"
     wait_for_fulfillment = true
     launch_specification {
         instance_type = "m1.small"
@@ -635,6 +634,7 @@ resource "aws_spot_fleet_request" "foo" {
     target_capacity = 2
     valid_until = "2019-11-04T20:44:20Z"
     terminate_instances_with_expiration = true
+    instance_interruption_behaviour = "stop"
     wait_for_fulfillment = true
     launch_specification {
         instance_type = "m1.small"

--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -111,7 +111,7 @@ lowestPrice.
   instances should be terminated when the Spot fleet request expires.
 * `instance_interruption_behavior` - (Optional) Indicates whether a Spot
   instance stops or terminates when it is interrupted. Default is
-  `terminate` as this is the current AWS behaviour.
+  `terminate`.
 * `valid_until` - The end date and time of the request, in UTC ISO8601 format
   (for example, YYYY-MM-DDTHH:MM:SSZ). At this point, no new Spot instance
 requests are placed or enabled to fulfill the request. Defaults to 24 hours.

--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -109,6 +109,9 @@ lowestPrice.
   request is decreased below the current size of the Spot fleet.
 * `terminate_instances_with_expiration` - Indicates whether running Spot
   instances should be terminated when the Spot fleet request expires.
+* `instance_interruption_behavior` - (Optional) Indicates whether a Spot
+  instance stops or terminates when it is interrupted. Default is
+  `terminate` as this is the current AWS behaviour.
 * `valid_until` - The end date and time of the request, in UTC ISO8601 format
   (for example, YYYY-MM-DDTHH:MM:SSZ). At this point, no new Spot instance
 requests are placed or enabled to fulfill the request. Defaults to 24 hours.


### PR DESCRIPTION
#1735 added it for `aws_spot_instance_request`. This is the same, but for `aws_spot_fleet_request`.