### PR TITLE
validateBatchName should allow hyphens

### DIFF
--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1490,8 +1490,8 @@ func validateSsmParameterType(v interface{}, k string) (ws []string, errors []er
 
 func validateBatchName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-	if !regexp.MustCompile(`^[A-Za-z0-9_]{1,128}$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf("%q (%q) must be up to 128 letters (uppercase and lowercase), numbers, and underscores.", k, v))
+	if !regexp.MustCompile(`^[A-Za-z0-9_-]{1,128}$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf("%q (%q) must be up to 128 letters (uppercase and lowercase), numbers, hyphens, and underscores.", k, v))
 	}
 	return
 }


### PR DESCRIPTION
Links to AWS docs 
http://docs.aws.amazon.com/batch/latest/APIReference/API_CreateComputeEnvironment.html#Batch-CreateComputeEnvironment-request-computeEnvironmentName
http://docs.aws.amazon.com/batch/latest/APIReference/API_RegisterJobDefinition.html#Batch-RegisterJobDefinition-request-jobDefinitionName