### PR TITLE
Bump AWS SDK to v1.12.8

### DIFF
--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.12.6"
+const SDKVersion = "1.12.8"

--- a/vendor/github.com/aws/aws-sdk-go/service/ec2/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ec2/api.go
@@ -1377,8 +1377,7 @@ func (c *EC2) AttachVpnGatewayRequest(input *AttachVpnGatewayInput) (req *reques
 // Attaches a virtual private gateway to a VPC. You can attach one virtual private
 // gateway to one VPC at a time.
 //
-// For more information, see Adding a Hardware Virtual Private Gateway to Your
-// VPC (http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_VPN.html)
+// For more information, see AWS Managed VPN Connections (http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_VPN.html)
 // in the Amazon Virtual Private Cloud User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -2612,9 +2611,9 @@ func (c *EC2) CreateCustomerGatewayRequest(input *CreateCustomerGatewayInput) (r
 // the exception of 7224, which is reserved in the us-east-1 region, and 9059,
 // which is reserved in the eu-west-1 region.
 //
-// For more information about VPN customer gateways, see Adding a Hardware Virtual
-// Private Gateway to Your VPC (http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_VPN.html)
-// in the Amazon Virtual Private Cloud User Guide.
+// For more information about VPN customer gateways, see AWS Managed VPN Connections
+// (http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_VPN.html) in the
+// Amazon Virtual Private Cloud User Guide.
 //
 // You cannot create more than one customer gateway with the same VPN type,
 // IP address, and BGP ASN parameter values. If you run an identical request
@@ -5122,9 +5121,9 @@ func (c *EC2) CreateVpnConnectionRouteRequest(input *CreateVpnConnectionRouteInp
 // traffic to be routed from the virtual private gateway to the VPN customer
 // gateway.
 //
-// For more information about VPN connections, see Adding a Hardware Virtual
-// Private Gateway to Your VPC (http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_VPN.html)
-// in the Amazon Virtual Private Cloud User Guide.
+// For more information about VPN connections, see AWS Managed VPN Connections
+// (http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_VPN.html) in the
+// Amazon Virtual Private Cloud User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -5202,8 +5201,8 @@ func (c *EC2) CreateVpnGatewayRequest(input *CreateVpnGatewayInput) (req *reques
 // on the VPC side of your VPN connection. You can create a virtual private
 // gateway before creating the VPC itself.
 //
-// For more information about virtual private gateways, see Adding a Hardware
-// Virtual Private Gateway to Your VPC (http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_VPN.html)
+// For more information about virtual private gateways, see AWS Managed VPN
+// Connections (http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_VPN.html)
 // in the Amazon Virtual Private Cloud User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -7957,9 +7956,9 @@ func (c *EC2) DescribeCustomerGatewaysRequest(input *DescribeCustomerGatewaysInp
 //
 // Describes one or more of your VPN customer gateways.
 //
-// For more information about VPN customer gateways, see Adding a Hardware Virtual
-// Private Gateway to Your VPC (http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_VPN.html)
-// in the Amazon Virtual Private Cloud User Guide.
+// For more information about VPN customer gateways, see AWS Managed VPN Connections
+// (http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_VPN.html) in the
+// Amazon Virtual Private Cloud User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -13572,9 +13571,9 @@ func (c *EC2) DescribeVpnConnectionsRequest(input *DescribeVpnConnectionsInput) 
 //
 // Describes one or more of your VPN connections.
 //
-// For more information about VPN connections, see Adding a Hardware Virtual
-// Private Gateway to Your VPC (http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_VPN.html)
-// in the Amazon Virtual Private Cloud User Guide.
+// For more information about VPN connections, see AWS Managed VPN Connections
+// (http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_VPN.html) in the
+// Amazon Virtual Private Cloud User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -13650,8 +13649,8 @@ func (c *EC2) DescribeVpnGatewaysRequest(input *DescribeVpnGatewaysInput) (req *
 //
 // Describes one or more of your virtual private gateways.
 //
-// For more information about virtual private gateways, see Adding an IPsec
-// Hardware VPN to Your VPC (http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_VPN.html)
+// For more information about virtual private gateways, see AWS Managed VPN
+// Connections (http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_VPN.html)
 // in the Amazon Virtual Private Cloud User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -16207,15 +16206,15 @@ func (c *EC2) ModifyImageAttributeRequest(input *ModifyImageAttributeInput) (req
 // ModifyImageAttribute API operation for Amazon Elastic Compute Cloud.
 //
 // Modifies the specified attribute of the specified AMI. You can specify only
-// one attribute at a time.
+// one attribute at a time. You can use the Attribute parameter to specify the
+// attribute or one of the following parameters: Description, LaunchPermission,
+// or ProductCode.
 //
 // AWS Marketplace product codes cannot be modified. Images with an AWS Marketplace
 // product code cannot be made public.
 //
-// The SriovNetSupport enhanced networking attribute cannot be changed using
-// this command. Instead, enable SriovNetSupport on an instance and create an
-// AMI from the instance. This will result in an image with SriovNetSupport
-// enabled.
+// To enable the SriovNetSupport enhanced networking attribute of an image,
+// enable SriovNetSupport on an instance and create an AMI from the instance.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -22139,8 +22138,7 @@ func (s *AttributeValue) SetValue(v string) *AttributeValue {
 type AuthorizeSecurityGroupEgressInput struct {
 	_ struct{} `type:"structure"`
 
-	// The CIDR IPv4 address range. We recommend that you specify the CIDR range
-	// in a set of IP permissions instead.
+	// Not supported. Use a set of IP permissions to specify the CIDR.
 	CidrIp *string `locationName:"cidrIp" type:"string"`
 
 	// Checks whether you have the required permissions for the action, without
@@ -22149,8 +22147,7 @@ type AuthorizeSecurityGroupEgressInput struct {
 	// it is UnauthorizedOperation.
 	DryRun *bool `locationName:"dryRun" type:"boolean"`
 
-	// The start of port range for the TCP and UDP protocols, or an ICMP type number.
-	// We recommend that you specify the port range in a set of IP permissions instead.
+	// Not supported. Use a set of IP permissions to specify the port.
 	FromPort *int64 `locationName:"fromPort" type:"integer"`
 
 	// The ID of the security group.
@@ -22158,26 +22155,23 @@ type AuthorizeSecurityGroupEgressInput struct {
 	// GroupId is a required field
 	GroupId *string `locationName:"groupId" type:"string" required:"true"`
 
-	// A set of IP permissions. You can't specify a destination security group and
-	// a CIDR IP address range.
+	// One or more sets of IP permissions. You can't specify a destination security
+	// group and a CIDR IP address range in the same set of permissions.
 	IpPermissions []*IpPermission `locationName:"ipPermissions" locationNameList:"item" type:"list"`
 
-	// The IP protocol name or number. We recommend that you specify the protocol
-	// in a set of IP permissions instead.
+	// Not supported. Use a set of IP permissions to specify the protocol name or
+	// number.
 	IpProtocol *string `locationName:"ipProtocol" type:"string"`
 
-	// The name of a destination security group. To authorize outbound access to
-	// a destination security group, we recommend that you use a set of IP permissions
-	// instead.
+	// Not supported. Use a set of IP permissions to specify a destination security
+	// group.
 	SourceSecurityGroupName *string `locationName:"sourceSecurityGroupName" type:"string"`
 
-	// The AWS account number for a destination security group. To authorize outbound
-	// access to a destination security group, we recommend that you use a set of
-	// IP permissions instead.
+	// Not supported. Use a set of IP permissions to specify a destination security
+	// group.
 	SourceSecurityGroupOwnerId *string `locationName:"sourceSecurityGroupOwnerId" type:"string"`
 
-	// The end of port range for the TCP and UDP protocols, or an ICMP type number.
-	// We recommend that you specify the port range in a set of IP permissions instead.
+	// Not supported. Use a set of IP permissions to specify the port.
 	ToPort *int64 `locationName:"toPort" type:"integer"`
 }
 
@@ -22302,8 +22296,8 @@ type AuthorizeSecurityGroupIngressInput struct {
 	// either the security group ID or the security group name in the request.
 	GroupName *string `type:"string"`
 
-	// A set of IP permissions. Can be used to specify multiple rules in a single
-	// command.
+	// One or more sets of IP permissions. Can be used to specify multiple rules
+	// in a single command.
 	IpPermissions []*IpPermission `locationNameList:"item" type:"list"`
 
 	// The IP protocol name (tcp, udp, icmp) or number (see Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)).
@@ -22323,8 +22317,8 @@ type AuthorizeSecurityGroupIngressInput struct {
 	// be in the same VPC.
 	SourceSecurityGroupName *string `type:"string"`
 
-	// [EC2-Classic] The AWS account number for the source security group, if the
-	// source security group is in a different account. You can't specify this parameter
+	// [EC2-Classic] The AWS account ID for the source security group, if the source
+	// security group is in a different account. You can't specify this parameter
 	// in combination with the following parameters: the CIDR IP address range,
 	// the IP protocol, the start of the port range, and the end of the port range.
 	// Creates rules that grant full ICMP, UDP, and TCP access. To create a rule
@@ -27537,6 +27531,13 @@ func (s CreateVpnConnectionRouteOutput) GoString() string {
 type CreateVpnGatewayInput struct {
 	_ struct{} `type:"structure"`
 
+	// A private Autonomous System Number (ASN) for the Amazon side of a BGP session.
+	// If you're using a 16-bit ASN, it must be in the 64512 to 65534 range. If
+	// you're using a 32-bit ASN, it must be in the 4200000000 to 4294967294 range.
+	//
+	// Default: 64512
+	AmazonSideAsn *int64 `type:"long"`
+
 	// The Availability Zone for the virtual private gateway.
 	AvailabilityZone *string `type:"string"`
 
@@ -27573,6 +27574,12 @@ func (s *CreateVpnGatewayInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAmazonSideAsn sets the AmazonSideAsn field's value.
+func (s *CreateVpnGatewayInput) SetAmazonSideAsn(v int64) *CreateVpnGatewayInput {
+	s.AmazonSideAsn = &v
+	return s
 }
 
 // SetAvailabilityZone sets the AvailabilityZone field's value.
@@ -37944,6 +37951,9 @@ type DescribeVpnGatewaysInput struct {
 
 	// One or more filters.
 	//
+	//    * amazon-side-asn - The Autonomous System Number (ASN) for the Amazon
+	//    side of the gateway.
+	//
 	//    * attachment.state - The current state of the attachment between the gateway
 	//    and the VPC (attaching | attached | detaching | detached).
 	//
@@ -44898,7 +44908,7 @@ func (s *InternetGatewayAttachment) SetVpcId(v string) *InternetGatewayAttachmen
 	return s
 }
 
-// Describes a security group rule.
+// Describes a set of permissions for a security group rule.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/IpPermission
 type IpPermission struct {
 	_ struct{} `type:"structure"`
@@ -44997,7 +45007,7 @@ type IpRange struct {
 	_ struct{} `type:"structure"`
 
 	// The IPv4 CIDR range. You can either specify a CIDR range or a source security
-	// group, not both. To specify a single IPv4 address, use the /32 prefix.
+	// group, not both. To specify a single IPv4 address, use the /32 prefix length.
 	CidrIp *string `locationName:"cidrIp" type:"string"`
 
 	// A description for the security group rule that references this IPv4 address
@@ -45061,7 +45071,7 @@ type Ipv6Range struct {
 	_ struct{} `type:"structure"`
 
 	// The IPv6 CIDR range. You can either specify a CIDR range or a source security
-	// group, not both. To specify a single IPv6 address, use the /128 prefix.
+	// group, not both. To specify a single IPv6 address, use the /128 prefix length.
 	CidrIpv6 *string `locationName:"cidrIpv6" type:"string"`
 
 	// A description for the security group rule that references this IPv6 address
@@ -45866,10 +45876,11 @@ func (s ModifyIdentityIdFormatOutput) GoString() string {
 type ModifyImageAttributeInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the attribute to modify.
+	// The name of the attribute to modify. The valid values are description, launchPermission,
+	// and productCodes.
 	Attribute *string `type:"string"`
 
-	// A description for the AMI.
+	// A new description for the AMI.
 	Description *AttributeValue `type:"structure"`
 
 	// Checks whether you have the required permissions for the action, without
@@ -45883,26 +45894,27 @@ type ModifyImageAttributeInput struct {
 	// ImageId is a required field
 	ImageId *string `type:"string" required:"true"`
 
-	// A launch permission modification.
+	// A new launch permission for the AMI.
 	LaunchPermission *LaunchPermissionModifications `type:"structure"`
 
-	// The operation type.
+	// The operation type. This parameter can be used only when the Attribute parameter
+	// is launchPermission.
 	OperationType *string `type:"string" enum:"OperationType"`
 
-	// One or more product codes. After you add a product code to an AMI, it can't
-	// be removed. This is only valid when modifying the productCodes attribute.
+	// One or more DevPay product codes. After you add a product code to an AMI,
+	// it can't be removed.
 	ProductCodes []*string `locationName:"ProductCode" locationNameList:"ProductCode" type:"list"`
 
-	// One or more user groups. This is only valid when modifying the launchPermission
-	// attribute.
+	// One or more user groups. This parameter can be used only when the Attribute
+	// parameter is launchPermission.
 	UserGroups []*string `locationName:"UserGroup" locationNameList:"UserGroup" type:"list"`
 
-	// One or more AWS account IDs. This is only valid when modifying the launchPermission
-	// attribute.
+	// One or more AWS account IDs. This parameter can be used only when the Attribute
+	// parameter is launchPermission.
 	UserIds []*string `locationName:"UserId" locationNameList:"UserId" type:"list"`
 
-	// The value of the attribute being modified. This is only valid when modifying
-	// the description attribute.
+	// The value of the attribute being modified. This parameter can be used only
+	// when the Attribute parameter is description or productCodes.
 	Value *string `type:"string"`
 }
 
@@ -52835,8 +52847,7 @@ func (s *RestoreAddressToClassicOutput) SetStatus(v string) *RestoreAddressToCla
 type RevokeSecurityGroupEgressInput struct {
 	_ struct{} `type:"structure"`
 
-	// The CIDR IP address range. We recommend that you specify the CIDR range in
-	// a set of IP permissions instead.
+	// Not supported. Use a set of IP permissions to specify the CIDR.
 	CidrIp *string `locationName:"cidrIp" type:"string"`
 
 	// Checks whether you have the required permissions for the action, without
@@ -52845,8 +52856,7 @@ type RevokeSecurityGroupEgressInput struct {
 	// it is UnauthorizedOperation.
 	DryRun *bool `locationName:"dryRun" type:"boolean"`
 
-	// The start of port range for the TCP and UDP protocols, or an ICMP type number.
-	// We recommend that you specify the port range in a set of IP permissions instead.
+	// Not supported. Use a set of IP permissions to specify the port.
 	FromPort *int64 `locationName:"fromPort" type:"integer"`
 
 	// The ID of the security group.
@@ -52854,26 +52864,23 @@ type RevokeSecurityGroupEgressInput struct {
 	// GroupId is a required field
 	GroupId *string `locationName:"groupId" type:"string" required:"true"`
 
-	// A set of IP permissions. You can't specify a destination security group and
-	// a CIDR IP address range.
+	// One or more sets of IP permissions. You can't specify a destination security
+	// group and a CIDR IP address range in the same set of permissions.
 	IpPermissions []*IpPermission `locationName:"ipPermissions" locationNameList:"item" type:"list"`
 
-	// The IP protocol name or number. We recommend that you specify the protocol
-	// in a set of IP permissions instead.
+	// Not supported. Use a set of IP permissions to specify the protocol name or
+	// number.
 	IpProtocol *string `locationName:"ipProtocol" type:"string"`
 
-	// The name of a destination security group. To revoke outbound access to a
-	// destination security group, we recommend that you use a set of IP permissions
-	// instead.
+	// Not supported. Use a set of IP permissions to specify a destination security
+	// group.
 	SourceSecurityGroupName *string `locationName:"sourceSecurityGroupName" type:"string"`
 
-	// The AWS account number for a destination security group. To revoke outbound
-	// access to a destination security group, we recommend that you use a set of
-	// IP permissions instead.
+	// Not supported. Use a set of IP permissions to specify a destination security
+	// group.
 	SourceSecurityGroupOwnerId *string `locationName:"sourceSecurityGroupOwnerId" type:"string"`
 
-	// The end of port range for the TCP and UDP protocols, or an ICMP type number.
-	// We recommend that you specify the port range in a set of IP permissions instead.
+	// Not supported. Use a set of IP permissions to specify the port.
 	ToPort *int64 `locationName:"toPort" type:"integer"`
 }
 
@@ -52988,15 +52995,17 @@ type RevokeSecurityGroupIngressInput struct {
 	// For the ICMP type number, use -1 to specify all ICMP types.
 	FromPort *int64 `type:"integer"`
 
-	// The ID of the security group. Required for a security group in a nondefault
-	// VPC.
+	// The ID of the security group. You must specify either the security group
+	// ID or the security group name in the request. For security groups in a nondefault
+	// VPC, you must specify the security group ID.
 	GroupId *string `type:"string"`
 
-	// [EC2-Classic, default VPC] The name of the security group.
+	// [EC2-Classic, default VPC] The name of the security group. You must specify
+	// either the security group ID or the security group name in the request.
 	GroupName *string `type:"string"`
 
-	// A set of IP permissions. You can't specify a source security group and a
-	// CIDR IP address range.
+	// One or more sets of IP permissions. You can't specify a source security group
+	// and a CIDR IP address range in the same set of permissions.
 	IpPermissions []*IpPermission `locationNameList:"item" type:"list"`
 
 	// The IP protocol name (tcp, udp, icmp) or number (see Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)).
@@ -59780,6 +59789,9 @@ func (s *VpnConnectionOptionsSpecification) SetTunnelOptions(v []*VpnTunnelOptio
 type VpnGateway struct {
 	_ struct{} `type:"structure"`
 
+	// The private Autonomous System Number (ASN) for the Amazon side of a BGP session.
+	AmazonSideAsn *int64 `locationName:"amazonSideAsn" type:"long"`
+
 	// The Availability Zone where the virtual private gateway was created, if applicable.
 	// This field may be empty or not returned.
 	AvailabilityZone *string `locationName:"availabilityZone" type:"string"`
@@ -59808,6 +59820,12 @@ func (s VpnGateway) String() string {
 // GoString returns the string representation
 func (s VpnGateway) GoString() string {
 	return s.String()
+}
+
+// SetAmazonSideAsn sets the AmazonSideAsn field's value.
+func (s *VpnGateway) SetAmazonSideAsn(v int64) *VpnGateway {
+	s.AmazonSideAsn = &v
+	return s
 }
 
 // SetAvailabilityZone sets the AvailabilityZone field's value.

--- a/vendor/github.com/aws/aws-sdk-go/service/elbv2/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/elbv2/api.go
@@ -11,6 +11,97 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 )
 
+const opAddListenerCertificates = "AddListenerCertificates"
+
+// AddListenerCertificatesRequest generates a "aws/request.Request" representing the
+// client's request for the AddListenerCertificates operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See AddListenerCertificates for more information on using the AddListenerCertificates
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the AddListenerCertificatesRequest method.
+//    req, resp := client.AddListenerCertificatesRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/AddListenerCertificates
+func (c *ELBV2) AddListenerCertificatesRequest(input *AddListenerCertificatesInput) (req *request.Request, output *AddListenerCertificatesOutput) {
+	op := &request.Operation{
+		Name:       opAddListenerCertificates,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &AddListenerCertificatesInput{}
+	}
+
+	output = &AddListenerCertificatesOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// AddListenerCertificates API operation for Elastic Load Balancing.
+//
+// Adds the specified certificate to the specified secure listener.
+//
+// If the certificate was already added, the call is successful but the certificate
+// is not added again.
+//
+// To list the certificates for your listener, use DescribeListenerCertificates.
+// To remove certificates from your listener, use RemoveListenerCertificates.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Elastic Load Balancing's
+// API operation AddListenerCertificates for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeListenerNotFoundException "ListenerNotFound"
+//   The specified listener does not exist.
+//
+//   * ErrCodeTooManyCertificatesException "TooManyCertificates"
+//   You've reached the limit on the number of certificates per load balancer.
+//
+//   * ErrCodeCertificateNotFoundException "CertificateNotFound"
+//   The specified certificate does not exist.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/AddListenerCertificates
+func (c *ELBV2) AddListenerCertificates(input *AddListenerCertificatesInput) (*AddListenerCertificatesOutput, error) {
+	req, out := c.AddListenerCertificatesRequest(input)
+	return out, req.Send()
+}
+
+// AddListenerCertificatesWithContext is the same as AddListenerCertificates with the addition of
+// the ability to pass a context and additional request options.
+//
+// See AddListenerCertificates for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ELBV2) AddListenerCertificatesWithContext(ctx aws.Context, input *AddListenerCertificatesInput, opts ...request.Option) (*AddListenerCertificatesOutput, error) {
+	req, out := c.AddListenerCertificatesRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opAddTags = "AddTags"
 
 // AddTagsRequest generates a "aws/request.Request" representing the
@@ -180,7 +271,7 @@ func (c *ELBV2) CreateListenerRequest(input *CreateListenerInput) (req *request.
 //   You've reached the limit on the number of listeners per load balancer.
 //
 //   * ErrCodeTooManyCertificatesException "TooManyCertificates"
-//   You've reached the limit on the number of certificates per listener.
+//   You've reached the limit on the number of certificates per load balancer.
 //
 //   * ErrCodeLoadBalancerNotFoundException "LoadBalancerNotFound"
 //   The specified load balancer does not exist.
@@ -1081,6 +1172,85 @@ func (c *ELBV2) DescribeAccountLimits(input *DescribeAccountLimitsInput) (*Descr
 // for more information on using Contexts.
 func (c *ELBV2) DescribeAccountLimitsWithContext(ctx aws.Context, input *DescribeAccountLimitsInput, opts ...request.Option) (*DescribeAccountLimitsOutput, error) {
 	req, out := c.DescribeAccountLimitsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDescribeListenerCertificates = "DescribeListenerCertificates"
+
+// DescribeListenerCertificatesRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeListenerCertificates operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeListenerCertificates for more information on using the DescribeListenerCertificates
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeListenerCertificatesRequest method.
+//    req, resp := client.DescribeListenerCertificatesRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/DescribeListenerCertificates
+func (c *ELBV2) DescribeListenerCertificatesRequest(input *DescribeListenerCertificatesInput) (req *request.Request, output *DescribeListenerCertificatesOutput) {
+	op := &request.Operation{
+		Name:       opDescribeListenerCertificates,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DescribeListenerCertificatesInput{}
+	}
+
+	output = &DescribeListenerCertificatesOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeListenerCertificates API operation for Elastic Load Balancing.
+//
+// Describes the certificates for the specified secure listener.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Elastic Load Balancing's
+// API operation DescribeListenerCertificates for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeListenerNotFoundException "ListenerNotFound"
+//   The specified listener does not exist.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/DescribeListenerCertificates
+func (c *ELBV2) DescribeListenerCertificates(input *DescribeListenerCertificatesInput) (*DescribeListenerCertificatesOutput, error) {
+	req, out := c.DescribeListenerCertificatesRequest(input)
+	return out, req.Send()
+}
+
+// DescribeListenerCertificatesWithContext is the same as DescribeListenerCertificates with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeListenerCertificates for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ELBV2) DescribeListenerCertificatesWithContext(ctx aws.Context, input *DescribeListenerCertificatesInput, opts ...request.Option) (*DescribeListenerCertificatesOutput, error) {
+	req, out := c.DescribeListenerCertificatesRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -2075,7 +2245,7 @@ func (c *ELBV2) ModifyListenerRequest(input *ModifyListenerInput) (req *request.
 //   You've reached the limit on the number of listeners per load balancer.
 //
 //   * ErrCodeTooManyCertificatesException "TooManyCertificates"
-//   You've reached the limit on the number of certificates per listener.
+//   You've reached the limit on the number of certificates per load balancer.
 //
 //   * ErrCodeListenerNotFoundException "ListenerNotFound"
 //   The specified listener does not exist.
@@ -2532,16 +2702,18 @@ func (c *ELBV2) RegisterTargetsRequest(input *RegisterTargetsInput) (req *reques
 //
 // Registers the specified targets with the specified target group.
 //
+// You can register targets by instance ID or by IP address. If the target is
+// an EC2 instance, it must be in the running state when you register it.
+//
 // By default, the load balancer routes requests to registered targets using
-// the protocol and port number for the target group. Alternatively, you can
-// override the port for a target when you register it.
+// the protocol and port for the target group. Alternatively, you can override
+// the port for a target when you register it. You can register each EC2 instance
+// or IP address with the same target group multiple times using different ports.
 //
-// The target must be in the virtual private cloud (VPC) that you specified
-// for the target group. If the target is an EC2 instance, it must be in the
-// running state when you register it.
-//
-// Network Load Balancers do not support the following instance types as targets:
-// C1, CC1, CC2, CG1, CG2, CR1, CS1, G1, G2, HI1, HS1, M1, M2, M3, and T1.
+// With a Network Load Balancer, you cannot register instances by instance ID
+// if they have the following instance types: C1, CC1, CC2, CG1, CG2, CR1, CS1,
+// G1, G2, HI1, HS1, M1, M2, M3, and T1. You can register instances of these
+// types by IP address.
 //
 // To remove a target from a target group, use DeregisterTargets.
 //
@@ -2584,6 +2756,93 @@ func (c *ELBV2) RegisterTargets(input *RegisterTargetsInput) (*RegisterTargetsOu
 // for more information on using Contexts.
 func (c *ELBV2) RegisterTargetsWithContext(ctx aws.Context, input *RegisterTargetsInput, opts ...request.Option) (*RegisterTargetsOutput, error) {
 	req, out := c.RegisterTargetsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opRemoveListenerCertificates = "RemoveListenerCertificates"
+
+// RemoveListenerCertificatesRequest generates a "aws/request.Request" representing the
+// client's request for the RemoveListenerCertificates operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See RemoveListenerCertificates for more information on using the RemoveListenerCertificates
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the RemoveListenerCertificatesRequest method.
+//    req, resp := client.RemoveListenerCertificatesRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/RemoveListenerCertificates
+func (c *ELBV2) RemoveListenerCertificatesRequest(input *RemoveListenerCertificatesInput) (req *request.Request, output *RemoveListenerCertificatesOutput) {
+	op := &request.Operation{
+		Name:       opRemoveListenerCertificates,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &RemoveListenerCertificatesInput{}
+	}
+
+	output = &RemoveListenerCertificatesOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// RemoveListenerCertificates API operation for Elastic Load Balancing.
+//
+// Removes the specified certificate from the specified secure listener.
+//
+// You can't remove the default certificate for a listener. To replace the default
+// certificate, call ModifyListener.
+//
+// To list the certificates for your listener, use DescribeListenerCertificates.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Elastic Load Balancing's
+// API operation RemoveListenerCertificates for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeListenerNotFoundException "ListenerNotFound"
+//   The specified listener does not exist.
+//
+//   * ErrCodeOperationNotPermittedException "OperationNotPermitted"
+//   This operation is not allowed.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/RemoveListenerCertificates
+func (c *ELBV2) RemoveListenerCertificates(input *RemoveListenerCertificatesInput) (*RemoveListenerCertificatesOutput, error) {
+	req, out := c.RemoveListenerCertificatesRequest(input)
+	return out, req.Send()
+}
+
+// RemoveListenerCertificatesWithContext is the same as RemoveListenerCertificates with the addition of
+// the ability to pass a context and additional request options.
+//
+// See RemoveListenerCertificates for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ELBV2) RemoveListenerCertificatesWithContext(ctx aws.Context, input *RemoveListenerCertificatesInput, opts ...request.Option) (*RemoveListenerCertificatesOutput, error) {
+	req, out := c.RemoveListenerCertificatesRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -3100,6 +3359,83 @@ func (s *Action) SetType(v string) *Action {
 	return s
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/AddListenerCertificatesInput
+type AddListenerCertificatesInput struct {
+	_ struct{} `type:"structure"`
+
+	// The certificate to add. You can specify one certificate per call.
+	//
+	// Certificates is a required field
+	Certificates []*Certificate `type:"list" required:"true"`
+
+	// The Amazon Resource Name (ARN) of the listener.
+	//
+	// ListenerArn is a required field
+	ListenerArn *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s AddListenerCertificatesInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AddListenerCertificatesInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AddListenerCertificatesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AddListenerCertificatesInput"}
+	if s.Certificates == nil {
+		invalidParams.Add(request.NewErrParamRequired("Certificates"))
+	}
+	if s.ListenerArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ListenerArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetCertificates sets the Certificates field's value.
+func (s *AddListenerCertificatesInput) SetCertificates(v []*Certificate) *AddListenerCertificatesInput {
+	s.Certificates = v
+	return s
+}
+
+// SetListenerArn sets the ListenerArn field's value.
+func (s *AddListenerCertificatesInput) SetListenerArn(v string) *AddListenerCertificatesInput {
+	s.ListenerArn = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/AddListenerCertificatesOutput
+type AddListenerCertificatesOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the certificates.
+	Certificates []*Certificate `type:"list"`
+}
+
+// String returns the string representation
+func (s AddListenerCertificatesOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AddListenerCertificatesOutput) GoString() string {
+	return s.String()
+}
+
+// SetCertificates sets the Certificates field's value.
+func (s *AddListenerCertificatesOutput) SetCertificates(v []*Certificate) *AddListenerCertificatesOutput {
+	s.Certificates = v
+	return s
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/AddTagsInput
 type AddTagsInput struct {
 	_ struct{} `type:"structure"`
@@ -3224,13 +3560,16 @@ func (s *AvailabilityZone) SetZoneName(v string) *AvailabilityZone {
 	return s
 }
 
-// Information about an SSL server certificate deployed on a load balancer.
+// Information about an SSL server certificate.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/Certificate
 type Certificate struct {
 	_ struct{} `type:"structure"`
 
 	// The Amazon Resource Name (ARN) of the certificate.
 	CertificateArn *string `type:"string"`
+
+	// Indicates whether the certificate is the default certificate.
+	IsDefault *bool `type:"boolean"`
 }
 
 // String returns the string representation
@@ -3246,6 +3585,12 @@ func (s Certificate) GoString() string {
 // SetCertificateArn sets the CertificateArn field's value.
 func (s *Certificate) SetCertificateArn(v string) *Certificate {
 	s.CertificateArn = &v
+	return s
+}
+
+// SetIsDefault sets the IsDefault field's value.
+func (s *Certificate) SetIsDefault(v bool) *Certificate {
+	s.IsDefault = &v
 	return s
 }
 
@@ -4357,6 +4702,101 @@ func (s *DescribeAccountLimitsOutput) SetLimits(v []*Limit) *DescribeAccountLimi
 
 // SetNextMarker sets the NextMarker field's value.
 func (s *DescribeAccountLimitsOutput) SetNextMarker(v string) *DescribeAccountLimitsOutput {
+	s.NextMarker = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/DescribeListenerCertificatesInput
+type DescribeListenerCertificatesInput struct {
+	_ struct{} `type:"structure"`
+
+	// The Amazon Resource Names (ARN) of the listener.
+	//
+	// ListenerArn is a required field
+	ListenerArn *string `type:"string" required:"true"`
+
+	// The marker for the next set of results. (You received this marker from a
+	// previous call.)
+	Marker *string `type:"string"`
+
+	// The maximum number of results to return with this call.
+	PageSize *int64 `min:"1" type:"integer"`
+}
+
+// String returns the string representation
+func (s DescribeListenerCertificatesInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeListenerCertificatesInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeListenerCertificatesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeListenerCertificatesInput"}
+	if s.ListenerArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ListenerArn"))
+	}
+	if s.PageSize != nil && *s.PageSize < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("PageSize", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetListenerArn sets the ListenerArn field's value.
+func (s *DescribeListenerCertificatesInput) SetListenerArn(v string) *DescribeListenerCertificatesInput {
+	s.ListenerArn = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeListenerCertificatesInput) SetMarker(v string) *DescribeListenerCertificatesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetPageSize sets the PageSize field's value.
+func (s *DescribeListenerCertificatesInput) SetPageSize(v int64) *DescribeListenerCertificatesInput {
+	s.PageSize = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/DescribeListenerCertificatesOutput
+type DescribeListenerCertificatesOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the certificates.
+	Certificates []*Certificate `type:"list"`
+
+	// The marker to use when requesting the next set of results. If there are no
+	// additional results, the string is empty.
+	NextMarker *string `type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeListenerCertificatesOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeListenerCertificatesOutput) GoString() string {
+	return s.String()
+}
+
+// SetCertificates sets the Certificates field's value.
+func (s *DescribeListenerCertificatesOutput) SetCertificates(v []*Certificate) *DescribeListenerCertificatesOutput {
+	s.Certificates = v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *DescribeListenerCertificatesOutput) SetNextMarker(v string) *DescribeListenerCertificatesOutput {
 	s.NextMarker = &v
 	return s
 }
@@ -5565,7 +6005,7 @@ func (s *Matcher) SetHttpCode(v string) *Matcher {
 type ModifyListenerInput struct {
 	_ struct{} `type:"structure"`
 
-	// The SSL server certificate.
+	// The default SSL server certificate.
 	Certificates []*Certificate `type:"list"`
 
 	// The default action. For Application Load Balancers, the protocol of the specified
@@ -6107,9 +6547,7 @@ type RegisterTargetsInput struct {
 	// TargetGroupArn is a required field
 	TargetGroupArn *string `type:"string" required:"true"`
 
-	// The targets. The default port for a target is the port for the target group.
-	// You can specify a port override. If a target is already registered, you can
-	// register it again using a different port.
+	// The targets.
 	//
 	// Targets is a required field
 	Targets []*TargetDescription `type:"list" required:"true"`
@@ -6175,6 +6613,74 @@ func (s RegisterTargetsOutput) String() string {
 
 // GoString returns the string representation
 func (s RegisterTargetsOutput) GoString() string {
+	return s.String()
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/RemoveListenerCertificatesInput
+type RemoveListenerCertificatesInput struct {
+	_ struct{} `type:"structure"`
+
+	// The certificate to remove. You can specify one certificate per call.
+	//
+	// Certificates is a required field
+	Certificates []*Certificate `type:"list" required:"true"`
+
+	// The Amazon Resource Name (ARN) of the listener.
+	//
+	// ListenerArn is a required field
+	ListenerArn *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s RemoveListenerCertificatesInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s RemoveListenerCertificatesInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RemoveListenerCertificatesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RemoveListenerCertificatesInput"}
+	if s.Certificates == nil {
+		invalidParams.Add(request.NewErrParamRequired("Certificates"))
+	}
+	if s.ListenerArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ListenerArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetCertificates sets the Certificates field's value.
+func (s *RemoveListenerCertificatesInput) SetCertificates(v []*Certificate) *RemoveListenerCertificatesInput {
+	s.Certificates = v
+	return s
+}
+
+// SetListenerArn sets the ListenerArn field's value.
+func (s *RemoveListenerCertificatesInput) SetListenerArn(v string) *RemoveListenerCertificatesInput {
+	s.ListenerArn = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/RemoveListenerCertificatesOutput
+type RemoveListenerCertificatesOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s RemoveListenerCertificatesOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s RemoveListenerCertificatesOutput) GoString() string {
 	return s.String()
 }
 
@@ -6906,15 +7412,17 @@ func (s *TagDescription) SetTags(v []*Tag) *TagDescription {
 type TargetDescription struct {
 	_ struct{} `type:"structure"`
 
-	// The Availability Zone where the IP address is to be registered. Specify all
-	// to register an IP address outside the target group VPC with all Availability
-	// Zones that are enabled for the load balancer.
-	//
-	// If the IP address is in a subnet of the VPC for the target group, the Availability
-	// Zone is automatically detected and this parameter is optional.
+	// An Availability Zone or all. This determines whether the target receives
+	// traffic from the load balancer nodes in the specified Availability Zone or
+	// from all enabled Availability Zones for the load balancer.
 	//
 	// This parameter is not supported if the target type of the target group is
-	// instance.
+	// instance. If the IP address is in a subnet of the VPC for the target group,
+	// the Availability Zone is automatically detected and this parameter is optional.
+	// If the IP address is outside the VPC, this parameter is required.
+	//
+	// With an Application Load Balancer, if the IP address is outside the VPC for
+	// the target group, the only supported value is all.
 	AvailabilityZone *string `type:"string"`
 
 	// The ID of the target. If the target type of the target group is instance,

--- a/vendor/github.com/aws/aws-sdk-go/service/elbv2/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/elbv2/errors.go
@@ -153,7 +153,7 @@ const (
 	// ErrCodeTooManyCertificatesException for service response error code
 	// "TooManyCertificates".
 	//
-	// You've reached the limit on the number of certificates per listener.
+	// You've reached the limit on the number of certificates per load balancer.
 	ErrCodeTooManyCertificatesException = "TooManyCertificates"
 
 	// ErrCodeTooManyListenersException for service response error code

--- a/vendor/github.com/aws/aws-sdk-go/service/sqs/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/sqs/api.go
@@ -167,14 +167,13 @@ func (c *SQS) ChangeMessageVisibilityRequest(input *ChangeMessageVisibilityInput
 // timeout of 12 hours. For more information, see Visibility Timeout (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html)
 // in the Amazon SQS Developer Guide.
 //
-// For example, you have a message and with the default visibility timeout of
-// 5 minutes. After 3 minutes, you call ChangeMessageVisiblity with a timeout
-// of 10 minutes. At that time, the timeout for the message is extended by 10
-// minutes beyond the time of the ChangeMessageVisibility action. This results
-// in a total visibility timeout of 13 minutes. You can continue to call the
-// ChangeMessageVisibility to extend the visibility timeout to a maximum of
-// 12 hours. If you try to extend the visibility timeout beyond 12 hours, your
-// request is rejected.
+// For example, you have a message with a visibility timeout of 5 minutes. After
+// 3 minutes, you call ChangeMessageVisiblity with a timeout of 10 minutes.
+// At that time, the timeout for the message is extended by 10 minutes beyond
+// the time of the ChangeMessageVisibility action. This results in a total visibility
+// timeout of 13 minutes. You can continue to call the ChangeMessageVisibility
+// to extend the visibility timeout to a maximum of 12 hours. If you try to
+// extend the visibility timeout beyond 12 hours, your request is rejected.
 //
 // A message is considered to be in flight after it's received from a queue
 // by a consumer, but not yet deleted from the queue.
@@ -713,7 +712,7 @@ func (c *SQS) DeleteQueueRequest(input *DeleteQueueInput) (req *request.Request,
 
 // DeleteQueue API operation for Amazon Simple Queue Service.
 //
-// Deletes the queue specified by the QueueUrl, even if the queue is empty.
+// Deletes the queue specified by the QueueUrl, regardless of the queue's contents.
 // If the specified queue doesn't exist, Amazon SQS returns a successful response.
 //
 // Be careful with the DeleteQueue action: When you delete a queue, any messages
@@ -976,10 +975,10 @@ func (c *SQS) ListDeadLetterSourceQueuesRequest(input *ListDeadLetterSourceQueue
 // ListDeadLetterSourceQueues API operation for Amazon Simple Queue Service.
 //
 // Returns a list of your queues that have the RedrivePolicy queue attribute
-// configured with a dead letter queue.
+// configured with a dead-letter queue.
 //
-// For more information about using dead letter queues, see Using Amazon SQS
-// Dead Letter Queues (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html)
+// For more information about using dead-letter queues, see Using Amazon SQS
+// Dead-Letter Queues (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html)
 // in the Amazon SQS Developer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -1271,8 +1270,8 @@ func (c *SQS) ReceiveMessageRequest(input *ReceiveMessageInput) (req *request.Re
 //
 // A message that isn't deleted or a message whose visibility isn't extended
 // before the visibility timeout expires counts as a failed receive. Depending
-// on the configuration of the queue, the message might be sent to the dead
-// letter queue.
+// on the configuration of the queue, the message might be sent to the dead-letter
+// queue.
 //
 // In the future, new attributes might be added. If you write code that calls
 // this action, we recommend that you structure your code so that it can handle
@@ -2203,13 +2202,21 @@ type CreateQueueInput struct {
 	//    which a ReceiveMessage action waits for a message to arrive. Valid values:
 	//    An integer from 0 to 20 (seconds). The default is 0 (zero).
 	//
-	//    * RedrivePolicy - The parameters for the dead letter queue functionality
-	//    of the source queue. For more information about the redrive policy and
-	//    dead letter queues, see Using Amazon SQS Dead Letter Queues (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html)
+	//    * RedrivePolicy - The string that includes the parameters for the dead-letter
+	//    queue functionality of the source queue. For more information about the
+	//    redrive policy and dead-letter queues, see Using Amazon SQS Dead-Letter
+	//    Queues (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html)
 	//    in the Amazon SQS Developer Guide.
 	//
-	// The dead letter queue of a FIFO queue must also be a FIFO queue. Similarly,
-	//    the dead letter queue of a standard queue must also be a standard queue.
+	// deadLetterTargetArn - The Amazon Resource Name (ARN) of the dead-letter queue
+	//    to which Amazon SQS moves messages after the value of maxReceiveCount
+	//    is exceeded.
+	//
+	// maxReceiveCount - The number of times a message is delivered to the source
+	//    queue before being moved to the dead-letter queue.
+	//
+	// The dead-letter queue of a FIFO queue must also be a FIFO queue. Similarly,
+	//    the dead-letter queue of a standard queue must also be a standard queue.
 	//
 	//    * VisibilityTimeout - The visibility timeout for the queue. Valid values:
 	//    An integer from 0 to 43,200 (12 hours). The default is 30. For more information
@@ -2221,7 +2228,7 @@ type CreateQueueInput struct {
 	//    * KmsMasterKeyId - The ID of an AWS-managed customer master key (CMK)
 	//    for Amazon SQS or a custom CMK. For more information, see Key Terms (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html#sqs-sse-key-terms).
 	//    While the alias of the AWS-managed CMK for Amazon SQS is always alias/aws/sqs,
-	//    the alias of a custom CMK can, for example, be alias/aws/sqs. For more
+	//    the alias of a custom CMK can, for example, be alias/MyAlias. For more
 	//    examples, see KeyId (http://docs.aws.amazon.com/kms/latest/APIReference/API_DescribeKey.html#API_DescribeKey_RequestParameters)
 	//    in the AWS Key Management Service API Reference.
 	//
@@ -2230,9 +2237,9 @@ type CreateQueueInput struct {
 	//    to encrypt or decrypt messages before calling AWS KMS again. An integer
 	//    representing seconds, between 60 seconds (1 minute) and 86,400 seconds
 	//    (24 hours). The default is 300 (5 minutes). A shorter time period provides
-	//    better security but results in more calls to KMS which incur charges after
-	//    Free Tier. For more information, see How Does the Data Key Reuse Period
-	//    Work? (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html#sqs-how-does-the-data-key-reuse-period-work).
+	//    better security but results in more calls to KMS which might incur charges
+	//    after Free Tier. For more information, see How Does the Data Key Reuse
+	//    Period Work? (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html#sqs-how-does-the-data-key-reuse-period-work).
 	//
 	//
 	// The following attributes apply only to FIFO (first-in-first-out) queues (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html):
@@ -2727,10 +2734,18 @@ type GetQueueAttributesInput struct {
 	//    * ReceiveMessageWaitTimeSeconds - Returns the length of time, in seconds,
 	//    for which the ReceiveMessage action waits for a message to arrive.
 	//
-	//    * RedrivePolicy - Returns the parameters for dead letter queue functionality
-	//    of the source queue. For more information about the redrive policy and
-	//    dead letter queues, see Using Amazon SQS Dead Letter Queues (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html)
+	//    * RedrivePolicy - Returns the string that includes the parameters for
+	//    dead-letter queue functionality of the source queue. For more information
+	//    about the redrive policy and dead-letter queues, see Using Amazon SQS
+	//    Dead-Letter Queues (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html)
 	//    in the Amazon SQS Developer Guide.
+	//
+	// deadLetterTargetArn - The Amazon Resource Name (ARN) of the dead-letter queue
+	//    to which Amazon SQS moves messages after the value of maxReceiveCount
+	//    is exceeded.
+	//
+	// maxReceiveCount - The number of times a message is delivered to the source
+	//    queue before being moved to the dead-letter queue.
 	//
 	//    * VisibilityTimeout - Returns the visibility timeout for the queue. For
 	//    more information about the visibility timeout, see Visibility Timeout
@@ -2746,7 +2761,9 @@ type GetQueueAttributesInput struct {
 	//
 	//    * KmsDataKeyReusePeriodSeconds - Returns the length of time, in seconds,
 	//    for which Amazon SQS can reuse a data key to encrypt or decrypt messages
-	//    before calling AWS KMS again.
+	//    before calling AWS KMS again. For more information, see How Does the Data
+	//    Key Reuse Period Work? (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html#sqs-how-does-the-data-key-reuse-period-work).
+	//
 	//
 	// The following attributes apply only to FIFO (first-in-first-out) queues (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html):
 	//
@@ -2912,7 +2929,7 @@ func (s *GetQueueUrlOutput) SetQueueUrl(v string) *GetQueueUrlOutput {
 type ListDeadLetterSourceQueuesInput struct {
 	_ struct{} `type:"structure"`
 
-	// The URL of a dead letter queue.
+	// The URL of a dead-letter queue.
 	//
 	// Queue URLs are case-sensitive.
 	//
@@ -2955,7 +2972,7 @@ type ListDeadLetterSourceQueuesOutput struct {
 	_ struct{} `type:"structure"`
 
 	// A list of source queue URLs that have the RedrivePolicy queue attribute configured
-	// with a dead letter queue.
+	// with a dead-letter queue.
 	//
 	// QueueUrls is a required field
 	QueueUrls []*string `locationName:"queueUrls" locationNameList:"QueueUrl" type:"list" flattened:"true" required:"true"`
@@ -3428,7 +3445,8 @@ type ReceiveMessageInput struct {
 
 	// The duration (in seconds) for which the call waits for a message to arrive
 	// in the queue before returning. If a message is available, the call returns
-	// sooner than WaitTimeSeconds.
+	// sooner than WaitTimeSeconds. If no messages are available and the wait time
+	// expires, the call returns successfully with an empty list of messages.
 	WaitTimeSeconds *int64 `type:"integer"`
 }
 
@@ -4240,13 +4258,21 @@ type SetQueueAttributesInput struct {
 	//    which a ReceiveMessage action waits for a message to arrive. Valid values:
 	//    an integer from 0 to 20 (seconds). The default is 0.
 	//
-	//    * RedrivePolicy - The parameters for the dead letter queue functionality
-	//    of the source queue. For more information about the redrive policy and
-	//    dead letter queues, see Using Amazon SQS Dead Letter Queues (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html)
+	//    * RedrivePolicy - The string that includes the parameters for the dead-letter
+	//    queue functionality of the source queue. For more information about the
+	//    redrive policy and dead-letter queues, see Using Amazon SQS Dead-Letter
+	//    Queues (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html)
 	//    in the Amazon SQS Developer Guide.
 	//
-	// The dead letter queue of a FIFO queue must also be a FIFO queue. Similarly,
-	//    the dead letter queue of a standard queue must also be a standard queue.
+	// deadLetterTargetArn - The Amazon Resource Name (ARN) of the dead-letter queue
+	//    to which Amazon SQS moves messages after the value of maxReceiveCount
+	//    is exceeded.
+	//
+	// maxReceiveCount - The number of times a message is delivered to the source
+	//    queue before being moved to the dead-letter queue.
+	//
+	// The dead-letter queue of a FIFO queue must also be a FIFO queue. Similarly,
+	//    the dead-letter queue of a standard queue must also be a standard queue.
 	//
 	//    * VisibilityTimeout - The visibility timeout for the queue. Valid values:
 	//    an integer from 0 to 43,200 (12 hours). The default is 30. For more information
@@ -4258,7 +4284,7 @@ type SetQueueAttributesInput struct {
 	//    * KmsMasterKeyId - The ID of an AWS-managed customer master key (CMK)
 	//    for Amazon SQS or a custom CMK. For more information, see Key Terms (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html#sqs-sse-key-terms).
 	//    While the alias of the AWS-managed CMK for Amazon SQS is always alias/aws/sqs,
-	//    the alias of a custom CMK can, for example, be alias/aws/sqs. For more
+	//    the alias of a custom CMK can, for example, be alias/MyAlias. For more
 	//    examples, see KeyId (http://docs.aws.amazon.com/kms/latest/APIReference/API_DescribeKey.html#API_DescribeKey_RequestParameters)
 	//    in the AWS Key Management Service API Reference.
 	//
@@ -4267,9 +4293,9 @@ type SetQueueAttributesInput struct {
 	//    to encrypt or decrypt messages before calling AWS KMS again. An integer
 	//    representing seconds, between 60 seconds (1 minute) and 86,400 seconds
 	//    (24 hours). The default is 300 (5 minutes). A shorter time period provides
-	//    better security but results in more calls to KMS which incur charges after
-	//    Free Tier. For more information, see How Does the Data Key Reuse Period
-	//    Work? (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html#sqs-how-does-the-data-key-reuse-period-work).
+	//    better security but results in more calls to KMS which might incur charges
+	//    after Free Tier. For more information, see How Does the Data Key Reuse
+	//    Period Work? (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html#sqs-how-does-the-data-key-reuse-period-work).
 	//
 	//
 	// The following attribute applies only to FIFO (first-in-first-out) queues

--- a/vendor/github.com/aws/aws-sdk-go/service/sqs/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/sqs/doc.go
@@ -12,7 +12,8 @@
 //
 // Standard queues (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/standard-queues.html)
 // are available in all regions. FIFO queues (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html)
-// are available in US West (Oregon) and US East (Ohio).
+// are available in the US East (N. Virginia), US East (Ohio), US West (Oregon),
+// and EU (Ireland) regions.
 //
 // You can use AWS SDKs (http://aws.amazon.com/tools/#sdk) to access Amazon
 // SQS using your favorite programming language. The SDKs perform tasks such
@@ -34,7 +35,7 @@
 //
 // Using Amazon SQS Message Attributes (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-attributes.html)
 //
-// Using Amazon SQS Dead Letter Queues (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html)
+// Using Amazon SQS Dead-Letter Queues (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html)
 //
 //    * Amazon Web Services General Reference
 //

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -45,700 +45,700 @@
 			"revisionTime": "2017-07-27T15:54:43Z"
 		},
 		{
-			"checksumSHA1": "cgCP+w+hE4Oj7uCgKl3n7VxNrZQ=",
+			"checksumSHA1": "oB3qh+PpOMbr9frqJwMyBuUTf2k=",
 			"path": "github.com/aws/aws-sdk-go/aws",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "DtuTqKH29YnLjrIJkRYX0HQtXY0=",
 			"path": "github.com/aws/aws-sdk-go/aws/arn",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "Y9W+4GimK4Fuxq+vyIskVYFRnX4=",
 			"path": "github.com/aws/aws-sdk-go/aws/awserr",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "yyYr41HZ1Aq0hWc3J5ijXwYEcac=",
 			"path": "github.com/aws/aws-sdk-go/aws/awsutil",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "n98FANpNeRT5kf6pizdpI7nm6Sw=",
 			"path": "github.com/aws/aws-sdk-go/aws/client",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "ieAJ+Cvp/PKv1LpUEnUXpc3OI6E=",
 			"path": "github.com/aws/aws-sdk-go/aws/client/metadata",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "7/8j/q0TWtOgXyvEcv4B2Dhl00o=",
 			"path": "github.com/aws/aws-sdk-go/aws/corehandlers",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "Y+cPwQL0dZMyqp3wI+KJWmA9KQ8=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "u3GOAJLmdvbuNUeUEcZSEAOeL/0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "NUJUTWlc1sV8b7WjfiYc4JZbXl0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/endpointcreds",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "JEYqmF83O5n5bHkupAzA6STm0no=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "ZdtYh3ZHSgP/WEIaqwJHTEhpkbs=",
 			"path": "github.com/aws/aws-sdk-go/aws/defaults",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "/EXbk/z2TWjWc1Hvb4QYs3Wmhb8=",
 			"path": "github.com/aws/aws-sdk-go/aws/ec2metadata",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "CxKCfgfTug8S/72YInl42ufsknE=",
 			"path": "github.com/aws/aws-sdk-go/aws/endpoints",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "n/tgGgh0wICYu+VDYSqlsRy4w9s=",
 			"path": "github.com/aws/aws-sdk-go/aws/request",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "HcGL4e6Uep4/80eCUI5xkcWjpQ0=",
 			"path": "github.com/aws/aws-sdk-go/aws/session",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "iywvraxbXf3A/FOzFWjKfBBEQRA=",
 			"path": "github.com/aws/aws-sdk-go/aws/signer/v4",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "04ypv4x12l4q0TksA1zEVsmgpvw=",
 			"path": "github.com/aws/aws-sdk-go/internal/shareddefaults",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "wk7EyvDaHwb5qqoOP/4d3cV0708=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "1QmQ3FqV37w0Zi44qv8pA1GeR0A=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/ec2query",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "O6hcK24yI6w7FA+g4Pbr+eQ7pys=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/json/jsonutil",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "R00RL5jJXRYq1iiK1+PGvMfvXyM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/jsonrpc",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "ZqY5RWavBLWTo6j9xqdyBEaNFRk=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "9V1PvtFQ9MObZTc3sa86WcuOtOU=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "VCTh+dEaqqhog5ncy/WTt9+/gFM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/rest",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "Rpu8KBtHZgvhkwHxUfaky+qW+G4=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restjson",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "ODo+ko8D6unAxZuN1jGzMcN4QCc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restxml",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "0qYPUga28aQVkxZgBR3Z86AbGUQ=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "F6mth+G7dXN1GI+nktaGo8Lx8aE=",
 			"path": "github.com/aws/aws-sdk-go/private/signer/v2",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "BXuQo73qo4WLmc+TdE5pAwalLUQ=",
 			"path": "github.com/aws/aws-sdk-go/service/acm",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "O2HA8qyuxiolOGr0a1o/mFKz/Xo=",
 			"path": "github.com/aws/aws-sdk-go/service/apigateway",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "lnbmn3cDZvFOpzV9jKe9jG7VIPs=",
 			"path": "github.com/aws/aws-sdk-go/service/applicationautoscaling",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "/C4QDOmEP7t8vawBcB7a2ygaXuI=",
 			"path": "github.com/aws/aws-sdk-go/service/athena",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "eudoAl5P0HqsQrzytWyb9uhUGU0=",
 			"path": "github.com/aws/aws-sdk-go/service/autoscaling",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "fNHsdfsdTzwSJwnfxqqGdkjT5HE=",
 			"path": "github.com/aws/aws-sdk-go/service/batch",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "XPE0OmyX5xPvxP7QSdGuB7TY7AE=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudformation",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "rjq4ZWRUGvQDjnXeflafkCWYsFU=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudfront",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "59kV70/8PuutX4eFkGfCCtdunIA=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudtrail",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "zm2qDEBdcJSJI3PGcE2UVr6Cxmc=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatch",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "2y8MKiWNwIVw/au7LBxCGLZusUU=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchevents",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "SGbv4ySdQtVIE7WJ+5HcNyWkbNY=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "EQj73ejMb8hAqCDC+hX4MuvJ7sk=",
 			"path": "github.com/aws/aws-sdk-go/service/codebuild",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "XkyZPfxHxB3ohK+/qdF54nvMS0o=",
 			"path": "github.com/aws/aws-sdk-go/service/codecommit",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "QJYewZzcmPbuN27AWiQ6XKQ9Vrw=",
 			"path": "github.com/aws/aws-sdk-go/service/codedeploy",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "y1X50fCNI6EIs5YWddiu/EAwD8o=",
 			"path": "github.com/aws/aws-sdk-go/service/codepipeline",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "7bm1eOY2oKYSesmEOd1qXvTRH2s=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentity",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "ouZ4H9foNRBFaElXZbpi5C3pqDQ=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentityprovider",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "Ryg2zV9xVlpTF1GVbP5GlYbynOc=",
 			"path": "github.com/aws/aws-sdk-go/service/configservice",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "8UoYKgC9u/gjExZe4a6ZZf4dDl8=",
 			"path": "github.com/aws/aws-sdk-go/service/databasemigrationservice",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "S4vcGUr3SNl3XKPFTqfwFanT4Cw=",
 			"path": "github.com/aws/aws-sdk-go/service/devicefarm",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "1O8BtYGfkXglIqgl/uxunrq3Djs=",
 			"path": "github.com/aws/aws-sdk-go/service/directoryservice",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "ycd0mxQjtWfbtlk+W2N7N6QdxFw=",
 			"path": "github.com/aws/aws-sdk-go/service/dynamodb",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
-			"checksumSHA1": "GNoW7onYG1kS9HuD5zGaIs8dWrg=",
+			"checksumSHA1": "K3NOqhe9pZJM7qlMjYWR772txQY=",
 			"path": "github.com/aws/aws-sdk-go/service/ec2",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "YNq7YhasHn9ceelWX2aG0Cg0Ga0=",
 			"path": "github.com/aws/aws-sdk-go/service/ecr",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "+Jyy6T5h4fYRUmU9EgV+ZtLNM80=",
 			"path": "github.com/aws/aws-sdk-go/service/ecs",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "pBkeSL8bCEbz/6ub0Jr6NsjQPSc=",
 			"path": "github.com/aws/aws-sdk-go/service/efs",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "4a4FO9D6RQluAwyYEW5H6p0Nz7I=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticache",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "RzBRmfKefl+oBHDzrtsuxv8ycKE=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticbeanstalk",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "lrrUXgK33baqXgfzh4Z2tSmxeBE=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticsearchservice",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "zMFn+iotI5JIiB9HFRo6BiX6CZE=",
 			"path": "github.com/aws/aws-sdk-go/service/elastictranscoder",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "sp5ZmzFBI5z1+kLkRoFjfm2GWuY=",
 			"path": "github.com/aws/aws-sdk-go/service/elb",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
-			"checksumSHA1": "Q3WXHwjJ0v6TWofDBLGN901nfi4=",
+			"checksumSHA1": "LjlrMBi+GR3kElFOfdV4WAJ10UU=",
 			"path": "github.com/aws/aws-sdk-go/service/elbv2",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "EEj7cYvIK+F25RIynBVArzedyPQ=",
 			"path": "github.com/aws/aws-sdk-go/service/emr",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "tuK++zhf2K0RBocTCU1ZltzS8ko=",
 			"path": "github.com/aws/aws-sdk-go/service/firehose",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "Ewp675B6bZe/eWipwJl7OXqCJRo=",
 			"path": "github.com/aws/aws-sdk-go/service/glacier",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "a+tKLYUEM3ZftY52P2ywtIxlCxE=",
 			"path": "github.com/aws/aws-sdk-go/service/iam",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "v0OUl6sTwF7EOmXyzk9ppc5ljLw=",
 			"path": "github.com/aws/aws-sdk-go/service/inspector",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "D92k3ymegRbjpgnuAy9rWjgV7vs=",
 			"path": "github.com/aws/aws-sdk-go/service/iot",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "fE6Lygzxvif/yfo9bncKyRUCqs8=",
 			"path": "github.com/aws/aws-sdk-go/service/kinesis",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "wwFYsrpInh4Tow/vTI7bD+r5gBU=",
 			"path": "github.com/aws/aws-sdk-go/service/kms",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "qu7WvUeSIFYQOqF9RXM/3w45kFg=",
 			"path": "github.com/aws/aws-sdk-go/service/lambda",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "eHMwitdHY0uOEA5kkmJ1nGHe0z0=",
 			"path": "github.com/aws/aws-sdk-go/service/lightsail",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "84rKGr+RvT8tjOalWGPKuNPC4T4=",
 			"path": "github.com/aws/aws-sdk-go/service/opsworks",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "xzvIMHbwgPpK4IdmzG07rZvb5x8=",
 			"path": "github.com/aws/aws-sdk-go/service/rds",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "dS8MjjzzX7csNyxiIpRPgHXMyss=",
 			"path": "github.com/aws/aws-sdk-go/service/redshift",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "Bx0UwkYHAU+LGL4Glg5le2UiirI=",
 			"path": "github.com/aws/aws-sdk-go/service/route53",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "QPxEB1a4X55kNCF/GlH18mOrHMA=",
 			"path": "github.com/aws/aws-sdk-go/service/s3",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "HQHIEdPu8wtbbJnECYl2HM9Ul5Q=",
 			"path": "github.com/aws/aws-sdk-go/service/servicecatalog",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "57zqW/AnJTqgM3/udtLTrusRalM=",
 			"path": "github.com/aws/aws-sdk-go/service/ses",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "u8xk+JtK/HwIKB2ume3or9Sstp8=",
 			"path": "github.com/aws/aws-sdk-go/service/sfn",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "hOcVb1zJiDUmafXSJQhkEascWwA=",
 			"path": "github.com/aws/aws-sdk-go/service/simpledb",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "1jN0ZDW5c9QEGSQIQ+KrbTACvm8=",
 			"path": "github.com/aws/aws-sdk-go/service/sns",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
-			"checksumSHA1": "SXH7QxrUFaor3KaNX0xPCV3eOhU=",
+			"checksumSHA1": "0y2X71gCB5ADXttecbyzuQy++HU=",
 			"path": "github.com/aws/aws-sdk-go/service/sqs",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "ODaF+6WgljmH1WhB3KmBdIz4C0U=",
 			"path": "github.com/aws/aws-sdk-go/service/ssm",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "MerduaV3PxtZAWvOGpgoBIglo38=",
 			"path": "github.com/aws/aws-sdk-go/service/sts",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "vFinPalK+r0kaIbPMaHhFbTi2QQ=",
 			"path": "github.com/aws/aws-sdk-go/service/waf",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "qe7HsjfCked/MaRvH2c0uJndWdM=",
 			"path": "github.com/aws/aws-sdk-go/service/wafregional",
-			"revision": "da415b5fa0ff3f91d4707348a8ea1be53f700c22",
-			"revisionTime": "2017-10-05T19:55:01Z",
-			"version": "v1.12.6",
-			"versionExact": "v1.12.6"
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
 		},
 		{
 			"checksumSHA1": "nqw2Qn5xUklssHTubS5HDvEL9L4=",


### PR DESCRIPTION
Required for
* https://github.com/terraform-providers/terraform-provider-aws/issues/1859
* https://github.com/terraform-providers/terraform-provider-aws/issues/1853

```
govendor fetch github.com/aws/aws-sdk-go/aws/...@v1.12.8
govendor fetch github.com/aws/aws-sdk-go/internal/...@v1.12.8
govendor fetch github.com/aws/aws-sdk-go/private/...@v1.12.8
govendor fetch github.com/aws/aws-sdk-go/service/...@v1.12.8
```