### PR TITLE
travis: Bump go to 1.9.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: trusty
 sudo: false
 language: go
 go:
-- 1.8.1
+- 1.9.1
 
 install:
 # This script is used by the Travis build to install a cookie for


### PR DESCRIPTION
Latest version of `hashicorp/terraform` we want to [upgrade to](https://github.com/terraform-providers/terraform-provider-aws/pull/2066) requires this.