### PR TITLE
d/aws_ip_ranges: Fix failing acceptance test

### DIFF
--- a/aws/data_source_aws_ip_ranges_test.go
+++ b/aws/data_source_aws_ip_ranges_test.go
@@ -89,7 +89,7 @@ func testAccAWSIPRanges(n string) resource.TestCheckFunc {
 
 			if regionMember.MatchString(k) {
 
-				if !(v == "eu-west-1" || v == "EU-central-1") {
+				if !(v == "eu-west-1" || v == "eu-central-1") {
 					return fmt.Errorf("unexpected region %s", v)
 				}
 
@@ -99,7 +99,7 @@ func testAccAWSIPRanges(n string) resource.TestCheckFunc {
 
 			if serviceMember.MatchString(k) {
 
-				if v != "EC2" {
+				if v != "ec2" {
 					return fmt.Errorf("unexpected service %s", v)
 				}
 
@@ -122,7 +122,7 @@ func testAccAWSIPRanges(n string) resource.TestCheckFunc {
 
 const testAccAWSIPRangesConfig = `
 data "aws_ip_ranges" "some" {
-  regions = [ "eu-west-1", "EU-central-1" ]
-  services = [ "EC2" ]
+  regions = [ "eu-west-1", "eu-central-1" ]
+  services = [ "ec2" ]
 }
 `


### PR DESCRIPTION
It seems Amazon's API just started to lowercase some attributes recently.

This is to address the following two failures:

```
=== RUN   TestAccAWSIPRanges
--- FAIL: TestAccAWSIPRanges (6.68s)
    testing.go:492: Step 0 error: Check failed: Check 1/1 error: unexpected region eu-central-1
```
```
=== RUN   TestAccAWSIPRanges
--- FAIL: TestAccAWSIPRanges (17.61s)
	testing.go:492: Step 0 error: Check failed: Check 1/1 error: unexpected service ec2
```

## Test results
```
TF_ACC=1 go test ./aws -v -run=TestAccAWSIPRanges -timeout 120m
=== RUN   TestAccAWSIPRanges
--- PASS: TestAccAWSIPRanges (24.46s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	24.493s
```