### PR TITLE
d/aws_elb_hosted_zone_name: ELB HostedZoneName datasource

### DIFF
--- a/aws/data_source_aws_elb_hosted_zone_name.go
+++ b/aws/data_source_aws_elb_hosted_zone_name.go
@@ -1,0 +1,60 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsElbHostedZoneName() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsElbHostedZoneNameRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"hosted_zone_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"hosted_zone_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"dns_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsElbHostedZoneNameRead(d *schema.ResourceData, meta interface{}) error {
+	elbconn := meta.(*AWSClient).elbconn
+
+	elbName := d.Get("name").(string)
+
+	describe, err := elbconn.DescribeLoadBalancers(&elb.DescribeLoadBalancersInput{
+		LoadBalancerNames: []*string{aws.String(elbName)},
+	})
+
+	if err != nil {
+		return err
+	}
+
+	if len(describe.LoadBalancerDescriptions) != 1 ||
+		*describe.LoadBalancerDescriptions[0].LoadBalancerName != elbName {
+		return fmt.Errorf("ELB not found")
+	}
+
+	d.Set("hosted_zone_id", describe.LoadBalancerDescriptions[0].CanonicalHostedZoneNameID)
+	d.Set("hosted_zone_name", describe.LoadBalancerDescriptions[0].CanonicalHostedZoneName)
+	d.Set("dns_name", describe.LoadBalancerDescriptions[0].DNSName)
+	d.SetId(*describe.LoadBalancerDescriptions[0].CanonicalHostedZoneName)
+
+	return nil
+}

--- a/aws/data_source_aws_elb_hosted_zone_name_test.go
+++ b/aws/data_source_aws_elb_hosted_zone_name_test.go
@@ -1,0 +1,95 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataSourceAwsElbHostedZoneName(t *testing.T) {
+	lbName := fmt.Sprintf("test-datasource-elb-zname-%s", acctest.RandString(6))
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataSourceAwsElbHostedZoneNameConfigNotFound(),
+				ExpectError: regexp.MustCompile(`There is no ACTIVE Load Balancer`),
+			},
+			{
+				Config: testAccDataSourceAwsElbHostedZoneNameConfig(lbName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsElbHostedZoneNameCheck("data.aws_elb_hosted_zone_name.test"),
+					resource.TestMatchResourceAttr("data.aws_elb_hosted_zone_name.test", "hosted_zone_name", regexp.MustCompile("^"+lbName)),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsElbHostedZoneNameCheck(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("root module has no resource called %s", name)
+		}
+
+		elb, ok := s.RootModule().Resources["aws_elb.test"]
+		if !ok {
+			return fmt.Errorf("can't find aws_elb.test in state")
+		}
+
+		attr := rs.Primary.Attributes
+
+		if attr["hosted_zone_id"] != elb.Primary.Attributes["zone_id"] {
+			return fmt.Errorf(
+				"zone_id is %s; want %s",
+				attr["hosted_zone_id"],
+				elb.Primary.Attributes["zone_id"],
+			)
+		}
+
+		if attr["dns_name"] != elb.Primary.Attributes["dns_name"] {
+			return fmt.Errorf(
+				"dns_name is %s; want %s",
+				attr["dns_name"],
+				elb.Primary.Attributes["dns_name"],
+			)
+		}
+
+		return nil
+	}
+}
+
+func testAccDataSourceAwsElbHostedZoneNameConfig(lbName string) string {
+	return fmt.Sprintf(`
+resource "aws_elb" "test" {
+  name               = "%s"
+  availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
+
+  listener {
+    instance_port = 8000
+    instance_protocol = "http"
+    lb_port = 80
+    lb_protocol = "http"
+  }
+}
+
+data "aws_elb_hosted_zone_name" "test" {
+  name = "%s"
+  depends_on = ["aws_elb.test"]
+}
+`, lbName, lbName)
+}
+
+func testAccDataSourceAwsElbHostedZoneNameConfigNotFound() string {
+	return fmt.Sprintf(`
+data "aws_elb_hosted_zone_name" "test_not_found" {
+  name = "non-existent-%s"
+}`, acctest.RandString(16))
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -185,6 +185,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_elastic_beanstalk_solution_stack": dataSourceAwsElasticBeanstalkSolutionStack(),
 			"aws_elasticache_cluster":              dataSourceAwsElastiCacheCluster(),
 			"aws_elb_hosted_zone_id":               dataSourceAwsElbHostedZoneId(),
+			"aws_elb_hosted_zone_name":             dataSourceAwsElbHostedZoneName(),
 			"aws_elb_service_account":              dataSourceAwsElbServiceAccount(),
 			"aws_iam_account_alias":                dataSourceAwsIamAccountAlias(),
 			"aws_iam_group":                        dataSourceAwsIAMGroup(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -98,6 +98,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-elb-hosted-zone-id") %>>
                             <a href="/docs/providers/aws/d/elb_hosted_zone_id.html">aws_elb_hosted_zone_id</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-elb-hosted-zone-name") %>>
+                            <a href="/docs/providers/aws/d/elb_hosted_zone_name.html">aws_elb_hosted_zone_name</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-elb-service-account") %>>
                             <a href="/docs/providers/aws/d/elb_service_account.html">aws_elb_service_account</a>
                         </li>

--- a/website/docs/d/elb_hosted_zone_name.html.markdown
+++ b/website/docs/d/elb_hosted_zone_name.html.markdown
@@ -1,0 +1,41 @@
+---
+layout: "aws"
+page_title: "AWS: aws_elb_hosted_zone_name"
+sidebar_current: "docs-aws-datasource-elb-hosted-zone-name"
+description: |-
+  Get AWS Elastic Load Balancing Hosted Zone Name and ID
+---
+
+# aws\_elb\_hosted\_zone\_name
+
+Use this data source to get the HostedZoneName and HostedZoneId of an existing AWS Elastic Load Balancer.
+
+## Example Usage
+
+```hcl
+data "aws_elb_hosted_zone_name" "main" {
+  name = "my-elb"
+}
+
+resource "aws_route53_record" "www" {
+  zone_id = "${aws_route53_zone.primary.zone_id}"
+  name    = "example.com"
+  type    = "A"
+
+  alias {
+    name                   = "${data.aws_elb_hosted_zone_id.main.hosted_zone_name}"
+    zone_id                = "${data.aws_elb_hosted_zone_id.main.hosted_zone_id}"
+    evaluate_target_health = true
+  }
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) Name of the ELB.
+
+## Attributes Reference
+
+* `hosted_zone_id` - The ID of the AWS ELB's HostedZoneId.
+* `hosted_zone_name` - The Hosted Zone Name of the AWS ELB.
+* `dns_name` - The DNS Name of the AWS ELB.


### PR DESCRIPTION
This is a companion for the existing ```data_source_aws_elb_hosted_zone_id```.
The use case is, for instance, when one need to add a DNS entry pointing
to an pre-existing ELB.

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsElbHostedZoneName'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccDataSourceAwsElbHostedZoneName -timeout 120m
=== RUN   TestAccDataSourceAwsElbHostedZoneName
--- PASS: TestAccDataSourceAwsElbHostedZoneName (33.32s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       33.333s
```