### PR TITLE
resource/aws_spot_instance_request: Fix being able to stop requests

### DIFF
--- a/aws/resource_aws_spot_instance_request.go
+++ b/aws/resource_aws_spot_instance_request.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsSpotInstanceRequest() *schema.Resource {
@@ -81,8 +82,12 @@ func resourceAwsSpotInstanceRequest() *schema.Resource {
 			s["instance_interruption_behaviour"] = &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "terminate",
+				Default:  ec2.InstanceInterruptionBehaviorTerminate,
 				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					ec2.InstanceInterruptionBehaviorTerminate,
+					ec2.InstanceInterruptionBehaviorStop,
+				}, false),
 			}
 			return s
 		}(),
@@ -115,7 +120,6 @@ func resourceAwsSpotInstanceRequestCreate(d *schema.ResourceData, meta interface
 			ImageId:             instanceOpts.ImageID,
 			InstanceType:        instanceOpts.InstanceType,
 			KeyName:             instanceOpts.KeyName,
-			Placement:           instanceOpts.SpotPlacement,
 			SecurityGroupIds:    instanceOpts.SecurityGroupIDs,
 			SecurityGroups:      instanceOpts.SecurityGroups,
 			SubnetId:            instanceOpts.SubnetID,
@@ -130,6 +134,11 @@ func resourceAwsSpotInstanceRequestCreate(d *schema.ResourceData, meta interface
 
 	if v, ok := d.GetOk("launch_group"); ok {
 		spotOpts.LaunchGroup = aws.String(v.(string))
+	}
+
+	// Placement GroupName can only be specified when instanceInterruptionBehavior is not set to 'stop'
+	if v, exists := d.GetOkExists("instance_interruption_behaviour"); v.(string) == ec2.InstanceInterruptionBehaviorTerminate || !exists {
+		spotOpts.LaunchSpecification.Placement = instanceOpts.SpotPlacement
 	}
 
 	// Make the spot instance request

--- a/aws/resource_aws_spot_instance_request.go
+++ b/aws/resource_aws_spot_instance_request.go
@@ -87,6 +87,7 @@ func resourceAwsSpotInstanceRequest() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					ec2.InstanceInterruptionBehaviorTerminate,
 					ec2.InstanceInterruptionBehaviorStop,
+					ec2.InstanceInterruptionBehaviorHibernate,
 				}, false),
 			}
 			return s
@@ -136,7 +137,7 @@ func resourceAwsSpotInstanceRequestCreate(d *schema.ResourceData, meta interface
 		spotOpts.LaunchGroup = aws.String(v.(string))
 	}
 
-	// Placement GroupName can only be specified when instanceInterruptionBehavior is not set to 'stop'
+	// Placement GroupName can only be specified when instanceInterruptionBehavior is not set or set to 'terminate'
 	if v, exists := d.GetOkExists("instance_interruption_behaviour"); v.(string) == ec2.InstanceInterruptionBehaviorTerminate || !exists {
 		spotOpts.LaunchSpecification.Placement = instanceOpts.SpotPlacement
 	}

--- a/aws/resource_aws_spot_instance_request_test.go
+++ b/aws/resource_aws_spot_instance_request_test.go
@@ -389,6 +389,31 @@ func testAccCheckAWSSpotInstanceRequestAttributesVPC(
 	}
 }
 
+func TestAccAWSSpotInstanceRequestStopInterrupt(t *testing.T) {
+	var sir ec2.SpotInstanceRequest
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSpotInstanceRequestDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSpotInstanceRequestStopInterruptConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSpotInstanceRequestExists(
+						"aws_spot_instance_request.foo", &sir),
+					resource.TestCheckResourceAttr(
+						"aws_spot_instance_request.foo", "spot_bid_status", "fulfilled"),
+					resource.TestCheckResourceAttr(
+						"aws_spot_instance_request.foo", "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(
+						"aws_spot_instance_request.foo", "instance_interruption_behaviour", "stop"),
+				),
+			},
+		},
+	})
+}
+
 func testAccAWSSpotInstanceRequestConfig(rInt int) string {
 	return fmt.Sprintf(`
 	resource "aws_key_pair" "debugging" {
@@ -588,4 +613,22 @@ func testAccAWSSpotInstanceRequestConfig_getPasswordData(rInt int) string {
 		get_password_data    = true
 	}
 	`, rInt)
+}
+
+func testAccAWSSpotInstanceRequestStopInterruptConfig() string {
+	return fmt.Sprintf(`
+	resource "aws_spot_instance_request" "foo" {
+		ami = "ami-19e92861"
+		instance_type = "m3.medium"
+
+		// base price is $0.067 hourly, so bidding above that should theoretically
+		// always fulfill
+		spot_price = "0.07"
+
+		// we wait for fulfillment because we want to inspect the launched instance
+		// and verify termination behavior
+		wait_for_fulfillment = true
+
+		instance_interruption_behaviour = "stop"
+	}`)
 }


### PR DESCRIPTION
As mentioned in https://github.com/terraform-providers/terraform-provider-aws/pull/1735#issuecomment-338249736 this was failing locally for me.

Fixes an issue when setting the instance interruption behaviour to anything other than terminate (hibernate has since been added but not included in this PR) and adds a test to cover it.