### PR TITLE
Add arn attribute to aws_elb resource

### DIFF
--- a/aws/resource_aws_elb.go
+++ b/aws/resource_aws_elb.go
@@ -47,7 +47,6 @@ func resourceAwsElb() *schema.Resource {
 
 			"arn": &schema.Schema{
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 

--- a/aws/resource_aws_elb.go
+++ b/aws/resource_aws_elb.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elb"
@@ -42,6 +43,12 @@ func resourceAwsElb() *schema.Resource {
 				Optional:     true,
 				ForceNew:     true,
 				ValidateFunc: validateElbNamePrefix,
+			},
+
+			"arn": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 			},
 
 			"internal": &schema.Schema{
@@ -328,6 +335,15 @@ func resourceAwsElbCreate(d *schema.ResourceData, meta interface{}) error {
 func resourceAwsElbRead(d *schema.ResourceData, meta interface{}) error {
 	elbconn := meta.(*AWSClient).elbconn
 	elbName := d.Id()
+
+	arn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Region:    meta.(*AWSClient).region,
+		Service:   "elasticloadbalancing",
+		AccountID: meta.(*AWSClient).accountid,
+		Resource:  fmt.Sprintf("loadbalancer/%s", d.Id()),
+	}
+	d.Set("arn", arn.String())
 
 	// Retrieve the ELB properties for updating the state
 	describeElbOpts := &elb.DescribeLoadBalancersInput{

--- a/aws/resource_aws_elb_test.go
+++ b/aws/resource_aws_elb_test.go
@@ -31,6 +31,7 @@ func TestAccAWSELB_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSELBExists("aws_elb.bar", &conf),
 					testAccCheckAWSELBAttributes(&conf),
+					resource.TestCheckResourceAttrSet("aws_elb.bar", "arn"),
 					resource.TestCheckResourceAttr(
 						"aws_elb.bar", "availability_zones.#", "3"),
 					resource.TestCheckResourceAttr(

--- a/website/docs/r/elb.html.markdown
+++ b/website/docs/r/elb.html.markdown
@@ -135,6 +135,7 @@ browser.
 The following attributes are exported:
 
 * `id` - The name of the ELB
+* `arn` - The ARN of the ELB
 * `name` - The name of the ELB
 * `dns_name` - The DNS name of the ELB
 * `instances` - The list of instances in the ELB


### PR DESCRIPTION
Not provided directly by DescribeLoadBalancers/DescribeLoadBalancerAttributes APIs, so built manually. References:
* http://docs.aws.amazon.com/sdk-for-go/api/service/elb/#LoadBalancerDescription
* http://docs.aws.amazon.com/sdk-for-go/api/service/elb/#LoadBalancerAttributes
* http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-elb

Closes #2123 

I cannot run `TestAccAWSELB_basic` since the default VPC has been removed from my own AWS account, but these are similar changes as #2271.