### PR TITLE
resource/aws_kinesis_firehose_delivery_stream_test: Fixed ExternalId being a random int

### DIFF
--- a/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
@@ -41,7 +41,7 @@ func TestAccAWSKinesisFirehoseDeliveryStream_s3KinesisStreamSource(t *testing.T)
 	var stream firehose.DeliveryStreamDescription
 	ri := acctest.RandInt()
 	config := fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_s3KinesisStreamSource,
-		ri, ri, ri, ri, ri, ri, ri, ri, ri)
+		ri, ri, ri, ri, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -672,7 +672,7 @@ resource "aws_iam_role" "kinesis_source" {
       "Action": "sts:AssumeRole",
       "Condition": {
         "StringEquals": {
-          "sts:ExternalId": "%s"
+          "sts:ExternalId": "${data.aws_caller_identity.current.account_id}"
         }
       }
     }


### PR DESCRIPTION
This fixes a bug where the ExternalId for a policy was a random int passed rather than the actual account id.

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSKinesisFirehoseDeliveryStream_s3KinesisStreamSource'          
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSKinesisFirehoseDeliveryStream_s3KinesisStreamSource -timeout 120m
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_s3KinesisStreamSource
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3KinesisStreamSource (145.14s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	145.179s
```