### PR TITLE
New Resource: Athena Named Query

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -261,6 +261,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_appautoscaling_target":                    resourceAwsAppautoscalingTarget(),
 			"aws_appautoscaling_policy":                    resourceAwsAppautoscalingPolicy(),
 			"aws_athena_database":                          resourceAwsAthenaDatabase(),
+			"aws_athena_named_query":                       resourceAwsAthenaNamedQuery(),
 			"aws_autoscaling_attachment":                   resourceAwsAutoscalingAttachment(),
 			"aws_autoscaling_group":                        resourceAwsAutoscalingGroup(),
 			"aws_autoscaling_notification":                 resourceAwsAutoscalingNotification(),

--- a/aws/resource_aws_athena_named_query.go
+++ b/aws/resource_aws_athena_named_query.go
@@ -1,8 +1,6 @@
 package aws
 
 import (
-	"fmt"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/athena"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -68,7 +66,7 @@ func resourceAwsAthenaNamedQueryRead(d *schema.ResourceData, meta interface{}) e
 
 	_, err := conn.GetNamedQuery(input)
 	if err != nil {
-		if isAWSErr(err, athena.ErrCodeInvalidRequestException, fmt.Sprintf("Athena Named Query (%s) does not exist", d.Id())) {
+		if isAWSErr(err, athena.ErrCodeInvalidRequestException, d.Id()) {
 			d.SetId("")
 			return nil
 		}

--- a/aws/resource_aws_athena_named_query.go
+++ b/aws/resource_aws_athena_named_query.go
@@ -1,0 +1,43 @@
+package aws
+
+func resourceAwsAthenaNamedQuery() *schema.Resource {
+ 	return &schema.Resource{
+ 		Create: resourceAwsAthenaNamedQueryCreate,
+ 		Read:   resourceAwsAthenaNamedQueryRead,
+ 		Delete: resourceAwsAthenaNamedQueryDelete,
+
+ 		Schema: map[string]*schema.Schema{
+      "name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+      "query": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+      "database": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+      "description": &schema.Schema{
+				Type:     schema.TypeString,
+        Optional:     true,
+			},
+    }
+  }
+}
+
+func resourceAwsAthenaNamedQueryCreate(d *schema.ResourceData, meta interface{}) error {
+  return nil
+}
+
+func resourceAwsAthenaNamedQueryRead(d *schema.ResourceData, meta interface{}) error {
+  return nil
+}
+
+func resourceAwsAthenaNamedQueryDelete(d *schema.ResourceData, meta interface{}) error {
+  return nil
+}

--- a/aws/resource_aws_athena_named_query.go
+++ b/aws/resource_aws_athena_named_query.go
@@ -82,5 +82,6 @@ func resourceAwsAthenaNamedQueryDelete(d *schema.ResourceData, meta interface{})
 	if err != nil {
 		return err
 	}
+	d.SetId("")
 	return nil
 }

--- a/aws/resource_aws_athena_named_query.go
+++ b/aws/resource_aws_athena_named_query.go
@@ -1,43 +1,86 @@
 package aws
 
-func resourceAwsAthenaNamedQuery() *schema.Resource {
- 	return &schema.Resource{
- 		Create: resourceAwsAthenaNamedQueryCreate,
- 		Read:   resourceAwsAthenaNamedQueryRead,
- 		Delete: resourceAwsAthenaNamedQueryDelete,
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/athena"
+	"github.com/hashicorp/terraform/helper/schema"
+)
 
- 		Schema: map[string]*schema.Schema{
-      "name": &schema.Schema{
+func resourceAwsAthenaNamedQuery() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsAthenaNamedQueryCreate,
+		Read:   resourceAwsAthenaNamedQueryRead,
+		Delete: resourceAwsAthenaNamedQueryDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-      "query": &schema.Schema{
+			"query": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-      "database": &schema.Schema{
+			"database": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-      "description": &schema.Schema{
+			"description": &schema.Schema{
 				Type:     schema.TypeString,
-        Optional:     true,
+				Optional: true,
+				ForceNew: true,
 			},
-    }
-  }
+		},
+	}
 }
 
 func resourceAwsAthenaNamedQueryCreate(d *schema.ResourceData, meta interface{}) error {
-  return nil
+	conn := meta.(*AWSClient).athenaconn
+
+	input := &athena.CreateNamedQueryInput{
+		Database:    aws.String(d.Get("database").(string)),
+		Name:        aws.String(d.Get("name").(string)),
+		QueryString: aws.String(d.Get("query").(string)),
+	}
+	if raw, ok := d.GetOk("description"); ok {
+		input.Description = aws.String(raw.(string))
+	}
+
+	resp, err := conn.CreateNamedQuery(input)
+	if err != nil {
+		return err
+	}
+	d.SetId(*resp.NamedQueryId)
+	return resourceAwsAthenaNamedQueryRead(d, meta)
 }
 
 func resourceAwsAthenaNamedQueryRead(d *schema.ResourceData, meta interface{}) error {
-  return nil
+	conn := meta.(*AWSClient).athenaconn
+
+	input := &athena.GetNamedQueryInput{
+		NamedQueryId: aws.String(d.Id()),
+	}
+
+	_, err := conn.GetNamedQuery(input)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func resourceAwsAthenaNamedQueryDelete(d *schema.ResourceData, meta interface{}) error {
-  return nil
+	conn := meta.(*AWSClient).athenaconn
+
+	input := &athena.DeleteNamedQueryInput{
+		NamedQueryId: aws.String(d.Id()),
+	}
+
+	_, err := conn.DeleteNamedQuery(input)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/aws/resource_aws_athena_named_query.go
+++ b/aws/resource_aws_athena_named_query.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/athena"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -66,6 +68,10 @@ func resourceAwsAthenaNamedQueryRead(d *schema.ResourceData, meta interface{}) e
 
 	_, err := conn.GetNamedQuery(input)
 	if err != nil {
+		if isAWSErr(err, athena.ErrCodeInvalidRequestException, fmt.Sprintf("Athena Named Query (%s) does not exist", d.Id())) {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	return nil

--- a/aws/resource_aws_athena_named_query_test.go
+++ b/aws/resource_aws_athena_named_query_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/athena"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -41,13 +40,8 @@ func testAccCheckAWSAthenaNamedQueryDestroy(s *terraform.State) error {
 
 		resp, err := conn.GetNamedQuery(input)
 		if err != nil {
-			if aerr, ok := err.(awserr.Error); ok {
-				switch aerr.Code() {
-				case athena.ErrCodeInvalidRequestException:
-					return nil
-				default:
-					return err
-				}
+			if isAWSErr(err, athena.ErrCodeInvalidRequestException, "does not exist") {
+				return nil
 			}
 			return err
 		}

--- a/aws/resource_aws_athena_named_query_test.go
+++ b/aws/resource_aws_athena_named_query_test.go
@@ -40,7 +40,7 @@ func testAccCheckAWSAthenaNamedQueryDestroy(s *terraform.State) error {
 
 		resp, err := conn.GetNamedQuery(input)
 		if err != nil {
-			if isAWSErr(err, athena.ErrCodeInvalidRequestException, "does not exist") {
+			if isAWSErr(err, athena.ErrCodeInvalidRequestException, rs.Primary.ID) {
 				return nil
 			}
 			return err

--- a/aws/resource_aws_athena_named_query_test.go
+++ b/aws/resource_aws_athena_named_query_test.go
@@ -1,0 +1,43 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSAthenaNamedQuery(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAthenaNamedQueryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAthenaNamedQueryConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAthenaNamedQueryExists("aws_athena_named_query.foo"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSAthenaNamedQueryDestroy(s *terraform.State) error {
+	return nil
+}
+
+func testAccCheckAWSAthenaNamedQueryExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		return nil
+	}
+}
+
+const testAccAthenaNamedQueryConfig = `
+`

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -302,6 +302,9 @@
                         <li<%= sidebar_current("docs-aws-resource-athena-database") %>>
                             <a href="/docs/providers/aws/r/athena_database.html">aws_athena_database</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-resource-athena-named-query") %>>
+                          <a href="/docs/providers/aws/r/athena_named_query.html">aws_athena_named_query</a>
+                        </li>
                     </ul>
                 </li>
 

--- a/website/docs/r/athena_named_query.html.markdown
+++ b/website/docs/r/athena_named_query.html.markdown
@@ -1,0 +1,39 @@
+---
+layout: "aws"
+page_title: "AWS: aws_athena_named_query"
+sidebar_current: "docs-aws-resource-athena-named-query"
+description: |-
+  Provides an Athena Named Query resource.
+---
+
+# aws_athena_named_query
+
+Provides an Athena Named Query resource.
+
+~> **NOTE on Athena Named Query**: AWS CLI for Athena haven't provided a feature to create database yet while named query api requires database name. So you have to create database in advance.
+[the AWS Docs](https://docs.aws.amazon.com/ja_jp/athena/latest/APIReference/API_CreateNamedQuery.html).
+
+## Example Usage
+
+```hcl
+resource "aws_athena_named_query" "foo" {
+  name = "bar"
+	database = "users"
+	query = "SELECT * FROM users limit 10;"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The plain language name for the query. Maximum length of 128.
+* `database` - (Required) The database to which the query belongs.
+* `query` - (Required) The text of the query itself. In other words, all query statements. Maximum length of 262144.
+* `description` - (Optional) A brief explanation of the query. Maximum length of 1024.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The unique ID of the query.

--- a/website/docs/r/athena_named_query.html.markdown
+++ b/website/docs/r/athena_named_query.html.markdown
@@ -10,16 +10,22 @@ description: |-
 
 Provides an Athena Named Query resource.
 
-~> **NOTE on Athena Named Query**: AWS CLI for Athena haven't provided a feature to create database yet while named query api requires database name. So you have to create database in advance.
-[the AWS Docs](https://docs.aws.amazon.com/ja_jp/athena/latest/APIReference/API_CreateNamedQuery.html).
-
 ## Example Usage
 
 ```hcl
+resource "aws_s3_bucket" "hoge" {
+	bucket = "tf-test"
+}
+
+resource "aws_athena_database" "hoge" {
+	name = "users"
+	bucket = "${aws_s3_bucket.hoge.bucket}"
+}
+
 resource "aws_athena_named_query" "foo" {
   name = "bar"
-	database = "users"
-	query = "SELECT * FROM users limit 10;"
+	database = "${aws_athena_database.hoge.name}"
+	query = "SELECT * FROM ${aws_athena_database.hoge.name} limit 10;"
 }
 ```
 


### PR DESCRIPTION
#1486 

Adds the feature to create athena's named query. Aws cli doesn't provide api to create database but named query api requires database name.
So you have to create database in advance.
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSAthena'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSAthena -timeout 120m
=== RUN   TestAccAWSAthenaNamedQuery
--- PASS: TestAccAWSAthenaNamedQuery (39.28s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	39.318s
```