### PR TITLE
Error in aws_api_gateway_integration.integration documentation

### DIFF
--- a/website/docs/r/api_gateway_integration.html.markdown
+++ b/website/docs/r/api_gateway_integration.html.markdown
@@ -81,7 +81,7 @@ resource "aws_api_gateway_method" "method" {
 
 resource "aws_api_gateway_integration" "integration" {
   rest_api_id             = "${aws_api_gateway_rest_api.api.id}"
-  resource_id             = "${aws_api_gateway_rest_api.api.root_resource_id}"
+  resource_id             = "${aws_api_gateway_resource.resource.id}"
   http_method             = "${aws_api_gateway_method.method.http_method}"
   integration_http_method = "POST"
   type                    = "AWS"


### PR DESCRIPTION
There is an error in the example, is not working properly as is. The api gateway integration is not pointing to the correct resource.

Terraform Version
v0.10.7

Debug Output
```
aws_api_gateway_integration.integration: Creating...
  cache_namespace:         "" => "<computed>"
  http_method:             "" => "GET"
  integration_http_method: "" => "POST"
  passthrough_behavior:    "" => "<computed>"
  resource_id:             "" => "puerg6ern4"
  rest_api_id:             "" => "iol8uvp2aa"
  type:                    "" => "AWS"
  uri:                     "" => "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:920915553078:function:wh_nightly_build/invocations"
Error applying plan:

1 error(s) occurred:

* aws_api_gateway_integration.integration: 1 error(s) occurred:

* aws_api_gateway_integration.integration: Error creating API Gateway Integration: NotFoundException: Invalid Method identifier specified
        status code: 404, request id: 7f56765f-b004-11e7-abb6-0990d7052fb7
```


