### PR TITLE
resource/aws_elasticsearch_domain: Added ForceNew to vpc_options

### DIFF
--- a/aws/resource_aws_elasticsearch_domain.go
+++ b/aws/resource_aws_elasticsearch_domain.go
@@ -140,6 +140,7 @@ func resourceAwsElasticSearchDomain() *schema.Resource {
 			"vpc_options": {
 				Type:     schema.TypeList,
 				Optional: true,
+				ForceNew: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides an ElasticSearch Domain.
 ---
 
-# aws\_elasticsearch\_domain
+# aws_elasticsearch_domain
 
 
 ## Example Usage
@@ -59,7 +59,7 @@ The following arguments are supported:
 * `ebs_options` - (Optional) EBS related options, may be required based on chosen [instance size](https://aws.amazon.com/elasticsearch-service/pricing/). See below.
 * `cluster_config` - (Optional) Cluster configuration of the domain, see below.
 * `snapshot_options` - (Optional) Snapshot related options, see below.
-* `vpc_options` - (Optional) VPC related options, see below.
+* `vpc_options` - (Optional) VPC related options, see below. Adding or removing this configuration forces a new resource.
 * `elasticsearch_version` - (Optional) The version of ElasticSearch to deploy. Defaults to `1.5`
 * `tags` - (Optional) A mapping of tags to assign to the resource
 

--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -59,7 +59,7 @@ The following arguments are supported:
 * `ebs_options` - (Optional) EBS related options, may be required based on chosen [instance size](https://aws.amazon.com/elasticsearch-service/pricing/). See below.
 * `cluster_config` - (Optional) Cluster configuration of the domain, see below.
 * `snapshot_options` - (Optional) Snapshot related options, see below.
-* `vpc_options` - (Optional) VPC related options, see below. Adding or removing this configuration forces a new resource.
+* `vpc_options` - (Optional) VPC related options, see below. Adding or removing this configuration forces a new resource ([documentation](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-vpc.html#es-vpc-limitations)).
 * `elasticsearch_version` - (Optional) The version of ElasticSearch to deploy. Defaults to `1.5`
 * `tags` - (Optional) A mapping of tags to assign to the resource
 


### PR DESCRIPTION
This fixes an issue where you could not switch from an internet-based ES endpoint to a VPC_based one, and vice-versa. [Documentation about those limitations](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-vpc.html#es-vpc-limitations)

### Before

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSElasticSearchDomain_internetToVpcEndpoint'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSElasticSearchDomain_internetToVpcEndpoint -timeout 120m
=== RUN   TestAccAWSElasticSearchDomain_internetToVpcEndpoint
--- FAIL: TestAccAWSElasticSearchDomain_internetToVpcEndpoint (737.45s)
	testing.go:492: Step 1 error: Error applying: 1 error(s) occurred:
		
		* aws_elasticsearch_domain.example: 1 error(s) occurred:
		
		* aws_elasticsearch_domain.example: ValidationException: Domain should be created with VPC options to update VPC options later
			status code: 400, request id: 92ffeaf5-bfc4-11e7-881d-b1dcd6c02d98
FAIL
exit status 1
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	737.489s
make: *** [testacc] Error 1
```

### After:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSElasticSearchDomain_internetToVpcEndpoint'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSElasticSearchDomain_internetToVpcEndpoint -timeout 120m
=== RUN   TestAccAWSElasticSearchDomain_internetToVpcEndpoint
--- PASS: TestAccAWSElasticSearchDomain_internetToVpcEndpoint (2083.19s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2083.229s
```