### PR TITLE
d/*: Don't rely on d.Id() in data sources

### DIFF
--- a/aws/data_source_aws_dynamodb_table.go
+++ b/aws/data_source_aws_dynamodb_table.go
@@ -176,9 +176,11 @@ func dataSourceAwsDynamoDbTable() *schema.Resource {
 
 func dataSourceAwsDynamoDbTableRead(d *schema.ResourceData, meta interface{}) error {
 	dynamodbconn := meta.(*AWSClient).dynamodbconn
-	log.Printf("[DEBUG] Loading data for DynamoDB table '%s'", d.Id())
+
+	name := d.Get("name").(string)
+	log.Printf("[DEBUG] Loading data for DynamoDB table %q", name)
 	req := &dynamodb.DescribeTableInput{
-		TableName: aws.String(d.Get("name").(string)),
+		TableName: aws.String(name),
 	}
 
 	result, err := dynamodbconn.DescribeTable(req)

--- a/aws/data_source_aws_eip.go
+++ b/aws/data_source_aws_eip.go
@@ -33,8 +33,8 @@ func dataSourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 
 	req := &ec2.DescribeAddressesInput{}
 
-	if id := d.Id(); id != "" {
-		req.AllocationIds = []*string{aws.String(id)}
+	if id, ok := d.GetOk("id"); ok {
+		req.AllocationIds = []*string{aws.String(id.(string))}
 	}
 
 	if public_ip := d.Get("public_ip"); public_ip != "" {

--- a/aws/data_source_aws_eip_test.go
+++ b/aws/data_source_aws_eip_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccDataSourceAwsEip(t *testing.T) {
+func TestAccDataSourceAwsEip_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,

--- a/aws/data_source_aws_security_group.go
+++ b/aws/data_source_aws_security_group.go
@@ -51,8 +51,8 @@ func dataSourceAwsSecurityGroupRead(d *schema.ResourceData, meta interface{}) er
 	conn := meta.(*AWSClient).ec2conn
 	req := &ec2.DescribeSecurityGroupsInput{}
 
-	if id := d.Id(); id != "" {
-		req.GroupIds = []*string{aws.String(id)}
+	if id, ok := d.GetOk("id"); ok {
+		req.GroupIds = []*string{aws.String(id.(string))}
 	}
 
 	req.Filters = buildEC2AttributeFilterList(

--- a/aws/data_source_aws_security_group_test.go
+++ b/aws/data_source_aws_security_group_test.go
@@ -104,9 +104,6 @@ func testAccDataSourceAwsSecurityGroupCheckDefault(name string) resource.TestChe
 
 func testAccDataSourceAwsSecurityGroupConfig(rInt int) string {
 	return fmt.Sprintf(`
-	provider "aws" {
-		region = "eu-west-1"
-	}
 	resource "aws_vpc" "test" {
 		cidr_block = "172.16.0.0/16"
 

--- a/aws/data_source_aws_security_group_test.go
+++ b/aws/data_source_aws_security_group_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccDataSourceAwsSecurityGroup(t *testing.T) {
+func TestAccDataSourceAwsSecurityGroup_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },

--- a/aws/data_source_aws_ssm_parameter.go
+++ b/aws/data_source_aws_ssm_parameter.go
@@ -34,11 +34,13 @@ func dataSourceAwsSsmParameter() *schema.Resource {
 func dataAwsSsmParameterRead(d *schema.ResourceData, meta interface{}) error {
 	ssmconn := meta.(*AWSClient).ssmconn
 
-	log.Printf("[DEBUG] Reading SSM Parameter: %s", d.Id())
+	name := d.Get("name").(string)
+
+	log.Printf("[DEBUG] Reading SSM Parameter: %q", name)
 
 	paramInput := &ssm.GetParametersInput{
 		Names: []*string{
-			aws.String(d.Get("name").(string)),
+			aws.String(name),
 		},
 		WithDecryption: aws.Bool(true),
 	}
@@ -50,7 +52,7 @@ func dataAwsSsmParameterRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if len(resp.InvalidParameters) > 0 {
-		return fmt.Errorf("[ERROR] SSM Parameter %s is invalid", d.Get("name").(string))
+		return fmt.Errorf("[ERROR] SSM Parameter %s is invalid", name)
 	}
 
 	param := resp.Parameters[0]

--- a/aws/data_source_aws_subnet.go
+++ b/aws/data_source_aws_subnet.go
@@ -83,8 +83,8 @@ func dataSourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
 
 	req := &ec2.DescribeSubnetsInput{}
 
-	if id := d.Id(); id != "" {
-		req.SubnetIds = []*string{aws.String(id)}
+	if id, ok := d.GetOk("id"); ok {
+		req.SubnetIds = []*string{aws.String(id.(string))}
 	}
 
 	// We specify default_for_az as boolean, but EC2 filters want

--- a/aws/data_source_aws_subnet_test.go
+++ b/aws/data_source_aws_subnet_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccDataSourceAwsSubnet(t *testing.T) {
+func TestAccDataSourceAwsSubnet_basic(t *testing.T) {
 	rInt := acctest.RandIntRange(0, 256)
 
 	resource.Test(t, resource.TestCase{
@@ -31,7 +31,7 @@ func TestAccDataSourceAwsSubnet(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceAwsSubnetIpv6ByIpv6Filter(t *testing.T) {
+func TestAccDataSourceAwsSubnet_ipv6ByIpv6Filter(t *testing.T) {
 	rInt := acctest.RandIntRange(0, 256)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -53,7 +53,7 @@ func TestAccDataSourceAwsSubnetIpv6ByIpv6Filter(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceAwsSubnetIpv6ByIpv6CidrBlock(t *testing.T) {
+func TestAccDataSourceAwsSubnet_ipv6ByIpv6CidrBlock(t *testing.T) {
 	rInt := acctest.RandIntRange(0, 256)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },

--- a/aws/data_source_aws_vpc_endpoint.go
+++ b/aws/data_source_aws_vpc_endpoint.go
@@ -61,8 +61,8 @@ func dataSourceAwsVpcEndpointRead(d *schema.ResourceData, meta interface{}) erro
 
 	req := &ec2.DescribeVpcEndpointsInput{}
 
-	if id := d.Id(); id != "" {
-		req.VpcEndpointIds = aws.StringSlice([]string{id})
+	if id, ok := d.GetOk("id"); ok {
+		req.VpcEndpointIds = aws.StringSlice([]string{id.(string)})
 	}
 
 	req.Filters = buildEC2AttributeFilterList(

--- a/aws/data_source_aws_vpc_endpoint_test.go
+++ b/aws/data_source_aws_vpc_endpoint_test.go
@@ -25,6 +25,23 @@ func TestAccDataSourceAwsVpcEndpoint_basic(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAwsVpcEndpoint_byId(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsVpcEndpointConfigById,
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsVpcEndpointCheckExists("data.aws_vpc_endpoint.by_id"),
+					resource.TestCheckResourceAttrSet("data.aws_vpc_endpoint.by_id", "prefix_list_id"),
+					resource.TestCheckResourceAttrSet("data.aws_vpc_endpoint.by_id", "id"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDataSourceAwsVpcEndpoint_withRouteTable(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -70,10 +87,6 @@ func testAccDataSourceAwsVpcEndpointCheckExists(name string) resource.TestCheckF
 }
 
 const testAccDataSourceAwsVpcEndpointConfig = `
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
@@ -96,11 +109,26 @@ data "aws_vpc_endpoint" "s3" {
 }
 `
 
-const testAccDataSourceAwsVpcEndpointWithRouteTableConfig = `
-provider "aws" {
-  region = "us-west-2"
+const testAccDataSourceAwsVpcEndpointConfigById = `
+resource "aws_vpc" "foo" {
+  cidr_block = "10.1.0.0/16"
+
+  tags {
+	  Name = "terraform-testacc-vpc-endpoint-data-source-foo"
+  }
 }
 
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id = "${aws_vpc.foo.id}"
+  service_name = "com.amazonaws.us-west-2.s3"
+}
+
+data "aws_vpc_endpoint" "by_id" {
+  id = "${aws_vpc_endpoint.s3.id}"
+}
+`
+
+const testAccDataSourceAwsVpcEndpointWithRouteTableConfig = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 

--- a/aws/data_source_aws_vpc_peering_connection.go
+++ b/aws/data_source_aws_vpc_peering_connection.go
@@ -77,8 +77,8 @@ func dataSourceAwsVpcPeeringConnectionRead(d *schema.ResourceData, meta interfac
 
 	req := &ec2.DescribeVpcPeeringConnectionsInput{}
 
-	if id := d.Id(); id != "" {
-		req.VpcPeeringConnectionIds = aws.StringSlice([]string{id})
+	if id, ok := d.GetOk("id"); ok {
+		req.VpcPeeringConnectionIds = aws.StringSlice([]string{id.(string)})
 	}
 
 	req.Filters = buildEC2AttributeFilterList(

--- a/aws/data_source_aws_vpc_peering_connection_test.go
+++ b/aws/data_source_aws_vpc_peering_connection_test.go
@@ -17,11 +17,23 @@ func TestAccDataSourceAwsVpcPeeringConnection_basic(t *testing.T) {
 				Config: testAccDataSourceAwsVpcPeeringConnectionConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceAwsVpcPeeringConnectionCheck("data.aws_vpc_peering_connection.test_by_id"),
+					resource.TestCheckResourceAttrSet("data.aws_vpc_peering_connection.test_by_id", "id"),
+					resource.TestCheckResourceAttrSet("data.aws_vpc_peering_connection.test_by_id", "cidr_block"),
 					testAccDataSourceAwsVpcPeeringConnectionCheck("data.aws_vpc_peering_connection.test_by_requester_vpc_id"),
+					resource.TestCheckResourceAttrSet("data.aws_vpc_peering_connection.test_by_requester_vpc_id", "id"),
+					resource.TestCheckResourceAttrSet("data.aws_vpc_peering_connection.test_by_requester_vpc_id", "cidr_block"),
 					testAccDataSourceAwsVpcPeeringConnectionCheck("data.aws_vpc_peering_connection.test_by_accepter_vpc_id"),
+					resource.TestCheckResourceAttrSet("data.aws_vpc_peering_connection.test_by_accepter_vpc_id", "id"),
+					resource.TestCheckResourceAttrSet("data.aws_vpc_peering_connection.test_by_accepter_vpc_id", "cidr_block"),
 					testAccDataSourceAwsVpcPeeringConnectionCheck("data.aws_vpc_peering_connection.test_by_requester_cidr_block"),
+					resource.TestCheckResourceAttrSet("data.aws_vpc_peering_connection.test_by_requester_cidr_block", "id"),
+					resource.TestCheckResourceAttrSet("data.aws_vpc_peering_connection.test_by_requester_cidr_block", "cidr_block"),
 					testAccDataSourceAwsVpcPeeringConnectionCheck("data.aws_vpc_peering_connection.test_by_accepter_cidr_block"),
+					resource.TestCheckResourceAttrSet("data.aws_vpc_peering_connection.test_by_accepter_cidr_block", "id"),
+					resource.TestCheckResourceAttrSet("data.aws_vpc_peering_connection.test_by_accepter_cidr_block", "cidr_block"),
 					testAccDataSourceAwsVpcPeeringConnectionCheck("data.aws_vpc_peering_connection.test_by_owner_ids"),
+					resource.TestCheckResourceAttrSet("data.aws_vpc_peering_connection.test_by_owner_ids", "id"),
+					resource.TestCheckResourceAttrSet("data.aws_vpc_peering_connection.test_by_owner_ids", "cidr_block"),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -56,10 +68,6 @@ func testAccDataSourceAwsVpcPeeringConnectionCheck(name string) resource.TestChe
 }
 
 const testAccDataSourceAwsVpcPeeringConnectionConfig = `
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 

--- a/aws/data_source_aws_vpn_gateway.go
+++ b/aws/data_source_aws_vpn_gateway.go
@@ -47,8 +47,8 @@ func dataSourceAwsVpnGatewayRead(d *schema.ResourceData, meta interface{}) error
 
 	req := &ec2.DescribeVpnGatewaysInput{}
 
-	if id := d.Id(); id != "" {
-		req.VpnGatewayIds = aws.StringSlice([]string{id})
+	if id, ok := d.GetOk("id"); ok {
+		req.VpnGatewayIds = aws.StringSlice([]string{id.(string)})
 	}
 
 	req.Filters = buildEC2AttributeFilterList(


### PR DESCRIPTION
## Context

This bug was introduced in https://github.com/terraform-providers/terraform-provider-aws/pull/1626 where we concluded that `id` fields should remain in data source schemas, which I addressed in the last commit of that PR. What I didn't address was related CRUD code.

`d.Id()` is always empty in data source `Read()` unless `d.SetId()` is called beforehand, because the state is always built from scratch. `d.Id()` also (for some reason) doesn't return value of `id` field set via config. I'm not sure if this is a feature or a bug, the goal is to get those tests green again.

## Before patch

```
TF_ACC=1 go test ./aws -v -run="(TestAccDataSourceAwsEip_basic|TestAccDataSourceAwsSecurityGroup_basic|TestAccDataSourceAwsSubnet_basic|TestAccDataSourceAwsVpcEndpoint_byId|TestAccDataSourceAwsVpcPeeringConnection_basic|TestAccDataSourceAwsVpnGateway_unattached)" -timeout 120m
=== RUN   TestAccDataSourceAwsEip_basic
--- FAIL: TestAccDataSourceAwsEip_basic (22.86s)
	testing.go:492: Step 0 error: Error applying: 1 error(s) occurred:

		* data.aws_eip.by_id: data.aws_eip.by_id: multiple Elastic IPs matched; use additional constraints to reduce matches to a single Elastic IP
	testing.go:552: Error destroying resource! WARNING: Dangling resources
		may exist. The full state and error is shown below.

		Error: Error refreshing: 1 error(s) occurred:

		* data.aws_eip.by_id: 1 error(s) occurred:

		* data.aws_eip.by_id: data.aws_eip.by_id: multiple Elastic IPs matched; use additional constraints to reduce matches to a single Elastic IP

		State: <nil>
=== RUN   TestAccDataSourceAwsSecurityGroup_basic
--- FAIL: TestAccDataSourceAwsSecurityGroup_basic (49.81s)
	testing.go:492: Step 0 error: Error applying: 1 error(s) occurred:

		* data.aws_security_group.by_id: data.aws_security_group.by_id: multiple Security Groups matched; use additional constraints to reduce matches to a single Security Group
	testing.go:552: Error destroying resource! WARNING: Dangling resources
		may exist. The full state and error is shown below.

		Error: Error refreshing: 1 error(s) occurred:

		* data.aws_security_group.by_id: 1 error(s) occurred:

		* data.aws_security_group.by_id: data.aws_security_group.by_id: multiple Security Groups matched; use additional constraints to reduce matches to a single Security Group

		State: <nil>
=== RUN   TestAccDataSourceAwsSubnet_basic
--- FAIL: TestAccDataSourceAwsSubnet_basic (49.39s)
	testing.go:492: Step 0 error: Error applying: 1 error(s) occurred:

		* data.aws_subnet.by_id: data.aws_subnet.by_id: multiple subnets matched; use additional constraints to reduce matches to a single subnet
	testing.go:552: Error destroying resource! WARNING: Dangling resources
		may exist. The full state and error is shown below.

		Error: Error refreshing: 1 error(s) occurred:

		* data.aws_subnet.by_id: 1 error(s) occurred:

		* data.aws_subnet.by_id: data.aws_subnet.by_id: multiple subnets matched; use additional constraints to reduce matches to a single subnet

		State: <nil>
=== RUN   TestAccDataSourceAwsVpcEndpoint_byId
--- FAIL: TestAccDataSourceAwsVpcEndpoint_byId (48.53s)
	testing.go:492: Step 0 error: Error applying: 1 error(s) occurred:

		* data.aws_vpc_endpoint.by_id: data.aws_vpc_endpoint.by_id: multiple VPC endpoints matched; use additional constraints to reduce matches to a single VPC endpoint
	testing.go:552: Error destroying resource! WARNING: Dangling resources
		may exist. The full state and error is shown below.

		Error: Error refreshing: 1 error(s) occurred:

		* data.aws_vpc_endpoint.by_id: 1 error(s) occurred:

		* data.aws_vpc_endpoint.by_id: data.aws_vpc_endpoint.by_id: multiple VPC endpoints matched; use additional constraints to reduce matches to a single VPC endpoint

		State: <nil>
=== RUN   TestAccDataSourceAwsVpcPeeringConnection_basic
--- FAIL: TestAccDataSourceAwsVpcPeeringConnection_basic (49.15s)
	testing.go:492: Step 0 error: Error applying: 4 error(s) occurred:

		* data.aws_vpc_peering_connection.test_by_id: data.aws_vpc_peering_connection.test_by_id: multiple VPC peering connections matched; use additional constraints to reduce matches to a single VPC peering connection
		* data.aws_vpc_peering_connection.test_by_accepter_cidr_block: data.aws_vpc_peering_connection.test_by_accepter_cidr_block: multiple VPC peering connections matched; use additional constraints to reduce matches to a single VPC peering connection
		* data.aws_vpc_peering_connection.test_by_owner_ids: data.aws_vpc_peering_connection.test_by_owner_ids: multiple VPC peering connections matched; use additional constraints to reduce matches to a single VPC peering connection
		* data.aws_vpc_peering_connection.test_by_requester_cidr_block: data.aws_vpc_peering_connection.test_by_requester_cidr_block: multiple VPC peering connections matched; use additional constraints to reduce matches to a single VPC peering connection
	testing.go:552: Error destroying resource! WARNING: Dangling resources
		may exist. The full state and error is shown below.

		Error: Error refreshing: 1 error(s) occurred:

		* data.aws_vpc_peering_connection.test_by_id: 1 error(s) occurred:

		* data.aws_vpc_peering_connection.test_by_id: data.aws_vpc_peering_connection.test_by_id: multiple VPC peering connections matched; use additional constraints to reduce matches to a single VPC peering connection

		State: <nil>
=== RUN   TestAccDataSourceAwsVpnGateway_unattached
--- FAIL: TestAccDataSourceAwsVpnGateway_unattached (21.74s)
	testing.go:492: Step 0 error: Error applying: 1 error(s) occurred:

		* data.aws_vpn_gateway.test_by_id: data.aws_vpn_gateway.test_by_id: multiple VPN gateways matched; use additional constraints to reduce matches to a single VPN gateway
	testing.go:552: Error destroying resource! WARNING: Dangling resources
		may exist. The full state and error is shown below.

		Error: Error refreshing: 1 error(s) occurred:

		* data.aws_vpn_gateway.test_by_id: 1 error(s) occurred:

		* data.aws_vpn_gateway.test_by_id: data.aws_vpn_gateway.test_by_id: multiple VPN gateways matched; use additional constraints to reduce matches to a single VPN gateway

		State: <nil>
FAIL
exit status 1
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	241.521s
```

## After patch

```
TF_ACC=1 go test ./aws -v -run="(TestAccDataSourceAwsEip_basic|TestAccDataSourceAwsSecurityGroup_basic|TestAccDataSourceAwsSubnet_basic|TestAccDataSourceAwsVpcEndpoint_byId|TestAccDataSourceAwsVpcPeeringConnection_basic|TestAccDataSourceAwsVpnGateway_unattached)" -timeout 120m
=== RUN   TestAccDataSourceAwsEip_basic
--- PASS: TestAccDataSourceAwsEip_basic (46.32s)
=== RUN   TestAccDataSourceAwsSecurityGroup_basic
--- PASS: TestAccDataSourceAwsSecurityGroup_basic (88.16s)
=== RUN   TestAccDataSourceAwsSubnet_basic
--- PASS: TestAccDataSourceAwsSubnet_basic (85.52s)
=== RUN   TestAccDataSourceAwsVpcEndpoint_byId
--- PASS: TestAccDataSourceAwsVpcEndpoint_byId (86.93s)
=== RUN   TestAccDataSourceAwsVpcPeeringConnection_basic
--- PASS: TestAccDataSourceAwsVpcPeeringConnection_basic (101.07s)
=== RUN   TestAccDataSourceAwsVpnGateway_unattached
--- PASS: TestAccDataSourceAwsVpnGateway_unattached (41.47s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	449.497s
```