### PR TITLE
update docs - lb_target_group matcher no longer optional

### DIFF
--- a/website/docs/r/lb_target_group.html.markdown
+++ b/website/docs/r/lb_target_group.html.markdown
@@ -62,7 +62,7 @@ Health Check Blocks (`health_check`) support the following:
 * `timeout` - (Optional) The amount of time, in seconds, during which no response means a failed health check. Defaults to 5 seconds.
 * `healthy_threshold` - (Optional) The number of consecutive health checks successes required before considering an unhealthy target healthy. Defaults to 5.
 * `unhealthy_threshold` - (Optional) The number of consecutive health check failures required before considering the target unhealthy. Defaults to 2.
-* `matcher` (Optional) The HTTP codes to use when checking for a successful response from a target. Defaults to `200`. You can specify multiple values (for example, "200,202") or a range of values (for example, "200-299").
+* `matcher` The HTTP codes to use when checking for a successful response from a target. Defaults to `200`. You can specify multiple values (for example, "200,202") or a range of values (for example, "200-299").
 
 ## Attributes Reference
 


### PR DESCRIPTION
the `matcher` attribute on `lb_target_group` is no longer optional.
This change happened today and broke my deployment 👎 