### PR TITLE
New Resource: aws_sagemaker_endpoint_configuration

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -616,6 +616,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_default_route_table":                          resourceAwsDefaultRouteTable(),
 			"aws_route_table_association":                      resourceAwsRouteTableAssociation(),
 			"aws_sagemaker_model":                              resourceAwsSagemakerModel(),
+			"aws_sagemaker_endpoint_configuration":             resourceAwsSagemakerEndpointConfiguration(),
 			"aws_secretsmanager_secret":                        resourceAwsSecretsManagerSecret(),
 			"aws_secretsmanager_secret_version":                resourceAwsSecretsManagerSecretVersion(),
 			"aws_ses_active_receipt_rule_set":                  resourceAwsSesActiveReceiptRuleSet(),

--- a/aws/resource_aws_sagemaker_endpoint_configuration.go
+++ b/aws/resource_aws_sagemaker_endpoint_configuration.go
@@ -1,0 +1,264 @@
+package aws
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"log"
+	"time"
+)
+
+func resourceAwsSagemakerEndpointConfiguration() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsSagemakerEndpointConfigurationCreate,
+		Read:   resourceAwsSagemakerEndpointConfigurationRead,
+		Update: resourceAwsSagemakerEndpointConfigurationUpdate,
+		Delete: resourceAwsSagemakerEndpointConfigurationDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validateSagemakerName,
+			},
+
+			"production_variants": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"variant_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+
+						"model_name": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+
+						"initial_instance_count": {
+							Type:     schema.TypeInt,
+							Required: true,
+							ForceNew: true,
+						},
+
+						"instance_type": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+
+						"initial_variant_weight": {
+							Type:     schema.TypeFloat,
+							Required: true,
+							ForceNew: true,
+						},
+					},
+				},
+				Set: resourceAwsSagmakerEndpointConfigEntryHash,
+			},
+
+			"kms_key_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"creation_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceAwsSagemakerEndpointConfigurationCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+
+	var name string
+	if v, ok := d.GetOk("name"); ok {
+		name = v.(string)
+	} else {
+		name = resource.UniqueId()
+	}
+
+	createOpts := &sagemaker.CreateEndpointConfigInput{
+		EndpointConfigName: aws.String(name),
+	}
+
+	prodVariants, err := expandProductionVariants(d.Get("production_variants").(*schema.Set).List())
+	if err != nil {
+		return err
+	}
+	createOpts.ProductionVariants = prodVariants
+
+	if v, ok := d.GetOk("kms_key_id"); ok {
+		createOpts.KmsKeyId = aws.String(v.(string))
+	}
+
+	log.Printf("[DEBUG] Sagemaker endpoint configuration create config: %#v", *createOpts)
+	resp, err := conn.CreateEndpointConfig(createOpts)
+	if err != nil {
+		return fmt.Errorf("Error creating Sagemaker endpoint configuration: %s", err)
+	}
+
+	d.SetId(name)
+	if err := d.Set("arn", resp.EndpointConfigArn); err != nil {
+		return err
+	}
+
+	return resourceAwsSagemakerEndpointConfigurationUpdate(d, meta)
+}
+
+func resourceAwsSagemakerEndpointConfigurationRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+
+	request := &sagemaker.DescribeEndpointConfigInput{
+		EndpointConfigName: aws.String(d.Id()),
+	}
+
+	endpointConfig, err := conn.DescribeEndpointConfig(request)
+	if err != nil {
+		if sagemakerErr, ok := err.(awserr.Error); ok && sagemakerErr.Code() == "ResourceNotFound" {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error reading Sagemaker endpoint configuration %s: %s", d.Id(), err)
+	}
+
+	if err := d.Set("arn", endpointConfig.EndpointConfigArn); err != nil {
+		return err
+	}
+	if err := d.Set("name", endpointConfig.EndpointConfigName); err != nil {
+		return err
+	}
+	if err := d.Set("production_variants", flattenProductionVariants(endpointConfig.ProductionVariants)); err != nil {
+		return err
+	}
+
+	if err := d.Set("kms_key_id", endpointConfig.KmsKeyId); err != nil {
+		return err
+	}
+	if err := d.Set("creation_time", endpointConfig.CreationTime.Format(time.RFC3339)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceAwsSagemakerEndpointConfigurationUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+
+	d.Partial(true)
+
+	if err := setSagemakerTags(conn, d); err != nil {
+		return err
+	} else {
+		d.SetPartial("tags")
+	}
+
+	d.Partial(false)
+
+	return resourceAwsSagemakerEndpointConfigurationRead(d, meta)
+}
+
+func resourceAwsSagemakerEndpointConfigurationDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+
+	deleteOpts := &sagemaker.DeleteEndpointConfigInput{
+		EndpointConfigName: aws.String(d.Id()),
+	}
+	log.Printf("[INFO] Deleting Sagemaker endpoint configuration: %s", d.Id())
+
+	return resource.Retry(5*time.Minute, func() *resource.RetryError {
+		_, err := conn.DeleteEndpointConfig(deleteOpts)
+		if err == nil {
+			return nil
+		}
+
+		sagemakerErr, ok := err.(awserr.Error)
+		if !ok {
+			return resource.NonRetryableError(err)
+		}
+
+		if sagemakerErr.Code() == "ResourceNotFound" {
+			return resource.RetryableError(err)
+		}
+
+		return resource.NonRetryableError(fmt.Errorf("Error deleting Sagemaker endpoint configuration: %s", err))
+	})
+}
+
+func expandProductionVariants(configured []interface{}) ([]*sagemaker.ProductionVariant, error) {
+	containers := make([]*sagemaker.ProductionVariant, 0, len(configured))
+
+	for _, lRaw := range configured {
+		data := lRaw.(map[string]interface{})
+
+		var name string
+		if v, ok := data["variant_name"]; ok {
+			name = v.(string)
+		} else {
+			name = resource.UniqueId()
+		}
+
+		l := &sagemaker.ProductionVariant{
+			VariantName:          aws.String(name),
+			InstanceType:         aws.String(data["instance_type"].(string)),
+			ModelName:            aws.String(data["model_name"].(string)),
+			InitialVariantWeight: aws.Float64(float64(data["initial_variant_weight"].(float64))),
+			InitialInstanceCount: aws.Int64(int64(data["initial_instance_count"].(int))),
+		}
+		containers = append(containers, l)
+	}
+
+	return containers, nil
+}
+
+func flattenProductionVariants(list []*sagemaker.ProductionVariant) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(list))
+	for _, i := range list {
+		l := map[string]interface{}{
+			"variant_name":           *i.VariantName,
+			"instance_type":          *i.InstanceType,
+			"model_name":             *i.ModelName,
+			"initial_variant_weight": *i.InitialVariantWeight,
+			"initial_instance_count": *i.InitialInstanceCount,
+		}
+		result = append(result, l)
+	}
+	return result
+}
+
+func resourceAwsSagmakerEndpointConfigEntryHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	buf.WriteString(fmt.Sprintf("%s-", m["variant_name"].(string)))
+	buf.WriteString(fmt.Sprintf("%s-", m["model_name"].(string)))
+	buf.WriteString(fmt.Sprintf("%s-", m["instance_type"].(string)))
+	buf.WriteString(fmt.Sprintf("%f-", m["initial_variant_weight"].(float64)))
+	buf.WriteString(fmt.Sprintf("%d-", m["initial_instance_count"].(int)))
+
+	return hashcode.String(buf.String())
+}

--- a/aws/resource_aws_sagemaker_endpoint_configuration_test.go
+++ b/aws/resource_aws_sagemaker_endpoint_configuration_test.go
@@ -1,0 +1,454 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"log"
+	"testing"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_sagemaker_endpoint_configuration", &resource.Sweeper{
+		Name: "aws_sagemaker_endpoint_configuration",
+		Dependencies: []string{
+			"aws_sagemaker_model",
+			"aws_iam_role",
+		},
+		F: testSweepSagemakerEndpointConfigs,
+	})
+}
+
+func testSweepSagemakerEndpointConfigs(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).sagemakerconn
+
+	req := &sagemaker.ListEndpointConfigsInput{
+		NameContains: aws.String("terraform-testacc-sagemaker-endpoint-config"),
+	}
+	resp, err := conn.ListEndpointConfigs(req)
+	if err != nil {
+		return fmt.Errorf("Error listing endpoint configs: %s", err)
+	}
+
+	if len(resp.EndpointConfigs) == 0 {
+		log.Print("[DEBUG] No SageMaker endpoint config to sweep")
+		return nil
+	}
+
+	for _, endpointConfig := range resp.EndpointConfigs {
+		_, err := conn.DeleteEndpointConfig(&sagemaker.DeleteEndpointConfigInput{
+			EndpointConfigName: endpointConfig.EndpointConfigName,
+		})
+		if err != nil {
+			return fmt.Errorf(
+				"failed to delete SageMaker endpoint config (%s): %s",
+				*endpointConfig.EndpointConfigName, err)
+		}
+	}
+
+	return nil
+}
+
+func TestAccAWSSagemakerEndpointConfig_basic(t *testing.T) {
+	var endpointConfig sagemaker.DescribeEndpointConfigOutput
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSagemakerEndpointConfigDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSagemakerEndpointConfigConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSagemakerEndpointConfigExists("aws_sagemaker_endpoint_configuration.foo",
+						&endpointConfig),
+					testAccCheckSagemakerEndpointConfigName(&endpointConfig,
+						"terraform-testacc-sagemaker-endpoint-config-foo"),
+
+					resource.TestCheckResourceAttr(
+						"aws_sagemaker_endpoint_configuration.foo", "name",
+						"terraform-testacc-sagemaker-endpoint-config-foo"),
+					resource.TestCheckResourceAttr(
+						"aws_sagemaker_endpoint_configuration.foo",
+						"production_variants.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_sagemaker_endpoint_configuration.foo",
+						"production_variants.2891507008.variant_name",
+						"variant-1"),
+					resource.TestCheckResourceAttr(
+						"aws_sagemaker_endpoint_configuration.foo",
+						"production_variants.2891507008.model_name",
+						"terraform-testacc-sagemaker-model-foo"),
+					resource.TestCheckResourceAttr(
+						"aws_sagemaker_endpoint_configuration.foo",
+						"production_variants.2891507008.initial_instance_count",
+						"1"),
+					resource.TestCheckResourceAttr(
+						"aws_sagemaker_endpoint_configuration.foo",
+						"production_variants.2891507008.instance_type",
+						"ml.t2.medium"),
+					resource.TestCheckResourceAttr(
+						"aws_sagemaker_endpoint_configuration.foo",
+						"production_variants.2891507008.initial_variant_weight",
+						"1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSagemakerEndpointConfig_kmsKeyId(t *testing.T) {
+	var endpointConfig sagemaker.DescribeEndpointConfigOutput
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSagemakerEndpointConfigDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSagemakerEndpointConfigKmsKeyIdConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSagemakerEndpointConfigExists("aws_sagemaker_endpoint_configuration.foo",
+						&endpointConfig),
+					testAccCheckSagemakerEndpointConfigKmsKeyId(&endpointConfig),
+
+					resource.TestCheckResourceAttrSet("aws_sagemaker_endpoint_configuration.foo", "kms_key_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSagemakerEndpointConfig_tags(t *testing.T) {
+	var endpointConfig sagemaker.DescribeEndpointConfigOutput
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSagemakerEndpointConfigDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSagemakerEndpointConfigConfigTags,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSagemakerEndpointConfigExists("aws_sagemaker_endpoint_configuration.foo",
+						&endpointConfig),
+					testAccCheckSagemakerEndpointConfigTags(&endpointConfig, "foo", "bar"),
+
+					resource.TestCheckResourceAttr(
+						"aws_sagemaker_endpoint_configuration.foo", "name",
+						"terraform-testacc-sagemaker-endpoint-config-foo"),
+					resource.TestCheckResourceAttr("aws_sagemaker_endpoint_configuration.foo",
+						"tags.%", "1"),
+					resource.TestCheckResourceAttr("aws_sagemaker_endpoint_configuration.foo",
+						"tags.foo", "bar"),
+				),
+			},
+
+			{
+				Config: testAccSagemakerEndpointConfigConfigTagsUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSagemakerEndpointConfigExists("aws_sagemaker_endpoint_configuration.foo",
+						&endpointConfig),
+					testAccCheckSagemakerEndpointConfigTags(&endpointConfig, "foo", ""),
+					testAccCheckSagemakerEndpointConfigTags(&endpointConfig, "bar", "baz"),
+
+					resource.TestCheckResourceAttr("aws_sagemaker_endpoint_configuration.foo",
+						"tags.%", "1"),
+					resource.TestCheckResourceAttr("aws_sagemaker_endpoint_configuration.foo",
+						"tags.bar", "baz"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckSagemakerEndpointConfigDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).sagemakerconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_sagemaker_endpoint_configuration" {
+			continue
+		}
+
+		resp, err := conn.ListEndpointConfigs(&sagemaker.ListEndpointConfigsInput{
+			NameContains: aws.String(rs.Primary.ID),
+		})
+		if err == nil {
+			if len(resp.EndpointConfigs) > 0 {
+				return fmt.Errorf("SageMaker endpoint configs still exists")
+			}
+
+			return nil
+		}
+
+		sagemakerErr, ok := err.(awserr.Error)
+		if !ok {
+			return err
+		}
+		if sagemakerErr.Code() != "ResourceNotFound" {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckSagemakerEndpointConfigExists(n string,
+	endpointConfig *sagemaker.DescribeEndpointConfigOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("SageMaker endpoint config not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no SageMaker endpoint config ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).sagemakerconn
+		opts := &sagemaker.DescribeEndpointConfigInput{
+			EndpointConfigName: aws.String(rs.Primary.ID),
+		}
+		resp, err := conn.DescribeEndpointConfig(opts)
+		if err != nil {
+			return err
+		}
+
+		*endpointConfig = *resp
+		return nil
+	}
+}
+
+func testAccCheckSagemakerEndpointConfigName(endpointConfig *sagemaker.DescribeEndpointConfigOutput,
+	expected string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		name := endpointConfig.EndpointConfigName
+		if *name != expected {
+			return fmt.Errorf("bad name: %s", *name)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckSagemakerEndpointConfigKmsKeyId(endpointConfig *sagemaker.DescribeEndpointConfigOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		id := endpointConfig.KmsKeyId
+		if id == nil || len(*id) < 20 {
+			return fmt.Errorf("bad KMS key ID: %s", *id)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckSagemakerEndpointConfigTags(endpointConfig *sagemaker.DescribeEndpointConfigOutput,
+	key string, value string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).sagemakerconn
+
+		ts, err := conn.ListTags(&sagemaker.ListTagsInput{
+			ResourceArn: endpointConfig.EndpointConfigArn,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to list tags: %s", err)
+		}
+
+		m := tagsToMapSagemaker(ts.Tags)
+		v, ok := m[key]
+		if value != "" && !ok {
+			return fmt.Errorf("missing tag: %s", key)
+		} else if value == "" && ok {
+			return fmt.Errorf("extra tag: %s", key)
+		}
+		if value == "" {
+			return nil
+		}
+
+		if v != value {
+			return fmt.Errorf("%s: bad value: %s", key, v)
+		}
+
+		return nil
+	}
+}
+
+const testAccSagemakerEndpointConfigConfig = `
+resource "aws_sagemaker_endpoint_configuration" "foo" {
+	name = "terraform-testacc-sagemaker-endpoint-config-foo"
+
+	production_variants {
+		variant_name = "variant-1"
+		model_name = "${aws_sagemaker_model.foo.name}"
+		initial_instance_count = 1
+		instance_type = "ml.t2.medium"
+		initial_variant_weight = 1
+	}
+}
+
+resource "aws_sagemaker_model" "foo" {
+	name = "terraform-testacc-sagemaker-model-foo"
+	execution_role_arn = "${aws_iam_role.foo.arn}"
+
+
+	primary_container {
+		image = "174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"
+	}
+}
+
+resource "aws_iam_role" "foo" {
+  name = "terraform-testacc-sagemaker-model-foo"
+  path = "/"
+  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    actions = [ "sts:AssumeRole" ]
+    principals {
+      type = "Service"
+      identifiers = [ "sagemaker.amazonaws.com" ]
+    }
+  }
+}
+`
+
+const testAccSagemakerEndpointConfigKmsKeyIdConfig = `
+resource "aws_sagemaker_endpoint_configuration" "foo" {
+	name = "terraform-testacc-sagemaker-endpoint-config-foo"
+	kms_key_id = "${aws_kms_key.foo.arn}"
+
+	production_variants {
+		variant_name = "variant-1"
+		model_name = "${aws_sagemaker_model.foo.name}"
+		initial_instance_count = 1
+		instance_type = "ml.t2.medium"
+		initial_variant_weight = 1
+	}
+}
+
+resource "aws_sagemaker_model" "foo" {
+	name = "terraform-testacc-sagemaker-model-foo"
+	execution_role_arn = "${aws_iam_role.foo.arn}"
+
+
+	primary_container {
+		image = "174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"
+	}
+}
+
+resource "aws_iam_role" "foo" {
+  name = "terraform-testacc-sagemaker-model-foo"
+  path = "/"
+  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    actions = [ "sts:AssumeRole" ]
+    principals {
+      type = "Service"
+      identifiers = [ "sagemaker.amazonaws.com" ]
+    }
+  }
+}
+
+resource "aws_kms_key" "foo" {
+  description             = "terraform-testacc-sagemaker-model-foo"
+  deletion_window_in_days = 10
+}
+`
+
+const testAccSagemakerEndpointConfigConfigTags = `
+resource "aws_sagemaker_endpoint_configuration" "foo" {
+	name = "terraform-testacc-sagemaker-endpoint-config-foo"
+
+	production_variants {
+		variant_name = "variant-1"
+		model_name = "${aws_sagemaker_model.foo.name}"
+		initial_instance_count = 1
+		instance_type = "ml.t2.medium"
+		initial_variant_weight = 1
+	}
+
+	tags {
+		foo = "bar"
+	}
+}
+
+resource "aws_sagemaker_model" "foo" {
+	name = "terraform-testacc-sagemaker-model-foo"
+	execution_role_arn = "${aws_iam_role.foo.arn}"
+
+
+	primary_container {
+		image = "174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"
+	}
+}
+
+resource "aws_iam_role" "foo" {
+  name = "terraform-testacc-sagemaker-model-foo"
+  path = "/"
+  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    actions = [ "sts:AssumeRole" ]
+    principals {
+      type = "Service"
+      identifiers = [ "sagemaker.amazonaws.com" ]
+    }
+  }
+}
+`
+
+const testAccSagemakerEndpointConfigConfigTagsUpdate = `
+resource "aws_sagemaker_endpoint_configuration" "foo" {
+	name = "terraform-testacc-sagemaker-endpoint-config-foo"
+
+	production_variants {
+		variant_name = "variant-1"
+		model_name = "${aws_sagemaker_model.foo.name}"
+		initial_instance_count = 1
+		instance_type = "ml.t2.medium"
+		initial_variant_weight = 1
+	}
+
+	tags {
+		bar = "baz"
+	}
+}
+
+resource "aws_sagemaker_model" "foo" {
+	name = "terraform-testacc-sagemaker-model-foo"
+	execution_role_arn = "${aws_iam_role.foo.arn}"
+
+	primary_container {
+		image = "174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"
+	}
+}
+
+resource "aws_iam_role" "foo" {
+  name = "terraform-testacc-sagemaker-model-foo"
+  path = "/"
+  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    actions = [ "sts:AssumeRole" ]
+    principals {
+      type = "Service"
+      identifiers = [ "sagemaker.amazonaws.com" ]
+    }
+  }
+}
+`

--- a/aws/resource_aws_sagemaker_endpoint_configuration_test.go
+++ b/aws/resource_aws_sagemaker_endpoint_configuration_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform/helper/acctest"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/sagemaker"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -20,11 +19,11 @@ func init() {
 		Dependencies: []string{
 			"aws_sagemaker_model",
 		},
-		F: testSweepSagemakerEndpointConfigs,
+		F: testSweepSagemakerEndpointConfigurations,
 	})
 }
 
-func testSweepSagemakerEndpointConfigs(region string) error {
+func testSweepSagemakerEndpointConfigurations(region string) error {
 	client, err := sharedClientForRegion(region)
 	if err != nil {
 		return fmt.Errorf("error getting client: %s", err)
@@ -58,48 +57,30 @@ func testSweepSagemakerEndpointConfigs(region string) error {
 	return nil
 }
 
-func TestAccAWSSagemakerEndpointConfig_basic(t *testing.T) {
-	rName := acctest.RandString(10)
+func TestAccAWSSagemakerEndpointConfiguration_Basic(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_sagemaker_endpoint_configuration.foo"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSagemakerEndpointConfigDestroy,
+		CheckDestroy: testAccCheckSagemakerEndpointConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSagemakerEndpointConfigConfig(rName),
+				Config: testAccSagemakerEndpointConfigurationConfig_Basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSagemakerEndpointConfigExists("aws_sagemaker_endpoint_configuration.foo"),
-					resource.TestCheckResourceAttr(
-						"aws_sagemaker_endpoint_configuration.foo", "name",
-						fmt.Sprintf("terraform-testacc-sagemaker-endpoint-config-%s", rName)),
-					resource.TestCheckResourceAttr(
-						"aws_sagemaker_endpoint_configuration.foo",
-						"production_variants.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_sagemaker_endpoint_configuration.foo",
-						"production_variants.0.variant_name",
-						"variant-1"),
-					resource.TestCheckResourceAttr(
-						"aws_sagemaker_endpoint_configuration.foo",
-						"production_variants.0.model_name",
-						fmt.Sprintf("terraform-testacc-sagemaker-model-%s", rName)),
-					resource.TestCheckResourceAttr(
-						"aws_sagemaker_endpoint_configuration.foo",
-						"production_variants.0.initial_instance_count",
-						"2"),
-					resource.TestCheckResourceAttr(
-						"aws_sagemaker_endpoint_configuration.foo",
-						"production_variants.0.instance_type",
-						"ml.t2.medium"),
-					resource.TestCheckResourceAttr(
-						"aws_sagemaker_endpoint_configuration.foo",
-						"production_variants.0.initial_variant_weight",
-						"1"),
+					testAccCheckSagemakerEndpointConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "production_variants.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "production_variants.0.variant_name", "variant-1"),
+					resource.TestCheckResourceAttr(resourceName, "production_variants.0.model_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "production_variants.0.initial_instance_count", "2"),
+					resource.TestCheckResourceAttr(resourceName, "production_variants.0.instance_type", "ml.t2.medium"),
+					resource.TestCheckResourceAttr(resourceName, "production_variants.0.initial_variant_weight", "1"),
 				),
 			},
 			{
-				ResourceName:      "aws_sagemaker_endpoint_configuration.foo",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -107,26 +88,25 @@ func TestAccAWSSagemakerEndpointConfig_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSSagemakerEndpointConfig_productionVariants_initialVariantWeight(t *testing.T) {
-	rName := acctest.RandString(10)
+func TestAccAWSSagemakerEndpointConfiguration_ProductionVariants_InitialVariantWeight(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_sagemaker_endpoint_configuration.foo"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSagemakerEndpointConfigDestroy,
+		CheckDestroy: testAccCheckSagemakerEndpointConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSagemakerEndpointConfigProductionVariantInitialVariantWeightConfig(rName),
+				Config: testAccSagemakerEndpointConfigurationConfig_ProductionVariants_InitialVariantWeight(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSagemakerEndpointConfigExists("aws_sagemaker_endpoint_configuration.foo"),
+					testAccCheckSagemakerEndpointConfigurationExists(resourceName),
 					resource.TestCheckResourceAttr(
-						"aws_sagemaker_endpoint_configuration.foo",
-						"production_variants.1.initial_variant_weight",
-						"0.5"),
+						resourceName, "production_variants.1.initial_variant_weight", "0.5"),
 				),
 			},
 			{
-				ResourceName:      "aws_sagemaker_endpoint_configuration.foo",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -134,26 +114,24 @@ func TestAccAWSSagemakerEndpointConfig_productionVariants_initialVariantWeight(t
 	})
 }
 
-func TestAccAWSSagemakerEndpointConfig_productionVariants_acceleratorType(t *testing.T) {
-	rName := acctest.RandString(10)
+func TestAccAWSSagemakerEndpointConfiguration_ProductionVariants_AcceleratorType(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_sagemaker_endpoint_configuration.foo"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSagemakerEndpointConfigDestroy,
+		CheckDestroy: testAccCheckSagemakerEndpointConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSagemakerEndpointConfigProductionVariantAcceleratorTypeConfig(rName),
+				Config: testAccSagemakerEndpointConfigurationConfig_ProductionVariant_AcceleratorType(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSagemakerEndpointConfigExists("aws_sagemaker_endpoint_configuration.foo"),
-					resource.TestCheckResourceAttr(
-						"aws_sagemaker_endpoint_configuration.foo",
-						"production_variants.0.accelerator_type",
-						"ml.eia1.medium"),
+					testAccCheckSagemakerEndpointConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "production_variants.0.accelerator_type", "ml.eia1.medium"),
 				),
 			},
 			{
-				ResourceName:      "aws_sagemaker_endpoint_configuration.foo",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -161,23 +139,24 @@ func TestAccAWSSagemakerEndpointConfig_productionVariants_acceleratorType(t *tes
 	})
 }
 
-func TestAccAWSSagemakerEndpointConfig_kmsKeyId(t *testing.T) {
-	rName := acctest.RandString(10)
+func TestAccAWSSagemakerEndpointConfiguration_KmsKeyId(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_sagemaker_endpoint_configuration.foo"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSagemakerEndpointConfigDestroy,
+		CheckDestroy: testAccCheckSagemakerEndpointConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSagemakerEndpointConfigKmsKeyIdConfig(rName),
+				Config: testAccSagemakerEndpointConfiguration_Config_KmsKeyId(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSagemakerEndpointConfigExists("aws_sagemaker_endpoint_configuration.foo"),
-					resource.TestCheckResourceAttrSet("aws_sagemaker_endpoint_configuration.foo", "kms_key_id"),
+					testAccCheckSagemakerEndpointConfigurationExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "kms_key_arn"),
 				),
 			},
 			{
-				ResourceName:      "aws_sagemaker_endpoint_configuration.foo",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -185,36 +164,33 @@ func TestAccAWSSagemakerEndpointConfig_kmsKeyId(t *testing.T) {
 	})
 }
 
-func TestAccAWSSagemakerEndpointConfig_tags(t *testing.T) {
-	rName := acctest.RandString(10)
+func TestAccAWSSagemakerEndpointConfiguration_Tags(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_sagemaker_endpoint_configuration.foo"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSagemakerEndpointConfigDestroy,
+		CheckDestroy: testAccCheckSagemakerEndpointConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSagemakerEndpointConfigConfigTags(rName),
+				Config: testAccSagemakerEndpointConfigurationConfig_Tags(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSagemakerEndpointConfigExists("aws_sagemaker_endpoint_configuration.foo"),
-					resource.TestCheckResourceAttr("aws_sagemaker_endpoint_configuration.foo",
-						"tags.%", "1"),
-					resource.TestCheckResourceAttr("aws_sagemaker_endpoint_configuration.foo",
-						"tags.foo", "bar"),
+					testAccCheckSagemakerEndpointConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 				),
 			},
 			{
-				Config: testAccSagemakerEndpointConfigTagsUpdateConfig(rName),
+				Config: testAccSagemakerEndpointConfigurationConfig_Tags_Update(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSagemakerEndpointConfigExists("aws_sagemaker_endpoint_configuration.foo"),
-					resource.TestCheckResourceAttr("aws_sagemaker_endpoint_configuration.foo",
-						"tags.%", "1"),
-					resource.TestCheckResourceAttr("aws_sagemaker_endpoint_configuration.foo",
-						"tags.bar", "baz"),
+					testAccCheckSagemakerEndpointConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.bar", "baz"),
 				),
 			},
 			{
-				ResourceName:      "aws_sagemaker_endpoint_configuration.foo",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -222,7 +198,7 @@ func TestAccAWSSagemakerEndpointConfig_tags(t *testing.T) {
 	})
 }
 
-func testAccCheckSagemakerEndpointConfigDestroy(s *terraform.State) error {
+func testAccCheckSagemakerEndpointConfigurationDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).sagemakerconn
 
 	for _, rs := range s.RootModule().Resources {
@@ -230,30 +206,27 @@ func testAccCheckSagemakerEndpointConfigDestroy(s *terraform.State) error {
 			continue
 		}
 
-		resp, err := conn.ListEndpointConfigs(&sagemaker.ListEndpointConfigsInput{
-			NameContains: aws.String(rs.Primary.ID),
-		})
-		if err == nil {
-			if len(resp.EndpointConfigs) > 0 {
-				return fmt.Errorf("SageMaker endpoint configs still exists")
-			}
-
-			return nil
+		input := &sagemaker.DescribeEndpointConfigInput{
+			EndpointConfigName: aws.String(rs.Primary.ID),
 		}
 
-		sagemakerErr, ok := err.(awserr.Error)
-		if !ok {
+		_, err := conn.DescribeEndpointConfig(input)
+
+		if isAWSErr(err, "ValidationException", "") {
+			continue
+		}
+
+		if err != nil {
 			return err
 		}
-		if sagemakerErr.Code() != "ResourceNotFound" {
-			return err
-		}
+
+		return fmt.Errorf("SageMaker Endpoint Configuration (%s) still exists", rs.Primary.ID)
 	}
 
 	return nil
 }
 
-func testAccCheckSagemakerEndpointConfigExists(n string) resource.TestCheckFunc {
+func testAccCheckSagemakerEndpointConfigurationExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -277,22 +250,10 @@ func testAccCheckSagemakerEndpointConfigExists(n string) resource.TestCheckFunc 
 	}
 }
 
-func testAccSagemakerEndpointConfigConfig(rName string) string {
+func testAccSagemakerEndpointConfig_Base(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_sagemaker_endpoint_configuration" "foo" {
-	name = "terraform-testacc-sagemaker-endpoint-config-%s"
-
-	production_variants {
-		variant_name = "variant-1"
-		model_name = "${aws_sagemaker_model.foo.name}"
-		initial_instance_count = 2
-		instance_type = "ml.t2.medium"
-		initial_variant_weight = 1
-	}
-}
-
 resource "aws_sagemaker_model" "foo" {
-	name = "terraform-testacc-sagemaker-model-%s"
+	name = %q
 	execution_role_arn = "${aws_iam_role.foo.arn}"
 
 
@@ -302,7 +263,7 @@ resource "aws_sagemaker_model" "foo" {
 }
 
 resource "aws_iam_role" "foo" {
-  name = "terraform-testacc-sagemaker-model-%s"
+  name = %q
   path = "/"
   assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
 }
@@ -316,13 +277,29 @@ data "aws_iam_policy_document" "assume_role" {
     }
   }
 }
-`, rName, rName, rName)
+`, rName, rName)
 }
 
-func testAccSagemakerEndpointConfigProductionVariantInitialVariantWeightConfig(rName string) string {
-	return fmt.Sprintf(`
+func testAccSagemakerEndpointConfigurationConfig_Basic(rName string) string {
+	return testAccSagemakerEndpointConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_endpoint_configuration" "foo" {
-	name = "terraform-testacc-sagemaker-endpoint-config-%s"
+	name = %q
+
+	production_variants {
+		variant_name = "variant-1"
+		model_name = "${aws_sagemaker_model.foo.name}"
+		initial_instance_count = 2
+		instance_type = "ml.t2.medium"
+		initial_variant_weight = 1
+	}
+}
+`, rName)
+}
+
+func testAccSagemakerEndpointConfigurationConfig_ProductionVariants_InitialVariantWeight(rName string) string {
+	return testAccSagemakerEndpointConfig_Base(rName) + fmt.Sprintf(`
+resource "aws_sagemaker_endpoint_configuration" "foo" {
+	name = %q
 
 	production_variants {
 		variant_name = "variant-1"
@@ -339,39 +316,13 @@ resource "aws_sagemaker_endpoint_configuration" "foo" {
 		initial_variant_weight = 0.5
 	}
 }
-
-resource "aws_sagemaker_model" "foo" {
-	name = "terraform-testacc-sagemaker-model-%s"
-	execution_role_arn = "${aws_iam_role.foo.arn}"
-
-
-	primary_container {
-		image = "174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"
-	}
+`, rName)
 }
 
-resource "aws_iam_role" "foo" {
-  name = "terraform-testacc-sagemaker-model-%s"
-  path = "/"
-  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
-}
-
-data "aws_iam_policy_document" "assume_role" {
-  statement {
-    actions = [ "sts:AssumeRole" ]
-    principals {
-      type = "Service"
-      identifiers = [ "sagemaker.amazonaws.com" ]
-    }
-  }
-}
-`, rName, rName, rName)
-}
-
-func testAccSagemakerEndpointConfigProductionVariantAcceleratorTypeConfig(rName string) string {
-	return fmt.Sprintf(`
+func testAccSagemakerEndpointConfigurationConfig_ProductionVariant_AcceleratorType(rName string) string {
+	return testAccSagemakerEndpointConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_endpoint_configuration" "foo" {
-	name = "terraform-testacc-sagemaker-endpoint-config-%s"
+	name = %q
 
 	production_variants {
 		variant_name = "variant-1"
@@ -382,40 +333,14 @@ resource "aws_sagemaker_endpoint_configuration" "foo" {
 		initial_variant_weight = 1
 	}
 }
-
-resource "aws_sagemaker_model" "foo" {
-	name = "terraform-testacc-sagemaker-model-%s"
-	execution_role_arn = "${aws_iam_role.foo.arn}"
-
-
-	primary_container {
-		image = "174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"
-	}
+`, rName)
 }
 
-resource "aws_iam_role" "foo" {
-  name = "terraform-testacc-sagemaker-model-%s"
-  path = "/"
-  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
-}
-
-data "aws_iam_policy_document" "assume_role" {
-  statement {
-    actions = [ "sts:AssumeRole" ]
-    principals {
-      type = "Service"
-      identifiers = [ "sagemaker.amazonaws.com" ]
-    }
-  }
-}
-`, rName, rName, rName)
-}
-
-func testAccSagemakerEndpointConfigKmsKeyIdConfig(rName string) string {
-	return fmt.Sprintf(`
+func testAccSagemakerEndpointConfiguration_Config_KmsKeyId(rName string) string {
+	return testAccSagemakerEndpointConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_endpoint_configuration" "foo" {
-	name = "terraform-testacc-sagemaker-endpoint-config-%s"
-	kms_key_id = "${aws_kms_key.foo.arn}"
+	name = %q
+	kms_key_arn = "${aws_kms_key.foo.arn}"
 
 	production_variants {
 		variant_name = "variant-1"
@@ -426,43 +351,17 @@ resource "aws_sagemaker_endpoint_configuration" "foo" {
 	}
 }
 
-resource "aws_sagemaker_model" "foo" {
-	name = "terraform-testacc-sagemaker-model-%s"
-	execution_role_arn = "${aws_iam_role.foo.arn}"
-
-
-	primary_container {
-		image = "174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"
-	}
-}
-
-resource "aws_iam_role" "foo" {
-  name = "terraform-testacc-sagemaker-model-%s"
-  path = "/"
-  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
-}
-
-data "aws_iam_policy_document" "assume_role" {
-  statement {
-    actions = [ "sts:AssumeRole" ]
-    principals {
-      type = "Service"
-      identifiers = [ "sagemaker.amazonaws.com" ]
-    }
-  }
-}
-
 resource "aws_kms_key" "foo" {
-  description             = "terraform-testacc-sagemaker-model-%s"
+  description             = %q
   deletion_window_in_days = 10
 }
-`, rName, rName, rName, rName)
+`, rName, rName)
 }
 
-func testAccSagemakerEndpointConfigConfigTags(rName string) string {
-	return fmt.Sprintf(`
+func testAccSagemakerEndpointConfigurationConfig_Tags(rName string) string {
+	return testAccSagemakerEndpointConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_endpoint_configuration" "foo" {
-	name = "terraform-testacc-sagemaker-endpoint-config-%s"
+	name = %q
 
 	production_variants {
 		variant_name = "variant-1"
@@ -476,39 +375,13 @@ resource "aws_sagemaker_endpoint_configuration" "foo" {
 		foo = "bar"
 	}
 }
-
-resource "aws_sagemaker_model" "foo" {
-	name = "terraform-testacc-sagemaker-model-%s"
-	execution_role_arn = "${aws_iam_role.foo.arn}"
-
-
-	primary_container {
-		image = "174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"
-	}
+`, rName)
 }
 
-resource "aws_iam_role" "foo" {
-  name = "terraform-testacc-sagemaker-model-%s"
-  path = "/"
-  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
-}
-
-data "aws_iam_policy_document" "assume_role" {
-  statement {
-    actions = [ "sts:AssumeRole" ]
-    principals {
-      type = "Service"
-      identifiers = [ "sagemaker.amazonaws.com" ]
-    }
-  }
-}
-`, rName, rName, rName)
-}
-
-func testAccSagemakerEndpointConfigTagsUpdateConfig(rName string) string {
-	return fmt.Sprintf(`
+func testAccSagemakerEndpointConfigurationConfig_Tags_Update(rName string) string {
+	return testAccSagemakerEndpointConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_endpoint_configuration" "foo" {
-	name = "terraform-testacc-sagemaker-endpoint-config-%s"
+	name = %q
 
 	production_variants {
 		variant_name = "variant-1"
@@ -522,30 +395,5 @@ resource "aws_sagemaker_endpoint_configuration" "foo" {
 		bar = "baz"
 	}
 }
-
-resource "aws_sagemaker_model" "foo" {
-	name = "terraform-testacc-sagemaker-model-%s"
-	execution_role_arn = "${aws_iam_role.foo.arn}"
-
-	primary_container {
-		image = "174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"
-	}
-}
-
-resource "aws_iam_role" "foo" {
-  name = "terraform-testacc-sagemaker-model-%s"
-  path = "/"
-  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
-}
-
-data "aws_iam_policy_document" "assume_role" {
-  statement {
-    actions = [ "sts:AssumeRole" ]
-    principals {
-      type = "Service"
-      identifiers = [ "sagemaker.amazonaws.com" ]
-    }
-  }
-}
-`, rName, rName, rName)
+`, rName)
 }

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -40,6 +40,25 @@ func validateAny(validators ...schema.SchemaValidateFunc) schema.SchemaValidateF
 	}
 }
 
+// FloatAtLeast returns a SchemaValidateFunc which tests if the provided value
+// is of type float and is at least min (inclusive)
+func FloatAtLeast(min float64) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(float64)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be float", k))
+			return
+		}
+
+		if v < min {
+			es = append(es, fmt.Errorf("expected %s to be at least (%f), got %f", k, min, v))
+			return
+		}
+
+		return
+	}
+}
+
 // validateTypeStringNullableBoolean provides custom error messaging for TypeString booleans
 // Some arguments require three values: true, false, and "" (unspecified).
 // This ValidateFunc returns a custom message since the message with

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -2272,6 +2272,10 @@
                     <a href="#">Sagemaker Resources</a>
                     <ul class="nav nav-visible">
 
+                        <li<%= sidebar_current("docs-aws-resource-sagemaker-endpoint-configuration") %>>
+                          <a href="/docs/providers/aws/r/sagemaker_endpoint_configuration.html">aws_sagemaker_endpoint_configuration</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-aws-resource-sagemaker-model") %>>
                           <a href="/docs/providers/aws/r/sagemaker_model.html">aws_sagemaker_model</a>
                         </li>

--- a/website/docs/r/sagemaker_endpoint_configuration.html.markdown
+++ b/website/docs/r/sagemaker_endpoint_configuration.html.markdown
@@ -1,0 +1,67 @@
+---
+layout: "aws"
+page_title: "AWS: sagemaker_endpoint"
+sidebar_current: "docs-aws-resource-sagemaker-endpoint-configuration"
+description: |-
+  Provides a Sagemaker endpoint configuration resource.
+---
+
+# aws\_sagemaker\_endpoint\_configuration
+
+Provides a Sagemaker endpoint configuration resource.
+
+## Example Usage
+
+
+Basic usage:
+
+```hcl
+resource "aws_sagemaker_endpoint_configuration" "ec" {
+    name = "my-endpoint-config"
+
+    production_variant {
+        variant_name            = "variant-1"
+        model_name              = "my-model"
+        initial_instance_count  = 1
+        instance_type           = ""
+        initial_variant_weight  = 1
+    }
+
+    tags {
+        Name = "foo"
+    }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Optional) The name of the endpoint configuration. If omitted, Terraform will assign a random, unique name.
+* `production_variants` - (Required) Fields are documented below.
+* `kms_key_id` - (Optional) KMS key to encrypt the model data.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
+The `production_variant` block supports:
+
+* `variant_name` - (Optional) The name of the variant. If omitted, Terraform will assign a random, unique name.
+* `model_name` - (Required) The name of the model to use.
+* `initial_instance_count` - (Required) Initial number of instances used for auto-scaling.
+* `instance_type` (Required) - The type of instance to start.
+* `initial_variant_weight` - (Required)
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `name` - The name of the endpoint configuration.
+* `arn` - The Amazon Resource Name (ARN) assigned by AWS to this endpoint configuration.
+* `creation_time` - The creation timestamp of this endpoint configuration.
+
+## Import
+
+Endpoint configurations can be imported using the `name`, e.g.
+
+```
+$ terraform import aws_sagemaker_endpoint_configuration.test_endpoint_config endpoint-config-foo
+```

--- a/website/docs/r/sagemaker_endpoint_configuration.html.markdown
+++ b/website/docs/r/sagemaker_endpoint_configuration.html.markdown
@@ -1,14 +1,14 @@
 ---
 layout: "aws"
-page_title: "AWS: sagemaker_endpoint"
+page_title: "AWS: aws_sagemaker_endpoint_configuration"
 sidebar_current: "docs-aws-resource-sagemaker-endpoint-configuration"
 description: |-
-  Provides a Sagemaker endpoint configuration resource.
+  Provides a SageMaker endpoint configuration resource.
 ---
 
-# aws\_sagemaker\_endpoint\_configuration
+# aws_sagemaker_endpoint_configuration
 
-Provides a Sagemaker endpoint configuration resource.
+Provides a SageMaker endpoint configuration resource.
 
 ## Example Usage
 
@@ -21,10 +21,9 @@ resource "aws_sagemaker_endpoint_configuration" "ec" {
 
     production_variant {
         variant_name            = "variant-1"
-        model_name              = "my-model"
+        model_name              = "${aws_sagemaker_model.m.name}"
         initial_instance_count  = 1
-        instance_type           = ""
-        initial_variant_weight  = 1
+        instance_type           = "ml.t2.medium"
     }
 
     tags {
@@ -48,15 +47,14 @@ The `production_variant` block supports:
 * `model_name` - (Required) The name of the model to use.
 * `initial_instance_count` - (Required) Initial number of instances used for auto-scaling.
 * `instance_type` (Required) - The type of instance to start.
-* `initial_variant_weight` - (Required)
-
+* `initial_variant_weight` (Optional) - Determines initial traffic distribution among all of the models that you specify in the endpoint configuration. If unspecified, it defaults to 1.0.
+* `accelerator_type` (Optional) - The size of the Elastic Inference (EI) instance to use for the production variant.
 ## Attributes Reference
 
 The following attributes are exported:
 
 * `name` - The name of the endpoint configuration.
 * `arn` - The Amazon Resource Name (ARN) assigned by AWS to this endpoint configuration.
-* `creation_time` - The creation timestamp of this endpoint configuration.
 
 ## Import
 

--- a/website/docs/r/sagemaker_endpoint_configuration.html.markdown
+++ b/website/docs/r/sagemaker_endpoint_configuration.html.markdown
@@ -3,7 +3,7 @@ layout: "aws"
 page_title: "AWS: aws_sagemaker_endpoint_configuration"
 sidebar_current: "docs-aws-resource-sagemaker-endpoint-configuration"
 description: |-
-  Provides a SageMaker endpoint configuration resource.
+  Provides a SageMaker Endpoint Configuration resource.
 ---
 
 # aws_sagemaker_endpoint_configuration
@@ -36,25 +36,25 @@ resource "aws_sagemaker_endpoint_configuration" "ec" {
 
 The following arguments are supported:
 
-* `name` - (Optional) The name of the endpoint configuration. If omitted, Terraform will assign a random, unique name.
 * `production_variants` - (Required) Fields are documented below.
-* `kms_key_id` - (Optional) KMS key to encrypt the model data.
+* `kms_key_arn` - (Optional) Amazon Resource Name (ARN) of a AWS Key Management Service key that Amazon SageMaker uses to encrypt data on the storage volume attached to the ML compute instance that hosts the endpoint.
+* `name` - (Optional) The name of the endpoint configuration. If omitted, Terraform will assign a random, unique name.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 The `production_variant` block supports:
 
-* `variant_name` - (Optional) The name of the variant. If omitted, Terraform will assign a random, unique name.
-* `model_name` - (Required) The name of the model to use.
 * `initial_instance_count` - (Required) Initial number of instances used for auto-scaling.
 * `instance_type` (Required) - The type of instance to start.
-* `initial_variant_weight` (Optional) - Determines initial traffic distribution among all of the models that you specify in the endpoint configuration. If unspecified, it defaults to 1.0.
 * `accelerator_type` (Optional) - The size of the Elastic Inference (EI) instance to use for the production variant.
+* `initial_variant_weight` (Optional) - Determines initial traffic distribution among all of the models that you specify in the endpoint configuration. If unspecified, it defaults to 1.0.
+* `model_name` - (Required) The name of the model to use.
+* `variant_name` - (Optional) The name of the variant. If omitted, Terraform will assign a random, unique name.
 ## Attributes Reference
 
 The following attributes are exported:
 
-* `name` - The name of the endpoint configuration.
 * `arn` - The Amazon Resource Name (ARN) assigned by AWS to this endpoint configuration.
+* `name` - The name of the endpoint configuration.
 
 ## Import
 


### PR DESCRIPTION
***Please only review the [last commit](https://github.com/terraform-providers/terraform-provider-aws/pull/2477/commits/f74eae4af2b0ec8983cb49248c2712df59921bb4). The reason is that this PR depends and is rebased on https://github.com/terraform-providers/terraform-provider-aws/pull/2478, as the tests need the resource `aws_sagemaker_endpoint_configuration` to work.***

Add the resource `aws_sagemaker_endpoint_configuration` for the newly announced service called [SageMaker](https://aws.amazon.com/blogs/aws/sagemaker/):

* Documentation/Website 
* Schema
* Implementation of CRUD operations
* Acceptance tests

### Acceptance tests

```
╰─$ make testacc TESTARGS='-run=TestAccAWSSagemakerEndpointConfig_*'                                                                     2 ↵
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSSagemakerEndpointConfig_* -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSSagemakerEndpointConfig_basic
--- PASS: TestAccAWSSagemakerEndpointConfig_basic (72.46s)
=== RUN   TestAccAWSSagemakerEndpointConfig_kmsKeyId
--- PASS: TestAccAWSSagemakerEndpointConfig_kmsKeyId (97.70s)
=== RUN   TestAccAWSSagemakerEndpointConfig_tags
--- PASS: TestAccAWSSagemakerEndpointConfig_tags (109.41s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	279.620s
```

### Updates

* *14th Feb 2018:* Support new parameter `kms_key_id`