### PR TITLE
r/spot_instances_request: Fix failing acceptance test (SubnetId)

### DIFF
--- a/aws/resource_aws_spot_instance_request_test.go
+++ b/aws/resource_aws_spot_instance_request_test.go
@@ -342,9 +342,9 @@ func testAccCheckAWSSpotInstanceRequest_InstanceAttributes(
 func testAccCheckAWSSpotInstanceRequest_NetworkInterfaceAttributes(
 	sir *ec2.SpotInstanceRequest) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-
-		if sir.LaunchSpecification.NetworkInterfaces == nil || len(sir.LaunchSpecification.NetworkInterfaces) != 1 {
-			return fmt.Errorf("Error with Spot Instance Network Interface count")
+		nis := sir.LaunchSpecification.NetworkInterfaces
+		if nis == nil || len(nis) != 1 {
+			return fmt.Errorf("Expected exactly 1 network interface, found %d", len(nis))
 		}
 
 		return nil
@@ -354,8 +354,15 @@ func testAccCheckAWSSpotInstanceRequest_NetworkInterfaceAttributes(
 func testAccCheckAWSSpotInstanceRequestAttributesVPC(
 	sir *ec2.SpotInstanceRequest) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if sir.LaunchSpecification.SubnetId == nil {
-			return fmt.Errorf("SubnetID was not passed, but should have been for this instance to belong to a VPC")
+		nis := sir.LaunchSpecification.NetworkInterfaces
+		if nis == nil || len(nis) != 1 {
+			return fmt.Errorf("Expected exactly 1 network interface, found %d", len(nis))
+		}
+
+		ni := nis[0]
+
+		if ni.SubnetId == nil {
+			return fmt.Errorf("Expected SubnetId not be non-empty for %s as the instance belongs to a VPC", *sir.InstanceId)
 		}
 		return nil
 	}


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSSpotInstanceRequest_vpc
--- FAIL: TestAccAWSSpotInstanceRequest_vpc (213.48s)
    testing.go:435: Step 0 error: Check failed: Check 4/6 error: SubnetID was not passed, but should have been for this instance to belong to a VPC
```

## Background

The test started failing since 9th August and there were no code changes involved in that test or resource in the first failure https://github.com/terraform-providers/terraform-provider-aws/blob/37cf4e6f4086285603c0a447de7d3b62bc3e9348/aws/resource_aws_spot_instance_request_test.go#L443

However on closer inspection it looks like AWS modified the API response. Here's one from 8th August:

```xml
2017/08/08 07:35:35 [DEBUG] [aws-sdk-go] <?xml version="1.0" encoding="UTF-8"?>
<DescribeSpotInstanceRequestsResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
    <requestId>7fc4cb62-c0f7-47e9-a232-ebbdb6be9381</requestId>
    <spotInstanceRequestSet>
        <item>
            <spotInstanceRequestId>sir-g1siaa9q</spotInstanceRequestId>
            <spotPrice>0.050000</spotPrice>
            <type>persistent</type>
            <state>active</state>
            <status>
                <code>fulfilled</code>
                <updateTime>2017-08-08T07:35:30.000Z</updateTime>
                <message>Your Spot request is fulfilled.</message>
            </status>
            <launchSpecification>
                <imageId>ami-4fccb37f</imageId>
                <keyName>tmp-key-3107743772220979371</keyName>
                <groupSet>
                    <item>
                        <groupId>sg-620d6418</groupId>
                        <groupName>default</groupName>
                    </item>
                </groupSet>
                <instanceType>m1.small</instanceType>
                <placement>
                    <availabilityZone>us-west-2c</availabilityZone>
                    <groupName/>
                </placement>
                <monitoring>
                    <enabled>false</enabled>
                </monitoring>
                <subnetId>subnet-4c920717</subnetId>
                <iamInstanceProfile>
                    <name/>
                </iamInstanceProfile>
                <ebsOptimized>false</ebsOptimized>
            </launchSpecification>
            <instanceId>i-0dc1542a6f9ab9485</instanceId>
            <createTime>2017-08-08T07:35:24.000Z</createTime>
            <productDescription>Linux/UNIX</productDescription>
            <tagSet>
                <item>
                    <key>Name</key>
                    <value>terraform-test-VPC</value>
                </item>
            </tagSet>
            <launchedAvailabilityZone>us-west-2c</launchedAvailabilityZone>
        </item>
    </spotInstanceRequestSet>
</DescribeSpotInstanceRequestsResponse>
```

and here's one from today:

```xml
<DescribeSpotInstanceRequestsResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
    <requestId>e261b1dd-11dc-41f5-ad95-7325ca07b9c8</requestId>
    <spotInstanceRequestSet>
        <item>
            <spotInstanceRequestId>sir-97vrasdm</spotInstanceRequestId>
            <spotPrice>0.050000</spotPrice>
            <type>persistent</type>
            <state>active</state>
            <status>
                <code>fulfilled</code>
                <updateTime>2017-10-25T14:19:37.000Z</updateTime>
                <message>Your Spot request is fulfilled.</message>
            </status>
            <launchSpecification>
                <imageId>ami-4fccb37f</imageId>
                <keyName>tmp-key-1789522026768986395</keyName>
                <groupSet>
                    <item>
                        <groupName>default</groupName>
                    </item>
                </groupSet>
                <instanceType>m1.small</instanceType>
                <placement>
                    <availabilityZone>us-west-2a</availabilityZone>
                    <groupName/>
                </placement>
                <monitoring>
                    <enabled>false</enabled>
                </monitoring>
                <networkInterfaceSet>
                    <item>
                        <deviceIndex>0</deviceIndex>
                        <subnetId>subnet-c558d78d</subnetId>
                        <groupSet>
                            <item>
                                <groupId>sg-409fe63d</groupId>
                            </item>
                        </groupSet>
                    </item>
                </networkInterfaceSet>
                <iamInstanceProfile>
                    <name/>
                </iamInstanceProfile>
                <ebsOptimized>false</ebsOptimized>
            </launchSpecification>
            <instanceId>i-007472e1e4096fbc9</instanceId>
            <createTime>2017-10-25T14:19:30.000Z</createTime>
            <productDescription>Linux/UNIX</productDescription>
            <launchedAvailabilityZone>us-west-2a</launchedAvailabilityZone>
            <instanceInterruptionBehavior>terminate</instanceInterruptionBehavior>
        </item>
    </spotInstanceRequestSet>
</DescribeSpotInstanceRequestsResponse>
```

## Test results

![screen shot 2017-10-25 at 15 54 30](https://user-images.githubusercontent.com/287584/32005855-40e949ec-b99d-11e7-9b6d-8539022b4ca6.png)
