### PR TITLE
r/kinesis_firehose_delivery_stream: Use data source instead of acc ID in tests

### DIFF
--- a/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -20,10 +19,10 @@ func TestAccAWSKinesisFirehoseDeliveryStream_s3basic(t *testing.T) {
 	var stream firehose.DeliveryStreamDescription
 	ri := acctest.RandInt()
 	config := fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_s3basic,
-		ri, os.Getenv("AWS_ACCOUNT_ID"), ri, ri, ri)
+		ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     testAccKinesisFirehosePreCheck(t),
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKinesisFirehoseDeliveryStreamDestroy,
 		Steps: []resource.TestStep{
@@ -42,10 +41,10 @@ func TestAccAWSKinesisFirehoseDeliveryStream_s3KinesisStreamSource(t *testing.T)
 	var stream firehose.DeliveryStreamDescription
 	ri := acctest.RandInt()
 	config := fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_s3KinesisStreamSource,
-		ri, os.Getenv("AWS_ACCOUNT_ID"), ri, ri, ri, ri, os.Getenv("AWS_ACCOUNT_ID"), ri, ri, ri)
+		ri, ri, ri, ri, ri, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     testAccKinesisFirehosePreCheck(t),
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKinesisFirehoseDeliveryStreamDestroy,
 		Steps: []resource.TestStep{
@@ -65,12 +64,12 @@ func TestAccAWSKinesisFirehoseDeliveryStream_s3WithCloudwatchLogging(t *testing.
 	ri := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     testAccKinesisFirehosePreCheck(t),
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKinesisFirehoseDeliveryStreamDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKinesisFirehoseDeliveryStreamConfig_s3WithCloudwatchLogging(os.Getenv("AWS_ACCOUNT_ID"), ri),
+				Config: testAccKinesisFirehoseDeliveryStreamConfig_s3WithCloudwatchLogging(ri),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKinesisFirehoseDeliveryStreamExists("aws_kinesis_firehose_delivery_stream.test_stream", &stream),
 					testAccCheckAWSKinesisFirehoseDeliveryStreamAttributes(&stream, nil, nil, nil, nil),
@@ -85,9 +84,9 @@ func TestAccAWSKinesisFirehoseDeliveryStream_s3ConfigUpdates(t *testing.T) {
 
 	ri := acctest.RandInt()
 	preConfig := fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_s3basic,
-		ri, os.Getenv("AWS_ACCOUNT_ID"), ri, ri, ri)
+		ri, ri, ri, ri)
 	postConfig := fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_s3Updates,
-		ri, os.Getenv("AWS_ACCOUNT_ID"), ri, ri, ri)
+		ri, ri, ri, ri)
 
 	updatedS3DestinationConfig := &firehose.S3DestinationDescription{
 		BufferingHints: &firehose.BufferingHints{
@@ -97,7 +96,7 @@ func TestAccAWSKinesisFirehoseDeliveryStream_s3ConfigUpdates(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     testAccKinesisFirehosePreCheck(t),
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKinesisFirehoseDeliveryStreamDestroy,
 		Steps: []resource.TestStep{
@@ -128,10 +127,10 @@ func TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3basic(t *testing.T) {
 	ri := acctest.RandInt()
 	config := testAccFirehoseAWSLambdaConfigBasic(rName, rSt) +
 		fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_extendedS3basic,
-			ri, os.Getenv("AWS_ACCOUNT_ID"), ri, ri, ri)
+			ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     testAccKinesisFirehosePreCheck(t),
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKinesisFirehoseDeliveryStreamDestroy_ExtendedS3,
 		Steps: []resource.TestStep{
@@ -154,10 +153,10 @@ func TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidProcessorType(t *t
 	ri := acctest.RandInt()
 	config := testAccFirehoseAWSLambdaConfigBasic(rName, rSt) +
 		fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_extendedS3InvalidProcessorType,
-			ri, os.Getenv("AWS_ACCOUNT_ID"), ri, ri, ri)
+			ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     testAccKinesisFirehosePreCheck(t),
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKinesisFirehoseDeliveryStreamDestroy_ExtendedS3,
 		Steps: []resource.TestStep{
@@ -177,10 +176,10 @@ func TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidParameterName(t *t
 	ri := acctest.RandInt()
 	config := testAccFirehoseAWSLambdaConfigBasic(rName, rSt) +
 		fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_extendedS3InvalidParameterName,
-			ri, os.Getenv("AWS_ACCOUNT_ID"), ri, ri, ri)
+			ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     testAccKinesisFirehosePreCheck(t),
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKinesisFirehoseDeliveryStreamDestroy_ExtendedS3,
 		Steps: []resource.TestStep{
@@ -202,10 +201,10 @@ func TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3Updates(t *testing.T) {
 
 	preConfig := testAccFirehoseAWSLambdaConfigBasic(rName, rSt) +
 		fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_extendedS3basic,
-			ri, os.Getenv("AWS_ACCOUNT_ID"), ri, ri, ri)
+			ri, ri, ri, ri)
 	postConfig := testAccFirehoseAWSLambdaConfigBasic(rName, rSt) +
 		fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_extendedS3Updates,
-			ri, os.Getenv("AWS_ACCOUNT_ID"), ri, ri, ri)
+			ri, ri, ri, ri)
 
 	updatedExtendedS3DestinationConfig := &firehose.ExtendedS3DestinationDescription{
 		BufferingHints: &firehose.BufferingHints{
@@ -229,7 +228,7 @@ func TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3Updates(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     testAccKinesisFirehosePreCheck(t),
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKinesisFirehoseDeliveryStreamDestroy_ExtendedS3,
 		Steps: []resource.TestStep{
@@ -256,9 +255,9 @@ func TestAccAWSKinesisFirehoseDeliveryStream_RedshiftConfigUpdates(t *testing.T)
 
 	ri := acctest.RandInt()
 	preConfig := fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_RedshiftBasic,
-		ri, os.Getenv("AWS_ACCOUNT_ID"), ri, ri, ri, ri)
+		ri, ri, ri, ri, ri)
 	postConfig := fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_RedshiftUpdates,
-		ri, os.Getenv("AWS_ACCOUNT_ID"), ri, ri, ri, ri)
+		ri, ri, ri, ri, ri)
 
 	updatedRedshiftConfig := &firehose.RedshiftDestinationDescription{
 		CopyCommand: &firehose.CopyCommand{
@@ -267,7 +266,7 @@ func TestAccAWSKinesisFirehoseDeliveryStream_RedshiftConfigUpdates(t *testing.T)
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     testAccKinesisFirehosePreCheck(t),
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKinesisFirehoseDeliveryStreamDestroy,
 		Steps: []resource.TestStep{
@@ -294,11 +293,10 @@ func TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigUpdates(t *testi
 	var stream firehose.DeliveryStreamDescription
 
 	ri := acctest.RandInt()
-	awsAccountId := os.Getenv("AWS_ACCOUNT_ID")
 	preConfig := fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_ElasticsearchBasic,
-		ri, awsAccountId, ri, ri, ri, awsAccountId, awsAccountId, ri, ri)
+		ri, ri, ri, ri, ri, ri)
 	postConfig := fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_ElasticsearchUpdate,
-		ri, awsAccountId, ri, ri, ri, awsAccountId, awsAccountId, ri, ri)
+		ri, ri, ri, ri, ri, ri)
 
 	updatedElasticSearchConfig := &firehose.ElasticsearchDestinationDescription{
 		BufferingHints: &firehose.ElasticsearchBufferingHints{
@@ -307,7 +305,7 @@ func TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigUpdates(t *testi
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     testAccKinesisFirehosePreCheck(t),
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKinesisFirehoseDeliveryStreamDestroy,
 		Steps: []resource.TestStep{
@@ -335,7 +333,7 @@ func TestAccAWSKinesisFirehoseDeliveryStream_missingProcessingConfiguration(t *t
 	ri := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     testAccKinesisFirehosePreCheck(t),
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKinesisFirehoseDeliveryStreamDestroy,
 		Steps: []resource.TestStep{
@@ -522,15 +520,6 @@ func testAccCheckFirehoseLambdaFunctionDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccKinesisFirehosePreCheck(t *testing.T) func() {
-	return func() {
-		testAccPreCheck(t)
-		if os.Getenv("AWS_ACCOUNT_ID") == "" {
-			t.Fatal("AWS_ACCOUNT_ID must be set")
-		}
-	}
-}
-
 func baseAccFirehoseAWSLambdaConfig(rst string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role_policy" "iam_policy_for_lambda" {
@@ -597,6 +586,8 @@ resource "aws_lambda_function" "lambda_function_test" {
 }
 
 const testAccKinesisFirehoseDeliveryStreamBaseConfig = `
+data "aws_caller_identity" "current" {}
+
 resource "aws_iam_role" "firehose" {
   name = "tf_acctest_firehose_delivery_role_%d"
   assume_role_policy = <<EOF
@@ -612,7 +603,7 @@ resource "aws_iam_role" "firehose" {
       "Action": "sts:AssumeRole",
       "Condition": {
         "StringEquals": {
-          "sts:ExternalId": "%s"
+          "sts:ExternalId": "${data.aws_caller_identity.current.account_id}"
         }
       }
     }
@@ -712,8 +703,10 @@ EOF
 
 `
 
-func testAccKinesisFirehoseDeliveryStreamConfig_s3WithCloudwatchLogging(accountId string, rInt int) string {
+func testAccKinesisFirehoseDeliveryStreamConfig_s3WithCloudwatchLogging(rInt int) string {
 	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
 resource "aws_iam_role" "firehose" {
   name = "tf_acctest_firehose_delivery_role_%d"
   assume_role_policy = <<EOF
@@ -729,7 +722,7 @@ resource "aws_iam_role" "firehose" {
       "Action": "sts:AssumeRole",
       "Condition": {
         "StringEquals": {
-          "sts:ExternalId": "%s"
+          "sts:ExternalId": "${data.aws_caller_identity.current.account_id}"
         }
       }
     }
@@ -803,7 +796,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
     }
   }
 }
-`, rInt, accountId, rInt, rInt, rInt, rInt, rInt)
+`, rInt, rInt, rInt, rInt, rInt, rInt)
 }
 
 var testAccKinesisFirehoseDeliveryStreamConfig_s3basic = testAccKinesisFirehoseDeliveryStreamBaseConfig + `
@@ -1003,10 +996,10 @@ resource "aws_elasticsearch_domain" "test_cluster" {
     {
       "Effect": "Allow",
       "Principal": {
-        "AWS": "arn:aws:iam::%s:root"
+        "AWS": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
       },
       "Action": "es:*",
-      "Resource": "arn:aws:es:us-east-1:%s:domain/es-test-%d/*"
+      "Resource": "arn:aws:es:us-east-1:${data.aws_caller_identity.current.account_id}:domain/es-test-%d/*"
     }
   ]
 }


### PR DESCRIPTION
There's no real reason for a static ID. I'm lowering the barrier this way so that anyone can `make testacc` without having find & specify the ID.