### PR TITLE
Docs: Remove tags from spot fleet example

### DIFF
--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -42,10 +42,6 @@ resource "aws_spot_fleet_request" "cheap_compute" {
       volume_size = "300"
       volume_type = "gp2"
     }
-
-    tags {
-      Name = "spot-fleet-example"
-    }
   }
 }
 ```


### PR DESCRIPTION
As indicated later in the documentation for this resource, `tags` is not
a valid key in the launch specification. Adding tags will result in the
following error at runtime:

    invalid or unknown key: tags