### PR TITLE
resource/aws_ssm_association: Allow for multiple targets

### DIFF
--- a/aws/resource_aws_ssm_association.go
+++ b/aws/resource_aws_ssm_association.go
@@ -75,7 +75,7 @@ func resourceAwsSsmAssociation() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 				Computed: true,
-				MaxItems: 1,
+				MaxItems: 5,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"key": {

--- a/aws/resource_aws_ssm_association_test.go
+++ b/aws/resource_aws_ssm_association_test.go
@@ -40,6 +40,10 @@ func TestAccAWSSSMAssociation_withTargets(t *testing.T) {
 				Config: testAccAWSSSMAssociationBasicConfigWithTargets(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMAssociationExists("aws_ssm_association.foo"),
+					resource.TestCheckResourceAttr(
+						"aws_ssm_association.foo", "targets.0.key", "tag:Name"),
+					resource.TestCheckResourceAttr(
+						"aws_ssm_association.foo", "targets.0.values.0", "acceptanceTest"),
 				),
 			},
 		},
@@ -57,6 +61,14 @@ func TestAccAWSSSMAssociation_withMultipleTargets(t *testing.T) {
 				Config: testAccAWSSSMAssociationBasicConfigWithMultipleTargets(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMAssociationExists("aws_ssm_association.foo"),
+					resource.TestCheckResourceAttr(
+						"aws_ssm_association.foo", "targets.0.key", "tag:Name"),
+					resource.TestCheckResourceAttr(
+						"aws_ssm_association.foo", "targets.0.values.0", "acceptanceTest"),
+					resource.TestCheckResourceAttr(
+						"aws_ssm_association.foo", "targets.1.key", "tag:Environment"),
+					resource.TestCheckResourceAttr(
+						"aws_ssm_association.foo", "targets.1.values.0", "acceptanceTest"),
 				),
 			},
 		},

--- a/website/docs/r/ssm_association.html.markdown
+++ b/website/docs/r/ssm_association.html.markdown
@@ -75,7 +75,7 @@ The following arguments are supported:
 * `output_location` - (Optional) An output location block. Output Location is documented below.
 * `parameters` - (Optional) A block of arbitrary string parameters to pass to the SSM document.
 * `schedule_expression` - (Optional) A cron expression when the association will be applied to the target(s).
-* `targets` - (Optional) A block containing the targets of the SSM association. Targets are documented below.
+* `targets` - (Optional) A block containing the targets of the SSM association. Targets are documented below. AWS currently supports a maximum of 5 targets.
 
 Output Location (`output_location`) is an S3 bucket where you want to store the results of this association:
 


### PR DESCRIPTION
AWS SSM Association supports a maximum of 5 targets - http://docs.aws.amazon.com/systems-manager/latest/APIReference/API_CreateAssociation.html

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSSSMAssociation'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSSSMAssociation -timeout 120m
=== RUN   TestAccAWSSSMAssociation_basic
--- PASS: TestAccAWSSSMAssociation_basic (141.40s)
=== RUN   TestAccAWSSSMAssociation_withTargets
--- PASS: TestAccAWSSSMAssociation_withTargets (39.53s)
=== RUN   TestAccAWSSSMAssociation_withMultipleTargets
--- PASS: TestAccAWSSSMAssociation_withMultipleTargets (39.34s)
=== RUN   TestAccAWSSSMAssociation_withParameters
--- PASS: TestAccAWSSSMAssociation_withParameters (66.54s)
=== RUN   TestAccAWSSSMAssociation_withDocumentVersion
--- PASS: TestAccAWSSSMAssociation_withDocumentVersion (40.69s)
=== RUN   TestAccAWSSSMAssociation_withOutputLocation
--- PASS: TestAccAWSSSMAssociation_withOutputLocation (149.35s)
=== RUN   TestAccAWSSSMAssociation_withScheduleExpression
--- PASS: TestAccAWSSSMAssociation_withScheduleExpression (65.68s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	542.558s
```