### PR TITLE
[WIP] remove id fields

### DIFF
--- a/aws/data_source_aws_subnet.go
+++ b/aws/data_source_aws_subnet.go
@@ -40,12 +40,6 @@ func dataSourceAwsSubnet() *schema.Resource {
 
 			"filter": ec2CustomFiltersSchema(),
 
-			"id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-
 			"state": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -83,7 +77,7 @@ func dataSourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
 
 	req := &ec2.DescribeSubnetsInput{}
 
-	if id := d.Get("id"); id != "" {
+	if id := d.GetId(); id != "" {
 		req.SubnetIds = []*string{aws.String(id.(string))}
 	}
 
@@ -139,7 +133,6 @@ func dataSourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
 	subnet := resp.Subnets[0]
 
 	d.SetId(*subnet.SubnetId)
-	d.Set("id", subnet.SubnetId)
 	d.Set("vpc_id", subnet.VpcId)
 	d.Set("availability_zone", subnet.AvailabilityZone)
 	d.Set("cidr_block", subnet.CidrBlock)

--- a/aws/data_source_aws_subnet.go
+++ b/aws/data_source_aws_subnet.go
@@ -77,7 +77,7 @@ func dataSourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
 
 	req := &ec2.DescribeSubnetsInput{}
 
-	if id := d.GetId(); id != "" {
+	if id := d.Id(); id != "" {
 		req.SubnetIds = []*string{aws.String(id.(string))}
 	}
 


### PR DESCRIPTION
According to https://github.com/hashicorp/terraform/pull/15695, id is now a reserved field name, and specifying it in the schema never actually did anything anyway.

Seems like all I need to do to make this provider past acceptance tests against > 0.10.1 is to remove id fields from affected resources:-
`
24 errors occurred:
* resource aws_opsworks_static_web_layer: id is a reserved field name for a resource
* resource aws_opsworks_java_app_layer: id is a reserved field name for a resource
* resource aws_opsworks_rails_app_layer: id is a reserved field name for a resource
* resource aws_ami_from_instance: id is a reserved field name for a resource
* resource aws_opsworks_memcached_layer: id is a reserved field name for a resource
* resource aws_opsworks_user_profile: id is a reserved field name for a resource
* resource aws_opsworks_php_app_layer: id is a reserved field name for a resource
* resource aws_opsworks_ganglia_layer: id is a reserved field name for a resource
* resource aws_opsworks_custom_layer: id is a reserved field name for a resource
* resource aws_opsworks_permission: id is a reserved field name for a resource
* resource aws_opsworks_haproxy_layer: id is a reserved field name for a resource
* resource aws_opsworks_instance: id is a reserved field name for a resource
* resource aws_ami: id is a reserved field name for a resource
* resource aws_opsworks_rds_db_instance: id is a reserved field name for a resource
* resource aws_ami_copy: id is a reserved field name for a resource
* resource aws_opsworks_nodejs_app_layer: id is a reserved field name for a resource
* resource aws_opsworks_application: id is a reserved field name for a resource
* resource aws_opsworks_mysql_layer: id is a reserved field name for a resource
* resource aws_opsworks_stack: id is a reserved field name for a resource
* data source aws_vpc_peering_connection: id is a reserved field name for a resource
* data source aws_subnet: id is a reserved field name for a resource
* data source aws_security_group: id is a reserved field name for a resource
* data source aws_vpc: id is a reserved field name for a resource
* data source aws_vpn_gateway: id is a reserved field name for a resource"
`

Here's a sample - any problems with this approach?