### PR TITLE
r/security_group_rule: parse description correctly

### DIFF
--- a/aws/resource_aws_security_group_rule_test.go
+++ b/aws/resource_aws_security_group_rule_test.go
@@ -676,6 +676,143 @@ func TestAccAWSSecurityGroupRule_EgressDescription_updates(t *testing.T) {
 	})
 }
 
+func TestAccAWSSecurityGroupRule_MultiDescription(t *testing.T) {
+	var group ec2.SecurityGroup
+	var nat ec2.SecurityGroup
+	rInt := acctest.RandInt()
+
+	rule1 := ec2.IpPermission{
+		FromPort:   aws.Int64(22),
+		ToPort:     aws.Int64(22),
+		IpProtocol: aws.String("tcp"),
+		IpRanges: []*ec2.IpRange{
+			{CidrIp: aws.String("0.0.0.0/0"), Description: aws.String("CIDR Description")},
+		},
+	}
+
+	rule2 := ec2.IpPermission{
+		FromPort:   aws.Int64(22),
+		ToPort:     aws.Int64(22),
+		IpProtocol: aws.String("tcp"),
+		Ipv6Ranges: []*ec2.Ipv6Range{
+			{CidrIpv6: aws.String("::/0"), Description: aws.String("IPv6 CIDR Description")},
+		},
+	}
+
+	var rule3 ec2.IpPermission
+
+	// This function creates the expected IPPermission with the group id from an
+	// external security group, needed because Security Group IDs are generated on
+	// AWS side and can't be known ahead of time.
+	setupSG := func(*terraform.State) error {
+		if nat.GroupId == nil {
+			return fmt.Errorf("Error: nat group has nil GroupID")
+		}
+
+		rule3 = ec2.IpPermission{
+			FromPort:   aws.Int64(22),
+			ToPort:     aws.Int64(22),
+			IpProtocol: aws.String("tcp"),
+			UserIdGroupPairs: []*ec2.UserIdGroupPair{
+				{GroupId: nat.GroupId, Description: aws.String("NAT SG Description")},
+			},
+		}
+
+		return nil
+	}
+
+	var endpoint ec2.VpcEndpoint
+	var rule4 ec2.IpPermission
+
+	// This function creates the expected IPPermission with the prefix list ID from
+	// the VPC Endpoint created in the test
+	setupPL := func(*terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+		prefixListInput := &ec2.DescribePrefixListsInput{
+			Filters: []*ec2.Filter{
+				{Name: aws.String("prefix-list-name"), Values: []*string{endpoint.ServiceName}},
+			},
+		}
+
+		log.Printf("[DEBUG] Reading VPC Endpoint prefix list: %s", prefixListInput)
+		prefixListsOutput, err := conn.DescribePrefixLists(prefixListInput)
+
+		if err != nil {
+			_, ok := err.(awserr.Error)
+			if !ok {
+				return fmt.Errorf("Error reading VPC Endpoint prefix list: %s", err.Error())
+			}
+		}
+
+		if len(prefixListsOutput.PrefixLists) != 1 {
+			return fmt.Errorf("There are multiple prefix lists associated with the service name '%s'. Unexpected", prefixListsOutput)
+		}
+
+		rule4 = ec2.IpPermission{
+			FromPort:   aws.Int64(22),
+			ToPort:     aws.Int64(22),
+			IpProtocol: aws.String("tcp"),
+			PrefixListIds: []*ec2.PrefixListId{
+				{PrefixListId: prefixListsOutput.PrefixLists[0].PrefixListId, Description: aws.String("Prefix List Description")},
+			},
+		}
+
+		return nil
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityGroupRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSecurityGroupRuleMultiDescription(rInt, "ingress"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.worker", &group),
+					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.nat", &nat),
+					testAccCheckVpcEndpointExists("aws_vpc_endpoint.s3-us-west-2", &endpoint),
+
+					testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.ingress_rule_1", &group, &rule1, "ingress"),
+					resource.TestCheckResourceAttr("aws_security_group_rule.ingress_rule_1", "description", "CIDR Description"),
+
+					testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.ingress_rule_2", &group, &rule2, "ingress"),
+					resource.TestCheckResourceAttr("aws_security_group_rule.ingress_rule_2", "description", "IPv6 CIDR Description"),
+
+					setupSG,
+					testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.ingress_rule_3", &group, &rule3, "ingress"),
+					resource.TestCheckResourceAttr("aws_security_group_rule.ingress_rule_3", "description", "NAT SG Description"),
+
+					setupPL,
+					testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.ingress_rule_4", &group, &rule4, "ingress"),
+					resource.TestCheckResourceAttr("aws_security_group_rule.ingress_rule_4", "description", "Prefix List Description"),
+				),
+			},
+			{
+				Config: testAccAWSSecurityGroupRuleMultiDescription(rInt, "egress"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.worker", &group),
+					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.nat", &nat),
+					testAccCheckVpcEndpointExists("aws_vpc_endpoint.s3-us-west-2", &endpoint),
+
+					testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.egress_rule_1", &group, &rule1, "egress"),
+					resource.TestCheckResourceAttr("aws_security_group_rule.egress_rule_1", "description", "CIDR Description"),
+
+					testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.egress_rule_2", &group, &rule2, "egress"),
+					resource.TestCheckResourceAttr("aws_security_group_rule.egress_rule_2", "description", "IPv6 CIDR Description"),
+
+					setupSG,
+					testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.egress_rule_3", &group, &rule3, "egress"),
+					resource.TestCheckResourceAttr("aws_security_group_rule.egress_rule_3", "description", "NAT SG Description"),
+
+					setupPL,
+					testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.egress_rule_4", &group, &rule4, "egress"),
+					resource.TestCheckResourceAttr("aws_security_group_rule.egress_rule_4", "description", "Prefix List Description"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSSecurityGroupRuleDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).ec2conn
 
@@ -1014,6 +1151,74 @@ resource "aws_security_group_rule" "ingress_2" {
   security_group_id = "${aws_security_group.web.id}"
 }
 `
+
+func testAccAWSSecurityGroupRuleMultiDescription(rInt int, rType string) string {
+	return fmt.Sprintf(`
+	resource "aws_vpc" "tf_sgrule_description_test" {
+		cidr_block = "10.0.0.0/16"
+		tags { Name = "tf-sg-rule-description" }
+	}
+
+	resource "aws_vpc_endpoint" "s3-us-west-2" {
+		vpc_id = "${aws_vpc.tf_sgrule_description_test.id}"
+		service_name = "com.amazonaws.us-west-2.s3"
+  	}
+
+	resource "aws_security_group" "worker" {
+		name = "terraform_test_%[1]d"
+		vpc_id = "${aws_vpc.tf_sgrule_description_test.id}"
+		description = "Used in the terraform acceptance tests"
+		tags { Name = "tf-sg-rule-description" }
+	}
+
+	resource "aws_security_group" "nat" {
+		name = "terraform_test_%[1]d_nat"
+		vpc_id = "${aws_vpc.tf_sgrule_description_test.id}"
+		description = "Used in the terraform acceptance tests"
+		tags { Name = "tf-sg-rule-description" }
+	}
+
+	resource "aws_security_group_rule" "%[2]s_rule_1" {
+		security_group_id = "${aws_security_group.worker.id}"
+		description = "CIDR Description"
+		type = "%[2]s"
+		protocol = "tcp"
+		from_port = 22
+		to_port = 22
+		cidr_blocks = ["0.0.0.0/0"]
+	}
+
+	resource "aws_security_group_rule" "%[2]s_rule_2" {
+		security_group_id = "${aws_security_group.worker.id}"
+		description = "IPv6 CIDR Description"
+		type = "%[2]s"
+		protocol = "tcp"
+		from_port = 22
+		to_port = 22
+		ipv6_cidr_blocks = ["::/0"]
+	}
+
+	resource "aws_security_group_rule" "%[2]s_rule_3" {
+		security_group_id = "${aws_security_group.worker.id}"
+		description = "NAT SG Description"
+		type = "%[2]s"
+		protocol = "tcp"
+		from_port = 22
+		to_port = 22
+		source_security_group_id = "${aws_security_group.nat.id}"
+	}
+
+	resource "aws_security_group_rule" "%[2]s_rule_4" {
+		security_group_id = "${aws_security_group.worker.id}"
+		description = "Prefix List Description"
+		type = "%[2]s"
+		protocol = "tcp"
+		from_port = 22
+		to_port = 22
+		prefix_list_ids = ["${aws_vpc_endpoint.s3-us-west-2.prefix_list_id}"]
+	}
+	`, rInt, rType)
+}
 
 // check for GH-1985 regression
 const testAccAWSSecurityGroupRuleConfigSelfReference = `

--- a/aws/resource_aws_security_group_rule_test.go
+++ b/aws/resource_aws_security_group_rule_test.go
@@ -930,6 +930,19 @@ func testAccCheckAWSSecurityGroupRuleAttributes(n string, group *ec2.SecurityGro
 				continue
 			}
 
+			remaining = len(p.Ipv6Ranges)
+			for _, ip := range p.Ipv6Ranges {
+				for _, rip := range r.Ipv6Ranges {
+					if *ip.CidrIpv6 == *rip.CidrIpv6 {
+						remaining--
+					}
+				}
+			}
+
+			if remaining > 0 {
+				continue
+			}
+
 			remaining = len(p.UserIdGroupPairs)
 			for _, ip := range p.UserIdGroupPairs {
 				for _, rip := range r.UserIdGroupPairs {


### PR DESCRIPTION
This PR is aimed to improve `description` discovery of `Security Group Rule` (with same protocol & port range) by matching `aws_security_group_rule` schema properties:

- has `cidr_blocks` - get description from matched item of `IpRanges`
- has `ipv6_cidr_blocks` - get description from matched item of `Ipv6Ranges`
- has `prefix_list_ids` - get description from matched item of `PrefixListIds`
- has `source_security_group_id` - get description from matched item of `UserIdGroupPairs`

## How to reproduce the issue:

Running `TestAccAWSSecurityGroupRule_MultiDescription` test on `master` fails with:

```
testing.go:434: Step 0 error: After applying this step and refreshing, the plan was not empty:
    DIFF:

    UPDATE: aws_security_group_rule.ingress_rule_1
        description: "NAT SG Description" => "CIDR Description"
    UPDATE: aws_security_group_rule.ingress_rule_2
        description: "NAT SG Description" => "IPv6 CIDR Description"
    UPDATE: aws_security_group_rule.ingress_rule_4
        description: "NAT SG Description" => "Prefix List Description"
```

Configuration what causes it:

```
resource "aws_security_group" "test" {
  vpc_id = "${aws_vpc.default.id}"
}

resource "aws_security_group_rule" "ingress_22_target1" {
  security_group_id        = "${aws_security_group.test.id}"
  source_security_group_id = "${aws_security_group.target1.id}"
  description              = "Allow Target One"
  type                     = "ingress"
  protocol                 = "tcp"
  from_port                = "22"
  to_port                  = "22"
}

resource "aws_security_group_rule" "ingress_22_target2" {
  security_group_id = "${aws_security_group.test.id}"
  cidr_blocks       = ["10.0.2.0/24"]
  description       = "Allow Target Two"
  type              = "ingress"
  protocol          = "tcp"
  from_port         = "22"
  to_port           = "22"
}
```

Initialization goes as expected

```
$ terraform plan
$ terraform apply

...[clipped]...
aws_security_group_rule.ingress_22_target2: Creation complete after 1s (ID: sgrule-3731331332)
aws_security_group_rule.ingress_22_target1: Creation complete after 2s (ID: sgrule-4216459885)
```

Run `plan` again w/o modifications:

```
$ terraform plan

...[clipped]...
Terraform will perform the following actions:

  ~ aws_security_group_rule.ingress_22_target2
      description: "Allow Target One" => "Allow Target Two"
```

That's it, it tries to overwrite it, as parsed incorrectly.
Even after `apply` it would try to make the same

