### PR TITLE
[WIP, Need Help]r/db_parameter_group: Add force_detach to aws_db_parameter_group

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -1153,6 +1153,21 @@ func resourceAwsDbInstanceStateRefreshFunc(
 	}
 }
 
+func dbInstanceRefreshStatusFunc(conn *rds.RDS, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		opts := &rds.DescribeDBInstancesInput{
+			DBInstanceIdentifier: aws.String(id),
+		}
+
+		resp, err := conn.DescribeDBInstances(opts)
+		if err != nil {
+			return nil, "failed", err
+		}
+
+		return resp, *resp.DBInstances[0].DBInstanceStatus, nil
+	}
+}
+
 func buildRDSARN(identifier, partition, accountid, region string) (string, error) {
 	if partition == "" {
 		return "", fmt.Errorf("Unable to construct RDS ARN because of missing AWS partition")

--- a/aws/resource_aws_db_parameter_group.go
+++ b/aws/resource_aws_db_parameter_group.go
@@ -269,7 +269,7 @@ func resourceAwsDbParameterGroupDelete(d *schema.ResourceData, meta interface{})
 			}
 			_, err = conn.ModifyDBInstance(req)
 			if err != nil {
-				return fmt.Errorf("Error modifying DB Instance %s: %s", instance.DBInstanceIdentifier, err)
+				return fmt.Errorf("Error modifying DB Instance %s: %s", *instance.DBInstanceIdentifier, err)
 			}
 
 			stateConf := &resource.StateChangeConf{

--- a/aws/resource_aws_db_parameter_group.go
+++ b/aws/resource_aws_db_parameter_group.go
@@ -80,7 +80,7 @@ func resourceAwsDbParameterGroup() *schema.Resource {
 				},
 				Set: resourceAwsDbParameterHash,
 			},
-			"force_detached": &schema.Schema{
+			"force_detach": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
@@ -256,8 +256,7 @@ func resourceAwsDbParameterGroupUpdate(d *schema.ResourceData, meta interface{})
 func resourceAwsDbParameterGroupDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).rdsconn
 
-	if d.Get("force_detached").(bool) {
-		log.Printf("[DEBUG] Modify DB instance which sync with PG %s", d.Id())
+	if d.Get("force_detach").(bool) {
 		instances, err := findDBInstancesWithParameterGroup(conn, d.Id())
 		if err != nil {
 			return err

--- a/aws/resource_aws_db_parameter_group_test.go
+++ b/aws/resource_aws_db_parameter_group_test.go
@@ -772,7 +772,7 @@ func testAccAWSDBParameterGroupConfig_withDBInstance(rName string, dbName string
 resource "aws_db_parameter_group" "test" {
   name = "%s"
   family = "mysql5.6"
-	force_detached = true
+	force_detach = true
   parameter {
     name = "character_set_server"
     value = "utf8"

--- a/aws/resource_aws_db_parameter_group_test.go
+++ b/aws/resource_aws_db_parameter_group_test.go
@@ -392,6 +392,35 @@ func TestAccAWSDBParameterGroup_Only(t *testing.T) {
 	})
 }
 
+func TestAccAWSDBParameterGroup_withDBInstance(t *testing.T) {
+	var v rds.DBParameterGroup
+
+	pgName1 := fmt.Sprintf("tf-pg-%s", acctest.RandString(5))
+	pgName2 := fmt.Sprintf("tf-pg-%s", acctest.RandString(5))
+	dbName := acctest.RandString(5)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBParameterGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSDBParameterGroupConfig_withDBInstance(pgName1, dbName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBParameterGroupExists("aws_db_parameter_group.test", &v),
+					resource.TestCheckResourceAttr("aws_db_instance.test", "parameter_group_name", pgName1),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSDBParameterGroupConfig_withDBInstance(pgName2, dbName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBParameterGroupExists("aws_db_parameter_group.test", &v),
+					resource.TestCheckResourceAttr("aws_db_instance.test", "parameter_group_name", pgName2),
+				),
+			},
+		},
+	})
+}
+
 func TestResourceAWSDBParameterGroupName_validation(t *testing.T) {
 	cases := []struct {
 		Value    string
@@ -737,3 +766,39 @@ resource "aws_db_parameter_group" "test" {
 	}
 }
 `
+
+func testAccAWSDBParameterGroupConfig_withDBInstance(rName string, dbName string) string {
+	return fmt.Sprintf(`
+resource "aws_db_parameter_group" "test" {
+  name = "%s"
+  family = "mysql5.6"
+	force_detached = true
+  parameter {
+    name = "character_set_server"
+    value = "utf8"
+  }
+  parameter {
+    name = "character_set_client"
+    value = "utf8"
+  }
+  parameter{
+    name = "character_set_results"
+    value = "utf8"
+  }
+}
+
+resource "aws_db_instance" "test" {
+  allocated_storage = 10
+  storage_type = "gp2"
+  engine = "mysql"
+  engine_version = "5.6.35"
+  instance_class = "db.t2.micro"
+  name = "tfdb%s"
+  username = "foo"
+  password = "barbarbar"
+  apply_immediately = true
+  skip_final_snapshot = true
+  parameter_group_name = "${aws_db_parameter_group.test.name}"
+}
+`, rName, dbName)
+}


### PR DESCRIPTION
To fix: #2402 
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSDBParameterGroup_withDBInstance'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSDBParameterGroup_withDBInstance -timeout 120m
=== RUN   TestAccAWSDBParameterGroup_withDBInstance
--- PASS: TestAccAWSDBParameterGroup_withDBInstance (724.81s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	724.857s
```