### PR TITLE
Fix bug that batch_compute_environment with batch_job_queue reconstruction failed

### DIFF
--- a/aws/resource_aws_batch_job_queue.go
+++ b/aws/resource_aws_batch_job_queue.go
@@ -23,6 +23,7 @@ func resourceAwsBatchJobQueue() *schema.Resource {
 			"compute_environments": {
 				Type:     schema.TypeList,
 				Required: true,
+				ForceNew: true,
 				MaxItems: 3,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},


### PR DESCRIPTION
## Description
Fix #2044 .

## Tests
```
$ make testacc TESTARGS='-run=TestAccAWSBatchJobQueue'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccAWSBatchJobQueue -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSBatchJobQueue_basic
--- PASS: TestAccAWSBatchJobQueue_basic (151.76s)
=== RUN   TestAccAWSBatchJobQueue_update
--- PASS: TestAccAWSBatchJobQueue_update (182.52s)
=== RUN   TestAccAWSBatchJobQueue_updateComputeEnvironment
--- PASS: TestAccAWSBatchJobQueue_updateComputeEnvironment (260.25s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	594.554s
```