### PR TITLE
Add support for Amazon side private ASN for aws_vpn_gateway

### DIFF
--- a/aws/data_source_aws_vpn_gateway.go
+++ b/aws/data_source_aws_vpn_gateway.go
@@ -36,7 +36,7 @@ func dataSourceAwsVpnGateway() *schema.Resource {
 				Computed: true,
 			},
 			"amazon_side_asn": {
-				Type:     schema.TypeString,
+				Type:     schema.TypeFloat,
 				Optional: true,
 				Computed: true,
 			},
@@ -64,7 +64,7 @@ func dataSourceAwsVpnGatewayRead(d *schema.ResourceData, meta interface{}) error
 	if asn, ok := d.GetOk("amazon_side_asn"); ok {
 		req.Filters = append(req.Filters, buildEC2AttributeFilterList(
 			map[string]string{
-				"amazon-side-asn": asn.(string),
+				"amazon-side-asn": strconv.FormatInt(int64(asn.(float64)), 10),
 			},
 		)...)
 	}
@@ -104,7 +104,7 @@ func dataSourceAwsVpnGatewayRead(d *schema.ResourceData, meta interface{}) error
 	d.SetId(aws.StringValue(vgw.VpnGatewayId))
 	d.Set("state", vgw.State)
 	d.Set("availability_zone", vgw.AvailabilityZone)
-	d.Set("amazon_side_asn", strconv.FormatInt(aws.Int64Value(vgw.AmazonSideAsn), 10))
+	d.Set("amazon_side_asn", float64(aws.Int64Value(vgw.AmazonSideAsn)))
 	d.Set("tags", tagsToMap(vgw.Tags))
 
 	for _, attachment := range vgw.VpcAttachments {

--- a/aws/data_source_aws_vpn_gateway.go
+++ b/aws/data_source_aws_vpn_gateway.go
@@ -36,7 +36,7 @@ func dataSourceAwsVpnGateway() *schema.Resource {
 				Computed: true,
 			},
 			"amazon_side_asn": {
-				Type:     schema.TypeFloat,
+				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
@@ -64,7 +64,7 @@ func dataSourceAwsVpnGatewayRead(d *schema.ResourceData, meta interface{}) error
 	if asn, ok := d.GetOk("amazon_side_asn"); ok {
 		req.Filters = append(req.Filters, buildEC2AttributeFilterList(
 			map[string]string{
-				"amazon-side-asn": strconv.FormatInt(int64(asn.(float64)), 10),
+				"amazon-side-asn": asn.(string),
 			},
 		)...)
 	}
@@ -104,7 +104,7 @@ func dataSourceAwsVpnGatewayRead(d *schema.ResourceData, meta interface{}) error
 	d.SetId(aws.StringValue(vgw.VpnGatewayId))
 	d.Set("state", vgw.State)
 	d.Set("availability_zone", vgw.AvailabilityZone)
-	d.Set("amazon_side_asn", float64(aws.Int64Value(vgw.AmazonSideAsn)))
+	d.Set("amazon_side_asn", strconv.FormatInt(aws.Int64Value(vgw.AmazonSideAsn), 10))
 	d.Set("tags", tagsToMap(vgw.Tags))
 
 	for _, attachment := range vgw.VpcAttachments {

--- a/aws/data_source_aws_vpn_gateway_test.go
+++ b/aws/data_source_aws_vpn_gateway_test.go
@@ -31,7 +31,7 @@ func TestAccDataSourceAwsVpnGateway_unattached(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.aws_vpn_gateway.test_by_id", "state"),
 					resource.TestCheckResourceAttr("data.aws_vpn_gateway.test_by_tags", "tags.%", "3"),
 					resource.TestCheckNoResourceAttr("data.aws_vpn_gateway.test_by_id", "attached_vpc_id"),
-					resource.TestCheckResourceAttr("data.aws_vpn_gateway.test_by_amazon_side_asn", "amazon_side_asn", "4294967293"),
+					resource.TestCheckResourceAttr("data.aws_vpn_gateway.test_by_amazon_side_asn", "amazon_side_asn", "4.294967293E+09"),
 				),
 			},
 		},

--- a/aws/data_source_aws_vpn_gateway_test.go
+++ b/aws/data_source_aws_vpn_gateway_test.go
@@ -63,10 +63,6 @@ func TestAccDataSourceAwsVpnGateway_attached(t *testing.T) {
 
 func testAccDataSourceAwsVpnGatewayUnattachedConfig(rInt int) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_vpn_gateway" "unattached" {
   tags {
     Name = "terraform-testacc-vpn-gateway-data-source-unattached-%d"
@@ -85,17 +81,14 @@ data "aws_vpn_gateway" "test_by_tags" {
 }
 
 data "aws_vpn_gateway" "test_by_amazon_side_asn" {
-	amazon_side_asn = "${aws_vpn_gateway.unattached.amazon_side_asn}"
+  amazon_side_asn = "${aws_vpn_gateway.unattached.amazon_side_asn}"
+  state           = "available"
 }
 `, rInt, rInt+1, rInt-1)
 }
 
 func testAccDataSourceAwsVpnGatewayAttachedConfig(rInt int) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 

--- a/aws/data_source_aws_vpn_gateway_test.go
+++ b/aws/data_source_aws_vpn_gateway_test.go
@@ -31,7 +31,7 @@ func TestAccDataSourceAwsVpnGateway_unattached(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.aws_vpn_gateway.test_by_id", "state"),
 					resource.TestCheckResourceAttr("data.aws_vpn_gateway.test_by_tags", "tags.%", "3"),
 					resource.TestCheckNoResourceAttr("data.aws_vpn_gateway.test_by_id", "attached_vpc_id"),
-					resource.TestCheckResourceAttr("data.aws_vpn_gateway.test_by_amazon_side_asn", "amazon_side_asn", "4.294967293E+09"),
+					resource.TestCheckResourceAttr("data.aws_vpn_gateway.test_by_amazon_side_asn", "amazon_side_asn", "4294967293"),
 				),
 			},
 		},

--- a/aws/data_source_aws_vpn_gateway_test.go
+++ b/aws/data_source_aws_vpn_gateway_test.go
@@ -25,9 +25,13 @@ func TestAccDataSourceAwsVpnGateway_unattached(t *testing.T) {
 					resource.TestCheckResourceAttrPair(
 						"data.aws_vpn_gateway.test_by_tags", "id",
 						"aws_vpn_gateway.unattached", "id"),
+					resource.TestCheckResourceAttrPair(
+						"data.aws_vpn_gateway.test_by_amazon_side_asn", "id",
+						"aws_vpn_gateway.unattached", "id"),
 					resource.TestCheckResourceAttrSet("data.aws_vpn_gateway.test_by_id", "state"),
 					resource.TestCheckResourceAttr("data.aws_vpn_gateway.test_by_tags", "tags.%", "3"),
 					resource.TestCheckNoResourceAttr("data.aws_vpn_gateway.test_by_id", "attached_vpc_id"),
+					resource.TestCheckResourceAttr("data.aws_vpn_gateway.test_by_amazon_side_asn", "amazon_side_asn", "4294967293"),
 				),
 			},
 		},
@@ -64,19 +68,24 @@ provider "aws" {
 }
 
 resource "aws_vpn_gateway" "unattached" {
-    tags {
-		Name = "terraform-testacc-vpn-gateway-data-source-unattached-%d"
-      	ABC  = "testacc-%d"
-		XYZ  = "testacc-%d"
-    }
+  tags {
+    Name = "terraform-testacc-vpn-gateway-data-source-unattached-%d"
+    ABC  = "testacc-%d"
+    XYZ  = "testacc-%d"
+  }
+  amazon_side_asn = 4294967293
 }
 
 data "aws_vpn_gateway" "test_by_id" {
-	id = "${aws_vpn_gateway.unattached.id}"
+  id = "${aws_vpn_gateway.unattached.id}"
 }
 
 data "aws_vpn_gateway" "test_by_tags" {
-	tags = "${aws_vpn_gateway.unattached.tags}"
+  tags = "${aws_vpn_gateway.unattached.tags}"
+}
+
+data "aws_vpn_gateway" "test_by_amazon_side_asn" {
+	amazon_side_asn = "${aws_vpn_gateway.unattached.amazon_side_asn}"
 }
 `, rInt, rInt+1, rInt-1)
 }
@@ -88,17 +97,17 @@ provider "aws" {
 }
 
 resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
+  cidr_block = "10.1.0.0/16"
 
-  	tags {
-    	Name = "terraform-testacc-vpn-gateway-data-source-foo-%d"
-  	}
+  tags {
+    Name = "terraform-testacc-vpn-gateway-data-source-foo-%d"
+  }
 }
 
 resource "aws_vpn_gateway" "attached" {
-    tags {
-		Name = "terraform-testacc-vpn-gateway-data-source-attached-%d"
-    }
+  tags {
+    Name = "terraform-testacc-vpn-gateway-data-source-attached-%d"
+  }
 }
 
 resource "aws_vpn_gateway_attachment" "vpn_attachment" {
@@ -107,7 +116,7 @@ resource "aws_vpn_gateway_attachment" "vpn_attachment" {
 }
 
 data "aws_vpn_gateway" "test_by_attached_vpc_id" {
-	attached_vpc_id = "${aws_vpn_gateway_attachment.vpn_attachment.vpc_id}"
+  attached_vpc_id = "${aws_vpn_gateway_attachment.vpn_attachment.vpc_id}"
 }
 `, rInt, rInt)
 }

--- a/aws/resource_aws_vpn_gateway.go
+++ b/aws/resource_aws_vpn_gateway.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -31,7 +30,7 @@ func resourceAwsVpnGateway() *schema.Resource {
 			},
 
 			"amazon_side_asn": {
-				Type:         schema.TypeString,
+				Type:         schema.TypeFloat,
 				Optional:     true,
 				ForceNew:     true,
 				Computed:     true,
@@ -57,11 +56,7 @@ func resourceAwsVpnGatewayCreate(d *schema.ResourceData, meta interface{}) error
 		Type:             aws.String("ipsec.1"),
 	}
 	if asn, ok := d.GetOk("amazon_side_asn"); ok {
-		i, err := strconv.ParseInt(asn.(string), 10, 64)
-		if err != nil {
-			return err
-		}
-		createOpts.AmazonSideAsn = aws.Int64(i)
+		createOpts.AmazonSideAsn = aws.Int64(int64(asn.(float64)))
 	}
 
 	// Create the VPN gateway
@@ -114,7 +109,7 @@ func resourceAwsVpnGatewayRead(d *schema.ResourceData, meta interface{}) error {
 	if vpnGateway.AvailabilityZone != nil && *vpnGateway.AvailabilityZone != "" {
 		d.Set("availability_zone", vpnGateway.AvailabilityZone)
 	}
-	d.Set("amazon_side_asn", strconv.FormatInt(aws.Int64Value(vpnGateway.AmazonSideAsn), 10))
+	d.Set("amazon_side_asn", float64(aws.Int64Value(vpnGateway.AmazonSideAsn)))
 	d.Set("tags", tagsToMap(vpnGateway.Tags))
 
 	return nil

--- a/aws/resource_aws_vpn_gateway.go
+++ b/aws/resource_aws_vpn_gateway.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -30,7 +31,7 @@ func resourceAwsVpnGateway() *schema.Resource {
 			},
 
 			"amazon_side_asn": {
-				Type:         schema.TypeFloat,
+				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
 				Computed:     true,
@@ -56,7 +57,11 @@ func resourceAwsVpnGatewayCreate(d *schema.ResourceData, meta interface{}) error
 		Type:             aws.String("ipsec.1"),
 	}
 	if asn, ok := d.GetOk("amazon_side_asn"); ok {
-		createOpts.AmazonSideAsn = aws.Int64(int64(asn.(float64)))
+		i, err := strconv.ParseInt(asn.(string), 10, 64)
+		if err != nil {
+			return err
+		}
+		createOpts.AmazonSideAsn = aws.Int64(i)
 	}
 
 	// Create the VPN gateway
@@ -109,7 +114,7 @@ func resourceAwsVpnGatewayRead(d *schema.ResourceData, meta interface{}) error {
 	if vpnGateway.AvailabilityZone != nil && *vpnGateway.AvailabilityZone != "" {
 		d.Set("availability_zone", vpnGateway.AvailabilityZone)
 	}
-	d.Set("amazon_side_asn", float64(aws.Int64Value(vpnGateway.AmazonSideAsn)))
+	d.Set("amazon_side_asn", strconv.FormatInt(aws.Int64Value(vpnGateway.AmazonSideAsn), 10))
 	d.Set("tags", tagsToMap(vpnGateway.Tags))
 
 	return nil

--- a/aws/resource_aws_vpn_gateway_test.go
+++ b/aws/resource_aws_vpn_gateway_test.go
@@ -140,7 +140,7 @@ func TestAccAWSVpnGateway_withAmazonSideAsnSetToState(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVpnGatewayExists("aws_vpn_gateway.foo", &v),
 					resource.TestCheckResourceAttr(
-						"aws_vpn_gateway.foo", "amazon_side_asn", "4294967294"),
+						"aws_vpn_gateway.foo", "amazon_side_asn", "4.294967294E+09"),
 				),
 			},
 		},

--- a/aws/resource_aws_vpn_gateway_test.go
+++ b/aws/resource_aws_vpn_gateway_test.go
@@ -140,7 +140,7 @@ func TestAccAWSVpnGateway_withAmazonSideAsnSetToState(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVpnGatewayExists("aws_vpn_gateway.foo", &v),
 					resource.TestCheckResourceAttr(
-						"aws_vpn_gateway.foo", "amazon_side_asn", "4.294967294E+09"),
+						"aws_vpn_gateway.foo", "amazon_side_asn", "4294967294"),
 				),
 			},
 		},

--- a/aws/resource_aws_vpn_gateway_test.go
+++ b/aws/resource_aws_vpn_gateway_test.go
@@ -127,6 +127,25 @@ func TestAccAWSVpnGateway_withAvailabilityZoneSetToState(t *testing.T) {
 		},
 	})
 }
+func TestAccAWSVpnGateway_withAmazonSideAsnSetToState(t *testing.T) {
+	var v ec2.VpnGateway
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVpnGatewayDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccVpnGatewayConfigWithASN,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVpnGatewayExists("aws_vpn_gateway.foo", &v),
+					resource.TestCheckResourceAttr(
+						"aws_vpn_gateway.foo", "amazon_side_asn", "4294967294"),
+				),
+			},
+		},
+	})
+}
 
 func TestAccAWSVpnGateway_disappears(t *testing.T) {
 	var v ec2.VpnGateway
@@ -420,150 +439,161 @@ func testAccCheckVpnGatewayExists(n string, ig *ec2.VpnGateway) resource.TestChe
 
 const testAccNoVpnGatewayConfig = `
 resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
-	tags {
-		Name = "terraform-testacc-vpn-gateway"
-	}
+  cidr_block = "10.1.0.0/16"
+  tags {
+    Name = "terraform-testacc-vpn-gateway"
+  }
 }
 `
 
 const testAccVpnGatewayConfig = `
 resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
-	tags {
-		Name = "terraform-testacc-vpn-gateway"
-	}
+  cidr_block = "10.1.0.0/16"
+  tags {
+    Name = "terraform-testacc-vpn-gateway"
+  }
 }
 
 resource "aws_vpn_gateway" "foo" {
-	vpc_id = "${aws_vpc.foo.id}"
-	tags {
-		Name = "terraform-testacc-vpn-gateway-basic"
-	}
+  vpc_id = "${aws_vpc.foo.id}"
+  tags {
+    Name = "terraform-testacc-vpn-gateway-basic"
+  }
 }
 `
 
 const testAccVpnGatewayConfigChangeVPC = `
 resource "aws_vpc" "bar" {
-	cidr_block = "10.2.0.0/16"
-	tags {
-		Name = "terraform-testacc-vpn-gateway"
-	}
+  cidr_block = "10.2.0.0/16"
+  tags {
+    Name = "terraform-testacc-vpn-gateway"
+  }
 }
 
 resource "aws_vpn_gateway" "foo" {
-	vpc_id = "${aws_vpc.bar.id}"
-	tags {
-		Name = "terraform-testacc-vpn-gateway-basic"
-	}
+  vpc_id = "${aws_vpc.bar.id}"
+  tags {
+    Name = "terraform-testacc-vpn-gateway-basic"
+  }
 }
 `
 
 const testAccCheckVpnGatewayConfigTags = `
 resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
-	tags {
-		Name = "terraform-testacc-vpn-gateway"
-	}
+  cidr_block = "10.1.0.0/16"
+  tags {
+    Name = "terraform-testacc-vpn-gateway"
+  }
 }
 
 resource "aws_vpn_gateway" "foo" {
-	vpc_id = "${aws_vpc.foo.id}"
-	tags {
-		Name = "terraform-testacc-vpn-gateway-tags"
-	}
+  vpc_id = "${aws_vpc.foo.id}"
+  tags {
+    Name = "terraform-testacc-vpn-gateway-tags"
+  }
 }
 `
 
 const testAccCheckVpnGatewayConfigTagsUpdate = `
 resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
-	tags {
-		Name = "terraform-testacc-vpn-gateway"
-	}
+  cidr_block = "10.1.0.0/16"
+  tags {
+    Name = "terraform-testacc-vpn-gateway"
+  }
 }
 
 resource "aws_vpn_gateway" "foo" {
-	vpc_id = "${aws_vpc.foo.id}"
-	tags {
-		Name = "terraform-testacc-vpn-gateway-tags-updated"
-	}
+  vpc_id = "${aws_vpc.foo.id}"
+  tags {
+    Name = "terraform-testacc-vpn-gateway-tags-updated"
+  }
 }
 `
 
 const testAccCheckVpnGatewayConfigReattach = `
 resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
-	tags {
-		Name = "terraform-testacc-vpn-gateway"
-	}
+  cidr_block = "10.1.0.0/16"
+  tags {
+    Name = "terraform-testacc-vpn-gateway"
+  }
 }
 
 resource "aws_vpc" "bar" {
-	cidr_block = "10.2.0.0/16"
-	tags {
-		Name = "terraform-testacc-vpn-gateway"
-	}
+  cidr_block = "10.2.0.0/16"
+  tags {
+    Name = "terraform-testacc-vpn-gateway"
+  }
 }
 
 resource "aws_vpn_gateway" "foo" {
-	vpc_id = "${aws_vpc.foo.id}"
-	tags {
-		Name = "terraform-testacc-vpn-gateway-reattach"
-	}
+  vpc_id = "${aws_vpc.foo.id}"
+  tags {
+    Name = "terraform-testacc-vpn-gateway-reattach"
+  }
 }
 
 resource "aws_vpn_gateway" "bar" {
-	vpc_id = "${aws_vpc.bar.id}"
-	tags {
-		Name = "terraform-testacc-vpn-gateway-reattach"
-	}
+  vpc_id = "${aws_vpc.bar.id}"
+  tags {
+    Name = "terraform-testacc-vpn-gateway-reattach"
+  }
 }
 `
 
 const testAccCheckVpnGatewayConfigReattachChange = `
 resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
-	tags {
-		Name = "terraform-testacc-vpn-gateway"
-	}
+  cidr_block = "10.1.0.0/16"
+  tags {
+    Name = "terraform-testacc-vpn-gateway"
+  }
 }
 
 resource "aws_vpc" "bar" {
-	cidr_block = "10.2.0.0/16"
-	tags {
-		Name = "terraform-testacc-vpn-gateway"
-	}
+  cidr_block = "10.2.0.0/16"
+  tags {
+    Name = "terraform-testacc-vpn-gateway"
+  }
 }
 
 resource "aws_vpn_gateway" "foo" {
-	vpc_id = "${aws_vpc.bar.id}"
-	tags {
-		Name = "terraform-testacc-vpn-gateway-reattach"
-	}
+  vpc_id = "${aws_vpc.bar.id}"
+  tags {
+    Name = "terraform-testacc-vpn-gateway-reattach"
+  }
 }
 
 resource "aws_vpn_gateway" "bar" {
-	vpc_id = "${aws_vpc.foo.id}"
-	tags {
-		Name = "terraform-testacc-vpn-gateway-reattach"
-	}
+  vpc_id = "${aws_vpc.foo.id}"
+  tags {
+    Name = "terraform-testacc-vpn-gateway-reattach"
+  }
 }
 `
 
 const testAccVpnGatewayConfigWithAZ = `
 resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
-	tags {
-		Name = "terraform-testacc-vpn-gateway"
-	}
+  cidr_block = "10.1.0.0/16"
+  tags {
+    Name = "terraform-testacc-vpn-gateway"
+  }
 }
 
 resource "aws_vpn_gateway" "foo" {
-	vpc_id = "${aws_vpc.foo.id}"
-	availability_zone = "us-west-2a"
-	tags {
-		Name = "terraform-testacc-vpn-gateway-with-az"
-	}
+  vpc_id = "${aws_vpc.foo.id}"
+  availability_zone = "us-west-2a"
+  tags {
+    Name = "terraform-testacc-vpn-gateway-with-az"
+  }
+}
+`
+
+const testAccVpnGatewayConfigWithASN = `
+resource "aws_vpc" "foo" {
+  cidr_block = "10.1.0.0/16"
+}
+
+resource "aws_vpn_gateway" "foo" {
+  vpc_id = "${aws_vpc.foo.id}"
+  amazon_side_asn = 4294967294
 }
 `

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -2256,10 +2257,14 @@ func validateStringIn(validValues ...string) schema.SchemaValidateFunc {
 }
 
 func validateAmazonSideAsn(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(float64)
+	value := v.(string)
 
 	// http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateVpnGateway.html
-	asn := int64(value)
+	asn, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		errors = append(errors, fmt.Errorf("%q (%q) must be a 64-bit integer", k, v))
+		return
+	}
 
 	if (asn < 64512) || (asn > 65534 && asn < 4200000000) || (asn > 4294967294) {
 		errors = append(errors, fmt.Errorf("%q (%q) must be in the range 64512 to 65534 or 4200000000 to 4294967294", k, v))

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"net/url"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 
@@ -2257,14 +2256,10 @@ func validateStringIn(validValues ...string) schema.SchemaValidateFunc {
 }
 
 func validateAmazonSideAsn(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
+	value := v.(float64)
 
 	// http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateVpnGateway.html
-	asn, err := strconv.ParseInt(value, 10, 64)
-	if err != nil {
-		errors = append(errors, fmt.Errorf("%q (%q) must be a 64-bit integer", k, v))
-		return
-	}
+	asn := int64(value)
 
 	if (asn < 64512) || (asn > 65534 && asn < 4200000000) || (asn > 4294967294) {
 		errors = append(errors, fmt.Errorf("%q (%q) must be in the range 64512 to 65534 or 4200000000 to 4294967294", k, v))

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -2253,4 +2254,20 @@ func validateStringIn(validValues ...string) schema.SchemaValidateFunc {
 			k, value, validValues))
 		return
 	}
+}
+
+func validateAmazonSideAsn(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+
+	// http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateVpnGateway.html
+	asn, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		errors = append(errors, fmt.Errorf("%q (%q) must be a 64-bit integer", k, v))
+		return
+	}
+
+	if (asn < 64512) || (asn > 65534 && asn < 4200000000) || (asn > 4294967294) {
+		errors = append(errors, fmt.Errorf("%q (%q) must be in the range 64512 to 65534 or 4200000000 to 4294967294", k, v))
+	}
+	return
 }

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -3070,15 +3070,15 @@ func TestValidateGuardDutyThreatIntelSetFormat(t *testing.T) {
 }
 
 func TestValidateAmazonSideAsn(t *testing.T) {
-	validAsns := []float64{
-		64512,
-		64513,
-		65533,
-		65534,
-		4200000000,
-		4200000001,
-		4294967293,
-		4294967294,
+	validAsns := []string{
+		"64512",
+		"64513",
+		"65533",
+		"65534",
+		"4200000000",
+		"4200000001",
+		"4294967293",
+		"4294967294",
 	}
 	for _, v := range validAsns {
 		_, errors := validateAmazonSideAsn(v, "amazon_side_asn")
@@ -3087,8 +3087,10 @@ func TestValidateAmazonSideAsn(t *testing.T) {
 		}
 	}
 
-	invalidAsns := []float64{
-		1,
+	invalidAsns := []string{
+		"1",
+		"ABCDEFG",
+		"",
 	}
 	for _, v := range invalidAsns {
 		_, errors := validateAmazonSideAsn(v, "amazon_side_asn")

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -3068,3 +3068,34 @@ func TestValidateGuardDutyThreatIntelSetFormat(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateAmazonSideAsn(t *testing.T) {
+	validAsns := []string{
+		"64512",
+		"64513",
+		"65533",
+		"65534",
+		"4200000000",
+		"4200000001",
+		"4294967293",
+		"4294967294",
+	}
+	for _, v := range validAsns {
+		_, errors := validateAmazonSideAsn(v, "amazon_side_asn")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid ASN: %q", v, errors)
+		}
+	}
+
+	invalidAsns := []string{
+		"1",
+		"ABCDEFG",
+		"",
+	}
+	for _, v := range invalidAsns {
+		_, errors := validateAmazonSideAsn(v, "amazon_side_asn")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be an invalid ASN", v)
+		}
+	}
+}

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -3070,15 +3070,15 @@ func TestValidateGuardDutyThreatIntelSetFormat(t *testing.T) {
 }
 
 func TestValidateAmazonSideAsn(t *testing.T) {
-	validAsns := []string{
-		"64512",
-		"64513",
-		"65533",
-		"65534",
-		"4200000000",
-		"4200000001",
-		"4294967293",
-		"4294967294",
+	validAsns := []float64{
+		64512,
+		64513,
+		65533,
+		65534,
+		4200000000,
+		4200000001,
+		4294967293,
+		4294967294,
 	}
 	for _, v := range validAsns {
 		_, errors := validateAmazonSideAsn(v, "amazon_side_asn")
@@ -3087,10 +3087,8 @@ func TestValidateAmazonSideAsn(t *testing.T) {
 		}
 	}
 
-	invalidAsns := []string{
-		"1",
-		"ABCDEFG",
-		"",
+	invalidAsns := []float64{
+		1,
 	}
 	for _, v := range invalidAsns {
 		_, errors := validateAmazonSideAsn(v, "amazon_side_asn")

--- a/website/docs/d/vpn_gateway.html.markdown
+++ b/website/docs/d/vpn_gateway.html.markdown
@@ -44,6 +44,8 @@ The given filters must match exactly one VPN gateway whose data will be exported
 * `tags` - (Optional) A mapping of tags, each pair of which must exactly match
   a pair on the desired VPN Gateway.
 
+* `amazon_side_asn` - (Optional) The Autonomous System Number (ASN) for the Amazon side of the specific VPN Gateway to retrieve.
+
 More complex filters can be expressed using one or more `filter` sub-blocks,
 which take the following arguments:
 

--- a/website/docs/r/vpn_gateway.html.markdown
+++ b/website/docs/r/vpn_gateway.html.markdown
@@ -29,6 +29,7 @@ The following arguments are supported:
 * `vpc_id` - (Optional) The VPC ID to create in.
 * `availability_zone` - (Optional) The Availability Zone for the virtual private gateway.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
+* `amazon_side_asn` - (Optional) The Autonomous System Number (ASN) for the Amazon side of the gateway. If you don't specify an ASN, the virtual private gateway is created with the default ASN.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fixes #1859
Acceptance tests:
```
Running tool: /usr/local/go/bin/go test -timeout 30s github.com/terraform-providers/terraform-provider-aws/aws -run ^TestValidateAmazonSideAsn$

ok  	github.com/terraform-providers/terraform-provider-aws/aws	0.014s
Success: Tests passed.
```
```
make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSVpnGateway_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAWSVpnGateway_ -timeout 120m
=== RUN   TestAccAWSVpnGateway_importBasic
--- PASS: TestAccAWSVpnGateway_importBasic (43.61s)
=== RUN   TestAccAWSVpnGateway_basic
--- PASS: TestAccAWSVpnGateway_basic (77.10s)
=== RUN   TestAccAWSVpnGateway_withAvailabilityZoneSetToState
--- PASS: TestAccAWSVpnGateway_withAvailabilityZoneSetToState (38.76s)
=== RUN   TestAccAWSVpnGateway_withAmazonSideAsnSetToState
--- PASS: TestAccAWSVpnGateway_withAmazonSideAsnSetToState (47.32s)
=== RUN   TestAccAWSVpnGateway_disappears
--- PASS: TestAccAWSVpnGateway_disappears (36.77s)
=== RUN   TestAccAWSVpnGateway_reattach
--- PASS: TestAccAWSVpnGateway_reattach (101.08s)
=== RUN   TestAccAWSVpnGateway_delete
--- PASS: TestAccAWSVpnGateway_delete (52.53s)
=== RUN   TestAccAWSVpnGateway_tags
--- PASS: TestAccAWSVpnGateway_tags (64.17s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	461.351s
```
```
make testacc TEST=./aws/ TESTARGS='-run=TestAccDataSourceAwsVpnGateway_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccDataSourceAwsVpnGateway_ -timeout 120m
=== RUN   TestAccDataSourceAwsVpnGateway_unattached
--- PASS: TestAccDataSourceAwsVpnGateway_unattached (18.27s)
=== RUN   TestAccDataSourceAwsVpnGateway_attached
--- PASS: TestAccDataSourceAwsVpnGateway_attached (52.50s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	70.778s
```