### PR TITLE
Examples: ecs-alb - alb_target_group port switch

### DIFF
--- a/examples/ecs-alb/main.tf
+++ b/examples/ecs-alb/main.tf
@@ -291,7 +291,7 @@ resource "aws_iam_role_policy" "instance" {
 
 resource "aws_alb_target_group" "test" {
   name     = "tf-example-ecs-ghost"
-  port     = 80
+  port     = 8080
   protocol = "HTTP"
   vpc_id   = "${aws_vpc.main.id}"
 }


### PR DESCRIPTION
Since the `aws_ecs_service` launches instances at port `8080` shouldn't the `aws_alb_target_group` be pointed at `8080`? I'm still quite fresh with AWS and terraform and I've noticed that when using your example, so correct me if I'm wrong. Also I didn't want open an issue for such a small thing.