### PR TITLE
Only compare the IP against the IPnet if it's IPv4

### DIFF
--- a/aws/validators.go
+++ b/aws/validators.go
@@ -427,14 +427,14 @@ func validatePolicyStatementId(v interface{}, k string) (ws []string, errors []e
 // represents a network address - it adds an error otherwise
 func validateCIDRNetworkAddress(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-	_, ipnet, err := net.ParseCIDR(value)
+	ip, ipnet, err := net.ParseCIDR(value)
 	if err != nil {
 		errors = append(errors, fmt.Errorf(
 			"%q must contain a valid CIDR, got error parsing: %s", k, err))
 		return
 	}
 
-	if ipnet == nil || value != ipnet.String() {
+	if ipnet == nil || (ip.To4() != nil && value != ipnet.String()) {
 		errors = append(errors, fmt.Errorf(
 			"%q must contain a valid network CIDR, got %q", k, value))
 	}

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -295,6 +295,7 @@ func TestValidateCIDRNetworkAddress(t *testing.T) {
 		{"notacidr", `must contain a valid CIDR`},
 		{"10.0.1.0/16", `must contain a valid network CIDR`},
 		{"10.0.1.0/24", ``},
+		{"2001:DB8::/32", ``},
 	}
 
 	for i, tc := range cases {

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -296,7 +296,7 @@ func TestValidateCIDRNetworkAddress(t *testing.T) {
 		{"10.0.1.0/16", `must contain a valid network CIDR`},
 		{"10.0.1.0/24", ``},
 		{"2001:DB8::/32", ``},
-                {"2001:DB8::FFFF/32", ``},
+		{"2001:DB8::FFFF/32", ``},
 	}
 
 	for i, tc := range cases {

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -296,6 +296,7 @@ func TestValidateCIDRNetworkAddress(t *testing.T) {
 		{"10.0.1.0/16", `must contain a valid network CIDR`},
 		{"10.0.1.0/24", ``},
 		{"2001:DB8::/32", ``},
+                {"2001:DB8::FFFF/32", ``},
 	}
 
 	for i, tc := range cases {


### PR DESCRIPTION
Only compare the IP against the IPnet if it's IPv4.

CIDR notation for IPv4 differ from IPv6 in that IPv4 host addresses
are /32, while an IPv6 host address always indicates its subnet
(/32, /56, /64, etc.)

This fix does not directly address the issue of lowercase hex digits
failing to match but that should no longer be an issue.

Added an IPv6 test case.