### PR TITLE
r/cognito_identity_pool: Fix failing acceptance test

### DIFF
--- a/aws/resource_aws_cognito_identity_pool_test.go
+++ b/aws/resource_aws_cognito_identity_pool_test.go
@@ -141,7 +141,7 @@ func TestAccAWSCognitoIdentityPool_samlProviderArns(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoIdentityPoolExists("aws_cognito_identity_pool.main"),
 					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
-					resource.TestCheckNoResourceAttr("aws_cognito_identity_pool.main", "saml_provider_arns.#"),
+					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "saml_provider_arns.#", "0"),
 				),
 			},
 		},


### PR DESCRIPTION
## Before

```
=== RUN   TestAccAWSCognitoIdentityPool_samlProviderArns
--- FAIL: TestAccAWSCognitoIdentityPool_samlProviderArns (25.85s)
    testing.go:492: Step 2 error: Check failed: 1 error(s) occurred:
        
        * Check 3/3 error: aws_cognito_identity_pool.main: Attribute 'saml_provider_arns.#' found when not expected
```

## After

```
=== RUN   TestAccAWSCognitoIdentityPool_samlProviderArns
--- PASS: TestAccAWSCognitoIdentityPool_samlProviderArns (86.90s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	86.926s
```