### PR TITLE
Cognito User Pool documentation clarifications

### DIFF
--- a/aws/resource_aws_cognito_user_pool.go
+++ b/aws/resource_aws_cognito_user_pool.go
@@ -261,7 +261,7 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"attribute_data_type": {
 							Type:     schema.TypeString,
-							Optional: true,
+							Required: true,
 							ValidateFunc: validation.StringInSlice([]string{
 								cognitoidentityprovider.AttributeDataTypeString,
 								cognitoidentityprovider.AttributeDataTypeNumber,
@@ -279,7 +279,7 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 						},
 						"name": {
 							Type:         schema.TypeString,
-							Optional:     true,
+							Required:     true,
 							ValidateFunc: validateCognitoUserPoolSchemaName,
 						},
 						"number_attribute_constraints": {

--- a/website/docs/r/cognito_user_pool.markdown
+++ b/website/docs/r/cognito_user_pool.markdown
@@ -111,12 +111,12 @@ The following arguments are supported:
 
 #### Verification Message Template
 
-  * `default_email_option` (Optional) - The default email option.
-  * `email_message` (Optional) - The email message template. Must contain the `{####}` placeholder.
+  * `default_email_option` (Optional) - The default email option. Must be either `CONFIRM_WITH_CODE` or `CONFIRM_WITH_LINK`.
+  * `email_message` (Optional) - The email message template. Must contain the `{####}` and `{username}` placeholders.
   * `email_message_by_link` (Optional) - The email message template for sending a confirmation link to the user.
   * `email_subject` (Optional) - The subject line for the email message template.
   * `email_subject_by_link` (Optional) - The subject line for the email message template for sending a confirmation link to the user.
-  * `sms_message` (Optional) - The SMS message template. Must contain the `{####}` placeholder.
+  * `sms_message` (Optional) - The SMS message template. Must contain the `{####}` and `{username}` placeholders.
 
 ## Attribute Reference
 

--- a/website/docs/r/cognito_user_pool.markdown
+++ b/website/docs/r/cognito_user_pool.markdown
@@ -51,9 +51,9 @@ The following arguments are supported:
 
 ##### Invite Message template
 
-  * `email_message` (Optional) - The message template for email messages. Must contain `{username}` and `{####}` placeholders.
+  * `email_message` (Optional) - The message template for email messages. Must contain `{username}` and `{####}` placeholders, for username and temporary password, respectively.
   * `email_subject` (Optional) - The subject line for email messages.
-  * `sms_message` (Optional) - The message template for SMS messages. Must contain `{username}` and `{####}` placeholders.
+  * `sms_message` (Optional) - The message template for SMS messages. Must contain `{username}` and `{####}` placeholders, for username and temporary password, respectively.
 
 #### Device Configuration
 

--- a/website/docs/r/cognito_user_pool.markdown
+++ b/website/docs/r/cognito_user_pool.markdown
@@ -86,10 +86,10 @@ The following arguments are supported:
 
 #### Schema Attributes
 
-  * `attribute_data_type` (Optional) - The attribute data type.
+  * `attribute_data_type` (Required) - The attribute data type. Must be one of `Boolean`, `Number`, `String`, `DateTime`.
   * `developer_only_attribute` (Optional) - Specifies whether the attribute type is developer only.
   * `mutable` (Optional) - Specifies whether the attribute can be changed once it has been created.
-  * `name` (Optional) - The name of the attribute.
+  * `name` (Required) - The name of the attribute.
   * `number_attribute_constraints` (Optional) - Specifies the [constraints for an attribute of the number type](#number-attribute-constraints).
   * `required` (Optional) - Specifies whether a user pool attribute is required. If the attribute is required and the user does not provide a value, registration or sign-in will fail.
   * `string_attribute_constraints` (Optional) -Specifies the [constraints for an attribute of the string type](#string-attribute-constraints).

--- a/website/docs/r/cognito_user_pool.markdown
+++ b/website/docs/r/cognito_user_pool.markdown
@@ -111,7 +111,7 @@ The following arguments are supported:
 
 #### Verification Message Template
 
-  * `default_email_option` (Optional) - The default email option. Must be either `CONFIRM_WITH_CODE` or `CONFIRM_WITH_LINK`.
+  * `default_email_option` (Optional) - The default email option. Must be either `CONFIRM_WITH_CODE` or `CONFIRM_WITH_LINK`. Defaults to `CONFIRM_WITH_CODE`.
   * `email_message` (Optional) - The email message template. Must contain the `{####}` placeholder.
   * `email_message_by_link` (Optional) - The email message template for sending a confirmation link to the user.
   * `email_subject` (Optional) - The subject line for the email message template.

--- a/website/docs/r/cognito_user_pool.markdown
+++ b/website/docs/r/cognito_user_pool.markdown
@@ -51,9 +51,9 @@ The following arguments are supported:
 
 ##### Invite Message template
 
-  * `email_message` (Optional) - The message template for email messages.
+  * `email_message` (Optional) - The message template for email messages. Must contain `{username}` and `{####}` placeholders.
   * `email_subject` (Optional) - The subject line for email messages.
-  * `sms_message` (Optional) - The message template for SMS messages.
+  * `sms_message` (Optional) - The message template for SMS messages. Must contain `{username}` and `{####}` placeholders.
 
 #### Device Configuration
 
@@ -112,11 +112,11 @@ The following arguments are supported:
 #### Verification Message Template
 
   * `default_email_option` (Optional) - The default email option. Must be either `CONFIRM_WITH_CODE` or `CONFIRM_WITH_LINK`.
-  * `email_message` (Optional) - The email message template. Must contain the `{####}` and `{username}` placeholders.
+  * `email_message` (Optional) - The email message template. Must contain the `{####}` placeholder.
   * `email_message_by_link` (Optional) - The email message template for sending a confirmation link to the user.
   * `email_subject` (Optional) - The subject line for the email message template.
   * `email_subject_by_link` (Optional) - The subject line for the email message template for sending a confirmation link to the user.
-  * `sms_message` (Optional) - The SMS message template. Must contain the `{####}` and `{username}` placeholders.
+  * `sms_message` (Optional) - The SMS message template. Must contain the `{####}` placeholder.
 
 ## Attribute Reference
 

--- a/website/docs/r/cognito_user_pool.markdown
+++ b/website/docs/r/cognito_user_pool.markdown
@@ -107,7 +107,7 @@ The following arguments are supported:
 #### SMS Configuration
 
   * `external_id` (Required) - The external ID used in IAM role trust relationships. For more information about using external IDs, see [How to Use an External ID When Granting Access to Your AWS Resources to a Third Party](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html).
-  * `source_arn` (Required) - The ARN of the Amazon SNS caller.
+  * `sns_caller_arn` (Required) - The ARN of the Amazon SNS caller. This is usually the IAM role that you've given Cognito permission to assume.
 
 #### Verification Message Template
 


### PR DESCRIPTION
Updating the documentation of the  Cognito User Pool resource to clarify the requirements for values:
* Verification Message Template: default_email_option can accept only one of two choices, neither of which were listed.
* Invite Message Template: email_message and sms_message both require `{username}`, which wasn’t documented.