### PR TITLE
r/cloudwatch_log_group: Use ID as name

### DIFF
--- a/aws/resource_aws_cloudwatch_log_group.go
+++ b/aws/resource_aws_cloudwatch_log_group.go
@@ -159,7 +159,7 @@ func lookupCloudWatchLogGroup(conn *cloudwatchlogs.CloudWatchLogs,
 func resourceAwsCloudWatchLogGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).cloudwatchlogsconn
 
-	name := d.Get("name").(string)
+	name := d.Id()
 	log.Printf("[DEBUG] Updating CloudWatch Log Group: %q", name)
 
 	if d.HasChange("retention_in_days") {

--- a/aws/resource_aws_cloudwatch_log_group_test.go
+++ b/aws/resource_aws_cloudwatch_log_group_test.go
@@ -50,6 +50,25 @@ func TestAccAWSCloudWatchLogGroup_namePrefix(t *testing.T) {
 	})
 }
 
+func TestAccAWSCloudWatchLogGroup_namePrefix_retention(t *testing.T) {
+	var lg cloudwatchlogs.LogGroup
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudWatchLogGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudWatchLogGroup_namePrefix_retention(acctest.RandString(5)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchLogGroupExists("aws_cloudwatch_log_group.test", &lg),
+					resource.TestMatchResourceAttr("aws_cloudwatch_log_group.test", "name", regexp.MustCompile("^tf-test-")),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSCloudWatchLogGroup_generatedName(t *testing.T) {
 	var lg cloudwatchlogs.LogGroup
 
@@ -412,6 +431,15 @@ resource "aws_cloudwatch_log_group" "test" {
     name_prefix = "tf-test-"
 }
 `
+
+func testAccAWSCloudWatchLogGroup_namePrefix_retention(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_log_group" "test" {
+		name_prefix = "tf-test-%s"
+		retention_in_days = 7
+}
+		`, rName)
+}
 
 const testAccAWSCloudWatchLogGroup_generatedName = `
 resource "aws_cloudwatch_log_group" "test" {}

--- a/aws/resource_aws_cloudwatch_log_group_test.go
+++ b/aws/resource_aws_cloudwatch_log_group_test.go
@@ -52,6 +52,7 @@ func TestAccAWSCloudWatchLogGroup_namePrefix(t *testing.T) {
 
 func TestAccAWSCloudWatchLogGroup_namePrefix_retention(t *testing.T) {
 	var lg cloudwatchlogs.LogGroup
+	rName := acctest.RandString(5)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -59,10 +60,19 @@ func TestAccAWSCloudWatchLogGroup_namePrefix_retention(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudWatchLogGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudWatchLogGroup_namePrefix_retention(acctest.RandString(5)),
+				Config: testAccAWSCloudWatchLogGroup_namePrefix_retention(rName, 365),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudWatchLogGroupExists("aws_cloudwatch_log_group.test", &lg),
 					resource.TestMatchResourceAttr("aws_cloudwatch_log_group.test", "name", regexp.MustCompile("^tf-test-")),
+					resource.TestCheckResourceAttr("aws_cloudwatch_log_group.test", "retention_in_days", "365"),
+				),
+			},
+			{
+				Config: testAccAWSCloudWatchLogGroup_namePrefix_retention(rName, 7),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchLogGroupExists("aws_cloudwatch_log_group.test", &lg),
+					resource.TestMatchResourceAttr("aws_cloudwatch_log_group.test", "name", regexp.MustCompile("^tf-test-")),
+					resource.TestCheckResourceAttr("aws_cloudwatch_log_group.test", "retention_in_days", "7"),
 				),
 			},
 		},
@@ -432,13 +442,13 @@ resource "aws_cloudwatch_log_group" "test" {
 }
 `
 
-func testAccAWSCloudWatchLogGroup_namePrefix_retention(rName string) string {
+func testAccAWSCloudWatchLogGroup_namePrefix_retention(rName string, retention int) string {
 	return fmt.Sprintf(`
 resource "aws_cloudwatch_log_group" "test" {
-		name_prefix = "tf-test-%s"
-		retention_in_days = 7
+  name_prefix = "tf-test-%s"
+  retention_in_days = %d
 }
-		`, rName)
+`, rName, retention)
 }
 
 const testAccAWSCloudWatchLogGroup_generatedName = `


### PR DESCRIPTION
#1752 
In `resourceAwsCloudWatchLogGroupUpdate`, d.Get("name") is required but when using `name_prefix`, it becomes empty.
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSCloudWatchLogGroup_namePrefix_retention'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCloudWatchLogGroup_namePrefix_retention -timeout 120m
=== RUN   TestAccAWSCloudWatchLogGroup_namePrefix_retention
--- PASS: TestAccAWSCloudWatchLogGroup_namePrefix_retention (42.28s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	42.389s
```
Other tests passed.
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSCloudWatchLogGroup_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCloudWatchLogGroup_ -timeout 120m
=== RUN   TestAccAWSCloudWatchLogGroup_importBasic
--- PASS: TestAccAWSCloudWatchLogGroup_importBasic (48.82s)
=== RUN   TestAccAWSCloudWatchLogGroup_basic
--- PASS: TestAccAWSCloudWatchLogGroup_basic (47.09s)
=== RUN   TestAccAWSCloudWatchLogGroup_namePrefix
--- PASS: TestAccAWSCloudWatchLogGroup_namePrefix (47.51s)
=== RUN   TestAccAWSCloudWatchLogGroup_namePrefix_retention
--- PASS: TestAccAWSCloudWatchLogGroup_namePrefix_retention (44.58s)
=== RUN   TestAccAWSCloudWatchLogGroup_generatedName
--- PASS: TestAccAWSCloudWatchLogGroup_generatedName (43.62s)
=== RUN   TestAccAWSCloudWatchLogGroup_retentionPolicy
--- PASS: TestAccAWSCloudWatchLogGroup_retentionPolicy (84.38s)
=== RUN   TestAccAWSCloudWatchLogGroup_multiple
--- PASS: TestAccAWSCloudWatchLogGroup_multiple (60.10s)
=== RUN   TestAccAWSCloudWatchLogGroup_disappears
--- PASS: TestAccAWSCloudWatchLogGroup_disappears (36.63s)
=== RUN   TestAccAWSCloudWatchLogGroup_tagging
--- PASS: TestAccAWSCloudWatchLogGroup_tagging (168.41s)
=== RUN   TestAccAWSCloudWatchLogGroup_kmsKey
--- PASS: TestAccAWSCloudWatchLogGroup_kmsKey (127.96s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	709.182s
```