### PR TITLE
New Data Source: aws_elasticsearch_domain

### DIFF
--- a/aws/data_source_aws_elasticsearch_domain.go
+++ b/aws/data_source_aws_elasticsearch_domain.go
@@ -1,0 +1,204 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elasticsearchservice"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsElasticSearchDomain() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsElasticSearchDomainRead,
+
+		Schema: map[string]*schema.Schema{
+			"domain_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"endpoint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"deleted": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"domain_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"access_policies": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"processing": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"elasticsearch_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cluster_config": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"dedicated_master_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"instance_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"zone_awareness_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"dedicated_master_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instance_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"dedicated_master_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"ebs_options": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"iops": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"volume_size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"volume_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ebs_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"snapshot_options": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"automated_snapshot_start_hour": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"advanced_options": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"tags": tagsSchemaComputed(),
+		},
+	}
+}
+
+func dataSourceAwsElasticSearchDomainRead(d *schema.ResourceData, meta interface{}) error {
+	esconn := meta.(*AWSClient).esconn
+
+	req := &elasticsearchservice.DescribeElasticsearchDomainInput{
+		DomainName: aws.String(d.Get("domain_name").(string)),
+	}
+
+	resp, err := esconn.DescribeElasticsearchDomain(req)
+	if err != nil {
+		return err
+	}
+
+	if resp.DomainStatus == nil {
+		return fmt.Errorf("Your query returned no results.  Please change your search criteria and try again.")
+	}
+
+	ds := resp.DomainStatus
+
+	d.SetId(*ds.ARN)
+
+	d.Set("domain_id", ds.DomainId)
+	d.Set("endpoint", ds.Endpoint)
+	d.Set("created", ds.Created)
+	d.Set("deleted", ds.Deleted)
+
+	if ds.AccessPolicies != nil && *ds.AccessPolicies != "" {
+		policies, err := normalizeJsonString(*ds.AccessPolicies)
+		if err != nil {
+			return errwrap.Wrapf("access policies contain an invalid JSON: {{err}}", err)
+		}
+		d.Set("access_policies", policies)
+	}
+
+	d.Set("processing", ds.Processing)
+	d.Set("elasticsearch_version", ds.ElasticsearchVersion)
+	arn := *ds.ARN
+	d.Set("arn", arn)
+
+	err = d.Set("advanced_options", pointersMapToStringList(ds.AdvancedOptions))
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("cluster_config", flattenESClusterConfig(ds.ElasticsearchClusterConfig))
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("ebs_options", flattenESEBSOptions(ds.EBSOptions))
+	if err != nil {
+		return err
+	}
+
+	if ds.SnapshotOptions != nil {
+		m := map[string]interface{}{}
+
+		m["automated_snapshot_start_hour"] = *ds.SnapshotOptions.AutomatedSnapshotStartHour
+
+		d.Set("snapshot_options", []map[string]interface{}{m})
+	}
+
+	tagResp, err := esconn.ListTags(&elasticsearchservice.ListTagsInput{
+		ARN: &arn,
+	})
+
+	if err != nil {
+		log.Printf("[DEBUG] Error retrieving tags for ARN: %s", arn)
+	}
+
+	d.Set("tags", tagsToMapElasticsearchService(tagResp.TagList))
+
+	return nil
+}

--- a/aws/data_source_aws_elasticsearch_domain.go
+++ b/aws/data_source_aws_elasticsearch_domain.go
@@ -193,7 +193,8 @@ func dataSourceAwsElasticSearchDomain() *schema.Resource {
 				Computed: true,
 			},
 			"cognito_options": {
-				Type: schema.TypeList,
+				Type:     schema.TypeList,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"enabled": {

--- a/aws/data_source_aws_elasticsearch_domain.go
+++ b/aws/data_source_aws_elasticsearch_domain.go
@@ -120,7 +120,7 @@ func dataSourceAwsElasticSearchDomain() *schema.Resource {
 							Computed: true,
 						},
 						"zone_awareness_config": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{

--- a/aws/data_source_aws_elasticsearch_domain_test.go
+++ b/aws/data_source_aws_elasticsearch_domain_test.go
@@ -1,0 +1,78 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSDataElasticsearchDomain_basic(t *testing.T) {
+	rInt := acctest.RandInt()
+
+	fmt.Println("Inside TestAccAWSDataElasticsearchDomain_basic")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSElasticsearchDomainConfigWithDataSource(rInt),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "elasticsearch_version", "1.5"),
+					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "cluster_config.#", "1"),
+					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "cluster_config.0.instance_type", "t2.micro.elasticsearch"),
+					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "cluster_config.0.instance_count", "2"),
+					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "cluster_config.0.dedicated_master_enabled", "false"),
+					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "cluster_config.0.zone_awareness_enabled", "true"),
+					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "ebs_options.#", "1"),
+					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "ebs_options.0.ebs_enabled", "true"),
+					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "ebs_options.0.volume_type", "gp2"),
+					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "ebs_options.0.volume_size", "20"),
+					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "snapshot_options.#", "1"),
+					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "snapshot_options.0.automated_snapshot_start_hour", "23"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAWSElasticsearchDomainConfigWithDataSource(rInt int) string {
+	return fmt.Sprintf(`
+provider "aws" {
+	region = "us-east-1"
+}
+
+resource "aws_elasticsearch_domain" "bar" {
+  domain_name = "test-es-%d"
+  elasticsearch_version = "1.5"
+
+  cluster_config {
+    instance_type = "t2.micro.elasticsearch"
+    instance_count = 2
+    dedicated_master_enabled = false
+    zone_awareness_enabled = true
+  }
+
+  ebs_options {
+    ebs_enabled = true
+    volume_type = "gp2"
+    volume_size = 20
+  }
+
+  snapshot_options {
+    automated_snapshot_start_hour = 23
+  }
+
+  tags {
+    Domain = "TestDomain"
+  }
+}
+
+data "aws_elasticsearch_domain" "bar" {
+	domain_name = "${aws_elasticsearch_domain.bar.domain_name}"
+}
+
+`, rInt)
+}

--- a/aws/data_source_aws_elasticsearch_domain_test.go
+++ b/aws/data_source_aws_elasticsearch_domain_test.go
@@ -63,7 +63,6 @@ func TestAccAWSDataElasticsearchDomain_advanced(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, "snapshot_options.#", resourceName, "snapshot_options.#"),
 					resource.TestCheckResourceAttrPair(datasourceName, "snapshot_options.0.automated_snapshot_start_hour", resourceName, "snapshot_options.0.automated_snapshot_start_hour"),
 					resource.TestCheckResourceAttrPair(datasourceName, "log_publishing_options.#", resourceName, "log_publishing_options.#"),
-					resource.TestCheckResourceAttrPair(datasourceName, "log_publishing_options.0.log_type", resourceName, "log_publishing_options.0.log_type"),
 					resource.TestCheckResourceAttrPair(datasourceName, "vpc_options.#", resourceName, "vpc_options.#"),
 				),
 			},

--- a/aws/data_source_aws_elasticsearch_domain_test.go
+++ b/aws/data_source_aws_elasticsearch_domain_test.go
@@ -10,26 +10,28 @@ import (
 
 func TestAccAWSDataElasticsearchDomain_basic(t *testing.T) {
 	rInt := acctest.RandInt()
+	datasourceName := "data.aws_elasticsearch_domain.test"
+	resourceName := "aws_elasticsearch_domain.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSElasticsearchDomainConfigWithDataSource(rInt),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "elasticsearch_version", "1.5"),
-					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "cluster_config.#", "1"),
-					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "cluster_config.0.instance_type", "t2.micro.elasticsearch"),
-					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "cluster_config.0.instance_count", "2"),
-					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "cluster_config.0.dedicated_master_enabled", "false"),
-					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "cluster_config.0.zone_awareness_enabled", "true"),
-					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "ebs_options.#", "1"),
-					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "ebs_options.0.ebs_enabled", "true"),
-					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "ebs_options.0.volume_type", "gp2"),
-					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "ebs_options.0.volume_size", "20"),
-					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "snapshot_options.#", "1"),
-					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "snapshot_options.0.automated_snapshot_start_hour", "23"),
+					resource.TestCheckResourceAttrPair(datasourceName, "elasticsearch_version", resourceName, "elasticsearch_version"),
+					resource.TestCheckResourceAttrPair(datasourceName, "cluster_config.#", resourceName, "cluster_config.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "cluster_config.0.instance_type", resourceName, "cluster_config.0.instance_type"),
+					resource.TestCheckResourceAttrPair(datasourceName, "cluster_config.0.instance_count", resourceName, "cluster_config.0.instance_count"),
+					resource.TestCheckResourceAttrPair(datasourceName, "cluster_config.0.dedicated_master_enabled", resourceName, "cluster_config.0.dedicated_master_enabled"),
+					resource.TestCheckResourceAttrPair(datasourceName, "cluster_config.0.zone_awareness_enabled", resourceName, "cluster_config.0.zone_awareness_enabled"),
+					resource.TestCheckResourceAttrPair(datasourceName, "ebs_options.#", resourceName, "ebs_options.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "ebs_options.0.ebs_enabled", resourceName, "ebs_options.0.ebs_enabled"),
+					resource.TestCheckResourceAttrPair(datasourceName, "ebs_options.0.volume_type", resourceName, "ebs_options.0.volume_type"),
+					resource.TestCheckResourceAttrPair(datasourceName, "ebs_options.0.volume_size", resourceName, "ebs_options.0.volume_size"),
+					resource.TestCheckResourceAttrPair(datasourceName, "snapshot_options.#", resourceName, "snapshot_options.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "snapshot_options.0.automated_snapshot_start_hour", resourceName, "snapshot_options.0.automated_snapshot_start_hour"),
 				),
 			},
 		},
@@ -38,29 +40,31 @@ func TestAccAWSDataElasticsearchDomain_basic(t *testing.T) {
 
 func TestAccAWSDataElasticsearchDomain_advanced(t *testing.T) {
 	rInt := acctest.RandInt()
+	datasourceName := "data.aws_elasticsearch_domain.test"
+	resourceName := "aws_elasticsearch_domain.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSElasticsearchDomainConfigAdvancedWithDataSource(rInt),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "elasticsearch_version", "1.5"),
-					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "cluster_config.#", "1"),
-					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "cluster_config.0.instance_type", "t2.micro.elasticsearch"),
-					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "cluster_config.0.instance_count", "2"),
-					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "cluster_config.0.dedicated_master_enabled", "false"),
-					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "cluster_config.0.zone_awareness_enabled", "true"),
-					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "ebs_options.#", "1"),
-					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "ebs_options.0.ebs_enabled", "true"),
-					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "ebs_options.0.volume_type", "gp2"),
-					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "ebs_options.0.volume_size", "20"),
-					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "snapshot_options.#", "1"),
-					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "snapshot_options.0.automated_snapshot_start_hour", "23"),
-					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "log_publishing_options.#", "1"),
-					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "log_publishing_options.0.log_type", "INDEX_SLOW_LOGS"),
-					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "vpc_options.#", "1"),
+					resource.TestCheckResourceAttrPair(datasourceName, "elasticsearch_version", resourceName, "elasticsearch_version"),
+					resource.TestCheckResourceAttrPair(datasourceName, "cluster_config.#", resourceName, "cluster_config.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "cluster_config.0.instance_type", resourceName, "cluster_config.0.instance_type"),
+					resource.TestCheckResourceAttrPair(datasourceName, "cluster_config.0.instance_count", resourceName, "cluster_config.0.instance_count"),
+					resource.TestCheckResourceAttrPair(datasourceName, "cluster_config.0.dedicated_master_enabled", resourceName, "cluster_config.0.dedicated_master_enabled"),
+					resource.TestCheckResourceAttrPair(datasourceName, "cluster_config.0.zone_awareness_enabled", resourceName, "cluster_config.0.zone_awareness_enabled"),
+					resource.TestCheckResourceAttrPair(datasourceName, "ebs_options.#", resourceName, "ebs_options.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "ebs_options.0.ebs_enabled", resourceName, "ebs_options.0.ebs_enabled"),
+					resource.TestCheckResourceAttrPair(datasourceName, "ebs_options.0.volume_type", resourceName, "ebs_options.0.volume_type"),
+					resource.TestCheckResourceAttrPair(datasourceName, "ebs_options.0.volume_size", resourceName, "ebs_options.0.volume_size"),
+					resource.TestCheckResourceAttrPair(datasourceName, "snapshot_options.#", resourceName, "snapshot_options.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "snapshot_options.0.automated_snapshot_start_hour", resourceName, "snapshot_options.0.automated_snapshot_start_hour"),
+					resource.TestCheckResourceAttrPair(datasourceName, "log_publishing_options.#", resourceName, "log_publishing_options.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "log_publishing_options.0.log_type", resourceName, "log_publishing_options.0.log_type"),
+					resource.TestCheckResourceAttrPair(datasourceName, "vpc_options.#", resourceName, "vpc_options.#"),
 				),
 			},
 		},
@@ -81,7 +85,7 @@ data "aws_region" "current" {}
 		
 data "aws_caller_identity" "current" {}
 					
-resource "aws_elasticsearch_domain" "bar" {
+resource "aws_elasticsearch_domain" "test" {
 	domain_name = "${local.random_name}"
 	elasticsearch_version = "1.5"
 	
@@ -95,7 +99,7 @@ resource "aws_elasticsearch_domain" "bar" {
 			"Effect": "Allow",
 			"Resource": "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${local.random_name}/*",
 			"Condition": {
-				"IpAddress": {"aws:SourceIp": ["66.193.100.22/32"]}
+				"IpAddress": {"aws:SourceIp": ["127.0.0.0/8"]}
 			}
 		}
 	]
@@ -105,7 +109,10 @@ POLICY
   cluster_config {
     instance_type = "t2.micro.elasticsearch"
     instance_count = 2
-    dedicated_master_enabled = false
+	dedicated_master_enabled = false
+	zone_awareness_config {
+		availability_zone_count = 2
+	}
     zone_awareness_enabled = true
   }
   ebs_options {
@@ -118,8 +125,8 @@ POLICY
   }
 }
 
-data "aws_elasticsearch_domain" "bar" {
-  domain_name = "${aws_elasticsearch_domain.bar.domain_name}"
+data "aws_elasticsearch_domain" "test" {
+  domain_name = "${aws_elasticsearch_domain.test.domain_name}"
 }
 		`, rInt)
 }
@@ -138,11 +145,11 @@ locals {
 	random_name = "test-es-%d"
 }
 
-resource "aws_cloudwatch_log_group" "bar" {
+resource "aws_cloudwatch_log_group" "test" {
 	name = "${local.random_name}"
 }
 
-resource "aws_cloudwatch_log_resource_policy" "bar" {
+resource "aws_cloudwatch_log_resource_policy" "test" {
 	policy_name = "${local.random_name}"
 	policy_document = <<CONFIG
 {
@@ -165,40 +172,40 @@ resource "aws_cloudwatch_log_resource_policy" "bar" {
 CONFIG
 }
 
-resource "aws_vpc" "bar" {
+resource "aws_vpc" "test" {
 	cidr_block = "10.0.0.0/16"
 }
 
-resource "aws_subnet" "bar" {
-	vpc_id = "${aws_vpc.bar.id}"
+resource "aws_subnet" "test" {
+	vpc_id = "${aws_vpc.test.id}"
 	cidr_block = "10.0.0.0/24"
 }
 
-resource "aws_subnet" "baz" {
-	vpc_id = "${aws_vpc.bar.id}"
+resource "aws_subnet" "test2" {
+	vpc_id = "${aws_vpc.test.id}"
 	cidr_block = "10.0.1.0/24"
 }
 
-resource "aws_security_group" "bar" {
+resource "aws_security_group" "test" {
 	name = "${local.random_name}"
-	vpc_id = "${aws_vpc.bar.id}"
+	vpc_id = "${aws_vpc.test.id}"
 }
 
-resource "aws_security_group_rule" "bar" {
+resource "aws_security_group_rule" "test" {
 	type = "ingress"
 	from_port = 443
 	to_port = 443
 	protocol = "tcp"
 	cidr_blocks = [ "0.0.0.0/0" ]
 
-	security_group_id = "${aws_security_group.bar.id}"
+	security_group_id = "${aws_security_group.test.id}"
 }
 
-resource "aws_iam_service_linked_role" "bar" {
+resource "aws_iam_service_linked_role" "test" {
 	aws_service_name = "es.amazonaws.com"
 }
 
-resource "aws_elasticsearch_domain" "bar" {
+resource "aws_elasticsearch_domain" "test" {
 	domain_name = "${local.random_name}"
 	elasticsearch_version = "1.5"
 	
@@ -220,6 +227,9 @@ POLICY
     instance_type = "t2.micro.elasticsearch"
     instance_count = 2
     dedicated_master_enabled = false
+	zone_awareness_config {
+		availability_zone_count = 2
+	}
     zone_awareness_enabled = true
   }
   ebs_options {
@@ -231,30 +241,30 @@ POLICY
     automated_snapshot_start_hour = 23
   }
   log_publishing_options {
-    cloudwatch_log_group_arn = "${aws_cloudwatch_log_group.bar.arn}"
+    cloudwatch_log_group_arn = "${aws_cloudwatch_log_group.test.arn}"
     log_type = "INDEX_SLOW_LOGS"
   }
   vpc_options {
 		security_group_ids = [
-			"${aws_security_group.bar.id}"
+			"${aws_security_group.test.id}"
 		]
 		subnet_ids = [
-			"${aws_subnet.bar.id}",
-			"${aws_subnet.baz.id}"
+			"${aws_subnet.test.id}",
+			"${aws_subnet.test2.id}"
 		]
   }
 
-  tags {
-	  Domain = "TestDomain"
-	}
+  tags = {
+	Domain = "TestDomain"
+  }
 	
-	depends_on = [
-    "aws_iam_service_linked_role.bar",
+  depends_on = [
+    "aws_iam_service_linked_role.test",
   ]
 }
 
-data "aws_elasticsearch_domain" "bar" {
-  domain_name = "${aws_elasticsearch_domain.bar.domain_name}"
+data "aws_elasticsearch_domain" "test" {
+  domain_name = "${aws_elasticsearch_domain.test.domain_name}"
 }
 				`, rInt)
 }

--- a/aws/data_source_aws_elasticsearch_domain_test.go
+++ b/aws/data_source_aws_elasticsearch_domain_test.go
@@ -11,8 +11,6 @@ import (
 func TestAccAWSDataElasticsearchDomain_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
-	fmt.Println("Inside TestAccAWSDataElasticsearchDomain_basic")
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,

--- a/aws/data_source_aws_elasticsearch_domain_test.go
+++ b/aws/data_source_aws_elasticsearch_domain_test.go
@@ -36,15 +36,71 @@ func TestAccAWSDataElasticsearchDomain_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSDataElasticsearchDomain_advanced(t *testing.T) {
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSElasticsearchDomainConfigAdvancedWithDataSource(rInt),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "elasticsearch_version", "1.5"),
+					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "cluster_config.#", "1"),
+					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "cluster_config.0.instance_type", "t2.micro.elasticsearch"),
+					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "cluster_config.0.instance_count", "2"),
+					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "cluster_config.0.dedicated_master_enabled", "false"),
+					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "cluster_config.0.zone_awareness_enabled", "true"),
+					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "ebs_options.#", "1"),
+					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "ebs_options.0.ebs_enabled", "true"),
+					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "ebs_options.0.volume_type", "gp2"),
+					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "ebs_options.0.volume_size", "20"),
+					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "snapshot_options.#", "1"),
+					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "snapshot_options.0.automated_snapshot_start_hour", "23"),
+					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "log_publishing_options.#", "1"),
+					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "log_publishing_options.0.log_type", "INDEX_SLOW_LOGS"),
+					resource.TestCheckResourceAttr("data.aws_elasticsearch_domain.bar", "vpc_options.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func testAccAWSElasticsearchDomainConfigWithDataSource(rInt int) string {
 	return fmt.Sprintf(`
 provider "aws" {
 	region = "us-east-1"
 }
 
+locals {
+	random_name = "test-es-%d"
+}
+		
+data "aws_region" "current" {}
+		
+data "aws_caller_identity" "current" {}
+					
 resource "aws_elasticsearch_domain" "bar" {
-  domain_name = "test-es-%d"
-  elasticsearch_version = "1.5"
+	domain_name = "${local.random_name}"
+	elasticsearch_version = "1.5"
+	
+	access_policies = <<POLICY
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Action": "es:*",
+			"Principal": "*",
+			"Effect": "Allow",
+			"Resource": "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${local.random_name}/*",
+			"Condition": {
+				"IpAddress": {"aws:SourceIp": ["66.193.100.22/32"]}
+			}
+		}
+	]
+}
+POLICY
 
   cluster_config {
     instance_type = "t2.micro.elasticsearch"
@@ -52,25 +108,153 @@ resource "aws_elasticsearch_domain" "bar" {
     dedicated_master_enabled = false
     zone_awareness_enabled = true
   }
-
   ebs_options {
-    ebs_enabled = true
-    volume_type = "gp2"
-    volume_size = 20
+	ebs_enabled = true
+	volume_type = "gp2"
+	volume_size = 20
   }
-
   snapshot_options {
     automated_snapshot_start_hour = 23
-  }
-
-  tags {
-    Domain = "TestDomain"
   }
 }
 
 data "aws_elasticsearch_domain" "bar" {
-	domain_name = "${aws_elasticsearch_domain.bar.domain_name}"
+  domain_name = "${aws_elasticsearch_domain.bar.domain_name}"
+}
+		`, rInt)
 }
 
-`, rInt)
+func testAccAWSElasticsearchDomainConfigAdvancedWithDataSource(rInt int) string {
+	return fmt.Sprintf(`
+provider "aws" {
+	region = "us-east-1"
+}
+		
+data "aws_region" "current" {}
+		
+data "aws_caller_identity" "current" {}
+
+locals {
+	random_name = "test-es-%d"
+}
+
+resource "aws_cloudwatch_log_group" "bar" {
+	name = "${local.random_name}"
+}
+
+resource "aws_cloudwatch_log_resource_policy" "bar" {
+	policy_name = "${local.random_name}"
+	policy_document = <<CONFIG
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Effect": "Allow",
+			"Principal": {
+				"Service": "es.amazonaws.com"
+			},
+			"Action": [
+				"logs:PutLogEvents",
+				"logs:PutLogEventsBatch",
+				"logs:CreateLogStream"
+			],
+			"Resource": "arn:aws:logs:*"
+		}
+	]
+}
+CONFIG
+}
+
+resource "aws_vpc" "bar" {
+	cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "bar" {
+	vpc_id = "${aws_vpc.bar.id}"
+	cidr_block = "10.0.0.0/24"
+}
+
+resource "aws_subnet" "baz" {
+	vpc_id = "${aws_vpc.bar.id}"
+	cidr_block = "10.0.1.0/24"
+}
+
+resource "aws_security_group" "bar" {
+	name = "${local.random_name}"
+	vpc_id = "${aws_vpc.bar.id}"
+}
+
+resource "aws_security_group_rule" "bar" {
+	type = "ingress"
+	from_port = 443
+	to_port = 443
+	protocol = "tcp"
+	cidr_blocks = [ "0.0.0.0/0" ]
+
+	security_group_id = "${aws_security_group.bar.id}"
+}
+
+resource "aws_iam_service_linked_role" "bar" {
+	aws_service_name = "es.amazonaws.com"
+}
+
+resource "aws_elasticsearch_domain" "bar" {
+	domain_name = "${local.random_name}"
+	elasticsearch_version = "1.5"
+	
+	access_policies = <<POLICY
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Action": "es:*",
+			"Principal": "*",
+			"Effect": "Allow",
+			"Resource": "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${local.random_name}/*"
+		}
+	]
+}
+POLICY
+
+  cluster_config {
+    instance_type = "t2.micro.elasticsearch"
+    instance_count = 2
+    dedicated_master_enabled = false
+    zone_awareness_enabled = true
+  }
+  ebs_options {
+	ebs_enabled = true
+	volume_type = "gp2"
+	volume_size = 20
+  }
+  snapshot_options {
+    automated_snapshot_start_hour = 23
+  }
+  log_publishing_options {
+    cloudwatch_log_group_arn = "${aws_cloudwatch_log_group.bar.arn}"
+    log_type = "INDEX_SLOW_LOGS"
+  }
+  vpc_options {
+		security_group_ids = [
+			"${aws_security_group.bar.id}"
+		]
+		subnet_ids = [
+			"${aws_subnet.bar.id}",
+			"${aws_subnet.baz.id}"
+		]
+  }
+
+  tags {
+	  Domain = "TestDomain"
+	}
+	
+	depends_on = [
+    "aws_iam_service_linked_role.bar",
+  ]
+}
+
+data "aws_elasticsearch_domain" "bar" {
+  domain_name = "${aws_elasticsearch_domain.bar.domain_name}"
+}
+				`, rInt)
 }

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -199,6 +199,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_elastic_beanstalk_hosted_zone":             dataSourceAwsElasticBeanstalkHostedZone(),
 			"aws_elastic_beanstalk_solution_stack":          dataSourceAwsElasticBeanstalkSolutionStack(),
 			"aws_elasticache_cluster":                       dataSourceAwsElastiCacheCluster(),
+			"aws_elasticsearch_domain":                      dataSourceAwsElasticSearchDomain(),
 			"aws_elb":                                       dataSourceAwsElb(),
 			"aws_elasticache_replication_group":             dataSourceAwsElasticacheReplicationGroup(),
 			"aws_elb_hosted_zone_id":                        dataSourceAwsElbHostedZoneId(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -30,7 +30,2171 @@
                     <a href="#">Provider Data Sources</a>
                     <ul class="nav">
                         <li>
+<<<<<<< HEAD
                             <a href="/docs/providers/aws/d/arn.html">aws_arn</a>
+=======
+                            <a href="/docs/providers/aws/d/acm_certificate.html">aws_acm_certificate</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/acmpca_certificate_authority.html">aws_acmpca_certificate_authority</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/lb.html">aws_alb</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/lb_listener.html">aws_alb_listener</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/lb_target_group.html">aws_alb_target_group</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/ami.html">aws_ami</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/ami_ids.html">aws_ami_ids</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/api_gateway_api_key.html">aws_api_gateway_api_key</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/api_gateway_resource.html">aws_api_gateway_resource</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/api_gateway_rest_api.html">aws_api_gateway_rest_api</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/api_gateway_vpc_link.html">aws_api_gateway_vpc_link</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/arn.html">aws_arn</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/autoscaling_group.html">aws_autoscaling_group</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/autoscaling_groups.html">aws_autoscaling_groups</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/availability_zone.html">aws_availability_zone</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/availability_zones.html">aws_availability_zones</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/d/batch_compute_environment.html">aws_batch_compute_environment</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/d/batch_job_queue.html">aws_batch_job_queue</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/billing_service_account.html">aws_billing_service_account</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/d/caller_identity.html">aws_caller_identity</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/canonical_user_id.html">aws_canonical_user_id</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/cloudformation_export.html">aws_cloudformation_export</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/cloudformation_stack.html">aws_cloudformation_stack</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/cloudhsm_v2_cluster.html">aws_cloudhsm_v2_cluster</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/cloudtrail_service_account.html">aws_cloudtrail_service_account</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/cloudwatch_log_group.html">aws_cloudwatch_log_group</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/codecommit_repository.html">aws_codecommit_repository</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/cognito_user_pools.html">aws_cognito_user_pools</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/cur_report_definition.html">aws_cur_report_definition</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/customer_gateway.html">aws_customer_gateway</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/d/db_cluster_snapshot.html">aws_db_cluster_snapshot</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/d/db_event_categories.html">aws_db_event_categories</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/db_instance.html">aws_db_instance</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/d/db_snapshot.html">aws_db_snapshot</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/d/dx_gateway.html">aws_dx_gateway</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/d/dynamodb_table.html">aws_dynamodb_table</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/d/ebs_default_kms_key.html">aws_ebs_default_kms_key</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/d/ebs_encryption_by_default.html">aws_ebs_encryption_by_default</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/d/ebs_snapshot.html">aws_ebs_snapshot</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/d/ebs_snapshot_ids.html">aws_ebs_snapshot_ids</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/d/ebs_volume.html">aws_ebs_volume</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/d/ec2_transit_gateway.html">aws_ec2_transit_gateway</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/d/ec2_transit_gateway_dx_gateway_attachment.html">aws_ec2_transit_gateway_dx_gateway_attachment</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/d/ec2_transit_gateway_route_table.html">aws_ec2_transit_gateway_route_table</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/d/ec2_transit_gateway_vpc_attachment.html">aws_ec2_transit_gateway_vpc_attachment</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/d/ec2_transit_gateway_vpn_attachment.html">aws_ec2_transit_gateway_vpn_attachment</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/d/ecr_image.html">aws_ecr_image</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/d/ecr_repository.html">aws_ecr_repository</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/d/ecs_cluster.html">aws_ecs_cluster</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/ecs_container_definition.html">aws_ecs_container_definition</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/ecs_service.html">aws_ecs_service</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/ecs_task_definition.html">aws_ecs_task_definition</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/efs_file_system.html">aws_efs_file_system</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/efs_mount_target.html">aws_efs_mount_target</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/eip.html">aws_eip</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/eks_cluster.html">aws_eks_cluster</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/eks_cluster_auth.html">aws_eks_cluster_auth</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/elastic_beanstalk_application.html">aws_elastic_beanstalk_application</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/elastic_beanstalk_hosted_zone.html">aws_elastic_beanstalk_hosted_zone</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/elastic_beanstalk_solution_stack.html">aws_elastic_beanstalk_solution_stack</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/elasticache_cluster.html">aws_elasticache_cluster</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/elasticache_replication_group.html">aws_elasticache_replication_group</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/elasticsearch_domain.html">aws_elasticsearch_domain</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/elb.html">aws_elb</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/elb_hosted_zone_id.html">aws_elb_hosted_zone_id</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/elb_service_account.html">aws_elb_service_account</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/glue_script.html">aws_glue_script</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/iam_account_alias.html">aws_iam_account_alias</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/iam_group.html">aws_iam_group</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/iam_instance_profile.html">aws_iam_instance_profile</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/iam_policy.html">aws_iam_policy</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/iam_policy_document.html">aws_iam_policy_document</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/iam_role.html">aws_iam_role</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/d/iam_server_certificate.html">aws_iam_server_certificate</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/iam_user.html">aws_iam_user</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/d/inspector_rules_packages.html">aws_inspector_rules_packages</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/d/instance.html">aws_instance</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/d/instances.html">aws_instances</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/d/internet_gateway.html">aws_internet_gateway</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/d/iot_endpoint.html">aws_iot_endpoint</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/ip_ranges.html">aws_ip_ranges</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/kinesis_stream.html">aws_kinesis_stream</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/kms_alias.html">aws_kms_alias</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/kms_ciphertext.html">aws_kms_ciphertext</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/d/kms_key.html">aws_kms_key</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/kms_secrets.html">aws_kms_secrets</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/lambda_function.html">aws_lambda_function</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/lambda_invocation.html">aws_lambda_invocation</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/lambda_layer_version.html">aws_lambda_layer_version</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/launch_configuration.html">aws_launch_configuration</a>
+                        </li>
+
+
+                        <li>
+                            <a href="/docs/providers/aws/d/launch_template.html">aws_launch_template</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/d/lb.html">aws_lb</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/lb_listener.html">aws_lb_listener</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/lb_target_group.html">aws_lb_target_group</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/mq_broker.html">aws_mq_broker</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/msk_cluster.html">aws_msk_cluster</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/msk_configuration.html">aws_msk_configuration</a>
+                        </li>
+                        <li>
+                           <a href="/docs/providers/aws/d/nat_gateway.html">aws_nat_gateway</a>
+                        </li>
+                        <li>
+                           <a href="/docs/providers/aws/d/network_acls.html">aws_network_acls</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/network_interface.html">aws_network_interface</a>
+                        </li>
+                         <li>
+                            <a href="/docs/providers/aws/d/network_interfaces.html">aws_network_interfaces</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/organizations_organization.html">aws_organizations_organization</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/partition.html">aws_partition</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/prefix_list.html">aws_prefix_list</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/pricing_product.html">aws_pricing_product</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/rds_cluster.html">aws_rds_cluster</a>
+                        </li>
+                        <li>
+                        <a href="/docs/providers/aws/d/ram_resource_share.html">aws_ram_resource_share</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/redshift_cluster.html">aws_redshift_cluster</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/redshift_service_account.html">aws_redshift_service_account</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/region.html">aws_region</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/d/route.html">aws_route</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/d/route53_delegation_set.html">aws_route53_delegation_set</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/d/route53_zone.html">aws_route53_zone</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/d/route_table.html">aws_route_table</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/d/route_tables.html">aws_route_tables</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/s3_bucket.html">aws_s3_bucket</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/s3_bucket_object.html">aws_s3_bucket_object</a>
+                        </li>
+                        <li>
+                         <a href="/docs/providers/aws/d/secretsmanager_secret.html">aws_secretsmanager_secret</a>
+                        </li>
+                        <li>
+                         <a href="/docs/providers/aws/d/secretsmanager_secret_version.html">aws_secretsmanager_secret_version</a>
+                        </li>
+                        <li>
+                         <a href="/docs/providers/aws/d/security_group.html">aws_security_group</a>
+                        </li>
+                        <li>
+                         <a href="/docs/providers/aws/d/security_groups.html">aws_security_groups</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/d/servicequotas_service.html">aws_servicequotas_service</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/d/servicequotas_service_quota.html">aws_servicequotas_service_quota</a>
+                        </li>
+                        <li>
+                         <a href="/docs/providers/aws/d/sns_topic.html">aws_sns_topic</a>
+                        </li>
+                        <li>
+                         <a href="/docs/providers/aws/d/sqs_queue.html">aws_sqs_queue</a>
+                        </li>
+
+                        <li>
+                         <a href="/docs/providers/aws/d/ssm_document.html">aws_ssm_document</a>
+                        </li>
+                        <li>
+                         <a href="/docs/providers/aws/d/ssm_parameter.html">aws_ssm_parameter</a>
+                        </li>
+                        <li>
+                         <a href="/docs/providers/aws/d/storagegateway_local_disk.html">aws_storagegateway_local_disk</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/subnet.html">aws_subnet</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/subnet_ids.html">aws_subnet_ids</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/transfer_server.html">aws_transfer_server</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/vpc.html">aws_vpc</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/vpc_dhcp_options.html">aws_vpc_dhcp_options</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/vpc_endpoint.html">aws_vpc_endpoint</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/vpc_endpoint_service.html">aws_vpc_endpoint_service</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/vpc_peering_connection.html">aws_vpc_peering_connection</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/vpcs.html">aws_vpcs</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/vpn_gateway.html">aws_vpn_gateway</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/waf_rule.html">aws_vpn_gateway</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/waf_web_acl.html">aws_waf_web_acl</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/wafregional_rule.html">aws_wafregional_rule</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/wafregional_web_acl.html">aws_wafregional_web_acl</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/d/workspaces_bundle.html">aws_workspaces_bundle</a>
+                        </li>
+                    </ul>
+                </li>
+
+                <li>
+                  <a href="#">ACM Resources</a>
+                  <ul class="nav">
+                    <li>
+                      <a href="/docs/providers/aws/r/acm_certificate.html">aws_acm_certificate</a>
+                    </li>
+                    <li>
+                      <a href="/docs/providers/aws/r/acm_certificate_validation.html">aws_acm_certificate_validation</a>
+                    </li>
+                  </ul>
+                </li>
+
+                <li>
+                  <a href="#">ACM PCA Resources</a>
+                  <ul class="nav">
+                    <li>
+                      <a href="/docs/providers/aws/r/acmpca_certificate_authority.html">aws_acmpca_certificate_authority</a>
+                    </li>
+                  </ul>
+                </li>
+
+                <li>
+                    <a href="#">API Gateway Resources</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="/docs/providers/aws/r/api_gateway_account.html">aws_api_gateway_account</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/api_gateway_api_key.html">aws_api_gateway_api_key</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/api_gateway_authorizer.html">aws_api_gateway_authorizer</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/api_gateway_base_path_mapping.html">aws_api_gateway_base_path_mapping</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/api_gateway_client_certificate.html">aws_api_gateway_client_certificate</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/api_gateway_deployment.html">aws_api_gateway_deployment</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/api_gateway_documentation_part.html">aws_api_gateway_documentation_part</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/api_gateway_documentation_version.html">aws_api_gateway_documentation_version</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/api_gateway_domain_name.html">aws_api_gateway_domain_name</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/api_gateway_gateway_response.html">aws_api_gateway_gateway_response</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/api_gateway_integration.html">aws_api_gateway_integration</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/api_gateway_integration_response.html">aws_api_gateway_integration_response</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/api_gateway_method.html">aws_api_gateway_method</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/api_gateway_method_response.html">aws_api_gateway_method_response</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/api_gateway_method_settings.html">aws_api_gateway_method_settings</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/api_gateway_model.html">aws_api_gateway_model</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/api_gateway_request_validator.html">aws_api_gateway_request_validator</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/api_gateway_resource.html">aws_api_gateway_resource</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/api_gateway_rest_api.html">aws_api_gateway_rest_api</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/api_gateway_stage.html">aws_api_gateway_stage</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/api_gateway_usage_plan.html">aws_api_gateway_usage_plan</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/api_gateway_usage_plan_key.html">aws_api_gateway_usage_plan_key</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/api_gateway_vpc_link.html">aws_api_gateway_vpc_link</a>
+                        </li>
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">Application Autoscaling Resources</a>
+                    <ul class="nav">
+                      <li>
+                        <a href="/docs/providers/aws/r/appautoscaling_policy.html">aws_appautoscaling_policy</a>
+                      </li>
+                      <li>
+                        <a href="/docs/providers/aws/r/appautoscaling_scheduled_action.html">aws_appautoscaling_scheduled_action</a>
+                      </li>
+                      <li>
+                        <a href="/docs/providers/aws/r/appautoscaling_target.html">aws_appautoscaling_target</a>
+                      </li>
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">AppMesh Resources</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="/docs/providers/aws/r/appmesh_mesh.html">aws_appmesh_mesh</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/appmesh_route.html">aws_appmesh_route</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/appmesh_virtual_node.html">aws_appmesh_virtual_node</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/appmesh_virtual_router.html">aws_appmesh_virtual_router</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/appmesh_virtual_service.html">aws_appmesh_virtual_service</a>
+                        </li>
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">AppSync Resources</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="/docs/providers/aws/r/appsync_datasource.html">aws_appsync_datasource</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/appsync_function.html">aws_appsync_function</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/appsync_graphql_api.html">aws_appsync_graphql_api</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/appsync_api_key.html">aws_appsync_api_key</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/appsync_resolver.html">aws_appsync_resolver</a>
+                        </li>
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">Athena Resources</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="/docs/providers/aws/r/athena_database.html">aws_athena_database</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/r/athena_named_query.html">aws_athena_named_query</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/r/athena_workgroup.html">aws_athena_workgroup</a>
+                        </li>
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">Autoscaling Resources</a>
+                    <ul class="nav">
+                        <li>
+                          <a href="/docs/providers/aws/r/autoscaling_attachment.html">aws_autoscaling_attachment</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/autoscaling_group.html">aws_autoscaling_group</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/autoscaling_lifecycle_hooks.html">aws_autoscaling_lifecycle_hook</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/autoscaling_notification.html">aws_autoscaling_notification</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/autoscaling_policy.html">aws_autoscaling_policy</a>
+                        </li>
+
+                        <li>
+                          <a href="/docs/providers/aws/r/autoscaling_schedule.html">aws_autoscaling_schedule</a>
+                        </li>
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">Backup Resources</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="/docs/providers/aws/r/backup_plan.html">aws_backup_plan</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/backup_selection.html">aws_backup_selection</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/backup_vault.html">aws_backup_vault</a>
+                        </li>
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">Batch Resources</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="/docs/providers/aws/r/batch_compute_environment.html">aws_batch_compute_environment</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/batch_job_definition.html">aws_batch_job_definition</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/batch_job_queue.html">aws_batch_job_queue</a>
+                        </li>
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">Budgets Resources</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="/docs/providers/aws/r/budgets_budget.html">aws_budgets_budget</a>
+                        </li>
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">Cloud9 Resources</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="/docs/providers/aws/r/cloud9_environment_ec2.html">aws_cloud9_environment_ec2</a>
+                        </li>
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">CloudFormation Resources</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="/docs/providers/aws/r/cloudformation_stack.html">aws_cloudformation_stack</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/cloudformation_stack_set.html">aws_cloudformation_stack_set</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/cloudformation_stack_set_instance.html">aws_cloudformation_stack_set_instance</a>
+                        </li>
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">CloudFront Resources</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="/docs/providers/aws/r/cloudfront_distribution.html">aws_cloudfront_distribution</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/cloudfront_origin_access_identity.html">aws_cloudfront_origin_access_identity</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/cloudfront_public_key.html">aws_cloudfront_public_key</a>
+                        </li>
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">CloudHSM v2 Resources</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="/docs/providers/aws/r/cloudhsm_v2_cluster.html">aws_cloudhsm_v2_cluster</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/cloudhsm_v2_hsm.html">aws_cloudhsm_v2_hsm</a>
+                        </li>
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">CloudTrail Resources</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="/docs/providers/aws/r/cloudtrail.html">aws_cloudtrail</a>
+                        </li>
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">CloudWatch Resources</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="/docs/providers/aws/r/cloudwatch_dashboard.html">aws_cloudwatch_dashboard</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/cloudwatch_event_permission.html">aws_cloudwatch_event_permission</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/cloudwatch_event_rule.html">aws_cloudwatch_event_rule</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/cloudwatch_event_target.html">aws_cloudwatch_event_target</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/cloudwatch_log_destination.html">aws_cloudwatch_log_destination</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/cloudwatch_log_destination_policy.html">aws_cloudwatch_log_destination_policy</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/cloudwatch_log_group.html">aws_cloudwatch_log_group</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/cloudwatch_log_metric_filter.html">aws_cloudwatch_log_metric_filter</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/cloudwatch_log_resource_policy.html">aws_cloudwatch_log_resource_policy</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/cloudwatch_log_stream.html">aws_cloudwatch_log_stream</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/cloudwatch_log_subscription_filter.html">aws_cloudwatch_log_subscription_filter</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/cloudwatch_metric_alarm.html">aws_cloudwatch_metric_alarm</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+
+                <li>
+                    <a href="#">CodeBuild Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                            <a href="/docs/providers/aws/r/codebuild_project.html">aws_codebuild_project</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/codebuild_webhook.html">aws_codebuild_webhook</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+
+                <li>
+                    <a href="#">CodeCommit Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                            <a href="/docs/providers/aws/r/codecommit_repository.html">aws_codecommit_repository</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/codecommit_trigger.html">aws_codecommit_trigger</a>
+                        </li>
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">CodeDeploy Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                            <a href="/docs/providers/aws/r/codedeploy_app.html">aws_codedeploy_app</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/codedeploy_deployment_config.html">aws_codedeploy_deployment_config</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/codedeploy_deployment_group.html">aws_codedeploy_deployment_group</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">CodePipeline Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                            <a href="/docs/providers/aws/r/codepipeline.html">aws_codepipeline</a>
+                        </li>
+
+
+                        <li>
+                            <a href="/docs/providers/aws/r/codepipeline_webhook.html">aws_codepipeline_webhook</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">Cognito Resources</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="/docs/providers/aws/r/cognito_identity_pool.html">aws_cognito_identity_pool</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/cognito_identity_pool_roles_attachment.html">aws_cognito_identity_pool_roles_attachment</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/cognito_identity_provider.html">aws_cognito_identity_provider</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/cognito_resource_server.html">aws_cognito_resource_server</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/cognito_user_group.html">aws_cognito_user_group</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/cognito_user_pool.html">aws_cognito_user_pool</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/cognito_user_pool_client.html">aws_cognito_user_pool_client</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/cognito_user_pool_domain.html">aws_cognito_user_pool_domain</a>
+                        </li>
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">Config Resources</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="/docs/providers/aws/r/config_aggregate_authorization.html">aws_config_aggregate_authorization</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/config_configuration_aggregator.html">aws_config_configuration_aggregator</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/config_config_rule.html">aws_config_config_rule</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/config_configuration_recorder.html">aws_config_configuration_recorder</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/config_configuration_recorder_status.html">aws_config_configuration_recorder_status</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/config_delivery_channel.html">aws_config_delivery_channel</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">Cost and Usage Report Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                            <a href="/docs/providers/aws/r/cur_report_definition.html">aws_cur_report_definition</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">Data Lifecycle Manager (DLM) Resources</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="/docs/providers/aws/r/dlm_lifecycle_policy.html">aws_dlm_lifecycle_policy</a>
+                        </li>
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">Database Migration Service (DMS) Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                            <a href="/docs/providers/aws/r/dms_certificate.html">aws_dms_certificate</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/dms_endpoint.html">aws_dms_endpoint</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/dms_replication_instance.html">aws_dms_replication_instance</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/dms_replication_subnet_group.html">aws_dms_replication_subnet_group</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/dms_replication_task.html">aws_dms_replication_task</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">DataPipeline Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                            <a href="/docs/providers/aws/r/datapipeline_pipeline.html">aws_datapipeline_pipeline</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">DataSync Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                            <a href="/docs/providers/aws/r/datasync_agent.html">aws_datasync_agent</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/datasync_location_efs.html">aws_datasync_location_efs</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/datasync_location_nfs.html">aws_datasync_location_nfs</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/datasync_location_s3.html">aws_datasync_location_s3</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/datasync_task.html">aws_datasync_task</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">Device Farm Resources</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="/docs/providers/aws/r/devicefarm_project.html">aws_devicefarm_project</a>
+                        </li>
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">Directory Service Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                            <a href="/docs/providers/aws/r/directory_service_directory.html">aws_directory_service_directory</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/directory_service_conditional_forwarder.html">aws_directory_service_conditional_forwarder</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/directory_service_log_subscription.html">aws_directory_service_log_subscription</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">Direct Connect Resources</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="/docs/providers/aws/r/dx_bgp_peer.html">aws_dx_bgp_peer</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/dx_connection.html">aws_dx_connection</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/dx_connection_association.html">aws_dx_connection_association</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/dx_gateway.html">aws_dx_gateway</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/dx_gateway_association.html">aws_dx_gateway_association</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/dx_gateway_association_proposal.html">aws_dx_gateway_association_proposal</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/dx_hosted_private_virtual_interface.html">aws_dx_hosted_private_virtual_interface</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/dx_hosted_private_virtual_interface_accepter.html">aws_dx_hosted_private_virtual_interface_accepter</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/dx_hosted_public_virtual_interface.html">aws_dx_hosted_public_virtual_interface</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/dx_hosted_public_virtual_interface_accepter.html">aws_dx_hosted_public_virtual_interface_accepter</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/dx_lag.html">aws_dx_lag</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/dx_private_virtual_interface.html">aws_dx_private_virtual_interface</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/dx_public_virtual_interface.html">aws_dx_public_virtual_interface</a>
+                        </li>
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">DynamoDB Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                            <a href="/docs/providers/aws/r/dynamodb_global_table.html">aws_dynamodb_global_table</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/dynamodb_table.html">aws_dynamodb_table</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/dynamodb_table_item.html">aws_dynamodb_table_item</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+
+                <li>
+                    <a href="#">DynamoDB Accelerator (DAX) Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                            <a href="/docs/providers/aws/r/dax_cluster.html">aws_dax_cluster</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/dax_parameter_group.html">aws_dax_parameter_group</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/dax_subnet_group.html">aws_dax_subnet_group</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">DocumentDB Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                            <a href="/docs/providers/aws/r/docdb_cluster.html">aws_docdb_cluster</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/docdb_cluster_instance.html">aws_docdb_cluster_instance</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/docdb_cluster_parameter_group.html">aws_docdb_cluster_parameter_group</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/docdb_cluster_snapshot.html">aws_docdb_cluster_snapshot</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/docdb_subnet_group.html">aws_docdb_subnet_group</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">EC2 Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                            <a href="/docs/providers/aws/r/ami.html">aws_ami</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/ami_copy.html">aws_ami_copy</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/ami_from_instance.html">aws_ami_from_instance</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/ami_launch_permission.html">aws_ami_launch_permission</a>
+                        </li>
+
+                        <li>
+                          <a href="/docs/providers/aws/r/ebs_default_kms_key.html">aws_ebs_default_kms_key</a>
+                        </li>
+
+                        <li>
+                          <a href="/docs/providers/aws/r/ebs_encryption_by_default.html">aws_ebs_encryption_by_default</a>
+                        </li>
+
+                        <li>
+                          <a href="/docs/providers/aws/r/ebs_snapshot.html">aws_ebs_snapshot</a>
+                        </li>
+
+                        <li>
+                          <a href="/docs/providers/aws/r/ebs_snapshot_copy.html">aws_ebs_snapshot_copy</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/ebs_volume.html">aws_ebs_volume</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/ec2_capacity_reservation.html">aws_ec2_capacity_reservation</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/ec2_client_vpn_endpoint.html">aws_ec2_client_vpn_endpoint</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/ec2_client_vpn_network_association.html">aws_ec2_client_vpn_network_association</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/ec2_fleet.html">aws_ec2_fleet</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/ec2_transit_gateway.html">aws_ec2_transit_gateway</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/ec2_transit_gateway_route.html">aws_ec2_transit_gateway_route</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/ec2_transit_gateway_route_table.html">aws_ec2_transit_gateway_route_table</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/ec2_transit_gateway_route_table_association.html">aws_ec2_transit_gateway_route_table_association</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/ec2_transit_gateway_route_table_propagation.html">aws_ec2_transit_gateway_route_table_propagation</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/ec2_transit_gateway_vpc_attachment.html">aws_ec2_transit_gateway_vpc_attachment</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/ec2_transit_gateway_vpc_attachment_accepter.html">aws_ec2_transit_gateway_vpc_attachment_accepter</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/eip.html">aws_eip</a>
+                        </li>
+
+                        <li>
+                          <a href="/docs/providers/aws/r/eip_association.html">aws_eip_association</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/instance.html">aws_instance</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/key_pair.html">aws_key_pair</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/launch_configuration.html">aws_launch_configuration</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/launch_template.html">aws_launch_template</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/placement_group.html">aws_placement_group</a>
+                        </li>
+
+                        <li>
+                          <a href="/docs/providers/aws/r/snapshot_create_volume_permission.html">aws_snapshot_create_volume_permission</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/spot_datafeed_subscription.html">aws_spot_datafeed_subscription</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/spot_fleet_request.html">aws_spot_fleet_request</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/spot_instance_request.html">aws_spot_instance_request</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/volume_attachment.html">aws_volume_attachment</a>
+                        </li>
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">ECR Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                            <a href="/docs/providers/aws/r/ecr_lifecycle_policy.html">aws_ecr_lifecycle_policy</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/ecr_repository.html">aws_ecr_repository</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/ecr_repository_policy.html">aws_ecr_repository_policy</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+
+                <li>
+                    <a href="#">ECS Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                            <a href="/docs/providers/aws/r/ecs_cluster.html">aws_ecs_cluster</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/ecs_service.html">aws_ecs_service</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/ecs_task_definition.html">aws_ecs_task_definition</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">EFS Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                            <a href="/docs/providers/aws/r/efs_file_system.html">aws_efs_file_system</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/efs_mount_target.html">aws_efs_mount_target</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+
+                <li>
+                    <a href="#">EKS Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                            <a href="/docs/providers/aws/r/eks_cluster.html">aws_eks_cluster</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+
+                <li>
+                    <a href="#">ElastiCache Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                            <a href="/docs/providers/aws/r/elasticache_cluster.html">aws_elasticache_cluster</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/elasticache_parameter_group.html">aws_elasticache_parameter_group</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/elasticache_replication_group.html">aws_elasticache_replication_group</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/elasticache_security_group.html">aws_elasticache_security_group</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/elasticache_subnet_group.html">aws_elasticache_subnet_group</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+
+                <li>
+                    <a href="#">Elastic Beanstalk Resources</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="/docs/providers/aws/r/elastic_beanstalk_application.html">aws_elastic_beanstalk_application</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/elastic_beanstalk_application_version.html">aws_elastic_beanstalk_application_version</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/elastic_beanstalk_configuration_template.html">aws_elastic_beanstalk_configuration_template</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/elastic_beanstalk_environment.html">aws_elastic_beanstalk_environment</a>
+                        </li>
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">Elastic Load Balancing (ELB Classic) Resources</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="/docs/providers/aws/r/app_cookie_stickiness_policy.html">aws_app_cookie_stickiness_policy</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/elb.html">aws_elb</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/elb_attachment.html">aws_elb_attachment</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/lb_cookie_stickiness_policy.html">aws_lb_cookie_stickiness_policy</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/lb_ssl_negotiation_policy.html">aws_lb_ssl_negotiation_policy</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/load_balancer_backend_server_policy.html">aws_load_balancer_backend_server_policy</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/load_balancer_listener_policy.html">aws_load_balancer_listener_policy</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/load_balancer_policy.html">aws_load_balancer_policy</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/proxy_protocol_policy.html">aws_proxy_protocol_policy</a>
+                        </li>
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">Elastic Load Balancing v2 (ALB/NLB) Resources</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="/docs/providers/aws/r/lb.html">aws_lb</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/lb_listener.html">aws_lb_listener</a>
+                        </li>
+
+                        <li>
+                          <a href="/docs/providers/aws/r/lb_listener_certificate.html">aws_lb_listener_certificate</a>
+                        </li>
+
+                        <li>
+                          <a href="/docs/providers/aws/r/lb_listener_rule.html">aws_lb_listener_rule</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/lb_target_group.html">aws_lb_target_group</a>
+                        </li>
+
+                        <li>
+                          <a href="/docs/providers/aws/r/lb_target_group_attachment.html">aws_lb_target_group_attachment</a>
+                        </li>
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">Elastic Map Reduce (EMR) Resources</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="/docs/providers/aws/r/emr_cluster.html">aws_emr_cluster</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/emr_instance_group.html">aws_emr_instance_group</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/emr_security_configuration.html">aws_emr_security_configuration</a>
+                        </li>
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">ElasticSearch Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                            <a href="/docs/providers/aws/r/elasticsearch_domain.html">aws_elasticsearch_domain</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/elasticsearch_domain_policy.html">aws_elasticsearch_domain_policy</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">Elastic Transcoder Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                            <a href="/docs/providers/aws/r/elastic_transcoder_pipeline.html">aws_elastictranscoder_pipeline</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/elastic_transcoder_preset.html">aws_elastictranscoder_preset</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">Gamelift Resources</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="/docs/providers/aws/r/gamelift_alias.html">aws_gamelift_alias</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/gamelift_build.html">aws_gamelift_build</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/gamelift_fleet.html">aws_gamelift_fleet</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/gamelift_game_session_queue.html">aws_gamelift_game_session_queue</a>
+                        </li>
+                    </ul>
+                 </li>
+
+                <li>
+                    <a href="#">Glacier Resources</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="/docs/providers/aws/r/glacier_vault.html">aws_glacier_vault</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/glacier_vault_lock.html">aws_glacier_vault_lock</a>
+                        </li>
+                    </ul>
+                 </li>
+
+                <li>
+                    <a href="#">Global Accelerator Resources</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="/docs/providers/aws/r/globalaccelerator_accelerator.html">aws_globalaccelerator_accelerator</a>
+                        </li>
+                    </ul>
+                    <ul class="nav">
+                        <li>
+                            <a href="/docs/providers/aws/r/globalaccelerator_endpoint_group.html">aws_globalaccelerator_endpoint_group</a>
+                        </li>
+                    </ul>
+                    <ul class="nav">
+                        <li>
+                            <a href="/docs/providers/aws/r/globalaccelerator_listener.html">aws_globalaccelerator_listener</a>
+                        </li>
+                    </ul>
+                 </li>
+
+                 <li>
+                    <a href="#">Glue Resources</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="/docs/providers/aws/r/glue_catalog_database.html">aws_glue_catalog_database</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/glue_catalog_table.html">aws_glue_catalog_table</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/glue_classifier.html">aws_glue_classifier</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/glue_connection.html">aws_glue_connection</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/glue_crawler.html">aws_glue_crawler</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/glue_job.html">aws_glue_job</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/glue_security_configuration.html">aws_glue_security_configuration</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/glue_trigger.html">aws_glue_trigger</a>
+                        </li>
+                    </ul>
+                 </li>
+
+                <li>
+                    <a href="#">GuardDuty Resources</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="/docs/providers/aws/r/guardduty_detector.html">aws_guardduty_detector</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/guardduty_invite_accepter.html">aws_guardduty_invite_accepter</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/guardduty_ipset.html">aws_guardduty_ipset</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/guardduty_member.html">aws_guardduty_member</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/guardduty_threatintelset.html">aws_guardduty_threatintelset</a>
+                        </li>
+                    </ul>
+                 </li>
+
+                <li>
+                    <a href="#">IAM Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                            <a href="/docs/providers/aws/r/iam_access_key.html">aws_iam_access_key</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/iam_account_alias.html">aws_iam_account_alias</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/iam_account_password_policy.html">aws_iam_account_password_policy</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/iam_group.html">aws_iam_group</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/iam_group_membership.html">aws_iam_group_membership</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/iam_group_policy.html">aws_iam_group_policy</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/iam_group_policy_attachment.html">aws_iam_group_policy_attachment</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/iam_instance_profile.html">aws_iam_instance_profile</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/iam_openid_connect_provider.html">aws_iam_openid_connect_provider</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/iam_policy.html">aws_iam_policy</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/iam_policy_attachment.html">aws_iam_policy_attachment</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/iam_role.html">aws_iam_role</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/iam_role_policy.html">aws_iam_role_policy</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/iam_role_policy_attachment.html">aws_iam_role_policy_attachment</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/iam_saml_provider.html">aws_iam_saml_provider</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/iam_server_certificate.html">aws_iam_server_certificate</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/iam_service_linked_role.html">aws_iam_service_linked_role</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/iam_user.html">aws_iam_user</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/iam_user_group_membership.html">aws_iam_user_group_membership</a>
+                        </li>
+
+                        <li>
+                          <a href="/docs/providers/aws/r/iam_user_login_profile.html">aws_iam_user_login_profile</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/iam_user_policy.html">aws_iam_user_policy</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/iam_user_policy_attachment.html">aws_iam_user_policy_attachment</a>
+                        </li>
+
+                        <li>
+                          <a href="/docs/providers/aws/r/iam_user_ssh_key.html">aws_iam_user_ssh_key</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">IoT Resources</a>
+                    <ul class="nav">
+
+                    <li>
+                      <a href="/docs/providers/aws/r/iot_certificate.html">aws_iot_certificate</a>
+                    </li>
+
+                    <li>
+                      <a href="/docs/providers/aws/r/iot_policy.html">aws_iot_policy</a>
+                    </li>
+
+                    <li>
+                      <a href="/docs/providers/aws/r/iot_policy_attachment.html">aws_iot_policy_attachment</a>
+                    </li>
+
+                    <li>
+                        <a href="/docs/providers/aws/r/iot_topic_rule.html">aws_iot_topic_rule</a>
+                    </li>
+                    <li>
+                        <a href="/docs/providers/aws/r/iot_thing.html">aws_iot_thing</a>
+                    </li>
+
+                    <li>
+                        <a href="/docs/providers/aws/r/iot_thing_principal_attachment.html">aws_iot_thing_principal_attachment</a>
+                    </li>
+
+                    <li>
+                        <a href="/docs/providers/aws/r/iot_thing_type.html">aws_iot_thing_type</a>
+                    </li>
+
+                    <li>
+                        <a href="/docs/providers/aws/r/iot_role_alias.html">aws_iot_role_alias</a>
+                    </li>
+                  </ul>
+                </li>
+
+                <li>
+                  <a href="#">Inspector Resources</a>
+                  <ul class="nav">
+
+                    <li>
+                      <a href="/docs/providers/aws/r/inspector_assessment_target.html">aws_inspector_assessment_target</a>
+                    </li>
+
+                    <li>
+                      <a href="/docs/providers/aws/r/inspector_assessment_template.html">aws_inspector_assessment_template</a>
+                    </li>
+
+                    <li>
+                      <a href="/docs/providers/aws/r/inspector_resource_group.html">aws_inspector_resource_group</a>
+                    </li>
+
+                  </ul>
+                </li>
+
+
+                <li>
+                    <a href="#">Kinesis Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                            <a href="/docs/providers/aws/r/kinesis_analytics_application.html">aws_kinesis_analytics_application</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/kinesis_stream.html">aws_kinesis_stream</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+              <li>
+                <a href="#">Kinesis Firehose Resources</a>
+                <ul class="nav">
+
+                  <li>
+                    <a href="/docs/providers/aws/r/kinesis_firehose_delivery_stream.html">aws_kinesis_firehose_delivery_stream</a>
+                  </li>
+
+                </ul>
+              </li>
+
+              <li>
+                <a href="#">KMS Resources</a>
+                <ul class="nav">
+
+                  <li>
+                    <a href="/docs/providers/aws/r/kms_alias.html">aws_kms_alias</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/providers/aws/r/kms_external_key.html">aws_kms_external_key</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/providers/aws/r/kms_grant.html">aws_kms_grant</a>
+                  </li>
+
+                  <li>
+                      <a href="/docs/providers/aws/r/kms_ciphertext.html">aws_kms_ciphertext</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/providers/aws/r/kms_key.html">aws_kms_key</a>
+                  </li>
+
+                </ul>
+              </li>
+
+              <li>
+                  <a href="#">Lambda Resources</a>
+                  <ul class="nav">
+                      <li>
+                          <a href="/docs/providers/aws/r/lambda_alias.html">aws_lambda_alias</a>
+                      </li>
+                      <li>
+                          <a href="/docs/providers/aws/r/lambda_event_source_mapping.html">aws_lambda_event_source_mapping</a>
+                      </li>
+                      <li>
+                          <a href="/docs/providers/aws/r/lambda_function.html">aws_lambda_function</a>
+                      </li>
+                      <li>
+                          <a href="/docs/providers/aws/r/lambda_layer_version.html">aws_lambda_layer_version</a>
+                      </li>
+                      <li>
+                          <a href="/docs/providers/aws/r/lambda_permission.html">aws_lambda_permission</a>
+                      </li>
+                  </ul>
+              </li>
+
+                <li>
+                    <a href="#">License Manager Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                            <a href="/docs/providers/aws/r/licensemanager_association.html">aws_licensemanager_association</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/licensemanager_license_configuration.html">aws_licensemanager_license_configuration</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">Lightsail Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                          <a href="/docs/providers/aws/r/lightsail_domain.html">aws_lightsail_domain</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/lightsail_instance.html">aws_lightsail_instance</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/lightsail_key_pair.html">aws_lightsail_key_pair</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/lightsail_static_ip.html">aws_lightsail_static_ip</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/lightsail_static_ip_attachment.html">aws_lightsail_static_ip_attachment</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">Macie Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                            <a href="/docs/providers/aws/r/macie_member_account_association.html">aws_macie_member_account_association</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/macie_s3_bucket_association.html">aws_macie_s3_bucket_association</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">MQ Resources</a>
+                    <ul class="nav">
+                        <li>
+                          <a href="/docs/providers/aws/r/mq_broker.html">aws_mq_broker</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/mq_configuration.html">aws_mq_configuration</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">MediaPackage Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                          <a href="/docs/providers/aws/r/media_package_channel.html">aws_media_package_channel</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">MediaStore Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                          <a href="/docs/providers/aws/r/media_store_container.html">aws_media_store_container</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/r/media_store_container_policy.html">aws_media_store_container_policy</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">Managed Streaming for Kafka (MSK) Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                            <a href="/docs/providers/aws/r/msk_cluster.html">aws_msk_cluster</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/msk_configuration.html">aws_msk_configuration</a>
+                        </li>
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">Neptune Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                            <a href="/docs/providers/aws/r/neptune_parameter_group.html">aws_neptune_parameter_group</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/neptune_subnet_group.html">aws_neptune_subnet_group</a>
+                        </li>
+
+                         <li>
+                            <a href="/docs/providers/aws/r/neptune_cluster_parameter_group.html">aws_neptune_cluster_parameter_group</a>
+                        </li>
+
+                         <li>
+                            <a href="/docs/providers/aws/r/neptune_cluster.html">aws_neptune_cluster</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/neptune_cluster_instance.html">aws_neptune_cluster_instance</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/neptune_cluster_snapshot.html">aws_neptune_cluster_snapshot</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/neptune_event_subscription.html">aws_neptune_event_subscription</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">OpsWorks Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                            <a href="/docs/providers/aws/r/opsworks_application.html">aws_opsworks_application</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/opsworks_custom_layer.html">aws_opsworks_custom_layer</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/opsworks_ganglia_layer.html">aws_opsworks_ganglia_layer</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/opsworks_haproxy_layer.html">aws_opsworks_haproxy_layer</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/opsworks_instance.html">aws_opsworks_instance</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/opsworks_java_app_layer.html">aws_opsworks_java_app_layer</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/opsworks_memcached_layer.html">aws_opsworks_memcached_layer</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/opsworks_mysql_layer.html">aws_opsworks_mysql_layer</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/opsworks_nodejs_app_layer.html">aws_opsworks_nodejs_app_layer</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/opsworks_permission.html">aws_opsworks_permission</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/opsworks_php_app_layer.html">aws_opsworks_php_app_layer</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/opsworks_rails_app_layer.html">aws_opsworks_rails_app_layer</a>
+                        </li>
+
+                        <li>
+                          <a href="/docs/providers/aws/r/opsworks_rds_db_instance.html">aws_opsworks_rds_db_instance</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/opsworks_stack.html">aws_opsworks_stack</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/opsworks_static_web_layer.html">aws_opsworks_static_web_layer</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/opsworks_user_profile.html">aws_opsworks_user_profile</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">Organizations Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                            <a href="/docs/providers/aws/r/organizations_account.html">aws_organizations_account</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/organizations_organization.html">aws_organizations_organization</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/organizations_organizational_unit.html">aws_organizations_organizational_unit</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/organizations_policy.html">aws_organizations_policy</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/organizations_policy_attachment.html">aws_organizations_policy_attachment</a>
+                        </li>
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">Pinpoint Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                            <a href="/docs/providers/aws/r/pinpoint_app.html">aws_pinpoint_app</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/pinpoint_adm_channel.html">aws_pinpoint_adm_channel</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/pinpoint_apns_channel.html">aws_pinpoint_apns_channel</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/pinpoint_apns_sandbox_channel.html">aws_pinpoint_apns_sandbox_channel</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/pinpoint_apns_voip_channel.html">aws_pinpoint_apns_voip_channel</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/pinpoint_apns_voip_sandbox_channel.html">aws_pinpoint_apns_voip_sandbox_channel</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/pinpoint_baidu_channel.html">aws_pinpoint_baidu_channel</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/pinpoint_email_channel.html">aws_pinpoint_email_channel</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/pinpoint_event_stream.html">aws_pinpoint_event_stream</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/pinpoint_gcm_channel.html">aws_pinpoint_gcm_channel</a>
+                        </li>
+                        <li>
+                            <a href="/docs/providers/aws/r/pinpoint_sms_channel.html">aws_pinpoint_sms_channel</a>
+                        </li>
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">QuickSight Resources</a>
+                    <ul class="nav">
+                        <li>
+                        <a href="/docs/providers/aws/r/quicksight_group.html">aws_quicksight_group</a>
+                        </li>
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">RAM Resources</a>
+                    <ul class="nav">
+                        <li>
+                        <a href="/docs/providers/aws/r/ram_principal_association.html">aws_ram_principal_association</a>
+                        </li>
+                        <li>
+                        <a href="/docs/providers/aws/r/ram_resource_association.html">aws_ram_resource_association</a>
+                        </li>
+                        <li>
+                        <a href="/docs/providers/aws/r/ram_resource_share.html">aws_ram_resource_share</a>
+                        </li>
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">RDS Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                          <a href="/docs/providers/aws/r/db_cluster_snapshot.html">aws_db_cluster_snapshot</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/db_event_subscription.html">aws_db_event_subscription</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/db_instance.html">aws_db_instance</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/db_instance_role_association.html">aws_db_instance_role_association</a>
+                        </li>
+
+                        <li>
+                          <a href="/docs/providers/aws/r/db_option_group.html">aws_db_option_group</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/db_parameter_group.html">aws_db_parameter_group</a>
+>>>>>>> Adding link to aws_elasticsearch_domain datasource docs page
                         </li>
                         <li>
                             <a href="/docs/providers/aws/d/availability_zone.html">aws_availability_zone</a>

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -30,9 +30,6 @@
                     <a href="#">Provider Data Sources</a>
                     <ul class="nav">
                         <li>
-<<<<<<< HEAD
-                            <a href="/docs/providers/aws/d/arn.html">aws_arn</a>
-=======
                             <a href="/docs/providers/aws/d/acm_certificate.html">aws_acm_certificate</a>
                         </li>
                         <li>
@@ -2194,7 +2191,6 @@
 
                         <li>
                             <a href="/docs/providers/aws/r/db_parameter_group.html">aws_db_parameter_group</a>
->>>>>>> Adding link to aws_elasticsearch_domain datasource docs page
                         </li>
                         <li>
                             <a href="/docs/providers/aws/d/availability_zone.html">aws_availability_zone</a>

--- a/website/docs/d/elasticsearch_domain.html.markdown
+++ b/website/docs/d/elasticsearch_domain.html.markdown
@@ -1,0 +1,57 @@
+---
+layout: "aws"
+page_title: "AWS: aws_elasticsearch_domain"
+sidebar_current: "docs-aws-datasource-elasticsearch-domain"
+description: |-
+  Get information on an ElasticSearch Domain resource.
+---
+
+# aws_elasticsearch_domain
+
+Use this data source to get information about an ElasticSearch Domain
+
+## Example Usage
+
+```hcl
+data "aws_elasticsearch_domain" "my_domain" {
+  domain_name = "my-domain-name"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domain_name` – (Required) Name of the domain.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `domain_id` – Unique identifier for the domain.
+* `endpoint` – Domain-specific endpoint used to submit index, search, and data upload requests.
+* `created` – Status of the creation of the domain.
+* `deleted` – Status of the deletion of the domain.
+* `access_policies` – The policy document attached to the domain.
+* `processing` – Status of a configuration change in the domain.
+* `elasticsearch_version` – ElasticSearch version for the domain.
+* `arn` – The Amazon Resource Name (ARN) of the domain.
+* `cluster_config` - Cluster configuration of the domain.
+** `instance_type` - Instance type of data nodes in the cluster.
+** `instance_count` - Number of instances in the cluster.
+** `dedicated_master_enabled` - Indicates whether dedicated master nodes are enabled for the cluster.
+** `dedicated_master_type` - Instance type of the dedicated master nodes in the cluster.
+** `dedicated_master_count` - Number of dedicated master nodes in the cluster.
+** `zone_awareness_enabled` - Indicates whether zone awareness is enabled.
+* `ebs_options` - EBS Options for the instances in the domain.
+** `ebs_enabled` - Whether EBS volumes are attached to data nodes in the domain.
+** `volume_type` - The type of EBS volumes attached to data nodes.
+** `volume_size` - The size of EBS volumes attached to data nodes (in GB).
+** `iops` - The baseline input/output (I/O) performance of EBS volumes
+	attached to data nodes.
+* `snapshot_options` – Domain snapshot related options.
+** `automated_snapshot_start_hour` - Hour during which the service takes an automated daily
+	snapshot of the indices in the domain.
+* `advanced_options` - Key-value string pairs to specify advanced configuration options.
+* `tags` - The tags assigned to the domain.

--- a/website/docs/d/elasticsearch_domain.html.markdown
+++ b/website/docs/d/elasticsearch_domain.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # aws_elasticsearch_domain
 
-Use this data source to get information about an ElasticSearch Domain
+Use this data source to get information about an Elasticsearch Domain
 
 ## Example Usage
 
@@ -31,6 +31,7 @@ The following attributes are exported:
 
 * `domain_id` – Unique identifier for the domain.
 * `endpoint` – Domain-specific endpoint used to submit index, search, and data upload requests.
+* `kibana_endpoint` - Domain-specific endpoint used to access the Kibana application.
 * `created` – Status of the creation of the domain.
 * `deleted` – Status of the deletion of the domain.
 * `access_policies` – The policy document attached to the domain.
@@ -50,6 +51,25 @@ The following attributes are exported:
 ** `volume_size` - The size of EBS volumes attached to data nodes (in GB).
 ** `iops` - The baseline input/output (I/O) performance of EBS volumes
 	attached to data nodes.
+* `encryption_at_rest` - Domain encryption at rest related options.
+** `enabled` - Whether encryption at rest is enabled in the domain.
+** `kms_key_id` - The KMS key id used to encrypt data at rest.
+* `node_to_node_encryption` - Domain in transit encryption related options.
+** `enabled` - Whether node to node encryption is enabled.
+* `vpc_options` - VPC Options for private Elasticsearch domains.
+** `availability_zones` - The availability zones used by the domain.
+** `security_group_ids` - The security groups used by the domain.
+** `subnet_ids` - The subnets used by the domain.
+** `vpc_id` - The VPC used by the domain.
+* `log_publishing_options` - Domain log publishing related options.
+** `log_type` - The type of Elasticsearch log being published.
+** `cloudwatch_log_group_arn` - The CloudWatch Log Group where the logs are published.
+** `enabled` - Whether log publishing is enabled.
+* `cognito_options` - Domain Amazon Cognito Authentication options for Kibana.
+** `enabled` - Whether Amazon Cognito Authentication is enabled.
+** `user_pool_id` - The Cognito User pool used by the domain.
+** `identity_pool_id` - The Cognito Identity pool used by the domain.
+** `role_arn` - The IAM Role with the AmazonESCognitoAccess policy attached.
 * `snapshot_options` – Domain snapshot related options.
 ** `automated_snapshot_start_hour` - Hour during which the service takes an automated daily
 	snapshot of the indices in the domain.

--- a/website/docs/d/elasticsearch_domain.html.markdown
+++ b/website/docs/d/elasticsearch_domain.html.markdown
@@ -45,6 +45,8 @@ The following attributes are exported:
 ** `dedicated_master_type` - Instance type of the dedicated master nodes in the cluster.
 ** `dedicated_master_count` - Number of dedicated master nodes in the cluster.
 ** `zone_awareness_enabled` - Indicates whether zone awareness is enabled.
+** `zone_awareness_config` - Configuration block containing zone awareness settings.
+*** `availability_zone_count` - Number of availability zones used.
 * `ebs_options` - EBS Options for the instances in the domain.
 ** `ebs_enabled` - Whether EBS volumes are attached to data nodes in the domain.
 ** `volume_type` - The type of EBS volumes attached to data nodes.

--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -228,7 +228,7 @@ The following arguments are supported:
 
 **ebs_options** supports the following attributes:
 
-* `ebs_enabled` - (Required) Whether EBS volumes are attached to data nodes in the domain
+* `ebs_enabled` - (Required) Whether EBS volumes are attached to data nodes in the domain.
 * `volume_type` - (Optional) The type of EBS volumes attached to data nodes.
 * `volume_size` - The size of EBS volumes attached to data nodes (in GB).
 **Required** if `ebs_enabled` is set to `true`.


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Fixes #7899

This PR adds an AWS ElasticsearchDomain data source that can be used to retrieve any of the attributes returned by the **describe-elasticsearch-domain** API call or tags returned by the **list-tags** API call, by simply providing the *domain_name*.

I've successfully ran the acceptance test (targeting my new test only).  However, I was unable to add a check for the tags.

I'm also including some missing punctuation in the AWS ElasticsearchDomain **resource** documentation page that I noticed.