### PR TITLE
Update ecr_lifecycle_policy.html.markdown

### DIFF
--- a/website/docs/r/ecr_lifecycle_policy.html.markdown
+++ b/website/docs/r/ecr_lifecycle_policy.html.markdown
@@ -52,7 +52,7 @@ resource "aws_ecr_repository" "foo" {
 }
 
 resource "aws_ecr_lifecycle_policy" "foopolicy" {
-  repository = "${aws_ecr_repository.api.name}"
+  repository = "${aws_ecr_repository.foo.name}"
 
   policy = <<EOF
 {


### PR DESCRIPTION
This fixes the example for tagged images, where the repository used by the policy didn't exist.