### PR TITLE
#2218 Allow adding/removing of ElastiCache Clusters to an existing ElastiCache Replication Group

### DIFF
--- a/aws/resource_aws_elasticache_cluster.go
+++ b/aws/resource_aws_elasticache_cluster.go
@@ -26,11 +26,14 @@ func resourceAwsElastiCacheCommonSchema() map[string]*schema.Schema {
 		},
 		"node_type": {
 			Type:     schema.TypeString,
-			Required: true,
+			Optional: true,
+			Computed: true,
 		},
 		"engine": {
 			Type:     schema.TypeString,
-			Required: true,
+			Optional: true,
+			//Computed: true, Set in resourceAwsElasticacheCluster because this Schema is used in resource_aws_elasticache_replication_group with a default value.
+			ForceNew: true,
 		},
 		"engine_version": {
 			Type:     schema.TypeString,
@@ -101,8 +104,9 @@ func resourceAwsElastiCacheCommonSchema() map[string]*schema.Schema {
 		},
 		"port": {
 			Type:     schema.TypeInt,
-			Required: true,
 			ForceNew: true,
+			Optional: true,
+			Computed: true,
 		},
 		"notification_topic_arn": {
 			Type:     schema.TypeString,
@@ -135,6 +139,8 @@ func resourceAwsElastiCacheCommonSchema() map[string]*schema.Schema {
 func resourceAwsElasticacheCluster() *schema.Resource {
 	resourceSchema := resourceAwsElastiCacheCommonSchema()
 
+	resourceSchema["engine"].Computed = true
+
 	resourceSchema["cluster_id"] = &schema.Schema{
 		Type:     schema.TypeString,
 		Required: true,
@@ -150,7 +156,8 @@ func resourceAwsElasticacheCluster() *schema.Resource {
 
 	resourceSchema["num_cache_nodes"] = &schema.Schema{
 		Type:     schema.TypeInt,
-		Required: true,
+		Optional: true,
+		Computed: true,
 	}
 
 	resourceSchema["az_mode"] = &schema.Schema{
@@ -172,11 +179,6 @@ func resourceAwsElasticacheCluster() *schema.Resource {
 	}
 
 	resourceSchema["cluster_address"] = &schema.Schema{
-		Type:     schema.TypeString,
-		Computed: true,
-	}
-
-	resourceSchema["replication_group_id"] = &schema.Schema{
 		Type:     schema.TypeString,
 		Computed: true,
 	}
@@ -206,6 +208,33 @@ func resourceAwsElasticacheCluster() *schema.Resource {
 		},
 	}
 
+	resourceSchema["replication_group_id"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+		ForceNew: true,
+		ConflictsWith: []string{
+			"availability_zone",
+			"availability_zones",
+			"az_mode",
+			"node_type",
+			"engine",
+			"engine_version",
+			"maintenance_window",
+			"notification_topic_arn",
+			"num_cache_nodes",
+			"parameter_group_name",
+			"port",
+			"security_group_names",
+			"security_group_ids",
+			"snapshot_arns",
+			"snapshot_name",
+			"snapshot_retention_limit",
+			"snapshot_window",
+			"subnet_group_name",
+		},
+		Computed: true,
+	}
+
 	return &schema.Resource{
 		Create: resourceAwsElasticacheClusterCreate,
 		Read:   resourceAwsElasticacheClusterRead,
@@ -222,31 +251,48 @@ func resourceAwsElasticacheCluster() *schema.Resource {
 func resourceAwsElasticacheClusterCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).elasticacheconn
 
-	clusterId := d.Get("cluster_id").(string)
-	nodeType := d.Get("node_type").(string)           // e.g) cache.m1.small
-	numNodes := int64(d.Get("num_cache_nodes").(int)) // 2
-	engine := d.Get("engine").(string)                // memcached
-	engineVersion := d.Get("engine_version").(string) // 1.4.14
-	port := int64(d.Get("port").(int))                // e.g) 11211
-	subnetGroupName := d.Get("subnet_group_name").(string)
-	securityNameSet := d.Get("security_group_names").(*schema.Set)
-	securityIdSet := d.Get("security_group_ids").(*schema.Set)
+	req := &elasticache.CreateCacheClusterInput{}
 
-	securityNames := expandStringList(securityNameSet.List())
-	securityIds := expandStringList(securityIdSet.List())
-	tags := tagsFromMapEC(d.Get("tags").(map[string]interface{}))
+	if v, ok := d.GetOk("replication_group_id"); ok {
+		req.ReplicationGroupId = aws.String(v.(string))
+	} else {
+		securityNameSet := d.Get("security_group_names").(*schema.Set)
+		securityIdSet := d.Get("security_group_ids").(*schema.Set)
+		securityNames := expandStringList(securityNameSet.List())
+		securityIds := expandStringList(securityIdSet.List())
+		tags := tagsFromMapEC(d.Get("tags").(map[string]interface{}))
 
-	req := &elasticache.CreateCacheClusterInput{
-		CacheClusterId:          aws.String(clusterId),
-		CacheNodeType:           aws.String(nodeType),
-		NumCacheNodes:           aws.Int64(numNodes),
-		Engine:                  aws.String(engine),
-		EngineVersion:           aws.String(engineVersion),
-		Port:                    aws.Int64(port),
-		CacheSubnetGroupName:    aws.String(subnetGroupName),
-		CacheSecurityGroupNames: securityNames,
-		SecurityGroupIds:        securityIds,
-		Tags:                    tags,
+		req.CacheSecurityGroupNames = securityNames
+		req.SecurityGroupIds = securityIds
+		req.Tags = tags
+	}
+
+	if v, ok := d.GetOk("cluster_id"); ok {
+		req.CacheClusterId = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("node_type"); ok {
+		req.CacheNodeType = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("num_cache_nodes"); ok {
+		req.NumCacheNodes = aws.Int64(v.(int64))
+	}
+
+	if v, ok := d.GetOk("engine"); ok {
+		req.Engine = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("engine_version"); ok {
+		req.EngineVersion = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("port"); ok {
+		req.Port = aws.Int64(v.(int64))
+	}
+
+	if v, ok := d.GetOk("subnet_group_name"); ok {
+		req.CacheSubnetGroupName = aws.String(v.(string))
 	}
 
 	// parameter groups are optional and can be defaulted by AWS
@@ -293,10 +339,6 @@ func resourceAwsElasticacheClusterCreate(d *schema.ResourceData, meta interface{
 	if len(preferred_azs) > 0 {
 		azs := expandStringList(preferred_azs)
 		req.PreferredAvailabilityZones = azs
-	}
-
-	if v, ok := d.GetOk("replication_group_id"); ok {
-		req.ReplicationGroupId = aws.String(v.(string))
 	}
 
 	resp, err := conn.CreateCacheCluster(req)

--- a/website/docs/r/elasticache_cluster.html.markdown
+++ b/website/docs/r/elasticache_cluster.html.markdown
@@ -21,6 +21,11 @@ phase because a modification has not yet taken place. You can use the
 brief downtime as the server reboots. See the AWS Docs on
 [Modifying an ElastiCache Cache Cluster][2] for more information.
 
+~> **Note:** when creating an ElastiCache Cache Cluster, you must either provide a `replication_group_id`
+to an existing ElastiCache Replication Group or all of the `engine`, `port`, `node_type`, and 
+`num_cache_nodes` arguments.  When providing a replication_group_id, the new Cache Cluster inherits all 
+of the properties of the Replication Group; no other options may be specified in your resource config.
+
 ## Example Usage
 
 ```hcl
@@ -34,6 +39,15 @@ resource "aws_elasticache_cluster" "bar" {
 }
 ```
 
+or
+
+```hcl
+resource "aws_elasticache_cluster" "bar" {
+  cluster_id           = "cluster-example"
+  replication_group_id = "cluster-repl-group"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -41,7 +55,7 @@ The following arguments are supported:
 * `cluster_id` – (Required) Group identifier. ElastiCache converts
   this name to lowercase
 
-* `engine` – (Required) Name of the cache engine to be used for this cache cluster.
+* `engine` – (Conditional, if no replication_group_id is provided) Name of the cache engine to be used for this cache cluster.
  Valid values for this parameter are `memcached` or `redis`
 
 * `engine_version` – (Optional) Version number of the cache engine to be used.
@@ -52,19 +66,19 @@ in the AWS Documentation center for supported versions
 on the cache cluster is performed. The format is `ddd:hh24:mi-ddd:hh24:mi` (24H Clock UTC).
 The minimum maintenance window is a 60 minute period. Example: `sun:05:00-sun:09:00`
 
-* `node_type` – (Required) The compute and memory capacity of the nodes. See
+* `node_type` – (Conditional, if no replication_group_id is provided) The compute and memory capacity of the nodes. See
 [Available Cache Node Types](https://aws.amazon.com/elasticache/details#Available_Cache_Node_Types) for
 supported node types
 
-* `num_cache_nodes` – (Required) The initial number of cache nodes that the
+* `num_cache_nodes` – (Conditional, if no replication_group_id is provided) The initial number of cache nodes that the
 cache cluster will have. For Redis, this value must be 1. For Memcache, this
 value must be between 1 and 20. If this number is reduced on subsequent runs,
 the highest numbered nodes will be removed.
 
-* `parameter_group_name` – (Required) Name of the parameter group to associate
+* `parameter_group_name` – (Conditional, if no replication_group_id is provided) Name of the parameter group to associate
 with this cache cluster
 
-* `port` – (Required) The port number on which each of the cache nodes will
+* `port` – (Conditional, if no replication_group_id is provided) The port number on which each of the cache nodes will
 accept connections. For Memcache the default is 11211, and for Redis the default port is 6379.
 
 * `subnet_group_name` – (Optional, VPC only) Name of the subnet group to be used


### PR DESCRIPTION
Hello all, I'm looking for feedback on this PR.  This covers issue #2218.  The current provider implementation requires updates to the `number_cache_clusters` property of the aws_elasticache_replication_group resource.  This is a "force new" operation, which means you cannot dynamically scale your cluster.  