### PR TITLE
resource/aws_rds_cluster_instance: Support Performance Insights

### DIFF
--- a/aws/resource_aws_rds_cluster_instance.go
+++ b/aws/resource_aws_rds_cluster_instance.go
@@ -237,7 +237,7 @@ func resourceAwsRDSClusterInstanceCreate(d *schema.ResourceData, meta interface{
 		createOpts.MonitoringRoleArn = aws.String(attr.(string))
 	}
 
-	if attr, _ := d.GetOk("engine"); attr == "aurora-postgresl" {
+	if attr, _ := d.GetOk("engine"); attr == "aurora-postgresql" {
 		if attr, ok := d.GetOk("enabled_performance_insights"); ok {
 			createOpts.EnablePerformanceInsights = aws.Bool(attr.(bool))
 		}

--- a/aws/resource_aws_rds_cluster_instance.go
+++ b/aws/resource_aws_rds_cluster_instance.go
@@ -237,12 +237,14 @@ func resourceAwsRDSClusterInstanceCreate(d *schema.ResourceData, meta interface{
 		createOpts.MonitoringRoleArn = aws.String(attr.(string))
 	}
 
-	if attr, ok := d.GetOk("enabled_performance_insights"); ok {
-		createOpts.EnablePerformanceInsights = aws.Bool(attr.(bool))
-	}
+	if attr, _ := d.GetOk("engine"); attr == "aurora-postgresl" {
+		if attr, ok := d.GetOk("enabled_performance_insights"); ok {
+			createOpts.EnablePerformanceInsights = aws.Bool(attr.(bool))
+		}
 
-	if attr, ok := d.GetOk("performance_insights_kms_key_id"); ok {
-		createOpts.PerformanceInsightsKMSKeyId = aws.String(attr.(string))
+		if attr, ok := d.GetOk("performance_insights_kms_key_id"); ok {
+			createOpts.PerformanceInsightsKMSKeyId = aws.String(attr.(string))
+		}
 	}
 
 	if attr, ok := d.GetOk("preferred_backup_window"); ok {

--- a/aws/resource_aws_rds_cluster_instance.go
+++ b/aws/resource_aws_rds_cluster_instance.go
@@ -179,7 +179,7 @@ func resourceAwsRDSClusterInstance() *schema.Resource {
 				Computed: true,
 			},
 
-			"enabled_performance_insights": {
+			"performance_insights_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Computed: true,
@@ -238,7 +238,7 @@ func resourceAwsRDSClusterInstanceCreate(d *schema.ResourceData, meta interface{
 	}
 
 	if attr, _ := d.GetOk("engine"); attr == "aurora-postgresql" {
-		if attr, ok := d.GetOk("enabled_performance_insights"); ok {
+		if attr, ok := d.GetOk("performance_insights_enabled"); ok {
 			createOpts.EnablePerformanceInsights = aws.Bool(attr.(bool))
 		}
 
@@ -349,7 +349,7 @@ func resourceAwsRDSClusterInstanceRead(d *schema.ResourceData, meta interface{})
 	d.Set("preferred_backup_window", db.PreferredBackupWindow)
 	d.Set("preferred_maintenance_window", db.PreferredMaintenanceWindow)
 	d.Set("availability_zone", db.AvailabilityZone)
-	d.Set("enabled_performance_insights", db.PerformanceInsightsEnabled)
+	d.Set("performance_insights_enabled", db.PerformanceInsightsEnabled)
 	d.Set("performance_insights_kms_key_id", db.PerformanceInsightsKMSKeyId)
 
 	if db.MonitoringInterval != nil {
@@ -402,9 +402,9 @@ func resourceAwsRDSClusterInstanceUpdate(d *schema.ResourceData, meta interface{
 		requestUpdate = true
 	}
 
-	if d.HasChange("enabled_performance_insights") {
-		d.SetPartial("enabled_performance_insights")
-		req.EnablePerformanceInsights = aws.Bool(d.Get("enabled_performance_insights").(bool))
+	if d.HasChange("performance_insights_enabled") {
+		d.SetPartial("performance_insights_enabled")
+		req.EnablePerformanceInsights = aws.Bool(d.Get("performance_insights_enabled").(bool))
 		requestUpdate = true
 	}
 

--- a/aws/resource_aws_rds_cluster_instance.go
+++ b/aws/resource_aws_rds_cluster_instance.go
@@ -179,6 +179,19 @@ func resourceAwsRDSClusterInstance() *schema.Resource {
 				Computed: true,
 			},
 
+			"enabled_performance_insights": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+
+			"performance_insights_kms_key_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validateArn,
+			},
+
 			"tags": tagsSchema(),
 		},
 	}
@@ -222,6 +235,14 @@ func resourceAwsRDSClusterInstanceCreate(d *schema.ResourceData, meta interface{
 
 	if attr, ok := d.GetOk("monitoring_role_arn"); ok {
 		createOpts.MonitoringRoleArn = aws.String(attr.(string))
+	}
+
+	if attr, ok := d.GetOk("enabled_performance_insights"); ok {
+		createOpts.EnablePerformanceInsights = aws.Bool(attr.(bool))
+	}
+
+	if attr, ok := d.GetOk("performance_insights_kms_key_id"); ok {
+		createOpts.PerformanceInsightsKMSKeyId = aws.String(attr.(string))
 	}
 
 	if attr, ok := d.GetOk("preferred_backup_window"); ok {
@@ -326,6 +347,8 @@ func resourceAwsRDSClusterInstanceRead(d *schema.ResourceData, meta interface{})
 	d.Set("preferred_backup_window", db.PreferredBackupWindow)
 	d.Set("preferred_maintenance_window", db.PreferredMaintenanceWindow)
 	d.Set("availability_zone", db.AvailabilityZone)
+	d.Set("enabled_performance_insights", db.PerformanceInsightsEnabled)
+	d.Set("performance_insights_kms_key_id", db.PerformanceInsightsKMSKeyId)
 
 	if db.MonitoringInterval != nil {
 		d.Set("monitoring_interval", db.MonitoringInterval)
@@ -374,6 +397,18 @@ func resourceAwsRDSClusterInstanceUpdate(d *schema.ResourceData, meta interface{
 	if d.HasChange("monitoring_role_arn") {
 		d.SetPartial("monitoring_role_arn")
 		req.MonitoringRoleArn = aws.String(d.Get("monitoring_role_arn").(string))
+		requestUpdate = true
+	}
+
+	if d.HasChange("enabled_performance_insights") {
+		d.SetPartial("enabled_performance_insights")
+		req.EnablePerformanceInsights = aws.Bool(d.Get("enabled_performance_insights").(bool))
+		requestUpdate = true
+	}
+
+	if d.HasChange("performance_insights_kms_key_id") {
+		d.SetPartial("performance_insights_kms_key_id")
+		req.PerformanceInsightsKMSKeyId = aws.String(d.Get("performance_insights_kms_key_id").(string))
 		requestUpdate = true
 	}
 

--- a/aws/resource_aws_rds_cluster_instance_test.go
+++ b/aws/resource_aws_rds_cluster_instance_test.go
@@ -138,8 +138,8 @@ func TestAccAWSRDSClusterInstance_disappears(t *testing.T) {
 func testAccCheckAWSDBClusterInstanceAttributes(v *rds.DBInstance) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		if *v.Engine != "aurora" {
-			return fmt.Errorf("bad engine, expected \"aurora\": %#v", *v.Engine)
+		if *v.Engine != "aurora" || *v.Engine != "aurora-postgresl" {
+			return fmt.Errorf("bad engine, expected \"aurora\" or \"aurora-postgresl\": %#v", *v.Engine)
 		}
 
 		if !strings.HasPrefix(*v.DBClusterIdentifier, "tf-aurora-cluster") {

--- a/aws/resource_aws_rds_cluster_instance_test.go
+++ b/aws/resource_aws_rds_cluster_instance_test.go
@@ -566,6 +566,7 @@ resource "aws_rds_cluster" "default" {
 }
 
 resource "aws_rds_cluster_instance" "cluster_instances" {
+  engine                  = "aurora-postgresql"
   identifier              = "tf-cluster-instance-%d"
   cluster_identifier      = "${aws_rds_cluster.default.id}"
   instance_class          = "db.r3.large"

--- a/aws/resource_aws_rds_cluster_instance_test.go
+++ b/aws/resource_aws_rds_cluster_instance_test.go
@@ -228,6 +228,30 @@ func TestAccAWSRDSClusterInstance_withInstanceEnhancedMonitor(t *testing.T) {
 	})
 }
 
+func TestAccAWSRDSClusterInstance_withInstancePerformanceInsights(t *testing.T) {
+	var v rds.DBInstance
+	keyRegex := regexp.MustCompile("^arn:aws:kms:")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSClusterInstancePerformanceInsights(acctest.RandInt()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSClusterInstanceExists("aws_rds_cluster_instance.cluster_instances", &v),
+					testAccCheckAWSDBClusterInstanceAttributes(&v),
+					resource.TestCheckResourceAttr(
+						"aws_rds_cluster_instance.cluster_instances", "enabled_performance_insights", "true"),
+					resource.TestMatchResourceAttr(
+						"aws_rds_cluster_instance.cluster_instances", "performance_insights_kms_key_id", keyRegex),
+				),
+			},
+		},
+	})
+}
+
 // Add some random to the name, to avoid collision
 func testAccAWSClusterInstanceConfig(n int) string {
 	return fmt.Sprintf(`
@@ -487,6 +511,66 @@ resource "aws_iam_policy_attachment" "rds_m_attach" {
     name = "AmazonRDSEnhancedMonitoringRole"
     roles = ["${aws_iam_role.tf_enhanced_monitor_role.name}"]
     policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
+}
+
+resource "aws_db_parameter_group" "bar" {
+  name   = "tfcluster-test-group-%d"
+  family = "aurora5.6"
+
+  parameter {
+    name         = "back_log"
+    value        = "32767"
+    apply_method = "pending-reboot"
+  }
+
+  tags {
+    foo = "bar"
+  }
+}
+`, n, n, n, n)
+}
+
+func testAccAWSClusterInstancePerformanceInsights(n int) string {
+	return fmt.Sprintf(`
+
+resource "aws_kms_key" "foo" {
+    description = "Terraform acc test %d"
+    policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Id": "kms-tf-1",
+  "Statement": [
+    {
+      "Sid": "Enable IAM User Permissions",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "kms:*",
+      "Resource": "*"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_rds_cluster" "default" {
+  cluster_identifier = "tf-aurora-cluster-test-%d"
+  availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  database_name      = "mydb"
+  master_username    = "foo"
+  master_password    = "mustbeeightcharaters"
+  storage_encrypted = true
+  skip_final_snapshot = true
+}
+
+resource "aws_rds_cluster_instance" "cluster_instances" {
+  identifier              = "tf-cluster-instance-%d"
+  cluster_identifier      = "${aws_rds_cluster.default.id}"
+  instance_class          = "db.r3.large"
+  db_parameter_group_name = "${aws_db_parameter_group.bar.name}"
+  enabled_performance_insights = true
+  performance_insights_kms_key_id = "${aws_kms_key.foo.arn}"
 }
 
 resource "aws_db_parameter_group" "bar" {

--- a/aws/resource_aws_rds_cluster_instance_test.go
+++ b/aws/resource_aws_rds_cluster_instance_test.go
@@ -569,7 +569,7 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
   engine                  = "aurora-postgresql"
   identifier              = "tf-cluster-instance-%d"
   cluster_identifier      = "${aws_rds_cluster.default.id}"
-  instance_class          = "db.r3.large"
+  instance_class          = "db.r4.large"
   db_parameter_group_name = "${aws_db_parameter_group.bar.name}"
   enabled_performance_insights = true
   performance_insights_kms_key_id = "${aws_kms_key.foo.arn}"

--- a/aws/resource_aws_rds_cluster_instance_test.go
+++ b/aws/resource_aws_rds_cluster_instance_test.go
@@ -138,8 +138,8 @@ func TestAccAWSRDSClusterInstance_disappears(t *testing.T) {
 func testAccCheckAWSDBClusterInstanceAttributes(v *rds.DBInstance) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		if *v.Engine != "aurora" || *v.Engine != "aurora-postgresl" {
-			return fmt.Errorf("bad engine, expected \"aurora\" or \"aurora-postgresl\": %#v", *v.Engine)
+		if *v.Engine != "aurora" || *v.Engine != "aurora-postgresql" {
+			return fmt.Errorf("bad engine, expected \"aurora\" or \"aurora-postgresql\": %#v", *v.Engine)
 		}
 
 		if !strings.HasPrefix(*v.DBClusterIdentifier, "tf-aurora-cluster") {

--- a/aws/resource_aws_rds_cluster_instance_test.go
+++ b/aws/resource_aws_rds_cluster_instance_test.go
@@ -555,6 +555,7 @@ POLICY
 }
 
 resource "aws_rds_cluster" "default" {
+  engine             = "aurora-postgresql"
   cluster_identifier = "tf-aurora-cluster-test-%d"
   availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
   database_name      = "mydb"

--- a/aws/resource_aws_rds_cluster_instance_test.go
+++ b/aws/resource_aws_rds_cluster_instance_test.go
@@ -243,7 +243,7 @@ func TestAccAWSRDSClusterInstance_withInstancePerformanceInsights(t *testing.T) 
 					testAccCheckAWSClusterInstanceExists("aws_rds_cluster_instance.cluster_instances", &v),
 					testAccCheckAWSDBClusterInstanceAttributes(&v),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_instance.cluster_instances", "enabled_performance_insights", "true"),
+						"aws_rds_cluster_instance.cluster_instances", "performance_insights_enabled", "true"),
 					resource.TestMatchResourceAttr(
 						"aws_rds_cluster_instance.cluster_instances", "performance_insights_kms_key_id", keyRegex),
 				),
@@ -571,7 +571,7 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
   cluster_identifier      = "${aws_rds_cluster.default.id}"
   instance_class          = "db.r4.large"
   db_parameter_group_name = "${aws_db_parameter_group.bar.name}"
-  enabled_performance_insights = true
+  performance_insights_enabled = true
   performance_insights_kms_key_id = "${aws_kms_key.foo.arn}"
 }
 

--- a/aws/resource_aws_rds_cluster_instance_test.go
+++ b/aws/resource_aws_rds_cluster_instance_test.go
@@ -577,12 +577,11 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
 
 resource "aws_db_parameter_group" "bar" {
   name   = "tfcluster-test-group-%d"
-  family = "aurora5.6"
+  family = "aurora-postgresql9.6"
 
   parameter {
-    name         = "back_log"
-    value        = "32767"
-    apply_method = "pending-reboot"
+    name  = "authentication_timeout"
+    value = "10"
   }
 
   tags {

--- a/aws/resource_aws_rds_cluster_instance_test.go
+++ b/aws/resource_aws_rds_cluster_instance_test.go
@@ -138,7 +138,7 @@ func TestAccAWSRDSClusterInstance_disappears(t *testing.T) {
 func testAccCheckAWSDBClusterInstanceAttributes(v *rds.DBInstance) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		if *v.Engine != "aurora" || *v.Engine != "aurora-postgresql" {
+		if *v.Engine != "aurora" && *v.Engine != "aurora-postgresql" {
 			return fmt.Errorf("bad engine, expected \"aurora\" or \"aurora-postgresql\": %#v", *v.Engine)
 		}
 

--- a/website/docs/r/rds_cluster_instance.html.markdown
+++ b/website/docs/r/rds_cluster_instance.html.markdown
@@ -79,6 +79,8 @@ what IAM permissions are needed to allow Enhanced Monitoring for RDS Instances.
 * `preferred_maintenance_window` - (Optional) The window to perform maintenance in.
   Syntax: "ddd:hh24:mi-ddd:hh24:mi". Eg: "Mon:00:00-Mon:03:00".
 * `auto_minor_version_upgrade` - (Optional) Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window. Default `true`.
+* `enabled_performance_insights` - (Optional) Specifies whether Performance Insights is enabled or not.
+* `performance_insights_kms_key_id` - (Optional) The ARN for the KMS key to encrypt Performance Insights data. When specifying `performance_insights_kms_key_id`, `enabled_performance_insights` needs to be set to true.
 * `tags` - (Optional) A mapping of tags to assign to the instance.
 
 ## Attributes Reference
@@ -101,6 +103,8 @@ this instance is a read replica
 * `storage_encrypted` - Specifies whether the DB cluster is encrypted.
 * `kms_key_id` - The ARN for the KMS encryption key if one is set to the cluster.
 * `dbi_resource_id` - The region-unique, immutable identifier for the DB instance.
+* `enabled_performance_insights` - Specifies whether Performance Insights is enabled or not.
+* `performance_insights_kms_key_id` - The ARN for the KMS encryption key used by Performance Insights.
 
 [2]: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html
 [3]: /docs/providers/aws/r/rds_cluster.html

--- a/website/docs/r/rds_cluster_instance.html.markdown
+++ b/website/docs/r/rds_cluster_instance.html.markdown
@@ -79,8 +79,8 @@ what IAM permissions are needed to allow Enhanced Monitoring for RDS Instances.
 * `preferred_maintenance_window` - (Optional) The window to perform maintenance in.
   Syntax: "ddd:hh24:mi-ddd:hh24:mi". Eg: "Mon:00:00-Mon:03:00".
 * `auto_minor_version_upgrade` - (Optional) Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window. Default `true`.
-* `enabled_performance_insights` - (Optional) Specifies whether Performance Insights is enabled or not.
-* `performance_insights_kms_key_id` - (Optional) The ARN for the KMS key to encrypt Performance Insights data. When specifying `performance_insights_kms_key_id`, `enabled_performance_insights` needs to be set to true.
+* `performance_insights_enabled` - (Optional) Specifies whether Performance Insights is enabled or not.
+* `performance_insights_kms_key_id` - (Optional) The ARN for the KMS key to encrypt Performance Insights data. When specifying `performance_insights_kms_key_id`, `performance_insights_enabled` needs to be set to true.
 * `tags` - (Optional) A mapping of tags to assign to the instance.
 
 ## Attributes Reference
@@ -103,7 +103,7 @@ this instance is a read replica
 * `storage_encrypted` - Specifies whether the DB cluster is encrypted.
 * `kms_key_id` - The ARN for the KMS encryption key if one is set to the cluster.
 * `dbi_resource_id` - The region-unique, immutable identifier for the DB instance.
-* `enabled_performance_insights` - Specifies whether Performance Insights is enabled or not.
+* `performance_insights_enabled` - Specifies whether Performance Insights is enabled or not.
 * `performance_insights_kms_key_id` - The ARN for the KMS encryption key used by Performance Insights.
 
 [2]: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html


### PR DESCRIPTION
## Support Performance Insights for rds_cluster_instance

Fixes: https://github.com/terraform-providers/terraform-provider-aws/issues/2198

```
$ go test -run=TestAccAWSRDSClusterInstance_withInstancePerformanceInsights -timeout=30s -parallel=4 ./aws
ok  	github.com/terraform-providers/terraform-provider-aws/aws	0.056s
```