### PR TITLE
r/ecs_task_definition: Fix equivalency comparator

### DIFF
--- a/aws/ecs_task_definition_equivalency.go
+++ b/aws/ecs_task_definition_equivalency.go
@@ -43,9 +43,12 @@ func ecsContainerDefinitionsAreEquivalent(def1, def2 string) (bool, error) {
 		return false, err
 	}
 
-	log.Printf("[DEBUG] Comparing canonical definitions,\nFirst: %s\nSecond: %s\n",
-		canonicalJson1, canonicalJson2)
-	return bytes.Compare(canonicalJson1, canonicalJson2) == 0, nil
+	equal := bytes.Compare(canonicalJson1, canonicalJson2) == 0
+	if !equal {
+		log.Printf("[DEBUG] Canonical definitions are not equal.\nFirst: %s\nSecond: %s\n",
+			canonicalJson1, canonicalJson2)
+	}
+	return equal, nil
 }
 
 type containerDefinitions []*ecs.ContainerDefinition

--- a/aws/ecs_task_definition_equivalency_test.go
+++ b/aws/ecs_task_definition_equivalency_test.go
@@ -134,6 +134,259 @@ func TestAwsEcsContainerDefinitionsAreEquivalent_portMappings(t *testing.T) {
 	}
 }
 
+func TestAwsEcsContainerDefinitionsAreEquivalent_arrays(t *testing.T) {
+	cfgRepresention := `
+[
+    {
+      "name": "wordpress",
+      "image": "wordpress",
+      "essential": true,
+      "links": ["container1", "container2", "container3"],
+      "portMappings": [
+        {"containerPort": 80},
+        {"containerPort": 81},
+        {"containerPort": 82}
+      ],
+      "environment": [
+        {"name": "VARNAME1", "value": "VARVAL1"},
+        {"name": "VARNAME2", "value": "VARVAL2"},
+        {"name": "VARNAME3", "value": "VARVAL3"}
+      ],
+      "extraHosts": [
+        {"hostname": "host1", "ipAddress": "127.0.0.1"},
+        {"hostname": "host2", "ipAddress": "127.0.0.2"},
+        {"hostname": "host3", "ipAddress": "127.0.0.3"}
+      ],
+      "mountPoints": [
+        {"sourceVolume": "vol1", "containerPath": "/vol1"},
+        {"sourceVolume": "vol2", "containerPath": "/vol2"},
+        {"sourceVolume": "vol3", "containerPath": "/vol3"}
+      ],
+      "volumesFrom": [
+        {"sourceContainer": "container1"},
+        {"sourceContainer": "container2"},
+        {"sourceContainer": "container3"}
+      ],
+      "ulimits": [
+        {
+          "name": "core",
+          "softLimit": 10, "hardLimit": 20
+        },
+        {
+          "name": "cpu",
+          "softLimit": 10, "hardLimit": 20
+        },
+        {
+          "name": "fsize",
+          "softLimit": 10, "hardLimit": 20
+        }
+      ],
+      "linuxParameters": {
+        "capabilities": {
+          "add": ["AUDIT_CONTROL", "AUDIT_WRITE", "BLOCK_SUSPEND"],
+          "drop": ["CHOWN", "IPC_LOCK", "KILL"]
+        }
+      },
+      "devices": [
+        {
+          "hostPath": "/path1",
+          "permissions": ["read", "write", "mknod"]
+        },
+        {
+          "hostPath": "/path2",
+          "permissions": ["read", "write"]
+        },
+        {
+          "hostPath": "/path3",
+          "permissions": ["read", "mknod"]
+        }
+      ],
+      "dockerSecurityOptions": ["label:one", "label:two", "label:three"],
+      "memory": 500,
+      "cpu": 10
+    },
+    {
+      "name": "container1",
+      "image": "busybox",
+      "memory": 100
+    },
+    {
+      "name": "container2",
+      "image": "busybox",
+      "memory": 100
+    },
+    {
+      "name": "container3",
+      "image": "busybox",
+      "memory": 100
+    }
+]`
+
+	apiRepresentation := `
+[
+  {
+    "cpu": 10,
+    "dockerSecurityOptions": [
+      "label:one",
+      "label:two",
+      "label:three"
+    ],
+    "environment": [
+      {
+        "name": "VARNAME3",
+        "value": "VARVAL3"
+      },
+      {
+        "name": "VARNAME2",
+        "value": "VARVAL2"
+      },
+      {
+        "name": "VARNAME1",
+        "value": "VARVAL1"
+      }
+    ],
+    "essential": true,
+    "extraHosts": [
+      {
+        "hostname": "host1",
+        "ipAddress": "127.0.0.1"
+      },
+      {
+        "hostname": "host2",
+        "ipAddress": "127.0.0.2"
+      },
+      {
+        "hostname": "host3",
+        "ipAddress": "127.0.0.3"
+      }
+    ],
+    "image": "wordpress",
+    "links": [
+      "container1",
+      "container2",
+      "container3"
+    ],
+    "linuxParameters": {
+      "capabilities": {
+        "add": [
+          "AUDIT_CONTROL",
+          "AUDIT_WRITE",
+          "BLOCK_SUSPEND"
+        ],
+        "drop": [
+          "CHOWN",
+          "IPC_LOCK",
+          "KILL"
+        ]
+      }
+    },
+    "memory": 500,
+    "mountPoints": [
+      {
+        "containerPath": "/vol1",
+        "sourceVolume": "vol1"
+      },
+      {
+        "containerPath": "/vol2",
+        "sourceVolume": "vol2"
+      },
+      {
+        "containerPath": "/vol3",
+        "sourceVolume": "vol3"
+      }
+    ],
+    "name": "wordpress",
+    "portMappings": [
+      {
+        "containerPort": 80,
+        "hostPort": 0,
+        "protocol": "tcp"
+      },
+      {
+        "containerPort": 81,
+        "hostPort": 0,
+        "protocol": "tcp"
+      },
+      {
+        "containerPort": 82,
+        "hostPort": 0,
+        "protocol": "tcp"
+      }
+    ],
+    "ulimits": [
+      {
+        "hardLimit": 20,
+        "name": "core",
+        "softLimit": 10
+      },
+      {
+        "hardLimit": 20,
+        "name": "cpu",
+        "softLimit": 10
+      },
+      {
+        "hardLimit": 20,
+        "name": "fsize",
+        "softLimit": 10
+      }
+    ],
+    "volumesFrom": [
+      {
+        "sourceContainer": "container1"
+      },
+      {
+        "sourceContainer": "container2"
+      },
+      {
+        "sourceContainer": "container3"
+      }
+    ]
+  },
+  {
+    "cpu": 0,
+    "environment": [],
+    "essential": true,
+    "image": "busybox",
+    "memory": 100,
+    "mountPoints": [],
+    "name": "container1",
+    "portMappings": [],
+    "volumesFrom": []
+  },
+  {
+    "cpu": 0,
+    "environment": [],
+    "essential": true,
+    "image": "busybox",
+    "memory": 100,
+    "mountPoints": [],
+    "name": "container2",
+    "portMappings": [],
+    "volumesFrom": []
+  },
+  {
+    "cpu": 0,
+    "environment": [],
+    "essential": true,
+    "image": "busybox",
+    "memory": 100,
+    "mountPoints": [],
+    "name": "container3",
+    "portMappings": [],
+    "volumesFrom": []
+  }
+]
+`
+
+	equal, err := ecsContainerDefinitionsAreEquivalent(cfgRepresention, apiRepresentation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !equal {
+		t.Fatal("Expected definitions to be equal.")
+	}
+}
+
 func TestAwsEcsContainerDefinitionsAreEquivalent_negative(t *testing.T) {
 	cfgRepresention := `
 [


### PR DESCRIPTION
Closes #2336

@ziggythehamster @nathanielks @achille-roussel @bturbes - do you folks mind testing this with your configs and/or pasting it here so we can test it to make sure the bug doesn't re-appear?

## Test results

```
TF_ACC=1 go test ./aws -v -run=TestAccAWSEcsTaskDefinition -timeout 120m
=== RUN   TestAccAWSEcsTaskDefinition_basic
--- PASS: TestAccAWSEcsTaskDefinition_basic (57.24s)
=== RUN   TestAccAWSEcsTaskDefinition_withScratchVolume
--- PASS: TestAccAWSEcsTaskDefinition_withScratchVolume (35.02s)
=== RUN   TestAccAWSEcsTaskDefinition_withEcsService
--- PASS: TestAccAWSEcsTaskDefinition_withEcsService (149.91s)
=== RUN   TestAccAWSEcsTaskDefinition_withTaskRoleArn
--- PASS: TestAccAWSEcsTaskDefinition_withTaskRoleArn (38.40s)
=== RUN   TestAccAWSEcsTaskDefinition_withNetworkMode
--- PASS: TestAccAWSEcsTaskDefinition_withNetworkMode (66.97s)
=== RUN   TestAccAWSEcsTaskDefinition_constraint
--- PASS: TestAccAWSEcsTaskDefinition_constraint (33.79s)
=== RUN   TestAccAWSEcsTaskDefinition_changeVolumesForcesNewResource
--- PASS: TestAccAWSEcsTaskDefinition_changeVolumesForcesNewResource (55.91s)
=== RUN   TestAccAWSEcsTaskDefinition_arrays
--- PASS: TestAccAWSEcsTaskDefinition_arrays (34.10s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	471.371s
```