### PR TITLE
Fix bug that not waiting batch_job_queue deleted.

### DIFF
--- a/aws/resource_aws_batch_job_queue.go
+++ b/aws/resource_aws_batch_job_queue.go
@@ -160,8 +160,8 @@ func resourceAwsBatchJobQueueDelete(d *schema.ResourceData, meta interface{}) er
 	_, err = conn.DeleteJobQueue(&batch.DeleteJobQueueInput{
 		JobQueue: aws.String(sn),
 	})
-	if err == nil {
-		return nil
+	if err != nil {
+		return err
 	}
 
 	deleteStateConf := &resource.StateChangeConf{


### PR DESCRIPTION
## Description
Fix bug that not waiting batch_job_queue deleted.
Deleting compute environment with job queue failed because of this.

This bug is reported at https://github.com/terraform-providers/terraform-provider-aws/pull/1710#discussion_r142713542

Closes #2044

## Tests before fix bug
```
$ make testacc TESTARGS='-run=TestAccAWSBatchJobQueue'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccAWSBatchJobQueue -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSBatchJobQueue_basic
--- FAIL: TestAccAWSBatchJobQueue_basic (90.23s)
	testing.go:563: Error destroying resource! WARNING: Dangling resources
		may exist. The full state and error is shown below.
		
		Error: Error applying: 1 error(s) occurred:
		
		* aws_batch_compute_environment.test_environment (destroy): 1 error(s) occurred:
		
		* aws_batch_compute_environment.test_environment: : Cannot delete, found existing JobQueue relationship
			status code: 400, request id: ee0fa6e3-cad4-11e7-aca4-a9d44b405df0
		
		State: aws_batch_compute_environment.test_environment:
		  ID = tf_acctest_batch_compute_environment_1033370647477831815
		  arn = arn:aws:batch:ap-northeast-1:370106426606:compute-environment/tf_acctest_batch_compute_environment_1033370647477831815
		  compute_environment_name = tf_acctest_batch_compute_environment_1033370647477831815
		  compute_resources.# = 1
		  compute_resources.0.bid_percentage = 0
		  compute_resources.0.desired_vcpus = 0
		  compute_resources.0.ec2_key_pair = 
		  compute_resources.0.image_id = 
		  compute_resources.0.instance_role = arn:aws:iam::370106426606:role/aws_batch_service_role_1033370647477831815
		  compute_resources.0.instance_type.# = 1
		  compute_resources.0.instance_type.2541086584 = m3.medium
		  compute_resources.0.max_vcpus = 1
		  compute_resources.0.min_vcpus = 0
		  compute_resources.0.security_group_ids.# = 1
		  compute_resources.0.security_group_ids.3924548866 = sg-ae21cbd7
		  compute_resources.0.spot_iam_fleet_role = 
		  compute_resources.0.subnets.# = 1
		  compute_resources.0.subnets.1319152816 = subnet-3603807f
		  compute_resources.0.tags.% = 0
		  compute_resources.0.type = EC2
		  ecc_cluster_arn = arn:aws:ecs:ap-northeast-1:370106426606:cluster/tf_acctest_batch_compute_environment_1033370647477831815_Batch_ab5b424d-0038-3815-b94d-49651b71f094
		  ecs_cluster_arn = arn:aws:ecs:ap-northeast-1:370106426606:cluster/tf_acctest_batch_compute_environment_1033370647477831815_Batch_ab5b424d-0038-3815-b94d-49651b71f094
		  service_role = arn:aws:iam::370106426606:role/aws_batch_service_role_1033370647477831815
		  state = ENABLED
		  status = VALID
		  status_reason = ComputeEnvironment Healthy
		  type = MANAGED
		
		  Dependencies:
		    aws_iam_role.aws_batch_service_role
		    aws_iam_role_policy_attachment.aws_batch_service_role
		    aws_security_group.test_acc
		    aws_subnet.test_acc
		aws_iam_role.aws_batch_service_role:
		  ID = aws_batch_service_role_1033370647477831815
		  arn = arn:aws:iam::370106426606:role/aws_batch_service_role_1033370647477831815
		  assume_role_policy = {"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"batch.amazonaws.com"},"Action":"sts:AssumeRole"}]}
		  create_date = 2017-11-16T13:47:56Z
		  force_detach_policies = false
		  name = aws_batch_service_role_1033370647477831815
		  path = /
		  unique_id = AROAJGJHYNQFGXV2MMGCE
		aws_iam_role_policy_attachment.aws_batch_service_role:
		  ID = aws_batch_service_role_1033370647477831815-20171116134757940900000002
		  policy_arn = arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole
		  role = aws_batch_service_role_1033370647477831815
		
		  Dependencies:
		    aws_iam_role.aws_batch_service_role
		aws_security_group.test_acc:
		  ID = sg-ae21cbd7
		  description = Managed by Terraform
		  egress.# = 0
		  ingress.# = 0
		  name = aws_batch_compute_environment_security_group_1033370647477831815
		  owner_id = 370106426606
		  revoke_rules_on_delete = false
		  tags.% = 0
		  vpc_id = vpc-3fac305a
		aws_subnet.test_acc:
		  ID = subnet-3603807f
		  assign_ipv6_address_on_creation = false
		  availability_zone = ap-northeast-1a
		  cidr_block = 10.1.0.0/24
		  map_public_ip_on_launch = false
		  tags.% = 0
		  vpc_id = vpc-beef01d9
		
		  Dependencies:
		    aws_vpc.test_acc
		aws_vpc.test_acc:
		  ID = vpc-beef01d9
		  assign_generated_ipv6_cidr_block = false
		  cidr_block = 10.1.0.0/16
		  default_network_acl_id = acl-0ece4e69
		  default_route_table_id = rtb-729df915
		  default_security_group_id = sg-f525cf8c
		  dhcp_options_id = dopt-86b04ae3
		  enable_classiclink = false
		  enable_classiclink_dns_support = false
		  enable_dns_hostnames = false
		  enable_dns_support = true
		  instance_tenancy = default
		  main_route_table_id = rtb-729df915
		  tags.% = 0
=== RUN   TestAccAWSBatchJobQueue_update
--- FAIL: TestAccAWSBatchJobQueue_update (123.27s)
	testing.go:563: Error destroying resource! WARNING: Dangling resources
		may exist. The full state and error is shown below.
		
		Error: Error applying: 1 error(s) occurred:
		
		* aws_batch_compute_environment.test_environment (destroy): 1 error(s) occurred:
		
		* aws_batch_compute_environment.test_environment: : Cannot delete, found existing JobQueue relationship
			status code: 400, request id: 37849550-cad5-11e7-85d1-47361c7bf9e3
		
		State: aws_batch_compute_environment.test_environment:
		  ID = tf_acctest_batch_compute_environment_4513372076304742280
		  arn = arn:aws:batch:ap-northeast-1:370106426606:compute-environment/tf_acctest_batch_compute_environment_4513372076304742280
		  compute_environment_name = tf_acctest_batch_compute_environment_4513372076304742280
		  compute_resources.# = 1
		  compute_resources.0.bid_percentage = 0
		  compute_resources.0.desired_vcpus = 0
		  compute_resources.0.ec2_key_pair = 
		  compute_resources.0.image_id = 
		  compute_resources.0.instance_role = arn:aws:iam::370106426606:role/aws_batch_service_role_4513372076304742280
		  compute_resources.0.instance_type.# = 1
		  compute_resources.0.instance_type.2541086584 = m3.medium
		  compute_resources.0.max_vcpus = 1
		  compute_resources.0.min_vcpus = 0
		  compute_resources.0.security_group_ids.# = 1
		  compute_resources.0.security_group_ids.360563874 = sg-6924ce10
		  compute_resources.0.spot_iam_fleet_role = 
		  compute_resources.0.subnets.# = 1
		  compute_resources.0.subnets.3621679962 = subnet-c8038081
		  compute_resources.0.tags.% = 0
		  compute_resources.0.type = EC2
		  ecc_cluster_arn = arn:aws:ecs:ap-northeast-1:370106426606:cluster/tf_acctest_batch_compute_environment_4513372076304742280_Batch_0349cbca-9b7b-36c3-ba12-61dd0a5715b1
		  ecs_cluster_arn = arn:aws:ecs:ap-northeast-1:370106426606:cluster/tf_acctest_batch_compute_environment_4513372076304742280_Batch_0349cbca-9b7b-36c3-ba12-61dd0a5715b1
		  service_role = arn:aws:iam::370106426606:role/aws_batch_service_role_4513372076304742280
		  state = ENABLED
		  status = VALID
		  status_reason = ComputeEnvironment Healthy
		  type = MANAGED
		
		  Dependencies:
		    aws_iam_role.aws_batch_service_role
		    aws_iam_role_policy_attachment.aws_batch_service_role
		    aws_security_group.test_acc
		    aws_subnet.test_acc
		aws_iam_role.aws_batch_service_role:
		  ID = aws_batch_service_role_4513372076304742280
		  arn = arn:aws:iam::370106426606:role/aws_batch_service_role_4513372076304742280
		  assume_role_policy = {"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"batch.amazonaws.com"},"Action":"sts:AssumeRole"}]}
		  create_date = 2017-11-16T13:49:21Z
		  force_detach_policies = false
		  name = aws_batch_service_role_4513372076304742280
		  path = /
		  unique_id = AROAJQCWO6OSYXTPBR4Q2
		aws_iam_role_policy_attachment.aws_batch_service_role:
		  ID = aws_batch_service_role_4513372076304742280-20171116134922814500000003
		  policy_arn = arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole
		  role = aws_batch_service_role_4513372076304742280
		
		  Dependencies:
		    aws_iam_role.aws_batch_service_role
		aws_security_group.test_acc:
		  ID = sg-6924ce10
		  description = Managed by Terraform
		  egress.# = 0
		  ingress.# = 0
		  name = aws_batch_compute_environment_security_group_4513372076304742280
		  owner_id = 370106426606
		  revoke_rules_on_delete = false
		  tags.% = 0
		  vpc_id = vpc-3fac305a
		aws_subnet.test_acc:
		  ID = subnet-c8038081
		  assign_ipv6_address_on_creation = false
		  availability_zone = ap-northeast-1a
		  cidr_block = 10.1.0.0/24
		  map_public_ip_on_launch = false
		  tags.% = 0
		  vpc_id = vpc-54917f33
		
		  Dependencies:
		    aws_vpc.test_acc
		aws_vpc.test_acc:
		  ID = vpc-54917f33
		  assign_generated_ipv6_cidr_block = false
		  cidr_block = 10.1.0.0/16
		  default_network_acl_id = acl-30cd4d57
		  default_route_table_id = rtb-d093f7b7
		  default_security_group_id = sg-5121cb28
		  dhcp_options_id = dopt-86b04ae3
		  enable_classiclink = false
		  enable_classiclink_dns_support = false
		  enable_dns_hostnames = false
		  enable_dns_support = true
		  instance_tenancy = default
		  main_route_table_id = rtb-d093f7b7
		  tags.% = 0
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	213.525s
```

## Tests after fix bug
```
$ make testacc TESTARGS='-run=TestAccAWSBatchJobQueue'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccAWSBatchJobQueue -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSBatchJobQueue_basic
--- PASS: TestAccAWSBatchJobQueue_basic (161.33s)
=== RUN   TestAccAWSBatchJobQueue_update
--- PASS: TestAccAWSBatchJobQueue_update (182.71s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	344.059s
```