### PR TITLE
r/aws_dynamodb_table: Ensure ttl is properly read

### DIFF
--- a/aws/import_aws_dynamodb_table_test.go
+++ b/aws/import_aws_dynamodb_table_test.go
@@ -49,3 +49,25 @@ func TestAccAWSDynamoDbTable_importTags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccAWSDynamoDbTable_importTimeToLive(t *testing.T) {
+	resourceName := "aws_dynamodb_table.basic-dynamodb-table"
+	rName := acctest.RandomWithPrefix("TerraformTestTable-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDynamoDbTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDynamoDbConfigAddTimeToLive(rName),
+			},
+
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/aws/resource_aws_dynamodb_table.go
+++ b/aws/resource_aws_dynamodb_table.go
@@ -816,15 +816,21 @@ func flattenAwsDynamoDbTableResource(d *schema.ResourceData, meta interface{}, t
 	if err != nil {
 		return err
 	}
-	timeToLive := []interface{}{}
-	attribute := map[string]*string{
-		"name": timeToLiveOutput.TimeToLiveDescription.AttributeName,
-		"type": timeToLiveOutput.TimeToLiveDescription.TimeToLiveStatus,
-	}
-	timeToLive = append(timeToLive, attribute)
-	d.Set("timeToLive", timeToLive)
 
-	log.Printf("[DEBUG] Loaded TimeToLive data for DynamoDB table '%s'", d.Id())
+	if timeToLiveOutput.TimeToLiveDescription.AttributeName != nil {
+		timeToLiveList := []interface{}{}
+		timeToLiveSet := map[string]interface{}{
+			"attribute_name": *timeToLiveOutput.TimeToLiveDescription.AttributeName,
+			"enabled":        (*timeToLiveOutput.TimeToLiveDescription.TimeToLiveStatus == dynamodb.TimeToLiveStatusEnabled),
+		}
+		timeToLiveList = append(timeToLiveList, timeToLiveSet)
+		err := d.Set("ttl", timeToLiveList)
+		if err != nil {
+			return err
+		}
+
+		log.Printf("[DEBUG] Loaded TimeToLive data for DynamoDB table '%s'", d.Id())
+	}
 
 	tags, err := readTableTags(d, meta)
 	if err != nil {

--- a/aws/resource_aws_dynamodb_table.go
+++ b/aws/resource_aws_dynamodb_table.go
@@ -817,13 +817,13 @@ func flattenAwsDynamoDbTableResource(d *schema.ResourceData, meta interface{}, t
 		return err
 	}
 
-	if timeToLiveOutput.TimeToLiveDescription.AttributeName != nil {
-		timeToLiveList := []interface{}{}
-		timeToLiveSet := map[string]interface{}{
-			"attribute_name": *timeToLiveOutput.TimeToLiveDescription.AttributeName,
-			"enabled":        (*timeToLiveOutput.TimeToLiveDescription.TimeToLiveStatus == dynamodb.TimeToLiveStatusEnabled),
+	if timeToLiveOutput.TimeToLiveDescription != nil && timeToLiveOutput.TimeToLiveDescription.AttributeName != nil {
+		timeToLiveList := []interface{}{
+			map[string]interface{}{
+				"attribute_name": *timeToLiveOutput.TimeToLiveDescription.AttributeName,
+				"enabled":        (*timeToLiveOutput.TimeToLiveDescription.TimeToLiveStatus == dynamodb.TimeToLiveStatusEnabled),
+			},
 		}
-		timeToLiveList = append(timeToLiveList, timeToLiveSet)
 		err := d.Set("ttl", timeToLiveList)
 		if err != nil {
 			return err


### PR DESCRIPTION
Closes #2442 

Previously it was pointing to a non-existent `timeToLive` attribute and not returning any errors.

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSDynamoDbTable'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSDynamoDbTable -timeout 120m
=== RUN   TestAccAWSDynamoDbTable_importBasic
--- PASS: TestAccAWSDynamoDbTable_importBasic (63.75s)
=== RUN   TestAccAWSDynamoDbTable_importTags
--- PASS: TestAccAWSDynamoDbTable_importTags (61.60s)
=== RUN   TestAccAWSDynamoDbTable_importTimeToLive
--- PASS: TestAccAWSDynamoDbTable_importTimeToLive (56.04s)
=== RUN   TestAccAWSDynamoDbTable_basic
--- PASS: TestAccAWSDynamoDbTable_basic (324.05s)
=== RUN   TestAccAWSDynamoDbTable_streamSpecification
--- PASS: TestAccAWSDynamoDbTable_streamSpecification (51.13s)
=== RUN   TestAccAWSDynamoDbTable_tags
--- PASS: TestAccAWSDynamoDbTable_tags (56.07s)
=== RUN   TestAccAWSDynamoDbTable_gsiUpdate
--- PASS: TestAccAWSDynamoDbTable_gsiUpdate (195.70s)
=== RUN   TestAccAWSDynamoDbTable_ttl
--- PASS: TestAccAWSDynamoDbTable_ttl (71.26s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	879.650s
```