### PR TITLE
Docs: Added codebuild as a possible service name for aws_ip_ranges

### DIFF
--- a/website/docs/d/ip_ranges.html.markdown
+++ b/website/docs/d/ip_ranges.html.markdown
@@ -42,7 +42,7 @@ omitted). Valid items are `global` (for `cloudfront`) as well as all AWS regions
 (e.g. `eu-central-1`)
 
 * `services` - (Required) Filter IP ranges by services. Valid items are `amazon`
-(for amazon.com), `cloudfront`, `ec2`, `route53`, `route53_healthchecks` and `S3`.
+(for amazon.com), `cloudfront`, `codebuild`, `ec2`, `route53`, `route53_healthchecks` and `S3`.
 
 ~> **NOTE:** If the specified combination of regions and services does not yield any
 CIDR blocks, Terraform will fail.


### PR DESCRIPTION
We can now obtain egress CIDRs for AWS CodeBuild as well.

See https://forums.aws.amazon.com/ann.jspa?annID=5044 and https://ip-ranges.amazonaws.com/ip-ranges.json
