### PR TITLE
Load balancer fixes

### DIFF
--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -122,7 +122,6 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 						"path": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							Default:      "/",
 							ValidateFunc: validateAwsLbTargetGroupHealthCheckPath,
 						},
 
@@ -146,27 +145,26 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 						"timeout": {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							Default:      5,
+							Default:      10,
 							ValidateFunc: validateAwsLbTargetGroupHealthCheckTimeout,
 						},
 
 						"healthy_threshold": {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							Default:      5,
+							Default:      3,
 							ValidateFunc: validateAwsLbTargetGroupHealthCheckHealthyThreshold,
 						},
 
 						"matcher": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Default:  "200",
 						},
 
 						"unhealthy_threshold": {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							Default:      2,
+							Default:      3,
 							ValidateFunc: validateAwsLbTargetGroupHealthCheckHealthyThreshold,
 						},
 					},
@@ -201,14 +199,17 @@ func resourceAwsLbTargetGroupCreate(d *schema.ResourceData, meta interface{}) er
 		healthCheck := healthChecks[0].(map[string]interface{})
 
 		params.HealthCheckIntervalSeconds = aws.Int64(int64(healthCheck["interval"].(int)))
-		params.HealthCheckPath = aws.String(healthCheck["path"].(string))
 		params.HealthCheckPort = aws.String(healthCheck["port"].(string))
 		params.HealthCheckProtocol = aws.String(healthCheck["protocol"].(string))
-		params.HealthCheckTimeoutSeconds = aws.Int64(int64(healthCheck["timeout"].(int)))
 		params.HealthyThresholdCount = aws.Int64(int64(healthCheck["healthy_threshold"].(int)))
-		params.UnhealthyThresholdCount = aws.Int64(int64(healthCheck["unhealthy_threshold"].(int)))
-		params.Matcher = &elbv2.Matcher{
-			HttpCode: aws.String(healthCheck["matcher"].(string)),
+
+		if *params.Protocol != "TCP" {
+			params.HealthCheckTimeoutSeconds = aws.Int64(int64(healthCheck["timeout"].(int)))
+			params.HealthCheckPath = aws.String(healthCheck["path"].(string))
+			params.Matcher = &elbv2.Matcher{
+				HttpCode: aws.String(healthCheck["matcher"].(string)),
+			}
+			params.UnhealthyThresholdCount = aws.Int64(int64(healthCheck["unhealthy_threshold"].(int)))
 		}
 	}
 
@@ -264,17 +265,23 @@ func resourceAwsLbTargetGroupUpdate(d *schema.ResourceData, meta interface{}) er
 			healthCheck := healthChecks[0].(map[string]interface{})
 
 			params = &elbv2.ModifyTargetGroupInput{
-				TargetGroupArn:             aws.String(d.Id()),
-				HealthCheckIntervalSeconds: aws.Int64(int64(healthCheck["interval"].(int))),
-				HealthCheckPath:            aws.String(healthCheck["path"].(string)),
-				HealthCheckPort:            aws.String(healthCheck["port"].(string)),
-				HealthCheckProtocol:        aws.String(healthCheck["protocol"].(string)),
-				HealthCheckTimeoutSeconds:  aws.Int64(int64(healthCheck["timeout"].(int))),
-				HealthyThresholdCount:      aws.Int64(int64(healthCheck["healthy_threshold"].(int))),
-				UnhealthyThresholdCount:    aws.Int64(int64(healthCheck["unhealthy_threshold"].(int))),
-				Matcher: &elbv2.Matcher{
+				TargetGroupArn:        aws.String(d.Id()),
+				HealthCheckPort:       aws.String(healthCheck["port"].(string)),
+				HealthCheckProtocol:   aws.String(healthCheck["protocol"].(string)),
+				HealthyThresholdCount: aws.Int64(int64(healthCheck["healthy_threshold"].(int))),
+			}
+
+			healthCheckProtocol := strings.ToLower(healthCheck["protocol"].(string))
+
+			if healthCheckProtocol != "tcp" {
+				params.Matcher = &elbv2.Matcher{
 					HttpCode: aws.String(healthCheck["matcher"].(string)),
-				},
+				}
+				params.HealthCheckPath = aws.String(healthCheck["path"].(string))
+
+				params.HealthCheckIntervalSeconds = aws.Int64(int64(healthCheck["interval"].(int)))
+				params.UnhealthyThresholdCount = aws.Int64(int64(healthCheck["unhealthy_threshold"].(int)))
+				params.HealthCheckIntervalSeconds = aws.Int64(int64(healthCheck["timeout"].(int)))
 			}
 		} else {
 			params = &elbv2.ModifyTargetGroupInput{
@@ -402,11 +409,11 @@ func validateAwsLbTargetGroupHealthCheckTimeout(v interface{}, k string) (ws []s
 
 func validateAwsLbTargetGroupHealthCheckProtocol(v interface{}, k string) (ws []string, errors []error) {
 	value := strings.ToLower(v.(string))
-	if value == "http" || value == "https" {
+	if value == "http" || value == "https" || value == "tcp" {
 		return
 	}
 
-	errors = append(errors, fmt.Errorf("%q must be either %q or %q", k, "HTTP", "HTTPS"))
+	errors = append(errors, fmt.Errorf("%q must be either %q, %q or %q", k, "HTTP", "HTTPS", "TCP"))
 	return
 }
 
@@ -420,11 +427,11 @@ func validateAwsLbTargetGroupPort(v interface{}, k string) (ws []string, errors 
 
 func validateAwsLbTargetGroupProtocol(v interface{}, k string) (ws []string, errors []error) {
 	protocol := strings.ToLower(v.(string))
-	if protocol == "http" || protocol == "https" {
+	if protocol == "http" || protocol == "https" || protocol == "tcp" {
 		return
 	}
 
-	errors = append(errors, fmt.Errorf("%q must be either %q or %q", k, "HTTP", "HTTPS"))
+	errors = append(errors, fmt.Errorf("%q must be either %q, %q or %q", k, "HTTP", "HTTPS", "TCP"))
 	return
 }
 
@@ -479,13 +486,16 @@ func flattenAwsLbTargetGroupResource(d *schema.ResourceData, meta interface{}, t
 
 	healthCheck := make(map[string]interface{})
 	healthCheck["interval"] = *targetGroup.HealthCheckIntervalSeconds
-	healthCheck["path"] = *targetGroup.HealthCheckPath
 	healthCheck["port"] = *targetGroup.HealthCheckPort
 	healthCheck["protocol"] = *targetGroup.HealthCheckProtocol
 	healthCheck["timeout"] = *targetGroup.HealthCheckTimeoutSeconds
 	healthCheck["healthy_threshold"] = *targetGroup.HealthyThresholdCount
 	healthCheck["unhealthy_threshold"] = *targetGroup.UnhealthyThresholdCount
-	healthCheck["matcher"] = *targetGroup.Matcher.HttpCode
+	if *targetGroup.Protocol != "TCP" {
+		healthCheck["path"] = *targetGroup.HealthCheckPath
+		healthCheck["matcher"] = *targetGroup.Matcher.HttpCode
+	}
+
 	d.Set("health_check", []interface{}{healthCheck})
 
 	attrResp, err := elbconn.DescribeTargetGroupAttributes(&elbv2.DescribeTargetGroupAttributesInput{

--- a/aws/resource_aws_lb_target_group_test.go
+++ b/aws/resource_aws_lb_target_group_test.go
@@ -794,6 +794,39 @@ resource "aws_vpc" "test" {
 }`, targetGroupName)
 }
 
+func testAccAWSLBTargetGroupConfig_typeTCP(targetGroupName string) string {
+	return fmt.Sprintf(`resource "aws_lb_target_group" "test" {
+  name = "%s"
+  port = 8082
+  protocol = "TCP"
+  vpc_id = "${aws_vpc.test.id}"
+
+  deregistration_delay = 200
+
+  stickiness {
+    type = "lb_cookie"
+    cookie_duration = 10000
+  }
+
+  health_check {
+    interval = 30
+    port = "traffic-port"
+    protocol = "TCP"
+    timeout = 10
+    healthy_threshold = 3
+    unhealthy_threshold = 3
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    TestName = "TestAccAWSLBtypeTCP"
+  }
+}`, targetGroupName)
+}
+
 func testAccAWSLBTargetGroupConfig_stickiness(targetGroupName string, addStickinessBlock bool, enabled bool) string {
 	var stickinessBlock string
 


### PR DESCRIPTION
The loadbalancer changes don't allow for a NLB to be created because the NLB uses TCP only, with most of the code only allowing HTTP or HTTPS.

I think there is probably some additional code coverage that can be added here, especially as NLB's are much more restrictive than ALB/ELB

Example

```sh
resource "aws_lb" "main" {
  name               = "test-nlb-tf"
  internal           = false
  load_balancer_type = "network"
  subnets            = ["subnet-123456"]

  enable_deletion_protection = true

  tags {
    Environment = "test"
  }
}

resource "aws_lb_target_group" "test" {
  name     = "tf-example"
  port     = 8085
  protocol = "TCP"
  vpc_id   = "vpc-c333ccc3"

  health_check {
    interval            = 30
    port                = "traffic-port"
    timeout             = 10
    protocol            = "TCP"
    healthy_threshold   = 3
    unhealthy_threshold = 3
  }
}

resource "aws_lb_listener" "front_end" {
  load_balancer_arn = "${aws_lb.main.id}"
  port              = "80"
  protocol          = "TCP"

  default_action {
    target_group_arn = "${aws_lb_target_group.test.id}"
    type             = "forward"
  }
}

resource "aws_lb_target_group_attachment" "test" {
  target_group_arn = "${aws_lb_target_group.test.arn}"
  target_id        = "i-0000000000000"
  port             = 80
}

```