### PR TITLE
WIP: opsworks endpoint region override

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -105,6 +105,7 @@ type Config struct {
 	IamEndpoint              string
 	KinesisEndpoint          string
 	KmsEndpoint              string
+	OpsworksRegion           string
 	RdsEndpoint              string
 	S3Endpoint               string
 	SnsEndpoint              string
@@ -298,6 +299,11 @@ func (c *Config) Client() (interface{}, error) {
 	awsSqsSess := sess.Copy(&aws.Config{Endpoint: aws.String(c.SqsEndpoint)})
 	awsDeviceFarmSess := sess.Copy(&aws.Config{Endpoint: aws.String(c.DeviceFarmEndpoint)})
 
+	awsOpsworksSess := sess
+	if c.OpsworksRegion != "" {
+		awsOpsworksSess = sess.Copy(&aws.Config{Region: aws.String(c.OpsworksRegion)})
+	}
+
 	log.Println("[INFO] Initializing DeviceFarm SDK connection")
 	client.devicefarmconn = devicefarm.New(awsDeviceFarmSess)
 
@@ -375,7 +381,7 @@ func (c *Config) Client() (interface{}, error) {
 	client.kmsconn = kms.New(awsKmsSess)
 	client.lambdaconn = lambda.New(sess)
 	client.lightsailconn = lightsail.New(sess)
-	client.opsworksconn = opsworks.New(sess)
+	client.opsworksconn = opsworks.New(awsOpsworksSess)
 	client.r53conn = route53.New(r53Sess)
 	client.rdsconn = rds.New(awsRdsSess)
 	client.redshiftconn = redshift.New(sess)

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -562,6 +562,8 @@ func init() {
 
 		"kms_endpoint": "Use this to override the default endpoint URL constructed from the `region`.\n",
 
+		"opsworks_region": "Use this to select a specific region for contacting Opsworks (eg: `us-east-1`) overriding the default region.\n",
+
 		"iam_endpoint": "Use this to override the default endpoint URL constructed from the `region`.\n",
 
 		"ec2_endpoint": "Use this to override the default endpoint URL constructed from the `region`.\n",
@@ -669,6 +671,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		config.IamEndpoint = endpoints["iam"].(string)
 		config.KinesisEndpoint = endpoints["kinesis"].(string)
 		config.KmsEndpoint = endpoints["kms"].(string)
+		config.OpsworksRegion = endpoints["opsworks"].(string)
 		config.RdsEndpoint = endpoints["rds"].(string)
 		config.S3Endpoint = endpoints["s3"].(string)
 		config.SnsEndpoint = endpoints["sns"].(string)
@@ -798,6 +801,12 @@ func endpointsSchema() *schema.Schema {
 					Default:     "",
 					Description: descriptions["kms_endpoint"],
 				},
+				"opsworks": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Default:     "",
+					Description: descriptions["opsworks_region"],
+				},
 				"rds": {
 					Type:        schema.TypeString,
 					Optional:    true,
@@ -842,6 +851,7 @@ func endpointsToHash(v interface{}) int {
 	buf.WriteString(fmt.Sprintf("%s-", m["elb"].(string)))
 	buf.WriteString(fmt.Sprintf("%s-", m["kinesis"].(string)))
 	buf.WriteString(fmt.Sprintf("%s-", m["kms"].(string)))
+	buf.WriteString(fmt.Sprintf("%s-", m["opsworks"].(string)))
 	buf.WriteString(fmt.Sprintf("%s-", m["rds"].(string)))
 	buf.WriteString(fmt.Sprintf("%s-", m["s3"].(string)))
 	buf.WriteString(fmt.Sprintf("%s-", m["sns"].(string)))


### PR DESCRIPTION
Add way to override opsworks region endpoint to workaround upgrade from pre-0.9 state file.

Usage:
```javascript
provider "aws" {
  region     = "${var.aws_region}"
  profile    = "qa"
  allowed_account_ids = ["${var.account_id}"]
  endpoints {
    opsworks = "us-east-1"
  }
}
```

TODO: 
  * documentation