### PR TITLE
r/redshift_cluster: Make snapshot identifiers ForceNew

### DIFF
--- a/aws/resource_aws_redshift_cluster.go
+++ b/aws/resource_aws_redshift_cluster.go
@@ -240,11 +240,13 @@ func resourceAwsRedshiftCluster() *schema.Resource {
 			"snapshot_identifier": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 			},
 
 			"snapshot_cluster_identifier": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 			},
 
 			"owner_account": {


### PR DESCRIPTION
None of those two are mutable [per docs](http://docs.aws.amazon.com/redshift/latest/APIReference/API_ModifyCluster.html), or to be more precise they're only valid during the creation of of the cluster.

In order to test this we'd need to spin up a separate cluster, take a snapshot, destroy it, pass it to a test, then delete the test cluster and delete the snapshot which may all take a couple of hours, so I'm not sure if it's worth it for such a simple (and IMO fairly obvious) change.