### PR TITLE
Add arn attribute to aws_ebs_volume resource and datasource

### DIFF
--- a/aws/data_source_aws_ebs_volume.go
+++ b/aws/data_source_aws_ebs_volume.go
@@ -103,7 +103,7 @@ func dataSourceAwsEbsVolumeRead(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	log.Printf("[DEBUG] aws_ebs_volume - Single Volume found: %s", *volume.VolumeId)
-	return volumeDescriptionAttributes(d, meta, volume)
+	return volumeDescriptionAttributes(d, meta.(*AWSClient), volume)
 }
 
 type volumeSort []*ec2.Volume
@@ -122,15 +122,15 @@ func mostRecentVolume(volumes []*ec2.Volume) *ec2.Volume {
 	return sortedVolumes[len(sortedVolumes)-1]
 }
 
-func volumeDescriptionAttributes(d *schema.ResourceData, meta interface{}, volume *ec2.Volume) error {
+func volumeDescriptionAttributes(d *schema.ResourceData, client *AWSClient, volume *ec2.Volume) error {
 	d.SetId(*volume.VolumeId)
 	d.Set("volume_id", volume.VolumeId)
 
 	arn := arn.ARN{
-		Partition: meta.(*AWSClient).partition,
-		Region:    meta.(*AWSClient).region,
+		Partition: client.partition,
+		Region:    client.region,
 		Service:   "ec2",
-		AccountID: meta.(*AWSClient).accountid,
+		AccountID: client.accountid,
 		Resource:  fmt.Sprintf("volume/%s", d.Id()),
 	}
 	d.Set("arn", arn.String())

--- a/aws/data_source_aws_ebs_volume.go
+++ b/aws/data_source_aws_ebs_volume.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"sort"
 
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -21,6 +22,10 @@ func dataSourceAwsEbsVolume() *schema.Resource {
 				Optional: true,
 				Default:  false,
 				ForceNew: true,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"availability_zone": {
 				Type:     schema.TypeString,
@@ -98,7 +103,7 @@ func dataSourceAwsEbsVolumeRead(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	log.Printf("[DEBUG] aws_ebs_volume - Single Volume found: %s", *volume.VolumeId)
-	return volumeDescriptionAttributes(d, volume)
+	return volumeDescriptionAttributes(d, meta, volume)
 }
 
 type volumeSort []*ec2.Volume
@@ -117,9 +122,19 @@ func mostRecentVolume(volumes []*ec2.Volume) *ec2.Volume {
 	return sortedVolumes[len(sortedVolumes)-1]
 }
 
-func volumeDescriptionAttributes(d *schema.ResourceData, volume *ec2.Volume) error {
+func volumeDescriptionAttributes(d *schema.ResourceData, meta interface{}, volume *ec2.Volume) error {
 	d.SetId(*volume.VolumeId)
 	d.Set("volume_id", volume.VolumeId)
+
+	arn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Region:    meta.(*AWSClient).region,
+		Service:   "ec2",
+		AccountID: meta.(*AWSClient).accountid,
+		Resource:  fmt.Sprintf("volume/%s", d.Id()),
+	}
+	d.Set("arn", arn.String())
+
 	d.Set("availability_zone", volume.AvailabilityZone)
 	d.Set("encrypted", volume.Encrypted)
 	d.Set("iops", volume.Iops)

--- a/aws/data_source_aws_ebs_volume_test.go
+++ b/aws/data_source_aws_ebs_volume_test.go
@@ -17,6 +17,7 @@ func TestAccAWSEbsVolumeDataSource_basic(t *testing.T) {
 				Config: testAccCheckAwsEbsVolumeDataSourceConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsEbsVolumeDataSourceID("data.aws_ebs_volume.ebs_volume"),
+					resource.TestCheckResourceAttrSet("data.aws_ebs_volume.ebs_volume", "arn"),
 					resource.TestCheckResourceAttr("data.aws_ebs_volume.ebs_volume", "size", "40"),
 					resource.TestCheckResourceAttr("data.aws_ebs_volume.ebs_volume", "tags.%", "1"),
 					resource.TestCheckResourceAttr("data.aws_ebs_volume.ebs_volume", "tags.Name", "External Volume"),

--- a/aws/resource_aws_ebs_volume.go
+++ b/aws/resource_aws_ebs_volume.go
@@ -28,7 +28,6 @@ func resourceAwsEbsVolume() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"arn": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"availability_zone": {
@@ -244,7 +243,7 @@ func resourceAwsEbsVolumeRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error reading EC2 volume %s: %s", d.Id(), err)
 	}
 
-	return readVolume(d, meta, response.Volumes[0])
+	return readVolume(d, meta.(*AWSClient), response.Volumes[0])
 }
 
 func resourceAwsEbsVolumeDelete(d *schema.ResourceData, meta interface{}) error {
@@ -273,14 +272,14 @@ func resourceAwsEbsVolumeDelete(d *schema.ResourceData, meta interface{}) error 
 
 }
 
-func readVolume(d *schema.ResourceData, meta interface{}, volume *ec2.Volume) error {
+func readVolume(d *schema.ResourceData, client *AWSClient, volume *ec2.Volume) error {
 	d.SetId(*volume.VolumeId)
 
 	arn := arn.ARN{
-		Partition: meta.(*AWSClient).partition,
-		Region:    meta.(*AWSClient).region,
+		Partition: client.partition,
+		Region:    client.region,
 		Service:   "ec2",
-		AccountID: meta.(*AWSClient).accountid,
+		AccountID: client.accountid,
 		Resource:  fmt.Sprintf("volume/%s", d.Id()),
 	}
 	d.Set("arn", arn.String())

--- a/aws/resource_aws_ebs_volume_test.go
+++ b/aws/resource_aws_ebs_volume_test.go
@@ -24,6 +24,7 @@ func TestAccAWSEBSVolume_basic(t *testing.T) {
 				Config: testAccAwsEbsVolumeConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists("aws_ebs_volume.test", &v),
+					resource.TestCheckResourceAttrSet("aws_ebs_volume.test", "arn"),
 				),
 			},
 		},

--- a/website/docs/d/ebs_volume.html.markdown
+++ b/website/docs/d/ebs_volume.html.markdown
@@ -46,6 +46,7 @@ The following attributes are exported:
 
 * `id` - The volume ID (e.g. vol-59fcb34e).
 * `volume_id` - The volume ID (e.g. vol-59fcb34e).
+* `arn` - The volume ARN (e.g. arn:aws:ec2:us-east-1:0123456789012:volume/vol-59fcb34e).
 * `availability_zone` - The AZ where the EBS volume exists.
 * `encrypted` - Whether the disk is encrypted.
 * `iops` - The amount of IOPS for the disk.

--- a/website/docs/r/ebs_volume.html.md
+++ b/website/docs/r/ebs_volume.html.md
@@ -44,6 +44,7 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The volume ID (e.g. vol-59fcb34e).
+* `arn` - The volume ARN (e.g. arn:aws:ec2:us-east-1:0123456789012:volume/vol-59fcb34e).
 
 
 ## Import


### PR DESCRIPTION
Not provided directly by EC2 DescribeVolumes API, so built manually. References:
* http://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#Volume
* http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-ec2

Closes #2261 

```
make testacc TESTARGS='-run=TestAccAWSEbsVolumeDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccAWSEbsVolumeDataSource_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSEbsVolumeDataSource_basic
--- PASS: TestAccAWSEbsVolumeDataSource_basic (25.51s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	25.547s

make testacc TESTARGS='-run=TestAccAWSEBSVolume_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccAWSEBSVolume_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSEBSVolume_basic
--- PASS: TestAccAWSEBSVolume_basic (22.02s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	22.057s
```