### PR TITLE
r/kms_alias: Retry creation on NotFoundException

### DIFF
--- a/aws/resource_aws_kms_alias.go
+++ b/aws/resource_aws_kms_alias.go
@@ -77,7 +77,11 @@ func resourceAwsKmsAliasCreate(d *schema.ResourceData, meta interface{}) error {
 		AliasName:   aws.String(name),
 		TargetKeyId: aws.String(targetKeyId),
 	}
-	_, err := conn.CreateAlias(req)
+
+	// KMS is eventually consistent
+	_, err := retryOnAwsCode("NotFoundException", func() (interface{}, error) {
+		return conn.CreateAlias(req)
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSKmsAlias_name_prefix
--- FAIL: TestAccAWSKmsAlias_name_prefix (24.56s)
    testing.go:434: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_kms_alias.name_prefix: 1 error(s) occurred:
        
        * aws_kms_alias.name_prefix: NotFoundException: Key 'arn:aws:kms:us-west-2:*******:key/d009dff4-27f4-4e10-ac07-aef1b74204e0' does not exist
            status code: 400, request id: 5334f913-b106-11e7-9f19-a3bd400081f8
```

Snippet from the log:
```
2017/10/14 17:37:17 [DEBUG] [aws-sdk-go] DEBUG: Response kms/DescribeKey Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 200 OK
Connection: close
Content-Length: 387
Content-Type: application/x-amz-json-1.1
X-Amzn-Requestid: 531d2abb-b106-11e7-9b02-a5418d0385e7


-----------------------------------------------------
2017/10/14 17:37:17 [DEBUG] [aws-sdk-go] {"KeyMetadata":{"AWSAccountId":"*REDACTED*","Arn":"arn:aws:kms:us-west-2:*REDACTED*:key/d009dff4-27f4-4e10-ac07-aef1b74204e0","CreationDate":1.508002637976E9,"Description":"Terraform acc test One Sat, 14 Oct 2017 17:37:14 UTC","Enabled":true,"KeyId":"d009dff4-27f4-4e10-ac07-aef1b74204e0","KeyManager":"CUSTOMER","KeyState":"Enabled","KeyUsage":"ENCRYPT_DECRYPT","Origin":"AWS_KMS"}}

-----------------------------------------------------
2017/10/14 17:37:18 [DEBUG] [aws-sdk-go] DEBUG: Request kms/CreateAlias Details:
---[ REQUEST POST-SIGN ]-----------------------------
POST / HTTP/1.1
Host: kms.us-west-2.amazonaws.com
User-Agent: aws-sdk-go/1.12.8 (go1.9; linux; amd64) APN/1.0 HashiCorp/1.0 Terraform/0.10.0-dev
Content-Length: 101
Authorization: AWS4-HMAC-SHA256 Credential=*REDACTED*/20171014/us-west-2/kms/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-date;x-amz-target, Signature=*REDACTED*
Content-Type: application/x-amz-json-1.1
X-Amz-Date: 20171014T173718Z
X-Amz-Target: TrentService.CreateAlias
Accept-Encoding: gzip

{"AliasName":"alias/20171014173718010800000001","TargetKeyId":"d009dff4-27f4-4e10-ac07-aef1b74204e0"}
-----------------------------------------------------

-----------------------------------------------------
2017/10/14 17:37:18 [DEBUG] [aws-sdk-go] DEBUG: Response kms/CreateAlias Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 400 Bad Request
Connection: close
Content-Length: 139
Content-Type: application/x-amz-json-1.1
X-Amzn-Requestid: 5334f913-b106-11e7-9f19-a3bd400081f8


-----------------------------------------------------
2017/10/14 17:37:18 [DEBUG] [aws-sdk-go] {"__type":"NotFoundException","message":"Key 'arn:aws:kms:us-west-2:187416307283:key/d009dff4-27f4-4e10-ac07-aef1b74204e0' does not exist"}
```