### PR TITLE
r/redshift_cluster: Make master_username ForceNew

### DIFF
--- a/aws/import_aws_redshift_cluster_test.go
+++ b/aws/import_aws_redshift_cluster_test.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -10,7 +9,7 @@ import (
 
 func TestAccAWSRedshiftCluster_importBasic(t *testing.T) {
 	resourceName := "aws_redshift_cluster.default"
-	config := fmt.Sprintf(testAccAWSRedshiftClusterConfig_basic, acctest.RandInt())
+	config := testAccAWSRedshiftClusterConfig_basic(acctest.RandInt())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/aws/resource_aws_redshift_cluster.go
+++ b/aws/resource_aws_redshift_cluster.go
@@ -52,6 +52,7 @@ func resourceAwsRedshiftCluster() *schema.Resource {
 			"master_username": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				ForceNew:     true,
 				ValidateFunc: validateRedshiftClusterMasterUsername,
 			},
 


### PR DESCRIPTION
This field is not updatable per API docs: http://docs.aws.amazon.com/redshift/latest/APIReference/API_ModifyCluster.html

## Test Results
```
TF_ACC=1 go test ./aws -v -run=TestAccAWSRedshiftCluster_forceNewUsername -timeout 120m
=== RUN   TestAccAWSRedshiftCluster_forceNewUsername
--- PASS: TestAccAWSRedshiftCluster_forceNewUsername (1449.60s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1449.644s
```