### PR TITLE
r/ami doc update and few typo and indentation fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ IMPROVEMENTS:
 * resource/aws_efs_file_system: Expose `dns_name` ([#1825](https://github.com/terraform-providers/terraform-provider-aws/issues/1825))
 * resource/aws_security_group+aws_security_group_rule: Add support for rule description ([#1587](https://github.com/terraform-providers/terraform-provider-aws/issues/1587))
 * resource/aws_emr_cluster: enable configuration of ebs root volume size ([#1375](https://github.com/terraform-providers/terraform-provider-aws/issues/1375))
-* resource/aws_aws_ami: Add `root_snapshot_id` attribute ([#1572](https://github.com/terraform-providers/terraform-provider-aws/issues/1572))
+* resource/aws_ami: Add `root_snapshot_id` attribute ([#1572](https://github.com/terraform-providers/terraform-provider-aws/issues/1572))
 * resource/aws_vpn_connection: Mark preshared keys as sensitive ([#1850](https://github.com/terraform-providers/terraform-provider-aws/issues/1850))
 * resource/aws_codedeploy_deployment_group: Support blue/green and in-place deployments with traffic control ([#1162](https://github.com/terraform-providers/terraform-provider-aws/issues/1162))
 * resource/aws_elb: Update ELB idle timeout to 4000s ([#1861](https://github.com/terraform-providers/terraform-provider-aws/issues/1861))

--- a/website/docs/r/ami.html.markdown
+++ b/website/docs/r/ami.html.markdown
@@ -71,7 +71,7 @@ Nested `ebs_block_device` blocks have the following structure:
 * `device_name` - (Required) The path at which the device is exposed to created instances.
 * `delete_on_termination` - (Optional) Boolean controlling whether the EBS volumes created to
   support each created instance will be deleted once that instance is terminated.
-* `encrypted` - (Optional) Boolean controlling whether the created EBS volumes will be encrypted.
+* `encrypted` - (Optional) Boolean controlling whether the created EBS volumes will be encrypted. Can't be used with `snapshot_id`.
 * `iops` - (Required only when `volume_type` is "io1") Number of I/O operations per second the
   created volumes will support.
 * `snapshot_id` - (Optional) The id of an EBS snapshot that will be used to initialize the created

--- a/website/docs/r/autoscaling_group.html.markdown
+++ b/website/docs/r/autoscaling_group.html.markdown
@@ -52,9 +52,9 @@ EOF
     propagate_at_launch = true
   }
 
-timeouts {
+  timeouts {
     delete = "15m"
-}
+  }
 
   tag {
     key                 = "lorem"


### PR DESCRIPTION
I don't mean to nitpick the slightest of errors. I am just trying to contribute with whatever low hanging issues I can find. :) Kindly have a look.

## Documentation Update

### Reasoning for docs update
- Fixes inconsistent indentation [(f081c8e)](https://github.com/abinashmeher999/terraform-provider-aws/commit/f081c8e8d54c3b70a1ce17c7e029b49d7ee591d0)
- Typo in CHANGELOG, fixed in [(27fe2af)](https://github.com/abinashmeher999/terraform-provider-aws/commit/27fe2af7dcf073094a1b01ca66de34fe8504135c)
- Mention in the docs for r/ami that we can't use `encrypted` with `snapshot_id` [(6c1bd5d)](https://github.com/abinashmeher999/terraform-provider-aws/commit/6c1bd5d6a30ff3df23cd50265f8a097790a4a377)

### Relevant Terraform version
The typo fix was made to 1.1.0 part of CHANGELOG, the rest don't refer to a specific Terraform version but are relevant for the latest docs on the website. There is no immediate need to deploy it to the site.