### PR TITLE
Bump AWS SDK to v1.12.19

### DIFF
--- a/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
@@ -319,6 +319,8 @@ var awsPartition = partition{
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
 				"ap-southeast-1": endpoint{},
+				"ap-southeast-2": endpoint{},
+				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
@@ -436,10 +438,16 @@ var awsPartition = partition{
 		"cloudhsmv2": service{
 
 			Endpoints: endpoints{
+				"ap-northeast-1": endpoint{},
+				"ap-south-1":     endpoint{},
 				"ap-southeast-1": endpoint{},
+				"ap-southeast-2": endpoint{},
+				"ca-central-1":   endpoint{},
+				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
+				"us-west-1":      endpoint{},
 				"us-west-2":      endpoint{},
 			},
 		},
@@ -711,6 +719,7 @@ var awsPartition = partition{
 				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
+				"us-west-1":      endpoint{},
 				"us-west-2":      endpoint{},
 			},
 		},
@@ -795,6 +804,7 @@ var awsPartition = partition{
 
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
+				"ap-northeast-2": endpoint{},
 				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
 				"ca-central-1":   endpoint{},
@@ -2002,6 +2012,7 @@ var awscnPartition = partition{
 				"cn-north-1": endpoint{},
 			},
 		},
+		"es": service{},
 		"events": service{
 
 			Endpoints: endpoints{

--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.12.14"
+const SDKVersion = "1.12.19"

--- a/vendor/github.com/aws/aws-sdk-go/service/cloudfront/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/cloudfront/api.go
@@ -90,7 +90,7 @@ func (c *CloudFront) CreateCloudFrontOriginAccessIdentityRequest(input *CreateCl
 //   The argument is invalid.
 //
 //   * ErrCodeInconsistentQuantities "InconsistentQuantities"
-//   The value of Quantity and the size of Items do not match.
+//   The value of Quantity and the size of Items don't match.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/CreateCloudFrontOriginAccessIdentity
 func (c *CloudFront) CreateCloudFrontOriginAccessIdentity(input *CreateCloudFrontOriginAccessIdentityInput) (*CreateCloudFrontOriginAccessIdentityOutput, error) {
@@ -189,7 +189,7 @@ func (c *CloudFront) CreateDistributionRequest(input *CreateDistributionInput) (
 //   Your request contains more trusted signers than are allowed per distribution.
 //
 //   * ErrCodeTrustedSignerDoesNotExist "TrustedSignerDoesNotExist"
-//   One or more of your trusted signers do not exist.
+//   One or more of your trusted signers don't exist.
 //
 //   * ErrCodeInvalidViewerCertificate "InvalidViewerCertificate"
 //
@@ -249,7 +249,7 @@ func (c *CloudFront) CreateDistributionRequest(input *CreateDistributionInput) (
 //   * ErrCodeInvalidHeadersForS3Origin "InvalidHeadersForS3Origin"
 //
 //   * ErrCodeInconsistentQuantities "InconsistentQuantities"
-//   The value of Quantity and the size of Items do not match.
+//   The value of Quantity and the size of Items don't match.
 //
 //   * ErrCodeTooManyCertificates "TooManyCertificates"
 //   You cannot create anymore custom SSL/TLS certificates.
@@ -383,7 +383,7 @@ func (c *CloudFront) CreateDistributionWithTagsRequest(input *CreateDistribution
 //   Your request contains more trusted signers than are allowed per distribution.
 //
 //   * ErrCodeTrustedSignerDoesNotExist "TrustedSignerDoesNotExist"
-//   One or more of your trusted signers do not exist.
+//   One or more of your trusted signers don't exist.
 //
 //   * ErrCodeInvalidViewerCertificate "InvalidViewerCertificate"
 //
@@ -443,7 +443,7 @@ func (c *CloudFront) CreateDistributionWithTagsRequest(input *CreateDistribution
 //   * ErrCodeInvalidHeadersForS3Origin "InvalidHeadersForS3Origin"
 //
 //   * ErrCodeInconsistentQuantities "InconsistentQuantities"
-//   The value of Quantity and the size of Items do not match.
+//   The value of Quantity and the size of Items don't match.
 //
 //   * ErrCodeTooManyCertificates "TooManyCertificates"
 //   You cannot create anymore custom SSL/TLS certificates.
@@ -579,7 +579,7 @@ func (c *CloudFront) CreateInvalidationRequest(input *CreateInvalidationInput) (
 //   batch requests, or invalidation objects.
 //
 //   * ErrCodeInconsistentQuantities "InconsistentQuantities"
-//   The value of Quantity and the size of Items do not match.
+//   The value of Quantity and the size of Items don't match.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/CreateInvalidation
 func (c *CloudFront) CreateInvalidation(input *CreateInvalidationInput) (*CreateInvalidationOutput, error) {
@@ -702,7 +702,7 @@ func (c *CloudFront) CreateStreamingDistributionRequest(input *CreateStreamingDi
 //   Your request contains more trusted signers than are allowed per distribution.
 //
 //   * ErrCodeTrustedSignerDoesNotExist "TrustedSignerDoesNotExist"
-//   One or more of your trusted signers do not exist.
+//   One or more of your trusted signers don't exist.
 //
 //   * ErrCodeMissingBody "MissingBody"
 //   This operation requires a body. Ensure that the body is present and the Content-Type
@@ -718,7 +718,7 @@ func (c *CloudFront) CreateStreamingDistributionRequest(input *CreateStreamingDi
 //   The argument is invalid.
 //
 //   * ErrCodeInconsistentQuantities "InconsistentQuantities"
-//   The value of Quantity and the size of Items do not match.
+//   The value of Quantity and the size of Items don't match.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/CreateStreamingDistribution
 func (c *CloudFront) CreateStreamingDistribution(input *CreateStreamingDistributionInput) (*CreateStreamingDistributionOutput, error) {
@@ -814,7 +814,7 @@ func (c *CloudFront) CreateStreamingDistributionWithTagsRequest(input *CreateStr
 //   Your request contains more trusted signers than are allowed per distribution.
 //
 //   * ErrCodeTrustedSignerDoesNotExist "TrustedSignerDoesNotExist"
-//   One or more of your trusted signers do not exist.
+//   One or more of your trusted signers don't exist.
 //
 //   * ErrCodeMissingBody "MissingBody"
 //   This operation requires a body. Ensure that the body is present and the Content-Type
@@ -830,7 +830,7 @@ func (c *CloudFront) CreateStreamingDistributionWithTagsRequest(input *CreateStr
 //   The argument is invalid.
 //
 //   * ErrCodeInconsistentQuantities "InconsistentQuantities"
-//   The value of Quantity and the size of Items do not match.
+//   The value of Quantity and the size of Items don't match.
 //
 //   * ErrCodeInvalidTagging "InvalidTagging"
 //
@@ -1037,6 +1037,92 @@ func (c *CloudFront) DeleteDistribution(input *DeleteDistributionInput) (*Delete
 // for more information on using Contexts.
 func (c *CloudFront) DeleteDistributionWithContext(ctx aws.Context, input *DeleteDistributionInput, opts ...request.Option) (*DeleteDistributionOutput, error) {
 	req, out := c.DeleteDistributionRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDeleteServiceLinkedRole = "DeleteServiceLinkedRole2017_03_25"
+
+// DeleteServiceLinkedRoleRequest generates a "aws/request.Request" representing the
+// client's request for the DeleteServiceLinkedRole operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DeleteServiceLinkedRole for more information on using the DeleteServiceLinkedRole
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DeleteServiceLinkedRoleRequest method.
+//    req, resp := client.DeleteServiceLinkedRoleRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/DeleteServiceLinkedRole
+func (c *CloudFront) DeleteServiceLinkedRoleRequest(input *DeleteServiceLinkedRoleInput) (req *request.Request, output *DeleteServiceLinkedRoleOutput) {
+	op := &request.Operation{
+		Name:       opDeleteServiceLinkedRole,
+		HTTPMethod: "DELETE",
+		HTTPPath:   "/2017-03-25/service-linked-role/{RoleName}",
+	}
+
+	if input == nil {
+		input = &DeleteServiceLinkedRoleInput{}
+	}
+
+	output = &DeleteServiceLinkedRoleOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restxml.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// DeleteServiceLinkedRole API operation for Amazon CloudFront.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon CloudFront's
+// API operation DeleteServiceLinkedRole for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidArgument "InvalidArgument"
+//   The argument is invalid.
+//
+//   * ErrCodeAccessDenied "AccessDenied"
+//   Access denied.
+//
+//   * ErrCodeResourceInUse "ResourceInUse"
+//
+//   * ErrCodeNoSuchResource "NoSuchResource"
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/DeleteServiceLinkedRole
+func (c *CloudFront) DeleteServiceLinkedRole(input *DeleteServiceLinkedRoleInput) (*DeleteServiceLinkedRoleOutput, error) {
+	req, out := c.DeleteServiceLinkedRoleRequest(input)
+	return out, req.Send()
+}
+
+// DeleteServiceLinkedRoleWithContext is the same as DeleteServiceLinkedRole with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeleteServiceLinkedRole for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CloudFront) DeleteServiceLinkedRoleWithContext(ctx aws.Context, input *DeleteServiceLinkedRoleInput, opts ...request.Option) (*DeleteServiceLinkedRoleOutput, error) {
+	req, out := c.DeleteServiceLinkedRoleRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -2715,7 +2801,7 @@ func (c *CloudFront) UpdateCloudFrontOriginAccessIdentityRequest(input *UpdateCl
 //   The argument is invalid.
 //
 //   * ErrCodeInconsistentQuantities "InconsistentQuantities"
-//   The value of Quantity and the size of Items do not match.
+//   The value of Quantity and the size of Items don't match.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/UpdateCloudFrontOriginAccessIdentity
 func (c *CloudFront) UpdateCloudFrontOriginAccessIdentity(input *UpdateCloudFrontOriginAccessIdentityInput) (*UpdateCloudFrontOriginAccessIdentityOutput, error) {
@@ -2888,7 +2974,7 @@ func (c *CloudFront) UpdateDistributionRequest(input *UpdateDistributionInput) (
 //   Your request contains more trusted signers than are allowed per distribution.
 //
 //   * ErrCodeTrustedSignerDoesNotExist "TrustedSignerDoesNotExist"
-//   One or more of your trusted signers do not exist.
+//   One or more of your trusted signers don't exist.
 //
 //   * ErrCodeInvalidViewerCertificate "InvalidViewerCertificate"
 //
@@ -2923,7 +3009,7 @@ func (c *CloudFront) UpdateDistributionRequest(input *UpdateDistributionInput) (
 //   * ErrCodeInvalidHeadersForS3Origin "InvalidHeadersForS3Origin"
 //
 //   * ErrCodeInconsistentQuantities "InconsistentQuantities"
-//   The value of Quantity and the size of Items do not match.
+//   The value of Quantity and the size of Items don't match.
 //
 //   * ErrCodeTooManyCertificates "TooManyCertificates"
 //   You cannot create anymore custom SSL/TLS certificates.
@@ -3067,10 +3153,10 @@ func (c *CloudFront) UpdateStreamingDistributionRequest(input *UpdateStreamingDi
 //   Your request contains more trusted signers than are allowed per distribution.
 //
 //   * ErrCodeTrustedSignerDoesNotExist "TrustedSignerDoesNotExist"
-//   One or more of your trusted signers do not exist.
+//   One or more of your trusted signers don't exist.
 //
 //   * ErrCodeInconsistentQuantities "InconsistentQuantities"
-//   The value of Quantity and the size of Items do not match.
+//   The value of Quantity and the size of Items don't match.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/UpdateStreamingDistribution
 func (c *CloudFront) UpdateStreamingDistribution(input *UpdateStreamingDistributionInput) (*UpdateStreamingDistributionOutput, error) {
@@ -4783,7 +4869,7 @@ func (s *CustomOriginConfig) SetOriginSslProtocols(v *OriginSslProtocols) *Custo
 	return s
 }
 
-// A complex type that describes the default cache behavior if you do not specify
+// A complex type that describes the default cache behavior if you don't specify
 // a CacheBehavior element or if files don't match any of the values of PathPattern
 // in CacheBehavior elements. You must create exactly one default cache behavior.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/DefaultCacheBehavior
@@ -5195,6 +5281,58 @@ func (s DeleteDistributionOutput) GoString() string {
 	return s.String()
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/DeleteServiceLinkedRoleRequest
+type DeleteServiceLinkedRoleInput struct {
+	_ struct{} `type:"structure"`
+
+	// RoleName is a required field
+	RoleName *string `location:"uri" locationName:"RoleName" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DeleteServiceLinkedRoleInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteServiceLinkedRoleInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteServiceLinkedRoleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteServiceLinkedRoleInput"}
+	if s.RoleName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetRoleName sets the RoleName field's value.
+func (s *DeleteServiceLinkedRoleInput) SetRoleName(v string) *DeleteServiceLinkedRoleInput {
+	s.RoleName = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/DeleteServiceLinkedRoleOutput
+type DeleteServiceLinkedRoleOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteServiceLinkedRoleOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteServiceLinkedRoleOutput) GoString() string {
+	return s.String()
+}
+
 // The request to delete a streaming distribution.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/DeleteStreamingDistributionRequest
 type DeleteStreamingDistributionInput struct {
@@ -5289,7 +5427,7 @@ type Distribution struct {
 	// DistributionConfig is a required field
 	DistributionConfig *DistributionConfig `type:"structure" required:"true"`
 
-	// The domain name corresponding to the distribution. For example: d604721fxaaqy9.cloudfront.net.
+	// The domain name corresponding to the distribution, for example, d111111abcdef8.cloudfront.net.
 	//
 	// DomainName is a required field
 	DomainName *string `type:"string" required:"true"`
@@ -5430,7 +5568,7 @@ type DistributionConfig struct {
 	// in the Amazon CloudFront Developer Guide.
 	CustomErrorResponses *CustomErrorResponses `type:"structure"`
 
-	// A complex type that describes the default cache behavior if you do not specify
+	// A complex type that describes the default cache behavior if you don't specify
 	// a CacheBehavior element or if files don't match any of the values of PathPattern
 	// in CacheBehavior elements. You must create exactly one default cache behavior.
 	//
@@ -5442,7 +5580,7 @@ type DistributionConfig struct {
 	// instead of an object in your distribution (http://www.example.com/product-description.html).
 	// Specifying a default root object avoids exposing the contents of your distribution.
 	//
-	// Specify only the object name, for example, index.html. Do not add a / before
+	// Specify only the object name, for example, index.html. Don't add a / before
 	// the object name.
 	//
 	// If you don't want to specify a default root object when you create a distribution,
@@ -5490,7 +5628,7 @@ type DistributionConfig struct {
 	// want to access your content. However, if you're using signed URLs or signed
 	// cookies to restrict access to your content, and if you're using a custom
 	// policy that includes the IpAddress parameter to restrict the IP addresses
-	// that can access your content, do not enable IPv6. If you want to restrict
+	// that can access your content, don't enable IPv6. If you want to restrict
 	// access to some content by IP address and not restrict access to other content
 	// (or restrict access but not by IP address), you can create two distributions.
 	// For more information, see Creating a Signed URL Using a Custom Policy (http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-creating-signed-url-custom-policy.html)
@@ -5548,18 +5686,90 @@ type DistributionConfig struct {
 
 	// A complex type that specifies the following:
 	//
-	//    * Which SSL/TLS certificate to use when viewers request objects using
-	//    HTTPS
+	//    * Whether you want viewers to use HTTP or HTTPS to request your objects.
 	//
-	//    * Whether you want CloudFront to use dedicated IP addresses or SNI when
-	//    you're using alternate domain names in your object names
+	//    * If you want viewers to use HTTPS, whether you're using an alternate
+	//    domain name such as example.com or the CloudFront domain name for your
+	//    distribution, such as d111111abcdef8.cloudfront.net.
 	//
-	//    * The minimum protocol version that you want CloudFront to use when communicating
-	//    with viewers
+	//    * If you're using an alternate domain name, whether AWS Certificate Manager
+	//    (ACM) provided the certificate, or you purchased a certificate from a
+	//    third-party certificate authority and imported it into ACM or uploaded
+	//    it to the IAM certificate store.
 	//
-	// For more information, see Using an HTTPS Connection to Access Your Objects
-	// (http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/SecureConnections.html)
-	// in the Amazon Amazon CloudFront Developer Guide.
+	// You must specify only one of the following values:
+	//
+	//    * ViewerCertificate$ACMCertificateArn
+	//
+	//    * ViewerCertificate$IAMCertificateId
+	//
+	//    * ViewerCertificate$CloudFrontDefaultCertificate
+	//
+	// Don't specify false for CloudFrontDefaultCertificate.
+	//
+	// If you want viewers to use HTTP instead of HTTPS to request your objects:
+	// Specify the following value:
+	//
+	// <CloudFrontDefaultCertificate>true<CloudFrontDefaultCertificate>
+	//
+	// In addition, specify allow-all for ViewerProtocolPolicy for all of your cache
+	// behaviors.
+	//
+	// If you want viewers to use HTTPS to request your objects: Choose the type
+	// of certificate that you want to use based on whether you're using an alternate
+	// domain name for your objects or the CloudFront domain name:
+	//
+	//    * If you're using an alternate domain name, such as example.com: Specify
+	//    one of the following values, depending on whether ACM provided your certificate
+	//    or you purchased your certificate from third-party certificate authority:
+	//
+	// <ACMCertificateArn>ARN for ACM SSL/TLS certificate<ACMCertificateArn> where
+	//    ARN for ACM SSL/TLS certificate is the ARN for the ACM SSL/TLS certificate
+	//    that you want to use for this distribution.
+	//
+	// <IAMCertificateId>IAM certificate ID<IAMCertificateId> where IAM certificate
+	//    ID is the ID that IAM returned when you added the certificate to the IAM
+	//    certificate store.
+	//
+	// If you specify ACMCertificateArn or IAMCertificateId, you must also specify
+	//    a value for SSLSupportMethod.
+	//
+	// If you choose to use an ACM certificate or a certificate in the IAM certificate
+	//    store, we recommend that you use only an alternate domain name in your
+	//    object URLs (https://example.com/logo.jpg). If you use the domain name
+	//    that is associated with your CloudFront distribution (such as https://d111111abcdef8.cloudfront.net/logo.jpg)
+	//    and the viewer supports SNI, then CloudFront behaves normally. However,
+	//    if the browser does not support SNI, the user's experience depends on
+	//    the value that you choose for SSLSupportMethod:
+	//
+	// vip: The viewer displays a warning because there is a mismatch between the
+	//    CloudFront domain name and the domain name in your SSL/TLS certificate.
+	//
+	// sni-only: CloudFront drops the connection with the browser without returning
+	//    the object.
+	//
+	//    * If you're using the CloudFront domain name for your distribution, such
+	//    as d111111abcdef8.cloudfront.net: Specify the following value:
+	//
+	// <CloudFrontDefaultCertificate>true<CloudFrontDefaultCertificate>
+	//
+	// If you want viewers to use HTTPS, you must also specify one of the following
+	// values in your cache behaviors:
+	//
+	//    *  <ViewerProtocolPolicy>https-only<ViewerProtocolPolicy>
+	//
+	//    * <ViewerProtocolPolicy>redirect-to-https<ViewerProtocolPolicy>
+	//
+	// You can also optionally require that CloudFront use HTTPS to communicate
+	// with your origin by specifying one of the following values for the applicable
+	// origins:
+	//
+	//    * <OriginProtocolPolicy>https-only<OriginProtocolPolicy>
+	//
+	//    * <OriginProtocolPolicy>match-viewer<OriginProtocolPolicy>
+	//
+	// For more information, see Using Alternate Domain Names and HTTPS (http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/SecureConnections.html#CNAMEsAndHTTPS)
+	// in the Amazon CloudFront Developer Guide.
 	ViewerCertificate *ViewerCertificate `type:"structure"`
 
 	// A unique identifier that specifies the AWS WAF web ACL, if any, to associate
@@ -5923,14 +6133,14 @@ type DistributionSummary struct {
 	// CustomErrorResponses is a required field
 	CustomErrorResponses *CustomErrorResponses `type:"structure" required:"true"`
 
-	// A complex type that describes the default cache behavior if you do not specify
+	// A complex type that describes the default cache behavior if you don't specify
 	// a CacheBehavior element or if files don't match any of the values of PathPattern
 	// in CacheBehavior elements. You must create exactly one default cache behavior.
 	//
 	// DefaultCacheBehavior is a required field
 	DefaultCacheBehavior *DefaultCacheBehavior `type:"structure" required:"true"`
 
-	// The domain name that corresponds to the distribution. For example: d604721fxaaqy9.cloudfront.net.
+	// The domain name that corresponds to the distribution, for example, d111111abcdef8.cloudfront.net.
 	//
 	// DomainName is a required field
 	DomainName *string `type:"string" required:"true"`
@@ -5985,18 +6195,90 @@ type DistributionSummary struct {
 
 	// A complex type that specifies the following:
 	//
-	//    * Which SSL/TLS certificate to use when viewers request objects using
-	//    HTTPS
+	//    * Whether you want viewers to use HTTP or HTTPS to request your objects.
 	//
-	//    * Whether you want CloudFront to use dedicated IP addresses or SNI when
-	//    you're using alternate domain names in your object names
+	//    * If you want viewers to use HTTPS, whether you're using an alternate
+	//    domain name such as example.com or the CloudFront domain name for your
+	//    distribution, such as d111111abcdef8.cloudfront.net.
 	//
-	//    * The minimum protocol version that you want CloudFront to use when communicating
-	//    with viewers
+	//    * If you're using an alternate domain name, whether AWS Certificate Manager
+	//    (ACM) provided the certificate, or you purchased a certificate from a
+	//    third-party certificate authority and imported it into ACM or uploaded
+	//    it to the IAM certificate store.
 	//
-	// For more information, see Using an HTTPS Connection to Access Your Objects
-	// (http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/SecureConnections.html)
-	// in the Amazon Amazon CloudFront Developer Guide.
+	// You must specify only one of the following values:
+	//
+	//    * ViewerCertificate$ACMCertificateArn
+	//
+	//    * ViewerCertificate$IAMCertificateId
+	//
+	//    * ViewerCertificate$CloudFrontDefaultCertificate
+	//
+	// Don't specify false for CloudFrontDefaultCertificate.
+	//
+	// If you want viewers to use HTTP instead of HTTPS to request your objects:
+	// Specify the following value:
+	//
+	// <CloudFrontDefaultCertificate>true<CloudFrontDefaultCertificate>
+	//
+	// In addition, specify allow-all for ViewerProtocolPolicy for all of your cache
+	// behaviors.
+	//
+	// If you want viewers to use HTTPS to request your objects: Choose the type
+	// of certificate that you want to use based on whether you're using an alternate
+	// domain name for your objects or the CloudFront domain name:
+	//
+	//    * If you're using an alternate domain name, such as example.com: Specify
+	//    one of the following values, depending on whether ACM provided your certificate
+	//    or you purchased your certificate from third-party certificate authority:
+	//
+	// <ACMCertificateArn>ARN for ACM SSL/TLS certificate<ACMCertificateArn> where
+	//    ARN for ACM SSL/TLS certificate is the ARN for the ACM SSL/TLS certificate
+	//    that you want to use for this distribution.
+	//
+	// <IAMCertificateId>IAM certificate ID<IAMCertificateId> where IAM certificate
+	//    ID is the ID that IAM returned when you added the certificate to the IAM
+	//    certificate store.
+	//
+	// If you specify ACMCertificateArn or IAMCertificateId, you must also specify
+	//    a value for SSLSupportMethod.
+	//
+	// If you choose to use an ACM certificate or a certificate in the IAM certificate
+	//    store, we recommend that you use only an alternate domain name in your
+	//    object URLs (https://example.com/logo.jpg). If you use the domain name
+	//    that is associated with your CloudFront distribution (such as https://d111111abcdef8.cloudfront.net/logo.jpg)
+	//    and the viewer supports SNI, then CloudFront behaves normally. However,
+	//    if the browser does not support SNI, the user's experience depends on
+	//    the value that you choose for SSLSupportMethod:
+	//
+	// vip: The viewer displays a warning because there is a mismatch between the
+	//    CloudFront domain name and the domain name in your SSL/TLS certificate.
+	//
+	// sni-only: CloudFront drops the connection with the browser without returning
+	//    the object.
+	//
+	//    * If you're using the CloudFront domain name for your distribution, such
+	//    as d111111abcdef8.cloudfront.net: Specify the following value:
+	//
+	// <CloudFrontDefaultCertificate>true<CloudFrontDefaultCertificate>
+	//
+	// If you want viewers to use HTTPS, you must also specify one of the following
+	// values in your cache behaviors:
+	//
+	//    *  <ViewerProtocolPolicy>https-only<ViewerProtocolPolicy>
+	//
+	//    * <ViewerProtocolPolicy>redirect-to-https<ViewerProtocolPolicy>
+	//
+	// You can also optionally require that CloudFront use HTTPS to communicate
+	// with your origin by specifying one of the following values for the applicable
+	// origins:
+	//
+	//    * <OriginProtocolPolicy>https-only<OriginProtocolPolicy>
+	//
+	//    * <OriginProtocolPolicy>match-viewer<OriginProtocolPolicy>
+	//
+	// For more information, see Using Alternate Domain Names and HTTPS (http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/SecureConnections.html#CNAMEsAndHTTPS)
+	// in the Amazon CloudFront Developer Guide.
 	//
 	// ViewerCertificate is a required field
 	ViewerCertificate *ViewerCertificate `type:"structure" required:"true"`
@@ -6140,7 +6422,7 @@ type ForwardedValues struct {
 	Cookies *CookiePreference `type:"structure" required:"true"`
 
 	// A complex type that specifies the Headers, if any, that you want CloudFront
-	// to vary upon for this cache behavior.
+	// to base caching on for this cache behavior.
 	Headers *Headers `type:"structure"`
 
 	// Indicates whether you want CloudFront to forward query strings to the origin
@@ -6257,7 +6539,7 @@ type GeoRestriction struct {
 	// CloudFront and MaxMind both use ISO 3166 country codes. For the current list
 	// of countries and the corresponding codes, see ISO 3166-1-alpha-2 code on
 	// the International Organization for Standardization website. You can also
-	// refer to the country list in the CloudFront console, which includes both
+	// refer to the country list on the CloudFront console, which includes both
 	// country names and codes.
 	Items []*string `locationNameList:"Location" type:"list"`
 
@@ -6275,7 +6557,7 @@ type GeoRestriction struct {
 	//    restricted by client geo location.
 	//
 	//    * blacklist: The Location elements specify the countries in which you
-	//    do not want CloudFront to distribute your content.
+	//    don't want CloudFront to distribute your content.
 	//
 	//    * whitelist: The Location elements specify the countries in which you
 	//    want CloudFront to distribute your content.
@@ -6855,48 +7137,53 @@ func (s *GetStreamingDistributionOutput) SetStreamingDistribution(v *StreamingDi
 	return s
 }
 
-// A complex type that specifies the headers that you want CloudFront to forward
-// to the origin for this cache behavior.
+// A complex type that specifies the request headers, if any, that you want
+// CloudFront to base caching on for this cache behavior.
 //
-// For the headers that you specify, CloudFront also caches separate versions
-// of a specified object based on the header values in viewer requests. For
-// example, suppose viewer requests for logo.jpg contain a custom Product header
-// that has a value of either Acme or Apex, and you configure CloudFront to
-// cache your content based on values in the Product header. CloudFront forwards
-// the Product header to the origin and caches the response from the origin
-// once for each header value. For more information about caching based on header
+// For the headers that you specify, CloudFront caches separate versions of
+// a specified object based on the header values in viewer requests. For example,
+// suppose viewer requests for logo.jpg contain a custom product header that
+// has a value of either acme or apex, and you configure CloudFront to cache
+// your content based on values in the product header. CloudFront forwards the
+// product header to the origin and caches the response from the origin once
+// for each header value. For more information about caching based on header
 // values, see How CloudFront Forwards and Caches Headers (http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/header-caching.html)
 // in the Amazon CloudFront Developer Guide.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/Headers
 type Headers struct {
 	_ struct{} `type:"structure"`
 
-	// A complex type that contains one Name element for each header that you want
-	// CloudFront to forward to the origin and to vary on for this cache behavior.
-	// If Quantity is 0, omit Items.
+	// A list that contains one Name element for each header that you want CloudFront
+	// to use for caching in this cache behavior. If Quantity is 0, omit Items.
 	Items []*string `locationNameList:"Name" type:"list"`
 
-	// The number of different headers that you want CloudFront to forward to the
-	// origin for this cache behavior. You can configure each cache behavior in
-	// a web distribution to do one of the following:
+	// The number of different headers that you want CloudFront to base caching
+	// on for this cache behavior. You can configure each cache behavior in a web
+	// distribution to do one of the following:
 	//
 	//    * Forward all headers to your origin: Specify 1 for Quantity and * for
 	//    Name.
 	//
-	// If you configure CloudFront to forward all headers to your origin, CloudFront
-	//    doesn't cache the objects associated with this cache behavior. Instead,
-	//    it sends every request to the origin.
+	// CloudFront doesn't cache the objects that are associated with this cache
+	//    behavior. Instead, CloudFront sends every request to the origin.
 	//
 	//    * Forward a whitelist of headers you specify: Specify the number of headers
-	//    that you want to forward, and specify the header names in Name elements.
-	//    CloudFront caches your objects based on the values in all of the specified
-	//    headers. CloudFront also forwards the headers that it forwards by default,
-	//    but it caches your objects based only on the headers that you specify.
-	//
+	//    that you want CloudFront to base caching on. Then specify the header names
+	//    in Name elements. CloudFront caches your objects based on the values in
+	//    the specified headers.
 	//
 	//    * Forward only the default headers: Specify 0 for Quantity and omit Items.
 	//    In this configuration, CloudFront doesn't cache based on the values in
 	//    the request headers.
+	//
+	// Regardless of which option you choose, CloudFront forwards headers to your
+	// origin based on whether the origin is an S3 bucket or a custom origin. See
+	// the following documentation:
+	//
+	//    * S3 bucket: See HTTP Request Headers That CloudFront Removes or Updates
+	//    (http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorS3Origin.html#request-s3-removed-headers)
+	//
+	//    * Custom origin: See HTTP Request Headers and CloudFront Behavior (http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorCustomOrigin.html#request-custom-headers-behavior)
 	//
 	// Quantity is a required field
 	Quantity *int64 `type:"integer" required:"true"`
@@ -7257,19 +7544,34 @@ func (s *KeyPairIds) SetQuantity(v int64) *KeyPairIds {
 type LambdaFunctionAssociation struct {
 	_ struct{} `type:"structure"`
 
-	// Specifies the event type that triggers a Lambda function invocation. Valid
-	// values are:
+	// Specifies the event type that triggers a Lambda function invocation. You
+	// can specify the following values:
 	//
-	//    * viewer-request
+	//    * viewer-request: The function executes when CloudFront receives a request
+	//    from a viewer and before it checks to see whether the requested object
+	//    is in the edge cache.
 	//
-	//    * origin-request
+	//    * origin-request: The function executes only when CloudFront forwards
+	//    a request to your origin. When the requested object is in the edge cache,
+	//    the function doesn't execute.
 	//
-	//    * viewer-response
+	//    * origin-response: The function executes after CloudFront receives a response
+	//    from the origin and before it caches the object in the response. When
+	//    the requested object is in the edge cache, the function doesn't execute.
 	//
-	//    * origin-response
+	// If the origin returns an HTTP status code other than HTTP 200 (OK), the function
+	//    doesn't execute.
+	//
+	//    * viewer-response: The function executes before CloudFront returns the
+	//    requested object to the viewer. The function executes regardless of whether
+	//    the object was already in the edge cache.
+	//
+	// If the origin returns an HTTP status code other than HTTP 200 (OK), the function
+	//    doesn't execute.
 	EventType *string `type:"string" enum:"EventType"`
 
-	// The ARN of the Lambda function.
+	// The ARN of the Lambda function. You must specify the ARN of a function version;
+	// you can't specify a Lambda alias or $LATEST.
 	LambdaFunctionARN *string `type:"string"`
 }
 
@@ -7800,7 +8102,7 @@ type LoggingConfig struct {
 	Bucket *string `type:"string" required:"true"`
 
 	// Specifies whether you want CloudFront to save access logs to an Amazon S3
-	// bucket. If you do not want to enable logging when you create a distribution
+	// bucket. If you don't want to enable logging when you create a distribution
 	// or if you want to disable logging for an existing distribution, specify false
 	// for Enabled, and specify empty Bucket and Prefix elements. If you specify
 	// false for Enabled but you specify values for Bucket, prefix, and IncludeCookies,
@@ -7812,7 +8114,7 @@ type LoggingConfig struct {
 	// Specifies whether you want CloudFront to include cookies in access logs,
 	// specify true for IncludeCookies. If you choose to include cookies in logs,
 	// CloudFront logs all cookies regardless of how you configure the cache behaviors
-	// for this distribution. If you do not want to include cookies when you create
+	// for this distribution. If you don't want to include cookies when you create
 	// a distribution or if you want to disable include cookies for an existing
 	// distribution, specify false for IncludeCookies.
 	//
@@ -7821,8 +8123,8 @@ type LoggingConfig struct {
 
 	// An optional string that you want CloudFront to prefix to the access log filenames
 	// for this distribution, for example, myprefix/. If you want to enable logging,
-	// but you do not want to specify a prefix, you still must include an empty
-	// Prefix element in the Logging element.
+	// but you don't want to specify a prefix, you still must include an empty Prefix
+	// element in the Logging element.
 	//
 	// Prefix is a required field
 	Prefix *string `type:"string" required:"true"`
@@ -7908,8 +8210,8 @@ type Origin struct {
 	//
 	// Constraints for Amazon S3 origins:
 	//
-	//    * If you configured Amazon S3 Transfer Acceleration for your bucket, do
-	//    not specify the s3-accelerate endpoint for DomainName.
+	//    * If you configured Amazon S3 Transfer Acceleration for your bucket, don't
+	//    specify the s3-accelerate endpoint for DomainName.
 	//
 	//    * The bucket name must be between 3 and 63 characters long (inclusive).
 	//
@@ -8056,7 +8358,7 @@ type OriginAccessIdentity struct {
 	// The current configuration information for the identity.
 	CloudFrontOriginAccessIdentityConfig *OriginAccessIdentityConfig `type:"structure"`
 
-	// The ID for the origin access identity. For example: E74FTE3AJFJ256A.
+	// The ID for the origin access identity, for example, E74FTE3AJFJ256A.
 	//
 	// Id is a required field
 	Id *string `type:"string" required:"true"`
@@ -8835,7 +9137,7 @@ type StreamingDistribution struct {
 	// ActiveTrustedSigners is a required field
 	ActiveTrustedSigners *ActiveTrustedSigners `type:"structure" required:"true"`
 
-	// The domain name that corresponds to the streaming distribution. For example:
+	// The domain name that corresponds to the streaming distribution, for example,
 	// s5c39gqb8ow64r.cloudfront.net.
 	//
 	// DomainName is a required field
@@ -9248,7 +9550,7 @@ type StreamingDistributionSummary struct {
 	// Comment is a required field
 	Comment *string `type:"string" required:"true"`
 
-	// The domain name corresponding to the distribution. For example: d604721fxaaqy9.cloudfront.net.
+	// The domain name corresponding to the distribution, for example, d111111abcdef8.cloudfront.net.
 	//
 	// DomainName is a required field
 	DomainName *string `type:"string" required:"true"`
@@ -9258,7 +9560,7 @@ type StreamingDistributionSummary struct {
 	// Enabled is a required field
 	Enabled *bool `type:"boolean" required:"true"`
 
-	// The identifier for the distribution. For example: EDFDVBD632BHDS5.
+	// The identifier for the distribution, for example, EDFDVBD632BHDS5.
 	//
 	// Id is a required field
 	Id *string `type:"string" required:"true"`
@@ -9387,19 +9689,19 @@ type StreamingLoggingConfig struct {
 	Bucket *string `type:"string" required:"true"`
 
 	// Specifies whether you want CloudFront to save access logs to an Amazon S3
-	// bucket. If you do not want to enable logging when you create a streaming
-	// distribution or if you want to disable logging for an existing streaming
-	// distribution, specify false for Enabled, and specify empty Bucket and Prefix
-	// elements. If you specify false for Enabled but you specify values for Bucket
-	// and Prefix, the values are automatically deleted.
+	// bucket. If you don't want to enable logging when you create a streaming distribution
+	// or if you want to disable logging for an existing streaming distribution,
+	// specify false for Enabled, and specify empty Bucket and Prefix elements.
+	// If you specify false for Enabled but you specify values for Bucket and Prefix,
+	// the values are automatically deleted.
 	//
 	// Enabled is a required field
 	Enabled *bool `type:"boolean" required:"true"`
 
 	// An optional string that you want CloudFront to prefix to the access log filenames
 	// for this streaming distribution, for example, myprefix/. If you want to enable
-	// logging, but you do not want to specify a prefix, you still must include
-	// an empty Prefix element in the Logging element.
+	// logging, but you don't want to specify a prefix, you still must include an
+	// empty Prefix element in the Logging element.
 	//
 	// Prefix is a required field
 	Prefix *string `type:"string" required:"true"`
@@ -10116,130 +10418,157 @@ func (s *UpdateStreamingDistributionOutput) SetStreamingDistribution(v *Streamin
 
 // A complex type that specifies the following:
 //
-//    * Which SSL/TLS certificate to use when viewers request objects using
-//    HTTPS
+//    * Whether you want viewers to use HTTP or HTTPS to request your objects.
 //
-//    * Whether you want CloudFront to use dedicated IP addresses or SNI when
-//    you're using alternate domain names in your object names
+//    * If you want viewers to use HTTPS, whether you're using an alternate
+//    domain name such as example.com or the CloudFront domain name for your
+//    distribution, such as d111111abcdef8.cloudfront.net.
 //
-//    * The minimum protocol version that you want CloudFront to use when communicating
-//    with viewers
+//    * If you're using an alternate domain name, whether AWS Certificate Manager
+//    (ACM) provided the certificate, or you purchased a certificate from a
+//    third-party certificate authority and imported it into ACM or uploaded
+//    it to the IAM certificate store.
 //
-// For more information, see Using an HTTPS Connection to Access Your Objects
-// (http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/SecureConnections.html)
-// in the Amazon Amazon CloudFront Developer Guide.
+// You must specify only one of the following values:
+//
+//    * ViewerCertificate$ACMCertificateArn
+//
+//    * ViewerCertificate$IAMCertificateId
+//
+//    * ViewerCertificate$CloudFrontDefaultCertificate
+//
+// Don't specify false for CloudFrontDefaultCertificate.
+//
+// If you want viewers to use HTTP instead of HTTPS to request your objects:
+// Specify the following value:
+//
+// <CloudFrontDefaultCertificate>true<CloudFrontDefaultCertificate>
+//
+// In addition, specify allow-all for ViewerProtocolPolicy for all of your cache
+// behaviors.
+//
+// If you want viewers to use HTTPS to request your objects: Choose the type
+// of certificate that you want to use based on whether you're using an alternate
+// domain name for your objects or the CloudFront domain name:
+//
+//    * If you're using an alternate domain name, such as example.com: Specify
+//    one of the following values, depending on whether ACM provided your certificate
+//    or you purchased your certificate from third-party certificate authority:
+//
+// <ACMCertificateArn>ARN for ACM SSL/TLS certificate<ACMCertificateArn> where
+//    ARN for ACM SSL/TLS certificate is the ARN for the ACM SSL/TLS certificate
+//    that you want to use for this distribution.
+//
+// <IAMCertificateId>IAM certificate ID<IAMCertificateId> where IAM certificate
+//    ID is the ID that IAM returned when you added the certificate to the IAM
+//    certificate store.
+//
+// If you specify ACMCertificateArn or IAMCertificateId, you must also specify
+//    a value for SSLSupportMethod.
+//
+// If you choose to use an ACM certificate or a certificate in the IAM certificate
+//    store, we recommend that you use only an alternate domain name in your
+//    object URLs (https://example.com/logo.jpg). If you use the domain name
+//    that is associated with your CloudFront distribution (such as https://d111111abcdef8.cloudfront.net/logo.jpg)
+//    and the viewer supports SNI, then CloudFront behaves normally. However,
+//    if the browser does not support SNI, the user's experience depends on
+//    the value that you choose for SSLSupportMethod:
+//
+// vip: The viewer displays a warning because there is a mismatch between the
+//    CloudFront domain name and the domain name in your SSL/TLS certificate.
+//
+// sni-only: CloudFront drops the connection with the browser without returning
+//    the object.
+//
+//    * If you're using the CloudFront domain name for your distribution, such
+//    as d111111abcdef8.cloudfront.net: Specify the following value:
+//
+// <CloudFrontDefaultCertificate>true<CloudFrontDefaultCertificate>
+//
+// If you want viewers to use HTTPS, you must also specify one of the following
+// values in your cache behaviors:
+//
+//    *  <ViewerProtocolPolicy>https-only<ViewerProtocolPolicy>
+//
+//    * <ViewerProtocolPolicy>redirect-to-https<ViewerProtocolPolicy>
+//
+// You can also optionally require that CloudFront use HTTPS to communicate
+// with your origin by specifying one of the following values for the applicable
+// origins:
+//
+//    * <OriginProtocolPolicy>https-only<OriginProtocolPolicy>
+//
+//    * <OriginProtocolPolicy>match-viewer<OriginProtocolPolicy>
+//
+// For more information, see Using Alternate Domain Names and HTTPS (http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/SecureConnections.html#CNAMEsAndHTTPS)
+// in the Amazon CloudFront Developer Guide.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/ViewerCertificate
 type ViewerCertificate struct {
 	_ struct{} `type:"structure"`
 
+	// For information about how and when to use ACMCertificateArn, see ViewerCertificate.
 	ACMCertificateArn *string `type:"string"`
 
-	// Include one of these values to specify the following:
+	// This field has been deprecated. Use one of the following fields instead:
 	//
-	//    * Whether you want viewers to use HTTP or HTTPS to request your objects.
+	//    * ViewerCertificate$ACMCertificateArn
 	//
-	//    * If you want viewers to use HTTPS, whether you're using an alternate
-	//    domain name such as example.com or the CloudFront domain name for your
-	//    distribution, such as d111111abcdef8.cloudfront.net.
+	//    * ViewerCertificate$IAMCertificateId
 	//
-	//    * If you're using an alternate domain name, whether AWS Certificate Manager
-	//    (ACM) provided the certificate, or you purchased a certificate from a
-	//    third-party certificate authority and imported it into ACM or uploaded
-	//    it to the IAM certificate store.
-	//
-	// You must specify one (and only one) of the three values. Do not specify false
-	// for CloudFrontDefaultCertificate.
-	//
-	// If you want viewers to use HTTP to request your objects: Specify the following
-	// value:
-	//
-	// <CloudFrontDefaultCertificate>true<CloudFrontDefaultCertificate>
-	//
-	// In addition, specify allow-all for ViewerProtocolPolicy for all of your cache
-	// behaviors.
-	//
-	// If you want viewers to use HTTPS to request your objects: Choose the type
-	// of certificate that you want to use based on whether you're using an alternate
-	// domain name for your objects or the CloudFront domain name:
-	//
-	//    * If you're using an alternate domain name, such as example.com: Specify
-	//    one of the following values, depending on whether ACM provided your certificate
-	//    or you purchased your certificate from third-party certificate authority:
-	//
-	// <ACMCertificateArn>ARN for ACM SSL/TLS certificate<ACMCertificateArn> where
-	//    ARN for ACM SSL/TLS certificate is the ARN for the ACM SSL/TLS certificate
-	//    that you want to use for this distribution.
-	//
-	// <IAMCertificateId>IAM certificate ID<IAMCertificateId> where IAM certificate
-	//    ID is the ID that IAM returned when you added the certificate to the IAM
-	//    certificate store.
-	//
-	// If you specify ACMCertificateArn or IAMCertificateId, you must also specify
-	//    a value for SSLSupportMethod.
-	//
-	// If you choose to use an ACM certificate or a certificate in the IAM certificate
-	//    store, we recommend that you use only an alternate domain name in your
-	//    object URLs (https://example.com/logo.jpg). If you use the domain name
-	//    that is associated with your CloudFront distribution (https://d111111abcdef8.cloudfront.net/logo.jpg)
-	//    and the viewer supports SNI, then CloudFront behaves normally. However,
-	//    if the browser does not support SNI, the user's experience depends on
-	//    the value that you choose for SSLSupportMethod:
-	//
-	// vip: The viewer displays a warning because there is a mismatch between the
-	//    CloudFront domain name and the domain name in your SSL/TLS certificate.
-	//
-	// sni-only: CloudFront drops the connection with the browser without returning
-	//    the object.
-	//
-	//    * If you're using the CloudFront domain name for your distribution, such
-	//    as d111111abcdef8.cloudfront.net: Specify the following value:
-	//
-	//  <CloudFrontDefaultCertificate>true<CloudFrontDefaultCertificate>
-	//
-	// If you want viewers to use HTTPS, you must also specify one of the following
-	//    values in your cache behaviors:
-	//
-	//  <ViewerProtocolPolicy>https-only<ViewerProtocolPolicy>
-	//
-	//  <ViewerProtocolPolicy>redirect-to-https<ViewerProtocolPolicy>
-	//
-	// You can also optionally require that CloudFront use HTTPS to communicate
-	//    with your origin by specifying one of the following values for the applicable
-	//    origins:
-	//
-	//  <OriginProtocolPolicy>https-only<OriginProtocolPolicy>
-	//
-	//  <OriginProtocolPolicy>match-viewer<OriginProtocolPolicy>
-	//
-	// For more information, see Using Alternate Domain Names and HTTPS (http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/SecureConnections.html#CNAMEsAndHTTPS)
-	//    in the Amazon CloudFront Developer Guide.
+	//    * ViewerCertificate$CloudFrontDefaultCertificate
 	Certificate *string `deprecated:"true" type:"string"`
 
-	// This field is deprecated. You can use one of the following: [ACMCertificateArn,
-	// IAMCertificateId, or CloudFrontDefaultCertificate].
+	// This field has been deprecated. Use one of the following fields instead:
+	//
+	//    * ViewerCertificate$ACMCertificateArn
+	//
+	//    * ViewerCertificate$IAMCertificateId
+	//
+	//    * ViewerCertificate$CloudFrontDefaultCertificate
 	CertificateSource *string `deprecated:"true" type:"string" enum:"CertificateSource"`
 
+	// For information about how and when to use CloudFrontDefaultCertificate, see
+	// ViewerCertificate.
 	CloudFrontDefaultCertificate *bool `type:"boolean"`
 
+	// For information about how and when to use IAMCertificateId, see ViewerCertificate.
 	IAMCertificateId *string `type:"string"`
 
-	// Specify the minimum version of the SSL/TLS protocol that you want CloudFront
-	// to use for HTTPS connections between viewers and CloudFront: SSLv3 or TLSv1.
-	// CloudFront serves your objects only to viewers that support SSL/TLS version
-	// that you specify and later versions. The TLSv1 protocol is more secure, so
-	// we recommend that you specify SSLv3 only if your users are using browsers
-	// or devices that don't support TLSv1. Note the following:
+	// Specify the security policy that you want CloudFront to use for HTTPS connections.
+	// A security policy determines two settings:
 	//
-	//    * If you specify <CloudFrontDefaultCertificate>true<CloudFrontDefaultCertificate>,
-	//    the minimum SSL protocol version is TLSv1 and can't be changed.
+	//    * The minimum SSL/TLS protocol that CloudFront uses to communicate with
+	//    viewers
 	//
-	//    * If you're using a custom certificate (if you specify a value for ACMCertificateArn
-	//    or for IAMCertificateId) and if you're using SNI (if you specify sni-only
-	//    for SSLSupportMethod), you must specify TLSv1 for MinimumProtocolVersion.
+	//    * The cipher that CloudFront uses to encrypt the content that it returns
+	//    to viewers
+	//
+	// On the CloudFront console, this setting is called Security policy.
+	//
+	// We recommend that you specify TLSv1.1_2016 unless your users are using browsers
+	// or devices that do not support TLSv1.1 or later.
+	//
+	// When both of the following are true, you must specify TLSv1 or later for
+	// the security policy:
+	//
+	//    * You're using a custom certificate: you specified a value for ACMCertificateArn
+	//    or for IAMCertificateId
+	//
+	//    * You're using SNI: you specified sni-only for SSLSupportMethod
+	//
+	// If you specify true for CloudFrontDefaultCertificate, CloudFront automatically
+	// sets the security policy to TLSv1 regardless of the value that you specify
+	// for MinimumProtocolVersion.
+	//
+	// For information about the relationship between the security policy that you
+	// choose and the protocols and ciphers that CloudFront uses to communicate
+	// with viewers, see  Supported SSL/TLS Protocols and Ciphers for Communication
+	// Between Viewers and CloudFront (http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html#secure-connections-supported-ciphers)
+	// in the Amazon CloudFront Developer Guide.
 	MinimumProtocolVersion *string `type:"string" enum:"MinimumProtocolVersion"`
 
-	// If you specify a value for ACMCertificateArn or for IAMCertificateId, you
-	// must also specify how you want CloudFront to serve HTTPS requests: using
+	// If you specify a value for ViewerCertificate$ACMCertificateArn or for ViewerCertificate$IAMCertificateId,
+	// you must also specify how you want CloudFront to serve HTTPS requests: using
 	// a method that works for all clients or one that works for most clients:
 	//
 	//    * vip: CloudFront uses dedicated IP addresses for your content and can
@@ -10262,7 +10591,7 @@ type ViewerCertificate struct {
 	//
 	// Use HTTP instead of HTTPS.
 	//
-	// Do not specify a value for SSLSupportMethod if you specified <CloudFrontDefaultCertificate>true<CloudFrontDefaultCertificate>.
+	// Don't specify a value for SSLSupportMethod if you specified <CloudFrontDefaultCertificate>true<CloudFrontDefaultCertificate>.
 	//
 	// For more information, see Using Alternate Domain Names and HTTPS (http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/SecureConnections.html#CNAMEsAndHTTPS.html)
 	// in the Amazon CloudFront Developer Guide.
@@ -10405,6 +10734,15 @@ const (
 
 	// MinimumProtocolVersionTlsv1 is a MinimumProtocolVersion enum value
 	MinimumProtocolVersionTlsv1 = "TLSv1"
+
+	// MinimumProtocolVersionTlsv12016 is a MinimumProtocolVersion enum value
+	MinimumProtocolVersionTlsv12016 = "TLSv1_2016"
+
+	// MinimumProtocolVersionTlsv112016 is a MinimumProtocolVersion enum value
+	MinimumProtocolVersionTlsv112016 = "TLSv1.1_2016"
+
+	// MinimumProtocolVersionTlsv122018 is a MinimumProtocolVersion enum value
+	MinimumProtocolVersionTlsv122018 = "TLSv1.2_2018"
 )
 
 const (

--- a/vendor/github.com/aws/aws-sdk-go/service/cloudfront/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/cloudfront/doc.go
@@ -4,9 +4,9 @@
 // requests to Amazon CloudFront.
 //
 // This is the Amazon CloudFront API Reference. This guide is for developers
-// who need detailed information about the CloudFront API actions, data types,
-// and errors. For detailed information about CloudFront features and their
-// associated API calls, see the Amazon CloudFront Developer Guide.
+// who need detailed information about CloudFront API actions, data types, and
+// errors. For detailed information about CloudFront features, see the Amazon
+// CloudFront Developer Guide.
 //
 // See https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25 for more information on this service.
 //

--- a/vendor/github.com/aws/aws-sdk-go/service/cloudfront/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/cloudfront/errors.go
@@ -38,7 +38,7 @@ const (
 	// ErrCodeInconsistentQuantities for service response error code
 	// "InconsistentQuantities".
 	//
-	// The value of Quantity and the size of Items do not match.
+	// The value of Quantity and the size of Items don't match.
 	ErrCodeInconsistentQuantities = "InconsistentQuantities"
 
 	// ErrCodeInvalidArgument for service response error code
@@ -222,6 +222,10 @@ const (
 	// to false.
 	ErrCodePreconditionFailed = "PreconditionFailed"
 
+	// ErrCodeResourceInUse for service response error code
+	// "ResourceInUse".
+	ErrCodeResourceInUse = "ResourceInUse"
+
 	// ErrCodeStreamingDistributionAlreadyExists for service response error code
 	// "StreamingDistributionAlreadyExists".
 	ErrCodeStreamingDistributionAlreadyExists = "StreamingDistributionAlreadyExists"
@@ -328,6 +332,6 @@ const (
 	// ErrCodeTrustedSignerDoesNotExist for service response error code
 	// "TrustedSignerDoesNotExist".
 	//
-	// One or more of your trusted signers do not exist.
+	// One or more of your trusted signers don't exist.
 	ErrCodeTrustedSignerDoesNotExist = "TrustedSignerDoesNotExist"
 )

--- a/vendor/github.com/aws/aws-sdk-go/service/configservice/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/configservice/api.go
@@ -6864,4 +6864,7 @@ const (
 
 	// ResourceTypeAwsAutoScalingScheduledAction is a ResourceType enum value
 	ResourceTypeAwsAutoScalingScheduledAction = "AWS::AutoScaling::ScheduledAction"
+
+	// ResourceTypeAwsCodeBuildProject is a ResourceType enum value
+	ResourceTypeAwsCodeBuildProject = "AWS::CodeBuild::Project"
 )

--- a/vendor/github.com/aws/aws-sdk-go/service/ec2/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ec2/api.go
@@ -35224,6 +35224,14 @@ type DescribeSecurityGroupsInput struct {
 	//
 	// Default: Describes all your security groups.
 	GroupNames []*string `locationName:"GroupName" locationNameList:"GroupName" type:"list"`
+
+	// The maximum number of results to return in a single call. To retrieve the
+	// remaining results, make another request with the returned NextToken value.
+	// This value can be between 5 and 1000.
+	MaxResults *int64 `type:"integer"`
+
+	// The token to request the next page of results.
+	NextToken *string `type:"string"`
 }
 
 // String returns the string representation
@@ -35260,10 +35268,26 @@ func (s *DescribeSecurityGroupsInput) SetGroupNames(v []*string) *DescribeSecuri
 	return s
 }
 
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeSecurityGroupsInput) SetMaxResults(v int64) *DescribeSecurityGroupsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeSecurityGroupsInput) SetNextToken(v string) *DescribeSecurityGroupsInput {
+	s.NextToken = &v
+	return s
+}
+
 // Contains the output of DescribeSecurityGroups.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DescribeSecurityGroupsResult
 type DescribeSecurityGroupsOutput struct {
 	_ struct{} `type:"structure"`
+
+	// The token to use to retrieve the next page of results. This value is null
+	// when there are no more results to return.
+	NextToken *string `locationName:"nextToken" type:"string"`
 
 	// Information about one or more security groups.
 	SecurityGroups []*SecurityGroup `locationName:"securityGroupInfo" locationNameList:"item" type:"list"`
@@ -35277,6 +35301,12 @@ func (s DescribeSecurityGroupsOutput) String() string {
 // GoString returns the string representation
 func (s DescribeSecurityGroupsOutput) GoString() string {
 	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeSecurityGroupsOutput) SetNextToken(v string) *DescribeSecurityGroupsOutput {
+	s.NextToken = &v
+	return s
 }
 
 // SetSecurityGroups sets the SecurityGroups field's value.
@@ -45303,9 +45333,6 @@ type LaunchSpecification struct {
 	AddressingType *string `locationName:"addressingType" type:"string"`
 
 	// One or more block device mapping entries.
-	//
-	// Although you can specify encrypted EBS volumes in this block device mapping
-	// for your Spot Instances, these volumes are not encrypted.
 	BlockDeviceMappings []*BlockDeviceMapping `locationName:"blockDeviceMapping" locationNameList:"item" type:"list"`
 
 	// Indicates whether the instance is optimized for EBS I/O. This optimization
@@ -51486,9 +51513,6 @@ type RequestSpotLaunchSpecification struct {
 	AddressingType *string `locationName:"addressingType" type:"string"`
 
 	// One or more block device mapping entries.
-	//
-	// Although you can specify encrypted EBS volumes in this block device mapping
-	// for your Spot Instances, these volumes are not encrypted.
 	BlockDeviceMappings []*BlockDeviceMapping `locationName:"blockDeviceMapping" locationNameList:"item" type:"list"`
 
 	// Indicates whether the instance is optimized for EBS I/O. This optimization
@@ -60900,6 +60924,15 @@ const (
 
 	// InstanceTypeP216xlarge is a InstanceType enum value
 	InstanceTypeP216xlarge = "p2.16xlarge"
+
+	// InstanceTypeP32xlarge is a InstanceType enum value
+	InstanceTypeP32xlarge = "p3.2xlarge"
+
+	// InstanceTypeP38xlarge is a InstanceType enum value
+	InstanceTypeP38xlarge = "p3.8xlarge"
+
+	// InstanceTypeP316xlarge is a InstanceType enum value
+	InstanceTypeP316xlarge = "p3.16xlarge"
 
 	// InstanceTypeD2Xlarge is a InstanceType enum value
 	InstanceTypeD2Xlarge = "d2.xlarge"

--- a/vendor/github.com/aws/aws-sdk-go/service/elasticache/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/elasticache/api.go
@@ -4143,6 +4143,14 @@ func (c *ElastiCache) RebootCacheClusterRequest(input *RebootCacheClusterInput) 
 //
 // When the reboot is complete, a cache cluster event is created.
 //
+// Rebooting a cluster is currently supported on Memcached and Redis (cluster
+// mode disabled) clusters. Rebooting is not supported on Redis (cluster mode
+// enabled) clusters.
+//
+// If you make changes to parameters that require a Redis (cluster mode enabled)
+// cluster reboot for the changes to be applied, see Rebooting a Cluster (http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Clusters.Rebooting.htm)
+// for an alternate process.
+//
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
 // the error.
@@ -4789,6 +4797,20 @@ func (s *AvailabilityZone) SetName(v string) *AvailabilityZone {
 type CacheCluster struct {
 	_ struct{} `type:"structure"`
 
+	// A flag that enables encryption at-rest when set to true.
+	//
+	// You cannot modify the value of AtRestEncryptionEnabled after the cluster
+	// is created. To enable at-rest encryption on a cluster you must set AtRestEncryptionEnabled
+	// to true when you create a cluster.
+	//
+	// Default: false
+	AtRestEncryptionEnabled *bool `type:"boolean"`
+
+	// A flag that enables using an AuthToken (password) when issuing Redis commands.
+	//
+	// Default: false
+	AuthTokenEnabled *bool `type:"boolean"`
+
 	// This parameter is currently disabled.
 	AutoMinorVersionUpgrade *bool `type:"boolean"`
 
@@ -4806,37 +4828,60 @@ type CacheCluster struct {
 
 	// The name of the compute and memory capacity node type for the cache cluster.
 	//
-	// Valid node types are as follows:
+	// The following node types are supported by ElastiCache. Generally speaking,
+	// the current generation types provide more memory and computational power
+	// at lower cost when compared to their equivalent previous generation counterparts.
 	//
 	//    * General purpose:
 	//
-	// Current generation: cache.t2.micro, cache.t2.small, cache.t2.medium, cache.m3.medium,
-	//    cache.m3.large, cache.m3.xlarge, cache.m3.2xlarge, cache.m4.large, cache.m4.xlarge,
-	//    cache.m4.2xlarge, cache.m4.4xlarge, cache.m4.10xlarge
+	// Current generation:
 	//
-	// Previous generation: cache.t1.micro, cache.m1.small, cache.m1.medium, cache.m1.large,
-	//    cache.m1.xlarge
+	// T2 node types:cache.t2.micro, cache.t2.small, cache.t2.medium
 	//
-	//    * Compute optimized: cache.c1.xlarge
+	// M3 node types:cache.m3.medium, cache.m3.large, cache.m3.xlarge, cache.m3.2xlarge
+	//
+	// M4 node types:cache.m4.large, cache.m4.xlarge, cache.m4.2xlarge, cache.m4.4xlarge,
+	//    cache.m4.10xlarge
+	//
+	// Previous generation: (not recommended)
+	//
+	// T1 node types:cache.t1.micro
+	//
+	// M1 node types:cache.m1.small, cache.m1.medium, cache.m1.large, cache.m1.xlarge
+	//
+	//    * Compute optimized:
+	//
+	// Previous generation: (not recommended)
+	//
+	// C1 node types:cache.c1.xlarge
 	//
 	//    * Memory optimized:
 	//
-	// Current generation: cache.r3.large, cache.r3.xlarge, cache.r3.2xlarge, cache.r3.4xlarge,
+	// Current generation:
+	//
+	// R3 node types:cache.r3.large, cache.r3.xlarge, cache.r3.2xlarge, cache.r3.4xlarge,
 	//    cache.r3.8xlarge
 	//
-	// Previous generation: cache.m2.xlarge, cache.m2.2xlarge, cache.m2.4xlarge
+	// Previous generation: (not recommended)
+	//
+	// M2 node types:cache.m2.xlarge, cache.m2.2xlarge, cache.m2.4xlarge
 	//
 	// Notes:
 	//
 	//    * All T2 instances are created in an Amazon Virtual Private Cloud (Amazon
 	//    VPC).
 	//
-	//    * Redis backup/restore is not supported for Redis (cluster mode disabled)
-	//    T1 and T2 instances. Backup/restore is supported on Redis (cluster mode
-	//    enabled) T2 instances.
+	//    * Redis (cluster mode disabled): Redis backup/restore is not supported
+	//    on T1 and T2 instances.
+	//
+	//    * Redis (cluster mode enabled): Backup/restore is not supported on T1
+	//    instances.
 	//
 	//    * Redis Append-only files (AOF) functionality is not supported for T1
 	//    or T2 instances.
+	//
+	// Supported node types are available in all regions except as noted in the
+	// following table.
 	//
 	// For a complete listing of node types and specifications, see Amazon ElastiCache
 	// Product Features and Details (http://aws.amazon.com/elasticache/details)
@@ -4937,6 +4982,15 @@ type CacheCluster struct {
 	//
 	// Example: 05:00-09:00
 	SnapshotWindow *string `type:"string"`
+
+	// A flag that enables in-transit encryption when set to true.
+	//
+	// You cannot modify the value of TransitEncryptionEnabled after the cluster
+	// is created. To enable in-transit encryption on a cluster you must set TransitEncryptionEnabled
+	// to true when you create a cluster.
+	//
+	// Default: false
+	TransitEncryptionEnabled *bool `type:"boolean"`
 }
 
 // String returns the string representation
@@ -4947,6 +5001,18 @@ func (s CacheCluster) String() string {
 // GoString returns the string representation
 func (s CacheCluster) GoString() string {
 	return s.String()
+}
+
+// SetAtRestEncryptionEnabled sets the AtRestEncryptionEnabled field's value.
+func (s *CacheCluster) SetAtRestEncryptionEnabled(v bool) *CacheCluster {
+	s.AtRestEncryptionEnabled = &v
+	return s
+}
+
+// SetAuthTokenEnabled sets the AuthTokenEnabled field's value.
+func (s *CacheCluster) SetAuthTokenEnabled(v bool) *CacheCluster {
+	s.AuthTokenEnabled = &v
+	return s
 }
 
 // SetAutoMinorVersionUpgrade sets the AutoMinorVersionUpgrade field's value.
@@ -5081,6 +5147,12 @@ func (s *CacheCluster) SetSnapshotWindow(v string) *CacheCluster {
 	return s
 }
 
+// SetTransitEncryptionEnabled sets the TransitEncryptionEnabled field's value.
+func (s *CacheCluster) SetTransitEncryptionEnabled(v bool) *CacheCluster {
+	s.TransitEncryptionEnabled = &v
+	return s
+}
+
 // Provides all of the details about a particular cache engine version.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/CacheEngineVersion
 type CacheEngineVersion struct {
@@ -5148,37 +5220,60 @@ func (s *CacheEngineVersion) SetEngineVersion(v string) *CacheEngineVersion {
 // runs its own instance of the cluster's protocol-compliant caching software
 // - either Memcached or Redis.
 //
-// Valid node types are as follows:
+// The following node types are supported by ElastiCache. Generally speaking,
+// the current generation types provide more memory and computational power
+// at lower cost when compared to their equivalent previous generation counterparts.
 //
 //    * General purpose:
 //
-// Current generation: cache.t2.micro, cache.t2.small, cache.t2.medium, cache.m3.medium,
-//    cache.m3.large, cache.m3.xlarge, cache.m3.2xlarge, cache.m4.large, cache.m4.xlarge,
-//    cache.m4.2xlarge, cache.m4.4xlarge, cache.m4.10xlarge
+// Current generation:
 //
-// Previous generation: cache.t1.micro, cache.m1.small, cache.m1.medium, cache.m1.large,
-//    cache.m1.xlarge
+// T2 node types:cache.t2.micro, cache.t2.small, cache.t2.medium
 //
-//    * Compute optimized: cache.c1.xlarge
+// M3 node types:cache.m3.medium, cache.m3.large, cache.m3.xlarge, cache.m3.2xlarge
+//
+// M4 node types:cache.m4.large, cache.m4.xlarge, cache.m4.2xlarge, cache.m4.4xlarge,
+//    cache.m4.10xlarge
+//
+// Previous generation: (not recommended)
+//
+// T1 node types:cache.t1.micro
+//
+// M1 node types:cache.m1.small, cache.m1.medium, cache.m1.large, cache.m1.xlarge
+//
+//    * Compute optimized:
+//
+// Previous generation: (not recommended)
+//
+// C1 node types:cache.c1.xlarge
 //
 //    * Memory optimized:
 //
-// Current generation: cache.r3.large, cache.r3.xlarge, cache.r3.2xlarge, cache.r3.4xlarge,
+// Current generation:
+//
+// R3 node types:cache.r3.large, cache.r3.xlarge, cache.r3.2xlarge, cache.r3.4xlarge,
 //    cache.r3.8xlarge
 //
-// Previous generation: cache.m2.xlarge, cache.m2.2xlarge, cache.m2.4xlarge
+// Previous generation: (not recommended)
+//
+// M2 node types:cache.m2.xlarge, cache.m2.2xlarge, cache.m2.4xlarge
 //
 // Notes:
 //
 //    * All T2 instances are created in an Amazon Virtual Private Cloud (Amazon
 //    VPC).
 //
-//    * Redis backup/restore is not supported for Redis (cluster mode disabled)
-//    T1 and T2 instances. Backup/restore is supported on Redis (cluster mode
-//    enabled) T2 instances.
+//    * Redis (cluster mode disabled): Redis backup/restore is not supported
+//    on T1 and T2 instances.
+//
+//    * Redis (cluster mode enabled): Backup/restore is not supported on T1
+//    instances.
 //
 //    * Redis Append-only files (AOF) functionality is not supported for T1
 //    or T2 instances.
+//
+// Supported node types are available in all regions except as noted in the
+// following table.
 //
 // For a complete listing of node types and specifications, see Amazon ElastiCache
 // Product Features and Details (http://aws.amazon.com/elasticache/details)
@@ -5797,10 +5892,10 @@ type CreateCacheClusterInput struct {
 	//
 	//    * Must be at least 16 characters and no more than 128 characters in length.
 	//
-	//    * Cannot contain any of the following characters: '/', '"', or "@".
+	//    * Cannot contain any of the following characters: '/', '"', or '@'.
 	//
 	// For more information, see AUTH password (http://redis.io/commands/AUTH) at
-	// Redis.
+	// http://redis.io/commands/AUTH.
 	AuthToken *string `type:"string"`
 
 	// This parameter is currently disabled.
@@ -5822,37 +5917,60 @@ type CreateCacheClusterInput struct {
 
 	// The compute and memory capacity of the nodes in the node group (shard).
 	//
-	// Valid node types are as follows:
+	// The following node types are supported by ElastiCache. Generally speaking,
+	// the current generation types provide more memory and computational power
+	// at lower cost when compared to their equivalent previous generation counterparts.
 	//
 	//    * General purpose:
 	//
-	// Current generation: cache.t2.micro, cache.t2.small, cache.t2.medium, cache.m3.medium,
-	//    cache.m3.large, cache.m3.xlarge, cache.m3.2xlarge, cache.m4.large, cache.m4.xlarge,
-	//    cache.m4.2xlarge, cache.m4.4xlarge, cache.m4.10xlarge
+	// Current generation:
 	//
-	// Previous generation: cache.t1.micro, cache.m1.small, cache.m1.medium, cache.m1.large,
-	//    cache.m1.xlarge
+	// T2 node types:cache.t2.micro, cache.t2.small, cache.t2.medium
 	//
-	//    * Compute optimized: cache.c1.xlarge
+	// M3 node types:cache.m3.medium, cache.m3.large, cache.m3.xlarge, cache.m3.2xlarge
+	//
+	// M4 node types:cache.m4.large, cache.m4.xlarge, cache.m4.2xlarge, cache.m4.4xlarge,
+	//    cache.m4.10xlarge
+	//
+	// Previous generation: (not recommended)
+	//
+	// T1 node types:cache.t1.micro
+	//
+	// M1 node types:cache.m1.small, cache.m1.medium, cache.m1.large, cache.m1.xlarge
+	//
+	//    * Compute optimized:
+	//
+	// Previous generation: (not recommended)
+	//
+	// C1 node types:cache.c1.xlarge
 	//
 	//    * Memory optimized:
 	//
-	// Current generation: cache.r3.large, cache.r3.xlarge, cache.r3.2xlarge, cache.r3.4xlarge,
+	// Current generation:
+	//
+	// R3 node types:cache.r3.large, cache.r3.xlarge, cache.r3.2xlarge, cache.r3.4xlarge,
 	//    cache.r3.8xlarge
 	//
-	// Previous generation: cache.m2.xlarge, cache.m2.2xlarge, cache.m2.4xlarge
+	// Previous generation: (not recommended)
+	//
+	// M2 node types:cache.m2.xlarge, cache.m2.2xlarge, cache.m2.4xlarge
 	//
 	// Notes:
 	//
 	//    * All T2 instances are created in an Amazon Virtual Private Cloud (Amazon
 	//    VPC).
 	//
-	//    * Redis backup/restore is not supported for Redis (cluster mode disabled)
-	//    T1 and T2 instances. Backup/restore is supported on Redis (cluster mode
-	//    enabled) T2 instances.
+	//    * Redis (cluster mode disabled): Redis backup/restore is not supported
+	//    on T1 and T2 instances.
+	//
+	//    * Redis (cluster mode enabled): Backup/restore is not supported on T1
+	//    instances.
 	//
 	//    * Redis Append-only files (AOF) functionality is not supported for T1
 	//    or T2 instances.
+	//
+	// Supported node types are available in all regions except as noted in the
+	// following table.
 	//
 	// For a complete listing of node types and specifications, see Amazon ElastiCache
 	// Product Features and Details (http://aws.amazon.com/elasticache/details)
@@ -6027,11 +6145,10 @@ type CreateCacheClusterInput struct {
 	// If you do not specify this parameter, ElastiCache automatically chooses an
 	// appropriate time range.
 	//
-	// Note: This parameter is only valid if the Engine parameter is redis.
+	// This parameter is only valid if the Engine parameter is redis.
 	SnapshotWindow *string `type:"string"`
 
-	// A list of cost allocation tags to be added to this resource. A tag is a key-value
-	// pair. A tag key must be accompanied by a tag value.
+	// A list of cost allocation tags to be added to this resource.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
 }
 
@@ -6510,7 +6627,27 @@ func (s *CreateCacheSubnetGroupOutput) SetCacheSubnetGroup(v *CacheSubnetGroup) 
 type CreateReplicationGroupInput struct {
 	_ struct{} `type:"structure"`
 
+	// A flag that enables encryption at rest when set to true.
+	//
+	// You cannot modify the value of AtRestEncryptionEnabled after the replication
+	// group is created. To enable encryption at rest on a replication group you
+	// must set AtRestEncryptionEnabled to true when you create the replication
+	// group.
+	//
+	// This parameter is valid only if the Engine parameter is redis and the cluster
+	// is being created in an Amazon VPC.
+	//
+	// Default: false
+	AtRestEncryptionEnabled *bool `type:"boolean"`
+
 	// Reserved parameter. The password used to access a password protected server.
+	//
+	// This parameter is valid only if:
+	//
+	//    * The parameter TransitEncryptionEnabled was set to true when the cluster
+	//    was created.
+	//
+	//    * The line requirepass was added to the database configuration file.
 	//
 	// Password constraints:
 	//
@@ -6518,10 +6655,10 @@ type CreateReplicationGroupInput struct {
 	//
 	//    * Must be at least 16 characters and no more than 128 characters in length.
 	//
-	//    * Cannot contain any of the following characters: '/', '"', or "@".
+	//    * Cannot contain any of the following characters: '/', '"', or '@'.
 	//
 	// For more information, see AUTH password (http://redis.io/commands/AUTH) at
-	// Redis.
+	// http://redis.io/commands/AUTH.
 	AuthToken *string `type:"string"`
 
 	// This parameter is currently disabled.
@@ -6538,48 +6675,72 @@ type CreateReplicationGroupInput struct {
 	//
 	// Default: false
 	//
-	// ElastiCache Multi-AZ replication groups is not supported on:
+	// Amazon ElastiCache for Redis does not support Multi-AZ with automatic failover
+	// on:
 	//
-	// Redis versions earlier than 2.8.6.
+	//    * Redis versions earlier than 2.8.6.
 	//
-	// Redis (cluster mode disabled): T1 and T2 node types.
+	//    * Redis (cluster mode disabled): T1 and T2 cache node types.
 	//
-	// Redis (cluster mode enabled): T2 node types.
+	//    * Redis (cluster mode enabled): T1 node types.
 	AutomaticFailoverEnabled *bool `type:"boolean"`
 
 	// The compute and memory capacity of the nodes in the node group (shard).
 	//
-	// Valid node types are as follows:
+	// The following node types are supported by ElastiCache. Generally speaking,
+	// the current generation types provide more memory and computational power
+	// at lower cost when compared to their equivalent previous generation counterparts.
 	//
 	//    * General purpose:
 	//
-	// Current generation: cache.t2.micro, cache.t2.small, cache.t2.medium, cache.m3.medium,
-	//    cache.m3.large, cache.m3.xlarge, cache.m3.2xlarge, cache.m4.large, cache.m4.xlarge,
-	//    cache.m4.2xlarge, cache.m4.4xlarge, cache.m4.10xlarge
+	// Current generation:
 	//
-	// Previous generation: cache.t1.micro, cache.m1.small, cache.m1.medium, cache.m1.large,
-	//    cache.m1.xlarge
+	// T2 node types:cache.t2.micro, cache.t2.small, cache.t2.medium
 	//
-	//    * Compute optimized: cache.c1.xlarge
+	// M3 node types:cache.m3.medium, cache.m3.large, cache.m3.xlarge, cache.m3.2xlarge
+	//
+	// M4 node types:cache.m4.large, cache.m4.xlarge, cache.m4.2xlarge, cache.m4.4xlarge,
+	//    cache.m4.10xlarge
+	//
+	// Previous generation: (not recommended)
+	//
+	// T1 node types:cache.t1.micro
+	//
+	// M1 node types:cache.m1.small, cache.m1.medium, cache.m1.large, cache.m1.xlarge
+	//
+	//    * Compute optimized:
+	//
+	// Previous generation: (not recommended)
+	//
+	// C1 node types:cache.c1.xlarge
 	//
 	//    * Memory optimized:
 	//
-	// Current generation: cache.r3.large, cache.r3.xlarge, cache.r3.2xlarge, cache.r3.4xlarge,
+	// Current generation:
+	//
+	// R3 node types:cache.r3.large, cache.r3.xlarge, cache.r3.2xlarge, cache.r3.4xlarge,
 	//    cache.r3.8xlarge
 	//
-	// Previous generation: cache.m2.xlarge, cache.m2.2xlarge, cache.m2.4xlarge
+	// Previous generation: (not recommended)
+	//
+	// M2 node types:cache.m2.xlarge, cache.m2.2xlarge, cache.m2.4xlarge
 	//
 	// Notes:
 	//
 	//    * All T2 instances are created in an Amazon Virtual Private Cloud (Amazon
 	//    VPC).
 	//
-	//    * Redis backup/restore is not supported for Redis (cluster mode disabled)
-	//    T1 and T2 instances. Backup/restore is supported on Redis (cluster mode
-	//    enabled) T2 instances.
+	//    * Redis (cluster mode disabled): Redis backup/restore is not supported
+	//    on T1 and T2 instances.
+	//
+	//    * Redis (cluster mode enabled): Backup/restore is not supported on T1
+	//    instances.
 	//
 	//    * Redis Append-only files (AOF) functionality is not supported for T1
 	//    or T2 instances.
+	//
+	// Supported node types are available in all regions except as noted in the
+	// following table.
 	//
 	// For a complete listing of node types and specifications, see Amazon ElastiCache
 	// Product Features and Details (http://aws.amazon.com/elasticache/details)
@@ -6753,23 +6914,17 @@ type CreateReplicationGroupInput struct {
 	// of node groups configured by NodeGroupConfiguration regardless of the number
 	// of ARNs specified here.
 	//
-	// This parameter is only valid if the Engine parameter is redis.
-	//
 	// Example of an Amazon S3 ARN: arn:aws:s3:::my_bucket/snapshot1.rdb
 	SnapshotArns []*string `locationNameList:"SnapshotArn" type:"list"`
 
 	// The name of a snapshot from which to restore data into the new replication
 	// group. The snapshot status changes to restoring while the new replication
 	// group is being created.
-	//
-	// This parameter is only valid if the Engine parameter is redis.
 	SnapshotName *string `type:"string"`
 
 	// The number of days for which ElastiCache retains automatic snapshots before
 	// deleting them. For example, if you set SnapshotRetentionLimit to 5, a snapshot
 	// that was taken today is retained for 5 days before being deleted.
-	//
-	// This parameter is only valid if the Engine parameter is redis.
 	//
 	// Default: 0 (i.e., automatic backups are disabled for this cache cluster).
 	SnapshotRetentionLimit *int64 `type:"integer"`
@@ -6781,13 +6936,26 @@ type CreateReplicationGroupInput struct {
 	//
 	// If you do not specify this parameter, ElastiCache automatically chooses an
 	// appropriate time range.
-	//
-	// This parameter is only valid if the Engine parameter is redis.
 	SnapshotWindow *string `type:"string"`
 
 	// A list of cost allocation tags to be added to this resource. A tag is a key-value
-	// pair. A tag key must be accompanied by a tag value.
+	// pair.
 	Tags []*Tag `locationNameList:"Tag" type:"list"`
+
+	// A flag that enables in-transit encryption when set to true.
+	//
+	// You cannot modify the value of TransitEncryptionEnabled after the cluster
+	// is created. To enable in-transit encryption on a cluster you must set TransitEncryptionEnabled
+	// to true when you create a cluster.
+	//
+	// This parameter is valid only if the Engine parameter is redis, the EngineVersion
+	// parameter is 3.2.4 or later, and the cluster is being created in an Amazon
+	// VPC.
+	//
+	// If you enable in-transit encryption, you must also specify a value for CacheSubnetGroup.
+	//
+	// Default: false
+	TransitEncryptionEnabled *bool `type:"boolean"`
 }
 
 // String returns the string representation
@@ -6814,6 +6982,12 @@ func (s *CreateReplicationGroupInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAtRestEncryptionEnabled sets the AtRestEncryptionEnabled field's value.
+func (s *CreateReplicationGroupInput) SetAtRestEncryptionEnabled(v bool) *CreateReplicationGroupInput {
+	s.AtRestEncryptionEnabled = &v
+	return s
 }
 
 // SetAuthToken sets the AuthToken field's value.
@@ -6969,6 +7143,12 @@ func (s *CreateReplicationGroupInput) SetSnapshotWindow(v string) *CreateReplica
 // SetTags sets the Tags field's value.
 func (s *CreateReplicationGroupInput) SetTags(v []*Tag) *CreateReplicationGroupInput {
 	s.Tags = v
+	return s
+}
+
+// SetTransitEncryptionEnabled sets the TransitEncryptionEnabled field's value.
+func (s *CreateReplicationGroupInput) SetTransitEncryptionEnabled(v bool) *CreateReplicationGroupInput {
+	s.TransitEncryptionEnabled = &v
 	return s
 }
 
@@ -8415,37 +8595,60 @@ type DescribeReservedCacheNodesInput struct {
 	// The cache node type filter value. Use this parameter to show only those reservations
 	// matching the specified cache node type.
 	//
-	// Valid node types are as follows:
+	// The following node types are supported by ElastiCache. Generally speaking,
+	// the current generation types provide more memory and computational power
+	// at lower cost when compared to their equivalent previous generation counterparts.
 	//
 	//    * General purpose:
 	//
-	// Current generation: cache.t2.micro, cache.t2.small, cache.t2.medium, cache.m3.medium,
-	//    cache.m3.large, cache.m3.xlarge, cache.m3.2xlarge, cache.m4.large, cache.m4.xlarge,
-	//    cache.m4.2xlarge, cache.m4.4xlarge, cache.m4.10xlarge
+	// Current generation:
 	//
-	// Previous generation: cache.t1.micro, cache.m1.small, cache.m1.medium, cache.m1.large,
-	//    cache.m1.xlarge
+	// T2 node types:cache.t2.micro, cache.t2.small, cache.t2.medium
 	//
-	//    * Compute optimized: cache.c1.xlarge
+	// M3 node types:cache.m3.medium, cache.m3.large, cache.m3.xlarge, cache.m3.2xlarge
+	//
+	// M4 node types:cache.m4.large, cache.m4.xlarge, cache.m4.2xlarge, cache.m4.4xlarge,
+	//    cache.m4.10xlarge
+	//
+	// Previous generation: (not recommended)
+	//
+	// T1 node types:cache.t1.micro
+	//
+	// M1 node types:cache.m1.small, cache.m1.medium, cache.m1.large, cache.m1.xlarge
+	//
+	//    * Compute optimized:
+	//
+	// Previous generation: (not recommended)
+	//
+	// C1 node types:cache.c1.xlarge
 	//
 	//    * Memory optimized:
 	//
-	// Current generation: cache.r3.large, cache.r3.xlarge, cache.r3.2xlarge, cache.r3.4xlarge,
+	// Current generation:
+	//
+	// R3 node types:cache.r3.large, cache.r3.xlarge, cache.r3.2xlarge, cache.r3.4xlarge,
 	//    cache.r3.8xlarge
 	//
-	// Previous generation: cache.m2.xlarge, cache.m2.2xlarge, cache.m2.4xlarge
+	// Previous generation: (not recommended)
+	//
+	// M2 node types:cache.m2.xlarge, cache.m2.2xlarge, cache.m2.4xlarge
 	//
 	// Notes:
 	//
 	//    * All T2 instances are created in an Amazon Virtual Private Cloud (Amazon
 	//    VPC).
 	//
-	//    * Redis backup/restore is not supported for Redis (cluster mode disabled)
-	//    T1 and T2 instances. Backup/restore is supported on Redis (cluster mode
-	//    enabled) T2 instances.
+	//    * Redis (cluster mode disabled): Redis backup/restore is not supported
+	//    on T1 and T2 instances.
+	//
+	//    * Redis (cluster mode enabled): Backup/restore is not supported on T1
+	//    instances.
 	//
 	//    * Redis Append-only files (AOF) functionality is not supported for T1
 	//    or T2 instances.
+	//
+	// Supported node types are available in all regions except as noted in the
+	// following table.
 	//
 	// For a complete listing of node types and specifications, see Amazon ElastiCache
 	// Product Features and Details (http://aws.amazon.com/elasticache/details)
@@ -8558,37 +8761,60 @@ type DescribeReservedCacheNodesOfferingsInput struct {
 	// The cache node type filter value. Use this parameter to show only the available
 	// offerings matching the specified cache node type.
 	//
-	// Valid node types are as follows:
+	// The following node types are supported by ElastiCache. Generally speaking,
+	// the current generation types provide more memory and computational power
+	// at lower cost when compared to their equivalent previous generation counterparts.
 	//
 	//    * General purpose:
 	//
-	// Current generation: cache.t2.micro, cache.t2.small, cache.t2.medium, cache.m3.medium,
-	//    cache.m3.large, cache.m3.xlarge, cache.m3.2xlarge, cache.m4.large, cache.m4.xlarge,
-	//    cache.m4.2xlarge, cache.m4.4xlarge, cache.m4.10xlarge
+	// Current generation:
 	//
-	// Previous generation: cache.t1.micro, cache.m1.small, cache.m1.medium, cache.m1.large,
-	//    cache.m1.xlarge
+	// T2 node types:cache.t2.micro, cache.t2.small, cache.t2.medium
 	//
-	//    * Compute optimized: cache.c1.xlarge
+	// M3 node types:cache.m3.medium, cache.m3.large, cache.m3.xlarge, cache.m3.2xlarge
+	//
+	// M4 node types:cache.m4.large, cache.m4.xlarge, cache.m4.2xlarge, cache.m4.4xlarge,
+	//    cache.m4.10xlarge
+	//
+	// Previous generation: (not recommended)
+	//
+	// T1 node types:cache.t1.micro
+	//
+	// M1 node types:cache.m1.small, cache.m1.medium, cache.m1.large, cache.m1.xlarge
+	//
+	//    * Compute optimized:
+	//
+	// Previous generation: (not recommended)
+	//
+	// C1 node types:cache.c1.xlarge
 	//
 	//    * Memory optimized:
 	//
-	// Current generation: cache.r3.large, cache.r3.xlarge, cache.r3.2xlarge, cache.r3.4xlarge,
+	// Current generation:
+	//
+	// R3 node types:cache.r3.large, cache.r3.xlarge, cache.r3.2xlarge, cache.r3.4xlarge,
 	//    cache.r3.8xlarge
 	//
-	// Previous generation: cache.m2.xlarge, cache.m2.2xlarge, cache.m2.4xlarge
+	// Previous generation: (not recommended)
+	//
+	// M2 node types:cache.m2.xlarge, cache.m2.2xlarge, cache.m2.4xlarge
 	//
 	// Notes:
 	//
 	//    * All T2 instances are created in an Amazon Virtual Private Cloud (Amazon
 	//    VPC).
 	//
-	//    * Redis backup/restore is not supported for Redis (cluster mode disabled)
-	//    T1 and T2 instances. Backup/restore is supported on Redis (cluster mode
-	//    enabled) T2 instances.
+	//    * Redis (cluster mode disabled): Redis backup/restore is not supported
+	//    on T1 and T2 instances.
+	//
+	//    * Redis (cluster mode enabled): Backup/restore is not supported on T1
+	//    instances.
 	//
 	//    * Redis Append-only files (AOF) functionality is not supported for T1
 	//    or T2 instances.
+	//
+	// Supported node types are available in all regions except as noted in the
+	// following table.
 	//
 	// For a complete listing of node types and specifications, see Amazon ElastiCache
 	// Product Features and Details (http://aws.amazon.com/elasticache/details)
@@ -9250,8 +9476,8 @@ type ModifyCacheClusterInput struct {
 	// and the value of NumCacheNodes in the request.
 	//
 	// For example: If you have 3 active cache nodes, 7 pending cache nodes, and
-	// the number of cache nodes in this ModifyCacheCluser call is 5, you must list
-	// 2 (7 - 5) cache node IDs to remove.
+	// the number of cache nodes in this ModifyCacheCluster call is 5, you must
+	// list 2 (7 - 5) cache node IDs to remove.
 	CacheNodeIdsToRemove []*string `locationNameList:"CacheNodeId" type:"list"`
 
 	// A valid cache node type that you want to scale this cache cluster up to.
@@ -9763,13 +9989,14 @@ type ModifyReplicationGroupInput struct {
 	//
 	// Valid values: true | false
 	//
-	// ElastiCache Multi-AZ replication groups are not supported on:
+	// Amazon ElastiCache for Redis does not support Multi-AZ with automatic failover
+	// on:
 	//
-	// Redis versions earlier than 2.8.6.
+	//    * Redis versions earlier than 2.8.6.
 	//
-	// Redis (cluster mode disabled):T1 and T2 cache node types.
+	//    * Redis (cluster mode disabled): T1 and T2 cache node types.
 	//
-	// Redis (cluster mode enabled): T1 node types.
+	//    * Redis (cluster mode enabled): T1 node types.
 	AutomaticFailoverEnabled *bool `type:"boolean"`
 
 	// A valid cache node type that you want to scale this replication group to.
@@ -10811,15 +11038,31 @@ func (s *RemoveTagsFromResourceInput) SetTagKeys(v []*string) *RemoveTagsFromRes
 type ReplicationGroup struct {
 	_ struct{} `type:"structure"`
 
-	// Indicates the status of Multi-AZ for this replication group.
+	// A flag that enables encryption at-rest when set to true.
 	//
-	// ElastiCache Multi-AZ replication groups are not supported on:
+	// You cannot modify the value of AtRestEncryptionEnabled after the cluster
+	// is created. To enable encryption at-rest on a cluster you must set AtRestEncryptionEnabled
+	// to true when you create a cluster.
 	//
-	// Redis versions earlier than 2.8.6.
+	// Default: false
+	AtRestEncryptionEnabled *bool `type:"boolean"`
+
+	// A flag that enables using an AuthToken (password) when issuing Redis commands.
 	//
-	// Redis (cluster mode disabled):T1 and T2 cache node types.
+	// Default: false
+	AuthTokenEnabled *bool `type:"boolean"`
+
+	// Indicates the status of Multi-AZ with automatic failover for this Redis replication
+	// group.
 	//
-	// Redis (cluster mode enabled): T1 node types.
+	// Amazon ElastiCache for Redis does not support Multi-AZ with automatic failover
+	// on:
+	//
+	//    * Redis versions earlier than 2.8.6.
+	//
+	//    * Redis (cluster mode disabled): T1 and T2 cache node types.
+	//
+	//    * Redis (cluster mode enabled): T1 node types.
 	AutomaticFailover *string `type:"string" enum:"AutomaticFailoverStatus"`
 
 	// The name of the compute and memory capacity node type for each node in the
@@ -10871,7 +11114,7 @@ type ReplicationGroup struct {
 	// If you do not specify this parameter, ElastiCache automatically chooses an
 	// appropriate time range.
 	//
-	// Note: This parameter is only valid if the Engine parameter is redis.
+	// This parameter is only valid if the Engine parameter is redis.
 	SnapshotWindow *string `type:"string"`
 
 	// The cache cluster ID that is used as the daily snapshot source for the replication
@@ -10881,6 +11124,15 @@ type ReplicationGroup struct {
 	// The current state of this replication group - creating, available, modifying,
 	// deleting, create-failed, snapshotting.
 	Status *string `type:"string"`
+
+	// A flag that enables in-transit encryption when set to true.
+	//
+	// You cannot modify the value of TransitEncryptionEnabled after the cluster
+	// is created. To enable in-transit encryption on a cluster you must set TransitEncryptionEnabled
+	// to true when you create a cluster.
+	//
+	// Default: false
+	TransitEncryptionEnabled *bool `type:"boolean"`
 }
 
 // String returns the string representation
@@ -10891,6 +11143,18 @@ func (s ReplicationGroup) String() string {
 // GoString returns the string representation
 func (s ReplicationGroup) GoString() string {
 	return s.String()
+}
+
+// SetAtRestEncryptionEnabled sets the AtRestEncryptionEnabled field's value.
+func (s *ReplicationGroup) SetAtRestEncryptionEnabled(v bool) *ReplicationGroup {
+	s.AtRestEncryptionEnabled = &v
+	return s
+}
+
+// SetAuthTokenEnabled sets the AuthTokenEnabled field's value.
+func (s *ReplicationGroup) SetAuthTokenEnabled(v bool) *ReplicationGroup {
+	s.AuthTokenEnabled = &v
+	return s
 }
 
 // SetAutomaticFailover sets the AutomaticFailover field's value.
@@ -10971,21 +11235,29 @@ func (s *ReplicationGroup) SetStatus(v string) *ReplicationGroup {
 	return s
 }
 
+// SetTransitEncryptionEnabled sets the TransitEncryptionEnabled field's value.
+func (s *ReplicationGroup) SetTransitEncryptionEnabled(v bool) *ReplicationGroup {
+	s.TransitEncryptionEnabled = &v
+	return s
+}
+
 // The settings to be applied to the Redis replication group, either immediately
 // or during the next maintenance window.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/ReplicationGroupPendingModifiedValues
 type ReplicationGroupPendingModifiedValues struct {
 	_ struct{} `type:"structure"`
 
-	// Indicates the status of Multi-AZ for this Redis replication group.
+	// Indicates the status of Multi-AZ with automatic failover for this Redis replication
+	// group.
 	//
-	// ElastiCache Multi-AZ replication groups are not supported on:
+	// Amazon ElastiCache for Redis does not support Multi-AZ with automatic failover
+	// on:
 	//
-	// Redis versions earlier than 2.8.6.
+	//    * Redis versions earlier than 2.8.6.
 	//
-	// Redis (cluster mode disabled):T1 and T2 cache node types.
+	//    * Redis (cluster mode disabled): T1 and T2 cache node types.
 	//
-	// Redis (cluster mode enabled): T1 node types.
+	//    * Redis (cluster mode enabled): T1 node types.
 	AutomaticFailoverStatus *string `type:"string" enum:"PendingAutomaticFailoverStatus"`
 
 	// The primary cluster ID that is applied immediately (if --apply-immediately
@@ -11025,37 +11297,60 @@ type ReservedCacheNode struct {
 
 	// The cache node type for the reserved cache nodes.
 	//
-	// Valid node types are as follows:
+	// The following node types are supported by ElastiCache. Generally speaking,
+	// the current generation types provide more memory and computational power
+	// at lower cost when compared to their equivalent previous generation counterparts.
 	//
 	//    * General purpose:
 	//
-	// Current generation: cache.t2.micro, cache.t2.small, cache.t2.medium, cache.m3.medium,
-	//    cache.m3.large, cache.m3.xlarge, cache.m3.2xlarge, cache.m4.large, cache.m4.xlarge,
-	//    cache.m4.2xlarge, cache.m4.4xlarge, cache.m4.10xlarge
+	// Current generation:
 	//
-	// Previous generation: cache.t1.micro, cache.m1.small, cache.m1.medium, cache.m1.large,
-	//    cache.m1.xlarge
+	// T2 node types:cache.t2.micro, cache.t2.small, cache.t2.medium
 	//
-	//    * Compute optimized: cache.c1.xlarge
+	// M3 node types:cache.m3.medium, cache.m3.large, cache.m3.xlarge, cache.m3.2xlarge
+	//
+	// M4 node types:cache.m4.large, cache.m4.xlarge, cache.m4.2xlarge, cache.m4.4xlarge,
+	//    cache.m4.10xlarge
+	//
+	// Previous generation: (not recommended)
+	//
+	// T1 node types:cache.t1.micro
+	//
+	// M1 node types:cache.m1.small, cache.m1.medium, cache.m1.large, cache.m1.xlarge
+	//
+	//    * Compute optimized:
+	//
+	// Previous generation: (not recommended)
+	//
+	// C1 node types:cache.c1.xlarge
 	//
 	//    * Memory optimized:
 	//
-	// Current generation: cache.r3.large, cache.r3.xlarge, cache.r3.2xlarge, cache.r3.4xlarge,
+	// Current generation:
+	//
+	// R3 node types:cache.r3.large, cache.r3.xlarge, cache.r3.2xlarge, cache.r3.4xlarge,
 	//    cache.r3.8xlarge
 	//
-	// Previous generation: cache.m2.xlarge, cache.m2.2xlarge, cache.m2.4xlarge
+	// Previous generation: (not recommended)
+	//
+	// M2 node types:cache.m2.xlarge, cache.m2.2xlarge, cache.m2.4xlarge
 	//
 	// Notes:
 	//
 	//    * All T2 instances are created in an Amazon Virtual Private Cloud (Amazon
 	//    VPC).
 	//
-	//    * Redis backup/restore is not supported for Redis (cluster mode disabled)
-	//    T1 and T2 instances. Backup/restore is supported on Redis (cluster mode
-	//    enabled) T2 instances.
+	//    * Redis (cluster mode disabled): Redis backup/restore is not supported
+	//    on T1 and T2 instances.
+	//
+	//    * Redis (cluster mode enabled): Backup/restore is not supported on T1
+	//    instances.
 	//
 	//    * Redis Append-only files (AOF) functionality is not supported for T1
 	//    or T2 instances.
+	//
+	// Supported node types are available in all regions except as noted in the
+	// following table.
 	//
 	// For a complete listing of node types and specifications, see Amazon ElastiCache
 	// Product Features and Details (http://aws.amazon.com/elasticache/details)
@@ -11183,37 +11478,60 @@ type ReservedCacheNodesOffering struct {
 
 	// The cache node type for the reserved cache node.
 	//
-	// Valid node types are as follows:
+	// The following node types are supported by ElastiCache. Generally speaking,
+	// the current generation types provide more memory and computational power
+	// at lower cost when compared to their equivalent previous generation counterparts.
 	//
 	//    * General purpose:
 	//
-	// Current generation: cache.t2.micro, cache.t2.small, cache.t2.medium, cache.m3.medium,
-	//    cache.m3.large, cache.m3.xlarge, cache.m3.2xlarge, cache.m4.large, cache.m4.xlarge,
-	//    cache.m4.2xlarge, cache.m4.4xlarge, cache.m4.10xlarge
+	// Current generation:
 	//
-	// Previous generation: cache.t1.micro, cache.m1.small, cache.m1.medium, cache.m1.large,
-	//    cache.m1.xlarge
+	// T2 node types:cache.t2.micro, cache.t2.small, cache.t2.medium
 	//
-	//    * Compute optimized: cache.c1.xlarge
+	// M3 node types:cache.m3.medium, cache.m3.large, cache.m3.xlarge, cache.m3.2xlarge
+	//
+	// M4 node types:cache.m4.large, cache.m4.xlarge, cache.m4.2xlarge, cache.m4.4xlarge,
+	//    cache.m4.10xlarge
+	//
+	// Previous generation: (not recommended)
+	//
+	// T1 node types:cache.t1.micro
+	//
+	// M1 node types:cache.m1.small, cache.m1.medium, cache.m1.large, cache.m1.xlarge
+	//
+	//    * Compute optimized:
+	//
+	// Previous generation: (not recommended)
+	//
+	// C1 node types:cache.c1.xlarge
 	//
 	//    * Memory optimized:
 	//
-	// Current generation: cache.r3.large, cache.r3.xlarge, cache.r3.2xlarge, cache.r3.4xlarge,
+	// Current generation:
+	//
+	// R3 node types:cache.r3.large, cache.r3.xlarge, cache.r3.2xlarge, cache.r3.4xlarge,
 	//    cache.r3.8xlarge
 	//
-	// Previous generation: cache.m2.xlarge, cache.m2.2xlarge, cache.m2.4xlarge
+	// Previous generation: (not recommended)
+	//
+	// M2 node types:cache.m2.xlarge, cache.m2.2xlarge, cache.m2.4xlarge
 	//
 	// Notes:
 	//
 	//    * All T2 instances are created in an Amazon Virtual Private Cloud (Amazon
 	//    VPC).
 	//
-	//    * Redis backup/restore is not supported for Redis (cluster mode disabled)
-	//    T1 and T2 instances. Backup/restore is supported on Redis (cluster mode
-	//    enabled) T2 instances.
+	//    * Redis (cluster mode disabled): Redis backup/restore is not supported
+	//    on T1 and T2 instances.
+	//
+	//    * Redis (cluster mode enabled): Backup/restore is not supported on T1
+	//    instances.
 	//
 	//    * Redis Append-only files (AOF) functionality is not supported for T1
 	//    or T2 instances.
+	//
+	// Supported node types are available in all regions except as noted in the
+	// following table.
 	//
 	// For a complete listing of node types and specifications, see Amazon ElastiCache
 	// Product Features and Details (http://aws.amazon.com/elasticache/details)
@@ -11510,15 +11828,17 @@ type Snapshot struct {
 	// This parameter is currently disabled.
 	AutoMinorVersionUpgrade *bool `type:"boolean"`
 
-	// Indicates the status of Multi-AZ for the source replication group.
+	// Indicates the status of Multi-AZ with automatic failover for the source Redis
+	// replication group.
 	//
-	// ElastiCache Multi-AZ replication groups are not supported on:
+	// Amazon ElastiCache for Redis does not support Multi-AZ with automatic failover
+	// on:
 	//
-	// Redis versions earlier than 2.8.6.
+	//    * Redis versions earlier than 2.8.6.
 	//
-	// Redis (cluster mode disabled):T1 and T2 cache node types.
+	//    * Redis (cluster mode disabled): T1 and T2 cache node types.
 	//
-	// Redis (cluster mode enabled): T1 node types.
+	//    * Redis (cluster mode enabled): T1 node types.
 	AutomaticFailover *string `type:"string" enum:"AutomaticFailoverStatus"`
 
 	// The date and time when the source cache cluster was created.
@@ -11530,37 +11850,60 @@ type Snapshot struct {
 	// The name of the compute and memory capacity node type for the source cache
 	// cluster.
 	//
-	// Valid node types are as follows:
+	// The following node types are supported by ElastiCache. Generally speaking,
+	// the current generation types provide more memory and computational power
+	// at lower cost when compared to their equivalent previous generation counterparts.
 	//
 	//    * General purpose:
 	//
-	// Current generation: cache.t2.micro, cache.t2.small, cache.t2.medium, cache.m3.medium,
-	//    cache.m3.large, cache.m3.xlarge, cache.m3.2xlarge, cache.m4.large, cache.m4.xlarge,
-	//    cache.m4.2xlarge, cache.m4.4xlarge, cache.m4.10xlarge
+	// Current generation:
 	//
-	// Previous generation: cache.t1.micro, cache.m1.small, cache.m1.medium, cache.m1.large,
-	//    cache.m1.xlarge
+	// T2 node types:cache.t2.micro, cache.t2.small, cache.t2.medium
 	//
-	//    * Compute optimized: cache.c1.xlarge
+	// M3 node types:cache.m3.medium, cache.m3.large, cache.m3.xlarge, cache.m3.2xlarge
+	//
+	// M4 node types:cache.m4.large, cache.m4.xlarge, cache.m4.2xlarge, cache.m4.4xlarge,
+	//    cache.m4.10xlarge
+	//
+	// Previous generation: (not recommended)
+	//
+	// T1 node types:cache.t1.micro
+	//
+	// M1 node types:cache.m1.small, cache.m1.medium, cache.m1.large, cache.m1.xlarge
+	//
+	//    * Compute optimized:
+	//
+	// Previous generation: (not recommended)
+	//
+	// C1 node types:cache.c1.xlarge
 	//
 	//    * Memory optimized:
 	//
-	// Current generation: cache.r3.large, cache.r3.xlarge, cache.r3.2xlarge, cache.r3.4xlarge,
+	// Current generation:
+	//
+	// R3 node types:cache.r3.large, cache.r3.xlarge, cache.r3.2xlarge, cache.r3.4xlarge,
 	//    cache.r3.8xlarge
 	//
-	// Previous generation: cache.m2.xlarge, cache.m2.2xlarge, cache.m2.4xlarge
+	// Previous generation: (not recommended)
+	//
+	// M2 node types:cache.m2.xlarge, cache.m2.2xlarge, cache.m2.4xlarge
 	//
 	// Notes:
 	//
 	//    * All T2 instances are created in an Amazon Virtual Private Cloud (Amazon
 	//    VPC).
 	//
-	//    * Redis backup/restore is not supported for Redis (cluster mode disabled)
-	//    T1 and T2 instances. Backup/restore is supported on Redis (cluster mode
-	//    enabled) T2 instances.
+	//    * Redis (cluster mode disabled): Redis backup/restore is not supported
+	//    on T1 and T2 instances.
+	//
+	//    * Redis (cluster mode enabled): Backup/restore is not supported on T1
+	//    instances.
 	//
 	//    * Redis Append-only files (AOF) functionality is not supported for T1
 	//    or T2 instances.
+	//
+	// Supported node types are available in all regions except as noted in the
+	// following table.
 	//
 	// For a complete listing of node types and specifications, see Amazon ElastiCache
 	// Product Features and Details (http://aws.amazon.com/elasticache/details)

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -111,732 +111,732 @@
 			"revisionTime": "2017-07-27T15:54:43Z"
 		},
 		{
-			"checksumSHA1": "AUz0tBoY6/urP8sUZ+4kTFIzIKM=",
+			"checksumSHA1": "YhARllgSKHk/9SL4UuyM7kpXFnk=",
 			"path": "github.com/aws/aws-sdk-go/aws",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "DtuTqKH29YnLjrIJkRYX0HQtXY0=",
 			"path": "github.com/aws/aws-sdk-go/aws/arn",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "Y9W+4GimK4Fuxq+vyIskVYFRnX4=",
 			"path": "github.com/aws/aws-sdk-go/aws/awserr",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "yyYr41HZ1Aq0hWc3J5ijXwYEcac=",
 			"path": "github.com/aws/aws-sdk-go/aws/awsutil",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "n98FANpNeRT5kf6pizdpI7nm6Sw=",
 			"path": "github.com/aws/aws-sdk-go/aws/client",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "ieAJ+Cvp/PKv1LpUEnUXpc3OI6E=",
 			"path": "github.com/aws/aws-sdk-go/aws/client/metadata",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "7/8j/q0TWtOgXyvEcv4B2Dhl00o=",
 			"path": "github.com/aws/aws-sdk-go/aws/corehandlers",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "Y+cPwQL0dZMyqp3wI+KJWmA9KQ8=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "u3GOAJLmdvbuNUeUEcZSEAOeL/0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "NUJUTWlc1sV8b7WjfiYc4JZbXl0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/endpointcreds",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "JEYqmF83O5n5bHkupAzA6STm0no=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "ZdtYh3ZHSgP/WEIaqwJHTEhpkbs=",
 			"path": "github.com/aws/aws-sdk-go/aws/defaults",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "/EXbk/z2TWjWc1Hvb4QYs3Wmhb8=",
 			"path": "github.com/aws/aws-sdk-go/aws/ec2metadata",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
-			"checksumSHA1": "SB60GS485F4IhgVMuBqSvnw6/OE=",
+			"checksumSHA1": "28TXzVpyhT3JFRT3vLo/GTKc3Wc=",
 			"path": "github.com/aws/aws-sdk-go/aws/endpoints",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "n/tgGgh0wICYu+VDYSqlsRy4w9s=",
 			"path": "github.com/aws/aws-sdk-go/aws/request",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "HcGL4e6Uep4/80eCUI5xkcWjpQ0=",
 			"path": "github.com/aws/aws-sdk-go/aws/session",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "iywvraxbXf3A/FOzFWjKfBBEQRA=",
 			"path": "github.com/aws/aws-sdk-go/aws/signer/v4",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "04ypv4x12l4q0TksA1zEVsmgpvw=",
 			"path": "github.com/aws/aws-sdk-go/internal/shareddefaults",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "wk7EyvDaHwb5qqoOP/4d3cV0708=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "1QmQ3FqV37w0Zi44qv8pA1GeR0A=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/ec2query",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "O6hcK24yI6w7FA+g4Pbr+eQ7pys=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/json/jsonutil",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "R00RL5jJXRYq1iiK1+PGvMfvXyM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/jsonrpc",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "ZqY5RWavBLWTo6j9xqdyBEaNFRk=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "9V1PvtFQ9MObZTc3sa86WcuOtOU=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "VCTh+dEaqqhog5ncy/WTt9+/gFM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/rest",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "Rpu8KBtHZgvhkwHxUfaky+qW+G4=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restjson",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "ODo+ko8D6unAxZuN1jGzMcN4QCc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restxml",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "0qYPUga28aQVkxZgBR3Z86AbGUQ=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "F6mth+G7dXN1GI+nktaGo8Lx8aE=",
 			"path": "github.com/aws/aws-sdk-go/private/signer/v2",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "BXuQo73qo4WLmc+TdE5pAwalLUQ=",
 			"path": "github.com/aws/aws-sdk-go/service/acm",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "O2HA8qyuxiolOGr0a1o/mFKz/Xo=",
 			"path": "github.com/aws/aws-sdk-go/service/apigateway",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "lnbmn3cDZvFOpzV9jKe9jG7VIPs=",
 			"path": "github.com/aws/aws-sdk-go/service/applicationautoscaling",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "/C4QDOmEP7t8vawBcB7a2ygaXuI=",
 			"path": "github.com/aws/aws-sdk-go/service/athena",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "eudoAl5P0HqsQrzytWyb9uhUGU0=",
 			"path": "github.com/aws/aws-sdk-go/service/autoscaling",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "fNHsdfsdTzwSJwnfxqqGdkjT5HE=",
 			"path": "github.com/aws/aws-sdk-go/service/batch",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "s3YX7GouNkKz4U+w/Id7ivv5i2c=",
 			"path": "github.com/aws/aws-sdk-go/service/budgets",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "XPE0OmyX5xPvxP7QSdGuB7TY7AE=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudformation",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
-			"checksumSHA1": "rjq4ZWRUGvQDjnXeflafkCWYsFU=",
+			"checksumSHA1": "DOHt4R6H0di36yc9j7YEGYn78+k=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudfront",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "59kV70/8PuutX4eFkGfCCtdunIA=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudtrail",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "zm2qDEBdcJSJI3PGcE2UVr6Cxmc=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatch",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "2y8MKiWNwIVw/au7LBxCGLZusUU=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchevents",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "SGbv4ySdQtVIE7WJ+5HcNyWkbNY=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "EQj73ejMb8hAqCDC+hX4MuvJ7sk=",
 			"path": "github.com/aws/aws-sdk-go/service/codebuild",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "mr7qWrs0Aw9Pb84eyJL80Z7lxXc=",
 			"path": "github.com/aws/aws-sdk-go/service/codecommit",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "QJYewZzcmPbuN27AWiQ6XKQ9Vrw=",
 			"path": "github.com/aws/aws-sdk-go/service/codedeploy",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "y1X50fCNI6EIs5YWddiu/EAwD8o=",
 			"path": "github.com/aws/aws-sdk-go/service/codepipeline",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "7bm1eOY2oKYSesmEOd1qXvTRH2s=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentity",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "ouZ4H9foNRBFaElXZbpi5C3pqDQ=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentityprovider",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
-			"checksumSHA1": "Ryg2zV9xVlpTF1GVbP5GlYbynOc=",
+			"checksumSHA1": "A+8ZG3eKa0jnOPfwhmCMw0C6U/o=",
 			"path": "github.com/aws/aws-sdk-go/service/configservice",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "QWfHksqdET4wKa3eKEbewFC6Ues=",
 			"path": "github.com/aws/aws-sdk-go/service/databasemigrationservice",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "S4vcGUr3SNl3XKPFTqfwFanT4Cw=",
 			"path": "github.com/aws/aws-sdk-go/service/devicefarm",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "vJAA3F/3UhmdWX7s3r+5YxEUuUg=",
 			"path": "github.com/aws/aws-sdk-go/service/directconnect",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "1O8BtYGfkXglIqgl/uxunrq3Djs=",
 			"path": "github.com/aws/aws-sdk-go/service/directoryservice",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "ycd0mxQjtWfbtlk+W2N7N6QdxFw=",
 			"path": "github.com/aws/aws-sdk-go/service/dynamodb",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
-			"checksumSHA1": "FjCSAoH/OdlkitoOJeml+sEFnfI=",
+			"checksumSHA1": "vU/6dpCdnPMy35VFUju8+Dxn4sA=",
 			"path": "github.com/aws/aws-sdk-go/service/ec2",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "bovxt5atRBvLXGPHMFE1kPfTL0k=",
 			"path": "github.com/aws/aws-sdk-go/service/ecr",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "+Jyy6T5h4fYRUmU9EgV+ZtLNM80=",
 			"path": "github.com/aws/aws-sdk-go/service/ecs",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "pBkeSL8bCEbz/6ub0Jr6NsjQPSc=",
 			"path": "github.com/aws/aws-sdk-go/service/efs",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
-			"checksumSHA1": "4a4FO9D6RQluAwyYEW5H6p0Nz7I=",
+			"checksumSHA1": "X64z8R2OswIFi5btZRJUuPeGbio=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticache",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "uyG5rBbcDDiRCN6gXLXyWy0oxpQ=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticbeanstalk",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "RiXeoiTqLn4uvNIm0EDbHuvYYFw=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticsearchservice",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "zMFn+iotI5JIiB9HFRo6BiX6CZE=",
 			"path": "github.com/aws/aws-sdk-go/service/elastictranscoder",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "sp5ZmzFBI5z1+kLkRoFjfm2GWuY=",
 			"path": "github.com/aws/aws-sdk-go/service/elb",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "LjlrMBi+GR3kElFOfdV4WAJ10UU=",
 			"path": "github.com/aws/aws-sdk-go/service/elbv2",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "EEj7cYvIK+F25RIynBVArzedyPQ=",
 			"path": "github.com/aws/aws-sdk-go/service/emr",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "tuK++zhf2K0RBocTCU1ZltzS8ko=",
 			"path": "github.com/aws/aws-sdk-go/service/firehose",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "Ewp675B6bZe/eWipwJl7OXqCJRo=",
 			"path": "github.com/aws/aws-sdk-go/service/glacier",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "a+tKLYUEM3ZftY52P2ywtIxlCxE=",
 			"path": "github.com/aws/aws-sdk-go/service/iam",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "v0OUl6sTwF7EOmXyzk9ppc5ljLw=",
 			"path": "github.com/aws/aws-sdk-go/service/inspector",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "D92k3ymegRbjpgnuAy9rWjgV7vs=",
 			"path": "github.com/aws/aws-sdk-go/service/iot",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "fE6Lygzxvif/yfo9bncKyRUCqs8=",
 			"path": "github.com/aws/aws-sdk-go/service/kinesis",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "wwFYsrpInh4Tow/vTI7bD+r5gBU=",
 			"path": "github.com/aws/aws-sdk-go/service/kms",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "qu7WvUeSIFYQOqF9RXM/3w45kFg=",
 			"path": "github.com/aws/aws-sdk-go/service/lambda",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "HqzHXp/Jd+K1we+1q/K+zE4qyqw=",
 			"path": "github.com/aws/aws-sdk-go/service/lightsail",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "84rKGr+RvT8tjOalWGPKuNPC4T4=",
 			"path": "github.com/aws/aws-sdk-go/service/opsworks",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "4im5y93mxsIQgXujPiM5iRtW0J4=",
 			"path": "github.com/aws/aws-sdk-go/service/rds",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "dS8MjjzzX7csNyxiIpRPgHXMyss=",
 			"path": "github.com/aws/aws-sdk-go/service/redshift",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "Bx0UwkYHAU+LGL4Glg5le2UiirI=",
 			"path": "github.com/aws/aws-sdk-go/service/route53",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "QPxEB1a4X55kNCF/GlH18mOrHMA=",
 			"path": "github.com/aws/aws-sdk-go/service/s3",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "HQHIEdPu8wtbbJnECYl2HM9Ul5Q=",
 			"path": "github.com/aws/aws-sdk-go/service/servicecatalog",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "oYKSvsZejNuttYCnuAzw6Lq33FY=",
 			"path": "github.com/aws/aws-sdk-go/service/ses",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "u8xk+JtK/HwIKB2ume3or9Sstp8=",
 			"path": "github.com/aws/aws-sdk-go/service/sfn",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "6DiA9x0ibBF3ZBnILXiugtdTufc=",
 			"path": "github.com/aws/aws-sdk-go/service/shield",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "hOcVb1zJiDUmafXSJQhkEascWwA=",
 			"path": "github.com/aws/aws-sdk-go/service/simpledb",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "1jN0ZDW5c9QEGSQIQ+KrbTACvm8=",
 			"path": "github.com/aws/aws-sdk-go/service/sns",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "vo3NUCT5DQeQc52HHfht8sCuaA4=",
 			"path": "github.com/aws/aws-sdk-go/service/sqs",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "jo8D8FG1KSYxqP5z9saasDziQLA=",
 			"path": "github.com/aws/aws-sdk-go/service/ssm",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "MerduaV3PxtZAWvOGpgoBIglo38=",
 			"path": "github.com/aws/aws-sdk-go/service/sts",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "4uvhHpzIP35jxtM1Iy0RsUPOaDg=",
 			"path": "github.com/aws/aws-sdk-go/service/waf",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "I0siM+RU1WsSwc6Pd9e3sRei7zM=",
 			"path": "github.com/aws/aws-sdk-go/service/wafregional",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "OHfwSU+p4N0Ft+BrzJfdE6AVRsY=",
 			"path": "github.com/aws/aws-sdk-go/service/workspaces",
-			"revision": "1e7792b681d9bc32eff919999321b2589e891688",
-			"revisionTime": "2017-10-19T22:20:31Z",
-			"version": "v1.12.14",
-			"versionExact": "v1.12.14"
+			"revision": "ee1f179877b2daf2aaabf71fa900773bf8842253",
+			"revisionTime": "2017-10-26T21:07:55Z",
+			"version": "v1.12.19",
+			"versionExact": "v1.12.19"
 		},
 		{
 			"checksumSHA1": "nqw2Qn5xUklssHTubS5HDvEL9L4=",


### PR DESCRIPTION
Required for
* https://github.com/terraform-providers/terraform-provider-aws/issues/2087

```
govendor fetch github.com/aws/aws-sdk-go/aws/...@v1.12.19
govendor fetch github.com/aws/aws-sdk-go/internal/...@v1.12.19
govendor fetch github.com/aws/aws-sdk-go/private/...@v1.12.19
govendor fetch github.com/aws/aws-sdk-go/service/...@v1.12.19
```