### PR TITLE
[Pending] New Resource: aws_workspaces_workspace

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -80,6 +80,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/aws/aws-sdk-go/service/wafregional"
+	"github.com/aws/aws-sdk-go/service/workspaces"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-cleanhttp"
@@ -206,6 +207,7 @@ type AWSClient struct {
 	athenaconn            *athena.Athena
 	dxconn                *directconnect.DirectConnect
 	mediastoreconn        *mediastore.MediaStore
+	wsconn                *workspaces.WorkSpaces
 }
 
 func (c *AWSClient) S3() *s3.S3 {
@@ -451,6 +453,7 @@ func (c *Config) Client() (interface{}, error) {
 	client.athenaconn = athena.New(sess)
 	client.dxconn = directconnect.New(sess)
 	client.mediastoreconn = mediastore.New(sess)
+	client.wsconn = workspaces.New(sess)
 
 	// Workaround for https://github.com/aws/aws-sdk-go/issues/1376
 	client.kinesisconn.Handlers.Retry.PushBack(func(r *request.Request) {

--- a/aws/config.go
+++ b/aws/config.go
@@ -201,6 +201,7 @@ type AWSClient struct {
 	ssmconn               *ssm.SSM
 	wafconn               *waf.WAF
 	wafregionalconn       *wafregional.WAFRegional
+	workspacesconn        *workspaces.WorkSpaces
 	iotconn               *iot.IoT
 	batchconn             *batch.Batch
 	glueconn              *glue.Glue
@@ -448,6 +449,7 @@ func (c *Config) Client() (interface{}, error) {
 	client.ssmconn = ssm.New(sess)
 	client.wafconn = waf.New(sess)
 	client.wafregionalconn = wafregional.New(sess)
+	client.workspacesconn = workspaces.New(sess)
 	client.batchconn = batch.New(sess)
 	client.glueconn = glue.New(sess)
 	client.athenaconn = athena.New(sess)

--- a/aws/data_source_aws_workspaces_bundle.go
+++ b/aws/data_source_aws_workspaces_bundle.go
@@ -1,0 +1,118 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/workspaces"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsWorkspaceBundle() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsWorkspaceBundleRead,
+
+		Schema: map[string]*schema.Schema{
+			"bundle_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"owner": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"compute_type": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"user_storage": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"capacity": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"root_storage": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"capacity": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAwsWorkspaceBundleRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wsconn
+
+	bundleID := d.Get("bundle_id").(string)
+	input := &workspaces.DescribeWorkspaceBundlesInput{
+		BundleIds: []*string{aws.String(bundleID)},
+	}
+
+	resp, err := conn.DescribeWorkspaceBundles(input)
+	if err != nil {
+		return err
+	}
+
+	if len(resp.Bundles) != 1 {
+		return fmt.Errorf("The number of Workspace Bundle (%s) should be 1, but %d", bundleID, len(resp.Bundles))
+	}
+
+	bundle := resp.Bundles[0]
+	d.SetId(bundleID)
+	d.Set("description", bundle.Description)
+	d.Set("name", bundle.Name)
+	d.Set("owner", bundle.Owner)
+	if bundle.ComputeType != nil {
+		r := map[string]interface{}{
+			"name": *bundle.ComputeType.Name,
+		}
+		ct := []map[string]interface{}{r}
+		d.Set("compute_type", ct)
+	}
+	if bundle.RootStorage != nil {
+		r := map[string]interface{}{
+			"capacity": *bundle.RootStorage.Capacity,
+		}
+		rs := []map[string]interface{}{r}
+		d.Set("root_storage", rs)
+	}
+	if bundle.UserStorage != nil {
+		r := map[string]interface{}{
+			"capacity": *bundle.UserStorage.Capacity,
+		}
+		us := []map[string]interface{}{r}
+		d.Set("user_storage", us)
+	}
+
+	return nil
+}

--- a/aws/data_source_aws_workspaces_bundle_test.go
+++ b/aws/data_source_aws_workspaces_bundle_test.go
@@ -1,0 +1,32 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceAwsWorkspaceBundle_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDataSourceAwsWorkspaceBundleConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_workspaces_bundle.test", "bundle_id", "wsb-b0s22j3d7"),
+					resource.TestCheckResourceAttrSet(
+						"data.aws_workspaces_bundle.test", "name"),
+					resource.TestCheckResourceAttrSet(
+						"data.aws_workspaces_bundle.test", "owner"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceAwsWorkspaceBundleConfig = `
+data "aws_workspaces_bundle" "test" {
+  bundle_id = "wsb-b0s22j3d7"
+}
+`

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -227,6 +227,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_vpc_endpoint_service":             dataSourceAwsVpcEndpointService(),
 			"aws_vpc_peering_connection":           dataSourceAwsVpcPeeringConnection(),
 			"aws_vpn_gateway":                      dataSourceAwsVpnGateway(),
+			"aws_workspaces_bundle":                dataSourceAwsWorkspaceBundle(),
 
 			// Adding the Aliases for the ALB -> LB Rename
 			"aws_lb":               dataSourceAwsLb(),

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -531,6 +531,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_waf_sql_injection_match_set":              resourceAwsWafSqlInjectionMatchSet(),
 			"aws_wafregional_byte_match_set":               resourceAwsWafRegionalByteMatchSet(),
 			"aws_wafregional_ipset":                        resourceAwsWafRegionalIPSet(),
+			"aws_workspaces_workspace":                     resourceAwsWorkspacesWorkspace(),
 			"aws_batch_compute_environment":                resourceAwsBatchComputeEnvironment(),
 			"aws_batch_job_definition":                     resourceAwsBatchJobDefinition(),
 			"aws_batch_job_queue":                          resourceAwsBatchJobQueue(),

--- a/aws/resource_aws_workspaces_workspace.go
+++ b/aws/resource_aws_workspaces_workspace.go
@@ -1,0 +1,30 @@
+package aws
+
+import "github.com/hashicorp/terraform/helper/schema"
+
+func resourceAwsWorkspacesWorkspace() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsWorkspacesWorkspaceCreate,
+		Read:   resourceAwsWorkspacesWorkspaceRead,
+		Update: resourceAwsWorkspacesWorkspaceUpdate,
+		Delete: resourceAwsWorkspacesWorkspaceDelete,
+
+		Schema: map[string]*schema.Schema{},
+	}
+}
+
+func resourceAwsWorkspacesWorkspaceCreate(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceAwsWorkspacesWorkspaceRead(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceAwsWorkspacesWorkspaceUpdate(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceAwsWorkspacesWorkspaceDelete(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}

--- a/aws/resource_aws_workspaces_workspace.go
+++ b/aws/resource_aws_workspaces_workspace.go
@@ -1,6 +1,15 @@
 package aws
 
-import "github.com/hashicorp/terraform/helper/schema"
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/workspaces"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
 
 func resourceAwsWorkspacesWorkspace() *schema.Resource {
 	return &schema.Resource{
@@ -9,22 +18,309 @@ func resourceAwsWorkspacesWorkspace() *schema.Resource {
 		Update: resourceAwsWorkspacesWorkspaceUpdate,
 		Delete: resourceAwsWorkspacesWorkspaceDelete,
 
-		Schema: map[string]*schema.Schema{},
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"bundle_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"directory_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"root_volume_encryption_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Default:  false,
+			},
+			"user_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"user_volume_encryption_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Default:  false,
+			},
+			"volume_encryption_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"workspace_properties": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"compute_type_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"running_mode": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"root_volume_size_gib": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+						},
+						"running_mode_auto_stop_timeout_in_minutes": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+						},
+						"user_volume_size_gib": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
 	}
 }
 
 func resourceAwsWorkspacesWorkspaceCreate(d *schema.ResourceData, meta interface{}) error {
-	return nil
+	conn := meta.(*AWSClient).wsconn
+
+	input := &workspaces.CreateWorkspacesInput{
+		Workspaces: buildWorkspaceRequests(d, meta),
+	}
+
+	resp, err := conn.CreateWorkspaces(input)
+	if err != nil {
+		return err
+	}
+
+	if len(resp.FailedRequests) > 0 {
+		failReq := resp.FailedRequests[0]
+		return fmt.Errorf("Creating Workspace failed due to %s", *failReq.ErrorMessage)
+	}
+
+	pendingReq := resp.PendingRequests[0]
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{
+			workspaces.WorkspaceStatePending,
+			workspaces.WorkspaceStateStarting,
+		},
+		Target:  []string{workspaces.WorkspaceStateAvailable},
+		Refresh: workspaceRefreshStatusFunc(conn, *pendingReq.WorkspaceId),
+		Timeout: 25 * time.Minute,
+	}
+
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("[WARN] Error waiting for Workspace state to be \"%s\": %s", workspaces.WorkspaceStateAvailable, err)
+	}
+
+	d.SetId(*pendingReq.WorkspaceId)
+
+	return resourceAwsWorkspacesWorkspaceRead(d, meta)
 }
 
 func resourceAwsWorkspacesWorkspaceRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wsconn
+
+	input := &workspaces.DescribeWorkspacesInput{
+		WorkspaceIds: []*string{aws.String(d.Id())},
+	}
+
+	resp, err := conn.DescribeWorkspaces(input)
+	if err != nil {
+		if isAWSErr(err, workspaces.ErrCodeResourceNotFoundException, "") {
+			log.Printf("[WARN] Workspace (%s) not found, error code (404)", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	workspace := resp.Workspaces[0]
+	d.Set("bundle_id", workspace.BundleId)
+	d.Set("bundle_id", workspace.DirectoryId)
+	d.Set("root_volume_encryption_enabled", workspace.RootVolumeEncryptionEnabled)
+	d.Set("user_name", workspace.UserName)
+	d.Set("user_volume_encryption_enabled", workspace.UserVolumeEncryptionEnabled)
+	d.Set("volume_encryption_key", workspace.VolumeEncryptionKey)
+	d.Set("workspace_properties", flattenWorkspaceProperties(workspace.WorkspaceProperties))
+
 	return nil
 }
 
 func resourceAwsWorkspacesWorkspaceUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wsconn
+
+	input := &workspaces.ModifyWorkspacePropertiesInput{
+		WorkspaceId: aws.String(d.Id()),
+	}
+
+	if d.HasChange("workspace_properties") {
+		properties := d.Get("workspace_properties").(*schema.Set).List()
+		if len(properties) > 0 {
+			prop := properties[0].(map[string]interface{})
+			input.WorkspaceProperties = expandWorkspaceProperties(prop)
+		}
+	}
+
+	_, err := conn.ModifyWorkspaceProperties(input)
+	if err != nil {
+		if isAWSErr(err, workspaces.ErrCodeResourceNotFoundException, "") {
+			log.Printf("[WARN] Workspace (%s) not found, error code (404)", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
 	return nil
 }
 
 func resourceAwsWorkspacesWorkspaceDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wsconn
+
+	input := &workspaces.TerminateWorkspacesInput{
+		TerminateWorkspaceRequests: []*workspaces.TerminateRequest{
+			&workspaces.TerminateRequest{
+				WorkspaceId: aws.String(d.Id()),
+			},
+		},
+	}
+
+	_, err := conn.TerminateWorkspaces(input)
+	if err != nil {
+		if isAWSErr(err, workspaces.ErrCodeResourceNotFoundException, "") {
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{
+			workspaces.WorkspaceStatePending,
+			workspaces.WorkspaceStateAvailable,
+			workspaces.WorkspaceStateImpaired,
+			workspaces.WorkspaceStateUnhealthy,
+			workspaces.WorkspaceStateRebooting,
+			workspaces.WorkspaceStateStarting,
+			workspaces.WorkspaceStateRebuilding,
+			workspaces.WorkspaceStateMaintenance,
+			workspaces.WorkspaceStateSuspended,
+			workspaces.WorkspaceStateUpdating,
+			workspaces.WorkspaceStateStopping,
+			workspaces.WorkspaceStateStopped,
+		},
+		Target: []string{
+			workspaces.WorkspaceStateTerminating,
+			workspaces.WorkspaceStateTerminated,
+		},
+		Refresh: workspaceRefreshStatusFunc(conn, d.Id()),
+		Timeout: 25 * time.Minute,
+	}
+
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("[WARN] Error waiting for Workspace state to be \"%s\", \"%s\": %s",
+			workspaces.WorkspaceStateTerminating,
+			workspaces.WorkspaceStateTerminated,
+			err)
+	}
+
 	return nil
+}
+
+func buildWorkspaceRequests(d *schema.ResourceData, meta interface{}) []*workspaces.WorkspaceRequest {
+	req := &workspaces.WorkspaceRequest{
+		BundleId:                    aws.String(d.Get("bundle_id").(string)),
+		DirectoryId:                 aws.String(d.Get("directory_id").(string)),
+		UserName:                    aws.String(d.Get("user_name").(string)),
+		RootVolumeEncryptionEnabled: aws.Bool(d.Get("root_volume_encryption_enabled").(bool)),
+		UserVolumeEncryptionEnabled: aws.Bool(d.Get("user_volume_encryption_enabled").(bool)),
+	}
+
+	if v, ok := d.GetOk("volume_encryption_key"); ok {
+		req.VolumeEncryptionKey = aws.String(v.(string))
+	}
+	properties := d.Get("workspace_properties").(*schema.Set).List()
+	if len(properties) > 0 {
+		prop := properties[0].(map[string]interface{})
+		req.WorkspaceProperties = expandWorkspaceProperties(prop)
+	}
+	return []*workspaces.WorkspaceRequest{req}
+}
+
+func expandWorkspaceProperties(configured map[string]interface{}) *workspaces.WorkspaceProperties {
+	if len(configured) > 0 {
+		return nil
+	}
+
+	wp := &workspaces.WorkspaceProperties{}
+	if v, ok := configured["compute_type_name"]; ok && v.(string) != "" {
+		wp.SetComputeTypeName(v.(string))
+	}
+	if v, ok := configured["running_mode"]; ok && v.(string) != "" {
+		wp.SetRunningMode(v.(string))
+	}
+	if v, ok := configured["root_volume_size_gib"]; ok && v.(int64) != 0 {
+		wp.SetRootVolumeSizeGib(v.(int64))
+	}
+	if v, ok := configured["running_mode_auto_stop_timeout_in_minutes"]; ok && v.(int64) != 0 {
+		wp.SetRunningModeAutoStopTimeoutInMinutes(v.(int64))
+	}
+	if v, ok := configured["user_volume_size_gib"]; ok && v.(int64) != 0 {
+		wp.SetUserVolumeSizeGib(v.(int64))
+	}
+
+	return wp
+}
+
+func flattenWorkspaceProperties(wp *workspaces.WorkspaceProperties) []map[string]interface{} {
+	if wp == nil {
+		return nil
+	}
+
+	result := make(map[string]interface{}, 1)
+	if wp.ComputeTypeName != nil {
+		result["compute_type_name"] = *wp.ComputeTypeName
+	}
+	if wp.RunningMode != nil {
+		result["running_mode"] = *wp.RunningMode
+	}
+	if wp.RootVolumeSizeGib != nil {
+		result["root_volume_size_gib"] = *wp.RootVolumeSizeGib
+	}
+	if wp.RunningModeAutoStopTimeoutInMinutes != nil {
+		result["running_mode_auto_stop_timeout_in_minutes"] = *wp.RunningModeAutoStopTimeoutInMinutes
+	}
+	if wp.UserVolumeSizeGib != nil {
+		result["user_volume_size_gib"] = *wp.UserVolumeSizeGib
+	}
+
+	return []map[string]interface{}{result}
+}
+
+func workspaceRefreshStatusFunc(conn *workspaces.WorkSpaces, workspaceID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		input := &workspaces.DescribeWorkspacesInput{
+			WorkspaceIds: []*string{aws.String(workspaceID)},
+		}
+		resp, err := conn.DescribeWorkspaces(input)
+		if err != nil {
+			return nil, "failed", err
+		}
+		workspace := resp.Workspaces[0]
+		return workspace, *workspace.State, nil
+	}
 }

--- a/aws/resource_aws_workspaces_workspace_test.go
+++ b/aws/resource_aws_workspaces_workspace_test.go
@@ -1,0 +1,1 @@
+package aws

--- a/aws/resource_aws_workspaces_workspace_test.go
+++ b/aws/resource_aws_workspaces_workspace_test.go
@@ -1,1 +1,143 @@
 package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/workspaces"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAwsWorkspacesWorkspace_basic(t *testing.T) {
+	rName := acctest.RandString(5)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsWorkspacesWorkspaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWorkspacesWorkspaceConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsWorkspacesWorkspaceExists("aws_workspaces_workspace.test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAwsWorkspacesWorkspace_import(t *testing.T) {
+	resourceName := "aws_workspaces_workspace.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsWorkspacesWorkspaceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccWorkspacesWorkspaceConfig(acctest.RandString(5)),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAwsWorkspacesWorkspaceDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).workspacesconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_workspaces_workspace" {
+			continue
+		}
+
+		input := &workspaces.DescribeWorkspacesInput{
+			WorkspaceIds: []*string{aws.String(rs.Primary.ID)},
+		}
+
+		resp, err := conn.DescribeWorkspaces(input)
+		if err != nil {
+			if isAWSErr(err, workspaces.ErrCodeResourceNotFoundException, "") {
+				return nil
+			}
+			return err
+		}
+
+		ws := resp.Workspaces[0]
+		if *ws.State != workspaces.WorkspaceStateTerminating ||
+			*ws.State != workspaces.WorkspaceStateTerminated {
+			return fmt.Errorf("Workspace (%s) not deleted", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAwsWorkspacesWorkspaceExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).workspacesconn
+
+		input := &workspaces.DescribeWorkspacesInput{
+			WorkspaceIds: []*string{aws.String(rs.Primary.ID)},
+		}
+
+		_, err := conn.DescribeWorkspaces(input)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+func testAccWorkspacesWorkspaceConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "test1" {
+  vpc_id = "${aws_vpc.test.id}"
+  availability_zone = "us-west-2a"
+  cidr_block = "10.0.1.0/24"
+}
+
+resource "aws_subnet" "test2" {
+  vpc_id = "${aws_vpc.test.id}"
+  availability_zone = "us-west-2b"
+  cidr_block = "10.0.2.0/24"
+}
+
+resource "aws_directory_service_directory" "test" {
+  name = "tf-test-%s.ikinari-steak.net"
+  password = "SuperSecretPassw0rd"
+  size = "Small"
+
+  vpc_settings {
+    vpc_id = "${aws_vpc.test.id}"
+    subnet_ids = ["${aws_subnet.test1.id}","${aws_subnet.test2.id}"]
+  }
+}
+
+data "aws_workspaces_bundle" "test" {
+  bundle_id = "wsb-b0s22j3d7"
+}
+
+resource "aws_workspaces_workspace" "test" {
+  bundle_id = "${data.aws_workspaces_bundle.test.bundle_id}"
+  directory_id = "${aws_directory_service_directory.test.id}"
+  user_name = "tf-test-%s"
+}
+`, rName, rName)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -893,6 +893,14 @@
 			"revisionTime": "2017-10-15T22:09:51Z"
 		},
 		{
+			"checksumSHA1": "OHfwSU+p4N0Ft+BrzJfdE6AVRsY=",
+			"path": "github.com/aws/aws-sdk-go/service/workspaces",
+			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
+			"revisionTime": "2017-10-10T17:54:20Z",
+			"version": "v1.12.8",
+			"versionExact": "v1.12.8"
+		},
+		{
 			"checksumSHA1": "nqw2Qn5xUklssHTubS5HDvEL9L4=",
 			"path": "github.com/bgentry/go-netrc/netrc",
 			"revision": "9fd32a8b3d3d3f9d43c341bfe098430e07609480",

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -233,6 +233,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-vpn-gateway") %>>
                             <a href="/docs/providers/aws/d/vpn_gateway.html">aws_vpn_gateway</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-workspaces-bundle") %>>
+                            <a href="/docs/providers/aws/d/workspaces_bundle.html">aws_workspaces_bundle</a>
+                        </li>
                     </ul>
                 </li>
 

--- a/website/docs/d/workspaces_bundle.html.markdown
+++ b/website/docs/d/workspaces_bundle.html.markdown
@@ -1,0 +1,48 @@
+---
+layout: "aws"
+page_title: "AWS: aws_workspaces_bundle"
+sidebar_current: "docs-aws-datasource-workspaces-bundle"
+description: |-  
+  Get information on a Workspaces Bundle.
+---
+
+# aws_workspaces_bundle
+
+Use this data source to get information about a Workspaces Bundle.
+
+## Example Usage
+
+```hcl
+data "aws_workspaces_bundle" "example" {
+  bundle_id = "wsb-b0s22j3d7"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `bundle_id` – (Required, ForceNew) The ID of the bundle.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `description` – The description of the bundle.
+* `name` – The name of the bundle.
+* `owner` – The owner of the bundle.
+* `compute_type` – The compute type. See supported fields below.
+* `root_storage` – The root volume. See supported fields below.
+* `user_storage` – The user storage. See supported fields below.
+
+### `compute_type`
+
+* `name` - The name of the compute type.
+
+### `root_storage`
+
+* `capacity` - The size of the root volume.
+
+### `user_storage`
+
+* `capacity` - The size of the user storage.


### PR DESCRIPTION
#434 
I have to crawl a website which only suits IE so I'd like to add workspaces resource.
AWS API provides `CreateWorkspaces` which can create some workspaces at a time, but it's complicated to write multi workspaces in one resource like below.
```
resource "aws_workspaces_workspaces" "hoge" {
  workspace = {
    a = a1
    b = b1
    ....
  }

  workspace = {
    a = a2
    b = b2
    ....
  }
}
```
So I'm going to add `aws_workspaces_workspace` and for each `CreateWorkspaces` works with one element.