### PR TITLE
Fix finding VPC data source by ID on initial create

### DIFF
--- a/aws/data_source_aws_vpc.go
+++ b/aws/data_source_aws_vpc.go
@@ -81,7 +81,12 @@ func dataSourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 
 	req := &ec2.DescribeVpcsInput{}
 
-	if id := d.Id(); id != "" {
+	var id string
+	if cid, ok := d.GetOk("id"); ok {
+		id = cid.(string)
+	}
+
+	if id != "" {
 		req.VpcIds = []*string{aws.String(id)}
 	}
 


### PR DESCRIPTION
Fix an issue finding a VPC by ID if this is the first time the data source is ran. 

Consider this configuration:

```
provider "aws" {
  region = "us-west-2"
}

resource "aws_vpc" "test" {
  cidr_block = "172.9.0.0/16"
}

data "aws_vpc" "by_id" {
  id = "${aws_vpc.test.id}"
}
```

Because the data source does not yet exist in state, the `id` will be `""` and so the `req.VpcIds` field of `ec2.DescribeVpcsInput` will not be set. 

Here we read the `id` from state, and from the config. If it exists in state but not config, that's fine, because we likely found it by another filter (`cidr`, et. al.). If it exists in both, use the one from config, in the event they have diverged. Fixes (part of) `TestAccDataSourceAwsVpc_basic` which has been leaking VPCs. There are other failures there but I'm working on those in a separate fix. 

Also adds sweepers to remove VPCs that match the tag `terraform-testacc-vpc-data-source-*`, such as the ones leaked from this test. This VPC should be "safe" because these tests only create VPCs, and should not have any dependency objects that would block deletion. 