### PR TITLE
Added tunnel options to vpn_connection

### DIFF
--- a/aws/resource_aws_vpn_connection_test.go
+++ b/aws/resource_aws_vpn_connection_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 	"time"
 
@@ -63,8 +64,70 @@ func TestAccAWSVpnConnection_tunnelOptions(t *testing.T) {
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccAwsVpnConnectionDestroy,
 		Steps: []resource.TestStep{
+
+			// Checking CIDR blocks
 			{
-				Config: testAccAwsVpnConnectionConfigTunnelOptions(rBgpAsn),
+				Config:      testAccAwsVpnConnectionConfigSingleTunnelOptions(rBgpAsn, "12345678", "not-a-cidr"),
+				ExpectError: regexp.MustCompile(`must contain a valid CIDR`),
+			},
+			{
+				Config:      testAccAwsVpnConnectionConfigSingleTunnelOptions(rBgpAsn, "12345678", "169.254.254.0/31"),
+				ExpectError: regexp.MustCompile(`must be /30 CIDR`),
+			},
+			{
+				Config:      testAccAwsVpnConnectionConfigSingleTunnelOptions(rBgpAsn, "12345678", "172.16.0.0/30"),
+				ExpectError: regexp.MustCompile(`must be within 169.254.0.0/16`),
+			},
+			{
+				Config:      testAccAwsVpnConnectionConfigSingleTunnelOptions(rBgpAsn, "12345678", "169.254.0.0/30"),
+				ExpectError: regexp.MustCompile(`cannot be 169.254.0.0/30`),
+			},
+			{
+				Config:      testAccAwsVpnConnectionConfigSingleTunnelOptions(rBgpAsn, "12345678", "169.254.1.0/30"),
+				ExpectError: regexp.MustCompile(`cannot be 169.254.1.0/30`),
+			},
+			{
+				Config:      testAccAwsVpnConnectionConfigSingleTunnelOptions(rBgpAsn, "12345678", "169.254.2.0/30"),
+				ExpectError: regexp.MustCompile(`cannot be 169.254.2.0/30`),
+			},
+			{
+				Config:      testAccAwsVpnConnectionConfigSingleTunnelOptions(rBgpAsn, "12345678", "169.254.3.0/30"),
+				ExpectError: regexp.MustCompile(`cannot be 169.254.3.0/30`),
+			},
+			{
+				Config:      testAccAwsVpnConnectionConfigSingleTunnelOptions(rBgpAsn, "12345678", "169.254.4.0/30"),
+				ExpectError: regexp.MustCompile(`cannot be 169.254.4.0/30`),
+			},
+			{
+				Config:      testAccAwsVpnConnectionConfigSingleTunnelOptions(rBgpAsn, "12345678", "169.254.5.0/30"),
+				ExpectError: regexp.MustCompile(`cannot be 169.254.5.0/30`),
+			},
+			{
+				Config:      testAccAwsVpnConnectionConfigSingleTunnelOptions(rBgpAsn, "12345678", "169.254.169.252/30"),
+				ExpectError: regexp.MustCompile(`cannot be 169.254.169.252/30`),
+			},
+
+			// Checking PreShared Key
+			{
+				Config:      testAccAwsVpnConnectionConfigSingleTunnelOptions(rBgpAsn, "1234567", "169.254.254.0/30"),
+				ExpectError: regexp.MustCompile(`must be between 8 and 64 characters in length`),
+			},
+			{
+				Config:      testAccAwsVpnConnectionConfigSingleTunnelOptions(rBgpAsn, acctest.RandStringFromCharSet(65, acctest.CharSetAlpha), "169.254.254.0/30"),
+				ExpectError: regexp.MustCompile(`must be between 8 and 64 characters in length`),
+			},
+			{
+				Config:      testAccAwsVpnConnectionConfigSingleTunnelOptions(rBgpAsn, "01234567", "169.254.254.0/30"),
+				ExpectError: regexp.MustCompile(`cannot start with zero character`),
+			},
+			{
+				Config:      testAccAwsVpnConnectionConfigSingleTunnelOptions(rBgpAsn, "1234567!", "169.254.254.0/30"),
+				ExpectError: regexp.MustCompile(`can only contain alphanumeric and underscore characters`),
+			},
+
+			//Try actual building
+			{
+				Config: testAccAwsVpnConnectionConfigTunnelOptions(rBgpAsn, "12345678", "169.254.8.0/30", "abcdefgh", "169.254.9.0/30"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccAwsVpnConnection(
 						"aws_vpc.vpc",
@@ -76,10 +139,10 @@ func TestAccAWSVpnConnection_tunnelOptions(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_vpn_connection.foo", "static_routes_only", "false"),
 
 					resource.TestCheckResourceAttr("aws_vpn_connection.foo", "tunnel1_inside_cidr", "169.254.8.0/30"),
-					resource.TestCheckResourceAttr("aws_vpn_connection.foo", "tunnel1_preshared_key", "lookatmethisisaprivatekey1"),
+					resource.TestCheckResourceAttr("aws_vpn_connection.foo", "tunnel1_preshared_key", "12345678"),
 
 					resource.TestCheckResourceAttr("aws_vpn_connection.foo", "tunnel2_inside_cidr", "169.254.9.0/30"),
-					resource.TestCheckResourceAttr("aws_vpn_connection.foo", "tunnel2_preshared_key", "lookatmethisisaprivatekey2"),
+					resource.TestCheckResourceAttr("aws_vpn_connection.foo", "tunnel2_preshared_key", "abcdefgh"),
 				),
 			},
 		},
@@ -308,87 +371,116 @@ func TestAWSVpnConnection_xmlconfig(t *testing.T) {
 
 func testAccAwsVpnConnectionConfig(rBgpAsn int) string {
 	return fmt.Sprintf(`
-		resource "aws_vpn_gateway" "vpn_gateway" {
-		  tags {
-		    Name = "vpn_gateway"
-		  }
-		}
+resource "aws_vpn_gateway" "vpn_gateway" {
+  tags {
+    Name = "vpn_gateway"
+  }
+}
 
-		resource "aws_customer_gateway" "customer_gateway" {
-		  bgp_asn = %d
-		  ip_address = "178.0.0.1"
-		  type = "ipsec.1"
-			tags {
-				Name = "main-customer-gateway"
-			}
-		}
+resource "aws_customer_gateway" "customer_gateway" {
+  bgp_asn = %d
+  ip_address = "178.0.0.1"
+  type = "ipsec.1"
+  tags {
+    Name = "main-customer-gateway"
+  }
+}
 
-		resource "aws_vpn_connection" "foo" {
-		  vpn_gateway_id = "${aws_vpn_gateway.vpn_gateway.id}"
-		  customer_gateway_id = "${aws_customer_gateway.customer_gateway.id}"
-		  type = "ipsec.1"
-		  static_routes_only = true
-		}
-		`, rBgpAsn)
+resource "aws_vpn_connection" "foo" {
+  vpn_gateway_id = "${aws_vpn_gateway.vpn_gateway.id}"
+  customer_gateway_id = "${aws_customer_gateway.customer_gateway.id}"
+  type = "ipsec.1"
+  static_routes_only = true
+}
+    `, rBgpAsn)
 }
 
 // Change static_routes_only to be false, forcing a refresh.
 func testAccAwsVpnConnectionConfigUpdate(rInt, rBgpAsn int) string {
 	return fmt.Sprintf(`
-	resource "aws_vpn_gateway" "vpn_gateway" {
-	  tags {
-	    Name = "vpn_gateway"
-	  }
-	}
-
-	resource "aws_customer_gateway" "customer_gateway" {
-	  bgp_asn = %d
-	  ip_address = "178.0.0.1"
-	  type = "ipsec.1"
-		tags {
-	    Name = "main-customer-gateway-%d"
-	  }
-	}
-
-	resource "aws_vpn_connection" "foo" {
-	  vpn_gateway_id = "${aws_vpn_gateway.vpn_gateway.id}"
-	  customer_gateway_id = "${aws_customer_gateway.customer_gateway.id}"
-	  type = "ipsec.1"
-	  static_routes_only = false
-	}
-	`, rBgpAsn, rInt)
+resource "aws_vpn_gateway" "vpn_gateway" {
+  tags {
+    Name = "vpn_gateway"
+  }
 }
 
-func testAccAwsVpnConnectionConfigTunnelOptions(rBgpAsn int) string {
+resource "aws_customer_gateway" "customer_gateway" {
+  bgp_asn = %d
+  ip_address = "178.0.0.1"
+  type = "ipsec.1"
+  tags {
+    Name = "main-customer-gateway-%d"
+  }
+}
+
+resource "aws_vpn_connection" "foo" {
+  vpn_gateway_id = "${aws_vpn_gateway.vpn_gateway.id}"
+  customer_gateway_id = "${aws_customer_gateway.customer_gateway.id}"
+  type = "ipsec.1"
+  static_routes_only = false
+}
+  `, rBgpAsn, rInt)
+}
+
+func testAccAwsVpnConnectionConfigSingleTunnelOptions(rBgpAsn int, psk string, tunnelCidr string) string {
 	return fmt.Sprintf(`
-		resource "aws_vpn_gateway" "vpn_gateway" {
-		  tags {
-		    Name = "vpn_gateway"
-		  }
-		}
+resource "aws_vpn_gateway" "vpn_gateway" {
+  tags {
+    Name = "vpn_gateway"
+  }
+}
 
-		resource "aws_customer_gateway" "customer_gateway" {
-		  bgp_asn = %d
-		  ip_address = "178.0.0.1"
-		  type = "ipsec.1"
-			tags {
-				Name = "main-customer-gateway"
-			}
-		}
+resource "aws_customer_gateway" "customer_gateway" {
+  bgp_asn = %d
+  ip_address = "178.0.0.1"
+  type = "ipsec.1"
+  tags {
+    Name = "main-customer-gateway"
+  }
+}
 
-		resource "aws_vpn_connection" "foo" {
-		  vpn_gateway_id = "${aws_vpn_gateway.vpn_gateway.id}"
-		  customer_gateway_id = "${aws_customer_gateway.customer_gateway.id}"
-		  type = "ipsec.1"
-	  	  static_routes_only = false
+resource "aws_vpn_connection" "foo" {
+  vpn_gateway_id = "${aws_vpn_gateway.vpn_gateway.id}"
+  customer_gateway_id = "${aws_customer_gateway.customer_gateway.id}"
+  type = "ipsec.1"
+    static_routes_only = false
 
-		  tunnel1_inside_cidr = "169.254.8.0/30"
-		  tunnel1_preshared_key = "lookatmethisisaprivatekey1"
+  tunnel1_inside_cidr = "%s"
+  tunnel1_preshared_key = "%s"
+}
+    `, rBgpAsn, tunnelCidr, psk)
+}
 
-		  tunnel2_inside_cidr = "169.254.9.0/30"
-		  tunnel2_preshared_key = "lookatmethisisaprivatekey2"
-		}
-		`, rBgpAsn)
+func testAccAwsVpnConnectionConfigTunnelOptions(rBgpAsn int, psk string, tunnelCidr string, psk2 string, tunnelCidr2 string) string {
+	return fmt.Sprintf(`
+resource "aws_vpn_gateway" "vpn_gateway" {
+  tags {
+    Name = "vpn_gateway"
+  }
+}
+
+resource "aws_customer_gateway" "customer_gateway" {
+  bgp_asn = %d
+  ip_address = "178.0.0.1"
+  type = "ipsec.1"
+  tags {
+    Name = "main-customer-gateway"
+  }
+}
+
+resource "aws_vpn_connection" "foo" {
+  vpn_gateway_id = "${aws_vpn_gateway.vpn_gateway.id}"
+  customer_gateway_id = "${aws_customer_gateway.customer_gateway.id}"
+  type = "ipsec.1"
+    static_routes_only = false
+
+  tunnel1_inside_cidr = "%s"
+  tunnel1_preshared_key = "%s"
+
+  tunnel2_inside_cidr = "%s"
+  tunnel2_preshared_key = "%s"
+}
+    `, rBgpAsn, tunnelCidr, psk, tunnelCidr2, psk2)
 }
 
 // Test our VPN tunnel config XML parsing

--- a/website/docs/r/vpn_connection.html.markdown
+++ b/website/docs/r/vpn_connection.html.markdown
@@ -14,6 +14,9 @@ Provides a VPN connection connected to a VPC. These objects can be connected to 
 ~> **Note:** All arguments including `tunnel1_preshared_key` and `tunnel2_preshared_key` will be stored in the raw state as plain-text.
 [Read more about sensitive data in state](/docs/state/sensitive-data.html).
 
+~> **Note:** The CIDR blocks in the arguments `tunnel1_inside_cidr` and `tunnel2_inside_cidr` must have a prefix of /30 and be a part of a specific range.
+[Read more about this in the AWS documentation](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_VpnTunnelOptionsSpecification.html).
+
 ## Example Usage
 
 ```hcl
@@ -48,6 +51,10 @@ The following arguments are supported:
 * `tags` - (Optional) Tags to apply to the connection.
 * `type` - (Required) The type of VPN connection. The only type AWS supports at this time is "ipsec.1".
 * `vpn_gateway_id` - (Required) The ID of the virtual private gateway.
+* `tunnel1_inside_cidr` - (Optional) The CIDR block of the inside IP addresses for the first VPN tunnel.
+* `tunnel2_inside_cidr` - (Optional) The CIDR block of the second IP addresses for the first VPN tunnel.
+* `tunnel1_preshared_key` - (Optional) The preshared key of the first VPN tunnel.
+* `tunnel2_preshared_key` - (Optional) The preshared key of the second VPN tunnel.
 
 ## Attribute Reference
 


### PR DESCRIPTION
Closes #2220

### Context

AWS recently allowed users to let them choose the CIDR and the PSK to use inside IPsec tunnels.
More details here : https://aws.amazon.com/about-aws/whats-new/2017/10/aws-vpn-update-custom-psk-inside-tunnel-ip-and-sdk-update/

### Changes

This Pull Request changes the way tunnel1_preshared_key and tunnel2_preshared_key behave (from read-only to writeable). 
The tunnel1_inside_cidr and tunnel2_inside_cidr have been introduced also to be used as parameters for the CreateVpnConnection API.
Test coverage has been added to test these features.

### Tests

```
⇒  TF_ACC=1 go test ./aws -v -run=TestAccAWSVpnConnection_ -timeout 120m 
=== RUN   TestAccAWSVpnConnection_importBasic 
--- PASS: TestAccAWSVpnConnection_importBasic (236.43s) 
=== RUN   TestAccAWSVpnConnection_basic 
--- PASS: TestAccAWSVpnConnection_basic (432.65s) 
=== RUN   TestAccAWSVpnConnection_tunnelOptions 
--- PASS: TestAccAWSVpnConnection_tunnelOptions (286.92s) 
=== RUN   TestAccAWSVpnConnection_withoutStaticRoutes 
--- PASS: TestAccAWSVpnConnection_withoutStaticRoutes (298.02s) 
=== RUN   TestAccAWSVpnConnection_disappears 
--- PASS: TestAccAWSVpnConnection_disappears (166.75s) 
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1420.829s
```