### PR TITLE
data_source_aws_security_group: add description

### DIFF
--- a/aws/data_source_aws_security_group.go
+++ b/aws/data_source_aws_security_group.go
@@ -38,6 +38,11 @@ func dataSourceAwsSecurityGroup() *schema.Resource {
 			},
 
 			"tags": tagsSchemaComputed(),
+
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }

--- a/aws/data_source_aws_security_group_test.go
+++ b/aws/data_source_aws_security_group_test.go
@@ -21,6 +21,7 @@ func TestAccDataSourceAwsSecurityGroup(t *testing.T) {
 				Config: testAccDataSourceAwsSecurityGroupConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceAwsSecurityGroupCheck("data.aws_security_group.by_id"),
+					resource.TestCheckResourceAttr("data.aws_security_group.by_id", "description", "sg description"),
 					testAccDataSourceAwsSecurityGroupCheck("data.aws_security_group.by_tag"),
 					testAccDataSourceAwsSecurityGroupCheck("data.aws_security_group.by_filter"),
 					testAccDataSourceAwsSecurityGroupCheck("data.aws_security_group.by_name"),
@@ -121,6 +122,7 @@ func testAccDataSourceAwsSecurityGroupConfig(rInt int) string {
 			Name = "tf-acctest"
 			Seed = "%d"
 		}
+		description = "sg description"
 	}
 
 	data "aws_security_group" "by_id" {


### PR DESCRIPTION
From #1940 I came across https://www.terraform.io/docs/providers/aws/d/security_group.html#description where `description` is an attribute reference. But in real, `description` isn't available. This change adds `description` to `data_source_aws_security_group`.

This doesn't f-ixes #1940, which talks about description for the SG rules, which I see already exist 🤷‍♀️.