### PR TITLE
SetSubnets not allowed on LB type network (supersedes #1941)

### DIFF
--- a/aws/resource_aws_lb.go
+++ b/aws/resource_aws_lb.go
@@ -389,9 +389,14 @@ func resourceAwsLbUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	}
 
-	if d.HasChange("subnets") {
+	if d.HasChange("subnets") && !d.IsNewResource() {
+		// subnets are assigned at Create; the 'change' here is an empty map for old
+		// and current subnets for new, so this change is redundant when the
+		// resource is just created.
 		if d.Get("load_balancer_type").(string) == "network" {
-			return fmt.Errorf("Unable to update subnets for loadbalancer %s, updating subnets is not supported for type network", d.Id())
+			// Load Balancers of type 'network' cannot update their subnets at this
+			// time.
+			return fmt.Errorf("Unable to update subnets for loadbalancer %s, updating subnets is not supported for type network. Please use the 'taint' command to force a recreation of this resource", d.Id())
 		}
 
 		subnets := expandStringList(d.Get("subnets").(*schema.Set).List())

--- a/aws/resource_aws_lb.go
+++ b/aws/resource_aws_lb.go
@@ -390,6 +390,10 @@ func resourceAwsLbUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("subnets") {
+		if d.Get("load_balancer_type").(string) == "network" {
+			return fmt.Errorf("Unable to update subnets for loadbalancer %s, updating subnets is not supported for type network", d.Id())
+		}
+
 		subnets := expandStringList(d.Get("subnets").(*schema.Set).List())
 
 		params := &elbv2.SetSubnetsInput{

--- a/website/docs/r/lb.html.markdown
+++ b/website/docs/r/lb.html.markdown
@@ -50,9 +50,12 @@ Terraform will autogenerate a name beginning with `tf-lb`.
 * `name_prefix` - (Optional) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `internal` - (Optional) If true, the LB will be internal.
 * `load_balancer_type` - (Optional) The type of load balancer to create. Possible values are `application` or `network`. The default value is `application`.
-* `security_groups` - (Optional) A list of security group IDs to assign to the LB.
+* `security_groups` - (Optional) A list of security group IDs to assign to the LB. Only valid for Load Balancers of type `application`. 
 * `access_logs` - (Optional) An Access Logs block. Access Logs documented below.
-* `subnets` - (Optional) A list of subnet IDs to attach to the LB.
+* `subnets` - (Optional) A list of subnet IDs to attach to the LB. Subnets
+cannot be updated for Load Balancers of type `network`; Please use
+[Taint](/docs/commands/taint.html) command to force a recreation of the Load
+Balancer and change subnets.
 * `subnet_mapping` - (Optional) A subnet mapping block as documented below.
 * `idle_timeout` - (Optional) The time in seconds that the connection is allowed to be idle. Default: 60.
 * `enable_deletion_protection` - (Optional) If true, deletion of the load balancer will be disabled via


### PR DESCRIPTION
Continuation of https://github.com/terraform-providers/terraform-provider-aws/pull/1941

- [x] document this in the lb documentation
- [x] mention that terraform taint is the way to do change the subnets in our error message
- [x] update the check on subnet update to only fire if it's not a new resource