### PR TITLE
Update ELB create to align with 4000s idle timeout

### DIFF
--- a/aws/resource_aws_elb.go
+++ b/aws/resource_aws_elb.go
@@ -104,7 +104,7 @@ func resourceAwsElb() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Default:      60,
-				ValidateFunc: validateIntegerInRange(1, 3600),
+				ValidateFunc: validateIntegerInRange(1, 4000),
 			},
 
 			"connection_draining": &schema.Schema{


### PR DESCRIPTION
AWS has updated the idle connection timeout to 4000 seconds (http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/config-idle-timeout.html).  This change is to bring the provider current with that setting.