### PR TITLE
Add 'tags' support to aws_spot_fleet_request

### DIFF
--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -382,10 +382,10 @@ func buildSpotFleetLaunchSpecification(d map[string]interface{}, meta interface{
 		}
 	}
 
-	if v, ok := d["tags"]; ok {
+	if m, ok := d["tags"].(map[string]interface{}); ok && len(m) > 0 {
 		tagsSpec := make([]*ec2.SpotFleetTagSpecification, 0)
 
-		tags := tagsFromMap(v.(map[string]interface{}))
+		tags := tagsFromMap(m)
 
 		spec := &ec2.SpotFleetTagSpecification{
 			ResourceType: aws.String("instance"),

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -377,6 +377,29 @@ func TestAccAWSSpotFleetRequest_withEBSDisk(t *testing.T) {
 	})
 }
 
+func TestAccAWSSpotFleetRequest_withTags(t *testing.T) {
+	var config ec2.SpotFleetRequestConfig
+	rName := acctest.RandString(10)
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSpotFleetRequestTagsConfig(rName, rInt),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSSpotFleetRequestExists("aws_spot_fleet_request.foo", &config),
+					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.24370212.tags.%", "2"),
+					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.24370212.tags.First", "TfAccTest"),
+					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.24370212.tags.Second", "Terraform"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSSpotFleetRequest_placementTenancy(t *testing.T) {
 	var sfr ec2.SpotFleetRequestConfig
 	rName := acctest.RandString(10)
@@ -1405,6 +1428,79 @@ resource "aws_spot_fleet_request" "foo" {
             device_name = "/dev/xvdcz"
 	    volume_type = "gp2"
 	    volume_size = "100"
+        }
+    }
+    depends_on = ["aws_iam_policy_attachment.test-attach"]
+}
+`, rInt, rInt, rName)
+}
+
+func testAccAWSSpotFleetRequestTagsConfig(rName string, rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_iam_policy" "test-policy" {
+  name = "test-policy-%d"
+  path = "/"
+  description = "Spot Fleet Request ACCTest Policy"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": [
+       "ec2:DescribeImages",
+       "ec2:DescribeSubnets",
+       "ec2:RequestSpotInstances",
+       "ec2:TerminateInstances",
+       "ec2:DescribeInstanceStatus",
+       "iam:PassRole"
+        ],
+    "Resource": ["*"]
+  }]
+}
+EOF
+}
+
+resource "aws_iam_policy_attachment" "test-attach" {
+    name = "test-attachment-%d"
+    roles = ["${aws_iam_role.test-role.name}"]
+    policy_arn = "${aws_iam_policy.test-policy.arn}"
+}
+
+resource "aws_iam_role" "test-role" {
+    name = "test-role-%s"
+    assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "spotfleet.amazonaws.com",
+          "ec2.amazonaws.com"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_spot_fleet_request" "foo" {
+    iam_fleet_role = "${aws_iam_role.test-role.arn}"
+    spot_price = "0.005"
+    target_capacity = 1
+    valid_until = "2019-11-04T20:44:20Z"
+    terminate_instances_with_expiration = true
+    wait_for_fulfillment = true
+    launch_specification {
+        instance_type = "m1.small"
+        ami = "ami-516b9131"
+        tags {
+            First = "TfAccTest"
+            Second = "Terraform"
         }
     }
     depends_on = ["aws_iam_policy_attachment.test-attach"]

--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -42,6 +42,10 @@ resource "aws_spot_fleet_request" "cheap_compute" {
       volume_size = "300"
       volume_type = "gp2"
     }
+
+    tags {
+      Name = "spot-fleet-example"
+    }
   }
 }
 ```


### PR DESCRIPTION
This adds support for [tags on spot fleet requests](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_SpotFleetTagSpecification.html). I tried to follow the pattern of the nearly-identical `tags` block in `resource_aws_instance.go` (the difference being Spot Fleet only supports `instance`, not `volume`, as a resource type).

Since the documentation for `aws_spot_fleet_request` simply references the `aws_instance` documentation, I didn't add any additional info about `tags`, but I did include a `tags` block in one of the examples.

This should resolve feature request #1232.

Closes #1232