### PR TITLE
Bump AWS SDK to v1.12.32

### DIFF
--- a/vendor/github.com/aws/aws-sdk-go/aws/client/default_retryer.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/client/default_retryer.go
@@ -47,10 +47,10 @@ func (d DefaultRetryer) RetryRules(r *request.Request) time.Duration {
 	}
 
 	retryCount := r.RetryCount
-	if retryCount > 13 {
-		retryCount = 13
-	} else if throttle && retryCount > 8 {
+	if throttle && retryCount > 8 {
 		retryCount = 8
+	} else if retryCount > 13 {
+		retryCount = 13
 	}
 
 	delay := (1 << uint(retryCount)) * (seededRand.Intn(minTime) + minTime)

--- a/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
@@ -70,6 +70,7 @@ const (
 	ConfigServiceID                       = "config"                       // Config.
 	CurServiceID                          = "cur"                          // Cur.
 	DatapipelineServiceID                 = "datapipeline"                 // Datapipeline.
+	DaxServiceID                          = "dax"                          // Dax.
 	DevicefarmServiceID                   = "devicefarm"                   // Devicefarm.
 	DirectconnectServiceID                = "directconnect"                // Directconnect.
 	DiscoveryServiceID                    = "discovery"                    // Discovery.
@@ -664,6 +665,18 @@ var awsPartition = partition{
 				"ap-southeast-2": endpoint{},
 				"eu-west-1":      endpoint{},
 				"us-east-1":      endpoint{},
+				"us-west-2":      endpoint{},
+			},
+		},
+		"dax": service{
+
+			Endpoints: endpoints{
+				"ap-northeast-1": endpoint{},
+				"ap-south-1":     endpoint{},
+				"eu-west-1":      endpoint{},
+				"sa-east-1":      endpoint{},
+				"us-east-1":      endpoint{},
+				"us-west-1":      endpoint{},
 				"us-west-2":      endpoint{},
 			},
 		},
@@ -1372,9 +1385,18 @@ var awsPartition = partition{
 
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
+				"ap-northeast-2": endpoint{},
+				"ap-south-1":     endpoint{},
+				"ap-southeast-1": endpoint{},
+				"ap-southeast-2": endpoint{},
+				"ca-central-1":   endpoint{},
+				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
+				"eu-west-2":      endpoint{},
+				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
+				"us-west-1":      endpoint{},
 				"us-west-2":      endpoint{},
 			},
 		},

--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.12.30"
+const SDKVersion = "1.12.32"

--- a/vendor/github.com/aws/aws-sdk-go/service/apigateway/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/apigateway/api.go
@@ -5408,7 +5408,7 @@ func (c *APIGateway) GetIntegrationRequest(input *GetIntegrationInput) (req *req
 
 // GetIntegration API operation for Amazon API Gateway.
 //
-// Represents a get integration.
+// Get the integration settings.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -10558,6 +10558,42 @@ func (c *APIGateway) UpdateUsagePlanWithContext(ctx aws.Context, input *UpdateUs
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
+}
+
+// Access log settings, including the access log format and access log destination
+// ARN.
+type AccessLogSettings struct {
+	_ struct{} `type:"structure"`
+
+	// The ARN of the CloudWatch Logs log group to receive access logs.
+	DestinationArn *string `locationName:"destinationArn" type:"string"`
+
+	// A single line format of the access logs of data, as specified by selected
+	// $context variables (http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html#context-variable-reference).
+	// The format must include at least $context.requestId.
+	Format *string `locationName:"format" type:"string"`
+}
+
+// String returns the string representation
+func (s AccessLogSettings) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AccessLogSettings) GoString() string {
+	return s.String()
+}
+
+// SetDestinationArn sets the DestinationArn field's value.
+func (s *AccessLogSettings) SetDestinationArn(v string) *AccessLogSettings {
+	s.DestinationArn = &v
+	return s
+}
+
+// SetFormat sets the Format field's value.
+func (s *AccessLogSettings) SetFormat(v string) *AccessLogSettings {
+	s.Format = &v
+	return s
 }
 
 // Represents an AWS account that is associated with Amazon API Gateway.
@@ -15933,7 +15969,7 @@ func (s *GetGatewayResponsesOutput) SetPosition(v string) *GetGatewayResponsesOu
 	return s
 }
 
-// Represents a get integration request.
+// Represents a request to get the integration configuration.
 type GetIntegrationInput struct {
 	_ struct{} `type:"structure"`
 
@@ -16911,7 +16947,7 @@ type GetSdkInput struct {
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
 
 	// The language for the generated SDK. Currently java, javascript, android,
-	// objectivec and swift (for iOS) are supported.
+	// objectivec (for iOS), swift (for iOS), and ruby are supported.
 	//
 	// SdkType is a required field
 	SdkType *string `location:"uri" locationName:"sdk_type" type:"string" required:"true"`
@@ -18011,6 +18047,10 @@ type Integration struct {
 	// value.
 	RequestTemplates map[string]*string `locationName:"requestTemplates" type:"map"`
 
+	// Custom timeout between 50 and 29,000 milliseconds. The default value is 29,000
+	// milliseconds or 29 seconds.
+	TimeoutInMillis *int64 `locationName:"timeoutInMillis" type:"integer"`
+
 	// Specifies the integration's type. The valid value is HTTP for integrating
 	// with an HTTP back end, AWS for any AWS service endpoints, MOCK for testing
 	// without actually invoking the back end, HTTP_PROXY for integrating with the
@@ -18091,6 +18131,12 @@ func (s *Integration) SetRequestParameters(v map[string]*string) *Integration {
 // SetRequestTemplates sets the RequestTemplates field's value.
 func (s *Integration) SetRequestTemplates(v map[string]*string) *Integration {
 	s.RequestTemplates = v
+	return s
+}
+
+// SetTimeoutInMillis sets the TimeoutInMillis field's value.
+func (s *Integration) SetTimeoutInMillis(v int64) *Integration {
+	s.TimeoutInMillis = &v
 	return s
 }
 
@@ -19017,6 +19063,10 @@ type PutIntegrationInput struct {
 	// RestApiId is a required field
 	RestApiId *string `location:"uri" locationName:"restapi_id" type:"string" required:"true"`
 
+	// Custom timeout between 50 and 29,000 milliseconds. The default value is 29,000
+	// milliseconds or 29 seconds.
+	TimeoutInMillis *int64 `locationName:"timeoutInMillis" type:"integer"`
+
 	// Specifies a put integration input's type.
 	//
 	// Type is a required field
@@ -19129,6 +19179,12 @@ func (s *PutIntegrationInput) SetResourceId(v string) *PutIntegrationInput {
 // SetRestApiId sets the RestApiId field's value.
 func (s *PutIntegrationInput) SetRestApiId(v string) *PutIntegrationInput {
 	s.RestApiId = &v
+	return s
+}
+
+// SetTimeoutInMillis sets the TimeoutInMillis field's value.
+func (s *PutIntegrationInput) SetTimeoutInMillis(v int64) *PutIntegrationInput {
+	s.TimeoutInMillis = &v
 	return s
 }
 
@@ -20003,6 +20059,9 @@ func (s *SdkType) SetId(v string) *SdkType {
 type Stage struct {
 	_ struct{} `type:"structure"`
 
+	// The access log settings in this stage.
+	AccessLogSettings *AccessLogSettings `locationName:"accessLogSettings" type:"structure"`
+
 	// Specifies whether a cache cluster is enabled for the stage.
 	CacheClusterEnabled *bool `locationName:"cacheClusterEnabled" type:"boolean"`
 
@@ -20054,6 +20113,12 @@ func (s Stage) String() string {
 // GoString returns the string representation
 func (s Stage) GoString() string {
 	return s.String()
+}
+
+// SetAccessLogSettings sets the AccessLogSettings field's value.
+func (s *Stage) SetAccessLogSettings(v *AccessLogSettings) *Stage {
+	s.AccessLogSettings = v
+	return s
 }
 
 // SetCacheClusterEnabled sets the CacheClusterEnabled field's value.

--- a/vendor/github.com/aws/aws-sdk-go/service/cloudformation/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/cloudformation/api.go
@@ -3461,6 +3461,119 @@ func (c *CloudFormation) UpdateStackWithContext(ctx aws.Context, input *UpdateSt
 	return out, req.Send()
 }
 
+const opUpdateStackInstances = "UpdateStackInstances"
+
+// UpdateStackInstancesRequest generates a "aws/request.Request" representing the
+// client's request for the UpdateStackInstances operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See UpdateStackInstances for more information on using the UpdateStackInstances
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the UpdateStackInstancesRequest method.
+//    req, resp := client.UpdateStackInstancesRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudformation-2010-05-15/UpdateStackInstances
+func (c *CloudFormation) UpdateStackInstancesRequest(input *UpdateStackInstancesInput) (req *request.Request, output *UpdateStackInstancesOutput) {
+	op := &request.Operation{
+		Name:       opUpdateStackInstances,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &UpdateStackInstancesInput{}
+	}
+
+	output = &UpdateStackInstancesOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// UpdateStackInstances API operation for AWS CloudFormation.
+//
+// Updates the parameter values for stack instances for the specified accounts,
+// within the specified regions. A stack instance refers to a stack in a specific
+// account and region.
+//
+// You can only update stack instances in regions and accounts where they already
+// exist; to create additional stack instances, use CreateStackInstances (http://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_CreateStackInstances.html).
+//
+// During stack set updates, any parameters overridden for a stack instance
+// are not updated, but retain their overridden value.
+//
+// You can only update the parameter values that are specified in the stack
+// set; to add or delete a parameter itself, use UpdateStackSet (http://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_UpdateStackSet.html)
+// to update the stack set template. If you add a parameter to a template, before
+// you can override the parameter value specified in the stack set you must
+// first use UpdateStackSet (http://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_UpdateStackSet.html)
+// to update all stack instances with the updated template and parameter value
+// specified in the stack set. Once a stack instance has been updated with the
+// new parameter, you can then override the parameter value using UpdateStackInstances.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS CloudFormation's
+// API operation UpdateStackInstances for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeStackSetNotFoundException "StackSetNotFoundException"
+//   The specified stack set doesn't exist.
+//
+//   * ErrCodeStackInstanceNotFoundException "StackInstanceNotFoundException"
+//   The specified stack instance doesn't exist.
+//
+//   * ErrCodeOperationInProgressException "OperationInProgressException"
+//   Another operation is currently in progress for this stack set. Only one operation
+//   can be performed for a stack set at a given time.
+//
+//   * ErrCodeOperationIdAlreadyExistsException "OperationIdAlreadyExistsException"
+//   The specified operation ID already exists.
+//
+//   * ErrCodeStaleRequestException "StaleRequestException"
+//   Another operation has been performed on this stack set since the specified
+//   operation was performed.
+//
+//   * ErrCodeInvalidOperationException "InvalidOperationException"
+//   The specified operation isn't valid.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudformation-2010-05-15/UpdateStackInstances
+func (c *CloudFormation) UpdateStackInstances(input *UpdateStackInstancesInput) (*UpdateStackInstancesOutput, error) {
+	req, out := c.UpdateStackInstancesRequest(input)
+	return out, req.Send()
+}
+
+// UpdateStackInstancesWithContext is the same as UpdateStackInstances with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UpdateStackInstances for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CloudFormation) UpdateStackInstancesWithContext(ctx aws.Context, input *UpdateStackInstancesInput, opts ...request.Option) (*UpdateStackInstancesOutput, error) {
+	req, out := c.UpdateStackInstancesRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opUpdateStackSet = "UpdateStackSet"
 
 // UpdateStackSetRequest generates a "aws/request.Request" representing the
@@ -4855,6 +4968,39 @@ type CreateStackInstancesInput struct {
 	// Preferences for how AWS CloudFormation performs this stack set operation.
 	OperationPreferences *StackSetOperationPreferences `type:"structure"`
 
+	// A list of stack set parameters whose values you want to override in the selected
+	// stack instances.
+	//
+	// Any overridden parameter values will be applied to all stack instances in
+	// the specified accounts and regions. When specifying parameters and their
+	// values, be aware of how AWS CloudFormation sets parameter values during stack
+	// instance operations:
+	//
+	//    * To override the current value for a parameter, include the parameter
+	//    and specify its value.
+	//
+	//    * To leave a parameter set to its present value, you can do one of the
+	//    following:
+	//
+	// Do not include the parameter in the list.
+	//
+	// Include the parameter and specify UsePreviousValue as true. (You cannot specify
+	//    both a value and set UsePreviousValue to true.)
+	//
+	//    * To set all overridden parameter back to the values specified in the
+	//    stack set, specify a parameter list but do not include any parameters.
+	//
+	//    * To leave all parameters set to their present values, do not specify
+	//    this property at all.
+	//
+	// During stack set updates, any parameter values overridden for a stack instance
+	// are not updated, but retain their overridden value.
+	//
+	// You can only override the parameter values that are specified in the stack
+	// set; to add or delete a parameter itself, use UpdateStackSet (http://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_UpdateStackSet.html)
+	// to update the stack set template.
+	ParameterOverrides []*Parameter `type:"list"`
+
 	// The names of one or more regions where you want to create stack instances
 	// using the specified AWS account(s).
 	//
@@ -4920,6 +5066,12 @@ func (s *CreateStackInstancesInput) SetOperationId(v string) *CreateStackInstanc
 // SetOperationPreferences sets the OperationPreferences field's value.
 func (s *CreateStackInstancesInput) SetOperationPreferences(v *StackSetOperationPreferences) *CreateStackInstancesInput {
 	s.OperationPreferences = v
+	return s
+}
+
+// SetParameterOverrides sets the ParameterOverrides field's value.
+func (s *CreateStackInstancesInput) SetParameterOverrides(v []*Parameter) *CreateStackInstancesInput {
+	s.ParameterOverrides = v
 	return s
 }
 
@@ -6931,7 +7083,7 @@ type GetTemplateSummaryInput struct {
 	//
 	// Conditional: You must specify only one of the following parameters: StackName,
 	// StackSetName, TemplateBody, or TemplateURL.
-	StackSetName *string `min:"1" type:"string"`
+	StackSetName *string `type:"string"`
 
 	// Structure containing the template body with a minimum length of 1 byte and
 	// a maximum length of 51,200 bytes. For more information about templates, see
@@ -6967,9 +7119,6 @@ func (s *GetTemplateSummaryInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetTemplateSummaryInput"}
 	if s.StackName != nil && len(*s.StackName) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("StackName", 1))
-	}
-	if s.StackSetName != nil && len(*s.StackSetName) < 1 {
-		invalidParams.Add(request.NewErrParamMinLen("StackSetName", 1))
 	}
 	if s.TemplateBody != nil && len(*s.TemplateBody) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("TemplateBody", 1))
@@ -8064,8 +8213,13 @@ type Parameter struct {
 	// is specified in your template.
 	ParameterKey *string `type:"string"`
 
-	// The value associated with the parameter.
+	// The input value associated with the parameter.
 	ParameterValue *string `type:"string"`
+
+	// Read-only. The value that corresponds to a Systems Manager parameter key.
+	// This field is returned only for SSM (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html#aws-ssm-parameter-types)
+	// parameter types in the template.
+	ResolvedValue *string `type:"string"`
 
 	// During a stack update, use the existing parameter value that the stack is
 	// using for a given parameter key. If you specify true, do not specify a parameter
@@ -8092,6 +8246,12 @@ func (s *Parameter) SetParameterKey(v string) *Parameter {
 // SetParameterValue sets the ParameterValue field's value.
 func (s *Parameter) SetParameterValue(v string) *Parameter {
 	s.ParameterValue = &v
+	return s
+}
+
+// SetResolvedValue sets the ResolvedValue field's value.
+func (s *Parameter) SetResolvedValue(v string) *Parameter {
+	s.ResolvedValue = &v
 	return s
 }
 
@@ -9192,6 +9352,10 @@ type StackInstance struct {
 	// The name of the AWS account that the stack instance is associated with.
 	Account *string `type:"string"`
 
+	// A list of parameters from the stack set template whose values have been overridden
+	// in this stack instance.
+	ParameterOverrides []*Parameter `type:"list"`
+
 	// The name of the AWS region that the stack instance is associated with.
 	Region *string `type:"string"`
 
@@ -9240,6 +9404,12 @@ func (s StackInstance) GoString() string {
 // SetAccount sets the Account field's value.
 func (s *StackInstance) SetAccount(v string) *StackInstance {
 	s.Account = &v
+	return s
+}
+
+// SetParameterOverrides sets the ParameterOverrides field's value.
+func (s *StackInstance) SetParameterOverrides(v []*Parameter) *StackInstance {
+	s.ParameterOverrides = v
 	return s
 }
 
@@ -10857,6 +11027,178 @@ func (s *UpdateStackInput) SetTemplateURL(v string) *UpdateStackInput {
 // SetUsePreviousTemplate sets the UsePreviousTemplate field's value.
 func (s *UpdateStackInput) SetUsePreviousTemplate(v bool) *UpdateStackInput {
 	s.UsePreviousTemplate = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudformation-2010-05-15/UpdateStackInstancesInput
+type UpdateStackInstancesInput struct {
+	_ struct{} `type:"structure"`
+
+	// The names of one or more AWS accounts for which you want to update parameter
+	// values for stack instances. The overridden parameter values will be applied
+	// to all stack instances in the specified accounts and regions.
+	//
+	// Accounts is a required field
+	Accounts []*string `type:"list" required:"true"`
+
+	// The unique identifier for this stack set operation.
+	//
+	// The operation ID also functions as an idempotency token, to ensure that AWS
+	// CloudFormation performs the stack set operation only once, even if you retry
+	// the request multiple times. You might retry stack set operation requests
+	// to ensure that AWS CloudFormation successfully received them.
+	//
+	// If you don't specify an operation ID, the SDK generates one automatically.
+	OperationId *string `min:"1" type:"string" idempotencyToken:"true"`
+
+	// Preferences for how AWS CloudFormation performs this stack set operation.
+	OperationPreferences *StackSetOperationPreferences `type:"structure"`
+
+	// A list of input parameters whose values you want to update for the specified
+	// stack instances.
+	//
+	// Any overridden parameter values will be applied to all stack instances in
+	// the specified accounts and regions. When specifying parameters and their
+	// values, be aware of how AWS CloudFormation sets parameter values during stack
+	// instance update operations:
+	//
+	//    * To override the current value for a parameter, include the parameter
+	//    and specify its value.
+	//
+	//    * To leave a parameter set to its present value, you can do one of the
+	//    following:
+	//
+	// Do not include the parameter in the list.
+	//
+	// Include the parameter and specify UsePreviousValue as true. (You cannot specify
+	//    both a value and set UsePreviousValue to true.)
+	//
+	//    * To set all overridden parameter back to the values specified in the
+	//    stack set, specify a parameter list but do not include any parameters.
+	//
+	//    * To leave all parameters set to their present values, do not specify
+	//    this property at all.
+	//
+	// During stack set updates, any parameter values overridden for a stack instance
+	// are not updated, but retain their overridden value.
+	//
+	// You can only override the parameter values that are specified in the stack
+	// set; to add or delete a parameter itself, use UpdateStackSet to update the
+	// stack set template. If you add a parameter to a template, before you can
+	// override the parameter value specified in the stack set you must first use
+	// UpdateStackSet (http://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_UpdateStackSet.html)
+	// to update all stack instances with the updated template and parameter value
+	// specified in the stack set. Once a stack instance has been updated with the
+	// new parameter, you can then override the parameter value using UpdateStackInstances.
+	ParameterOverrides []*Parameter `type:"list"`
+
+	// The names of one or more regions in which you want to update parameter values
+	// for stack instances. The overridden parameter values will be applied to all
+	// stack instances in the specified accounts and regions.
+	//
+	// Regions is a required field
+	Regions []*string `type:"list" required:"true"`
+
+	// The name or unique ID of the stack set associated with the stack instances.
+	//
+	// StackSetName is a required field
+	StackSetName *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s UpdateStackInstancesInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateStackInstancesInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateStackInstancesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateStackInstancesInput"}
+	if s.Accounts == nil {
+		invalidParams.Add(request.NewErrParamRequired("Accounts"))
+	}
+	if s.OperationId != nil && len(*s.OperationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("OperationId", 1))
+	}
+	if s.Regions == nil {
+		invalidParams.Add(request.NewErrParamRequired("Regions"))
+	}
+	if s.StackSetName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StackSetName"))
+	}
+	if s.OperationPreferences != nil {
+		if err := s.OperationPreferences.Validate(); err != nil {
+			invalidParams.AddNested("OperationPreferences", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAccounts sets the Accounts field's value.
+func (s *UpdateStackInstancesInput) SetAccounts(v []*string) *UpdateStackInstancesInput {
+	s.Accounts = v
+	return s
+}
+
+// SetOperationId sets the OperationId field's value.
+func (s *UpdateStackInstancesInput) SetOperationId(v string) *UpdateStackInstancesInput {
+	s.OperationId = &v
+	return s
+}
+
+// SetOperationPreferences sets the OperationPreferences field's value.
+func (s *UpdateStackInstancesInput) SetOperationPreferences(v *StackSetOperationPreferences) *UpdateStackInstancesInput {
+	s.OperationPreferences = v
+	return s
+}
+
+// SetParameterOverrides sets the ParameterOverrides field's value.
+func (s *UpdateStackInstancesInput) SetParameterOverrides(v []*Parameter) *UpdateStackInstancesInput {
+	s.ParameterOverrides = v
+	return s
+}
+
+// SetRegions sets the Regions field's value.
+func (s *UpdateStackInstancesInput) SetRegions(v []*string) *UpdateStackInstancesInput {
+	s.Regions = v
+	return s
+}
+
+// SetStackSetName sets the StackSetName field's value.
+func (s *UpdateStackInstancesInput) SetStackSetName(v string) *UpdateStackInstancesInput {
+	s.StackSetName = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudformation-2010-05-15/UpdateStackInstancesOutput
+type UpdateStackInstancesOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The unique identifier for this stack set operation.
+	OperationId *string `min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s UpdateStackInstancesOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateStackInstancesOutput) GoString() string {
+	return s.String()
+}
+
+// SetOperationId sets the OperationId field's value.
+func (s *UpdateStackInstancesOutput) SetOperationId(v string) *UpdateStackInstancesOutput {
+	s.OperationId = &v
 	return s
 }
 

--- a/vendor/github.com/aws/aws-sdk-go/service/codebuild/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/codebuild/api.go
@@ -600,6 +600,88 @@ func (c *CodeBuild) DeleteWebhookWithContext(ctx aws.Context, input *DeleteWebho
 	return out, req.Send()
 }
 
+const opInvalidateProjectCache = "InvalidateProjectCache"
+
+// InvalidateProjectCacheRequest generates a "aws/request.Request" representing the
+// client's request for the InvalidateProjectCache operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See InvalidateProjectCache for more information on using the InvalidateProjectCache
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the InvalidateProjectCacheRequest method.
+//    req, resp := client.InvalidateProjectCacheRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codebuild-2016-10-06/InvalidateProjectCache
+func (c *CodeBuild) InvalidateProjectCacheRequest(input *InvalidateProjectCacheInput) (req *request.Request, output *InvalidateProjectCacheOutput) {
+	op := &request.Operation{
+		Name:       opInvalidateProjectCache,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &InvalidateProjectCacheInput{}
+	}
+
+	output = &InvalidateProjectCacheOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// InvalidateProjectCache API operation for AWS CodeBuild.
+//
+// Resets the cache for a project.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS CodeBuild's
+// API operation InvalidateProjectCache for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidInputException "InvalidInputException"
+//   The input value that was provided is not valid.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified AWS resource cannot be found.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codebuild-2016-10-06/InvalidateProjectCache
+func (c *CodeBuild) InvalidateProjectCache(input *InvalidateProjectCacheInput) (*InvalidateProjectCacheOutput, error) {
+	req, out := c.InvalidateProjectCacheRequest(input)
+	return out, req.Send()
+}
+
+// InvalidateProjectCacheWithContext is the same as InvalidateProjectCache with the addition of
+// the ability to pass a context and additional request options.
+//
+// See InvalidateProjectCache for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CodeBuild) InvalidateProjectCacheWithContext(ctx aws.Context, input *InvalidateProjectCacheInput, opts ...request.Option) (*InvalidateProjectCacheOutput, error) {
+	req, out := c.InvalidateProjectCacheRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opListBuilds = "ListBuilds"
 
 // ListBuildsRequest generates a "aws/request.Request" representing the
@@ -1419,6 +1501,9 @@ type Build struct {
 	//    * TIMED_OUT: The build timed out.
 	BuildStatus *string `locationName:"buildStatus" type:"string" enum:"StatusType"`
 
+	// Information about the cache for the build.
+	Cache *ProjectCache `locationName:"cache" type:"structure"`
+
 	// The current build phase.
 	CurrentPhase *string `locationName:"currentPhase" type:"string"`
 
@@ -1446,6 +1531,9 @@ type Build struct {
 	// Information about the build's logs in Amazon CloudWatch Logs.
 	Logs *LogsLocation `locationName:"logs" type:"structure"`
 
+	// Describes a network interface.
+	NetworkInterface *NetworkInterface `locationName:"networkInterface" type:"structure"`
+
 	// Information about all previous build phases that are completed and information
 	// about any current build phase that is not yet complete.
 	Phases []*BuildPhase `locationName:"phases" type:"list"`
@@ -1465,6 +1553,12 @@ type Build struct {
 	// How long, in minutes, for AWS CodeBuild to wait before timing out this build
 	// if it does not get marked as completed.
 	TimeoutInMinutes *int64 `locationName:"timeoutInMinutes" type:"integer"`
+
+	// If your AWS CodeBuild project accesses resources in an Amazon VPC, you provide
+	// this parameter that identifies the VPC ID and the list of security group
+	// IDs and subnet IDs. The security groups and subnets must belong to the same
+	// VPC. You must provide at least one security group and one subnet ID.
+	VpcConfig *VpcConfig `locationName:"vpcConfig" type:"structure"`
 }
 
 // String returns the string representation
@@ -1498,6 +1592,12 @@ func (s *Build) SetBuildComplete(v bool) *Build {
 // SetBuildStatus sets the BuildStatus field's value.
 func (s *Build) SetBuildStatus(v string) *Build {
 	s.BuildStatus = &v
+	return s
+}
+
+// SetCache sets the Cache field's value.
+func (s *Build) SetCache(v *ProjectCache) *Build {
+	s.Cache = v
 	return s
 }
 
@@ -1537,6 +1637,12 @@ func (s *Build) SetLogs(v *LogsLocation) *Build {
 	return s
 }
 
+// SetNetworkInterface sets the NetworkInterface field's value.
+func (s *Build) SetNetworkInterface(v *NetworkInterface) *Build {
+	s.NetworkInterface = v
+	return s
+}
+
 // SetPhases sets the Phases field's value.
 func (s *Build) SetPhases(v []*BuildPhase) *Build {
 	s.Phases = v
@@ -1570,6 +1676,12 @@ func (s *Build) SetStartTime(v time.Time) *Build {
 // SetTimeoutInMinutes sets the TimeoutInMinutes field's value.
 func (s *Build) SetTimeoutInMinutes(v int64) *Build {
 	s.TimeoutInMinutes = &v
+	return s
+}
+
+// SetVpcConfig sets the VpcConfig field's value.
+func (s *Build) SetVpcConfig(v *VpcConfig) *Build {
+	s.VpcConfig = v
 	return s
 }
 
@@ -1776,6 +1888,14 @@ type CreateProjectInput struct {
 	// Artifacts is a required field
 	Artifacts *ProjectArtifacts `locationName:"artifacts" type:"structure" required:"true"`
 
+	// Set this to true to generate a publicly-accessible URL for your project's
+	// build badge.
+	BadgeEnabled *bool `locationName:"badgeEnabled" type:"boolean"`
+
+	// Stores recently used information so that it can be quickly accessed at a
+	// later time.
+	Cache *ProjectCache `locationName:"cache" type:"structure"`
+
 	// A description that makes the build project easy to identify.
 	Description *string `locationName:"description" type:"string"`
 
@@ -1816,6 +1936,9 @@ type CreateProjectInput struct {
 	// until timing out any build that has not been marked as completed. The default
 	// is 60 minutes.
 	TimeoutInMinutes *int64 `locationName:"timeoutInMinutes" min:"5" type:"integer"`
+
+	// VpcConfig enables AWS CodeBuild to access resources in an Amazon VPC.
+	VpcConfig *VpcConfig `locationName:"vpcConfig" type:"structure"`
 }
 
 // String returns the string representation
@@ -1860,6 +1983,11 @@ func (s *CreateProjectInput) Validate() error {
 			invalidParams.AddNested("Artifacts", err.(request.ErrInvalidParams))
 		}
 	}
+	if s.Cache != nil {
+		if err := s.Cache.Validate(); err != nil {
+			invalidParams.AddNested("Cache", err.(request.ErrInvalidParams))
+		}
+	}
 	if s.Environment != nil {
 		if err := s.Environment.Validate(); err != nil {
 			invalidParams.AddNested("Environment", err.(request.ErrInvalidParams))
@@ -1880,6 +2008,11 @@ func (s *CreateProjectInput) Validate() error {
 			}
 		}
 	}
+	if s.VpcConfig != nil {
+		if err := s.VpcConfig.Validate(); err != nil {
+			invalidParams.AddNested("VpcConfig", err.(request.ErrInvalidParams))
+		}
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -1890,6 +2023,18 @@ func (s *CreateProjectInput) Validate() error {
 // SetArtifacts sets the Artifacts field's value.
 func (s *CreateProjectInput) SetArtifacts(v *ProjectArtifacts) *CreateProjectInput {
 	s.Artifacts = v
+	return s
+}
+
+// SetBadgeEnabled sets the BadgeEnabled field's value.
+func (s *CreateProjectInput) SetBadgeEnabled(v bool) *CreateProjectInput {
+	s.BadgeEnabled = &v
+	return s
+}
+
+// SetCache sets the Cache field's value.
+func (s *CreateProjectInput) SetCache(v *ProjectCache) *CreateProjectInput {
+	s.Cache = v
 	return s
 }
 
@@ -1938,6 +2083,12 @@ func (s *CreateProjectInput) SetTags(v []*Tag) *CreateProjectInput {
 // SetTimeoutInMinutes sets the TimeoutInMinutes field's value.
 func (s *CreateProjectInput) SetTimeoutInMinutes(v int64) *CreateProjectInput {
 	s.TimeoutInMinutes = &v
+	return s
+}
+
+// SetVpcConfig sets the VpcConfig field's value.
+func (s *CreateProjectInput) SetVpcConfig(v *VpcConfig) *CreateProjectInput {
+	s.VpcConfig = v
 	return s
 }
 
@@ -2326,6 +2477,63 @@ func (s *EnvironmentVariable) SetValue(v string) *EnvironmentVariable {
 	return s
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codebuild-2016-10-06/InvalidateProjectCacheInput
+type InvalidateProjectCacheInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the build project that the cache will be reset for.
+	//
+	// ProjectName is a required field
+	ProjectName *string `locationName:"projectName" min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s InvalidateProjectCacheInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s InvalidateProjectCacheInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InvalidateProjectCacheInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InvalidateProjectCacheInput"}
+	if s.ProjectName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ProjectName"))
+	}
+	if s.ProjectName != nil && len(*s.ProjectName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ProjectName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetProjectName sets the ProjectName field's value.
+func (s *InvalidateProjectCacheInput) SetProjectName(v string) *InvalidateProjectCacheInput {
+	s.ProjectName = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codebuild-2016-10-06/InvalidateProjectCacheOutput
+type InvalidateProjectCacheOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s InvalidateProjectCacheOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s InvalidateProjectCacheOutput) GoString() string {
+	return s.String()
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/codebuild-2016-10-06/ListBuildsForProjectInput
 type ListBuildsForProjectInput struct {
 	_ struct{} `type:"structure"`
@@ -2707,6 +2915,40 @@ func (s *LogsLocation) SetStreamName(v string) *LogsLocation {
 	return s
 }
 
+// Describes a network interface.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codebuild-2016-10-06/NetworkInterface
+type NetworkInterface struct {
+	_ struct{} `type:"structure"`
+
+	// The ID of the network interface.
+	NetworkInterfaceId *string `locationName:"networkInterfaceId" min:"1" type:"string"`
+
+	// The ID of the subnet.
+	SubnetId *string `locationName:"subnetId" min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s NetworkInterface) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s NetworkInterface) GoString() string {
+	return s.String()
+}
+
+// SetNetworkInterfaceId sets the NetworkInterfaceId field's value.
+func (s *NetworkInterface) SetNetworkInterfaceId(v string) *NetworkInterface {
+	s.NetworkInterfaceId = &v
+	return s
+}
+
+// SetSubnetId sets the SubnetId field's value.
+func (s *NetworkInterface) SetSubnetId(v string) *NetworkInterface {
+	s.SubnetId = &v
+	return s
+}
+
 // Additional information about a build phase that has an error. You can use
 // this information to help troubleshoot a failed build.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/codebuild-2016-10-06/PhaseContext
@@ -2754,6 +2996,12 @@ type Project struct {
 	// Information about the build output artifacts for the build project.
 	Artifacts *ProjectArtifacts `locationName:"artifacts" type:"structure"`
 
+	// Information about the build badge for the build project.
+	Badge *ProjectBadge `locationName:"badge" type:"structure"`
+
+	// Information about the cache for the build project.
+	Cache *ProjectCache `locationName:"cache" type:"structure"`
+
 	// When the build project was created, expressed in Unix time format.
 	Created *time.Time `locationName:"created" type:"timestamp" timestampFormat:"unix"`
 
@@ -2796,6 +3044,12 @@ type Project struct {
 	// The default is 60 minutes.
 	TimeoutInMinutes *int64 `locationName:"timeoutInMinutes" min:"5" type:"integer"`
 
+	// If your AWS CodeBuild project accesses resources in an Amazon VPC, you provide
+	// this parameter that identifies the VPC ID and the list of security group
+	// IDs and subnet IDs. The security groups and subnets must belong to the same
+	// VPC. You must provide at least one security group and one subnet ID.
+	VpcConfig *VpcConfig `locationName:"vpcConfig" type:"structure"`
+
 	// Information about a webhook in GitHub that connects repository events to
 	// a build project in AWS CodeBuild.
 	Webhook *Webhook `locationName:"webhook" type:"structure"`
@@ -2820,6 +3074,18 @@ func (s *Project) SetArn(v string) *Project {
 // SetArtifacts sets the Artifacts field's value.
 func (s *Project) SetArtifacts(v *ProjectArtifacts) *Project {
 	s.Artifacts = v
+	return s
+}
+
+// SetBadge sets the Badge field's value.
+func (s *Project) SetBadge(v *ProjectBadge) *Project {
+	s.Badge = v
+	return s
+}
+
+// SetCache sets the Cache field's value.
+func (s *Project) SetCache(v *ProjectCache) *Project {
+	s.Cache = v
 	return s
 }
 
@@ -2880,6 +3146,12 @@ func (s *Project) SetTags(v []*Tag) *Project {
 // SetTimeoutInMinutes sets the TimeoutInMinutes field's value.
 func (s *Project) SetTimeoutInMinutes(v int64) *Project {
 	s.TimeoutInMinutes = &v
+	return s
+}
+
+// SetVpcConfig sets the VpcConfig field's value.
+func (s *Project) SetVpcConfig(v *VpcConfig) *Project {
+	s.VpcConfig = v
 	return s
 }
 
@@ -3050,6 +3322,99 @@ func (s *ProjectArtifacts) SetPath(v string) *ProjectArtifacts {
 
 // SetType sets the Type field's value.
 func (s *ProjectArtifacts) SetType(v string) *ProjectArtifacts {
+	s.Type = &v
+	return s
+}
+
+// Information about the build badge for the build project.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codebuild-2016-10-06/ProjectBadge
+type ProjectBadge struct {
+	_ struct{} `type:"structure"`
+
+	// Set this to true to generate a publicly-accessible URL for your project's
+	// build badge.
+	BadgeEnabled *bool `locationName:"badgeEnabled" type:"boolean"`
+
+	// The publicly-accessible URL through which you can access the build badge
+	// for your project.
+	BadgeRequestUrl *string `locationName:"badgeRequestUrl" type:"string"`
+}
+
+// String returns the string representation
+func (s ProjectBadge) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ProjectBadge) GoString() string {
+	return s.String()
+}
+
+// SetBadgeEnabled sets the BadgeEnabled field's value.
+func (s *ProjectBadge) SetBadgeEnabled(v bool) *ProjectBadge {
+	s.BadgeEnabled = &v
+	return s
+}
+
+// SetBadgeRequestUrl sets the BadgeRequestUrl field's value.
+func (s *ProjectBadge) SetBadgeRequestUrl(v string) *ProjectBadge {
+	s.BadgeRequestUrl = &v
+	return s
+}
+
+// Information about the cache for the build project.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codebuild-2016-10-06/ProjectCache
+type ProjectCache struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the cache location, as follows:
+	//
+	//    * NO_CACHE: This value will be ignored.
+	//
+	//    * S3: This is the S3 bucket name/prefix.
+	Location *string `locationName:"location" type:"string"`
+
+	// The type of cache used by the build project. Valid values include:
+	//
+	//    * NO_CACHE: The build project will not use any cache.
+	//
+	//    * S3: The build project will read and write from/to S3.
+	//
+	// Type is a required field
+	Type *string `locationName:"type" type:"string" required:"true" enum:"CacheType"`
+}
+
+// String returns the string representation
+func (s ProjectCache) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ProjectCache) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ProjectCache) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ProjectCache"}
+	if s.Type == nil {
+		invalidParams.Add(request.NewErrParamRequired("Type"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetLocation sets the Location field's value.
+func (s *ProjectCache) SetLocation(v string) *ProjectCache {
+	s.Location = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *ProjectCache) SetType(v string) *ProjectCache {
 	s.Type = &v
 	return s
 }
@@ -3638,6 +4003,14 @@ type UpdateProjectInput struct {
 	// project.
 	Artifacts *ProjectArtifacts `locationName:"artifacts" type:"structure"`
 
+	// Set this to true to generate a publicly-accessible URL for your project's
+	// build badge.
+	BadgeEnabled *bool `locationName:"badgeEnabled" type:"boolean"`
+
+	// Stores recently used information so that it can be quickly accessed at a
+	// later time.
+	Cache *ProjectCache `locationName:"cache" type:"structure"`
+
 	// A new or replacement description of the build project.
 	Description *string `locationName:"description" type:"string"`
 
@@ -3676,6 +4049,9 @@ type UpdateProjectInput struct {
 	// The replacement value in minutes, from 5 to 480 (8 hours), for AWS CodeBuild
 	// to wait before timing out any related build that did not get marked as completed.
 	TimeoutInMinutes *int64 `locationName:"timeoutInMinutes" min:"5" type:"integer"`
+
+	// VpcConfig enables AWS CodeBuild to access resources in an Amazon VPC.
+	VpcConfig *VpcConfig `locationName:"vpcConfig" type:"structure"`
 }
 
 // String returns the string representation
@@ -3711,6 +4087,11 @@ func (s *UpdateProjectInput) Validate() error {
 			invalidParams.AddNested("Artifacts", err.(request.ErrInvalidParams))
 		}
 	}
+	if s.Cache != nil {
+		if err := s.Cache.Validate(); err != nil {
+			invalidParams.AddNested("Cache", err.(request.ErrInvalidParams))
+		}
+	}
 	if s.Environment != nil {
 		if err := s.Environment.Validate(); err != nil {
 			invalidParams.AddNested("Environment", err.(request.ErrInvalidParams))
@@ -3731,6 +4112,11 @@ func (s *UpdateProjectInput) Validate() error {
 			}
 		}
 	}
+	if s.VpcConfig != nil {
+		if err := s.VpcConfig.Validate(); err != nil {
+			invalidParams.AddNested("VpcConfig", err.(request.ErrInvalidParams))
+		}
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -3741,6 +4127,18 @@ func (s *UpdateProjectInput) Validate() error {
 // SetArtifacts sets the Artifacts field's value.
 func (s *UpdateProjectInput) SetArtifacts(v *ProjectArtifacts) *UpdateProjectInput {
 	s.Artifacts = v
+	return s
+}
+
+// SetBadgeEnabled sets the BadgeEnabled field's value.
+func (s *UpdateProjectInput) SetBadgeEnabled(v bool) *UpdateProjectInput {
+	s.BadgeEnabled = &v
+	return s
+}
+
+// SetCache sets the Cache field's value.
+func (s *UpdateProjectInput) SetCache(v *ProjectCache) *UpdateProjectInput {
+	s.Cache = v
 	return s
 }
 
@@ -3792,6 +4190,12 @@ func (s *UpdateProjectInput) SetTimeoutInMinutes(v int64) *UpdateProjectInput {
 	return s
 }
 
+// SetVpcConfig sets the VpcConfig field's value.
+func (s *UpdateProjectInput) SetVpcConfig(v *VpcConfig) *UpdateProjectInput {
+	s.VpcConfig = v
+	return s
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/codebuild-2016-10-06/UpdateProjectOutput
 type UpdateProjectOutput struct {
 	_ struct{} `type:"structure"`
@@ -3813,6 +4217,65 @@ func (s UpdateProjectOutput) GoString() string {
 // SetProject sets the Project field's value.
 func (s *UpdateProjectOutput) SetProject(v *Project) *UpdateProjectOutput {
 	s.Project = v
+	return s
+}
+
+// If your AWS CodeBuild project accesses resources in an Amazon VPC, you provide
+// this parameter that identifies the VPC ID and the list of security group
+// IDs and subnet IDs. The security groups and subnets must belong to the same
+// VPC. You must provide at least one security group and one subnet ID.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codebuild-2016-10-06/VpcConfig
+type VpcConfig struct {
+	_ struct{} `type:"structure"`
+
+	// A list of one or more security groups IDs in your Amazon VPC.
+	SecurityGroupIds []*string `locationName:"securityGroupIds" type:"list"`
+
+	// A list of one or more subnet IDs in your Amazon VPC.
+	Subnets []*string `locationName:"subnets" type:"list"`
+
+	// The ID of the Amazon VPC.
+	VpcId *string `locationName:"vpcId" min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s VpcConfig) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s VpcConfig) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *VpcConfig) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "VpcConfig"}
+	if s.VpcId != nil && len(*s.VpcId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VpcId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetSecurityGroupIds sets the SecurityGroupIds field's value.
+func (s *VpcConfig) SetSecurityGroupIds(v []*string) *VpcConfig {
+	s.SecurityGroupIds = v
+	return s
+}
+
+// SetSubnets sets the Subnets field's value.
+func (s *VpcConfig) SetSubnets(v []*string) *VpcConfig {
+	s.Subnets = v
+	return s
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *VpcConfig) SetVpcId(v string) *VpcConfig {
+	s.VpcId = &v
 	return s
 }
 
@@ -3899,6 +4362,14 @@ const (
 
 	// BuildPhaseTypeCompleted is a BuildPhaseType enum value
 	BuildPhaseTypeCompleted = "COMPLETED"
+)
+
+const (
+	// CacheTypeNoCache is a CacheType enum value
+	CacheTypeNoCache = "NO_CACHE"
+
+	// CacheTypeS3 is a CacheType enum value
+	CacheTypeS3 = "S3"
 )
 
 const (

--- a/vendor/github.com/aws/aws-sdk-go/service/codecommit/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/codecommit/api.go
@@ -203,7 +203,7 @@ func (c *CodeCommit) CreateBranchRequest(input *CreateBranchInput) (req *request
 //   The specified branch name already exists.
 //
 //   * ErrCodeInvalidBranchNameException "InvalidBranchNameException"
-//   The specified branch name is not valid.
+//   The specified reference name is not valid.
 //
 //   * ErrCodeCommitIdRequiredException "CommitIdRequiredException"
 //   A commit ID was not specified.
@@ -247,6 +247,183 @@ func (c *CodeCommit) CreateBranch(input *CreateBranchInput) (*CreateBranchOutput
 // for more information on using Contexts.
 func (c *CodeCommit) CreateBranchWithContext(ctx aws.Context, input *CreateBranchInput, opts ...request.Option) (*CreateBranchOutput, error) {
 	req, out := c.CreateBranchRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opCreatePullRequest = "CreatePullRequest"
+
+// CreatePullRequestRequest generates a "aws/request.Request" representing the
+// client's request for the CreatePullRequest operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See CreatePullRequest for more information on using the CreatePullRequest
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the CreatePullRequestRequest method.
+//    req, resp := client.CreatePullRequestRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/CreatePullRequest
+func (c *CodeCommit) CreatePullRequestRequest(input *CreatePullRequestInput) (req *request.Request, output *CreatePullRequestOutput) {
+	op := &request.Operation{
+		Name:       opCreatePullRequest,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &CreatePullRequestInput{}
+	}
+
+	output = &CreatePullRequestOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// CreatePullRequest API operation for AWS CodeCommit.
+//
+// Creates a pull request in the specified repository.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS CodeCommit's
+// API operation CreatePullRequest for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeRepositoryNameRequiredException "RepositoryNameRequiredException"
+//   A repository name is required but was not specified.
+//
+//   * ErrCodeInvalidRepositoryNameException "InvalidRepositoryNameException"
+//   At least one specified repository name is not valid.
+//
+//   This exception only occurs when a specified repository name is not valid.
+//   Other exceptions occur when a required repository parameter is missing, or
+//   when a specified repository does not exist.
+//
+//   * ErrCodeRepositoryDoesNotExistException "RepositoryDoesNotExistException"
+//   The specified repository does not exist.
+//
+//   * ErrCodeEncryptionIntegrityChecksFailedException "EncryptionIntegrityChecksFailedException"
+//   An encryption integrity check failed.
+//
+//   * ErrCodeEncryptionKeyAccessDeniedException "EncryptionKeyAccessDeniedException"
+//   An encryption key could not be accessed.
+//
+//   * ErrCodeEncryptionKeyDisabledException "EncryptionKeyDisabledException"
+//   The encryption key is disabled.
+//
+//   * ErrCodeEncryptionKeyNotFoundException "EncryptionKeyNotFoundException"
+//   No encryption key was found.
+//
+//   * ErrCodeEncryptionKeyUnavailableException "EncryptionKeyUnavailableException"
+//   The encryption key is not available.
+//
+//   * ErrCodeClientRequestTokenRequiredException "ClientRequestTokenRequiredException"
+//   A client request token is required. A client request token is an unique,
+//   client-generated idempotency token that when provided in a request, ensures
+//   the request cannot be repeated with a changed parameter. If a request is
+//   received with the same parameters and a token is included, the request will
+//   return information about the initial request that used that token.
+//
+//   * ErrCodeInvalidClientRequestTokenException "InvalidClientRequestTokenException"
+//   The client request token is not valid.
+//
+//   * ErrCodeIdempotencyParameterMismatchException "IdempotencyParameterMismatchException"
+//   The client request token is not valid. Either the token is not in a valid
+//   format, or the token has been used in a previous request and cannot be re-used.
+//
+//   * ErrCodeReferenceNameRequiredException "ReferenceNameRequiredException"
+//   A reference name is required, but none was provided.
+//
+//   * ErrCodeInvalidReferenceNameException "InvalidReferenceNameException"
+//   The specified reference name format is not valid. Reference names must conform
+//   to the Git references format, for example refs/heads/master. For more information,
+//   see Git Internals - Git References (https://git-scm.com/book/en/v2/Git-Internals-Git-References)
+//   or consult your Git documentation.
+//
+//   * ErrCodeReferenceDoesNotExistException "ReferenceDoesNotExistException"
+//   The specified reference does not exist. You must provide a full commit ID.
+//
+//   * ErrCodeReferenceTypeNotSupportedException "ReferenceTypeNotSupportedException"
+//   The specified reference is not a supported type.
+//
+//   * ErrCodeTitleRequiredException "TitleRequiredException"
+//   A pull request title is required. It cannot be empty or null.
+//
+//   * ErrCodeInvalidTitleException "InvalidTitleException"
+//   The title of the pull request is not valid. Pull request titles cannot exceed
+//   100 characters in length.
+//
+//   * ErrCodeInvalidDescriptionException "InvalidDescriptionException"
+//   The pull request description is not valid. Descriptions are limited to 1,000
+//   characters in length.
+//
+//   * ErrCodeTargetsRequiredException "TargetsRequiredException"
+//   An array of target objects is required. It cannot be empty or null.
+//
+//   * ErrCodeInvalidTargetsException "InvalidTargetsException"
+//   The targets for the pull request is not valid or not in a valid format. Targets
+//   are a list of target objects. Each target object must contain the full values
+//   for the repository name, source branch, and destination branch for a pull
+//   request.
+//
+//   * ErrCodeTargetRequiredException "TargetRequiredException"
+//   A pull request target is required. It cannot be empty or null. A pull request
+//   target must contain the full values for the repository name, source branch,
+//   and destination branch for the pull request.
+//
+//   * ErrCodeInvalidTargetException "InvalidTargetException"
+//   The target for the pull request is not valid. A target must contain the full
+//   values for the repository name, source branch, and destination branch for
+//   the pull request.
+//
+//   * ErrCodeMultipleRepositoriesInPullRequestException "MultipleRepositoriesInPullRequestException"
+//   You cannot include more than one repository in a pull request. Make sure
+//   you have specified only one repository name in your request, and then try
+//   again.
+//
+//   * ErrCodeMaximumOpenPullRequestsExceededException "MaximumOpenPullRequestsExceededException"
+//   You cannot create the pull request because the repository has too many open
+//   pull requests. The maximum number of open pull requests for a repository
+//   is 1,000. Close one or more open pull requests, and then try again.
+//
+//   * ErrCodeSourceAndDestinationAreSameException "SourceAndDestinationAreSameException"
+//   The source branch and the destination branch for the pull request are the
+//   same. You must specify different branches for the source and destination.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/CreatePullRequest
+func (c *CodeCommit) CreatePullRequest(input *CreatePullRequestInput) (*CreatePullRequestOutput, error) {
+	req, out := c.CreatePullRequestRequest(input)
+	return out, req.Send()
+}
+
+// CreatePullRequestWithContext is the same as CreatePullRequest with the addition of
+// the ability to pass a context and additional request options.
+//
+// See CreatePullRequest for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CodeCommit) CreatePullRequestWithContext(ctx aws.Context, input *CreatePullRequestInput, opts ...request.Option) (*CreatePullRequestOutput, error) {
+	req, out := c.CreatePullRequestRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -434,7 +611,7 @@ func (c *CodeCommit) DeleteBranchRequest(input *DeleteBranchInput) (req *request
 //   A branch name is required but was not specified.
 //
 //   * ErrCodeInvalidBranchNameException "InvalidBranchNameException"
-//   The specified branch name is not valid.
+//   The specified reference name is not valid.
 //
 //   * ErrCodeDefaultBranchCannotBeDeletedException "DefaultBranchCannotBeDeletedException"
 //   The specified branch is the default branch for the repository, and cannot
@@ -473,6 +650,97 @@ func (c *CodeCommit) DeleteBranch(input *DeleteBranchInput) (*DeleteBranchOutput
 // for more information on using Contexts.
 func (c *CodeCommit) DeleteBranchWithContext(ctx aws.Context, input *DeleteBranchInput, opts ...request.Option) (*DeleteBranchOutput, error) {
 	req, out := c.DeleteBranchRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDeleteCommentContent = "DeleteCommentContent"
+
+// DeleteCommentContentRequest generates a "aws/request.Request" representing the
+// client's request for the DeleteCommentContent operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DeleteCommentContent for more information on using the DeleteCommentContent
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DeleteCommentContentRequest method.
+//    req, resp := client.DeleteCommentContentRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/DeleteCommentContent
+func (c *CodeCommit) DeleteCommentContentRequest(input *DeleteCommentContentInput) (req *request.Request, output *DeleteCommentContentOutput) {
+	op := &request.Operation{
+		Name:       opDeleteCommentContent,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DeleteCommentContentInput{}
+	}
+
+	output = &DeleteCommentContentOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DeleteCommentContent API operation for AWS CodeCommit.
+//
+// Deletes the content of a comment made on a change, file, or commit in a repository.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS CodeCommit's
+// API operation DeleteCommentContent for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeCommentDoesNotExistException "CommentDoesNotExistException"
+//   No comment exists with the provided ID. Verify that you have provided the
+//   correct ID, and then try again.
+//
+//   * ErrCodeCommentIdRequiredException "CommentIdRequiredException"
+//   The comment ID is missing or null. A comment ID is required.
+//
+//   * ErrCodeInvalidCommentIdException "InvalidCommentIdException"
+//   The comment ID is not in a valid format. Make sure that you have provided
+//   the full comment ID.
+//
+//   * ErrCodeCommentDeletedException "CommentDeletedException"
+//   This comment has already been deleted. You cannot edit or delete a deleted
+//   comment.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/DeleteCommentContent
+func (c *CodeCommit) DeleteCommentContent(input *DeleteCommentContentInput) (*DeleteCommentContentOutput, error) {
+	req, out := c.DeleteCommentContentRequest(input)
+	return out, req.Send()
+}
+
+// DeleteCommentContentWithContext is the same as DeleteCommentContent with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeleteCommentContent for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CodeCommit) DeleteCommentContentWithContext(ctx aws.Context, input *DeleteCommentContentInput, opts ...request.Option) (*DeleteCommentContentOutput, error) {
+	req, out := c.DeleteCommentContentRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -582,6 +850,182 @@ func (c *CodeCommit) DeleteRepositoryWithContext(ctx aws.Context, input *DeleteR
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
+}
+
+const opDescribePullRequestEvents = "DescribePullRequestEvents"
+
+// DescribePullRequestEventsRequest generates a "aws/request.Request" representing the
+// client's request for the DescribePullRequestEvents operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribePullRequestEvents for more information on using the DescribePullRequestEvents
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribePullRequestEventsRequest method.
+//    req, resp := client.DescribePullRequestEventsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/DescribePullRequestEvents
+func (c *CodeCommit) DescribePullRequestEventsRequest(input *DescribePullRequestEventsInput) (req *request.Request, output *DescribePullRequestEventsOutput) {
+	op := &request.Operation{
+		Name:       opDescribePullRequestEvents,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"nextToken"},
+			OutputTokens:    []string{"nextToken"},
+			LimitToken:      "maxResults",
+			TruncationToken: "",
+		},
+	}
+
+	if input == nil {
+		input = &DescribePullRequestEventsInput{}
+	}
+
+	output = &DescribePullRequestEventsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribePullRequestEvents API operation for AWS CodeCommit.
+//
+// Returns information about one or more pull request events.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS CodeCommit's
+// API operation DescribePullRequestEvents for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodePullRequestDoesNotExistException "PullRequestDoesNotExistException"
+//   The pull request ID could not be found. Make sure that you have specified
+//   the correct repository name and pull request ID, and then try again.
+//
+//   * ErrCodeInvalidPullRequestIdException "InvalidPullRequestIdException"
+//   The pull request ID is not valid. Make sure that you have provided the full
+//   ID and that the pull request is in the specified repository, and then try
+//   again.
+//
+//   * ErrCodePullRequestIdRequiredException "PullRequestIdRequiredException"
+//   A pull request ID is required, but none was provided.
+//
+//   * ErrCodeInvalidPullRequestEventTypeException "InvalidPullRequestEventTypeException"
+//   The pull request event type is not valid.
+//
+//   * ErrCodeInvalidActorArnException "InvalidActorArnException"
+//   The Amazon Resource Name (ARN) is not valid. Make sure that you have provided
+//   the full ARN for the user who initiated the change for the pull request,
+//   and then try again.
+//
+//   * ErrCodeActorDoesNotExistException "ActorDoesNotExistException"
+//   The specified Amazon Resource Name (ARN) does not exist in the AWS account.
+//
+//   * ErrCodeInvalidMaxResultsException "InvalidMaxResultsException"
+//   The specified number of maximum results is not valid.
+//
+//   * ErrCodeInvalidContinuationTokenException "InvalidContinuationTokenException"
+//   The specified continuation token is not valid.
+//
+//   * ErrCodeEncryptionIntegrityChecksFailedException "EncryptionIntegrityChecksFailedException"
+//   An encryption integrity check failed.
+//
+//   * ErrCodeEncryptionKeyAccessDeniedException "EncryptionKeyAccessDeniedException"
+//   An encryption key could not be accessed.
+//
+//   * ErrCodeEncryptionKeyDisabledException "EncryptionKeyDisabledException"
+//   The encryption key is disabled.
+//
+//   * ErrCodeEncryptionKeyNotFoundException "EncryptionKeyNotFoundException"
+//   No encryption key was found.
+//
+//   * ErrCodeEncryptionKeyUnavailableException "EncryptionKeyUnavailableException"
+//   The encryption key is not available.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/DescribePullRequestEvents
+func (c *CodeCommit) DescribePullRequestEvents(input *DescribePullRequestEventsInput) (*DescribePullRequestEventsOutput, error) {
+	req, out := c.DescribePullRequestEventsRequest(input)
+	return out, req.Send()
+}
+
+// DescribePullRequestEventsWithContext is the same as DescribePullRequestEvents with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribePullRequestEvents for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CodeCommit) DescribePullRequestEventsWithContext(ctx aws.Context, input *DescribePullRequestEventsInput, opts ...request.Option) (*DescribePullRequestEventsOutput, error) {
+	req, out := c.DescribePullRequestEventsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+// DescribePullRequestEventsPages iterates over the pages of a DescribePullRequestEvents operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See DescribePullRequestEvents method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a DescribePullRequestEvents operation.
+//    pageNum := 0
+//    err := client.DescribePullRequestEventsPages(params,
+//        func(page *DescribePullRequestEventsOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *CodeCommit) DescribePullRequestEventsPages(input *DescribePullRequestEventsInput, fn func(*DescribePullRequestEventsOutput, bool) bool) error {
+	return c.DescribePullRequestEventsPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// DescribePullRequestEventsPagesWithContext same as DescribePullRequestEventsPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CodeCommit) DescribePullRequestEventsPagesWithContext(ctx aws.Context, input *DescribePullRequestEventsInput, fn func(*DescribePullRequestEventsOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *DescribePullRequestEventsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribePullRequestEventsRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	cont := true
+	for p.Next() && cont {
+		cont = fn(p.Page().(*DescribePullRequestEventsOutput), !p.HasNextPage())
+	}
+	return p.Err()
 }
 
 const opGetBlob = "GetBlob"
@@ -774,7 +1218,7 @@ func (c *CodeCommit) GetBranchRequest(input *GetBranchInput) (req *request.Reque
 //   A branch name is required but was not specified.
 //
 //   * ErrCodeInvalidBranchNameException "InvalidBranchNameException"
-//   The specified branch name is not valid.
+//   The specified reference name is not valid.
 //
 //   * ErrCodeBranchDoesNotExistException "BranchDoesNotExistException"
 //   The specified branch does not exist.
@@ -814,6 +1258,466 @@ func (c *CodeCommit) GetBranchWithContext(ctx aws.Context, input *GetBranchInput
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
+}
+
+const opGetComment = "GetComment"
+
+// GetCommentRequest generates a "aws/request.Request" representing the
+// client's request for the GetComment operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See GetComment for more information on using the GetComment
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the GetCommentRequest method.
+//    req, resp := client.GetCommentRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/GetComment
+func (c *CodeCommit) GetCommentRequest(input *GetCommentInput) (req *request.Request, output *GetCommentOutput) {
+	op := &request.Operation{
+		Name:       opGetComment,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &GetCommentInput{}
+	}
+
+	output = &GetCommentOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// GetComment API operation for AWS CodeCommit.
+//
+// Returns the content of a comment made on a change, file, or commit in a repository.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS CodeCommit's
+// API operation GetComment for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeCommentDoesNotExistException "CommentDoesNotExistException"
+//   No comment exists with the provided ID. Verify that you have provided the
+//   correct ID, and then try again.
+//
+//   * ErrCodeCommentIdRequiredException "CommentIdRequiredException"
+//   The comment ID is missing or null. A comment ID is required.
+//
+//   * ErrCodeInvalidCommentIdException "InvalidCommentIdException"
+//   The comment ID is not in a valid format. Make sure that you have provided
+//   the full comment ID.
+//
+//   * ErrCodeCommentDeletedException "CommentDeletedException"
+//   This comment has already been deleted. You cannot edit or delete a deleted
+//   comment.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/GetComment
+func (c *CodeCommit) GetComment(input *GetCommentInput) (*GetCommentOutput, error) {
+	req, out := c.GetCommentRequest(input)
+	return out, req.Send()
+}
+
+// GetCommentWithContext is the same as GetComment with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetComment for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CodeCommit) GetCommentWithContext(ctx aws.Context, input *GetCommentInput, opts ...request.Option) (*GetCommentOutput, error) {
+	req, out := c.GetCommentRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opGetCommentsForComparedCommit = "GetCommentsForComparedCommit"
+
+// GetCommentsForComparedCommitRequest generates a "aws/request.Request" representing the
+// client's request for the GetCommentsForComparedCommit operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See GetCommentsForComparedCommit for more information on using the GetCommentsForComparedCommit
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the GetCommentsForComparedCommitRequest method.
+//    req, resp := client.GetCommentsForComparedCommitRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/GetCommentsForComparedCommit
+func (c *CodeCommit) GetCommentsForComparedCommitRequest(input *GetCommentsForComparedCommitInput) (req *request.Request, output *GetCommentsForComparedCommitOutput) {
+	op := &request.Operation{
+		Name:       opGetCommentsForComparedCommit,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"nextToken"},
+			OutputTokens:    []string{"nextToken"},
+			LimitToken:      "maxResults",
+			TruncationToken: "",
+		},
+	}
+
+	if input == nil {
+		input = &GetCommentsForComparedCommitInput{}
+	}
+
+	output = &GetCommentsForComparedCommitOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// GetCommentsForComparedCommit API operation for AWS CodeCommit.
+//
+// Returns information about comments made on the comparison between two commits.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS CodeCommit's
+// API operation GetCommentsForComparedCommit for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeRepositoryNameRequiredException "RepositoryNameRequiredException"
+//   A repository name is required but was not specified.
+//
+//   * ErrCodeRepositoryDoesNotExistException "RepositoryDoesNotExistException"
+//   The specified repository does not exist.
+//
+//   * ErrCodeInvalidRepositoryNameException "InvalidRepositoryNameException"
+//   At least one specified repository name is not valid.
+//
+//   This exception only occurs when a specified repository name is not valid.
+//   Other exceptions occur when a required repository parameter is missing, or
+//   when a specified repository does not exist.
+//
+//   * ErrCodeCommitIdRequiredException "CommitIdRequiredException"
+//   A commit ID was not specified.
+//
+//   * ErrCodeInvalidCommitIdException "InvalidCommitIdException"
+//   The specified commit ID is not valid.
+//
+//   * ErrCodeCommitDoesNotExistException "CommitDoesNotExistException"
+//   The specified commit does not exist or no commit was specified, and the specified
+//   repository has no default branch.
+//
+//   * ErrCodeInvalidMaxResultsException "InvalidMaxResultsException"
+//   The specified number of maximum results is not valid.
+//
+//   * ErrCodeInvalidContinuationTokenException "InvalidContinuationTokenException"
+//   The specified continuation token is not valid.
+//
+//   * ErrCodeEncryptionIntegrityChecksFailedException "EncryptionIntegrityChecksFailedException"
+//   An encryption integrity check failed.
+//
+//   * ErrCodeEncryptionKeyAccessDeniedException "EncryptionKeyAccessDeniedException"
+//   An encryption key could not be accessed.
+//
+//   * ErrCodeEncryptionKeyDisabledException "EncryptionKeyDisabledException"
+//   The encryption key is disabled.
+//
+//   * ErrCodeEncryptionKeyNotFoundException "EncryptionKeyNotFoundException"
+//   No encryption key was found.
+//
+//   * ErrCodeEncryptionKeyUnavailableException "EncryptionKeyUnavailableException"
+//   The encryption key is not available.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/GetCommentsForComparedCommit
+func (c *CodeCommit) GetCommentsForComparedCommit(input *GetCommentsForComparedCommitInput) (*GetCommentsForComparedCommitOutput, error) {
+	req, out := c.GetCommentsForComparedCommitRequest(input)
+	return out, req.Send()
+}
+
+// GetCommentsForComparedCommitWithContext is the same as GetCommentsForComparedCommit with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetCommentsForComparedCommit for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CodeCommit) GetCommentsForComparedCommitWithContext(ctx aws.Context, input *GetCommentsForComparedCommitInput, opts ...request.Option) (*GetCommentsForComparedCommitOutput, error) {
+	req, out := c.GetCommentsForComparedCommitRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+// GetCommentsForComparedCommitPages iterates over the pages of a GetCommentsForComparedCommit operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See GetCommentsForComparedCommit method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a GetCommentsForComparedCommit operation.
+//    pageNum := 0
+//    err := client.GetCommentsForComparedCommitPages(params,
+//        func(page *GetCommentsForComparedCommitOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *CodeCommit) GetCommentsForComparedCommitPages(input *GetCommentsForComparedCommitInput, fn func(*GetCommentsForComparedCommitOutput, bool) bool) error {
+	return c.GetCommentsForComparedCommitPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// GetCommentsForComparedCommitPagesWithContext same as GetCommentsForComparedCommitPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CodeCommit) GetCommentsForComparedCommitPagesWithContext(ctx aws.Context, input *GetCommentsForComparedCommitInput, fn func(*GetCommentsForComparedCommitOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *GetCommentsForComparedCommitInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.GetCommentsForComparedCommitRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	cont := true
+	for p.Next() && cont {
+		cont = fn(p.Page().(*GetCommentsForComparedCommitOutput), !p.HasNextPage())
+	}
+	return p.Err()
+}
+
+const opGetCommentsForPullRequest = "GetCommentsForPullRequest"
+
+// GetCommentsForPullRequestRequest generates a "aws/request.Request" representing the
+// client's request for the GetCommentsForPullRequest operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See GetCommentsForPullRequest for more information on using the GetCommentsForPullRequest
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the GetCommentsForPullRequestRequest method.
+//    req, resp := client.GetCommentsForPullRequestRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/GetCommentsForPullRequest
+func (c *CodeCommit) GetCommentsForPullRequestRequest(input *GetCommentsForPullRequestInput) (req *request.Request, output *GetCommentsForPullRequestOutput) {
+	op := &request.Operation{
+		Name:       opGetCommentsForPullRequest,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"nextToken"},
+			OutputTokens:    []string{"nextToken"},
+			LimitToken:      "maxResults",
+			TruncationToken: "",
+		},
+	}
+
+	if input == nil {
+		input = &GetCommentsForPullRequestInput{}
+	}
+
+	output = &GetCommentsForPullRequestOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// GetCommentsForPullRequest API operation for AWS CodeCommit.
+//
+// Returns comments made on a pull request.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS CodeCommit's
+// API operation GetCommentsForPullRequest for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodePullRequestIdRequiredException "PullRequestIdRequiredException"
+//   A pull request ID is required, but none was provided.
+//
+//   * ErrCodePullRequestDoesNotExistException "PullRequestDoesNotExistException"
+//   The pull request ID could not be found. Make sure that you have specified
+//   the correct repository name and pull request ID, and then try again.
+//
+//   * ErrCodeInvalidPullRequestIdException "InvalidPullRequestIdException"
+//   The pull request ID is not valid. Make sure that you have provided the full
+//   ID and that the pull request is in the specified repository, and then try
+//   again.
+//
+//   * ErrCodeRepositoryNameRequiredException "RepositoryNameRequiredException"
+//   A repository name is required but was not specified.
+//
+//   * ErrCodeRepositoryDoesNotExistException "RepositoryDoesNotExistException"
+//   The specified repository does not exist.
+//
+//   * ErrCodeInvalidRepositoryNameException "InvalidRepositoryNameException"
+//   At least one specified repository name is not valid.
+//
+//   This exception only occurs when a specified repository name is not valid.
+//   Other exceptions occur when a required repository parameter is missing, or
+//   when a specified repository does not exist.
+//
+//   * ErrCodeCommitIdRequiredException "CommitIdRequiredException"
+//   A commit ID was not specified.
+//
+//   * ErrCodeInvalidCommitIdException "InvalidCommitIdException"
+//   The specified commit ID is not valid.
+//
+//   * ErrCodeCommitDoesNotExistException "CommitDoesNotExistException"
+//   The specified commit does not exist or no commit was specified, and the specified
+//   repository has no default branch.
+//
+//   * ErrCodeInvalidMaxResultsException "InvalidMaxResultsException"
+//   The specified number of maximum results is not valid.
+//
+//   * ErrCodeInvalidContinuationTokenException "InvalidContinuationTokenException"
+//   The specified continuation token is not valid.
+//
+//   * ErrCodeRepositoryNotAssociatedWithPullRequestException "RepositoryNotAssociatedWithPullRequestException"
+//   The repository does not contain any pull requests with that pull request
+//   ID. Check to make sure you have provided the correct repository name for
+//   the pull request.
+//
+//   * ErrCodeEncryptionIntegrityChecksFailedException "EncryptionIntegrityChecksFailedException"
+//   An encryption integrity check failed.
+//
+//   * ErrCodeEncryptionKeyAccessDeniedException "EncryptionKeyAccessDeniedException"
+//   An encryption key could not be accessed.
+//
+//   * ErrCodeEncryptionKeyDisabledException "EncryptionKeyDisabledException"
+//   The encryption key is disabled.
+//
+//   * ErrCodeEncryptionKeyNotFoundException "EncryptionKeyNotFoundException"
+//   No encryption key was found.
+//
+//   * ErrCodeEncryptionKeyUnavailableException "EncryptionKeyUnavailableException"
+//   The encryption key is not available.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/GetCommentsForPullRequest
+func (c *CodeCommit) GetCommentsForPullRequest(input *GetCommentsForPullRequestInput) (*GetCommentsForPullRequestOutput, error) {
+	req, out := c.GetCommentsForPullRequestRequest(input)
+	return out, req.Send()
+}
+
+// GetCommentsForPullRequestWithContext is the same as GetCommentsForPullRequest with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetCommentsForPullRequest for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CodeCommit) GetCommentsForPullRequestWithContext(ctx aws.Context, input *GetCommentsForPullRequestInput, opts ...request.Option) (*GetCommentsForPullRequestOutput, error) {
+	req, out := c.GetCommentsForPullRequestRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+// GetCommentsForPullRequestPages iterates over the pages of a GetCommentsForPullRequest operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See GetCommentsForPullRequest method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a GetCommentsForPullRequest operation.
+//    pageNum := 0
+//    err := client.GetCommentsForPullRequestPages(params,
+//        func(page *GetCommentsForPullRequestOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *CodeCommit) GetCommentsForPullRequestPages(input *GetCommentsForPullRequestInput, fn func(*GetCommentsForPullRequestOutput, bool) bool) error {
+	return c.GetCommentsForPullRequestPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// GetCommentsForPullRequestPagesWithContext same as GetCommentsForPullRequestPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CodeCommit) GetCommentsForPullRequestPagesWithContext(ctx aws.Context, input *GetCommentsForPullRequestInput, fn func(*GetCommentsForPullRequestOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *GetCommentsForPullRequestInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.GetCommentsForPullRequestRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	cont := true
+	for p.Next() && cont {
+		cont = fn(p.Page().(*GetCommentsForPullRequestOutput), !p.HasNextPage())
+	}
+	return p.Err()
 }
 
 const opGetCommit = "GetCommit"
@@ -1115,6 +2019,243 @@ func (c *CodeCommit) GetDifferencesPagesWithContext(ctx aws.Context, input *GetD
 		cont = fn(p.Page().(*GetDifferencesOutput), !p.HasNextPage())
 	}
 	return p.Err()
+}
+
+const opGetMergeConflicts = "GetMergeConflicts"
+
+// GetMergeConflictsRequest generates a "aws/request.Request" representing the
+// client's request for the GetMergeConflicts operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See GetMergeConflicts for more information on using the GetMergeConflicts
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the GetMergeConflictsRequest method.
+//    req, resp := client.GetMergeConflictsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/GetMergeConflicts
+func (c *CodeCommit) GetMergeConflictsRequest(input *GetMergeConflictsInput) (req *request.Request, output *GetMergeConflictsOutput) {
+	op := &request.Operation{
+		Name:       opGetMergeConflicts,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &GetMergeConflictsInput{}
+	}
+
+	output = &GetMergeConflictsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// GetMergeConflicts API operation for AWS CodeCommit.
+//
+// Returns information about merge conflicts between the before and after commit
+// IDs for a pull request in a repository.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS CodeCommit's
+// API operation GetMergeConflicts for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeRepositoryNameRequiredException "RepositoryNameRequiredException"
+//   A repository name is required but was not specified.
+//
+//   * ErrCodeInvalidRepositoryNameException "InvalidRepositoryNameException"
+//   At least one specified repository name is not valid.
+//
+//   This exception only occurs when a specified repository name is not valid.
+//   Other exceptions occur when a required repository parameter is missing, or
+//   when a specified repository does not exist.
+//
+//   * ErrCodeRepositoryDoesNotExistException "RepositoryDoesNotExistException"
+//   The specified repository does not exist.
+//
+//   * ErrCodeMergeOptionRequiredException "MergeOptionRequiredException"
+//   A merge option or stategy is required, and none was provided.
+//
+//   * ErrCodeInvalidMergeOptionException "InvalidMergeOptionException"
+//   The specified merge option is not valid. The only valid value is FAST_FORWARD_MERGE.
+//
+//   * ErrCodeInvalidDestinationCommitSpecifierException "InvalidDestinationCommitSpecifierException"
+//   The destination commit specifier is not valid. You must provide a valid branch
+//   name, tag, or full commit ID.
+//
+//   * ErrCodeInvalidSourceCommitSpecifierException "InvalidSourceCommitSpecifierException"
+//   The source commit specifier is not valid. You must provide a valid branch
+//   name, tag, or full commit ID.
+//
+//   * ErrCodeCommitRequiredException "CommitRequiredException"
+//   A commit was not specified.
+//
+//   * ErrCodeCommitDoesNotExistException "CommitDoesNotExistException"
+//   The specified commit does not exist or no commit was specified, and the specified
+//   repository has no default branch.
+//
+//   * ErrCodeInvalidCommitException "InvalidCommitException"
+//   The specified commit is not valid.
+//
+//   * ErrCodeTipsDivergenceExceededException "TipsDivergenceExceededException"
+//   The divergence between the tips of the provided commit specifiers is too
+//   great to determine whether there might be any merge conflicts. Locally compare
+//   the specifiers using git diff or a diff tool.
+//
+//   * ErrCodeEncryptionIntegrityChecksFailedException "EncryptionIntegrityChecksFailedException"
+//   An encryption integrity check failed.
+//
+//   * ErrCodeEncryptionKeyAccessDeniedException "EncryptionKeyAccessDeniedException"
+//   An encryption key could not be accessed.
+//
+//   * ErrCodeEncryptionKeyDisabledException "EncryptionKeyDisabledException"
+//   The encryption key is disabled.
+//
+//   * ErrCodeEncryptionKeyNotFoundException "EncryptionKeyNotFoundException"
+//   No encryption key was found.
+//
+//   * ErrCodeEncryptionKeyUnavailableException "EncryptionKeyUnavailableException"
+//   The encryption key is not available.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/GetMergeConflicts
+func (c *CodeCommit) GetMergeConflicts(input *GetMergeConflictsInput) (*GetMergeConflictsOutput, error) {
+	req, out := c.GetMergeConflictsRequest(input)
+	return out, req.Send()
+}
+
+// GetMergeConflictsWithContext is the same as GetMergeConflicts with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetMergeConflicts for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CodeCommit) GetMergeConflictsWithContext(ctx aws.Context, input *GetMergeConflictsInput, opts ...request.Option) (*GetMergeConflictsOutput, error) {
+	req, out := c.GetMergeConflictsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opGetPullRequest = "GetPullRequest"
+
+// GetPullRequestRequest generates a "aws/request.Request" representing the
+// client's request for the GetPullRequest operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See GetPullRequest for more information on using the GetPullRequest
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the GetPullRequestRequest method.
+//    req, resp := client.GetPullRequestRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/GetPullRequest
+func (c *CodeCommit) GetPullRequestRequest(input *GetPullRequestInput) (req *request.Request, output *GetPullRequestOutput) {
+	op := &request.Operation{
+		Name:       opGetPullRequest,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &GetPullRequestInput{}
+	}
+
+	output = &GetPullRequestOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// GetPullRequest API operation for AWS CodeCommit.
+//
+// Gets information about a pull request in a specified repository.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS CodeCommit's
+// API operation GetPullRequest for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodePullRequestDoesNotExistException "PullRequestDoesNotExistException"
+//   The pull request ID could not be found. Make sure that you have specified
+//   the correct repository name and pull request ID, and then try again.
+//
+//   * ErrCodeInvalidPullRequestIdException "InvalidPullRequestIdException"
+//   The pull request ID is not valid. Make sure that you have provided the full
+//   ID and that the pull request is in the specified repository, and then try
+//   again.
+//
+//   * ErrCodePullRequestIdRequiredException "PullRequestIdRequiredException"
+//   A pull request ID is required, but none was provided.
+//
+//   * ErrCodeEncryptionIntegrityChecksFailedException "EncryptionIntegrityChecksFailedException"
+//   An encryption integrity check failed.
+//
+//   * ErrCodeEncryptionKeyAccessDeniedException "EncryptionKeyAccessDeniedException"
+//   An encryption key could not be accessed.
+//
+//   * ErrCodeEncryptionKeyDisabledException "EncryptionKeyDisabledException"
+//   The encryption key is disabled.
+//
+//   * ErrCodeEncryptionKeyNotFoundException "EncryptionKeyNotFoundException"
+//   No encryption key was found.
+//
+//   * ErrCodeEncryptionKeyUnavailableException "EncryptionKeyUnavailableException"
+//   The encryption key is not available.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/GetPullRequest
+func (c *CodeCommit) GetPullRequest(input *GetPullRequestInput) (*GetPullRequestOutput, error) {
+	req, out := c.GetPullRequestRequest(input)
+	return out, req.Send()
+}
+
+// GetPullRequestWithContext is the same as GetPullRequest with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetPullRequest for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CodeCommit) GetPullRequestWithContext(ctx aws.Context, input *GetPullRequestInput, opts ...request.Option) (*GetPullRequestOutput, error) {
+	req, out := c.GetPullRequestRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
 }
 
 const opGetRepository = "GetRepository"
@@ -1494,6 +2635,184 @@ func (c *CodeCommit) ListBranchesPagesWithContext(ctx aws.Context, input *ListBr
 	return p.Err()
 }
 
+const opListPullRequests = "ListPullRequests"
+
+// ListPullRequestsRequest generates a "aws/request.Request" representing the
+// client's request for the ListPullRequests operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ListPullRequests for more information on using the ListPullRequests
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ListPullRequestsRequest method.
+//    req, resp := client.ListPullRequestsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/ListPullRequests
+func (c *CodeCommit) ListPullRequestsRequest(input *ListPullRequestsInput) (req *request.Request, output *ListPullRequestsOutput) {
+	op := &request.Operation{
+		Name:       opListPullRequests,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"nextToken"},
+			OutputTokens:    []string{"nextToken"},
+			LimitToken:      "maxResults",
+			TruncationToken: "",
+		},
+	}
+
+	if input == nil {
+		input = &ListPullRequestsInput{}
+	}
+
+	output = &ListPullRequestsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListPullRequests API operation for AWS CodeCommit.
+//
+// Returns a list of pull requests for a specified repository. The return list
+// can be refined by pull request status or pull request author ARN.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS CodeCommit's
+// API operation ListPullRequests for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidPullRequestStatusException "InvalidPullRequestStatusException"
+//   The pull request status is not valid. The only valid values are OPEN and
+//   CLOSED.
+//
+//   * ErrCodeInvalidAuthorArnException "InvalidAuthorArnException"
+//   The Amazon Resource Name (ARN) is not valid. Make sure that you have provided
+//   the full ARN for the author of the pull request, and then try again.
+//
+//   * ErrCodeAuthorDoesNotExistException "AuthorDoesNotExistException"
+//   The specified Amazon Resource Name (ARN) does not exist in the AWS account.
+//
+//   * ErrCodeRepositoryNameRequiredException "RepositoryNameRequiredException"
+//   A repository name is required but was not specified.
+//
+//   * ErrCodeInvalidRepositoryNameException "InvalidRepositoryNameException"
+//   At least one specified repository name is not valid.
+//
+//   This exception only occurs when a specified repository name is not valid.
+//   Other exceptions occur when a required repository parameter is missing, or
+//   when a specified repository does not exist.
+//
+//   * ErrCodeRepositoryDoesNotExistException "RepositoryDoesNotExistException"
+//   The specified repository does not exist.
+//
+//   * ErrCodeInvalidMaxResultsException "InvalidMaxResultsException"
+//   The specified number of maximum results is not valid.
+//
+//   * ErrCodeInvalidContinuationTokenException "InvalidContinuationTokenException"
+//   The specified continuation token is not valid.
+//
+//   * ErrCodeEncryptionIntegrityChecksFailedException "EncryptionIntegrityChecksFailedException"
+//   An encryption integrity check failed.
+//
+//   * ErrCodeEncryptionKeyAccessDeniedException "EncryptionKeyAccessDeniedException"
+//   An encryption key could not be accessed.
+//
+//   * ErrCodeEncryptionKeyDisabledException "EncryptionKeyDisabledException"
+//   The encryption key is disabled.
+//
+//   * ErrCodeEncryptionKeyNotFoundException "EncryptionKeyNotFoundException"
+//   No encryption key was found.
+//
+//   * ErrCodeEncryptionKeyUnavailableException "EncryptionKeyUnavailableException"
+//   The encryption key is not available.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/ListPullRequests
+func (c *CodeCommit) ListPullRequests(input *ListPullRequestsInput) (*ListPullRequestsOutput, error) {
+	req, out := c.ListPullRequestsRequest(input)
+	return out, req.Send()
+}
+
+// ListPullRequestsWithContext is the same as ListPullRequests with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListPullRequests for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CodeCommit) ListPullRequestsWithContext(ctx aws.Context, input *ListPullRequestsInput, opts ...request.Option) (*ListPullRequestsOutput, error) {
+	req, out := c.ListPullRequestsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+// ListPullRequestsPages iterates over the pages of a ListPullRequests operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See ListPullRequests method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a ListPullRequests operation.
+//    pageNum := 0
+//    err := client.ListPullRequestsPages(params,
+//        func(page *ListPullRequestsOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *CodeCommit) ListPullRequestsPages(input *ListPullRequestsInput, fn func(*ListPullRequestsOutput, bool) bool) error {
+	return c.ListPullRequestsPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// ListPullRequestsPagesWithContext same as ListPullRequestsPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CodeCommit) ListPullRequestsPagesWithContext(ctx aws.Context, input *ListPullRequestsInput, fn func(*ListPullRequestsOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *ListPullRequestsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListPullRequestsRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	cont := true
+	for p.Next() && cont {
+		cont = fn(p.Page().(*ListPullRequestsOutput), !p.HasNextPage())
+	}
+	return p.Err()
+}
+
 const opListRepositories = "ListRepositories"
 
 // ListRepositoriesRequest generates a "aws/request.Request" representing the
@@ -1633,6 +2952,591 @@ func (c *CodeCommit) ListRepositoriesPagesWithContext(ctx aws.Context, input *Li
 		cont = fn(p.Page().(*ListRepositoriesOutput), !p.HasNextPage())
 	}
 	return p.Err()
+}
+
+const opMergePullRequestByFastForward = "MergePullRequestByFastForward"
+
+// MergePullRequestByFastForwardRequest generates a "aws/request.Request" representing the
+// client's request for the MergePullRequestByFastForward operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See MergePullRequestByFastForward for more information on using the MergePullRequestByFastForward
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the MergePullRequestByFastForwardRequest method.
+//    req, resp := client.MergePullRequestByFastForwardRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/MergePullRequestByFastForward
+func (c *CodeCommit) MergePullRequestByFastForwardRequest(input *MergePullRequestByFastForwardInput) (req *request.Request, output *MergePullRequestByFastForwardOutput) {
+	op := &request.Operation{
+		Name:       opMergePullRequestByFastForward,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &MergePullRequestByFastForwardInput{}
+	}
+
+	output = &MergePullRequestByFastForwardOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// MergePullRequestByFastForward API operation for AWS CodeCommit.
+//
+// Closes a pull request and attempts to merge the source commit of a pull request
+// into the specified destination branch for that pull request at the specified
+// commit using the fast-forward merge option.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS CodeCommit's
+// API operation MergePullRequestByFastForward for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeManualMergeRequiredException "ManualMergeRequiredException"
+//   The pull request cannot be merged automatically into the destination branch.
+//   You must manually merge the branches and resolve any conflicts.
+//
+//   * ErrCodePullRequestAlreadyClosedException "PullRequestAlreadyClosedException"
+//   The pull request status cannot be updated because it is already closed.
+//
+//   * ErrCodePullRequestDoesNotExistException "PullRequestDoesNotExistException"
+//   The pull request ID could not be found. Make sure that you have specified
+//   the correct repository name and pull request ID, and then try again.
+//
+//   * ErrCodeInvalidPullRequestIdException "InvalidPullRequestIdException"
+//   The pull request ID is not valid. Make sure that you have provided the full
+//   ID and that the pull request is in the specified repository, and then try
+//   again.
+//
+//   * ErrCodePullRequestIdRequiredException "PullRequestIdRequiredException"
+//   A pull request ID is required, but none was provided.
+//
+//   * ErrCodeTipOfSourceReferenceIsDifferentException "TipOfSourceReferenceIsDifferentException"
+//   The tip of the source branch in the destination repository does not match
+//   the tip of the source branch specified in your request. The pull request
+//   might have been updated. Make sure that you have the latest changes.
+//
+//   * ErrCodeReferenceDoesNotExistException "ReferenceDoesNotExistException"
+//   The specified reference does not exist. You must provide a full commit ID.
+//
+//   * ErrCodeInvalidCommitIdException "InvalidCommitIdException"
+//   The specified commit ID is not valid.
+//
+//   * ErrCodeRepositoryNameRequiredException "RepositoryNameRequiredException"
+//   A repository name is required but was not specified.
+//
+//   * ErrCodeInvalidRepositoryNameException "InvalidRepositoryNameException"
+//   At least one specified repository name is not valid.
+//
+//   This exception only occurs when a specified repository name is not valid.
+//   Other exceptions occur when a required repository parameter is missing, or
+//   when a specified repository does not exist.
+//
+//   * ErrCodeRepositoryDoesNotExistException "RepositoryDoesNotExistException"
+//   The specified repository does not exist.
+//
+//   * ErrCodeEncryptionIntegrityChecksFailedException "EncryptionIntegrityChecksFailedException"
+//   An encryption integrity check failed.
+//
+//   * ErrCodeEncryptionKeyAccessDeniedException "EncryptionKeyAccessDeniedException"
+//   An encryption key could not be accessed.
+//
+//   * ErrCodeEncryptionKeyDisabledException "EncryptionKeyDisabledException"
+//   The encryption key is disabled.
+//
+//   * ErrCodeEncryptionKeyNotFoundException "EncryptionKeyNotFoundException"
+//   No encryption key was found.
+//
+//   * ErrCodeEncryptionKeyUnavailableException "EncryptionKeyUnavailableException"
+//   The encryption key is not available.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/MergePullRequestByFastForward
+func (c *CodeCommit) MergePullRequestByFastForward(input *MergePullRequestByFastForwardInput) (*MergePullRequestByFastForwardOutput, error) {
+	req, out := c.MergePullRequestByFastForwardRequest(input)
+	return out, req.Send()
+}
+
+// MergePullRequestByFastForwardWithContext is the same as MergePullRequestByFastForward with the addition of
+// the ability to pass a context and additional request options.
+//
+// See MergePullRequestByFastForward for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CodeCommit) MergePullRequestByFastForwardWithContext(ctx aws.Context, input *MergePullRequestByFastForwardInput, opts ...request.Option) (*MergePullRequestByFastForwardOutput, error) {
+	req, out := c.MergePullRequestByFastForwardRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opPostCommentForComparedCommit = "PostCommentForComparedCommit"
+
+// PostCommentForComparedCommitRequest generates a "aws/request.Request" representing the
+// client's request for the PostCommentForComparedCommit operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See PostCommentForComparedCommit for more information on using the PostCommentForComparedCommit
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the PostCommentForComparedCommitRequest method.
+//    req, resp := client.PostCommentForComparedCommitRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/PostCommentForComparedCommit
+func (c *CodeCommit) PostCommentForComparedCommitRequest(input *PostCommentForComparedCommitInput) (req *request.Request, output *PostCommentForComparedCommitOutput) {
+	op := &request.Operation{
+		Name:       opPostCommentForComparedCommit,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &PostCommentForComparedCommitInput{}
+	}
+
+	output = &PostCommentForComparedCommitOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// PostCommentForComparedCommit API operation for AWS CodeCommit.
+//
+// Posts a comment on the comparison between two commits.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS CodeCommit's
+// API operation PostCommentForComparedCommit for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeRepositoryNameRequiredException "RepositoryNameRequiredException"
+//   A repository name is required but was not specified.
+//
+//   * ErrCodeRepositoryDoesNotExistException "RepositoryDoesNotExistException"
+//   The specified repository does not exist.
+//
+//   * ErrCodeInvalidRepositoryNameException "InvalidRepositoryNameException"
+//   At least one specified repository name is not valid.
+//
+//   This exception only occurs when a specified repository name is not valid.
+//   Other exceptions occur when a required repository parameter is missing, or
+//   when a specified repository does not exist.
+//
+//   * ErrCodeClientRequestTokenRequiredException "ClientRequestTokenRequiredException"
+//   A client request token is required. A client request token is an unique,
+//   client-generated idempotency token that when provided in a request, ensures
+//   the request cannot be repeated with a changed parameter. If a request is
+//   received with the same parameters and a token is included, the request will
+//   return information about the initial request that used that token.
+//
+//   * ErrCodeInvalidClientRequestTokenException "InvalidClientRequestTokenException"
+//   The client request token is not valid.
+//
+//   * ErrCodeIdempotencyParameterMismatchException "IdempotencyParameterMismatchException"
+//   The client request token is not valid. Either the token is not in a valid
+//   format, or the token has been used in a previous request and cannot be re-used.
+//
+//   * ErrCodeCommentContentRequiredException "CommentContentRequiredException"
+//   The comment is empty. You must provide some content for a comment. The content
+//   cannot be null.
+//
+//   * ErrCodeCommentContentSizeLimitExceededException "CommentContentSizeLimitExceededException"
+//   The comment is too large. Comments are limited to 1,000 characters.
+//
+//   * ErrCodeInvalidFileLocationException "InvalidFileLocationException"
+//   The location of the file is not valid. Make sure that you include the extension
+//   of the file as well as the file name.
+//
+//   * ErrCodeInvalidRelativeFileVersionEnumException "InvalidRelativeFileVersionEnumException"
+//   Either the enum is not in a valid format, or the specified file version enum
+//   is not valid in respect to the current file version.
+//
+//   * ErrCodePathRequiredException "PathRequiredException"
+//   The filePath for a location cannot be empty or null.
+//
+//   * ErrCodeInvalidFilePositionException "InvalidFilePositionException"
+//   The position is not valid. Make sure that the line number exists in the version
+//   of the file you want to comment on.
+//
+//   * ErrCodeCommitIdRequiredException "CommitIdRequiredException"
+//   A commit ID was not specified.
+//
+//   * ErrCodeInvalidCommitIdException "InvalidCommitIdException"
+//   The specified commit ID is not valid.
+//
+//   * ErrCodeEncryptionIntegrityChecksFailedException "EncryptionIntegrityChecksFailedException"
+//   An encryption integrity check failed.
+//
+//   * ErrCodeEncryptionKeyAccessDeniedException "EncryptionKeyAccessDeniedException"
+//   An encryption key could not be accessed.
+//
+//   * ErrCodeEncryptionKeyDisabledException "EncryptionKeyDisabledException"
+//   The encryption key is disabled.
+//
+//   * ErrCodeEncryptionKeyNotFoundException "EncryptionKeyNotFoundException"
+//   No encryption key was found.
+//
+//   * ErrCodeEncryptionKeyUnavailableException "EncryptionKeyUnavailableException"
+//   The encryption key is not available.
+//
+//   * ErrCodeBeforeCommitIdAndAfterCommitIdAreSameException "BeforeCommitIdAndAfterCommitIdAreSameException"
+//   The before commit ID and the after commit ID are the same, which is not valid.
+//   The before commit ID and the after commit ID must be different commit IDs.
+//
+//   * ErrCodeCommitDoesNotExistException "CommitDoesNotExistException"
+//   The specified commit does not exist or no commit was specified, and the specified
+//   repository has no default branch.
+//
+//   * ErrCodeInvalidPathException "InvalidPathException"
+//   The specified path is not valid.
+//
+//   * ErrCodePathDoesNotExistException "PathDoesNotExistException"
+//   The specified path does not exist.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/PostCommentForComparedCommit
+func (c *CodeCommit) PostCommentForComparedCommit(input *PostCommentForComparedCommitInput) (*PostCommentForComparedCommitOutput, error) {
+	req, out := c.PostCommentForComparedCommitRequest(input)
+	return out, req.Send()
+}
+
+// PostCommentForComparedCommitWithContext is the same as PostCommentForComparedCommit with the addition of
+// the ability to pass a context and additional request options.
+//
+// See PostCommentForComparedCommit for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CodeCommit) PostCommentForComparedCommitWithContext(ctx aws.Context, input *PostCommentForComparedCommitInput, opts ...request.Option) (*PostCommentForComparedCommitOutput, error) {
+	req, out := c.PostCommentForComparedCommitRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opPostCommentForPullRequest = "PostCommentForPullRequest"
+
+// PostCommentForPullRequestRequest generates a "aws/request.Request" representing the
+// client's request for the PostCommentForPullRequest operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See PostCommentForPullRequest for more information on using the PostCommentForPullRequest
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the PostCommentForPullRequestRequest method.
+//    req, resp := client.PostCommentForPullRequestRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/PostCommentForPullRequest
+func (c *CodeCommit) PostCommentForPullRequestRequest(input *PostCommentForPullRequestInput) (req *request.Request, output *PostCommentForPullRequestOutput) {
+	op := &request.Operation{
+		Name:       opPostCommentForPullRequest,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &PostCommentForPullRequestInput{}
+	}
+
+	output = &PostCommentForPullRequestOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// PostCommentForPullRequest API operation for AWS CodeCommit.
+//
+// Posts a comment on a pull request.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS CodeCommit's
+// API operation PostCommentForPullRequest for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodePullRequestDoesNotExistException "PullRequestDoesNotExistException"
+//   The pull request ID could not be found. Make sure that you have specified
+//   the correct repository name and pull request ID, and then try again.
+//
+//   * ErrCodeInvalidPullRequestIdException "InvalidPullRequestIdException"
+//   The pull request ID is not valid. Make sure that you have provided the full
+//   ID and that the pull request is in the specified repository, and then try
+//   again.
+//
+//   * ErrCodePullRequestIdRequiredException "PullRequestIdRequiredException"
+//   A pull request ID is required, but none was provided.
+//
+//   * ErrCodeRepositoryNotAssociatedWithPullRequestException "RepositoryNotAssociatedWithPullRequestException"
+//   The repository does not contain any pull requests with that pull request
+//   ID. Check to make sure you have provided the correct repository name for
+//   the pull request.
+//
+//   * ErrCodeRepositoryNameRequiredException "RepositoryNameRequiredException"
+//   A repository name is required but was not specified.
+//
+//   * ErrCodeRepositoryDoesNotExistException "RepositoryDoesNotExistException"
+//   The specified repository does not exist.
+//
+//   * ErrCodeInvalidRepositoryNameException "InvalidRepositoryNameException"
+//   At least one specified repository name is not valid.
+//
+//   This exception only occurs when a specified repository name is not valid.
+//   Other exceptions occur when a required repository parameter is missing, or
+//   when a specified repository does not exist.
+//
+//   * ErrCodeClientRequestTokenRequiredException "ClientRequestTokenRequiredException"
+//   A client request token is required. A client request token is an unique,
+//   client-generated idempotency token that when provided in a request, ensures
+//   the request cannot be repeated with a changed parameter. If a request is
+//   received with the same parameters and a token is included, the request will
+//   return information about the initial request that used that token.
+//
+//   * ErrCodeInvalidClientRequestTokenException "InvalidClientRequestTokenException"
+//   The client request token is not valid.
+//
+//   * ErrCodeIdempotencyParameterMismatchException "IdempotencyParameterMismatchException"
+//   The client request token is not valid. Either the token is not in a valid
+//   format, or the token has been used in a previous request and cannot be re-used.
+//
+//   * ErrCodeCommentContentRequiredException "CommentContentRequiredException"
+//   The comment is empty. You must provide some content for a comment. The content
+//   cannot be null.
+//
+//   * ErrCodeCommentContentSizeLimitExceededException "CommentContentSizeLimitExceededException"
+//   The comment is too large. Comments are limited to 1,000 characters.
+//
+//   * ErrCodeInvalidFileLocationException "InvalidFileLocationException"
+//   The location of the file is not valid. Make sure that you include the extension
+//   of the file as well as the file name.
+//
+//   * ErrCodeInvalidRelativeFileVersionEnumException "InvalidRelativeFileVersionEnumException"
+//   Either the enum is not in a valid format, or the specified file version enum
+//   is not valid in respect to the current file version.
+//
+//   * ErrCodePathRequiredException "PathRequiredException"
+//   The filePath for a location cannot be empty or null.
+//
+//   * ErrCodeInvalidFilePositionException "InvalidFilePositionException"
+//   The position is not valid. Make sure that the line number exists in the version
+//   of the file you want to comment on.
+//
+//   * ErrCodeCommitIdRequiredException "CommitIdRequiredException"
+//   A commit ID was not specified.
+//
+//   * ErrCodeInvalidCommitIdException "InvalidCommitIdException"
+//   The specified commit ID is not valid.
+//
+//   * ErrCodeEncryptionIntegrityChecksFailedException "EncryptionIntegrityChecksFailedException"
+//   An encryption integrity check failed.
+//
+//   * ErrCodeEncryptionKeyAccessDeniedException "EncryptionKeyAccessDeniedException"
+//   An encryption key could not be accessed.
+//
+//   * ErrCodeEncryptionKeyDisabledException "EncryptionKeyDisabledException"
+//   The encryption key is disabled.
+//
+//   * ErrCodeEncryptionKeyNotFoundException "EncryptionKeyNotFoundException"
+//   No encryption key was found.
+//
+//   * ErrCodeEncryptionKeyUnavailableException "EncryptionKeyUnavailableException"
+//   The encryption key is not available.
+//
+//   * ErrCodeCommitDoesNotExistException "CommitDoesNotExistException"
+//   The specified commit does not exist or no commit was specified, and the specified
+//   repository has no default branch.
+//
+//   * ErrCodeInvalidPathException "InvalidPathException"
+//   The specified path is not valid.
+//
+//   * ErrCodePathDoesNotExistException "PathDoesNotExistException"
+//   The specified path does not exist.
+//
+//   * ErrCodePathRequiredException "PathRequiredException"
+//   The filePath for a location cannot be empty or null.
+//
+//   * ErrCodeBeforeCommitIdAndAfterCommitIdAreSameException "BeforeCommitIdAndAfterCommitIdAreSameException"
+//   The before commit ID and the after commit ID are the same, which is not valid.
+//   The before commit ID and the after commit ID must be different commit IDs.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/PostCommentForPullRequest
+func (c *CodeCommit) PostCommentForPullRequest(input *PostCommentForPullRequestInput) (*PostCommentForPullRequestOutput, error) {
+	req, out := c.PostCommentForPullRequestRequest(input)
+	return out, req.Send()
+}
+
+// PostCommentForPullRequestWithContext is the same as PostCommentForPullRequest with the addition of
+// the ability to pass a context and additional request options.
+//
+// See PostCommentForPullRequest for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CodeCommit) PostCommentForPullRequestWithContext(ctx aws.Context, input *PostCommentForPullRequestInput, opts ...request.Option) (*PostCommentForPullRequestOutput, error) {
+	req, out := c.PostCommentForPullRequestRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opPostCommentReply = "PostCommentReply"
+
+// PostCommentReplyRequest generates a "aws/request.Request" representing the
+// client's request for the PostCommentReply operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See PostCommentReply for more information on using the PostCommentReply
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the PostCommentReplyRequest method.
+//    req, resp := client.PostCommentReplyRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/PostCommentReply
+func (c *CodeCommit) PostCommentReplyRequest(input *PostCommentReplyInput) (req *request.Request, output *PostCommentReplyOutput) {
+	op := &request.Operation{
+		Name:       opPostCommentReply,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &PostCommentReplyInput{}
+	}
+
+	output = &PostCommentReplyOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// PostCommentReply API operation for AWS CodeCommit.
+//
+// Posts a comment in reply to an existing comment on a comparison between commits
+// or a pull request.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS CodeCommit's
+// API operation PostCommentReply for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeClientRequestTokenRequiredException "ClientRequestTokenRequiredException"
+//   A client request token is required. A client request token is an unique,
+//   client-generated idempotency token that when provided in a request, ensures
+//   the request cannot be repeated with a changed parameter. If a request is
+//   received with the same parameters and a token is included, the request will
+//   return information about the initial request that used that token.
+//
+//   * ErrCodeInvalidClientRequestTokenException "InvalidClientRequestTokenException"
+//   The client request token is not valid.
+//
+//   * ErrCodeIdempotencyParameterMismatchException "IdempotencyParameterMismatchException"
+//   The client request token is not valid. Either the token is not in a valid
+//   format, or the token has been used in a previous request and cannot be re-used.
+//
+//   * ErrCodeCommentContentRequiredException "CommentContentRequiredException"
+//   The comment is empty. You must provide some content for a comment. The content
+//   cannot be null.
+//
+//   * ErrCodeCommentContentSizeLimitExceededException "CommentContentSizeLimitExceededException"
+//   The comment is too large. Comments are limited to 1,000 characters.
+//
+//   * ErrCodeCommentDoesNotExistException "CommentDoesNotExistException"
+//   No comment exists with the provided ID. Verify that you have provided the
+//   correct ID, and then try again.
+//
+//   * ErrCodeCommentIdRequiredException "CommentIdRequiredException"
+//   The comment ID is missing or null. A comment ID is required.
+//
+//   * ErrCodeInvalidCommentIdException "InvalidCommentIdException"
+//   The comment ID is not in a valid format. Make sure that you have provided
+//   the full comment ID.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/PostCommentReply
+func (c *CodeCommit) PostCommentReply(input *PostCommentReplyInput) (*PostCommentReplyOutput, error) {
+	req, out := c.PostCommentReplyRequest(input)
+	return out, req.Send()
+}
+
+// PostCommentReplyWithContext is the same as PostCommentReply with the addition of
+// the ability to pass a context and additional request options.
+//
+// See PostCommentReply for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CodeCommit) PostCommentReplyWithContext(ctx aws.Context, input *PostCommentReplyInput, opts ...request.Option) (*PostCommentReplyOutput, error) {
+	req, out := c.PostCommentReplyRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
 }
 
 const opPutRepositoryTriggers = "PutRepositoryTriggers"
@@ -1937,6 +3841,108 @@ func (c *CodeCommit) TestRepositoryTriggersWithContext(ctx aws.Context, input *T
 	return out, req.Send()
 }
 
+const opUpdateComment = "UpdateComment"
+
+// UpdateCommentRequest generates a "aws/request.Request" representing the
+// client's request for the UpdateComment operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See UpdateComment for more information on using the UpdateComment
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the UpdateCommentRequest method.
+//    req, resp := client.UpdateCommentRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/UpdateComment
+func (c *CodeCommit) UpdateCommentRequest(input *UpdateCommentInput) (req *request.Request, output *UpdateCommentOutput) {
+	op := &request.Operation{
+		Name:       opUpdateComment,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &UpdateCommentInput{}
+	}
+
+	output = &UpdateCommentOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// UpdateComment API operation for AWS CodeCommit.
+//
+// Replaces the contents of a comment.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS CodeCommit's
+// API operation UpdateComment for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeCommentContentRequiredException "CommentContentRequiredException"
+//   The comment is empty. You must provide some content for a comment. The content
+//   cannot be null.
+//
+//   * ErrCodeCommentContentSizeLimitExceededException "CommentContentSizeLimitExceededException"
+//   The comment is too large. Comments are limited to 1,000 characters.
+//
+//   * ErrCodeCommentDoesNotExistException "CommentDoesNotExistException"
+//   No comment exists with the provided ID. Verify that you have provided the
+//   correct ID, and then try again.
+//
+//   * ErrCodeCommentIdRequiredException "CommentIdRequiredException"
+//   The comment ID is missing or null. A comment ID is required.
+//
+//   * ErrCodeInvalidCommentIdException "InvalidCommentIdException"
+//   The comment ID is not in a valid format. Make sure that you have provided
+//   the full comment ID.
+//
+//   * ErrCodeCommentNotCreatedByCallerException "CommentNotCreatedByCallerException"
+//   You cannot modify or delete this comment. Only comment authors can modify
+//   or delete their comments.
+//
+//   * ErrCodeCommentDeletedException "CommentDeletedException"
+//   This comment has already been deleted. You cannot edit or delete a deleted
+//   comment.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/UpdateComment
+func (c *CodeCommit) UpdateComment(input *UpdateCommentInput) (*UpdateCommentOutput, error) {
+	req, out := c.UpdateCommentRequest(input)
+	return out, req.Send()
+}
+
+// UpdateCommentWithContext is the same as UpdateComment with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UpdateComment for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CodeCommit) UpdateCommentWithContext(ctx aws.Context, input *UpdateCommentInput, opts ...request.Option) (*UpdateCommentOutput, error) {
+	req, out := c.UpdateCommentRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opUpdateDefaultBranch = "UpdateDefaultBranch"
 
 // UpdateDefaultBranchRequest generates a "aws/request.Request" representing the
@@ -2014,7 +4020,7 @@ func (c *CodeCommit) UpdateDefaultBranchRequest(input *UpdateDefaultBranchInput)
 //   A branch name is required but was not specified.
 //
 //   * ErrCodeInvalidBranchNameException "InvalidBranchNameException"
-//   The specified branch name is not valid.
+//   The specified reference name is not valid.
 //
 //   * ErrCodeBranchDoesNotExistException "BranchDoesNotExistException"
 //   The specified branch does not exist.
@@ -2051,6 +4057,313 @@ func (c *CodeCommit) UpdateDefaultBranch(input *UpdateDefaultBranchInput) (*Upda
 // for more information on using Contexts.
 func (c *CodeCommit) UpdateDefaultBranchWithContext(ctx aws.Context, input *UpdateDefaultBranchInput, opts ...request.Option) (*UpdateDefaultBranchOutput, error) {
 	req, out := c.UpdateDefaultBranchRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opUpdatePullRequestDescription = "UpdatePullRequestDescription"
+
+// UpdatePullRequestDescriptionRequest generates a "aws/request.Request" representing the
+// client's request for the UpdatePullRequestDescription operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See UpdatePullRequestDescription for more information on using the UpdatePullRequestDescription
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the UpdatePullRequestDescriptionRequest method.
+//    req, resp := client.UpdatePullRequestDescriptionRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/UpdatePullRequestDescription
+func (c *CodeCommit) UpdatePullRequestDescriptionRequest(input *UpdatePullRequestDescriptionInput) (req *request.Request, output *UpdatePullRequestDescriptionOutput) {
+	op := &request.Operation{
+		Name:       opUpdatePullRequestDescription,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &UpdatePullRequestDescriptionInput{}
+	}
+
+	output = &UpdatePullRequestDescriptionOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// UpdatePullRequestDescription API operation for AWS CodeCommit.
+//
+// Replaces the contents of the description of a pull request.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS CodeCommit's
+// API operation UpdatePullRequestDescription for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodePullRequestDoesNotExistException "PullRequestDoesNotExistException"
+//   The pull request ID could not be found. Make sure that you have specified
+//   the correct repository name and pull request ID, and then try again.
+//
+//   * ErrCodeInvalidPullRequestIdException "InvalidPullRequestIdException"
+//   The pull request ID is not valid. Make sure that you have provided the full
+//   ID and that the pull request is in the specified repository, and then try
+//   again.
+//
+//   * ErrCodePullRequestIdRequiredException "PullRequestIdRequiredException"
+//   A pull request ID is required, but none was provided.
+//
+//   * ErrCodeInvalidDescriptionException "InvalidDescriptionException"
+//   The pull request description is not valid. Descriptions are limited to 1,000
+//   characters in length.
+//
+//   * ErrCodePullRequestAlreadyClosedException "PullRequestAlreadyClosedException"
+//   The pull request status cannot be updated because it is already closed.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/UpdatePullRequestDescription
+func (c *CodeCommit) UpdatePullRequestDescription(input *UpdatePullRequestDescriptionInput) (*UpdatePullRequestDescriptionOutput, error) {
+	req, out := c.UpdatePullRequestDescriptionRequest(input)
+	return out, req.Send()
+}
+
+// UpdatePullRequestDescriptionWithContext is the same as UpdatePullRequestDescription with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UpdatePullRequestDescription for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CodeCommit) UpdatePullRequestDescriptionWithContext(ctx aws.Context, input *UpdatePullRequestDescriptionInput, opts ...request.Option) (*UpdatePullRequestDescriptionOutput, error) {
+	req, out := c.UpdatePullRequestDescriptionRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opUpdatePullRequestStatus = "UpdatePullRequestStatus"
+
+// UpdatePullRequestStatusRequest generates a "aws/request.Request" representing the
+// client's request for the UpdatePullRequestStatus operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See UpdatePullRequestStatus for more information on using the UpdatePullRequestStatus
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the UpdatePullRequestStatusRequest method.
+//    req, resp := client.UpdatePullRequestStatusRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/UpdatePullRequestStatus
+func (c *CodeCommit) UpdatePullRequestStatusRequest(input *UpdatePullRequestStatusInput) (req *request.Request, output *UpdatePullRequestStatusOutput) {
+	op := &request.Operation{
+		Name:       opUpdatePullRequestStatus,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &UpdatePullRequestStatusInput{}
+	}
+
+	output = &UpdatePullRequestStatusOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// UpdatePullRequestStatus API operation for AWS CodeCommit.
+//
+// Updates the status of a pull request.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS CodeCommit's
+// API operation UpdatePullRequestStatus for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodePullRequestDoesNotExistException "PullRequestDoesNotExistException"
+//   The pull request ID could not be found. Make sure that you have specified
+//   the correct repository name and pull request ID, and then try again.
+//
+//   * ErrCodeInvalidPullRequestIdException "InvalidPullRequestIdException"
+//   The pull request ID is not valid. Make sure that you have provided the full
+//   ID and that the pull request is in the specified repository, and then try
+//   again.
+//
+//   * ErrCodePullRequestIdRequiredException "PullRequestIdRequiredException"
+//   A pull request ID is required, but none was provided.
+//
+//   * ErrCodeInvalidPullRequestStatusUpdateException "InvalidPullRequestStatusUpdateException"
+//   The pull request status update is not valid. The only valid update is from
+//   OPEN to CLOSED.
+//
+//   * ErrCodeInvalidPullRequestStatusException "InvalidPullRequestStatusException"
+//   The pull request status is not valid. The only valid values are OPEN and
+//   CLOSED.
+//
+//   * ErrCodePullRequestStatusRequiredException "PullRequestStatusRequiredException"
+//   A pull request status is required, but none was provided.
+//
+//   * ErrCodeEncryptionIntegrityChecksFailedException "EncryptionIntegrityChecksFailedException"
+//   An encryption integrity check failed.
+//
+//   * ErrCodeEncryptionKeyAccessDeniedException "EncryptionKeyAccessDeniedException"
+//   An encryption key could not be accessed.
+//
+//   * ErrCodeEncryptionKeyDisabledException "EncryptionKeyDisabledException"
+//   The encryption key is disabled.
+//
+//   * ErrCodeEncryptionKeyNotFoundException "EncryptionKeyNotFoundException"
+//   No encryption key was found.
+//
+//   * ErrCodeEncryptionKeyUnavailableException "EncryptionKeyUnavailableException"
+//   The encryption key is not available.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/UpdatePullRequestStatus
+func (c *CodeCommit) UpdatePullRequestStatus(input *UpdatePullRequestStatusInput) (*UpdatePullRequestStatusOutput, error) {
+	req, out := c.UpdatePullRequestStatusRequest(input)
+	return out, req.Send()
+}
+
+// UpdatePullRequestStatusWithContext is the same as UpdatePullRequestStatus with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UpdatePullRequestStatus for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CodeCommit) UpdatePullRequestStatusWithContext(ctx aws.Context, input *UpdatePullRequestStatusInput, opts ...request.Option) (*UpdatePullRequestStatusOutput, error) {
+	req, out := c.UpdatePullRequestStatusRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opUpdatePullRequestTitle = "UpdatePullRequestTitle"
+
+// UpdatePullRequestTitleRequest generates a "aws/request.Request" representing the
+// client's request for the UpdatePullRequestTitle operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See UpdatePullRequestTitle for more information on using the UpdatePullRequestTitle
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the UpdatePullRequestTitleRequest method.
+//    req, resp := client.UpdatePullRequestTitleRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/UpdatePullRequestTitle
+func (c *CodeCommit) UpdatePullRequestTitleRequest(input *UpdatePullRequestTitleInput) (req *request.Request, output *UpdatePullRequestTitleOutput) {
+	op := &request.Operation{
+		Name:       opUpdatePullRequestTitle,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &UpdatePullRequestTitleInput{}
+	}
+
+	output = &UpdatePullRequestTitleOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// UpdatePullRequestTitle API operation for AWS CodeCommit.
+//
+// Replaces the title of a pull request.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS CodeCommit's
+// API operation UpdatePullRequestTitle for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodePullRequestDoesNotExistException "PullRequestDoesNotExistException"
+//   The pull request ID could not be found. Make sure that you have specified
+//   the correct repository name and pull request ID, and then try again.
+//
+//   * ErrCodeInvalidPullRequestIdException "InvalidPullRequestIdException"
+//   The pull request ID is not valid. Make sure that you have provided the full
+//   ID and that the pull request is in the specified repository, and then try
+//   again.
+//
+//   * ErrCodePullRequestIdRequiredException "PullRequestIdRequiredException"
+//   A pull request ID is required, but none was provided.
+//
+//   * ErrCodeTitleRequiredException "TitleRequiredException"
+//   A pull request title is required. It cannot be empty or null.
+//
+//   * ErrCodeInvalidTitleException "InvalidTitleException"
+//   The title of the pull request is not valid. Pull request titles cannot exceed
+//   100 characters in length.
+//
+//   * ErrCodePullRequestAlreadyClosedException "PullRequestAlreadyClosedException"
+//   The pull request status cannot be updated because it is already closed.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/UpdatePullRequestTitle
+func (c *CodeCommit) UpdatePullRequestTitle(input *UpdatePullRequestTitleInput) (*UpdatePullRequestTitleOutput, error) {
+	req, out := c.UpdatePullRequestTitleRequest(input)
+	return out, req.Send()
+}
+
+// UpdatePullRequestTitleWithContext is the same as UpdatePullRequestTitle with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UpdatePullRequestTitle for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CodeCommit) UpdatePullRequestTitleWithContext(ctx aws.Context, input *UpdatePullRequestTitleInput, opts ...request.Option) (*UpdatePullRequestTitleOutput, error) {
+	req, out := c.UpdatePullRequestTitleRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -2429,6 +4742,275 @@ func (s *BranchInfo) SetCommitId(v string) *BranchInfo {
 	return s
 }
 
+// Returns information about a specific comment.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/Comment
+type Comment struct {
+	_ struct{} `type:"structure"`
+
+	// The Amazon Resource Name (ARN) of the person who posted the comment.
+	AuthorArn *string `locationName:"authorArn" type:"string"`
+
+	// A unique, client-generated idempotency token that when provided in a request,
+	// ensures the request cannot be repeated with a changed parameter. If a request
+	// is received with the same parameters and a token is included, the request
+	// will return information about the initial request that used that token.
+	ClientRequestToken *string `locationName:"clientRequestToken" type:"string"`
+
+	// The system-generated comment ID.
+	CommentId *string `locationName:"commentId" type:"string"`
+
+	// The content of the comment.
+	Content *string `locationName:"content" type:"string"`
+
+	// The date and time the comment was created, in timestamp format.
+	CreationDate *time.Time `locationName:"creationDate" type:"timestamp" timestampFormat:"unix"`
+
+	// A Boolean value indicating whether the comment has been deleted.
+	Deleted *bool `locationName:"deleted" type:"boolean"`
+
+	// The ID of the comment for which this comment is a reply, if any.
+	InReplyTo *string `locationName:"inReplyTo" type:"string"`
+
+	// The date and time the comment was most recently modified, in timestamp format.
+	LastModifiedDate *time.Time `locationName:"lastModifiedDate" type:"timestamp" timestampFormat:"unix"`
+}
+
+// String returns the string representation
+func (s Comment) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s Comment) GoString() string {
+	return s.String()
+}
+
+// SetAuthorArn sets the AuthorArn field's value.
+func (s *Comment) SetAuthorArn(v string) *Comment {
+	s.AuthorArn = &v
+	return s
+}
+
+// SetClientRequestToken sets the ClientRequestToken field's value.
+func (s *Comment) SetClientRequestToken(v string) *Comment {
+	s.ClientRequestToken = &v
+	return s
+}
+
+// SetCommentId sets the CommentId field's value.
+func (s *Comment) SetCommentId(v string) *Comment {
+	s.CommentId = &v
+	return s
+}
+
+// SetContent sets the Content field's value.
+func (s *Comment) SetContent(v string) *Comment {
+	s.Content = &v
+	return s
+}
+
+// SetCreationDate sets the CreationDate field's value.
+func (s *Comment) SetCreationDate(v time.Time) *Comment {
+	s.CreationDate = &v
+	return s
+}
+
+// SetDeleted sets the Deleted field's value.
+func (s *Comment) SetDeleted(v bool) *Comment {
+	s.Deleted = &v
+	return s
+}
+
+// SetInReplyTo sets the InReplyTo field's value.
+func (s *Comment) SetInReplyTo(v string) *Comment {
+	s.InReplyTo = &v
+	return s
+}
+
+// SetLastModifiedDate sets the LastModifiedDate field's value.
+func (s *Comment) SetLastModifiedDate(v time.Time) *Comment {
+	s.LastModifiedDate = &v
+	return s
+}
+
+// Returns information about comments on the comparison between two commits.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/CommentsForComparedCommit
+type CommentsForComparedCommit struct {
+	_ struct{} `type:"structure"`
+
+	// The full blob ID of the commit used to establish the 'after' of the comparison.
+	AfterBlobId *string `locationName:"afterBlobId" type:"string"`
+
+	// The full commit ID of the commit used to establish the 'after' of the comparison.
+	AfterCommitId *string `locationName:"afterCommitId" type:"string"`
+
+	// The full blob ID of the commit used to establish the 'before' of the comparison.
+	BeforeBlobId *string `locationName:"beforeBlobId" type:"string"`
+
+	// The full commit ID of the commit used to establish the 'before' of the comparison.
+	BeforeCommitId *string `locationName:"beforeCommitId" type:"string"`
+
+	// An array of comment objects. Each comment object contains information about
+	// a comment on the comparison between commits.
+	Comments []*Comment `locationName:"comments" type:"list"`
+
+	// Location information about the comment on the comparison, including the file
+	// name, line number, and whether the version of the file where the comment
+	// was made is 'BEFORE' or 'AFTER'.
+	Location *Location `locationName:"location" type:"structure"`
+
+	// The name of the repository that contains the compared commits.
+	RepositoryName *string `locationName:"repositoryName" min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s CommentsForComparedCommit) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CommentsForComparedCommit) GoString() string {
+	return s.String()
+}
+
+// SetAfterBlobId sets the AfterBlobId field's value.
+func (s *CommentsForComparedCommit) SetAfterBlobId(v string) *CommentsForComparedCommit {
+	s.AfterBlobId = &v
+	return s
+}
+
+// SetAfterCommitId sets the AfterCommitId field's value.
+func (s *CommentsForComparedCommit) SetAfterCommitId(v string) *CommentsForComparedCommit {
+	s.AfterCommitId = &v
+	return s
+}
+
+// SetBeforeBlobId sets the BeforeBlobId field's value.
+func (s *CommentsForComparedCommit) SetBeforeBlobId(v string) *CommentsForComparedCommit {
+	s.BeforeBlobId = &v
+	return s
+}
+
+// SetBeforeCommitId sets the BeforeCommitId field's value.
+func (s *CommentsForComparedCommit) SetBeforeCommitId(v string) *CommentsForComparedCommit {
+	s.BeforeCommitId = &v
+	return s
+}
+
+// SetComments sets the Comments field's value.
+func (s *CommentsForComparedCommit) SetComments(v []*Comment) *CommentsForComparedCommit {
+	s.Comments = v
+	return s
+}
+
+// SetLocation sets the Location field's value.
+func (s *CommentsForComparedCommit) SetLocation(v *Location) *CommentsForComparedCommit {
+	s.Location = v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *CommentsForComparedCommit) SetRepositoryName(v string) *CommentsForComparedCommit {
+	s.RepositoryName = &v
+	return s
+}
+
+// Returns information about comments on a pull request.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/CommentsForPullRequest
+type CommentsForPullRequest struct {
+	_ struct{} `type:"structure"`
+
+	// The full blob ID of the file on which you want to comment on the source commit.
+	AfterBlobId *string `locationName:"afterBlobId" type:"string"`
+
+	// he full commit ID of the commit that was the tip of the source branch at
+	// the time the comment was made.
+	AfterCommitId *string `locationName:"afterCommitId" type:"string"`
+
+	// The full blob ID of the file on which you want to comment on the destination
+	// commit.
+	BeforeBlobId *string `locationName:"beforeBlobId" type:"string"`
+
+	// The full commit ID of the commit that was the tip of the destination branch
+	// when the pull request was created. This commit will be superceded by the
+	// after commit in the source branch when and if you merge the source branch
+	// into the destination branch.
+	BeforeCommitId *string `locationName:"beforeCommitId" type:"string"`
+
+	// An array of comment objects. Each comment object contains information about
+	// a comment on the pull request.
+	Comments []*Comment `locationName:"comments" type:"list"`
+
+	// Location information about the comment on the pull request, including the
+	// file name, line number, and whether the version of the file where the comment
+	// was made is 'BEFORE' (destination branch) or 'AFTER' (source branch).
+	Location *Location `locationName:"location" type:"structure"`
+
+	// The system-generated ID of the pull request.
+	PullRequestId *string `locationName:"pullRequestId" type:"string"`
+
+	// The name of the repository that contains the pull request.
+	RepositoryName *string `locationName:"repositoryName" min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s CommentsForPullRequest) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CommentsForPullRequest) GoString() string {
+	return s.String()
+}
+
+// SetAfterBlobId sets the AfterBlobId field's value.
+func (s *CommentsForPullRequest) SetAfterBlobId(v string) *CommentsForPullRequest {
+	s.AfterBlobId = &v
+	return s
+}
+
+// SetAfterCommitId sets the AfterCommitId field's value.
+func (s *CommentsForPullRequest) SetAfterCommitId(v string) *CommentsForPullRequest {
+	s.AfterCommitId = &v
+	return s
+}
+
+// SetBeforeBlobId sets the BeforeBlobId field's value.
+func (s *CommentsForPullRequest) SetBeforeBlobId(v string) *CommentsForPullRequest {
+	s.BeforeBlobId = &v
+	return s
+}
+
+// SetBeforeCommitId sets the BeforeCommitId field's value.
+func (s *CommentsForPullRequest) SetBeforeCommitId(v string) *CommentsForPullRequest {
+	s.BeforeCommitId = &v
+	return s
+}
+
+// SetComments sets the Comments field's value.
+func (s *CommentsForPullRequest) SetComments(v []*Comment) *CommentsForPullRequest {
+	s.Comments = v
+	return s
+}
+
+// SetLocation sets the Location field's value.
+func (s *CommentsForPullRequest) SetLocation(v *Location) *CommentsForPullRequest {
+	s.Location = v
+	return s
+}
+
+// SetPullRequestId sets the PullRequestId field's value.
+func (s *CommentsForPullRequest) SetPullRequestId(v string) *CommentsForPullRequest {
+	s.PullRequestId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *CommentsForPullRequest) SetRepositoryName(v string) *CommentsForPullRequest {
+	s.RepositoryName = &v
+	return s
+}
+
 // Returns information about a specific commit.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/Commit
 type Commit struct {
@@ -2606,6 +5188,123 @@ func (s CreateBranchOutput) GoString() string {
 	return s.String()
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/CreatePullRequestInput
+type CreatePullRequestInput struct {
+	_ struct{} `type:"structure"`
+
+	// A unique, client-generated idempotency token that when provided in a request,
+	// ensures the request cannot be repeated with a changed parameter. If a request
+	// is received with the same parameters and a token is included, the request
+	// will return information about the initial request that used that token.
+	//
+	// The AWS SDKs prepopulate client request tokens. If using an AWS SDK, you
+	// do not have to generate an idempotency token, as this will be done for you.
+	ClientRequestToken *string `locationName:"clientRequestToken" type:"string" idempotencyToken:"true"`
+
+	// A description of the pull request.
+	Description *string `locationName:"description" type:"string"`
+
+	// The targets for the pull request, including the source of the code to be
+	// reviewed (the source branch), and the destination where the creator of the
+	// pull request intends the code to be merged after the pull request is closed
+	// (the destination branch).
+	//
+	// Targets is a required field
+	Targets []*Target `locationName:"targets" type:"list" required:"true"`
+
+	// The title of the pull request. This title will be used to identify the pull
+	// request to other users in the repository.
+	//
+	// Title is a required field
+	Title *string `locationName:"title" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s CreatePullRequestInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreatePullRequestInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreatePullRequestInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreatePullRequestInput"}
+	if s.Targets == nil {
+		invalidParams.Add(request.NewErrParamRequired("Targets"))
+	}
+	if s.Title == nil {
+		invalidParams.Add(request.NewErrParamRequired("Title"))
+	}
+	if s.Targets != nil {
+		for i, v := range s.Targets {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Targets", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetClientRequestToken sets the ClientRequestToken field's value.
+func (s *CreatePullRequestInput) SetClientRequestToken(v string) *CreatePullRequestInput {
+	s.ClientRequestToken = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *CreatePullRequestInput) SetDescription(v string) *CreatePullRequestInput {
+	s.Description = &v
+	return s
+}
+
+// SetTargets sets the Targets field's value.
+func (s *CreatePullRequestInput) SetTargets(v []*Target) *CreatePullRequestInput {
+	s.Targets = v
+	return s
+}
+
+// SetTitle sets the Title field's value.
+func (s *CreatePullRequestInput) SetTitle(v string) *CreatePullRequestInput {
+	s.Title = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/CreatePullRequestOutput
+type CreatePullRequestOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the newly created pull request.
+	//
+	// PullRequest is a required field
+	PullRequest *PullRequest `locationName:"pullRequest" type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s CreatePullRequestOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreatePullRequestOutput) GoString() string {
+	return s.String()
+}
+
+// SetPullRequest sets the PullRequest field's value.
+func (s *CreatePullRequestOutput) SetPullRequest(v *PullRequest) *CreatePullRequestOutput {
+	s.PullRequest = v
+	return s
+}
+
 // Represents the input of a create repository operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/CreateRepositoryInput
 type CreateRepositoryInput struct {
@@ -2781,6 +5480,70 @@ func (s *DeleteBranchOutput) SetDeletedBranch(v *BranchInfo) *DeleteBranchOutput
 	return s
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/DeleteCommentContentInput
+type DeleteCommentContentInput struct {
+	_ struct{} `type:"structure"`
+
+	// The unique, system-generated ID of the comment. To get this ID, use GetCommentsForComparedCommit
+	// or GetCommentsForPullRequest.
+	//
+	// CommentId is a required field
+	CommentId *string `locationName:"commentId" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DeleteCommentContentInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteCommentContentInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteCommentContentInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteCommentContentInput"}
+	if s.CommentId == nil {
+		invalidParams.Add(request.NewErrParamRequired("CommentId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetCommentId sets the CommentId field's value.
+func (s *DeleteCommentContentInput) SetCommentId(v string) *DeleteCommentContentInput {
+	s.CommentId = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/DeleteCommentContentOutput
+type DeleteCommentContentOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the comment you just deleted.
+	Comment *Comment `locationName:"comment" type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteCommentContentOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteCommentContentOutput) GoString() string {
+	return s.String()
+}
+
+// SetComment sets the Comment field's value.
+func (s *DeleteCommentContentOutput) SetComment(v *Comment) *DeleteCommentContentOutput {
+	s.Comment = v
+	return s
+}
+
 // Represents the input of a delete repository operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/DeleteRepositoryInput
 type DeleteRepositoryInput struct {
@@ -2846,6 +5609,122 @@ func (s DeleteRepositoryOutput) GoString() string {
 // SetRepositoryId sets the RepositoryId field's value.
 func (s *DeleteRepositoryOutput) SetRepositoryId(v string) *DeleteRepositoryOutput {
 	s.RepositoryId = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/DescribePullRequestEventsInput
+type DescribePullRequestEventsInput struct {
+	_ struct{} `type:"structure"`
+
+	// The Amazon Resource Name (ARN) of the user whose actions resulted in the
+	// event. Examples include updating the pull request with additional commits
+	// or changing the status of a pull request.
+	ActorArn *string `locationName:"actorArn" type:"string"`
+
+	// A non-negative integer used to limit the number of returned results. The
+	// default is 100 events, which is also the maximum number of events that can
+	// be returned in a result.
+	MaxResults *int64 `locationName:"maxResults" type:"integer"`
+
+	// An enumeration token that when provided in a request, returns the next batch
+	// of the results.
+	NextToken *string `locationName:"nextToken" type:"string"`
+
+	// Optional. The pull request event type about which you want to return information.
+	PullRequestEventType *string `locationName:"pullRequestEventType" type:"string" enum:"PullRequestEventType"`
+
+	// The system-generated ID of the pull request. To get this ID, use ListPullRequests.
+	//
+	// PullRequestId is a required field
+	PullRequestId *string `locationName:"pullRequestId" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DescribePullRequestEventsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribePullRequestEventsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribePullRequestEventsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribePullRequestEventsInput"}
+	if s.PullRequestId == nil {
+		invalidParams.Add(request.NewErrParamRequired("PullRequestId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetActorArn sets the ActorArn field's value.
+func (s *DescribePullRequestEventsInput) SetActorArn(v string) *DescribePullRequestEventsInput {
+	s.ActorArn = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribePullRequestEventsInput) SetMaxResults(v int64) *DescribePullRequestEventsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribePullRequestEventsInput) SetNextToken(v string) *DescribePullRequestEventsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetPullRequestEventType sets the PullRequestEventType field's value.
+func (s *DescribePullRequestEventsInput) SetPullRequestEventType(v string) *DescribePullRequestEventsInput {
+	s.PullRequestEventType = &v
+	return s
+}
+
+// SetPullRequestId sets the PullRequestId field's value.
+func (s *DescribePullRequestEventsInput) SetPullRequestId(v string) *DescribePullRequestEventsInput {
+	s.PullRequestId = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/DescribePullRequestEventsOutput
+type DescribePullRequestEventsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// An enumeration token that can be used in a request to return the next batch
+	// of the results.
+	NextToken *string `locationName:"nextToken" type:"string"`
+
+	// Information about the pull request events.
+	//
+	// PullRequestEvents is a required field
+	PullRequestEvents []*PullRequestEvent `locationName:"pullRequestEvents" type:"list" required:"true"`
+}
+
+// String returns the string representation
+func (s DescribePullRequestEventsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribePullRequestEventsOutput) GoString() string {
+	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribePullRequestEventsOutput) SetNextToken(v string) *DescribePullRequestEventsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetPullRequestEvents sets the PullRequestEvents field's value.
+func (s *DescribePullRequestEventsOutput) SetPullRequestEvents(v []*PullRequestEvent) *DescribePullRequestEventsOutput {
+	s.PullRequestEvents = v
 	return s
 }
 
@@ -3054,6 +5933,317 @@ func (s GetBranchOutput) GoString() string {
 // SetBranch sets the Branch field's value.
 func (s *GetBranchOutput) SetBranch(v *BranchInfo) *GetBranchOutput {
 	s.Branch = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/GetCommentInput
+type GetCommentInput struct {
+	_ struct{} `type:"structure"`
+
+	// The unique, system-generated ID of the comment. To get this ID, use GetCommentsForComparedCommit
+	// or GetCommentsForPullRequest.
+	//
+	// CommentId is a required field
+	CommentId *string `locationName:"commentId" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s GetCommentInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetCommentInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetCommentInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetCommentInput"}
+	if s.CommentId == nil {
+		invalidParams.Add(request.NewErrParamRequired("CommentId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetCommentId sets the CommentId field's value.
+func (s *GetCommentInput) SetCommentId(v string) *GetCommentInput {
+	s.CommentId = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/GetCommentOutput
+type GetCommentOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The contents of the comment.
+	Comment *Comment `locationName:"comment" type:"structure"`
+}
+
+// String returns the string representation
+func (s GetCommentOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetCommentOutput) GoString() string {
+	return s.String()
+}
+
+// SetComment sets the Comment field's value.
+func (s *GetCommentOutput) SetComment(v *Comment) *GetCommentOutput {
+	s.Comment = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/GetCommentsForComparedCommitInput
+type GetCommentsForComparedCommitInput struct {
+	_ struct{} `type:"structure"`
+
+	// To establish the directionality of the comparison, the full commit ID of
+	// the 'after' commit.
+	//
+	// AfterCommitId is a required field
+	AfterCommitId *string `locationName:"afterCommitId" type:"string" required:"true"`
+
+	// To establish the directionality of the comparison, the full commit ID of
+	// the 'before' commit.
+	BeforeCommitId *string `locationName:"beforeCommitId" type:"string"`
+
+	// A non-negative integer used to limit the number of returned results. The
+	// default is 100 comments, and is configurable up to 500.
+	MaxResults *int64 `locationName:"maxResults" type:"integer"`
+
+	// An enumeration token that when provided in a request, returns the next batch
+	// of the results.
+	NextToken *string `locationName:"nextToken" type:"string"`
+
+	// The name of the repository where you want to compare commits.
+	//
+	// RepositoryName is a required field
+	RepositoryName *string `locationName:"repositoryName" min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s GetCommentsForComparedCommitInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetCommentsForComparedCommitInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetCommentsForComparedCommitInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetCommentsForComparedCommitInput"}
+	if s.AfterCommitId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AfterCommitId"))
+	}
+	if s.RepositoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RepositoryName"))
+	}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAfterCommitId sets the AfterCommitId field's value.
+func (s *GetCommentsForComparedCommitInput) SetAfterCommitId(v string) *GetCommentsForComparedCommitInput {
+	s.AfterCommitId = &v
+	return s
+}
+
+// SetBeforeCommitId sets the BeforeCommitId field's value.
+func (s *GetCommentsForComparedCommitInput) SetBeforeCommitId(v string) *GetCommentsForComparedCommitInput {
+	s.BeforeCommitId = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *GetCommentsForComparedCommitInput) SetMaxResults(v int64) *GetCommentsForComparedCommitInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *GetCommentsForComparedCommitInput) SetNextToken(v string) *GetCommentsForComparedCommitInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *GetCommentsForComparedCommitInput) SetRepositoryName(v string) *GetCommentsForComparedCommitInput {
+	s.RepositoryName = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/GetCommentsForComparedCommitOutput
+type GetCommentsForComparedCommitOutput struct {
+	_ struct{} `type:"structure"`
+
+	// A list of comment objects on the compared commit.
+	CommentsForComparedCommitData []*CommentsForComparedCommit `locationName:"commentsForComparedCommitData" type:"list"`
+
+	// An enumeration token that can be used in a request to return the next batch
+	// of the results.
+	NextToken *string `locationName:"nextToken" type:"string"`
+}
+
+// String returns the string representation
+func (s GetCommentsForComparedCommitOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetCommentsForComparedCommitOutput) GoString() string {
+	return s.String()
+}
+
+// SetCommentsForComparedCommitData sets the CommentsForComparedCommitData field's value.
+func (s *GetCommentsForComparedCommitOutput) SetCommentsForComparedCommitData(v []*CommentsForComparedCommit) *GetCommentsForComparedCommitOutput {
+	s.CommentsForComparedCommitData = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *GetCommentsForComparedCommitOutput) SetNextToken(v string) *GetCommentsForComparedCommitOutput {
+	s.NextToken = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/GetCommentsForPullRequestInput
+type GetCommentsForPullRequestInput struct {
+	_ struct{} `type:"structure"`
+
+	// The full commit ID of the commit in the source branch that was the tip of
+	// the branch at the time the comment was made.
+	AfterCommitId *string `locationName:"afterCommitId" type:"string"`
+
+	// The full commit ID of the commit in the destination branch that was the tip
+	// of the branch at the time the pull request was created.
+	BeforeCommitId *string `locationName:"beforeCommitId" type:"string"`
+
+	// A non-negative integer used to limit the number of returned results. The
+	// default is 100 comments. You can return up to 500 comments with a single
+	// request.
+	MaxResults *int64 `locationName:"maxResults" type:"integer"`
+
+	// An enumeration token that when provided in a request, returns the next batch
+	// of the results.
+	NextToken *string `locationName:"nextToken" type:"string"`
+
+	// The system-generated ID of the pull request. To get this ID, use ListPullRequests.
+	//
+	// PullRequestId is a required field
+	PullRequestId *string `locationName:"pullRequestId" type:"string" required:"true"`
+
+	// The name of the repository that contains the pull request.
+	RepositoryName *string `locationName:"repositoryName" min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s GetCommentsForPullRequestInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetCommentsForPullRequestInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetCommentsForPullRequestInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetCommentsForPullRequestInput"}
+	if s.PullRequestId == nil {
+		invalidParams.Add(request.NewErrParamRequired("PullRequestId"))
+	}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAfterCommitId sets the AfterCommitId field's value.
+func (s *GetCommentsForPullRequestInput) SetAfterCommitId(v string) *GetCommentsForPullRequestInput {
+	s.AfterCommitId = &v
+	return s
+}
+
+// SetBeforeCommitId sets the BeforeCommitId field's value.
+func (s *GetCommentsForPullRequestInput) SetBeforeCommitId(v string) *GetCommentsForPullRequestInput {
+	s.BeforeCommitId = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *GetCommentsForPullRequestInput) SetMaxResults(v int64) *GetCommentsForPullRequestInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *GetCommentsForPullRequestInput) SetNextToken(v string) *GetCommentsForPullRequestInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetPullRequestId sets the PullRequestId field's value.
+func (s *GetCommentsForPullRequestInput) SetPullRequestId(v string) *GetCommentsForPullRequestInput {
+	s.PullRequestId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *GetCommentsForPullRequestInput) SetRepositoryName(v string) *GetCommentsForPullRequestInput {
+	s.RepositoryName = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/GetCommentsForPullRequestOutput
+type GetCommentsForPullRequestOutput struct {
+	_ struct{} `type:"structure"`
+
+	// An array of comment objects on the pull request.
+	CommentsForPullRequestData []*CommentsForPullRequest `locationName:"commentsForPullRequestData" type:"list"`
+
+	// An enumeration token that can be used in a request to return the next batch
+	// of the results.
+	NextToken *string `locationName:"nextToken" type:"string"`
+}
+
+// String returns the string representation
+func (s GetCommentsForPullRequestOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetCommentsForPullRequestOutput) GoString() string {
+	return s.String()
+}
+
+// SetCommentsForPullRequestData sets the CommentsForPullRequestData field's value.
+func (s *GetCommentsForPullRequestOutput) SetCommentsForPullRequestData(v []*CommentsForPullRequest) *GetCommentsForPullRequestOutput {
+	s.CommentsForPullRequestData = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *GetCommentsForPullRequestOutput) SetNextToken(v string) *GetCommentsForPullRequestOutput {
+	s.NextToken = &v
 	return s
 }
 
@@ -3288,6 +6478,208 @@ func (s *GetDifferencesOutput) SetNextToken(v string) *GetDifferencesOutput {
 	return s
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/GetMergeConflictsInput
+type GetMergeConflictsInput struct {
+	_ struct{} `type:"structure"`
+
+	// The branch, tag, HEAD, or other fully qualified reference used to identify
+	// a commit. For example, a branch name or a full commit ID.
+	//
+	// DestinationCommitSpecifier is a required field
+	DestinationCommitSpecifier *string `locationName:"destinationCommitSpecifier" type:"string" required:"true"`
+
+	// The merge option or strategy you want to use to merge the code. The only
+	// valid value is FAST_FORWARD_MERGE.
+	//
+	// MergeOption is a required field
+	MergeOption *string `locationName:"mergeOption" type:"string" required:"true" enum:"MergeOptionTypeEnum"`
+
+	// The name of the repository where the pull request was created.
+	//
+	// RepositoryName is a required field
+	RepositoryName *string `locationName:"repositoryName" min:"1" type:"string" required:"true"`
+
+	// The branch, tag, HEAD, or other fully qualified reference used to identify
+	// a commit. For example, a branch name or a full commit ID.
+	//
+	// SourceCommitSpecifier is a required field
+	SourceCommitSpecifier *string `locationName:"sourceCommitSpecifier" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s GetMergeConflictsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetMergeConflictsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetMergeConflictsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetMergeConflictsInput"}
+	if s.DestinationCommitSpecifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("DestinationCommitSpecifier"))
+	}
+	if s.MergeOption == nil {
+		invalidParams.Add(request.NewErrParamRequired("MergeOption"))
+	}
+	if s.RepositoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RepositoryName"))
+	}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 1))
+	}
+	if s.SourceCommitSpecifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("SourceCommitSpecifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDestinationCommitSpecifier sets the DestinationCommitSpecifier field's value.
+func (s *GetMergeConflictsInput) SetDestinationCommitSpecifier(v string) *GetMergeConflictsInput {
+	s.DestinationCommitSpecifier = &v
+	return s
+}
+
+// SetMergeOption sets the MergeOption field's value.
+func (s *GetMergeConflictsInput) SetMergeOption(v string) *GetMergeConflictsInput {
+	s.MergeOption = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *GetMergeConflictsInput) SetRepositoryName(v string) *GetMergeConflictsInput {
+	s.RepositoryName = &v
+	return s
+}
+
+// SetSourceCommitSpecifier sets the SourceCommitSpecifier field's value.
+func (s *GetMergeConflictsInput) SetSourceCommitSpecifier(v string) *GetMergeConflictsInput {
+	s.SourceCommitSpecifier = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/GetMergeConflictsOutput
+type GetMergeConflictsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The commit ID of the destination commit specifier that was used in the merge
+	// evaluation.
+	//
+	// DestinationCommitId is a required field
+	DestinationCommitId *string `locationName:"destinationCommitId" type:"string" required:"true"`
+
+	// A Boolean value that indicates whether the code is mergable by the specified
+	// merge option.
+	//
+	// Mergeable is a required field
+	Mergeable *bool `locationName:"mergeable" type:"boolean" required:"true"`
+
+	// The commit ID of the source commit specifier that was used in the merge evaluation.
+	//
+	// SourceCommitId is a required field
+	SourceCommitId *string `locationName:"sourceCommitId" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s GetMergeConflictsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetMergeConflictsOutput) GoString() string {
+	return s.String()
+}
+
+// SetDestinationCommitId sets the DestinationCommitId field's value.
+func (s *GetMergeConflictsOutput) SetDestinationCommitId(v string) *GetMergeConflictsOutput {
+	s.DestinationCommitId = &v
+	return s
+}
+
+// SetMergeable sets the Mergeable field's value.
+func (s *GetMergeConflictsOutput) SetMergeable(v bool) *GetMergeConflictsOutput {
+	s.Mergeable = &v
+	return s
+}
+
+// SetSourceCommitId sets the SourceCommitId field's value.
+func (s *GetMergeConflictsOutput) SetSourceCommitId(v string) *GetMergeConflictsOutput {
+	s.SourceCommitId = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/GetPullRequestInput
+type GetPullRequestInput struct {
+	_ struct{} `type:"structure"`
+
+	// The system-generated ID of the pull request. To get this ID, use ListPullRequests.
+	//
+	// PullRequestId is a required field
+	PullRequestId *string `locationName:"pullRequestId" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s GetPullRequestInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetPullRequestInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetPullRequestInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetPullRequestInput"}
+	if s.PullRequestId == nil {
+		invalidParams.Add(request.NewErrParamRequired("PullRequestId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetPullRequestId sets the PullRequestId field's value.
+func (s *GetPullRequestInput) SetPullRequestId(v string) *GetPullRequestInput {
+	s.PullRequestId = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/GetPullRequestOutput
+type GetPullRequestOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the specified pull request.
+	//
+	// PullRequest is a required field
+	PullRequest *PullRequest `locationName:"pullRequest" type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s GetPullRequestOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetPullRequestOutput) GoString() string {
+	return s.String()
+}
+
+// SetPullRequest sets the PullRequest field's value.
+func (s *GetPullRequestOutput) SetPullRequest(v *PullRequest) *GetPullRequestOutput {
+	s.PullRequest = v
+	return s
+}
+
 // Represents the input of a get repository operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/GetRepositoryInput
 type GetRepositoryInput struct {
@@ -3519,6 +6911,124 @@ func (s *ListBranchesOutput) SetNextToken(v string) *ListBranchesOutput {
 	return s
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/ListPullRequestsInput
+type ListPullRequestsInput struct {
+	_ struct{} `type:"structure"`
+
+	// Optional. The Amazon Resource Name (ARN) of the user who created the pull
+	// request. If used, this filters the results to pull requests created by that
+	// user.
+	AuthorArn *string `locationName:"authorArn" type:"string"`
+
+	// A non-negative integer used to limit the number of returned results.
+	MaxResults *int64 `locationName:"maxResults" type:"integer"`
+
+	// An enumeration token that when provided in a request, returns the next batch
+	// of the results.
+	NextToken *string `locationName:"nextToken" type:"string"`
+
+	// Optional. The status of the pull request. If used, this refines the results
+	// to the pull requests that match the specified status.
+	PullRequestStatus *string `locationName:"pullRequestStatus" type:"string" enum:"PullRequestStatusEnum"`
+
+	// The name of the repository for which you want to list pull requests.
+	//
+	// RepositoryName is a required field
+	RepositoryName *string `locationName:"repositoryName" min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s ListPullRequestsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListPullRequestsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListPullRequestsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListPullRequestsInput"}
+	if s.RepositoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RepositoryName"))
+	}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAuthorArn sets the AuthorArn field's value.
+func (s *ListPullRequestsInput) SetAuthorArn(v string) *ListPullRequestsInput {
+	s.AuthorArn = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListPullRequestsInput) SetMaxResults(v int64) *ListPullRequestsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListPullRequestsInput) SetNextToken(v string) *ListPullRequestsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetPullRequestStatus sets the PullRequestStatus field's value.
+func (s *ListPullRequestsInput) SetPullRequestStatus(v string) *ListPullRequestsInput {
+	s.PullRequestStatus = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *ListPullRequestsInput) SetRepositoryName(v string) *ListPullRequestsInput {
+	s.RepositoryName = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/ListPullRequestsOutput
+type ListPullRequestsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// An enumeration token that when provided in a request, returns the next batch
+	// of the results.
+	NextToken *string `locationName:"nextToken" type:"string"`
+
+	// The system-generated IDs of the pull requests.
+	//
+	// PullRequestIds is a required field
+	PullRequestIds []*string `locationName:"pullRequestIds" type:"list" required:"true"`
+}
+
+// String returns the string representation
+func (s ListPullRequestsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListPullRequestsOutput) GoString() string {
+	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListPullRequestsOutput) SetNextToken(v string) *ListPullRequestsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetPullRequestIds sets the PullRequestIds field's value.
+func (s *ListPullRequestsOutput) SetPullRequestIds(v []*string) *ListPullRequestsOutput {
+	s.PullRequestIds = v
+	return s
+}
+
 // Represents the input of a list repositories operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/ListRepositoriesInput
 type ListRepositoriesInput struct {
@@ -3599,6 +7109,1044 @@ func (s *ListRepositoriesOutput) SetNextToken(v string) *ListRepositoriesOutput 
 // SetRepositories sets the Repositories field's value.
 func (s *ListRepositoriesOutput) SetRepositories(v []*RepositoryNameIdPair) *ListRepositoriesOutput {
 	s.Repositories = v
+	return s
+}
+
+// Returns information about the location of a change or comment in the comparison
+// between two commits or a pull request.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/Location
+type Location struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the file being compared, including its extension and subdirectory,
+	// if any.
+	FilePath *string `locationName:"filePath" type:"string"`
+
+	// The position of a change within a compared file, in line number format.
+	FilePosition *int64 `locationName:"filePosition" type:"long"`
+
+	// In a comparison of commits or a pull request, whether the change is in the
+	// 'before' or 'after' of that comparison.
+	RelativeFileVersion *string `locationName:"relativeFileVersion" type:"string" enum:"RelativeFileVersionEnum"`
+}
+
+// String returns the string representation
+func (s Location) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s Location) GoString() string {
+	return s.String()
+}
+
+// SetFilePath sets the FilePath field's value.
+func (s *Location) SetFilePath(v string) *Location {
+	s.FilePath = &v
+	return s
+}
+
+// SetFilePosition sets the FilePosition field's value.
+func (s *Location) SetFilePosition(v int64) *Location {
+	s.FilePosition = &v
+	return s
+}
+
+// SetRelativeFileVersion sets the RelativeFileVersion field's value.
+func (s *Location) SetRelativeFileVersion(v string) *Location {
+	s.RelativeFileVersion = &v
+	return s
+}
+
+// Returns information about a merge or potential merge between a source reference
+// and a destination reference in a pull request.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/MergeMetadata
+type MergeMetadata struct {
+	_ struct{} `type:"structure"`
+
+	// A Boolean value indicating whether the merge has been made.
+	IsMerged *bool `locationName:"isMerged" type:"boolean"`
+
+	// The Amazon Resource Name (ARN) of the user who merged the branches.
+	MergedBy *string `locationName:"mergedBy" type:"string"`
+}
+
+// String returns the string representation
+func (s MergeMetadata) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s MergeMetadata) GoString() string {
+	return s.String()
+}
+
+// SetIsMerged sets the IsMerged field's value.
+func (s *MergeMetadata) SetIsMerged(v bool) *MergeMetadata {
+	s.IsMerged = &v
+	return s
+}
+
+// SetMergedBy sets the MergedBy field's value.
+func (s *MergeMetadata) SetMergedBy(v string) *MergeMetadata {
+	s.MergedBy = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/MergePullRequestByFastForwardInput
+type MergePullRequestByFastForwardInput struct {
+	_ struct{} `type:"structure"`
+
+	// The system-generated ID of the pull request. To get this ID, use ListPullRequests.
+	//
+	// PullRequestId is a required field
+	PullRequestId *string `locationName:"pullRequestId" type:"string" required:"true"`
+
+	// The name of the repository where the pull request was created.
+	//
+	// RepositoryName is a required field
+	RepositoryName *string `locationName:"repositoryName" min:"1" type:"string" required:"true"`
+
+	// The full commit ID of the original or updated commit in the pull request
+	// source branch. Pass this value if you want an exception thrown if the current
+	// commit ID of the tip of the source branch does not match this commit ID.
+	SourceCommitId *string `locationName:"sourceCommitId" type:"string"`
+}
+
+// String returns the string representation
+func (s MergePullRequestByFastForwardInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s MergePullRequestByFastForwardInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *MergePullRequestByFastForwardInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "MergePullRequestByFastForwardInput"}
+	if s.PullRequestId == nil {
+		invalidParams.Add(request.NewErrParamRequired("PullRequestId"))
+	}
+	if s.RepositoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RepositoryName"))
+	}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetPullRequestId sets the PullRequestId field's value.
+func (s *MergePullRequestByFastForwardInput) SetPullRequestId(v string) *MergePullRequestByFastForwardInput {
+	s.PullRequestId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *MergePullRequestByFastForwardInput) SetRepositoryName(v string) *MergePullRequestByFastForwardInput {
+	s.RepositoryName = &v
+	return s
+}
+
+// SetSourceCommitId sets the SourceCommitId field's value.
+func (s *MergePullRequestByFastForwardInput) SetSourceCommitId(v string) *MergePullRequestByFastForwardInput {
+	s.SourceCommitId = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/MergePullRequestByFastForwardOutput
+type MergePullRequestByFastForwardOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the specified pull request, including information about
+	// the merge.
+	PullRequest *PullRequest `locationName:"pullRequest" type:"structure"`
+}
+
+// String returns the string representation
+func (s MergePullRequestByFastForwardOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s MergePullRequestByFastForwardOutput) GoString() string {
+	return s.String()
+}
+
+// SetPullRequest sets the PullRequest field's value.
+func (s *MergePullRequestByFastForwardOutput) SetPullRequest(v *PullRequest) *MergePullRequestByFastForwardOutput {
+	s.PullRequest = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/PostCommentForComparedCommitInput
+type PostCommentForComparedCommitInput struct {
+	_ struct{} `type:"structure"`
+
+	// To establish the directionality of the comparison, the full commit ID of
+	// the 'after' commit.
+	//
+	// AfterCommitId is a required field
+	AfterCommitId *string `locationName:"afterCommitId" type:"string" required:"true"`
+
+	// To establish the directionality of the comparison, the full commit ID of
+	// the 'before' commit.
+	BeforeCommitId *string `locationName:"beforeCommitId" type:"string"`
+
+	// A unique, client-generated idempotency token that when provided in a request,
+	// ensures the request cannot be repeated with a changed parameter. If a request
+	// is received with the same parameters and a token is included, the request
+	// will return information about the initial request that used that token.
+	ClientRequestToken *string `locationName:"clientRequestToken" type:"string" idempotencyToken:"true"`
+
+	// The content of the comment you want to make.
+	//
+	// Content is a required field
+	Content *string `locationName:"content" type:"string" required:"true"`
+
+	// The location of the comparison where you want to comment.
+	Location *Location `locationName:"location" type:"structure"`
+
+	// The name of the repository where you want to post a comment on the comparison
+	// between commits.
+	//
+	// RepositoryName is a required field
+	RepositoryName *string `locationName:"repositoryName" min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s PostCommentForComparedCommitInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PostCommentForComparedCommitInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PostCommentForComparedCommitInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PostCommentForComparedCommitInput"}
+	if s.AfterCommitId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AfterCommitId"))
+	}
+	if s.Content == nil {
+		invalidParams.Add(request.NewErrParamRequired("Content"))
+	}
+	if s.RepositoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RepositoryName"))
+	}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAfterCommitId sets the AfterCommitId field's value.
+func (s *PostCommentForComparedCommitInput) SetAfterCommitId(v string) *PostCommentForComparedCommitInput {
+	s.AfterCommitId = &v
+	return s
+}
+
+// SetBeforeCommitId sets the BeforeCommitId field's value.
+func (s *PostCommentForComparedCommitInput) SetBeforeCommitId(v string) *PostCommentForComparedCommitInput {
+	s.BeforeCommitId = &v
+	return s
+}
+
+// SetClientRequestToken sets the ClientRequestToken field's value.
+func (s *PostCommentForComparedCommitInput) SetClientRequestToken(v string) *PostCommentForComparedCommitInput {
+	s.ClientRequestToken = &v
+	return s
+}
+
+// SetContent sets the Content field's value.
+func (s *PostCommentForComparedCommitInput) SetContent(v string) *PostCommentForComparedCommitInput {
+	s.Content = &v
+	return s
+}
+
+// SetLocation sets the Location field's value.
+func (s *PostCommentForComparedCommitInput) SetLocation(v *Location) *PostCommentForComparedCommitInput {
+	s.Location = v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *PostCommentForComparedCommitInput) SetRepositoryName(v string) *PostCommentForComparedCommitInput {
+	s.RepositoryName = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/PostCommentForComparedCommitOutput
+type PostCommentForComparedCommitOutput struct {
+	_ struct{} `type:"structure"`
+
+	// In the directionality you established, the blob ID of the 'after' blob.
+	AfterBlobId *string `locationName:"afterBlobId" type:"string"`
+
+	// In the directionality you established, the full commit ID of the 'after'
+	// commit.
+	AfterCommitId *string `locationName:"afterCommitId" type:"string"`
+
+	// In the directionality you established, the blob ID of the 'before' blob.
+	BeforeBlobId *string `locationName:"beforeBlobId" type:"string"`
+
+	// In the directionality you established, the full commit ID of the 'before'
+	// commit.
+	BeforeCommitId *string `locationName:"beforeCommitId" type:"string"`
+
+	// The content of the comment you posted.
+	Comment *Comment `locationName:"comment" type:"structure"`
+
+	// The location of the comment in the comparison between the two commits.
+	Location *Location `locationName:"location" type:"structure"`
+
+	// The name of the repository where you posted a comment on the comparison between
+	// commits.
+	RepositoryName *string `locationName:"repositoryName" min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s PostCommentForComparedCommitOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PostCommentForComparedCommitOutput) GoString() string {
+	return s.String()
+}
+
+// SetAfterBlobId sets the AfterBlobId field's value.
+func (s *PostCommentForComparedCommitOutput) SetAfterBlobId(v string) *PostCommentForComparedCommitOutput {
+	s.AfterBlobId = &v
+	return s
+}
+
+// SetAfterCommitId sets the AfterCommitId field's value.
+func (s *PostCommentForComparedCommitOutput) SetAfterCommitId(v string) *PostCommentForComparedCommitOutput {
+	s.AfterCommitId = &v
+	return s
+}
+
+// SetBeforeBlobId sets the BeforeBlobId field's value.
+func (s *PostCommentForComparedCommitOutput) SetBeforeBlobId(v string) *PostCommentForComparedCommitOutput {
+	s.BeforeBlobId = &v
+	return s
+}
+
+// SetBeforeCommitId sets the BeforeCommitId field's value.
+func (s *PostCommentForComparedCommitOutput) SetBeforeCommitId(v string) *PostCommentForComparedCommitOutput {
+	s.BeforeCommitId = &v
+	return s
+}
+
+// SetComment sets the Comment field's value.
+func (s *PostCommentForComparedCommitOutput) SetComment(v *Comment) *PostCommentForComparedCommitOutput {
+	s.Comment = v
+	return s
+}
+
+// SetLocation sets the Location field's value.
+func (s *PostCommentForComparedCommitOutput) SetLocation(v *Location) *PostCommentForComparedCommitOutput {
+	s.Location = v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *PostCommentForComparedCommitOutput) SetRepositoryName(v string) *PostCommentForComparedCommitOutput {
+	s.RepositoryName = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/PostCommentForPullRequestInput
+type PostCommentForPullRequestInput struct {
+	_ struct{} `type:"structure"`
+
+	// The full commit ID of the commit in the source branch that is the current
+	// tip of the branch for the pull request when you post the comment.
+	//
+	// AfterCommitId is a required field
+	AfterCommitId *string `locationName:"afterCommitId" type:"string" required:"true"`
+
+	// The full commit ID of the commit in the destination branch that was the tip
+	// of the branch at the time the pull request was created.
+	//
+	// BeforeCommitId is a required field
+	BeforeCommitId *string `locationName:"beforeCommitId" type:"string" required:"true"`
+
+	// A unique, client-generated idempotency token that when provided in a request,
+	// ensures the request cannot be repeated with a changed parameter. If a request
+	// is received with the same parameters and a token is included, the request
+	// will return information about the initial request that used that token.
+	ClientRequestToken *string `locationName:"clientRequestToken" type:"string" idempotencyToken:"true"`
+
+	// The content of your comment on the change.
+	//
+	// Content is a required field
+	Content *string `locationName:"content" type:"string" required:"true"`
+
+	// The location of the change where you want to post your comment. If no location
+	// is provided, the comment will be posted as a general comment on the pull
+	// request difference between the before commit ID and the after commit ID.
+	Location *Location `locationName:"location" type:"structure"`
+
+	// The system-generated ID of the pull request. To get this ID, use ListPullRequests.
+	//
+	// PullRequestId is a required field
+	PullRequestId *string `locationName:"pullRequestId" type:"string" required:"true"`
+
+	// The name of the repository where you want to post a comment on a pull request.
+	//
+	// RepositoryName is a required field
+	RepositoryName *string `locationName:"repositoryName" min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s PostCommentForPullRequestInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PostCommentForPullRequestInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PostCommentForPullRequestInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PostCommentForPullRequestInput"}
+	if s.AfterCommitId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AfterCommitId"))
+	}
+	if s.BeforeCommitId == nil {
+		invalidParams.Add(request.NewErrParamRequired("BeforeCommitId"))
+	}
+	if s.Content == nil {
+		invalidParams.Add(request.NewErrParamRequired("Content"))
+	}
+	if s.PullRequestId == nil {
+		invalidParams.Add(request.NewErrParamRequired("PullRequestId"))
+	}
+	if s.RepositoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RepositoryName"))
+	}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAfterCommitId sets the AfterCommitId field's value.
+func (s *PostCommentForPullRequestInput) SetAfterCommitId(v string) *PostCommentForPullRequestInput {
+	s.AfterCommitId = &v
+	return s
+}
+
+// SetBeforeCommitId sets the BeforeCommitId field's value.
+func (s *PostCommentForPullRequestInput) SetBeforeCommitId(v string) *PostCommentForPullRequestInput {
+	s.BeforeCommitId = &v
+	return s
+}
+
+// SetClientRequestToken sets the ClientRequestToken field's value.
+func (s *PostCommentForPullRequestInput) SetClientRequestToken(v string) *PostCommentForPullRequestInput {
+	s.ClientRequestToken = &v
+	return s
+}
+
+// SetContent sets the Content field's value.
+func (s *PostCommentForPullRequestInput) SetContent(v string) *PostCommentForPullRequestInput {
+	s.Content = &v
+	return s
+}
+
+// SetLocation sets the Location field's value.
+func (s *PostCommentForPullRequestInput) SetLocation(v *Location) *PostCommentForPullRequestInput {
+	s.Location = v
+	return s
+}
+
+// SetPullRequestId sets the PullRequestId field's value.
+func (s *PostCommentForPullRequestInput) SetPullRequestId(v string) *PostCommentForPullRequestInput {
+	s.PullRequestId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *PostCommentForPullRequestInput) SetRepositoryName(v string) *PostCommentForPullRequestInput {
+	s.RepositoryName = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/PostCommentForPullRequestOutput
+type PostCommentForPullRequestOutput struct {
+	_ struct{} `type:"structure"`
+
+	// In the directionality of the pull request, the blob ID of the 'after' blob.
+	AfterBlobId *string `locationName:"afterBlobId" type:"string"`
+
+	// The full commit ID of the commit in the destination branch where the pull
+	// request will be merged.
+	AfterCommitId *string `locationName:"afterCommitId" type:"string"`
+
+	// In the directionality of the pull request, the blob ID of the 'before' blob.
+	BeforeBlobId *string `locationName:"beforeBlobId" type:"string"`
+
+	// The full commit ID of the commit in the source branch used to create the
+	// pull request, or in the case of an updated pull request, the full commit
+	// ID of the commit used to update the pull request.
+	BeforeCommitId *string `locationName:"beforeCommitId" type:"string"`
+
+	// The content of the comment you posted.
+	Comment *Comment `locationName:"comment" type:"structure"`
+
+	// The location of the change where you posted your comment.
+	Location *Location `locationName:"location" type:"structure"`
+
+	// The system-generated ID of the pull request.
+	PullRequestId *string `locationName:"pullRequestId" type:"string"`
+
+	// The name of the repository where you posted a comment on a pull request.
+	RepositoryName *string `locationName:"repositoryName" min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s PostCommentForPullRequestOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PostCommentForPullRequestOutput) GoString() string {
+	return s.String()
+}
+
+// SetAfterBlobId sets the AfterBlobId field's value.
+func (s *PostCommentForPullRequestOutput) SetAfterBlobId(v string) *PostCommentForPullRequestOutput {
+	s.AfterBlobId = &v
+	return s
+}
+
+// SetAfterCommitId sets the AfterCommitId field's value.
+func (s *PostCommentForPullRequestOutput) SetAfterCommitId(v string) *PostCommentForPullRequestOutput {
+	s.AfterCommitId = &v
+	return s
+}
+
+// SetBeforeBlobId sets the BeforeBlobId field's value.
+func (s *PostCommentForPullRequestOutput) SetBeforeBlobId(v string) *PostCommentForPullRequestOutput {
+	s.BeforeBlobId = &v
+	return s
+}
+
+// SetBeforeCommitId sets the BeforeCommitId field's value.
+func (s *PostCommentForPullRequestOutput) SetBeforeCommitId(v string) *PostCommentForPullRequestOutput {
+	s.BeforeCommitId = &v
+	return s
+}
+
+// SetComment sets the Comment field's value.
+func (s *PostCommentForPullRequestOutput) SetComment(v *Comment) *PostCommentForPullRequestOutput {
+	s.Comment = v
+	return s
+}
+
+// SetLocation sets the Location field's value.
+func (s *PostCommentForPullRequestOutput) SetLocation(v *Location) *PostCommentForPullRequestOutput {
+	s.Location = v
+	return s
+}
+
+// SetPullRequestId sets the PullRequestId field's value.
+func (s *PostCommentForPullRequestOutput) SetPullRequestId(v string) *PostCommentForPullRequestOutput {
+	s.PullRequestId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *PostCommentForPullRequestOutput) SetRepositoryName(v string) *PostCommentForPullRequestOutput {
+	s.RepositoryName = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/PostCommentReplyInput
+type PostCommentReplyInput struct {
+	_ struct{} `type:"structure"`
+
+	// A unique, client-generated idempotency token that when provided in a request,
+	// ensures the request cannot be repeated with a changed parameter. If a request
+	// is received with the same parameters and a token is included, the request
+	// will return information about the initial request that used that token.
+	ClientRequestToken *string `locationName:"clientRequestToken" type:"string" idempotencyToken:"true"`
+
+	// The contents of your reply to a comment.
+	//
+	// Content is a required field
+	Content *string `locationName:"content" type:"string" required:"true"`
+
+	// The system-generated ID of the comment to which you want to reply. To get
+	// this ID, use GetCommentsForComparedCommit or GetCommentsForPullRequest.
+	//
+	// InReplyTo is a required field
+	InReplyTo *string `locationName:"inReplyTo" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s PostCommentReplyInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PostCommentReplyInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PostCommentReplyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PostCommentReplyInput"}
+	if s.Content == nil {
+		invalidParams.Add(request.NewErrParamRequired("Content"))
+	}
+	if s.InReplyTo == nil {
+		invalidParams.Add(request.NewErrParamRequired("InReplyTo"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetClientRequestToken sets the ClientRequestToken field's value.
+func (s *PostCommentReplyInput) SetClientRequestToken(v string) *PostCommentReplyInput {
+	s.ClientRequestToken = &v
+	return s
+}
+
+// SetContent sets the Content field's value.
+func (s *PostCommentReplyInput) SetContent(v string) *PostCommentReplyInput {
+	s.Content = &v
+	return s
+}
+
+// SetInReplyTo sets the InReplyTo field's value.
+func (s *PostCommentReplyInput) SetInReplyTo(v string) *PostCommentReplyInput {
+	s.InReplyTo = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/PostCommentReplyOutput
+type PostCommentReplyOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the reply to a comment.
+	Comment *Comment `locationName:"comment" type:"structure"`
+}
+
+// String returns the string representation
+func (s PostCommentReplyOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PostCommentReplyOutput) GoString() string {
+	return s.String()
+}
+
+// SetComment sets the Comment field's value.
+func (s *PostCommentReplyOutput) SetComment(v *Comment) *PostCommentReplyOutput {
+	s.Comment = v
+	return s
+}
+
+// Returns information about a pull request.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/PullRequest
+type PullRequest struct {
+	_ struct{} `type:"structure"`
+
+	// The Amazon Resource Name (ARN) of the user who created the pull request.
+	AuthorArn *string `locationName:"authorArn" type:"string"`
+
+	// A unique, client-generated idempotency token that when provided in a request,
+	// ensures the request cannot be repeated with a changed parameter. If a request
+	// is received with the same parameters and a token is included, the request
+	// will return information about the initial request that used that token.
+	ClientRequestToken *string `locationName:"clientRequestToken" type:"string"`
+
+	// The date and time the pull request was originally created, in timestamp format.
+	CreationDate *time.Time `locationName:"creationDate" type:"timestamp" timestampFormat:"unix"`
+
+	// The user-defined description of the pull request. This description can be
+	// used to clarify what should be reviewed and other details of the request.
+	Description *string `locationName:"description" type:"string"`
+
+	// The day and time of the last user or system activity on the pull request,
+	// in timestamp format.
+	LastActivityDate *time.Time `locationName:"lastActivityDate" type:"timestamp" timestampFormat:"unix"`
+
+	// The system-generated ID of the pull request.
+	PullRequestId *string `locationName:"pullRequestId" type:"string"`
+
+	// The status of the pull request. Pull request status can only change from
+	// OPEN to CLOSED.
+	PullRequestStatus *string `locationName:"pullRequestStatus" type:"string" enum:"PullRequestStatusEnum"`
+
+	// The targets of the pull request, including the source branch and destination
+	// branch for the pull request.
+	PullRequestTargets []*PullRequestTarget `locationName:"pullRequestTargets" type:"list"`
+
+	// The user-defined title of the pull request. This title is displayed in the
+	// list of pull requests to other users of the repository.
+	Title *string `locationName:"title" type:"string"`
+}
+
+// String returns the string representation
+func (s PullRequest) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PullRequest) GoString() string {
+	return s.String()
+}
+
+// SetAuthorArn sets the AuthorArn field's value.
+func (s *PullRequest) SetAuthorArn(v string) *PullRequest {
+	s.AuthorArn = &v
+	return s
+}
+
+// SetClientRequestToken sets the ClientRequestToken field's value.
+func (s *PullRequest) SetClientRequestToken(v string) *PullRequest {
+	s.ClientRequestToken = &v
+	return s
+}
+
+// SetCreationDate sets the CreationDate field's value.
+func (s *PullRequest) SetCreationDate(v time.Time) *PullRequest {
+	s.CreationDate = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *PullRequest) SetDescription(v string) *PullRequest {
+	s.Description = &v
+	return s
+}
+
+// SetLastActivityDate sets the LastActivityDate field's value.
+func (s *PullRequest) SetLastActivityDate(v time.Time) *PullRequest {
+	s.LastActivityDate = &v
+	return s
+}
+
+// SetPullRequestId sets the PullRequestId field's value.
+func (s *PullRequest) SetPullRequestId(v string) *PullRequest {
+	s.PullRequestId = &v
+	return s
+}
+
+// SetPullRequestStatus sets the PullRequestStatus field's value.
+func (s *PullRequest) SetPullRequestStatus(v string) *PullRequest {
+	s.PullRequestStatus = &v
+	return s
+}
+
+// SetPullRequestTargets sets the PullRequestTargets field's value.
+func (s *PullRequest) SetPullRequestTargets(v []*PullRequestTarget) *PullRequest {
+	s.PullRequestTargets = v
+	return s
+}
+
+// SetTitle sets the Title field's value.
+func (s *PullRequest) SetTitle(v string) *PullRequest {
+	s.Title = &v
+	return s
+}
+
+// Returns information about a pull request event.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/PullRequestEvent
+type PullRequestEvent struct {
+	_ struct{} `type:"structure"`
+
+	// The Amazon Resource Name (ARN) of the user whose actions resulted in the
+	// event. Examples include updating the pull request with additional commits
+	// or changing the status of a pull request.
+	ActorArn *string `locationName:"actorArn" type:"string"`
+
+	// The day and time of the pull request event, in timestamp format.
+	EventDate *time.Time `locationName:"eventDate" type:"timestamp" timestampFormat:"unix"`
+
+	// The type of the pull request event, for example a status change event (PULL_REQUEST_STATUS_CHANGED)
+	// or update event (PULL_REQUEST_SOURCE_REFERENCE_UPDATED).
+	PullRequestEventType *string `locationName:"pullRequestEventType" type:"string" enum:"PullRequestEventType"`
+
+	// The system-generated ID of the pull request.
+	PullRequestId *string `locationName:"pullRequestId" type:"string"`
+
+	// Information about the change in mergability state for the pull request event.
+	PullRequestMergedStateChangedEventMetadata *PullRequestMergedStateChangedEventMetadata `locationName:"pullRequestMergedStateChangedEventMetadata" type:"structure"`
+
+	// Information about the updated source branch for the pull request event.
+	PullRequestSourceReferenceUpdatedEventMetadata *PullRequestSourceReferenceUpdatedEventMetadata `locationName:"pullRequestSourceReferenceUpdatedEventMetadata" type:"structure"`
+
+	// Information about the change in status for the pull request event.
+	PullRequestStatusChangedEventMetadata *PullRequestStatusChangedEventMetadata `locationName:"pullRequestStatusChangedEventMetadata" type:"structure"`
+}
+
+// String returns the string representation
+func (s PullRequestEvent) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PullRequestEvent) GoString() string {
+	return s.String()
+}
+
+// SetActorArn sets the ActorArn field's value.
+func (s *PullRequestEvent) SetActorArn(v string) *PullRequestEvent {
+	s.ActorArn = &v
+	return s
+}
+
+// SetEventDate sets the EventDate field's value.
+func (s *PullRequestEvent) SetEventDate(v time.Time) *PullRequestEvent {
+	s.EventDate = &v
+	return s
+}
+
+// SetPullRequestEventType sets the PullRequestEventType field's value.
+func (s *PullRequestEvent) SetPullRequestEventType(v string) *PullRequestEvent {
+	s.PullRequestEventType = &v
+	return s
+}
+
+// SetPullRequestId sets the PullRequestId field's value.
+func (s *PullRequestEvent) SetPullRequestId(v string) *PullRequestEvent {
+	s.PullRequestId = &v
+	return s
+}
+
+// SetPullRequestMergedStateChangedEventMetadata sets the PullRequestMergedStateChangedEventMetadata field's value.
+func (s *PullRequestEvent) SetPullRequestMergedStateChangedEventMetadata(v *PullRequestMergedStateChangedEventMetadata) *PullRequestEvent {
+	s.PullRequestMergedStateChangedEventMetadata = v
+	return s
+}
+
+// SetPullRequestSourceReferenceUpdatedEventMetadata sets the PullRequestSourceReferenceUpdatedEventMetadata field's value.
+func (s *PullRequestEvent) SetPullRequestSourceReferenceUpdatedEventMetadata(v *PullRequestSourceReferenceUpdatedEventMetadata) *PullRequestEvent {
+	s.PullRequestSourceReferenceUpdatedEventMetadata = v
+	return s
+}
+
+// SetPullRequestStatusChangedEventMetadata sets the PullRequestStatusChangedEventMetadata field's value.
+func (s *PullRequestEvent) SetPullRequestStatusChangedEventMetadata(v *PullRequestStatusChangedEventMetadata) *PullRequestEvent {
+	s.PullRequestStatusChangedEventMetadata = v
+	return s
+}
+
+// Returns information about the change in the merge state for a pull request
+// event.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/PullRequestMergedStateChangedEventMetadata
+type PullRequestMergedStateChangedEventMetadata struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the branch that the pull request will be merged into.
+	DestinationReference *string `locationName:"destinationReference" type:"string"`
+
+	// Information about the merge state change event.
+	MergeMetadata *MergeMetadata `locationName:"mergeMetadata" type:"structure"`
+
+	// The name of the repository where the pull request was created.
+	RepositoryName *string `locationName:"repositoryName" min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s PullRequestMergedStateChangedEventMetadata) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PullRequestMergedStateChangedEventMetadata) GoString() string {
+	return s.String()
+}
+
+// SetDestinationReference sets the DestinationReference field's value.
+func (s *PullRequestMergedStateChangedEventMetadata) SetDestinationReference(v string) *PullRequestMergedStateChangedEventMetadata {
+	s.DestinationReference = &v
+	return s
+}
+
+// SetMergeMetadata sets the MergeMetadata field's value.
+func (s *PullRequestMergedStateChangedEventMetadata) SetMergeMetadata(v *MergeMetadata) *PullRequestMergedStateChangedEventMetadata {
+	s.MergeMetadata = v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *PullRequestMergedStateChangedEventMetadata) SetRepositoryName(v string) *PullRequestMergedStateChangedEventMetadata {
+	s.RepositoryName = &v
+	return s
+}
+
+// Information about an update to the source branch of a pull request.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/PullRequestSourceReferenceUpdatedEventMetadata
+type PullRequestSourceReferenceUpdatedEventMetadata struct {
+	_ struct{} `type:"structure"`
+
+	// The full commit ID of the commit in the source branch that was the tip of
+	// the branch at the time the pull request was updated.
+	AfterCommitId *string `locationName:"afterCommitId" type:"string"`
+
+	// The full commit ID of the commit in the destination branch that was the tip
+	// of the branch at the time the pull request was updated.
+	BeforeCommitId *string `locationName:"beforeCommitId" type:"string"`
+
+	// The name of the repository where the pull request was updated.
+	RepositoryName *string `locationName:"repositoryName" min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s PullRequestSourceReferenceUpdatedEventMetadata) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PullRequestSourceReferenceUpdatedEventMetadata) GoString() string {
+	return s.String()
+}
+
+// SetAfterCommitId sets the AfterCommitId field's value.
+func (s *PullRequestSourceReferenceUpdatedEventMetadata) SetAfterCommitId(v string) *PullRequestSourceReferenceUpdatedEventMetadata {
+	s.AfterCommitId = &v
+	return s
+}
+
+// SetBeforeCommitId sets the BeforeCommitId field's value.
+func (s *PullRequestSourceReferenceUpdatedEventMetadata) SetBeforeCommitId(v string) *PullRequestSourceReferenceUpdatedEventMetadata {
+	s.BeforeCommitId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *PullRequestSourceReferenceUpdatedEventMetadata) SetRepositoryName(v string) *PullRequestSourceReferenceUpdatedEventMetadata {
+	s.RepositoryName = &v
+	return s
+}
+
+// Information about a change to the status of a pull request.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/PullRequestStatusChangedEventMetadata
+type PullRequestStatusChangedEventMetadata struct {
+	_ struct{} `type:"structure"`
+
+	// The changed status of the pull request.
+	PullRequestStatus *string `locationName:"pullRequestStatus" type:"string" enum:"PullRequestStatusEnum"`
+}
+
+// String returns the string representation
+func (s PullRequestStatusChangedEventMetadata) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PullRequestStatusChangedEventMetadata) GoString() string {
+	return s.String()
+}
+
+// SetPullRequestStatus sets the PullRequestStatus field's value.
+func (s *PullRequestStatusChangedEventMetadata) SetPullRequestStatus(v string) *PullRequestStatusChangedEventMetadata {
+	s.PullRequestStatus = &v
+	return s
+}
+
+// Returns information about a pull request target.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/PullRequestTarget
+type PullRequestTarget struct {
+	_ struct{} `type:"structure"`
+
+	// The full commit ID that is the tip of the destination branch. This is the
+	// commit where the pull request was or will be merged.
+	DestinationCommit *string `locationName:"destinationCommit" type:"string"`
+
+	// The branch of the repository where the pull request changes will be merged
+	// into. Also known as the destination branch.
+	DestinationReference *string `locationName:"destinationReference" type:"string"`
+
+	// Returns metadata about the state of the merge, including whether the merge
+	// has been made.
+	MergeMetadata *MergeMetadata `locationName:"mergeMetadata" type:"structure"`
+
+	// The name of the repository that contains the pull request source and destination
+	// branches.
+	RepositoryName *string `locationName:"repositoryName" min:"1" type:"string"`
+
+	// The full commit ID of the tip of the source branch used to create the pull
+	// request. If the pull request branch is updated by a push while the pull request
+	// is open, the commit ID will change to reflect the new tip of the branch.
+	SourceCommit *string `locationName:"sourceCommit" type:"string"`
+
+	// The branch of the repository that contains the changes for the pull request.
+	// Also known as the source branch.
+	SourceReference *string `locationName:"sourceReference" type:"string"`
+}
+
+// String returns the string representation
+func (s PullRequestTarget) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PullRequestTarget) GoString() string {
+	return s.String()
+}
+
+// SetDestinationCommit sets the DestinationCommit field's value.
+func (s *PullRequestTarget) SetDestinationCommit(v string) *PullRequestTarget {
+	s.DestinationCommit = &v
+	return s
+}
+
+// SetDestinationReference sets the DestinationReference field's value.
+func (s *PullRequestTarget) SetDestinationReference(v string) *PullRequestTarget {
+	s.DestinationReference = &v
+	return s
+}
+
+// SetMergeMetadata sets the MergeMetadata field's value.
+func (s *PullRequestTarget) SetMergeMetadata(v *MergeMetadata) *PullRequestTarget {
+	s.MergeMetadata = v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *PullRequestTarget) SetRepositoryName(v string) *PullRequestTarget {
+	s.RepositoryName = &v
+	return s
+}
+
+// SetSourceCommit sets the SourceCommit field's value.
+func (s *PullRequestTarget) SetSourceCommit(v string) *PullRequestTarget {
+	s.SourceCommit = &v
+	return s
+}
+
+// SetSourceReference sets the SourceReference field's value.
+func (s *PullRequestTarget) SetSourceReference(v string) *PullRequestTarget {
+	s.SourceReference = &v
 	return s
 }
 
@@ -3963,6 +8511,74 @@ func (s *RepositoryTriggerExecutionFailure) SetTrigger(v string) *RepositoryTrig
 	return s
 }
 
+// Returns information about a target for a pull request.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/Target
+type Target struct {
+	_ struct{} `type:"structure"`
+
+	// The branch of the repository where the pull request changes will be merged
+	// into. Also known as the destination branch.
+	DestinationReference *string `locationName:"destinationReference" type:"string"`
+
+	// The name of the repository that contains the pull request.
+	//
+	// RepositoryName is a required field
+	RepositoryName *string `locationName:"repositoryName" min:"1" type:"string" required:"true"`
+
+	// The branch of the repository that contains the changes for the pull request.
+	// Also known as the source branch.
+	//
+	// SourceReference is a required field
+	SourceReference *string `locationName:"sourceReference" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s Target) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s Target) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Target) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Target"}
+	if s.RepositoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RepositoryName"))
+	}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 1))
+	}
+	if s.SourceReference == nil {
+		invalidParams.Add(request.NewErrParamRequired("SourceReference"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDestinationReference sets the DestinationReference field's value.
+func (s *Target) SetDestinationReference(v string) *Target {
+	s.DestinationReference = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *Target) SetRepositoryName(v string) *Target {
+	s.RepositoryName = &v
+	return s
+}
+
+// SetSourceReference sets the SourceReference field's value.
+func (s *Target) SetSourceReference(v string) *Target {
+	s.SourceReference = &v
+	return s
+}
+
 // Represents the input of a test repository triggers operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/TestRepositoryTriggersInput
 type TestRepositoryTriggersInput struct {
@@ -4066,6 +8682,85 @@ func (s *TestRepositoryTriggersOutput) SetSuccessfulExecutions(v []*string) *Tes
 	return s
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/UpdateCommentInput
+type UpdateCommentInput struct {
+	_ struct{} `type:"structure"`
+
+	// The system-generated ID of the comment you want to update. To get this ID,
+	// use GetCommentsForComparedCommit or GetCommentsForPullRequest.
+	//
+	// CommentId is a required field
+	CommentId *string `locationName:"commentId" type:"string" required:"true"`
+
+	// The updated content with which you want to replace the existing content of
+	// the comment.
+	//
+	// Content is a required field
+	Content *string `locationName:"content" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s UpdateCommentInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateCommentInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateCommentInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateCommentInput"}
+	if s.CommentId == nil {
+		invalidParams.Add(request.NewErrParamRequired("CommentId"))
+	}
+	if s.Content == nil {
+		invalidParams.Add(request.NewErrParamRequired("Content"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetCommentId sets the CommentId field's value.
+func (s *UpdateCommentInput) SetCommentId(v string) *UpdateCommentInput {
+	s.CommentId = &v
+	return s
+}
+
+// SetContent sets the Content field's value.
+func (s *UpdateCommentInput) SetContent(v string) *UpdateCommentInput {
+	s.Content = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/UpdateCommentOutput
+type UpdateCommentOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the updated comment.
+	Comment *Comment `locationName:"comment" type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateCommentOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateCommentOutput) GoString() string {
+	return s.String()
+}
+
+// SetComment sets the Comment field's value.
+func (s *UpdateCommentOutput) SetComment(v *Comment) *UpdateCommentOutput {
+	s.Comment = v
+	return s
+}
+
 // Represents the input of an update default branch operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/UpdateDefaultBranchInput
 type UpdateDefaultBranchInput struct {
@@ -4139,6 +8834,245 @@ func (s UpdateDefaultBranchOutput) String() string {
 // GoString returns the string representation
 func (s UpdateDefaultBranchOutput) GoString() string {
 	return s.String()
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/UpdatePullRequestDescriptionInput
+type UpdatePullRequestDescriptionInput struct {
+	_ struct{} `type:"structure"`
+
+	// The updated content of the description for the pull request. This content
+	// will replace the existing description.
+	//
+	// Description is a required field
+	Description *string `locationName:"description" type:"string" required:"true"`
+
+	// The system-generated ID of the pull request. To get this ID, use ListPullRequests.
+	//
+	// PullRequestId is a required field
+	PullRequestId *string `locationName:"pullRequestId" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s UpdatePullRequestDescriptionInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdatePullRequestDescriptionInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdatePullRequestDescriptionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdatePullRequestDescriptionInput"}
+	if s.Description == nil {
+		invalidParams.Add(request.NewErrParamRequired("Description"))
+	}
+	if s.PullRequestId == nil {
+		invalidParams.Add(request.NewErrParamRequired("PullRequestId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDescription sets the Description field's value.
+func (s *UpdatePullRequestDescriptionInput) SetDescription(v string) *UpdatePullRequestDescriptionInput {
+	s.Description = &v
+	return s
+}
+
+// SetPullRequestId sets the PullRequestId field's value.
+func (s *UpdatePullRequestDescriptionInput) SetPullRequestId(v string) *UpdatePullRequestDescriptionInput {
+	s.PullRequestId = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/UpdatePullRequestDescriptionOutput
+type UpdatePullRequestDescriptionOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the updated pull request.
+	//
+	// PullRequest is a required field
+	PullRequest *PullRequest `locationName:"pullRequest" type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s UpdatePullRequestDescriptionOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdatePullRequestDescriptionOutput) GoString() string {
+	return s.String()
+}
+
+// SetPullRequest sets the PullRequest field's value.
+func (s *UpdatePullRequestDescriptionOutput) SetPullRequest(v *PullRequest) *UpdatePullRequestDescriptionOutput {
+	s.PullRequest = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/UpdatePullRequestStatusInput
+type UpdatePullRequestStatusInput struct {
+	_ struct{} `type:"structure"`
+
+	// The system-generated ID of the pull request. To get this ID, use ListPullRequests.
+	//
+	// PullRequestId is a required field
+	PullRequestId *string `locationName:"pullRequestId" type:"string" required:"true"`
+
+	// The status of the pull request. The only valid operations are to update the
+	// status from OPEN to OPEN, OPEN to CLOSED or from from CLOSED to CLOSED.
+	//
+	// PullRequestStatus is a required field
+	PullRequestStatus *string `locationName:"pullRequestStatus" type:"string" required:"true" enum:"PullRequestStatusEnum"`
+}
+
+// String returns the string representation
+func (s UpdatePullRequestStatusInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdatePullRequestStatusInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdatePullRequestStatusInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdatePullRequestStatusInput"}
+	if s.PullRequestId == nil {
+		invalidParams.Add(request.NewErrParamRequired("PullRequestId"))
+	}
+	if s.PullRequestStatus == nil {
+		invalidParams.Add(request.NewErrParamRequired("PullRequestStatus"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetPullRequestId sets the PullRequestId field's value.
+func (s *UpdatePullRequestStatusInput) SetPullRequestId(v string) *UpdatePullRequestStatusInput {
+	s.PullRequestId = &v
+	return s
+}
+
+// SetPullRequestStatus sets the PullRequestStatus field's value.
+func (s *UpdatePullRequestStatusInput) SetPullRequestStatus(v string) *UpdatePullRequestStatusInput {
+	s.PullRequestStatus = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/UpdatePullRequestStatusOutput
+type UpdatePullRequestStatusOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the pull request.
+	//
+	// PullRequest is a required field
+	PullRequest *PullRequest `locationName:"pullRequest" type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s UpdatePullRequestStatusOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdatePullRequestStatusOutput) GoString() string {
+	return s.String()
+}
+
+// SetPullRequest sets the PullRequest field's value.
+func (s *UpdatePullRequestStatusOutput) SetPullRequest(v *PullRequest) *UpdatePullRequestStatusOutput {
+	s.PullRequest = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/UpdatePullRequestTitleInput
+type UpdatePullRequestTitleInput struct {
+	_ struct{} `type:"structure"`
+
+	// The system-generated ID of the pull request. To get this ID, use ListPullRequests.
+	//
+	// PullRequestId is a required field
+	PullRequestId *string `locationName:"pullRequestId" type:"string" required:"true"`
+
+	// The updated title of the pull request. This will replace the existing title.
+	//
+	// Title is a required field
+	Title *string `locationName:"title" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s UpdatePullRequestTitleInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdatePullRequestTitleInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdatePullRequestTitleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdatePullRequestTitleInput"}
+	if s.PullRequestId == nil {
+		invalidParams.Add(request.NewErrParamRequired("PullRequestId"))
+	}
+	if s.Title == nil {
+		invalidParams.Add(request.NewErrParamRequired("Title"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetPullRequestId sets the PullRequestId field's value.
+func (s *UpdatePullRequestTitleInput) SetPullRequestId(v string) *UpdatePullRequestTitleInput {
+	s.PullRequestId = &v
+	return s
+}
+
+// SetTitle sets the Title field's value.
+func (s *UpdatePullRequestTitleInput) SetTitle(v string) *UpdatePullRequestTitleInput {
+	s.Title = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/UpdatePullRequestTitleOutput
+type UpdatePullRequestTitleOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the updated pull request.
+	//
+	// PullRequest is a required field
+	PullRequest *PullRequest `locationName:"pullRequest" type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s UpdatePullRequestTitleOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdatePullRequestTitleOutput) GoString() string {
+	return s.String()
+}
+
+// SetPullRequest sets the PullRequest field's value.
+func (s *UpdatePullRequestTitleOutput) SetPullRequest(v *PullRequest) *UpdatePullRequestTitleOutput {
+	s.PullRequest = v
+	return s
 }
 
 // Represents the input of an update repository description operation.
@@ -4339,11 +9273,46 @@ const (
 )
 
 const (
+	// MergeOptionTypeEnumFastForwardMerge is a MergeOptionTypeEnum enum value
+	MergeOptionTypeEnumFastForwardMerge = "FAST_FORWARD_MERGE"
+)
+
+const (
 	// OrderEnumAscending is a OrderEnum enum value
 	OrderEnumAscending = "ascending"
 
 	// OrderEnumDescending is a OrderEnum enum value
 	OrderEnumDescending = "descending"
+)
+
+const (
+	// PullRequestEventTypePullRequestCreated is a PullRequestEventType enum value
+	PullRequestEventTypePullRequestCreated = "PULL_REQUEST_CREATED"
+
+	// PullRequestEventTypePullRequestStatusChanged is a PullRequestEventType enum value
+	PullRequestEventTypePullRequestStatusChanged = "PULL_REQUEST_STATUS_CHANGED"
+
+	// PullRequestEventTypePullRequestSourceReferenceUpdated is a PullRequestEventType enum value
+	PullRequestEventTypePullRequestSourceReferenceUpdated = "PULL_REQUEST_SOURCE_REFERENCE_UPDATED"
+
+	// PullRequestEventTypePullRequestMergeStateChanged is a PullRequestEventType enum value
+	PullRequestEventTypePullRequestMergeStateChanged = "PULL_REQUEST_MERGE_STATE_CHANGED"
+)
+
+const (
+	// PullRequestStatusEnumOpen is a PullRequestStatusEnum enum value
+	PullRequestStatusEnumOpen = "OPEN"
+
+	// PullRequestStatusEnumClosed is a PullRequestStatusEnum enum value
+	PullRequestStatusEnumClosed = "CLOSED"
+)
+
+const (
+	// RelativeFileVersionEnumBefore is a RelativeFileVersionEnum enum value
+	RelativeFileVersionEnumBefore = "BEFORE"
+
+	// RelativeFileVersionEnumAfter is a RelativeFileVersionEnum enum value
+	RelativeFileVersionEnumAfter = "AFTER"
 )
 
 const (

--- a/vendor/github.com/aws/aws-sdk-go/service/codecommit/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/codecommit/doc.go
@@ -12,19 +12,19 @@
 // Repositories, by calling the following:
 //
 //    * BatchGetRepositories, which returns information about one or more repositories
-//    associated with your AWS account
+//    associated with your AWS account.
 //
-//    * CreateRepository, which creates an AWS CodeCommit repository
+//    * CreateRepository, which creates an AWS CodeCommit repository.
 //
-//    * DeleteRepository, which deletes an AWS CodeCommit repository
+//    * DeleteRepository, which deletes an AWS CodeCommit repository.
 //
-//    * GetRepository, which returns information about a specified repository
+//    * GetRepository, which returns information about a specified repository.
 //
 //    * ListRepositories, which lists all AWS CodeCommit repositories associated
-//    with your AWS account
+//    with your AWS account.
 //
 //    * UpdateRepositoryDescription, which sets or updates the description of
-//    the repository
+//    the repository.
 //
 //    * UpdateRepositoryName, which changes the name of the repository. If you
 //    change the name of a repository, no other users of that repository will
@@ -32,39 +32,88 @@
 //
 // Branches, by calling the following:
 //
-//    * CreateBranch, which creates a new branch in a specified repository
+//    * CreateBranch, which creates a new branch in a specified repository.
 //
 //    * DeleteBranch, which deletes the specified branch in a repository unless
-//    it is the default branch
+//    it is the default branch.
 //
-//    * GetBranch, which returns information about a specified branch
+//    * GetBranch, which returns information about a specified branch.
 //
-//    * ListBranches, which lists all branches for a specified repository
+//    * ListBranches, which lists all branches for a specified repository.
 //
-//    * UpdateDefaultBranch, which changes the default branch for a repository
+//    * UpdateDefaultBranch, which changes the default branch for a repository.
 //
 // Information about committed code in a repository, by calling the following:
 //
 //    * GetBlob, which returns the base-64 encoded content of an individual
-//    Git blob object within a repository
+//    Git blob object within a repository.
 //
 //    * GetCommit, which returns information about a commit, including commit
-//    messages and author and committer information
+//    messages and author and committer information.
 //
 //    * GetDifferences, which returns information about the differences in a
 //    valid commit specifier (such as a branch, tag, HEAD, commit ID or other
-//    fully qualified reference)
+//    fully qualified reference).
+//
+// Pull requests, by calling the following:
+//
+//    * CreatePullRequest, which creates a pull request in a specified repository.
+//
+//    * DescribePullRequestEvents, which returns information about one or more
+//    pull request events.
+//
+//    * GetCommentsForPullRequest, which returns information about comments
+//    on a specified pull request.
+//
+//    * GetMergeConflicts, which returns information about merge conflicts between
+//    the source and destination branch in a pull request.
+//
+//    * GetPullRequest, which returns information about a specified pull request.
+//
+//    * ListPullRequests, which lists all pull requests for a repository.
+//
+//    * MergePullRequestByFastForward, which merges the source destination branch
+//    of a pull request into the specified destination branch for that pull
+//    request using the fast-forward merge option.
+//
+//    * PostCommentForPullRequest, which posts a comment to a pull request at
+//    the specified line, file, or request.
+//
+//    * UpdatePullRequestDescription, which updates the description of a pull
+//    request.
+//
+//    * UpdatePullRequestStatus, which updates the status of a pull request.
+//
+//    * UpdatePullRequestTitle, which updates the title of a pull request.
+//
+// Information about comments in a repository, by calling the following:
+//
+//    * DeleteCommentContent, which deletes the content of a comment on a commit
+//    in a repository.
+//
+//    * GetComment, which returns information about a comment on a commit.
+//
+//    * GetCommentsForComparedCommit, which returns information about comments
+//    on the comparison between two commit specifiers in a repository.
+//
+//    * PostCommentForComparedCommit, which creates a comment on the comparison
+//    between two commit specifiers in a repository.
+//
+//    * PostCommentReply, which creates a reply to a comment.
+//
+//    * UpdateComment, which updates the content of a comment on a commit in
+//    a repository.
 //
 // Triggers, by calling the following:
 //
 //    * GetRepositoryTriggers, which returns information about triggers configured
-//    for a repository
+//    for a repository.
 //
 //    * PutRepositoryTriggers, which replaces all triggers for a repository
-//    and can be used to create or delete triggers
+//    and can be used to create or delete triggers.
 //
 //    * TestRepositoryTriggers, which tests the functionality of a repository
-//    trigger by sending data to the trigger target
+//    trigger by sending data to the trigger target.
 //
 // For information about how to use AWS CodeCommit, see the AWS CodeCommit User
 // Guide (http://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html).

--- a/vendor/github.com/aws/aws-sdk-go/service/codecommit/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/codecommit/errors.go
@@ -4,6 +4,25 @@ package codecommit
 
 const (
 
+	// ErrCodeActorDoesNotExistException for service response error code
+	// "ActorDoesNotExistException".
+	//
+	// The specified Amazon Resource Name (ARN) does not exist in the AWS account.
+	ErrCodeActorDoesNotExistException = "ActorDoesNotExistException"
+
+	// ErrCodeAuthorDoesNotExistException for service response error code
+	// "AuthorDoesNotExistException".
+	//
+	// The specified Amazon Resource Name (ARN) does not exist in the AWS account.
+	ErrCodeAuthorDoesNotExistException = "AuthorDoesNotExistException"
+
+	// ErrCodeBeforeCommitIdAndAfterCommitIdAreSameException for service response error code
+	// "BeforeCommitIdAndAfterCommitIdAreSameException".
+	//
+	// The before commit ID and the after commit ID are the same, which is not valid.
+	// The before commit ID and the after commit ID must be different commit IDs.
+	ErrCodeBeforeCommitIdAndAfterCommitIdAreSameException = "BeforeCommitIdAndAfterCommitIdAreSameException"
+
 	// ErrCodeBlobIdDoesNotExistException for service response error code
 	// "BlobIdDoesNotExistException".
 	//
@@ -33,6 +52,56 @@ const (
 	//
 	// A branch name is required but was not specified.
 	ErrCodeBranchNameRequiredException = "BranchNameRequiredException"
+
+	// ErrCodeClientRequestTokenRequiredException for service response error code
+	// "ClientRequestTokenRequiredException".
+	//
+	// A client request token is required. A client request token is an unique,
+	// client-generated idempotency token that when provided in a request, ensures
+	// the request cannot be repeated with a changed parameter. If a request is
+	// received with the same parameters and a token is included, the request will
+	// return information about the initial request that used that token.
+	ErrCodeClientRequestTokenRequiredException = "ClientRequestTokenRequiredException"
+
+	// ErrCodeCommentContentRequiredException for service response error code
+	// "CommentContentRequiredException".
+	//
+	// The comment is empty. You must provide some content for a comment. The content
+	// cannot be null.
+	ErrCodeCommentContentRequiredException = "CommentContentRequiredException"
+
+	// ErrCodeCommentContentSizeLimitExceededException for service response error code
+	// "CommentContentSizeLimitExceededException".
+	//
+	// The comment is too large. Comments are limited to 1,000 characters.
+	ErrCodeCommentContentSizeLimitExceededException = "CommentContentSizeLimitExceededException"
+
+	// ErrCodeCommentDeletedException for service response error code
+	// "CommentDeletedException".
+	//
+	// This comment has already been deleted. You cannot edit or delete a deleted
+	// comment.
+	ErrCodeCommentDeletedException = "CommentDeletedException"
+
+	// ErrCodeCommentDoesNotExistException for service response error code
+	// "CommentDoesNotExistException".
+	//
+	// No comment exists with the provided ID. Verify that you have provided the
+	// correct ID, and then try again.
+	ErrCodeCommentDoesNotExistException = "CommentDoesNotExistException"
+
+	// ErrCodeCommentIdRequiredException for service response error code
+	// "CommentIdRequiredException".
+	//
+	// The comment ID is missing or null. A comment ID is required.
+	ErrCodeCommentIdRequiredException = "CommentIdRequiredException"
+
+	// ErrCodeCommentNotCreatedByCallerException for service response error code
+	// "CommentNotCreatedByCallerException".
+	//
+	// You cannot modify or delete this comment. Only comment authors can modify
+	// or delete their comments.
+	ErrCodeCommentNotCreatedByCallerException = "CommentNotCreatedByCallerException"
 
 	// ErrCodeCommitDoesNotExistException for service response error code
 	// "CommitDoesNotExistException".
@@ -105,6 +174,28 @@ const (
 	// (http://docs.aws.amazon.com/codecommit/latest/userguide/limits.html).
 	ErrCodeFileTooLargeException = "FileTooLargeException"
 
+	// ErrCodeIdempotencyParameterMismatchException for service response error code
+	// "IdempotencyParameterMismatchException".
+	//
+	// The client request token is not valid. Either the token is not in a valid
+	// format, or the token has been used in a previous request and cannot be re-used.
+	ErrCodeIdempotencyParameterMismatchException = "IdempotencyParameterMismatchException"
+
+	// ErrCodeInvalidActorArnException for service response error code
+	// "InvalidActorArnException".
+	//
+	// The Amazon Resource Name (ARN) is not valid. Make sure that you have provided
+	// the full ARN for the user who initiated the change for the pull request,
+	// and then try again.
+	ErrCodeInvalidActorArnException = "InvalidActorArnException"
+
+	// ErrCodeInvalidAuthorArnException for service response error code
+	// "InvalidAuthorArnException".
+	//
+	// The Amazon Resource Name (ARN) is not valid. Make sure that you have provided
+	// the full ARN for the author of the pull request, and then try again.
+	ErrCodeInvalidAuthorArnException = "InvalidAuthorArnException"
+
 	// ErrCodeInvalidBlobIdException for service response error code
 	// "InvalidBlobIdException".
 	//
@@ -114,8 +205,21 @@ const (
 	// ErrCodeInvalidBranchNameException for service response error code
 	// "InvalidBranchNameException".
 	//
-	// The specified branch name is not valid.
+	// The specified reference name is not valid.
 	ErrCodeInvalidBranchNameException = "InvalidBranchNameException"
+
+	// ErrCodeInvalidClientRequestTokenException for service response error code
+	// "InvalidClientRequestTokenException".
+	//
+	// The client request token is not valid.
+	ErrCodeInvalidClientRequestTokenException = "InvalidClientRequestTokenException"
+
+	// ErrCodeInvalidCommentIdException for service response error code
+	// "InvalidCommentIdException".
+	//
+	// The comment ID is not in a valid format. Make sure that you have provided
+	// the full comment ID.
+	ErrCodeInvalidCommentIdException = "InvalidCommentIdException"
 
 	// ErrCodeInvalidCommitException for service response error code
 	// "InvalidCommitException".
@@ -135,11 +239,45 @@ const (
 	// The specified continuation token is not valid.
 	ErrCodeInvalidContinuationTokenException = "InvalidContinuationTokenException"
 
+	// ErrCodeInvalidDescriptionException for service response error code
+	// "InvalidDescriptionException".
+	//
+	// The pull request description is not valid. Descriptions are limited to 1,000
+	// characters in length.
+	ErrCodeInvalidDescriptionException = "InvalidDescriptionException"
+
+	// ErrCodeInvalidDestinationCommitSpecifierException for service response error code
+	// "InvalidDestinationCommitSpecifierException".
+	//
+	// The destination commit specifier is not valid. You must provide a valid branch
+	// name, tag, or full commit ID.
+	ErrCodeInvalidDestinationCommitSpecifierException = "InvalidDestinationCommitSpecifierException"
+
+	// ErrCodeInvalidFileLocationException for service response error code
+	// "InvalidFileLocationException".
+	//
+	// The location of the file is not valid. Make sure that you include the extension
+	// of the file as well as the file name.
+	ErrCodeInvalidFileLocationException = "InvalidFileLocationException"
+
+	// ErrCodeInvalidFilePositionException for service response error code
+	// "InvalidFilePositionException".
+	//
+	// The position is not valid. Make sure that the line number exists in the version
+	// of the file you want to comment on.
+	ErrCodeInvalidFilePositionException = "InvalidFilePositionException"
+
 	// ErrCodeInvalidMaxResultsException for service response error code
 	// "InvalidMaxResultsException".
 	//
 	// The specified number of maximum results is not valid.
 	ErrCodeInvalidMaxResultsException = "InvalidMaxResultsException"
+
+	// ErrCodeInvalidMergeOptionException for service response error code
+	// "InvalidMergeOptionException".
+	//
+	// The specified merge option is not valid. The only valid value is FAST_FORWARD_MERGE.
+	ErrCodeInvalidMergeOptionException = "InvalidMergeOptionException"
 
 	// ErrCodeInvalidOrderException for service response error code
 	// "InvalidOrderException".
@@ -152,6 +290,50 @@ const (
 	//
 	// The specified path is not valid.
 	ErrCodeInvalidPathException = "InvalidPathException"
+
+	// ErrCodeInvalidPullRequestEventTypeException for service response error code
+	// "InvalidPullRequestEventTypeException".
+	//
+	// The pull request event type is not valid.
+	ErrCodeInvalidPullRequestEventTypeException = "InvalidPullRequestEventTypeException"
+
+	// ErrCodeInvalidPullRequestIdException for service response error code
+	// "InvalidPullRequestIdException".
+	//
+	// The pull request ID is not valid. Make sure that you have provided the full
+	// ID and that the pull request is in the specified repository, and then try
+	// again.
+	ErrCodeInvalidPullRequestIdException = "InvalidPullRequestIdException"
+
+	// ErrCodeInvalidPullRequestStatusException for service response error code
+	// "InvalidPullRequestStatusException".
+	//
+	// The pull request status is not valid. The only valid values are OPEN and
+	// CLOSED.
+	ErrCodeInvalidPullRequestStatusException = "InvalidPullRequestStatusException"
+
+	// ErrCodeInvalidPullRequestStatusUpdateException for service response error code
+	// "InvalidPullRequestStatusUpdateException".
+	//
+	// The pull request status update is not valid. The only valid update is from
+	// OPEN to CLOSED.
+	ErrCodeInvalidPullRequestStatusUpdateException = "InvalidPullRequestStatusUpdateException"
+
+	// ErrCodeInvalidReferenceNameException for service response error code
+	// "InvalidReferenceNameException".
+	//
+	// The specified reference name format is not valid. Reference names must conform
+	// to the Git references format, for example refs/heads/master. For more information,
+	// see Git Internals - Git References (https://git-scm.com/book/en/v2/Git-Internals-Git-References)
+	// or consult your Git documentation.
+	ErrCodeInvalidReferenceNameException = "InvalidReferenceNameException"
+
+	// ErrCodeInvalidRelativeFileVersionEnumException for service response error code
+	// "InvalidRelativeFileVersionEnumException".
+	//
+	// Either the enum is not in a valid format, or the specified file version enum
+	// is not valid in respect to the current file version.
+	ErrCodeInvalidRelativeFileVersionEnumException = "InvalidRelativeFileVersionEnumException"
 
 	// ErrCodeInvalidRepositoryDescriptionException for service response error code
 	// "InvalidRepositoryDescriptionException".
@@ -215,11 +397,57 @@ const (
 	// The specified sort by value is not valid.
 	ErrCodeInvalidSortByException = "InvalidSortByException"
 
+	// ErrCodeInvalidSourceCommitSpecifierException for service response error code
+	// "InvalidSourceCommitSpecifierException".
+	//
+	// The source commit specifier is not valid. You must provide a valid branch
+	// name, tag, or full commit ID.
+	ErrCodeInvalidSourceCommitSpecifierException = "InvalidSourceCommitSpecifierException"
+
+	// ErrCodeInvalidTargetException for service response error code
+	// "InvalidTargetException".
+	//
+	// The target for the pull request is not valid. A target must contain the full
+	// values for the repository name, source branch, and destination branch for
+	// the pull request.
+	ErrCodeInvalidTargetException = "InvalidTargetException"
+
+	// ErrCodeInvalidTargetsException for service response error code
+	// "InvalidTargetsException".
+	//
+	// The targets for the pull request is not valid or not in a valid format. Targets
+	// are a list of target objects. Each target object must contain the full values
+	// for the repository name, source branch, and destination branch for a pull
+	// request.
+	ErrCodeInvalidTargetsException = "InvalidTargetsException"
+
+	// ErrCodeInvalidTitleException for service response error code
+	// "InvalidTitleException".
+	//
+	// The title of the pull request is not valid. Pull request titles cannot exceed
+	// 100 characters in length.
+	ErrCodeInvalidTitleException = "InvalidTitleException"
+
+	// ErrCodeManualMergeRequiredException for service response error code
+	// "ManualMergeRequiredException".
+	//
+	// The pull request cannot be merged automatically into the destination branch.
+	// You must manually merge the branches and resolve any conflicts.
+	ErrCodeManualMergeRequiredException = "ManualMergeRequiredException"
+
 	// ErrCodeMaximumBranchesExceededException for service response error code
 	// "MaximumBranchesExceededException".
 	//
 	// The number of branches for the trigger was exceeded.
 	ErrCodeMaximumBranchesExceededException = "MaximumBranchesExceededException"
+
+	// ErrCodeMaximumOpenPullRequestsExceededException for service response error code
+	// "MaximumOpenPullRequestsExceededException".
+	//
+	// You cannot create the pull request because the repository has too many open
+	// pull requests. The maximum number of open pull requests for a repository
+	// is 1,000. Close one or more open pull requests, and then try again.
+	ErrCodeMaximumOpenPullRequestsExceededException = "MaximumOpenPullRequestsExceededException"
 
 	// ErrCodeMaximumRepositoryNamesExceededException for service response error code
 	// "MaximumRepositoryNamesExceededException".
@@ -234,11 +462,74 @@ const (
 	// The number of triggers allowed for the repository was exceeded.
 	ErrCodeMaximumRepositoryTriggersExceededException = "MaximumRepositoryTriggersExceededException"
 
+	// ErrCodeMergeOptionRequiredException for service response error code
+	// "MergeOptionRequiredException".
+	//
+	// A merge option or stategy is required, and none was provided.
+	ErrCodeMergeOptionRequiredException = "MergeOptionRequiredException"
+
+	// ErrCodeMultipleRepositoriesInPullRequestException for service response error code
+	// "MultipleRepositoriesInPullRequestException".
+	//
+	// You cannot include more than one repository in a pull request. Make sure
+	// you have specified only one repository name in your request, and then try
+	// again.
+	ErrCodeMultipleRepositoriesInPullRequestException = "MultipleRepositoriesInPullRequestException"
+
 	// ErrCodePathDoesNotExistException for service response error code
 	// "PathDoesNotExistException".
 	//
 	// The specified path does not exist.
 	ErrCodePathDoesNotExistException = "PathDoesNotExistException"
+
+	// ErrCodePathRequiredException for service response error code
+	// "PathRequiredException".
+	//
+	// The filePath for a location cannot be empty or null.
+	ErrCodePathRequiredException = "PathRequiredException"
+
+	// ErrCodePullRequestAlreadyClosedException for service response error code
+	// "PullRequestAlreadyClosedException".
+	//
+	// The pull request status cannot be updated because it is already closed.
+	ErrCodePullRequestAlreadyClosedException = "PullRequestAlreadyClosedException"
+
+	// ErrCodePullRequestDoesNotExistException for service response error code
+	// "PullRequestDoesNotExistException".
+	//
+	// The pull request ID could not be found. Make sure that you have specified
+	// the correct repository name and pull request ID, and then try again.
+	ErrCodePullRequestDoesNotExistException = "PullRequestDoesNotExistException"
+
+	// ErrCodePullRequestIdRequiredException for service response error code
+	// "PullRequestIdRequiredException".
+	//
+	// A pull request ID is required, but none was provided.
+	ErrCodePullRequestIdRequiredException = "PullRequestIdRequiredException"
+
+	// ErrCodePullRequestStatusRequiredException for service response error code
+	// "PullRequestStatusRequiredException".
+	//
+	// A pull request status is required, but none was provided.
+	ErrCodePullRequestStatusRequiredException = "PullRequestStatusRequiredException"
+
+	// ErrCodeReferenceDoesNotExistException for service response error code
+	// "ReferenceDoesNotExistException".
+	//
+	// The specified reference does not exist. You must provide a full commit ID.
+	ErrCodeReferenceDoesNotExistException = "ReferenceDoesNotExistException"
+
+	// ErrCodeReferenceNameRequiredException for service response error code
+	// "ReferenceNameRequiredException".
+	//
+	// A reference name is required, but none was provided.
+	ErrCodeReferenceNameRequiredException = "ReferenceNameRequiredException"
+
+	// ErrCodeReferenceTypeNotSupportedException for service response error code
+	// "ReferenceTypeNotSupportedException".
+	//
+	// The specified reference is not a supported type.
+	ErrCodeReferenceTypeNotSupportedException = "ReferenceTypeNotSupportedException"
 
 	// ErrCodeRepositoryDoesNotExistException for service response error code
 	// "RepositoryDoesNotExistException".
@@ -269,6 +560,14 @@ const (
 	//
 	// A repository names object is required but was not specified.
 	ErrCodeRepositoryNamesRequiredException = "RepositoryNamesRequiredException"
+
+	// ErrCodeRepositoryNotAssociatedWithPullRequestException for service response error code
+	// "RepositoryNotAssociatedWithPullRequestException".
+	//
+	// The repository does not contain any pull requests with that pull request
+	// ID. Check to make sure you have provided the correct repository name for
+	// the pull request.
+	ErrCodeRepositoryNotAssociatedWithPullRequestException = "RepositoryNotAssociatedWithPullRequestException"
 
 	// ErrCodeRepositoryTriggerBranchNameListRequiredException for service response error code
 	// "RepositoryTriggerBranchNameListRequiredException".
@@ -301,4 +600,47 @@ const (
 	//
 	// The list of triggers for the repository is required but was not specified.
 	ErrCodeRepositoryTriggersListRequiredException = "RepositoryTriggersListRequiredException"
+
+	// ErrCodeSourceAndDestinationAreSameException for service response error code
+	// "SourceAndDestinationAreSameException".
+	//
+	// The source branch and the destination branch for the pull request are the
+	// same. You must specify different branches for the source and destination.
+	ErrCodeSourceAndDestinationAreSameException = "SourceAndDestinationAreSameException"
+
+	// ErrCodeTargetRequiredException for service response error code
+	// "TargetRequiredException".
+	//
+	// A pull request target is required. It cannot be empty or null. A pull request
+	// target must contain the full values for the repository name, source branch,
+	// and destination branch for the pull request.
+	ErrCodeTargetRequiredException = "TargetRequiredException"
+
+	// ErrCodeTargetsRequiredException for service response error code
+	// "TargetsRequiredException".
+	//
+	// An array of target objects is required. It cannot be empty or null.
+	ErrCodeTargetsRequiredException = "TargetsRequiredException"
+
+	// ErrCodeTipOfSourceReferenceIsDifferentException for service response error code
+	// "TipOfSourceReferenceIsDifferentException".
+	//
+	// The tip of the source branch in the destination repository does not match
+	// the tip of the source branch specified in your request. The pull request
+	// might have been updated. Make sure that you have the latest changes.
+	ErrCodeTipOfSourceReferenceIsDifferentException = "TipOfSourceReferenceIsDifferentException"
+
+	// ErrCodeTipsDivergenceExceededException for service response error code
+	// "TipsDivergenceExceededException".
+	//
+	// The divergence between the tips of the provided commit specifiers is too
+	// great to determine whether there might be any merge conflicts. Locally compare
+	// the specifiers using git diff or a diff tool.
+	ErrCodeTipsDivergenceExceededException = "TipsDivergenceExceededException"
+
+	// ErrCodeTitleRequiredException for service response error code
+	// "TitleRequiredException".
+	//
+	// A pull request title is required. It cannot be empty or null.
+	ErrCodeTitleRequiredException = "TitleRequiredException"
 )

--- a/vendor/github.com/aws/aws-sdk-go/service/firehose/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/firehose/api.go
@@ -322,88 +322,6 @@ func (c *Firehose) DescribeDeliveryStreamWithContext(ctx aws.Context, input *Des
 	return out, req.Send()
 }
 
-const opGetKinesisStream = "GetKinesisStream"
-
-// GetKinesisStreamRequest generates a "aws/request.Request" representing the
-// client's request for the GetKinesisStream operation. The "output" return
-// value will be populated with the request's response once the request complets
-// successfuly.
-//
-// Use "Send" method on the returned Request to send the API call to the service.
-// the "output" return value is not valid until after Send returns without error.
-//
-// See GetKinesisStream for more information on using the GetKinesisStream
-// API call, and error handling.
-//
-// This method is useful when you want to inject custom logic or configuration
-// into the SDK's request lifecycle. Such as custom headers, or retry logic.
-//
-//
-//    // Example sending a request using the GetKinesisStreamRequest method.
-//    req, resp := client.GetKinesisStreamRequest(params)
-//
-//    err := req.Send()
-//    if err == nil { // resp is now filled
-//        fmt.Println(resp)
-//    }
-//
-// Please also see https://docs.aws.amazon.com/goto/WebAPI/firehose-2015-08-04/GetKinesisStream
-func (c *Firehose) GetKinesisStreamRequest(input *GetKinesisStreamInput) (req *request.Request, output *GetKinesisStreamOutput) {
-	op := &request.Operation{
-		Name:       opGetKinesisStream,
-		HTTPMethod: "POST",
-		HTTPPath:   "/",
-	}
-
-	if input == nil {
-		input = &GetKinesisStreamInput{}
-	}
-
-	output = &GetKinesisStreamOutput{}
-	req = c.newRequest(op, input, output)
-	return
-}
-
-// GetKinesisStream API operation for Amazon Kinesis Firehose.
-//
-// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
-// with awserr.Error's Code and Message methods to get detailed information about
-// the error.
-//
-// See the AWS API reference guide for Amazon Kinesis Firehose's
-// API operation GetKinesisStream for usage and error information.
-//
-// Returned Error Codes:
-//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
-//   The specified resource could not be found.
-//
-//   * ErrCodeInvalidArgumentException "InvalidArgumentException"
-//   The specified input parameter has a value that is not valid.
-//
-//   * ErrCodeInvalidStreamTypeException "InvalidStreamTypeException"
-//
-// Please also see https://docs.aws.amazon.com/goto/WebAPI/firehose-2015-08-04/GetKinesisStream
-func (c *Firehose) GetKinesisStream(input *GetKinesisStreamInput) (*GetKinesisStreamOutput, error) {
-	req, out := c.GetKinesisStreamRequest(input)
-	return out, req.Send()
-}
-
-// GetKinesisStreamWithContext is the same as GetKinesisStream with the addition of
-// the ability to pass a context and additional request options.
-//
-// See GetKinesisStream for details on how to use this API operation.
-//
-// The context must be non-nil and will be used for request cancellation. If
-// the context is nil a panic will occur. In the future the SDK may create
-// sub-contexts for http.Requests. See https://golang.org/pkg/context/
-// for more information on using Contexts.
-func (c *Firehose) GetKinesisStreamWithContext(ctx aws.Context, input *GetKinesisStreamInput, opts ...request.Option) (*GetKinesisStreamOutput, error) {
-	req, out := c.GetKinesisStreamRequest(input)
-	req.SetContext(ctx)
-	req.ApplyOptions(opts...)
-	return out, req.Send()
-}
-
 const opListDeliveryStreams = "ListDeliveryStreams"
 
 // ListDeliveryStreamsRequest generates a "aws/request.Request" representing the
@@ -1086,6 +1004,9 @@ type CreateDeliveryStreamInput struct {
 
 	// [Deprecated] The destination in Amazon S3. You can specify only one destination.
 	S3DestinationConfiguration *S3DestinationConfiguration `deprecated:"true" type:"structure"`
+
+	// The destination in Splunk. You can specify only one destination.
+	SplunkDestinationConfiguration *SplunkDestinationConfiguration `type:"structure"`
 }
 
 // String returns the string representation
@@ -1130,6 +1051,11 @@ func (s *CreateDeliveryStreamInput) Validate() error {
 	if s.S3DestinationConfiguration != nil {
 		if err := s.S3DestinationConfiguration.Validate(); err != nil {
 			invalidParams.AddNested("S3DestinationConfiguration", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.SplunkDestinationConfiguration != nil {
+		if err := s.SplunkDestinationConfiguration.Validate(); err != nil {
+			invalidParams.AddNested("SplunkDestinationConfiguration", err.(request.ErrInvalidParams))
 		}
 	}
 
@@ -1178,6 +1104,12 @@ func (s *CreateDeliveryStreamInput) SetRedshiftDestinationConfiguration(v *Redsh
 // SetS3DestinationConfiguration sets the S3DestinationConfiguration field's value.
 func (s *CreateDeliveryStreamInput) SetS3DestinationConfiguration(v *S3DestinationConfiguration) *CreateDeliveryStreamInput {
 	s.S3DestinationConfiguration = v
+	return s
+}
+
+// SetSplunkDestinationConfiguration sets the SplunkDestinationConfiguration field's value.
+func (s *CreateDeliveryStreamInput) SetSplunkDestinationConfiguration(v *SplunkDestinationConfiguration) *CreateDeliveryStreamInput {
+	s.SplunkDestinationConfiguration = v
 	return s
 }
 
@@ -1506,6 +1438,9 @@ type DestinationDescription struct {
 
 	// [Deprecated] The destination in Amazon S3.
 	S3DestinationDescription *S3DestinationDescription `type:"structure"`
+
+	// The destination in Splunk.
+	SplunkDestinationDescription *SplunkDestinationDescription `type:"structure"`
 }
 
 // String returns the string representation
@@ -1545,6 +1480,12 @@ func (s *DestinationDescription) SetRedshiftDestinationDescription(v *RedshiftDe
 // SetS3DestinationDescription sets the S3DestinationDescription field's value.
 func (s *DestinationDescription) SetS3DestinationDescription(v *S3DestinationDescription) *DestinationDescription {
 	s.S3DestinationDescription = v
+	return s
+}
+
+// SetSplunkDestinationDescription sets the SplunkDestinationDescription field's value.
+func (s *DestinationDescription) SetSplunkDestinationDescription(v *SplunkDestinationDescription) *DestinationDescription {
+	s.SplunkDestinationDescription = v
 	return s
 }
 
@@ -2570,77 +2511,6 @@ func (s *ExtendedS3DestinationUpdate) SetS3BackupUpdate(v *S3DestinationUpdate) 
 	return s
 }
 
-// Please also see https://docs.aws.amazon.com/goto/WebAPI/firehose-2015-08-04/GetKinesisStreamInput
-type GetKinesisStreamInput struct {
-	_ struct{} `type:"structure"`
-
-	// DeliveryStreamARN is a required field
-	DeliveryStreamARN *string `min:"1" type:"string" required:"true"`
-}
-
-// String returns the string representation
-func (s GetKinesisStreamInput) String() string {
-	return awsutil.Prettify(s)
-}
-
-// GoString returns the string representation
-func (s GetKinesisStreamInput) GoString() string {
-	return s.String()
-}
-
-// Validate inspects the fields of the type to determine if they are valid.
-func (s *GetKinesisStreamInput) Validate() error {
-	invalidParams := request.ErrInvalidParams{Context: "GetKinesisStreamInput"}
-	if s.DeliveryStreamARN == nil {
-		invalidParams.Add(request.NewErrParamRequired("DeliveryStreamARN"))
-	}
-	if s.DeliveryStreamARN != nil && len(*s.DeliveryStreamARN) < 1 {
-		invalidParams.Add(request.NewErrParamMinLen("DeliveryStreamARN", 1))
-	}
-
-	if invalidParams.Len() > 0 {
-		return invalidParams
-	}
-	return nil
-}
-
-// SetDeliveryStreamARN sets the DeliveryStreamARN field's value.
-func (s *GetKinesisStreamInput) SetDeliveryStreamARN(v string) *GetKinesisStreamInput {
-	s.DeliveryStreamARN = &v
-	return s
-}
-
-// Please also see https://docs.aws.amazon.com/goto/WebAPI/firehose-2015-08-04/GetKinesisStreamOutput
-type GetKinesisStreamOutput struct {
-	_ struct{} `type:"structure"`
-
-	CredentialsForReadingKinesisStream *SessionCredentials `type:"structure"`
-
-	KinesisStreamARN *string `min:"1" type:"string"`
-}
-
-// String returns the string representation
-func (s GetKinesisStreamOutput) String() string {
-	return awsutil.Prettify(s)
-}
-
-// GoString returns the string representation
-func (s GetKinesisStreamOutput) GoString() string {
-	return s.String()
-}
-
-// SetCredentialsForReadingKinesisStream sets the CredentialsForReadingKinesisStream field's value.
-func (s *GetKinesisStreamOutput) SetCredentialsForReadingKinesisStream(v *SessionCredentials) *GetKinesisStreamOutput {
-	s.CredentialsForReadingKinesisStream = v
-	return s
-}
-
-// SetKinesisStreamARN sets the KinesisStreamARN field's value.
-func (s *GetKinesisStreamOutput) SetKinesisStreamARN(v string) *GetKinesisStreamOutput {
-	s.KinesisStreamARN = &v
-	return s
-}
-
 // Describes an encryption key for a destination in Amazon S3.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/firehose-2015-08-04/KMSEncryptionConfig
 type KMSEncryptionConfig struct {
@@ -2809,7 +2679,7 @@ type ListDeliveryStreamsInput struct {
 	// The name of the delivery stream to start the list with.
 	ExclusiveStartDeliveryStreamName *string `min:"1" type:"string"`
 
-	// The maximum number of delivery streams to list.
+	// The maximum number of delivery streams to list. The default value is 10.
 	Limit *int64 `min:"1" type:"integer"`
 }
 
@@ -4184,57 +4054,6 @@ func (s *S3DestinationUpdate) SetRoleARN(v string) *S3DestinationUpdate {
 	return s
 }
 
-// Please also see https://docs.aws.amazon.com/goto/WebAPI/firehose-2015-08-04/SessionCredentials
-type SessionCredentials struct {
-	_ struct{} `type:"structure"`
-
-	// AccessKeyId is a required field
-	AccessKeyId *string `type:"string" required:"true"`
-
-	// Expiration is a required field
-	Expiration *time.Time `type:"timestamp" timestampFormat:"unix" required:"true"`
-
-	// SecretAccessKey is a required field
-	SecretAccessKey *string `type:"string" required:"true"`
-
-	// SessionToken is a required field
-	SessionToken *string `type:"string" required:"true"`
-}
-
-// String returns the string representation
-func (s SessionCredentials) String() string {
-	return awsutil.Prettify(s)
-}
-
-// GoString returns the string representation
-func (s SessionCredentials) GoString() string {
-	return s.String()
-}
-
-// SetAccessKeyId sets the AccessKeyId field's value.
-func (s *SessionCredentials) SetAccessKeyId(v string) *SessionCredentials {
-	s.AccessKeyId = &v
-	return s
-}
-
-// SetExpiration sets the Expiration field's value.
-func (s *SessionCredentials) SetExpiration(v time.Time) *SessionCredentials {
-	s.Expiration = &v
-	return s
-}
-
-// SetSecretAccessKey sets the SecretAccessKey field's value.
-func (s *SessionCredentials) SetSecretAccessKey(v string) *SessionCredentials {
-	s.SecretAccessKey = &v
-	return s
-}
-
-// SetSessionToken sets the SessionToken field's value.
-func (s *SessionCredentials) SetSessionToken(v string) *SessionCredentials {
-	s.SessionToken = &v
-	return s
-}
-
 // Details about a Kinesis stream used as the source for a Kinesis Firehose
 // delivery stream.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/firehose-2015-08-04/SourceDescription
@@ -4258,6 +4077,422 @@ func (s SourceDescription) GoString() string {
 // SetKinesisStreamSourceDescription sets the KinesisStreamSourceDescription field's value.
 func (s *SourceDescription) SetKinesisStreamSourceDescription(v *KinesisStreamSourceDescription) *SourceDescription {
 	s.KinesisStreamSourceDescription = v
+	return s
+}
+
+// Describes the configuration of a destination in Splunk.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/firehose-2015-08-04/SplunkDestinationConfiguration
+type SplunkDestinationConfiguration struct {
+	_ struct{} `type:"structure"`
+
+	// The CloudWatch logging options for your delivery stream.
+	CloudWatchLoggingOptions *CloudWatchLoggingOptions `type:"structure"`
+
+	// The amount of time that Kinesis Firehose waits to receive an acknowledgment
+	// from Splunk after it sends it data. At the end of the timeout period Kinesis
+	// Firehose either tries to send the data again or considers it an error, based
+	// on your retry settings.
+	HECAcknowledgmentTimeoutInSeconds *int64 `min:"180" type:"integer"`
+
+	// The HTTP Event Collector (HEC) endpoint to which Kinesis Firehose sends your
+	// data.
+	//
+	// HECEndpoint is a required field
+	HECEndpoint *string `type:"string" required:"true"`
+
+	// This type can be either "Raw" or "Event".
+	//
+	// HECEndpointType is a required field
+	HECEndpointType *string `type:"string" required:"true" enum:"HECEndpointType"`
+
+	// This is a GUID you obtain from your Splunk cluster when you create a new
+	// HEC endpoint.
+	//
+	// HECToken is a required field
+	HECToken *string `type:"string" required:"true"`
+
+	// The data processing configuration.
+	ProcessingConfiguration *ProcessingConfiguration `type:"structure"`
+
+	// The retry behavior in case Kinesis Firehose is unable to deliver data to
+	// Splunk or if it doesn't receive an acknowledgment of receipt from Splunk.
+	RetryOptions *SplunkRetryOptions `type:"structure"`
+
+	// Defines how documents should be delivered to Amazon S3. When set to FailedDocumentsOnly,
+	// Kinesis Firehose writes any data that could not be indexed to the configured
+	// Amazon S3 destination. When set to AllDocuments, Kinesis Firehose delivers
+	// all incoming records to Amazon S3, and also writes failed documents to Amazon
+	// S3. Default value is FailedDocumentsOnly.
+	S3BackupMode *string `type:"string" enum:"SplunkS3BackupMode"`
+
+	// The configuration for the backup Amazon S3 location.
+	//
+	// S3Configuration is a required field
+	S3Configuration *S3DestinationConfiguration `type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s SplunkDestinationConfiguration) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SplunkDestinationConfiguration) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SplunkDestinationConfiguration) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SplunkDestinationConfiguration"}
+	if s.HECAcknowledgmentTimeoutInSeconds != nil && *s.HECAcknowledgmentTimeoutInSeconds < 180 {
+		invalidParams.Add(request.NewErrParamMinValue("HECAcknowledgmentTimeoutInSeconds", 180))
+	}
+	if s.HECEndpoint == nil {
+		invalidParams.Add(request.NewErrParamRequired("HECEndpoint"))
+	}
+	if s.HECEndpointType == nil {
+		invalidParams.Add(request.NewErrParamRequired("HECEndpointType"))
+	}
+	if s.HECToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("HECToken"))
+	}
+	if s.S3Configuration == nil {
+		invalidParams.Add(request.NewErrParamRequired("S3Configuration"))
+	}
+	if s.ProcessingConfiguration != nil {
+		if err := s.ProcessingConfiguration.Validate(); err != nil {
+			invalidParams.AddNested("ProcessingConfiguration", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.S3Configuration != nil {
+		if err := s.S3Configuration.Validate(); err != nil {
+			invalidParams.AddNested("S3Configuration", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetCloudWatchLoggingOptions sets the CloudWatchLoggingOptions field's value.
+func (s *SplunkDestinationConfiguration) SetCloudWatchLoggingOptions(v *CloudWatchLoggingOptions) *SplunkDestinationConfiguration {
+	s.CloudWatchLoggingOptions = v
+	return s
+}
+
+// SetHECAcknowledgmentTimeoutInSeconds sets the HECAcknowledgmentTimeoutInSeconds field's value.
+func (s *SplunkDestinationConfiguration) SetHECAcknowledgmentTimeoutInSeconds(v int64) *SplunkDestinationConfiguration {
+	s.HECAcknowledgmentTimeoutInSeconds = &v
+	return s
+}
+
+// SetHECEndpoint sets the HECEndpoint field's value.
+func (s *SplunkDestinationConfiguration) SetHECEndpoint(v string) *SplunkDestinationConfiguration {
+	s.HECEndpoint = &v
+	return s
+}
+
+// SetHECEndpointType sets the HECEndpointType field's value.
+func (s *SplunkDestinationConfiguration) SetHECEndpointType(v string) *SplunkDestinationConfiguration {
+	s.HECEndpointType = &v
+	return s
+}
+
+// SetHECToken sets the HECToken field's value.
+func (s *SplunkDestinationConfiguration) SetHECToken(v string) *SplunkDestinationConfiguration {
+	s.HECToken = &v
+	return s
+}
+
+// SetProcessingConfiguration sets the ProcessingConfiguration field's value.
+func (s *SplunkDestinationConfiguration) SetProcessingConfiguration(v *ProcessingConfiguration) *SplunkDestinationConfiguration {
+	s.ProcessingConfiguration = v
+	return s
+}
+
+// SetRetryOptions sets the RetryOptions field's value.
+func (s *SplunkDestinationConfiguration) SetRetryOptions(v *SplunkRetryOptions) *SplunkDestinationConfiguration {
+	s.RetryOptions = v
+	return s
+}
+
+// SetS3BackupMode sets the S3BackupMode field's value.
+func (s *SplunkDestinationConfiguration) SetS3BackupMode(v string) *SplunkDestinationConfiguration {
+	s.S3BackupMode = &v
+	return s
+}
+
+// SetS3Configuration sets the S3Configuration field's value.
+func (s *SplunkDestinationConfiguration) SetS3Configuration(v *S3DestinationConfiguration) *SplunkDestinationConfiguration {
+	s.S3Configuration = v
+	return s
+}
+
+// Describes a destination in Splunk.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/firehose-2015-08-04/SplunkDestinationDescription
+type SplunkDestinationDescription struct {
+	_ struct{} `type:"structure"`
+
+	// The CloudWatch logging options for your delivery stream.
+	CloudWatchLoggingOptions *CloudWatchLoggingOptions `type:"structure"`
+
+	// The amount of time that Kinesis Firehose waits to receive an acknowledgment
+	// from Splunk after it sends it data. At the end of the timeout period Kinesis
+	// Firehose either tries to send the data again or considers it an error, based
+	// on your retry settings.
+	HECAcknowledgmentTimeoutInSeconds *int64 `min:"180" type:"integer"`
+
+	// The HTTP Event Collector (HEC) endpoint to which Kinesis Firehose sends your
+	// data.
+	HECEndpoint *string `type:"string"`
+
+	// This type can be either "Raw" or "Event".
+	HECEndpointType *string `type:"string" enum:"HECEndpointType"`
+
+	// This is a GUID you obtain from your Splunk cluster when you create a new
+	// HEC endpoint.
+	HECToken *string `type:"string"`
+
+	// The data processing configuration.
+	ProcessingConfiguration *ProcessingConfiguration `type:"structure"`
+
+	// The retry behavior in case Kinesis Firehose is unable to deliver data to
+	// Splunk or if it doesn't receive an acknowledgment of receipt from Splunk.
+	RetryOptions *SplunkRetryOptions `type:"structure"`
+
+	// Defines how documents should be delivered to Amazon S3. When set to FailedDocumentsOnly,
+	// Kinesis Firehose writes any data that could not be indexed to the configured
+	// Amazon S3 destination. When set to AllDocuments, Kinesis Firehose delivers
+	// all incoming records to Amazon S3, and also writes failed documents to Amazon
+	// S3. Default value is FailedDocumentsOnly.
+	S3BackupMode *string `type:"string" enum:"SplunkS3BackupMode"`
+
+	// The Amazon S3 destination.>
+	S3DestinationDescription *S3DestinationDescription `type:"structure"`
+}
+
+// String returns the string representation
+func (s SplunkDestinationDescription) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SplunkDestinationDescription) GoString() string {
+	return s.String()
+}
+
+// SetCloudWatchLoggingOptions sets the CloudWatchLoggingOptions field's value.
+func (s *SplunkDestinationDescription) SetCloudWatchLoggingOptions(v *CloudWatchLoggingOptions) *SplunkDestinationDescription {
+	s.CloudWatchLoggingOptions = v
+	return s
+}
+
+// SetHECAcknowledgmentTimeoutInSeconds sets the HECAcknowledgmentTimeoutInSeconds field's value.
+func (s *SplunkDestinationDescription) SetHECAcknowledgmentTimeoutInSeconds(v int64) *SplunkDestinationDescription {
+	s.HECAcknowledgmentTimeoutInSeconds = &v
+	return s
+}
+
+// SetHECEndpoint sets the HECEndpoint field's value.
+func (s *SplunkDestinationDescription) SetHECEndpoint(v string) *SplunkDestinationDescription {
+	s.HECEndpoint = &v
+	return s
+}
+
+// SetHECEndpointType sets the HECEndpointType field's value.
+func (s *SplunkDestinationDescription) SetHECEndpointType(v string) *SplunkDestinationDescription {
+	s.HECEndpointType = &v
+	return s
+}
+
+// SetHECToken sets the HECToken field's value.
+func (s *SplunkDestinationDescription) SetHECToken(v string) *SplunkDestinationDescription {
+	s.HECToken = &v
+	return s
+}
+
+// SetProcessingConfiguration sets the ProcessingConfiguration field's value.
+func (s *SplunkDestinationDescription) SetProcessingConfiguration(v *ProcessingConfiguration) *SplunkDestinationDescription {
+	s.ProcessingConfiguration = v
+	return s
+}
+
+// SetRetryOptions sets the RetryOptions field's value.
+func (s *SplunkDestinationDescription) SetRetryOptions(v *SplunkRetryOptions) *SplunkDestinationDescription {
+	s.RetryOptions = v
+	return s
+}
+
+// SetS3BackupMode sets the S3BackupMode field's value.
+func (s *SplunkDestinationDescription) SetS3BackupMode(v string) *SplunkDestinationDescription {
+	s.S3BackupMode = &v
+	return s
+}
+
+// SetS3DestinationDescription sets the S3DestinationDescription field's value.
+func (s *SplunkDestinationDescription) SetS3DestinationDescription(v *S3DestinationDescription) *SplunkDestinationDescription {
+	s.S3DestinationDescription = v
+	return s
+}
+
+// Describes an update for a destination in Splunk.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/firehose-2015-08-04/SplunkDestinationUpdate
+type SplunkDestinationUpdate struct {
+	_ struct{} `type:"structure"`
+
+	// The CloudWatch logging options for your delivery stream.
+	CloudWatchLoggingOptions *CloudWatchLoggingOptions `type:"structure"`
+
+	// The amount of time that Kinesis Firehose waits to receive an acknowledgment
+	// from Splunk after it sends it data. At the end of the timeout period Kinesis
+	// Firehose either tries to send the data again or considers it an error, based
+	// on your retry settings.
+	HECAcknowledgmentTimeoutInSeconds *int64 `min:"180" type:"integer"`
+
+	// The HTTP Event Collector (HEC) endpoint to which Kinesis Firehose sends your
+	// data.
+	HECEndpoint *string `type:"string"`
+
+	// This type can be either "Raw" or "Event".
+	HECEndpointType *string `type:"string" enum:"HECEndpointType"`
+
+	// This is a GUID you obtain from your Splunk cluster when you create a new
+	// HEC endpoint.
+	HECToken *string `type:"string"`
+
+	// The data processing configuration.
+	ProcessingConfiguration *ProcessingConfiguration `type:"structure"`
+
+	// The retry behavior in case Kinesis Firehose is unable to deliver data to
+	// Splunk or if it doesn't receive an acknowledgment of receipt from Splunk.
+	RetryOptions *SplunkRetryOptions `type:"structure"`
+
+	// Defines how documents should be delivered to Amazon S3. When set to FailedDocumentsOnly,
+	// Kinesis Firehose writes any data that could not be indexed to the configured
+	// Amazon S3 destination. When set to AllDocuments, Kinesis Firehose delivers
+	// all incoming records to Amazon S3, and also writes failed documents to Amazon
+	// S3. Default value is FailedDocumentsOnly.
+	S3BackupMode *string `type:"string" enum:"SplunkS3BackupMode"`
+
+	// Your update to the configuration of the backup Amazon S3 location.
+	S3Update *S3DestinationUpdate `type:"structure"`
+}
+
+// String returns the string representation
+func (s SplunkDestinationUpdate) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SplunkDestinationUpdate) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SplunkDestinationUpdate) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SplunkDestinationUpdate"}
+	if s.HECAcknowledgmentTimeoutInSeconds != nil && *s.HECAcknowledgmentTimeoutInSeconds < 180 {
+		invalidParams.Add(request.NewErrParamMinValue("HECAcknowledgmentTimeoutInSeconds", 180))
+	}
+	if s.ProcessingConfiguration != nil {
+		if err := s.ProcessingConfiguration.Validate(); err != nil {
+			invalidParams.AddNested("ProcessingConfiguration", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.S3Update != nil {
+		if err := s.S3Update.Validate(); err != nil {
+			invalidParams.AddNested("S3Update", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetCloudWatchLoggingOptions sets the CloudWatchLoggingOptions field's value.
+func (s *SplunkDestinationUpdate) SetCloudWatchLoggingOptions(v *CloudWatchLoggingOptions) *SplunkDestinationUpdate {
+	s.CloudWatchLoggingOptions = v
+	return s
+}
+
+// SetHECAcknowledgmentTimeoutInSeconds sets the HECAcknowledgmentTimeoutInSeconds field's value.
+func (s *SplunkDestinationUpdate) SetHECAcknowledgmentTimeoutInSeconds(v int64) *SplunkDestinationUpdate {
+	s.HECAcknowledgmentTimeoutInSeconds = &v
+	return s
+}
+
+// SetHECEndpoint sets the HECEndpoint field's value.
+func (s *SplunkDestinationUpdate) SetHECEndpoint(v string) *SplunkDestinationUpdate {
+	s.HECEndpoint = &v
+	return s
+}
+
+// SetHECEndpointType sets the HECEndpointType field's value.
+func (s *SplunkDestinationUpdate) SetHECEndpointType(v string) *SplunkDestinationUpdate {
+	s.HECEndpointType = &v
+	return s
+}
+
+// SetHECToken sets the HECToken field's value.
+func (s *SplunkDestinationUpdate) SetHECToken(v string) *SplunkDestinationUpdate {
+	s.HECToken = &v
+	return s
+}
+
+// SetProcessingConfiguration sets the ProcessingConfiguration field's value.
+func (s *SplunkDestinationUpdate) SetProcessingConfiguration(v *ProcessingConfiguration) *SplunkDestinationUpdate {
+	s.ProcessingConfiguration = v
+	return s
+}
+
+// SetRetryOptions sets the RetryOptions field's value.
+func (s *SplunkDestinationUpdate) SetRetryOptions(v *SplunkRetryOptions) *SplunkDestinationUpdate {
+	s.RetryOptions = v
+	return s
+}
+
+// SetS3BackupMode sets the S3BackupMode field's value.
+func (s *SplunkDestinationUpdate) SetS3BackupMode(v string) *SplunkDestinationUpdate {
+	s.S3BackupMode = &v
+	return s
+}
+
+// SetS3Update sets the S3Update field's value.
+func (s *SplunkDestinationUpdate) SetS3Update(v *S3DestinationUpdate) *SplunkDestinationUpdate {
+	s.S3Update = v
+	return s
+}
+
+// Configures retry behavior in case Kinesis Firehose is unable to deliver documents
+// to Splunk or if it doesn't receive an acknowledgment from Splunk.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/firehose-2015-08-04/SplunkRetryOptions
+type SplunkRetryOptions struct {
+	_ struct{} `type:"structure"`
+
+	// The total amount of time that Kinesis Firehose spends on retries. This duration
+	// starts after the initial attempt to send data to Splunk fails and doesn't
+	// include the periods during which Kinesis Firehose waits for acknowledgment
+	// from Splunk after each attempt.
+	DurationInSeconds *int64 `type:"integer"`
+}
+
+// String returns the string representation
+func (s SplunkRetryOptions) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SplunkRetryOptions) GoString() string {
+	return s.String()
+}
+
+// SetDurationInSeconds sets the DurationInSeconds field's value.
+func (s *SplunkRetryOptions) SetDurationInSeconds(v int64) *SplunkRetryOptions {
+	s.DurationInSeconds = &v
 	return s
 }
 
@@ -4296,6 +4531,9 @@ type UpdateDestinationInput struct {
 
 	// [Deprecated] Describes an update for a destination in Amazon S3.
 	S3DestinationUpdate *S3DestinationUpdate `deprecated:"true" type:"structure"`
+
+	// Describes an update for a destination in Splunk.
+	SplunkDestinationUpdate *SplunkDestinationUpdate `type:"structure"`
 }
 
 // String returns the string representation
@@ -4349,6 +4587,11 @@ func (s *UpdateDestinationInput) Validate() error {
 			invalidParams.AddNested("S3DestinationUpdate", err.(request.ErrInvalidParams))
 		}
 	}
+	if s.SplunkDestinationUpdate != nil {
+		if err := s.SplunkDestinationUpdate.Validate(); err != nil {
+			invalidParams.AddNested("SplunkDestinationUpdate", err.(request.ErrInvalidParams))
+		}
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -4395,6 +4638,12 @@ func (s *UpdateDestinationInput) SetRedshiftDestinationUpdate(v *RedshiftDestina
 // SetS3DestinationUpdate sets the S3DestinationUpdate field's value.
 func (s *UpdateDestinationInput) SetS3DestinationUpdate(v *S3DestinationUpdate) *UpdateDestinationInput {
 	s.S3DestinationUpdate = v
+	return s
+}
+
+// SetSplunkDestinationUpdate sets the SplunkDestinationUpdate field's value.
+func (s *UpdateDestinationInput) SetSplunkDestinationUpdate(v *SplunkDestinationUpdate) *UpdateDestinationInput {
+	s.SplunkDestinationUpdate = v
 	return s
 }
 
@@ -4472,6 +4721,14 @@ const (
 )
 
 const (
+	// HECEndpointTypeRaw is a HECEndpointType enum value
+	HECEndpointTypeRaw = "Raw"
+
+	// HECEndpointTypeEvent is a HECEndpointType enum value
+	HECEndpointTypeEvent = "Event"
+)
+
+const (
 	// NoEncryptionConfigNoEncryption is a NoEncryptionConfig enum value
 	NoEncryptionConfigNoEncryption = "NoEncryption"
 )
@@ -4482,6 +4739,15 @@ const (
 
 	// ProcessorParameterNameNumberOfRetries is a ProcessorParameterName enum value
 	ProcessorParameterNameNumberOfRetries = "NumberOfRetries"
+
+	// ProcessorParameterNameRoleArn is a ProcessorParameterName enum value
+	ProcessorParameterNameRoleArn = "RoleArn"
+
+	// ProcessorParameterNameBufferSizeInMbs is a ProcessorParameterName enum value
+	ProcessorParameterNameBufferSizeInMbs = "BufferSizeInMBs"
+
+	// ProcessorParameterNameBufferIntervalInSeconds is a ProcessorParameterName enum value
+	ProcessorParameterNameBufferIntervalInSeconds = "BufferIntervalInSeconds"
 )
 
 const (
@@ -4503,4 +4769,12 @@ const (
 
 	// S3BackupModeEnabled is a S3BackupMode enum value
 	S3BackupModeEnabled = "Enabled"
+)
+
+const (
+	// SplunkS3BackupModeFailedEventsOnly is a SplunkS3BackupMode enum value
+	SplunkS3BackupModeFailedEventsOnly = "FailedEventsOnly"
+
+	// SplunkS3BackupModeAllEvents is a SplunkS3BackupMode enum value
+	SplunkS3BackupModeAllEvents = "AllEvents"
 )

--- a/vendor/github.com/aws/aws-sdk-go/service/firehose/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/firehose/errors.go
@@ -17,10 +17,6 @@ const (
 	// The specified input parameter has a value that is not valid.
 	ErrCodeInvalidArgumentException = "InvalidArgumentException"
 
-	// ErrCodeInvalidStreamTypeException for service response error code
-	// "InvalidStreamTypeException".
-	ErrCodeInvalidStreamTypeException = "InvalidStreamTypeException"
-
 	// ErrCodeLimitExceededException for service response error code
 	// "LimitExceededException".
 	//

--- a/vendor/github.com/aws/aws-sdk-go/service/kinesis/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/kinesis/api.go
@@ -59,8 +59,8 @@ func (c *Kinesis) AddTagsToStreamRequest(input *AddTagsToStreamInput) (req *requ
 
 // AddTagsToStream API operation for Amazon Kinesis.
 //
-// Adds or updates tags for the specified Amazon Kinesis stream. Each stream
-// can have up to 10 tags.
+// Adds or updates tags for the specified Kinesis stream. Each stream can have
+// up to 10 tags.
 //
 // If tags have already been assigned to the stream, AddTagsToStream overwrites
 // any existing tags that correspond to the specified tag keys.
@@ -79,7 +79,7 @@ func (c *Kinesis) AddTagsToStreamRequest(input *AddTagsToStreamInput) (req *requ
 //
 //   * ErrCodeResourceInUseException "ResourceInUseException"
 //   The resource is not available for this operation. For successful operation,
-//   the resource needs to be in the ACTIVE state.
+//   the resource must be in the ACTIVE state.
 //
 //   * ErrCodeInvalidArgumentException "InvalidArgumentException"
 //   A specified parameter exceeds its restrictions, is not supported, or can't
@@ -87,7 +87,7 @@ func (c *Kinesis) AddTagsToStreamRequest(input *AddTagsToStreamInput) (req *requ
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
 //   The requested resource exceeds the maximum number allowed, or the number
-//   of concurrent stream requests exceeds the maximum number allowed (5).
+//   of concurrent stream requests exceeds the maximum number allowed.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/kinesis-2013-12-02/AddTagsToStream
 func (c *Kinesis) AddTagsToStream(input *AddTagsToStreamInput) (*AddTagsToStreamOutput, error) {
@@ -157,8 +157,8 @@ func (c *Kinesis) CreateStreamRequest(input *CreateStreamInput) (req *request.Re
 
 // CreateStream API operation for Amazon Kinesis.
 //
-// Creates an Amazon Kinesis stream. A stream captures and transports data records
-// that are continuously emitted from different data sources or producers. Scale-out
+// Creates a Kinesis stream. A stream captures and transports data records that
+// are continuously emitted from different data sources or producers. Scale-out
 // within a stream is explicitly supported by means of shards, which are uniquely
 // identified groups of data records in a stream.
 //
@@ -166,8 +166,8 @@ func (c *Kinesis) CreateStreamRequest(input *CreateStreamInput) (req *request.Re
 // Each shard can support reads up to 5 transactions per second, up to a maximum
 // data read total of 2 MB per second. Each shard can support writes up to 1,000
 // records per second, up to a maximum data write total of 1 MB per second.
-// You can add shards to a stream if the amount of data input increases and
-// you can remove shards if the amount of data input decreases.
+// I the amount of data input increases or decreases, you can add or remove
+// shards.
 //
 // The stream name identifies the stream. The name is scoped to the AWS account
 // used by the application. It is also scoped by region. That is, two streams
@@ -175,12 +175,12 @@ func (c *Kinesis) CreateStreamRequest(input *CreateStreamInput) (req *request.Re
 // same account, but in two different regions, can have the same name.
 //
 // CreateStream is an asynchronous operation. Upon receiving a CreateStream
-// request, Amazon Kinesis immediately returns and sets the stream status to
-// CREATING. After the stream is created, Amazon Kinesis sets the stream status
+// request, Kinesis Streams immediately returns and sets the stream status to
+// CREATING. After the stream is created, Kinesis Streams sets the stream status
 // to ACTIVE. You should perform read and write operations only on an ACTIVE
 // stream.
 //
-// You receive a LimitExceededException when making a CreateStream request if
+// You receive a LimitExceededException when making a CreateStream request when
 // you try to do one of the following:
 //
 //    * Have more than five streams in the CREATING state at any point in time.
@@ -188,8 +188,8 @@ func (c *Kinesis) CreateStreamRequest(input *CreateStreamInput) (req *request.Re
 //    * Create more shards than are authorized for your account.
 //
 // For the default shard limit for an AWS account, see Streams Limits (http://docs.aws.amazon.com/kinesis/latest/dev/service-sizes-and-limits.html)
-// in the Amazon Kinesis Streams Developer Guide. If you need to increase this
-// limit, contact AWS Support (http://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html).
+// in the Amazon Kinesis Streams Developer Guide. To increase this limit, contact
+// AWS Support (http://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html).
 //
 // You can use DescribeStream to check the stream status, which is returned
 // in StreamStatus.
@@ -206,11 +206,11 @@ func (c *Kinesis) CreateStreamRequest(input *CreateStreamInput) (req *request.Re
 // Returned Error Codes:
 //   * ErrCodeResourceInUseException "ResourceInUseException"
 //   The resource is not available for this operation. For successful operation,
-//   the resource needs to be in the ACTIVE state.
+//   the resource must be in the ACTIVE state.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
 //   The requested resource exceeds the maximum number allowed, or the number
-//   of concurrent stream requests exceeds the maximum number allowed (5).
+//   of concurrent stream requests exceeds the maximum number allowed.
 //
 //   * ErrCodeInvalidArgumentException "InvalidArgumentException"
 //   A specified parameter exceeds its restrictions, is not supported, or can't
@@ -284,9 +284,9 @@ func (c *Kinesis) DecreaseStreamRetentionPeriodRequest(input *DecreaseStreamRete
 
 // DecreaseStreamRetentionPeriod API operation for Amazon Kinesis.
 //
-// Decreases the Amazon Kinesis stream's retention period, which is the length
-// of time data records are accessible after they are added to the stream. The
-// minimum value of a stream's retention period is 24 hours.
+// Decreases the Kinesis stream's retention period, which is the length of time
+// data records are accessible after they are added to the stream. The minimum
+// value of a stream's retention period is 24 hours.
 //
 // This operation may result in lost data. For example, if the stream's retention
 // period is 48 hours and is decreased to 24 hours, any data already in the
@@ -302,7 +302,7 @@ func (c *Kinesis) DecreaseStreamRetentionPeriodRequest(input *DecreaseStreamRete
 // Returned Error Codes:
 //   * ErrCodeResourceInUseException "ResourceInUseException"
 //   The resource is not available for this operation. For successful operation,
-//   the resource needs to be in the ACTIVE state.
+//   the resource must be in the ACTIVE state.
 //
 //   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
 //   The requested resource could not be found. The stream might not be specified
@@ -380,16 +380,16 @@ func (c *Kinesis) DeleteStreamRequest(input *DeleteStreamInput) (req *request.Re
 
 // DeleteStream API operation for Amazon Kinesis.
 //
-// Deletes an Amazon Kinesis stream and all its shards and data. You must shut
-// down any applications that are operating on the stream before you delete
-// the stream. If an application attempts to operate on a deleted stream, it
-// will receive the exception ResourceNotFoundException.
+// Deletes a Kinesis stream and all its shards and data. You must shut down
+// any applications that are operating on the stream before you delete the stream.
+// If an application attempts to operate on a deleted stream, it receives the
+// exception ResourceNotFoundException.
 //
 // If the stream is in the ACTIVE state, you can delete it. After a DeleteStream
-// request, the specified stream is in the DELETING state until Amazon Kinesis
+// request, the specified stream is in the DELETING state until Kinesis Streams
 // completes the deletion.
 //
-// Note: Amazon Kinesis might continue to accept data read and write operations,
+// Note: Kinesis Streams might continue to accept data read and write operations,
 // such as PutRecord, PutRecords, and GetRecords, on a stream in the DELETING
 // state until the stream deletion is complete.
 //
@@ -415,7 +415,7 @@ func (c *Kinesis) DeleteStreamRequest(input *DeleteStreamInput) (req *request.Re
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
 //   The requested resource exceeds the maximum number allowed, or the number
-//   of concurrent stream requests exceeds the maximum number allowed (5).
+//   of concurrent stream requests exceeds the maximum number allowed.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/kinesis-2013-12-02/DeleteStream
 func (c *Kinesis) DeleteStream(input *DeleteStreamInput) (*DeleteStreamOutput, error) {
@@ -500,7 +500,7 @@ func (c *Kinesis) DescribeLimitsRequest(input *DescribeLimitsInput) (req *reques
 // Returned Error Codes:
 //   * ErrCodeLimitExceededException "LimitExceededException"
 //   The requested resource exceeds the maximum number allowed, or the number
-//   of concurrent stream requests exceeds the maximum number allowed (5).
+//   of concurrent stream requests exceeds the maximum number allowed.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/kinesis-2013-12-02/DescribeLimits
 func (c *Kinesis) DescribeLimits(input *DescribeLimitsInput) (*DescribeLimitsOutput, error) {
@@ -574,7 +574,7 @@ func (c *Kinesis) DescribeStreamRequest(input *DescribeStreamInput) (req *reques
 
 // DescribeStream API operation for Amazon Kinesis.
 //
-// Describes the specified Amazon Kinesis stream.
+// Describes the specified Kinesis stream.
 //
 // The information returned includes the stream name, Amazon Resource Name (ARN),
 // creation time, enhanced metric configuration, and shard map. The shard map
@@ -608,7 +608,7 @@ func (c *Kinesis) DescribeStreamRequest(input *DescribeStreamInput) (req *reques
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
 //   The requested resource exceeds the maximum number allowed, or the number
-//   of concurrent stream requests exceeds the maximum number allowed (5).
+//   of concurrent stream requests exceeds the maximum number allowed.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/kinesis-2013-12-02/DescribeStream
 func (c *Kinesis) DescribeStream(input *DescribeStreamInput) (*DescribeStreamOutput, error) {
@@ -682,6 +682,95 @@ func (c *Kinesis) DescribeStreamPagesWithContext(ctx aws.Context, input *Describ
 	return p.Err()
 }
 
+const opDescribeStreamSummary = "DescribeStreamSummary"
+
+// DescribeStreamSummaryRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeStreamSummary operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeStreamSummary for more information on using the DescribeStreamSummary
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeStreamSummaryRequest method.
+//    req, resp := client.DescribeStreamSummaryRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/kinesis-2013-12-02/DescribeStreamSummary
+func (c *Kinesis) DescribeStreamSummaryRequest(input *DescribeStreamSummaryInput) (req *request.Request, output *DescribeStreamSummaryOutput) {
+	op := &request.Operation{
+		Name:       opDescribeStreamSummary,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DescribeStreamSummaryInput{}
+	}
+
+	output = &DescribeStreamSummaryOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeStreamSummary API operation for Amazon Kinesis.
+//
+// Provides a summarized description of the specified Kinesis stream without
+// the shard list.
+//
+// The information returned includes the stream name, Amazon Resource Name (ARN),
+// status, record retention period, approximate creation time, monitoring, encryption
+// details, and open shard count.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Kinesis's
+// API operation DescribeStreamSummary for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The requested resource could not be found. The stream might not be specified
+//   correctly.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   The requested resource exceeds the maximum number allowed, or the number
+//   of concurrent stream requests exceeds the maximum number allowed.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/kinesis-2013-12-02/DescribeStreamSummary
+func (c *Kinesis) DescribeStreamSummary(input *DescribeStreamSummaryInput) (*DescribeStreamSummaryOutput, error) {
+	req, out := c.DescribeStreamSummaryRequest(input)
+	return out, req.Send()
+}
+
+// DescribeStreamSummaryWithContext is the same as DescribeStreamSummary with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeStreamSummary for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Kinesis) DescribeStreamSummaryWithContext(ctx aws.Context, input *DescribeStreamSummaryInput, opts ...request.Option) (*DescribeStreamSummaryOutput, error) {
+	req, out := c.DescribeStreamSummaryRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opDisableEnhancedMonitoring = "DisableEnhancedMonitoring"
 
 // DisableEnhancedMonitoringRequest generates a "aws/request.Request" representing the
@@ -742,11 +831,11 @@ func (c *Kinesis) DisableEnhancedMonitoringRequest(input *DisableEnhancedMonitor
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
 //   The requested resource exceeds the maximum number allowed, or the number
-//   of concurrent stream requests exceeds the maximum number allowed (5).
+//   of concurrent stream requests exceeds the maximum number allowed.
 //
 //   * ErrCodeResourceInUseException "ResourceInUseException"
 //   The resource is not available for this operation. For successful operation,
-//   the resource needs to be in the ACTIVE state.
+//   the resource must be in the ACTIVE state.
 //
 //   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
 //   The requested resource could not be found. The stream might not be specified
@@ -818,7 +907,7 @@ func (c *Kinesis) EnableEnhancedMonitoringRequest(input *EnableEnhancedMonitorin
 
 // EnableEnhancedMonitoring API operation for Amazon Kinesis.
 //
-// Enables enhanced Amazon Kinesis stream monitoring for shard-level metrics.
+// Enables enhanced Kinesis stream monitoring for shard-level metrics.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -834,11 +923,11 @@ func (c *Kinesis) EnableEnhancedMonitoringRequest(input *EnableEnhancedMonitorin
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
 //   The requested resource exceeds the maximum number allowed, or the number
-//   of concurrent stream requests exceeds the maximum number allowed (5).
+//   of concurrent stream requests exceeds the maximum number allowed.
 //
 //   * ErrCodeResourceInUseException "ResourceInUseException"
 //   The resource is not available for this operation. For successful operation,
-//   the resource needs to be in the ACTIVE state.
+//   the resource must be in the ACTIVE state.
 //
 //   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
 //   The requested resource could not be found. The stream might not be specified
@@ -910,14 +999,14 @@ func (c *Kinesis) GetRecordsRequest(input *GetRecordsInput) (req *request.Reques
 
 // GetRecords API operation for Amazon Kinesis.
 //
-// Gets data records from an Amazon Kinesis stream's shard.
+// Gets data records from a Kinesis stream's shard.
 //
 // Specify a shard iterator using the ShardIterator parameter. The shard iterator
 // specifies the position in the shard from which you want to start reading
 // data records sequentially. If there are no records available in the portion
 // of the shard that the iterator points to, GetRecords returns an empty list.
-// Note that it might take multiple calls to get to a portion of the shard that
-// contains records.
+// It might take multiple calls to get to a portion of the shard that contains
+// records.
 //
 // You can scale by provisioning multiple shards per stream while considering
 // service limits (for more information, see Streams Limits (http://docs.aws.amazon.com/kinesis/latest/dev/service-sizes-and-limits.html)
@@ -926,12 +1015,11 @@ func (c *Kinesis) GetRecordsRequest(input *GetRecordsInput) (req *request.Reques
 // from a stream continually, call GetRecords in a loop. Use GetShardIterator
 // to get the shard iterator to specify in the first GetRecords call. GetRecords
 // returns a new shard iterator in NextShardIterator. Specify the shard iterator
-// returned in NextShardIterator in subsequent calls to GetRecords. Note that
-// if the shard has been closed, the shard iterator can't return more data and
-// GetRecords returns null in NextShardIterator. You can terminate the loop
-// when the shard is closed, or when the shard iterator reaches the record with
-// the sequence number or other attribute that marks it as the last record to
-// process.
+// returned in NextShardIterator in subsequent calls to GetRecords. If the shard
+// has been closed, the shard iterator can't return more data and GetRecords
+// returns null in NextShardIterator. You can terminate the loop when the shard
+// is closed, or when the shard iterator reaches the record with the sequence
+// number or other attribute that marks it as the last record to process.
 //
 // Each data record can be up to 1 MB in size, and each shard can read up to
 // 2 MB per second. You can ensure that your calls don't exceed the maximum
@@ -944,10 +1032,10 @@ func (c *Kinesis) GetRecordsRequest(input *GetRecordsInput) (req *request.Reques
 // If a call returns this amount of data, subsequent calls made within the next
 // 5 seconds throw ProvisionedThroughputExceededException. If there is insufficient
 // provisioned throughput on the shard, subsequent calls made within the next
-// 1 second throw ProvisionedThroughputExceededException. Note that GetRecords
-// won't return any data when it throws an exception. For this reason, we recommend
-// that you wait one second between calls to GetRecords; however, it's possible
-// that the application will get exceptions for longer than 1 second.
+// 1 second throw ProvisionedThroughputExceededException. GetRecords won't return
+// any data when it throws an exception. For this reason, we recommend that
+// you wait one second between calls to GetRecords; however, it's possible that
+// the application will get exceptions for longer than 1 second.
 //
 // To detect whether the application is falling behind in processing, you can
 // use the MillisBehindLatest response attribute. You can also monitor the stream
@@ -956,13 +1044,13 @@ func (c *Kinesis) GetRecordsRequest(input *GetRecordsInput) (req *request.Reques
 //
 // Each Amazon Kinesis record includes a value, ApproximateArrivalTimestamp,
 // that is set when a stream successfully receives and stores a record. This
-// is commonly referred to as a server-side timestamp, whereas a client-side
-// timestamp is set when a data producer creates or sends the record to a stream
+// is commonly referred to as a server-side time stamp, whereas a client-side
+// time stamp is set when a data producer creates or sends the record to a stream
 // (a data producer is any data source putting data records into a stream, for
-// example with PutRecords). The timestamp has millisecond precision. There
-// are no guarantees about the timestamp accuracy, or that the timestamp is
+// example with PutRecords). The time stamp has millisecond precision. There
+// are no guarantees about the time stamp accuracy, or that the time stamp is
 // always increasing. For example, records in a shard or across a stream might
-// have timestamps that are out of order.
+// have time stamps that are out of order.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -992,7 +1080,8 @@ func (c *Kinesis) GetRecordsRequest(input *GetRecordsInput) (req *request.Reques
 //   The provided iterator exceeds the maximum age allowed.
 //
 //   * ErrCodeKMSDisabledException "KMSDisabledException"
-//   The request was rejected because the specified CMK isn't enabled.
+//   The request was rejected because the specified customer master key (CMK)
+//   isn't enabled.
 //
 //   * ErrCodeKMSInvalidStateException "KMSInvalidStateException"
 //   The request was rejected because the state of the specified resource isn't
@@ -1005,8 +1094,8 @@ func (c *Kinesis) GetRecordsRequest(input *GetRecordsInput) (req *request.Reques
 //   access to.
 //
 //   * ErrCodeKMSNotFoundException "KMSNotFoundException"
-//   The request was rejected because the specified entity or resource couldn't
-//   be found.
+//   The request was rejected because the specified entity or resource can't be
+//   found.
 //
 //   * ErrCodeKMSOptInRequired "KMSOptInRequired"
 //   The AWS access key ID needs a subscription for the service.
@@ -1093,14 +1182,15 @@ func (c *Kinesis) GetShardIteratorRequest(input *GetShardIteratorInput) (req *re
 //
 // You must specify the shard iterator type. For example, you can set the ShardIteratorType
 // parameter to read exactly from the position denoted by a specific sequence
-// number by using the AT_SEQUENCE_NUMBER shard iterator type, or right after
-// the sequence number by using the AFTER_SEQUENCE_NUMBER shard iterator type,
-// using sequence numbers returned by earlier calls to PutRecord, PutRecords,
-// GetRecords, or DescribeStream. In the request, you can specify the shard
-// iterator type AT_TIMESTAMP to read records from an arbitrary point in time,
-// TRIM_HORIZON to cause ShardIterator to point to the last untrimmed record
-// in the shard in the system (the oldest data record in the shard), or LATEST
-// so that you always read the most recent data in the shard.
+// number by using the AT_SEQUENCE_NUMBER shard iterator type. Alternatively,
+// the parameter can read right after the sequence number by using the AFTER_SEQUENCE_NUMBER
+// shard iterator type, using sequence numbers returned by earlier calls to
+// PutRecord, PutRecords, GetRecords, or DescribeStream. In the request, you
+// can specify the shard iterator type AT_TIMESTAMP to read records from an
+// arbitrary point in time, TRIM_HORIZON to cause ShardIterator to point to
+// the last untrimmed record in the shard in the system (the oldest data record
+// in the shard), or LATEST so that you always read the most recent data in
+// the shard.
 //
 // When you read repeatedly from a stream, use a GetShardIterator request to
 // get the first shard iterator for use in your first GetRecords request and
@@ -1115,8 +1205,8 @@ func (c *Kinesis) GetShardIteratorRequest(input *GetShardIteratorInput) (req *re
 // in the Amazon Kinesis Streams Developer Guide.
 //
 // If the shard is closed, GetShardIterator returns a valid iterator for the
-// last sequence number of the shard. Note that a shard can be closed as a result
-// of using SplitShard or MergeShards.
+// last sequence number of the shard. A shard can be closed as a result of using
+// SplitShard or MergeShards.
 //
 // GetShardIterator has a limit of 5 transactions per second per account per
 // open shard.
@@ -1217,13 +1307,13 @@ func (c *Kinesis) IncreaseStreamRetentionPeriodRequest(input *IncreaseStreamRete
 // of time data records are accessible after they are added to the stream. The
 // maximum value of a stream's retention period is 168 hours (7 days).
 //
-// Upon choosing a longer stream retention period, this operation will increase
-// the time period records are accessible that have not yet expired. However,
-// it will not make previous data that has expired (older than the stream's
+// If you choose a longer stream retention period, this operation increases
+// the time period during which records that have not yet expired are accessible.
+// However, it does not make previous, expired data (older than the stream's
 // previous retention period) accessible after the operation has been called.
 // For example, if a stream's retention period is set to 24 hours and is increased
-// to 168 hours, any data that is older than 24 hours will remain inaccessible
-// to consumer applications.
+// to 168 hours, any data that is older than 24 hours remains inaccessible to
+// consumer applications.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1235,7 +1325,7 @@ func (c *Kinesis) IncreaseStreamRetentionPeriodRequest(input *IncreaseStreamRete
 // Returned Error Codes:
 //   * ErrCodeResourceInUseException "ResourceInUseException"
 //   The resource is not available for this operation. For successful operation,
-//   the resource needs to be in the ACTIVE state.
+//   the resource must be in the ACTIVE state.
 //
 //   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
 //   The requested resource could not be found. The stream might not be specified
@@ -1317,12 +1407,12 @@ func (c *Kinesis) ListStreamsRequest(input *ListStreamsInput) (req *request.Requ
 
 // ListStreams API operation for Amazon Kinesis.
 //
-// Lists your Amazon Kinesis streams.
+// Lists your Kinesis streams.
 //
 // The number of streams may be too large to return from a single call to ListStreams.
 // You can limit the number of returned streams using the Limit parameter. If
-// you do not specify a value for the Limit parameter, Amazon Kinesis uses the
-// default limit, which is currently 10.
+// you do not specify a value for the Limit parameter, Kinesis Streams uses
+// the default limit, which is currently 10.
 //
 // You can detect if there are more streams available to list by using the HasMoreStreams
 // flag from the returned output. If there are more streams available, you can
@@ -1344,7 +1434,7 @@ func (c *Kinesis) ListStreamsRequest(input *ListStreamsInput) (req *request.Requ
 // Returned Error Codes:
 //   * ErrCodeLimitExceededException "LimitExceededException"
 //   The requested resource exceeds the maximum number allowed, or the number
-//   of concurrent stream requests exceeds the maximum number allowed (5).
+//   of concurrent stream requests exceeds the maximum number allowed.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/kinesis-2013-12-02/ListStreams
 func (c *Kinesis) ListStreams(input *ListStreamsInput) (*ListStreamsOutput, error) {
@@ -1462,7 +1552,7 @@ func (c *Kinesis) ListTagsForStreamRequest(input *ListTagsForStreamInput) (req *
 
 // ListTagsForStream API operation for Amazon Kinesis.
 //
-// Lists the tags for the specified Amazon Kinesis stream.
+// Lists the tags for the specified Kinesis stream.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1482,7 +1572,7 @@ func (c *Kinesis) ListTagsForStreamRequest(input *ListTagsForStreamInput) (req *
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
 //   The requested resource exceeds the maximum number allowed, or the number
-//   of concurrent stream requests exceeds the maximum number allowed (5).
+//   of concurrent stream requests exceeds the maximum number allowed.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/kinesis-2013-12-02/ListTagsForStream
 func (c *Kinesis) ListTagsForStream(input *ListTagsForStreamInput) (*ListTagsForStreamOutput, error) {
@@ -1552,15 +1642,14 @@ func (c *Kinesis) MergeShardsRequest(input *MergeShardsInput) (req *request.Requ
 
 // MergeShards API operation for Amazon Kinesis.
 //
-// Merges two adjacent shards in an Amazon Kinesis stream and combines them
-// into a single shard to reduce the stream's capacity to ingest and transport
-// data. Two shards are considered adjacent if the union of the hash key ranges
-// for the two shards form a contiguous set with no gaps. For example, if you
-// have two shards, one with a hash key range of 276...381 and the other with
-// a hash key range of 382...454, then you could merge these two shards into
-// a single shard that would have a hash key range of 276...454. After the merge,
-// the single child shard receives data for all hash key values covered by the
-// two parent shards.
+// Merges two adjacent shards in a Kinesis stream and combines them into a single
+// shard to reduce the stream's capacity to ingest and transport data. Two shards
+// are considered adjacent if the union of the hash key ranges for the two shards
+// form a contiguous set with no gaps. For example, if you have two shards,
+// one with a hash key range of 276...381 and the other with a hash key range
+// of 382...454, then you could merge these two shards into a single shard that
+// would have a hash key range of 276...454. After the merge, the single child
+// shard receives data for all hash key values covered by the two parent shards.
 //
 // MergeShards is called when there is a need to reduce the overall capacity
 // of a stream because of excess capacity that is not being used. You must specify
@@ -1587,7 +1676,7 @@ func (c *Kinesis) MergeShardsRequest(input *MergeShardsInput) (req *request.Requ
 // If you try to operate on too many streams in parallel using CreateStream,
 // DeleteStream, MergeShards or SplitShard, you will receive a LimitExceededException.
 //
-// MergeShards has limit of 5 transactions per second per account.
+// MergeShards has a limit of 5 transactions per second per account.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1603,7 +1692,7 @@ func (c *Kinesis) MergeShardsRequest(input *MergeShardsInput) (req *request.Requ
 //
 //   * ErrCodeResourceInUseException "ResourceInUseException"
 //   The resource is not available for this operation. For successful operation,
-//   the resource needs to be in the ACTIVE state.
+//   the resource must be in the ACTIVE state.
 //
 //   * ErrCodeInvalidArgumentException "InvalidArgumentException"
 //   A specified parameter exceeds its restrictions, is not supported, or can't
@@ -1611,7 +1700,7 @@ func (c *Kinesis) MergeShardsRequest(input *MergeShardsInput) (req *request.Requ
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
 //   The requested resource exceeds the maximum number allowed, or the number
-//   of concurrent stream requests exceeds the maximum number allowed (5).
+//   of concurrent stream requests exceeds the maximum number allowed.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/kinesis-2013-12-02/MergeShards
 func (c *Kinesis) MergeShards(input *MergeShardsInput) (*MergeShardsOutput, error) {
@@ -1690,10 +1779,10 @@ func (c *Kinesis) PutRecordRequest(input *PutRecordInput) (req *request.Request,
 // The data blob can be any type of data; for example, a segment from a log
 // file, geographic/location data, website clickstream data, and so on.
 //
-// The partition key is used by Amazon Kinesis to distribute data across shards.
-// Amazon Kinesis segregates the data records that belong to a stream into multiple
-// shards, using the partition key associated with each data record to determine
-// which shard a given data record belongs to.
+// The partition key is used by Kinesis Streams to distribute data across shards.
+// Kinesis Streams segregates the data records that belong to a stream into
+// multiple shards, using the partition key associated with each data record
+// to determine the shard to which a given data record belongs.
 //
 // Partition keys are Unicode strings, with a maximum length limit of 256 characters
 // for each key. An MD5 hash function is used to map partition keys to 128-bit
@@ -1744,7 +1833,8 @@ func (c *Kinesis) PutRecordRequest(input *PutRecordInput) (req *request.Request,
 //   in the AWS General Reference.
 //
 //   * ErrCodeKMSDisabledException "KMSDisabledException"
-//   The request was rejected because the specified CMK isn't enabled.
+//   The request was rejected because the specified customer master key (CMK)
+//   isn't enabled.
 //
 //   * ErrCodeKMSInvalidStateException "KMSInvalidStateException"
 //   The request was rejected because the state of the specified resource isn't
@@ -1757,8 +1847,8 @@ func (c *Kinesis) PutRecordRequest(input *PutRecordInput) (req *request.Request,
 //   access to.
 //
 //   * ErrCodeKMSNotFoundException "KMSNotFoundException"
-//   The request was rejected because the specified entity or resource couldn't
-//   be found.
+//   The request was rejected because the specified entity or resource can't be
+//   found.
 //
 //   * ErrCodeKMSOptInRequired "KMSOptInRequired"
 //   The AWS access key ID needs a subscription for the service.
@@ -1834,9 +1924,9 @@ func (c *Kinesis) PutRecordsRequest(input *PutRecordsInput) (req *request.Reques
 
 // PutRecords API operation for Amazon Kinesis.
 //
-// Writes multiple data records into an Amazon Kinesis stream in a single call
-// (also referred to as a PutRecords request). Use this operation to send data
-// into the stream for data ingestion and processing.
+// Writes multiple data records into a Kinesis stream in a single call (also
+// referred to as a PutRecords request). Use this operation to send data into
+// the stream for data ingestion and processing.
 //
 // Each PutRecords request can support up to 500 records. Each record in the
 // request can be as large as 1 MB, up to a limit of 5 MB for the entire request,
@@ -1851,10 +1941,10 @@ func (c *Kinesis) PutRecordsRequest(input *PutRecordsInput) (req *request.Reques
 // The data blob can be any type of data; for example, a segment from a log
 // file, geographic/location data, website clickstream data, and so on.
 //
-// The partition key is used by Amazon Kinesis as input to a hash function that
-// maps the partition key and associated data to a specific shard. An MD5 hash
-// function is used to map partition keys to 128-bit integer values and to map
-// associated data records to shards. As a result of this hashing mechanism,
+// The partition key is used by Kinesis Streams as input to a hash function
+// that maps the partition key and associated data to a specific shard. An MD5
+// hash function is used to map partition keys to 128-bit integer values and
+// to map associated data records to shards. As a result of this hashing mechanism,
 // all data records with the same partition key map to the same shard within
 // the stream. For more information, see Adding Data to a Stream (http://docs.aws.amazon.com/kinesis/latest/dev/developing-producers-with-sdk.html#kinesis-using-sdk-java-add-data-to-stream)
 // in the Amazon Kinesis Streams Developer Guide.
@@ -1876,12 +1966,12 @@ func (c *Kinesis) PutRecordsRequest(input *PutRecordsInput) (req *request.Reques
 // PutRecords request. A single record failure does not stop the processing
 // of subsequent records.
 //
-// A successfully-processed record includes ShardId and SequenceNumber values.
+// A successfully processed record includes ShardId and SequenceNumber values.
 // The ShardId parameter identifies the shard in the stream where the record
 // is stored. The SequenceNumber parameter is an identifier assigned to the
 // put record, unique to all records in the stream.
 //
-// An unsuccessfully-processed record includes ErrorCode and ErrorMessage values.
+// An unsuccessfully processed record includes ErrorCode and ErrorMessage values.
 // ErrorCode reflects the type of error and can be one of the following values:
 // ProvisionedThroughputExceededException or InternalFailure. ErrorMessage provides
 // more detailed information about the ProvisionedThroughputExceededException
@@ -1919,7 +2009,8 @@ func (c *Kinesis) PutRecordsRequest(input *PutRecordsInput) (req *request.Reques
 //   in the AWS General Reference.
 //
 //   * ErrCodeKMSDisabledException "KMSDisabledException"
-//   The request was rejected because the specified CMK isn't enabled.
+//   The request was rejected because the specified customer master key (CMK)
+//   isn't enabled.
 //
 //   * ErrCodeKMSInvalidStateException "KMSInvalidStateException"
 //   The request was rejected because the state of the specified resource isn't
@@ -1932,8 +2023,8 @@ func (c *Kinesis) PutRecordsRequest(input *PutRecordsInput) (req *request.Reques
 //   access to.
 //
 //   * ErrCodeKMSNotFoundException "KMSNotFoundException"
-//   The request was rejected because the specified entity or resource couldn't
-//   be found.
+//   The request was rejected because the specified entity or resource can't be
+//   found.
 //
 //   * ErrCodeKMSOptInRequired "KMSOptInRequired"
 //   The AWS access key ID needs a subscription for the service.
@@ -2011,7 +2102,7 @@ func (c *Kinesis) RemoveTagsFromStreamRequest(input *RemoveTagsFromStreamInput) 
 
 // RemoveTagsFromStream API operation for Amazon Kinesis.
 //
-// Removes tags from the specified Amazon Kinesis stream. Removed tags are deleted
+// Removes tags from the specified Kinesis stream. Removed tags are deleted
 // and cannot be recovered after this operation successfully completes.
 //
 // If you specify a tag that does not exist, it is ignored.
@@ -2030,7 +2121,7 @@ func (c *Kinesis) RemoveTagsFromStreamRequest(input *RemoveTagsFromStreamInput) 
 //
 //   * ErrCodeResourceInUseException "ResourceInUseException"
 //   The resource is not available for this operation. For successful operation,
-//   the resource needs to be in the ACTIVE state.
+//   the resource must be in the ACTIVE state.
 //
 //   * ErrCodeInvalidArgumentException "InvalidArgumentException"
 //   A specified parameter exceeds its restrictions, is not supported, or can't
@@ -2038,7 +2129,7 @@ func (c *Kinesis) RemoveTagsFromStreamRequest(input *RemoveTagsFromStreamInput) 
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
 //   The requested resource exceeds the maximum number allowed, or the number
-//   of concurrent stream requests exceeds the maximum number allowed (5).
+//   of concurrent stream requests exceeds the maximum number allowed.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/kinesis-2013-12-02/RemoveTagsFromStream
 func (c *Kinesis) RemoveTagsFromStream(input *RemoveTagsFromStreamInput) (*RemoveTagsFromStreamOutput, error) {
@@ -2108,22 +2199,22 @@ func (c *Kinesis) SplitShardRequest(input *SplitShardInput) (req *request.Reques
 
 // SplitShard API operation for Amazon Kinesis.
 //
-// Splits a shard into two new shards in the Amazon Kinesis stream to increase
-// the stream's capacity to ingest and transport data. SplitShard is called
-// when there is a need to increase the overall capacity of a stream because
-// of an expected increase in the volume of data records being ingested.
+// Splits a shard into two new shards in the Kinesis stream, to increase the
+// stream's capacity to ingest and transport data. SplitShard is called when
+// there is a need to increase the overall capacity of a stream because of an
+// expected increase in the volume of data records being ingested.
 //
 // You can also use SplitShard when a shard appears to be approaching its maximum
 // utilization; for example, the producers sending data into the specific shard
 // are suddenly sending more than previously anticipated. You can also call
-// SplitShard to increase stream capacity, so that more Amazon Kinesis applications
+// SplitShard to increase stream capacity, so that more Kinesis Streams applications
 // can simultaneously read data from the stream for real-time processing.
 //
 // You must specify the shard to be split and the new hash key, which is the
 // position in the shard where the shard gets split in two. In many cases, the
-// new hash key might simply be the average of the beginning and ending hash
-// key, but it can be any hash key value in the range being mapped into the
-// shard. For more information about splitting shards, see Split a Shard (http://docs.aws.amazon.com/kinesis/latest/dev/kinesis-using-sdk-java-resharding-split.html)
+// new hash key might be the average of the beginning and ending hash key, but
+// it can be any hash key value in the range being mapped into the shard. For
+// more information, see Split a Shard (http://docs.aws.amazon.com/kinesis/latest/dev/kinesis-using-sdk-java-resharding-split.html)
 // in the Amazon Kinesis Streams Developer Guide.
 //
 // You can use DescribeStream to determine the shard ID and hash key values
@@ -2131,8 +2222,8 @@ func (c *Kinesis) SplitShardRequest(input *SplitShardInput) (req *request.Reques
 // in the SplitShard request.
 //
 // SplitShard is an asynchronous operation. Upon receiving a SplitShard request,
-// Amazon Kinesis immediately returns a response and sets the stream status
-// to UPDATING. After the operation is completed, Amazon Kinesis sets the stream
+// Kinesis Streams immediately returns a response and sets the stream status
+// to UPDATING. After the operation is completed, Kinesis Streams sets the stream
 // status to ACTIVE. Read and write operations continue to work while the stream
 // is in the UPDATING state.
 //
@@ -2146,13 +2237,13 @@ func (c *Kinesis) SplitShardRequest(input *SplitShardInput) (req *request.Reques
 // receive a LimitExceededException.
 //
 // For the default shard limit for an AWS account, see Streams Limits (http://docs.aws.amazon.com/kinesis/latest/dev/service-sizes-and-limits.html)
-// in the Amazon Kinesis Streams Developer Guide. If you need to increase this
-// limit, contact AWS Support (http://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html).
+// in the Amazon Kinesis Streams Developer Guide. To increase this limit, contact
+// AWS Support (http://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html).
 //
 // If you try to operate on too many streams simultaneously using CreateStream,
 // DeleteStream, MergeShards, and/or SplitShard, you receive a LimitExceededException.
 //
-// SplitShard has limit of 5 transactions per second per account.
+// SplitShard has a limit of 5 transactions per second per account.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2168,7 +2259,7 @@ func (c *Kinesis) SplitShardRequest(input *SplitShardInput) (req *request.Reques
 //
 //   * ErrCodeResourceInUseException "ResourceInUseException"
 //   The resource is not available for this operation. For successful operation,
-//   the resource needs to be in the ACTIVE state.
+//   the resource must be in the ACTIVE state.
 //
 //   * ErrCodeInvalidArgumentException "InvalidArgumentException"
 //   A specified parameter exceeds its restrictions, is not supported, or can't
@@ -2176,7 +2267,7 @@ func (c *Kinesis) SplitShardRequest(input *SplitShardInput) (req *request.Reques
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
 //   The requested resource exceeds the maximum number allowed, or the number
-//   of concurrent stream requests exceeds the maximum number allowed (5).
+//   of concurrent stream requests exceeds the maximum number allowed.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/kinesis-2013-12-02/SplitShard
 func (c *Kinesis) SplitShard(input *SplitShardInput) (*SplitShardOutput, error) {
@@ -2250,20 +2341,20 @@ func (c *Kinesis) StartStreamEncryptionRequest(input *StartStreamEncryptionInput
 // stream.
 //
 // Starting encryption is an asynchronous operation. Upon receiving the request,
-// Amazon Kinesis returns immediately and sets the status of the stream to UPDATING.
-// After the update is complete, Amazon Kinesis sets the status of the stream
-// back to ACTIVE. Updating or applying encryption normally takes a few seconds
-// to complete but it can take minutes. You can continue to read and write data
-// to your stream while its status is UPDATING. Once the status of the stream
-// is ACTIVE, records written to the stream will begin to be encrypted.
+// Kinesis Streams returns immediately and sets the status of the stream to
+// UPDATING. After the update is complete, Kinesis Streams sets the status of
+// the stream back to ACTIVE. Updating or applying encryption normally takes
+// a few seconds to complete, but it can take minutes. You can continue to read
+// and write data to your stream while its status is UPDATING. Once the status
+// of the stream is ACTIVE, encryption begins for records written to the stream.
 //
 // API Limits: You can successfully apply a new AWS KMS key for server-side
-// encryption 25 times in a rolling 24 hour period.
+// encryption 25 times in a rolling 24-hour period.
 //
-// Note: It can take up to 5 seconds after the stream is in an ACTIVE status
-// before all records written to the stream are encrypted. After you’ve enabled
-// encryption, you can verify encryption was applied by inspecting the API response
-// from PutRecord or PutRecords.
+// Note: It can take up to five seconds after the stream is in an ACTIVE status
+// before all records written to the stream are encrypted. After you enable
+// encryption, you can verify that encryption is applied by inspecting the API
+// response from PutRecord or PutRecords.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2279,18 +2370,19 @@ func (c *Kinesis) StartStreamEncryptionRequest(input *StartStreamEncryptionInput
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
 //   The requested resource exceeds the maximum number allowed, or the number
-//   of concurrent stream requests exceeds the maximum number allowed (5).
+//   of concurrent stream requests exceeds the maximum number allowed.
 //
 //   * ErrCodeResourceInUseException "ResourceInUseException"
 //   The resource is not available for this operation. For successful operation,
-//   the resource needs to be in the ACTIVE state.
+//   the resource must be in the ACTIVE state.
 //
 //   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
 //   The requested resource could not be found. The stream might not be specified
 //   correctly.
 //
 //   * ErrCodeKMSDisabledException "KMSDisabledException"
-//   The request was rejected because the specified CMK isn't enabled.
+//   The request was rejected because the specified customer master key (CMK)
+//   isn't enabled.
 //
 //   * ErrCodeKMSInvalidStateException "KMSInvalidStateException"
 //   The request was rejected because the state of the specified resource isn't
@@ -2303,8 +2395,8 @@ func (c *Kinesis) StartStreamEncryptionRequest(input *StartStreamEncryptionInput
 //   access to.
 //
 //   * ErrCodeKMSNotFoundException "KMSNotFoundException"
-//   The request was rejected because the specified entity or resource couldn't
-//   be found.
+//   The request was rejected because the specified entity or resource can't be
+//   found.
 //
 //   * ErrCodeKMSOptInRequired "KMSOptInRequired"
 //   The AWS access key ID needs a subscription for the service.
@@ -2385,20 +2477,20 @@ func (c *Kinesis) StopStreamEncryptionRequest(input *StopStreamEncryptionInput) 
 // Disables server-side encryption for a specified stream.
 //
 // Stopping encryption is an asynchronous operation. Upon receiving the request,
-// Amazon Kinesis returns immediately and sets the status of the stream to UPDATING.
-// After the update is complete, Amazon Kinesis sets the status of the stream
-// back to ACTIVE. Stopping encryption normally takes a few seconds to complete
-// but it can take minutes. You can continue to read and write data to your
-// stream while its status is UPDATING. Once the status of the stream is ACTIVE
-// records written to the stream will no longer be encrypted by the Amazon Kinesis
-// Streams service.
+// Kinesis Streams returns immediately and sets the status of the stream to
+// UPDATING. After the update is complete, Kinesis Streams sets the status of
+// the stream back to ACTIVE. Stopping encryption normally takes a few seconds
+// to complete, but it can take minutes. You can continue to read and write
+// data to your stream while its status is UPDATING. Once the status of the
+// stream is ACTIVE, records written to the stream are no longer encrypted by
+// Kinesis Streams.
 //
 // API Limits: You can successfully disable server-side encryption 25 times
-// in a rolling 24 hour period.
+// in a rolling 24-hour period.
 //
-// Note: It can take up to 5 seconds after the stream is in an ACTIVE status
+// Note: It can take up to five seconds after the stream is in an ACTIVE status
 // before all records written to the stream are no longer subject to encryption.
-// After you’ve disabled encryption, you can verify encryption was not applied
+// After you disabled encryption, you can verify that encryption is not applied
 // by inspecting the API response from PutRecord or PutRecords.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -2415,11 +2507,11 @@ func (c *Kinesis) StopStreamEncryptionRequest(input *StopStreamEncryptionInput) 
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
 //   The requested resource exceeds the maximum number allowed, or the number
-//   of concurrent stream requests exceeds the maximum number allowed (5).
+//   of concurrent stream requests exceeds the maximum number allowed.
 //
 //   * ErrCodeResourceInUseException "ResourceInUseException"
 //   The resource is not available for this operation. For successful operation,
-//   the resource needs to be in the ACTIVE state.
+//   the resource must be in the ACTIVE state.
 //
 //   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
 //   The requested resource could not be found. The stream might not be specified
@@ -2495,36 +2587,36 @@ func (c *Kinesis) UpdateShardCountRequest(input *UpdateShardCountInput) (req *re
 // shards.
 //
 // Updating the shard count is an asynchronous operation. Upon receiving the
-// request, Amazon Kinesis returns immediately and sets the status of the stream
-// to UPDATING. After the update is complete, Amazon Kinesis sets the status
+// request, Kinesis Streams returns immediately and sets the status of the stream
+// to UPDATING. After the update is complete, Kinesis Streams sets the status
 // of the stream back to ACTIVE. Depending on the size of the stream, the scaling
 // action could take a few minutes to complete. You can continue to read and
 // write data to your stream while its status is UPDATING.
 //
-// To update the shard count, Amazon Kinesis performs splits or merges on individual
+// To update the shard count, Kinesis Streams performs splits or merges on individual
 // shards. This can cause short-lived shards to be created, in addition to the
 // final shards. We recommend that you double or halve the shard count, as this
 // results in the fewest number of splits or merges.
 //
 // This operation has the following limits, which are per region per account
-// unless otherwise noted:
+// unless otherwise noted. You cannot:
 //
-//    * scale more than twice per rolling 24 hour period
+//    * Scale more than twice per rolling 24 hour period
 //
-//    * scale up above double your current shard count
+//    * Scale up to double your current shard count
 //
-//    * scale down below half your current shard count
+//    * Scale down below half your current shard count
 //
-//    * scale up above 200 shards in a stream
+//    * Scale up to more 500 shards in a stream
 //
-//    * scale a stream with more than 200 shards down unless the result is less
-//    than 200 shards
+//    * Scale a stream with more than 500 shards down unless the result is less
+//    than 500 shards
 //
-//    * scale up above the shard limits for your account
+//    * Scale up more the shard limits for your account
 //
 //    *
 //
-// For the default limits for an AWS account, see Streams Limits (http://docs.aws.amazon.com/kinesis/latest/dev/service-sizes-and-limits.html)in the Amazon Kinesis Streams Developer Guide. If you need to increase a limit, contact AWS Support (http://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html)
+// For the default limits for an AWS account, see Streams Limits (http://docs.aws.amazon.com/kinesis/latest/dev/service-sizes-and-limits.html)in the Amazon Kinesis Streams Developer Guide. To increase a limit, contact AWS Support (http://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html)
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2540,11 +2632,11 @@ func (c *Kinesis) UpdateShardCountRequest(input *UpdateShardCountInput) (req *re
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
 //   The requested resource exceeds the maximum number allowed, or the number
-//   of concurrent stream requests exceeds the maximum number allowed (5).
+//   of concurrent stream requests exceeds the maximum number allowed.
 //
 //   * ErrCodeResourceInUseException "ResourceInUseException"
 //   The resource is not available for this operation. For successful operation,
-//   the resource needs to be in the ACTIVE state.
+//   the resource must be in the ACTIVE state.
 //
 //   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
 //   The requested resource could not be found. The stream might not be specified
@@ -2663,8 +2755,8 @@ type CreateStreamInput struct {
 
 	// A name to identify the stream. The stream name is scoped to the AWS account
 	// used by the application that creates the stream. It is also scoped by region.
-	// That is, two streams in two different AWS accounts can have the same name,
-	// and two streams in the same AWS account but in two different regions can
+	// That is, two streams in two different AWS accounts can have the same name.
+	// Two streams in the same AWS account but in two different regions can also
 	// have the same name.
 	//
 	// StreamName is a required field
@@ -3012,6 +3104,74 @@ func (s *DescribeStreamOutput) SetStreamDescription(v *StreamDescription) *Descr
 	return s
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/kinesis-2013-12-02/DescribeStreamSummaryInput
+type DescribeStreamSummaryInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the stream to describe.
+	//
+	// StreamName is a required field
+	StreamName *string `min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DescribeStreamSummaryInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeStreamSummaryInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeStreamSummaryInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeStreamSummaryInput"}
+	if s.StreamName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StreamName"))
+	}
+	if s.StreamName != nil && len(*s.StreamName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StreamName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetStreamName sets the StreamName field's value.
+func (s *DescribeStreamSummaryInput) SetStreamName(v string) *DescribeStreamSummaryInput {
+	s.StreamName = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/kinesis-2013-12-02/DescribeStreamSummaryOutput
+type DescribeStreamSummaryOutput struct {
+	_ struct{} `type:"structure"`
+
+	// A StreamDescriptionSummary containing information about the stream.
+	//
+	// StreamDescriptionSummary is a required field
+	StreamDescriptionSummary *StreamDescriptionSummary `type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s DescribeStreamSummaryOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeStreamSummaryOutput) GoString() string {
+	return s.String()
+}
+
+// SetStreamDescriptionSummary sets the StreamDescriptionSummary field's value.
+func (s *DescribeStreamSummaryOutput) SetStreamDescriptionSummary(v *StreamDescriptionSummary) *DescribeStreamSummaryOutput {
+	s.StreamDescriptionSummary = v
+	return s
+}
+
 // Represents the input for DisableEnhancedMonitoring.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/kinesis-2013-12-02/DisableEnhancedMonitoringInput
 type DisableEnhancedMonitoringInput struct {
@@ -3045,7 +3205,7 @@ type DisableEnhancedMonitoringInput struct {
 	// ShardLevelMetrics is a required field
 	ShardLevelMetrics []*string `min:"1" type:"list" required:"true"`
 
-	// The name of the Amazon Kinesis stream for which to disable enhanced monitoring.
+	// The name of the Kinesis stream for which to disable enhanced monitoring.
 	//
 	// StreamName is a required field
 	StreamName *string `min:"1" type:"string" required:"true"`
@@ -3239,7 +3399,7 @@ type EnhancedMonitoringOutput struct {
 	// after the operation.
 	DesiredShardLevelMetrics []*string `min:"1" type:"list"`
 
-	// The name of the Amazon Kinesis stream.
+	// The name of the Kinesis stream.
 	StreamName *string `min:"1" type:"string"`
 }
 
@@ -3336,13 +3496,13 @@ type GetRecordsOutput struct {
 
 	// The number of milliseconds the GetRecords response is from the tip of the
 	// stream, indicating how far behind current time the consumer is. A value of
-	// zero indicates record processing is caught up, and there are no new records
-	// to process at this moment.
+	// zero indicates that record processing is caught up, and there are no new
+	// records to process at this moment.
 	MillisBehindLatest *int64 `type:"long"`
 
 	// The next position in the shard from which to start sequentially reading data
 	// records. If set to null, the shard has been closed and the requested iterator
-	// will not return any more data.
+	// does not return any more data.
 	NextShardIterator *string `min:"1" type:"string"`
 
 	// The data records retrieved from the shard.
@@ -3384,7 +3544,7 @@ func (s *GetRecordsOutput) SetRecords(v []*Record) *GetRecordsOutput {
 type GetShardIteratorInput struct {
 	_ struct{} `type:"structure"`
 
-	// The shard ID of the Amazon Kinesis shard to get the iterator for.
+	// The shard ID of the Kinesis Streams shard to get the iterator for.
 	//
 	// ShardId is a required field
 	ShardId *string `min:"1" type:"string" required:"true"`
@@ -3401,7 +3561,7 @@ type GetShardIteratorInput struct {
 	//    by a specific sequence number, provided in the value StartingSequenceNumber.
 	//
 	//    * AT_TIMESTAMP - Start reading from the position denoted by a specific
-	//    timestamp, provided in the value Timestamp.
+	//    time stamp, provided in the value Timestamp.
 	//
 	//    * TRIM_HORIZON - Start reading at the last untrimmed record in the shard
 	//    in the system, which is the oldest data record in the shard.
@@ -3421,13 +3581,13 @@ type GetShardIteratorInput struct {
 	// StreamName is a required field
 	StreamName *string `min:"1" type:"string" required:"true"`
 
-	// The timestamp of the data record from which to start reading. Used with shard
-	// iterator type AT_TIMESTAMP. A timestamp is the Unix epoch date with precision
-	// in milliseconds. For example, 2016-04-04T19:58:46.480-00:00 or 1459799926.480.
-	// If a record with this exact timestamp does not exist, the iterator returned
-	// is for the next (later) record. If the timestamp is older than the current
-	// trim horizon, the iterator returned is for the oldest untrimmed data record
-	// (TRIM_HORIZON).
+	// The time stamp of the data record from which to start reading. Used with
+	// shard iterator type AT_TIMESTAMP. A time stamp is the Unix epoch date with
+	// precision in milliseconds. For example, 2016-04-04T19:58:46.480-00:00 or
+	// 1459799926.480. If a record with this exact time stamp does not exist, the
+	// iterator returned is for the next (later) record. If the time stamp is older
+	// than the current trim horizon, the iterator returned is for the oldest untrimmed
+	// data record (TRIM_HORIZON).
 	Timestamp *time.Time `type:"timestamp" timestampFormat:"unix"`
 }
 
@@ -3963,7 +4123,7 @@ type PutRecordInput struct {
 	// Guarantees strictly increasing sequence numbers, for puts from the same client
 	// and to the same partition key. Usage: set the SequenceNumberForOrdering of
 	// record n to the sequence number of record n-1 (as returned in the result
-	// when putting record n-1). If this parameter is not set, records will be coarsely
+	// when putting record n-1). If this parameter is not set, records are coarsely
 	// ordered based on arrival time.
 	SequenceNumberForOrdering *string `type:"string"`
 
@@ -4357,8 +4517,8 @@ func (s *PutRecordsResultEntry) SetShardId(v string) *PutRecordsResultEntry {
 	return s
 }
 
-// The unit of data of the Amazon Kinesis stream, which is composed of a sequence
-// number, a partition key, and a data blob.
+// The unit of data of the Kinesis stream, which is composed of a sequence number,
+// a partition key, and a data blob.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/kinesis-2013-12-02/Record
 type Record struct {
 	_ struct{} `type:"structure"`
@@ -4366,11 +4526,11 @@ type Record struct {
 	// The approximate time that the record was inserted into the stream.
 	ApproximateArrivalTimestamp *time.Time `type:"timestamp" timestampFormat:"unix"`
 
-	// The data blob. The data in the blob is both opaque and immutable to the Amazon
-	// Kinesis service, which does not inspect, interpret, or change the data in
-	// the blob in any way. When the data blob (the payload before base64-encoding)
-	// is added to the partition key size, the total size must not exceed the maximum
-	// record size (1 MB).
+	// The data blob. The data in the blob is both opaque and immutable to Kinesis
+	// Streams, which does not inspect, interpret, or change the data in the blob
+	// in any way. When the data blob (the payload before base64-encoding) is added
+	// to the partition key size, the total size must not exceed the maximum record
+	// size (1 MB).
 	//
 	// Data is automatically base64 encoded/decoded by the SDK.
 	//
@@ -4549,7 +4709,7 @@ func (s *SequenceNumberRange) SetStartingSequenceNumber(v string) *SequenceNumbe
 	return s
 }
 
-// A uniquely identified group of data records in an Amazon Kinesis stream.
+// A uniquely identified group of data records in a Kinesis stream.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/kinesis-2013-12-02/Shard
 type Shard struct {
 	_ struct{} `type:"structure"`
@@ -4716,19 +4876,25 @@ func (s SplitShardOutput) GoString() string {
 type StartStreamEncryptionInput struct {
 	_ struct{} `type:"structure"`
 
-	// The encryption type to use. This parameter can be one of the following values:
-	//
-	//    * NONE: Not valid for this operation. An InvalidOperationException will
-	//    be thrown.
-	//
-	//    * KMS: Use server-side encryption on the records in the stream using a
-	//    customer-managed KMS key.
+	// The encryption type to use. The only valid value is KMS.
 	//
 	// EncryptionType is a required field
 	EncryptionType *string `type:"string" required:"true" enum:"EncryptionType"`
 
-	// The GUID for the customer-managed KMS key to use for encryption. You can
-	// also use a Kinesis-owned master key by specifying the alias aws/kinesis.
+	// The GUID for the customer-managed KMS key to use for encryption. This value
+	// can be a globally unique identifier, a fully specified ARN to either an alias
+	// or a key, or an alias name prefixed by "alias/".You can also use a master
+	// key owned by Kinesis Streams by specifying the alias aws/kinesis.
+	//
+	//    * Key ARN example: arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012
+	//
+	//    * Alias ARN example: arn:aws:kms:us-east-1:123456789012:alias/MyAliasName
+	//
+	//    * Globally unique key ID example: 12345678-1234-1234-1234-123456789012
+	//
+	//    * Alias name example: alias/MyAliasName
+	//
+	//    * Master key owned by Kinesis Streams: alias/aws/kinesis
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
@@ -4811,18 +4977,25 @@ func (s StartStreamEncryptionOutput) GoString() string {
 type StopStreamEncryptionInput struct {
 	_ struct{} `type:"structure"`
 
-	// The encryption type. This parameter can be one of the following values:
-	//
-	//    * NONE: Not valid for this operation. An InvalidOperationException will
-	//    be thrown.
-	//
-	//    * KMS: Use server-side encryption on the records in the stream using a
-	//    customer-managed KMS key.
+	// The encryption type. The only valid value is KMS.
 	//
 	// EncryptionType is a required field
 	EncryptionType *string `type:"string" required:"true" enum:"EncryptionType"`
 
-	// The GUID for the customer-managed key that was used for encryption.
+	// The GUID for the customer-managed KMS key to use for encryption. This value
+	// can be a globally unique identifier, a fully specified ARN to either an alias
+	// or a key, or an alias name prefixed by "alias/".You can also use a master
+	// key owned by Kinesis Streams by specifying the alias aws/kinesis.
+	//
+	//    * Key ARN example: arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012
+	//
+	//    * Alias ARN example: arn:aws:kms:us-east-1:123456789012:alias/MyAliasName
+	//
+	//    * Globally unique key ID example: 12345678-1234-1234-1234-123456789012
+	//
+	//    * Alias name example: alias/MyAliasName
+	//
+	//    * Master key owned by Kinesis Streams: alias/aws/kinesis
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
@@ -4925,7 +5098,20 @@ type StreamDescription struct {
 	// HasMoreShards is a required field
 	HasMoreShards *bool `type:"boolean" required:"true"`
 
-	// The GUID for the customer-managed KMS key used for encryption on the stream.
+	// The GUID for the customer-managed KMS key to use for encryption. This value
+	// can be a globally unique identifier, a fully specified ARN to either an alias
+	// or a key, or an alias name prefixed by "alias/".You can also use a master
+	// key owned by Kinesis Streams by specifying the alias aws/kinesis.
+	//
+	//    * Key ARN example: arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012
+	//
+	//    * Alias ARN example: arn:aws:kms:us-east-1:123456789012:alias/MyAliasName
+	//
+	//    * Globally unique key ID example: 12345678-1234-1234-1234-123456789012
+	//
+	//    * Alias name example: alias/MyAliasName
+	//
+	//    * Master key owned by Kinesis Streams: alias/aws/kinesis
 	KeyId *string `min:"1" type:"string"`
 
 	// The current retention period, in hours.
@@ -4956,11 +5142,11 @@ type StreamDescription struct {
 	// The current status of the stream being described. The stream status is one
 	// of the following states:
 	//
-	//    * CREATING - The stream is being created. Amazon Kinesis immediately returns
-	//    and sets StreamStatus to CREATING.
+	//    * CREATING - The stream is being created. Kinesis Streams immediately
+	//    returns and sets StreamStatus to CREATING.
 	//
 	//    * DELETING - The stream is being deleted. The specified stream is in the
-	//    DELETING state until Amazon Kinesis completes the deletion.
+	//    DELETING state until Kinesis Streams completes the deletion.
 	//
 	//    * ACTIVE - The stream exists and is ready for read and write operations
 	//    or deletion. You should perform read and write operations only on an ACTIVE
@@ -5040,6 +5226,149 @@ func (s *StreamDescription) SetStreamName(v string) *StreamDescription {
 
 // SetStreamStatus sets the StreamStatus field's value.
 func (s *StreamDescription) SetStreamStatus(v string) *StreamDescription {
+	s.StreamStatus = &v
+	return s
+}
+
+// Represents the output for DescribeStreamSummary
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/kinesis-2013-12-02/StreamDescriptionSummary
+type StreamDescriptionSummary struct {
+	_ struct{} `type:"structure"`
+
+	// The encryption type used. This value is one of the following:
+	//
+	//    * KMS
+	//
+	//    * NONE
+	EncryptionType *string `type:"string" enum:"EncryptionType"`
+
+	// Represents the current enhanced monitoring settings of the stream.
+	//
+	// EnhancedMonitoring is a required field
+	EnhancedMonitoring []*EnhancedMetrics `type:"list" required:"true"`
+
+	// The GUID for the customer-managed KMS key to use for encryption. This value
+	// can be a globally unique identifier, a fully specified ARN to either an alias
+	// or a key, or an alias name prefixed by "alias/".You can also use a master
+	// key owned by Kinesis Streams by specifying the alias aws/kinesis.
+	//
+	//    * Key ARN example: arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012
+	//
+	//    * Alias ARN example:  arn:aws:kms:us-east-1:123456789012:alias/MyAliasName
+	//
+	//    * Globally unique key ID example: 12345678-1234-1234-1234-123456789012
+	//
+	//    * Alias name example: alias/MyAliasName
+	//
+	//    * Master key owned by Kinesis: alias/aws/kinesis
+	KeyId *string `min:"1" type:"string"`
+
+	// The number of open shards in the stream.
+	//
+	// OpenShardCount is a required field
+	OpenShardCount *int64 `type:"integer" required:"true"`
+
+	// The current retention period, in hours.
+	//
+	// RetentionPeriodHours is a required field
+	RetentionPeriodHours *int64 `min:"1" type:"integer" required:"true"`
+
+	// The Amazon Resource Name (ARN) for the stream being described.
+	//
+	// StreamARN is a required field
+	StreamARN *string `type:"string" required:"true"`
+
+	// The approximate time that the stream was created.
+	//
+	// StreamCreationTimestamp is a required field
+	StreamCreationTimestamp *time.Time `type:"timestamp" timestampFormat:"unix" required:"true"`
+
+	// The name of the stream being described.
+	//
+	// StreamName is a required field
+	StreamName *string `min:"1" type:"string" required:"true"`
+
+	// The current status of the stream being described. The stream status is one
+	// of the following states:
+	//
+	//    * CREATING - The stream is being created. Kinesis Streams immediately
+	//    returns and sets StreamStatus to CREATING.
+	//
+	//    * DELETING - The stream is being deleted. The specified stream is in the
+	//    DELETING state until Kinesis Streams completes the deletion.
+	//
+	//    * ACTIVE - The stream exists and is ready for read and write operations
+	//    or deletion. You should perform read and write operations only on an ACTIVE
+	//    stream.
+	//
+	//    * UPDATING - Shards in the stream are being merged or split. Read and
+	//    write operations continue to work while the stream is in the UPDATING
+	//    state.
+	//
+	// StreamStatus is a required field
+	StreamStatus *string `type:"string" required:"true" enum:"StreamStatus"`
+}
+
+// String returns the string representation
+func (s StreamDescriptionSummary) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s StreamDescriptionSummary) GoString() string {
+	return s.String()
+}
+
+// SetEncryptionType sets the EncryptionType field's value.
+func (s *StreamDescriptionSummary) SetEncryptionType(v string) *StreamDescriptionSummary {
+	s.EncryptionType = &v
+	return s
+}
+
+// SetEnhancedMonitoring sets the EnhancedMonitoring field's value.
+func (s *StreamDescriptionSummary) SetEnhancedMonitoring(v []*EnhancedMetrics) *StreamDescriptionSummary {
+	s.EnhancedMonitoring = v
+	return s
+}
+
+// SetKeyId sets the KeyId field's value.
+func (s *StreamDescriptionSummary) SetKeyId(v string) *StreamDescriptionSummary {
+	s.KeyId = &v
+	return s
+}
+
+// SetOpenShardCount sets the OpenShardCount field's value.
+func (s *StreamDescriptionSummary) SetOpenShardCount(v int64) *StreamDescriptionSummary {
+	s.OpenShardCount = &v
+	return s
+}
+
+// SetRetentionPeriodHours sets the RetentionPeriodHours field's value.
+func (s *StreamDescriptionSummary) SetRetentionPeriodHours(v int64) *StreamDescriptionSummary {
+	s.RetentionPeriodHours = &v
+	return s
+}
+
+// SetStreamARN sets the StreamARN field's value.
+func (s *StreamDescriptionSummary) SetStreamARN(v string) *StreamDescriptionSummary {
+	s.StreamARN = &v
+	return s
+}
+
+// SetStreamCreationTimestamp sets the StreamCreationTimestamp field's value.
+func (s *StreamDescriptionSummary) SetStreamCreationTimestamp(v time.Time) *StreamDescriptionSummary {
+	s.StreamCreationTimestamp = &v
+	return s
+}
+
+// SetStreamName sets the StreamName field's value.
+func (s *StreamDescriptionSummary) SetStreamName(v string) *StreamDescriptionSummary {
+	s.StreamName = &v
+	return s
+}
+
+// SetStreamStatus sets the StreamStatus field's value.
+func (s *StreamDescriptionSummary) SetStreamStatus(v string) *StreamDescriptionSummary {
 	s.StreamStatus = &v
 	return s
 }

--- a/vendor/github.com/aws/aws-sdk-go/service/kinesis/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/kinesis/errors.go
@@ -27,7 +27,8 @@ const (
 	// ErrCodeKMSDisabledException for service response error code
 	// "KMSDisabledException".
 	//
-	// The request was rejected because the specified CMK isn't enabled.
+	// The request was rejected because the specified customer master key (CMK)
+	// isn't enabled.
 	ErrCodeKMSDisabledException = "KMSDisabledException"
 
 	// ErrCodeKMSInvalidStateException for service response error code
@@ -42,8 +43,8 @@ const (
 	// ErrCodeKMSNotFoundException for service response error code
 	// "KMSNotFoundException".
 	//
-	// The request was rejected because the specified entity or resource couldn't
-	// be found.
+	// The request was rejected because the specified entity or resource can't be
+	// found.
 	ErrCodeKMSNotFoundException = "KMSNotFoundException"
 
 	// ErrCodeKMSOptInRequired for service response error code
@@ -64,7 +65,7 @@ const (
 	// "LimitExceededException".
 	//
 	// The requested resource exceeds the maximum number allowed, or the number
-	// of concurrent stream requests exceeds the maximum number allowed (5).
+	// of concurrent stream requests exceeds the maximum number allowed.
 	ErrCodeLimitExceededException = "LimitExceededException"
 
 	// ErrCodeProvisionedThroughputExceededException for service response error code
@@ -82,7 +83,7 @@ const (
 	// "ResourceInUseException".
 	//
 	// The resource is not available for this operation. For successful operation,
-	// the resource needs to be in the ACTIVE state.
+	// the resource must be in the ACTIVE state.
 	ErrCodeResourceInUseException = "ResourceInUseException"
 
 	// ErrCodeResourceNotFoundException for service response error code

--- a/vendor/github.com/aws/aws-sdk-go/service/s3/doc_custom.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/s3/doc_custom.go
@@ -35,7 +35,7 @@
 //
 // The s3manager package's Downloader provides concurrently downloading of Objects
 // from S3. The Downloader will write S3 Object content with an io.WriterAt.
-// Once the Downloader instance is created you can call Upload concurrently from
+// Once the Downloader instance is created you can call Download concurrently from
 // multiple goroutines safely.
 //
 //   // The session the S3 Downloader will use
@@ -56,7 +56,7 @@
 //       Key:    aws.String(myString),
 //   })
 //   if err != nil {
-//       return fmt.Errorf("failed to upload file, %v", err)
+//       return fmt.Errorf("failed to download file, %v", err)
 //   }
 //   fmt.Printf("file downloaded, %d bytes\n", n)
 //

--- a/vendor/github.com/aws/aws-sdk-go/service/shield/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/shield/errors.go
@@ -35,13 +35,17 @@ const (
 	// "LimitsExceededException".
 	//
 	// Exception that indicates that the operation would exceed a limit.
+	//
+	// Type is the type of limit that would be exceeded.
+	//
+	// Limit is the threshold that would be exceeded.
 	ErrCodeLimitsExceededException = "LimitsExceededException"
 
 	// ErrCodeLockedSubscriptionException for service response error code
 	// "LockedSubscriptionException".
 	//
-	// Exception that indicates that the subscription has been modified by another
-	// client. You can retry the request.
+	// Exception that indicates that the subscription you are trying to delete has
+	// not yet completed the 1-year commitment. You cannot delete this subscription.
 	ErrCodeLockedSubscriptionException = "LockedSubscriptionException"
 
 	// ErrCodeOptimisticLockException for service response error code

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -141,748 +141,748 @@
 			"revisionTime": "2017-07-27T15:54:43Z"
 		},
 		{
-			"checksumSHA1": "mZZ7VDSBTvyFGJ3nL+LRznMTuSE=",
+			"checksumSHA1": "eRUmyUWvOPK7gRZCc3g3TqwBnr8=",
 			"path": "github.com/aws/aws-sdk-go/aws",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "DtuTqKH29YnLjrIJkRYX0HQtXY0=",
 			"path": "github.com/aws/aws-sdk-go/aws/arn",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "Y9W+4GimK4Fuxq+vyIskVYFRnX4=",
 			"path": "github.com/aws/aws-sdk-go/aws/awserr",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "yyYr41HZ1Aq0hWc3J5ijXwYEcac=",
 			"path": "github.com/aws/aws-sdk-go/aws/awsutil",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
-			"checksumSHA1": "slpNCdnZ2JbBr94ZHc/9UzOaP5A=",
+			"checksumSHA1": "9nE/FjZ4pYrT883KtV2/aI+Gayo=",
 			"path": "github.com/aws/aws-sdk-go/aws/client",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "ieAJ+Cvp/PKv1LpUEnUXpc3OI6E=",
 			"path": "github.com/aws/aws-sdk-go/aws/client/metadata",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "7/8j/q0TWtOgXyvEcv4B2Dhl00o=",
 			"path": "github.com/aws/aws-sdk-go/aws/corehandlers",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "Y+cPwQL0dZMyqp3wI+KJWmA9KQ8=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "u3GOAJLmdvbuNUeUEcZSEAOeL/0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "NUJUTWlc1sV8b7WjfiYc4JZbXl0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/endpointcreds",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "JEYqmF83O5n5bHkupAzA6STm0no=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "ZdtYh3ZHSgP/WEIaqwJHTEhpkbs=",
 			"path": "github.com/aws/aws-sdk-go/aws/defaults",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "/EXbk/z2TWjWc1Hvb4QYs3Wmhb8=",
 			"path": "github.com/aws/aws-sdk-go/aws/ec2metadata",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
-			"checksumSHA1": "9iORBrL6nxgB9rChLQ70T7eye/c=",
+			"checksumSHA1": "3Zvhi9PXEQXGz8e7FE2RcxBXZ0s=",
 			"path": "github.com/aws/aws-sdk-go/aws/endpoints",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "9GvAyILJ7g+VUg8Ef5DsT5GuYsg=",
 			"path": "github.com/aws/aws-sdk-go/aws/request",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "HcGL4e6Uep4/80eCUI5xkcWjpQ0=",
 			"path": "github.com/aws/aws-sdk-go/aws/session",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "iU00ZjhAml/13g+1YXT21IqoXqg=",
 			"path": "github.com/aws/aws-sdk-go/aws/signer/v4",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "04ypv4x12l4q0TksA1zEVsmgpvw=",
 			"path": "github.com/aws/aws-sdk-go/internal/shareddefaults",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "NStHCXEvYqG72GknZyv1jaKaeH0=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "1QmQ3FqV37w0Zi44qv8pA1GeR0A=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/ec2query",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "yHfT5DTbeCLs4NE2Rgnqrhe15ls=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/json/jsonutil",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "R00RL5jJXRYq1iiK1+PGvMfvXyM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/jsonrpc",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "ZqY5RWavBLWTo6j9xqdyBEaNFRk=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "9V1PvtFQ9MObZTc3sa86WcuOtOU=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "pkeoOfZpHRvFG/AOZeTf0lwtsFg=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/rest",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "Rpu8KBtHZgvhkwHxUfaky+qW+G4=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restjson",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "ODo+ko8D6unAxZuN1jGzMcN4QCc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restxml",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "0qYPUga28aQVkxZgBR3Z86AbGUQ=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "F6mth+G7dXN1GI+nktaGo8Lx8aE=",
 			"path": "github.com/aws/aws-sdk-go/private/signer/v2",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "2O+F6NwIHEgAHqLGKTJbxYwsUHs=",
 			"path": "github.com/aws/aws-sdk-go/service/acm",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
-			"checksumSHA1": "mTG0NKBXMcz+sX376GITJBzpioA=",
+			"checksumSHA1": "iF8FO4xVatyPaAq5sF0jQ86kXpA=",
 			"path": "github.com/aws/aws-sdk-go/service/apigateway",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "s+mt8VBjyMOBCZbr4/uOhUGZdYY=",
 			"path": "github.com/aws/aws-sdk-go/service/applicationautoscaling",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "1/p8oChMJW38gBTOA8AUCWkHuM8=",
 			"path": "github.com/aws/aws-sdk-go/service/athena",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "ILLTTjBCwDHKcx6D/Ja5k4Nn5Ww=",
 			"path": "github.com/aws/aws-sdk-go/service/autoscaling",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "kR7Urxv5JUC6cx3bBQ3lX1/0cEM=",
 			"path": "github.com/aws/aws-sdk-go/service/batch",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "86Gd/aNE5+OAAibFQg6YWh7YKU0=",
 			"path": "github.com/aws/aws-sdk-go/service/budgets",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
-			"checksumSHA1": "DV0NlREKdcYMrsmdJbtZyuUDK+8=",
+			"checksumSHA1": "NTUkkfytXTRTbjLiiZrHS0FO9A4=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudformation",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "vbSfNKXjDDYLLAYafrD37T5xBFk=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudfront",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "V5UO7ojp8/EuLhPIS4OOOurke3M=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudtrail",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "Rx8tIQPEmYZhy1zbRpDmMBmGfvg=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatch",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "UlNtqtd2PcKoWqqXmOj4kfu8hyc=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchevents",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "7SPaq0IXgoe1Cqph7ws9vFYr3zg=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
-			"checksumSHA1": "bufH/3DIJxDr0DAskWeAXGaLSNU=",
+			"checksumSHA1": "iOGHSGv16gPEKX+DHoOoXIeGm70=",
 			"path": "github.com/aws/aws-sdk-go/service/codebuild",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
-			"checksumSHA1": "ySI/pbSD5vrnosWYB3qI6KuXH7g=",
+			"checksumSHA1": "B8CSJW3k+VJ6neD1ddrSJJ/5TF8=",
 			"path": "github.com/aws/aws-sdk-go/service/codecommit",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "8T1UkQcbxF08m5xJL16lsWLdT6k=",
 			"path": "github.com/aws/aws-sdk-go/service/codedeploy",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "EEVCD+xa8rnlVXoFULjc9fWcVzY=",
 			"path": "github.com/aws/aws-sdk-go/service/codepipeline",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "GHaVqY5f85olNwlO5J4f160D+mI=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentity",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "svRJtQKo7tvAZYpW7UCpxFlG8mQ=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentityprovider",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "YONbbZXdr13qIiKYzqk4cptd2XE=",
 			"path": "github.com/aws/aws-sdk-go/service/configservice",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "3EkRSF6NzJkEuZUvOt3TdpABXYc=",
 			"path": "github.com/aws/aws-sdk-go/service/databasemigrationservice",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "TSYWqKDCe6RaR2kYrExoDIC+7LU=",
 			"path": "github.com/aws/aws-sdk-go/service/devicefarm",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "2139YRKSqXN9N49CFTopzwftCDw=",
 			"path": "github.com/aws/aws-sdk-go/service/directconnect",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "0T4esELn9yJKr3D7b1/apnu1ZOA=",
 			"path": "github.com/aws/aws-sdk-go/service/directoryservice",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "kEGGjvoqrbTSX3Kno7GJrV7UflY=",
 			"path": "github.com/aws/aws-sdk-go/service/dynamodb",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "hGhUGbG0E3RrhhJpfKq6bKUebz4=",
 			"path": "github.com/aws/aws-sdk-go/service/ec2",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "tvxhxL5w10Qau4eUabsLK4L60iA=",
 			"path": "github.com/aws/aws-sdk-go/service/ecr",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "vIOUiTgp58sppu4baTu5VxXKs/s=",
 			"path": "github.com/aws/aws-sdk-go/service/ecs",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "9I1RdgcMUEYJlyNIqdtSgFTdWKM=",
 			"path": "github.com/aws/aws-sdk-go/service/efs",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "jmTYmZVr8dw9kPDYlBhe4oG556U=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticache",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "xylCApLVAqLTW6uTYCziTDxgRMI=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticbeanstalk",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "RmVY7K2zivKjDe0ad8Grd+81J/M=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticsearchservice",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "SZ7yLDZ6RvMhpWe0Goyem64kgyA=",
 			"path": "github.com/aws/aws-sdk-go/service/elastictranscoder",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "i+zp7see74G8qx251yfQiTvbz4U=",
 			"path": "github.com/aws/aws-sdk-go/service/elb",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "i9eKrHV2n3LuYoMVnMpNjF34ih8=",
 			"path": "github.com/aws/aws-sdk-go/service/elbv2",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
-			"checksumSHA1": "jrndlHaS4MJcOsRIX91tFg6tbfM=",
+			"checksumSHA1": "LJrVm902tsUu83HoxW5+twvlMSA=",
 			"path": "github.com/aws/aws-sdk-go/service/emr",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
-			"checksumSHA1": "eBESkYAb0koQ4a+pg5k2Ikwo/dA=",
+			"checksumSHA1": "cEKm/PVdmVyoRD1wu9jDHIh52G4=",
 			"path": "github.com/aws/aws-sdk-go/service/firehose",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "+gED8OQZsY/taXgjkGbBJlx1hnY=",
 			"path": "github.com/aws/aws-sdk-go/service/glacier",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "GEw6g6/GwkskwL5bGj/KYJ8BENY=",
 			"path": "github.com/aws/aws-sdk-go/service/glue",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "HBlNyNP2zLI589MIX82zMvANmLY=",
 			"path": "github.com/aws/aws-sdk-go/service/iam",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "WoIsJOP3M2BAhZ5p46LJNd9FQPk=",
 			"path": "github.com/aws/aws-sdk-go/service/inspector",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "jWoHNr5dOtwUmlC5bi5kRcW30wE=",
 			"path": "github.com/aws/aws-sdk-go/service/iot",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
-			"checksumSHA1": "I8rx/IBJ6NXPOQXoJs6AthfAAd0=",
+			"checksumSHA1": "yrji9KybkQLQBcP0ti5X6FrEXoc=",
 			"path": "github.com/aws/aws-sdk-go/service/kinesis",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "CqvUs/OKC5GYojf8InoQpTWUI30=",
 			"path": "github.com/aws/aws-sdk-go/service/kms",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "UNmVsLSjqCWcNd30lHo3T/qOHOY=",
 			"path": "github.com/aws/aws-sdk-go/service/lambda",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "c51LPR75+eskzYq8cj9zdKd3DXk=",
 			"path": "github.com/aws/aws-sdk-go/service/lightsail",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "xkNWwN2rw+szg+zXAxCun34zxhs=",
 			"path": "github.com/aws/aws-sdk-go/service/opsworks",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "saFo2jqsWU43Lax6lL8PhQKRl8s=",
 			"path": "github.com/aws/aws-sdk-go/service/rds",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "BwFxr+n+xU7TOQxxONFxdtrWjG4=",
 			"path": "github.com/aws/aws-sdk-go/service/redshift",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "S1md3W8h4/TLxScptLYbD5ukfrM=",
 			"path": "github.com/aws/aws-sdk-go/service/route53",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
-			"checksumSHA1": "qUQOJWTjE3vWZoe4XsD1kFwdX+k=",
+			"checksumSHA1": "soLaAo4O4kxArCMP1r3ctgwhmC4=",
 			"path": "github.com/aws/aws-sdk-go/service/s3",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "Tz5NbDa/SGUINmuFD8KQLh1HDOI=",
 			"path": "github.com/aws/aws-sdk-go/service/servicecatalog",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "/ztCHg70ElmJqzKYIRwDB6TiBOc=",
 			"path": "github.com/aws/aws-sdk-go/service/ses",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "4fkXdvKPVnJvu6yUBc+MHkN4t20=",
 			"path": "github.com/aws/aws-sdk-go/service/sfn",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
-			"checksumSHA1": "Ip9SzZFvBpbH2BuqLDawUAyFTCA=",
+			"checksumSHA1": "rrsHusPbMvyKM0WvbZyYjDgKG00=",
 			"path": "github.com/aws/aws-sdk-go/service/shield",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "B3CgAFSREebpsFoFOo4vrQ6u04w=",
 			"path": "github.com/aws/aws-sdk-go/service/simpledb",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "rwSNHPn9iLEaoDx6vX0KbWefcHY=",
 			"path": "github.com/aws/aws-sdk-go/service/sns",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "aWWSD60GhNwldZ7mxL9Z8Q+fiXo=",
 			"path": "github.com/aws/aws-sdk-go/service/sqs",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "U1lCM+/AZ5khvQcsgZy1c/qp86Q=",
 			"path": "github.com/aws/aws-sdk-go/service/ssm",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "d9vR1rl8kmJxJBwe00byziVFR/o=",
 			"path": "github.com/aws/aws-sdk-go/service/sts",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "Uw4pOUxSMbx4xBHUcOUkNhtnywE=",
 			"path": "github.com/aws/aws-sdk-go/service/swf",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "sjZeBzVjWM2tWSIOr7p13Kx2iNU=",
 			"path": "github.com/aws/aws-sdk-go/service/waf",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "rM51Xn6MSt2XJzSF1p51m6G4u/8=",
 			"path": "github.com/aws/aws-sdk-go/service/wafregional",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "AUwsvYff1GCOYtCgB6wd0doC9kc=",
 			"path": "github.com/aws/aws-sdk-go/service/workspaces",
-			"revision": "e4f7e38b704e3ed0acc4a7f8196b777696f6f1f3",
-			"revisionTime": "2017-11-17T22:19:00Z",
-			"version": "v1.12.30",
-			"versionExact": "v1.12.30"
+			"revision": "991fe2497a95d757bb53f95cbcebf3d26134c9fe",
+			"revisionTime": "2017-11-22T01:35:17Z",
+			"version": "v1.12.32",
+			"versionExact": "v1.12.32"
 		},
 		{
 			"checksumSHA1": "nqw2Qn5xUklssHTubS5HDvEL9L4=",


### PR DESCRIPTION
Closes #2403 

Updated via:
```
govendor fetch github.com/aws/aws-sdk-go/aws/...@v1.12.32
govendor fetch github.com/aws/aws-sdk-go/internal/...@v1.12.32
govendor fetch github.com/aws/aws-sdk-go/private/...@v1.12.32
govendor fetch github.com/aws/aws-sdk-go/service/...@v1.12.32
govendor --version
v1.0.9
```