### PR TITLE
Add import support for kinesis firehose delivery stream

### DIFF
--- a/aws/import_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/import_aws_kinesis_firehose_delivery_stream_test.go
@@ -1,12 +1,12 @@
 package aws
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
-	"fmt"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
-	"os"
 )
 
 func TestAccAWSKinesisFirehoseDeliveryStream_importBasic(t *testing.T) {

--- a/aws/import_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/import_aws_kinesis_firehose_delivery_stream_test.go
@@ -16,7 +16,7 @@ func TestAccAWSKinesisFirehoseDeliveryStream_importBasic(t *testing.T) {
 		rInt, os.Getenv("AWS_ACCOUNT_ID"), rInt, rInt, rInt)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     testAccKinesisFirehosePreCheck(t),
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKinesisFirehoseDeliveryStreamDestroy,
 		Steps: []resource.TestStep{

--- a/aws/import_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/import_aws_kinesis_firehose_delivery_stream_test.go
@@ -1,0 +1,33 @@
+package aws
+
+import (
+	"testing"
+
+	"fmt"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"os"
+)
+
+func TestAccAWSKinesisFirehoseDeliveryStream_importBasic(t *testing.T) {
+	resName := "aws_kinesis_firehose_delivery_stream.test_stream"
+	rInt := acctest.RandInt()
+	config := fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_s3basic,
+		rInt, os.Getenv("AWS_ACCOUNT_ID"), rInt, rInt, rInt)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKinesisFirehoseDeliveryStreamDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/aws/import_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/import_aws_kinesis_firehose_delivery_stream_test.go
@@ -16,7 +16,7 @@ func TestAccAWSKinesisFirehoseDeliveryStream_importBasic(t *testing.T) {
 		rInt, os.Getenv("AWS_ACCOUNT_ID"), rInt, rInt, rInt)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     testAccKinesisFirehosePreCheck(t),
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKinesisFirehoseDeliveryStreamDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -167,16 +167,20 @@ func cloudwatchLoggingOptionsHash(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
 	buf.WriteString(fmt.Sprintf("%t-", m["enabled"].(bool)))
-	buf.WriteString(fmt.Sprintf("%s-", m["log_group_name"].(string)))
-	buf.WriteString(fmt.Sprintf("%s-", m["log_stream_name"].(string)))
+	if m["enabled"].(bool) {
+		buf.WriteString(fmt.Sprintf("%s-", m["log_group_name"].(string)))
+		buf.WriteString(fmt.Sprintf("%s-", m["log_stream_name"].(string)))
+	}
 	return hashcode.String(buf.String())
 }
 
 func flattenCloudwatchLoggingOptions(clo firehose.CloudWatchLoggingOptions) *schema.Set {
 	cloudwatchLoggingOptions := map[string]interface{}{
-		"enabled":         *clo.Enabled,
-		"log_group_name":  *clo.LogGroupName,
-		"log_stream_name": *clo.LogStreamName,
+		"enabled": *clo.Enabled,
+	}
+	if *clo.Enabled {
+		cloudwatchLoggingOptions["log_group_name"] = *clo.LogGroupName
+		cloudwatchLoggingOptions["log_stream_name"] = *clo.LogStreamName
 	}
 	return schema.NewSet(cloudwatchLoggingOptionsHash, []interface{}{cloudwatchLoggingOptions})
 }

--- a/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -8,6 +8,7 @@ import (
 
 	"bytes"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/firehose"
 	"github.com/hashicorp/terraform/helper/hashcode"
@@ -308,7 +309,11 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 
 		Importer: &schema.ResourceImporter{
 			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-				d.Set("name", d.Id())
+				resARN, err := arn.Parse(d.Id())
+				if err != nil {
+					return []*schema.ResourceData{}, err
+				}
+				d.Set("name", strings.Split(resARN.Resource, "/")[1])
 				return []*schema.ResourceData{d}, nil
 			},
 		},

--- a/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -311,7 +311,7 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 				resARN, err := arn.Parse(d.Id())
 				if err != nil {
-					return []*schema.ResourceData{}, err
+					return nil, err
 				}
 				d.Set("name", strings.Split(resARN.Resource, "/")[1])
 				return []*schema.ResourceData{d}, nil

--- a/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -1,12 +1,12 @@
 package aws
 
 import (
+	"bytes"
 	"fmt"
 	"log"
 	"strings"
 	"time"
 
-	"bytes"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/awserr"


### PR DESCRIPTION
@radeksimko Right now, I've just added import support just for Redshift destination. I want to make sure I'm on the right track.

`cloudwatch_logging_options` aren't working yet. Looks like it expects `*schema.Set` and I'm giving `map[string]interface{}`. How do we handle this?

EDIT: We use "flatteners" to create required `*schema.Set` for converting `*awsservice.Struct` to `[]map[string]interface{}`.

TODO:

- [x] Add support for elasticsearch and s3 destinations
- [x] Add acceptance tests