### PR TITLE
t/ecr_lifecycle_policy: Randomize repo name

### DIFF
--- a/aws/resource_aws_ecr_lifecycle_policy_test.go
+++ b/aws/resource_aws_ecr_lifecycle_policy_test.go
@@ -7,18 +7,22 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccAWSEcrLifecyclePolicy_basic(t *testing.T) {
+	randString := acctest.RandString(10)
+	rName := fmt.Sprintf("tf-acc-test-lifecycle-%s", randString)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEcrLifecyclePolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEcrLifecyclePolicyConfig,
+				Config: testAccEcrLifecyclePolicyConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcrLifecyclePolicyExists("aws_ecr_lifecycle_policy.foo"),
 				),
@@ -68,9 +72,10 @@ func testAccCheckAWSEcrLifecyclePolicyExists(name string) resource.TestCheckFunc
 	}
 }
 
-const testAccEcrLifecyclePolicyConfig = `
+func testAccEcrLifecyclePolicyConfig(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_ecr_repository" "foo" {
-  name = "bar"
+  name = "%s"
 }
 resource "aws_ecr_lifecycle_policy" "foo" {
 	repository = "${aws_ecr_repository.foo.name}"
@@ -94,4 +99,5 @@ resource "aws_ecr_lifecycle_policy" "foo" {
 }
 EOF
 }
-`
+`, rName)
+}


### PR DESCRIPTION
This is to address the following test failure from this morning:

```
=== RUN   TestAccAWSEcrLifecyclePolicy_basic
--- FAIL: TestAccAWSEcrLifecyclePolicy_basic (2.36s)
    testing.go:503: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_ecr_repository.foo: 1 error(s) occurred:
        
        * aws_ecr_repository.foo: RepositoryAlreadyExistsException: The repository with name 'bar' already exists in the registry with id '*******'
            status code: 400, request id: 26dbdb35-ca95-11e7-8e23-55344c4ae920
```

## Test results (after patch)

```
TF_ACC=1 go test ./aws -v -run=TestAccAWSEcrLifecyclePolicy_basic -timeout 120m
=== RUN   TestAccAWSEcrLifecyclePolicy_basic
--- PASS: TestAccAWSEcrLifecyclePolicy_basic (33.55s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	33.581s
```