### PR TITLE
New Resource: aws_dx_connection_association

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -315,6 +315,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_dms_replication_task":                     resourceAwsDmsReplicationTask(),
 			"aws_dx_lag":                                   resourceAwsDxLag(),
 			"aws_dx_connection":                            resourceAwsDxConnection(),
+			"aws_dx_connection_association":                resourceAwsDxConnectionAssociation(),
 			"aws_dynamodb_table":                           resourceAwsDynamoDbTable(),
 			"aws_ebs_snapshot":                             resourceAwsEbsSnapshot(),
 			"aws_ebs_volume":                               resourceAwsEbsVolume(),

--- a/aws/resource_aws_dx_connection_association.go
+++ b/aws/resource_aws_dx_connection_association.go
@@ -63,6 +63,10 @@ func resourceAwsDxConnectionAssociationRead(d *schema.ResourceData, meta interfa
 	if len(resp.Connections) != 1 {
 		return fmt.Errorf("Found %d DX connections for %s, expected 1", len(resp.Connections), d.Id())
 	}
+	if *resp.Connections[0].LagId != d.Get("lag_id").(string) {
+		d.SetId("")
+		return nil
+	}
 
 	return nil
 }

--- a/aws/resource_aws_dx_connection_association.go
+++ b/aws/resource_aws_dx_connection_association.go
@@ -62,18 +62,9 @@ func resourceAwsDxConnectionAssociationRead(d *schema.ResourceData, meta interfa
 		return nil
 	}
 	if len(resp.Connections) != 1 {
-		return fmt.Errorf("Number of DX Connection (%s) isn't one, got %d", connectionId, len(resp.Connections))
+		return fmt.Errorf("Found %d DX connections for %s, expected 1", len(resp.Connections))
 	}
-	if d.Id() != *resp.Connections[0].ConnectionId {
-		return fmt.Errorf("DX Connection (%s) not found", connectionId)
-	}
-	if resp.Connections[0].LagId == nil {
-		d.SetId("")
-		return nil
-	}
-	if *resp.Connections[0].LagId != d.Get("lag_id").(string) {
-		return fmt.Errorf("DX Connection (%s) is associated with unexpected LAG (%s)", connectionId, *resp.Connections[0].LagId)
-	}
+
 	return nil
 }
 
@@ -88,9 +79,6 @@ func resourceAwsDxConnectionAssociationDelete(d *schema.ResourceData, meta inter
 	resp, err := conn.DisassociateConnectionFromLag(input)
 	if err != nil {
 		return err
-	}
-	if resp.LagId != nil {
-		return fmt.Errorf("DX Connection (%s) is still associated with LAG", d.Id())
 	}
 
 	d.SetId("")

--- a/aws/resource_aws_dx_connection_association.go
+++ b/aws/resource_aws_dx_connection_association.go
@@ -1,0 +1,98 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/directconnect"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsDxConnectionAssociation() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsDxConnectionAssociationCreate,
+		Read:   resourceAwsDxConnectionAssociationRead,
+		Delete: resourceAwsDxConnectionAssociationDelete,
+
+		Schema: map[string]*schema.Schema{
+			"connection_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"lag_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAwsDxConnectionAssociationCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).dxconn
+
+	input := &directconnect.AssociateConnectionWithLagInput{
+		ConnectionId: aws.String(d.Get("connection_id").(string)),
+		LagId:        aws.String(d.Get("lag_id").(string)),
+	}
+	resp, err := conn.AssociateConnectionWithLag(input)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(*resp.ConnectionId)
+	return nil
+}
+
+func resourceAwsDxConnectionAssociationRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).dxconn
+
+	connectionId := d.Id()
+	input := &directconnect.DescribeConnectionsInput{
+		ConnectionId: aws.String(connectionId),
+	}
+
+	resp, err := conn.DescribeConnections(input)
+	if err != nil {
+		return err
+	}
+	if len(resp.Connections) < 1 {
+		d.SetId("")
+		return nil
+	}
+	if len(resp.Connections) != 1 {
+		return fmt.Errorf("Number of DX Connection (%s) isn't one, got %d", connectionId, len(resp.Connections))
+	}
+	if d.Id() != *resp.Connections[0].ConnectionId {
+		return fmt.Errorf("DX Connection (%s) not found", connectionId)
+	}
+	if resp.Connections[0].LagId == nil {
+		d.SetId("")
+		return nil
+	}
+	if *resp.Connections[0].LagId != d.Get("lag_id").(string) {
+		return fmt.Errorf("DX Connection (%s) is associated with unexpected LAG (%s)", connectionId, *resp.Connections[0].LagId)
+	}
+	return nil
+}
+
+func resourceAwsDxConnectionAssociationDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).dxconn
+
+	input := &directconnect.DisassociateConnectionFromLagInput{
+		ConnectionId: aws.String(d.Id()),
+		LagId:        aws.String(d.Get("lag_id").(string)),
+	}
+
+	resp, err := conn.DisassociateConnectionFromLag(input)
+	if err != nil {
+		return err
+	}
+	if resp.LagId != nil {
+		return fmt.Errorf("DX Connection (%s) is still associated with LAG", d.Id())
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/aws/resource_aws_dx_connection_association.go
+++ b/aws/resource_aws_dx_connection_association.go
@@ -48,9 +48,8 @@ func resourceAwsDxConnectionAssociationCreate(d *schema.ResourceData, meta inter
 func resourceAwsDxConnectionAssociationRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).dxconn
 
-	connectionId := d.Id()
 	input := &directconnect.DescribeConnectionsInput{
-		ConnectionId: aws.String(connectionId),
+		ConnectionId: aws.String(d.Id()),
 	}
 
 	resp, err := conn.DescribeConnections(input)
@@ -62,7 +61,7 @@ func resourceAwsDxConnectionAssociationRead(d *schema.ResourceData, meta interfa
 		return nil
 	}
 	if len(resp.Connections) != 1 {
-		return fmt.Errorf("Found %d DX connections for %s, expected 1", len(resp.Connections))
+		return fmt.Errorf("Found %d DX connections for %s, expected 1", len(resp.Connections), d.Id())
 	}
 
 	return nil

--- a/aws/resource_aws_dx_connection_association.go
+++ b/aws/resource_aws_dx_connection_association.go
@@ -76,7 +76,7 @@ func resourceAwsDxConnectionAssociationDelete(d *schema.ResourceData, meta inter
 		LagId:        aws.String(d.Get("lag_id").(string)),
 	}
 
-	resp, err := conn.DisassociateConnectionFromLag(input)
+	_, err := conn.DisassociateConnectionFromLag(input)
 	if err != nil {
 		return err
 	}

--- a/aws/resource_aws_dx_connection_association_test.go
+++ b/aws/resource_aws_dx_connection_association_test.go
@@ -1,0 +1,87 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/directconnect"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAwsDxConnectionAssociation_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsDxConnectionAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDxConnectionAssociationConfig(acctest.RandString(5)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsDxConnectionAssociationExists("aws_dx_connection_association.test"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsDxConnectionAssociationDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).dxconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_dx_connection_association" {
+			continue
+		}
+
+		input := &directconnect.DescribeConnectionsInput{
+			ConnectionId: aws.String(rs.Primary.ID),
+		}
+
+		resp, err := conn.DescribeConnections(input)
+		if err != nil {
+			return err
+		}
+		for _, v := range resp.Connections {
+			if *v.ConnectionId == rs.Primary.ID && v.LagId != nil {
+				return fmt.Errorf("Dx Connection (%s) is not diasociated with Lag", rs.Primary.ID)
+			}
+		}
+	}
+	return nil
+}
+
+func testAccCheckAwsDxConnectionAssociationExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		return nil
+	}
+}
+
+func testAccDxConnectionAssociationConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_dx_connection" "test" {
+  name = "tf-dx-%s"
+  bandwidth = "1Gbps"
+  location = "EqSe2"
+}
+
+resource "aws_dx_lag" "test" {
+  name = "tf-dx-%s"
+  connections_bandwidth = "1Gbps"
+  location = "EqSe2"
+  number_of_connections = 1
+  force_destroy = true
+}
+
+resource "aws_dx_connection_association" "test" {
+  connection_id = "${aws_dx_connection.test.id}"
+  lag_id = "${aws_dx_lag.test.id}"
+}
+`, rName, rName)
+}

--- a/aws/resource_aws_dx_connection_association_test.go
+++ b/aws/resource_aws_dx_connection_association_test.go
@@ -45,7 +45,7 @@ func testAccCheckAwsDxConnectionAssociationDestroy(s *terraform.State) error {
 		}
 		for _, v := range resp.Connections {
 			if *v.ConnectionId == rs.Primary.ID && v.LagId != nil {
-				return fmt.Errorf("Dx Connection (%s) is not diasociated with Lag", rs.Primary.ID)
+				return fmt.Errorf("Dx Connection (%s) is not dissociated with Lag", rs.Primary.ID)
 			}
 		}
 	}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -553,6 +553,9 @@
                         <li<%= sidebar_current("docs-aws-resource-dx-connection") %>>
                             <a href="/docs/providers/aws/r/dx_connection.html">aws_dx_connection</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-resource-dx-connection-association") %>>
+                            <a href="/docs/providers/aws/r/dx_connection_association.html">aws_dx_connection_association</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-resource-dx-lag") %>>
                             <a href="/docs/providers/aws/r/dx_lag.html">aws_dx_lag</a>
                         </li>

--- a/website/docs/r/dx_connection_association.html.markdown
+++ b/website/docs/r/dx_connection_association.html.markdown
@@ -3,12 +3,12 @@ layout: "aws"
 page_title: "AWS: aws_dx_connection_association"
 sidebar_current: "docs-aws-resource-dx-connection-association"
 description: |-
-  Associates a Connection with LAG.
+  Associates a Direct Connect Connection with a LAG.
 ---
 
 # aws_dx_connection_association
 
-Associates a Connection with LAG.
+Associates a Direct Connect Connection with a LAG.
 
 ## Example Usage
 

--- a/website/docs/r/dx_connection_association.html.markdown
+++ b/website/docs/r/dx_connection_association.html.markdown
@@ -1,0 +1,40 @@
+---
+layout: "aws"
+page_title: "AWS: aws_dx_connection_association"
+sidebar_current: "docs-aws-resource-dx-connection-association"
+description: |-
+  Associates a Connection with LAG.
+---
+
+# aws_dx_connection_association
+
+Associates a Connection with LAG.
+
+## Example Usage
+
+```hcl
+resource "aws_dx_connection" "example" {
+  name = "example"
+  bandwidth = "1Gbps"
+  location = "EqSe2"
+}
+
+resource "aws_dx_lag" "example" {
+  name = "example"
+  connections_bandwidth = "1Gbps"
+  location = "EqSe2"
+  number_of_connections = 1
+}
+
+resource "aws_dx_connection_association" "example" {
+  connection_id = "${aws_dx_connection.example.id}"
+  lag_id = "${aws_dx_lag.example.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `connection_id` - (Required) The ID of the connection.
+* `lag_id` - (Required) The ID of the LAG with which to associate the connection.


### PR DESCRIPTION
```
make testacc TEST=./aws TESTARGS='-run=TestAccAwsDxConnectionAssociation_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAwsDxConnectionAssociation_basic -timeout 120m
=== RUN   TestAccAwsDxConnectionAssociation_basic
--- PASS: TestAccAwsDxConnectionAssociation_basic (100.67s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	100.725s
```