### PR TITLE
Dynamic DNS records count in aws_ses_domain_dkim example

### DIFF
--- a/website/docs/r/ses_domain_dkim.html.markdown
+++ b/website/docs/r/ses_domain_dkim.html.markdown
@@ -41,7 +41,7 @@ resource "aws_ses_domain_dkim" "example" {
 }
 
 resource "aws_route53_record" "example_amazonses_verification_record" {
-  count   = 3
+  count   = "${length(aws_ses_domain_dkim.example.dkim_tokens)}"
   zone_id = "ABCDEFGHIJ123"
   name    = "${element(aws_ses_domain_dkim.example.dkim_tokens, count.index)}._domainkey.example.com"
   type    = "CNAME"


### PR DESCRIPTION
The example for `aws_ses_domain_dkim` DNS records had a static `count = 3` value. It's correct, since AWS SES DKIM currently uses 3 tokens, but I'm wondering if it would be more correct to have it dynamic.