### PR TITLE
Check VPC array size

### DIFF
--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -1477,6 +1477,7 @@ func readSecurityGroups(d *schema.ResourceData, instance *ec2.Instance, conn *ec
 	if err != nil {
 		log.Printf("[WARN] Unable to describe VPC %q: %s", *instance.VpcId, err)
 	} else if len(out.Vpcs) == 0 {
+		// This may happen in Eucalyptus Cloud
 		log.Printf("[WARN] Unable to retrieve VPCs")
 	} else {
 		isInDefaultVpc := *out.Vpcs[0].IsDefault

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -1476,6 +1476,8 @@ func readSecurityGroups(d *schema.ResourceData, instance *ec2.Instance, conn *ec
 	})
 	if err != nil {
 		log.Printf("[WARN] Unable to describe VPC %q: %s", *instance.VpcId, err)
+	} else if len(out.Vpcs) == 0 {
+		log.Printf("[WARN] Unable to retrieve VPCs")
 	} else {
 		isInDefaultVpc := *out.Vpcs[0].IsDefault
 		useID = !isInDefaultVpc


### PR DESCRIPTION
This missing check causes a terraform crash when used with Eucalyptus Cloud.
I know that supporting AWS clones is not a target for this project but the fix here just increase robustness of the implementation IMO.
