### PR TITLE
Adjust aws_dynamodb_table CreateTable LimitExceededException handling for different error messaging

### DIFF
--- a/aws/resource_aws_dynamodb_table.go
+++ b/aws/resource_aws_dynamodb_table.go
@@ -335,7 +335,7 @@ func resourceAwsDynamoDbTableCreate(d *schema.ResourceData, meta interface{}) er
 					// Subscriber limit exceeded: There is a limit of 256 tables per subscriber
 					// Do not error out on this similar throttling message:
 					// Subscriber limit exceeded: Only 10 tables can be created, updated, or deleted simultaneously
-					if strings.Contains(awsErr.Message(), "Subscriber limit exceeded:") && !strings.Contains(awsErr.Message(), "simultaneously") {
+					if strings.Contains(awsErr.Message(), "Subscriber limit exceeded:") && !strings.Contains(awsErr.Message(), "can be created, updated, or deleted simultaneously") {
 						return fmt.Errorf("AWS Error creating DynamoDB table: %s", err)
 					}
 					log.Printf("[DEBUG] Limit on concurrent table creations hit, sleeping for a bit")

--- a/aws/resource_aws_dynamodb_table.go
+++ b/aws/resource_aws_dynamodb_table.go
@@ -331,8 +331,11 @@ func resourceAwsDynamoDbTableCreate(d *schema.ResourceData, meta interface{}) er
 					time.Sleep(DYNAMODB_THROTTLE_SLEEP)
 					attemptCount += 1
 				case "LimitExceededException":
-					// If we're at resource capacity, error out without retry
-					if strings.Contains(awsErr.Message(), "Subscriber limit exceeded:") {
+					// If we're at resource capacity, error out without retry. e.g.
+					// Subscriber limit exceeded: There is a limit of 256 tables per subscriber
+					// Do not error out on this similar throttling message:
+					// Subscriber limit exceeded: Only 10 tables can be created, updated, or deleted simultaneously
+					if strings.Contains(awsErr.Message(), "Subscriber limit exceeded:") && !strings.Contains(awsErr.Message(), "simultaneously") {
 						return fmt.Errorf("AWS Error creating DynamoDB table: %s", err)
 					}
 					log.Printf("[DEBUG] Limit on concurrent table creations hit, sleeping for a bit")


### PR DESCRIPTION
The AWS API is returning multiple, similar messages for DynamoDB throttling vs hitting the account limit. This "regression" was introduced in 130cdfe987a29a58b7ad4495dccdef236d64ce9e.

Closes #1776
Closes #2146 