### PR TITLE
Fix missing negation when validating Cognito RoleMapping of type token

### DIFF
--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1582,7 +1582,7 @@ func validateCognitoRoleMappingsRulesConfiguration(v map[string]interface{}) (er
 		errors = append(errors, fmt.Errorf("mapping_rule is required for Rules"))
 	}
 
-	if (ok || valLength > 0) && t == cognitoidentity.RoleMappingTypeToken {
+	if (!ok || valLength > 0) && t == cognitoidentity.RoleMappingTypeToken {
 		errors = append(errors, fmt.Errorf("mapping_rule must not be set for Token based role mapping"))
 	}
 


### PR DESCRIPTION
Adds the missing negation as described in issue #2232 , because otherwise `ok` always leads to an error in case of `RoleMappingTypeToken `.