### PR TITLE
resource/aws_route: Support changing network_interface_id

### DIFF
--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
 
@@ -251,6 +252,29 @@ func TestAccAWSRoute_doesNotCrashWithVPCEndpoint(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAWSRoute_instanceIdChange(t *testing.T) {
+	r := resourceAwsRoute()
+
+	state := map[string]string{
+		"instance_id":          "i-1",
+		"network_interface_id": "eni-1",
+	}
+	raw := map[string]interface{}{
+		"instance_id": "i-2",
+	}
+	d := schema.TestResourceDataStateRaw(t, r.Schema, state, raw)
+	replaceOpts, err := prepareRouteUpdate(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replaceOpts.NetworkInterfaceId != nil {
+		t.Error("NetworkInterfaceId changed", replaceOpts)
+	}
+	if replaceOpts.InstanceId == nil || *replaceOpts.InstanceId != "i-2" {
+		t.Error("InstanceId unchanged", replaceOpts)
+	}
 }
 
 func testAccCheckAWSRouteExists(n string, res *ec2.Route) resource.TestCheckFunc {

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -277,6 +277,29 @@ func TestAWSRoute_instanceIdChange(t *testing.T) {
 	}
 }
 
+func TestAWSRoute_networkInterfaceIdChange(t *testing.T) {
+	r := resourceAwsRoute()
+
+	state := map[string]string{
+		"instance_id":          "i-1",
+		"network_interface_id": "eni-1",
+	}
+	raw := map[string]interface{}{
+		"network_interface_id": "eni-2",
+	}
+	d := schema.TestResourceDataStateRaw(t, r.Schema, state, raw)
+	replaceOpts, err := prepareRouteUpdate(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replaceOpts.InstanceId != nil {
+		t.Error("InstanceId changed", replaceOpts)
+	}
+	if replaceOpts.NetworkInterfaceId == nil || *replaceOpts.NetworkInterfaceId != "eni-2" {
+		t.Error("NetworkInterfaceId unchanged", replaceOpts)
+	}
+}
+
 func testAccCheckAWSRouteExists(n string, res *ec2.Route) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]


### PR DESCRIPTION
`network_interface_id` and `instance_id` are both optional and computed. If you specify one, the other is computed by `resourceAwsRouteSetResourceData`.

https://github.com/hashicorp/terraform/pull/7686 made it so that if you specified `instance_id`, applied, changed the `instance_id`, and applied again, we would ignore the computed `network_interface_id` (an ENI on the old instance) and update the `instance_id` correctly. This broke the opposite case (specify `network_interface_id`, apply, change, apply again).

This PR checks which has changed instead of preferring one over the other, fixing #2270. It depends on https://github.com/hashicorp/terraform/pull/16693.