### PR TITLE
r/appautoscaling_policy: Retry putting policy on invalid token

### DIFF
--- a/aws/resource_aws_appautoscaling_policy.go
+++ b/aws/resource_aws_appautoscaling_policy.go
@@ -265,6 +265,9 @@ func resourceAwsAppautoscalingPolicyCreate(d *schema.ResourceData, meta interfac
 			if isAWSErr(err, "FailedResourceAccessException", "is not authorized to perform") {
 				return resource.RetryableError(err)
 			}
+			if isAWSErr(err, "FailedResourceAccessException", "token included in the request is invalid") {
+				return resource.RetryableError(err)
+			}
 			return resource.NonRetryableError(fmt.Errorf("Error putting scaling policy: %s", err))
 		}
 		return nil


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSAppautoScalingPolicy_multiplePolicies
--- FAIL: TestAccAWSAppautoScalingPolicy_multiplePolicies (19.28s)
    testing.go:492: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_appautoscaling_policy.write: 1 error(s) occurred:
        
        * aws_appautoscaling_policy.write: Failed to create scaling policy: Error putting scaling policy: FailedResourceAccessException: Unable to retrieve capacity for resource: table/tf-autoscaled-table-ripo7, scalable dimension: dynamodb:table:WriteCapacityUnits. Reason: The security token included in the request is invalid.
            status code: 400, request id: bf9634d5-becb-11e7-9257-63487abac333
```