### PR TITLE
d/aws_instance: Set placement_group if available

### DIFF
--- a/aws/data_source_aws_instance.go
+++ b/aws/data_source_aws_instance.go
@@ -38,6 +38,10 @@ func dataSourceAwsInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"placement_group": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"tenancy": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -276,6 +280,9 @@ func instanceDescriptionAttributes(d *schema.ResourceData, instance *ec2.Instanc
 	d.Set("instance_state", instance.State.Name)
 	if instance.Placement != nil {
 		d.Set("availability_zone", instance.Placement.AvailabilityZone)
+	}
+	if instance.Placement.GroupName != nil {
+		d.Set("placement_group", instance.Placement.GroupName)
 	}
 	if instance.Placement.Tenancy != nil {
 		d.Set("tenancy", instance.Placement.Tenancy)

--- a/aws/data_source_aws_instance_test.go
+++ b/aws/data_source_aws_instance_test.go
@@ -179,14 +179,16 @@ func TestAccAWSInstanceDataSource_VPC(t *testing.T) {
 }
 
 func TestAccAWSInstanceDataSource_PlacementGroup(t *testing.T) {
+	rStr := acctest.RandString(5)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceDataSourceConfig_PlacementGroup,
+				Config: testAccInstanceDataSourceConfig_PlacementGroup(rStr),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_instance.foo", "placement_group", "testAccInstanceDataSourceConfig_PlacementGroup"),
+					resource.TestCheckResourceAttr("data.aws_instance.foo", "placement_group", fmt.Sprintf("testAccInstanceDataSourceConfig_PlacementGroup_%s", rStr)),
 				),
 			},
 		},
@@ -444,11 +446,12 @@ data "aws_instance" "foo" {
 }
 `
 
-const testAccInstanceDataSourceConfig_PlacementGroup = `
+func testAccInstanceDataSourceConfig_PlacementGroup(rStr string) string {
+	return fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
   tags {
-    Name = "testAccInstanceDataSourceConfig_PlacementGroup"
+    Name = "testAccInstanceDataSourceConfig_PlacementGroup_%s"
   }
 }
 
@@ -458,7 +461,7 @@ resource "aws_subnet" "foo" {
 }
 
 resource "aws_placement_group" "foo" {
-  name = "testAccInstanceDataSourceConfig_PlacementGroup"
+  name = "testAccInstanceDataSourceConfig_PlacementGroup_%s"
   strategy = "cluster"
 }
 
@@ -470,7 +473,6 @@ resource "aws_instance" "foo" {
   subnet_id = "${aws_subnet.foo.id}"
   associate_public_ip_address = true
   placement_group = "${aws_placement_group.foo.name}"
-  tenancy = "dedicated"
   # pre-encoded base64 data
   user_data = "3dc39dda39be1205215e776bad998da361a5955d"
 }
@@ -478,7 +480,8 @@ resource "aws_instance" "foo" {
 data "aws_instance" "foo" {
   instance_id = "${aws_instance.foo.id}"
 }
-`
+`, rStr, rStr)
+}
 
 func testAccInstanceDataSourceConfig_SecurityGroups(rInt int) string {
 	return fmt.Sprintf(`

--- a/aws/data_source_aws_instance_test.go
+++ b/aws/data_source_aws_instance_test.go
@@ -433,7 +433,7 @@ resource "aws_instance" "foo" {
   ami = "ami-4fccb37f"
   instance_type = "m1.small"
   subnet_id = "${aws_subnet.foo.id}"
-	associate_public_ip_address = true
+  associate_public_ip_address = true
   tenancy = "dedicated"
   # pre-encoded base64 data
   user_data = "3dc39dda39be1205215e776bad998da361a5955d"
@@ -458,8 +458,8 @@ resource "aws_subnet" "foo" {
 }
 
 resource "aws_placement_group" "foo" {
-	name = "testAccInstanceDataSourceConfig_PlacementGroup"
-	strategy = "cluster"
+  name = "testAccInstanceDataSourceConfig_PlacementGroup"
+  strategy = "cluster"
 }
 
 # Limitations: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html#concepts-placement-groups
@@ -468,8 +468,8 @@ resource "aws_instance" "foo" {
   ami = "ami-55a7ea65"
   instance_type = "c3.large"
   subnet_id = "${aws_subnet.foo.id}"
-	associate_public_ip_address = true
-	placement_group = "${aws_placement_group.foo.name}"
+  associate_public_ip_address = true
+  placement_group = "${aws_placement_group.foo.name}"
   tenancy = "dedicated"
   # pre-encoded base64 data
   user_data = "3dc39dda39be1205215e776bad998da361a5955d"

--- a/aws/data_source_aws_instance_test.go
+++ b/aws/data_source_aws_instance_test.go
@@ -178,6 +178,21 @@ func TestAccAWSInstanceDataSource_VPC(t *testing.T) {
 	})
 }
 
+func TestAccAWSInstanceDataSource_PlacementGroup(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceDataSourceConfig_PlacementGroup,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_instance.foo", "placement_group", "testAccInstanceDataSourceConfig_PlacementGroup"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSInstanceDataSource_SecurityGroups(t *testing.T) {
 	rInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
@@ -418,7 +433,43 @@ resource "aws_instance" "foo" {
   ami = "ami-4fccb37f"
   instance_type = "m1.small"
   subnet_id = "${aws_subnet.foo.id}"
-  associate_public_ip_address = true
+	associate_public_ip_address = true
+  tenancy = "dedicated"
+  # pre-encoded base64 data
+  user_data = "3dc39dda39be1205215e776bad998da361a5955d"
+}
+
+data "aws_instance" "foo" {
+  instance_id = "${aws_instance.foo.id}"
+}
+`
+
+const testAccInstanceDataSourceConfig_PlacementGroup = `
+resource "aws_vpc" "foo" {
+  cidr_block = "10.1.0.0/16"
+  tags {
+    Name = "testAccInstanceDataSourceConfig_PlacementGroup"
+  }
+}
+
+resource "aws_subnet" "foo" {
+  cidr_block = "10.1.1.0/24"
+  vpc_id = "${aws_vpc.foo.id}"
+}
+
+resource "aws_placement_group" "foo" {
+	name = "testAccInstanceDataSourceConfig_PlacementGroup"
+	strategy = "cluster"
+}
+
+# Limitations: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html#concepts-placement-groups
+resource "aws_instance" "foo" {
+  # us-west-2
+  ami = "ami-55a7ea65"
+  instance_type = "c3.large"
+  subnet_id = "${aws_subnet.foo.id}"
+	associate_public_ip_address = true
+	placement_group = "${aws_placement_group.foo.name}"
   tenancy = "dedicated"
   # pre-encoded base64 data
   user_data = "3dc39dda39be1205215e776bad998da361a5955d"


### PR DESCRIPTION
This is complementary PR to #2398 since the read functions are different between the resource and data source. The [data source docs](https://www.terraform.io/docs/providers/aws/d/instance.html#placement_group) already note that `placement_group` may be set.

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSInstanceDataSource_PlacementGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSInstanceDataSource_PlacementGroup -timeout 120m
=== RUN   TestAccAWSInstanceDataSource_PlacementGroup
--- PASS: TestAccAWSInstanceDataSource_PlacementGroup (84.20s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	84.240s
```