### PR TITLE
resource/aws_cognito_identity_pool: Fixed refresh of providers

### DIFF
--- a/aws/resource_aws_cognito_identity_pool.go
+++ b/aws/resource_aws_cognito_identity_pool.go
@@ -155,28 +155,20 @@ func resourceAwsCognitoIdentityPoolRead(d *schema.ResourceData, meta interface{}
 	d.Set("allow_unauthenticated_identities", ip.AllowUnauthenticatedIdentities)
 	d.Set("developer_provider_name", ip.DeveloperProviderName)
 
-	if ip.CognitoIdentityProviders != nil {
-		if err := d.Set("cognito_identity_providers", flattenCognitoIdentityProviders(ip.CognitoIdentityProviders)); err != nil {
-			return fmt.Errorf("[DEBUG] Error setting cognito_identity_providers error: %#v", err)
-		}
+	if err := d.Set("cognito_identity_providers", flattenCognitoIdentityProviders(ip.CognitoIdentityProviders)); err != nil {
+		return fmt.Errorf("[DEBUG] Error setting cognito_identity_providers error: %#v", err)
 	}
 
-	if ip.OpenIdConnectProviderARNs != nil {
-		if err := d.Set("openid_connect_provider_arns", flattenStringList(ip.OpenIdConnectProviderARNs)); err != nil {
-			return fmt.Errorf("[DEBUG] Error setting openid_connect_provider_arns error: %#v", err)
-		}
+	if err := d.Set("openid_connect_provider_arns", flattenStringList(ip.OpenIdConnectProviderARNs)); err != nil {
+		return fmt.Errorf("[DEBUG] Error setting openid_connect_provider_arns error: %#v", err)
 	}
 
-	if ip.SamlProviderARNs != nil {
-		if err := d.Set("saml_provider_arns", flattenStringList(ip.SamlProviderARNs)); err != nil {
-			return fmt.Errorf("[DEBUG] Error setting saml_provider_arns error: %#v", err)
-		}
+	if err := d.Set("saml_provider_arns", flattenStringList(ip.SamlProviderARNs)); err != nil {
+		return fmt.Errorf("[DEBUG] Error setting saml_provider_arns error: %#v", err)
 	}
 
-	if ip.SupportedLoginProviders != nil {
-		if err := d.Set("supported_login_providers", flattenCognitoSupportedLoginProviders(ip.SupportedLoginProviders)); err != nil {
-			return fmt.Errorf("[DEBUG] Error setting supported_login_providers error: %#v", err)
-		}
+	if err := d.Set("supported_login_providers", flattenCognitoSupportedLoginProviders(ip.SupportedLoginProviders)); err != nil {
+		return fmt.Errorf("[DEBUG] Error setting supported_login_providers error: %#v", err)
 	}
 
 	return nil


### PR DESCRIPTION
This fixes an issue encountered playing with [Cognito Identity Pool Roles Attachment](https://github.com/terraform-providers/terraform-provider-aws/pull/863): providers were not being refreshed when evaluated as nil.