### PR TITLE
Batch name extra checks

### DIFF
--- a/aws/resource_aws_batch_job_queue.go
+++ b/aws/resource_aws_batch_job_queue.go
@@ -27,8 +27,9 @@ func resourceAwsBatchJobQueue() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateBatchName,
 			},
 			"priority": {
 				Type:     schema.TypeInt,

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1490,8 +1490,8 @@ func validateSsmParameterType(v interface{}, k string) (ws []string, errors []er
 
 func validateBatchName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-	if !regexp.MustCompile(`^[A-Za-z0-9_]{1,128}$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf("%q (%q) must be up to 128 letters (uppercase and lowercase), numbers, and underscores.", k, v))
+	if !regexp.MustCompile(`^[0-9a-zA-Z]{1}[0-9a-zA-Z_\-]{0,127}$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf("%q (%q) must be up to 128 letters (uppercase and lowercase), numbers, underscores and dashes, and must start with an alphanumeric.", k, v))
 	}
 	return
 }


### PR DESCRIPTION
- Augment the `validateBatchName` method to ensure name begins with alphanumeric (i.e., no underscore or hyphen). 
- Enforce the same name qualifications for **job queues**.

Neither of the above is officially documented by AWS; however they are real restrictions that will cause resource creation to fail if not adhered to. All have been hand-tested.