### PR TITLE
New Resource: aws_cognito_user_pool_domain

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -288,6 +288,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_cognito_identity_pool":                    resourceAwsCognitoIdentityPool(),
 			"aws_cognito_identity_pool_roles_attachment":   resourceAwsCognitoIdentityPoolRolesAttachment(),
 			"aws_cognito_user_pool":                        resourceAwsCognitoUserPool(),
+			"aws_cognito_user_pool_domain":                 resourceAwsCognitoUserPoolDomain(),
 			"aws_autoscaling_lifecycle_hook":               resourceAwsAutoscalingLifecycleHook(),
 			"aws_cloudwatch_metric_alarm":                  resourceAwsCloudWatchMetricAlarm(),
 			"aws_cloudwatch_dashboard":                     resourceAwsCloudWatchDashboard(),

--- a/aws/resource_aws_cognito_user_pool_domain.go
+++ b/aws/resource_aws_cognito_user_pool_domain.go
@@ -1,0 +1,115 @@
+package aws
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsCognitoUserPoolDomain() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsCognitoUserPoolDomainCreate,
+		Read:   resourceAwsCognitoUserPoolDomainRead,
+		Delete: resourceAwsCognitoUserPoolDomainDelete,
+
+		Schema: map[string]*schema.Schema{
+			"domain": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateCognitoUserPoolDomain,
+			},
+			"user_pool_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAwsCognitoUserPoolDomainCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cognitoidpconn
+
+	input := &cognitoidentityprovider.CreateUserPoolDomainInput{
+		Domain:     aws.String(d.Get("domain").(string)),
+		UserPoolId: aws.String(d.Get("user_pool_id").(string)),
+	}
+
+	_, err := conn.CreateUserPoolDomain(input)
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId(d.Get("domain").(string))
+	return resourceAwsCognitoUserPoolDomainRead(d, meta)
+}
+
+func resourceAwsCognitoUserPoolDomainRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cognitoidpconn
+
+	domainStateConf := &resource.StateChangeConf{
+		Pending:    []string{"CREATING", "UPDATING"},
+		Target:     []string{"ACTIVE"},
+		Refresh:    cognitoUserPoolDomainStateRefreshFunc(d.Id(), conn),
+		Timeout:    10 * time.Minute,
+		Delay:      3 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err := domainStateConf.WaitForState()
+
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case cognitoidentityprovider.ErrCodeResourceNotFoundException:
+				d.SetId("")
+				return nil
+			default:
+				return err
+			}
+		}
+		return err
+	}
+
+	return nil
+}
+
+func resourceAwsCognitoUserPoolDomainDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cognitoidpconn
+
+	input := &cognitoidentityprovider.DeleteUserPoolDomainInput{
+		Domain:     aws.String(d.Id()),
+		UserPoolId: aws.String(d.Get("user_pool_id").(string)),
+	}
+
+	_, err := conn.DeleteUserPoolDomain(input)
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func cognitoUserPoolDomainStateRefreshFunc(domain string, conn *cognitoidentityprovider.CognitoIdentityProvider) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		input := &cognitoidentityprovider.DescribeUserPoolDomainInput{
+			Domain: aws.String(domain),
+		}
+		out, err := conn.DescribeUserPoolDomain(input)
+		if err != nil {
+			return nil, "failed", err
+		}
+		if out.DomainDescription.Status == nil {
+			return nil, "not found", nil
+		}
+		return out, *out.DomainDescription.Status, nil
+	}
+}

--- a/aws/resource_aws_cognito_user_pool_domain_test.go
+++ b/aws/resource_aws_cognito_user_pool_domain_test.go
@@ -1,0 +1,88 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAwsCognitoUserPoolDomain_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsCognitoUserPoolDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsCognitoUserPoolDomainConfig(acctest.RandString(5)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsCognitoUserPoolDomainExists("aws_cognito_user_pool_domain.test"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsCognitoUserPoolDomainDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).cognitoidpconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_cognito_user_pool_domain" {
+			continue
+		}
+		domainStateConf := &resource.StateChangeConf{
+			Pending:    []string{"ACTIVE", "DELETING"},
+			Target:     []string{},
+			Refresh:    cognitoUserPoolDomainStateRefreshFunc(rs.Primary.ID, conn),
+			Timeout:    10 * time.Minute,
+			Delay:      3 * time.Second,
+			MinTimeout: 3 * time.Second,
+		}
+
+		_, err := domainStateConf.WaitForState()
+
+		if err != nil {
+			if aerr, ok := err.(awserr.Error); ok {
+				switch aerr.Code() {
+				case cognitoidentityprovider.ErrCodeResourceNotFoundException:
+					return nil
+				default:
+					return err
+				}
+			}
+			return err
+		}
+	}
+
+	return nil
+
+}
+
+func testAccCheckAwsCognitoUserPoolDomainExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		return nil
+	}
+}
+
+func testAccAwsCognitoUserPoolDomainConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cognito_user_pool" "test" {
+  name = "tf-user-pool-%s"
+}
+
+resource "aws_cognito_user_pool_domain" "test" {
+  user_pool_id = "${aws_cognito_user_pool.test.id}"
+  domain = "tf-user-pool-domain-%s"
+}
+`, rName, rName)
+}

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1714,6 +1714,15 @@ func validateCognitoUserPoolSchemaName(v interface{}, k string) (ws []string, es
 	return
 }
 
+func validateCognitoUserPoolDomain(v interface{}, k string) (ws []string, es []error) {
+	value := v.(string)
+
+	if !regexp.MustCompile(`^[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?$`).MatchString(value) {
+		es = append(es, fmt.Errorf("%q must satisfy regular expression pattern: ^[a-z0-9](?:[a-z0-9\\-]{0,61}[a-z0-9])?$", k))
+	}
+	return
+}
+
 func validateWafMetricName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if !regexp.MustCompile(`^[0-9A-Za-z]+$`).MatchString(value) {

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -474,6 +474,9 @@
                         <li<%= sidebar_current("docs-aws-resource-cognito-user-pool") %>>
                             <a href="/docs/providers/aws/r/cognito_user_pool.html">aws_cognito_user_pool</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-resource-cognito-user-pool-domain") %>>
+                            <a href="/docs/providers/aws/r/cognito_user_pool_domain.html">aws_cognito_user_pool_domain</a>
+                        </li>
                     </ul>
                 </li>
 

--- a/website/docs/r/cognito_user_pool_domain.html.markdown
+++ b/website/docs/r/cognito_user_pool_domain.html.markdown
@@ -1,0 +1,31 @@
+---
+layout: "aws"
+page_title: "AWS: aws_cognito_user_pool_domain"
+side_bar_current: "docs-aws-resource-cognito-user-pool-domain"
+description: |-
+  Provides a Cognito User Pool Domain resource.
+---
+
+# aws_cognito_user_pool_domain
+
+Provides a Cognito User Pool Domain resource.
+
+## Example Usage
+
+```hcl
+resource "aws_cognito_user_pool" "pool" {
+  name = "mypool"
+}
+
+resource "aws_cognito_user_pool_domain" "domain" {
+  domain = "mydomain"
+  user_pool_id = "${aws_cognito_user_pool.pool.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domain` - (Required) The domain string.
+* `user_pool_id` - (Required) The user pool ID.


### PR DESCRIPTION
```
make testacc TEST=./aws TESTARGS='-run=TestAccAwsCognitoUserPoolDomain_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAwsCognitoUserPoolDomain_basic -timeout 120m
=== RUN   TestAccAwsCognitoUserPoolDomain_basic
--- PASS: TestAccAwsCognitoUserPoolDomain_basic (48.72s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	48.791s
```