### PR TITLE
Bump AWS SDK to v1.12.14

### DIFF
--- a/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
@@ -436,10 +436,11 @@ var awsPartition = partition{
 		"cloudhsmv2": service{
 
 			Endpoints: endpoints{
-				"eu-west-1": endpoint{},
-				"us-east-1": endpoint{},
-				"us-east-2": endpoint{},
-				"us-west-2": endpoint{},
+				"ap-southeast-1": endpoint{},
+				"eu-west-1":      endpoint{},
+				"us-east-1":      endpoint{},
+				"us-east-2":      endpoint{},
+				"us-west-2":      endpoint{},
 			},
 		},
 		"cloudsearch": service{
@@ -777,6 +778,7 @@ var awsPartition = partition{
 
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
+				"ap-northeast-2": endpoint{},
 				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
 				"ca-central-1":   endpoint{},

--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.12.8"
+const SDKVersion = "1.12.14"

--- a/vendor/github.com/aws/aws-sdk-go/service/sqs/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/sqs/api.go
@@ -64,12 +64,12 @@ func (c *SQS) AddPermissionRequest(input *AddPermissionInput) (req *request.Requ
 // When you create a queue, you have full control access rights for the queue.
 // Only you, the owner of the queue, can grant or deny permissions to the queue.
 // For more information about these permissions, see Shared Queues (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/acp-overview.html)
-// in the Amazon SQS Developer Guide.
+// in the Amazon Simple Queue Service Developer Guide.
 //
 // AddPermission writes an Amazon-SQS-generated policy. If you want to write
 // your own policy, use SetQueueAttributes to upload your policy. For more information
 // about writing your own policy, see Using The Access Policy Language (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/AccessPolicyLanguage.html)
-// in the Amazon SQS Developer Guide.
+// in the Amazon Simple Queue Service Developer Guide.
 //
 // Some actions take lists of parameters. These lists are specified using the
 // param.n notation. Values of n are integers starting from 1. For example,
@@ -165,7 +165,7 @@ func (c *SQS) ChangeMessageVisibilityRequest(input *ChangeMessageVisibilityInput
 // value. The maximum allowed timeout value is 12 hours. Thus, you can't extend
 // the timeout of a message in an existing queue to more than a total visibility
 // timeout of 12 hours. For more information, see Visibility Timeout (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html)
-// in the Amazon SQS Developer Guide.
+// in the Amazon Simple Queue Service Developer Guide.
 //
 // For example, you have a message with a visibility timeout of 5 minutes. After
 // 3 minutes, you call ChangeMessageVisiblity with a timeout of 10 minutes.
@@ -392,7 +392,7 @@ func (c *SQS) CreateQueueRequest(input *CreateQueueInput) (req *request.Request,
 //    new FIFO queue for your application or delete your existing standard queue
 //    and recreate it as a FIFO queue. For more information, see  Moving From
 //    a Standard Queue to a FIFO Queue (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html#FIFO-queues-moving)
-//    in the Amazon SQS Developer Guide.
+//    in the Amazon Simple Queue Service Developer Guide.
 //
 //    * If you don't provide a value for an attribute, the queue is created
 //    with the default value for the attribute.
@@ -895,7 +895,7 @@ func (c *SQS) GetQueueUrlRequest(input *GetQueueUrlInput) (req *request.Request,
 // parameter to specify the account ID of the queue's owner. The queue's owner
 // must grant you permission to access the queue. For more information about
 // shared queue access, see AddPermission or see Shared Queues (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/acp-overview.html)
-// in the Amazon SQS Developer Guide.
+// in the Amazon Simple Queue Service Developer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -979,7 +979,7 @@ func (c *SQS) ListDeadLetterSourceQueuesRequest(input *ListDeadLetterSourceQueue
 //
 // For more information about using dead-letter queues, see Using Amazon SQS
 // Dead-Letter Queues (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html)
-// in the Amazon SQS Developer Guide.
+// in the Amazon Simple Queue Service Developer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1009,6 +1009,100 @@ func (c *SQS) ListDeadLetterSourceQueues(input *ListDeadLetterSourceQueuesInput)
 // for more information on using Contexts.
 func (c *SQS) ListDeadLetterSourceQueuesWithContext(ctx aws.Context, input *ListDeadLetterSourceQueuesInput, opts ...request.Option) (*ListDeadLetterSourceQueuesOutput, error) {
 	req, out := c.ListDeadLetterSourceQueuesRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opListQueueTags = "ListQueueTags"
+
+// ListQueueTagsRequest generates a "aws/request.Request" representing the
+// client's request for the ListQueueTags operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ListQueueTags for more information on using the ListQueueTags
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ListQueueTagsRequest method.
+//    req, resp := client.ListQueueTagsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/sqs-2012-11-05/ListQueueTags
+func (c *SQS) ListQueueTagsRequest(input *ListQueueTagsInput) (req *request.Request, output *ListQueueTagsOutput) {
+	op := &request.Operation{
+		Name:       opListQueueTags,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &ListQueueTagsInput{}
+	}
+
+	output = &ListQueueTagsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListQueueTags API operation for Amazon Simple Queue Service.
+//
+// List all cost allocation tags added to the specified Amazon SQS queue. For
+// an overview, see Tagging Amazon SQS Queues (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-tagging-queues.html)
+// in the Amazon Simple Queue Service Developer Guide.
+//
+// When you use queue tags, keep the following guidelines in mind:
+//
+//    * Adding more than 50 tags to a queue isn't recommended.
+//
+//    * Tags don't have any semantic meaning. Amazon SQS interprets tags as
+//    character strings.
+//
+//    * Tags are case-sensitive.
+//
+//    * A new tag with a key identical to that of an existing tag overwrites
+//    the existing tag.
+//
+//    * Tagging API actions are limited to 5 TPS per AWS account. If your application
+//    requires a higher throughput, file a technical support request (https://console.aws.amazon.com/support/home#/case/create?issueType=technical).
+//
+// For a full list of tag restrictions, see Limits Related to Queues (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/limits-queues.html)
+// in the Amazon Simple Queue Service Developer Guide.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Simple Queue Service's
+// API operation ListQueueTags for usage and error information.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/sqs-2012-11-05/ListQueueTags
+func (c *SQS) ListQueueTags(input *ListQueueTagsInput) (*ListQueueTagsOutput, error) {
+	req, out := c.ListQueueTagsRequest(input)
+	return out, req.Send()
+}
+
+// ListQueueTagsWithContext is the same as ListQueueTags with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListQueueTags for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *SQS) ListQueueTagsWithContext(ctx aws.Context, input *ListQueueTagsInput, opts ...request.Option) (*ListQueueTagsOutput, error) {
+	req, out := c.ListQueueTagsRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -1232,7 +1326,7 @@ func (c *SQS) ReceiveMessageRequest(input *ReceiveMessageInput) (req *request.Re
 // Retrieves one or more messages (up to 10), from the specified queue. Using
 // the WaitTimeSeconds parameter enables long-poll support. For more information,
 // see Amazon SQS Long Polling (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html)
-// in the Amazon SQS Developer Guide.
+// in the Amazon Simple Queue Service Developer Guide.
 //
 // Short poll is the default behavior where a weighted random set of machines
 // is sampled on a ReceiveMessage call. Thus, only the messages on the sampled
@@ -1259,14 +1353,14 @@ func (c *SQS) ReceiveMessageRequest(input *ReceiveMessageInput) (req *request.Re
 //
 // The receipt handle is the identifier you must provide when deleting the message.
 // For more information, see Queue and Message Identifiers (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-queue-message-identifiers.html)
-// in the Amazon SQS Developer Guide.
+// in the Amazon Simple Queue Service Developer Guide.
 //
 // You can provide the VisibilityTimeout parameter in your request. The parameter
 // is applied to the messages that Amazon SQS returns in the response. If you
 // don't include the parameter, the overall visibility timeout for the queue
 // is used for the returned messages. For more information, see Visibility Timeout
 // (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html)
-// in the Amazon SQS Developer Guide.
+// in the Amazon Simple Queue Service Developer Guide.
 //
 // A message that isn't deleted or a message whose visibility isn't extended
 // before the visibility timeout expires counts as a failed receive. Depending
@@ -1692,6 +1786,198 @@ func (c *SQS) SetQueueAttributesWithContext(ctx aws.Context, input *SetQueueAttr
 	return out, req.Send()
 }
 
+const opTagQueue = "TagQueue"
+
+// TagQueueRequest generates a "aws/request.Request" representing the
+// client's request for the TagQueue operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See TagQueue for more information on using the TagQueue
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the TagQueueRequest method.
+//    req, resp := client.TagQueueRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/sqs-2012-11-05/TagQueue
+func (c *SQS) TagQueueRequest(input *TagQueueInput) (req *request.Request, output *TagQueueOutput) {
+	op := &request.Operation{
+		Name:       opTagQueue,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &TagQueueInput{}
+	}
+
+	output = &TagQueueOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(query.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// TagQueue API operation for Amazon Simple Queue Service.
+//
+// Add cost allocation tags to the specified Amazon SQS queue. For an overview,
+// see Tagging Amazon SQS Queues (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-tagging-queues.html)
+// in the Amazon Simple Queue Service Developer Guide.
+//
+// When you use queue tags, keep the following guidelines in mind:
+//
+//    * Adding more than 50 tags to a queue isn't recommended.
+//
+//    * Tags don't have any semantic meaning. Amazon SQS interprets tags as
+//    character strings.
+//
+//    * Tags are case-sensitive.
+//
+//    * A new tag with a key identical to that of an existing tag overwrites
+//    the existing tag.
+//
+//    * Tagging API actions are limited to 5 TPS per AWS account. If your application
+//    requires a higher throughput, file a technical support request (https://console.aws.amazon.com/support/home#/case/create?issueType=technical).
+//
+// For a full list of tag restrictions, see Limits Related to Queues (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/limits-queues.html)
+// in the Amazon Simple Queue Service Developer Guide.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Simple Queue Service's
+// API operation TagQueue for usage and error information.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/sqs-2012-11-05/TagQueue
+func (c *SQS) TagQueue(input *TagQueueInput) (*TagQueueOutput, error) {
+	req, out := c.TagQueueRequest(input)
+	return out, req.Send()
+}
+
+// TagQueueWithContext is the same as TagQueue with the addition of
+// the ability to pass a context and additional request options.
+//
+// See TagQueue for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *SQS) TagQueueWithContext(ctx aws.Context, input *TagQueueInput, opts ...request.Option) (*TagQueueOutput, error) {
+	req, out := c.TagQueueRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opUntagQueue = "UntagQueue"
+
+// UntagQueueRequest generates a "aws/request.Request" representing the
+// client's request for the UntagQueue operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See UntagQueue for more information on using the UntagQueue
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the UntagQueueRequest method.
+//    req, resp := client.UntagQueueRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/sqs-2012-11-05/UntagQueue
+func (c *SQS) UntagQueueRequest(input *UntagQueueInput) (req *request.Request, output *UntagQueueOutput) {
+	op := &request.Operation{
+		Name:       opUntagQueue,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &UntagQueueInput{}
+	}
+
+	output = &UntagQueueOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(query.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// UntagQueue API operation for Amazon Simple Queue Service.
+//
+// Remove cost allocation tags from the specified Amazon SQS queue. For an overview,
+// see Tagging Amazon SQS Queues (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-tagging-queues.html)
+// in the Amazon Simple Queue Service Developer Guide.
+//
+// When you use queue tags, keep the following guidelines in mind:
+//
+//    * Adding more than 50 tags to a queue isn't recommended.
+//
+//    * Tags don't have any semantic meaning. Amazon SQS interprets tags as
+//    character strings.
+//
+//    * Tags are case-sensitive.
+//
+//    * A new tag with a key identical to that of an existing tag overwrites
+//    the existing tag.
+//
+//    * Tagging API actions are limited to 5 TPS per AWS account. If your application
+//    requires a higher throughput, file a technical support request (https://console.aws.amazon.com/support/home#/case/create?issueType=technical).
+//
+// For a full list of tag restrictions, see Limits Related to Queues (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/limits-queues.html)
+// in the Amazon Simple Queue Service Developer Guide.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Simple Queue Service's
+// API operation UntagQueue for usage and error information.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/sqs-2012-11-05/UntagQueue
+func (c *SQS) UntagQueue(input *UntagQueueInput) (*UntagQueueOutput, error) {
+	req, out := c.UntagQueueRequest(input)
+	return out, req.Send()
+}
+
+// UntagQueueWithContext is the same as UntagQueue with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UntagQueue for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *SQS) UntagQueueWithContext(ctx aws.Context, input *UntagQueueInput, opts ...request.Option) (*UntagQueueOutput, error) {
+	req, out := c.UntagQueueRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/sqs-2012-11-05/AddPermissionRequest
 type AddPermissionInput struct {
 	_ struct{} `type:"structure"`
@@ -1700,7 +1986,7 @@ type AddPermissionInput struct {
 	// who is given permission. The principal must have an AWS account, but does
 	// not need to be signed up for Amazon SQS. For information about locating the
 	// AWS account identification, see Your AWS Identifiers (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/AWSCredentials.html)
-	// in the Amazon SQS Developer Guide.
+	// in the Amazon Simple Queue Service Developer Guide.
 	//
 	// AWSAccountIds is a required field
 	AWSAccountIds []*string `locationNameList:"AWSAccountId" type:"list" flattened:"true" required:"true"`
@@ -1723,7 +2009,7 @@ type AddPermissionInput struct {
 	//    * SendMessage
 	//
 	// For more information about these actions, see Understanding Permissions (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/acp-overview.html#PermissionTypes)
-	// in the Amazon SQS Developer Guide.
+	// in the Amazon Simple Queue Service Developer Guide.
 	//
 	// Specifying SendMessage, DeleteMessage, or ChangeMessageVisibility for ActionName.n
 	// also grants permissions for the corresponding batch versions of those actions:
@@ -2206,7 +2492,7 @@ type CreateQueueInput struct {
 	//    queue functionality of the source queue. For more information about the
 	//    redrive policy and dead-letter queues, see Using Amazon SQS Dead-Letter
 	//    Queues (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html)
-	//    in the Amazon SQS Developer Guide.
+	//    in the Amazon Simple Queue Service Developer Guide.
 	//
 	// deadLetterTargetArn - The Amazon Resource Name (ARN) of the dead-letter queue
 	//    to which Amazon SQS moves messages after the value of maxReceiveCount
@@ -2221,7 +2507,7 @@ type CreateQueueInput struct {
 	//    * VisibilityTimeout - The visibility timeout for the queue. Valid values:
 	//    An integer from 0 to 43,200 (12 hours). The default is 30. For more information
 	//    about the visibility timeout, see Visibility Timeout (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html)
-	//    in the Amazon SQS Developer Guide.
+	//    in the Amazon Simple Queue Service Developer Guide.
 	//
 	// The following attributes apply only to server-side-encryption (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html):
 	//
@@ -2250,12 +2536,12 @@ type CreateQueueInput struct {
 	//    the MessageGroupId for your messages explicitly.
 	//
 	// For more information, see FIFO Queue Logic (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html#FIFO-queues-understanding-logic)
-	//    in the Amazon SQS Developer Guide.
+	//    in the Amazon Simple Queue Service Developer Guide.
 	//
 	//    * ContentBasedDeduplication - Enables content-based deduplication. Valid
 	//    values: true, false. For more information, see Exactly-Once Processing
 	//    (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html#FIFO-queues-exactly-once-processing)
-	//    in the Amazon SQS Developer Guide.
+	//    in the Amazon Simple Queue Service Developer Guide.
 	//
 	// Every message must have a unique MessageDeduplicationId,
 	//
@@ -2703,7 +2989,7 @@ type GetQueueAttributesInput struct {
 	//    * ApproximateNumberOfMessages - Returns the approximate number of visible
 	//    messages in a queue. For more information, see Resources Required to Process
 	//    Messages (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-resources-required-process-messages.html)
-	//    in the Amazon SQS Developer Guide.
+	//    in the Amazon Simple Queue Service Developer Guide.
 	//
 	//    * ApproximateNumberOfMessagesDelayed - Returns the approximate number
 	//    of messages that are waiting to be added to the queue.
@@ -2711,7 +2997,7 @@ type GetQueueAttributesInput struct {
 	//    * ApproximateNumberOfMessagesNotVisible - Returns the approximate number
 	//    of messages that have not timed-out and aren't deleted. For more information,
 	//    see Resources Required to Process Messages (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-resources-required-process-messages.html)
-	//    in the Amazon SQS Developer Guide.
+	//    in the Amazon Simple Queue Service Developer Guide.
 	//
 	//    * CreatedTimestamp - Returns the time when the queue was created in seconds
 	//    (epoch time (http://en.wikipedia.org/wiki/Unix_time)).
@@ -2738,7 +3024,7 @@ type GetQueueAttributesInput struct {
 	//    dead-letter queue functionality of the source queue. For more information
 	//    about the redrive policy and dead-letter queues, see Using Amazon SQS
 	//    Dead-Letter Queues (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html)
-	//    in the Amazon SQS Developer Guide.
+	//    in the Amazon Simple Queue Service Developer Guide.
 	//
 	// deadLetterTargetArn - The Amazon Resource Name (ARN) of the dead-letter queue
 	//    to which Amazon SQS moves messages after the value of maxReceiveCount
@@ -2750,7 +3036,7 @@ type GetQueueAttributesInput struct {
 	//    * VisibilityTimeout - Returns the visibility timeout for the queue. For
 	//    more information about the visibility timeout, see Visibility Timeout
 	//    (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html)
-	//    in the Amazon SQS Developer Guide.
+	//    in the Amazon Simple Queue Service Developer Guide.
 	//
 	// The following attributes apply only to server-side-encryption (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html):
 	//
@@ -2769,7 +3055,7 @@ type GetQueueAttributesInput struct {
 	//
 	//    * FifoQueue - Returns whether the queue is FIFO. For more information,
 	//    see FIFO Queue Logic (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html#FIFO-queues-understanding-logic)
-	//    in the Amazon SQS Developer Guide.
+	//    in the Amazon Simple Queue Service Developer Guide.
 	//
 	// To determine whether a queue is FIFO (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html),
 	//    you can check whether QueueName ends with the .fifo suffix.
@@ -2777,7 +3063,7 @@ type GetQueueAttributesInput struct {
 	//    * ContentBasedDeduplication - Returns whether content-based deduplication
 	//    is enabled for the queue. For more information, see Exactly-Once Processing
 	//    (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html#FIFO-queues-exactly-once-processing)
-	//    in the Amazon SQS Developer Guide.
+	//    in the Amazon Simple Queue Service Developer Guide.
 	AttributeNames []*string `locationNameList:"AttributeName" type:"list" flattened:"true"`
 
 	// The URL of the Amazon SQS queue whose attribute information is retrieved.
@@ -2900,7 +3186,7 @@ func (s *GetQueueUrlInput) SetQueueOwnerAWSAccountId(v string) *GetQueueUrlInput
 }
 
 // For more information, see Responses (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/UnderstandingResponses.html)
-// in the Amazon SQS Developer Guide.
+// in the Amazon Simple Queue Service Developer Guide.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/sqs-2012-11-05/GetQueueUrlResult
 type GetQueueUrlOutput struct {
 	_ struct{} `type:"structure"`
@@ -2994,6 +3280,69 @@ func (s *ListDeadLetterSourceQueuesOutput) SetQueueUrls(v []*string) *ListDeadLe
 	return s
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/sqs-2012-11-05/ListQueueTagsRequest
+type ListQueueTagsInput struct {
+	_ struct{} `type:"structure"`
+
+	// The URL of the queue.
+	//
+	// QueueUrl is a required field
+	QueueUrl *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s ListQueueTagsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListQueueTagsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListQueueTagsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListQueueTagsInput"}
+	if s.QueueUrl == nil {
+		invalidParams.Add(request.NewErrParamRequired("QueueUrl"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetQueueUrl sets the QueueUrl field's value.
+func (s *ListQueueTagsInput) SetQueueUrl(v string) *ListQueueTagsInput {
+	s.QueueUrl = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/sqs-2012-11-05/ListQueueTagsResult
+type ListQueueTagsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The list of all tags added to the specified queue.
+	Tags map[string]*string `locationName:"Tag" locationNameKey:"Key" locationNameValue:"Value" type:"map" flattened:"true"`
+}
+
+// String returns the string representation
+func (s ListQueueTagsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListQueueTagsOutput) GoString() string {
+	return s.String()
+}
+
+// SetTags sets the Tags field's value.
+func (s *ListQueueTagsOutput) SetTags(v map[string]*string) *ListQueueTagsOutput {
+	s.Tags = v
+	return s
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/sqs-2012-11-05/ListQueuesRequest
 type ListQueuesInput struct {
 	_ struct{} `type:"structure"`
@@ -3071,7 +3420,7 @@ type Message struct {
 
 	// Each message attribute consists of a Name, Type, and Value. For more information,
 	// see Message Attribute Items and Validation (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-attributes.html#message-attributes-items-validation)
-	// in the Amazon SQS Developer Guide.
+	// in the Amazon Simple Queue Service Developer Guide.
 	MessageAttributes map[string]*MessageAttributeValue `locationName:"MessageAttribute" locationNameKey:"Name" locationNameValue:"Value" type:"map" flattened:"true"`
 
 	// A unique identifier for the message. A MessageIdis considered unique across
@@ -3161,7 +3510,7 @@ type MessageAttributeValue struct {
 	//
 	// You can also append custom labels. For more information, see Message Attribute
 	// Data Types and Validation (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-attributes.html#message-attributes-data-types-validation)
-	// in the Amazon SQS Developer Guide.
+	// in the Amazon Simple Queue Service Developer Guide.
 	//
 	// DataType is a required field
 	DataType *string `type:"string" required:"true"`
@@ -3740,7 +4089,7 @@ type SendMessageBatchRequestEntry struct {
 
 	// Each message attribute consists of a Name, Type, and Value. For more information,
 	// see Message Attribute Items and Validation (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-attributes.html#message-attributes-items-validation)
-	// in the Amazon SQS Developer Guide.
+	// in the Amazon Simple Queue Service Developer Guide.
 	MessageAttributes map[string]*MessageAttributeValue `locationName:"MessageAttribute" locationNameKey:"Name" locationNameValue:"Value" type:"map" flattened:"true"`
 
 	// The body of the message.
@@ -3755,7 +4104,7 @@ type SendMessageBatchRequestEntry struct {
 	// subsequent messages with the same MessageDeduplicationId are accepted successfully
 	// but aren't delivered. For more information, see  Exactly-Once Processing
 	// (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html#FIFO-queues-exactly-once-processing)
-	// in the Amazon SQS Developer Guide.
+	// in the Amazon Simple Queue Service Developer Guide.
 	//
 	//    * Every message must have a unique MessageDeduplicationId,
 	//
@@ -3990,7 +4339,7 @@ type SendMessageInput struct {
 
 	// Each message attribute consists of a Name, Type, and Value. For more information,
 	// see Message Attribute Items and Validation (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-attributes.html#message-attributes-items-validation)
-	// in the Amazon SQS Developer Guide.
+	// in the Amazon Simple Queue Service Developer Guide.
 	MessageAttributes map[string]*MessageAttributeValue `locationName:"MessageAttribute" locationNameKey:"Name" locationNameValue:"Value" type:"map" flattened:"true"`
 
 	// The message to send. The maximum string size is 256 KB.
@@ -4013,7 +4362,7 @@ type SendMessageInput struct {
 	// MessageDeduplicationId are accepted successfully but aren't delivered during
 	// the 5-minute deduplication interval. For more information, see  Exactly-Once
 	// Processing (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html#FIFO-queues-exactly-once-processing)
-	// in the Amazon SQS Developer Guide.
+	// in the Amazon Simple Queue Service Developer Guide.
 	//
 	//    * Every message must have a unique MessageDeduplicationId,
 	//
@@ -4181,7 +4530,7 @@ type SendMessageOutput struct {
 
 	// An attribute containing the MessageId of the message sent to the queue. For
 	// more information, see Queue and Message Identifiers (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-queue-message-identifiers.html)
-	// in the Amazon SQS Developer Guide.
+	// in the Amazon Simple Queue Service Developer Guide.
 	MessageId *string `type:"string"`
 
 	// This parameter applies only to FIFO (first-in-first-out) queues.
@@ -4262,7 +4611,7 @@ type SetQueueAttributesInput struct {
 	//    queue functionality of the source queue. For more information about the
 	//    redrive policy and dead-letter queues, see Using Amazon SQS Dead-Letter
 	//    Queues (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html)
-	//    in the Amazon SQS Developer Guide.
+	//    in the Amazon Simple Queue Service Developer Guide.
 	//
 	// deadLetterTargetArn - The Amazon Resource Name (ARN) of the dead-letter queue
 	//    to which Amazon SQS moves messages after the value of maxReceiveCount
@@ -4277,7 +4626,7 @@ type SetQueueAttributesInput struct {
 	//    * VisibilityTimeout - The visibility timeout for the queue. Valid values:
 	//    an integer from 0 to 43,200 (12 hours). The default is 30. For more information
 	//    about the visibility timeout, see Visibility Timeout (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html)
-	//    in the Amazon SQS Developer Guide.
+	//    in the Amazon Simple Queue Service Developer Guide.
 	//
 	// The following attributes apply only to server-side-encryption (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html):
 	//
@@ -4303,7 +4652,7 @@ type SetQueueAttributesInput struct {
 	//
 	//    * ContentBasedDeduplication - Enables content-based deduplication. For
 	//    more information, see Exactly-Once Processing (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html#FIFO-queues-exactly-once-processing)
-	//    in the Amazon SQS Developer Guide.
+	//    in the Amazon Simple Queue Service Developer Guide.
 	//
 	// Every message must have a unique MessageDeduplicationId,
 	//
@@ -4404,6 +4753,142 @@ func (s SetQueueAttributesOutput) String() string {
 
 // GoString returns the string representation
 func (s SetQueueAttributesOutput) GoString() string {
+	return s.String()
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/sqs-2012-11-05/TagQueueRequest
+type TagQueueInput struct {
+	_ struct{} `type:"structure"`
+
+	// The URL of the queue.
+	//
+	// QueueUrl is a required field
+	QueueUrl *string `type:"string" required:"true"`
+
+	// The list of tags to be added to the specified queue.
+	//
+	// Tags is a required field
+	Tags map[string]*string `locationName:"Tag" locationNameKey:"Key" locationNameValue:"Value" type:"map" flattened:"true" required:"true"`
+}
+
+// String returns the string representation
+func (s TagQueueInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TagQueueInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TagQueueInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TagQueueInput"}
+	if s.QueueUrl == nil {
+		invalidParams.Add(request.NewErrParamRequired("QueueUrl"))
+	}
+	if s.Tags == nil {
+		invalidParams.Add(request.NewErrParamRequired("Tags"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetQueueUrl sets the QueueUrl field's value.
+func (s *TagQueueInput) SetQueueUrl(v string) *TagQueueInput {
+	s.QueueUrl = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *TagQueueInput) SetTags(v map[string]*string) *TagQueueInput {
+	s.Tags = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/sqs-2012-11-05/TagQueueOutput
+type TagQueueOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s TagQueueOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TagQueueOutput) GoString() string {
+	return s.String()
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/sqs-2012-11-05/UntagQueueRequest
+type UntagQueueInput struct {
+	_ struct{} `type:"structure"`
+
+	// The URL of the queue.
+	//
+	// QueueUrl is a required field
+	QueueUrl *string `type:"string" required:"true"`
+
+	// The list of tags to be removed from the specified queue.
+	//
+	// TagKeys is a required field
+	TagKeys []*string `locationNameList:"TagKey" type:"list" flattened:"true" required:"true"`
+}
+
+// String returns the string representation
+func (s UntagQueueInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UntagQueueInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UntagQueueInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UntagQueueInput"}
+	if s.QueueUrl == nil {
+		invalidParams.Add(request.NewErrParamRequired("QueueUrl"))
+	}
+	if s.TagKeys == nil {
+		invalidParams.Add(request.NewErrParamRequired("TagKeys"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetQueueUrl sets the QueueUrl field's value.
+func (s *UntagQueueInput) SetQueueUrl(v string) *UntagQueueInput {
+	s.QueueUrl = &v
+	return s
+}
+
+// SetTagKeys sets the TagKeys field's value.
+func (s *UntagQueueInput) SetTagKeys(v []*string) *UntagQueueInput {
+	s.TagKeys = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/sqs-2012-11-05/UntagQueueOutput
+type UntagQueueOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s UntagQueueOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UntagQueueOutput) GoString() string {
 	return s.String()
 }
 

--- a/vendor/github.com/aws/aws-sdk-go/service/sqs/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/sqs/doc.go
@@ -29,7 +29,7 @@
 //
 //    * Amazon SQS Product Page (http://aws.amazon.com/sqs/)
 //
-//    * Amazon SQS Developer Guide
+//    * Amazon Simple Queue Service Developer Guide
 //
 // Making API Requests (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/MakingRequestsArticle.html)
 //

--- a/vendor/github.com/aws/aws-sdk-go/service/ssm/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ssm/api.go
@@ -1008,6 +1008,10 @@ func (c *SSM) DeleteActivationRequest(input *DeleteActivationInput) (req *reques
 //   * ErrCodeInternalServerError "InternalServerError"
 //   An error occurred on the server side.
 //
+//   * ErrCodeTooManyUpdates "TooManyUpdates"
+//   There are concurrent updates for a resource that supports one update at a
+//   time.
+//
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/DeleteActivation
 func (c *SSM) DeleteActivation(input *DeleteActivationInput) (*DeleteActivationOutput, error) {
 	req, out := c.DeleteActivationRequest(input)
@@ -5284,6 +5288,10 @@ func (c *SSM) GetParameterRequest(input *GetParameterInput) (req *request.Reques
 //   * ErrCodeParameterNotFound "ParameterNotFound"
 //   The parameter could not be found. Verify the name and try again.
 //
+//   * ErrCodeParameterVersionNotFound "ParameterVersionNotFound"
+//   The specified parameter version was not found. Verify the parameter name
+//   and version, and try again.
+//
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/GetParameter
 func (c *SSM) GetParameter(input *GetParameterInput) (*GetParameterOutput, error) {
 	req, out := c.GetParameterRequest(input)
@@ -7602,6 +7610,9 @@ func (c *SSM) PutParameterRequest(input *PutParameterInput) (req *request.Reques
 //   * ErrCodeInvalidAllowedPatternException "InvalidAllowedPatternException"
 //   The request does not meet the regular expression requirement.
 //
+//   * ErrCodeParameterMaxVersionLimitExceeded "ParameterMaxVersionLimitExceeded"
+//   The parameter exceeded the maximum number of allowed versions.
+//
 //   * ErrCodeParameterPatternMismatchException "ParameterPatternMismatchException"
 //   The parameter name is not valid.
 //
@@ -9466,6 +9477,11 @@ type AddTagsToResourceInput struct {
 	_ struct{} `type:"structure"`
 
 	// The resource ID you want to tag.
+	//
+	// For the ManagedInstance, MaintenanceWindow, and PatchBaseline values, use
+	// the ID of the resource, such as mw-01234361858c9b57b for a Maintenance Window.
+	//
+	// For the Document and Parameter values, use the name of the resource.
 	//
 	// ResourceId is a required field
 	ResourceId *string `type:"string" required:"true"`
@@ -22676,6 +22692,9 @@ type Parameter struct {
 
 	// The parameter value.
 	Value *string `min:"1" type:"string"`
+
+	// The parameter version.
+	Version *int64 `type:"long"`
 }
 
 // String returns the string representation
@@ -22706,6 +22725,12 @@ func (s *Parameter) SetValue(v string) *Parameter {
 	return s
 }
 
+// SetVersion sets the Version field's value.
+func (s *Parameter) SetVersion(v int64) *Parameter {
+	s.Version = &v
+	return s
+}
+
 // Information about parameter usage.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/ParameterHistory
 type ParameterHistory struct {
@@ -22717,7 +22742,7 @@ type ParameterHistory struct {
 	AllowedPattern *string `type:"string"`
 
 	// Information about the parameter.
-	Description *string `min:"1" type:"string"`
+	Description *string `type:"string"`
 
 	// The ID of the query key used for this parameter.
 	KeyId *string `min:"1" type:"string"`
@@ -22736,6 +22761,9 @@ type ParameterHistory struct {
 
 	// The parameter value.
 	Value *string `min:"1" type:"string"`
+
+	// The parameter version.
+	Version *int64 `type:"long"`
 }
 
 // String returns the string representation
@@ -22796,6 +22824,12 @@ func (s *ParameterHistory) SetValue(v string) *ParameterHistory {
 	return s
 }
 
+// SetVersion sets the Version field's value.
+func (s *ParameterHistory) SetVersion(v int64) *ParameterHistory {
+	s.Version = &v
+	return s
+}
+
 // Metada includes information like the ARN of the last user and the date/time
 // the parameter was last used.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/ParameterMetadata
@@ -22808,7 +22842,7 @@ type ParameterMetadata struct {
 	AllowedPattern *string `type:"string"`
 
 	// Description of the parameter actions.
-	Description *string `min:"1" type:"string"`
+	Description *string `type:"string"`
 
 	// The ID of the query key used for this parameter.
 	KeyId *string `min:"1" type:"string"`
@@ -22825,6 +22859,9 @@ type ParameterMetadata struct {
 	// The type of parameter. Valid parameter types include the following: String,
 	// String list, Secure string.
 	Type *string `type:"string" enum:"ParameterType"`
+
+	// The parameter version.
+	Version *int64 `type:"long"`
 }
 
 // String returns the string representation
@@ -22876,6 +22913,12 @@ func (s *ParameterMetadata) SetName(v string) *ParameterMetadata {
 // SetType sets the Type field's value.
 func (s *ParameterMetadata) SetType(v string) *ParameterMetadata {
 	s.Type = &v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *ParameterMetadata) SetVersion(v int64) *ParameterMetadata {
+	s.Version = &v
 	return s
 }
 
@@ -23885,7 +23928,7 @@ type PutParameterInput struct {
 	AllowedPattern *string `type:"string"`
 
 	// Information about the parameter that you want to add to the system
-	Description *string `min:"1" type:"string"`
+	Description *string `type:"string"`
 
 	// The KMS Key ID that you want to use to encrypt a parameter when you choose
 	// the SecureString data type. If you don't specify a key ID, the system uses
@@ -23924,9 +23967,6 @@ func (s PutParameterInput) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *PutParameterInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "PutParameterInput"}
-	if s.Description != nil && len(*s.Description) < 1 {
-		invalidParams.Add(request.NewErrParamMinLen("Description", 1))
-	}
 	if s.KeyId != nil && len(*s.KeyId) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("KeyId", 1))
 	}
@@ -23997,6 +24037,14 @@ func (s *PutParameterInput) SetValue(v string) *PutParameterInput {
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/PutParameterResult
 type PutParameterOutput struct {
 	_ struct{} `type:"structure"`
+
+	// The new version number of a parameter. If you edit a parameter value, Parameter
+	// Store automatically creates a new version and assigns this new version a
+	// unique ID. You can reference a parameter version ID in API actions or in
+	// Systems Manager documents (SSM documents). By default, if you don't specify
+	// a specific version, the system returns the latest parameter value when a
+	// parameter is called.
+	Version *int64 `type:"long"`
 }
 
 // String returns the string representation
@@ -24007,6 +24055,12 @@ func (s PutParameterOutput) String() string {
 // GoString returns the string representation
 func (s PutParameterOutput) GoString() string {
 	return s.String()
+}
+
+// SetVersion sets the Version field's value.
+func (s *PutParameterOutput) SetVersion(v int64) *PutParameterOutput {
+	s.Version = &v
+	return s
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/RegisterDefaultPatchBaselineRequest

--- a/vendor/github.com/aws/aws-sdk-go/service/ssm/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ssm/errors.go
@@ -453,6 +453,12 @@ const (
 	// or more parameters and try again.
 	ErrCodeParameterLimitExceeded = "ParameterLimitExceeded"
 
+	// ErrCodeParameterMaxVersionLimitExceeded for service response error code
+	// "ParameterMaxVersionLimitExceeded".
+	//
+	// The parameter exceeded the maximum number of allowed versions.
+	ErrCodeParameterMaxVersionLimitExceeded = "ParameterMaxVersionLimitExceeded"
+
 	// ErrCodeParameterNotFound for service response error code
 	// "ParameterNotFound".
 	//
@@ -464,6 +470,13 @@ const (
 	//
 	// The parameter name is not valid.
 	ErrCodeParameterPatternMismatchException = "ParameterPatternMismatchException"
+
+	// ErrCodeParameterVersionNotFound for service response error code
+	// "ParameterVersionNotFound".
+	//
+	// The specified parameter version was not found. Verify the parameter name
+	// and version, and try again.
+	ErrCodeParameterVersionNotFound = "ParameterVersionNotFound"
 
 	// ErrCodeResourceDataSyncAlreadyExistsException for service response error code
 	// "ResourceDataSyncAlreadyExistsException".

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -45,732 +45,732 @@
 			"revisionTime": "2017-07-27T15:54:43Z"
 		},
 		{
-			"checksumSHA1": "oB3qh+PpOMbr9frqJwMyBuUTf2k=",
+			"checksumSHA1": "AUz0tBoY6/urP8sUZ+4kTFIzIKM=",
 			"path": "github.com/aws/aws-sdk-go/aws",
-			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
-			"revisionTime": "2017-10-10T17:54:20Z",
-			"version": "v1.12.8",
-			"versionExact": "v1.12.8"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "DtuTqKH29YnLjrIJkRYX0HQtXY0=",
 			"path": "github.com/aws/aws-sdk-go/aws/arn",
-			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
-			"revisionTime": "2017-10-10T17:54:20Z",
-			"version": "v1.12.8",
-			"versionExact": "v1.12.8"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "Y9W+4GimK4Fuxq+vyIskVYFRnX4=",
 			"path": "github.com/aws/aws-sdk-go/aws/awserr",
-			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
-			"revisionTime": "2017-10-10T17:54:20Z",
-			"version": "v1.12.8",
-			"versionExact": "v1.12.8"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "yyYr41HZ1Aq0hWc3J5ijXwYEcac=",
 			"path": "github.com/aws/aws-sdk-go/aws/awsutil",
-			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
-			"revisionTime": "2017-10-10T17:54:20Z",
-			"version": "v1.12.8",
-			"versionExact": "v1.12.8"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "n98FANpNeRT5kf6pizdpI7nm6Sw=",
 			"path": "github.com/aws/aws-sdk-go/aws/client",
-			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
-			"revisionTime": "2017-10-10T17:54:20Z",
-			"version": "v1.12.8",
-			"versionExact": "v1.12.8"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "ieAJ+Cvp/PKv1LpUEnUXpc3OI6E=",
 			"path": "github.com/aws/aws-sdk-go/aws/client/metadata",
-			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
-			"revisionTime": "2017-10-10T17:54:20Z",
-			"version": "v1.12.8",
-			"versionExact": "v1.12.8"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "7/8j/q0TWtOgXyvEcv4B2Dhl00o=",
 			"path": "github.com/aws/aws-sdk-go/aws/corehandlers",
-			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
-			"revisionTime": "2017-10-10T17:54:20Z",
-			"version": "v1.12.8",
-			"versionExact": "v1.12.8"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "Y+cPwQL0dZMyqp3wI+KJWmA9KQ8=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials",
-			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
-			"revisionTime": "2017-10-10T17:54:20Z",
-			"version": "v1.12.8",
-			"versionExact": "v1.12.8"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "u3GOAJLmdvbuNUeUEcZSEAOeL/0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
-			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
-			"revisionTime": "2017-10-10T17:54:20Z",
-			"version": "v1.12.8",
-			"versionExact": "v1.12.8"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "NUJUTWlc1sV8b7WjfiYc4JZbXl0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/endpointcreds",
-			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
-			"revisionTime": "2017-10-10T17:54:20Z",
-			"version": "v1.12.8",
-			"versionExact": "v1.12.8"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "JEYqmF83O5n5bHkupAzA6STm0no=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
-			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
-			"revisionTime": "2017-10-10T17:54:20Z",
-			"version": "v1.12.8",
-			"versionExact": "v1.12.8"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "ZdtYh3ZHSgP/WEIaqwJHTEhpkbs=",
 			"path": "github.com/aws/aws-sdk-go/aws/defaults",
-			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
-			"revisionTime": "2017-10-10T17:54:20Z",
-			"version": "v1.12.8",
-			"versionExact": "v1.12.8"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "/EXbk/z2TWjWc1Hvb4QYs3Wmhb8=",
 			"path": "github.com/aws/aws-sdk-go/aws/ec2metadata",
-			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
-			"revisionTime": "2017-10-10T17:54:20Z",
-			"version": "v1.12.8",
-			"versionExact": "v1.12.8"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
-			"checksumSHA1": "CxKCfgfTug8S/72YInl42ufsknE=",
+			"checksumSHA1": "SB60GS485F4IhgVMuBqSvnw6/OE=",
 			"path": "github.com/aws/aws-sdk-go/aws/endpoints",
-			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
-			"revisionTime": "2017-10-10T17:54:20Z",
-			"version": "v1.12.8",
-			"versionExact": "v1.12.8"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "n/tgGgh0wICYu+VDYSqlsRy4w9s=",
 			"path": "github.com/aws/aws-sdk-go/aws/request",
-			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
-			"revisionTime": "2017-10-10T17:54:20Z",
-			"version": "v1.12.8",
-			"versionExact": "v1.12.8"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "HcGL4e6Uep4/80eCUI5xkcWjpQ0=",
 			"path": "github.com/aws/aws-sdk-go/aws/session",
-			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
-			"revisionTime": "2017-10-10T17:54:20Z",
-			"version": "v1.12.8",
-			"versionExact": "v1.12.8"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "iywvraxbXf3A/FOzFWjKfBBEQRA=",
 			"path": "github.com/aws/aws-sdk-go/aws/signer/v4",
-			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
-			"revisionTime": "2017-10-10T17:54:20Z",
-			"version": "v1.12.8",
-			"versionExact": "v1.12.8"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "04ypv4x12l4q0TksA1zEVsmgpvw=",
 			"path": "github.com/aws/aws-sdk-go/internal/shareddefaults",
-			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
-			"revisionTime": "2017-10-10T17:54:20Z",
-			"version": "v1.12.8",
-			"versionExact": "v1.12.8"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "wk7EyvDaHwb5qqoOP/4d3cV0708=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol",
-			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
-			"revisionTime": "2017-10-10T17:54:20Z",
-			"version": "v1.12.8",
-			"versionExact": "v1.12.8"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "1QmQ3FqV37w0Zi44qv8pA1GeR0A=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/ec2query",
-			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
-			"revisionTime": "2017-10-10T17:54:20Z",
-			"version": "v1.12.8",
-			"versionExact": "v1.12.8"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "O6hcK24yI6w7FA+g4Pbr+eQ7pys=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/json/jsonutil",
-			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
-			"revisionTime": "2017-10-10T17:54:20Z",
-			"version": "v1.12.8",
-			"versionExact": "v1.12.8"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "R00RL5jJXRYq1iiK1+PGvMfvXyM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/jsonrpc",
-			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
-			"revisionTime": "2017-10-10T17:54:20Z",
-			"version": "v1.12.8",
-			"versionExact": "v1.12.8"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "ZqY5RWavBLWTo6j9xqdyBEaNFRk=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query",
-			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
-			"revisionTime": "2017-10-10T17:54:20Z",
-			"version": "v1.12.8",
-			"versionExact": "v1.12.8"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "9V1PvtFQ9MObZTc3sa86WcuOtOU=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
-			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
-			"revisionTime": "2017-10-10T17:54:20Z",
-			"version": "v1.12.8",
-			"versionExact": "v1.12.8"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "VCTh+dEaqqhog5ncy/WTt9+/gFM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/rest",
-			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
-			"revisionTime": "2017-10-10T17:54:20Z",
-			"version": "v1.12.8",
-			"versionExact": "v1.12.8"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "Rpu8KBtHZgvhkwHxUfaky+qW+G4=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restjson",
-			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
-			"revisionTime": "2017-10-10T17:54:20Z",
-			"version": "v1.12.8",
-			"versionExact": "v1.12.8"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "ODo+ko8D6unAxZuN1jGzMcN4QCc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restxml",
-			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
-			"revisionTime": "2017-10-10T17:54:20Z",
-			"version": "v1.12.8",
-			"versionExact": "v1.12.8"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "0qYPUga28aQVkxZgBR3Z86AbGUQ=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
-			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
-			"revisionTime": "2017-10-10T17:54:20Z",
-			"version": "v1.12.8",
-			"versionExact": "v1.12.8"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "F6mth+G7dXN1GI+nktaGo8Lx8aE=",
 			"path": "github.com/aws/aws-sdk-go/private/signer/v2",
-			"revision": "885962fbd7bf49bf62db54f63fb89f75611677cf",
-			"revisionTime": "2017-10-10T17:54:20Z",
-			"version": "v1.12.8",
-			"versionExact": "v1.12.8"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "BXuQo73qo4WLmc+TdE5pAwalLUQ=",
 			"path": "github.com/aws/aws-sdk-go/service/acm",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "O2HA8qyuxiolOGr0a1o/mFKz/Xo=",
 			"path": "github.com/aws/aws-sdk-go/service/apigateway",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "lnbmn3cDZvFOpzV9jKe9jG7VIPs=",
 			"path": "github.com/aws/aws-sdk-go/service/applicationautoscaling",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "/C4QDOmEP7t8vawBcB7a2ygaXuI=",
 			"path": "github.com/aws/aws-sdk-go/service/athena",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "eudoAl5P0HqsQrzytWyb9uhUGU0=",
 			"path": "github.com/aws/aws-sdk-go/service/autoscaling",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "fNHsdfsdTzwSJwnfxqqGdkjT5HE=",
 			"path": "github.com/aws/aws-sdk-go/service/batch",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "s3YX7GouNkKz4U+w/Id7ivv5i2c=",
 			"path": "github.com/aws/aws-sdk-go/service/budgets",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "XPE0OmyX5xPvxP7QSdGuB7TY7AE=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudformation",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "rjq4ZWRUGvQDjnXeflafkCWYsFU=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudfront",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "59kV70/8PuutX4eFkGfCCtdunIA=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudtrail",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "zm2qDEBdcJSJI3PGcE2UVr6Cxmc=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatch",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "2y8MKiWNwIVw/au7LBxCGLZusUU=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchevents",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "SGbv4ySdQtVIE7WJ+5HcNyWkbNY=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "EQj73ejMb8hAqCDC+hX4MuvJ7sk=",
 			"path": "github.com/aws/aws-sdk-go/service/codebuild",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "mr7qWrs0Aw9Pb84eyJL80Z7lxXc=",
 			"path": "github.com/aws/aws-sdk-go/service/codecommit",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "QJYewZzcmPbuN27AWiQ6XKQ9Vrw=",
 			"path": "github.com/aws/aws-sdk-go/service/codedeploy",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "y1X50fCNI6EIs5YWddiu/EAwD8o=",
 			"path": "github.com/aws/aws-sdk-go/service/codepipeline",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "7bm1eOY2oKYSesmEOd1qXvTRH2s=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentity",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "ouZ4H9foNRBFaElXZbpi5C3pqDQ=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentityprovider",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "Ryg2zV9xVlpTF1GVbP5GlYbynOc=",
 			"path": "github.com/aws/aws-sdk-go/service/configservice",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "QWfHksqdET4wKa3eKEbewFC6Ues=",
 			"path": "github.com/aws/aws-sdk-go/service/databasemigrationservice",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "S4vcGUr3SNl3XKPFTqfwFanT4Cw=",
 			"path": "github.com/aws/aws-sdk-go/service/devicefarm",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "vJAA3F/3UhmdWX7s3r+5YxEUuUg=",
 			"path": "github.com/aws/aws-sdk-go/service/directconnect",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "1O8BtYGfkXglIqgl/uxunrq3Djs=",
 			"path": "github.com/aws/aws-sdk-go/service/directoryservice",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "ycd0mxQjtWfbtlk+W2N7N6QdxFw=",
 			"path": "github.com/aws/aws-sdk-go/service/dynamodb",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "FjCSAoH/OdlkitoOJeml+sEFnfI=",
 			"path": "github.com/aws/aws-sdk-go/service/ec2",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "bovxt5atRBvLXGPHMFE1kPfTL0k=",
 			"path": "github.com/aws/aws-sdk-go/service/ecr",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "+Jyy6T5h4fYRUmU9EgV+ZtLNM80=",
 			"path": "github.com/aws/aws-sdk-go/service/ecs",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "pBkeSL8bCEbz/6ub0Jr6NsjQPSc=",
 			"path": "github.com/aws/aws-sdk-go/service/efs",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "4a4FO9D6RQluAwyYEW5H6p0Nz7I=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticache",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "uyG5rBbcDDiRCN6gXLXyWy0oxpQ=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticbeanstalk",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "RiXeoiTqLn4uvNIm0EDbHuvYYFw=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticsearchservice",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "zMFn+iotI5JIiB9HFRo6BiX6CZE=",
 			"path": "github.com/aws/aws-sdk-go/service/elastictranscoder",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "sp5ZmzFBI5z1+kLkRoFjfm2GWuY=",
 			"path": "github.com/aws/aws-sdk-go/service/elb",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "LjlrMBi+GR3kElFOfdV4WAJ10UU=",
 			"path": "github.com/aws/aws-sdk-go/service/elbv2",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "EEj7cYvIK+F25RIynBVArzedyPQ=",
 			"path": "github.com/aws/aws-sdk-go/service/emr",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "tuK++zhf2K0RBocTCU1ZltzS8ko=",
 			"path": "github.com/aws/aws-sdk-go/service/firehose",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "Ewp675B6bZe/eWipwJl7OXqCJRo=",
 			"path": "github.com/aws/aws-sdk-go/service/glacier",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "a+tKLYUEM3ZftY52P2ywtIxlCxE=",
 			"path": "github.com/aws/aws-sdk-go/service/iam",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "v0OUl6sTwF7EOmXyzk9ppc5ljLw=",
 			"path": "github.com/aws/aws-sdk-go/service/inspector",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "D92k3ymegRbjpgnuAy9rWjgV7vs=",
 			"path": "github.com/aws/aws-sdk-go/service/iot",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "fE6Lygzxvif/yfo9bncKyRUCqs8=",
 			"path": "github.com/aws/aws-sdk-go/service/kinesis",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "wwFYsrpInh4Tow/vTI7bD+r5gBU=",
 			"path": "github.com/aws/aws-sdk-go/service/kms",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "qu7WvUeSIFYQOqF9RXM/3w45kFg=",
 			"path": "github.com/aws/aws-sdk-go/service/lambda",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
-			"checksumSHA1": "eHMwitdHY0uOEA5kkmJ1nGHe0z0=",
+			"checksumSHA1": "HqzHXp/Jd+K1we+1q/K+zE4qyqw=",
 			"path": "github.com/aws/aws-sdk-go/service/lightsail",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "84rKGr+RvT8tjOalWGPKuNPC4T4=",
 			"path": "github.com/aws/aws-sdk-go/service/opsworks",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "4im5y93mxsIQgXujPiM5iRtW0J4=",
 			"path": "github.com/aws/aws-sdk-go/service/rds",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "dS8MjjzzX7csNyxiIpRPgHXMyss=",
 			"path": "github.com/aws/aws-sdk-go/service/redshift",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "Bx0UwkYHAU+LGL4Glg5le2UiirI=",
 			"path": "github.com/aws/aws-sdk-go/service/route53",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "QPxEB1a4X55kNCF/GlH18mOrHMA=",
 			"path": "github.com/aws/aws-sdk-go/service/s3",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "HQHIEdPu8wtbbJnECYl2HM9Ul5Q=",
 			"path": "github.com/aws/aws-sdk-go/service/servicecatalog",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "oYKSvsZejNuttYCnuAzw6Lq33FY=",
 			"path": "github.com/aws/aws-sdk-go/service/ses",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "u8xk+JtK/HwIKB2ume3or9Sstp8=",
 			"path": "github.com/aws/aws-sdk-go/service/sfn",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "6DiA9x0ibBF3ZBnILXiugtdTufc=",
 			"path": "github.com/aws/aws-sdk-go/service/shield",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "hOcVb1zJiDUmafXSJQhkEascWwA=",
 			"path": "github.com/aws/aws-sdk-go/service/simpledb",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "1jN0ZDW5c9QEGSQIQ+KrbTACvm8=",
 			"path": "github.com/aws/aws-sdk-go/service/sns",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
-			"checksumSHA1": "0y2X71gCB5ADXttecbyzuQy++HU=",
+			"checksumSHA1": "vo3NUCT5DQeQc52HHfht8sCuaA4=",
 			"path": "github.com/aws/aws-sdk-go/service/sqs",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
-			"checksumSHA1": "ODaF+6WgljmH1WhB3KmBdIz4C0U=",
+			"checksumSHA1": "jo8D8FG1KSYxqP5z9saasDziQLA=",
 			"path": "github.com/aws/aws-sdk-go/service/ssm",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "MerduaV3PxtZAWvOGpgoBIglo38=",
 			"path": "github.com/aws/aws-sdk-go/service/sts",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "4uvhHpzIP35jxtM1Iy0RsUPOaDg=",
 			"path": "github.com/aws/aws-sdk-go/service/waf",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "I0siM+RU1WsSwc6Pd9e3sRei7zM=",
 			"path": "github.com/aws/aws-sdk-go/service/wafregional",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "OHfwSU+p4N0Ft+BrzJfdE6AVRsY=",
 			"path": "github.com/aws/aws-sdk-go/service/workspaces",
-			"revision": "044a61f1536640ce1def6088c0914f5905990202",
-			"revisionTime": "2017-10-17T19:54:32Z",
-			"version": "v1.12.12",
-			"versionExact": "v1.12.12"
+			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
+			"revisionTime": "2017-10-19T22:20:31Z",
+			"version": "v1.12.14",
+			"versionExact": "v1.12.14"
 		},
 		{
 			"checksumSHA1": "nqw2Qn5xUklssHTubS5HDvEL9L4=",


### PR DESCRIPTION
Required for
* https://github.com/terraform-providers/terraform-provider-aws/issues/1983

```
govendor fetch github.com/aws/aws-sdk-go/aws/...@v1.12.14
govendor fetch github.com/aws/aws-sdk-go/internal/...@v1.12.14
govendor fetch github.com/aws/aws-sdk-go/private/...@v1.12.14
govendor fetch github.com/aws/aws-sdk-go/service/...@v1.12.14
```