### PR TITLE
Fix Cognito Userpool email_subject_by_link 

### DIFF
--- a/aws/structure.go
+++ b/aws/structure.go
@@ -2629,7 +2629,7 @@ func flattenCognitoUserPoolVerificationMessageTemplate(s *cognitoidentityprovide
 		m["email_subject"] = *s.EmailSubject
 	}
 
-	if s.EmailMessageByLink != nil {
+	if s.EmailSubjectByLink != nil {
 		m["email_subject_by_link"] = *s.EmailSubjectByLink
 	}
 


### PR DESCRIPTION
Currently creating an aws_cognito_userpool with an `email_message_by_link` set with an `email_subject_by_link` unset will segfault terraform. This commit prevents that segfault.

@Ninir, looks like a simple typo in the work recently merged around #232.