### PR TITLE
Find LB listener by the LB ARN

### DIFF
--- a/aws/data_source_aws_lb_listener_test.go
+++ b/aws/data_source_aws_lb_listener_test.go
@@ -34,6 +34,30 @@ func TestAccDataSourceAWSLBListener_basic(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAWSLBListenerByLBArn(t *testing.T) {
+	lbName := fmt.Sprintf("testlistener-lbarn-%s", acctest.RandStringFromCharSet(13, acctest.CharSetAlphaNum))
+	targetGroupName := fmt.Sprintf("testtargetgroup-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAWSLBListenerConfigByLBArn(lbName, targetGroupName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.aws_lb_listener.front_end", "load_balancer_arn"),
+					resource.TestCheckResourceAttrSet("data.aws_lb_listener.front_end", "arn"),
+					resource.TestCheckResourceAttr("data.aws_lb_listener.front_end", "protocol", "HTTP"),
+					resource.TestCheckResourceAttr("data.aws_lb_listener.front_end", "port", "80"),
+					resource.TestCheckResourceAttr("data.aws_lb_listener.front_end", "default_action.#", "1"),
+					resource.TestCheckResourceAttr("data.aws_lb_listener.front_end", "default_action.0.type", "forward"),
+					resource.TestCheckResourceAttrSet("data.aws_lb_listener.front_end", "default_action.0.target_group_arn"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDataSourceAWSLBListenerBackwardsCompatibility(t *testing.T) {
 	lbName := fmt.Sprintf("testlistener-basic-%s", acctest.RandStringFromCharSet(13, acctest.CharSetAlphaNum))
 	targetGroupName := fmt.Sprintf("testtargetgroup-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
@@ -181,6 +205,106 @@ resource "aws_security_group" "alb_test" {
 
 data "aws_lb_listener" "front_end" {
 	arn = "${aws_lb_listener.front_end.arn}"
+}`, lbName, targetGroupName)
+}
+
+func testAccDataSourceAWSLBListenerConfigByLBArn(lbName, targetGroupName string) string {
+	return fmt.Sprintf(`resource "aws_lb_listener" "front_end" {
+   load_balancer_arn = "${aws_lb.alb_test.id}"
+   protocol = "HTTP"
+   port = "80"
+
+   default_action {
+     target_group_arn = "${aws_lb_target_group.test.id}"
+     type = "forward"
+   }
+}
+
+resource "aws_lb" "alb_test" {
+  name            = "%s"
+  internal        = true
+  security_groups = ["${aws_security_group.alb_test.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id}"]
+
+  idle_timeout = 30
+  enable_deletion_protection = false
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+resource "aws_lb_target_group" "test" {
+  name = "%s"
+  port = 8080
+  protocol = "HTTP"
+  vpc_id = "${aws_vpc.alb_test.id}"
+
+  health_check {
+    path = "/health"
+    interval = 60
+    port = 8081
+    protocol = "HTTP"
+    timeout = 3
+    healthy_threshold = 3
+    unhealthy_threshold = 3
+    matcher = "200-299"
+  }
+}
+
+variable "subnets" {
+  default = ["10.0.1.0/24", "10.0.2.0/24"]
+  type    = "list"
+}
+
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc" "alb_test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+resource "aws_subnet" "alb_test" {
+  count                   = 2
+  vpc_id                  = "${aws_vpc.alb_test.id}"
+  cidr_block              = "${element(var.subnets, count.index)}"
+  map_public_ip_on_launch = true
+  availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+resource "aws_security_group" "alb_test" {
+  name        = "allow_all_alb_test"
+  description = "Used for ALB Testing"
+  vpc_id      = "${aws_vpc.alb_test.id}"
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+data "aws_lb_listener" "front_end" {
+	load_balancer_arn = "${aws_lb_listener.front_end.load_balancer_arn}"
 }`, lbName, targetGroupName)
 }
 

--- a/website/docs/d/lb_listener.html.markdown
+++ b/website/docs/d/lb_listener.html.markdown
@@ -28,11 +28,26 @@ data "aws_lb_listener" "listener" {
 }
 ```
 
+```hcl
+variable "lb_name" {
+  type = "string"
+}
+
+data "aws_lb" "load_balancer" {
+  name = "${var.lb_name}"
+}
+
+data "aws_lb_listener" "listener" {
+  load_balancer_arn = "${data.aws_lb.load_balancer.arn}"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
-* `arn` - (Required) The ARN of the listener.
+* `arn` - (Optional) The ARN of the listener.
+* `load_balancer_arn` - (Optional) The ARN of the load balancer.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Right now the aws_lb_listener data source isn't particularly useful unless you somehow know the ARN of the listener.
Being able to search by the load balancer ARN means you can chain the aws_lb data source to find the LB listener from an LB name.

As an example we can now do something like this:

```hcl
variable "lb_name" {
  default = "foo"
}

variable "vpc" {
  default = "my_vpc"
}

variable "listener_rule_priority" {
  default = 99
}

data "aws_vpc" "vpc" {
  tags {
    Name = "${var.vpc}"
  }
}

data "aws_lb" "load_balancer" {
  name = "${var.lb_name}"
}

data "aws_lb_listener" "listener" {
  load_balancer_arn = "${data.aws_lb.load_balancer.arn}"
}

resource "aws_lb_listener_rule" "host_based_routing" {
  listener_arn = "${data.aws_lb_listener.listener.arn}"
  priority     = "${var.listener_rule_priority}"

  action {
    type             = "forward"
    target_group_arn = "${aws_lb_target_group.service.arn}"
  }

  condition {
    field  = "host-header"
    values = ["my-service.*.terraform.io"]
  }
}

resource "aws_lb_target_group" "service" {
  name     = "dynamic"
  port     = 80
  protocol = "HTTP"
  vpc_id   = "${data.aws_vpc.vpc.id}"
}
```

In particular this will allow me to go from creating an ALB with every single ECS service I deploy to a single one per ECS cluster (separated by environments) because now I can easily create a listener rule to forward to the service's target group.

In reality I don't really want to have to provide the priority statically with each service so I intend to add some more functionality to the AWS provider at a later date that fetches the highest priority rule for a load balancer listener and then just increment from there. There is an issue for this already at https://github.com/terraform-providers/terraform-provider-aws/issues/1574

Note that if a load balancer has multiple listeners this will error when searching by load_balancer_arn.