### PR TITLE
Spot Instance Request: handle "closed" requests

### DIFF
--- a/aws/resource_aws_spot_instance_request.go
+++ b/aws/resource_aws_spot_instance_request.go
@@ -215,8 +215,8 @@ func resourceAwsSpotInstanceRequestRead(d *schema.ResourceData, meta interface{}
 
 	request := resp.SpotInstanceRequests[0]
 
-	// if the request is cancelled, then it is gone
-	if *request.State == "cancelled" {
+	// if the request is cancelled or closed, then it is gone
+	if *request.State == "cancelled" || *request.State == "closed" {
 		d.SetId("")
 		return nil
 	}

--- a/aws/resource_aws_spot_instance_request_test.go
+++ b/aws/resource_aws_spot_instance_request_test.go
@@ -211,8 +211,9 @@ func testAccCheckAWSSpotInstanceRequestDestroy(s *terraform.State) error {
 			return nil
 		}
 
-		if *s.State == "canceled" {
+		if *s.State == "canceled" || *s.State == "closed" {
 			// Requests stick around for a while, so we make sure it's cancelled
+			// or closed.
 			return nil
 		}
 


### PR DESCRIPTION
For one-time spot instance requests, when the instance is terminated,
the request is automatically marked as "closed" and removed by aws after
some time. This is same as "cancelled" requests. This change handles
"closed" state scenario and treats the request as deleted.

fixes #1327 