### PR TITLE
r/aws_lb: Allow assigning EIP to network LB

### DIFF
--- a/aws/resource_aws_lb.go
+++ b/aws/resource_aws_lb.go
@@ -223,9 +223,7 @@ func resourceAwsLbCreate(d *schema.ResourceData, meta interface{}) error {
 			}
 
 			if subnetMap["allocation_id"].(string) != "" {
-				elbOpts.SubnetMappings[i] = &elbv2.SubnetMapping{
-					AllocationId: aws.String(subnetMap["allocation_id"].(string)),
-				}
+				elbOpts.SubnetMappings[i].AllocationId = aws.String(subnetMap["allocation_id"].(string))
 			}
 		}
 	}

--- a/aws/resource_aws_lb.go
+++ b/aws/resource_aws_lb.go
@@ -460,9 +460,16 @@ func resourceAwsLbDelete(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error deleting ALB: %s", err)
 	}
 
-	err := cleanupLBNetworkInterfaces(meta.(*AWSClient).ec2conn, d.Id())
+	conn := meta.(*AWSClient).ec2conn
+
+	err := cleanupLBNetworkInterfaces(conn, d.Id())
 	if err != nil {
 		log.Printf("[WARN] Failed to cleanup ENIs for ALB %q: %#v", d.Id(), err)
+	}
+
+	err = waitForNLBNetworkInterfacesToDetach(conn, d.Id())
+	if err != nil {
+		log.Printf("[WARN] Failed to wait for ENIs to disappear for NLB %q: %#v", d.Id(), err)
 	}
 
 	return nil
@@ -473,14 +480,10 @@ func resourceAwsLbDelete(d *schema.ResourceData, meta interface{}) error {
 // which then blocks IGW, SG or VPC on deletion
 // So we make the cleanup "synchronous" here
 func cleanupLBNetworkInterfaces(conn *ec2.EC2, lbArn string) error {
-	re := regexp.MustCompile("([^/]+/[^/]+/[^/]+)$")
-	matches := re.FindStringSubmatch(lbArn)
-	if len(matches) != 2 {
-		return fmt.Errorf("Unexpected ARN format: %q", lbArn)
+	name, err := getLbNameFromArn(lbArn)
+	if err != nil {
+		return err
 	}
-
-	// e.g. app/example-alb/b26e625cdde161e6
-	name := matches[1]
 
 	out, err := conn.DescribeNetworkInterfaces(&ec2.DescribeNetworkInterfacesInput{
 		Filters: []*ec2.Filter{
@@ -498,7 +501,7 @@ func cleanupLBNetworkInterfaces(conn *ec2.EC2, lbArn string) error {
 		return err
 	}
 
-	log.Printf("[DEBUG] Found %d ENIs to cleanup for ALB %q",
+	log.Printf("[DEBUG] Found %d ENIs to cleanup for LB %q",
 		len(out.NetworkInterfaces), name)
 
 	if len(out.NetworkInterfaces) == 0 {
@@ -517,6 +520,59 @@ func cleanupLBNetworkInterfaces(conn *ec2.EC2, lbArn string) error {
 	}
 
 	return nil
+}
+
+func waitForNLBNetworkInterfacesToDetach(conn *ec2.EC2, lbArn string) error {
+	name, err := getLbNameFromArn(lbArn)
+	if err != nil {
+		return err
+	}
+
+	// We cannot cleanup these ENIs ourselves as that would result in
+	// OperationNotPermitted: You are not allowed to manage 'ela-attach' attachments.
+	// yet presence of these ENIs may prevent us from deleting EIPs associated w/ the NLB
+
+	return resource.Retry(1*time.Minute, func() *resource.RetryError {
+		out, err := conn.DescribeNetworkInterfaces(&ec2.DescribeNetworkInterfacesInput{
+			Filters: []*ec2.Filter{
+				{
+					Name:   aws.String("attachment.instance-owner-id"),
+					Values: []*string{aws.String("amazon-aws")},
+				},
+				{
+					Name:   aws.String("attachment.attachment-id"),
+					Values: []*string{aws.String("ela-attach-*")},
+				},
+				{
+					Name:   aws.String("description"),
+					Values: []*string{aws.String("ELB " + name)},
+				},
+			},
+		})
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		niCount := len(out.NetworkInterfaces)
+		if niCount > 0 {
+			log.Printf("[DEBUG] Found %d ENIs to cleanup for NLB %q", niCount, lbArn)
+			return resource.RetryableError(fmt.Errorf("Waiting for %d ENIs of %q to clean up", niCount, lbArn))
+		}
+		log.Printf("[DEBUG] ENIs gone for NLB %q", lbArn)
+
+		return nil
+	})
+}
+
+func getLbNameFromArn(arn string) (string, error) {
+	re := regexp.MustCompile("([^/]+/[^/]+/[^/]+)$")
+	matches := re.FindStringSubmatch(arn)
+	if len(matches) != 2 {
+		return "", fmt.Errorf("Unexpected ARN format: %q", arn)
+	}
+
+	// e.g. app/example-alb/b26e625cdde161e6
+	return matches[1], nil
 }
 
 // flattenSubnetsFromAvailabilityZones creates a slice of strings containing the subnet IDs


### PR DESCRIPTION
Apologies for slightly bigger scope of this PR, but it was necessary to make tests pass.

Passing allocation ID w/out subnet causes AWS API to return `500 Internal Server Error` and the SDK to retry for ~1-2 hours. The API bug was reported and acked by AWS support, so it replies with something more sensible, e.g. 400.

NLBs create their own ENIs, like other load balancers, and leaves them around for a short while after deletion which upsets other depending resources as we try to clean them up - EIPs in this case:

```
        Error: Error applying: 2 error(s) occurred:
        
        * aws_eip.lb[1] (destroy): 1 error(s) occurred:
        
        * aws_eip.lb.1: AuthFailure: You do not have permission to access the specified resource.
            status code: 400, request id: def27ac4-2f37-4f91-ad56-2774e4c7029e
        * aws_eip.lb[0] (destroy): 1 error(s) occurred:
        
        * aws_eip.lb.0: AuthFailure: You do not have permission to access the specified resource.
            status code: 400, request id: f916f6d1-bc0e-4616-816d-0799151e43c6
```


As opposed to ALB's & ELB's ENIs we can't cleanup those ENIs, so I just added retry. 🤷‍♂️ 

## Snippet from debug log

to prove that waiter is actually necessary & effective:

```
2017/10/19 10:10:15 [DEBUG] Found 2 ENIs to cleanup for NLB "arn:aws:elasticloadbalancing:eu-west-2:187416307283:loadbalancer/net/radek-test/033bdf33f3c50e5c"
2017/10/19 10:10:16 [DEBUG] Found 2 ENIs to cleanup for NLB "arn:aws:elasticloadbalancing:eu-west-2:187416307283:loadbalancer/net/radek-test/033bdf33f3c50e5c"
2017/10/19 10:10:17 [DEBUG] Found 2 ENIs to cleanup for NLB "arn:aws:elasticloadbalancing:eu-west-2:187416307283:loadbalancer/net/radek-test/033bdf33f3c50e5c"
2017/10/19 10:10:20 [DEBUG] Found 2 ENIs to cleanup for NLB "arn:aws:elasticloadbalancing:eu-west-2:187416307283:loadbalancer/net/radek-test/033bdf33f3c50e5c"
2017/10/19 10:10:24 [DEBUG] Found 2 ENIs to cleanup for NLB "arn:aws:elasticloadbalancing:eu-west-2:187416307283:loadbalancer/net/radek-test/033bdf33f3c50e5c"
2017/10/19 10:10:32 [DEBUG] Found 2 ENIs to cleanup for NLB "arn:aws:elasticloadbalancing:eu-west-2:187416307283:loadbalancer/net/radek-test/033bdf33f3c50e5c"
2017/10/19 10:10:43 [DEBUG] ENIs gone for NLB "arn:aws:elasticloadbalancing:eu-west-2:187416307283:loadbalancer/net/radek-test/033bdf33f3c50e5c"
```

### Test results

<img width="408" alt="screen shot 2017-10-19 at 11 06 15" src="https://user-images.githubusercontent.com/287584/31760550-b87d3cb4-b4bd-11e7-82cc-ffa7610586e6.png">
