### PR TITLE
WIP: Expose AMI's root volume size

### DIFF
--- a/aws/data_source_aws_ami_test.go
+++ b/aws/data_source_aws_ami_test.go
@@ -42,6 +42,7 @@ func TestAccAWSAmiDataSource_natInstance(t *testing.T) {
 					resource.TestCheckResourceAttr("data.aws_ami.nat_ami", "root_device_name", "/dev/xvda"),
 					resource.TestCheckResourceAttr("data.aws_ami.nat_ami", "root_device_type", "ebs"),
 					resource.TestMatchResourceAttr("data.aws_ami.nat_ami", "root_snapshot_id", regexp.MustCompile("^snap-")),
+					resource.TestCheckResourceAttrSet("data.aws_ami.nat_ami", "root_volume_size"),
 					resource.TestCheckResourceAttr("data.aws_ami.nat_ami", "sriov_net_support", "simple"),
 					resource.TestCheckResourceAttr("data.aws_ami.nat_ami", "state", "available"),
 					resource.TestCheckResourceAttr("data.aws_ami.nat_ami", "state_reason.code", "UNSET"),

--- a/aws/resource_aws_ami.go
+++ b/aws/resource_aws_ami.go
@@ -197,7 +197,8 @@ func resourceAwsAmiRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("kernel_id", image.KernelId)
 	d.Set("ramdisk_id", image.RamdiskId)
 	d.Set("root_device_name", image.RootDeviceName)
-	d.Set("root_snapshot_id", amiRootSnapshotId(image))
+	d.Set("root_snapshot_id", amiRootVolumeInfo(image).snapshotId)
+	d.Set("root_volume_size", amiRootVolumeInfo(image).volumeSize)
 	d.Set("sriov_net_support", image.SriovNetSupport)
 	d.Set("virtualization_type", image.VirtualizationType)
 
@@ -443,6 +444,10 @@ func resourceAwsAmiCommonSchema(computed bool) map[string]*schema.Schema {
 			ForceNew: !computed,
 		},
 		"root_snapshot_id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"root_volume_size": {
 			Type:     schema.TypeString,
 			Computed: true,
 		},

--- a/aws/resource_aws_ami_test.go
+++ b/aws/resource_aws_ami_test.go
@@ -32,6 +32,8 @@ func TestAccAWSAMI_basic(t *testing.T) {
 						"aws_ami.foo", "name", fmt.Sprintf("tf-testing-%d", rInt)),
 					resource.TestMatchResourceAttr(
 						"aws_ami.foo", "root_snapshot_id", regexp.MustCompile("^snap-")),
+					resource.TestCheckResourceAttrSet(
+						"aws_ami.foo", "root_volume_size"),
 				),
 			},
 		},


### PR DESCRIPTION
Attempting to implement https://github.com/terraform-providers/terraform-provider-aws/issues/1623

The idea is that an instance module should be able to default the root volume to the size of the AMI's root volume. Right now I have a couple of AMIs that have a considerably larger root volume (CUDA/NVidia drivers take a lot of space) and I'd ideally not have to remember to override the root volume size before an apply time failure due to the root volume size being defaulted to a smaller size than the AMI root volume size.

Right now the tests I've added are failing with the root_volume_size not being set at all.
I'll debug this when I get a chance but just want to push the work up for now.

The work here carries on from https://github.com/terraform-providers/terraform-provider-aws/pull/1572