### PR TITLE
Add Redis AUTH, in-transit and at-rest encryption

### DIFF
--- a/aws/resource_aws_elasticache_replication_group.go
+++ b/aws/resource_aws_elasticache_replication_group.go
@@ -87,14 +87,14 @@ func resourceAwsElasticacheReplicationGroup() *schema.Resource {
 	resourceSchema["engine"].Default = "redis"
 	resourceSchema["engine"].ValidateFunc = validateAwsElastiCacheReplicationGroupEngine
 
-	resourceSchema["at_rest_encryption"] = &schema.Schema{
+	resourceSchema["at_rest_encryption_enabled"] = &schema.Schema{
 		Type:     schema.TypeBool,
 		Optional: true,
 		Default:  false,
 		ForceNew: true,
 	}
 
-	resourceSchema["transit_encryption"] = &schema.Schema{
+	resourceSchema["transit_encryption_enabled"] = &schema.Schema{
 		Type:     schema.TypeBool,
 		Optional: true,
 		Default:  false,
@@ -190,12 +190,12 @@ func resourceAwsElasticacheReplicationGroupCreate(d *schema.ResourceData, meta i
 		params.SnapshotName = aws.String(v.(string))
 	}
 
-	if _, ok := d.GetOk("transit_encryption"); ok {
-		params.TransitEncryptionEnabled = aws.Bool(d.Get("transit_encryption").(bool))
+	if _, ok := d.GetOk("transit_encryption_enabled"); ok {
+		params.TransitEncryptionEnabled = aws.Bool(d.Get("transit_encryption_enabled").(bool))
 	}
 
-	if _, ok := d.GetOk("at_rest_encryption"); ok {
-		params.AtRestEncryptionEnabled = aws.Bool(d.Get("at_rest_encryption").(bool))
+	if _, ok := d.GetOk("at_rest_encryption_enabled"); ok {
+		params.AtRestEncryptionEnabled = aws.Bool(d.Get("at_rest_encryption_enabled").(bool))
 	}
 
 	if v, ok := d.GetOk("auth_token"); ok {
@@ -347,8 +347,8 @@ func resourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta int
 		}
 
 		d.Set("auto_minor_version_upgrade", c.AutoMinorVersionUpgrade)
-		d.Set("at_rest_encryption", c.AtRestEncryptionEnabled)
-		d.Set("transit_encryption", c.TransitEncryptionEnabled)
+		d.Set("at_rest_encryption_enabled", c.AtRestEncryptionEnabled)
+		d.Set("transit_encryption_enabled", c.TransitEncryptionEnabled)
 		d.Set("auth_token", c.TransitEncryptionEnabled)
 	}
 

--- a/aws/resource_aws_elasticache_replication_group.go
+++ b/aws/resource_aws_elasticache_replication_group.go
@@ -572,16 +572,3 @@ func validateAwsElastiCacheReplicationGroupId(v interface{}, k string) (ws []str
 	}
 	return
 }
-
-func validateAwsElastiCacheReplicationGroupAuthToken(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if (len(value) < 16) || (len(value) > 128) {
-		errors = append(errors, fmt.Errorf(
-			"%q must contain from 16 to 128 alphanumeric characters or symbols (excluding @, \", and /)", k))
-	}
-	if !regexp.MustCompile(`^[^@"\/]+$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"only alphanumeric characters or symbols (excluding @, \", and /) allowed in %q", k))
-	}
-	return
-}

--- a/aws/resource_aws_elasticache_replication_group.go
+++ b/aws/resource_aws_elasticache_replication_group.go
@@ -349,7 +349,10 @@ func resourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta int
 		d.Set("auto_minor_version_upgrade", c.AutoMinorVersionUpgrade)
 		d.Set("at_rest_encryption_enabled", c.AtRestEncryptionEnabled)
 		d.Set("transit_encryption_enabled", c.TransitEncryptionEnabled)
-		d.Set("auth_token", c.TransitEncryptionEnabled)
+
+		if c.AuthTokenEnabled != nil && !*c.AuthTokenEnabled {
+			d.Set("auth_token", nil)
+		}
 	}
 
 	return nil

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -347,7 +347,7 @@ func TestAccAWSElasticacheReplicationGroup_enableAuthTokenTransitEncryption(t *t
 		CheckDestroy: testAccCheckAWSElasticacheReplicationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSElasticacheReplicationGroupEnableAuthTokenTransitEncryptionConfig,
+				Config: testAccAWSElasticacheReplicationGroup_EnableAuthTokenTransitEncryptionConfig(acctest.RandInt(), acctest.RandString(10), acctest.RandString(16)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
 					resource.TestCheckResourceAttr(
@@ -366,7 +366,7 @@ func TestAccAWSElasticacheReplicationGroup_enableAtRestEncryption(t *testing.T) 
 		CheckDestroy: testAccCheckAWSElasticacheReplicationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSElasticacheReplicationGroupEnableAtRestEncryptionConfig,
+				Config: testAccAWSElasticacheReplicationGroup_EnableAtRestEncryptionConfig(acctest.RandInt(), acctest.RandString(10)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
 					resource.TestCheckResourceAttr(
@@ -1041,107 +1041,111 @@ resource "aws_elasticache_replication_group" "bar" {
 }`, rInt, rInt, rInt, rInt, rName)
 }
 
-var testAccAWSElasticacheReplicationGroupEnableAtRestEncryptionConfig = fmt.Sprintf(`
-resource "aws_vpc" "foo" {
-    cidr_block = "192.168.0.0/16"
-    tags {
-            Name = "tf-test"
-    }
+func testAccAWSElasticacheReplicationGroup_EnableAtRestEncryptionConfig(rInt int, rString string) string {
+	return fmt.Sprintf(`
+	resource "aws_vpc" "foo" {
+			cidr_block = "192.168.0.0/16"
+			tags {
+							Name = "tf-test"
+			}
+	}
+
+	resource "aws_subnet" "foo" {
+			vpc_id = "${aws_vpc.foo.id}"
+			cidr_block = "192.168.0.0/20"
+			availability_zone = "us-west-2a"
+			tags {
+							Name = "tf-test-%03d"
+			}
+	}
+
+	resource "aws_elasticache_subnet_group" "bar" {
+			name = "tf-test-cache-subnet-%03d"
+			description = "tf-test-cache-subnet-group-descr"
+			subnet_ids = [
+					"${aws_subnet.foo.id}",
+			]
+	}
+
+	resource "aws_security_group" "bar" {
+			name = "tf-test-security-group-%03d"
+			description = "tf-test-security-group-descr"
+			vpc_id = "${aws_vpc.foo.id}"
+			ingress {
+					from_port = -1
+					to_port = -1
+					protocol = "icmp"
+					cidr_blocks = ["0.0.0.0/0"]
+			}
+	}
+
+	resource "aws_elasticache_replication_group" "bar" {
+			replication_group_id = "tf-%s"
+			replication_group_description = "test description"
+			node_type = "cache.t2.micro"
+			number_cache_clusters = "1"
+			port = 6379
+			subnet_group_name = "${aws_elasticache_subnet_group.bar.name}"
+			security_group_ids = ["${aws_security_group.bar.id}"]
+			parameter_group_name = "default.redis3.2"
+			availability_zones = ["us-west-2a"]
+			engine_version = "3.2.6"
+			at_rest_encryption_enabled = true
+	}
+	`, rInt, rInt, rInt, rString)
 }
 
-resource "aws_subnet" "foo" {
-    vpc_id = "${aws_vpc.foo.id}"
-    cidr_block = "192.168.0.0/20"
-    availability_zone = "us-west-2a"
-    tags {
-            Name = "tf-test-%03d"
-    }
-}
+func testAccAWSElasticacheReplicationGroup_EnableAuthTokenTransitEncryptionConfig(rInt int, rString10 string, rString16 string) string {
+	return fmt.Sprintf(`
+	resource "aws_vpc" "foo" {
+			cidr_block = "192.168.0.0/16"
+			tags {
+							Name = "tf-test"
+			}
+	}
 
-resource "aws_elasticache_subnet_group" "bar" {
-    name = "tf-test-cache-subnet-%03d"
-    description = "tf-test-cache-subnet-group-descr"
-    subnet_ids = [
-        "${aws_subnet.foo.id}",
-    ]
-}
+	resource "aws_subnet" "foo" {
+			vpc_id = "${aws_vpc.foo.id}"
+			cidr_block = "192.168.0.0/20"
+			availability_zone = "us-west-2a"
+			tags {
+							Name = "tf-test-%03d"
+			}
+	}
 
-resource "aws_security_group" "bar" {
-    name = "tf-test-security-group-%03d"
-    description = "tf-test-security-group-descr"
-    vpc_id = "${aws_vpc.foo.id}"
-    ingress {
-        from_port = -1
-        to_port = -1
-        protocol = "icmp"
-        cidr_blocks = ["0.0.0.0/0"]
-    }
-}
+	resource "aws_elasticache_subnet_group" "bar" {
+			name = "tf-test-cache-subnet-%03d"
+			description = "tf-test-cache-subnet-group-descr"
+			subnet_ids = [
+					"${aws_subnet.foo.id}",
+			]
+	}
 
-resource "aws_elasticache_replication_group" "bar" {
-    replication_group_id = "tf-%s"
-    replication_group_description = "test description"
-    node_type = "cache.t2.micro"
-    number_cache_clusters = "1"
-    port = 6379
-    subnet_group_name = "${aws_elasticache_subnet_group.bar.name}"
-    security_group_ids = ["${aws_security_group.bar.id}"]
-    parameter_group_name = "default.redis3.2"
-    availability_zones = ["us-west-2a"]
-    engine_version = "3.2.6"
-		at_rest_encryption_enabled = true
-}
-`, acctest.RandInt(), acctest.RandInt(), acctest.RandInt(), acctest.RandString(10))
+	resource "aws_security_group" "bar" {
+			name = "tf-test-security-group-%03d"
+			description = "tf-test-security-group-descr"
+			vpc_id = "${aws_vpc.foo.id}"
+			ingress {
+					from_port = -1
+					to_port = -1
+					protocol = "icmp"
+					cidr_blocks = ["0.0.0.0/0"]
+			}
+	}
 
-var testAccAWSElasticacheReplicationGroupEnableAuthTokenTransitEncryptionConfig = fmt.Sprintf(`
-resource "aws_vpc" "foo" {
-    cidr_block = "192.168.0.0/16"
-    tags {
-            Name = "tf-test"
-    }
+	resource "aws_elasticache_replication_group" "bar" {
+			replication_group_id = "tf-%s"
+			replication_group_description = "test description"
+			node_type = "cache.t2.micro"
+			number_cache_clusters = "1"
+			port = 6379
+			subnet_group_name = "${aws_elasticache_subnet_group.bar.name}"
+			security_group_ids = ["${aws_security_group.bar.id}"]
+			parameter_group_name = "default.redis3.2"
+			availability_zones = ["us-west-2a"]
+			engine_version = "3.2.6"
+			transit_encryption_enabled = true
+			auth_token = "%s"
+	}
+	`, rInt, rInt, rInt, rString10, rString16)
 }
-
-resource "aws_subnet" "foo" {
-    vpc_id = "${aws_vpc.foo.id}"
-    cidr_block = "192.168.0.0/20"
-    availability_zone = "us-west-2a"
-    tags {
-            Name = "tf-test-%03d"
-    }
-}
-
-resource "aws_elasticache_subnet_group" "bar" {
-    name = "tf-test-cache-subnet-%03d"
-    description = "tf-test-cache-subnet-group-descr"
-    subnet_ids = [
-        "${aws_subnet.foo.id}",
-    ]
-}
-
-resource "aws_security_group" "bar" {
-    name = "tf-test-security-group-%03d"
-    description = "tf-test-security-group-descr"
-    vpc_id = "${aws_vpc.foo.id}"
-    ingress {
-        from_port = -1
-        to_port = -1
-        protocol = "icmp"
-        cidr_blocks = ["0.0.0.0/0"]
-    }
-}
-
-resource "aws_elasticache_replication_group" "bar" {
-    replication_group_id = "tf-%s"
-    replication_group_description = "test description"
-    node_type = "cache.t2.micro"
-    number_cache_clusters = "1"
-    port = 6379
-    subnet_group_name = "${aws_elasticache_subnet_group.bar.name}"
-    security_group_ids = ["${aws_security_group.bar.id}"]
-    parameter_group_name = "default.redis3.2"
-    availability_zones = ["us-west-2a"]
-    engine_version = "3.2.6"
-		transit_encryption_enabled = true
-		auth_token = "%s"
-}
-`, acctest.RandInt(), acctest.RandInt(), acctest.RandInt(), acctest.RandString(10), acctest.RandString(16))

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -351,7 +351,7 @@ func TestAccAWSElasticacheReplicationGroup_enableAuthTokenTransitEncryption(t *t
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "transit_encryption", "true"),
+						"aws_elasticache_replication_group.bar", "transit_encryption_enabled", "true"),
 				),
 			},
 		},
@@ -1129,7 +1129,7 @@ resource "aws_elasticache_replication_group" "bar" {
     parameter_group_name = "default.redis3.2"
     availability_zones = ["us-west-2a"]
     engine_version = "3.2.6"
-		at_rest_encryption = true
+		at_rest_encryption_enabled = true
 }
 `, acctest.RandInt(), acctest.RandInt(), acctest.RandInt(), acctest.RandString(10))
 
@@ -1181,7 +1181,7 @@ resource "aws_elasticache_replication_group" "bar" {
     parameter_group_name = "default.redis3.2"
     availability_zones = ["us-west-2a"]
     engine_version = "3.2.6"
-		transit_encryption = true
+		transit_encryption_enabled = true
 		auth_token = "%s"
 }
 `, acctest.RandInt(), acctest.RandInt(), acctest.RandInt(), acctest.RandString(10), acctest.RandString(16))

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -377,46 +377,6 @@ func TestAccAWSElasticacheReplicationGroup_enableAtRestEncryption(t *testing.T) 
 	})
 }
 
-func TestResourceAWSElastiCacheReplicationGroupAuthTokenValidation(t *testing.T) {
-	cases := []struct {
-		Value    string
-		ErrCount int
-	}{
-		{
-			Value:    "this-is-valid!#%()^",
-			ErrCount: 0,
-		},
-		{
-			Value:    "this-is-not",
-			ErrCount: 1,
-		},
-		{
-			Value:    "this-is-not-valid\"",
-			ErrCount: 1,
-		},
-		{
-			Value:    "this-is-not-valid@",
-			ErrCount: 1,
-		},
-		{
-			Value:    "this-is-not-valid/",
-			ErrCount: 1,
-		},
-		{
-			Value:    randomString(129),
-			ErrCount: 1,
-		},
-	}
-
-	for _, tc := range cases {
-		_, errors := validateAwsElastiCacheReplicationGroupAuthToken(tc.Value, "aws_elasticache_replication_group_auth_token")
-
-		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected the ElastiCache Replication Group AuthToken to trigger a validation error")
-		}
-	}
-}
-
 func TestResourceAWSElastiCacheReplicationGroupIdValidation(t *testing.T) {
 	cases := []struct {
 		Value    string

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -370,7 +370,7 @@ func TestAccAWSElasticacheReplicationGroup_enableAtRestEncryption(t *testing.T) 
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "at_rest_encryption", "true"),
+						"aws_elasticache_replication_group.bar", "at_rest_encryption_enabled", "true"),
 				),
 			},
 		},

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -1043,109 +1043,109 @@ resource "aws_elasticache_replication_group" "bar" {
 
 func testAccAWSElasticacheReplicationGroup_EnableAtRestEncryptionConfig(rInt int, rString string) string {
 	return fmt.Sprintf(`
-	resource "aws_vpc" "foo" {
-			cidr_block = "192.168.0.0/16"
-			tags {
-							Name = "tf-test"
-			}
-	}
+resource "aws_vpc" "foo" {
+  cidr_block = "192.168.0.0/16"
+  tags {
+    Name = "tf-test"
+  }
+}
 
-	resource "aws_subnet" "foo" {
-			vpc_id = "${aws_vpc.foo.id}"
-			cidr_block = "192.168.0.0/20"
-			availability_zone = "us-west-2a"
-			tags {
-							Name = "tf-test-%03d"
-			}
-	}
+resource "aws_subnet" "foo" {
+  vpc_id = "${aws_vpc.foo.id}"
+  cidr_block = "192.168.0.0/20"
+  availability_zone = "us-west-2a"
+  tags {
+    Name = "tf-test-%03d"
+  }
+}
 
-	resource "aws_elasticache_subnet_group" "bar" {
-			name = "tf-test-cache-subnet-%03d"
-			description = "tf-test-cache-subnet-group-descr"
-			subnet_ids = [
-					"${aws_subnet.foo.id}",
-			]
-	}
+resource "aws_elasticache_subnet_group" "bar" {
+  name = "tf-test-cache-subnet-%03d"
+  description = "tf-test-cache-subnet-group-descr"
+  subnet_ids = [
+    "${aws_subnet.foo.id}",
+  ]
+}
 
-	resource "aws_security_group" "bar" {
-			name = "tf-test-security-group-%03d"
-			description = "tf-test-security-group-descr"
-			vpc_id = "${aws_vpc.foo.id}"
-			ingress {
-					from_port = -1
-					to_port = -1
-					protocol = "icmp"
-					cidr_blocks = ["0.0.0.0/0"]
-			}
-	}
+resource "aws_security_group" "bar" {
+  name = "tf-test-security-group-%03d"
+  description = "tf-test-security-group-descr"
+  vpc_id = "${aws_vpc.foo.id}"
+  ingress {
+    from_port = -1
+    to_port = -1
+    protocol = "icmp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
 
-	resource "aws_elasticache_replication_group" "bar" {
-			replication_group_id = "tf-%s"
-			replication_group_description = "test description"
-			node_type = "cache.t2.micro"
-			number_cache_clusters = "1"
-			port = 6379
-			subnet_group_name = "${aws_elasticache_subnet_group.bar.name}"
-			security_group_ids = ["${aws_security_group.bar.id}"]
-			parameter_group_name = "default.redis3.2"
-			availability_zones = ["us-west-2a"]
-			engine_version = "3.2.6"
-			at_rest_encryption_enabled = true
-	}
-	`, rInt, rInt, rInt, rString)
+resource "aws_elasticache_replication_group" "bar" {
+  replication_group_id = "tf-%s"
+  replication_group_description = "test description"
+  node_type = "cache.t2.micro"
+  number_cache_clusters = "1"
+  port = 6379
+  subnet_group_name = "${aws_elasticache_subnet_group.bar.name}"
+  security_group_ids = ["${aws_security_group.bar.id}"]
+  parameter_group_name = "default.redis3.2"
+  availability_zones = ["us-west-2a"]
+  engine_version = "3.2.6"
+  at_rest_encryption_enabled = true
+}
+`, rInt, rInt, rInt, rString)
 }
 
 func testAccAWSElasticacheReplicationGroup_EnableAuthTokenTransitEncryptionConfig(rInt int, rString10 string, rString16 string) string {
 	return fmt.Sprintf(`
-	resource "aws_vpc" "foo" {
-			cidr_block = "192.168.0.0/16"
-			tags {
-							Name = "tf-test"
-			}
-	}
+resource "aws_vpc" "foo" {
+  cidr_block = "192.168.0.0/16"
+  tags {
+    Name = "tf-test"
+  }
+}
 
-	resource "aws_subnet" "foo" {
-			vpc_id = "${aws_vpc.foo.id}"
-			cidr_block = "192.168.0.0/20"
-			availability_zone = "us-west-2a"
-			tags {
-							Name = "tf-test-%03d"
-			}
-	}
+resource "aws_subnet" "foo" {
+  vpc_id = "${aws_vpc.foo.id}"
+  cidr_block = "192.168.0.0/20"
+  availability_zone = "us-west-2a"
+  tags {
+    Name = "tf-test-%03d"
+  }
+}
 
-	resource "aws_elasticache_subnet_group" "bar" {
-			name = "tf-test-cache-subnet-%03d"
-			description = "tf-test-cache-subnet-group-descr"
-			subnet_ids = [
-					"${aws_subnet.foo.id}",
-			]
-	}
+resource "aws_elasticache_subnet_group" "bar" {
+  name = "tf-test-cache-subnet-%03d"
+  description = "tf-test-cache-subnet-group-descr"
+  subnet_ids = [
+    "${aws_subnet.foo.id}",
+  ]
+}
 
-	resource "aws_security_group" "bar" {
-			name = "tf-test-security-group-%03d"
-			description = "tf-test-security-group-descr"
-			vpc_id = "${aws_vpc.foo.id}"
-			ingress {
-					from_port = -1
-					to_port = -1
-					protocol = "icmp"
-					cidr_blocks = ["0.0.0.0/0"]
-			}
-	}
+resource "aws_security_group" "bar" {
+  name = "tf-test-security-group-%03d"
+  description = "tf-test-security-group-descr"
+  vpc_id = "${aws_vpc.foo.id}"
+  ingress {
+    from_port = -1
+    to_port = -1
+    protocol = "icmp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
 
-	resource "aws_elasticache_replication_group" "bar" {
-			replication_group_id = "tf-%s"
-			replication_group_description = "test description"
-			node_type = "cache.t2.micro"
-			number_cache_clusters = "1"
-			port = 6379
-			subnet_group_name = "${aws_elasticache_subnet_group.bar.name}"
-			security_group_ids = ["${aws_security_group.bar.id}"]
-			parameter_group_name = "default.redis3.2"
-			availability_zones = ["us-west-2a"]
-			engine_version = "3.2.6"
-			transit_encryption_enabled = true
-			auth_token = "%s"
-	}
-	`, rInt, rInt, rInt, rString10, rString16)
+resource "aws_elasticache_replication_group" "bar" {
+  replication_group_id = "tf-%s"
+  replication_group_description = "test description"
+  node_type = "cache.t2.micro"
+  number_cache_clusters = "1"
+  port = 6379
+  subnet_group_name = "${aws_elasticache_subnet_group.bar.name}"
+  security_group_ids = ["${aws_security_group.bar.id}"]
+  parameter_group_name = "default.redis3.2"
+  availability_zones = ["us-west-2a"]
+  engine_version = "3.2.6"
+  transit_encryption_enabled = true
+  auth_token = "%s"
+}
+`, rInt, rInt, rInt, rString10, rString16)
 }

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1984,3 +1984,16 @@ func validateDxConnectionBandWidth(v interface{}, k string) (ws []string, errors
 	errors = append(errors, fmt.Errorf("expected %s to be one of %v, got %s", k, validBandWidth, val))
 	return
 }
+
+func validateAwsElastiCacheReplicationGroupAuthToken(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if (len(value) < 16) || (len(value) > 128) {
+		errors = append(errors, fmt.Errorf(
+			"%q must contain from 16 to 128 alphanumeric characters or symbols (excluding @, \", and /)", k))
+	}
+	if !regexp.MustCompile(`^[^@"\/]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only alphanumeric characters or symbols (excluding @, \", and /) allowed in %q", k))
+	}
+	return
+}

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -2799,3 +2799,43 @@ func TestValidateCognitoUserPoolReplyEmailAddress(t *testing.T) {
 		}
 	}
 }
+
+func TestResourceAWSElastiCacheReplicationGroupAuthTokenValidation(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "this-is-valid!#%()^",
+			ErrCount: 0,
+		},
+		{
+			Value:    "this-is-not",
+			ErrCount: 1,
+		},
+		{
+			Value:    "this-is-not-valid\"",
+			ErrCount: 1,
+		},
+		{
+			Value:    "this-is-not-valid@",
+			ErrCount: 1,
+		},
+		{
+			Value:    "this-is-not-valid/",
+			ErrCount: 1,
+		},
+		{
+			Value:    randomString(129),
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateAwsElastiCacheReplicationGroupAuthToken(tc.Value, "aws_elasticache_replication_group_auth_token")
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected the ElastiCache Replication Group AuthToken to trigger a validation error")
+		}
+	}
+}


### PR DESCRIPTION
AWS [announced](https://aws.amazon.com/blogs/security/amazon-elasticache-now-supports-encryption-for-elasticache-for-redis/) support for `AUTH`, in-transit and at-rest encryption. This aims to add that to terraform!