### PR TITLE
resource/aws_api_gateway_usag_plan: Fixed setting of rate_limit

### DIFF
--- a/aws/resource_aws_api_gateway_usage_plan.go
+++ b/aws/resource_aws_api_gateway_usage_plan.go
@@ -92,7 +92,7 @@ func resourceAwsApiGatewayUsagePlan() *schema.Resource {
 						},
 
 						"rate_limit": {
-							Type:     schema.TypeInt,
+							Type:     schema.TypeFloat,
 							Default:  0,
 							Optional: true,
 						},
@@ -188,7 +188,7 @@ func resourceAwsApiGatewayUsagePlanCreate(d *schema.ResourceData, meta interface
 		}
 
 		if sv, ok := q["rate_limit"].(float64); ok {
-			ts.RateLimit = aws.Float64(float64(sv))
+			ts.RateLimit = aws.Float64(sv)
 		}
 
 		params.Throttle = ts
@@ -355,7 +355,7 @@ func resourceAwsApiGatewayUsagePlanUpdate(d *schema.ResourceData, meta interface
 				operations = append(operations, &apigateway.PatchOperation{
 					Op:    aws.String("replace"),
 					Path:  aws.String("/throttle/rateLimit"),
-					Value: aws.String(strconv.Itoa(d["rate_limit"].(int))),
+					Value: aws.String(strconv.FormatFloat(d["rate_limit"].(float64), 'f', -1, 64)),
 				})
 				operations = append(operations, &apigateway.PatchOperation{
 					Op:    aws.String("replace"),
@@ -369,7 +369,7 @@ func resourceAwsApiGatewayUsagePlanUpdate(d *schema.ResourceData, meta interface
 				operations = append(operations, &apigateway.PatchOperation{
 					Op:    aws.String("add"),
 					Path:  aws.String("/throttle/rateLimit"),
-					Value: aws.String(strconv.Itoa(d["rate_limit"].(int))),
+					Value: aws.String(strconv.FormatFloat(d["rate_limit"].(float64), 'f', -1, 64)),
 				})
 				operations = append(operations, &apigateway.PatchOperation{
 					Op:    aws.String("add"),

--- a/aws/resource_aws_api_gateway_usage_plan_test.go
+++ b/aws/resource_aws_api_gateway_usage_plan_test.go
@@ -190,6 +190,27 @@ func TestAccAWSAPIGatewayUsagePlan_throttling(t *testing.T) {
 	})
 }
 
+// https://github.com/terraform-providers/terraform-provider-aws/issues/2057
+func TestAccAWSAPIGatewayUsagePlan_throttlingInitialRateLimit(t *testing.T) {
+	var conf apigateway.UsagePlan
+	name := acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayUsagePlanDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSApiGatewayUsagePlanThrottlingConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayUsagePlanExists("aws_api_gateway_usage_plan.main", &conf),
+					resource.TestCheckResourceAttr("aws_api_gateway_usage_plan.main", "throttle_settings.4173790118.rate_limit", "5"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSAPIGatewayUsagePlan_quota(t *testing.T) {
 	var conf apigateway.UsagePlan
 	name := acctest.RandString(10)


### PR DESCRIPTION
Fixes #2057

This fixes the fact to correctly send the value on creation, due to the casting made: as the schema type is of type int and we try to check if the value cast as a float64 is ok, the check was always ignored on creation.


```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAPIGatewayUsagePlan_'                               
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSAPIGatewayUsagePlan_ -timeout 120m
=== RUN   TestAccAWSAPIGatewayUsagePlan_importBasic
--- PASS: TestAccAWSAPIGatewayUsagePlan_importBasic (18.08s)
=== RUN   TestAccAWSAPIGatewayUsagePlan_basic
--- PASS: TestAccAWSAPIGatewayUsagePlan_basic (98.03s)
=== RUN   TestAccAWSAPIGatewayUsagePlan_description
--- PASS: TestAccAWSAPIGatewayUsagePlan_description (83.69s)
=== RUN   TestAccAWSAPIGatewayUsagePlan_productCode
--- PASS: TestAccAWSAPIGatewayUsagePlan_productCode (78.23s)
=== RUN   TestAccAWSAPIGatewayUsagePlan_throttling
--- PASS: TestAccAWSAPIGatewayUsagePlan_throttling (59.58s)
=== RUN   TestAccAWSAPIGatewayUsagePlan_quota
--- PASS: TestAccAWSAPIGatewayUsagePlan_quota (73.80s)
=== RUN   TestAccAWSAPIGatewayUsagePlan_apiStages
--- PASS: TestAccAWSAPIGatewayUsagePlan_apiStages (87.80s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	499.266s
```