### PR TITLE
resource/aws_iam_user_policy: Fix updates for resource.UniqueId() named policies, support import, validate and suppress diff with policy

### DIFF
--- a/aws/resource_aws_iam_user_policy.go
+++ b/aws/resource_aws_iam_user_policy.go
@@ -21,11 +21,16 @@ func resourceAwsIamUserPolicy() *schema.Resource {
 
 		Read:   resourceAwsIamUserPolicyRead,
 		Delete: resourceAwsIamUserPolicyDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"policy": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateFunc:     validateIAMPolicyJson,
+				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
 			},
 			"name": &schema.Schema{
 				Type:          schema.TypeString,
@@ -57,9 +62,7 @@ func resourceAwsIamUserPolicyPut(d *schema.ResourceData, meta interface{}) error
 	}
 
 	var policyName string
-	if d.Id() != "" {
-		_, policyName = resourceAwsIamUserPolicyParseId(d.Id())
-	} else if v, ok := d.GetOk("name"); ok {
+	if v, ok := d.GetOk("name"); ok {
 		policyName = v.(string)
 	} else if v, ok := d.GetOk("name_prefix"); ok {
 		policyName = resource.PrefixedUniqueId(v.(string))
@@ -79,14 +82,16 @@ func resourceAwsIamUserPolicyPut(d *schema.ResourceData, meta interface{}) error
 func resourceAwsIamUserPolicyRead(d *schema.ResourceData, meta interface{}) error {
 	iamconn := meta.(*AWSClient).iamconn
 
-	user, name := resourceAwsIamUserPolicyParseId(d.Id())
+	user, name, err := resourceAwsIamUserPolicyParseId(d.Id())
+	if err != nil {
+		return err
+	}
 
 	request := &iam.GetUserPolicyInput{
 		PolicyName: aws.String(name),
 		UserName:   aws.String(user),
 	}
 
-	var err error
 	getResp, err := iamconn.GetUserPolicy(request)
 	if err != nil {
 		if iamerr, ok := err.(awserr.Error); ok && iamerr.Code() == "NoSuchEntity" { // XXX test me
@@ -104,13 +109,22 @@ func resourceAwsIamUserPolicyRead(d *schema.ResourceData, meta interface{}) erro
 	if err != nil {
 		return err
 	}
-	return d.Set("policy", policy)
+	if err := d.Set("policy", policy); err != nil {
+		return err
+	}
+	if err := d.Set("name", name); err != nil {
+		return err
+	}
+	return d.Set("user", user)
 }
 
 func resourceAwsIamUserPolicyDelete(d *schema.ResourceData, meta interface{}) error {
 	iamconn := meta.(*AWSClient).iamconn
 
-	user, name := resourceAwsIamUserPolicyParseId(d.Id())
+	user, name, err := resourceAwsIamUserPolicyParseId(d.Id())
+	if err != nil {
+		return err
+	}
 
 	request := &iam.DeleteUserPolicyInput{
 		PolicyName: aws.String(name),
@@ -123,8 +137,13 @@ func resourceAwsIamUserPolicyDelete(d *schema.ResourceData, meta interface{}) er
 	return nil
 }
 
-func resourceAwsIamUserPolicyParseId(id string) (userName, policyName string) {
+func resourceAwsIamUserPolicyParseId(id string) (userName, policyName string, err error) {
 	parts := strings.SplitN(id, ":", 2)
+	if len(parts) != 2 {
+		err = fmt.Errorf("user_policy id must be of the form <user name>:<policy name>")
+		return
+	}
+
 	userName = parts[0]
 	policyName = parts[1]
 	return

--- a/aws/resource_aws_iam_user_policy.go
+++ b/aws/resource_aws_iam_user_policy.go
@@ -57,7 +57,9 @@ func resourceAwsIamUserPolicyPut(d *schema.ResourceData, meta interface{}) error
 	}
 
 	var policyName string
-	if v, ok := d.GetOk("name"); ok {
+	if d.Id() != "" {
+		_, policyName = resourceAwsIamUserPolicyParseId(d.Id())
+	} else if v, ok := d.GetOk("name"); ok {
 		policyName = v.(string)
 	} else if v, ok := d.GetOk("name_prefix"); ok {
 		policyName = resource.PrefixedUniqueId(v.(string))

--- a/aws/resource_aws_iam_user_policy_test.go
+++ b/aws/resource_aws_iam_user_policy_test.go
@@ -220,16 +220,16 @@ func testAccIAMUserPolicyConfig(rInt int) string {
 
 func testAccIAMUserPolicyConfig_invalidJSON(rInt int) string {
 	return fmt.Sprintf(`
-	resource "aws_iam_user" "user" {
-		name = "test_user_%d"
-		path = "/"
-	}
+  resource "aws_iam_user" "user" {
+    name = "test_user_%d"
+    path = "/"
+  }
 
-	resource "aws_iam_user_policy" "foo" {
-		name = "foo_policy_%d"
-		user = "${aws_iam_user.user.name}"
-		policy = "NonJSONString"
-	}`, rInt, rInt)
+  resource "aws_iam_user_policy" "foo" {
+    name = "foo_policy_%d"
+    user = "${aws_iam_user.user.name}"
+    policy = "NonJSONString"
+  }`, rInt, rInt)
 }
 
 func testAccIAMUserPolicyConfig_namePrefix(rInt int) string {
@@ -261,15 +261,15 @@ func testAccIAMUserPolicyConfig_generatedName(rInt int) string {
 
 func testAccIAMUserPolicyConfig_generatedNameUpdate(rInt int) string {
 	return fmt.Sprintf(`
-	resource "aws_iam_user" "test" {
-		name = "test_user_%d"
-		path = "/"
-	}
+  resource "aws_iam_user" "test" {
+    name = "test_user_%d"
+    path = "/"
+  }
 
-	resource "aws_iam_user_policy" "test" {
-		user = "${aws_iam_user.test.name}"
-		policy = "{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Allow\",\"Action\":\"iam:*\",\"Resource\":\"*\"}}"
-	}`, rInt)
+  resource "aws_iam_user_policy" "test" {
+    user = "${aws_iam_user.test.name}"
+    policy = "{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Allow\",\"Action\":\"iam:*\",\"Resource\":\"*\"}}"
+  }`, rInt)
 }
 
 func testAccIAMUserPolicyConfigUpdate(rInt int) string {

--- a/website/docs/r/iam_user_policy.html.markdown
+++ b/website/docs/r/iam_user_policy.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides an IAM policy attached to a user.
 ---
 
-# aws\_iam\_user\_policy
+# aws_iam_user_policy
 
 Provides an IAM policy attached to a user.
 
@@ -55,4 +55,14 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-This resource has no attributes.
+* `id` - The user policy ID, in the form of `user_name:user_policy_name`.
+* `name` - The name of the policy (always set).
+
+## Import
+
+IAM User Policies can be imported using the `user_name:user_policy_name`, e.g.
+
+```
+$ terraform import aws_iam_user_policy.mypolicy user_of_mypolicy_name:mypolicy_name
+```
+


### PR DESCRIPTION
Closes #781

* Fixes policy updates for resources not using `name` or `name_prefix` (e.g. depending on Terraform `resource.UniqueId()`). It was always creating new user policies since it had no way to determine existing user policy name from state. Added acceptance testing to cover situation and fixed by having read function `d.Set("name")`.
* Adds import functionality
* Validate IAM policy JSON
* Suppress equivalent IAM policy differences
* `testAccCheckIAMUserPolicyDestroy` was checking *role* policies, fixed to check *user* policies

Failing updated test before resource fixes:
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSIAMUserPolicy_generatedName'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSIAMUserPolicy_generatedName -timeout 120m
=== RUN   TestAccAWSIAMUserPolicy_generatedName
--- FAIL: TestAccAWSIAMUserPolicy_generatedName (12.64s)
	testing.go:563: Error destroying resource! WARNING: Dangling resources
		may exist. The full state and error is shown below.

		Error: Error applying: 1 error(s) occurred:

		* aws_iam_user.test (destroy): 1 error(s) occurred:

		* aws_iam_user.test: Error deleting IAM User test_user_8722814785024408515: DeleteConflict: Cannot delete entity, must delete policies first.
			status code: 409, request id: e974fc12-d3ec-11e7-b57f-af3e065a40e2

		State: aws_iam_user.test:
		  ID = test_user_8722814785024408515
		  arn = arn:aws:iam::0123456789012:user/test_user_8722814785024408515
		  force_destroy = false
		  name = test_user_8722814785024408515
		  path = /
		  unique_id = AIDAIW6KC63RL42BVNHUG
FAIL
exit status 1
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	12.676s
```

Passes testing:
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSIAMUserPolicy'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSIAMUserPolicy -timeout 120m
=== RUN   TestAccAWSIAMUserPolicy_basic
--- PASS: TestAccAWSIAMUserPolicy_basic (14.29s)
=== RUN   TestAccAWSIAMUserPolicy_namePrefix
--- PASS: TestAccAWSIAMUserPolicy_namePrefix (7.28s)
=== RUN   TestAccAWSIAMUserPolicy_generatedName
--- PASS: TestAccAWSIAMUserPolicy_generatedName (14.21s)
=== RUN   TestAccAWSIAMUserPolicy_importBasic
--- PASS: TestAccAWSIAMUserPolicy_importBasic (8.16s)
=== RUN   TestAccAWSIAMUserPolicy_invalidJSON
--- PASS: TestAccAWSIAMUserPolicy_invalidJSON (0.84s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	44.817s
```