### PR TITLE
resource/aws_cloudformation_stack: Support updating tags

### DIFF
--- a/aws/resource_aws_cloudformation_stack.go
+++ b/aws/resource_aws_cloudformation_stack.go
@@ -104,7 +104,6 @@ func resourceAwsCloudFormationStack() *schema.Resource {
 			"tags": {
 				Type:     schema.TypeMap,
 				Optional: true,
-				ForceNew: true,
 			},
 			"iam_role_arn": {
 				Type:     schema.TypeString,
@@ -384,6 +383,10 @@ func resourceAwsCloudFormationStackUpdate(d *schema.ResourceData, meta interface
 	// Parameters must be present whether they are changed or not
 	if v, ok := d.GetOk("parameters"); ok {
 		input.Parameters = expandCloudFormationParameters(v.(map[string]interface{}))
+	}
+
+	if v, ok := d.GetOk("tags"); ok {
+		input.Tags = expandCloudFormationTags(v.(map[string]interface{}))
 	}
 
 	if d.HasChange("policy_body") {


### PR DESCRIPTION
Adding support to update tags of a cloudformation stack.

This is supported as documented in https://docs.aws.amazon.com/sdk-for-go/api/service/cloudformation/#UpdateStackInput

Tested using: https://github.com/seriousben/test-terraform-cloudformation-tag-force-new