### PR TITLE
Log complete error while creating Kinesis Firehose Delivery Stream

### DIFF
--- a/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -898,7 +898,7 @@ func resourceAwsKinesisFirehoseDeliveryStreamCreate(d *schema.ResourceData, meta
 	})
 	if err != nil {
 		if awsErr, ok := lastError.(awserr.Error); ok {
-			return fmt.Errorf("[WARN] Error creating Kinesis Firehose Delivery Stream: \"%s\", code: \"%s\"", awsErr.Message(), awsErr.Code())
+			return fmt.Errorf("[WARN] Error creating Kinesis Firehose Delivery Stream: %s", awsErr.Error())
 		}
 		return err
 	}


### PR DESCRIPTION
Fixes #1122 

Here's how this changes the log when Redshift Destination password length is less than 6.

## Before:
```
Error applying plan:

1 error(s) occurred:

* module.kinesis_firehose_test_stream.aws_kinesis_firehose_delivery_stream.kinesis_firehose_redshift: 1 error(s) occurred:

* aws_kinesis_firehose_delivery_stream.kinesis_firehose_redshift: [WARN] Error creating Kinesis Firehose Delivery Stream: "1 validation error(s) found.", code: "InvalidParameter"

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.
```

## After:
```
Error applying plan:

1 error(s) occurred:

* module.kinesis_firehose_test_stream.aws_kinesis_firehose_delivery_stream.kinesis_firehose_redshift: 1 error(s) occurred:

* aws_kinesis_firehose_delivery_stream.kinesis_firehose_redshift: [WARN] Error creating Kinesis Firehose Delivery Stream: InvalidParameter: 1 validation error(s) found.
- minimum field size of 6, CreateDeliveryStreamInput.RedshiftDestinationConfiguration.Password.


Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.```