### PR TITLE
r/aws_db_instance: Move create/delete/update pending states to their own variables and add storage-optimization

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -525,8 +525,7 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 				"[INFO] Waiting for DB Instance to be available")
 
 			stateConf := &resource.StateChangeConf{
-				Pending: []string{"creating", "backing-up", "modifying", "resetting-master-credentials",
-					"maintenance", "renaming", "rebooting", "upgrading"},
+				Pending:    resourceAwsDbInstanceCreatePendingStates,
 				Target:     []string{"available"},
 				Refresh:    resourceAwsDbInstanceStateRefreshFunc(d, meta),
 				Timeout:    d.Timeout(schema.TimeoutCreate),
@@ -687,8 +686,7 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 		"[INFO] Waiting for DB Instance to be available")
 
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{"creating", "backing-up", "modifying", "resetting-master-credentials",
-			"maintenance", "renaming", "rebooting", "upgrading", "configuring-enhanced-monitoring"},
+		Pending:    resourceAwsDbInstanceCreatePendingStates,
 		Target:     []string{"available"},
 		Refresh:    resourceAwsDbInstanceStateRefreshFunc(d, meta),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
@@ -863,8 +861,7 @@ func resourceAwsDbInstanceDelete(d *schema.ResourceData, meta interface{}) error
 	log.Println(
 		"[INFO] Waiting for DB Instance to be destroyed")
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{"creating", "backing-up",
-			"modifying", "deleting", "available"},
+		Pending:    resourceAwsDbInstanceDeletePendingStates,
 		Target:     []string{},
 		Refresh:    resourceAwsDbInstanceStateRefreshFunc(d, meta),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
@@ -1039,8 +1036,7 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 		log.Println("[INFO] Waiting for DB Instance to be available")
 
 		stateConf := &resource.StateChangeConf{
-			Pending: []string{"creating", "backing-up", "modifying", "resetting-master-credentials",
-				"maintenance", "renaming", "rebooting", "upgrading", "configuring-enhanced-monitoring", "moving-to-vpc"},
+			Pending:    resourceAwsDbInstanceUpdatePendingStates,
 			Target:     []string{"available"},
 			Refresh:    resourceAwsDbInstanceStateRefreshFunc(d, meta),
 			Timeout:    d.Timeout(schema.TimeoutUpdate),
@@ -1162,4 +1158,41 @@ func buildRDSARN(identifier, partition, accountid, region string) (string, error
 	}
 	arn := fmt.Sprintf("arn:%s:rds:%s:%s:db:%s", partition, region, accountid, identifier)
 	return arn, nil
+}
+
+// Database instance status: http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.DBInstance.Status.html
+var resourceAwsDbInstanceCreatePendingStates = []string{
+	"backing-up",
+	"configuring-enhanced-monitoring",
+	"creating",
+	"maintenance",
+	"modifying",
+	"rebooting",
+	"renaming",
+	"resetting-master-credentials",
+	"storage-optimization",
+	"upgrading",
+}
+
+var resourceAwsDbInstanceDeletePendingStates = []string{
+	"available",
+	"backing-up",
+	"creating",
+	"deleting",
+	"modifying",
+	"storage-optimization",
+}
+
+var resourceAwsDbInstanceUpdatePendingStates = []string{
+	"backing-up",
+	"configuring-enhanced-monitoring",
+	"creating",
+	"maintenance",
+	"modifying",
+	"moving-to-vpc",
+	"rebooting",
+	"renaming",
+	"resetting-master-credentials",
+	"storage-optimization",
+	"upgrading",
 }

--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -526,7 +526,7 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 
 			stateConf := &resource.StateChangeConf{
 				Pending:    resourceAwsDbInstanceCreatePendingStates,
-				Target:     []string{"available"},
+				Target:     []string{"available", "storage-optimization"},
 				Refresh:    resourceAwsDbInstanceStateRefreshFunc(d, meta),
 				Timeout:    d.Timeout(schema.TimeoutCreate),
 				MinTimeout: 10 * time.Second,
@@ -687,7 +687,7 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    resourceAwsDbInstanceCreatePendingStates,
-		Target:     []string{"available"},
+		Target:     []string{"available", "storage-optimization"},
 		Refresh:    resourceAwsDbInstanceStateRefreshFunc(d, meta),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
 		MinTimeout: 10 * time.Second,
@@ -1037,7 +1037,7 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 
 		stateConf := &resource.StateChangeConf{
 			Pending:    resourceAwsDbInstanceUpdatePendingStates,
-			Target:     []string{"available"},
+			Target:     []string{"available", "storage-optimization"},
 			Refresh:    resourceAwsDbInstanceStateRefreshFunc(d, meta),
 			Timeout:    d.Timeout(schema.TimeoutUpdate),
 			MinTimeout: 10 * time.Second,
@@ -1170,16 +1170,20 @@ var resourceAwsDbInstanceCreatePendingStates = []string{
 	"rebooting",
 	"renaming",
 	"resetting-master-credentials",
-	"storage-optimization",
+	"starting",
+	"stopping",
 	"upgrading",
 }
 
 var resourceAwsDbInstanceDeletePendingStates = []string{
 	"available",
 	"backing-up",
+	"configuring-enhanced-monitoring",
 	"creating",
 	"deleting",
 	"modifying",
+	"starting",
+	"stopping",
 	"storage-optimization",
 }
 
@@ -1193,6 +1197,7 @@ var resourceAwsDbInstanceUpdatePendingStates = []string{
 	"rebooting",
 	"renaming",
 	"resetting-master-credentials",
-	"storage-optimization",
+	"starting",
+	"stopping",
 	"upgrading",
 }


### PR DESCRIPTION
Closes #2408 

There are some things that should be noted though, according to the [DB Instance Status docs](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.DBInstance.Status.html):
* For `storage-optimization`: "The storage optimization process is usually short, but can sometimes take up to and even beyond 24 hours." Likely this means this will generally hit the timeout. Should this status be moved to the `resource.StateChangeConf` `Target` instead?
* Any reason why `configuring-enhanced-monitoring` is not in delete pending states?
* I noticed we don't have statuses like `stopping` and `starting` in any of the pending states, should we add them? There might be others too.

Thoughts and opinions on the above are appreciated!