### PR TITLE
New Resource: aws_dx_lag

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -33,6 +33,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/configservice"
 	"github.com/aws/aws-sdk-go/service/databasemigrationservice"
 	"github.com/aws/aws-sdk-go/service/devicefarm"
+	"github.com/aws/aws-sdk-go/service/directconnect"
 	"github.com/aws/aws-sdk-go/service/directoryservice"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -180,6 +181,7 @@ type AWSClient struct {
 	wafregionalconn       *wafregional.WAFRegional
 	iotconn               *iot.IoT
 	batchconn             *batch.Batch
+	dxconn                *directconnect.DirectConnect
 }
 
 func (c *AWSClient) S3() *s3.S3 {
@@ -390,6 +392,7 @@ func (c *Config) Client() (interface{}, error) {
 	client.wafconn = waf.New(sess)
 	client.wafregionalconn = wafregional.New(sess)
 	client.batchconn = batch.New(sess)
+	client.dxconn = directconnect.New(sess)
 
 	// Workaround for https://github.com/aws/aws-sdk-go/issues/1376
 	client.kinesisconn.Handlers.Retry.PushBack(func(r *request.Request) {

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -307,6 +307,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_dms_replication_instance":                 resourceAwsDmsReplicationInstance(),
 			"aws_dms_replication_subnet_group":             resourceAwsDmsReplicationSubnetGroup(),
 			"aws_dms_replication_task":                     resourceAwsDmsReplicationTask(),
+			"aws_dx_lag":                                   resourceAwsDxLag(),
 			"aws_dynamodb_table":                           resourceAwsDynamoDbTable(),
 			"aws_ebs_snapshot":                             resourceAwsEbsSnapshot(),
 			"aws_ebs_volume":                               resourceAwsEbsVolume(),

--- a/aws/resource_aws_dx_lag.go
+++ b/aws/resource_aws_dx_lag.go
@@ -1,0 +1,162 @@
+package aws
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/directconnect"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsDxLag() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsDxLagCreate,
+		Read:   resourceAwsDxLagRead,
+		Update: resourceAwsDxLagUpdate,
+		Delete: resourceAwsDxLagDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"band_width": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateDxLagBandWidth,
+			},
+			"location": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"num_connections": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: true,
+			},
+			"force_destroy": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+		},
+	}
+}
+
+func resourceAwsDxLagCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).dxconn
+
+	input := &directconnect.CreateLagInput{
+		ConnectionsBandwidth: aws.String(d.Get("band_width").(string)),
+		LagName:              aws.String(d.Get("name").(string)),
+		Location:             aws.String(d.Get("location").(string)),
+		NumberOfConnections:  aws.Int64(int64(d.Get("num_connections").(int))),
+	}
+	resp, err := conn.CreateLag(input)
+	if err != nil {
+		return err
+	}
+	d.SetId(*resp.LagId)
+	return resourceAwsDxLagRead(d, meta)
+}
+
+func resourceAwsDxLagRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).dxconn
+
+	lagId := d.Id()
+	input := &directconnect.DescribeLagsInput{
+		LagId: aws.String(lagId),
+	}
+	resp, err := conn.DescribeLags(input)
+	if err != nil {
+		d.SetId("")
+		return err
+	}
+	if len(resp.Lags) != 1 {
+		d.SetId("")
+		return fmt.Errorf("[ERROR] Number of DX Lag (%s) isn't one, got %d", lagId, len(resp.Lags))
+	}
+	if d.Id() != *resp.Lags[0].LagId {
+		d.SetId("")
+		return fmt.Errorf("[ERROR] DX Lag (%s) not found", lagId)
+	}
+	return nil
+}
+
+func resourceAwsDxLagUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).dxconn
+
+	input := &directconnect.UpdateLagInput{
+		LagId: aws.String(d.Id()),
+	}
+	if d.HasChange("name") {
+		input.LagName = aws.String(d.Get("name").(string))
+	}
+	_, err := conn.UpdateLag(input)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func resourceAwsDxLagDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).dxconn
+
+	if d.Get("force_destroy").(bool) {
+		input := &directconnect.DescribeLagsInput{
+			LagId: aws.String(d.Id()),
+		}
+		resp, err := conn.DescribeLags(input)
+		if err != nil {
+			return err
+		}
+		lag := resp.Lags[0]
+		for _, v := range lag.Connections {
+			dcinput := &directconnect.DeleteConnectionInput{
+				ConnectionId: v.ConnectionId,
+			}
+			if _, err := conn.DeleteConnection(dcinput); err != nil {
+				return err
+			}
+		}
+	}
+
+	input := &directconnect.DeleteLagInput{
+		LagId: aws.String(d.Id()),
+	}
+	_, err := conn.DeleteLag(input)
+	if err != nil {
+		return err
+	}
+	deleteStateConf := &resource.StateChangeConf{
+		Pending:    []string{directconnect.LagStateAvailable, directconnect.LagStateRequested, directconnect.LagStatePending},
+		Target:     []string{directconnect.LagStateDeleted, directconnect.LagStateDeleting},
+		Refresh:    dxLagRefreshStateFunc(conn, d.Id()),
+		Timeout:    10 * time.Minute,
+		Delay:      10 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+	_, err = deleteStateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error waiting for Dx Lag (%s) to be deleted: %s", d.Id(), err)
+	}
+	d.SetId("")
+	return nil
+}
+
+func dxLagRefreshStateFunc(conn *directconnect.DirectConnect, lagId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		input := &directconnect.DescribeLagsInput{
+			LagId: aws.String(lagId),
+		}
+		resp, err := conn.DescribeLags(input)
+		if err != nil {
+			return nil, "failed", err
+		}
+		return resp, *resp.Lags[0].LagState, nil
+	}
+}

--- a/aws/resource_aws_dx_lag.go
+++ b/aws/resource_aws_dx_lag.go
@@ -75,10 +75,11 @@ func resourceAwsDxLagRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
+	if len(resp.Lags) < 1 {
+		d.SetId("")
+		return nil
+	}
 	if len(resp.Lags) != 1 {
-		if len(resp.Lags) < 1 {
-			d.SetId("")
-		}
 		return fmt.Errorf("[ERROR] Number of DX Lag (%s) isn't one, got %d", lagId, len(resp.Lags))
 	}
 	if d.Id() != *resp.Lags[0].LagId {

--- a/aws/resource_aws_dx_lag_test.go
+++ b/aws/resource_aws_dx_lag_test.go
@@ -1,0 +1,77 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/directconnect"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAwsDxLag_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsDxLagDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDxLagConfig(acctest.RandString(5)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsDxLagExists("aws_dx_lag.hoge"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsDxLagDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).dxconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_dx_lag" {
+			continue
+		}
+
+		input := &directconnect.DescribeLagsInput{
+			LagId: aws.String(rs.Primary.ID),
+		}
+
+		resp, err := conn.DescribeLags(input)
+		if err != nil {
+			return err
+		}
+		for _, v := range resp.Lags {
+			if *v.LagId == rs.Primary.ID && !(*v.LagState == directconnect.LagStateDeleting || *v.LagState == directconnect.LagStateDeleted) {
+				return fmt.Errorf("[DESTROY ERROR] Dx Lag (%s) found", rs.Primary.ID)
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAwsDxLagExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		return nil
+	}
+}
+
+func testAccDxLagConfig(rName string) string {
+	return fmt.Sprintf(`
+    resource "aws_dx_lag" "hoge" {
+      name = "tf-dx-lag-%s"
+      band_width = "1Gbps"
+      location = "EqDC2"
+      num_connections = 2
+      force_destroy = true
+    }
+    `, rName)
+}

--- a/aws/resource_aws_dx_lag_test.go
+++ b/aws/resource_aws_dx_lag_test.go
@@ -44,7 +44,7 @@ func testAccCheckAwsDxLagDestroy(s *terraform.State) error {
 			return err
 		}
 		for _, v := range resp.Lags {
-			if *v.LagId == rs.Primary.ID && !(*v.LagState == directconnect.LagStateDeleting || *v.LagState == directconnect.LagStateDeleted) {
+			if *v.LagId == rs.Primary.ID && !(*v.LagState == directconnect.LagStateDeleted) {
 				return fmt.Errorf("[DESTROY ERROR] Dx Lag (%s) found", rs.Primary.ID)
 			}
 		}
@@ -68,9 +68,9 @@ func testAccDxLagConfig(rName string) string {
 	return fmt.Sprintf(`
     resource "aws_dx_lag" "hoge" {
       name = "tf-dx-lag-%s"
-      band_width = "1Gbps"
-      location = "EqDC2"
-      num_connections = 2
+      connections_bandwidth = "1Gbps"
+      location = "EqSe2"
+      number_of_connections = 2
       force_destroy = true
     }
     `, rName)

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1651,3 +1651,21 @@ func validateCognitoRoles(v map[string]interface{}, k string) (errors []error) {
 
 	return
 }
+
+func validateDxLagBandWidth(v interface{}, k string) (ws []string, errors []error) {
+	val, ok := v.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
+		return
+	}
+
+	validBandWidth := []string{"1Gbps", "10Gbps"}
+	for _, str := range validBandWidth {
+		if val == str {
+			return
+		}
+	}
+
+	errors = append(errors, fmt.Errorf("expected %s to be one of %v, got %s", k, validBandWidth, val))
+	return
+}

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -2603,3 +2603,30 @@ func TestValidateCognitoRoleMappingsType(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateDxLagBandWidth(t *testing.T) {
+	validValues := []string{
+		"1Gbps",
+		"10Gbps",
+	}
+
+	for _, s := range validValues {
+		_, errors := validateDxLagBandWidth(s, "match_type")
+		if len(errors) > 0 {
+			t.Fatalf("%s should be a valid Direct Connect Lag Bandwidth: %v", s, errors)
+		}
+	}
+
+	invalidValues := []string{
+		"1gbps",
+		"10GBPS",
+		"invalid character",
+	}
+
+	for _, s := range invalidValues {
+		_, errors := validateDxLagBandWidth(s, "match_type")
+		if len(errors) == 0 {
+			t.Fatalf("%s should not be a valid Direct Connect Lag Bandwidth: %v", s, errors)
+		}
+	}
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -512,6 +512,15 @@
                     </ul>
                 </li>
 
+                <li<%= sidebar_current("docs-aws-resource-dx") %>>
+                    <a href="#">Direct Connect Resources</a>
+                    <ul class="nav nav-visible">
+                        <li<%= sidebar_current("docs-aws-resource-dx-lag") %>>
+                            <a href="/docs/providers/aws/r/dx_lag.html">aws_dx_lag</a>
+                        </li>
+                    </ul>
+                </li>
+
                 <li<%= sidebar_current("docs-aws-resource-directory-service") %>>
                     <a href="#">Directory Service Resources</a>
                     <ul class="nav nav-visible">

--- a/website/docs/r/dx_lag.html.markdown
+++ b/website/docs/r/dx_lag.html.markdown
@@ -1,0 +1,39 @@
+---
+layout: "aws"
+page_title: "AWS: aws_athena_database"
+sidebar_current: "docs-aws-resource-athena-database"
+description: |-  
+  Provides an Athena database.
+---
+
+# aws_dx_lag
+
+Provides a Direct Connect LAG.
+
+## Example Usage
+
+```hcl
+resource "aws_dx_lag" "hoge" {
+  name = "tf-dx-lag"
+  band_width = "1Gbps"
+  location = "EqDC2"
+  num_connections = 2
+  force_destroy = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the LAG.
+* `band_width` - (Required) The bandwidth of the individual physical connections bundled by the LAG. Available values: 1Gbps, 10Gbps. Case sensitive.
+* `location` - (Required) The AWS Direct Connect location in which the LAG should be allocated. See [DescribeLocations](https://docs.aws.amazon.com/directconnect/latest/APIReference/API_DescribeLocations.html) for the list of AWS Direct Connect locations. Use `locationCode`.
+* `num_connections` - (Required) The number of physical connections initially provisioned and bundled by the LAG.
+* `force_destroy` - (Optional, Default:false) A boolean that indicates all connections associated with the LAG should be deleted so that the LAG can be destroyed without error. These objects are *not* recoverable.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the LAG.

--- a/website/docs/r/dx_lag.html.markdown
+++ b/website/docs/r/dx_lag.html.markdown
@@ -15,9 +15,9 @@ Provides a Direct Connect LAG.
 ```hcl
 resource "aws_dx_lag" "hoge" {
   name = "tf-dx-lag"
-  band_width = "1Gbps"
+  connections_bandwidth = "1Gbps"
   location = "EqDC2"
-  num_connections = 2
+  number_of_connections = 2
   force_destroy = true
 }
 ```
@@ -27,9 +27,9 @@ resource "aws_dx_lag" "hoge" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the LAG.
-* `band_width` - (Required) The bandwidth of the individual physical connections bundled by the LAG. Available values: 1Gbps, 10Gbps. Case sensitive.
+* `connections_bandwidth` - (Required) The bandwidth of the individual physical connections bundled by the LAG. Available values: 1Gbps, 10Gbps. Case sensitive.
 * `location` - (Required) The AWS Direct Connect location in which the LAG should be allocated. See [DescribeLocations](https://docs.aws.amazon.com/directconnect/latest/APIReference/API_DescribeLocations.html) for the list of AWS Direct Connect locations. Use `locationCode`.
-* `num_connections` - (Required) The number of physical connections initially provisioned and bundled by the LAG.
+* `number_of_connections` - (Required) The number of physical connections initially provisioned and bundled by the LAG.
 * `force_destroy` - (Optional, Default:false) A boolean that indicates all connections associated with the LAG should be deleted so that the LAG can be destroyed without error. These objects are *not* recoverable.
 
 ## Attributes Reference

--- a/website/docs/r/dx_lag.html.markdown
+++ b/website/docs/r/dx_lag.html.markdown
@@ -1,9 +1,9 @@
 ---
 layout: "aws"
-page_title: "AWS: aws_athena_database"
-sidebar_current: "docs-aws-resource-athena-database"
+page_title: "AWS: aws_dx_lag"
+sidebar_current: "docs-aws-resource-dx-lag"
 description: |-  
-  Provides an Athena database.
+  Provides a Direct Connect LAG.
 ---
 
 # aws_dx_lag


### PR DESCRIPTION
```
make testacc TEST=./aws TESTARGS='-run=TestAccAwsDxLag_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAwsDxLag_basic -timeout 120m
=== RUN   TestAccAwsDxLag_basic
--- PASS: TestAccAwsDxLag_basic (40.91s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	40.984s
```