### PR TITLE
Remove id field from aws_servicecatalog_portfolio

### DIFF
--- a/aws/resource_aws_servicecatalog_portfolio.go
+++ b/aws/resource_aws_servicecatalog_portfolio.go
@@ -29,10 +29,6 @@ func resourceAwsServiceCatalogPortfolio() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,


### PR DESCRIPTION
`id` field is not required in the schema, similar to https://github.com/terraform-providers/terraform-provider-aws/pull/1626

Next up is upgrading vendored `hashicorp/terraform` which has validation for this and should prevent resources with `id` in schema from coming up in the future.