### PR TITLE
d/aws_ecs_container_definition: add port mappings to output

### DIFF
--- a/aws/data_source_aws_ecs_container_definition.go
+++ b/aws/data_source_aws_ecs_container_definition.go
@@ -59,6 +59,11 @@ func dataSourceAwsEcsContainerDefinition() *schema.Resource {
 				Computed: true,
 				Elem:     schema.TypeString,
 			},
+			"port_mappings": &schema.Schema{
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeMap, Elem: schema.TypeString},
+			},
 		},
 	}
 }
@@ -93,10 +98,20 @@ func dataSourceAwsEcsContainerDefinitionRead(d *schema.ResourceData, meta interf
 		d.Set("docker_labels", aws.StringValueMap(def.DockerLabels))
 
 		var environment = map[string]string{}
-		for _, keyValuePair := range def.Environment {
-			environment[aws.StringValue(keyValuePair.Name)] = aws.StringValue(keyValuePair.Value)
+		for _, envKeyValuePair := range def.Environment {
+			environment[aws.StringValue(envKeyValuePair.Name)] = aws.StringValue(envKeyValuePair.Value)
 		}
 		d.Set("environment", environment)
+
+		var portMappings = make([]map[string]string, 0)
+		for _, portKeyValuePair := range def.PortMappings {
+			var portMapping = make(map[string]string)
+			portMapping["container_port"] = fmt.Sprintf("%d", aws.Int64Value(portKeyValuePair.ContainerPort))
+			portMapping["host_port"] = fmt.Sprintf("%d", aws.Int64Value(portKeyValuePair.HostPort))
+			portMapping["protocol"] = aws.StringValue(portKeyValuePair.Protocol)
+			portMappings = append(portMappings, portMapping)
+		}
+		d.Set("port_mappings", portMappings)
 	}
 
 	if d.Id() == "" {

--- a/aws/data_source_aws_ecs_container_definition.go
+++ b/aws/data_source_aws_ecs_container_definition.go
@@ -62,7 +62,22 @@ func dataSourceAwsEcsContainerDefinition() *schema.Resource {
 			"port_mappings": &schema.Schema{
 				Type:     schema.TypeSet,
 				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeMap, Elem: schema.TypeString},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"host_port": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"container_port": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"protocol": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
 			},
 		},
 	}
@@ -103,7 +118,7 @@ func dataSourceAwsEcsContainerDefinitionRead(d *schema.ResourceData, meta interf
 		}
 		d.Set("environment", environment)
 
-		var portMappings = make([]map[string]string, 0)
+		var portMappings = make([]map[string]string, len(def.PortMappings), len(def.PortMappings))
 		for _, portKeyValuePair := range def.PortMappings {
 			var portMapping = make(map[string]string)
 			portMapping["container_port"] = fmt.Sprintf("%d", aws.Int64Value(portKeyValuePair.ContainerPort))

--- a/aws/data_source_aws_ecs_container_definition_test.go
+++ b/aws/data_source_aws_ecs_container_definition_test.go
@@ -20,6 +20,7 @@ func TestAccAWSEcsDataSource_ecsContainerDefinition(t *testing.T) {
 					resource.TestCheckResourceAttr("data.aws_ecs_container_definition.mongo", "memory_reservation", "64"),
 					resource.TestCheckResourceAttr("data.aws_ecs_container_definition.mongo", "cpu", "128"),
 					resource.TestCheckResourceAttr("data.aws_ecs_container_definition.mongo", "environment.SECRET", "KEY"),
+					resource.TestCheckResourceAttr("data.aws_ecs_container_definition.mongo", "port_mappings.#", "2"),
 				),
 			},
 		},
@@ -45,7 +46,19 @@ resource "aws_ecs_task_definition" "mongo" {
     "image": "mongo:latest",
     "memory": 128,
     "memoryReservation": 64,
-    "name": "mongodb"
+    "name": "mongodb",
+    "portMappings": [
+      {
+        "hostPort": 8080,
+        "containerPort": 8080,
+        "protocol": "udp"
+      },
+      {
+        "hostPort": 8888,
+        "containerPort": 8888,
+        "protocol": "tcp"
+      }
+    ]
   }
 ]
 DEFINITION

--- a/aws/data_source_aws_ecs_container_definition_test.go
+++ b/aws/data_source_aws_ecs_container_definition_test.go
@@ -21,6 +21,9 @@ func TestAccAWSEcsDataSource_ecsContainerDefinition(t *testing.T) {
 					resource.TestCheckResourceAttr("data.aws_ecs_container_definition.mongo", "cpu", "128"),
 					resource.TestCheckResourceAttr("data.aws_ecs_container_definition.mongo", "environment.SECRET", "KEY"),
 					resource.TestCheckResourceAttr("data.aws_ecs_container_definition.mongo", "port_mappings.#", "2"),
+					resource.TestCheckResourceAttr("data.aws_ecs_container_definition.mongo", "port_mappings.0.host_port", "8080"),
+					resource.TestCheckResourceAttr("data.aws_ecs_container_definition.mongo", "port_mappings.0.container_port", "8081"),
+					resource.TestCheckResourceAttr("data.aws_ecs_container_definition.mongo", "port_mappings.0.protocol", "udp"),
 				),
 			},
 		},
@@ -50,7 +53,7 @@ resource "aws_ecs_task_definition" "mongo" {
     "portMappings": [
       {
         "hostPort": 8080,
-        "containerPort": 8080,
+        "containerPort": 8081,
         "protocol": "udp"
       },
       {


### PR DESCRIPTION
This adds container port mappings to data source output. One use case for this is creating lb target groups based on exposed ports:

```hcl
variable "task_definition" {}
variable "container_name" {}
variable "vpc_id" {}

data "aws_ecs_task_definition" "task" {
  task_definition = "${var.task_definition}"
}

data "aws_ecs_container_definition" "container" {
  task_definition = "${data.aws_ecs_task_definition.task.id}"
  container_name  = "${var.container_name}"
}

resource "aws_lb_target_group" "test" {
  count    = "${length(data.aws_ecs_container_definition.container.port_mappings)}"
  name     = "tf-example-lb-tg"
  port     = "${lookup(data.aws_ecs_container_definition.container.port_mappings[count.index], "host_port")}"
  protocol = "HTTP"
  vpc_id   = "${var.vpc_id}"
}
```
