### PR TITLE
resource/aws_instance: Store sg as ID for default VPC

### DIFF
--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -1480,8 +1480,7 @@ func readSecurityGroups(d *schema.ResourceData, instance *ec2.Instance, conn *ec
 		// This may happen in Eucalyptus Cloud
 		log.Printf("[WARN] Unable to retrieve VPCs")
 	} else {
-		isInDefaultVpc := *out.Vpcs[0].IsDefault
-		useID = !isInDefaultVpc
+		useID = *out.Vpcs[0].IsDefault
 	}
 
 	if v := d.Get("security_groups"); v != nil {


### PR DESCRIPTION
Security group was being stored as name, although vpc_security_group_ids
accepts IDs. Due to this, there were mismatches right after applying.
This was happening only for default VPC, not a custom VPC.
This change enables saving default VPC sgs as IDs, not name.

fixes #1799 