### PR TITLE
r/lb+elb: Suppress diff for LBs w/ empty name

### DIFF
--- a/aws/resource_aws_elb.go
+++ b/aws/resource_aws_elb.go
@@ -37,6 +37,10 @@ func resourceAwsElb() *schema.Resource {
 				ForceNew:      true,
 				ConflictsWith: []string{"name_prefix"},
 				ValidateFunc:  validateElbName,
+				// This is to work around an unexpected schema behaviour returning diff
+				// for an empty field when it has a pre-computed value from previous run
+				// (e.g. from name_prefix)
+				// TODO: Revisit after we find the real root cause
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					if new == "" {
 						return true

--- a/aws/resource_aws_elb.go
+++ b/aws/resource_aws_elb.go
@@ -37,6 +37,12 @@ func resourceAwsElb() *schema.Resource {
 				ForceNew:      true,
 				ConflictsWith: []string{"name_prefix"},
 				ValidateFunc:  validateElbName,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if new == "" {
+						return true
+					}
+					return false
+				},
 			},
 			"name_prefix": &schema.Schema{
 				Type:         schema.TypeString,

--- a/aws/resource_aws_lb.go
+++ b/aws/resource_aws_lb.go
@@ -52,6 +52,12 @@ func resourceAwsLb() *schema.Resource {
 				ForceNew:      true,
 				ConflictsWith: []string{"name_prefix"},
 				ValidateFunc:  validateElbName,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if new == "" {
+						return true
+					}
+					return false
+				},
 			},
 
 			"name_prefix": {

--- a/aws/resource_aws_lb.go
+++ b/aws/resource_aws_lb.go
@@ -52,6 +52,10 @@ func resourceAwsLb() *schema.Resource {
 				ForceNew:      true,
 				ConflictsWith: []string{"name_prefix"},
 				ValidateFunc:  validateElbName,
+				// This is to work around an unexpected schema behaviour returning diff
+				// for an empty field when it has a pre-computed value from previous run
+				// (e.g. from name_prefix)
+				// TODO: Revisit after we find the real root cause
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					if new == "" {
 						return true


### PR DESCRIPTION
This is to address the following test failures we started observing since upgrading the schema in https://github.com/terraform-providers/terraform-provider-aws/pull/2185

```
=== RUN   TestAccAWSELB_generatesNameForZeroValue
--- FAIL: TestAccAWSELB_generatesNameForZeroValue (7.30s)
    testing.go:503: Step 0 error: After applying this step, the plan was not empty:
        
        DIFF:
        
        DESTROY/CREATE: aws_elb.foo
          arn:                                   "arn:aws:elasticloadbalancing:us-west-2:*******:loadbalancer/tf-lb-20171116064611950500000001" => "<computed>"
          availability_zones.#:                  "3" => "3"
          availability_zones.2050015877:         "us-west-2c" => "us-west-2c"
          availability_zones.221770259:          "us-west-2b" => "us-west-2b"
          availability_zones.2487133097:         "us-west-2a" => "us-west-2a"
          connection_draining:                   "false" => "false"
          connection_draining_timeout:           "300" => "300"
          cross_zone_load_balancing:             "true" => "true"
          dns_name:                              "tf-lb-20171116064611950500000001-1860373339.us-west-2.elb.amazonaws.com" => "<computed>"
          health_check.#:                        "1" => "<computed>"
          idle_timeout:                          "60" => "60"
          instances.#:                           "0" => "<computed>"
          internal:                              "false" => "<computed>"
          listener.#:                            "1" => "1"
          listener.206423021.instance_port:      "8000" => "8000"
          listener.206423021.instance_protocol:  "http" => "http"
          listener.206423021.lb_port:            "80" => "80"
          listener.206423021.lb_protocol:        "http" => "http"
          listener.206423021.ssl_certificate_id: "" => ""
          name:                                  "tf-lb-20171116064611950500000001" => "<computed>" (forces new resource)
          security_groups.#:                     "1" => "<computed>"
          source_security_group:                 "*******/default_elb_486905dd-70a9-3149-9400-be14d7a94e54" => "<computed>"
          source_security_group_id:              "sg-68ed4611" => "<computed>"
          subnets.#:                             "3" => "<computed>"
          zone_id:                               "Z1H1FL5HABSF5" => "<computed>"
=== RUN   TestAccAWSLB_generatesNameForZeroValue
--- FAIL: TestAccAWSLB_generatesNameForZeroValue (304.46s)
    testing.go:503: Step 0 error: After applying this step, the plan was not empty:
        
        DIFF:
        
        DESTROY/CREATE: aws_lb.lb_test
          access_logs.#:              "0" => "<computed>"
          arn:                        "arn:aws:elasticloadbalancing:us-west-2:*******:loadbalancer/app/tf-lb-20171116072237141200000001/824b60ad8b68d1b2" => "<computed>"
          arn_suffix:                 "app/tf-lb-20171116072237141200000001/824b60ad8b68d1b2" => "<computed>"
          dns_name:                   "internal-tf-lb-20171116072237141200000001-721876436.us-west-2.elb.amazonaws.com" => "<computed>"
          enable_deletion_protection: "false" => "false"
          idle_timeout:               "30" => "30"
          internal:                   "true" => "true"
          ip_address_type:            "ipv4" => "<computed>"
          load_balancer_type:         "application" => "application"
          name:                       "tf-lb-20171116072237141200000001" => "<computed>" (forces new resource)
          security_groups.#:          "1" => "1"
          security_groups.3318027541: "sg-ae979dd3" => "sg-ae979dd3"
          subnets.#:                  "2" => "2"
          subnets.3559705844:         "subnet-47014d21" => "subnet-47014d21"
          subnets.3908916108:         "subnet-fdf499b5" => "subnet-fdf499b5"
          tags.%:                     "1" => "1"
          tags.Name:                  "TestAccAWSALB_basic" => "TestAccAWSALB_basic"
          vpc_id:                     "vpc-f03c3996" => "<computed>"
          zone_id:                    "Z1H1FL5HABSF5" => "<computed>"
```

I'm not sure if the behaviour change was intentional (@apparentlymart ?), but I'll just make it work the same way as it did before. Admittedly wanting to create LB with `name = ""` is rather a workaround for [the bug related to conditionals](https://github.com/hashicorp/terraform/issues/15605) than a real scenario, so we may just remove this eventually once that bug is addressed.

Original PR: https://github.com/hashicorp/terraform/pull/14304

## Test Results (after patch)

```
TF_ACC=1 go test ./aws -v -run="(TestAccAWSLB_generatesNameForZeroValue|TestAccAWSELB_generatesNameForZeroValue)" -timeout 120m
=== RUN   TestAccAWSELB_generatesNameForZeroValue
--- PASS: TestAccAWSELB_generatesNameForZeroValue (70.58s)
=== RUN   TestAccAWSLB_generatesNameForZeroValue
--- PASS: TestAccAWSLB_generatesNameForZeroValue (342.22s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	412.832s
```