### PR TITLE
Fix typo in d/route53_zone.html

### DIFF
--- a/website/docs/d/route53_zone.html.markdown
+++ b/website/docs/d/route53_zone.html.markdown
@@ -44,7 +44,7 @@ Hosted Zone. If you use `name` field for private Hosted Zone, you need to add `p
 * `private_zone` - (Optional) Used with `name` field to get a private Hosted Zone.
 * `vpc_id` - (Optional) Used with `name` field to get a private Hosted Zone associated with the vpc_id (in this case, private_zone is not mandatory).
 * `tags` - (Optional) Used with `name` field. A mapping of tags, each pair of which must exactly match
-a pair on the desired security group.
+a pair on the desired Hosted Zone.
 ## Attributes Reference
 
 All of the argument attributes are also exported as


### PR DESCRIPTION
## Documentation Update

### Reasoning for docs update
There was a typo in the docs for `data "aws_route53_zone"` as noted in #1877.
> There seems to be a typo in the docs for `data "aws_route53_zone"` where in [Argument Reference](https://github.com/terraform-providers/terraform-provider-aws/blob/master/website/docs/d/route53_zone.html.markdown#argument-reference) > `tags`, the sentence '... must exactly match a pair on the desired security group.' seems to have mistakenly referred 'Hosted Zone' as 'security group'. The same reflects in the [latest docs](https://www.terraform.io/docs/providers/aws/d/route53_zone.html) on the website

### Relevant Terraform version
This update doesn't refer to a specific Terraform version but is relevant for the latest docs on the website.  There is no immediate need to deploy it to the site.