### PR TITLE
resource/aws_cloudwatch_log_metric_filter: fixed flattenCloudWachLogMetricTransformations return value

### DIFF
--- a/aws/structure.go
+++ b/aws/structure.go
@@ -1513,14 +1513,17 @@ func expandCloudWachLogMetricTransformations(m map[string]interface{}) []*cloudw
 	return []*cloudwatchlogs.MetricTransformation{&transformation}
 }
 
-func flattenCloudWachLogMetricTransformations(ts []*cloudwatchlogs.MetricTransformation) map[string]string {
-	m := make(map[string]string, 0)
+func flattenCloudWachLogMetricTransformations(ts []*cloudwatchlogs.MetricTransformation) []interface{} {
+	mts := make([]interface{}, 0)
+	m := make(map[string]interface{}, 0)
 
 	m["name"] = *ts[0].MetricName
 	m["namespace"] = *ts[0].MetricNamespace
 	m["value"] = *ts[0].MetricValue
 
-	return m
+	mts = append(mts, m)
+
+	return mts
 }
 
 func flattenBeanstalkAsg(list []*elasticbeanstalk.AutoScalingGroup) []string {


### PR DESCRIPTION
This updates the `flattenCloudWachLogMetricTransformations`  method.
Until now, the `d.Set("metric_transformation")` for this particular structure was not working as expected: the value passed was just never set, meaning you could not update one of the structure value in the console, making Terraform be aware of it at plan-time. The value stored in the state only depended on the value set by the user in the configuration file.

Required for https://github.com/terraform-providers/terraform-provider-aws/pull/1578