### PR TITLE
r/elasticache_replication_group: Raise creation timeout to 50mins

### DIFF
--- a/aws/resource_aws_elasticache_replication_group.go
+++ b/aws/resource_aws_elasticache_replication_group.go
@@ -201,7 +201,7 @@ func resourceAwsElasticacheReplicationGroupCreate(d *schema.ResourceData, meta i
 		Pending:    pending,
 		Target:     []string{"available"},
 		Refresh:    cacheReplicationGroupStateRefreshFunc(conn, d.Id(), "available", pending),
-		Timeout:    40 * time.Minute,
+		Timeout:    50 * time.Minute,
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second,
 	}


### PR DESCRIPTION
This is to address the following acceptance test failure from today:

```
=== RUN   TestAccAWSElasticacheReplicationGroup_multiAzInVpc
--- FAIL: TestAccAWSElasticacheReplicationGroup_multiAzInVpc (2442.99s)
    testing.go:434: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_elasticache_replication_group.bar: 1 error(s) occurred:
        
        * aws_elasticache_replication_group.bar: Error waiting for elasticache replication group (tf-x8tbqodaig) to be created: timeout while waiting for state to become 'available' (last state: 'creating', timeout: 40m0s)
```