### PR TITLE
r/elasticache_replication_group: Modify validation, make replication_group_id to lowercase

### DIFF
--- a/aws/resource_aws_elasticache_replication_group.go
+++ b/aws/resource_aws_elasticache_replication_group.go
@@ -23,6 +23,9 @@ func resourceAwsElasticacheReplicationGroup() *schema.Resource {
 		Required:     true,
 		ForceNew:     true,
 		ValidateFunc: validateAwsElastiCacheReplicationGroupId,
+		StateFunc: func(val interface{}) string {
+			return strings.ToLower(val.(string))
+		},
 	}
 
 	resourceSchema["automatic_failover_enabled"] = &schema.Schema{
@@ -518,7 +521,7 @@ func validateAwsElastiCacheReplicationGroupId(v interface{}, k string) (ws []str
 		errors = append(errors, fmt.Errorf(
 			"only alphanumeric characters and hyphens allowed in %q", k))
 	}
-	if !regexp.MustCompile(`^[a-z]`).MatchString(value) {
+	if !regexp.MustCompile(`^[a-zA-Z]`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
 			"first character of %q must be a letter", k))
 	}

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -35,6 +35,27 @@ func TestAccAWSElasticacheReplicationGroup_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSElasticacheReplicationGroup_Uppercase(t *testing.T) {
+	var rg elasticache.ReplicationGroup
+	rStr := acctest.RandString(5)
+	rgName := fmt.Sprintf("TF-ELASTIRG-%s", rStr)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheReplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSElasticacheReplicationGroupConfig_Uppercase(rgName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_replication_group.bar", "replication_group_id", fmt.Sprintf("tf-elastirg-%s", rStr)),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSElasticacheReplicationGroup_updateDescription(t *testing.T) {
 	var rg elasticache.ReplicationGroup
 	rName := acctest.RandString(10)
@@ -474,6 +495,17 @@ resource "aws_elasticache_replication_group" "bar" {
     maintenance_window = "tue:06:30-tue:07:30"
     snapshot_window = "01:00-02:00"
 }`, rName, rName, rName)
+}
+
+func testAccAWSElasticacheReplicationGroupConfig_Uppercase(rgName string) string {
+	return fmt.Sprintf(`
+resource "aws_elasticache_replication_group" "bar" {
+  replication_group_id = "%s"
+  replication_group_description = "test description"
+  node_type = "cache.t2.micro"
+  number_cache_clusters = 1
+  port = 6379
+}`, rgName)
 }
 
 func testAccAWSElasticacheReplicationGroupConfigEnableSnapshotting(rName string) string {


### PR DESCRIPTION
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSElasticacheReplicationGroup_Uppercase'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSElasticacheReplicationGroup_Uppercase -timeout 120m
=== RUN   TestAccAWSElasticacheReplicationGroup_Uppercase
--- PASS: TestAccAWSElasticacheReplicationGroup_Uppercase (660.74s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	661.043s
```