### PR TITLE
RDS Aurora Cross Region replication for encrypted clusters

### DIFF
--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -232,6 +232,11 @@ func resourceAwsRDSCluster() *schema.Resource {
 				Optional: true,
 			},
 
+			"source_region": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
 			"iam_roles": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -365,7 +370,8 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 			Engine:                      aws.String(d.Get("engine").(string)),
 			StorageEncrypted:            aws.Bool(d.Get("storage_encrypted").(bool)),
 			ReplicationSourceIdentifier: aws.String(d.Get("replication_source_identifier").(string)),
-			Tags: tags,
+			SourceRegion:                aws.String(d.Get("source_region").(string)),
+			Tags:                        tags,
 		}
 
 		if attr, ok := d.GetOk("port"); ok {

--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -233,8 +233,8 @@ func resourceAwsRDSCluster() *schema.Resource {
 			},
 
 			"source_region": {
-				Type:     	   schema.TypeString,
-				Optional: 		 true,
+				Type:          schema.TypeString,
+				Optional:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"snapshot_identifier"},
 			},

--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -233,10 +233,10 @@ func resourceAwsRDSCluster() *schema.Resource {
 			},
 
 			"source_region": {
-				Type:     	  	schema.TypeString,
-				Optional: 			true,
-				ForceNew: 			true,
-				ConflictsWith: 	[]string{"snapshot_identifier"},
+				Type:     	   schema.TypeString,
+				Optional: 		 true,
+				ForceNew:      true,
+				ConflictsWith: []string{"snapshot_identifier"},
 			},
 
 			"iam_roles": {

--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -233,8 +233,10 @@ func resourceAwsRDSCluster() *schema.Resource {
 			},
 
 			"source_region": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:     	  	schema.TypeString,
+				Optional: 			true,
+				ForceNew: 			true,
+				ConflictsWith: 	[]string{"snapshot_identifier"},
 			},
 
 			"iam_roles": {

--- a/aws/resource_aws_rds_cluster_test.go
+++ b/aws/resource_aws_rds_cluster_test.go
@@ -40,6 +40,8 @@ func TestAccAWSRDSCluster_basic(t *testing.T) {
 						"aws_rds_cluster.default", "engine", "aurora"),
 					resource.TestCheckResourceAttrSet(
 						"aws_rds_cluster.default", "engine_version"),
+					resource.TestCheckResourceAttrSet(
+						"aws_rds_cluster.default", "source_region"),
 				),
 			},
 		},

--- a/aws/resource_aws_rds_cluster_test.go
+++ b/aws/resource_aws_rds_cluster_test.go
@@ -40,8 +40,40 @@ func TestAccAWSRDSCluster_basic(t *testing.T) {
 						"aws_rds_cluster.default", "engine", "aurora"),
 					resource.TestCheckResourceAttrSet(
 						"aws_rds_cluster.default", "engine_version"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSRDSCluster_crossRegion(t *testing.T) {
+	var v rds.DBCluster
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSClusterConfig(acctest.RandInt()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSClusterExists("aws_rds_cluster.default", &v),
+					resource.TestCheckResourceAttr(
+						"aws_rds_cluster.default", "storage_encrypted", "true"),
+					resource.TestCheckResourceAttr(
+						"aws_rds_cluster.default", "db_cluster_parameter_group_name", "default.aurora5.6"),
+					resource.TestCheckResourceAttrSet(
+						"aws_rds_cluster.default", "reader_endpoint"),
+					resource.TestCheckResourceAttrSet(
+						"aws_rds_cluster.default", "cluster_resource_id"),
+					resource.TestCheckResourceAttr(
+						"aws_rds_cluster.default", "engine", "aurora"),
+					resource.TestCheckResourceAttrSet(
+						"aws_rds_cluster.default", "engine_version"),
 					resource.TestCheckResourceAttrSet(
 						"aws_rds_cluster.default", "source_region"),
+					resource.TestCheckResourceAttrSet(
+						"aws_rds_cluster.default", "kms_key_id"),
 				),
 			},
 		},


### PR DESCRIPTION
This fixes issue RDS Aurora Cross-Region replication for encrypted cluster failing #630.  Issue was it was missing source_region within the module which was making it fail when trying to create a cross region replication cluster that was encrypted with the errror "aws_rds_cluster.replica: InvalidParameterCombination: Source cluster arn:aws:rds:us-east-1:<id>:cluster:<cluster_name> is encrypted; pre-signed URL has to be specified status code: 400, request id: b59ab0b3-812b-11e7-8467-c192637e53bf"