### PR TITLE
New Resource: aws_sagemaker_model

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -127,7 +127,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/worklink"
 	"github.com/aws/aws-sdk-go/service/workspaces"
 	"github.com/davecgh/go-spew/spew"
-	"github.com/hashicorp/go-cleanhttp"
+	cleanhttp "github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/terraform/helper/logging"
 	"github.com/hashicorp/terraform/terraform"
 )

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -613,6 +613,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_route_table":                                  resourceAwsRouteTable(),
 			"aws_default_route_table":                          resourceAwsDefaultRouteTable(),
 			"aws_route_table_association":                      resourceAwsRouteTableAssociation(),
+			"aws_sagemaker_model":                              resourceAwsSagemakerModel(),
 			"aws_secretsmanager_secret":                        resourceAwsSecretsManagerSecret(),
 			"aws_secretsmanager_secret_version":                resourceAwsSecretsManagerSecretVersion(),
 			"aws_ses_active_receipt_rule_set":                  resourceAwsSesActiveReceiptRuleSet(),

--- a/aws/resource_aws_sagemaker_model.go
+++ b/aws/resource_aws_sagemaker_model.go
@@ -73,6 +73,27 @@ func resourceAwsSagemakerModel() *schema.Resource {
 				},
 			},
 
+			"vpc_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"subnets": {
+							Type:     schema.TypeSet,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"security_group_ids": {
+							Type:     schema.TypeSet,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+
 			"execution_role_arn": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -110,6 +131,11 @@ func resourceAwsSagemakerModelCreate(d *schema.ResourceData, meta interface{}) e
 		createOpts.Tags = tagsFromMapSagemaker(v.(map[string]interface{}))
 	}
 
+	if v, ok := d.GetOk("vpc_config"); ok {
+		vpcConfig := expandSageMakerVpcConfigRequest(v.([]interface{}))
+		createOpts.SetVpcConfig(vpcConfig)
+	}
+
 	log.Printf("[DEBUG] Sagemaker model create config: %#v", *createOpts)
 	_, err := retryOnAwsCode("ValidationException", func() (interface{}, error) {
 		return conn.CreateModel(createOpts)
@@ -120,6 +146,19 @@ func resourceAwsSagemakerModelCreate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	return resourceAwsSagemakerModelRead(d, meta)
+}
+
+func expandSageMakerVpcConfigRequest(l []interface{}) *sagemaker.VpcConfig {
+	if len(l) == 0 {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	return &sagemaker.VpcConfig{
+		SecurityGroupIds: expandStringSet(m["security_group_ids"].(*schema.Set)),
+		Subnets:          expandStringSet(m["subnets"].(*schema.Set)),
+	}
 }
 
 func resourceAwsSagemakerModelRead(d *schema.ResourceData, meta interface{}) error {
@@ -151,6 +190,9 @@ func resourceAwsSagemakerModelRead(d *schema.ResourceData, meta interface{}) err
 	if err := d.Set("primary_container", flattenPrimaryContainer(model.PrimaryContainer)); err != nil {
 		return err
 	}
+	if err := d.Set("vpc_config", flattenSageMakerVpcConfigResponse(model.VpcConfig)); err != nil {
+		return fmt.Errorf("error setting vpc_config: %s", err)
+	}
 
 	tagsOutput, err := conn.ListTags(&sagemaker.ListTagsInput{
 		ResourceArn: model.ModelArn,
@@ -159,6 +201,19 @@ func resourceAwsSagemakerModelRead(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 	return nil
+}
+
+func flattenSageMakerVpcConfigResponse(vpcConfig *sagemaker.VpcConfig) []map[string]interface{} {
+	if vpcConfig == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"security_group_ids": schema.NewSet(schema.HashString, flattenStringList(vpcConfig.SecurityGroupIds)),
+		"subnets":            schema.NewSet(schema.HashString, flattenStringList(vpcConfig.Subnets)),
+	}
+
+	return []map[string]interface{}{m}
 }
 
 func resourceAwsSagemakerModelUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_sagemaker_model.go
+++ b/aws/resource_aws_sagemaker_model.go
@@ -1,0 +1,259 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"log"
+	"time"
+)
+
+func resourceAwsSagemakerModel() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsSagemakerModelCreate,
+		Read:   resourceAwsSagemakerModelRead,
+		Update: resourceAwsSagemakerModelUpdate,
+		Delete: resourceAwsSagemakerModelDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validateSagemakerName,
+			},
+
+			"primary_container": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"container_hostname": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+
+						"image": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+
+						"model_data_url": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+
+						"environment": {
+							Type:     schema.TypeMap,
+							Optional: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
+
+			"execution_role_arn": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"creation_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceAwsSagemakerModelCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+
+	var name string
+	if v, ok := d.GetOk("name"); ok {
+		name = v.(string)
+	} else {
+		name = resource.UniqueId()
+	}
+
+	createOpts := &sagemaker.CreateModelInput{
+		ModelName: aws.String(name),
+	}
+
+	pContainer := d.Get("primary_container").([]interface{})
+	if len(pContainer) > 1 {
+		return fmt.Errorf("Only a single primary_container block is expected")
+	} else if len(pContainer) == 1 {
+		m := pContainer[0].(map[string]interface{})
+		createOpts.PrimaryContainer = expandPrimaryContainers(m)
+	}
+
+	if v, ok := d.GetOk("execution_role_arn"); ok {
+		createOpts.ExecutionRoleArn = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("tags"); ok {
+		createOpts.Tags = tagsFromMapSagemaker(v.(map[string]interface{}))
+	}
+
+	log.Printf("[DEBUG] Sagemaker model create config: %#v", *createOpts)
+	modelResponse, err := retryOnAwsCode("ValidationException", func() (interface{}, error) {
+		return conn.CreateModel(createOpts)
+	})
+	model := modelResponse.(*sagemaker.CreateModelOutput)
+
+	if err != nil {
+		return fmt.Errorf("Error creating Sagemaker model: %s", err)
+	}
+
+	d.SetId(name)
+	if err := d.Set("arn", model.ModelArn); err != nil {
+		return err
+	}
+
+	return resourceAwsSagemakerModelUpdate(d, meta)
+}
+
+func resourceAwsSagemakerModelRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+
+	request := &sagemaker.DescribeModelInput{
+		ModelName: aws.String(d.Id()),
+	}
+
+	model, err := conn.DescribeModel(request)
+	if err != nil {
+		if sagemakerErr, ok := err.(awserr.Error); ok && sagemakerErr.Code() == "ResourceNotFound" {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error reading Sagemaker model %s: %s", d.Id(), err)
+	}
+
+	if err := d.Set("arn", model.ModelArn); err != nil {
+		return err
+	}
+	if err := d.Set("name", model.ModelName); err != nil {
+		return err
+	}
+	if err := d.Set("execution_role_arn", model.ExecutionRoleArn); err != nil {
+		return err
+	}
+	if err := d.Set("primary_container", flattenPrimaryContainer(model.PrimaryContainer)); err != nil {
+		return err
+	}
+	if err := d.Set("creation_time", model.CreationTime.Format(time.RFC3339)); err != nil {
+		return err
+	}
+
+	tagsOutput, err := conn.ListTags(&sagemaker.ListTagsInput{
+		ResourceArn: model.ModelArn,
+	})
+	d.Set("tags", tagsToMapSagemaker(tagsOutput.Tags))
+
+	return nil
+}
+
+func resourceAwsSagemakerModelUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+
+	d.Partial(true)
+
+	if err := setSagemakerTags(conn, d); err != nil {
+		return err
+	} else {
+		d.SetPartial("tags")
+	}
+
+	d.Partial(false)
+
+	return resourceAwsSagemakerModelRead(d, meta)
+}
+
+func resourceAwsSagemakerModelDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+
+	deleteOpts := &sagemaker.DeleteModelInput{
+		ModelName: aws.String(d.Id()),
+	}
+	log.Printf("[INFO] Deleting Sagemaker model: %s", d.Id())
+
+	return resource.Retry(5*time.Minute, func() *resource.RetryError {
+		_, err := conn.DeleteModel(deleteOpts)
+		if err == nil {
+			return nil
+		}
+
+		sagemakerErr, ok := err.(awserr.Error)
+		if !ok {
+			return resource.NonRetryableError(err)
+		}
+
+		if sagemakerErr.Code() == "ResourceNotFound" {
+			return resource.RetryableError(err)
+		}
+
+		return resource.NonRetryableError(fmt.Errorf("Error deleting Sagemaker model: %s", err))
+	})
+}
+
+func expandPrimaryContainers(m map[string]interface{}) *sagemaker.ContainerDefinition {
+	container := sagemaker.ContainerDefinition{
+		Image: aws.String(m["image"].(string)),
+	}
+
+	if v, ok := m["container_hostname"]; ok && v.(string) != "" {
+		container.ContainerHostname = aws.String(v.(string))
+	}
+	if v, ok := m["model_data_url"]; ok && v.(string) != "" {
+		container.ModelDataUrl = aws.String(v.(string))
+	}
+	if v, ok := m["environment"]; ok {
+		container.Environment = stringMapToPointers(v.(map[string]interface{}))
+	}
+
+	return &container
+}
+
+func flattenPrimaryContainer(container *sagemaker.ContainerDefinition) []interface{} {
+	cfg := make(map[string]interface{}, 0)
+
+	cfg["image"] = *container.Image
+
+	if container.ContainerHostname != nil {
+		cfg["container_hostname"] = *container.ContainerHostname
+	}
+	if container.ModelDataUrl != nil {
+		cfg["model_data_url"] = *container.ModelDataUrl
+	}
+	if container.Environment != nil {
+		cfg["environment"] = flattenEnvironment(container.Environment)
+	}
+
+	return []interface{}{cfg}
+}
+
+func flattenEnvironment(env map[string]*string) map[string]string {
+	m := map[string]string{}
+	for k, v := range env {
+		m[k] = *v
+	}
+	return m
+}

--- a/aws/resource_aws_sagemaker_model.go
+++ b/aws/resource_aws_sagemaker_model.go
@@ -357,7 +357,7 @@ func flattenContainer(container *sagemaker.ContainerDefinition) []interface{} {
 		return []interface{}{}
 	}
 
-	cfg := make(map[string]interface{}, 0)
+	cfg := make(map[string]interface{})
 
 	cfg["image"] = *container.Image
 

--- a/aws/resource_aws_sagemaker_model_test.go
+++ b/aws/resource_aws_sagemaker_model_test.go
@@ -1,0 +1,576 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"log"
+	reflect "reflect"
+	"strings"
+	"testing"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_sagemaker_model", &resource.Sweeper{
+		Name: "aws_sagemaker_model",
+		F:    testSweepSagemakerModels,
+	})
+}
+
+func testSweepSagemakerModels(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).sagemakerconn
+
+	req := &sagemaker.ListModelsInput{
+		NameContains: aws.String("terraform-testacc-sagemaker-model"),
+	}
+	resp, err := conn.ListModels(req)
+	if err != nil {
+		return fmt.Errorf("Error listing models: %s", err)
+	}
+
+	if len(resp.Models) == 0 {
+		log.Print("[DEBUG] No sagemaker models to sweep")
+		return nil
+	}
+
+	for _, model := range resp.Models {
+		_, err := conn.DeleteModel(&sagemaker.DeleteModelInput{
+			ModelName: model.ModelName,
+		})
+		if err != nil {
+			return fmt.Errorf(
+				"Error deleting sagemaker model (%s): %s",
+				*model.ModelName, err)
+		}
+	}
+
+	return nil
+}
+
+func TestAccAWSSagemakerModel_basic(t *testing.T) {
+	var model sagemaker.DescribeModelOutput
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSagemakerModelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSagemakerModelConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSagemakerModelExists("aws_sagemaker_model.foo", &model),
+					testAccCheckSagemakerModelName(&model, "terraform-testacc-sagemaker-model-foo"),
+					testAccCheckSagemakerModelExecutionRoleArn(&model, "terraform-testacc-sagemaker-model-foo"),
+					testAccCheckSagemakerModelPrimaryContainerImage(&model,
+						"174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"),
+
+					resource.TestCheckResourceAttr(
+						"aws_sagemaker_model.foo", "name", "terraform-testacc-sagemaker-model-foo"),
+					resource.TestCheckResourceAttr("aws_sagemaker_model.foo", "primary_container.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_sagemaker_model.foo", "primary_container.0.image",
+						"174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"),
+					resource.TestCheckResourceAttrSet("aws_sagemaker_model.foo", "execution_role_arn"),
+					resource.TestCheckResourceAttrSet("aws_sagemaker_model.foo", "arn"),
+					resource.TestCheckResourceAttrSet("aws_sagemaker_model.foo", "creation_time"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSagemakerModel_tags(t *testing.T) {
+	var model sagemaker.DescribeModelOutput
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSagemakerModelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSagemakerModelConfigTags,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSagemakerModelExists("aws_sagemaker_model.foo", &model),
+					testAccCheckSagemakerTags(&model, "foo", "bar"),
+
+					resource.TestCheckResourceAttr(
+						"aws_sagemaker_model.foo", "name", "terraform-testacc-sagemaker-model-foo"),
+					resource.TestCheckResourceAttr("aws_sagemaker_model.foo", "tags.%", "1"),
+					resource.TestCheckResourceAttr("aws_sagemaker_model.foo", "tags.foo", "bar"),
+				),
+			},
+
+			{
+				Config: testAccSagemakerModelConfigTagsUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSagemakerModelExists("aws_sagemaker_model.foo", &model),
+					testAccCheckSagemakerTags(&model, "foo", ""),
+					testAccCheckSagemakerTags(&model, "bar", "baz"),
+
+					resource.TestCheckResourceAttr("aws_sagemaker_model.foo", "tags.%", "1"),
+					resource.TestCheckResourceAttr("aws_sagemaker_model.foo", "tags.bar", "baz"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSagemakerModel_primaryContainerModelDataUrl(t *testing.T) {
+	var model sagemaker.DescribeModelOutput
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSagemakerModelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSagemakerPrimaryContainerModelDataUrlConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSagemakerModelExists("aws_sagemaker_model.foo", &model),
+					testAccCheckSagemakerModelPrimaryContainerModelDataUrl(&model,
+						"https://s3-us-west-2.amazonaws.com/terraform-testacc-sagemaker-model-data-bucket/model.tar.gz"),
+
+					resource.TestCheckResourceAttr("aws_sagemaker_model.foo",
+						"primary_container.0.model_data_url",
+						"https://s3-us-west-2.amazonaws.com/terraform-testacc-sagemaker-model-data-bucket/model.tar.gz"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSagemakerModel_primaryContainerHostname(t *testing.T) {
+	var model sagemaker.DescribeModelOutput
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSagemakerModelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSagemakerPrimaryContainerHostnameConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSagemakerModelExists("aws_sagemaker_model.foo", &model),
+					testAccCheckSagemakerModelPrimaryContainerHostname(&model, "primary-hostname-foo"),
+
+					resource.TestCheckResourceAttr("aws_sagemaker_model.foo",
+						"primary_container.0.container_hostname", "primary-hostname-foo"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSagemakerModel_primaryContainerEnvironment(t *testing.T) {
+	var model sagemaker.DescribeModelOutput
+	environment := map[string]*string{
+		"foo": aws.String("bar"),
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSagemakerModelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSagemakerPrimaryContainerEnvironmentConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSagemakerModelExists("aws_sagemaker_model.foo", &model),
+					testAccCheckSagemakerModelPrimaryContainerEnvironment(&model, environment),
+
+					resource.TestCheckResourceAttr("aws_sagemaker_model.foo",
+						"primary_container.0.environment.%", "1"),
+					resource.TestCheckResourceAttr("aws_sagemaker_model.foo",
+						"primary_container.0.environment.foo", "bar"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckSagemakerModelDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).sagemakerconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_sagemaker_model" {
+			continue
+		}
+
+		resp, err := conn.ListModels(&sagemaker.ListModelsInput{
+			NameContains: aws.String(rs.Primary.ID),
+		})
+		if err == nil {
+			if len(resp.Models) > 0 {
+				return fmt.Errorf("Sagemaker models still exist.")
+			}
+
+			return nil
+		}
+
+		sagemakerErr, ok := err.(awserr.Error)
+		if !ok {
+			return err
+		}
+		if sagemakerErr.Code() != "ResourceNotFound" {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckSagemakerModelExists(n string, model *sagemaker.DescribeModelOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No sagmaker model ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).sagemakerconn
+		DescribeModelOpts := &sagemaker.DescribeModelInput{
+			ModelName: aws.String(rs.Primary.ID),
+		}
+		resp, err := conn.DescribeModel(DescribeModelOpts)
+		if err != nil {
+			return err
+		}
+
+		*model = *resp
+		return nil
+	}
+}
+
+func testAccCheckSagemakerModelName(model *sagemaker.DescribeModelOutput, expected string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		name := model.ModelName
+		if *name != expected {
+			return fmt.Errorf("Bad sagemaker model name: %s", *name)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckSagemakerModelPrimaryContainerImage(model *sagemaker.DescribeModelOutput, expected string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		image := model.PrimaryContainer.Image
+		if *image != expected {
+			return fmt.Errorf("Bad image of primary container: %s", *image)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckSagemakerTags(model *sagemaker.DescribeModelOutput, key string, value string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).sagemakerconn
+
+		ts, err := conn.ListTags(&sagemaker.ListTagsInput{
+			ResourceArn: model.ModelArn,
+		})
+		if err != nil {
+			return fmt.Errorf("Error listing tags: %s", err)
+		}
+
+		m := tagsToMapSagemaker(ts.Tags)
+		v, ok := m[key]
+		if value != "" && !ok {
+			return fmt.Errorf("Missing tag: %s", key)
+		} else if value == "" && ok {
+			return fmt.Errorf("Extra tag: %s", key)
+		}
+		if value == "" {
+			return nil
+		}
+
+		if v != value {
+			return fmt.Errorf("%s: bad value: %s", key, v)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckSagemakerModelExecutionRoleArn(model *sagemaker.DescribeModelOutput, expected string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		arn := model.ExecutionRoleArn
+		if !strings.HasSuffix(*arn, expected) {
+			return fmt.Errorf("Bad execution role arn: %s", *arn)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckSagemakerModelPrimaryContainerModelDataUrl(model *sagemaker.DescribeModelOutput, expected string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		modelDataUrl := model.PrimaryContainer.ModelDataUrl
+		if *modelDataUrl != expected {
+			return fmt.Errorf("Bad model data url of primary container: %s", *modelDataUrl)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckSagemakerModelPrimaryContainerHostname(model *sagemaker.DescribeModelOutput, expected string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		hostname := model.PrimaryContainer.ContainerHostname
+		if *hostname != expected {
+			return fmt.Errorf("Bad container hostname of primary container: %s", *hostname)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckSagemakerModelPrimaryContainerEnvironment(model *sagemaker.DescribeModelOutput, expected map[string]*string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		environment := model.PrimaryContainer.Environment
+
+		if !reflect.DeepEqual(environment, expected) {
+			return fmt.Errorf("Bad environment of primary container.")
+		}
+
+		return nil
+	}
+}
+
+const testAccSagemakerModelConfig = `
+resource "aws_sagemaker_model" "foo" {
+	name = "terraform-testacc-sagemaker-model-foo"
+	execution_role_arn = "${aws_iam_role.foo.arn}"
+
+	primary_container {
+		image = "174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"
+	}
+}
+
+resource "aws_iam_role" "foo" {
+  name = "terraform-testacc-sagemaker-model-foo"
+  path = "/"
+  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    actions = [ "sts:AssumeRole" ]
+    principals {
+      type = "Service"
+      identifiers = [ "sagemaker.amazonaws.com" ]
+    }
+  }
+}
+`
+
+const testAccSagemakerModelConfigTags = `
+resource "aws_sagemaker_model" "foo" {
+	name = "terraform-testacc-sagemaker-model-foo"
+	execution_role_arn = "${aws_iam_role.foo.arn}"
+
+	primary_container {
+		image = "174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"
+	}
+
+	tags {
+		foo = "bar"
+	}
+}
+
+resource "aws_iam_role" "foo" {
+  name = "terraform-testacc-sagemaker-model-foo"
+  path = "/"
+  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    actions = [ "sts:AssumeRole" ]
+    principals {
+      type = "Service"
+      identifiers = [ "sagemaker.amazonaws.com" ]
+    }
+  }
+}
+`
+
+const testAccSagemakerModelConfigTagsUpdate = `
+resource "aws_sagemaker_model" "foo" {
+	name = "terraform-testacc-sagemaker-model-foo"
+	execution_role_arn = "${aws_iam_role.foo.arn}"
+
+	primary_container {
+		image = "174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"
+	}
+
+	tags {
+		bar = "baz"
+	}
+}
+
+resource "aws_iam_role" "foo" {
+  name = "terraform-testacc-sagemaker-model-foo"
+  path = "/"
+  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    actions = [ "sts:AssumeRole" ]
+    principals {
+      type = "Service"
+      identifiers = [ "sagemaker.amazonaws.com" ]
+    }
+  }
+}
+`
+
+const testAccSagemakerPrimaryContainerModelDataUrlConfig = `
+resource "aws_sagemaker_model" "foo" {
+	name = "terraform-testacc-sagemaker-model-foo"
+	execution_role_arn = "${aws_iam_role.foo.arn}"
+
+	primary_container {
+		image = "174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"
+		model_data_url = "https://s3-us-west-2.amazonaws.com/${aws_s3_bucket.foo.bucket}/model.tar.gz"
+	}
+}
+
+resource "aws_iam_role" "foo" {
+  name = "terraform-testacc-sagemaker-model-foo"
+  path = "/"
+  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    actions = [ "sts:AssumeRole" ]
+    principals {
+      type = "Service"
+      identifiers = [ "sagemaker.amazonaws.com" ]
+    }
+  }
+}
+
+resource "aws_iam_policy" "foo" {
+  name = "terraform-testacc-sagemaker-model-foo"
+  description = "Allow Sagemaker to create model"
+  policy = "${data.aws_iam_policy_document.foo.json}"
+}
+
+data "aws_iam_policy_document" "foo" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "cloudwatch:PutMetricData",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:CreateLogGroup",
+      "logs:DescribeLogStreams",
+      "ecr:GetAuthorizationToken",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage"
+    ]
+    resources = [
+      "*"]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetObject"
+    ]
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.foo.bucket}",
+      "arn:aws:s3:::${aws_s3_bucket.foo.bucket}/*"
+    ]
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "foo" {
+  role = "${aws_iam_role.foo.name}"
+  policy_arn = "${aws_iam_policy.foo.arn}"
+}
+
+resource "aws_s3_bucket" "foo" {
+  bucket = "terraform-testacc-sagemaker-model-data-bucket"
+  acl    = "private"
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_object" "object" {
+  bucket = "${aws_s3_bucket.foo.bucket}"
+  key    = "model.tar.gz"
+  content = "some-data"
+}
+`
+
+const testAccSagemakerPrimaryContainerHostnameConfig = `
+resource "aws_sagemaker_model" "foo" {
+	name = "terraform-testacc-sagemaker-model-foo"
+	execution_role_arn = "${aws_iam_role.foo.arn}"
+
+	primary_container {
+		image = "174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"
+		container_hostname = "primary-hostname-foo"
+	}
+}
+
+resource "aws_iam_role" "foo" {
+  name = "terraform-testacc-sagemaker-model-foo"
+  path = "/"
+  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    actions = [ "sts:AssumeRole" ]
+    principals {
+      type = "Service"
+      identifiers = [ "sagemaker.amazonaws.com" ]
+    }
+  }
+}
+`
+
+const testAccSagemakerPrimaryContainerEnvironmentConfig = `
+resource "aws_sagemaker_model" "foo" {
+	name = "terraform-testacc-sagemaker-model-foo"
+	execution_role_arn = "${aws_iam_role.foo.arn}"
+
+	primary_container {
+		image = "174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"
+		environment {
+			foo = "bar"
+		}
+	}
+}
+
+resource "aws_iam_role" "foo" {
+  name = "terraform-testacc-sagemaker-model-foo"
+  path = "/"
+  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    actions = [ "sts:AssumeRole" ]
+    principals {
+      type = "Service"
+      identifiers = [ "sagemaker.amazonaws.com" ]
+    }
+  }
+}
+`

--- a/aws/resource_aws_sagemaker_model_test.go
+++ b/aws/resource_aws_sagemaker_model_test.go
@@ -13,6 +13,10 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+const (
+	image = "174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"
+)
+
 func init() {
 	resource.AddTestSweepers("aws_sagemaker_model", &resource.Sweeper{
 		Name: "aws_sagemaker_model",
@@ -32,7 +36,7 @@ func testSweepSagemakerModels(region string) error {
 	}
 	resp, err := conn.ListModels(req)
 	if err != nil {
-		return fmt.Errorf("Error listing models: %s", err)
+		return fmt.Errorf("error listing models: %s", err)
 	}
 
 	if len(resp.Models) == 0 {
@@ -46,7 +50,7 @@ func testSweepSagemakerModels(region string) error {
 		})
 		if err != nil {
 			return fmt.Errorf(
-				"Error deleting sagemaker model (%s): %s",
+				"error deleting sagemaker model (%s): %s",
 				*model.ModelName, err)
 		}
 	}
@@ -54,31 +58,8 @@ func testSweepSagemakerModels(region string) error {
 	return nil
 }
 
-func TestAccAWSSagemakerModel_importBasic(t *testing.T) {
-	rName := acctest.RandString(10)
-	image := "174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSagemakerModelDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccSagemakerModelConfig(rName, image),
-			},
-
-			{
-				ResourceName:      "aws_sagemaker_model.foo",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccAWSSagemakerModel_basic(t *testing.T) {
 	rName := acctest.RandString(10)
-	image := "174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -89,7 +70,6 @@ func TestAccAWSSagemakerModel_basic(t *testing.T) {
 				Config: testAccSagemakerModelConfig(rName, image),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSagemakerModelExists("aws_sagemaker_model.foo"),
-
 					resource.TestCheckResourceAttr(
 						"aws_sagemaker_model.foo", "name",
 						fmt.Sprintf("terraform-testacc-sagemaker-model-%s", rName)),
@@ -99,6 +79,11 @@ func TestAccAWSSagemakerModel_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("aws_sagemaker_model.foo", "execution_role_arn"),
 					resource.TestCheckResourceAttrSet("aws_sagemaker_model.foo", "arn"),
 				),
+			},
+			{
+				ResourceName:      "aws_sagemaker_model.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -113,7 +98,7 @@ func TestAccAWSSagemakerModel_tags(t *testing.T) {
 		CheckDestroy: testAccCheckSagemakerModelDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSagemakerModelConfigTags(rName),
+				Config: testAccSagemakerModelConfigTags(rName, image),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSagemakerModelExists("aws_sagemaker_model.foo"),
 					resource.TestCheckResourceAttr("aws_sagemaker_model.foo", "tags.%", "1"),
@@ -121,12 +106,17 @@ func TestAccAWSSagemakerModel_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSagemakerModelConfigTagsUpdate(rName),
+				Config: testAccSagemakerModelConfigTagsUpdate(rName, image),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSagemakerModelExists("aws_sagemaker_model.foo"),
 					resource.TestCheckResourceAttr("aws_sagemaker_model.foo", "tags.%", "1"),
 					resource.TestCheckResourceAttr("aws_sagemaker_model.foo", "tags.bar", "baz"),
 				),
+			},
+			{
+				ResourceName:      "aws_sagemaker_model.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -142,12 +132,17 @@ func TestAccAWSSagemakerModel_primaryContainerModelDataUrl(t *testing.T) {
 		CheckDestroy: testAccCheckSagemakerModelDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSagemakerPrimaryContainerModelDataUrlConfig(rName, modelDataUrl),
+				Config: testAccSagemakerPrimaryContainerModelDataUrlConfig(rName, image, modelDataUrl),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSagemakerModelExists("aws_sagemaker_model.foo"),
 					resource.TestCheckResourceAttr("aws_sagemaker_model.foo",
 						"primary_container.0.model_data_url", modelDataUrl),
 				),
+			},
+			{
+				ResourceName:      "aws_sagemaker_model.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -162,12 +157,17 @@ func TestAccAWSSagemakerModel_primaryContainerHostname(t *testing.T) {
 		CheckDestroy: testAccCheckSagemakerModelDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSagemakerPrimaryContainerHostnameConfig(rName),
+				Config: testAccSagemakerPrimaryContainerHostnameConfig(rName, image),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSagemakerModelExists("aws_sagemaker_model.foo"),
 					resource.TestCheckResourceAttr("aws_sagemaker_model.foo",
 						"primary_container.0.container_hostname", "foo"),
 				),
+			},
+			{
+				ResourceName:      "aws_sagemaker_model.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -182,7 +182,7 @@ func TestAccAWSSagemakerModel_primaryContainerEnvironment(t *testing.T) {
 		CheckDestroy: testAccCheckSagemakerModelDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSagemakerPrimaryContainerEnvironmentConfig(rName),
+				Config: testAccSagemakerPrimaryContainerEnvironmentConfig(rName, image),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSagemakerModelExists("aws_sagemaker_model.foo"),
 					resource.TestCheckResourceAttr("aws_sagemaker_model.foo",
@@ -191,13 +191,17 @@ func TestAccAWSSagemakerModel_primaryContainerEnvironment(t *testing.T) {
 						"primary_container.0.environment.foo", "bar"),
 				),
 			},
+			{
+				ResourceName:      "aws_sagemaker_model.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
 
 func TestAccAWSSagemakerModel_containers(t *testing.T) {
 	rName := acctest.RandString(10)
-	image := "174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -215,6 +219,11 @@ func TestAccAWSSagemakerModel_containers(t *testing.T) {
 						"aws_sagemaker_model.foo", "container.1.image", image),
 				),
 			},
+			{
+				ResourceName:      "aws_sagemaker_model.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -228,13 +237,18 @@ func TestAccAWSSagemakerModel_vpcConfig(t *testing.T) {
 		CheckDestroy: testAccCheckSagemakerModelDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSagemakerModelVpcConfig(rName),
+				Config: testAccSagemakerModelVpcConfig(rName, image),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSagemakerModelExists("aws_sagemaker_model.foo"),
 					resource.TestCheckResourceAttr("aws_sagemaker_model.foo", "vpc_config.#", "1"),
 					resource.TestCheckResourceAttr("aws_sagemaker_model.foo", "vpc_config.0.subnets.#", "2"),
 					resource.TestCheckResourceAttr("aws_sagemaker_model.foo", "vpc_config.0.security_group_ids.#", "2"),
 				),
+			},
+			{
+				ResourceName:      "aws_sagemaker_model.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -249,13 +263,17 @@ func TestAccAWSSagemakerModel_networkIsolation(t *testing.T) {
 		CheckDestroy: testAccCheckSagemakerModelDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSagemakerModelNetworkIsolation(rName),
+				Config: testAccSagemakerModelNetworkIsolation(rName, image),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSagemakerModelExists("aws_sagemaker_model.foo"),
-
 					resource.TestCheckResourceAttr(
 						"aws_sagemaker_model.foo", "enable_network_isolation", "true"),
 				),
+			},
+			{
+				ResourceName:      "aws_sagemaker_model.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -345,14 +363,14 @@ data "aws_iam_policy_document" "assume_role" {
 `, rName, image, rName)
 }
 
-func testAccSagemakerModelConfigTags(rName string) string {
+func testAccSagemakerModelConfigTags(rName string, image string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_model" "foo" {
 	name = "terraform-testacc-sagemaker-model-%s"
 	execution_role_arn = "${aws_iam_role.foo.arn}"
 
 	primary_container {
-		image = "174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"
+		image = "%s"
 	}
 
 	tags {
@@ -375,17 +393,17 @@ data "aws_iam_policy_document" "assume_role" {
     }
   }
 }
-`, rName, rName)
+`, rName, image, rName)
 }
 
-func testAccSagemakerModelConfigTagsUpdate(rName string) string {
+func testAccSagemakerModelConfigTagsUpdate(rName string, image string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_model" "foo" {
 	name = "terraform-testacc-sagemaker-model-%s"
 	execution_role_arn = "${aws_iam_role.foo.arn}"
 
 	primary_container {
-		image = "174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"
+		image = "%s"
 	}
 
 	tags {
@@ -408,17 +426,17 @@ data "aws_iam_policy_document" "assume_role" {
     }
   }
 }
-`, rName, rName)
+`, rName, image, rName)
 }
 
-func testAccSagemakerPrimaryContainerModelDataUrlConfig(rName string, modelDataUrl string) string {
+func testAccSagemakerPrimaryContainerModelDataUrlConfig(rName string, image string, modelDataUrl string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_model" "foo" {
 	name = "terraform-testacc-sagemaker-model-%s"
 	execution_role_arn = "${aws_iam_role.foo.arn}"
 
 	primary_container {
-		image = "174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"
+		image = "%s"
 		model_data_url = "%s"
 	}
 }
@@ -490,17 +508,17 @@ resource "aws_s3_bucket_object" "object" {
   key    = "model.tar.gz"
   content = "some-data"
 }
-`, rName, modelDataUrl, rName, rName, rName)
+`, rName, image, modelDataUrl, rName, rName, rName)
 }
 
-func testAccSagemakerPrimaryContainerHostnameConfig(rName string) string {
+func testAccSagemakerPrimaryContainerHostnameConfig(rName string, image string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_model" "foo" {
 	name = "terraform-testacc-sagemaker-model-%s"
 	execution_role_arn = "${aws_iam_role.foo.arn}"
 
 	primary_container {
-		image = "174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"
+		image = "%s"
 		container_hostname = "foo"
 	}
 }
@@ -520,17 +538,18 @@ data "aws_iam_policy_document" "assume_role" {
     }
   }
 }
-`, rName, rName)
+`, rName, image, rName)
 }
 
-func testAccSagemakerPrimaryContainerEnvironmentConfig(rName string) string {
+func testAccSagemakerPrimaryContainerEnvironmentConfig(rName string, image string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_model" "foo" {
 	name = "terraform-testacc-sagemaker-model-%s"
 	execution_role_arn = "${aws_iam_role.foo.arn}"
 
 	primary_container {
-		image = "174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"
+		image = "%s"
+
 		environment {
 			foo = "bar"
 		}
@@ -552,7 +571,7 @@ data "aws_iam_policy_document" "assume_role" {
     }
   }
 }
-`, rName, rName)
+`, rName, image, rName)
 }
 
 func testAccSagemakerModelContainers(rName string, image string) string {
@@ -588,7 +607,7 @@ data "aws_iam_policy_document" "assume_role" {
 `, rName, image, image, rName)
 }
 
-func testAccSagemakerModelNetworkIsolation(rName string) string {
+func testAccSagemakerModelNetworkIsolation(rName string, image string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_model" "foo" {
 	name = "terraform-testacc-sagemaker-model-%s"
@@ -596,7 +615,7 @@ resource "aws_sagemaker_model" "foo" {
 	enable_network_isolation = true
 
     primary_container {
-		image = "174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"
+		image = "%s"
 	}
 }
 
@@ -615,10 +634,10 @@ data "aws_iam_policy_document" "assume_role" {
     }
   }
 }
-`, rName, rName)
+`, rName, image, rName)
 }
 
-func testAccSagemakerModelVpcConfig(rName string) string {
+func testAccSagemakerModelVpcConfig(rName string, image string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_model" "foo" {
 	name = "terraform-testacc-sagemaker-model-%s"
@@ -626,7 +645,7 @@ resource "aws_sagemaker_model" "foo" {
 	enable_network_isolation = true
 
     primary_container {
-		image = "174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"
+		image = "%s"
 	}
 
     vpc_config {
@@ -686,5 +705,5 @@ resource "aws_security_group" "bar" {
 	name 	= "terraform-testacc-sagemaker-model-bar-%s"
 	vpc_id 	= "${aws_vpc.foo.id}"
 }
-`, rName, rName, rName, rName, rName, rName, rName)
+`, rName, image, rName, rName, rName, rName, rName, rName)
 }

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -401,19 +401,25 @@ func validateSagemakerName(v interface{}, k string) (ws []string, errors []error
 }
 
 func validateSagemakerEnvironment(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if !regexp.MustCompile(`^[0-9A-Za-z_]+$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"only alphanumeric characters and underscore allowed in %q: %q",
-			k, value))
-	}
-	if len(value) > 1024 {
-		errors = append(errors, fmt.Errorf(
-			"%q cannot be longer than 1024 characters: %q", k, value))
-	}
-	if regexp.MustCompile(`^[0-9]`).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"%q cannot begin with a digit: %q", k, value))
+	value := v.(map[string]interface{})
+	for envK, envV := range value {
+		if !regexp.MustCompile(`^[0-9A-Za-z_]+$`).MatchString(envK) {
+			errors = append(errors, fmt.Errorf(
+				"only alphanumeric characters and underscore allowed in %q: %q",
+				k, envK))
+		}
+		if len(envK) > 1024 {
+			errors = append(errors, fmt.Errorf(
+				"%q cannot be longer than 1024 characters: %q", k, envK))
+		}
+		if len(envV.(string)) > 1024 {
+			errors = append(errors, fmt.Errorf(
+				"%q cannot be longer than 1024 characters: %q", k, envV.(string)))
+		}
+		if regexp.MustCompile(`^[0-9]`).MatchString(envK) {
+			errors = append(errors, fmt.Errorf(
+				"%q cannot begin with a digit: %q", k, envK))
+		}
 	}
 	return
 }
@@ -443,32 +449,10 @@ func validateSagemakerModelDataUrl(v interface{}, k string) (ws []string, errors
 		errors = append(errors, fmt.Errorf(
 			"%q cannot be longer than 1024 characters: %q", k, value))
 	}
-	if regexp.MustCompile(`^(https|s3)://`).MatchString(value) {
+	if !regexp.MustCompile(`^(https|s3)://`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
 			"%q must be a path that starts with either s3 or https: %q", k, value))
 	}
-	return
-}
-
-func validateEcrRepositoryName(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if len(value) < 2 {
-		errors = append(errors, fmt.Errorf(
-			"%q must be at least 2 characters long: %q", k, value))
-	}
-	if len(value) > 256 {
-		errors = append(errors, fmt.Errorf(
-			"%q cannot be longer than 256 characters: %q", k, value))
-	}
-
-	// http://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_CreateRepository.html
-	pattern := `^(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*$`
-	if !regexp.MustCompile(pattern).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"%q doesn't comply with restrictions (%q): %q",
-			k, pattern, value))
-	}
-
 	return
 }
 

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -400,6 +400,56 @@ func validateSagemakerName(v interface{}, k string) (ws []string, errors []error
 	return
 }
 
+func validateSagemakerEnvironment(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^[0-9A-Za-z_]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only alphanumeric characters and underscore allowed in %q: %q",
+			k, value))
+	}
+	if len(value) > 1024 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be longer than 1024 characters: %q", k, value))
+	}
+	if regexp.MustCompile(`^[0-9]`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot begin with a digit: %q", k, value))
+	}
+	return
+}
+
+func validateSagemakerImage(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`[\S]+`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"no whitespace allowed in %q: %q",
+			k, value))
+	}
+	if len(value) > 255 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be longer than 255 characters: %q", k, value))
+	}
+	return
+}
+
+func validateSagemakerModelDataUrl(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^(https|s3)://([^/]+)/?(.*)$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q must be a valid path: %q",
+			k, value))
+	}
+	if len(value) > 1024 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be longer than 1024 characters: %q", k, value))
+	}
+	if regexp.MustCompile(`^(https|s3)://`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q must be a path that starts with either s3 or https: %q", k, value))
+	}
+	return
+}
+
 func validateEcrRepositoryName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if len(value) < 2 {

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -382,6 +382,46 @@ func validateElbNamePrefix(v interface{}, k string) (ws []string, errors []error
 	return
 }
 
+func validateSagemakerName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^[0-9A-Za-z-]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only alphanumeric characters and hyphens allowed in %q: %q",
+			k, value))
+	}
+	if len(value) > 63 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be longer than 63 characters: %q", k, value))
+	}
+	if regexp.MustCompile(`^-`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot begin with a hyphen: %q", k, value))
+	}
+	return
+}
+
+func validateEcrRepositoryName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if len(value) < 2 {
+		errors = append(errors, fmt.Errorf(
+			"%q must be at least 2 characters long: %q", k, value))
+	}
+	if len(value) > 256 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be longer than 256 characters: %q", k, value))
+	}
+
+	// http://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_CreateRepository.html
+	pattern := `^(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*$`
+	if !regexp.MustCompile(pattern).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q doesn't comply with restrictions (%q): %q",
+			k, pattern, value))
+	}
+
+	return
+}
+
 func validateCloudWatchDashboardName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if len(value) > 255 {

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -801,24 +801,6 @@ func validateS3BucketLifecycleTransitionStorageClass() schema.SchemaValidateFunc
 	}, false)
 }
 
-func validateSagemakerName(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if !regexp.MustCompile(`^[0-9A-Za-z-]+$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"only alphanumeric characters and hyphens allowed in %q: %q",
-			k, value))
-	}
-	if len(value) > 63 {
-		errors = append(errors, fmt.Errorf(
-			"%q cannot be longer than 63 characters: %q", k, value))
-	}
-	if regexp.MustCompile(`^-`).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"%q cannot begin with a hyphen: %q", k, value))
-	}
-	return
-}
-
 func validateDbEventSubscriptionName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if !regexp.MustCompile(`^[0-9A-Za-z-]+$`).MatchString(value) {

--- a/website/docs/r/sagemaker_model.html.markdown
+++ b/website/docs/r/sagemaker_model.html.markdown
@@ -31,6 +31,9 @@ The following arguments are supported:
 * `name` - (Optional) The name of the model (must be unique). If omitted, Terraform will assign a random, unique name.
 * `primary_container` - (Required) Fields are documented below.
 * `execution_role_arn` - (Optional) A role to with permissions that allows SageMaker to call other services on your behalf.
+* `containers` (Optional) -  Specifies additional containers in the inference pipeline.
+* `enable_network_isolation` (Optional) - Isolates the model container. No inbound or outbound network calls can be made to or from the model container.
+* `vpc_config` (Optional) - Specifies the VPC that you want your model to connect to. VpcConfig is used in hosting services and in batch transform.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 The `primary_container` block supports:
@@ -41,14 +44,12 @@ The `primary_container` block supports:
 * `environment` - (Optional) Environment variables for the Docker container.
    A list of key value pairs.
 
-
 ## Attributes Reference
 
 The following attributes are exported:
 
 * `name` - The name of the model.
 * `arn` - The Amazon Resource Name (ARN) assigned by AWS to this model.
-* `creation_time` - The creation timestamp of the model.
 
 ## Import
 

--- a/website/docs/r/sagemaker_model.html.markdown
+++ b/website/docs/r/sagemaker_model.html.markdown
@@ -24,39 +24,12 @@ resource "aws_sagemaker_model" "m" {
 }
 ```
 
-Usage with supplemental container and tags:
-
-```hcl
-resource "aws_sagemaker_model" "m" {
-    name = "my-model"
-
-    primary_container {
-        image = "111111111111.ecr.us-west-2.amazonaws.com/my-docker-image:latest"
-        model_data_url  = "s3://111111111111-foo/model.tar.gz"
-    }
-
-    supplemental_container {
-        image = "111111111111.ecr.us-west-2.amazonaws.com/my-other-docker-image:latest"
-        environment = [
-            KeyName1 = "value"
-            KeyName2 = "value"
-        ]
-    }
-
-    tags {
-        Name = "foo"
-    }
-}
-```
-
 ## Argument Reference
 
 The following arguments are supported:
 
 * `name` - (Optional) The name of the model (must be unique). If omitted, Terraform will assign a random, unique name.
 * `primary_container` - (Required) Fields are documented below.
-* `supplemental_container` - (Optional) Can be specified multiple times for each
-   additional docker container to use. Each supplemental block supports the same fields as the primary container.
 * `execution_role_arn` - (Optional) A role to with permissions that allows SageMaker to call other services on your behalf.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/sagemaker_model.html.markdown
+++ b/website/docs/r/sagemaker_model.html.markdown
@@ -1,0 +1,86 @@
+---
+layout: "aws"
+page_title: "AWS: sagemaker_model"
+sidebar_current: "docs-aws-resource-sagemaker-model"
+description: |-
+  Provides a Sagemaker model resource.
+---
+
+# aws\_sagemaker\_model
+
+Provides a Sagemaker model resource.
+
+## Example Usage
+
+Basic usage:
+
+```hcl
+resource "aws_sagemaker_model" "m" {
+    name = "my-model"
+
+    primary_container {
+        image = "111111111111.ecr.us-west-2.amazonaws.com/my-docker-image:latest"
+    }
+}
+```
+
+Usage with supplemental container and tags:
+
+```hcl
+resource "aws_sagemaker_model" "m" {
+    name = "my-model"
+
+    primary_container {
+        image = "111111111111.ecr.us-west-2.amazonaws.com/my-docker-image:latest"
+        model_data_url  = "s3://111111111111-foo/model.tar.gz"
+    }
+
+    supplemental_container {
+        image = "111111111111.ecr.us-west-2.amazonaws.com/my-other-docker-image:latest"
+        environment = [
+            KeyName1 = "value"
+            KeyName2 = "value"
+        ]
+    }
+
+    tags {
+        Name = "foo"
+    }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Optional) The name of the model (must be unique). If omitted, Terraform will assign a random, unique name.
+* `primary_container` - (Required) Fields are documented below.
+* `supplemental_container` - (Optional) Can be specified multiple times for each
+   additional docker container to use. Each supplemental block supports the same fields as the primary container.
+* `execution_role_arn` - (Optional) A role to with permissions that allows SageMaker to call other services on your behalf.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
+The `primary_container` block supports:
+
+* `image` - (Required) The registry path where the inference code image is stored in Amazon ECR.
+* `model_data_url` - (Optional) The URL for the S3 location where model artifacts are stored.
+* `container_hostname` - (Optional) The DNS host name for the container.
+* `environment` - (Optional) Environment variables for the Docker container.
+   A list of key value pairs.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `name` - The name of the model.
+* `arn` - The Amazon Resource Name (ARN) assigned by AWS to this model.
+* `creation_time` - The creation timestamp of the model.
+
+## Import
+
+Models can be imported using the `name`, e.g.
+
+```
+$ terraform import aws_sagemaker_model.test_model model-foo
+```

--- a/website/docs/r/sagemaker_model.html.markdown
+++ b/website/docs/r/sagemaker_model.html.markdown
@@ -3,12 +3,12 @@ layout: "aws"
 page_title: "AWS: sagemaker_model"
 sidebar_current: "docs-aws-resource-sagemaker-model"
 description: |-
-  Provides a Sagemaker model resource.
+  Provides a SageMaker model resource.
 ---
 
 # aws\_sagemaker\_model
 
-Provides a Sagemaker model resource.
+Provides a SageMaker model resource.
 
 ## Example Usage
 
@@ -17,10 +17,25 @@ Basic usage:
 ```hcl
 resource "aws_sagemaker_model" "m" {
     name = "my-model"
+    execution_role_arn = "${aws_iam_role.foo.arn}"
 
     primary_container {
-        image = "111111111111.ecr.us-west-2.amazonaws.com/my-docker-image:latest"
+        image = "174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"
     }
+}
+
+resource "aws_iam_role" "r" {
+  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    actions = [ "sts:AssumeRole" ]
+    principals {
+      type = "Service"
+      identifiers = [ "sagemaker.amazonaws.com" ]
+    }
+  }
 }
 ```
 
@@ -29,14 +44,14 @@ resource "aws_sagemaker_model" "m" {
 The following arguments are supported:
 
 * `name` - (Optional) The name of the model (must be unique). If omitted, Terraform will assign a random, unique name.
-* `primary_container` - (Required) Fields are documented below.
-* `execution_role_arn` - (Optional) A role to with permissions that allows SageMaker to call other services on your behalf.
-* `containers` (Optional) -  Specifies additional containers in the inference pipeline.
+* `primary_container` - (Optional) The primary docker image containing inference code that is used when the model is deployed for predictions.  If not specified, the `container` argument is required. Fields are documented below.
+* `execution_role_arn` - (Required) A role that SageMaker can assume to access model artifacts and docker images for deployment.
+* `container` (Optional) -  Specifies containers in the inference pipeline. If not specified, the `primary_container` argument is required. Fields are documented below.
 * `enable_network_isolation` (Optional) - Isolates the model container. No inbound or outbound network calls can be made to or from the model container.
 * `vpc_config` (Optional) - Specifies the VPC that you want your model to connect to. VpcConfig is used in hosting services and in batch transform.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
-The `primary_container` block supports:
+The `primary_container` and `container` block both support:
 
 * `image` - (Required) The registry path where the inference code image is stored in Amazon ECR.
 * `model_data_url` - (Optional) The URL for the S3 location where model artifacts are stored.


### PR DESCRIPTION
Add the resource `aws_sagemaker_model` for the newly announced service called [SageMaker](https://aws.amazon.com/blogs/aws/sagemaker/):

* documentation/website
* implementation of CRUD operations
* acceptance tests

### Acceptance tests

```
$ make testacc TESTARGS='-run=TestAccAWSSagemakerModel_*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSSagemakerModel_* -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSSagemakerModel_basic
--- PASS: TestAccAWSSagemakerModel_basic (65.17s)
=== RUN   TestAccAWSSagemakerModel_tags
--- PASS: TestAccAWSSagemakerModel_tags (101.68s)
=== RUN   TestAccAWSSagemakerModel_primaryContainerModelDataUrl
--- PASS: TestAccAWSSagemakerModel_primaryContainerModelDataUrl (113.42s)
=== RUN   TestAccAWSSagemakerModel_primaryContainerHostname
--- PASS: TestAccAWSSagemakerModel_primaryContainerHostname (63.63s)
=== RUN   TestAccAWSSagemakerModel_primaryContainerEnvironment
--- PASS: TestAccAWSSagemakerModel_primaryContainerEnvironment (64.25s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	408.175s
```

### Updates

* *24th Apr 2018:* Rebase on master branch