### PR TITLE
Documentation: r/ecs_task_definition note about quote escaping container_definition

### DIFF
--- a/website/docs/r/ecs_task_definition.html.markdown
+++ b/website/docs/r/ecs_task_definition.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides an ECS task definition.
 ---
 
-# aws\_ecs\_task\_definition
+# aws_ecs_task_definition
 
 Provides an ECS task definition to be used in `aws_ecs_service`.
 
@@ -76,6 +76,9 @@ single valid JSON document. Please note that you should only provide values that
 definition document. For a detailed description of what parameters are available, see the [Task Definition Parameters]
 (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html) section from the
 official [Developer Guide](https://docs.aws.amazon.com/AmazonECS/latest/developerguide).
+
+~> **NOTE**: Proper escaping is required for JSON field values containing quotes (`"`) such as `environment` values. If directly setting the JSON, they should be escaped as `\"` in the JSON,  e.g. `"value": "I \"love\" escaped quotes"`. If using a Terraform variable value, they should be escaped as `\\\"` in the variable, e.g. `value = "I \\\"love\\\" escaped quotes"` in the variable and `"value": "${var.myvariable}"` in the JSON.
+
 * `task_role_arn` - (Optional) The ARN of IAM role that allows your Amazon ECS container task to make calls to other AWS services.
 * `network_mode` - (Optional) The Docker networking mode to use for the containers in the task. The valid values are `none`, `bridge`, and `host`.
 * `volume` - (Optional) A set of [volume blocks](#volume-block-arguments) that containers in your task may use.


### PR DESCRIPTION
This is a targeted documentation note, but maybe it could be put somewhere more generic and referenced in various places where the Terraform/API input is raw JSON for a field and could contain quotes in values?

Closes #2142 