### PR TITLE
resource/aws_db_instance: Add ForceNew to db_subnet_group_name

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -234,6 +234,7 @@ func resourceAwsDbInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				ForceNew: true,
 			},
 
 			"parameter_group_name": {


### PR DESCRIPTION
Unfortunately, it's not possible to change an existing RDS instance's DB Subnet Group without a [workaround](https://serverfault.com/a/817598). Addresses https://github.com/terraform-providers/terraform-provider-aws/issues/512 by requiring a new DB instance to be created when changing.