### PR TITLE
r/elasticache_parameter_group: Raise timeout for retry on pending changes

### DIFF
--- a/aws/resource_aws_elasticache_parameter_group.go
+++ b/aws/resource_aws_elasticache_parameter_group.go
@@ -174,7 +174,7 @@ func resourceAwsElasticacheParameterGroupUpdate(d *schema.ResourceData, meta int
 			}
 
 			log.Printf("[DEBUG] Reset Cache Parameter Group: %s", resetOpts)
-			err := resource.Retry(15*time.Second, func() *resource.RetryError {
+			err := resource.Retry(30*time.Second, func() *resource.RetryError {
 				_, err = conn.ResetCacheParameterGroup(&resetOpts)
 				if err != nil {
 					if isAWSErr(err, "InvalidCacheParameterGroupState", " has pending changes") {


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSElasticacheParameterGroup_removeParam
--- FAIL: TestAccAWSElasticacheParameterGroup_removeParam (23.51s)
    testing.go:492: Step 1 error: Error applying: 1 error(s) occurred:
        
        * aws_elasticache_parameter_group.bar: 1 error(s) occurred:
        
        * aws_elasticache_parameter_group.bar: Error resetting Cache Parameter Group: InvalidCacheParameterGroupState: Cannot reset the parameter group because the parameter appendfsync has pending changes.
            status code: 400, request id: cfb9ec1f-bed1-11e7-9df1-6f235b4356e9
```