### PR TITLE
"SetSubnets is not supported for load balancers of type 'network'

### DIFF
--- a/aws/resource_aws_lb.go
+++ b/aws/resource_aws_lb.go
@@ -386,8 +386,9 @@ func resourceAwsLbUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 	}
-
-	if d.HasChange("subnets") {
+        
+	//Note, that you can't change the subnets for a Network Load Balancer
+	if d.Get("load_balancer_type").(string) != "network" && d.HasChange("subnets") {
 		subnets := expandStringList(d.Get("subnets").(*schema.Set).List())
 
 		params := &elbv2.SetSubnetsInput{

--- a/aws/resource_aws_lb.go
+++ b/aws/resource_aws_lb.go
@@ -387,7 +387,7 @@ func resourceAwsLbUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	}
         
-	//Note, that you can't change the subnets for a Network Load Balancer
+	// Note, that you can't change the subnets for a Network Load Balancer
 	if d.Get("load_balancer_type").(string) != "network" && d.HasChange("subnets") {
 		subnets := expandStringList(d.Get("subnets").(*schema.Set).List())
 


### PR DESCRIPTION
Error message "Failure Setting ALB Subnets: InvalidConfigurationRequest: SetSubnets is not supported for load balancers of type 'network'"
appears, because it is impossible to update the subnets for Network Load Balancer.