### PR TITLE
r/aws_elasticache_security_group: add import support

### DIFF
--- a/aws/resource_aws_elasticache_security_group.go
+++ b/aws/resource_aws_elasticache_security_group.go
@@ -17,6 +17,12 @@ func resourceAwsElasticacheSecurityGroup() *schema.Resource {
 		Create: resourceAwsElasticacheSecurityGroupCreate,
 		Read:   resourceAwsElasticacheSecurityGroupRead,
 		Delete: resourceAwsElasticacheSecurityGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				d.Set("name", d.Id())
+				return []*schema.ResourceData{d}, nil
+			},
+		},
 
 		Schema: map[string]*schema.Schema{
 			"description": &schema.Schema{

--- a/aws/resource_aws_elasticache_security_group_test.go
+++ b/aws/resource_aws_elasticache_security_group_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -31,6 +32,11 @@ func TestAccAWSElasticacheSecurityGroup_basic(t *testing.T) {
 }
 
 func TestAccAWSElasticacheSecurityGroup_Import(t *testing.T) {
+	// Use EC2-Classic enabled us-east-1 for testing
+	oldRegion := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldRegion)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/aws/resource_aws_elasticache_security_group_test.go
+++ b/aws/resource_aws_elasticache_security_group_test.go
@@ -30,6 +30,25 @@ func TestAccAWSElasticacheSecurityGroup_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSElasticacheSecurityGroup_Import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheSecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSElasticacheSecurityGroupConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      "aws_elasticache_security_group.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAWSElasticacheSecurityGroupDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).elasticacheconn
 

--- a/website/docs/r/elasticache_security_group.html.markdown
+++ b/website/docs/r/elasticache_security_group.html.markdown
@@ -45,3 +45,11 @@ The following attributes are exported:
 * `description`
 * `name`
 * `security_group_names`
+
+## Import
+
+ElastiCache Security Groups can be imported by name, e.g.
+
+```
+$ terraform import aws_elasticache_security_group.my_ec_security_group ec-security-group-1
+```


### PR DESCRIPTION
Closes #2260 

Sorry I cannot run `TestAccAWSElasticacheSecurityGroup_Import` as my AWS account has its default VPCs removed.