### PR TITLE
Accept query strings in s3 redirect hosts

### DIFF
--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -652,19 +652,22 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 			} else {
 				var host string
 				var path string
+				var query string
 				parsedHostName, err := url.Parse(*v.HostName)
 				if err == nil {
 					host = parsedHostName.Host
 					path = parsedHostName.Path
+					query = parsedHostName.RawQuery
 				} else {
 					host = *v.HostName
 					path = ""
 				}
 
 				w["redirect_all_requests_to"] = (&url.URL{
-					Host:   host,
-					Path:   path,
-					Scheme: *v.Protocol,
+					Host:     host,
+					Path:     path,
+					Scheme:   *v.Protocol,
+					RawQuery: query,
 				}).String()
 			}
 		}
@@ -1226,6 +1229,10 @@ func resourceAwsS3BucketWebsitePut(s3conn *s3.S3, d *schema.ResourceData, websit
 			redirectHostBuf.WriteString(redirect.Host)
 			if redirect.Path != "" {
 				redirectHostBuf.WriteString(redirect.Path)
+			}
+			if redirect.RawQuery != "" {
+				redirectHostBuf.WriteString("?")
+				redirectHostBuf.WriteString(redirect.RawQuery)
 			}
 			websiteConfiguration.RedirectAllRequestsTo = &s3.RedirectAllRequestsTo{HostName: aws.String(redirectHostBuf.String()), Protocol: aws.String(redirect.Scheme)}
 		} else {

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -338,7 +338,7 @@ func TestAccAWSS3Bucket_WebsiteRedirect(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
 					testAccCheckAWSS3BucketWebsite(
-						"aws_s3_bucket.bucket", "", "", "", "hashicorp.com"),
+						"aws_s3_bucket.bucket", "", "", "", "hashicorp.com?my=query"),
 					resource.TestCheckResourceAttr(
 						"aws_s3_bucket.bucket", "website_endpoint", testAccWebsiteEndpoint(rInt)),
 				),
@@ -348,7 +348,7 @@ func TestAccAWSS3Bucket_WebsiteRedirect(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
 					testAccCheckAWSS3BucketWebsite(
-						"aws_s3_bucket.bucket", "", "", "https", "hashicorp.com"),
+						"aws_s3_bucket.bucket", "", "", "https", "hashicorp.com?my=query"),
 					resource.TestCheckResourceAttr(
 						"aws_s3_bucket.bucket", "website_endpoint", testAccWebsiteEndpoint(rInt)),
 				),
@@ -1307,7 +1307,7 @@ resource "aws_s3_bucket" "bucket" {
 	acl = "public-read"
 
 	website {
-		redirect_all_requests_to = "hashicorp.com"
+		redirect_all_requests_to = "hashicorp.com?my=query"
 	}
 }
 `, randInt)
@@ -1320,7 +1320,7 @@ resource "aws_s3_bucket" "bucket" {
 	acl = "public-read"
 
 	website {
-		redirect_all_requests_to = "https://hashicorp.com"
+		redirect_all_requests_to = "https://hashicorp.com?my=query"
 	}
 }
 `, randInt)


### PR DESCRIPTION
Previously, they were being stripped by url.Parse.

https://github.com/hashicorp/terraform/issues/16454

Closes #2061