### PR TITLE
r/emr_cluster: Expose error on TERMINATED_WITH_ERRORS

### DIFF
--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -1006,9 +1006,9 @@ func resourceAwsEMRClusterStateRefreshFunc(d *schema.ResourceData, meta interfac
 		}
 
 		status := emrc.Status
-		if *status.State == "TERMINATING" {
+		if *status.State == "TERMINATING" || *status.State == "TERMINATED_WITH_ERRORS" {
 			reason := *status.StateChangeReason
-			return emrc, *status.State, fmt.Errorf("EMR Cluster is terminating. %s: %s",
+			return emrc, *status.State, fmt.Errorf("%s: %s",
 				*reason.Code, *reason.Message)
 		}
 


### PR DESCRIPTION
This should help users in debugging root cause of the state.

Specifically we're turning this:

> * aws_emr_cluster.emr-test-cluster: [WARN] Error waiting for EMR Cluster state to be "WAITING" or "RUNNING": unexpected state 'TERMINATED_WITH_ERRORS', wanted target 'WAITING, RUNNING'. last error: %!s(<nil>)

into this

> * aws_emr_cluster.emr-test-cluster: [WARN] Error waiting for EMR Cluster state to be "WAITING" or "RUNNING": VALIDATION_ERROR: The subnet configuration was invalid: No route to any external sources detected in Route Table for Subnet: subnet-f1fba4b8 for VPC: vpc-b25309d5