### PR TITLE
r/aws_lb: mark subnets as ForceNew for network load balancers

### DIFF
--- a/aws/resource_aws_lb_test.go
+++ b/aws/resource_aws_lb_test.go
@@ -458,6 +458,31 @@ func TestAccAWSLB_accesslogs(t *testing.T) {
 	})
 }
 
+func TestAccAWSLB_networkLoadbalancer_subnet_change(t *testing.T) {
+	var conf elbv2.LoadBalancer
+	lbName := fmt.Sprintf("testaccawslb-basic-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_lb.lb_test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSLBDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLBConfig_networkLoadbalancer_subnets(lbName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLBExists("aws_lb.lb_test", &conf),
+					resource.TestCheckResourceAttr("aws_lb.lb_test", "name", lbName),
+					resource.TestCheckResourceAttr("aws_lb.lb_test", "internal", "true"),
+					resource.TestCheckResourceAttr("aws_lb.lb_test", "tags.%", "1"),
+					resource.TestCheckResourceAttr("aws_lb.lb_test", "tags.Name", "testAccAWSLBConfig_networkLoadbalancer_subnets"),
+					resource.TestCheckResourceAttr("aws_lb.lb_test", "load_balancer_type", "network"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSlbARNs(pre, post *elbv2.LoadBalancer) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if *pre.LoadBalancerArn != *post.LoadBalancerArn {
@@ -818,6 +843,65 @@ resource "aws_security_group" "alb_test" {
 }`, lbName)
 }
 
+func testAccAWSLBConfig_networkLoadbalancer_subnets(lbName string) string {
+	return fmt.Sprintf(`resource "aws_vpc" "alb_test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    Name = "testAccAWSLBConfig_networkLoadbalancer_subnets"
+  }
+}
+
+resource "aws_lb" "lb_test" {
+  name = "%s"
+
+  subnets = [
+    "${aws_subnet.alb_test_1.id}",
+    "${aws_subnet.alb_test_2.id}",
+    "${aws_subnet.alb_test_3.id}",
+  ]
+
+  load_balancer_type         = "network"
+  internal                   = true
+  idle_timeout               = 60
+  enable_deletion_protection = false
+
+  tags {
+    Name = "testAccAWSLBConfig_networkLoadbalancer_subnets"
+  }
+}
+
+resource "aws_subnet" "alb_test_1" {
+  vpc_id            = "${aws_vpc.alb_test.id}"
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "us-west-2a"
+
+  tags {
+    Name = "testAccAWSLBConfig_networkLoadbalancer_subnets"
+  }
+}
+
+resource "aws_subnet" "alb_test_3" {
+  vpc_id            = "${aws_vpc.alb_test.id}"
+  cidr_block        = "10.0.3.0/24"
+  availability_zone = "us-west-2c"
+
+  tags {
+    Name = "testAccAWSLBConfig_networkLoadbalancer_subnets"
+  }
+}
+
+resource "aws_subnet" "alb_test_2" {
+  vpc_id            = "${aws_vpc.alb_test.id}"
+  cidr_block        = "10.0.2.0/24"
+  availability_zone = "us-west-2b"
+
+  tags {
+    Name = "testAccAWSLBConfig_networkLoadbalancer_subnets"
+  }
+}
+`, lbName)
+}
 func testAccAWSLBConfig_networkLoadbalancer(lbName string) string {
 	return fmt.Sprintf(`resource "aws_lb" "lb_test" {
   name            = "%s"

--- a/aws/resource_aws_lb_test.go
+++ b/aws/resource_aws_lb_test.go
@@ -881,20 +881,20 @@ resource "aws_subnet" "alb_test_1" {
   }
 }
 
-resource "aws_subnet" "alb_test_3" {
+resource "aws_subnet" "alb_test_2" {
   vpc_id            = "${aws_vpc.alb_test.id}"
-  cidr_block        = "10.0.3.0/24"
-  availability_zone = "us-west-2c"
+  cidr_block        = "10.0.2.0/24"
+  availability_zone = "us-west-2b"
 
   tags {
     Name = "testAccAWSLBConfig_networkLoadbalancer_subnets"
   }
 }
 
-resource "aws_subnet" "alb_test_2" {
+resource "aws_subnet" "alb_test_3" {
   vpc_id            = "${aws_vpc.alb_test.id}"
-  cidr_block        = "10.0.2.0/24"
-  availability_zone = "us-west-2b"
+  cidr_block        = "10.0.3.0/24"
+  availability_zone = "us-west-2c"
 
   tags {
     Name = "testAccAWSLBConfig_networkLoadbalancer_subnets"

--- a/website/docs/r/lb.html.markdown
+++ b/website/docs/r/lb.html.markdown
@@ -50,9 +50,11 @@ Terraform will autogenerate a name beginning with `tf-lb`.
 * `name_prefix` - (Optional) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `internal` - (Optional) If true, the LB will be internal.
 * `load_balancer_type` - (Optional) The type of load balancer to create. Possible values are `application` or `network`. The default value is `application`.
-* `security_groups` - (Optional) A list of security group IDs to assign to the LB.
+* `security_groups` - (Optional) A list of security group IDs to assign to the LB. Only valid for Load Balancers of type `application`.
 * `access_logs` - (Optional) An Access Logs block. Access Logs documented below.
-* `subnets` - (Optional) A list of subnet IDs to attach to the LB.
+* `subnets` - (Optional) A list of subnet IDs to attach to the LB. Subnets
+cannot be updated for Load Balancers of type `network`. Changing this value
+will for load balancers of type `network` will force a recreation of the resource. 
 * `subnet_mapping` - (Optional) A subnet mapping block as documented below.
 * `idle_timeout` - (Optional) The time in seconds that the connection is allowed to be idle. Default: 60.
 * `enable_deletion_protection` - (Optional) If true, deletion of the load balancer will be disabled via


### PR DESCRIPTION
Replaces #2293

Subnets cannot be updated on Load Balancers of type `network` at this time:

- [x] Documentation 
- [x] Conditionally mark `subnets` as `ForceNew` if the `load_balancer_type` is set to `network`

Fixes #1925