### PR TITLE
r/eip: Add explicit dependencies on IGW

### DIFF
--- a/aws/resource_aws_eip.go
+++ b/aws/resource_aws_eip.go
@@ -254,10 +254,8 @@ func resourceAwsEipUpdate(d *schema.ResourceData, meta interface{}) error {
 		err := resource.Retry(5*time.Minute, func() *resource.RetryError {
 			_, err := ec2conn.AssociateAddress(assocOpts)
 			if err != nil {
-				if awsErr, ok := err.(awserr.Error); ok {
-					if awsErr.Code() == "InvalidAllocationID.NotFound" {
-						return resource.RetryableError(awsErr)
-					}
+				if isAWSErr(err, "InvalidAllocationID.NotFound", "") {
+					return resource.RetryableError(err)
 				}
 				return resource.NonRetryableError(err)
 			}

--- a/aws/resource_aws_eip_test.go
+++ b/aws/resource_aws_eip_test.go
@@ -640,12 +640,14 @@ resource "aws_eip" "one" {
   vpc                       = "true"
   network_interface         = "${aws_network_interface.bar.id}"
   associate_with_private_ip = "10.0.0.10"
+  depends_on                = ["aws_internet_gateway.bar"]
 }
 
 resource "aws_eip" "two" {
   vpc                       = "true"
   network_interface         = "${aws_network_interface.bar.id}"
   associate_with_private_ip = "10.0.0.11"
+  depends_on                = ["aws_internet_gateway.bar"]
 }
 `
 

--- a/website/docs/r/eip.html.markdown
+++ b/website/docs/r/eip.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides an Elastic IP resource.
 
+~> **Note:** EIP may require IGW to exist prior to association. Use `depends_on` to set an explicit dependency on the IGW.
+
 ## Example Usage
 
 Single EIP associated with an instance:
@@ -76,6 +78,7 @@ resource "aws_eip" "bar" {
 
   instance                  = "${aws_instance.foo.id}"
   associate_with_private_ip = "10.0.0.12"
+  depends_on                = ["${aws_internet_gateway.gw}"]
 }
 ```
 


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSEIP_twoEIPsOneNetworkInterface
--- FAIL: TestAccAWSEIP_twoEIPsOneNetworkInterface (73.97s)
    testing.go:492: Step 0 error: Error applying: 2 error(s) occurred:
        
        * aws_eip.one: 1 error(s) occurred:
        
        * aws_eip.one: Failure associating EIP: Gateway.NotAttached: Network vpc-9d1832fb is not attached to any internet gateway
            status code: 400, request id: 2e275df4-cf4c-4a1a-9be8-6d0ea73a1881
        * aws_eip.two: 1 error(s) occurred:
        
        * aws_eip.two: Failure associating EIP: Gateway.NotAttached: Network vpc-9d1832fb is not attached to any internet gateway
            status code: 400, request id: 89c32335-1ed1-4515-ae44-0bcd3ee26729
```

## Test Results

```
TF_ACC=1 go test ./aws -v -run=TestAccAWSEIP_twoEIPsOneNetworkInterface -timeout 120m
=== RUN   TestAccAWSEIP_twoEIPsOneNetworkInterface
--- PASS: TestAccAWSEIP_twoEIPsOneNetworkInterface (184.94s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	184.984s
```