### PR TITLE
Add arn attribute to aws_ssm_parameter resource and datasource

### DIFF
--- a/aws/data_source_aws_ssm_parameter_test.go
+++ b/aws/data_source_aws_ssm_parameter_test.go
@@ -18,6 +18,7 @@ func TestAccAwsSsmParameterDataSource_basic(t *testing.T) {
 			{
 				Config: testAccCheckAwsSsmParameterDataSourceConfig(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.aws_ssm_parameter.test", "arn"),
 					resource.TestCheckResourceAttr("data.aws_ssm_parameter.test", "name", name),
 					resource.TestCheckResourceAttr("data.aws_ssm_parameter.test", "type", "String"),
 					resource.TestCheckResourceAttr("data.aws_ssm_parameter.test", "value", "TestValue"),

--- a/aws/resource_aws_ssm_parameter.go
+++ b/aws/resource_aws_ssm_parameter.go
@@ -1,9 +1,11 @@
 package aws
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -35,6 +37,11 @@ func resourceAwsSsmParameter() *schema.Resource {
 				Type:      schema.TypeString,
 				Required:  true,
 				Sensitive: true,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 			},
 			"key_id": {
 				Type:     schema.TypeString,
@@ -78,6 +85,15 @@ func resourceAwsSsmParameterRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("name", param.Name)
 	d.Set("type", param.Type)
 	d.Set("value", param.Value)
+
+	arn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Region:    meta.(*AWSClient).region,
+		Service:   "ssm",
+		AccountID: meta.(*AWSClient).accountid,
+		Resource:  fmt.Sprintf("parameter/%s", d.Id()),
+	}
+	d.Set("arn", arn.String())
 
 	return nil
 }

--- a/aws/resource_aws_ssm_parameter_test.go
+++ b/aws/resource_aws_ssm_parameter_test.go
@@ -23,6 +23,7 @@ func TestAccAWSSSMParameter_basic(t *testing.T) {
 				Config: testAccAWSSSMParameterBasicConfig(name, "bar"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMParameterExists("aws_ssm_parameter.foo", &param),
+					resource.TestCheckResourceAttrSet("aws_ssm_parameter.foo", "arn"),
 					resource.TestCheckResourceAttr("aws_ssm_parameter.foo", "value", "bar"),
 					resource.TestCheckResourceAttr("aws_ssm_parameter.foo", "type", "String"),
 				),

--- a/website/docs/d/ssm_parameter.html.markdown
+++ b/website/docs/d/ssm_parameter.html.markdown
@@ -32,6 +32,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
+* `arn` - The ARN of the parameter.
 * `name` - (Required) The name of the parameter.
 * `type` - (Required) The type of the parameter. Valid types are `String`, `StringList` and `SecureString`.
 * `value` - (Required) The value of the parameter.

--- a/website/docs/r/ssm_parameter.html.markdown
+++ b/website/docs/r/ssm_parameter.html.markdown
@@ -62,6 +62,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
+* `arn` - The ARN of the parameter.
 * `name` - (Required) The name of the parameter.
 * `type` - (Required) The type of the parameter. Valid types are `String`, `StringList` and `SecureString`.
 * `value` - (Required) The value of the parameter.


### PR DESCRIPTION
Not provided by DescribeParameters API, so built manually. References:
* http://docs.aws.amazon.com/sdk-for-go/api/service/ssm/#ParameterMetadata
* http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-ssm

Closes #2041 

```
make testacc TESTARGS='-run=TestAccAwsSsmParameterDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccAwsSsmParameterDataSource_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAwsSsmParameterDataSource_basic
--- PASS: TestAccAwsSsmParameterDataSource_basic (14.16s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	14.193s

make testacc TESTARGS='-run=TestAccAWSSSMParameter_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccAWSSSMParameter_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSSSMParameter_basic
--- PASS: TestAccAWSSSMParameter_basic (12.16s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	12.196s
```