### PR TITLE
r/aws_ssm_association: add association_name to aws_ssm_association

### DIFF
--- a/aws/resource_aws_ssm_association.go
+++ b/aws/resource_aws_ssm_association.go
@@ -21,6 +21,10 @@ func resourceAwsSsmAssociation() *schema.Resource {
 		SchemaVersion: 1,
 
 		Schema: map[string]*schema.Schema{
+			"association_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"association_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -99,6 +103,10 @@ func resourceAwsSsmAssociationCreate(d *schema.ResourceData, meta interface{}) e
 		Name: aws.String(d.Get("name").(string)),
 	}
 
+	if v, ok := d.GetOk("association_name"); ok {
+		assosciationInput.AssociationName = aws.String(v.(string))
+	}
+
 	if v, ok := d.GetOk("instance_id"); ok {
 		assosciationInput.InstanceId = aws.String(v.(string))
 	}
@@ -157,6 +165,7 @@ func resourceAwsSsmAssociationRead(d *schema.ResourceData, meta interface{}) err
 	}
 
 	association := resp.AssociationDescription
+	d.Set("association_name", association.AssociationName)
 	d.Set("instance_id", association.InstanceId)
 	d.Set("name", association.Name)
 	d.Set("parameters", association.Parameters)
@@ -182,6 +191,10 @@ func resourceAwsSsmAssocationUpdate(d *schema.ResourceData, meta interface{}) er
 
 	associationInput := &ssm.UpdateAssociationInput{
 		AssociationId: aws.String(d.Get("association_id").(string)),
+	}
+
+	if d.HasChange("association_name") {
+		associationInput.AssociationName = aws.String(d.Get("association_name").(string))
 	}
 
 	if d.HasChange("schedule_expression") {

--- a/website/docs/r/ssm_association.html.markdown
+++ b/website/docs/r/ssm_association.html.markdown
@@ -69,6 +69,7 @@ resource "aws_ssm_association" "foo" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the SSM document to apply.
+* `association_name` - (Optional) The descriptive name for the association.
 * `instance_id` - (Optional) The instance id to apply an SSM document to.
 * `parameters` - (Optional) Additional parameters to pass to the SSM document.
 * `targets` - (Optional) The targets (either instances or tags). Instances are specified using Key=instanceids,Values=instanceid1,instanceid2. Tags are specified using Key=tag name,Values=tag value. Only 1 target is currently supported by AWS.


### PR DESCRIPTION
Closes #2205 
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSSSMAssociation_withAssociationName'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSSSMAssociation_withAssociationName -timeout 120m
=== RUN   TestAccAWSSSMAssociation_withAssociationName
--- PASS: TestAccAWSSSMAssociation_withAssociationName (97.49s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	97.539s
```