### PR TITLE
resource/aws_db_instance: Allow ARN for the replicate_source_db when in the same region

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -858,7 +858,7 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("[DEBUG] Error setting replicas attribute: %#v, error: %#v", replicas, err)
 	}
 
-	//  If an ARN was passed in, do NOT use what AWS passes back for replicaste_source_id,
+	//  If an ARN was passed in, do NOT use what AWS passes back for replicate_source_id,
 	//  as it passes back the master's ID-
 	//  see https://github.com/terraform-providers/terraform-provider-aws/issues/2399
 	_, arnErr := arn.Parse(d.Get("replicate_source_db").(string))

--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -420,11 +420,11 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 		//
 		// go figure, eh?
 		//
+		replicaRegion := meta.(*AWSClient).region
+
 		arnParts, arnErr := arn.Parse(d.Get("replicate_source_db").(string))
 		if arnErr == nil {
-			var replicaRegion string
-			replicaRegion = (string)(*opts.AvailabilityZone)
-			if arnParts.Region != replicaRegion[0:len(replicaRegion)-1] {
+			if arnParts.Region != replicaRegion {
 				opts.SourceRegion = aws.String(arnParts.Region)
 			}
 		}

--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -807,7 +807,7 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	// list tags for resource
 	// set tags
 	conn := meta.(*AWSClient).rdsconn
-	arn, err := buildRDSARN(d.Id(), meta.(*AWSClient).partition, meta.(*AWSClient).accountid, meta.(*AWSClient).region)
+	builtArn, err := buildRDSARN(d.Id(), meta.(*AWSClient).partition, meta.(*AWSClient).accountid, meta.(*AWSClient).region)
 	if err != nil {
 		name := "<empty>"
 		if v.DBName != nil && *v.DBName != "" {
@@ -815,13 +815,13 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 		}
 		log.Printf("[DEBUG] Error building ARN for DB Instance, not setting Tags for DB %s", name)
 	} else {
-		d.Set("arn", arn)
+		d.Set("arn", builtArn)
 		resp, err := conn.ListTagsForResource(&rds.ListTagsForResourceInput{
-			ResourceName: aws.String(arn),
+			ResourceName: aws.String(builtArn),
 		})
 
 		if err != nil {
-			log.Printf("[DEBUG] Error retrieving tags for ARN: %s", arn)
+			log.Printf("[DEBUG] Error retrieving tags for ARN: %s", builtArn)
 		}
 
 		var dt []*rds.Tag

--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -861,7 +861,7 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	//  If an ARN was passed in, do NOT use what AWS passes back for replicaste_source_id,
 	//  as it passes back the master's ID-
 	//  see https://github.com/terraform-providers/terraform-provider-aws/issues/2399
-	arnParts, arnErr := arn.Parse(d.Get("replicate_source_db").(string))
+	_, arnErr := arn.Parse(d.Get("replicate_source_db").(string))
 	if arnErr != nil {
 		d.Set("replicate_source_db", v.ReadReplicaSourceDBInstanceIdentifier)
 	}

--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -387,6 +387,11 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			PubliclyAccessible:         aws.Bool(d.Get("publicly_accessible").(bool)),
 			Tags:                       tags,
 		}
+
+		if arnParts := strings.Split(d.Get("replicate_source_db").(string), ":"); len(arnParts) >= 4 {
+			opts.SourceRegion = aws.String(arnParts[3])
+		}
+
 		if attr, ok := d.GetOk("iops"); ok {
 			opts.Iops = aws.Int64(int64(attr.(int)))
 		}
@@ -409,9 +414,6 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 
 		if attr, ok := d.GetOk("kms_key_id"); ok {
 			opts.KmsKeyId = aws.String(attr.(string))
-			if arnParts := strings.Split(v.(string), ":"); len(arnParts) >= 4 {
-				opts.SourceRegion = aws.String(arnParts[3])
-			}
 		}
 
 		if attr, ok := d.GetOk("monitoring_role_arn"); ok {

--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -858,6 +858,14 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("[DEBUG] Error setting replicas attribute: %#v, error: %#v", replicas, err)
 	}
 
+	//  If an ARN was passed in, do NOT use what AWS passes back for replicaste_source_id,
+	//  as it passes back the master's ID-
+	//  see https://github.com/terraform-providers/terraform-provider-aws/issues/2399
+	arnParts, arnErr := arn.Parse(d.Get("replicate_source_db").(string))
+	if arnErr != nil {
+		d.Set("replicate_source_db", v.ReadReplicaSourceDBInstanceIdentifier)
+	}
+
 	d.Set("replicate_source_db", v.ReadReplicaSourceDBInstanceIdentifier)
 
 	d.Set("ca_cert_identifier", v.CACertificateIdentifier)

--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/rds"
 
@@ -388,8 +389,9 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			Tags:                       tags,
 		}
 
-		if arnParts := strings.Split(d.Get("replicate_source_db").(string), ":"); len(arnParts) >= 4 {
-			opts.SourceRegion = aws.String(arnParts[3])
+		arnParts, arnErr := arn.Parse(d.Get("replicate_source_db").(string))
+		if arnErr == nil {
+			opts.SourceRegion = aws.String(arnParts.Region)
 		}
 
 		if attr, ok := d.GetOk("iops"); ok {

--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -866,8 +866,6 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("replicate_source_db", v.ReadReplicaSourceDBInstanceIdentifier)
 	}
 
-	d.Set("replicate_source_db", v.ReadReplicaSourceDBInstanceIdentifier)
-
 	d.Set("ca_cert_identifier", v.CACertificateIdentifier)
 
 	return nil

--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -266,7 +266,7 @@ func TestAccAWSDBInstance_replica(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists("aws_db_instance.bar", &s),
 					testAccCheckAWSDBInstanceExists("aws_db_instance.replica", &r),
-					resource.TestCheckNoResourceAttrSet("aws_db_instance.replica", "source_region"),
+					resource.TestCheckNoResourceAttr("aws_db_instance.replica", "source_region"),
 					testAccCheckAWSDBInstanceReplicaAttributes(&s, &r),
 				),
 			},
@@ -298,7 +298,7 @@ func TestAccAWSDBInstanceReplicaSameRegionWithArn(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists("aws_db_instance.bar", &s),
 					testAccCheckAWSDBInstanceExists("aws_db_instance.replica", &r),
-					resource.TestCheckNoResourceAttrSet("aws_db_instance.replica", "source_region"),
+					resource.TestCheckNoResourceAttr("aws_db_instance.replica", "source_region"),
 					testAccCheckAWSDBInstanceReplicaAttributes(&s, &r),
 				),
 			},

--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -266,6 +266,39 @@ func TestAccAWSDBInstance_replica(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists("aws_db_instance.bar", &s),
 					testAccCheckAWSDBInstanceExists("aws_db_instance.replica", &r),
+					resource.TestCheckNoResourceAttrSet("aws_db_instance.replica", "source_region"),
+					testAccCheckAWSDBInstanceReplicaAttributes(&s, &r),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDBInstanceReplicaSameRegionWithArn(t *testing.T) {
+	var s, r rds.DBInstance
+	var id int
+
+	region := "us-east-1"
+	id = rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReplicaInstanceSameRegionWithArnConfig(
+					id,
+					fmt.Sprintf("arn:aws:rds:%s:%s:db:foobarbaz-test-terraform-%v",
+						region,
+						"123456789012",
+						id,
+					),
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBInstanceExists("aws_db_instance.bar", &s),
+					testAccCheckAWSDBInstanceExists("aws_db_instance.replica", &r),
+					resource.TestCheckNoResourceAttrSet("aws_db_instance.replica", "source_region"),
 					testAccCheckAWSDBInstanceReplicaAttributes(&s, &r),
 				),
 			},
@@ -962,6 +995,45 @@ func testAccReplicaInstanceConfig(val int) string {
 		}
 	}
 	`, val, val)
+}
+
+func testAccReplicaInstanceSameRegionWithArnConfig(val int, arn string) string {
+	return fmt.Sprintf(`
+	resource "aws_db_instance" "bar" {
+		identifier = "%s"
+
+		allocated_storage = 5
+		engine = "mysql"
+		engine_version = "5.6.35"
+		instance_class = "db.t2.micro"
+		name = "baz"
+		password = "barbarbarbar"
+		username = "foo"
+		availability_zone = "us-east-1a"
+
+		backup_retention_period = 1
+		skip_final_snapshot = true
+
+		parameter_group_name = "default.mysql5.6"
+	}
+
+	resource "aws_db_instance" "replica" {
+		identifier = "tf-replica-db-%d"
+		backup_retention_period = 0
+		availability_zone = "us-east-1a"
+		replicate_source_db = "${aws_db_instance.bar.identifier}"
+		allocated_storage = "${aws_db_instance.bar.allocated_storage}"
+		engine = "${aws_db_instance.bar.engine}"
+		engine_version = "${aws_db_instance.bar.engine_version}"
+		instance_class = "${aws_db_instance.bar.instance_class}"
+		password = "${aws_db_instance.bar.password}"
+		username = "${aws_db_instance.bar.username}"
+		skip_final_snapshot = true
+		tags {
+			Name = "tf-replica-db"
+		}
+	}
+	`, arn, val)
 }
 
 func testAccReplicaInstanceCrossRegionConfig(val int, arn string) string {


### PR DESCRIPTION
I believe this addresses a possible bug we ran into that was triggered by https://github.com/terraform-providers/terraform-provider-aws/pull/865/files and mentioned at https://groups.google.com/forum/#!topic/terraform-tool/zX-bWBZgViI

If you pass both an ARN and a kms_key_id to create a replica in the same region as the master, you get an error of the form "* aws_db_instance.read_replica: Error creating DB Instance: InvalidParameterCombination: Your request does not require the preSignedUrl parameter. Please remove the preSignedUrl parameter and try your request again."

I think this is because of AWS code - in aws/aws-sdk-go/service/rds/customizations.go, a preSignedUrl will get added to the CreateDBInstanceReadReplicaInput if the SourceRegion is set for the replica.  If SourceRegion is nil, the presignedURL is skipped.
```
     58         if originParams.SourceRegion == nil || originParams.PreSignedUrl != nil || originParams.DestinationRegion != nil {
     59                 return
     60         }
```

We are still verifying that this is working for our installation, hence the WIP tag.  We are able to create the same-region replica reliably (after push c84c16d), but we are getting a destroy-add on the next plan for the replica.  We are tracking that down currently.

I've modified the test for creating a replica, and added two more, one for the replica created with a source ARN in the same region, and one for creating a replica from a source ARN in a different region.  I have not yet run the tests, however.