### PR TITLE
resource/aws_cloudformation_stack: Remove ForceNew from on_failure

### DIFF
--- a/aws/resource_aws_cloudformation_stack.go
+++ b/aws/resource_aws_cloudformation_stack.go
@@ -71,7 +71,6 @@ func resourceAwsCloudFormationStack() *schema.Resource {
 			"on_failure": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 			},
 			"parameters": {
 				Type:     schema.TypeMap,


### PR DESCRIPTION
The `on_failure` argument is used only during stack creation. For stack that already exists it is only used when stack has to be recreated (e.g. it is tainted).