### PR TITLE
r/snapshot_create_volume_permission: Raise timeout

### DIFF
--- a/aws/resource_aws_snapshot_create_volume_permission.go
+++ b/aws/resource_aws_snapshot_create_volume_permission.go
@@ -66,7 +66,7 @@ func resourceAwsSnapshotCreateVolumePermissionCreate(d *schema.ResourceData, met
 		Pending:    []string{"denied"},
 		Target:     []string{"granted"},
 		Refresh:    resourceAwsSnapshotCreateVolumePermissionStateRefreshFunc(conn, snapshot_id, account_id),
-		Timeout:    5 * time.Minute,
+		Timeout:    10 * time.Minute,
 		Delay:      10 * time.Second,
 		MinTimeout: 10 * time.Second,
 	}


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSSnapshotCreateVolumePermission_Basic
--- FAIL: TestAccAWSSnapshotCreateVolumePermission_Basic (355.14s)
    testing.go:434: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_snapshot_create_volume_permission.self-test: 1 error(s) occurred:
        
        * aws_snapshot_create_volume_permission.self-test: Error waiting for snapshot createVolumePermission (snap-01753ece1322c31a4-*******) to be added: timeout while waiting for state to become 'granted' (last state: 'denied', timeout: 5m0s)
```