### PR TITLE
Impossible to create a target group with TCP protocol.

### DIFF
--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -427,7 +427,7 @@ func validateAwsLbTargetGroupHealthCheckProtocol(v interface{}, k string) (ws []
 		return
 	}
 
-	errors = append(errors, fmt.Errorf("%q must be either %q or %q", k, "HTTP", "HTTPS", "TCP"))
+	errors = append(errors, fmt.Errorf("%q must be either %q, %q or %q", k, "HTTP", "HTTPS", "TCP"))
 	return
 }
 
@@ -445,7 +445,7 @@ func validateAwsLbTargetGroupProtocol(v interface{}, k string) (ws []string, err
 		return
 	}
 
-	errors = append(errors, fmt.Errorf("%q must be either %q or %q", k, "HTTP", "HTTPS", "TCP"))
+	errors = append(errors, fmt.Errorf("%q must be either %q, %q or %q", k, "HTTP", "HTTPS", "TCP"))
 	return
 }
 

--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -209,14 +209,16 @@ func resourceAwsLbTargetGroupCreate(d *schema.ResourceData, meta interface{}) er
 		healthCheck := healthChecks[0].(map[string]interface{})
 
 		params.HealthCheckIntervalSeconds = aws.Int64(int64(healthCheck["interval"].(int)))
-		params.HealthCheckPath = aws.String(healthCheck["path"].(string))
 		params.HealthCheckPort = aws.String(healthCheck["port"].(string))
 		params.HealthCheckProtocol = aws.String(healthCheck["protocol"].(string))
 		params.HealthCheckTimeoutSeconds = aws.Int64(int64(healthCheck["timeout"].(int)))
 		params.HealthyThresholdCount = aws.Int64(int64(healthCheck["healthy_threshold"].(int)))
 		params.UnhealthyThresholdCount = aws.Int64(int64(healthCheck["unhealthy_threshold"].(int)))
-		params.Matcher = &elbv2.Matcher{
-			HttpCode: aws.String(healthCheck["matcher"].(string)),
+		if d.Get("protocol") != "TCP" {
+			params.HealthCheckPath = aws.String(healthCheck["path"].(string))
+			params.Matcher = &elbv2.Matcher{
+				HttpCode: aws.String(healthCheck["matcher"].(string)),
+			}
 		}
 	}
 
@@ -270,19 +272,30 @@ func resourceAwsLbTargetGroupUpdate(d *schema.ResourceData, meta interface{}) er
 		var params *elbv2.ModifyTargetGroupInput
 		if len(healthChecks) == 1 {
 			healthCheck := healthChecks[0].(map[string]interface{})
-
-			params = &elbv2.ModifyTargetGroupInput{
-				TargetGroupArn:             aws.String(d.Id()),
-				HealthCheckIntervalSeconds: aws.Int64(int64(healthCheck["interval"].(int))),
-				HealthCheckPath:            aws.String(healthCheck["path"].(string)),
-				HealthCheckPort:            aws.String(healthCheck["port"].(string)),
-				HealthCheckProtocol:        aws.String(healthCheck["protocol"].(string)),
-				HealthCheckTimeoutSeconds:  aws.Int64(int64(healthCheck["timeout"].(int))),
-				HealthyThresholdCount:      aws.Int64(int64(healthCheck["healthy_threshold"].(int))),
-				UnhealthyThresholdCount:    aws.Int64(int64(healthCheck["unhealthy_threshold"].(int))),
-				Matcher: &elbv2.Matcher{
-					HttpCode: aws.String(healthCheck["matcher"].(string)),
-				},
+			if d.Get("protocol") != "TCP" {
+				params = &elbv2.ModifyTargetGroupInput{
+					TargetGroupArn:             aws.String(d.Id()),
+					HealthCheckIntervalSeconds: aws.Int64(int64(healthCheck["interval"].(int))),
+					HealthCheckPath:            aws.String(healthCheck["path"].(string)),
+					HealthCheckPort:            aws.String(healthCheck["port"].(string)),
+					HealthCheckProtocol:        aws.String(healthCheck["protocol"].(string)),
+					HealthCheckTimeoutSeconds:  aws.Int64(int64(healthCheck["timeout"].(int))),
+					HealthyThresholdCount:      aws.Int64(int64(healthCheck["healthy_threshold"].(int))),
+					UnhealthyThresholdCount:    aws.Int64(int64(healthCheck["unhealthy_threshold"].(int))),
+					Matcher: &elbv2.Matcher{
+						HttpCode: aws.String(healthCheck["matcher"].(string)),
+					},
+				}
+			} else {
+				params = &elbv2.ModifyTargetGroupInput{
+					TargetGroupArn:             aws.String(d.Id()),
+					HealthCheckIntervalSeconds: aws.Int64(int64(healthCheck["interval"].(int))),
+					HealthCheckPort:            aws.String(healthCheck["port"].(string)),
+					HealthCheckProtocol:        aws.String(healthCheck["protocol"].(string)),
+					HealthCheckTimeoutSeconds:  aws.Int64(int64(healthCheck["timeout"].(int))),
+					HealthyThresholdCount:      aws.Int64(int64(healthCheck["healthy_threshold"].(int))),
+					UnhealthyThresholdCount:    aws.Int64(int64(healthCheck["unhealthy_threshold"].(int))),
+				}
 			}
 		} else {
 			params = &elbv2.ModifyTargetGroupInput{
@@ -410,11 +423,11 @@ func validateAwsLbTargetGroupHealthCheckTimeout(v interface{}, k string) (ws []s
 
 func validateAwsLbTargetGroupHealthCheckProtocol(v interface{}, k string) (ws []string, errors []error) {
 	value := strings.ToLower(v.(string))
-	if value == "http" || value == "https" {
+	if value == "http" || value == "https" || value == "tcp" {
 		return
 	}
 
-	errors = append(errors, fmt.Errorf("%q must be either %q or %q", k, "HTTP", "HTTPS"))
+	errors = append(errors, fmt.Errorf("%q must be either %q or %q", k, "HTTP", "HTTPS", "TCP"))
 	return
 }
 
@@ -428,11 +441,11 @@ func validateAwsLbTargetGroupPort(v interface{}, k string) (ws []string, errors 
 
 func validateAwsLbTargetGroupProtocol(v interface{}, k string) (ws []string, errors []error) {
 	protocol := strings.ToLower(v.(string))
-	if protocol == "http" || protocol == "https" {
+	if protocol == "http" || protocol == "https" || protocol == "tcp" {
 		return
 	}
 
-	errors = append(errors, fmt.Errorf("%q must be either %q or %q", k, "HTTP", "HTTPS"))
+	errors = append(errors, fmt.Errorf("%q must be either %q or %q", k, "HTTP", "HTTPS", "TCP"))
 	return
 }
 
@@ -488,13 +501,15 @@ func flattenAwsLbTargetGroupResource(d *schema.ResourceData, meta interface{}, t
 
 	healthCheck := make(map[string]interface{})
 	healthCheck["interval"] = *targetGroup.HealthCheckIntervalSeconds
-	healthCheck["path"] = *targetGroup.HealthCheckPath
+	if d.Get("protocol") != "TCP" {
+		healthCheck["path"] = *targetGroup.HealthCheckPath
+		healthCheck["matcher"] = *targetGroup.Matcher.HttpCode
+	}
 	healthCheck["port"] = *targetGroup.HealthCheckPort
 	healthCheck["protocol"] = *targetGroup.HealthCheckProtocol
 	healthCheck["timeout"] = *targetGroup.HealthCheckTimeoutSeconds
 	healthCheck["healthy_threshold"] = *targetGroup.HealthyThresholdCount
 	healthCheck["unhealthy_threshold"] = *targetGroup.UnhealthyThresholdCount
-	healthCheck["matcher"] = *targetGroup.Matcher.HttpCode
 	d.Set("health_check", []interface{}{healthCheck})
 
 	attrResp, err := elbconn.DescribeTargetGroupAttributes(&elbv2.DescribeTargetGroupAttributesInput{


### PR DESCRIPTION
Current fix should solve errors like ' Health check paths are not supported for TCP health checks' and 'Health check matchers are not supported for TCP health checks'