### PR TITLE
r/spot_fleet_request: Raise bid price in acceptance test

### DIFF
--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -879,7 +879,7 @@ resource "aws_subnet" "bar" {
 
 resource "aws_spot_fleet_request" "foo" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
-    spot_price = "0.025"
+    spot_price = "0.0265"
     target_capacity = 4
     valid_until = "2019-11-04T20:44:20Z"
     terminate_instances_with_expiration = true


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList
--- FAIL: TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList (124.78s)
    testing.go:434: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_spot_fleet_request.foo: 1 error(s) occurred:
        
        * aws_spot_fleet_request.foo: unexpected state 'error', wanted target 'fulfilled'. last error: %!s(<nil>)
```

I had to pull the reason for `error` state from the event log:

```
m3.large, ami-d0f506b0, Linux/UNIX, us-west-2b, Spot bid price is less than Spot market price $0.0264
```
and it would be great if we could do it automatically and attach that as error, but filtering the log to get what we need (just errors) isn't easy, so I opened an AWS support ticket about that and we can address that in a separate PR.