### PR TITLE
r/batch_job_queue: Wait for update completion when disabling

### DIFF
--- a/aws/resource_aws_batch_job_queue.go
+++ b/aws/resource_aws_batch_job_queue.go
@@ -143,9 +143,9 @@ func resourceAwsBatchJobQueueDelete(d *schema.ResourceData, meta interface{}) er
 
 	// Wait until the Job Queue is disabled before deleting
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{batch.JQStateEnabled},
-		Target:     []string{batch.JQStateDisabled},
-		Refresh:    batchJobQueueRefreshStateFunc(conn, sn),
+		Pending:    []string{batch.JQStatusUpdating},
+		Target:     []string{batch.JQStatusValid},
+		Refresh:    batchJobQueueRefreshStatusFunc(conn, sn),
 		Timeout:    10 * time.Minute,
 		Delay:      10 * time.Second,
 		MinTimeout: 3 * time.Second,
@@ -154,6 +154,7 @@ func resourceAwsBatchJobQueueDelete(d *schema.ResourceData, meta interface{}) er
 	if err != nil {
 		return err
 	}
+
 	log.Printf("[DEBUG] Trying to delete Job Queue %s", sn)
 	_, err = conn.DeleteJobQueue(&batch.DeleteJobQueueInput{
 		JobQueue: aws.String(sn),


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSBatchJobQueue_basic
--- FAIL: TestAccAWSBatchJobQueue_basic (84.93s)
    testing.go:494: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Error applying: 1 error(s) occurred:
        
        * aws_batch_job_queue.test_queue (destroy): 1 error(s) occurred:
        
        * aws_batch_job_queue.test_queue: Error waiting for Job Queue (tf_acctest_batch_job_queue_985542259809348371) to be deleted: unexpected state 'VALID', wanted target 'DELETED'. last error: %!s(<nil>)
```

## Test results

<img width="354" alt="screen shot 2017-10-14 at 17 20 18" src="https://user-images.githubusercontent.com/287584/31576479-60556a64-b104-11e7-8fb0-77d93e344639.png">
