### PR TITLE
Fix Elastic Beanstalk dependency issue causing delete failure.

### DIFF
--- a/aws/resource_aws_elastic_beanstalk_application.go
+++ b/aws/resource_aws_elastic_beanstalk_application.go
@@ -112,11 +112,14 @@ func resourceAwsElasticBeanstalkApplicationDelete(d *schema.ResourceData, meta i
 	_, err = beanstalkConn.DeleteApplication(&elasticbeanstalk.DeleteApplicationInput{
 		ApplicationName: aws.String(d.Id()),
 	})
+	if err != nil {
+		return err
+	}
 
 	return resource.Retry(10*time.Second, func() *resource.RetryError {
-		if a, _ = getBeanstalkApplication(d, meta); a != nil {
+		if a, err = getBeanstalkApplication(d, meta); a != nil {
 			return resource.RetryableError(
-				fmt.Errorf("Beanstalk Application still exists"))
+				fmt.Errorf("Beanstalk Application (%s) still exists: %s", d.Id(), err))
 		}
 		return nil
 	})


### PR DESCRIPTION
Commonly we were seeing that Elastic Beanstalk failed to destroy
before it timed out. The reason that it failed to destroy was that
the destroy operation was silently ignoring an error on the Elastic
Beanstalk Application - reporting that it could not be destroyed
because there was still an Elastic Beanstalk Application Version
attached to it.

This change fixes the Terraform code so that this error is reported
when if the delete happens.