### PR TITLE
Change the default minimum_protocol_version to TLSv1

### DIFF
--- a/aws/resource_aws_cloudfront_distribution.go
+++ b/aws/resource_aws_cloudfront_distribution.go
@@ -484,7 +484,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 						"minimum_protocol_version": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Default:  "SSLv3",
+							Default:  "TLSv1",
 						},
 						"ssl_support_method": {
 							Type:     schema.TypeString,

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -355,10 +355,14 @@ The arguments of `geo_restriction` are:
     this, `acm_certificate_arn`, or `cloudfront_default_certificate`.
 
   * `minimum_protocol_version` - The minimum version of the SSL protocol that
-    you want CloudFront to use for HTTPS connections. One of `SSLv3` or `TLSv1`.
-    Default: `SSLv3`. **NOTE**: If you are using a custom certificate (specified
-    with `acm_certificate_arn` or `iam_certificate_id`), and have specified
-    `sni-only` in `ssl_support_method`, `TLSv1` must be specified.
+    you want CloudFront to use for HTTPS connections. One of `SSLv3`, `TLSv1`,
+    `TLSv1_2016`, `TLSv1.1_2016` or `TLSv1.2_2018`. Default: `TLSv1`. **NOTE**:
+    If you are using a custom certificate (specified with `acm_certificate_arn`
+    or `iam_certificate_id`), and have specified `sni-only` in
+    `ssl_support_method`, `TLSv1` or later must be specified. If you have
+    specified `vip` in `ssl_support_method`, only `SSLv3` or `TLSv1` can be
+    specified. If you have specified `cloudfront_default_certificate`, `TLSv1`
+    must be specified.
 
   * `ssl_support_method`: Specifies how you want CloudFront to serve HTTPS
     requests. One of `vip` or `sni-only`. Required if you specify


### PR DESCRIPTION
 And update the documentation to fall in line with changes in AWS. Fixes #1829 