### PR TITLE
New Data Source: aws_rds_cluster

### DIFF
--- a/aws/data_source_aws_rds_cluster.go
+++ b/aws/data_source_aws_rds_cluster.go
@@ -1,0 +1,164 @@
+package aws
+
+import (
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsRdsCluster() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsRdsClusterRead,
+		Schema: map[string]*schema.Schema{
+			"cluster_identifier": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"availability_zones": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+				Set:      schema.HashString,
+			},
+
+			"backup_retention_period": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"cluster_members": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+				Set:      schema.HashString,
+			},
+
+			"cluster_resource_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"database_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"db_subnet_group_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"db_cluster_parameter_group_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"endpoint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"engine": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"engine_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"final_snapshot_identifier": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"iam_database_authentication_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"iam_roles": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+
+			"kms_key_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"master_username": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"preferred_backup_window": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"preferred_maintenance_window": {
+				Type:     schema.TypeString,
+				Computed: true,
+				StateFunc: func(val interface{}) string {
+					if val == nil {
+						return ""
+					}
+					return strings.ToLower(val.(string))
+				},
+			},
+
+			"port": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"reader_endpoint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"replication_source_identifier": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"storage_encrypted": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"tags": tagsSchemaComputed(),
+
+			"vpc_security_group_ids": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+		},
+	}
+}
+
+func dataSourceAwsRdsClusterRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).rdsconn
+
+	resp, err := conn.DescribeDBClusters(&rds.DescribeDBClustersInput{
+		DBClusterIdentifier: aws.String(d.Get("cluster_identifier").(string)),
+	})
+
+	if err != nil {
+		return errwrap.Wrapf("Error retrieving RDS cluster: {{err}}", err)
+	}
+
+	d.SetId(*resp.DBClusters[0].DBClusterIdentifier)
+
+	return flattenAwsRdsClusterResource(d, meta, resp.DBClusters[0])
+}

--- a/aws/data_source_aws_rds_cluster_test.go
+++ b/aws/data_source_aws_rds_cluster_test.go
@@ -1,0 +1,74 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceAwsRdsCluster_basic(t *testing.T) {
+	clusterName := fmt.Sprintf("testaccawsrdscluster-basic-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsRdsClusterConfigBasic(clusterName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_rds_cluster.rds_cluster_test", "cluster_identifier", clusterName),
+					resource.TestCheckResourceAttr("data.aws_rds_cluster.rds_cluster_test", "database_name", "mydb"),
+					resource.TestCheckResourceAttr("data.aws_rds_cluster.rds_cluster_test", "db_cluster_parameter_group_name", "default.aurora5.6"),
+					resource.TestCheckResourceAttr("data.aws_rds_cluster.rds_cluster_test", "db_subnet_group_name", clusterName),
+					resource.TestCheckResourceAttr("data.aws_rds_cluster.rds_cluster_test", "master_username", "foo"),
+					resource.TestCheckResourceAttr("data.aws_rds_cluster.rds_cluster_test", "tags.%", "1"),
+					resource.TestCheckResourceAttr("data.aws_rds_cluster.rds_cluster_test", "tags.Environment", "test"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsRdsClusterConfigBasic(clusterName string) string {
+	return fmt.Sprintf(`resource "aws_rds_cluster" "rds_cluster_test" {
+	cluster_identifier = "%s"
+	database_name = "mydb"
+	db_cluster_parameter_group_name = "default.aurora5.6"
+	db_subnet_group_name = "${aws_db_subnet_group.test.name}"
+	master_password = "mustbeeightcharacters"
+	master_username = "foo"
+	skip_final_snapshot = true
+	tags {
+		Environment = "test"
+	}
+}
+resource "aws_vpc" "test" {
+	cidr_block = "10.0.0.0/16"
+	tags {
+	  Name = "testAccDataSourceAwsRdsClusterConfigBasic"
+	}
+}
+  
+resource "aws_subnet" "a" {
+	vpc_id = "${aws_vpc.test.id}"
+	cidr_block = "10.0.0.0/24"
+	availability_zone = "us-west-2a"
+}
+  
+resource "aws_subnet" "b" {
+	vpc_id = "${aws_vpc.test.id}"
+	cidr_block = "10.0.1.0/24"
+	availability_zone = "us-west-2b"
+}
+  
+resource "aws_db_subnet_group" "test" {
+	name = "%s"
+	subnet_ids = ["${aws_subnet.a.id}", "${aws_subnet.b.id}"]
+}
+
+data "aws_rds_cluster" "rds_cluster_test" {
+	cluster_identifier = "${aws_rds_cluster.rds_cluster_test.cluster_identifier}"
+}`, clusterName, clusterName)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -202,6 +202,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_kms_secret":                       dataSourceAwsKmsSecret(),
 			"aws_partition":                        dataSourceAwsPartition(),
 			"aws_prefix_list":                      dataSourceAwsPrefixList(),
+			"aws_rds_cluster":                      dataSourceAwsRdsCluster(),
 			"aws_redshift_service_account":         dataSourceAwsRedshiftServiceAccount(),
 			"aws_region":                           dataSourceAwsRegion(),
 			"aws_route_table":                      dataSourceAwsRouteTable(),

--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -555,6 +555,12 @@ func resourceAwsRDSClusterRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
+	return flattenAwsRdsClusterResource(d, meta, dbc)
+}
+
+func flattenAwsRdsClusterResource(d *schema.ResourceData, meta interface{}, dbc *rds.DBCluster) error {
+	conn := meta.(*AWSClient).rdsconn
+
 	if err := d.Set("availability_zones", aws.StringValueSlice(dbc.AvailabilityZones)); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving AvailabilityZones to state for RDS Cluster (%s): %s", d.Id(), err)
 	}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -158,6 +158,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-prefix-list") %>>
                             <a href="/docs/providers/aws/d/prefix_list.html">aws_prefix_list</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-rds-cluster") %>>
+                            <a href="/docs/providers/aws/d/rds_cluster.html">aws_rds_cluster</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-redshift-service-account") %>>
                             <a href="/docs/providers/aws/d/redshift_service_account.html">aws_redshift_service_account</a>
                         </li>

--- a/website/docs/d/rds_cluster.html.markdown
+++ b/website/docs/d/rds_cluster.html.markdown
@@ -1,0 +1,30 @@
+---
+layout: "aws"
+page_title: "AWS: aws_rds_cluster"
+sidebar_current: "docs-aws-datasource-rds-cluster"
+description: |-
+  Provides a RDS cluster data source.
+---
+
+# aws_elb
+
+Provides information about a RDS cluster.
+
+## Example Usage
+
+```hcl
+data "aws_rds_cluster" "clusterName" {
+  name = "clusterName"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `cluster_identifier` - (Required) The cluster identifier of the RDS cluster.
+
+## Attributes Reference
+
+See the [RDS Cluster Resource](/docs/providers/aws/r/rds_cluster.html) for details on the
+returned attributes - they are identical.


### PR DESCRIPTION
Closes #2019 

```
make testacc TESTARGS='-run=TestAccDataSourceAwsRdsCluster_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDataSourceAwsRdsCluster_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccDataSourceAwsRdsCluster_basic
--- PASS: TestAccDataSourceAwsRdsCluster_basic (130.70s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	130.738s
```