### PR TITLE
Normalize JSON policy document

### DIFF
--- a/aws/resource_aws_iam_policy.go
+++ b/aws/resource_aws_iam_policy.go
@@ -99,10 +99,16 @@ func resourceAwsIamPolicyCreate(d *schema.ResourceData, meta interface{}) error 
 		name = resource.UniqueId()
 	}
 
+	// Normalize the Policy Document.
+	normalizedPolicyDocument, err := normalizeJsonString(d.Get("policy").(string))
+	if err != nil {
+		return fmt.Errorf("Error normalizing JSON Policy Document: %s", err)
+	}
+
 	request := &iam.CreatePolicyInput{
 		Description:    aws.String(d.Get("description").(string)),
 		Path:           aws.String(d.Get("path").(string)),
-		PolicyDocument: aws.String(d.Get("policy").(string)),
+		PolicyDocument: aws.String(normalizedPolicyDocument),
 		PolicyName:     aws.String(name),
 	}
 

--- a/aws/resource_aws_iam_policy_test.go
+++ b/aws/resource_aws_iam_policy_test.go
@@ -46,6 +46,24 @@ func TestAWSPolicy_invalidJson(t *testing.T) {
 	})
 }
 
+func TestAWSPolicy_leadingWhitespaceJson(t *testing.T) {
+	var out iam.GetPolicyOutput
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSPolicyLeadingWhitespaceJsonConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSPolicyExists("aws_iam_policy.policy", &out),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSPolicyExists(resource string, res *iam.GetPolicyOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resource]
@@ -127,5 +145,26 @@ resource "aws_iam_policy" "policy" {
     ]
   }
   EOF
+}
+`
+
+const testAccAWSPolicyLeadingWhitespaceJsonConfig = `
+resource "aws_iam_policy" "policy" {
+  name_prefix = "test-policy-"
+  path = "/"
+  policy = <<EOF
+      {
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:Describe*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
 }
 `

--- a/aws/resource_aws_iam_role_test.go
+++ b/aws/resource_aws_iam_role_test.go
@@ -138,6 +138,25 @@ func TestAccAWSIAMRole_badJSON(t *testing.T) {
 	})
 }
 
+func TestAccAWSIAMRole_leadingWhitespaceJSON(t *testing.T) {
+	var conf iam.GetRoleOutput
+	rName := acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSIAMRoleConfig_leadingWhitespaceJson(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRoleExists("aws_iam_role.role", &conf),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSRoleDestroy(s *terraform.State) error {
 	iamconn := testAccProvider.Meta().(*AWSClient).iamconn
 
@@ -372,6 +391,33 @@ resource "aws_iam_role" "my_instance_role" {
   ]
 }
 POLICY
+}
+`, rName)
+}
+
+func testAccAWSIAMRoleConfig_leadingWhitespaceJson(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "role" {
+  name   = "test-role-%s"
+  path = "/"
+  assume_role_policy = <<EOF
+    {
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "ec2.amazonaws.com"
+        ]
+      },
+      "Action": [
+        "sts:AssumeRole"
+      ]
+    }
+  ]
+}
+EOF
 }
 `, rName)
 }

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -662,7 +662,8 @@ func validateJsonString(v interface{}, k string) (ws []string, errors []error) {
 
 func validateIAMPolicyJson(v interface{}, k string) (ws []string, errors []error) {
 	// IAM Policy documents need to be valid JSON, and pass legacy parsing
-	value := v.(string)
+	// Trim away any whitespace " " and "\t".
+	value := strings.TrimLeft(v.(string), " \t")
 	if len(value) < 1 {
 		errors = append(errors, fmt.Errorf("%q contains an invalid JSON policy", k))
 		return

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -908,10 +908,6 @@ func TestValidateIAMPolicyJsonString(t *testing.T) {
 			Value:    ``,
 			ErrCount: 1,
 		},
-		{
-			Value:    `    {"xyz": "foo"}`,
-			ErrCount: 1,
-		},
 	}
 
 	for _, tc := range invalidCases {
@@ -928,6 +924,10 @@ func TestValidateIAMPolicyJsonString(t *testing.T) {
 		},
 		{
 			Value:    `{"abc":["1","2"]}`,
+			ErrCount: 0,
+		},
+		{
+			Value:    `    {"xyz": "foo"}`,
 			ErrCount: 0,
 		},
 	}


### PR DESCRIPTION
This change normalizes the provided JSON policy document and uses the
same to create IAM policy and role. ~Also, the normalized json is indented with 4
spaces.~

fixes #1873 