### PR TITLE
r/aws_lb_target_group: various fixes to behavior based on protocol type

### DIFF
--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -594,7 +594,7 @@ func resourceAwsLbTargetGroupCustomizeDiff(diff *schema.ResourceDiff, v interfac
                 // TCP load balancers do not support stickiness
                 stickinessBlocks := diff.Get("stickiness").([]interface{})
                 if len(stickinessBlocks) != 0 {
-                        return fmt.Errorf("Network Load Balancers do not support Stickiness", diff.Id())
+                        return fmt.Errorf("Network Load Balancers do not support Stickiness")
                 }
                 // Network Load Balancers have many special qwirks to them.
                 // See http://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateTargetGroup.html

--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -8,26 +8,26 @@ import (
 	"strconv"
 	"strings"
 
-        "github.com/aws/aws-sdk-go/aws"
-        "github.com/aws/aws-sdk-go/aws/awserr"
-        "github.com/aws/aws-sdk-go/service/elbv2"
-        "github.com/hashicorp/errwrap"
-        "github.com/hashicorp/terraform/helper/resource"
-        "github.com/hashicorp/terraform/helper/schema"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
 )
 
 func resourceAwsLbTargetGroup() *schema.Resource {
-        return &schema.Resource{
-                // NLBs have restrictions on them at this time
-                CustomizeDiff: resourceAwsLbTargetGroupCustomizeDiff,
+	return &schema.Resource{
+		// NLBs have restrictions on them at this time
+		CustomizeDiff: resourceAwsLbTargetGroupCustomizeDiff,
 
-                Create: resourceAwsLbTargetGroupCreate,
-                Read:   resourceAwsLbTargetGroupRead,
-                Update: resourceAwsLbTargetGroupUpdate,
-                Delete: resourceAwsLbTargetGroupDelete,
-                Importer: &schema.ResourceImporter{
-                        State: schema.ImportStatePassthrough,
-                },
+		Create: resourceAwsLbTargetGroupCreate,
+		Read:   resourceAwsLbTargetGroupRead,
+		Update: resourceAwsLbTargetGroupUpdate,
+		Delete: resourceAwsLbTargetGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"arn": {
@@ -132,7 +132,7 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 						"path": {
 							Type:         schema.TypeString,
 							Optional:     true,
-                                                        Computed:     true,
+							Computed:     true,
 							ValidateFunc: validateAwsLbTargetGroupHealthCheckPath,
 						},
 
@@ -156,7 +156,7 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 						"timeout": {
 							Type:         schema.TypeInt,
 							Optional:     true,
-                                                        Computed:     true,
+							Computed:     true,
 							ValidateFunc: validateAwsLbTargetGroupHealthCheckTimeout,
 						},
 
@@ -169,7 +169,7 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 
 						"matcher": {
 							Type:     schema.TypeString,
-                                                        Computed: true,
+							Computed: true,
 							Optional: true,
 						},
 
@@ -216,28 +216,28 @@ func resourceAwsLbTargetGroupCreate(d *schema.ResourceData, meta interface{}) er
 		params.HealthCheckProtocol = aws.String(healthCheck["protocol"].(string))
 		params.HealthyThresholdCount = aws.Int64(int64(healthCheck["healthy_threshold"].(int)))
 		params.UnhealthyThresholdCount = aws.Int64(int64(healthCheck["unhealthy_threshold"].(int)))
-                t := healthCheck["timeout"].(int)
-                if t != 0 {
-                        params.HealthCheckTimeoutSeconds = aws.Int64(int64(t))
-                }
+		t := healthCheck["timeout"].(int)
+		if t != 0 {
+			params.HealthCheckTimeoutSeconds = aws.Int64(int64(t))
+		}
 
-                if *params.HealthCheckProtocol != "TCP" {
-                        p := healthCheck["path"].(string)
-                        if p != "" {
-                                params.HealthCheckPath = aws.String(p)
-                        }
+		if *params.HealthCheckProtocol != "TCP" {
+			p := healthCheck["path"].(string)
+			if p != "" {
+				params.HealthCheckPath = aws.String(p)
+			}
 
-                        m := healthCheck["matcher"].(string)
-                        if m != "" {
-                                params.Matcher = &elbv2.Matcher{
-                                        HttpCode: aws.String(m),
-                                }
-                        }
-                }
-        }
+			m := healthCheck["matcher"].(string)
+			if m != "" {
+				params.Matcher = &elbv2.Matcher{
+					HttpCode: aws.String(m),
+				}
+			}
+		}
+	}
 
-        resp, err := elbconn.CreateTargetGroup(params)
-        if err != nil {
+	resp, err := elbconn.CreateTargetGroup(params)
+	if err != nil {
 		return errwrap.Wrapf("Error creating LB Target Group: {{err}}", err)
 	}
 
@@ -280,44 +280,44 @@ func resourceAwsLbTargetGroupUpdate(d *schema.ResourceData, meta interface{}) er
 		return errwrap.Wrapf("Error Modifying Tags on LB Target Group: {{err}}", err)
 	}
 
-        if d.HasChange("health_check") {
-                var params *elbv2.ModifyTargetGroupInput
-                healthChecks := d.Get("health_check").([]interface{})
-                if len(healthChecks) == 1 {
-                        params = &elbv2.ModifyTargetGroupInput{
-                                TargetGroupArn: aws.String(d.Id()),
-                        }
-                        healthCheck := healthChecks[0].(map[string]interface{})
+	if d.HasChange("health_check") {
+		var params *elbv2.ModifyTargetGroupInput
+		healthChecks := d.Get("health_check").([]interface{})
+		if len(healthChecks) == 1 {
+			params = &elbv2.ModifyTargetGroupInput{
+				TargetGroupArn: aws.String(d.Id()),
+			}
+			healthCheck := healthChecks[0].(map[string]interface{})
 
-                        params = &elbv2.ModifyTargetGroupInput{
+			params = &elbv2.ModifyTargetGroupInput{
 				TargetGroupArn:          aws.String(d.Id()),
 				HealthCheckPort:         aws.String(healthCheck["port"].(string)),
 				HealthCheckProtocol:     aws.String(healthCheck["protocol"].(string)),
 				HealthyThresholdCount:   aws.Int64(int64(healthCheck["healthy_threshold"].(int))),
-                                UnhealthyThresholdCount: aws.Int64(int64(healthCheck["unhealthy_threshold"].(int))),
-                        }
+				UnhealthyThresholdCount: aws.Int64(int64(healthCheck["unhealthy_threshold"].(int))),
+			}
 
-                        t := healthCheck["timeout"].(int)
-                        if t != 0 {
-                                params.HealthCheckTimeoutSeconds = aws.Int64(int64(t))
-                        }
+			t := healthCheck["timeout"].(int)
+			if t != 0 {
+				params.HealthCheckTimeoutSeconds = aws.Int64(int64(t))
+			}
 
-                        healthCheckProtocol := strings.ToLower(healthCheck["protocol"].(string))
+			healthCheckProtocol := strings.ToLower(healthCheck["protocol"].(string))
 
-                        if healthCheckProtocol != "tcp" && !d.IsNewResource() {
+			if healthCheckProtocol != "tcp" && !d.IsNewResource() {
 				params.Matcher = &elbv2.Matcher{
 					HttpCode: aws.String(healthCheck["matcher"].(string)),
 				}
-                                params.HealthCheckPath = aws.String(healthCheck["path"].(string))
-                                params.HealthCheckIntervalSeconds = aws.Int64(int64(healthCheck["interval"].(int)))
-                        }
-                }
+				params.HealthCheckPath = aws.String(healthCheck["path"].(string))
+				params.HealthCheckIntervalSeconds = aws.Int64(int64(healthCheck["interval"].(int)))
+			}
+		}
 
-                if params != nil {
-                        _, err := elbconn.ModifyTargetGroup(params)
-                        if err != nil {
-                                return errwrap.Wrapf("Error modifying Target Group: {{err}}", err)
-                        }
+		if params != nil {
+			_, err := elbconn.ModifyTargetGroup(params)
+			if err != nil {
+				return errwrap.Wrapf("Error modifying Target Group: {{err}}", err)
+			}
 		}
 	}
 
@@ -563,11 +563,11 @@ func flattenAwsLbTargetGroupResource(d *schema.ResourceData, meta interface{}, t
 		}
 	}
 
-        setStickyMap := []interface{}{}
-        if len(stickinessMap) > 0 {
-                setStickyMap = []interface{}{stickinessMap}
-        }
-        if err := d.Set("stickiness", setStickyMap); err != nil {
+	setStickyMap := []interface{}{}
+	if len(stickinessMap) > 0 {
+		setStickyMap = []interface{}{stickinessMap}
+	}
+	if err := d.Set("stickiness", setStickyMap); err != nil {
 		return err
 	}
 
@@ -589,55 +589,55 @@ func flattenAwsLbTargetGroupResource(d *schema.ResourceData, meta interface{}, t
 }
 
 func resourceAwsLbTargetGroupCustomizeDiff(diff *schema.ResourceDiff, v interface{}) error {
-        protocol := diff.Get("protocol").(string)
-        if protocol == "TCP" {
-                // TCP load balancers do not support stickiness
-                stickinessBlocks := diff.Get("stickiness").([]interface{})
-                if len(stickinessBlocks) != 0 {
-                        return fmt.Errorf("Network Load Balancers do not support Stickiness")
-                }
-                // Network Load Balancers have many special qwirks to them.
-                // See http://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateTargetGroup.html
-                if healthChecks := diff.Get("health_check").([]interface{}); len(healthChecks) == 1 {
-                        healthCheck := healthChecks[0].(map[string]interface{})
-                        // Cannot set custom matcher on TCP health checks
-                        if m := healthCheck["matcher"].(string); m != "" {
-                                return fmt.Errorf("%s: custom matcher is not supported for target_groups with TCP protocol", diff.Id())
-                        }
-                        // Cannot set custom path on TCP health checks
-                        if m := healthCheck["path"].(string); m != "" {
-                                return fmt.Errorf("%s: custom path is not supported for target_groups with TCP protocol", diff.Id())
-                        }
-                        // Cannot set custom timeout on TCP health checks
-                        if t := healthCheck["timeout"].(int); t != 0 && diff.Id() == "" {
-                                // timeout has a default value, so only check this if this is a network
-                                // LB and is a first run
-                                return fmt.Errorf("%s: custom timeout is not supported for target_groups with TCP protocol", diff.Id())
-                        }
-                }
-        }
+	protocol := diff.Get("protocol").(string)
+	if protocol == "TCP" {
+		// TCP load balancers do not support stickiness
+		stickinessBlocks := diff.Get("stickiness").([]interface{})
+		if len(stickinessBlocks) != 0 {
+			return fmt.Errorf("Network Load Balancers do not support Stickiness")
+		}
+		// Network Load Balancers have many special qwirks to them.
+		// See http://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateTargetGroup.html
+		if healthChecks := diff.Get("health_check").([]interface{}); len(healthChecks) == 1 {
+			healthCheck := healthChecks[0].(map[string]interface{})
+			// Cannot set custom matcher on TCP health checks
+			if m := healthCheck["matcher"].(string); m != "" {
+				return fmt.Errorf("%s: custom matcher is not supported for target_groups with TCP protocol", diff.Id())
+			}
+			// Cannot set custom path on TCP health checks
+			if m := healthCheck["path"].(string); m != "" {
+				return fmt.Errorf("%s: custom path is not supported for target_groups with TCP protocol", diff.Id())
+			}
+			// Cannot set custom timeout on TCP health checks
+			if t := healthCheck["timeout"].(int); t != 0 && diff.Id() == "" {
+				// timeout has a default value, so only check this if this is a network
+				// LB and is a first run
+				return fmt.Errorf("%s: custom timeout is not supported for target_groups with TCP protocol", diff.Id())
+			}
+		}
+	}
 
-        if strings.Contains(protocol, "HTTP") {
-                if healthChecks := diff.Get("health_check").([]interface{}); len(healthChecks) == 1 {
-                        healthCheck := healthChecks[0].(map[string]interface{})
-                        // HTTP(S) Target Groups cannot use TCP health checks
-                        if p := healthCheck["protocol"].(string); strings.ToLower(p) == "tcp" {
-                                return fmt.Errorf("HTTP Target Groups cannot use TCP health checks")
-                        }
-                }
-        }
+	if strings.Contains(protocol, "HTTP") {
+		if healthChecks := diff.Get("health_check").([]interface{}); len(healthChecks) == 1 {
+			healthCheck := healthChecks[0].(map[string]interface{})
+			// HTTP(S) Target Groups cannot use TCP health checks
+			if p := healthCheck["protocol"].(string); strings.ToLower(p) == "tcp" {
+				return fmt.Errorf("HTTP Target Groups cannot use TCP health checks")
+			}
+		}
+	}
 
-        if diff.Id() == "" {
-                return nil
-        }
+	if diff.Id() == "" {
+		return nil
+	}
 
-        if protocol == "TCP" {
-                if diff.HasChange("health_check.0.interval") {
-                        old, new := diff.GetChange("health_check.0.interval")
-                        return fmt.Errorf("Health check interval cannot be updated from %d to %d for TCP based Target Group %s,"+
-                                " use 'terraform taint' to recreate the resource if you wish",
-                                old, new, diff.Id())
-                }
-        }
-        return nil
+	if protocol == "TCP" {
+		if diff.HasChange("health_check.0.interval") {
+			old, new := diff.GetChange("health_check.0.interval")
+			return fmt.Errorf("Health check interval cannot be updated from %d to %d for TCP based Target Group %s,"+
+				" use 'terraform taint' to recreate the resource if you wish",
+				old, new, diff.Id())
+		}
+	}
+	return nil
 }

--- a/aws/resource_aws_lb_target_group_test.go
+++ b/aws/resource_aws_lb_target_group_test.go
@@ -528,117 +528,117 @@ func TestAccAWSLBTargetGroup_updateSticknessEnabled(t *testing.T) {
 				),
 			},
 		},
-        })
+	})
 }
 
 func TestAccAWSLBTargetGroup_defaults_application(t *testing.T) {
-        var conf elbv2.TargetGroup
-        targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	var conf elbv2.TargetGroup
+	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
-        resource.Test(t, resource.TestCase{
-                PreCheck:      func() { testAccPreCheck(t) },
-                IDRefreshName: "aws_lb_target_group.test",
-                Providers:     testAccProviders,
-                CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
-                Steps: []resource.TestStep{
-                        {
-                                Config: testAccALB_defaults(targetGroupName),
-                                Check: resource.ComposeAggregateTestCheckFunc(
-                                        testAccCheckAWSLBTargetGroupExists("aws_lb_target_group.test", &conf),
-                                        resource.TestCheckResourceAttrSet("aws_lb_target_group.test", "arn"),
-                                        resource.TestCheckResourceAttr("aws_lb_target_group.test", "name", targetGroupName),
-                                        resource.TestCheckResourceAttr("aws_lb_target_group.test", "port", "443"),
-                                        resource.TestCheckResourceAttr("aws_lb_target_group.test", "protocol", "HTTP"),
-                                        resource.TestCheckResourceAttrSet("aws_lb_target_group.test", "vpc_id"),
-                                        resource.TestCheckResourceAttr("aws_lb_target_group.test", "deregistration_delay", "200"),
-                                        resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.#", "1"),
-                                        resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.interval", "10"),
-                                        resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.port", "8081"),
-                                        resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.protocol", "HTTP"),
-                                        resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.timeout", "5"),
-                                        resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.healthy_threshold", "3"),
-                                        resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.unhealthy_threshold", "3"),
-                                        resource.TestCheckResourceAttr("aws_lb_target_group.test", "tags.%", "1"),
-                                        resource.TestCheckResourceAttr("aws_lb_target_group.test", "tags.Name", "TestAccAWSLBTargetGroup_application_LB_defaults"),
-                                ),
-                        },
-                },
-        })
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_lb_target_group.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccALB_defaults(targetGroupName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLBTargetGroupExists("aws_lb_target_group.test", &conf),
+					resource.TestCheckResourceAttrSet("aws_lb_target_group.test", "arn"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "name", targetGroupName),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "port", "443"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "protocol", "HTTP"),
+					resource.TestCheckResourceAttrSet("aws_lb_target_group.test", "vpc_id"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "deregistration_delay", "200"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.#", "1"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.interval", "10"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.port", "8081"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.protocol", "HTTP"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.timeout", "5"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.healthy_threshold", "3"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.unhealthy_threshold", "3"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "tags.%", "1"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "tags.Name", "TestAccAWSLBTargetGroup_application_LB_defaults"),
+				),
+			},
+		},
+	})
 }
 
 func TestAccAWSLBTargetGroup_defaults_network(t *testing.T) {
-        var conf elbv2.TargetGroup
-        targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
-        healthCheckInvalid1 := `
+	var conf elbv2.TargetGroup
+	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	healthCheckInvalid1 := `
     path = "/health"
     interval = 10
     port     = 8081
     protocol = "TCP"
         `
-        healthCheckInvalid2 := `
+	healthCheckInvalid2 := `
     interval = 10
     port     = 8081
     protocol = "TCP"
                 matcher = "200"
         `
-        healthCheckInvalid3 := `
+	healthCheckInvalid3 := `
     interval = 10
     port     = 8081
     protocol = "TCP"
                 timeout = 4
         `
-        healthCheckValid := `
+	healthCheckValid := `
     interval = 10
     port     = 8081
     protocol = "TCP"
         `
 
-        resource.Test(t, resource.TestCase{
-                PreCheck:      func() { testAccPreCheck(t) },
-                IDRefreshName: "aws_lb_target_group.test",
-                Providers:     testAccProviders,
-                CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
-                Steps: []resource.TestStep{
-                        {
-                                Config:      testAccNLB_defaults(targetGroupName, healthCheckInvalid1),
-                                ExpectError: regexp.MustCompile("custom path is not supported for target_groups with TCP protocol"),
-                        },
-                        {
-                                Config:      testAccNLB_defaults(targetGroupName, healthCheckInvalid2),
-                                ExpectError: regexp.MustCompile("custom matcher is not supported for target_groups with TCP protocol"),
-                        },
-                        {
-                                Config:      testAccNLB_defaults(targetGroupName, healthCheckInvalid3),
-                                ExpectError: regexp.MustCompile("custom timeout is not supported for target_groups with TCP protocol"),
-                        },
-                        {
-                                Config: testAccNLB_defaults(targetGroupName, healthCheckValid),
-                                Check: resource.ComposeAggregateTestCheckFunc(
-                                        testAccCheckAWSLBTargetGroupExists("aws_lb_target_group.test", &conf),
-                                        resource.TestCheckResourceAttrSet("aws_lb_target_group.test", "arn"),
-                                        resource.TestCheckResourceAttr("aws_lb_target_group.test", "name", targetGroupName),
-                                        resource.TestCheckResourceAttr("aws_lb_target_group.test", "port", "443"),
-                                        resource.TestCheckResourceAttr("aws_lb_target_group.test", "protocol", "TCP"),
-                                        resource.TestCheckResourceAttrSet("aws_lb_target_group.test", "vpc_id"),
-                                        resource.TestCheckResourceAttr("aws_lb_target_group.test", "deregistration_delay", "200"),
-                                        resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.#", "1"),
-                                        resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.interval", "10"),
-                                        resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.port", "8081"),
-                                        resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.protocol", "TCP"),
-                                        resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.timeout", "10"),
-                                        resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.healthy_threshold", "3"),
-                                        resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.unhealthy_threshold", "3"),
-                                        resource.TestCheckResourceAttr("aws_lb_target_group.test", "tags.%", "1"),
-                                        resource.TestCheckResourceAttr("aws_lb_target_group.test", "tags.Name", "TestAccAWSLBTargetGroup_application_LB_defaults"),
-                                ),
-                        },
-                },
-        })
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_lb_target_group.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccNLB_defaults(targetGroupName, healthCheckInvalid1),
+				ExpectError: regexp.MustCompile("custom path is not supported for target_groups with TCP protocol"),
+			},
+			{
+				Config:      testAccNLB_defaults(targetGroupName, healthCheckInvalid2),
+				ExpectError: regexp.MustCompile("custom matcher is not supported for target_groups with TCP protocol"),
+			},
+			{
+				Config:      testAccNLB_defaults(targetGroupName, healthCheckInvalid3),
+				ExpectError: regexp.MustCompile("custom timeout is not supported for target_groups with TCP protocol"),
+			},
+			{
+				Config: testAccNLB_defaults(targetGroupName, healthCheckValid),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLBTargetGroupExists("aws_lb_target_group.test", &conf),
+					resource.TestCheckResourceAttrSet("aws_lb_target_group.test", "arn"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "name", targetGroupName),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "port", "443"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "protocol", "TCP"),
+					resource.TestCheckResourceAttrSet("aws_lb_target_group.test", "vpc_id"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "deregistration_delay", "200"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.#", "1"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.interval", "10"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.port", "8081"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.protocol", "TCP"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.timeout", "10"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.healthy_threshold", "3"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.unhealthy_threshold", "3"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "tags.%", "1"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "tags.Name", "TestAccAWSLBTargetGroup_application_LB_defaults"),
+				),
+			},
+		},
+	})
 }
 
 func testAccCheckAWSLBTargetGroupExists(n string, res *elbv2.TargetGroup) resource.TestCheckFunc {
-        return func(s *terraform.State) error {
-                rs, ok := s.RootModule().Resources[n]
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
@@ -750,11 +750,11 @@ func testAccCheckAWSLBTargetGroupDestroy(s *terraform.State) error {
 		}
 	}
 
-        return nil
+	return nil
 }
 
 func testAccALB_defaults(name string) string {
-        return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "aws_lb_target_group" "test" {
   name     = "%s"
   port     = 443
@@ -791,7 +791,7 @@ resource "aws_vpc" "test" {
 }
 
 func testAccNLB_defaults(name, healthCheckBlock string) string {
-        return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "aws_lb_target_group" "test" {
   name     = "%s"
   port     = 443

--- a/website/docs/r/lb_target_group.html.markdown
+++ b/website/docs/r/lb_target_group.html.markdown
@@ -68,7 +68,7 @@ for a complete reference.
 * `timeout` - (Optional) The amount of time, in seconds, during which no response means a failed health check. For Application Load Balancers, the range is 2 to 60 seconds and the default is 5 seconds. For Network Load Balancers, you cannot set a custom value, and the default is 10 seconds for TCP and HTTPS health checks and 6 seconds for HTTP health checks.
 * `healthy_threshold` - (Optional) The number of consecutive health checks successes required before considering an unhealthy target healthy. Defaults to 5.
 * `unhealthy_threshold` - (Optional) The number of consecutive health check failures required before considering the target unhealthy. Defaults to 2.
-* `matcher` (Required, only available for Application Load Balancers): The HTTP codes to use when checking for a successful response from a target. You can specify multiple values (for example, "200,202") or a range of values (for example, "200-299").
+* `matcher` (Optiona, only supported on Application Load Balancers): The HTTP codes to use when checking for a successful response from a target. You can specify multiple values (for example, "200,202") or a range of values (for example, "200-299").
 
 ## Attributes Reference
 

--- a/website/docs/r/lb_target_group.html.markdown
+++ b/website/docs/r/lb_target_group.html.markdown
@@ -53,16 +53,22 @@ Stickiness Blocks (`stickiness`) support the following:
 * `cookie_duration` - (Optional) The time period, in seconds, during which requests from a client should be routed to the same target. After this time period expires, the load balancer-generated cookie is considered stale. The range is 1 second to 1 week (604800 seconds). The default value is 1 day (86400 seconds).
 * `enabled` - (Optional) Boolean to enable / disable `stickiness`. Default is `true`
 
-Health Check Blocks (`health_check`) support the following:
+Health Check Blocks (`health_check`):
+
+~> **Note:** The Health Check parameters you can set vary by the `protocol` of
+the Target Group. Many parameters cannot be set to custom values for `network`
+load balancers at this time. See
+http://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateTargetGroup.html
+for a complete reference.
 
 * `interval` - (Optional) The approximate amount of time, in seconds, between health checks of an individual target. Minimum value 5 seconds, Maximum value 300 seconds. Default 30 seconds.
 * `path` - (Optional) The destination for the health check request. Default `/`.
 * `port` - (Optional) The port to use to connect with the target. Valid values are either ports 1-65536, or `traffic-port`. Defaults to `traffic-port`.
 * `protocol` - (Optional) The protocol to use to connect with the target. Defaults to `HTTP`.
-* `timeout` - (Optional) The amount of time, in seconds, during which no response means a failed health check. Defaults to 5 seconds.
-* `healthy_threshold` - (Optional) The number of consecutive health checks successes required before considering an unhealthy target healthy. Defaults to 3.
-* `unhealthy_threshold` - (Optional) The number of consecutive health check failures required before considering the target unhealthy. Defaults to 3.
-* `matcher` (Optional) The HTTP codes to use when checking for a successful response from a target. Defaults to `200`. You can specify multiple values (for example, "200,202") or a range of values (for example, "200-299").
+* `timeout` - (Optional) The amount of time, in seconds, during which no response means a failed health check. For Application Load Balancers, the range is 2 to 60 seconds and the default is 5 seconds. For Network Load Balancers, you cannot set a custom value, and the default is 10 seconds for TCP and HTTPS health checks and 6 seconds for HTTP health checks.
+* `healthy_threshold` - (Optional) The number of consecutive health checks successes required before considering an unhealthy target healthy. Defaults to 5.
+* `unhealthy_threshold` - (Optional) The number of consecutive health check failures required before considering the target unhealthy. Defaults to 2.
+* `matcher` (Required, only available for Application Load Balancers): The HTTP codes to use when checking for a successful response from a target. You can specify multiple values (for example, "200,202") or a range of values (for example, "200-299").
 
 ## Attributes Reference
 

--- a/website/docs/r/lb_target_group.html.markdown
+++ b/website/docs/r/lb_target_group.html.markdown
@@ -68,7 +68,7 @@ for a complete reference.
 * `timeout` - (Optional) The amount of time, in seconds, during which no response means a failed health check. For Application Load Balancers, the range is 2 to 60 seconds and the default is 5 seconds. For Network Load Balancers, you cannot set a custom value, and the default is 10 seconds for TCP and HTTPS health checks and 6 seconds for HTTP health checks.
 * `healthy_threshold` - (Optional) The number of consecutive health checks successes required before considering an unhealthy target healthy. Defaults to 5.
 * `unhealthy_threshold` - (Optional) The number of consecutive health check failures required before considering the target unhealthy. Defaults to 2.
-* `matcher` (Optiona, only supported on Application Load Balancers): The HTTP codes to use when checking for a successful response from a target. You can specify multiple values (for example, "200,202") or a range of values (for example, "200-299").
+* `matcher` (Optional, only supported on Application Load Balancers): The HTTP codes to use when checking for a successful response from a target. You can specify multiple values (for example, "200,202") or a range of values (for example, "200-299").
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR includes a number of fixes and adjustments for working with Application and Network Load Balancers. Specifically, some items in #2251 had their defaults removed, others changed.

Here we guard against setting certain health check attributes for network load balancers, et. al, and mark other fields as computed. 

The rules are unfortunately complicated:

- http://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateTargetGroup.html

Fixes / related: 

- #2327, #2343

------

Test results:

```
TF_ACC=1 go test ./aws -v -run=TestAccAWSLBTargetGroup_ -timeout 120m
=== RUN   TestAccAWSLBTargetGroup_basic
--- PASS: TestAccAWSLBTargetGroup_basic (23.48s)
=== RUN   TestAccAWSLBTargetGroup_networkLB_TargetGroup
--- PASS: TestAccAWSLBTargetGroup_networkLB_TargetGroup (43.68s)
=== RUN   TestAccAWSLBTargetGroup_namePrefix
--- PASS: TestAccAWSLBTargetGroup_namePrefix (22.23s)
=== RUN   TestAccAWSLBTargetGroup_generatedName
--- PASS: TestAccAWSLBTargetGroup_generatedName (22.28s)
=== RUN   TestAccAWSLBTargetGroup_changeNameForceNew
--- PASS: TestAccAWSLBTargetGroup_changeNameForceNew (38.19s)
=== RUN   TestAccAWSLBTargetGroup_changeProtocolForceNew
--- PASS: TestAccAWSLBTargetGroup_changeProtocolForceNew (44.55s)
=== RUN   TestAccAWSLBTargetGroup_changePortForceNew
--- PASS: TestAccAWSLBTargetGroup_changePortForceNew (37.90s)
=== RUN   TestAccAWSLBTargetGroup_changeVpcForceNew
--- PASS: TestAccAWSLBTargetGroup_changeVpcForceNew (38.93s)
=== RUN   TestAccAWSLBTargetGroup_tags
--- PASS: TestAccAWSLBTargetGroup_tags (37.78s)
=== RUN   TestAccAWSLBTargetGroup_updateHealthCheck
--- PASS: TestAccAWSLBTargetGroup_updateHealthCheck (37.99s)
=== RUN   TestAccAWSLBTargetGroup_updateSticknessEnabled
--- PASS: TestAccAWSLBTargetGroup_updateSticknessEnabled (55.36s)
=== RUN   TestAccAWSLBTargetGroup_defaults_application
--- PASS: TestAccAWSLBTargetGroup_defaults_application (21.98s)
=== RUN   TestAccAWSLBTargetGroup_defaults_network
--- PASS: TestAccAWSLBTargetGroup_defaults_network (26.25s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       450.653s
```