### PR TITLE
data-source/efs_file_system: Added dns_name

### DIFF
--- a/aws/data_source_aws_efs_file_system.go
+++ b/aws/data_source_aws_efs_file_system.go
@@ -40,6 +40,10 @@ func dataSourceAwsEfsFileSystem() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"dns_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"tags": tagsSchemaComputed(),
 		},
 	}
@@ -118,6 +122,12 @@ func dataSourceAwsEfsFileSystemRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("file_system_id", fs.FileSystemId)
 	d.Set("encrypted", fs.Encrypted)
 	d.Set("kms_key_id", fs.KmsKeyId)
+
+	region := meta.(*AWSClient).region
+	err = d.Set("dns_name", resourceAwsEfsDnsName(*fs.FileSystemId, region))
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/aws/data_source_aws_efs_file_system_test.go
+++ b/aws/data_source_aws_efs_file_system_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	"regexp"
 )
 
 func TestAccDataSourceAwsEfsFileSystem(t *testing.T) {
@@ -18,6 +19,8 @@ func TestAccDataSourceAwsEfsFileSystem(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceAwsEfsFileSystemCheck("data.aws_efs_file_system.by_creation_token"),
 					testAccDataSourceAwsEfsFileSystemCheck("data.aws_efs_file_system.by_id"),
+					resource.TestMatchResourceAttr("data.aws_efs_file_system.by_creation_token", "dns_name", regexp.MustCompile("^[^.]+.efs.([a-z]{2}-(gov-)?[a-z]+-\\d{1})?.amazonaws.com$")),
+					resource.TestMatchResourceAttr("data.aws_efs_file_system.by_id", "dns_name", regexp.MustCompile("^[^.]+.efs.([a-z]{2}-(gov-)?[a-z]+-\\d{1})?.amazonaws.com$")),
 				),
 			},
 		},

--- a/website/docs/r/efs_file_system.html.markdown
+++ b/website/docs/r/efs_file_system.html.markdown
@@ -48,6 +48,7 @@ The following attributes are exported:
 
 * `id` - The ID that identifies the file system (e.g. fs-ccfc0d65).
 * `kms_key_id` - The ARN for the KMS encryption key.
+* `dns_name` - The DNS name for the filesystem per [documented convention](http://docs.aws.amazon.com/efs/latest/ug/mounting-fs-mount-cmd-dns-name.html).
 
 ## Import
 


### PR DESCRIPTION
Fixes #2104

This adds the `dns_name` to the `efs_file_system` data source. Its documentation was exposing the attribute whereas it was only available in the resource.