### PR TITLE
New Resource: aws_cloudwatch_log_resource_policy

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -279,6 +279,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_cloudwatch_log_destination_policy":        resourceAwsCloudWatchLogDestinationPolicy(),
 			"aws_cloudwatch_log_group":                     resourceAwsCloudWatchLogGroup(),
 			"aws_cloudwatch_log_metric_filter":             resourceAwsCloudWatchLogMetricFilter(),
+			"aws_cloudwatch_log_resource_policy":           resourceAwsCloudWatchLogResourcePolicy(),
 			"aws_cloudwatch_log_stream":                    resourceAwsCloudWatchLogStream(),
 			"aws_cloudwatch_log_subscription_filter":       resourceAwsCloudwatchLogSubscriptionFilter(),
 			"aws_config_config_rule":                       resourceAwsConfigConfigRule(),

--- a/aws/resource_aws_cloudwatch_log_resource_policy.go
+++ b/aws/resource_aws_cloudwatch_log_resource_policy.go
@@ -1,0 +1,121 @@
+package aws
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+)
+
+func resourceAwsCloudWatchLogResourcePolicy() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsCloudWatchLogResourcePolicyPut,
+		Update: resourceAwsCloudWatchLogResourcePolicyPut,
+		Read:   resourceAwsCloudWatchLogResourcePolicyRead,
+		Delete: resourceAwsCloudWatchLogResourcePolicyDelete,
+
+		Schema: map[string]*schema.Schema{
+			"policy_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"policy_document": &schema.Schema{
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateFunc:     validateJsonString,
+				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
+			},
+		},
+	}
+}
+
+func resourceAwsCloudWatchLogResourcePolicyPut(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudwatchlogsconn
+
+	input := &cloudwatchlogs.PutResourcePolicyInput{}
+
+	if v, ok := d.GetOk("policy_name"); ok {
+		input.PolicyName = aws.String(v.(string))
+	}
+	if v, ok := d.GetOk("policy_document"); ok {
+		input.PolicyDocument = aws.String(v.(string))
+	}
+
+	resp, err := conn.PutResourcePolicy(input)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(*resp.ResourcePolicy.PolicyName)
+	return resourceAwsCloudWatchLogResourcePolicyRead(d, meta)
+}
+
+func resourceAwsCloudWatchLogResourcePolicyRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudwatchlogsconn
+
+	resourcePolicy, exists, err := lookupCloudWatchLogResourcePolicy(conn, d.Id(), nil)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		d.SetId("")
+		return nil
+	}
+
+	if resourcePolicy.PolicyDocument != nil {
+		d.Set("policy_document", resourcePolicy.PolicyDocument)
+	}
+
+	return nil
+}
+
+func resourceAwsCloudWatchLogResourcePolicyDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudwatchlogsconn
+
+	input := &cloudwatchlogs.DeleteResourcePolicyInput{
+		PolicyName: aws.String(d.Id()),
+	}
+
+	_, err := conn.DeleteResourcePolicy(input)
+
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case cloudwatchlogs.ErrCodeResourceNotFoundException:
+				d.SetId("")
+				return nil
+			default:
+				return err
+			}
+		}
+		return err
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func lookupCloudWatchLogResourcePolicy(conn *cloudwatchlogs.CloudWatchLogs, name string, nextToken *string) (*cloudwatchlogs.ResourcePolicy, bool, error) {
+	input := &cloudwatchlogs.DescribeResourcePoliciesInput{
+		NextToken: nextToken,
+	}
+
+	resp, err := conn.DescribeResourcePolicies(input)
+	if err != nil {
+		return nil, true, err
+	}
+
+	for _, resourcePolicy := range resp.ResourcePolicies {
+		if *resourcePolicy.PolicyName == name {
+			return resourcePolicy, true, nil
+		}
+	}
+
+	if resp.NextToken != nil {
+		return lookupCloudWatchLogResourcePolicy(conn, name, resp.NextToken)
+	}
+
+	return nil, false, nil
+}

--- a/aws/resource_aws_cloudwatch_log_resource_policy_test.go
+++ b/aws/resource_aws_cloudwatch_log_resource_policy_test.go
@@ -1,0 +1,88 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAwsCloudwatchLogResourcePolicy_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsCloudwatchLogResourcePolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsCloudwatchLogResourcePolicyConfig(acctest.RandString(5)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsCloudwatchLogResourcePolicyExists("aws_cloudwatch_log_resource_policy.test"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsCloudwatchLogResourcePolicyDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).cloudwatchlogsconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_cloudwatch_log_resource_policy" {
+			continue
+		}
+		_, exists, err := lookupCloudWatchLogResourcePolicy(conn, rs.Primary.ID, nil)
+		if err != nil {
+			return nil
+		}
+
+		if exists {
+			return fmt.Errorf("Cloudwatch Logs Resource Policy still exists: %s", rs.Primary.ID)
+		}
+	}
+
+	return nil
+
+}
+
+func testAccCheckAwsCloudwatchLogResourcePolicyExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		return nil
+	}
+}
+
+func testAccAwsCloudwatchLogResourcePolicyConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_log_group" "test" {
+  name = "tf-cwl-%s"
+}
+
+resource "aws_cloudwatch_log_resource_policy" "test" {
+  policy_name = "tf-cwl-rp-%s"
+  policy_document = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+  {
+    "Sid": "Route53LogsToCloudWatchLogs",
+    "Effect": "Allow",
+    "Principal": {
+      "Service": [
+      "route53.amazonaws.com"
+      ]
+    },
+    "Action": "logs:PutLogEvents",
+    "Resource": "${aws_cloudwatch_log_group.test.arn}"
+  }
+  ]
+}
+POLICY
+}
+`, rName, rName)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -390,6 +390,10 @@
                             <a href="/docs/providers/aws/r/cloudwatch_log_metric_filter.html">aws_cloudwatch_log_metric_filter</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-cloudwatch-log-resource-policy") %>>
+                            <a href="/docs/providers/aws/r/cloudwatch_log_resource_policy.html">aws_cloudwatch_log_resource_policy</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-aws-resource-cloudwatch-log-stream") %>>
                             <a href="/docs/providers/aws/r/cloudwatch_log_stream.html">aws_cloudwatch_log_stream</a>
                         </li>

--- a/website/docs/r/cloudwatch_log_resource_policy.html.markdown
+++ b/website/docs/r/cloudwatch_log_resource_policy.html.markdown
@@ -1,0 +1,48 @@
+---
+layout: "aws"
+page_title: "AWS: aws_cloudwatch_log_resource_policy"
+sidebar_current: "docs-aws-resource-cloudwatch-log-resource-policy"
+description: |-
+  Provides a CloudWatch Logs Resource Policy.
+---
+
+# aws_cloudwatch_log_resource_policy
+
+Provides a CloudWatch Logs Resource Policy resource.
+
+## Example Usage
+
+```hcl
+resource "aws_cloudwatch_log_group" "example" {
+  name = "example"
+}
+
+resource "aws_cloudwatch_log_resource_policy" "example" {
+  policy_name = "example"
+  policy_document = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Route53LogsToCloudWatchLogs",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "route53.amazonaws.com"
+        ]
+      },
+      "Action": "logs:PutLogEvents",
+      "Resource": "${aws_cloudwatch_log_group.example.arn}"
+    }
+  ]
+}
+EOF
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `policy_name` - (Optional) Name of the policy.
+* `policy_document` - (Optional) The policy document. This is a JSON formatted string.


### PR DESCRIPTION
```
make testacc TEST=./aws TESTARGS='-run=TestAccAwsCloudwatchLogResourcePolicy_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAwsCloudwatchLogResourcePolicy_basic -timeout 120m
=== RUN   TestAccAwsCloudwatchLogResourcePolicy_basic
--- PASS: TestAccAwsCloudwatchLogResourcePolicy_basic (37.95s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	37.995s
```