### PR TITLE
Fix pattern length for cloudwatch metric filter

### DIFF
--- a/aws/resource_aws_cloudwatch_log_metric_filter.go
+++ b/aws/resource_aws_cloudwatch_log_metric_filter.go
@@ -31,7 +31,7 @@ func resourceAwsCloudWatchLogMetricFilter() *schema.Resource {
 			"pattern": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validateMaxLength(512),
+				ValidateFunc: validateMaxLength(1024),
 				StateFunc: func(v interface{}) string {
 					s, ok := v.(string)
 					if !ok {


### PR DESCRIPTION
Documentation specifies max length of a pattern is 1024, not 512.

http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutMetricFilter.html

Fixes: #2099 