### PR TITLE
Set ipv6 properties even if no ipv6 is enabled in VPC to allow usage in conditionals (fixes #688)

### DIFF
--- a/aws/resource_aws_vpc.go
+++ b/aws/resource_aws_vpc.go
@@ -182,15 +182,16 @@ func resourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 	// Tags
 	d.Set("tags", tagsToMap(vpc.Tags))
 
+	// Make sure those values are set, if an IPv6 block exists it'll be set in the loop
+	d.Set("assign_generated_ipv6_cidr_block", false)
+	d.Set("ipv6_association_id", "")
+	d.Set("ipv6_cidr_block", "")
+
 	for _, a := range vpc.Ipv6CidrBlockAssociationSet {
 		if *a.Ipv6CidrBlockState.State == "associated" { //we can only ever have 1 IPv6 block associated at once
 			d.Set("assign_generated_ipv6_cidr_block", true)
 			d.Set("ipv6_association_id", a.AssociationId)
 			d.Set("ipv6_cidr_block", a.Ipv6CidrBlock)
-		} else {
-			d.Set("assign_generated_ipv6_cidr_block", false)
-			d.Set("ipv6_association_id", "") // we blank these out to remove old entries
-			d.Set("ipv6_cidr_block", "")
 		}
 	}
 

--- a/aws/resource_aws_vpc_test.go
+++ b/aws/resource_aws_vpc_test.go
@@ -83,6 +83,9 @@ func TestAccAWSVpc_basic(t *testing.T) {
 					testAccCheckVpcCidr(&vpc, "10.1.0.0/16"),
 					resource.TestCheckResourceAttr(
 						"aws_vpc.foo", "cidr_block", "10.1.0.0/16"),
+					// ipv6 should be empty if disabled so we can still use the property in conditionals
+					resource.TestCheckResourceAttr(
+						"aws_vpc.foo", "ipv6_cidr_block", ""),
 					resource.TestCheckResourceAttrSet(
 						"aws_vpc.foo", "default_route_table_id"),
 					resource.TestCheckResourceAttr(


### PR DESCRIPTION
This sets IPv6-related attributes of a VPC to empty-string instead of leaving them undefined in case the VPC doesn't have VPC enabled. This allows us to use the attributes in a conditional as described in #688. 

In a way, this feels like a very specific workaround for hashicorp/hil#50. However, it might help some people creating modules where IPv6-support is optional. 

Feel free to reject this PR if you feel it adds more tech-debt than value. 