### PR TITLE
r/snapshot_create_volume_permission: Raise creation timeout to 20mins

### DIFF
--- a/aws/resource_aws_snapshot_create_volume_permission.go
+++ b/aws/resource_aws_snapshot_create_volume_permission.go
@@ -66,7 +66,7 @@ func resourceAwsSnapshotCreateVolumePermissionCreate(d *schema.ResourceData, met
 		Pending:    []string{"denied"},
 		Target:     []string{"granted"},
 		Refresh:    resourceAwsSnapshotCreateVolumePermissionStateRefreshFunc(conn, snapshot_id, account_id),
-		Timeout:    10 * time.Minute,
+		Timeout:    20 * time.Minute,
 		Delay:      10 * time.Second,
 		MinTimeout: 10 * time.Second,
 	}


### PR DESCRIPTION
This is a second attempt to address the following test failure:

```
=== RUN   TestAccAWSSnapshotCreateVolumePermission_Basic
--- FAIL: TestAccAWSSnapshotCreateVolumePermission_Basic (662.59s)
    testing.go:434: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_snapshot_create_volume_permission.self-test: 1 error(s) occurred:
        
        * aws_snapshot_create_volume_permission.self-test: Error waiting for snapshot createVolumePermission (snap-09d6818069913807b-*******) to be added: timeout while waiting for state to become 'granted' (last state: 'denied', timeout: 10m0s)
```

because https://github.com/terraform-providers/terraform-provider-aws/pull/1894 clearly wasn't sufficient.