### PR TITLE
Create a default subnet in an Availability Zone that does not have one

### DIFF
--- a/aws/resource_aws_default_subnet_test.go
+++ b/aws/resource_aws_default_subnet_test.go
@@ -8,16 +8,16 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSDefaultSubnet_basic(t *testing.T) {
+func TestAccAwsDefaultSubnet_basic(t *testing.T) {
 	var v ec2.Subnet
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSDefaultSubnetDestroy,
+		CheckDestroy: testAccCheckAwsDefaultSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDefaultSubnetConfigBasic,
+				Config: testAccAwsDefaultSubnetConfigBasic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists("aws_default_subnet.foo", &v),
 					resource.TestCheckResourceAttr(
@@ -36,20 +36,73 @@ func TestAccAWSDefaultSubnet_basic(t *testing.T) {
 	})
 }
 
-func testAccCheckAWSDefaultSubnetDestroy(s *terraform.State) error {
+func TestAccAwsDefaultSubnet_createNew(t *testing.T) {
+	var v ec2.Subnet
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsDefaultSubnetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsDefaultSubnetConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSubnetExists("aws_default_subnet.foo", &v),
+					resource.TestCheckResourceAttr(
+						"aws_default_subnet.foo", "availability_zone", "us-west-2a"),
+					resource.TestCheckResourceAttr(
+						"aws_default_subnet.foo", "map_public_ip_on_launch", "true"),
+					resource.TestCheckResourceAttr(
+						"aws_default_subnet.foo", "assign_ipv6_address_on_creation", "false"),
+					resource.TestCheckResourceAttr(
+						"aws_default_subnet.foo", "tags.%", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_default_subnet.foo", "tags.Name", "Default subnet for us-west-2a"),
+					testAccDeleteAwsDefaultSubnet(&v),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: testAccAwsDefaultSubnetConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSubnetExists("aws_default_subnet.foo", &v),
+					resource.TestCheckResourceAttr(
+						"aws_default_subnet.foo", "availability_zone", "us-west-2a"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsDefaultSubnetDestroy(s *terraform.State) error {
 	// We expect subnet to still exist
 	return nil
 }
 
-const testAccAWSDefaultSubnetConfigBasic = `
+func testAccDeleteAwsDefaultSubnet(sn *ec2.Subnet) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
+		_, err := conn.DeleteSubnet(&ec2.DeleteSubnetInput{
+			SubnetId: sn.SubnetId,
+		})
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+const testAccAwsDefaultSubnetConfigBasic = `
 provider "aws" {
-    region = "us-west-2"
+  region = "us-west-2"
 }
 
 resource "aws_default_subnet" "foo" {
-	availability_zone = "us-west-2a"
-	tags {
-		Name = "Default subnet for us-west-2a"
-	}
+  availability_zone = "us-west-2a"
+  tags {
+    Name = "Default subnet for us-west-2a"
+  }
 }
 `

--- a/website/docs/r/default_subnet.html.markdown
+++ b/website/docs/r/default_subnet.html.markdown
@@ -6,26 +6,26 @@ description: |-
   Manage a default VPC subnet resource.
 ---
 
-# aws\_default\_subnet
+# aws_default_subnet
 
 Provides a resource to manage a [default AWS VPC subnet](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/default-vpc.html#default-vpc-basics)
 in the current region.
 
 The `aws_default_subnet` behaves differently from normal resources, in that
-Terraform does not _create_ this resource, but instead "adopts" it
-into management. 
+Terraform does not _create_ this resource, but instead "adopts" it into management.
+If no default subnet for an Availability Zone exits Terraform will [create a new one] (http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/default-vpc.html#create-default-subnet).
 
 ## Example Usage
 
 Basic usage with tags:
 
-```
+```hcl
 resource "aws_default_subnet" "default_az1" {
   availability_zone = "us-west-2a"
 
-	tags {
-		Name = "Default subnet for us-west-2a"
-	}
+  tags {
+    Name = "Default subnet for us-west-2a"
+  }
 }
 ```
 
@@ -34,7 +34,7 @@ resource "aws_default_subnet" "default_az1" {
 The arguments of an `aws_default_subnet` differ from `aws_subnet` resources.
 Namely, the `availability_zone` argument is required and the `vpc_id`, `cidr_block`, `ipv6_cidr_block`,
 `map_public_ip_on_launch` and `assign_ipv6_address_on_creation` arguments are computed.
-The following arguments are still supported: 
+The following arguments are still supported:
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/2254.
Same decision as in https://github.com/terraform-providers/terraform-provider-aws/pull/1400, create the defaults subnet for an Availability Zone if it doesn't exist.

Acceptance tests:
```
make testacc TEST=./aws/ TESTARGS='-run=TestAccAwsDefaultSubnet_'==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAwsDefaultSubnet_ -timeout 120m
=== RUN   TestAccAwsDefaultSubnet_basic
--- PASS: TestAccAwsDefaultSubnet_basic (13.70s)
=== RUN   TestAccAwsDefaultSubnet_createNew
--- PASS: TestAccAwsDefaultSubnet_createNew (22.74s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	36.455s
```