### PR TITLE
New Resource: aws_sagemaker_endpoint

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -620,6 +620,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_route_table_association":                      resourceAwsRouteTableAssociation(),
 			"aws_sagemaker_model":                              resourceAwsSagemakerModel(),
 			"aws_sagemaker_endpoint_configuration":             resourceAwsSagemakerEndpointConfiguration(),
+			"aws_sagemaker_endpoint":                           resourceAwsSagemakerEndpoint(),
 			"aws_secretsmanager_secret":                        resourceAwsSecretsManagerSecret(),
 			"aws_secretsmanager_secret_version":                resourceAwsSecretsManagerSecretVersion(),
 			"aws_ses_active_receipt_rule_set":                  resourceAwsSesActiveReceiptRuleSet(),

--- a/aws/resource_aws_sagemaker_endpoint.go
+++ b/aws/resource_aws_sagemaker_endpoint.go
@@ -103,6 +103,10 @@ func resourceAwsSagemakerEndpointRead(d *schema.ResourceData, meta interface{}) 
 
 	endpointRaw, _, err := SagemakerEndpointStateRefreshFunc(conn, d.Id())()
 	if err != nil {
+		if sagemakerErr, ok := err.(awserr.Error); ok && sagemakerErr.Code() == "ValidationException" {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	if endpointRaw == nil {

--- a/aws/resource_aws_sagemaker_endpoint.go
+++ b/aws/resource_aws_sagemaker_endpoint.go
@@ -1,0 +1,230 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"log"
+	"time"
+)
+
+func resourceAwsSagemakerEndpoint() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsSagemakerEndpointCreate,
+		Read:   resourceAwsSagemakerEndpointRead,
+		Update: resourceAwsSagemakerEndpointUpdate,
+		Delete: resourceAwsSagemakerEndpointDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validateSagemakerName,
+			},
+
+			"endpoint_config_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"creation_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"last_modified_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceAwsSagemakerEndpointCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+
+	var name string
+	if v, ok := d.GetOk("name"); ok {
+		name = v.(string)
+	} else {
+		name = resource.UniqueId()
+	}
+
+	createOpts := &sagemaker.CreateEndpointInput{
+		EndpointName:       aws.String(name),
+		EndpointConfigName: aws.String(d.Get("endpoint_config_name").(string)),
+	}
+
+	log.Printf("[DEBUG] SageMaker endpoint create config: %#v", *createOpts)
+	endpoint, err := conn.CreateEndpoint(createOpts)
+	if err != nil {
+		return fmt.Errorf("error creating SageMaker endpoint: %s", err)
+	}
+
+	d.SetId(name)
+	if err := d.Set("arn", endpoint.EndpointArn); err != nil {
+		return err
+	}
+	log.Printf("[INFO] SageMaker endpoint ID: %s", d.Id())
+
+	log.Printf("[DEBUG] Waiting for SageMaker endpoint (%s) to become available", d.Id())
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"Creating"},
+		Target:  []string{"InService"},
+		Refresh: SagemakerEndpointStateRefreshFunc(conn, d.Id()),
+		Timeout: 15 * time.Minute,
+	}
+	if _, err := stateConf.WaitForState(); err != nil {
+		return fmt.Errorf(
+			"error while waiting for SageMaker endpoint (%s) to become available: %s",
+			d.Id(), err)
+	}
+
+	return resourceAwsSagemakerEndpointUpdate(d, meta)
+}
+
+func resourceAwsSagemakerEndpointRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+
+	endpointRaw, _, err := SagemakerEndpointStateRefreshFunc(conn, d.Id())()
+	if err != nil {
+		return err
+	}
+	if endpointRaw == nil {
+		d.SetId("")
+		return nil
+	}
+
+	endpoint := endpointRaw.(*sagemaker.DescribeEndpointOutput)
+
+	if err := d.Set("name", endpoint.EndpointName); err != nil {
+		return err
+	}
+	if err := d.Set("endpoint_config_name", endpoint.EndpointConfigName); err != nil {
+		return err
+	}
+	if err := d.Set("creation_time", endpoint.CreationTime.Format(time.RFC3339)); err != nil {
+		return err
+	}
+	if err := d.Set("last_modified_time", endpoint.LastModifiedTime.Format(time.RFC3339)); err != nil {
+		return err
+	}
+	if err := d.Set("arn", endpoint.EndpointArn); err != nil {
+		return err
+	}
+
+	tagsOutput, err := conn.ListTags(&sagemaker.ListTagsInput{
+		ResourceArn: endpoint.EndpointArn,
+	})
+
+	d.Set("tags", tagsToMapSagemaker(tagsOutput.Tags))
+
+	return nil
+}
+
+func resourceAwsSagemakerEndpointUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+
+	d.Partial(true)
+
+	if err := setSagemakerTags(conn, d); err != nil {
+		return err
+	}
+	d.SetPartial("tags")
+
+	if d.HasChange("endpoint_config_name") && !d.IsNewResource() {
+		modifyOpts := &sagemaker.UpdateEndpointInput{
+			EndpointName:       aws.String(d.Id()),
+			EndpointConfigName: aws.String(d.Get("endpoint_config_name").(string)),
+		}
+		log.Printf(
+			"[INFO] Modifying endpoint_config_name attribute for %s: %#v",
+			d.Id(), modifyOpts)
+		if _, err := conn.UpdateEndpoint(modifyOpts); err != nil {
+			return err
+		}
+		d.SetPartial("endpoint_config_name")
+
+		log.Printf("[DEBUG] Waiting for SageMaker endpoint (%s) to be updated", d.Id())
+		stateConf := &resource.StateChangeConf{
+			Pending: []string{"Updating"},
+			Target:  []string{"InService"},
+			Refresh: SagemakerEndpointStateRefreshFunc(conn, d.Id()),
+			Timeout: 15 * time.Minute,
+		}
+		if _, err := stateConf.WaitForState(); err != nil {
+			return fmt.Errorf(
+				"error updating SageMaker endpoint (%s): %s",
+				d.Id(), err)
+		}
+	}
+
+	d.Partial(false)
+
+	return resourceAwsSagemakerEndpointRead(d, meta)
+}
+
+func resourceAwsSagemakerEndpointDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+
+	deleteEndpointOpts := &sagemaker.DeleteEndpointInput{
+		EndpointName: aws.String(d.Id()),
+	}
+	log.Printf("[INFO] Deleting Sagemaker endpoint: %s", d.Id())
+
+	return resource.Retry(5*time.Minute, func() *resource.RetryError {
+		_, err := conn.DeleteEndpoint(deleteEndpointOpts)
+		if err == nil {
+			return nil
+		}
+
+		sagemakerErr, ok := err.(awserr.Error)
+		if !ok {
+			return resource.NonRetryableError(err)
+		}
+
+		if sagemakerErr.Code() == "ResourceNotFound" {
+			return resource.RetryableError(err)
+		}
+
+		return resource.NonRetryableError(fmt.Errorf("Error deleting Sagemaker endpoint: %s", err))
+	})
+}
+
+func SagemakerEndpointStateRefreshFunc(conn *sagemaker.SageMaker, name string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		describeEndpointOpts := &sagemaker.DescribeEndpointInput{
+			EndpointName: aws.String(name),
+		}
+		endpoint, err := conn.DescribeEndpoint(describeEndpointOpts)
+		if err != nil {
+			if sagemakerErr, ok := err.(awserr.Error); ok && sagemakerErr.Code() == "ResourceNotFound" {
+				endpoint = nil
+			} else {
+				log.Printf("Error on SagemakerEndpointStateRefresh: %s", err)
+				return nil, "", err
+			}
+		}
+
+		if endpoint == nil {
+			return nil, "", nil
+		}
+
+		return endpoint, *endpoint.EndpointStatus, nil
+	}
+}

--- a/aws/resource_aws_sagemaker_endpoint_configuration_test.go
+++ b/aws/resource_aws_sagemaker_endpoint_configuration_test.go
@@ -31,7 +31,7 @@ func testSweepSagemakerEndpointConfigurations(region string) error {
 	conn := client.(*AWSClient).sagemakerconn
 
 	req := &sagemaker.ListEndpointConfigsInput{
-		NameContains: aws.String("terraform-testacc-sagemaker-endpoint-config"),
+		NameContains: aws.String("tf-acc-test"),
 	}
 	resp, err := conn.ListEndpointConfigs(req)
 	if err != nil {
@@ -250,7 +250,7 @@ func testAccCheckSagemakerEndpointConfigurationExists(n string) resource.TestChe
 	}
 }
 
-func testAccSagemakerEndpointConfig_Base(rName string) string {
+func testAccSagemakerEndpointConfigurationConfig_Base(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_model" "foo" {
 	name = %q
@@ -281,7 +281,7 @@ data "aws_iam_policy_document" "assume_role" {
 }
 
 func testAccSagemakerEndpointConfigurationConfig_Basic(rName string) string {
-	return testAccSagemakerEndpointConfig_Base(rName) + fmt.Sprintf(`
+	return testAccSagemakerEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_endpoint_configuration" "foo" {
 	name = %q
 
@@ -297,7 +297,7 @@ resource "aws_sagemaker_endpoint_configuration" "foo" {
 }
 
 func testAccSagemakerEndpointConfigurationConfig_ProductionVariants_InitialVariantWeight(rName string) string {
-	return testAccSagemakerEndpointConfig_Base(rName) + fmt.Sprintf(`
+	return testAccSagemakerEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_endpoint_configuration" "foo" {
 	name = %q
 
@@ -320,7 +320,7 @@ resource "aws_sagemaker_endpoint_configuration" "foo" {
 }
 
 func testAccSagemakerEndpointConfigurationConfig_ProductionVariant_AcceleratorType(rName string) string {
-	return testAccSagemakerEndpointConfig_Base(rName) + fmt.Sprintf(`
+	return testAccSagemakerEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_endpoint_configuration" "foo" {
 	name = %q
 
@@ -337,7 +337,7 @@ resource "aws_sagemaker_endpoint_configuration" "foo" {
 }
 
 func testAccSagemakerEndpointConfiguration_Config_KmsKeyId(rName string) string {
-	return testAccSagemakerEndpointConfig_Base(rName) + fmt.Sprintf(`
+	return testAccSagemakerEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_endpoint_configuration" "foo" {
 	name = %q
 	kms_key_arn = "${aws_kms_key.foo.arn}"
@@ -359,7 +359,7 @@ resource "aws_kms_key" "foo" {
 }
 
 func testAccSagemakerEndpointConfigurationConfig_Tags(rName string) string {
-	return testAccSagemakerEndpointConfig_Base(rName) + fmt.Sprintf(`
+	return testAccSagemakerEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_endpoint_configuration" "foo" {
 	name = %q
 
@@ -379,7 +379,7 @@ resource "aws_sagemaker_endpoint_configuration" "foo" {
 }
 
 func testAccSagemakerEndpointConfigurationConfig_Tags_Update(rName string) string {
-	return testAccSagemakerEndpointConfig_Base(rName) + fmt.Sprintf(`
+	return testAccSagemakerEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_endpoint_configuration" "foo" {
 	name = %q
 

--- a/aws/resource_aws_sagemaker_endpoint_test.go
+++ b/aws/resource_aws_sagemaker_endpoint_test.go
@@ -1,0 +1,524 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"log"
+	"regexp"
+	"testing"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_sagemaker_endpoint", &resource.Sweeper{
+		Name: "aws_sagemaker_endpoint",
+		Dependencies: []string{
+			"aws_sagemaker_model",
+			"aws_sagemaker_endpoint_configuration",
+		},
+		F: testSweepSagemakerEndpoints,
+	})
+}
+
+func testSweepSagemakerEndpoints(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).sagemakerconn
+
+	req := &sagemaker.ListEndpointsInput{
+		NameContains: aws.String("terraform-testacc-sagemaker-endpoint"),
+	}
+	resp, err := conn.ListEndpoints(req)
+	if err != nil {
+		return fmt.Errorf("error listing endpoints: %s", err)
+	}
+
+	if len(resp.Endpoints) == 0 {
+		log.Print("[DEBUG] No SageMaker endpoint to sweep")
+		return nil
+	}
+
+	for _, endpoint := range resp.Endpoints {
+		_, err := conn.DeleteEndpoint(&sagemaker.DeleteEndpointInput{
+			EndpointName: endpoint.EndpointName,
+		})
+		if err != nil {
+			return fmt.Errorf(
+				"error deleting sagemaker endpoint (%s): %s",
+				*endpoint.EndpointName, err)
+		}
+	}
+
+	return nil
+}
+
+func TestAccAWSSagemakerEndpoint_basic(t *testing.T) {
+	var endpoint sagemaker.DescribeEndpointOutput
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSagemakerEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSagemakerEndpointConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSagemakerEndpointExists("aws_sagemaker_endpoint.foo", &endpoint),
+					testAccCheckSagemakerEndpointName(&endpoint, "terraform-testacc-sagemaker-endpoint-foo"),
+					testAccCheckSagemakerEndpointEndpointConfigName(&endpoint,
+						"terraform-testacc-sagemaker-endpoint-config-foo"),
+
+					resource.TestCheckResourceAttr(
+						"aws_sagemaker_endpoint.foo",
+						"name",
+						"terraform-testacc-sagemaker-endpoint-foo"),
+					resource.TestCheckResourceAttr(
+						"aws_sagemaker_endpoint.foo",
+						"endpoint_config_name",
+						"terraform-testacc-sagemaker-endpoint-config-foo"),
+				),
+				ExpectError: regexp.MustCompile(`.*unexpected state 'Failed', wanted target 'InService'.*`),
+			},
+		},
+	})
+}
+
+func TestAccAWSSagemakerEndpoint_tags(t *testing.T) {
+	var endpoint sagemaker.DescribeEndpointOutput
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSagemakerEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSagemakerEndpointConfigTags,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSagemakerEndpointExists("aws_sagemaker_endpoint.foo", &endpoint),
+					testAccCheckSagemakerEndpointTags(&endpoint, "foo", "bar"),
+
+					resource.TestCheckResourceAttr(
+						"aws_sagemaker_endpoint.foo",
+						"name",
+						"terraform-testacc-sagemaker-endpoint-foo"),
+					resource.TestCheckResourceAttr("aws_sagemaker_endpoint.foo", "tags.%", "1"),
+					resource.TestCheckResourceAttr("aws_sagemaker_endpoint.foo", "tags.foo", "bar"),
+				),
+				ExpectError: regexp.MustCompile(`.*unexpected state 'Failed', wanted target 'InService'.*`),
+			},
+
+			{
+				Config: testAccSagemakerEndpointConfigTagsUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSagemakerEndpointExists("aws_sagemaker_endpoint.foo", &endpoint),
+					testAccCheckSagemakerEndpointTags(&endpoint, "foo", ""),
+					testAccCheckSagemakerEndpointTags(&endpoint, "bar", "baz"),
+
+					resource.TestCheckResourceAttr("aws_sagemaker_endpoint.foo", "tags.%", "1"),
+					resource.TestCheckResourceAttr("aws_sagemaker_endpoint.foo", "tags.bar", "baz"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSagemakerEndpoint_update(t *testing.T) {
+	// Cannot update failed endpoint
+	t.Skip()
+
+	var endpoint sagemaker.DescribeEndpointOutput
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSagemakerEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSagemakerEndpointConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSagemakerEndpointExists("aws_sagemaker_endpoint.foo", &endpoint),
+					testAccCheckSagemakerEndpointName(&endpoint, "terraform-testacc-sagemaker-endpoint-foo"),
+					testAccCheckSagemakerEndpointEndpointConfigName(&endpoint,
+						"terraform-testacc-sagemaker-endpoint-config-foo"),
+
+					resource.TestCheckResourceAttr(
+						"aws_sagemaker_endpoint.foo",
+						"name",
+						"terraform-testacc-sagemaker-endpoint-foo"),
+					resource.TestCheckResourceAttr(
+						"aws_sagemaker_endpoint.foo",
+						"endpoint_config_name",
+						"terraform-testacc-sagemaker-endpoint-config-foo"),
+				),
+				ExpectError: regexp.MustCompile(`.*unexpected state 'Failed', wanted target 'InService'.*`),
+			},
+			{
+				Config: testAccSagemakerEndpointConfigUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSagemakerEndpointExists("aws_sagemaker_endpoint.foo", &endpoint),
+					testAccCheckSagemakerEndpointName(&endpoint, "terraform-testacc-sagemaker-endpoint-foo"),
+					testAccCheckSagemakerEndpointEndpointConfigName(&endpoint,
+						"terraform-testacc-sagemaker-endpoint-config-foo-updated"),
+
+					resource.TestCheckResourceAttr(
+						"aws_sagemaker_endpoint.foo",
+						"name",
+						"terraform-testacc-sagemaker-endpoint-foo"),
+					resource.TestCheckResourceAttr(
+						"aws_sagemaker_endpoint.foo",
+						"endpoint_config_name",
+						"terraform-testacc-sagemaker-endpoint-config-foo-updated"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckSagemakerEndpointDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).sagemakerconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_sagemaker_endpoint" {
+			continue
+		}
+
+		resp, err := conn.ListEndpoints(&sagemaker.ListEndpointsInput{
+			NameContains: aws.String(rs.Primary.ID),
+		})
+		if err == nil {
+			if len(resp.Endpoints) > 0 {
+				return fmt.Errorf("SageMaker endpoint still exists")
+			}
+
+			return nil
+		}
+
+		sagemakerErr, ok := err.(awserr.Error)
+		if !ok {
+			return err
+		}
+		if sagemakerErr.Code() != "ResourceNotFound" {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckSagemakerEndpointExists(n string, endpoint *sagemaker.DescribeEndpointOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no SageMaker endpoint ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).sagemakerconn
+		opts := &sagemaker.DescribeEndpointInput{
+			EndpointName: aws.String(rs.Primary.ID),
+		}
+		resp, err := conn.DescribeEndpoint(opts)
+		if err != nil {
+			return err
+		}
+
+		*endpoint = *resp
+
+		return nil
+	}
+}
+
+func testAccCheckSagemakerEndpointName(endpoint *sagemaker.DescribeEndpointOutput, expected string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		endpointName := endpoint.EndpointName
+		if *endpointName != expected {
+			return fmt.Errorf("bad SageMaker endpoint name: %s", *endpoint.EndpointName)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckSagemakerEndpointEndpointConfigName(endpoint *sagemaker.DescribeEndpointOutput, expected string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		name := endpoint.EndpointConfigName
+		if *name != expected {
+			return fmt.Errorf("bad SageMaker endpoint config name: %s", *endpoint.EndpointConfigName)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckSagemakerEndpointTags(endpoint *sagemaker.DescribeEndpointOutput, key string, value string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).sagemakerconn
+
+		ts, err := conn.ListTags(&sagemaker.ListTagsInput{
+			ResourceArn: endpoint.EndpointArn,
+		})
+		if err != nil {
+			return fmt.Errorf("failed listing tags: %s", err)
+		}
+
+		m := tagsToMapSagemaker(ts.Tags)
+		v, ok := m[key]
+		if value != "" && !ok {
+			return fmt.Errorf("missing tag: %s", key)
+		} else if value == "" && ok {
+			return fmt.Errorf("extra tag: %s", key)
+		}
+		if value == "" {
+			return nil
+		}
+
+		if v != value {
+			return fmt.Errorf("%s: bad value: %s", key, v)
+		}
+
+		return nil
+	}
+}
+
+const testAccSagemakerEndpointConfig = `
+resource "aws_sagemaker_endpoint" "foo" {
+	name = "terraform-testacc-sagemaker-endpoint-foo"
+	endpoint_config_name = "${aws_sagemaker_endpoint_configuration.foo.name}"
+}
+
+resource "aws_sagemaker_endpoint_configuration" "foo" {
+	name = "terraform-testacc-sagemaker-endpoint-config-foo"
+
+	production_variants {
+		variant_name = "variant-1"
+		model_name = "${aws_sagemaker_model.foo.name}"
+		initial_instance_count = 1
+		instance_type = "ml.t2.medium"
+		initial_variant_weight = 1
+	}
+}
+
+resource "aws_sagemaker_model" "foo" {
+	name = "terraform-testacc-sagemaker-model-foo"
+	execution_role_arn = "${aws_iam_role.foo.arn}"
+
+	primary_container {
+		image = "174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"
+	}
+}
+
+resource "aws_iam_role" "foo" {
+	name = "terraform-testacc-sagemaker-model-foo"
+	path = "/"
+	assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+}
+
+data "aws_iam_policy_document" "assume_role" {
+	statement {
+		actions = [ "sts:AssumeRole" ]
+		principals {
+			type = "Service"
+			identifiers = [ "sagemaker.amazonaws.com" ]
+		}
+	}
+}
+
+resource "aws_iam_policy" "foo" {
+  name = "terraform-testacc-sagemaker-endpoint-foo"
+  description = "Allow SageMaker to create endpoint"
+  policy = "${data.aws_iam_policy_document.foo.json}"
+}
+
+data "aws_iam_policy_document" "foo" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "sagemaker:*"
+    ]
+    resources = [
+      "*"
+    ]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "cloudwatch:PutMetricData",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:CreateLogGroup",
+      "logs:DescribeLogStreams",
+      "ecr:GetAuthorizationToken",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage"
+    ]
+    resources = [
+      "*"]
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "foo" {
+  role = "${aws_iam_role.foo.name}"
+  policy_arn = "${aws_iam_policy.foo.arn}"
+}
+`
+
+const testAccSagemakerEndpointConfigUpdate = `
+resource "aws_sagemaker_endpoint" "foo" {
+	name = "terraform-testacc-sagemaker-endpoint-foo"
+	endpoint_config_name = "${aws_sagemaker_endpoint_configuration.foo_updated.name}"
+}
+
+resource "aws_sagemaker_endpoint_configuration" "foo_updated" {
+	name = "terraform-testacc-sagemaker-endpoint-config-foo-updated"
+
+	production_variants {
+		variant_name = "variant-2"
+		model_name = "${aws_sagemaker_model.foo.name}"
+		initial_instance_count = 2
+		instance_type = "ml.t2.medium"
+		initial_variant_weight = 1
+	}
+}
+
+resource "aws_sagemaker_endpoint_configuration" "foo" {
+	name = "terraform-testacc-sagemaker-endpoint-config-foo"
+
+	production_variants {
+		variant_name = "variant-1"
+		model_name = "${aws_sagemaker_model.foo.name}"
+		initial_instance_count = 1
+		instance_type = "ml.t2.medium"
+		initial_variant_weight = 1
+	}
+}
+
+resource "aws_sagemaker_model" "foo" {
+	name = "terraform-testacc-sagemaker-model-foo"
+	execution_role_arn = "${aws_iam_role.foo.arn}"
+
+	primary_container {
+		image = "174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"
+	}
+}
+
+resource "aws_iam_role" "foo" {
+	name = "terraform-testacc-sagemaker-model-foo"
+	path = "/"
+	assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+}
+
+data "aws_iam_policy_document" "assume_role" {
+	statement {
+		actions = [ "sts:AssumeRole" ]
+		principals {
+			type = "Service"
+			identifiers = [ "sagemaker.amazonaws.com" ]
+		}
+	}
+}
+`
+
+const testAccSagemakerEndpointConfigTags = `
+resource "aws_sagemaker_endpoint" "foo" {
+	name = "terraform-testacc-sagemaker-endpoint-foo"
+	endpoint_config_name = "${aws_sagemaker_endpoint_configuration.foo.name}"
+
+	tags {
+		foo = "bar"
+	}
+}
+
+resource "aws_sagemaker_endpoint_configuration" "foo" {
+	name = "terraform-testacc-sagemaker-endpoint-config-foo"
+
+	production_variants {
+		variant_name = "variant-1"
+		model_name = "${aws_sagemaker_model.foo.name}"
+		initial_instance_count = 1
+		instance_type = "ml.t2.medium"
+		initial_variant_weight = 1
+	}
+}
+
+resource "aws_sagemaker_model" "foo" {
+	name = "terraform-testacc-sagemaker-model-foo"
+	execution_role_arn = "${aws_iam_role.foo.arn}"
+
+	primary_container {
+		image = "174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"
+	}
+}
+
+resource "aws_iam_role" "foo" {
+	name = "terraform-testacc-sagemaker-model-foo"
+	path = "/"
+	assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+}
+
+data "aws_iam_policy_document" "assume_role" {
+	statement {
+		actions = [ "sts:AssumeRole" ]
+		principals {
+			type = "Service"
+			identifiers = [ "sagemaker.amazonaws.com" ]
+		}
+	}
+}
+`
+
+const testAccSagemakerEndpointConfigTagsUpdate = `
+resource "aws_sagemaker_endpoint" "foo" {
+	name = "terraform-testacc-sagemaker-endpoint-foo"
+	endpoint_config_name = "${aws_sagemaker_endpoint_configuration.foo.name}"
+
+	tags {
+		bar = "baz"
+	}
+}
+
+resource "aws_sagemaker_endpoint_configuration" "foo" {
+	name = "terraform-testacc-sagemaker-endpoint-config-foo"
+
+	production_variants {
+		variant_name = "variant-1"
+		model_name = "${aws_sagemaker_model.foo.name}"
+		initial_instance_count = 1
+		instance_type = "ml.t2.medium"
+		initial_variant_weight = 1
+	}
+}
+
+resource "aws_sagemaker_model" "foo" {
+	name = "terraform-testacc-sagemaker-model-foo"
+	execution_role_arn = "${aws_iam_role.foo.arn}"
+
+	primary_container {
+		image = "174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"
+	}
+}
+
+resource "aws_iam_role" "foo" {
+	name = "terraform-testacc-sagemaker-model-foo"
+	path = "/"
+	assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+}
+
+data "aws_iam_policy_document" "assume_role" {
+	statement {
+		actions = [ "sts:AssumeRole" ]
+		principals {
+			type = "Service"
+			identifiers = [ "sagemaker.amazonaws.com" ]
+		}
+	}
+}
+`

--- a/aws/resource_aws_sagemaker_model.go
+++ b/aws/resource_aws_sagemaker_model.go
@@ -84,29 +84,6 @@ func resourceAwsSagemakerModel() *schema.Resource {
 							Type:     schema.TypeSet,
 							Required: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
-							Set:      schema.HashString,
-						},
-						"security_group_ids": {
-							Type:     schema.TypeSet,
-							Required: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-							Set:      schema.HashString,
-						},
-					},
-				},
-			},
-
-			"vpc_config": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"subnets": {
-							Type:     schema.TypeSet,
-							Required: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 						"security_group_ids": {
 							Type:     schema.TypeSet,
@@ -211,11 +188,6 @@ func resourceAwsSagemakerModelCreate(d *schema.ResourceData, meta interface{}) e
 		createOpts.SetEnableNetworkIsolation(v.(bool))
 	}
 
-	if v, ok := d.GetOk("vpc_config"); ok {
-		vpcConfig := expandSageMakerVpcConfigRequest(v.([]interface{}))
-		createOpts.SetVpcConfig(vpcConfig)
-	}
-
 	log.Printf("[DEBUG] Sagemaker model create config: %#v", *createOpts)
 	_, err := retryOnAwsCode("ValidationException", func() (interface{}, error) {
 		return conn.CreateModel(createOpts)
@@ -227,19 +199,6 @@ func resourceAwsSagemakerModelCreate(d *schema.ResourceData, meta interface{}) e
 	d.SetId(name)
 
 	return resourceAwsSagemakerModelRead(d, meta)
-}
-
-func expandSageMakerVpcConfigRequest(l []interface{}) *sagemaker.VpcConfig {
-	if len(l) == 0 {
-		return nil
-	}
-
-	m := l[0].(map[string]interface{})
-
-	return &sagemaker.VpcConfig{
-		SecurityGroupIds: expandStringSet(m["security_group_ids"].(*schema.Set)),
-		Subnets:          expandStringSet(m["subnets"].(*schema.Set)),
-	}
 }
 
 func expandSageMakerVpcConfigRequest(l []interface{}) *sagemaker.VpcConfig {

--- a/aws/resource_aws_sagemaker_model.go
+++ b/aws/resource_aws_sagemaker_model.go
@@ -96,6 +96,27 @@ func resourceAwsSagemakerModel() *schema.Resource {
 				},
 			},
 
+			"vpc_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"subnets": {
+							Type:     schema.TypeSet,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"security_group_ids": {
+							Type:     schema.TypeSet,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+
 			"execution_role_arn": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -190,6 +211,11 @@ func resourceAwsSagemakerModelCreate(d *schema.ResourceData, meta interface{}) e
 		createOpts.SetEnableNetworkIsolation(v.(bool))
 	}
 
+	if v, ok := d.GetOk("vpc_config"); ok {
+		vpcConfig := expandSageMakerVpcConfigRequest(v.([]interface{}))
+		createOpts.SetVpcConfig(vpcConfig)
+	}
+
 	log.Printf("[DEBUG] Sagemaker model create config: %#v", *createOpts)
 	_, err := retryOnAwsCode("ValidationException", func() (interface{}, error) {
 		return conn.CreateModel(createOpts)
@@ -201,6 +227,19 @@ func resourceAwsSagemakerModelCreate(d *schema.ResourceData, meta interface{}) e
 	d.SetId(name)
 
 	return resourceAwsSagemakerModelRead(d, meta)
+}
+
+func expandSageMakerVpcConfigRequest(l []interface{}) *sagemaker.VpcConfig {
+	if len(l) == 0 {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	return &sagemaker.VpcConfig{
+		SecurityGroupIds: expandStringSet(m["security_group_ids"].(*schema.Set)),
+		Subnets:          expandStringSet(m["subnets"].(*schema.Set)),
+	}
 }
 
 func expandSageMakerVpcConfigRequest(l []interface{}) *sagemaker.VpcConfig {

--- a/aws/resource_aws_sagemaker_model.go
+++ b/aws/resource_aws_sagemaker_model.go
@@ -84,11 +84,13 @@ func resourceAwsSagemakerModel() *schema.Resource {
 							Type:     schema.TypeSet,
 							Required: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
 						},
 						"security_group_ids": {
 							Type:     schema.TypeSet,
 							Required: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
 						},
 					},
 				},

--- a/website/docs/r/sagemaker_endpoint.html.markdown
+++ b/website/docs/r/sagemaker_endpoint.html.markdown
@@ -17,10 +17,10 @@ Basic usage:
 ```hcl
 resource "aws_sagemaker_endpoint" "e" {
     name = "my-endpoint"
-    configuration_name = "my-endpoint-config"
+    configuration_name = "${aws_sagemaker_endpoint_configuration.ec.name}"
 
     tags {
-      Name = "main"
+      Name = "foo"
     }
 }
 ```
@@ -39,8 +39,6 @@ The following attributes are exported:
 
 * `name` - The name of the endpoint.
 * `arn` - The Amazon Resource Name (ARN) assigned by AWS to this endpoint.
-* `creation_timestamp` - The creation timestamp of this endpoint.
-* `last_modified_time` - Last time the endpoint has been modified.
 
 ## Import
 

--- a/website/docs/r/sagemaker_endpoint.html.markdown
+++ b/website/docs/r/sagemaker_endpoint.html.markdown
@@ -1,0 +1,51 @@
+---
+layout: "aws"
+page_title: "AWS: sagemaker_endpoint"
+sidebar_current: "docs-aws-resource-sagemaker-endpoint"
+description: |-
+  Provides a Sagemaker endpoint resource.
+---
+
+# aws\_sagemaker\_endpoint
+
+Provides a Sagemaker endpoint resource.
+
+## Example Usage
+
+Basic usage:
+
+```hcl
+resource "aws_sagemaker_endpoint" "e" {
+    name = "my-endpoint"
+    configuration_name = "my-endpoint-config"
+
+    tags {
+      Name = "main"
+    }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Optional) The name of the endpoint. If omitted, Terraform will assign a random, unique name.
+* `configuration_name` - (Required) The name of the endpoint configuration to use.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `name` - The name of the endpoint.
+* `arn` - The Amazon Resource Name (ARN) assigned by AWS to this endpoint.
+* `creation_timestamp` - The creation timestamp of this endpoint.
+* `last_modified_time` - Last time the endpoint has been modified.
+
+## Import
+
+Endpoints can be imported using the `name`, e.g.
+
+```
+$ terraform import aws_sagemaker_endpoint.test_endpoint my-endpoint
+```

--- a/website/docs/r/sagemaker_endpoint.html.markdown
+++ b/website/docs/r/sagemaker_endpoint.html.markdown
@@ -1,14 +1,14 @@
 ---
 layout: "aws"
-page_title: "AWS: sagemaker_endpoint"
+page_title: "AWS: aws_sagemaker_endpoint"
 sidebar_current: "docs-aws-resource-sagemaker-endpoint"
 description: |-
-  Provides a Sagemaker endpoint resource.
+  Provides a SageMaker Endpoint resource.
 ---
 
-# aws\_sagemaker\_endpoint
+# aws_sagemaker_endpoint
 
-Provides a Sagemaker endpoint resource.
+Provides a SageMaker Endpoint resource.
 
 ## Example Usage
 
@@ -19,7 +19,7 @@ resource "aws_sagemaker_endpoint" "e" {
     name = "my-endpoint"
     configuration_name = "${aws_sagemaker_endpoint_configuration.ec.name}"
 
-    tags {
+    tags = {
       Name = "foo"
     }
 }
@@ -29,16 +29,16 @@ resource "aws_sagemaker_endpoint" "e" {
 
 The following arguments are supported:
 
-* `name` - (Optional) The name of the endpoint. If omitted, Terraform will assign a random, unique name.
 * `configuration_name` - (Required) The name of the endpoint configuration to use.
+* `name` - (Optional) The name of the endpoint. If omitted, Terraform will assign a random, unique name.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
-* `name` - The name of the endpoint.
 * `arn` - The Amazon Resource Name (ARN) assigned by AWS to this endpoint.
+* `name` - The name of the endpoint.
 
 ## Import
 


### PR DESCRIPTION
 ***Please review only the [last commit](https://github.com/terraform-providers/terraform-provider-aws/pull/2585/commits/8b76f4941c06954d05451b8f34ba4a908aca48b9) of this PR (contains the `aws_sagemaker_endpoint` resource). The other commits come from rebasing the PRs of the`resource_aws_sagemaker_model` (https://github.com/terraform-providers/terraform-provider-aws/pull/2478) and `resource_aws_sagemaker_endpoint_configuration` (https://github.com/terraform-providers/terraform-provider-aws/pull/2477), which are needed for the tests here.***

Add the resource `aws_sagemaker_endpoint` for the newly announced service called [SageMaker](https://aws.amazon.com/blogs/aws/sagemaker/).

This PR contributes:
* Documentation/Website 
* Schema
* Implementation of CRUD operations
* Acceptance tests

### Questions
* A SageMaker endpoint can be in one  of the following states: "Creating", "Updating", "InService", or "Failed". To create an endpoint that ends up "InService", a Docker container serving a REST API returning status code 200 for `http://localhost:8080/ping` is needed (acting as a health check for the endpoint). Otherwise, the endpoint is going to end up in state "Failed" (see my example PR https://github.com/terraform-providers/terraform-provider-aws/pull/2585 about how to create an endpoint that will be "InService"). 
My question: Currently, I am using an [expected error](https://github.com/terraform-providers/terraform-provider-aws/pull/2479/files#diff-18f0a49c700a6954cce00b7ca936a2dfR116) in the tests; is this sufficient or de we want "real working model" for the tests here to test endpoints being "InService"? (this is not so easy to achieve and needs a lot of boilerplate to set up the test; I also tried to use a model provided by Amazon, `174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1`, but it needs the trained model data in an S3 bucket to work, *sigh*).