### PR TITLE
r/db_snapshot: Raise creation timeout to 20mins

### DIFF
--- a/aws/resource_aws_db_snapshot.go
+++ b/aws/resource_aws_db_snapshot.go
@@ -19,7 +19,7 @@ func resourceAwsDbSnapshot() *schema.Resource {
 		Delete: resourceAwsDbSnapshotDelete,
 
 		Timeouts: &schema.ResourceTimeout{
-			Read: schema.DefaultTimeout(10 * time.Minute),
+			Read: schema.DefaultTimeout(20 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{


### PR DESCRIPTION
This is to address the following test failure which came out of nightly test run:

```
=== RUN   TestAccAWSDBSnapshot_basic
--- FAIL: TestAccAWSDBSnapshot_basic (767.41s)
    testing.go:434: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_db_snapshot.test: 1 error(s) occurred:
        
        * aws_db_snapshot.test: timeout while waiting for state to become 'available' (last state: 'creating', timeout: 10m0s)
    testing.go:494: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
```

The timeout part of schema is admittedly wrong as the timeout belongs to `Create` action, not Read, but that's a breaking change we should address in a separate PR as it will also require major version bump.