### PR TITLE
Fix TestAccAWSEMRCluster_terminationProtected

### DIFF
--- a/aws/resource_aws_emr_cluster_test.go
+++ b/aws/resource_aws_emr_cluster_test.go
@@ -112,7 +112,7 @@ func TestAccAWSEMRCluster_terminationProtected(t *testing.T) {
 		CheckDestroy: testAccCheckAWSEmrDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEmrClusterConfig(r),
+				Config: testAccAWSEmrClusterConfigTerminationPolicy(r, "false"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEmrClusterExists("aws_emr_cluster.tf-test-cluster", &cluster),
 					resource.TestCheckResourceAttr(
@@ -120,7 +120,7 @@ func TestAccAWSEMRCluster_terminationProtected(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSEmrClusterConfigTerminationPolicyUpdated(r),
+				Config: testAccAWSEmrClusterConfigTerminationPolicy(r, "true"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEmrClusterExists("aws_emr_cluster.tf-test-cluster", &cluster),
 					resource.TestCheckResourceAttr(
@@ -129,9 +129,11 @@ func TestAccAWSEMRCluster_terminationProtected(t *testing.T) {
 			},
 			{
 				//Need to turn off termination_protection to allow the job to be deleted
-				Config: testAccAWSEmrClusterConfig(r),
+				Config: testAccAWSEmrClusterConfigTerminationPolicy(r, "false"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEmrClusterExists("aws_emr_cluster.tf-test-cluster", &cluster),
+					resource.TestCheckResourceAttr(
+						"aws_emr_cluster.tf-test-cluster", "termination_protection", "false"),
 				),
 			},
 		},
@@ -1637,7 +1639,7 @@ resource "aws_iam_role_policy_attachment" "emr-autoscaling-role" {
 `, r, r, r, r, r, r, r, r, r, r)
 }
 
-func testAccAWSEmrClusterConfigTerminationPolicyUpdated(r int) string {
+func testAccAWSEmrClusterConfigTerminationPolicy(r int, term string) string {
 	return fmt.Sprintf(`
 provider "aws" {
   region = "us-west-2"
@@ -1667,7 +1669,7 @@ resource "aws_emr_cluster" "tf-test-cluster" {
   }
 
   keep_job_flow_alive_when_no_steps = true
-  termination_protection = true
+  termination_protection = %s
 
   bootstrap_action {
     path = "s3://elasticmapreduce/bootstrap-actions/run-if"
@@ -1941,7 +1943,7 @@ resource "aws_iam_role_policy_attachment" "emr-autoscaling-role" {
   role       = "${aws_iam_role.emr-autoscaling-role.name}"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceforAutoScalingRole"
 }
-`, r, r, r, r, r, r, r, r, r, r)
+`, r, term, r, r, r, r, r, r, r, r, r)
 }
 
 func testAccAWSEmrClusterConfigVisibleToAllUsersUpdated(r int) string {

--- a/aws/resource_aws_emr_cluster_test.go
+++ b/aws/resource_aws_emr_cluster_test.go
@@ -570,7 +570,7 @@ resource "aws_vpc" "main" {
   enable_dns_hostnames = true
 
   tags {
-    name = "emr_test_cts"
+    Name = "emr_test_cts"
   }
 }
 
@@ -579,7 +579,7 @@ resource "aws_subnet" "main" {
   cidr_block = "168.31.0.0/20"
 
   tags {
-    name = "emr_test_cts"
+    Name = "emr_test_cts"
   }
 }
 
@@ -627,7 +627,7 @@ resource "aws_security_group" "allow_all" {
   }
 
   tags {
-    name = "emr_test"
+    Name = "emr_test"
   }
 }
 
@@ -731,7 +731,7 @@ resource "aws_security_group" "allow_all" {
   }
 
   tags {
-    name = "emr_test"
+    Name = "emr_test"
   }
 }
 
@@ -740,7 +740,7 @@ resource "aws_vpc" "main" {
   enable_dns_hostnames = true
 
   tags {
-    name = "emr_test_%d"
+    Name = "emr_test_%d"
   }
 }
 
@@ -749,7 +749,7 @@ resource "aws_subnet" "main" {
   cidr_block = "168.31.0.0/20"
 
   tags {
-    name = "emr_test_%d"
+    Name = "emr_test_%d"
   }
 }
 
@@ -895,7 +895,7 @@ EOT
 
 resource "aws_iam_instance_profile" "emr_profile" {
   name  = "emr_profile_%d"
-  roles = ["${aws_iam_role.iam_emr_profile_role.name}"]
+  role = "${aws_iam_role.iam_emr_profile_role.name}"
 }
 
 resource "aws_iam_role_policy_attachment" "profile-attach" {
@@ -1039,7 +1039,7 @@ resource "aws_security_group" "allow_all" {
   }
 
   tags {
-    name = "emr_test"
+    Name = "emr_test"
   }
 }
 
@@ -1048,7 +1048,7 @@ resource "aws_vpc" "main" {
   enable_dns_hostnames = true
 
   tags {
-    name = "emr_test_%d"
+    Name = "emr_test_%d"
   }
 }
 
@@ -1057,7 +1057,7 @@ resource "aws_subnet" "main" {
   cidr_block = "168.31.0.0/20"
 
   tags {
-    name = "emr_test_%d"
+    Name = "emr_test_%d"
   }
 }
 
@@ -1203,7 +1203,7 @@ EOT
 
 resource "aws_iam_instance_profile" "emr_profile" {
   name  = "emr_profile_%d"
-  roles = ["${aws_iam_role.iam_emr_profile_role.name}"]
+  role = "${aws_iam_role.iam_emr_profile_role.name}"
 }
 
 resource "aws_iam_role_policy_attachment" "profile-attach" {
@@ -1402,7 +1402,7 @@ resource "aws_security_group" "allow_all" {
   }
 
   tags {
-    name = "emr_test"
+    Name = "emr_test"
   }
 }
 
@@ -1411,7 +1411,7 @@ resource "aws_vpc" "main" {
   enable_dns_hostnames = true
 
   tags {
-    name = "emr_test_%d"
+    Name = "emr_test_%d"
   }
 }
 
@@ -1420,7 +1420,7 @@ resource "aws_subnet" "main" {
   cidr_block = "168.31.0.0/20"
 
   tags {
-    name = "emr_test_%d"
+    Name = "emr_test_%d"
   }
 }
 
@@ -1566,7 +1566,7 @@ EOT
 
 resource "aws_iam_instance_profile" "emr_profile" {
   name  = "emr_profile_%d"
-  roles = ["${aws_iam_role.iam_emr_profile_role.name}"]
+  role = "${aws_iam_role.iam_emr_profile_role.name}"
 }
 
 resource "aws_iam_role_policy_attachment" "profile-attach" {
@@ -1709,7 +1709,7 @@ resource "aws_security_group" "allow_all" {
   }
 
   tags {
-    name = "emr_test"
+    Name = "emr_test"
   }
 }
 
@@ -1718,7 +1718,7 @@ resource "aws_vpc" "main" {
   enable_dns_hostnames = true
 
   tags {
-    name = "emr_test_%d"
+    Name = "emr_test_%d"
   }
 }
 
@@ -1727,7 +1727,7 @@ resource "aws_subnet" "main" {
   cidr_block = "168.31.0.0/20"
 
   tags {
-    name = "emr_test_%d"
+    Name = "emr_test_%d"
   }
 }
 
@@ -1873,7 +1873,7 @@ EOT
 
 resource "aws_iam_instance_profile" "emr_profile" {
   name  = "emr_profile_%d"
-  roles = ["${aws_iam_role.iam_emr_profile_role.name}"]
+  role = "${aws_iam_role.iam_emr_profile_role.name}"
 }
 
 resource "aws_iam_role_policy_attachment" "profile-attach" {
@@ -2016,7 +2016,7 @@ resource "aws_security_group" "allow_all" {
   }
 
   tags {
-    name = "emr_test"
+    Name = "emr_test"
   }
 }
 
@@ -2025,7 +2025,7 @@ resource "aws_vpc" "main" {
   enable_dns_hostnames = true
 
   tags {
-    name = "emr_test_%d"
+    Name = "emr_test_%d"
   }
 }
 
@@ -2034,7 +2034,7 @@ resource "aws_subnet" "main" {
   cidr_block = "168.31.0.0/20"
 
   tags {
-    name = "emr_test_%d"
+    Name = "emr_test_%d"
   }
 }
 
@@ -2180,7 +2180,7 @@ EOT
 
 resource "aws_iam_instance_profile" "emr_profile" {
   name  = "emr_profile_%d"
-  roles = ["${aws_iam_role.iam_emr_profile_role.name}"]
+  role = "${aws_iam_role.iam_emr_profile_role.name}"
 }
 
 resource "aws_iam_role_policy_attachment" "profile-attach" {
@@ -2322,7 +2322,7 @@ resource "aws_security_group" "allow_all" {
   }
 
   tags {
-    name = "emr_test"
+    Name = "emr_test"
   }
 }
 
@@ -2331,7 +2331,7 @@ resource "aws_vpc" "main" {
   enable_dns_hostnames = true
 
   tags {
-    name = "emr_test_%d"
+    Name = "emr_test_%d"
   }
 }
 
@@ -2340,7 +2340,7 @@ resource "aws_subnet" "main" {
   cidr_block = "168.31.0.0/20"
 
   tags {
-    name = "emr_test_%d"
+    Name = "emr_test_%d"
   }
 }
 
@@ -2486,7 +2486,7 @@ EOT
 
 resource "aws_iam_instance_profile" "emr_profile" {
   name  = "emr_profile_%d"
-  roles = ["${aws_iam_role.iam_emr_profile_role.name}"]
+  role = "${aws_iam_role.iam_emr_profile_role.name}"
 }
 
 resource "aws_iam_role_policy_attachment" "profile-attach" {
@@ -2630,7 +2630,7 @@ resource "aws_security_group" "allow_all" {
   }
 
   tags {
-    name = "emr_test"
+    Name = "emr_test"
   }
 }
 
@@ -2639,7 +2639,7 @@ resource "aws_vpc" "main" {
   enable_dns_hostnames = true
 
   tags {
-    name = "emr_test_%d"
+    Name = "emr_test_%d"
   }
 }
 
@@ -2648,7 +2648,7 @@ resource "aws_subnet" "main" {
   cidr_block = "168.31.0.0/20"
 
   tags {
-    name = "emr_test_%d"
+    Name = "emr_test_%d"
   }
 }
 
@@ -2794,7 +2794,7 @@ EOT
 
 resource "aws_iam_instance_profile" "emr_profile" {
   name  = "emr_profile_%d"
-  roles = ["${aws_iam_role.iam_emr_profile_role.name}"]
+  role = "${aws_iam_role.iam_emr_profile_role.name}"
 }
 
 resource "aws_iam_role_policy_attachment" "profile-attach" {


### PR DESCRIPTION
Fix the `TestAccAWSEMRCluster_terminationProtected` test by using a consistent function to generate the configuration between test steps. `TestAccAWSEMRCluster_terminationProtected` was failing and leaking EMR clusters (and vpcs, et. al). 

It's a 3 step test:

1) create the repo with config A, with `termination_protection` set to `false`. It also has `ebs_root_volume_size` set to `21`. Verify `termination_protection` is `false` in state.
2)  run config B, a copy of config A but with `termination_protection` set to `true`. It also has `ebs_root_volume_size` omitted. Verify `termination_protection` is `true` in state.
3) run config A again, where `termination_protection` is `false` and  `ebs_root_volume_size` is again specified.

The test is failing going from step 2 to 3, because `ebs_root_volume_size` is an `Optional` attribute; it's omission is ok, however, it's also a `ForceNew` attribute, so changing it's value (set to not set) is a `ForceNew` operation. 

Step 1 -> Step 2 is fine, but it does not happen by an in-place update as intended, but a force-new recreation. In this transition, `termination_protection` is turned on. Step 2->Step 3 is where `termination_protection` is turned off, but because `ebs_root_volume_size` is also changed, it's by recreation and not in-place update, so Terraform doesn't try to update the `termination_protection` attribute, it tries to destroy the old and create the new. This fails because `termination_protection` is still on. 

In the PR I use the same method to generate config for A and B, with `ebs_root_volume_size` consistent in both, and `termination_protection` injected in each step. 

I also fix some configuration issues, like a proper `Name` tag, and no longer use the deprecated `roles` attribute of `aws_iam_instance_profile`