### PR TITLE
r/aws_lb_listener: add support for additional SSL certificates

### DIFF
--- a/aws/data_source_aws_lb_listener.go
+++ b/aws/data_source_aws_lb_listener.go
@@ -36,6 +36,13 @@ func dataSourceAwsLbListener() *schema.Resource {
 				Computed: true,
 			},
 
+			"additional_certificate_arns": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+
 			"default_action": {
 				Type:     schema.TypeList,
 				Computed: true,

--- a/aws/data_source_aws_lb_listener_test.go
+++ b/aws/data_source_aws_lb_listener_test.go
@@ -77,6 +77,7 @@ func TestAccDataSourceAWSLBListener_https(t *testing.T) {
 					resource.TestCheckResourceAttr("data.aws_lb_listener.front_end", "default_action.0.type", "forward"),
 					resource.TestCheckResourceAttrSet("data.aws_lb_listener.front_end", "default_action.0.target_group_arn"),
 					resource.TestCheckResourceAttrSet("data.aws_lb_listener.front_end", "certificate_arn"),
+					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "additional_certificate_arns.#", "2"),
 					resource.TestCheckResourceAttr("data.aws_lb_listener.front_end", "ssl_policy", "ELBSecurityPolicy-2015-05"),
 				),
 			},
@@ -285,12 +286,17 @@ data "aws_alb_listener" "front_end" {
 }
 
 func testAccDataSourceAWSLBListenerConfigHTTPS(lbName, targetGroupName string) string {
+	n := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	return fmt.Sprintf(`resource "aws_lb_listener" "front_end" {
    load_balancer_arn = "${aws_lb.alb_test.id}"
    protocol = "HTTPS"
    port = "443"
    ssl_policy = "ELBSecurityPolicy-2015-05"
-   certificate_arn = "${aws_iam_server_certificate.test_cert.arn}"
+   certificate_arn = "${aws_iam_server_certificate.test_cert1.arn}"
+   additional_certificate_arns = [
+     "${aws_iam_server_certificate.test_cert2.arn}",
+     "${aws_iam_server_certificate.test_cert3.arn}",
+   ]
 
    default_action {
      target_group_arn = "${aws_lb_target_group.test.id}"
@@ -389,19 +395,31 @@ resource "aws_security_group" "alb_test" {
   }
 }
 
-resource "aws_iam_server_certificate" "test_cert" {
-  name = "terraform-test-cert-%d"
-  certificate_body = "${tls_self_signed_cert.example.cert_pem}"
-  private_key      = "${tls_private_key.example.private_key_pem}"
+resource "aws_iam_server_certificate" "test_cert1" {
+  name = "terraform-test-cert-1-%d"
+  certificate_body = "${tls_self_signed_cert.example1.cert_pem}"
+  private_key      = "${tls_private_key.example1.private_key_pem}"
 }
 
-resource "tls_private_key" "example" {
+resource "aws_iam_server_certificate" "test_cert2" {
+  name = "terraform-test-cert-2-%d"
+  certificate_body = "${tls_self_signed_cert.example2.cert_pem}"
+  private_key      = "${tls_private_key.example2.private_key_pem}"
+}
+
+resource "aws_iam_server_certificate" "test_cert3" {
+  name = "terraform-test-cert-3-%d"
+  certificate_body = "${tls_self_signed_cert.example3.cert_pem}"
+  private_key      = "${tls_private_key.example3.private_key_pem}"
+}
+
+resource "tls_private_key" "example1" {
   algorithm = "RSA"
 }
 
-resource "tls_self_signed_cert" "example" {
+resource "tls_self_signed_cert" "example1" {
   key_algorithm   = "RSA"
-  private_key_pem = "${tls_private_key.example.private_key_pem}"
+  private_key_pem = "${tls_private_key.example1.private_key_pem}"
 
   subject {
     common_name  = "example.com"
@@ -417,7 +435,51 @@ resource "tls_self_signed_cert" "example" {
   ]
 }
 
+resource "tls_private_key" "example2" {
+  algorithm = "RSA"
+}
+
+resource "tls_self_signed_cert" "example2" {
+  key_algorithm   = "RSA"
+  private_key_pem = "${tls_private_key.example2.private_key_pem}"
+
+  subject {
+    common_name  = "sub.example.com"
+    organization = "ACME Examples, Inc"
+  }
+
+  validity_period_hours = 12
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+  ]
+}
+
+resource "tls_private_key" "example3" {
+  algorithm = "RSA"
+}
+
+resource "tls_self_signed_cert" "example3" {
+  key_algorithm   = "RSA"
+  private_key_pem = "${tls_private_key.example3.private_key_pem}"
+
+  subject {
+    common_name  = "test.example.com"
+    organization = "ACME Examples, Inc"
+  }
+
+  validity_period_hours = 12
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+  ]
+}
+
 data "aws_lb_listener" "front_end" {
 	arn = "${aws_lb_listener.front_end.arn}"
-}`, lbName, targetGroupName, rand.New(rand.NewSource(time.Now().UnixNano())).Int())
+}`, lbName, targetGroupName, n, n, n)
 }

--- a/aws/resource_aws_lb_listener.go
+++ b/aws/resource_aws_lb_listener.go
@@ -162,7 +162,6 @@ func resourceAwsLbListenerCreate(d *schema.ResourceData, meta interface{}) error
 				_, err := elbconn.AddListenerCertificates(&elbv2.AddListenerCertificatesInput{
 					Certificates: []*elbv2.Certificate{&elbv2.Certificate{
 						CertificateArn: aws.String(carn),
-						IsDefault:      aws.Bool(false),
 					}},
 					ListenerArn: aws.String(larn),
 				})

--- a/aws/resource_aws_lb_listener.go
+++ b/aws/resource_aws_lb_listener.go
@@ -158,10 +158,10 @@ func resourceAwsLbListenerCreate(d *schema.ResourceData, meta interface{}) error
 
 	err = resource.Retry(2*time.Minute, func() *resource.RetryError {
 		if carns, ok := d.GetOk("additional_certificate_arns"); ok {
-			for _, carn := range carns.([]string) {
+			for _, carn := range expandStringList(carns.(*schema.Set).List()) {
 				_, err := elbconn.AddListenerCertificates(&elbv2.AddListenerCertificatesInput{
 					Certificates: []*elbv2.Certificate{&elbv2.Certificate{
-						CertificateArn: aws.String(carn),
+						CertificateArn: carn,
 					}},
 					ListenerArn: aws.String(larn),
 				})

--- a/aws/resource_aws_lb_listener.go
+++ b/aws/resource_aws_lb_listener.go
@@ -200,7 +200,9 @@ func resourceAwsLbListenerRead(d *schema.ResourceData, meta interface{}) error {
 	if certs.Certificates != nil && len(certs.Certificates) > 0 {
 		cl := make([]string, 0)
 		for _, cert := range certs.Certificates {
-			cl = append(cl, *cert.CertificateArn)
+			if !*cert.IsDefault {
+				cl = append(cl, *cert.CertificateArn)
+			}
 		}
 		d.Set("additional_certificate_arns", cl)
 	}

--- a/aws/resource_aws_lb_listener.go
+++ b/aws/resource_aws_lb_listener.go
@@ -64,6 +64,13 @@ func resourceAwsLbListener() *schema.Resource {
 				Optional: true,
 			},
 
+			"additional_certificate_arns": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+
 			"default_action": {
 				Type:     schema.TypeList,
 				Required: true,

--- a/aws/resource_aws_lb_listener.go
+++ b/aws/resource_aws_lb_listener.go
@@ -190,6 +190,21 @@ func resourceAwsLbListenerRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("certificate_arn", listener.Certificates[0].CertificateArn)
 	}
 
+	certs, err := elbconn.DescribeListenerCertificates(&elbv2.DescribeListenerCertificatesInput{
+		ListenerArn: aws.String(d.Id()),
+	})
+	if err != nil {
+		return errwrap.Wrapf("Error retrieving ListenerCertficates: {{err}}", err)
+	}
+
+	if certs.Certificates != nil && len(certs.Certificates) > 0 {
+		cl := make([]string, 0)
+		for _, cert := range certs.Certificates {
+			cl = append(cl, *cert.CertificateArn)
+		}
+		d.Set("additional_certificate_arns", cl)
+	}
+
 	defaultActions := make([]map[string]interface{}, 0)
 	if listener.DefaultActions != nil && len(listener.DefaultActions) > 0 {
 		for _, defaultAction := range listener.DefaultActions {

--- a/website/docs/r/lb_listener.html.markdown
+++ b/website/docs/r/lb_listener.html.markdown
@@ -25,11 +25,15 @@ resource "aws_lb_target_group" "front_end" {
 }
 
 resource "aws_lb_listener" "front_end" {
-  load_balancer_arn = "${aws_lb.front_end.arn}"
-  port              = "443"
-  protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-2015-05"
-  certificate_arn   = "arn:aws:iam::187416307283:server-certificate/test_cert_rab3wuqwgja25ct3n4jdj2tzu4"
+  load_balancer_arn           = "${aws_lb.front_end.arn}"
+  port                        = "443"
+  protocol                    = "HTTPS"
+  ssl_policy                  = "ELBSecurityPolicy-2015-05"
+  certificate_arn             = "arn:aws:iam::187416307283:server-certificate/test_cert_rab3wuqwgja25ct3n4jdj2tzu4"
+  additional_certificate_arns = [
+    "arn:aws:iam::187416307283:server-certificate/21fa6f1b-d0e0-4644-80aa-0d1f34f0329f",
+    "arn:aws:iam::187416307283:server-certificate/cc2b8c75-7362-4a90-b4d6-35b15d7e3914",
+  ]
 
   default_action {
     target_group_arn = "${aws_lb_target_group.front_end.arn}"
@@ -47,6 +51,7 @@ The following arguments are supported:
 * `protocol` - (Optional) The protocol for connections from clients to the load balancer. Valid values are `TCP`, `HTTP` and `HTTPS`. Defaults to `HTTP`.
 * `ssl_policy` - (Optional) The name of the SSL Policy for the listener. Required if `protocol` is `HTTPS`.
 * `certificate_arn` - (Optional) The ARN of the SSL server certificate. Exactly one certificate is required if the protocol is HTTPS.
+* `additional_certificate_arns` - (Optional) A list of ARNs for additional certificates to be added. These are used in conjunction with SNI by the load balancer and can only be set if the protocol is HTTPS.
 * `default_action` - (Required) An Action block. Action blocks are documented below.
 
 Action Blocks (for `default_action`) support the following:


### PR DESCRIPTION
This PR is for #1853.

We add an additional argument (`additional_certificate_arns`) to the `aws_lb_listener` resource. This argument allows for adding additional non-default certificates to a listener.

I'm well aware that there are currently no tests or documentation and that still needs to be done. It has been manually tested with as many cases as I could think of though. The existing test suite still runs, but I have not run the acceptance tests at all.

If at all possible, some feedback on the general style of my code would be great. Variable naming and error checking are two points that I've been particularly bad at in the past. I'm also not sure about defining https://github.com/terraform-providers/terraform-provider-aws/pull/2203/files#diff-6f5ff88b797d88c79786bcdb04a23eefR314 in line like that. Do we have an existing function somewhere that does the same job or should I move this elsewhere?

Another suggestion in the linked issue is for it to be possible to define additional certificates as a separate resource - must like security group rules. I'm not too sure if this design would allow for that?

As a final question, how would you like the commits before this can be merged in? Squished? Some kind of prefix to the messages?

Appreciate your time. Hopefully there isn't anything too major wrong with my code and I can get the documentation and tests done quickly too.