### PR TITLE
docs: Add missing link to d/s3_bucket

### DIFF
--- a/website/aws.erb
+++ b/website/aws.erb
@@ -170,6 +170,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-route-table") %>>
                           <a href="/docs/providers/aws/d/route_table.html">aws_route_table</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-s3-bucket") %>>
+                            <a href="/docs/providers/aws/d/s3_bucket.html">aws_s3_bucket</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-s3-bucket-object") %>>
                             <a href="/docs/providers/aws/d/s3_bucket_object.html">aws_s3_bucket_object</a>
                         </li>


### PR DESCRIPTION
This was just forgotten in https://github.com/terraform-providers/terraform-provider-aws/pull/1505