### PR TITLE
r/aws_cognito_identity_pool_roles_attachment: Fix typo "authenticated" -> "unauthenticated"

### DIFF
--- a/aws/resource_aws_cognito_identity_pool_roles_attachment_test.go
+++ b/aws/resource_aws_cognito_identity_pool_roles_attachment_test.go
@@ -43,35 +43,6 @@ func TestAccAWSCognitoIdentityPoolRolesAttachment_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSCognitoIdentityPoolRolesAttachment_unauthenticated(t *testing.T) {
-	name := fmt.Sprintf("%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
-	updatedName := fmt.Sprintf("%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSCognitoIdentityPoolRolesAttachmentDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSCognitoIdentityPoolRolesAttachmentConfig_unauthenticated(name),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoIdentityPoolRolesAttachmentExists("aws_cognito_identity_pool_roles_attachment.main"),
-					resource.TestCheckResourceAttrSet("aws_cognito_identity_pool_roles_attachment.main", "identity_pool_id"),
-					resource.TestCheckResourceAttrSet("aws_cognito_identity_pool_roles_attachment.main", "roles.unauthenticated"),
-				),
-			},
-			{
-				Config: testAccAWSCognitoIdentityPoolRolesAttachmentConfig_unauthenticated(updatedName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoIdentityPoolRolesAttachmentExists("aws_cognito_identity_pool_roles_attachment.main"),
-					resource.TestCheckResourceAttrSet("aws_cognito_identity_pool_roles_attachment.main", "identity_pool_id"),
-					resource.TestCheckResourceAttrSet("aws_cognito_identity_pool_roles_attachment.main", "roles.unauthenticated"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappings(t *testing.T) {
 	name := fmt.Sprintf("%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
@@ -339,18 +310,6 @@ resource "aws_cognito_identity_pool_roles_attachment" "main" {
 
   roles {
     "authenticated" = "${aws_iam_role.authenticated.arn}"
-  }
-}
-`)
-}
-
-func testAccAWSCognitoIdentityPoolRolesAttachmentConfig_unauthenticated(name string) string {
-	return fmt.Sprintf(baseAWSCognitoIdentityPoolRolesAttachmentConfig(name) + `
-resource "aws_cognito_identity_pool_roles_attachment" "main" {
-  identity_pool_id = "${aws_cognito_identity_pool.main.id}"
-
-  roles {
-    "unauthenticated" = "${aws_iam_role.unauthenticated.arn}"
   }
 }
 `)

--- a/aws/resource_aws_cognito_identity_pool_roles_attachment_test.go
+++ b/aws/resource_aws_cognito_identity_pool_roles_attachment_test.go
@@ -43,6 +43,35 @@ func TestAccAWSCognitoIdentityPoolRolesAttachment_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSCognitoIdentityPoolRolesAttachment_unauthenticated(t *testing.T) {
+	name := fmt.Sprintf("%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	updatedName := fmt.Sprintf("%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCognitoIdentityPoolRolesAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCognitoIdentityPoolRolesAttachmentConfig_unauthenticated(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoIdentityPoolRolesAttachmentExists("aws_cognito_identity_pool_roles_attachment.main"),
+					resource.TestCheckResourceAttrSet("aws_cognito_identity_pool_roles_attachment.main", "identity_pool_id"),
+					resource.TestCheckResourceAttrSet("aws_cognito_identity_pool_roles_attachment.main", "roles.unauthenticated"),
+				),
+			},
+			{
+				Config: testAccAWSCognitoIdentityPoolRolesAttachmentConfig_unauthenticated(updatedName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoIdentityPoolRolesAttachmentExists("aws_cognito_identity_pool_roles_attachment.main"),
+					resource.TestCheckResourceAttrSet("aws_cognito_identity_pool_roles_attachment.main", "identity_pool_id"),
+					resource.TestCheckResourceAttrSet("aws_cognito_identity_pool_roles_attachment.main", "roles.unauthenticated"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappings(t *testing.T) {
 	name := fmt.Sprintf("%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
@@ -310,6 +339,18 @@ resource "aws_cognito_identity_pool_roles_attachment" "main" {
 
   roles {
     "authenticated" = "${aws_iam_role.authenticated.arn}"
+  }
+}
+`)
+}
+
+func testAccAWSCognitoIdentityPoolRolesAttachmentConfig_unauthenticated(name string) string {
+	return fmt.Sprintf(baseAWSCognitoIdentityPoolRolesAttachmentConfig(name) + `
+resource "aws_cognito_identity_pool_roles_attachment" "main" {
+  identity_pool_id = "${aws_cognito_identity_pool.main.id}"
+
+  roles {
+    "unauthenticated" = "${aws_iam_role.unauthenticated.arn}"
   }
 }
 `)

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1946,7 +1946,7 @@ func validateCognitoRoleMappingsType(v interface{}, k string) (ws []string, erro
 // Validates that either authenticated or unauthenticated is defined
 func validateCognitoRoles(v map[string]interface{}, k string) (errors []error) {
 	_, hasAuthenticated := v["authenticated"].(string)
-	_, hasUnauthenticated := v["authenticated"].(string)
+	_, hasUnauthenticated := v["unauthenticated"].(string)
 
 	if !hasAuthenticated && !hasUnauthenticated {
 		errors = append(errors, fmt.Errorf("%q: Either \"authenticated\" or \"unauthenticated\" must be defined", k))

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -2720,6 +2720,33 @@ func TestValidateCognitoRoleMappingsType(t *testing.T) {
 	}
 }
 
+func TestValidateCognitoRoles(t *testing.T) {
+	validValues := []map[string]interface{}{
+		map[string]interface{}{"authenticated": "hoge"},
+		map[string]interface{}{"unauthenticated": "hoge"},
+		map[string]interface{}{"authenticated": "hoge", "unauthenticated": "hoge"},
+	}
+
+	for _, s := range validValues {
+		errors := validateCognitoRoles(s, "roles")
+		if len(errors) > 0 {
+			t.Fatalf("%q should be a valid Cognito Roles: %v", s, errors)
+		}
+	}
+
+	invalidValues := []map[string]interface{}{
+		map[string]interface{}{},
+		map[string]interface{}{"invalid": "hoge"},
+	}
+
+	for _, s := range invalidValues {
+		errors := validateCognitoRoles(s, "roles")
+		if len(errors) == 0 {
+			t.Fatalf("%q should not be a valid Cognito Roles: %v", s, errors)
+		}
+	}
+}
+
 func TestValidateDxConnectionBandWidth(t *testing.T) {
 	validValues := []string{
 		"1Gbps",


### PR DESCRIPTION
Fix: #2356
Add a test case for unauthenticated role
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSCognitoIdentityPoolRolesAttachment_unauthenticated'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCognitoIdentityPoolRolesAttachment_unauthenticated -timeout 120m
=== RUN   TestAccAWSCognitoIdentityPoolRolesAttachment_unauthenticated
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_unauthenticated (88.01s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	88.049s
```