### PR TITLE
r/aws_appautoscaling_policy: Retry PutScalingPolicy on rate exceeded message

### DIFF
--- a/aws/resource_aws_appautoscaling_policy.go
+++ b/aws/resource_aws_appautoscaling_policy.go
@@ -262,6 +262,9 @@ func resourceAwsAppautoscalingPolicyCreate(d *schema.ResourceData, meta interfac
 		var err error
 		resp, err = conn.PutScalingPolicy(&params)
 		if err != nil {
+			if isAWSErr(err, "FailedResourceAccessException", "Rate exceeded") {
+				return resource.RetryableError(err)
+			}
 			if isAWSErr(err, "FailedResourceAccessException", "is not authorized to perform") {
 				return resource.RetryableError(err)
 			}


### PR DESCRIPTION
Example:
```
* aws_appautoscaling_policy.EXAMPLE: 1 error(s) occurred:

* aws_appautoscaling_policy.EXAMPLE: Failed to create scaling policy: Error putting scaling policy: FailedResourceAccessException: Unable to create alarms for scaling policy DynamoDBReadCapacityUtilization:table/EXAMPLE due to reason: Rate exceeded (Service: AmazonCloudWatch; Status Code: 400; Error Code: Throttling; Request ID: 22fe569e-b29e-11e7-b187-ab649256b7c7)
    status code: 400, request id: 21614877-b29e-11e7-ac2e-d52b986f4ede
```