### PR TITLE
website: Add AWS documentation link to elastic_beanstalk_solution_stack datasource

### DIFF
--- a/website/docs/d/elastic_beanstalk_solution_stack.html.markdown
+++ b/website/docs/d/elastic_beanstalk_solution_stack.html.markdown
@@ -26,7 +26,8 @@ data "aws_elastic_beanstalk_solution_stack" "multi_docker" {
 recent solution stack.
 
 * `name_regex` - A regex string to apply to the solution stack list returned
-by AWS.
+by AWS. See [Elastic Beanstalk Supported Platforms][beanstalk-platforms] from
+AWS documentation for reference solution stack names.
 
 ~> **NOTE:** If more or less than a single match is returned by the search,
 Terraform will fail. Ensure that your search is specific enough to return
@@ -35,3 +36,5 @@ a single solution stack, or use `most_recent` to choose the most recent one.
 ## Attributes Reference
 
 * `name` - The name of the solution stack.
+
+[beanstalk-platforms]: http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/concepts.platforms.html "AWS Elastic Beanstalk Supported Platforms documentation"


### PR DESCRIPTION
Link to Elastic Beanstalk Supported Platforms documentation for solution
stack name reference.