### PR TITLE
Ignore the 'ResourceNotFoundException' when deleting ElasticSearch Po…

### DIFF
--- a/aws/resource_aws_elasticsearch_domain_policy.go
+++ b/aws/resource_aws_elasticsearch_domain_policy.go
@@ -40,7 +40,7 @@ func resourceAwsElasticSearchDomainPolicyRead(d *schema.ResourceData, meta inter
 		DomainName: aws.String(name),
 	})
 	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "ResourceNotFound" {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "ResourceNotFoundException" {
 			log.Printf("[WARN] ElasticSearch Domain %q not found, removing", name)
 			d.SetId("")
 			return nil
@@ -93,19 +93,27 @@ func resourceAwsElasticSearchDomainPolicyUpsert(d *schema.ResourceData, meta int
 
 func resourceAwsElasticSearchDomainPolicyDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).esconn
+	domainName := d.Get("domain_name").(string)
 
 	_, err := conn.UpdateElasticsearchDomainConfig(&elasticsearch.UpdateElasticsearchDomainConfigInput{
-		DomainName:     aws.String(d.Get("domain_name").(string)),
+		DomainName:     aws.String(domainName),
 		AccessPolicies: aws.String(""),
 	})
 	if err != nil {
+		log.Printf("[WARN] ElasticSearch Domain Policy for %s delete failed: %s", domainName, err)
+
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "ResourceNotFoundException" {
+			log.Printf("[WARN] ElasticSearch Domain %q not found, removing", domainName)
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 
-	log.Printf("[DEBUG] Waiting for ElasticSearch domain policy %q to be deleted", d.Get("domain_name").(string))
+	log.Printf("[DEBUG] Waiting for ElasticSearch domain policy %q to be deleted", domainName)
 	err = resource.Retry(60*time.Minute, func() *resource.RetryError {
 		out, err := conn.DescribeElasticsearchDomain(&elasticsearch.DescribeElasticsearchDomainInput{
-			DomainName: aws.String(d.Get("domain_name").(string)),
+			DomainName: aws.String(domainName),
 		})
 		if err != nil {
 			return resource.NonRetryableError(err)


### PR DESCRIPTION
…licies.

If the Elastic Search Domain Policy has already been deleted, and then you
try to destroy it with Terraform, the detroy will fail, reporting that the
resource is not found. This goes against the rest of the implementation of
the Terraform destroy process that already gone resources are silently
ignored.

The problem was caused by one instance of the code using the wrong name for
the exception, and another instance failing to ignore the lack of the
resource as an acceptable error.

Both of these are addressed here. In passing through, more debugging was
added, in line with other functions, and the common domainName value
held in a local variable.