### PR TITLE
Bump AWS SDK to v1.12.24

### DIFF
--- a/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
@@ -44,6 +44,7 @@ const (
 // Service identifiers
 const (
 	AcmServiceID                          = "acm"                          // Acm.
+	ApiPricingServiceID                   = "api.pricing"                  // ApiPricing.
 	ApigatewayServiceID                   = "apigateway"                   // Apigateway.
 	ApplicationAutoscalingServiceID       = "application-autoscaling"      // ApplicationAutoscaling.
 	Appstream2ServiceID                   = "appstream2"                   // Appstream2.
@@ -254,6 +255,16 @@ var awsPartition = partition{
 				"us-east-2":      endpoint{},
 				"us-west-1":      endpoint{},
 				"us-west-2":      endpoint{},
+			},
+		},
+		"api.pricing": service{
+			Defaults: endpoint{
+				CredentialScope: credentialScope{
+					Service: "pricing",
+				},
+			},
+			Endpoints: endpoints{
+				"us-east-1": endpoint{},
 			},
 		},
 		"apigateway": service{
@@ -1359,10 +1370,11 @@ var awsPartition = partition{
 		"polly": service{
 
 			Endpoints: endpoints{
-				"eu-west-1": endpoint{},
-				"us-east-1": endpoint{},
-				"us-east-2": endpoint{},
-				"us-west-2": endpoint{},
+				"ap-northeast-1": endpoint{},
+				"eu-west-1":      endpoint{},
+				"us-east-1":      endpoint{},
+				"us-east-2":      endpoint{},
+				"us-west-2":      endpoint{},
 			},
 		},
 		"rds": service{
@@ -1523,14 +1535,17 @@ var awsPartition = partition{
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
+				"ap-south-1":     endpoint{},
 				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
 				"ca-central-1":   endpoint{},
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
+				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
+				"us-west-1":      endpoint{},
 				"us-west-2":      endpoint{},
 			},
 		},
@@ -1928,6 +1943,12 @@ var awscnPartition = partition{
 			},
 		},
 		"codedeploy": service{
+
+			Endpoints: endpoints{
+				"cn-north-1": endpoint{},
+			},
+		},
+		"cognito-identity": service{
 
 			Endpoints: endpoints{
 				"cn-north-1": endpoint{},

--- a/vendor/github.com/aws/aws-sdk-go/aws/request/connection_reset_error_other.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/request/connection_reset_error_other.go
@@ -1,0 +1,11 @@
+// +build appengine plan9
+
+package request
+
+import (
+	"strings"
+)
+
+func isErrConnectionReset(err error) bool {
+	return strings.Contains(err.Error(), "connection reset")
+}

--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.12.21"
+const SDKVersion = "1.12.24"

--- a/vendor/github.com/aws/aws-sdk-go/service/ec2/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ec2/api.go
@@ -60892,6 +60892,24 @@ const (
 	// InstanceTypeC48xlarge is a InstanceType enum value
 	InstanceTypeC48xlarge = "c4.8xlarge"
 
+	// InstanceTypeC5Large is a InstanceType enum value
+	InstanceTypeC5Large = "c5.large"
+
+	// InstanceTypeC5Xlarge is a InstanceType enum value
+	InstanceTypeC5Xlarge = "c5.xlarge"
+
+	// InstanceTypeC52xlarge is a InstanceType enum value
+	InstanceTypeC52xlarge = "c5.2xlarge"
+
+	// InstanceTypeC54xlarge is a InstanceType enum value
+	InstanceTypeC54xlarge = "c5.4xlarge"
+
+	// InstanceTypeC59xlarge is a InstanceType enum value
+	InstanceTypeC59xlarge = "c5.9xlarge"
+
+	// InstanceTypeC518xlarge is a InstanceType enum value
+	InstanceTypeC518xlarge = "c5.18xlarge"
+
 	// InstanceTypeCc14xlarge is a InstanceType enum value
 	InstanceTypeCc14xlarge = "cc1.4xlarge"
 

--- a/vendor/github.com/aws/aws-sdk-go/service/ecs/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ecs/api.go
@@ -3731,8 +3731,8 @@ type ContainerDefinition struct {
 	_ struct{} `type:"structure"`
 
 	// The command that is passed to the container. This parameter maps to Cmd in
-	// the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/)
+	// the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
 	// and the COMMAND parameter to docker run (https://docs.docker.com/engine/reference/run/).
 	// For more information, see https://docs.docker.com/engine/reference/builder/#cmd
 	// (https://docs.docker.com/engine/reference/builder/#cmd).
@@ -3743,8 +3743,8 @@ type ContainerDefinition struct {
 	// amount of CPU to reserve for a container, and containers share unallocated
 	// CPU units with other containers on the instance with the same ratio as their
 	// allocated amount. This parameter maps to CpuShares in the Create a container
-	// (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/)
+	// (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
 	// and the --cpu-shares option to docker run (https://docs.docker.com/engine/reference/run/).
 	//
 	// You can determine the number of CPU units that are available per EC2 instance
@@ -3780,25 +3780,25 @@ type ContainerDefinition struct {
 	Cpu *int64 `locationName:"cpu" type:"integer"`
 
 	// When this parameter is true, networking is disabled within the container.
-	// This parameter maps to NetworkDisabled in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/).
+	// This parameter maps to NetworkDisabled in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/).
 	DisableNetworking *bool `locationName:"disableNetworking" type:"boolean"`
 
 	// A list of DNS search domains that are presented to the container. This parameter
-	// maps to DnsSearch in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/)
+	// maps to DnsSearch in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
 	// and the --dns-search option to docker run (https://docs.docker.com/engine/reference/run/).
 	DnsSearchDomains []*string `locationName:"dnsSearchDomains" type:"list"`
 
 	// A list of DNS servers that are presented to the container. This parameter
-	// maps to Dns in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/)
+	// maps to Dns in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
 	// and the --dns option to docker run (https://docs.docker.com/engine/reference/run/).
 	DnsServers []*string `locationName:"dnsServers" type:"list"`
 
 	// A key/value map of labels to add to the container. This parameter maps to
-	// Labels in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/)
+	// Labels in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
 	// and the --label option to docker run (https://docs.docker.com/engine/reference/run/).
 	// This parameter requires version 1.18 of the Docker Remote API or greater
 	// on your container instance. To check the Docker Remote API version on your
@@ -3808,8 +3808,8 @@ type ContainerDefinition struct {
 
 	// A list of strings to provide custom labels for SELinux and AppArmor multi-level
 	// security systems. This parameter maps to SecurityOpt in the Create a container
-	// (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/)
+	// (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
 	// and the --security-opt option to docker run (https://docs.docker.com/engine/reference/run/).
 	//
 	// The Amazon ECS container agent running on a container instance must register
@@ -3825,16 +3825,16 @@ type ContainerDefinition struct {
 	// agent or enter your commands and arguments as command array items instead.
 	//
 	// The entry point that is passed to the container. This parameter maps to Entrypoint
-	// in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/)
+	// in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
 	// and the --entrypoint option to docker run (https://docs.docker.com/engine/reference/run/).
 	// For more information, see https://docs.docker.com/engine/reference/builder/#entrypoint
 	// (https://docs.docker.com/engine/reference/builder/#entrypoint).
 	EntryPoint []*string `locationName:"entryPoint" type:"list"`
 
 	// The environment variables to pass to a container. This parameter maps to
-	// Env in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/)
+	// Env in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
 	// and the --env option to docker run (https://docs.docker.com/engine/reference/run/).
 	//
 	// We do not recommend using plain text environment variables for sensitive
@@ -3857,14 +3857,14 @@ type ContainerDefinition struct {
 
 	// A list of hostnames and IP address mappings to append to the /etc/hosts file
 	// on the container. This parameter maps to ExtraHosts in the Create a container
-	// (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/)
+	// (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
 	// and the --add-host option to docker run (https://docs.docker.com/engine/reference/run/).
 	ExtraHosts []*HostEntry `locationName:"extraHosts" type:"list"`
 
 	// The hostname to use for your container. This parameter maps to Hostname in
-	// the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/)
+	// the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
 	// and the --hostname option to docker run (https://docs.docker.com/engine/reference/run/).
 	Hostname *string `locationName:"hostname" type:"string"`
 
@@ -3874,8 +3874,8 @@ type ContainerDefinition struct {
 	// repository-url/image@digest. Up to 255 letters (uppercase and lowercase),
 	// numbers, hyphens, underscores, colons, periods, forward slashes, and number
 	// signs are allowed. This parameter maps to Image in the Create a container
-	// (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/)
+	// (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
 	// and the IMAGE parameter of docker run (https://docs.docker.com/engine/reference/run/).
 	//
 	//    * Images in Amazon ECR repositories can be specified by either using the
@@ -3901,8 +3901,8 @@ type ContainerDefinition struct {
 	// are allowed for each name and alias. For more information on linking Docker
 	// containers, see https://docs.docker.com/engine/userguide/networking/default_network/dockerlinks/
 	// (https://docs.docker.com/engine/userguide/networking/default_network/dockerlinks/).
-	// This parameter maps to Links in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/)
+	// This parameter maps to Links in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
 	// and the --link option to docker run (https://docs.docker.com/engine/reference/run/).
 	//
 	// Containers that are collocated on a single container instance may be able
@@ -3916,8 +3916,8 @@ type ContainerDefinition struct {
 	LinuxParameters *LinuxParameters `locationName:"linuxParameters" type:"structure"`
 
 	// The log configuration specification for the container. This parameter maps
-	// to LogConfig in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/)
+	// to LogConfig in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
 	// and the --log-driver option to docker run (https://docs.docker.com/engine/reference/run/).
 	// By default, containers use the same logging driver that the Docker daemon
 	// uses; however the container may use a different logging driver than the Docker
@@ -3947,8 +3947,8 @@ type ContainerDefinition struct {
 
 	// The hard limit (in MiB) of memory to present to the container. If your container
 	// attempts to exceed the memory specified here, the container is killed. This
-	// parameter maps to Memory in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/)
+	// parameter maps to Memory in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
 	// and the --memory option to docker run (https://docs.docker.com/engine/reference/run/).
 	//
 	// You must specify a non-zero integer for one or both of memory or memoryReservation
@@ -3967,8 +3967,8 @@ type ContainerDefinition struct {
 	// it needs to, up to either the hard limit specified with the memory parameter
 	// (if applicable), or all of the available memory on the container instance,
 	// whichever comes first. This parameter maps to MemoryReservation in the Create
-	// a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/)
+	// a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
 	// and the --memory-reservation option to docker run (https://docs.docker.com/engine/reference/run/).
 	//
 	// You must specify a non-zero integer for one or both of memory or memoryReservation
@@ -3986,8 +3986,8 @@ type ContainerDefinition struct {
 	MemoryReservation *int64 `locationName:"memoryReservation" type:"integer"`
 
 	// The mount points for data volumes in your container. This parameter maps
-	// to Volumes in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/)
+	// to Volumes in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
 	// and the --volume option to docker run (https://docs.docker.com/engine/reference/run/).
 	MountPoints []*MountPoint `locationName:"mountPoints" type:"list"`
 
@@ -3995,15 +3995,15 @@ type ContainerDefinition struct {
 	// in a task definition, the name of one container can be entered in the links
 	// of another container to connect the containers. Up to 255 letters (uppercase
 	// and lowercase), numbers, hyphens, and underscores are allowed. This parameter
-	// maps to name in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/)
+	// maps to name in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
 	// and the --name option to docker run (https://docs.docker.com/engine/reference/run/).
 	Name *string `locationName:"name" type:"string"`
 
 	// The list of port mappings for the container. Port mappings allow containers
 	// to access ports on the host container instance to send or receive traffic.
-	// This parameter maps to PortBindings in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/)
+	// This parameter maps to PortBindings in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
 	// and the --publish option to docker run (https://docs.docker.com/engine/reference/run/).
 	// If the network mode of a task definition is set to none, then you cannot
 	// specify port mappings. If the network mode of a task definition is set to
@@ -4018,21 +4018,21 @@ type ContainerDefinition struct {
 
 	// When this parameter is true, the container is given elevated privileges on
 	// the host container instance (similar to the root user). This parameter maps
-	// to Privileged in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/)
+	// to Privileged in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
 	// and the --privileged option to docker run (https://docs.docker.com/engine/reference/run/).
 	Privileged *bool `locationName:"privileged" type:"boolean"`
 
 	// When this parameter is true, the container is given read-only access to its
 	// root file system. This parameter maps to ReadonlyRootfs in the Create a container
-	// (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/)
+	// (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
 	// and the --read-only option to docker run.
 	ReadonlyRootFilesystem *bool `locationName:"readonlyRootFilesystem" type:"boolean"`
 
 	// A list of ulimits to set in the container. This parameter maps to Ulimits
-	// in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/)
+	// in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
 	// and the --ulimit option to docker run (https://docs.docker.com/engine/reference/run/).
 	// Valid naming values are displayed in the Ulimit data type. This parameter
 	// requires version 1.18 of the Docker Remote API or greater on your container
@@ -4042,20 +4042,20 @@ type ContainerDefinition struct {
 	Ulimits []*Ulimit `locationName:"ulimits" type:"list"`
 
 	// The user name to use inside the container. This parameter maps to User in
-	// the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/)
+	// the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
 	// and the --user option to docker run (https://docs.docker.com/engine/reference/run/).
 	User *string `locationName:"user" type:"string"`
 
 	// Data volumes to mount from another container. This parameter maps to VolumesFrom
-	// in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/)
+	// in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
 	// and the --volumes-from option to docker run (https://docs.docker.com/engine/reference/run/).
 	VolumesFrom []*VolumeFrom `locationName:"volumesFrom" type:"list"`
 
 	// The working directory in which to run commands inside the container. This
-	// parameter maps to WorkingDir in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/)
+	// parameter maps to WorkingDir in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
 	// and the --workdir option to docker run (https://docs.docker.com/engine/reference/run/).
 	WorkingDirectory *string `locationName:"workingDirectory" type:"string"`
 }
@@ -4081,6 +4081,11 @@ func (s *ContainerDefinition) Validate() error {
 			if err := v.Validate(); err != nil {
 				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "ExtraHosts", i), err.(request.ErrInvalidParams))
 			}
+		}
+	}
+	if s.LinuxParameters != nil {
+		if err := s.LinuxParameters.Validate(); err != nil {
+			invalidParams.AddNested("LinuxParameters", err.(request.ErrInvalidParams))
 		}
 	}
 	if s.LogConfiguration != nil {
@@ -5648,6 +5653,65 @@ func (s *DescribeTasksOutput) SetTasks(v []*Task) *DescribeTasksOutput {
 	return s
 }
 
+// An object representing a container instance host device.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/Device
+type Device struct {
+	_ struct{} `type:"structure"`
+
+	// The path inside the container at which to expose the host device.
+	ContainerPath *string `locationName:"containerPath" type:"string"`
+
+	// The path for the device on the host container instance.
+	//
+	// HostPath is a required field
+	HostPath *string `locationName:"hostPath" type:"string" required:"true"`
+
+	// The explicit permissions to provide to the container for the device. By default,
+	// the container will be able to read, write, and mknod the device.
+	Permissions []*string `locationName:"permissions" type:"list"`
+}
+
+// String returns the string representation
+func (s Device) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s Device) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Device) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Device"}
+	if s.HostPath == nil {
+		invalidParams.Add(request.NewErrParamRequired("HostPath"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetContainerPath sets the ContainerPath field's value.
+func (s *Device) SetContainerPath(v string) *Device {
+	s.ContainerPath = &v
+	return s
+}
+
+// SetHostPath sets the HostPath field's value.
+func (s *Device) SetHostPath(v string) *Device {
+	s.HostPath = &v
+	return s
+}
+
+// SetPermissions sets the Permissions field's value.
+func (s *Device) SetPermissions(v []*string) *Device {
+	s.Permissions = v
+	return s
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/DiscoverPollEndpointRequest
 type DiscoverPollEndpointInput struct {
 	_ struct{} `type:"structure"`
@@ -5852,16 +5916,34 @@ type KernelCapabilities struct {
 
 	// The Linux capabilities for the container that have been added to the default
 	// configuration provided by Docker. This parameter maps to CapAdd in the Create
-	// a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/)
+	// a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
 	// and the --cap-add option to docker run (https://docs.docker.com/engine/reference/run/).
+	//
+	// Valid values: "ALL" | "AUDIT_CONTROL" | "AUDIT_WRITE" | "BLOCK_SUSPEND" |
+	// "CHOWN" | "DAC_OVERRIDE" | "DAC_READ_SEARCH" | "FOWNER" | "FSETID" | "IPC_LOCK"
+	// | "IPC_OWNER" | "KILL" | "LEASE" | "LINUX_IMMUTABLE" | "MAC_ADMIN" | "MAC_OVERRIDE"
+	// | "MKNOD" | "NET_ADMIN" | "NET_BIND_SERVICE" | "NET_BROADCAST" | "NET_RAW"
+	// | "SETFCAP" | "SETGID" | "SETPCAP" | "SETUID" | "SYS_ADMIN" | "SYS_BOOT"
+	// | "SYS_CHROOT" | "SYS_MODULE" | "SYS_NICE" | "SYS_PACCT" | "SYS_PTRACE" |
+	// "SYS_RAWIO" | "SYS_RESOURCE" | "SYS_TIME" | "SYS_TTY_CONFIG" | "SYSLOG" |
+	// "WAKE_ALARM"
 	Add []*string `locationName:"add" type:"list"`
 
 	// The Linux capabilities for the container that have been removed from the
 	// default configuration provided by Docker. This parameter maps to CapDrop
-	// in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/)
+	// in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
 	// and the --cap-drop option to docker run (https://docs.docker.com/engine/reference/run/).
+	//
+	// Valid values: "ALL" | "AUDIT_CONTROL" | "AUDIT_WRITE" | "BLOCK_SUSPEND" |
+	// "CHOWN" | "DAC_OVERRIDE" | "DAC_READ_SEARCH" | "FOWNER" | "FSETID" | "IPC_LOCK"
+	// | "IPC_OWNER" | "KILL" | "LEASE" | "LINUX_IMMUTABLE" | "MAC_ADMIN" | "MAC_OVERRIDE"
+	// | "MKNOD" | "NET_ADMIN" | "NET_BIND_SERVICE" | "NET_BROADCAST" | "NET_RAW"
+	// | "SETFCAP" | "SETGID" | "SETPCAP" | "SETUID" | "SYS_ADMIN" | "SYS_BOOT"
+	// | "SYS_CHROOT" | "SYS_MODULE" | "SYS_NICE" | "SYS_PACCT" | "SYS_PTRACE" |
+	// "SYS_RAWIO" | "SYS_RESOURCE" | "SYS_TIME" | "SYS_TTY_CONFIG" | "SYSLOG" |
+	// "WAKE_ALARM"
 	Drop []*string `locationName:"drop" type:"list"`
 }
 
@@ -5931,6 +6013,20 @@ type LinuxParameters struct {
 	// The Linux capabilities for the container that are added to or dropped from
 	// the default configuration provided by Docker.
 	Capabilities *KernelCapabilities `locationName:"capabilities" type:"structure"`
+
+	// Any host devices to expose to the container. This parameter maps to Devices
+	// in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
+	// and the --device option to docker run (https://docs.docker.com/engine/reference/run/).
+	Devices []*Device `locationName:"devices" type:"list"`
+
+	// Run an init process inside the container that forwards signals and reaps
+	// processes. This parameter maps to the --init option to docker run (https://docs.docker.com/engine/reference/run/).
+	// This parameter requires version 1.25 of the Docker Remote API or greater
+	// on your container instance. To check the Docker Remote API version on your
+	// container instance, log into your container instance and run the following
+	// command: sudo docker version | grep "Server API version"
+	InitProcessEnabled *bool `locationName:"initProcessEnabled" type:"boolean"`
 }
 
 // String returns the string representation
@@ -5943,9 +6039,41 @@ func (s LinuxParameters) GoString() string {
 	return s.String()
 }
 
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *LinuxParameters) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "LinuxParameters"}
+	if s.Devices != nil {
+		for i, v := range s.Devices {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Devices", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
 // SetCapabilities sets the Capabilities field's value.
 func (s *LinuxParameters) SetCapabilities(v *KernelCapabilities) *LinuxParameters {
 	s.Capabilities = v
+	return s
+}
+
+// SetDevices sets the Devices field's value.
+func (s *LinuxParameters) SetDevices(v []*Device) *LinuxParameters {
+	s.Devices = v
+	return s
+}
+
+// SetInitProcessEnabled sets the InitProcessEnabled field's value.
+func (s *LinuxParameters) SetInitProcessEnabled(v bool) *LinuxParameters {
+	s.InitProcessEnabled = &v
 	return s
 }
 
@@ -6294,13 +6422,13 @@ type ListServicesInput struct {
 	// is assumed.
 	Cluster *string `locationName:"cluster" type:"string"`
 
-	// The maximum number of container instance results returned by ListServices
-	// in paginated output. When this parameter is used, ListServices only returns
-	// maxResults results in a single page along with a nextToken response element.
-	// The remaining results of the initial request can be seen by sending another
-	// ListServices request with the returned nextToken value. This value can be
-	// between 1 and 10. If this parameter is not used, then ListServices returns
-	// up to 10 results and a nextToken value if applicable.
+	// The maximum number of service results returned by ListServices in paginated
+	// output. When this parameter is used, ListServices only returns maxResults
+	// results in a single page along with a nextToken response element. The remaining
+	// results of the initial request can be seen by sending another ListServices
+	// request with the returned nextToken value. This value can be between 1 and
+	// 10. If this parameter is not used, then ListServices returns up to 10 results
+	// and a nextToken value if applicable.
 	MaxResults *int64 `locationName:"maxResults" type:"integer"`
 
 	// The nextToken value returned from a previous paginated ListServices request
@@ -9250,6 +9378,17 @@ const (
 
 	// DesiredStatusStopped is a DesiredStatus enum value
 	DesiredStatusStopped = "STOPPED"
+)
+
+const (
+	// DeviceCgroupPermissionRead is a DeviceCgroupPermission enum value
+	DeviceCgroupPermissionRead = "read"
+
+	// DeviceCgroupPermissionWrite is a DeviceCgroupPermission enum value
+	DeviceCgroupPermissionWrite = "write"
+
+	// DeviceCgroupPermissionMknod is a DeviceCgroupPermission enum value
+	DeviceCgroupPermissionMknod = "mknod"
 )
 
 const (

--- a/vendor/github.com/aws/aws-sdk-go/service/elbv2/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/elbv2/errors.go
@@ -86,8 +86,8 @@ const (
 	// ErrCodeInvalidTargetException for service response error code
 	// "InvalidTarget".
 	//
-	// The specified target does not exist or is not in the same VPC as the target
-	// group.
+	// The specified target does not exist, is not in the same VPC as the target
+	// group, or has an unsupported instance type.
 	ErrCodeInvalidTargetException = "InvalidTarget"
 
 	// ErrCodeListenerNotFoundException for service response error code

--- a/vendor/github.com/aws/aws-sdk-go/service/kms/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/kms/errors.go
@@ -28,9 +28,8 @@ const (
 	// "ExpiredImportTokenException".
 	//
 	// The request was rejected because the provided import token is expired. Use
-	// GetParametersForImport to retrieve a new import token and public key, use
-	// the new public key to encrypt the key material, and then try the request
-	// again.
+	// GetParametersForImport to get a new import token and public key, use the
+	// new public key to encrypt the key material, and then try the request again.
 	ErrCodeExpiredImportTokenException = "ExpiredImportTokenException"
 
 	// ErrCodeIncorrectKeyMaterialException for service response error code
@@ -63,8 +62,9 @@ const (
 	// ErrCodeInvalidCiphertextException for service response error code
 	// "InvalidCiphertextException".
 	//
-	// The request was rejected because the specified ciphertext has been corrupted
-	// or is otherwise invalid.
+	// The request was rejected because the specified ciphertext, or additional
+	// authenticated data incorporated into the ciphertext, such as the encryption
+	// context, is corrupted, missing, or otherwise invalid.
 	ErrCodeInvalidCiphertextException = "InvalidCiphertextException"
 
 	// ErrCodeInvalidGrantIdException for service response error code

--- a/vendor/github.com/aws/aws-sdk-go/service/rds/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/rds/api.go
@@ -609,10 +609,10 @@ func (c *RDS) CopyDBClusterSnapshotRequest(input *CopyDBClusterSnapshotInput) (r
 //
 //    * PreSignedUrl - A URL that contains a Signature Version 4 signed request
 //    for the CopyDBClusterSnapshot action to be called in the source AWS Region
-//    where the DB cluster snapshot will be copied from. The pre-signed URL
-//    must be a valid request for the CopyDBClusterSnapshot API action that
-//    can be executed in the source AWS Region that contains the encrypted DB
-//    cluster snapshot to be copied.
+//    where the DB cluster snapshot is copied from. The pre-signed URL must
+//    be a valid request for the CopyDBClusterSnapshot API action that can be
+//    executed in the source AWS Region that contains the encrypted DB cluster
+//    snapshot to be copied.
 //
 // The pre-signed URL request must contain the following parameter values:
 //
@@ -2037,12 +2037,12 @@ func (c *RDS) CreateEventSubscriptionRequest(input *CreateEventSubscriptionInput
 // mydbinstance2 and EventCategories = Availability, Backup.
 //
 // If you specify both the SourceType and SourceIds, such as SourceType = db-instance
-// and SourceIdentifier = myDBInstance1, you will be notified of all the db-instance
+// and SourceIdentifier = myDBInstance1, you are notified of all the db-instance
 // events for the specified source. If you specify a SourceType but do not specify
-// a SourceIdentifier, you will receive notice of the events for that source
-// type for all your RDS sources. If you do not specify either the SourceType
-// nor the SourceIdentifier, you will be notified of events generated from all
-// RDS sources belonging to your customer account.
+// a SourceIdentifier, you receive notice of the events for that source type
+// for all your RDS sources. If you do not specify either the SourceType nor
+// the SourceIdentifier, you are notified of events generated from all RDS sources
+// belonging to your customer account.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -7946,8 +7946,8 @@ func (c *RDS) RebootDBInstanceRequest(input *RebootDBInstanceInput) (req *reques
 // group that were pending. Rebooting a DB instance results in a momentary outage
 // of the instance, during which the DB instance status is set to rebooting.
 // If the RDS instance is configured for MultiAZ, it is possible that the reboot
-// will be conducted through a failover. An Amazon RDS event is created when
-// the reboot is completed.
+// is conducted through a failover. An Amazon RDS event is created when the
+// reboot is completed.
 //
 // If your DB instance is deployed in multiple Availability Zones, you can force
 // a failover from one AZ to the other during the reboot. You might force a
@@ -9686,7 +9686,7 @@ func (s *AddSourceIdentifierToSubscriptionOutput) SetEventSubscription(v *EventS
 type AddTagsToResourceInput struct {
 	_ struct{} `type:"structure"`
 
-	// The Amazon RDS resource the tags will be added to. This value is an Amazon
+	// The Amazon RDS resource that the tags are added to. This value is an Amazon
 	// Resource Name (ARN). For information about creating an ARN, see  Constructing
 	// an RDS Amazon Resource Name (ARN) (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.ARN.html#USER_Tagging.ARN.Constructing).
 	//
@@ -10635,9 +10635,9 @@ type CopyDBSnapshotInput struct {
 	// DB snapshot to be copied. The presigned URL request must contain the following
 	// parameter values:
 	//
-	//    * DestinationRegion - The AWS Region that the encrypted DB snapshot will
-	//    be copied to. This AWS Region is the same one where the CopyDBSnapshot
-	//    action is called that contains this presigned URL.
+	//    * DestinationRegion - The AWS Region that the encrypted DB snapshot is
+	//    copied to. This AWS Region is the same one where the CopyDBSnapshot action
+	//    is called that contains this presigned URL.
 	//
 	// For example, if you copy an encrypted DB snapshot from the us-west-2 region
 	//    to the us-east-1 region, then you call the CopyDBSnapshot action in the
@@ -10986,7 +10986,7 @@ type CreateDBClusterInput struct {
 	DBClusterIdentifier *string `type:"string" required:"true"`
 
 	// The name of the DB cluster parameter group to associate with this DB cluster.
-	// If this argument is omitted, default.aurora5.6 will be used.
+	// If this argument is omitted, default.aurora5.6 is used.
 	//
 	// Constraints:
 	//
@@ -11083,9 +11083,9 @@ type CreateDBClusterInput struct {
 	Port *int64 `type:"integer"`
 
 	// A URL that contains a Signature Version 4 signed request for the CreateDBCluster
-	// action to be called in the source AWS Region where the DB cluster will be
-	// replicated from. You only need to specify PreSignedUrl when you are performing
-	// cross-region replication from an encrypted DB cluster.
+	// action to be called in the source AWS Region where the DB cluster is replicated
+	// from. You only need to specify PreSignedUrl when you are performing cross-region
+	// replication from an encrypted DB cluster.
 	//
 	// The pre-signed URL must be a valid request for the CreateDBCluster API action
 	// that can be executed in the source AWS Region that contains the encrypted
@@ -11677,15 +11677,14 @@ type CreateDBInstanceInput struct {
 	// Web and Express editions: Must be an integer from 20 to 1024.
 	AllocatedStorage *int64 `type:"integer"`
 
-	// Indicates that minor engine upgrades will be applied automatically to the
-	// DB instance during the maintenance window.
+	// Indicates that minor engine upgrades are applied automatically to the DB
+	// instance during the maintenance window.
 	//
 	// Default: true
 	AutoMinorVersionUpgrade *bool `type:"boolean"`
 
-	// The EC2 Availability Zone that the database instance will be created in.
-	// For information on regions and Availability Zones, see Regions and Availability
-	// Zones (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html).
+	// The EC2 Availability Zone that the database instance is created in. For information
+	// on regions and Availability Zones, see Regions and Availability Zones (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html).
 	//
 	// Default: A random, system-chosen Availability Zone in the endpoint's AWS
 	// Region.
@@ -11735,15 +11734,11 @@ type CreateDBInstanceInput struct {
 	// Type: String
 	DBClusterIdentifier *string `type:"string"`
 
-	// The compute and memory capacity of the DB instance. Note that not all instance
-	// classes are available in all regions for all DB engines.
-	//
-	// Valid Values: db.t1.micro | db.m1.small | db.m1.medium | db.m1.large | db.m1.xlarge
-	// | db.m2.xlarge |db.m2.2xlarge | db.m2.4xlarge | db.m3.medium | db.m3.large
-	// | db.m3.xlarge | db.m3.2xlarge | db.m4.large | db.m4.xlarge | db.m4.2xlarge
-	// | db.m4.4xlarge | db.m4.10xlarge | db.r3.large | db.r3.xlarge | db.r3.2xlarge
-	// | db.r3.4xlarge | db.r3.8xlarge | db.t2.micro | db.t2.small | db.t2.medium
-	// | db.t2.large
+	// The compute and memory capacity of the DB instance, for example, db.m4.large.
+	// Not all DB instance classes are available in all regions, or for all database
+	// engines. For the full list of DB instance classes, and availability for your
+	// engine, see DB Instance Class (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html)
+	// in the Amazon RDS User Guide.
 	//
 	// DBInstanceClass is a required field
 	DBInstanceClass *string `type:"string" required:"true"`
@@ -11836,7 +11831,7 @@ type CreateDBInstanceInput struct {
 
 	// The name of the DB parameter group to associate with this DB instance. If
 	// this argument is omitted, the default DBParameterGroup for the specified
-	// engine will be used.
+	// engine is used.
 	//
 	// Constraints:
 	//
@@ -11883,6 +11878,7 @@ type CreateDBInstanceInput struct {
 	// Default: false
 	EnableIAMDatabaseAuthentication *bool `type:"boolean"`
 
+	// True to enable Performance Insights for the DB instance; otherwise false.
 	EnablePerformanceInsights *bool `type:"boolean"`
 
 	// The name of the database engine to be used for this instance.
@@ -11985,11 +11981,15 @@ type CreateDBInstanceInput struct {
 	//
 	// MySQL
 	//
-	// 5.7.17 (supported in all AWS regions)
+	// 5.7.19 (supported in all AWS regions)
+	//
+	//    * 5.7.17 (supported in all AWS regions)
 	//
 	//    * 5.7.16 (supported in all AWS regions)
 	//
 	//    * 5.7.11 (supported in all AWS regions)
+	//
+	//    * 5.6.37 (supported in all AWS regions)
 	//
 	//    * 5.6.35 (supported in all AWS regions)
 	//
@@ -11999,6 +11999,8 @@ type CreateDBInstanceInput struct {
 	//
 	//    * 5.6.27 (supported in all regions except us-east-2, ca-central-1, eu-west-2)
 	//
+	// 5.5.57(supported in all AWS regions)
+	//
 	// 5.5.54(supported in all AWS regions)
 	//
 	// 5.5.53(supported in all AWS regions)
@@ -12006,6 +12008,8 @@ type CreateDBInstanceInput struct {
 	// 5.5.46(supported in all AWS regions)
 	//
 	// Oracle 12c
+	//
+	// 12.1.0.2.v9(supported for EE in all AWS regions, and SE2 in all AWS regions except us-gov-west-1)
 	//
 	// 12.1.0.2.v8(supported for EE in all AWS regions, and SE2 in all AWS regions except us-gov-west-1)
 	//
@@ -12024,6 +12028,8 @@ type CreateDBInstanceInput struct {
 	// 12.1.0.2.v1(supported for EE in all AWS regions, and SE2 in all AWS regions except us-gov-west-1)
 	//
 	// Oracle 11g
+	//
+	// 11.2.0.4.v13(supported for EE, SE1, and SE, in all AWS regions)
 	//
 	// 11.2.0.4.v12(supported for EE, SE1, and SE, in all AWS regions)
 	//
@@ -12049,13 +12055,13 @@ type CreateDBInstanceInput struct {
 	//
 	// PostgreSQL
 	//
-	// Version 9.6.x: 9.6.1 | 9.6.2 | 9.6.3
+	// Version 9.6.x: 9.6.5 | 9.6.3 | 9.6.2 | 9.6.1
 	//
-	// Version 9.5.x:9.5.6 | 9.5.4 | 9.5.2
+	// Version 9.5.x: 9.5.9 | 9.5.7 | 9.5.6 | 9.5.4 | 9.5.2
 	//
-	// Version 9.4.x:9.4.11 | 9.4.9 | 9.4.7
+	// Version 9.4.x: 9.4.14 | 9.4.12 | 9.4.11 | 9.4.9 | 9.4.7
 	//
-	// Version 9.3.x:9.3.16 | 9.3.14 | 9.3.12
+	// Version 9.3.x: 9.3.19 | 9.3.17 | 9.3.16 | 9.3.14 | 9.3.12
 	EngineVersion *string `type:"string"`
 
 	// The amount of Provisioned IOPS (input/output operations per second) to be
@@ -12216,6 +12222,9 @@ type CreateDBInstanceInput struct {
 	// from a DB instance once it is associated with a DB instance
 	OptionGroupName *string `type:"string"`
 
+	// The KMS key identifier for encryption of Performance Insights data. The KMS
+	// key ID is the Amazon Resource Name (ARN), KMS key identifier, or the KMS
+	// key alias for the KMS encryption key.
 	PerformanceInsightsKMSKeyId *string `type:"string"`
 
 	// The port number on which the database accepts connections.
@@ -12328,9 +12337,9 @@ type CreateDBInstanceInput struct {
 	//    * VPC: false
 	//
 	// If no DB subnet group has been specified as part of the request and the PubliclyAccessible
-	// value has not been set, the DB instance will be publicly accessible. If a
-	// specific DB subnet group has been specified as part of the request and the
-	// PubliclyAccessible value has not been set, the DB instance will be private.
+	// value has not been set, the DB instance is publicly accessible. If a specific
+	// DB subnet group has been specified as part of the request and the PubliclyAccessible
+	// value has not been set, the DB instance is private.
 	PubliclyAccessible *bool `type:"boolean"`
 
 	// Specifies whether the DB instance is encrypted.
@@ -12692,13 +12701,13 @@ func (s *CreateDBInstanceOutput) SetDBInstance(v *DBInstance) *CreateDBInstanceO
 type CreateDBInstanceReadReplicaInput struct {
 	_ struct{} `type:"structure"`
 
-	// Indicates that minor engine upgrades will be applied automatically to the
-	// Read Replica during the maintenance window.
+	// Indicates that minor engine upgrades are applied automatically to the Read
+	// Replica during the maintenance window.
 	//
 	// Default: Inherits from the source DB instance
 	AutoMinorVersionUpgrade *bool `type:"boolean"`
 
-	// The Amazon EC2 Availability Zone that the Read Replica will be created in.
+	// The Amazon EC2 Availability Zone that the Read Replica is created in.
 	//
 	// Default: A random, system-chosen Availability Zone in the endpoint's AWS
 	// Region.
@@ -12710,14 +12719,11 @@ type CreateDBInstanceReadReplicaInput struct {
 	// otherwise false. The default is false.
 	CopyTagsToSnapshot *bool `type:"boolean"`
 
-	// The compute and memory capacity of the Read Replica. Note that not all instance
-	// classes are available in all regions for all DB engines.
-	//
-	// Valid Values: db.m1.small | db.m1.medium | db.m1.large | db.m1.xlarge | db.m2.xlarge
-	// |db.m2.2xlarge | db.m2.4xlarge | db.m3.medium | db.m3.large | db.m3.xlarge
-	// | db.m3.2xlarge | db.m4.large | db.m4.xlarge | db.m4.2xlarge | db.m4.4xlarge
-	// | db.m4.10xlarge | db.r3.large | db.r3.xlarge | db.r3.2xlarge | db.r3.4xlarge
-	// | db.r3.8xlarge | db.t2.micro | db.t2.small | db.t2.medium | db.t2.large
+	// The compute and memory capacity of the Read Replica, for example, db.m4.large.
+	// Not all DB instance classes are available in all regions, or for all database
+	// engines. For the full list of DB instance classes, and availability for your
+	// engine, see DB Instance Class (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html)
+	// in the Amazon RDS User Guide.
 	//
 	// Default: Inherits from the source DB instance.
 	DBInstanceClass *string `type:"string"`
@@ -12729,9 +12735,9 @@ type CreateDBInstanceReadReplicaInput struct {
 	// DBInstanceIdentifier is a required field
 	DBInstanceIdentifier *string `type:"string" required:"true"`
 
-	// Specifies a DB subnet group for the DB instance. The new DB instance will
-	// be created in the VPC associated with the DB subnet group. If no DB subnet
-	// group is specified, then the new DB instance is not created in a VPC.
+	// Specifies a DB subnet group for the DB instance. The new DB instance is created
+	// in the VPC associated with the DB subnet group. If no DB subnet group is
+	// specified, then the new DB instance is not created in a VPC.
 	//
 	// Constraints:
 	//
@@ -12746,10 +12752,10 @@ type CreateDBInstanceReadReplicaInput struct {
 	//    * All Read Replicas in one AWS Region that are created from the same source
 	//    DB instance must either:>
 	//
-	// Specify DB subnet groups from the same VPC. All these Read Replicas will
-	//    be created in the same VPC.
+	// Specify DB subnet groups from the same VPC. All these Read Replicas are created
+	//    in the same VPC.
 	//
-	// Not specify a DB subnet group. All these Read Replicas will be created outside
+	// Not specify a DB subnet group. All these Read Replicas are created outside
 	//    of any VPC.
 	//
 	// Example: mySubnetgroup
@@ -12772,6 +12778,7 @@ type CreateDBInstanceReadReplicaInput struct {
 	// Default: false
 	EnableIAMDatabaseAuthentication *bool `type:"boolean"`
 
+	// True to enable Performance Insights for the read replica; otherwise false.
 	EnablePerformanceInsights *bool `type:"boolean"`
 
 	// The amount of Provisioned IOPS (input/output operations per second) to be
@@ -12814,10 +12821,13 @@ type CreateDBInstanceReadReplicaInput struct {
 	// a MonitoringRoleArn value.
 	MonitoringRoleArn *string `type:"string"`
 
-	// The option group the DB instance will be associated with. If omitted, the
-	// default option group for the engine specified will be used.
+	// The option group the DB instance is associated with. If omitted, the default
+	// option group for the engine specified is used.
 	OptionGroupName *string `type:"string"`
 
+	// The KMS key identifier for encryption of Performance Insights data. The KMS
+	// key ID is the Amazon Resource Name (ARN), KMS key identifier, or the KMS
+	// key alias for the KMS encryption key.
 	PerformanceInsightsKMSKeyId *string `type:"string"`
 
 	// The port number that the DB instance uses for connections.
@@ -12840,8 +12850,8 @@ type CreateDBInstanceReadReplicaInput struct {
 	// encrypted source DB instance. The presigned URL request must contain the
 	// following parameter values:
 	//
-	//    * DestinationRegion - The AWS Region that the encrypted Read Replica will
-	//    be created in. This AWS Region is the same one where the CreateDBInstanceReadReplica
+	//    * DestinationRegion - The AWS Region that the encrypted Read Replica is
+	//    created in. This AWS Region is the same one where the CreateDBInstanceReadReplica
 	//    action is called that contains this presigned URL.
 	//
 	// For example, if you create an encrypted DB instance in the us-west-1 region,
@@ -12883,9 +12893,9 @@ type CreateDBInstanceReadReplicaInput struct {
 	//    * VPC:false
 	//
 	// If no DB subnet group has been specified as part of the request and the PubliclyAccessible
-	// value has not been set, the DB instance will be publicly accessible. If a
-	// specific DB subnet group has been specified as part of the request and the
-	// PubliclyAccessible value has not been set, the DB instance will be private.
+	// value has not been set, the DB instance is publicly accessible. If a specific
+	// DB subnet group has been specified as part of the request and the PubliclyAccessible
+	// value has not been set, the DB instance is private.
 	PubliclyAccessible *bool `type:"boolean"`
 
 	// The identifier of the DB instance that will act as the source for the Read
@@ -13600,7 +13610,7 @@ type CreateEventSubscriptionInput struct {
 	// SnsTopicArn is a required field
 	SnsTopicArn *string `type:"string" required:"true"`
 
-	// The list of identifiers of the event sources for which events will be returned.
+	// The list of identifiers of the event sources for which events are returned.
 	// If not specified, then all sources are included in the response. An identifier
 	// must begin with a letter and must contain only ASCII letters, digits, and
 	// hyphens; it cannot end with a hyphen or contain two consecutive hyphens.
@@ -13622,10 +13632,9 @@ type CreateEventSubscriptionInput struct {
 	//    supplied.
 	SourceIds []*string `locationNameList:"SourceId" type:"list"`
 
-	// The type of source that will be generating the events. For example, if you
-	// want to be notified of events generated by a DB instance, you would set this
-	// parameter to db-instance. if this value is not specified, all events are
-	// returned.
+	// The type of source that is generating the events. For example, if you want
+	// to be notified of events generated by a DB instance, you would set this parameter
+	// to db-instance. if this value is not specified, all events are returned.
 	//
 	// Valid values: db-instance | db-cluster | db-parameter-group | db-security-group
 	// | db-snapshot | db-cluster-snapshot
@@ -13999,9 +14008,9 @@ type DBCluster struct {
 	// multiple Aurora Replicas in your DB cluster.
 	//
 	// If a failover occurs, and the Aurora Replica that you are connected to is
-	// promoted to be the primary instance, your connection will be dropped. To
-	// continue sending your read workload to other Aurora Replicas in the cluster,
-	// you can then reconnect to the reader endpoint.
+	// promoted to be the primary instance, your connection is dropped. To continue
+	// sending your read workload to other Aurora Replicas in the cluster, you can
+	// then reconnect to the reader endpoint.
 	ReaderEndpoint *string `type:"string"`
 
 	// Contains the identifier of the source DB cluster if this DB cluster is a
@@ -15031,8 +15040,12 @@ type DBInstance struct {
 	// included when changes are pending. Specific changes are identified by subelements.
 	PendingModifiedValues *PendingModifiedValues `type:"structure"`
 
+	// True if Performance Insights is enabled for the DB instance; otherwise false.
 	PerformanceInsightsEnabled *bool `type:"boolean"`
 
+	// The KMS key identifier for encryption of Performance Insights data. The KMS
+	// key ID is the Amazon Resource Name (ARN), KMS key identifier, or the KMS
+	// key alias for the KMS encryption key.
 	PerformanceInsightsKMSKeyId *string `type:"string"`
 
 	// Specifies the daily time range during which automated backups are created
@@ -15061,9 +15074,9 @@ type DBInstance struct {
 	//    * VPC:false
 	//
 	// If no DB subnet group has been specified as part of the request and the PubliclyAccessible
-	// value has not been set, the DB instance will be publicly accessible. If a
-	// specific DB subnet group has been specified as part of the request and the
-	// PubliclyAccessible value has not been set, the DB instance will be private.
+	// value has not been set, the DB instance is publicly accessible. If a specific
+	// DB subnet group has been specified as part of the request and the PubliclyAccessible
+	// value has not been set, the DB instance is private.
 	PubliclyAccessible *bool `type:"boolean"`
 
 	// Contains one or more identifiers of Aurora DB clusters that are Read Replicas
@@ -15083,7 +15096,7 @@ type DBInstance struct {
 	SecondaryAvailabilityZone *string `type:"string"`
 
 	// The status of a Read Replica. If the instance is not a Read Replica, this
-	// will be blank.
+	// is blank.
 	StatusInfos []*DBInstanceStatusInfo `locationNameList:"DBInstanceStatusInfo" type:"list"`
 
 	// Specifies whether the DB instance is encrypted.
@@ -19223,7 +19236,7 @@ type DescribeEventCategoriesInput struct {
 	// This parameter is not currently supported.
 	Filters []*Filter `locationNameList:"Filter" type:"list"`
 
-	// The type of source that will be generating the events.
+	// The type of source that is generating the events.
 	//
 	// Valid values: db-instance | db-parameter-group | db-security-group | db-snapshot
 	SourceType *string `type:"string"`
@@ -19448,8 +19461,8 @@ type DescribeEventsInput struct {
 	// Constraints: Minimum 20, maximum 100.
 	MaxRecords *int64 `type:"integer"`
 
-	// The identifier of the event source for which events will be returned. If
-	// not specified, then all sources are included in the response.
+	// The identifier of the event source for which events are returned. If not
+	// specified, then all sources are included in the response.
 	//
 	// Constraints:
 	//
@@ -19605,8 +19618,7 @@ func (s *DescribeEventsOutput) SetMarker(v string) *DescribeEventsOutput {
 type DescribeOptionGroupOptionsInput struct {
 	_ struct{} `type:"structure"`
 
-	// A required parameter. Options available for the given engine name will be
-	// described.
+	// A required parameter. Options available for the given engine name are described.
 	//
 	// EngineName is a required field
 	EngineName *string `type:"string" required:"true"`
@@ -20809,7 +20821,7 @@ type DownloadDBLogFilePortionInput struct {
 	Marker *string `type:"string"`
 
 	// The number of lines to download. If the number of lines specified results
-	// in a file over 1 MB in size, the file will be truncated at 1 MB in size.
+	// in a file over 1 MB in size, the file is truncated at 1 MB in size.
 	//
 	// If the NumberOfLines parameter is specified, then the block of lines returned
 	// can be from the beginning or the end of the log file, depending on the value
@@ -22052,12 +22064,11 @@ type ModifyDBInstanceInput struct {
 	// or Provisioned IOPS), amount of IOPS provisioned (if any), and the number
 	// of prior scale storage operations. Typical migration times are under 24 hours,
 	// but the process can take up to several days in some cases. During the migration,
-	// the DB instance will be available for use, but might experience performance
-	// degradation. While the migration takes place, nightly backups for the instance
-	// will be suspended. No other Amazon RDS operations can take place for the
-	// instance, including modifying the instance, rebooting the instance, deleting
-	// the instance, creating a Read Replica for the instance, and creating a DB
-	// snapshot of the instance.
+	// the DB instance is available for use, but might experience performance degradation.
+	// While the migration takes place, nightly backups for the instance are suspended.
+	// No other Amazon RDS operations can take place for the instance, including
+	// modifying the instance, rebooting the instance, deleting the instance, creating
+	// a Read Replica for the instance, and creating a DB snapshot of the instance.
 	AllocatedStorage *int64 `type:"integer"`
 
 	// Indicates that major version upgrades are allowed. Changing this parameter
@@ -22075,17 +22086,17 @@ type ModifyDBInstanceInput struct {
 	//
 	// If this parameter is set to false, changes to the DB instance are applied
 	// during the next maintenance window. Some parameter changes can cause an outage
-	// and will be applied on the next call to RebootDBInstance, or the next failure
+	// and are applied on the next call to RebootDBInstance, or the next failure
 	// reboot. Review the table of parameters in Modifying a DB Instance and Using
 	// the Apply Immediately Parameter (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.DBInstance.Modifying.html)
 	// to see the impact that setting ApplyImmediately to true or false has for
-	// each modified parameter and to determine when the changes will be applied.
+	// each modified parameter and to determine when the changes are applied.
 	//
 	// Default: false
 	ApplyImmediately *bool `type:"boolean"`
 
-	// Indicates that minor version upgrades will be applied automatically to the
-	// DB instance during the maintenance window. Changing this parameter does not
+	// Indicates that minor version upgrades are applied automatically to the DB
+	// instance during the maintenance window. Changing this parameter does not
 	// result in an outage except in the following case and the change is asynchronously
 	// applied as soon as possible. An outage will result if this parameter is set
 	// to true during the maintenance window, and a newer minor version is available,
@@ -22130,23 +22141,17 @@ type ModifyDBInstanceInput struct {
 	// otherwise false. The default is false.
 	CopyTagsToSnapshot *bool `type:"boolean"`
 
-	// The new compute and memory capacity of the DB instance. To determine the
-	// instance classes that are available for a particular DB engine, use the DescribeOrderableDBInstanceOptions
-	// action. Note that not all instance classes are available in all regions for
-	// all DB engines.
+	// The new compute and memory capacity of the DB instance, for example, db.m4.large.
+	// Not all DB instance classes are available in all regions, or for all database
+	// engines. For the full list of DB instance classes, and availability for your
+	// engine, see DB Instance Class (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html)
+	// in the Amazon RDS User Guide.
 	//
-	// Passing a value for this setting causes an outage during the change and is
-	// applied during the next maintenance window, unless ApplyImmediately is specified
-	// as true for this request.
+	// If you modify the DB instance class, an outage occurs during the change.
+	// The change is applied during the next maintenance window, unless ApplyImmediately
+	// is specified as true for this request.
 	//
 	// Default: Uses existing setting
-	//
-	// Valid Values: db.t1.micro | db.m1.small | db.m1.medium | db.m1.large | db.m1.xlarge
-	// | db.m2.xlarge | db.m2.2xlarge | db.m2.4xlarge | db.m3.medium | db.m3.large
-	// | db.m3.xlarge | db.m3.2xlarge | db.m4.large | db.m4.xlarge | db.m4.2xlarge
-	// | db.m4.4xlarge | db.m4.10xlarge | db.r3.large | db.r3.xlarge | db.r3.2xlarge
-	// | db.r3.4xlarge | db.r3.8xlarge | db.t2.micro | db.t2.small | db.t2.medium
-	// | db.t2.large
 	DBInstanceClass *string `type:"string"`
 
 	// The DB instance identifier. This value is stored as a lowercase string.
@@ -22270,6 +22275,7 @@ type ModifyDBInstanceInput struct {
 	// Default: false
 	EnableIAMDatabaseAuthentication *bool `type:"boolean"`
 
+	// True to enable Performance Insights for the DB instance; otherwise false.
 	EnablePerformanceInsights *bool `type:"boolean"`
 
 	// The version number of the database engine to upgrade to. Changing this parameter
@@ -22311,12 +22317,11 @@ type ModifyDBInstanceInput struct {
 	// or Provisioned IOPS), amount of IOPS provisioned (if any), and the number
 	// of prior scale storage operations. Typical migration times are under 24 hours,
 	// but the process can take up to several days in some cases. During the migration,
-	// the DB instance will be available for use, but might experience performance
-	// degradation. While the migration takes place, nightly backups for the instance
-	// will be suspended. No other Amazon RDS operations can take place for the
-	// instance, including modifying the instance, rebooting the instance, deleting
-	// the instance, creating a Read Replica for the instance, and creating a DB
-	// snapshot of the instance.
+	// the DB instance is available for use, but might experience performance degradation.
+	// While the migration takes place, nightly backups for the instance are suspended.
+	// No other Amazon RDS operations can take place for the instance, including
+	// modifying the instance, rebooting the instance, deleting the instance, creating
+	// a Read Replica for the instance, and creating a DB snapshot of the instance.
 	Iops *int64 `type:"integer"`
 
 	// The license model for the DB instance.
@@ -22420,6 +22425,9 @@ type ModifyDBInstanceInput struct {
 	// from a DB instance once it is associated with a DB instance
 	OptionGroupName *string `type:"string"`
 
+	// The KMS key identifier for encryption of Performance Insights data. The KMS
+	// key ID is the Amazon Resource Name (ARN), KMS key identifier, or the KMS
+	// key alias for the KMS encryption key.
 	PerformanceInsightsKMSKeyId *string `type:"string"`
 
 	// The daily time range during which automated backups are created if automated
@@ -23196,10 +23204,9 @@ type ModifyEventSubscriptionInput struct {
 	// it.
 	SnsTopicArn *string `type:"string"`
 
-	// The type of source that will be generating the events. For example, if you
-	// want to be notified of events generated by a DB instance, you would set this
-	// parameter to db-instance. if this value is not specified, all events are
-	// returned.
+	// The type of source that is generating the events. For example, if you want
+	// to be notified of events generated by a DB instance, you would set this parameter
+	// to db-instance. if this value is not specified, all events are returned.
 	//
 	// Valid values: db-instance | db-parameter-group | db-security-group | db-snapshot
 	SourceType *string `type:"string"`
@@ -24084,7 +24091,7 @@ func (s *OptionVersion) SetVersion(v string) *OptionVersion {
 	return s
 }
 
-// Contains a list of available options for a DB instance
+// Contains a list of available options for a DB instance.
 //
 // This data type is used as a response element in the DescribeOrderableDBInstanceOptions
 // action.
@@ -24092,46 +24099,65 @@ func (s *OptionVersion) SetVersion(v string) *OptionVersion {
 type OrderableDBInstanceOption struct {
 	_ struct{} `type:"structure"`
 
-	// A list of Availability Zones for the orderable DB instance.
+	// A list of Availability Zones for a DB instance.
 	AvailabilityZones []*AvailabilityZone `locationNameList:"AvailabilityZone" type:"list"`
 
-	// The DB instance class for the orderable DB instance.
+	// The DB instance class for a DB instance.
 	DBInstanceClass *string `type:"string"`
 
-	// The engine type of the orderable DB instance.
+	// The engine type of a DB instance.
 	Engine *string `type:"string"`
 
-	// The engine version of the orderable DB instance.
+	// The engine version of a DB instance.
 	EngineVersion *string `type:"string"`
 
-	// The license model for the orderable DB instance.
+	// The license model for a DB instance.
 	LicenseModel *string `type:"string"`
 
-	// Indicates whether this orderable DB instance is multi-AZ capable.
+	// Maximum total provisioned IOPS for a DB instance.
+	MaxIopsPerDbInstance *int64 `type:"integer"`
+
+	// Maximum provisioned IOPS per GiB for a DB instance.
+	MaxIopsPerGib *float64 `type:"double"`
+
+	// Maximum storage size for a DB instance.
+	MaxStorageSize *int64 `type:"integer"`
+
+	// Minimum total provisioned IOPS for a DB instance.
+	MinIopsPerDbInstance *int64 `type:"integer"`
+
+	// Minimum provisioned IOPS per GiB for a DB instance.
+	MinIopsPerGib *float64 `type:"double"`
+
+	// Minimum storage size for a DB instance.
+	MinStorageSize *int64 `type:"integer"`
+
+	// Indicates whether a DB instance is Multi-AZ capable.
 	MultiAZCapable *bool `type:"boolean"`
 
-	// Indicates whether this orderable DB instance can have a Read Replica.
+	// Indicates whether a DB instance can have a Read Replica.
 	ReadReplicaCapable *bool `type:"boolean"`
 
-	// Indicates the storage type for this orderable DB instance.
+	// Indicates the storage type for a DB instance.
 	StorageType *string `type:"string"`
 
-	// Indicates whether the DB instance supports enhanced monitoring at intervals
+	// Indicates whether a DB instance supports Enhanced Monitoring at intervals
 	// from 1 to 60 seconds.
 	SupportsEnhancedMonitoring *bool `type:"boolean"`
 
-	// Indicates whether this orderable DB instance supports IAM database authentication.
+	// Indicates whether a DB instance supports IAM database authentication.
 	SupportsIAMDatabaseAuthentication *bool `type:"boolean"`
 
-	// Indicates whether this orderable DB instance supports provisioned IOPS.
+	// Indicates whether a DB instance supports provisioned IOPS.
 	SupportsIops *bool `type:"boolean"`
 
+	// True if a DB instance supports Performance Insights, otherwise false.
 	SupportsPerformanceInsights *bool `type:"boolean"`
 
-	// Indicates whether this orderable DB instance supports encrypted storage.
+	// Indicates whether a DB instance supports encrypted storage.
 	SupportsStorageEncryption *bool `type:"boolean"`
 
-	// Indicates whether this is a VPC orderable DB instance.
+	// Indicates whether a DB instance is in a VPC.
 	Vpc *bool `type:"boolean"`
 }
 
@@ -24172,6 +24198,42 @@ func (s *OrderableDBInstanceOption) SetEngineVersion(v string) *OrderableDBInsta
 // SetLicenseModel sets the LicenseModel field's value.
 func (s *OrderableDBInstanceOption) SetLicenseModel(v string) *OrderableDBInstanceOption {
 	s.LicenseModel = &v
+	return s
+}
+
+// SetMaxIopsPerDbInstance sets the MaxIopsPerDbInstance field's value.
+func (s *OrderableDBInstanceOption) SetMaxIopsPerDbInstance(v int64) *OrderableDBInstanceOption {
+	s.MaxIopsPerDbInstance = &v
+	return s
+}
+
+// SetMaxIopsPerGib sets the MaxIopsPerGib field's value.
+func (s *OrderableDBInstanceOption) SetMaxIopsPerGib(v float64) *OrderableDBInstanceOption {
+	s.MaxIopsPerGib = &v
+	return s
+}
+
+// SetMaxStorageSize sets the MaxStorageSize field's value.
+func (s *OrderableDBInstanceOption) SetMaxStorageSize(v int64) *OrderableDBInstanceOption {
+	s.MaxStorageSize = &v
+	return s
+}
+
+// SetMinIopsPerDbInstance sets the MinIopsPerDbInstance field's value.
+func (s *OrderableDBInstanceOption) SetMinIopsPerDbInstance(v int64) *OrderableDBInstanceOption {
+	s.MinIopsPerDbInstance = &v
+	return s
+}
+
+// SetMinIopsPerGib sets the MinIopsPerGib field's value.
+func (s *OrderableDBInstanceOption) SetMinIopsPerGib(v float64) *OrderableDBInstanceOption {
+	s.MinIopsPerGib = &v
+	return s
+}
+
+// SetMinStorageSize sets the MinStorageSize field's value.
+func (s *OrderableDBInstanceOption) SetMinStorageSize(v int64) *OrderableDBInstanceOption {
+	s.MinStorageSize = &v
 	return s
 }
 
@@ -24349,24 +24411,24 @@ type PendingMaintenanceAction struct {
 	// The type of pending maintenance action that is available for the resource.
 	Action *string `type:"string"`
 
-	// The date of the maintenance window when the action will be applied. The maintenance
-	// action will be applied to the resource during its first maintenance window
-	// after this date. If this date is specified, any next-maintenance opt-in requests
+	// The date of the maintenance window when the action is applied. The maintenance
+	// action is applied to the resource during its first maintenance window after
+	// this date. If this date is specified, any next-maintenance opt-in requests
 	// are ignored.
 	AutoAppliedAfterDate *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	// The effective date when the pending maintenance action will be applied to
-	// the resource. This date takes into account opt-in requests received from
-	// the ApplyPendingMaintenanceAction API, the AutoAppliedAfterDate, and the
-	// ForcedApplyDate. This value is blank if an opt-in request has not been received
-	// and nothing has been specified as AutoAppliedAfterDate or ForcedApplyDate.
+	// The effective date when the pending maintenance action is applied to the
+	// resource. This date takes into account opt-in requests received from the
+	// ApplyPendingMaintenanceAction API, the AutoAppliedAfterDate, and the ForcedApplyDate.
+	// This value is blank if an opt-in request has not been received and nothing
+	// has been specified as AutoAppliedAfterDate or ForcedApplyDate.
 	CurrentApplyDate *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
 	// A description providing more detail about the maintenance action.
 	Description *string `type:"string"`
 
-	// The date when the maintenance action will be automatically applied. The maintenance
-	// action will be applied to the resource on this date regardless of the maintenance
+	// The date when the maintenance action is automatically applied. The maintenance
+	// action is applied to the resource on this date regardless of the maintenance
 	// window for the resource. If this date is specified, any immediate opt-in
 	// requests are ignored.
 	ForcedApplyDate *time.Time `type:"timestamp" timestampFormat:"iso8601"`
@@ -24427,7 +24489,7 @@ type PendingModifiedValues struct {
 	_ struct{} `type:"structure"`
 
 	// Contains the new AllocatedStorage size for the DB instance that will be applied
-	// or is in progress.
+	// or is currently being applied.
 	AllocatedStorage *int64 `type:"integer"`
 
 	// Specifies the pending number of days for which automated backups are retained.
@@ -24437,11 +24499,11 @@ type PendingModifiedValues struct {
 	CACertificateIdentifier *string `type:"string"`
 
 	// Contains the new DBInstanceClass for the DB instance that will be applied
-	// or is in progress.
+	// or is currently being applied.
 	DBInstanceClass *string `type:"string"`
 
 	// Contains the new DBInstanceIdentifier for the DB instance that will be applied
-	// or is in progress.
+	// or is currently being applied.
 	DBInstanceIdentifier *string `type:"string"`
 
 	// The new DB subnet group for the DB instance.
@@ -24451,7 +24513,7 @@ type PendingModifiedValues struct {
 	EngineVersion *string `type:"string"`
 
 	// Specifies the new Provisioned IOPS value for the DB instance that will be
-	// applied or is being applied.
+	// applied or is currently being applied.
 	Iops *int64 `type:"integer"`
 
 	// The license model for the DB instance.
@@ -24459,8 +24521,8 @@ type PendingModifiedValues struct {
 	// Valid values: license-included | bring-your-own-license | general-public-license
 	LicenseModel *string `type:"string"`
 
-	// Contains the pending or in-progress change of the master credentials for
-	// the DB instance.
+	// Contains the pending or currently-in-progress change of the master credentials
+	// for the DB instance.
 	MasterUserPassword *string `type:"string"`
 
 	// Indicates that the Single-AZ DB instance is to change to a Multi-AZ deployment.
@@ -24924,7 +24986,7 @@ type RebootDBInstanceInput struct {
 	// DBInstanceIdentifier is a required field
 	DBInstanceIdentifier *string `type:"string" required:"true"`
 
-	// When true, the reboot will be conducted through a MultiAZ failover.
+	// When true, the reboot is conducted through a MultiAZ failover.
 	//
 	// Constraint: You cannot specify true if the instance is not configured for
 	// MultiAZ.
@@ -25190,8 +25252,8 @@ func (s *RemoveSourceIdentifierFromSubscriptionOutput) SetEventSubscription(v *E
 type RemoveTagsFromResourceInput struct {
 	_ struct{} `type:"structure"`
 
-	// The Amazon RDS resource the tags will be removed from. This value is an Amazon
-	// Resource Name (ARN). For information about creating an ARN, see  Constructing
+	// The Amazon RDS resource that the tags are removed from. This value is an
+	// Amazon Resource Name (ARN). For information about creating an ARN, see  Constructing
 	// an RDS Amazon Resource Name (ARN) (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.ARN.html#USER_Tagging.ARN.Constructing).
 	//
 	// ResourceName is a required field
@@ -25737,7 +25799,7 @@ type RestoreDBClusterFromS3Input struct {
 	DBClusterIdentifier *string `type:"string" required:"true"`
 
 	// The name of the DB cluster parameter group to associate with the restored
-	// DB cluster. If this argument is omitted, default.aurora5.6 will be used.
+	// DB cluster. If this argument is omitted, default.aurora5.6 is used.
 	//
 	// Constraints:
 	//
@@ -26419,8 +26481,8 @@ type RestoreDBClusterToPointInTimeInput struct {
 	//
 	// You can restore to a new DB cluster and encrypt the new DB cluster with a
 	// KMS key that is different than the KMS key used to encrypt the source DB
-	// cluster. The new DB cluster will be encrypted with the KMS key identified
-	// by the KmsKeyId parameter.
+	// cluster. The new DB cluster is encrypted with the KMS key identified by the
+	// KmsKeyId parameter.
 	//
 	// If you do not specify a value for the KmsKeyId parameter, then the following
 	// will occur:
@@ -26642,11 +26704,11 @@ func (s *RestoreDBClusterToPointInTimeOutput) SetDBCluster(v *DBCluster) *Restor
 type RestoreDBInstanceFromDBSnapshotInput struct {
 	_ struct{} `type:"structure"`
 
-	// Indicates that minor version upgrades will be applied automatically to the
-	// DB instance during the maintenance window.
+	// Indicates that minor version upgrades are applied automatically to the DB
+	// instance during the maintenance window.
 	AutoMinorVersionUpgrade *bool `type:"boolean"`
 
-	// The EC2 Availability Zone that the database instance will be created in.
+	// The EC2 Availability Zone that the database instance is created in.
 	//
 	// Default: A random, system-chosen Availability Zone.
 	//
@@ -26660,13 +26722,13 @@ type RestoreDBInstanceFromDBSnapshotInput struct {
 	// instance; otherwise false. The default is false.
 	CopyTagsToSnapshot *bool `type:"boolean"`
 
-	// The compute and memory capacity of the Amazon RDS DB instance.
+	// The compute and memory capacity of the Amazon RDS DB instance, for example,
+	// db.m4.large. Not all DB instance classes are available in all regions, or
+	// for all database engines. For the full list of DB instance classes, and availability
+	// for your engine, see DB Instance Class (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html)
+	// in the Amazon RDS User Guide.
 	//
-	// Valid Values: db.t1.micro | db.m1.small | db.m1.medium | db.m1.large | db.m1.xlarge
-	// | db.m2.2xlarge | db.m2.4xlarge | db.m3.medium | db.m3.large | db.m3.xlarge
-	// | db.m3.2xlarge | db.m4.large | db.m4.xlarge | db.m4.2xlarge | db.m4.4xlarge
-	// | db.m4.10xlarge | db.r3.large | db.r3.xlarge | db.r3.2xlarge | db.r3.4xlarge
-	// | db.r3.8xlarge | db.t2.micro | db.t2.small | db.t2.medium | db.t2.large
+	// Default: The same DBInstanceClass as the original DB instance.
 	DBInstanceClass *string `type:"string"`
 
 	// Name of the DB instance to create from the DB snapshot. This parameter isn't
@@ -26766,16 +26828,16 @@ type RestoreDBInstanceFromDBSnapshotInput struct {
 
 	// Specifies the amount of provisioned IOPS for the DB instance, expressed in
 	// I/O operations per second. If this parameter is not specified, the IOPS value
-	// will be taken from the backup. If this parameter is set to 0, the new instance
-	// will be converted to a non-PIOPS instance, which will take additional time,
-	// though your DB instance will be available for connections before the conversion
+	// is taken from the backup. If this parameter is set to 0, the new instance
+	// is converted to a non-PIOPS instance. The conversion takes additional time,
+	// though your DB instance is available for connections before the conversion
 	// starts.
 	//
+	// The provisioned IOPS value must follow the requirements for your database
+	// engine. For more information, see Amazon RDS Provisioned IOPS Storage to
+	// Improve Performance (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html#USER_PIOPS).
+	//
 	// Constraints: Must be an integer greater than 1000.
-	//
-	// SQL Server
-	//
-	// Setting the IOPS value for the SQL Server database engine is not supported.
 	Iops *int64 `type:"integer"`
 
 	// License model information for the restored DB instance.
@@ -26818,9 +26880,9 @@ type RestoreDBInstanceFromDBSnapshotInput struct {
 	//    * VPC: false
 	//
 	// If no DB subnet group has been specified as part of the request and the PubliclyAccessible
-	// value has not been set, the DB instance will be publicly accessible. If a
-	// specific DB subnet group has been specified as part of the request and the
-	// PubliclyAccessible value has not been set, the DB instance will be private.
+	// value has not been set, the DB instance is publicly accessible. If a specific
+	// DB subnet group has been specified as part of the request and the PubliclyAccessible
+	// value has not been set, the DB instance is private.
 	PubliclyAccessible *bool `type:"boolean"`
 
 	// Specifies the storage type to be associated with the DB instance.
@@ -27041,11 +27103,11 @@ func (s *RestoreDBInstanceFromDBSnapshotOutput) SetDBInstance(v *DBInstance) *Re
 type RestoreDBInstanceToPointInTimeInput struct {
 	_ struct{} `type:"structure"`
 
-	// Indicates that minor version upgrades will be applied automatically to the
-	// DB instance during the maintenance window.
+	// Indicates that minor version upgrades are applied automatically to the DB
+	// instance during the maintenance window.
 	AutoMinorVersionUpgrade *bool `type:"boolean"`
 
-	// The EC2 Availability Zone that the database instance will be created in.
+	// The EC2 Availability Zone that the database instance is created in.
 	//
 	// Default: A random, system-chosen Availability Zone.
 	//
@@ -27059,13 +27121,11 @@ type RestoreDBInstanceToPointInTimeInput struct {
 	// instance; otherwise false. The default is false.
 	CopyTagsToSnapshot *bool `type:"boolean"`
 
-	// The compute and memory capacity of the Amazon RDS DB instance.
-	//
-	// Valid Values: db.t1.micro | db.m1.small | db.m1.medium | db.m1.large | db.m1.xlarge
-	// | db.m2.2xlarge | db.m2.4xlarge | db.m3.medium | db.m3.large | db.m3.xlarge
-	// | db.m3.2xlarge | db.m4.large | db.m4.xlarge | db.m4.2xlarge | db.m4.4xlarge
-	// | db.m4.10xlarge | db.r3.large | db.r3.xlarge | db.r3.2xlarge | db.r3.4xlarge
-	// | db.r3.8xlarge | db.t2.micro | db.t2.small | db.t2.medium | db.t2.large
+	// The compute and memory capacity of the Amazon RDS DB instance, for example,
+	// db.m4.large. Not all DB instance classes are available in all regions, or
+	// for all database engines. For the full list of DB instance classes, and availability
+	// for your engine, see DB Instance Class (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html)
+	// in the Amazon RDS User Guide.
 	//
 	// Default: The same DBInstanceClass as the original DB instance.
 	DBInstanceClass *string `type:"string"`
@@ -27186,9 +27246,9 @@ type RestoreDBInstanceToPointInTimeInput struct {
 	//    * VPC:false
 	//
 	// If no DB subnet group has been specified as part of the request and the PubliclyAccessible
-	// value has not been set, the DB instance will be publicly accessible. If a
-	// specific DB subnet group has been specified as part of the request and the
-	// PubliclyAccessible value has not been set, the DB instance will be private.
+	// value has not been set, the DB instance is publicly accessible. If a specific
+	// DB subnet group has been specified as part of the request and the PubliclyAccessible
+	// value has not been set, the DB instance is private.
 	PubliclyAccessible *bool `type:"boolean"`
 
 	// The date and time to restore from.
@@ -27904,8 +27964,8 @@ func (s *Timezone) SetTimezoneName(v string) *Timezone {
 type UpgradeTarget struct {
 	_ struct{} `type:"structure"`
 
-	// A value that indicates whether the target version will be applied to any
-	// source DB instances that have AutoMinorVersionUpgrade set to true.
+	// A value that indicates whether the target version is applied to any source
+	// DB instances that have AutoMinorVersionUpgrade set to true.
 	AutoUpgrade *bool `type:"boolean"`
 
 	// The version of the database engine that a DB instance can be upgraded to.
@@ -27917,8 +27977,7 @@ type UpgradeTarget struct {
 	// The version number of the upgrade target database engine.
 	EngineVersion *string `type:"string"`
 
-	// A value that indicates whether a database engine will be upgraded to a major
-	// version.
+	// A value that indicates whether a database engine is upgraded to a major version.
 	IsMajorVersionUpgrade *bool `type:"boolean"`
 }
 

--- a/vendor/github.com/aws/aws-sdk-go/service/s3/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/s3/api.go
@@ -643,6 +643,82 @@ func (c *S3) DeleteBucketCorsWithContext(ctx aws.Context, input *DeleteBucketCor
 	return out, req.Send()
 }
 
+const opDeleteBucketEncryption = "DeleteBucketEncryption"
+
+// DeleteBucketEncryptionRequest generates a "aws/request.Request" representing the
+// client's request for the DeleteBucketEncryption operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DeleteBucketEncryption for more information on using the DeleteBucketEncryption
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DeleteBucketEncryptionRequest method.
+//    req, resp := client.DeleteBucketEncryptionRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketEncryption
+func (c *S3) DeleteBucketEncryptionRequest(input *DeleteBucketEncryptionInput) (req *request.Request, output *DeleteBucketEncryptionOutput) {
+	op := &request.Operation{
+		Name:       opDeleteBucketEncryption,
+		HTTPMethod: "DELETE",
+		HTTPPath:   "/{Bucket}?encryption",
+	}
+
+	if input == nil {
+		input = &DeleteBucketEncryptionInput{}
+	}
+
+	output = &DeleteBucketEncryptionOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restxml.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// DeleteBucketEncryption API operation for Amazon Simple Storage Service.
+//
+// Deletes the server-side encryption configuration from the bucket.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Simple Storage Service's
+// API operation DeleteBucketEncryption for usage and error information.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketEncryption
+func (c *S3) DeleteBucketEncryption(input *DeleteBucketEncryptionInput) (*DeleteBucketEncryptionOutput, error) {
+	req, out := c.DeleteBucketEncryptionRequest(input)
+	return out, req.Send()
+}
+
+// DeleteBucketEncryptionWithContext is the same as DeleteBucketEncryption with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeleteBucketEncryption for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *S3) DeleteBucketEncryptionWithContext(ctx aws.Context, input *DeleteBucketEncryptionInput, opts ...request.Option) (*DeleteBucketEncryptionOutput, error) {
+	req, out := c.DeleteBucketEncryptionRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opDeleteBucketInventoryConfiguration = "DeleteBucketInventoryConfiguration"
 
 // DeleteBucketInventoryConfigurationRequest generates a "aws/request.Request" representing the
@@ -1694,6 +1770,80 @@ func (c *S3) GetBucketCors(input *GetBucketCorsInput) (*GetBucketCorsOutput, err
 // for more information on using Contexts.
 func (c *S3) GetBucketCorsWithContext(ctx aws.Context, input *GetBucketCorsInput, opts ...request.Option) (*GetBucketCorsOutput, error) {
 	req, out := c.GetBucketCorsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opGetBucketEncryption = "GetBucketEncryption"
+
+// GetBucketEncryptionRequest generates a "aws/request.Request" representing the
+// client's request for the GetBucketEncryption operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See GetBucketEncryption for more information on using the GetBucketEncryption
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the GetBucketEncryptionRequest method.
+//    req, resp := client.GetBucketEncryptionRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketEncryption
+func (c *S3) GetBucketEncryptionRequest(input *GetBucketEncryptionInput) (req *request.Request, output *GetBucketEncryptionOutput) {
+	op := &request.Operation{
+		Name:       opGetBucketEncryption,
+		HTTPMethod: "GET",
+		HTTPPath:   "/{Bucket}?encryption",
+	}
+
+	if input == nil {
+		input = &GetBucketEncryptionInput{}
+	}
+
+	output = &GetBucketEncryptionOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// GetBucketEncryption API operation for Amazon Simple Storage Service.
+//
+// Returns the server-side encryption configuration of a bucket.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Simple Storage Service's
+// API operation GetBucketEncryption for usage and error information.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketEncryption
+func (c *S3) GetBucketEncryption(input *GetBucketEncryptionInput) (*GetBucketEncryptionOutput, error) {
+	req, out := c.GetBucketEncryptionRequest(input)
+	return out, req.Send()
+}
+
+// GetBucketEncryptionWithContext is the same as GetBucketEncryption with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetBucketEncryption for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *S3) GetBucketEncryptionWithContext(ctx aws.Context, input *GetBucketEncryptionInput, opts ...request.Option) (*GetBucketEncryptionOutput, error) {
+	req, out := c.GetBucketEncryptionRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -4477,6 +4627,83 @@ func (c *S3) PutBucketCorsWithContext(ctx aws.Context, input *PutBucketCorsInput
 	return out, req.Send()
 }
 
+const opPutBucketEncryption = "PutBucketEncryption"
+
+// PutBucketEncryptionRequest generates a "aws/request.Request" representing the
+// client's request for the PutBucketEncryption operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See PutBucketEncryption for more information on using the PutBucketEncryption
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the PutBucketEncryptionRequest method.
+//    req, resp := client.PutBucketEncryptionRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketEncryption
+func (c *S3) PutBucketEncryptionRequest(input *PutBucketEncryptionInput) (req *request.Request, output *PutBucketEncryptionOutput) {
+	op := &request.Operation{
+		Name:       opPutBucketEncryption,
+		HTTPMethod: "PUT",
+		HTTPPath:   "/{Bucket}?encryption",
+	}
+
+	if input == nil {
+		input = &PutBucketEncryptionInput{}
+	}
+
+	output = &PutBucketEncryptionOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restxml.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// PutBucketEncryption API operation for Amazon Simple Storage Service.
+//
+// Creates a new server-side encryption configuration (or replaces an existing
+// one, if present).
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Simple Storage Service's
+// API operation PutBucketEncryption for usage and error information.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketEncryption
+func (c *S3) PutBucketEncryption(input *PutBucketEncryptionInput) (*PutBucketEncryptionOutput, error) {
+	req, out := c.PutBucketEncryptionRequest(input)
+	return out, req.Send()
+}
+
+// PutBucketEncryptionWithContext is the same as PutBucketEncryption with the addition of
+// the ability to pass a context and additional request options.
+//
+// See PutBucketEncryption for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *S3) PutBucketEncryptionWithContext(ctx aws.Context, input *PutBucketEncryptionInput, opts ...request.Option) (*PutBucketEncryptionOutput, error) {
+	req, out := c.PutBucketEncryptionRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opPutBucketInventoryConfiguration = "PutBucketInventoryConfiguration"
 
 // PutBucketInventoryConfigurationRequest generates a "aws/request.Request" representing the
@@ -6152,6 +6379,46 @@ func (s *AccessControlPolicy) SetGrants(v []*Grant) *AccessControlPolicy {
 // SetOwner sets the Owner field's value.
 func (s *AccessControlPolicy) SetOwner(v *Owner) *AccessControlPolicy {
 	s.Owner = v
+	return s
+}
+
+// Container for information regarding the access control for replicas.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/AccessControlTranslation
+type AccessControlTranslation struct {
+	_ struct{} `type:"structure"`
+
+	// The override value for the owner of the replica object.
+	//
+	// Owner is a required field
+	Owner *string `type:"string" required:"true" enum:"OwnerOverride"`
+}
+
+// String returns the string representation
+func (s AccessControlTranslation) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AccessControlTranslation) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AccessControlTranslation) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AccessControlTranslation"}
+	if s.Owner == nil {
+		invalidParams.Add(request.NewErrParamRequired("Owner"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetOwner sets the Owner field's value.
+func (s *AccessControlTranslation) SetOwner(v string) *AccessControlTranslation {
+	s.Owner = &v
 	return s
 }
 
@@ -8382,6 +8649,68 @@ func (s DeleteBucketCorsOutput) GoString() string {
 	return s.String()
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketEncryptionRequest
+type DeleteBucketEncryptionInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the bucket containing the server-side encryption configuration
+	// to delete.
+	//
+	// Bucket is a required field
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DeleteBucketEncryptionInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteBucketEncryptionInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteBucketEncryptionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteBucketEncryptionInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *DeleteBucketEncryptionInput) SetBucket(v string) *DeleteBucketEncryptionInput {
+	s.Bucket = &v
+	return s
+}
+
+func (s *DeleteBucketEncryptionInput) getBucket() (v string) {
+	if s.Bucket == nil {
+		return v
+	}
+	return *s.Bucket
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketEncryptionOutput
+type DeleteBucketEncryptionOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteBucketEncryptionOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteBucketEncryptionOutput) GoString() string {
+	return s.String()
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketRequest
 type DeleteBucketInput struct {
 	_ struct{} `type:"structure"`
@@ -9344,15 +9673,26 @@ func (s *DeletedObject) SetVersionId(v string) *DeletedObject {
 	return s
 }
 
+// Container for replication destination information.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/Destination
 type Destination struct {
 	_ struct{} `type:"structure"`
+
+	// Container for information regarding the access control for replicas.
+	AccessControlTranslation *AccessControlTranslation `type:"structure"`
+
+	// Account ID of the destination bucket. Currently this is only being verified
+	// if Access Control Translation is enabled
+	Account *string `type:"string"`
 
 	// Amazon resource name (ARN) of the bucket where you want Amazon S3 to store
 	// replicas of the object identified by the rule.
 	//
 	// Bucket is a required field
 	Bucket *string `type:"string" required:"true"`
+
+	// Container for information regarding encryption based configuration for replicas.
+	EncryptionConfiguration *EncryptionConfiguration `type:"structure"`
 
 	// The class of storage used to store the object.
 	StorageClass *string `type:"string" enum:"StorageClass"`
@@ -9374,11 +9714,28 @@ func (s *Destination) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.AccessControlTranslation != nil {
+		if err := s.AccessControlTranslation.Validate(); err != nil {
+			invalidParams.AddNested("AccessControlTranslation", err.(request.ErrInvalidParams))
+		}
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAccessControlTranslation sets the AccessControlTranslation field's value.
+func (s *Destination) SetAccessControlTranslation(v *AccessControlTranslation) *Destination {
+	s.AccessControlTranslation = v
+	return s
+}
+
+// SetAccount sets the Account field's value.
+func (s *Destination) SetAccount(v string) *Destination {
+	s.Account = &v
+	return s
 }
 
 // SetBucket sets the Bucket field's value.
@@ -9394,9 +9751,40 @@ func (s *Destination) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// SetEncryptionConfiguration sets the EncryptionConfiguration field's value.
+func (s *Destination) SetEncryptionConfiguration(v *EncryptionConfiguration) *Destination {
+	s.EncryptionConfiguration = v
+	return s
+}
+
 // SetStorageClass sets the StorageClass field's value.
 func (s *Destination) SetStorageClass(v string) *Destination {
 	s.StorageClass = &v
+	return s
+}
+
+// Container for information regarding encryption based configuration for replicas.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/EncryptionConfiguration
+type EncryptionConfiguration struct {
+	_ struct{} `type:"structure"`
+
+	// The id of the KMS key used to encrypt the replica object.
+	ReplicaKmsKeyID *string `type:"string"`
+}
+
+// String returns the string representation
+func (s EncryptionConfiguration) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s EncryptionConfiguration) GoString() string {
+	return s.String()
+}
+
+// SetReplicaKmsKeyID sets the ReplicaKmsKeyID field's value.
+func (s *EncryptionConfiguration) SetReplicaKmsKeyID(v string) *EncryptionConfiguration {
+	s.ReplicaKmsKeyID = &v
 	return s
 }
 
@@ -9819,6 +10207,78 @@ func (s GetBucketCorsOutput) GoString() string {
 // SetCORSRules sets the CORSRules field's value.
 func (s *GetBucketCorsOutput) SetCORSRules(v []*CORSRule) *GetBucketCorsOutput {
 	s.CORSRules = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketEncryptionRequest
+type GetBucketEncryptionInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the bucket from which the server-side encryption configuration
+	// is retrieved.
+	//
+	// Bucket is a required field
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s GetBucketEncryptionInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetBucketEncryptionInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetBucketEncryptionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetBucketEncryptionInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *GetBucketEncryptionInput) SetBucket(v string) *GetBucketEncryptionInput {
+	s.Bucket = &v
+	return s
+}
+
+func (s *GetBucketEncryptionInput) getBucket() (v string) {
+	if s.Bucket == nil {
+		return v
+	}
+	return *s.Bucket
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketEncryptionOutput
+type GetBucketEncryptionOutput struct {
+	_ struct{} `type:"structure" payload:"ServerSideEncryptionConfiguration"`
+
+	// Container for server-side encryption configuration rules. Currently S3 supports
+	// one rule only.
+	ServerSideEncryptionConfiguration *ServerSideEncryptionConfiguration `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetBucketEncryptionOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetBucketEncryptionOutput) GoString() string {
+	return s.String()
+}
+
+// SetServerSideEncryptionConfiguration sets the ServerSideEncryptionConfiguration field's value.
+func (s *GetBucketEncryptionOutput) SetServerSideEncryptionConfiguration(v *ServerSideEncryptionConfiguration) *GetBucketEncryptionOutput {
+	s.ServerSideEncryptionConfiguration = v
 	return s
 }
 
@@ -12500,6 +12960,56 @@ func (s *InventoryDestination) SetS3BucketDestination(v *InventoryS3BucketDestin
 	return s
 }
 
+// Contains the type of server-side encryption used to encrypt the inventory
+// results.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/InventoryEncryption
+type InventoryEncryption struct {
+	_ struct{} `type:"structure"`
+
+	// Specifies the use of SSE-KMS to encrypt delievered Inventory reports.
+	SSEKMS *SSEKMS `locationName:"SSE-KMS" type:"structure"`
+
+	// Specifies the use of SSE-S3 to encrypt delievered Inventory reports.
+	SSES3 *SSES3 `locationName:"SSE-S3" type:"structure"`
+}
+
+// String returns the string representation
+func (s InventoryEncryption) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s InventoryEncryption) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InventoryEncryption) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InventoryEncryption"}
+	if s.SSEKMS != nil {
+		if err := s.SSEKMS.Validate(); err != nil {
+			invalidParams.AddNested("SSEKMS", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetSSEKMS sets the SSEKMS field's value.
+func (s *InventoryEncryption) SetSSEKMS(v *SSEKMS) *InventoryEncryption {
+	s.SSEKMS = v
+	return s
+}
+
+// SetSSES3 sets the SSES3 field's value.
+func (s *InventoryEncryption) SetSSES3(v *SSES3) *InventoryEncryption {
+	s.SSES3 = v
+	return s
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/InventoryFilter
 type InventoryFilter struct {
 	_ struct{} `type:"structure"`
@@ -12552,6 +13062,10 @@ type InventoryS3BucketDestination struct {
 	// Bucket is a required field
 	Bucket *string `type:"string" required:"true"`
 
+	// Contains the type of server-side encryption used to encrypt the inventory
+	// results.
+	Encryption *InventoryEncryption `type:"structure"`
+
 	// Specifies the output format of the inventory results.
 	//
 	// Format is a required field
@@ -12580,6 +13094,11 @@ func (s *InventoryS3BucketDestination) Validate() error {
 	if s.Format == nil {
 		invalidParams.Add(request.NewErrParamRequired("Format"))
 	}
+	if s.Encryption != nil {
+		if err := s.Encryption.Validate(); err != nil {
+			invalidParams.AddNested("Encryption", err.(request.ErrInvalidParams))
+		}
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -12604,6 +13123,12 @@ func (s *InventoryS3BucketDestination) getBucket() (v string) {
 		return v
 	}
 	return *s.Bucket
+}
+
+// SetEncryption sets the Encryption field's value.
+func (s *InventoryS3BucketDestination) SetEncryption(v *InventoryEncryption) *InventoryS3BucketDestination {
+	s.Encryption = v
+	return s
 }
 
 // SetFormat sets the Format field's value.
@@ -15860,6 +16385,88 @@ func (s PutBucketCorsOutput) GoString() string {
 	return s.String()
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketEncryptionRequest
+type PutBucketEncryptionInput struct {
+	_ struct{} `type:"structure" payload:"ServerSideEncryptionConfiguration"`
+
+	// The name of the bucket for which the server-side encryption configuration
+	// is set.
+	//
+	// Bucket is a required field
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
+
+	// Container for server-side encryption configuration rules. Currently S3 supports
+	// one rule only.
+	//
+	// ServerSideEncryptionConfiguration is a required field
+	ServerSideEncryptionConfiguration *ServerSideEncryptionConfiguration `locationName:"ServerSideEncryptionConfiguration" type:"structure" required:"true" xmlURI:"http://s3.amazonaws.com/doc/2006-03-01/"`
+}
+
+// String returns the string representation
+func (s PutBucketEncryptionInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PutBucketEncryptionInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutBucketEncryptionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutBucketEncryptionInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.ServerSideEncryptionConfiguration == nil {
+		invalidParams.Add(request.NewErrParamRequired("ServerSideEncryptionConfiguration"))
+	}
+	if s.ServerSideEncryptionConfiguration != nil {
+		if err := s.ServerSideEncryptionConfiguration.Validate(); err != nil {
+			invalidParams.AddNested("ServerSideEncryptionConfiguration", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *PutBucketEncryptionInput) SetBucket(v string) *PutBucketEncryptionInput {
+	s.Bucket = &v
+	return s
+}
+
+func (s *PutBucketEncryptionInput) getBucket() (v string) {
+	if s.Bucket == nil {
+		return v
+	}
+	return *s.Bucket
+}
+
+// SetServerSideEncryptionConfiguration sets the ServerSideEncryptionConfiguration field's value.
+func (s *PutBucketEncryptionInput) SetServerSideEncryptionConfiguration(v *ServerSideEncryptionConfiguration) *PutBucketEncryptionInput {
+	s.ServerSideEncryptionConfiguration = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketEncryptionOutput
+type PutBucketEncryptionOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutBucketEncryptionOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PutBucketEncryptionOutput) GoString() string {
+	return s.String()
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketInventoryConfigurationRequest
 type PutBucketInventoryConfigurationInput struct {
 	_ struct{} `type:"structure" payload:"InventoryConfiguration"`
@@ -16425,6 +17032,10 @@ type PutBucketPolicyInput struct {
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
+	// Set this parameter to true to confirm that you want to remove your permissions
+	// to change this bucket policy in the future.
+	ConfirmRemoveSelfBucketAccess *bool `location:"header" locationName:"x-amz-confirm-remove-self-bucket-access" type:"boolean"`
+
 	// The bucket policy as a JSON document.
 	//
 	// Policy is a required field
@@ -16468,6 +17079,12 @@ func (s *PutBucketPolicyInput) getBucket() (v string) {
 		return v
 	}
 	return *s.Bucket
+}
+
+// SetConfirmRemoveSelfBucketAccess sets the ConfirmRemoveSelfBucketAccess field's value.
+func (s *PutBucketPolicyInput) SetConfirmRemoveSelfBucketAccess(v bool) *PutBucketPolicyInput {
+	s.ConfirmRemoveSelfBucketAccess = &v
+	return s
 }
 
 // SetPolicy sets the Policy field's value.
@@ -17867,10 +18484,13 @@ func (s *ReplicationConfiguration) SetRules(v []*ReplicationRule) *ReplicationCo
 	return s
 }
 
+// Container for information about a particular replication rule.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ReplicationRule
 type ReplicationRule struct {
 	_ struct{} `type:"structure"`
 
+	// Container for replication destination information.
+	//
 	// Destination is a required field
 	Destination *Destination `type:"structure" required:"true"`
 
@@ -17883,6 +18503,9 @@ type ReplicationRule struct {
 	//
 	// Prefix is a required field
 	Prefix *string `type:"string" required:"true"`
+
+	// Container for filters that define which source objects should be replicated.
+	SourceSelectionCriteria *SourceSelectionCriteria `type:"structure"`
 
 	// The rule is ignored if status is not Enabled.
 	//
@@ -17917,6 +18540,11 @@ func (s *ReplicationRule) Validate() error {
 			invalidParams.AddNested("Destination", err.(request.ErrInvalidParams))
 		}
 	}
+	if s.SourceSelectionCriteria != nil {
+		if err := s.SourceSelectionCriteria.Validate(); err != nil {
+			invalidParams.AddNested("SourceSelectionCriteria", err.(request.ErrInvalidParams))
+		}
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -17939,6 +18567,12 @@ func (s *ReplicationRule) SetID(v string) *ReplicationRule {
 // SetPrefix sets the Prefix field's value.
 func (s *ReplicationRule) SetPrefix(v string) *ReplicationRule {
 	s.Prefix = &v
+	return s
+}
+
+// SetSourceSelectionCriteria sets the SourceSelectionCriteria field's value.
+func (s *ReplicationRule) SetSourceSelectionCriteria(v *SourceSelectionCriteria) *ReplicationRule {
+	s.SourceSelectionCriteria = v
 	return s
 }
 
@@ -18322,6 +18956,291 @@ func (s *Rule) SetStatus(v string) *Rule {
 // SetTransition sets the Transition field's value.
 func (s *Rule) SetTransition(v *Transition) *Rule {
 	s.Transition = v
+	return s
+}
+
+// Specifies the use of SSE-KMS to encrypt delievered Inventory reports.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/SSEKMS
+type SSEKMS struct {
+	_ struct{} `locationName:"SSE-KMS" type:"structure"`
+
+	// Specifies the ID of the AWS Key Management Service (KMS) master encryption
+	// key to use for encrypting Inventory reports.
+	//
+	// KeyId is a required field
+	KeyId *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s SSEKMS) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SSEKMS) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SSEKMS) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SSEKMS"}
+	if s.KeyId == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeyId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *SSEKMS) SetKeyId(v string) *SSEKMS {
+	s.KeyId = &v
+	return s
+}
+
+// Specifies the use of SSE-S3 to encrypt delievered Inventory reports.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/SSES3
+type SSES3 struct {
+	_ struct{} `locationName:"SSE-S3" type:"structure"`
+}
+
+// String returns the string representation
+func (s SSES3) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SSES3) GoString() string {
+	return s.String()
+}
+
+// Describes the default server-side encryption to apply to new objects in the
+// bucket. If Put Object request does not specify any server-side encryption,
+// this default encryption will be applied.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ServerSideEncryptionByDefault
+type ServerSideEncryptionByDefault struct {
+	_ struct{} `type:"structure"`
+
+	// KMS master key ID to use for the default encryption. This parameter is allowed
+	// if SSEAlgorithm is aws:kms.
+	KMSMasterKeyID *string `type:"string"`
+
+	// Server-side encryption algorithm to use for the default encryption.
+	//
+	// SSEAlgorithm is a required field
+	SSEAlgorithm *string `type:"string" required:"true" enum:"ServerSideEncryption"`
+}
+
+// String returns the string representation
+func (s ServerSideEncryptionByDefault) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ServerSideEncryptionByDefault) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ServerSideEncryptionByDefault) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ServerSideEncryptionByDefault"}
+	if s.SSEAlgorithm == nil {
+		invalidParams.Add(request.NewErrParamRequired("SSEAlgorithm"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetKMSMasterKeyID sets the KMSMasterKeyID field's value.
+func (s *ServerSideEncryptionByDefault) SetKMSMasterKeyID(v string) *ServerSideEncryptionByDefault {
+	s.KMSMasterKeyID = &v
+	return s
+}
+
+// SetSSEAlgorithm sets the SSEAlgorithm field's value.
+func (s *ServerSideEncryptionByDefault) SetSSEAlgorithm(v string) *ServerSideEncryptionByDefault {
+	s.SSEAlgorithm = &v
+	return s
+}
+
+// Container for server-side encryption configuration rules. Currently S3 supports
+// one rule only.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ServerSideEncryptionConfiguration
+type ServerSideEncryptionConfiguration struct {
+	_ struct{} `type:"structure"`
+
+	// Container for information about a particular server-side encryption configuration
+	// rule.
+	//
+	// Rules is a required field
+	Rules []*ServerSideEncryptionRule `locationName:"Rule" type:"list" flattened:"true" required:"true"`
+}
+
+// String returns the string representation
+func (s ServerSideEncryptionConfiguration) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ServerSideEncryptionConfiguration) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ServerSideEncryptionConfiguration) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ServerSideEncryptionConfiguration"}
+	if s.Rules == nil {
+		invalidParams.Add(request.NewErrParamRequired("Rules"))
+	}
+	if s.Rules != nil {
+		for i, v := range s.Rules {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Rules", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetRules sets the Rules field's value.
+func (s *ServerSideEncryptionConfiguration) SetRules(v []*ServerSideEncryptionRule) *ServerSideEncryptionConfiguration {
+	s.Rules = v
+	return s
+}
+
+// Container for information about a particular server-side encryption configuration
+// rule.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ServerSideEncryptionRule
+type ServerSideEncryptionRule struct {
+	_ struct{} `type:"structure"`
+
+	// Describes the default server-side encryption to apply to new objects in the
+	// bucket. If Put Object request does not specify any server-side encryption,
+	// this default encryption will be applied.
+	ApplyServerSideEncryptionByDefault *ServerSideEncryptionByDefault `type:"structure"`
+}
+
+// String returns the string representation
+func (s ServerSideEncryptionRule) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ServerSideEncryptionRule) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ServerSideEncryptionRule) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ServerSideEncryptionRule"}
+	if s.ApplyServerSideEncryptionByDefault != nil {
+		if err := s.ApplyServerSideEncryptionByDefault.Validate(); err != nil {
+			invalidParams.AddNested("ApplyServerSideEncryptionByDefault", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetApplyServerSideEncryptionByDefault sets the ApplyServerSideEncryptionByDefault field's value.
+func (s *ServerSideEncryptionRule) SetApplyServerSideEncryptionByDefault(v *ServerSideEncryptionByDefault) *ServerSideEncryptionRule {
+	s.ApplyServerSideEncryptionByDefault = v
+	return s
+}
+
+// Container for filters that define which source objects should be replicated.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/SourceSelectionCriteria
+type SourceSelectionCriteria struct {
+	_ struct{} `type:"structure"`
+
+	// Container for filter information of selection of KMS Encrypted S3 objects.
+	SseKmsEncryptedObjects *SseKmsEncryptedObjects `type:"structure"`
+}
+
+// String returns the string representation
+func (s SourceSelectionCriteria) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SourceSelectionCriteria) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SourceSelectionCriteria) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SourceSelectionCriteria"}
+	if s.SseKmsEncryptedObjects != nil {
+		if err := s.SseKmsEncryptedObjects.Validate(); err != nil {
+			invalidParams.AddNested("SseKmsEncryptedObjects", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetSseKmsEncryptedObjects sets the SseKmsEncryptedObjects field's value.
+func (s *SourceSelectionCriteria) SetSseKmsEncryptedObjects(v *SseKmsEncryptedObjects) *SourceSelectionCriteria {
+	s.SseKmsEncryptedObjects = v
+	return s
+}
+
+// Container for filter information of selection of KMS Encrypted S3 objects.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/SseKmsEncryptedObjects
+type SseKmsEncryptedObjects struct {
+	_ struct{} `type:"structure"`
+
+	// The replication for KMS encrypted S3 objects is disabled if status is not
+	// Enabled.
+	//
+	// Status is a required field
+	Status *string `type:"string" required:"true" enum:"SseKmsEncryptedObjectsStatus"`
+}
+
+// String returns the string representation
+func (s SseKmsEncryptedObjects) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SseKmsEncryptedObjects) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SseKmsEncryptedObjects) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SseKmsEncryptedObjects"}
+	if s.Status == nil {
+		invalidParams.Add(request.NewErrParamRequired("Status"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetStatus sets the Status field's value.
+func (s *SseKmsEncryptedObjects) SetStatus(v string) *SseKmsEncryptedObjects {
+	s.Status = &v
 	return s
 }
 
@@ -19615,6 +20534,9 @@ const (
 
 	// InventoryOptionalFieldReplicationStatus is a InventoryOptionalField enum value
 	InventoryOptionalFieldReplicationStatus = "ReplicationStatus"
+
+	// InventoryOptionalFieldEncryptionStatus is a InventoryOptionalField enum value
+	InventoryOptionalFieldEncryptionStatus = "EncryptionStatus"
 )
 
 const (
@@ -19678,6 +20600,11 @@ const (
 const (
 	// ObjectVersionStorageClassStandard is a ObjectVersionStorageClass enum value
 	ObjectVersionStorageClassStandard = "STANDARD"
+)
+
+const (
+	// OwnerOverrideDestination is a OwnerOverride enum value
+	OwnerOverrideDestination = "Destination"
 )
 
 const (
@@ -19757,6 +20684,14 @@ const (
 
 	// ServerSideEncryptionAwsKms is a ServerSideEncryption enum value
 	ServerSideEncryptionAwsKms = "aws:kms"
+)
+
+const (
+	// SseKmsEncryptedObjectsStatusEnabled is a SseKmsEncryptedObjectsStatus enum value
+	SseKmsEncryptedObjectsStatusEnabled = "Enabled"
+
+	// SseKmsEncryptedObjectsStatusDisabled is a SseKmsEncryptedObjectsStatus enum value
+	SseKmsEncryptedObjectsStatusDisabled = "Disabled"
 )
 
 const (

--- a/vendor/github.com/aws/aws-sdk-go/service/sfn/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/sfn/api.go
@@ -54,7 +54,12 @@ func (c *SFN) CreateActivityRequest(input *CreateActivityInput) (req *request.Re
 
 // CreateActivity API operation for AWS Step Functions.
 //
-// Creates an activity.
+// Creates an activity. An Activity is a task which you write, in any language
+// and hosted on any machine which has access to AWS Step Functions. Activities
+// must poll Step Functions using the GetActivityTask and respond using SendTask*
+// API calls. This function lets Step Functions know the existence of your activity
+// and returns an identifier for use in a state machine and when polling from
+// the activity.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -137,7 +142,10 @@ func (c *SFN) CreateStateMachineRequest(input *CreateStateMachineInput) (req *re
 
 // CreateStateMachine API operation for AWS Step Functions.
 //
-// Creates a state machine.
+// Creates a state machine. A state machine consists of a collection of states
+// that can do work (Task states), determine which states to transition to next
+// (Choice states), stop an execution with an error (Fail states), and so on.
+// State machines are specified using a JSON-based, structured language.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -313,7 +321,10 @@ func (c *SFN) DeleteStateMachineRequest(input *DeleteStateMachineInput) (req *re
 // DeleteStateMachine API operation for AWS Step Functions.
 //
 // Deletes a state machine. This is an asynchronous operation-- it sets the
-// state machine's status to "DELETING" and begins the delete process.
+// state machine's status to "DELETING" and begins the delete process. Each
+// state machine execution will be deleted the next time it makes a state transition.
+// After all executions have completed or been deleted, the state machine itself
+// will be deleted.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -638,13 +649,13 @@ func (c *SFN) GetActivityTaskRequest(input *GetActivityTaskInput) (req *request.
 
 // GetActivityTask API operation for AWS Step Functions.
 //
-// Used by workers to retrieve a task (with the specified activity ARN) scheduled
-// for execution by a running state machine. This initiates a long poll, where
-// the service holds the HTTP connection open and responds as soon as a task
-// becomes available (i.e. an execution of a task of this type is needed.) The
-// maximum time the service holds on to the request before responding is 60
-// seconds. If no task is available within 60 seconds, the poll will return
-// an empty result, that is, the taskToken returned is an empty string.
+// Used by workers to retrieve a task (with the specified activity ARN) which
+// has been scheduled for execution by a running state machine. This initiates
+// a long poll, where the service holds the HTTP connection open and responds
+// as soon as a task becomes available (i.e. an execution of a task of this
+// type is needed.) The maximum time the service holds on to the request before
+// responding is 60 seconds. If no task is available within 60 seconds, the
+// poll will return a taskToken with a null string.
 //
 // Workers should set their client side socket timeout to at least 65 seconds
 // (5 seconds higher than the maximum time the service may hold the poll request).
@@ -1575,7 +1586,9 @@ func (c *SFN) StartExecutionRequest(input *StartExecutionInput) (req *request.Re
 //   must end or be stopped before a new execution can be started.
 //
 //   * ErrCodeExecutionAlreadyExists "ExecutionAlreadyExists"
-//   An execution with the same name already exists.
+//   The execution has the same name as another execution (but a different input).
+//
+//   Executions with the same name and input are considered idempotent.
 //
 //   * ErrCodeInvalidArn "InvalidArn"
 //   The provided Amazon Resource Name (ARN) is invalid.
@@ -1696,6 +1709,7 @@ func (c *SFN) StopExecutionWithContext(ctx aws.Context, input *StopExecutionInpu
 	return out, req.Send()
 }
 
+// Contains details about an activity which failed during an execution.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/states-2016-11-23/ActivityFailedEventDetails
 type ActivityFailedEventDetails struct {
 	_ struct{} `type:"structure"`
@@ -1729,6 +1743,7 @@ func (s *ActivityFailedEventDetails) SetError(v string) *ActivityFailedEventDeta
 	return s
 }
 
+// Contains details about an activity.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/states-2016-11-23/ActivityListItem
 type ActivityListItem struct {
 	_ struct{} `type:"structure"`
@@ -1744,6 +1759,18 @@ type ActivityListItem struct {
 	CreationDate *time.Time `locationName:"creationDate" type:"timestamp" timestampFormat:"unix" required:"true"`
 
 	// The name of the activity.
+	//
+	// A name must not contain:
+	//
+	//    * whitespace
+	//
+	//    * brackets < > { } [ ]
+	//
+	//    * wildcard characters ? *
+	//
+	//    * special characters " # % \ ^ | ~ ` $ & , ; : /
+	//
+	//    * control characters (U+0000-001F, U+007F-009F)
 	//
 	// Name is a required field
 	Name *string `locationName:"name" min:"1" type:"string" required:"true"`
@@ -1777,6 +1804,8 @@ func (s *ActivityListItem) SetName(v string) *ActivityListItem {
 	return s
 }
 
+// Contains details about an activity schedule failure which occurred during
+// an execution.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/states-2016-11-23/ActivityScheduleFailedEventDetails
 type ActivityScheduleFailedEventDetails struct {
 	_ struct{} `type:"structure"`
@@ -1810,6 +1839,7 @@ func (s *ActivityScheduleFailedEventDetails) SetError(v string) *ActivitySchedul
 	return s
 }
 
+// Contains details about an activity scheduled during an execution.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/states-2016-11-23/ActivityScheduledEventDetails
 type ActivityScheduledEventDetails struct {
 	_ struct{} `type:"structure"`
@@ -1863,6 +1893,7 @@ func (s *ActivityScheduledEventDetails) SetTimeoutInSeconds(v int64) *ActivitySc
 	return s
 }
 
+// Contains details about the start of an activity during an execution.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/states-2016-11-23/ActivityStartedEventDetails
 type ActivityStartedEventDetails struct {
 	_ struct{} `type:"structure"`
@@ -1888,6 +1919,8 @@ func (s *ActivityStartedEventDetails) SetWorkerName(v string) *ActivityStartedEv
 	return s
 }
 
+// Contains details about an activity which successfully terminated during an
+// execution.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/states-2016-11-23/ActivitySucceededEventDetails
 type ActivitySucceededEventDetails struct {
 	_ struct{} `type:"structure"`
@@ -1912,6 +1945,7 @@ func (s *ActivitySucceededEventDetails) SetOutput(v string) *ActivitySucceededEv
 	return s
 }
 
+// Contains details about an activity timeout which occurred during an execution.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/states-2016-11-23/ActivityTimedOutEventDetails
 type ActivityTimedOutEventDetails struct {
 	_ struct{} `type:"structure"`
@@ -1950,7 +1984,21 @@ type CreateActivityInput struct {
 	_ struct{} `type:"structure"`
 
 	// The name of the activity to create. This name must be unique for your AWS
-	// account and region.
+	// account and region for 90 days. For more information, see  Limits Related
+	// to State Machine Executions (http://docs.aws.amazon.com/step-functions/latest/dg/limits.html#service-limits-state-machine-executions)
+	// in the AWS Step Functions Developer Guide.
+	//
+	// A name must not contain:
+	//
+	//    * whitespace
+	//
+	//    * brackets < > { } [ ]
+	//
+	//    * wildcard characters ? *
+	//
+	//    * special characters " # % \ ^ | ~ ` $ & , ; : /
+	//
+	//    * control characters (U+0000-001F, U+007F-009F)
 	//
 	// Name is a required field
 	Name *string `locationName:"name" min:"1" type:"string" required:"true"`
@@ -2035,7 +2083,21 @@ type CreateStateMachineInput struct {
 	Definition *string `locationName:"definition" min:"1" type:"string" required:"true"`
 
 	// The name of the state machine. This name must be unique for your AWS account
-	// and region.
+	// and region for 90 days. For more information, see  Limits Related to State
+	// Machine Executions (http://docs.aws.amazon.com/step-functions/latest/dg/limits.html#service-limits-state-machine-executions)
+	// in the AWS Step Functions Developer Guide.
+	//
+	// A name must not contain:
+	//
+	//    * whitespace
+	//
+	//    * brackets < > { } [ ]
+	//
+	//    * wildcard characters ? *
+	//
+	//    * special characters " # % \ ^ | ~ ` $ & , ; : /
+	//
+	//    * control characters (U+0000-001F, U+007F-009F)
 	//
 	// Name is a required field
 	Name *string `locationName:"name" min:"1" type:"string" required:"true"`
@@ -2311,6 +2373,18 @@ type DescribeActivityOutput struct {
 
 	// The name of the activity.
 	//
+	// A name must not contain:
+	//
+	//    * whitespace
+	//
+	//    * brackets < > { } [ ]
+	//
+	//    * wildcard characters ? *
+	//
+	//    * special characters " # % \ ^ | ~ ` $ & , ; : /
+	//
+	//    * control characters (U+0000-001F, U+007F-009F)
+	//
 	// Name is a required field
 	Name *string `locationName:"name" min:"1" type:"string" required:"true"`
 }
@@ -2394,12 +2468,24 @@ type DescribeExecutionOutput struct {
 	// ExecutionArn is a required field
 	ExecutionArn *string `locationName:"executionArn" min:"1" type:"string" required:"true"`
 
-	// The JSON input data of the execution.
+	// The string that contains the JSON input data of the execution.
 	//
 	// Input is a required field
 	Input *string `locationName:"input" type:"string" required:"true"`
 
 	// The name of the execution.
+	//
+	// A name must not contain:
+	//
+	//    * whitespace
+	//
+	//    * brackets < > { } [ ]
+	//
+	//    * wildcard characters ? *
+	//
+	//    * special characters " # % \ ^ | ~ ` $ & , ; : /
+	//
+	//    * control characters (U+0000-001F, U+007F-009F)
 	Name *string `locationName:"name" min:"1" type:"string"`
 
 	// The JSON output data of the execution.
@@ -2540,11 +2626,24 @@ type DescribeStateMachineOutput struct {
 
 	// The name of the state machine.
 	//
+	// A name must not contain:
+	//
+	//    * whitespace
+	//
+	//    * brackets < > { } [ ]
+	//
+	//    * wildcard characters ? *
+	//
+	//    * special characters " # % \ ^ | ~ ` $ & , ; : /
+	//
+	//    * control characters (U+0000-001F, U+007F-009F)
+	//
 	// Name is a required field
 	Name *string `locationName:"name" min:"1" type:"string" required:"true"`
 
-	// The Amazon Resource Name (ARN) of the IAM role used for executing this state
-	// machine.
+	// The Amazon Resource Name (ARN) of the IAM role used when creating this state
+	// machine. (The IAM role maintains security by granting Step Functions access
+	// to AWS resources.)
 	//
 	// RoleArn is a required field
 	RoleArn *string `locationName:"roleArn" min:"1" type:"string" required:"true"`
@@ -2604,6 +2703,7 @@ func (s *DescribeStateMachineOutput) SetStatus(v string) *DescribeStateMachineOu
 	return s
 }
 
+// Contains details about an abort of an execution.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/states-2016-11-23/ExecutionAbortedEventDetails
 type ExecutionAbortedEventDetails struct {
 	_ struct{} `type:"structure"`
@@ -2637,6 +2737,7 @@ func (s *ExecutionAbortedEventDetails) SetError(v string) *ExecutionAbortedEvent
 	return s
 }
 
+// Contains details about an execution failure event.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/states-2016-11-23/ExecutionFailedEventDetails
 type ExecutionFailedEventDetails struct {
 	_ struct{} `type:"structure"`
@@ -2670,6 +2771,7 @@ func (s *ExecutionFailedEventDetails) SetError(v string) *ExecutionFailedEventDe
 	return s
 }
 
+// Contains details about an execution.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/states-2016-11-23/ExecutionListItem
 type ExecutionListItem struct {
 	_ struct{} `type:"structure"`
@@ -2680,6 +2782,18 @@ type ExecutionListItem struct {
 	ExecutionArn *string `locationName:"executionArn" min:"1" type:"string" required:"true"`
 
 	// The name of the execution.
+	//
+	// A name must not contain:
+	//
+	//    * whitespace
+	//
+	//    * brackets < > { } [ ]
+	//
+	//    * wildcard characters ? *
+	//
+	//    * special characters " # % \ ^ | ~ ` $ & , ; : /
+	//
+	//    * control characters (U+0000-001F, U+007F-009F)
 	//
 	// Name is a required field
 	Name *string `locationName:"name" min:"1" type:"string" required:"true"`
@@ -2749,6 +2863,7 @@ func (s *ExecutionListItem) SetStopDate(v time.Time) *ExecutionListItem {
 	return s
 }
 
+// Contains details about the start of the execution.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/states-2016-11-23/ExecutionStartedEventDetails
 type ExecutionStartedEventDetails struct {
 	_ struct{} `type:"structure"`
@@ -2783,6 +2898,7 @@ func (s *ExecutionStartedEventDetails) SetRoleArn(v string) *ExecutionStartedEve
 	return s
 }
 
+// Contains details about the successful termination of the execution.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/states-2016-11-23/ExecutionSucceededEventDetails
 type ExecutionSucceededEventDetails struct {
 	_ struct{} `type:"structure"`
@@ -2807,6 +2923,7 @@ func (s *ExecutionSucceededEventDetails) SetOutput(v string) *ExecutionSucceeded
 	return s
 }
 
+// Contains details about the execution timeout which occurred during the execution.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/states-2016-11-23/ExecutionTimedOutEventDetails
 type ExecutionTimedOutEventDetails struct {
 	_ struct{} `type:"structure"`
@@ -2844,12 +2961,13 @@ func (s *ExecutionTimedOutEventDetails) SetError(v string) *ExecutionTimedOutEve
 type GetActivityTaskInput struct {
 	_ struct{} `type:"structure"`
 
-	// The Amazon Resource Name (ARN) of the activity to retrieve tasks from.
+	// The Amazon Resource Name (ARN) of the activity to retrieve tasks from (assigned
+	// when you create the task using CreateActivity.)
 	//
 	// ActivityArn is a required field
 	ActivityArn *string `locationName:"activityArn" min:"1" type:"string" required:"true"`
 
-	// An arbitrary name may be provided in order to identify the worker that the
+	// You can provide an arbitrary name in order to identify the worker that the
 	// task is assigned to. This name will be used when it is logged in the execution
 	// history.
 	WorkerName *string `locationName:"workerName" min:"1" type:"string"`
@@ -2900,7 +3018,7 @@ func (s *GetActivityTaskInput) SetWorkerName(v string) *GetActivityTaskInput {
 type GetActivityTaskOutput struct {
 	_ struct{} `type:"structure"`
 
-	// The JSON input data for the task.
+	// The string that contains the JSON input data for the task.
 	Input *string `locationName:"input" type:"string"`
 
 	// A token that identifies the scheduled task. This token must be copied and
@@ -2942,7 +3060,7 @@ type GetExecutionHistoryInput struct {
 
 	// The maximum number of results that will be returned per call. nextToken can
 	// be used to obtain further pages of results. The default is 100 and the maximum
-	// allowed page size is 1000.
+	// allowed page size is 100. A value of 0 means to use the default.
 	//
 	// This is an upper limit only; the actual number of results returned per call
 	// may be fewer than the specified maximum.
@@ -3053,30 +3171,44 @@ func (s *GetExecutionHistoryOutput) SetNextToken(v string) *GetExecutionHistoryO
 	return s
 }
 
+// Contains details about the events of an execution.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/states-2016-11-23/HistoryEvent
 type HistoryEvent struct {
 	_ struct{} `type:"structure"`
 
+	// Contains details about an activity which failed during an execution.
 	ActivityFailedEventDetails *ActivityFailedEventDetails `locationName:"activityFailedEventDetails" type:"structure"`
 
+	// Contains details about an activity schedule event which failed during an
+	// execution.
 	ActivityScheduleFailedEventDetails *ActivityScheduleFailedEventDetails `locationName:"activityScheduleFailedEventDetails" type:"structure"`
 
+	// Contains details about an activity scheduled during an execution.
 	ActivityScheduledEventDetails *ActivityScheduledEventDetails `locationName:"activityScheduledEventDetails" type:"structure"`
 
+	// Contains details about the start of an activity during an execution.
 	ActivityStartedEventDetails *ActivityStartedEventDetails `locationName:"activityStartedEventDetails" type:"structure"`
 
+	// Contains details about an activity which successfully terminated during an
+	// execution.
 	ActivitySucceededEventDetails *ActivitySucceededEventDetails `locationName:"activitySucceededEventDetails" type:"structure"`
 
+	// Contains details about an activity timeout which occurred during an execution.
 	ActivityTimedOutEventDetails *ActivityTimedOutEventDetails `locationName:"activityTimedOutEventDetails" type:"structure"`
 
+	// Contains details about an abort of an execution.
 	ExecutionAbortedEventDetails *ExecutionAbortedEventDetails `locationName:"executionAbortedEventDetails" type:"structure"`
 
+	// Contains details about an execution failure event.
 	ExecutionFailedEventDetails *ExecutionFailedEventDetails `locationName:"executionFailedEventDetails" type:"structure"`
 
+	// Contains details about the start of the execution.
 	ExecutionStartedEventDetails *ExecutionStartedEventDetails `locationName:"executionStartedEventDetails" type:"structure"`
 
+	// Contains details about the successful termination of the execution.
 	ExecutionSucceededEventDetails *ExecutionSucceededEventDetails `locationName:"executionSucceededEventDetails" type:"structure"`
 
+	// Contains details about the execution timeout which occurred during the execution.
 	ExecutionTimedOutEventDetails *ExecutionTimedOutEventDetails `locationName:"executionTimedOutEventDetails" type:"structure"`
 
 	// The id of the event. Events are numbered sequentially, starting at one.
@@ -3084,26 +3216,38 @@ type HistoryEvent struct {
 	// Id is a required field
 	Id *int64 `locationName:"id" type:"long" required:"true"`
 
+	// Contains details about a lambda function which failed during an execution.
 	LambdaFunctionFailedEventDetails *LambdaFunctionFailedEventDetails `locationName:"lambdaFunctionFailedEventDetails" type:"structure"`
 
+	// Contains details about a failed lambda function schedule event which occurred
+	// during an execution.
 	LambdaFunctionScheduleFailedEventDetails *LambdaFunctionScheduleFailedEventDetails `locationName:"lambdaFunctionScheduleFailedEventDetails" type:"structure"`
 
+	// Contains details about a lambda function scheduled during an execution.
 	LambdaFunctionScheduledEventDetails *LambdaFunctionScheduledEventDetails `locationName:"lambdaFunctionScheduledEventDetails" type:"structure"`
 
+	// Contains details about a lambda function which failed to start during an
+	// execution.
 	LambdaFunctionStartFailedEventDetails *LambdaFunctionStartFailedEventDetails `locationName:"lambdaFunctionStartFailedEventDetails" type:"structure"`
 
+	// Contains details about a lambda function which terminated successfully during
+	// an execution.
 	LambdaFunctionSucceededEventDetails *LambdaFunctionSucceededEventDetails `locationName:"lambdaFunctionSucceededEventDetails" type:"structure"`
 
+	// Contains details about a lambda function timeout which occurred during an
+	// execution.
 	LambdaFunctionTimedOutEventDetails *LambdaFunctionTimedOutEventDetails `locationName:"lambdaFunctionTimedOutEventDetails" type:"structure"`
 
 	// The id of the previous event.
 	PreviousEventId *int64 `locationName:"previousEventId" type:"long"`
 
+	// Contains details about a state entered during an execution.
 	StateEnteredEventDetails *StateEnteredEventDetails `locationName:"stateEnteredEventDetails" type:"structure"`
 
+	// Contains details about an exit from a state during an execution.
 	StateExitedEventDetails *StateExitedEventDetails `locationName:"stateExitedEventDetails" type:"structure"`
 
-	// The date the event occured.
+	// The date the event occurred.
 	//
 	// Timestamp is a required field
 	Timestamp *time.Time `locationName:"timestamp" type:"timestamp" timestampFormat:"unix" required:"true"`
@@ -3262,6 +3406,7 @@ func (s *HistoryEvent) SetType(v string) *HistoryEvent {
 	return s
 }
 
+// Contains details about a lambda function which failed during an execution.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/states-2016-11-23/LambdaFunctionFailedEventDetails
 type LambdaFunctionFailedEventDetails struct {
 	_ struct{} `type:"structure"`
@@ -3295,6 +3440,8 @@ func (s *LambdaFunctionFailedEventDetails) SetError(v string) *LambdaFunctionFai
 	return s
 }
 
+// Contains details about a failed lambda function schedule event which occurred
+// during an execution.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/states-2016-11-23/LambdaFunctionScheduleFailedEventDetails
 type LambdaFunctionScheduleFailedEventDetails struct {
 	_ struct{} `type:"structure"`
@@ -3328,6 +3475,7 @@ func (s *LambdaFunctionScheduleFailedEventDetails) SetError(v string) *LambdaFun
 	return s
 }
 
+// Contains details about a lambda function scheduled during an execution.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/states-2016-11-23/LambdaFunctionScheduledEventDetails
 type LambdaFunctionScheduledEventDetails struct {
 	_ struct{} `type:"structure"`
@@ -3372,6 +3520,8 @@ func (s *LambdaFunctionScheduledEventDetails) SetTimeoutInSeconds(v int64) *Lamb
 	return s
 }
 
+// Contains details about a lambda function which failed to start during an
+// execution.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/states-2016-11-23/LambdaFunctionStartFailedEventDetails
 type LambdaFunctionStartFailedEventDetails struct {
 	_ struct{} `type:"structure"`
@@ -3405,6 +3555,8 @@ func (s *LambdaFunctionStartFailedEventDetails) SetError(v string) *LambdaFuncti
 	return s
 }
 
+// Contains details about a lambda function which successfully terminated during
+// an execution.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/states-2016-11-23/LambdaFunctionSucceededEventDetails
 type LambdaFunctionSucceededEventDetails struct {
 	_ struct{} `type:"structure"`
@@ -3429,6 +3581,8 @@ func (s *LambdaFunctionSucceededEventDetails) SetOutput(v string) *LambdaFunctio
 	return s
 }
 
+// Contains details about a lambda function timeout which occurred during an
+// execution.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/states-2016-11-23/LambdaFunctionTimedOutEventDetails
 type LambdaFunctionTimedOutEventDetails struct {
 	_ struct{} `type:"structure"`
@@ -3468,7 +3622,7 @@ type ListActivitiesInput struct {
 
 	// The maximum number of results that will be returned per call. nextToken can
 	// be used to obtain further pages of results. The default is 100 and the maximum
-	// allowed page size is 1000.
+	// allowed page size is 100. A value of 0 means to use the default.
 	//
 	// This is an upper limit only; the actual number of results returned per call
 	// may be fewer than the specified maximum.
@@ -3564,7 +3718,7 @@ type ListExecutionsInput struct {
 
 	// The maximum number of results that will be returned per call. nextToken can
 	// be used to obtain further pages of results. The default is 100 and the maximum
-	// allowed page size is 1000.
+	// allowed page size is 100. A value of 0 means to use the default.
 	//
 	// This is an upper limit only; the actual number of results returned per call
 	// may be fewer than the specified maximum.
@@ -3688,7 +3842,7 @@ type ListStateMachinesInput struct {
 
 	// The maximum number of results that will be returned per call. nextToken can
 	// be used to obtain further pages of results. The default is 100 and the maximum
-	// allowed page size is 1000.
+	// allowed page size is 100. A value of 0 means to use the default.
 	//
 	// This is an upper limit only; the actual number of results returned per call
 	// may be fewer than the specified maximum.
@@ -3986,11 +4140,30 @@ func (s SendTaskSuccessOutput) GoString() string {
 type StartExecutionInput struct {
 	_ struct{} `type:"structure"`
 
-	// The JSON input data for the execution.
+	// The string that contains the JSON input data for the execution, for example:
+	//
+	// "input": "{\"first_name\" : \"test\"}"
+	//
+	// If you don't include any JSON input data, you still must include the two
+	// braces, for example: "input": "{}"
 	Input *string `locationName:"input" type:"string"`
 
 	// The name of the execution. This name must be unique for your AWS account
-	// and region.
+	// and region for 90 days. For more information, see  Limits Related to State
+	// Machine Executions (http://docs.aws.amazon.com/step-functions/latest/dg/limits.html#service-limits-state-machine-executions)
+	// in the AWS Step Functions Developer Guide.
+	//
+	// A name must not contain:
+	//
+	//    * whitespace
+	//
+	//    * brackets < > { } [ ]
+	//
+	//    * wildcard characters ? *
+	//
+	//    * special characters " # % \ ^ | ~ ` $ & , ; : /
+	//
+	//    * control characters (U+0000-001F, U+007F-009F)
 	Name *string `locationName:"name" min:"1" type:"string"`
 
 	// The Amazon Resource Name (ARN) of the state machine to execute.
@@ -4083,11 +4256,12 @@ func (s *StartExecutionOutput) SetStartDate(v time.Time) *StartExecutionOutput {
 	return s
 }
 
+// Contains details about a state entered during an execution.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/states-2016-11-23/StateEnteredEventDetails
 type StateEnteredEventDetails struct {
 	_ struct{} `type:"structure"`
 
-	// The JSON input data to the state.
+	// The string that contains the JSON input data for the state.
 	Input *string `locationName:"input" type:"string"`
 
 	// The name of the state.
@@ -4118,11 +4292,24 @@ func (s *StateEnteredEventDetails) SetName(v string) *StateEnteredEventDetails {
 	return s
 }
 
+// Contains details about an exit from a state during an execution.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/states-2016-11-23/StateExitedEventDetails
 type StateExitedEventDetails struct {
 	_ struct{} `type:"structure"`
 
 	// The name of the state.
+	//
+	// A name must not contain:
+	//
+	//    * whitespace
+	//
+	//    * brackets < > { } [ ]
+	//
+	//    * wildcard characters ? *
+	//
+	//    * special characters " # % \ ^ | ~ ` $ & , ; : /
+	//
+	//    * control characters (U+0000-001F, U+007F-009F)
 	//
 	// Name is a required field
 	Name *string `locationName:"name" min:"1" type:"string" required:"true"`
@@ -4153,6 +4340,7 @@ func (s *StateExitedEventDetails) SetOutput(v string) *StateExitedEventDetails {
 	return s
 }
 
+// Contains details about the state machine.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/states-2016-11-23/StateMachineListItem
 type StateMachineListItem struct {
 	_ struct{} `type:"structure"`
@@ -4163,6 +4351,18 @@ type StateMachineListItem struct {
 	CreationDate *time.Time `locationName:"creationDate" type:"timestamp" timestampFormat:"unix" required:"true"`
 
 	// The name of the state machine.
+	//
+	// A name must not contain:
+	//
+	//    * whitespace
+	//
+	//    * brackets < > { } [ ]
+	//
+	//    * wildcard characters ? *
+	//
+	//    * special characters " # % \ ^ | ~ ` $ & , ; : /
+	//
+	//    * control characters (U+0000-001F, U+007F-009F)
 	//
 	// Name is a required field
 	Name *string `locationName:"name" min:"1" type:"string" required:"true"`
@@ -4374,6 +4574,9 @@ const (
 	// HistoryEventTypeSucceedStateExited is a HistoryEventType enum value
 	HistoryEventTypeSucceedStateExited = "SucceedStateExited"
 
+	// HistoryEventTypeTaskStateAborted is a HistoryEventType enum value
+	HistoryEventTypeTaskStateAborted = "TaskStateAborted"
+
 	// HistoryEventTypeTaskStateEntered is a HistoryEventType enum value
 	HistoryEventTypeTaskStateEntered = "TaskStateEntered"
 
@@ -4386,11 +4589,26 @@ const (
 	// HistoryEventTypePassStateExited is a HistoryEventType enum value
 	HistoryEventTypePassStateExited = "PassStateExited"
 
+	// HistoryEventTypeParallelStateAborted is a HistoryEventType enum value
+	HistoryEventTypeParallelStateAborted = "ParallelStateAborted"
+
 	// HistoryEventTypeParallelStateEntered is a HistoryEventType enum value
 	HistoryEventTypeParallelStateEntered = "ParallelStateEntered"
 
 	// HistoryEventTypeParallelStateExited is a HistoryEventType enum value
 	HistoryEventTypeParallelStateExited = "ParallelStateExited"
+
+	// HistoryEventTypeParallelStateFailed is a HistoryEventType enum value
+	HistoryEventTypeParallelStateFailed = "ParallelStateFailed"
+
+	// HistoryEventTypeParallelStateStarted is a HistoryEventType enum value
+	HistoryEventTypeParallelStateStarted = "ParallelStateStarted"
+
+	// HistoryEventTypeParallelStateSucceeded is a HistoryEventType enum value
+	HistoryEventTypeParallelStateSucceeded = "ParallelStateSucceeded"
+
+	// HistoryEventTypeWaitStateAborted is a HistoryEventType enum value
+	HistoryEventTypeWaitStateAborted = "WaitStateAborted"
 
 	// HistoryEventTypeWaitStateEntered is a HistoryEventType enum value
 	HistoryEventTypeWaitStateEntered = "WaitStateEntered"

--- a/vendor/github.com/aws/aws-sdk-go/service/sfn/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/sfn/doc.go
@@ -3,22 +3,24 @@
 // Package sfn provides the client and types for making API
 // requests to AWS Step Functions.
 //
-// AWS Step Functions is a web service that enables you to coordinate the components
-// of distributed applications and microservices using visual workflows. You
-// build applications from individual components that each perform a discrete
-// function, or task, allowing you to scale and change applications quickly.
-// Step Functions provides a graphical console to visualize the components of
-// your application as a series of steps. It automatically triggers and tracks
-// each step, and retries when there are errors, so your application executes
-// in order and as expected, every time. Step Functions logs the state of each
-// step, so when things do go wrong, you can diagnose and debug problems quickly.
+// AWS Step Functions is a service that lets you coordinate the components of
+// distributed applications and microservices using visual workflows.
 //
-// Step Functions manages the operations and underlying infrastructure for you
-// to ensure your application is available at any scale. You can run tasks on
-// the AWS cloud, on your own servers, or an any system that has access to AWS.
-// Step Functions can be accessed and used with the Step Functions console,
-// the AWS SDKs (included with your Beta release invitation email), or an HTTP
-// API (the subject of this document).
+// You can use Step Functions to build applications from individual components,
+// each of which performs a discrete function, or task, allowing you to scale
+// and change applications quickly. Step Functions provides a console that helps
+// visualize the components of your application as a series of steps. Step Functions
+// automatically triggers and tracks each step, and retries steps when there
+// are errors, so your application executes in order and as expected, every
+// time. Step Functions logs the state of each step, so you can diagnose and
+// debug problems quickly.
+//
+// Step Functions manages operations and underlying infrastructure to ensure
+// your application is available at any scale. You can run tasks on AWS, your
+// own servers, or any system that has access to AWS. You can access and use
+// Step Functions using the console, the AWS SDKs, or an HTTP API. For more
+// information about Step Functions, see the AWS Step Functions Developer Guide
+// (http://docs.aws.amazon.com/step-functions/latest/dg/welcome.html).
 //
 // See https://docs.aws.amazon.com/goto/WebAPI/states-2016-11-23 for more information on this service.
 //

--- a/vendor/github.com/aws/aws-sdk-go/service/sfn/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/sfn/errors.go
@@ -27,7 +27,9 @@ const (
 	// ErrCodeExecutionAlreadyExists for service response error code
 	// "ExecutionAlreadyExists".
 	//
-	// An execution with the same name already exists.
+	// The execution has the same name as another execution (but a different input).
+	//
+	// Executions with the same name and input are considered idempotent.
 	ErrCodeExecutionAlreadyExists = "ExecutionAlreadyExists"
 
 	// ErrCodeExecutionDoesNotExist for service response error code

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -141,732 +141,732 @@
 			"revisionTime": "2017-07-27T15:54:43Z"
 		},
 		{
-			"checksumSHA1": "LzM9Zc1nBSPiGCInsLh2nI37XCg=",
+			"checksumSHA1": "5bPcc9FwZ1Su3Vn5od0Fe7jO+fk=",
 			"path": "github.com/aws/aws-sdk-go/aws",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "DtuTqKH29YnLjrIJkRYX0HQtXY0=",
 			"path": "github.com/aws/aws-sdk-go/aws/arn",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "Y9W+4GimK4Fuxq+vyIskVYFRnX4=",
 			"path": "github.com/aws/aws-sdk-go/aws/awserr",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "yyYr41HZ1Aq0hWc3J5ijXwYEcac=",
 			"path": "github.com/aws/aws-sdk-go/aws/awsutil",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "slpNCdnZ2JbBr94ZHc/9UzOaP5A=",
 			"path": "github.com/aws/aws-sdk-go/aws/client",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "ieAJ+Cvp/PKv1LpUEnUXpc3OI6E=",
 			"path": "github.com/aws/aws-sdk-go/aws/client/metadata",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "7/8j/q0TWtOgXyvEcv4B2Dhl00o=",
 			"path": "github.com/aws/aws-sdk-go/aws/corehandlers",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "Y+cPwQL0dZMyqp3wI+KJWmA9KQ8=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "u3GOAJLmdvbuNUeUEcZSEAOeL/0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "NUJUTWlc1sV8b7WjfiYc4JZbXl0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/endpointcreds",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "JEYqmF83O5n5bHkupAzA6STm0no=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "ZdtYh3ZHSgP/WEIaqwJHTEhpkbs=",
 			"path": "github.com/aws/aws-sdk-go/aws/defaults",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "/EXbk/z2TWjWc1Hvb4QYs3Wmhb8=",
 			"path": "github.com/aws/aws-sdk-go/aws/ec2metadata",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
-			"checksumSHA1": "28TXzVpyhT3JFRT3vLo/GTKc3Wc=",
+			"checksumSHA1": "Hj9iT6huoUegFzCDOQJckafUoo8=",
 			"path": "github.com/aws/aws-sdk-go/aws/endpoints",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
-			"checksumSHA1": "a4cO6dubzj2e4ux5+hC0bm5WQiM=",
+			"checksumSHA1": "OB2foQOM27puEGoW4+bM/K2KR5g=",
 			"path": "github.com/aws/aws-sdk-go/aws/request",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "HcGL4e6Uep4/80eCUI5xkcWjpQ0=",
 			"path": "github.com/aws/aws-sdk-go/aws/session",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "yzP2WtJtlWQ07Yxlb8NUJREAUEU=",
 			"path": "github.com/aws/aws-sdk-go/aws/signer/v4",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "04ypv4x12l4q0TksA1zEVsmgpvw=",
 			"path": "github.com/aws/aws-sdk-go/internal/shareddefaults",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "wk7EyvDaHwb5qqoOP/4d3cV0708=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "1QmQ3FqV37w0Zi44qv8pA1GeR0A=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/ec2query",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "O6hcK24yI6w7FA+g4Pbr+eQ7pys=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/json/jsonutil",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "R00RL5jJXRYq1iiK1+PGvMfvXyM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/jsonrpc",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "ZqY5RWavBLWTo6j9xqdyBEaNFRk=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "9V1PvtFQ9MObZTc3sa86WcuOtOU=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "VCTh+dEaqqhog5ncy/WTt9+/gFM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/rest",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "Rpu8KBtHZgvhkwHxUfaky+qW+G4=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restjson",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "ODo+ko8D6unAxZuN1jGzMcN4QCc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restxml",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "0qYPUga28aQVkxZgBR3Z86AbGUQ=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "F6mth+G7dXN1GI+nktaGo8Lx8aE=",
 			"path": "github.com/aws/aws-sdk-go/private/signer/v2",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "2O+F6NwIHEgAHqLGKTJbxYwsUHs=",
 			"path": "github.com/aws/aws-sdk-go/service/acm",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "tOhN1amVVhAATGDCc4tMTubP964=",
 			"path": "github.com/aws/aws-sdk-go/service/apigateway",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "0TbHKByWg6RPu30FVvWXg7RxMAo=",
 			"path": "github.com/aws/aws-sdk-go/service/applicationautoscaling",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "1/p8oChMJW38gBTOA8AUCWkHuM8=",
 			"path": "github.com/aws/aws-sdk-go/service/athena",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "ILLTTjBCwDHKcx6D/Ja5k4Nn5Ww=",
 			"path": "github.com/aws/aws-sdk-go/service/autoscaling",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "PFK/7hvqrbzGWQz1b6cn5Hsv7qY=",
 			"path": "github.com/aws/aws-sdk-go/service/batch",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "86Gd/aNE5+OAAibFQg6YWh7YKU0=",
 			"path": "github.com/aws/aws-sdk-go/service/budgets",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "DV0NlREKdcYMrsmdJbtZyuUDK+8=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudformation",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "vbSfNKXjDDYLLAYafrD37T5xBFk=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudfront",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "V5UO7ojp8/EuLhPIS4OOOurke3M=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudtrail",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "Rx8tIQPEmYZhy1zbRpDmMBmGfvg=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatch",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "UlNtqtd2PcKoWqqXmOj4kfu8hyc=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchevents",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "7SPaq0IXgoe1Cqph7ws9vFYr3zg=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "bufH/3DIJxDr0DAskWeAXGaLSNU=",
 			"path": "github.com/aws/aws-sdk-go/service/codebuild",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "ySI/pbSD5vrnosWYB3qI6KuXH7g=",
 			"path": "github.com/aws/aws-sdk-go/service/codecommit",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "8T1UkQcbxF08m5xJL16lsWLdT6k=",
 			"path": "github.com/aws/aws-sdk-go/service/codedeploy",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "EEVCD+xa8rnlVXoFULjc9fWcVzY=",
 			"path": "github.com/aws/aws-sdk-go/service/codepipeline",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "GHaVqY5f85olNwlO5J4f160D+mI=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentity",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "svRJtQKo7tvAZYpW7UCpxFlG8mQ=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentityprovider",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "YONbbZXdr13qIiKYzqk4cptd2XE=",
 			"path": "github.com/aws/aws-sdk-go/service/configservice",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "FAIF4ppLR5URLY2m0BuQO2Gwdg0=",
 			"path": "github.com/aws/aws-sdk-go/service/databasemigrationservice",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "TSYWqKDCe6RaR2kYrExoDIC+7LU=",
 			"path": "github.com/aws/aws-sdk-go/service/devicefarm",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "2139YRKSqXN9N49CFTopzwftCDw=",
 			"path": "github.com/aws/aws-sdk-go/service/directconnect",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "0T4esELn9yJKr3D7b1/apnu1ZOA=",
 			"path": "github.com/aws/aws-sdk-go/service/directoryservice",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "kEGGjvoqrbTSX3Kno7GJrV7UflY=",
 			"path": "github.com/aws/aws-sdk-go/service/dynamodb",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
-			"checksumSHA1": "5crDZnafljBUDR4qJbEGWXvN/JA=",
+			"checksumSHA1": "zvDKPZq2ASeHn4F5xtjIbemmn9Q=",
 			"path": "github.com/aws/aws-sdk-go/service/ec2",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "tvxhxL5w10Qau4eUabsLK4L60iA=",
 			"path": "github.com/aws/aws-sdk-go/service/ecr",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
-			"checksumSHA1": "VCR5x2AcAZolkWKYS1owfHX7PK8=",
+			"checksumSHA1": "mAxOqBf3ogPggwlAeqbOowg0kns=",
 			"path": "github.com/aws/aws-sdk-go/service/ecs",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "9I1RdgcMUEYJlyNIqdtSgFTdWKM=",
 			"path": "github.com/aws/aws-sdk-go/service/efs",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "v90avWqlg/3wgBuJdAXgkGoRbkY=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticache",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "xylCApLVAqLTW6uTYCziTDxgRMI=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticbeanstalk",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "RmVY7K2zivKjDe0ad8Grd+81J/M=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticsearchservice",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "SZ7yLDZ6RvMhpWe0Goyem64kgyA=",
 			"path": "github.com/aws/aws-sdk-go/service/elastictranscoder",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "i+zp7see74G8qx251yfQiTvbz4U=",
 			"path": "github.com/aws/aws-sdk-go/service/elb",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
-			"checksumSHA1": "hkAKfSkv5Do+r7eqVpZCphnl4Wc=",
+			"checksumSHA1": "/YIietAo4WlCdiZFayAMsqjW2TM=",
 			"path": "github.com/aws/aws-sdk-go/service/elbv2",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "jrndlHaS4MJcOsRIX91tFg6tbfM=",
 			"path": "github.com/aws/aws-sdk-go/service/emr",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "eBESkYAb0koQ4a+pg5k2Ikwo/dA=",
 			"path": "github.com/aws/aws-sdk-go/service/firehose",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "+gED8OQZsY/taXgjkGbBJlx1hnY=",
 			"path": "github.com/aws/aws-sdk-go/service/glacier",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "HBlNyNP2zLI589MIX82zMvANmLY=",
 			"path": "github.com/aws/aws-sdk-go/service/iam",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "WoIsJOP3M2BAhZ5p46LJNd9FQPk=",
 			"path": "github.com/aws/aws-sdk-go/service/inspector",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "jWoHNr5dOtwUmlC5bi5kRcW30wE=",
 			"path": "github.com/aws/aws-sdk-go/service/iot",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "I8rx/IBJ6NXPOQXoJs6AthfAAd0=",
 			"path": "github.com/aws/aws-sdk-go/service/kinesis",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
-			"checksumSHA1": "X8L2PrB5AzaBDfwbQJHNL40UdzA=",
+			"checksumSHA1": "CqvUs/OKC5GYojf8InoQpTWUI30=",
 			"path": "github.com/aws/aws-sdk-go/service/kms",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "UNmVsLSjqCWcNd30lHo3T/qOHOY=",
 			"path": "github.com/aws/aws-sdk-go/service/lambda",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "j8nuIO3+q7Xb2wywXNNBTVUZbQM=",
 			"path": "github.com/aws/aws-sdk-go/service/lightsail",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "xkNWwN2rw+szg+zXAxCun34zxhs=",
 			"path": "github.com/aws/aws-sdk-go/service/opsworks",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
-			"checksumSHA1": "AWW6ZU9sjscuKUr0TeCFGKAFQJY=",
+			"checksumSHA1": "rW2FYtv/Vh+XA5UulIfiTFyCGQs=",
 			"path": "github.com/aws/aws-sdk-go/service/rds",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "BwFxr+n+xU7TOQxxONFxdtrWjG4=",
 			"path": "github.com/aws/aws-sdk-go/service/redshift",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "J7ie0uuhhyWKkYsveypGUBTP+vM=",
 			"path": "github.com/aws/aws-sdk-go/service/route53",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
-			"checksumSHA1": "QIvfPsSyVxlxNvJQQlqI2k8DBcA=",
+			"checksumSHA1": "ZjWHq0sDldcDC+Zd/ZIBy5Oj3hI=",
 			"path": "github.com/aws/aws-sdk-go/service/s3",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "Tz5NbDa/SGUINmuFD8KQLh1HDOI=",
 			"path": "github.com/aws/aws-sdk-go/service/servicecatalog",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "I/ZZixFzXbdhPrhhvAnbG26eark=",
 			"path": "github.com/aws/aws-sdk-go/service/ses",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
-			"checksumSHA1": "adawdch+DzzKotTDjpgLXF0EcZA=",
+			"checksumSHA1": "PFP/uQld8X4SiwNDc98IPVMsmjE=",
 			"path": "github.com/aws/aws-sdk-go/service/sfn",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "Ip9SzZFvBpbH2BuqLDawUAyFTCA=",
 			"path": "github.com/aws/aws-sdk-go/service/shield",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "B3CgAFSREebpsFoFOo4vrQ6u04w=",
 			"path": "github.com/aws/aws-sdk-go/service/simpledb",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "rwSNHPn9iLEaoDx6vX0KbWefcHY=",
 			"path": "github.com/aws/aws-sdk-go/service/sns",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "aWWSD60GhNwldZ7mxL9Z8Q+fiXo=",
 			"path": "github.com/aws/aws-sdk-go/service/sqs",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "PtuIN89eMO5SviABD90qwoGPD4M=",
 			"path": "github.com/aws/aws-sdk-go/service/ssm",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "d9vR1rl8kmJxJBwe00byziVFR/o=",
 			"path": "github.com/aws/aws-sdk-go/service/sts",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "sjZeBzVjWM2tWSIOr7p13Kx2iNU=",
 			"path": "github.com/aws/aws-sdk-go/service/waf",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "rM51Xn6MSt2XJzSF1p51m6G4u/8=",
 			"path": "github.com/aws/aws-sdk-go/service/wafregional",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "AUwsvYff1GCOYtCgB6wd0doC9kc=",
 			"path": "github.com/aws/aws-sdk-go/service/workspaces",
-			"revision": "f2da704aa06ae2df47ad1e86221e6c1abd3b6742",
-			"revisionTime": "2017-11-03T00:05:43Z",
-			"version": "=v1.12.21",
-			"versionExact": "v1.12.21"
+			"revision": "6061953e33da7e141a16c70ec9535467ce7f189a",
+			"revisionTime": "2017-11-07T21:12:33Z",
+			"version": "v1.12.24",
+			"versionExact": "v1.12.24"
 		},
 		{
 			"checksumSHA1": "nqw2Qn5xUklssHTubS5HDvEL9L4=",


### PR DESCRIPTION
Required for
* https://github.com/terraform-providers/terraform-provider-aws/issues/2196
* https://github.com/terraform-providers/terraform-provider-aws/issues/2200

```
govendor fetch github.com/aws/aws-sdk-go/aws/...@v1.12.24
govendor fetch github.com/aws/aws-sdk-go/internal/...@v1.12.24
govendor fetch github.com/aws/aws-sdk-go/private/...@v1.12.24
govendor fetch github.com/aws/aws-sdk-go/service/...@v1.12.24
```
