### PR TITLE
resource/aws_security_group: Avoid dropping group from state on AWS consistency issues

### DIFF
--- a/aws/resource_aws_security_group.go
+++ b/aws/resource_aws_security_group.go
@@ -346,7 +346,7 @@ func resourceAwsSecurityGroupCreate(d *schema.ResourceData, meta interface{}) er
 
 	}
 
-	return resourceAwsSecurityGroupUpdate(d, meta)
+	return resourceAwsSecurityGroupUpdateExisting(d, meta)
 }
 
 func resourceAwsSecurityGroupRead(d *schema.ResourceData, meta interface{}) error {
@@ -405,7 +405,11 @@ func resourceAwsSecurityGroupUpdate(d *schema.ResourceData, meta interface{}) er
 
 	group := sgRaw.(*ec2.SecurityGroup)
 
-	err = resourceAwsSecurityGroupUpdateRules(d, "ingress", meta, group)
+	return resourceAwsSecurityGroupUpdateExisting(group, d, meta)
+}
+
+func resourceAwsSecurityGroupUpdateExisting(group *ec2.SecurityGroup, d *schema.ResourceData, meta interface{}) error {
+	err := resourceAwsSecurityGroupUpdateRules(d, "ingress", meta, group)
 	if err != nil {
 		return err
 	}
@@ -418,6 +422,7 @@ func resourceAwsSecurityGroupUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if !d.IsNewResource() {
+		conn := meta.(*AWSClient).ec2conn
 		if err := setTags(conn, d); err != nil {
 			return err
 		}


### PR DESCRIPTION
It appears, based on the report in https://github.com/hashicorp/terraform/issues/6991
that the EC2 API is being
inconsistent in reporting that a security group exists shortly after it
has been created; we've seen Terraform get past the "Waiting for
Security Group to exist" step but then apparently detect that it's gone
again once we get into the Update function.

Rewrite of https://github.com/hashicorp/terraform/pull/11361