### PR TITLE
Documentation fix for aws_billing_service_account - Those id needs to be arn

### DIFF
--- a/website/docs/d/billing_service_account.html.markdown
+++ b/website/docs/d/billing_service_account.html.markdown
@@ -32,7 +32,7 @@ resource "aws_s3_bucket" "billing_logs" {
       "Resource": "arn:aws:s3:::my-billing-tf-test-bucket",
       "Principal": {
         "AWS": [
-          "${data.aws_billing_service_account.main.id}"
+          "${data.aws_billing_service_account.main.arn}"
         ]
       }
     },
@@ -44,7 +44,7 @@ resource "aws_s3_bucket" "billing_logs" {
       "Resource": "arn:aws:s3:::my-billing-tf-test-bucket/AWSLogs/*",
       "Principal": {
         "AWS": [
-          "${data.aws_billing_service_account.main.id}"
+          "${data.aws_billing_service_account.main.arn}"
         ]
       }
     }


### PR DESCRIPTION
As per the [documentation](http://docs.aws.amazon.com/AmazonS3/latest/dev/s3-bucket-user-policy-specifying-principal-intro.html), the AWS Principal should be an ARN