### PR TITLE
r/aws_instance: Set placement_group in state on read if available

### DIFF
--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -612,6 +612,9 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	if instance.Placement != nil {
 		d.Set("availability_zone", instance.Placement.AvailabilityZone)
 	}
+	if instance.Placement.GroupName != nil {
+		d.Set("placement_group", instance.Placement.GroupName)
+	}
 	if instance.Placement.Tenancy != nil {
 		d.Set("tenancy", instance.Placement.Tenancy)
 	}

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -1715,32 +1715,32 @@ resource "aws_instance" "foo" {
 func testAccInstanceConfigPlacementGroup(rStr string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
-	tags {
-		Name = "testAccInstanceConfigPlacementGroup_%s"
-	}
+  cidr_block = "10.1.0.0/16"
+  tags {
+    Name = "testAccInstanceConfigPlacementGroup_%s"
+  }
 }
 
 resource "aws_subnet" "foo" {
-	cidr_block = "10.1.1.0/24"
-	vpc_id = "${aws_vpc.foo.id}"
+  cidr_block = "10.1.1.0/24"
+  vpc_id = "${aws_vpc.foo.id}"
 }
 
 resource "aws_placement_group" "foo" {
-	name = "testAccInstanceConfigPlacementGroup_%s"
-	strategy = "cluster"
+  name = "testAccInstanceConfigPlacementGroup_%s"
+  strategy = "cluster"
 }
 
 # Limitations: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html#concepts-placement-groups
 resource "aws_instance" "foo" {
-	# us-west-2
-	ami = "ami-55a7ea65"
-	instance_type = "c3.large"
-	subnet_id = "${aws_subnet.foo.id}"
-	associate_public_ip_address = true
-	placement_group = "${aws_placement_group.foo.name}"
-	# pre-encoded base64 data
-	user_data = "3dc39dda39be1205215e776bad998da361a5955d"
+  # us-west-2
+  ami = "ami-55a7ea65"
+  instance_type = "c3.large"
+  subnet_id = "${aws_subnet.foo.id}"
+  associate_public_ip_address = true
+  placement_group = "${aws_placement_group.foo.name}"
+  # pre-encoded base64 data
+  user_data = "3dc39dda39be1205215e776bad998da361a5955d"
 }
 `, rStr, rStr)
 }

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -561,6 +561,7 @@ func TestAccAWSInstance_vpc(t *testing.T) {
 
 func TestAccAWSInstance_placementGroup(t *testing.T) {
 	var v ec2.Instance
+	rStr := acctest.RandString(5)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
@@ -570,14 +571,14 @@ func TestAccAWSInstance_placementGroup(t *testing.T) {
 		CheckDestroy:    testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigPlacementGroup,
+				Config: testAccInstanceConfigPlacementGroup(rStr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(
 						"aws_instance.foo", &v),
 					resource.TestCheckResourceAttr(
 						"aws_instance.foo",
 						"placement_group",
-						"testAccInstanceConfigPlacementGroup"),
+						fmt.Sprintf("testAccInstanceConfigPlacementGroup_%s", rStr)),
 				),
 			},
 		},
@@ -1711,11 +1712,12 @@ resource "aws_instance" "foo" {
 }
 `
 
-const testAccInstanceConfigPlacementGroup = `
+func testAccInstanceConfigPlacementGroup(rStr string) string {
+	return fmt.Sprintf(`
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "testAccInstanceConfigPlacementGroup"
+		Name = "testAccInstanceConfigPlacementGroup_%s"
 	}
 }
 
@@ -1725,7 +1727,7 @@ resource "aws_subnet" "foo" {
 }
 
 resource "aws_placement_group" "foo" {
-	name = "testAccInstanceConfigPlacementGroup"
+	name = "testAccInstanceConfigPlacementGroup_%s"
 	strategy = "cluster"
 }
 
@@ -1737,11 +1739,11 @@ resource "aws_instance" "foo" {
 	subnet_id = "${aws_subnet.foo.id}"
 	associate_public_ip_address = true
 	placement_group = "${aws_placement_group.foo.name}"
-	tenancy = "dedicated"
 	# pre-encoded base64 data
 	user_data = "3dc39dda39be1205215e776bad998da361a5955d"
 }
-`
+`, rStr, rStr)
+}
 
 const testAccInstanceConfigIpv6ErrorConfig = `
 resource "aws_vpc" "foo" {


### PR DESCRIPTION
Closes #2392.

New test:
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSInstance_placementGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSInstance_placementGroup -timeout 120m
=== RUN   TestAccAWSInstance_placementGroup
--- PASS: TestAccAWSInstance_placementGroup (76.91s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	76.948s
```

Hopefully passing other tests still, e.g.
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSInstance_vpc'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSInstance_vpc -timeout 120m
=== RUN   TestAccAWSInstance_vpc
--- PASS: TestAccAWSInstance_vpc (95.32s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	95.352s
```