### PR TITLE
Bump aws-sdk-go to v1.12.37

### DIFF
--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.12.35"
+const SDKVersion = "1.12.37"

--- a/vendor/github.com/aws/aws-sdk-go/service/autoscaling/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/autoscaling/api.go
@@ -5240,7 +5240,7 @@ func (s *Alarm) SetAlarmName(v string) *Alarm {
 type AttachInstancesInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the group.
+	// The name of the Auto Scaling group.
 	//
 	// AutoScalingGroupName is a required field
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
@@ -5377,7 +5377,7 @@ func (s AttachLoadBalancerTargetGroupsOutput) GoString() string {
 type AttachLoadBalancersInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the group.
+	// The name of the Auto Scaling group.
 	//
 	// AutoScalingGroupName is a required field
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
@@ -5530,7 +5530,7 @@ func (s *BlockDeviceMapping) SetVirtualName(v string) *BlockDeviceMapping {
 type CompleteLifecycleActionInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the group for the lifecycle hook.
+	// The name of the Auto Scaling group.
 	//
 	// AutoScalingGroupName is a required field
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
@@ -5645,8 +5645,8 @@ func (s CompleteLifecycleActionOutput) GoString() string {
 type CreateAutoScalingGroupInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the group. This name must be unique within the scope of your
-	// AWS account.
+	// The name of the Auto Scaling group. This name must be unique within the scope
+	// of your AWS account.
 	//
 	// AutoScalingGroupName is a required field
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
@@ -5687,7 +5687,8 @@ type CreateAutoScalingGroupInput struct {
 	HealthCheckType *string `min:"1" type:"string"`
 
 	// The ID of the instance used to create a launch configuration for the group.
-	// Alternatively, specify a launch configuration instead of an EC2 instance.
+	// You must specify one of the following: an EC2 instance, a launch configuration,
+	// or a launch template.
 	//
 	// When you specify an ID of an instance, Auto Scaling creates a new launch
 	// configuration and associates it with the group. This launch configuration
@@ -5699,9 +5700,13 @@ type CreateAutoScalingGroupInput struct {
 	// in the Auto Scaling User Guide.
 	InstanceId *string `min:"1" type:"string"`
 
-	// The name of the launch configuration. Alternatively, specify an EC2 instance
-	// instead of a launch configuration.
+	// The name of the launch configuration. You must specify one of the following:
+	// a launch configuration, a launch template, or an EC2 instance.
 	LaunchConfigurationName *string `min:"1" type:"string"`
+
+	// The launch template to use to launch instances. You must specify one of the
+	// following: a launch template, a launch configuration, or an EC2 instance.
+	LaunchTemplate *LaunchTemplateSpecification `type:"structure"`
 
 	// One or more lifecycle hooks.
 	LifecycleHookSpecificationList []*LifecycleHookSpecification `type:"list"`
@@ -5804,6 +5809,11 @@ func (s *CreateAutoScalingGroupInput) Validate() error {
 	if s.VPCZoneIdentifier != nil && len(*s.VPCZoneIdentifier) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("VPCZoneIdentifier", 1))
 	}
+	if s.LaunchTemplate != nil {
+		if err := s.LaunchTemplate.Validate(); err != nil {
+			invalidParams.AddNested("LaunchTemplate", err.(request.ErrInvalidParams))
+		}
+	}
 	if s.LifecycleHookSpecificationList != nil {
 		for i, v := range s.LifecycleHookSpecificationList {
 			if v == nil {
@@ -5876,6 +5886,12 @@ func (s *CreateAutoScalingGroupInput) SetInstanceId(v string) *CreateAutoScaling
 // SetLaunchConfigurationName sets the LaunchConfigurationName field's value.
 func (s *CreateAutoScalingGroupInput) SetLaunchConfigurationName(v string) *CreateAutoScalingGroupInput {
 	s.LaunchConfigurationName = &v
+	return s
+}
+
+// SetLaunchTemplate sets the LaunchTemplate field's value.
+func (s *CreateAutoScalingGroupInput) SetLaunchTemplate(v *LaunchTemplateSpecification) *CreateAutoScalingGroupInput {
+	s.LaunchTemplate = v
 	return s
 }
 
@@ -6455,7 +6471,7 @@ func (s *CustomizedMetricSpecification) SetUnit(v string) *CustomizedMetricSpeci
 type DeleteAutoScalingGroupInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the group to delete.
+	// The name of the Auto Scaling group.
 	//
 	// AutoScalingGroupName is a required field
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
@@ -6580,7 +6596,7 @@ func (s DeleteLaunchConfigurationOutput) GoString() string {
 type DeleteLifecycleHookInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the Auto Scaling group for the lifecycle hook.
+	// The name of the Auto Scaling group.
 	//
 	// AutoScalingGroupName is a required field
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
@@ -7043,8 +7059,8 @@ func (s *DescribeAdjustmentTypesOutput) SetAdjustmentTypes(v []*AdjustmentType) 
 type DescribeAutoScalingGroupsInput struct {
 	_ struct{} `type:"structure"`
 
-	// The group names. If you omit this parameter, all Auto Scaling groups are
-	// described.
+	// The names of the Auto Scaling groups. If you omit this parameter, all Auto
+	// Scaling groups are described.
 	AutoScalingGroupNames []*string `type:"list"`
 
 	// The maximum number of items to return with this call. The default value is
@@ -7363,7 +7379,7 @@ func (s *DescribeLifecycleHookTypesOutput) SetLifecycleHookTypes(v []*string) *D
 type DescribeLifecycleHooksInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the group.
+	// The name of the Auto Scaling group.
 	//
 	// AutoScalingGroupName is a required field
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
@@ -7535,7 +7551,7 @@ func (s *DescribeLoadBalancerTargetGroupsOutput) SetNextToken(v string) *Describ
 type DescribeLoadBalancersInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the group.
+	// The name of the Auto Scaling group.
 	//
 	// AutoScalingGroupName is a required field
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
@@ -7679,7 +7695,7 @@ func (s *DescribeMetricCollectionTypesOutput) SetMetrics(v []*MetricCollectionTy
 type DescribeNotificationConfigurationsInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the group.
+	// The name of the Auto Scaling group.
 	AutoScalingGroupNames []*string `type:"list"`
 
 	// The maximum number of items to return with this call. The default value is
@@ -7759,7 +7775,7 @@ func (s *DescribeNotificationConfigurationsOutput) SetNotificationConfigurations
 type DescribePoliciesInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the group.
+	// The name of the Auto Scaling group.
 	AutoScalingGroupName *string `min:"1" type:"string"`
 
 	// The maximum number of items to be returned with each call. The default value
@@ -7770,10 +7786,10 @@ type DescribePoliciesInput struct {
 	// a previous call.)
 	NextToken *string `type:"string"`
 
-	// One or more policy names or policy ARNs to be described. If you omit this
-	// parameter, all policy names are described. If an group name is provided,
-	// the results are limited to that group. This list is limited to 50 items.
-	// If you specify an unknown policy name, it is ignored with no error.
+	// The names of one or more policies. If you omit this parameter, all policies
+	// are described. If an group name is provided, the results are limited to that
+	// group. This list is limited to 50 items. If you specify an unknown policy
+	// name, it is ignored with no error.
 	PolicyNames []*string `type:"list"`
 
 	// One or more policy types. Valid values are SimpleScaling and StepScaling.
@@ -7878,7 +7894,7 @@ type DescribeScalingActivitiesInput struct {
 	// they are ignored with no error.
 	ActivityIds []*string `type:"list"`
 
-	// The name of the group.
+	// The name of the Auto Scaling group.
 	AutoScalingGroupName *string `min:"1" type:"string"`
 
 	// The maximum number of items to return with this call. The default value is
@@ -8017,7 +8033,7 @@ func (s *DescribeScalingProcessTypesOutput) SetProcesses(v []*ProcessType) *Desc
 type DescribeScheduledActionsInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the group.
+	// The name of the Auto Scaling group.
 	AutoScalingGroupName *string `min:"1" type:"string"`
 
 	// The latest scheduled start time to return. If scheduled action names are
@@ -8261,7 +8277,7 @@ func (s *DescribeTerminationPolicyTypesOutput) SetTerminationPolicyTypes(v []*st
 type DetachInstancesInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the group.
+	// The name of the Auto Scaling group.
 	//
 	// AutoScalingGroupName is a required field
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
@@ -8493,7 +8509,7 @@ func (s DetachLoadBalancersOutput) GoString() string {
 type DisableMetricsCollectionInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name or Amazon Resource Name (ARN) of the group.
+	// The name of the Auto Scaling group.
 	//
 	// AutoScalingGroupName is a required field
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
@@ -8689,7 +8705,7 @@ func (s *Ebs) SetVolumeType(v string) *Ebs {
 type EnableMetricsCollectionInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name or ARN of the Auto Scaling group.
+	// The name of the Auto Scaling group.
 	//
 	// AutoScalingGroupName is a required field
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
@@ -8933,7 +8949,7 @@ func (s *EnterStandbyOutput) SetActivities(v []*Activity) *EnterStandbyOutput {
 type ExecutePolicyInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name or Amazon Resource Name (ARN) of the Auto Scaling group.
+	// The name of the Auto Scaling group.
 	AutoScalingGroupName *string `min:"1" type:"string"`
 
 	// The breach threshold for the alarm.
@@ -9160,10 +9176,10 @@ func (s *Filter) SetValues(v []*string) *Filter {
 type Group struct {
 	_ struct{} `type:"structure"`
 
-	// The Amazon Resource Name (ARN) of the group.
+	// The Amazon Resource Name (ARN) of the Auto Scaling group.
 	AutoScalingGroupARN *string `min:"1" type:"string"`
 
-	// The name of the group.
+	// The name of the Auto Scaling group.
 	//
 	// AutoScalingGroupName is a required field
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
@@ -9206,6 +9222,9 @@ type Group struct {
 
 	// The name of the associated launch configuration.
 	LaunchConfigurationName *string `min:"1" type:"string"`
+
+	// The launch template for the group.
+	LaunchTemplate *LaunchTemplateSpecification `type:"structure"`
 
 	// One or more load balancers associated with the group.
 	LoadBalancerNames []*string `type:"list"`
@@ -9327,6 +9346,12 @@ func (s *Group) SetLaunchConfigurationName(v string) *Group {
 	return s
 }
 
+// SetLaunchTemplate sets the LaunchTemplate field's value.
+func (s *Group) SetLaunchTemplate(v *LaunchTemplateSpecification) *Group {
+	s.LaunchTemplate = v
+	return s
+}
+
 // SetLoadBalancerNames sets the LoadBalancerNames field's value.
 func (s *Group) SetLoadBalancerNames(v []*string) *Group {
 	s.LoadBalancerNames = v
@@ -9416,9 +9441,10 @@ type Instance struct {
 	InstanceId *string `min:"1" type:"string" required:"true"`
 
 	// The launch configuration associated with the instance.
-	//
-	// LaunchConfigurationName is a required field
-	LaunchConfigurationName *string `min:"1" type:"string" required:"true"`
+	LaunchConfigurationName *string `min:"1" type:"string"`
+
+	// The launch template for the instance.
+	LaunchTemplate *LaunchTemplateSpecification `type:"structure"`
 
 	// A description of the current lifecycle state. Note that the Quarantined state
 	// is not used.
@@ -9467,6 +9493,12 @@ func (s *Instance) SetLaunchConfigurationName(v string) *Instance {
 	return s
 }
 
+// SetLaunchTemplate sets the LaunchTemplate field's value.
+func (s *Instance) SetLaunchTemplate(v *LaunchTemplateSpecification) *Instance {
+	s.LaunchTemplate = v
+	return s
+}
+
 // SetLifecycleState sets the LifecycleState field's value.
 func (s *Instance) SetLifecycleState(v string) *Instance {
 	s.LifecycleState = &v
@@ -9484,7 +9516,7 @@ func (s *Instance) SetProtectedFromScaleIn(v bool) *Instance {
 type InstanceDetails struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the Auto Scaling group associated with the instance.
+	// The name of the Auto Scaling group for the instance.
 	//
 	// AutoScalingGroupName is a required field
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
@@ -9508,9 +9540,10 @@ type InstanceDetails struct {
 
 	// The launch configuration used to launch the instance. This value is not available
 	// if you attached the instance to the Auto Scaling group.
-	//
-	// LaunchConfigurationName is a required field
-	LaunchConfigurationName *string `min:"1" type:"string" required:"true"`
+	LaunchConfigurationName *string `min:"1" type:"string"`
+
+	// The launch template for the instance.
+	LaunchTemplate *LaunchTemplateSpecification `type:"structure"`
 
 	// The lifecycle state for the instance. For more information, see Auto Scaling
 	// Lifecycle (http://docs.aws.amazon.com/autoscaling/latest/userguide/AutoScalingGroupLifecycle.html)
@@ -9563,6 +9596,12 @@ func (s *InstanceDetails) SetInstanceId(v string) *InstanceDetails {
 // SetLaunchConfigurationName sets the LaunchConfigurationName field's value.
 func (s *InstanceDetails) SetLaunchConfigurationName(v string) *InstanceDetails {
 	s.LaunchConfigurationName = &v
+	return s
+}
+
+// SetLaunchTemplate sets the LaunchTemplate field's value.
+func (s *InstanceDetails) SetLaunchTemplate(v *LaunchTemplateSpecification) *InstanceDetails {
+	s.LaunchTemplate = v
 	return s
 }
 
@@ -9808,6 +9847,71 @@ func (s *LaunchConfiguration) SetUserData(v string) *LaunchConfiguration {
 	return s
 }
 
+// Describes a launch template.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/LaunchTemplateSpecification
+type LaunchTemplateSpecification struct {
+	_ struct{} `type:"structure"`
+
+	// The ID of the launch template. You must specify either a template ID or a
+	// template name.
+	LaunchTemplateId *string `min:"1" type:"string"`
+
+	// The name of the launch template. You must specify either a template name
+	// or a template ID.
+	LaunchTemplateName *string `min:"3" type:"string"`
+
+	// The version number. By default, the default version of the launch template
+	// is used.
+	Version *string `min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s LaunchTemplateSpecification) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s LaunchTemplateSpecification) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *LaunchTemplateSpecification) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "LaunchTemplateSpecification"}
+	if s.LaunchTemplateId != nil && len(*s.LaunchTemplateId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LaunchTemplateId", 1))
+	}
+	if s.LaunchTemplateName != nil && len(*s.LaunchTemplateName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("LaunchTemplateName", 3))
+	}
+	if s.Version != nil && len(*s.Version) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Version", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetLaunchTemplateId sets the LaunchTemplateId field's value.
+func (s *LaunchTemplateSpecification) SetLaunchTemplateId(v string) *LaunchTemplateSpecification {
+	s.LaunchTemplateId = &v
+	return s
+}
+
+// SetLaunchTemplateName sets the LaunchTemplateName field's value.
+func (s *LaunchTemplateSpecification) SetLaunchTemplateName(v string) *LaunchTemplateSpecification {
+	s.LaunchTemplateName = &v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *LaunchTemplateSpecification) SetVersion(v string) *LaunchTemplateSpecification {
+	s.Version = &v
+	return s
+}
+
 // Describes a lifecycle hook, which tells Auto Scaling that you want to perform
 // an action whenever it launches instances or whenever it terminates instances.
 //
@@ -9931,7 +10035,7 @@ type LifecycleHookSpecification struct {
 
 	// Defines the action the Auto Scaling group should take when the lifecycle
 	// hook timeout elapses or if an unexpected failure occurs. The valid values
-	// are CONTINUE and ABANDON. The default value is CONTINUE.
+	// are CONTINUE and ABANDON.
 	DefaultResult *string `type:"string"`
 
 	// The maximum time, in seconds, that can elapse before the lifecycle hook times
@@ -9946,7 +10050,9 @@ type LifecycleHookSpecification struct {
 
 	// The state of the EC2 instance to which you want to attach the lifecycle hook.
 	// For a list of lifecycle hook types, see DescribeLifecycleHookTypes.
-	LifecycleTransition *string `type:"string"`
+	//
+	// LifecycleTransition is a required field
+	LifecycleTransition *string `type:"string" required:"true"`
 
 	// Additional information that you want to include any time Auto Scaling sends
 	// a message to the notification target.
@@ -9980,6 +10086,9 @@ func (s *LifecycleHookSpecification) Validate() error {
 	}
 	if s.LifecycleHookName != nil && len(*s.LifecycleHookName) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("LifecycleHookName", 1))
+	}
+	if s.LifecycleTransition == nil {
+		invalidParams.Add(request.NewErrParamRequired("LifecycleTransition"))
 	}
 	if s.NotificationMetadata != nil && len(*s.NotificationMetadata) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("NotificationMetadata", 1))
@@ -10276,7 +10385,7 @@ func (s *MetricGranularityType) SetGranularity(v string) *MetricGranularityType 
 type NotificationConfiguration struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the group.
+	// The name of the Auto Scaling group.
 	AutoScalingGroupName *string `min:"1" type:"string"`
 
 	// One of the following event notification types:
@@ -10350,7 +10459,7 @@ type PredefinedMetricSpecification struct {
 	//    * ALBRequestCountPerTarget - number of requests completed per target in
 	//    an Application Load Balancer target group
 	//
-	// For predefined metric types ASGAverageCPUUtilization, ASGAverageNetworkIn
+	// For predefined metric types ASGAverageCPUUtilization, ASGAverageNetworkIn,
 	// and ASGAverageNetworkOut, the parameter must not be specified as the resource
 	// associated with the metric type is the Auto Scaling group. For predefined
 	// metric type ALBRequestCountPerTarget, the parameter must be specified in
@@ -10450,8 +10559,7 @@ func (s *ProcessType) SetProcessName(v string) *ProcessType {
 type PutLifecycleHookInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the Auto Scaling group to which you want to assign the lifecycle
-	// hook.
+	// The name of the Auto Scaling group.
 	//
 	// AutoScalingGroupName is a required field
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
@@ -10711,7 +10819,7 @@ type PutScalingPolicyInput struct {
 	// in the Auto Scaling User Guide.
 	AdjustmentType *string `min:"1" type:"string"`
 
-	// The name or ARN of the group.
+	// The name of the Auto Scaling group.
 	//
 	// AutoScalingGroupName is a required field
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
@@ -10948,7 +11056,7 @@ func (s *PutScalingPolicyOutput) SetPolicyARN(v string) *PutScalingPolicyOutput 
 type PutScheduledUpdateGroupActionInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name or Amazon Resource Name (ARN) of the Auto Scaling group.
+	// The name of the Auto Scaling group.
 	//
 	// AutoScalingGroupName is a required field
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
@@ -11097,7 +11205,7 @@ func (s PutScheduledUpdateGroupActionOutput) GoString() string {
 type RecordLifecycleActionHeartbeatInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the Auto Scaling group for the hook.
+	// The name of the Auto Scaling group.
 	//
 	// AutoScalingGroupName is a required field
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
@@ -11220,7 +11328,7 @@ type ScalingPolicy struct {
 	// The CloudWatch alarms related to the policy.
 	Alarms []*Alarm `type:"list"`
 
-	// The name of the Auto Scaling group associated with this scaling policy.
+	// The name of the Auto Scaling group.
 	AutoScalingGroupName *string `min:"1" type:"string"`
 
 	// The amount of time, in seconds, after a scaling activity completes before
@@ -11364,7 +11472,7 @@ func (s *ScalingPolicy) SetTargetTrackingConfiguration(v *TargetTrackingConfigur
 type ScalingProcessQuery struct {
 	_ struct{} `type:"structure"`
 
-	// The name or Amazon Resource Name (ARN) of the Auto Scaling group.
+	// The name of the Auto Scaling group.
 	//
 	// AutoScalingGroupName is a required field
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
@@ -11433,7 +11541,7 @@ func (s *ScalingProcessQuery) SetScalingProcesses(v []*string) *ScalingProcessQu
 type ScheduledUpdateGroupAction struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the group.
+	// The name of the Auto Scaling group.
 	AutoScalingGroupName *string `min:"1" type:"string"`
 
 	// The number of instances you prefer to maintain in the group.
@@ -11717,7 +11825,7 @@ func (s SetInstanceHealthOutput) GoString() string {
 type SetInstanceProtectionInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the group.
+	// The name of the Auto Scaling group.
 	//
 	// AutoScalingGroupName is a required field
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
@@ -12287,8 +12395,13 @@ type UpdateAutoScalingGroupInput struct {
 	// The service to use for the health checks. The valid values are EC2 and ELB.
 	HealthCheckType *string `min:"1" type:"string"`
 
-	// The name of the launch configuration.
+	// The name of the launch configuration. You must specify either a launch configuration
+	// or a launch template.
 	LaunchConfigurationName *string `min:"1" type:"string"`
+
+	// The launch template to use to specify the updates. You must specify a launch
+	// configuration or a launch template.
+	LaunchTemplate *LaunchTemplateSpecification `type:"structure"`
 
 	// The maximum size of the Auto Scaling group.
 	MaxSize *int64 `type:"integer"`
@@ -12359,6 +12472,11 @@ func (s *UpdateAutoScalingGroupInput) Validate() error {
 	if s.VPCZoneIdentifier != nil && len(*s.VPCZoneIdentifier) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("VPCZoneIdentifier", 1))
 	}
+	if s.LaunchTemplate != nil {
+		if err := s.LaunchTemplate.Validate(); err != nil {
+			invalidParams.AddNested("LaunchTemplate", err.(request.ErrInvalidParams))
+		}
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -12405,6 +12523,12 @@ func (s *UpdateAutoScalingGroupInput) SetHealthCheckType(v string) *UpdateAutoSc
 // SetLaunchConfigurationName sets the LaunchConfigurationName field's value.
 func (s *UpdateAutoScalingGroupInput) SetLaunchConfigurationName(v string) *UpdateAutoScalingGroupInput {
 	s.LaunchConfigurationName = &v
+	return s
+}
+
+// SetLaunchTemplate sets the LaunchTemplate field's value.
+func (s *UpdateAutoScalingGroupInput) SetLaunchTemplate(v *LaunchTemplateSpecification) *UpdateAutoScalingGroupInput {
+	s.LaunchTemplate = v
 	return s
 }
 

--- a/vendor/github.com/aws/aws-sdk-go/service/dynamodb/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/dynamodb/api.go
@@ -371,6 +371,249 @@ func (c *DynamoDB) BatchWriteItemWithContext(ctx aws.Context, input *BatchWriteI
 	return out, req.Send()
 }
 
+const opCreateBackup = "CreateBackup"
+
+// CreateBackupRequest generates a "aws/request.Request" representing the
+// client's request for the CreateBackup operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See CreateBackup for more information on using the CreateBackup
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the CreateBackupRequest method.
+//    req, resp := client.CreateBackupRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/CreateBackup
+func (c *DynamoDB) CreateBackupRequest(input *CreateBackupInput) (req *request.Request, output *CreateBackupOutput) {
+	op := &request.Operation{
+		Name:       opCreateBackup,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &CreateBackupInput{}
+	}
+
+	output = &CreateBackupOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// CreateBackup API operation for Amazon DynamoDB.
+//
+// Creates a backup for an existing table.
+//
+// Each time you create an On-Demand Backup, the entire table data is backed
+// up. There is no limit to the number of on-demand backups that can be taken.
+//
+// You can call CreateBackup at a maximum rate of 50 times per second.
+//
+// All backups in DynamoDB work without consuming any provisioned throughput
+// on the table. This results in a fast, low-cost, and scalable backup process.
+// In general, the larger the table, the more time it takes to back up. The
+// backup is stored in an S3 data store that is maintained and managed by DynamoDB.
+//
+// Backups incorporate all writes (delete, put, update) that were completed
+// within the last minute before the backup request was initiated. Backups might
+// include some writes (delete, put, update) that were completed before the
+// backup request was finished.
+//
+// For example, if you submit the backup request on 2018-12-14 at 14:25:00,
+// the backup is guaranteed to contain all data committed to the table up to
+// 14:24:00, and data committed after 14:26:00 will not be. The backup may or
+// may not contain data modifications made between 14:24:00 and 14:26:00. On-Demand
+// Backup does not support causal consistency.
+//
+// Along with data, the following are also included on the backups:
+//
+//    * Global secondary indexes (GSIs)
+//
+//    * Local secondary indexes (LSIs)
+//
+//    * Streams
+//
+//    * Provisioned read and write capacity
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon DynamoDB's
+// API operation CreateBackup for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeTableNotFoundException "TableNotFoundException"
+//   A table with the name TableName does not currently exist within the subscriber's
+//   account.
+//
+//   * ErrCodeTableInUseException "TableInUseException"
+//   A table by that name is either being created or deleted.
+//
+//   * ErrCodeContinuousBackupsUnavailableException "ContinuousBackupsUnavailableException"
+//   Backups have not yet been enabled for this table.
+//
+//   * ErrCodeBackupInUseException "BackupInUseException"
+//   There is another ongoing conflicting backup control plane operation on the
+//   table. The backups is either being created, deleted or restored to a table.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   The number of concurrent table requests (cumulative number of tables in the
+//   CREATING, DELETING or UPDATING state) exceeds the maximum allowed of 10.
+//
+//   Also, for tables with secondary indexes, only one of those tables can be
+//   in the CREATING state at any point in time. Do not attempt to create more
+//   than one such table simultaneously.
+//
+//   The total limit of tables in the ACTIVE state is 250.
+//
+//   * ErrCodeInternalServerError "InternalServerError"
+//   An error occurred on the server side.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/CreateBackup
+func (c *DynamoDB) CreateBackup(input *CreateBackupInput) (*CreateBackupOutput, error) {
+	req, out := c.CreateBackupRequest(input)
+	return out, req.Send()
+}
+
+// CreateBackupWithContext is the same as CreateBackup with the addition of
+// the ability to pass a context and additional request options.
+//
+// See CreateBackup for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *DynamoDB) CreateBackupWithContext(ctx aws.Context, input *CreateBackupInput, opts ...request.Option) (*CreateBackupOutput, error) {
+	req, out := c.CreateBackupRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opCreateGlobalTable = "CreateGlobalTable"
+
+// CreateGlobalTableRequest generates a "aws/request.Request" representing the
+// client's request for the CreateGlobalTable operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See CreateGlobalTable for more information on using the CreateGlobalTable
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the CreateGlobalTableRequest method.
+//    req, resp := client.CreateGlobalTableRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/CreateGlobalTable
+func (c *DynamoDB) CreateGlobalTableRequest(input *CreateGlobalTableInput) (req *request.Request, output *CreateGlobalTableOutput) {
+	op := &request.Operation{
+		Name:       opCreateGlobalTable,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &CreateGlobalTableInput{}
+	}
+
+	output = &CreateGlobalTableOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// CreateGlobalTable API operation for Amazon DynamoDB.
+//
+// Creates a global table from an existing table. A global table creates a replication
+// relationship between two or more DynamoDB tables with the same table name
+// in the provided regions.
+//
+// Tables can only be added as the replicas of a global table group under the
+// following conditions:
+//
+//    *  The tables must have the same name.
+//
+//    *  The tables must contain no items.
+//
+//    *  The tables must have the same hash key and sort key (if present).
+//
+//    *  The tables must have DynamoDB Streams enabled (NEW_AND_OLD_IMAGES).
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon DynamoDB's
+// API operation CreateGlobalTable for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   The number of concurrent table requests (cumulative number of tables in the
+//   CREATING, DELETING or UPDATING state) exceeds the maximum allowed of 10.
+//
+//   Also, for tables with secondary indexes, only one of those tables can be
+//   in the CREATING state at any point in time. Do not attempt to create more
+//   than one such table simultaneously.
+//
+//   The total limit of tables in the ACTIVE state is 250.
+//
+//   * ErrCodeInternalServerError "InternalServerError"
+//   An error occurred on the server side.
+//
+//   * ErrCodeGlobalTableAlreadyExistsException "GlobalTableAlreadyExistsException"
+//   The specified global table already exists.
+//
+//   * ErrCodeTableNotFoundException "TableNotFoundException"
+//   A table with the name TableName does not currently exist within the subscriber's
+//   account.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/CreateGlobalTable
+func (c *DynamoDB) CreateGlobalTable(input *CreateGlobalTableInput) (*CreateGlobalTableOutput, error) {
+	req, out := c.CreateGlobalTableRequest(input)
+	return out, req.Send()
+}
+
+// CreateGlobalTableWithContext is the same as CreateGlobalTable with the addition of
+// the ability to pass a context and additional request options.
+//
+// See CreateGlobalTable for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *DynamoDB) CreateGlobalTableWithContext(ctx aws.Context, input *CreateGlobalTableInput, opts ...request.Option) (*CreateGlobalTableOutput, error) {
+	req, out := c.CreateGlobalTableRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opCreateTable = "CreateTable"
 
 // CreateTableRequest generates a "aws/request.Request" representing the
@@ -474,6 +717,104 @@ func (c *DynamoDB) CreateTable(input *CreateTableInput) (*CreateTableOutput, err
 // for more information on using Contexts.
 func (c *DynamoDB) CreateTableWithContext(ctx aws.Context, input *CreateTableInput, opts ...request.Option) (*CreateTableOutput, error) {
 	req, out := c.CreateTableRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDeleteBackup = "DeleteBackup"
+
+// DeleteBackupRequest generates a "aws/request.Request" representing the
+// client's request for the DeleteBackup operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DeleteBackup for more information on using the DeleteBackup
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DeleteBackupRequest method.
+//    req, resp := client.DeleteBackupRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/DeleteBackup
+func (c *DynamoDB) DeleteBackupRequest(input *DeleteBackupInput) (req *request.Request, output *DeleteBackupOutput) {
+	op := &request.Operation{
+		Name:       opDeleteBackup,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DeleteBackupInput{}
+	}
+
+	output = &DeleteBackupOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DeleteBackup API operation for Amazon DynamoDB.
+//
+// Deletes an existing backup of a table.
+//
+// You can call DeleteBackup at a maximum rate of 10 times per second.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon DynamoDB's
+// API operation DeleteBackup for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeBackupNotFoundException "BackupNotFoundException"
+//   Backup not found for the given BackupARN.
+//
+//   * ErrCodeBackupInUseException "BackupInUseException"
+//   There is another ongoing conflicting backup control plane operation on the
+//   table. The backups is either being created, deleted or restored to a table.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   The number of concurrent table requests (cumulative number of tables in the
+//   CREATING, DELETING or UPDATING state) exceeds the maximum allowed of 10.
+//
+//   Also, for tables with secondary indexes, only one of those tables can be
+//   in the CREATING state at any point in time. Do not attempt to create more
+//   than one such table simultaneously.
+//
+//   The total limit of tables in the ACTIVE state is 250.
+//
+//   * ErrCodeInternalServerError "InternalServerError"
+//   An error occurred on the server side.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/DeleteBackup
+func (c *DynamoDB) DeleteBackup(input *DeleteBackupInput) (*DeleteBackupOutput, error) {
+	req, out := c.DeleteBackupRequest(input)
+	return out, req.Send()
+}
+
+// DeleteBackupWithContext is the same as DeleteBackup with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeleteBackup for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *DynamoDB) DeleteBackupWithContext(ctx aws.Context, input *DeleteBackupInput, opts ...request.Option) (*DeleteBackupOutput, error) {
+	req, out := c.DeleteBackupRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -700,6 +1041,259 @@ func (c *DynamoDB) DeleteTable(input *DeleteTableInput) (*DeleteTableOutput, err
 // for more information on using Contexts.
 func (c *DynamoDB) DeleteTableWithContext(ctx aws.Context, input *DeleteTableInput, opts ...request.Option) (*DeleteTableOutput, error) {
 	req, out := c.DeleteTableRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDescribeBackup = "DescribeBackup"
+
+// DescribeBackupRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeBackup operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeBackup for more information on using the DescribeBackup
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeBackupRequest method.
+//    req, resp := client.DescribeBackupRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/DescribeBackup
+func (c *DynamoDB) DescribeBackupRequest(input *DescribeBackupInput) (req *request.Request, output *DescribeBackupOutput) {
+	op := &request.Operation{
+		Name:       opDescribeBackup,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DescribeBackupInput{}
+	}
+
+	output = &DescribeBackupOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeBackup API operation for Amazon DynamoDB.
+//
+// Describes an existing backup of a table.
+//
+// You can call DescribeBackup at a maximum rate of 10 times per second.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon DynamoDB's
+// API operation DescribeBackup for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeBackupNotFoundException "BackupNotFoundException"
+//   Backup not found for the given BackupARN.
+//
+//   * ErrCodeInternalServerError "InternalServerError"
+//   An error occurred on the server side.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/DescribeBackup
+func (c *DynamoDB) DescribeBackup(input *DescribeBackupInput) (*DescribeBackupOutput, error) {
+	req, out := c.DescribeBackupRequest(input)
+	return out, req.Send()
+}
+
+// DescribeBackupWithContext is the same as DescribeBackup with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeBackup for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *DynamoDB) DescribeBackupWithContext(ctx aws.Context, input *DescribeBackupInput, opts ...request.Option) (*DescribeBackupOutput, error) {
+	req, out := c.DescribeBackupRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDescribeContinuousBackups = "DescribeContinuousBackups"
+
+// DescribeContinuousBackupsRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeContinuousBackups operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeContinuousBackups for more information on using the DescribeContinuousBackups
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeContinuousBackupsRequest method.
+//    req, resp := client.DescribeContinuousBackupsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/DescribeContinuousBackups
+func (c *DynamoDB) DescribeContinuousBackupsRequest(input *DescribeContinuousBackupsInput) (req *request.Request, output *DescribeContinuousBackupsOutput) {
+	op := &request.Operation{
+		Name:       opDescribeContinuousBackups,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DescribeContinuousBackupsInput{}
+	}
+
+	output = &DescribeContinuousBackupsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeContinuousBackups API operation for Amazon DynamoDB.
+//
+// Checks the status of the backup restore settings on the specified table.
+// If backups are enabled, ContinuousBackupsStatus will bet set to ENABLED.
+//
+// You can call DescribeContinuousBackups at a maximum rate of 10 times per
+// second.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon DynamoDB's
+// API operation DescribeContinuousBackups for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeTableNotFoundException "TableNotFoundException"
+//   A table with the name TableName does not currently exist within the subscriber's
+//   account.
+//
+//   * ErrCodeInternalServerError "InternalServerError"
+//   An error occurred on the server side.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/DescribeContinuousBackups
+func (c *DynamoDB) DescribeContinuousBackups(input *DescribeContinuousBackupsInput) (*DescribeContinuousBackupsOutput, error) {
+	req, out := c.DescribeContinuousBackupsRequest(input)
+	return out, req.Send()
+}
+
+// DescribeContinuousBackupsWithContext is the same as DescribeContinuousBackups with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeContinuousBackups for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *DynamoDB) DescribeContinuousBackupsWithContext(ctx aws.Context, input *DescribeContinuousBackupsInput, opts ...request.Option) (*DescribeContinuousBackupsOutput, error) {
+	req, out := c.DescribeContinuousBackupsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDescribeGlobalTable = "DescribeGlobalTable"
+
+// DescribeGlobalTableRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeGlobalTable operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeGlobalTable for more information on using the DescribeGlobalTable
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeGlobalTableRequest method.
+//    req, resp := client.DescribeGlobalTableRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/DescribeGlobalTable
+func (c *DynamoDB) DescribeGlobalTableRequest(input *DescribeGlobalTableInput) (req *request.Request, output *DescribeGlobalTableOutput) {
+	op := &request.Operation{
+		Name:       opDescribeGlobalTable,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DescribeGlobalTableInput{}
+	}
+
+	output = &DescribeGlobalTableOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeGlobalTable API operation for Amazon DynamoDB.
+//
+// Returns information about the global table.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon DynamoDB's
+// API operation DescribeGlobalTable for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalServerError "InternalServerError"
+//   An error occurred on the server side.
+//
+//   * ErrCodeGlobalTableNotFoundException "GlobalTableNotFoundException"
+//   The specified global table does not exist.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/DescribeGlobalTable
+func (c *DynamoDB) DescribeGlobalTable(input *DescribeGlobalTableInput) (*DescribeGlobalTableOutput, error) {
+	req, out := c.DescribeGlobalTableRequest(input)
+	return out, req.Send()
+}
+
+// DescribeGlobalTableWithContext is the same as DescribeGlobalTable with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeGlobalTable for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *DynamoDB) DescribeGlobalTableWithContext(ctx aws.Context, input *DescribeGlobalTableInput, opts ...request.Option) (*DescribeGlobalTableOutput, error) {
+	req, out := c.DescribeGlobalTableRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -1107,6 +1701,173 @@ func (c *DynamoDB) GetItem(input *GetItemInput) (*GetItemOutput, error) {
 // for more information on using Contexts.
 func (c *DynamoDB) GetItemWithContext(ctx aws.Context, input *GetItemInput, opts ...request.Option) (*GetItemOutput, error) {
 	req, out := c.GetItemRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opListBackups = "ListBackups"
+
+// ListBackupsRequest generates a "aws/request.Request" representing the
+// client's request for the ListBackups operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ListBackups for more information on using the ListBackups
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ListBackupsRequest method.
+//    req, resp := client.ListBackupsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/ListBackups
+func (c *DynamoDB) ListBackupsRequest(input *ListBackupsInput) (req *request.Request, output *ListBackupsOutput) {
+	op := &request.Operation{
+		Name:       opListBackups,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &ListBackupsInput{}
+	}
+
+	output = &ListBackupsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListBackups API operation for Amazon DynamoDB.
+//
+// List backups associated with an AWS account. To list backups for a given
+// table, specify TableName. ListBackups returns a paginated list of results
+// with at most 1MB worth of items in a page. You can also specify a limit for
+// the maximum number of entries to be returned in a page.
+//
+// In the request, start time is inclusive but end time is exclusive. Note that
+// these limits are for the time at which the original backup was requested.
+//
+// You can call ListBackups a maximum of 5 times per second.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon DynamoDB's
+// API operation ListBackups for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalServerError "InternalServerError"
+//   An error occurred on the server side.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/ListBackups
+func (c *DynamoDB) ListBackups(input *ListBackupsInput) (*ListBackupsOutput, error) {
+	req, out := c.ListBackupsRequest(input)
+	return out, req.Send()
+}
+
+// ListBackupsWithContext is the same as ListBackups with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListBackups for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *DynamoDB) ListBackupsWithContext(ctx aws.Context, input *ListBackupsInput, opts ...request.Option) (*ListBackupsOutput, error) {
+	req, out := c.ListBackupsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opListGlobalTables = "ListGlobalTables"
+
+// ListGlobalTablesRequest generates a "aws/request.Request" representing the
+// client's request for the ListGlobalTables operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ListGlobalTables for more information on using the ListGlobalTables
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ListGlobalTablesRequest method.
+//    req, resp := client.ListGlobalTablesRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/ListGlobalTables
+func (c *DynamoDB) ListGlobalTablesRequest(input *ListGlobalTablesInput) (req *request.Request, output *ListGlobalTablesOutput) {
+	op := &request.Operation{
+		Name:       opListGlobalTables,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &ListGlobalTablesInput{}
+	}
+
+	output = &ListGlobalTablesOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListGlobalTables API operation for Amazon DynamoDB.
+//
+// Lists all the global tables. Only those global tables that have replicas
+// in the region specified as input are returned.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon DynamoDB's
+// API operation ListGlobalTables for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalServerError "InternalServerError"
+//   An error occurred on the server side.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/ListGlobalTables
+func (c *DynamoDB) ListGlobalTables(input *ListGlobalTablesInput) (*ListGlobalTablesOutput, error) {
+	req, out := c.ListGlobalTablesRequest(input)
+	return out, req.Send()
+}
+
+// ListGlobalTablesWithContext is the same as ListGlobalTables with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListGlobalTables for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *DynamoDB) ListGlobalTablesWithContext(ctx aws.Context, input *ListGlobalTablesInput, opts ...request.Option) (*ListGlobalTablesOutput, error) {
+	req, out := c.ListGlobalTablesRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -1671,6 +2432,123 @@ func (c *DynamoDB) QueryPagesWithContext(ctx aws.Context, input *QueryInput, fn 
 	return p.Err()
 }
 
+const opRestoreTableFromBackup = "RestoreTableFromBackup"
+
+// RestoreTableFromBackupRequest generates a "aws/request.Request" representing the
+// client's request for the RestoreTableFromBackup operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See RestoreTableFromBackup for more information on using the RestoreTableFromBackup
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the RestoreTableFromBackupRequest method.
+//    req, resp := client.RestoreTableFromBackupRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/RestoreTableFromBackup
+func (c *DynamoDB) RestoreTableFromBackupRequest(input *RestoreTableFromBackupInput) (req *request.Request, output *RestoreTableFromBackupOutput) {
+	op := &request.Operation{
+		Name:       opRestoreTableFromBackup,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &RestoreTableFromBackupInput{}
+	}
+
+	output = &RestoreTableFromBackupOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// RestoreTableFromBackup API operation for Amazon DynamoDB.
+//
+// Creates a new table from an existing backup. Any number of users can execute
+// up to 10 concurrent restores in a given account.
+//
+// You can call RestoreTableFromBackup at a maximum rate of 10 times per second.
+//
+// You must manually set up the following on the restored table:
+//
+//    * Auto scaling policies
+//
+//    * IAM policies
+//
+//    * Cloudwatch metrics and alarms
+//
+//    * Tags
+//
+//    * Time to Live (TTL) settings
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon DynamoDB's
+// API operation RestoreTableFromBackup for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeTableAlreadyExistsException "TableAlreadyExistsException"
+//   A table with the name already exists.
+//
+//   * ErrCodeTableInUseException "TableInUseException"
+//   A table by that name is either being created or deleted.
+//
+//   * ErrCodeBackupNotFoundException "BackupNotFoundException"
+//   Backup not found for the given BackupARN.
+//
+//   * ErrCodeBackupInUseException "BackupInUseException"
+//   There is another ongoing conflicting backup control plane operation on the
+//   table. The backups is either being created, deleted or restored to a table.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   The number of concurrent table requests (cumulative number of tables in the
+//   CREATING, DELETING or UPDATING state) exceeds the maximum allowed of 10.
+//
+//   Also, for tables with secondary indexes, only one of those tables can be
+//   in the CREATING state at any point in time. Do not attempt to create more
+//   than one such table simultaneously.
+//
+//   The total limit of tables in the ACTIVE state is 250.
+//
+//   * ErrCodeInternalServerError "InternalServerError"
+//   An error occurred on the server side.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/RestoreTableFromBackup
+func (c *DynamoDB) RestoreTableFromBackup(input *RestoreTableFromBackupInput) (*RestoreTableFromBackupOutput, error) {
+	req, out := c.RestoreTableFromBackupRequest(input)
+	return out, req.Send()
+}
+
+// RestoreTableFromBackupWithContext is the same as RestoreTableFromBackup with the addition of
+// the ability to pass a context and additional request options.
+//
+// See RestoreTableFromBackup for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *DynamoDB) RestoreTableFromBackupWithContext(ctx aws.Context, input *RestoreTableFromBackupInput, opts ...request.Option) (*RestoreTableFromBackupOutput, error) {
+	req, out := c.RestoreTableFromBackupRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opScan = "Scan"
 
 // ScanRequest generates a "aws/request.Request" representing the
@@ -2050,6 +2928,100 @@ func (c *DynamoDB) UntagResource(input *UntagResourceInput) (*UntagResourceOutpu
 // for more information on using Contexts.
 func (c *DynamoDB) UntagResourceWithContext(ctx aws.Context, input *UntagResourceInput, opts ...request.Option) (*UntagResourceOutput, error) {
 	req, out := c.UntagResourceRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opUpdateGlobalTable = "UpdateGlobalTable"
+
+// UpdateGlobalTableRequest generates a "aws/request.Request" representing the
+// client's request for the UpdateGlobalTable operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See UpdateGlobalTable for more information on using the UpdateGlobalTable
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the UpdateGlobalTableRequest method.
+//    req, resp := client.UpdateGlobalTableRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/UpdateGlobalTable
+func (c *DynamoDB) UpdateGlobalTableRequest(input *UpdateGlobalTableInput) (req *request.Request, output *UpdateGlobalTableOutput) {
+	op := &request.Operation{
+		Name:       opUpdateGlobalTable,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &UpdateGlobalTableInput{}
+	}
+
+	output = &UpdateGlobalTableOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// UpdateGlobalTable API operation for Amazon DynamoDB.
+//
+// Adds or removes replicas to the specified global table. The global table
+// should already exist to be able to use this operation. Currently, the replica
+// to be added should be empty.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon DynamoDB's
+// API operation UpdateGlobalTable for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalServerError "InternalServerError"
+//   An error occurred on the server side.
+//
+//   * ErrCodeGlobalTableNotFoundException "GlobalTableNotFoundException"
+//   The specified global table does not exist.
+//
+//   * ErrCodeReplicaAlreadyExistsException "ReplicaAlreadyExistsException"
+//   The specified replica is already part of the global table.
+//
+//   * ErrCodeReplicaNotFoundException "ReplicaNotFoundException"
+//   The specified replica is no longer part of the global table.
+//
+//   * ErrCodeTableNotFoundException "TableNotFoundException"
+//   A table with the name TableName does not currently exist within the subscriber's
+//   account.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/UpdateGlobalTable
+func (c *DynamoDB) UpdateGlobalTable(input *UpdateGlobalTableInput) (*UpdateGlobalTableOutput, error) {
+	req, out := c.UpdateGlobalTableRequest(input)
+	return out, req.Send()
+}
+
+// UpdateGlobalTableWithContext is the same as UpdateGlobalTable with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UpdateGlobalTable for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *DynamoDB) UpdateGlobalTableWithContext(ctx aws.Context, input *UpdateGlobalTableInput, opts ...request.Option) (*UpdateGlobalTableOutput, error) {
+	req, out := c.UpdateGlobalTableRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -2716,6 +3688,207 @@ func (s *AttributeValueUpdate) SetValue(v *AttributeValue) *AttributeValueUpdate
 	return s
 }
 
+// Contains the description of the backup created for the table.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/BackupDescription
+type BackupDescription struct {
+	_ struct{} `type:"structure"`
+
+	// Contains the details of the backup created for the table.
+	BackupDetails *BackupDetails `type:"structure"`
+
+	// Contains the details of the table when the backup was created.
+	SourceTableDetails *SourceTableDetails `type:"structure"`
+
+	// Contains the details of the features enabled on the table when the backup
+	// was created. For example, LSIs, GSIs, streams, TTL.
+	SourceTableFeatureDetails *SourceTableFeatureDetails `type:"structure"`
+}
+
+// String returns the string representation
+func (s BackupDescription) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s BackupDescription) GoString() string {
+	return s.String()
+}
+
+// SetBackupDetails sets the BackupDetails field's value.
+func (s *BackupDescription) SetBackupDetails(v *BackupDetails) *BackupDescription {
+	s.BackupDetails = v
+	return s
+}
+
+// SetSourceTableDetails sets the SourceTableDetails field's value.
+func (s *BackupDescription) SetSourceTableDetails(v *SourceTableDetails) *BackupDescription {
+	s.SourceTableDetails = v
+	return s
+}
+
+// SetSourceTableFeatureDetails sets the SourceTableFeatureDetails field's value.
+func (s *BackupDescription) SetSourceTableFeatureDetails(v *SourceTableFeatureDetails) *BackupDescription {
+	s.SourceTableFeatureDetails = v
+	return s
+}
+
+// Contains the details of the backup created for the table.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/BackupDetails
+type BackupDetails struct {
+	_ struct{} `type:"structure"`
+
+	// ARN associated with the backup.
+	//
+	// BackupArn is a required field
+	BackupArn *string `min:"37" type:"string" required:"true"`
+
+	// Time at which the backup was created. This is the request time of the backup.
+	//
+	// BackupCreationDateTime is a required field
+	BackupCreationDateTime *time.Time `type:"timestamp" timestampFormat:"unix" required:"true"`
+
+	// Name of the requested backup.
+	//
+	// BackupName is a required field
+	BackupName *string `min:"3" type:"string" required:"true"`
+
+	// Size of the backup in bytes.
+	BackupSizeBytes *int64 `type:"long"`
+
+	// Backup can be in one of the following states: CREATING, ACTIVE, DELETED.
+	//
+	// BackupStatus is a required field
+	BackupStatus *string `type:"string" required:"true" enum:"BackupStatus"`
+}
+
+// String returns the string representation
+func (s BackupDetails) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s BackupDetails) GoString() string {
+	return s.String()
+}
+
+// SetBackupArn sets the BackupArn field's value.
+func (s *BackupDetails) SetBackupArn(v string) *BackupDetails {
+	s.BackupArn = &v
+	return s
+}
+
+// SetBackupCreationDateTime sets the BackupCreationDateTime field's value.
+func (s *BackupDetails) SetBackupCreationDateTime(v time.Time) *BackupDetails {
+	s.BackupCreationDateTime = &v
+	return s
+}
+
+// SetBackupName sets the BackupName field's value.
+func (s *BackupDetails) SetBackupName(v string) *BackupDetails {
+	s.BackupName = &v
+	return s
+}
+
+// SetBackupSizeBytes sets the BackupSizeBytes field's value.
+func (s *BackupDetails) SetBackupSizeBytes(v int64) *BackupDetails {
+	s.BackupSizeBytes = &v
+	return s
+}
+
+// SetBackupStatus sets the BackupStatus field's value.
+func (s *BackupDetails) SetBackupStatus(v string) *BackupDetails {
+	s.BackupStatus = &v
+	return s
+}
+
+// Contains details for the backup.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/BackupSummary
+type BackupSummary struct {
+	_ struct{} `type:"structure"`
+
+	// ARN associated with the backup.
+	BackupArn *string `min:"37" type:"string"`
+
+	// Time at which the backup was created.
+	BackupCreationDateTime *time.Time `type:"timestamp" timestampFormat:"unix"`
+
+	// Name of the specified backup.
+	BackupName *string `min:"3" type:"string"`
+
+	// Size of the backup in bytes.
+	BackupSizeBytes *int64 `type:"long"`
+
+	// Backup can be in one of the following states: CREATING, ACTIVE, DELETED.
+	BackupStatus *string `type:"string" enum:"BackupStatus"`
+
+	// ARN associated with the table.
+	TableArn *string `type:"string"`
+
+	// Unique identifier for the table.
+	TableId *string `type:"string"`
+
+	// Name of the table.
+	TableName *string `min:"3" type:"string"`
+}
+
+// String returns the string representation
+func (s BackupSummary) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s BackupSummary) GoString() string {
+	return s.String()
+}
+
+// SetBackupArn sets the BackupArn field's value.
+func (s *BackupSummary) SetBackupArn(v string) *BackupSummary {
+	s.BackupArn = &v
+	return s
+}
+
+// SetBackupCreationDateTime sets the BackupCreationDateTime field's value.
+func (s *BackupSummary) SetBackupCreationDateTime(v time.Time) *BackupSummary {
+	s.BackupCreationDateTime = &v
+	return s
+}
+
+// SetBackupName sets the BackupName field's value.
+func (s *BackupSummary) SetBackupName(v string) *BackupSummary {
+	s.BackupName = &v
+	return s
+}
+
+// SetBackupSizeBytes sets the BackupSizeBytes field's value.
+func (s *BackupSummary) SetBackupSizeBytes(v int64) *BackupSummary {
+	s.BackupSizeBytes = &v
+	return s
+}
+
+// SetBackupStatus sets the BackupStatus field's value.
+func (s *BackupSummary) SetBackupStatus(v string) *BackupSummary {
+	s.BackupStatus = &v
+	return s
+}
+
+// SetTableArn sets the TableArn field's value.
+func (s *BackupSummary) SetTableArn(v string) *BackupSummary {
+	s.TableArn = &v
+	return s
+}
+
+// SetTableId sets the TableId field's value.
+func (s *BackupSummary) SetTableId(v string) *BackupSummary {
+	s.TableId = &v
+	return s
+}
+
+// SetTableName sets the TableName field's value.
+func (s *BackupSummary) SetTableName(v string) *BackupSummary {
+	s.TableName = &v
+	return s
+}
+
 // Represents the input of a BatchGetItem operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/BatchGetItemInput
 type BatchGetItemInput struct {
@@ -3053,8 +4226,8 @@ type BatchWriteItemOutput struct {
 	//    * ItemCollectionKey - The partition key value of the item collection.
 	//    This is the same as the partition key value of the item.
 	//
-	//    * SizeEstimateRange - An estimate of item collection size, expressed in
-	//    GB. This is a two-element array containing a lower bound and an upper
+	//    * SizeEstimateRangeGB - An estimate of item collection size, expressed
+	//    in GB. This is a two-element array containing a lower bound and an upper
 	//    bound for the estimate. The estimate includes the size of all the items
 	//    in the table, plus the size of all attributes projected into all of the
 	//    local secondary indexes on the table. Use this estimate to measure whether
@@ -3329,6 +4502,117 @@ func (s *ConsumedCapacity) SetTableName(v string) *ConsumedCapacity {
 	return s
 }
 
+// Represents the backup and restore settings on the table when the backup was
+// created.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/ContinuousBackupsDescription
+type ContinuousBackupsDescription struct {
+	_ struct{} `type:"structure"`
+
+	// ContinuousBackupsStatus can be one of the following states : ENABLED, DISABLED
+	//
+	// ContinuousBackupsStatus is a required field
+	ContinuousBackupsStatus *string `type:"string" required:"true" enum:"ContinuousBackupsStatus"`
+}
+
+// String returns the string representation
+func (s ContinuousBackupsDescription) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ContinuousBackupsDescription) GoString() string {
+	return s.String()
+}
+
+// SetContinuousBackupsStatus sets the ContinuousBackupsStatus field's value.
+func (s *ContinuousBackupsDescription) SetContinuousBackupsStatus(v string) *ContinuousBackupsDescription {
+	s.ContinuousBackupsStatus = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/CreateBackupInput
+type CreateBackupInput struct {
+	_ struct{} `type:"structure"`
+
+	// Specified name for the backup.
+	//
+	// BackupName is a required field
+	BackupName *string `min:"3" type:"string" required:"true"`
+
+	// The name of the table.
+	//
+	// TableName is a required field
+	TableName *string `min:"3" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s CreateBackupInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateBackupInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateBackupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateBackupInput"}
+	if s.BackupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("BackupName"))
+	}
+	if s.BackupName != nil && len(*s.BackupName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("BackupName", 3))
+	}
+	if s.TableName == nil {
+		invalidParams.Add(request.NewErrParamRequired("TableName"))
+	}
+	if s.TableName != nil && len(*s.TableName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("TableName", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetBackupName sets the BackupName field's value.
+func (s *CreateBackupInput) SetBackupName(v string) *CreateBackupInput {
+	s.BackupName = &v
+	return s
+}
+
+// SetTableName sets the TableName field's value.
+func (s *CreateBackupInput) SetTableName(v string) *CreateBackupInput {
+	s.TableName = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/CreateBackupOutput
+type CreateBackupOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Contains the details of the backup created for the table.
+	BackupDetails *BackupDetails `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateBackupOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateBackupOutput) GoString() string {
+	return s.String()
+}
+
+// SetBackupDetails sets the BackupDetails field's value.
+func (s *CreateBackupOutput) SetBackupDetails(v *BackupDetails) *CreateBackupOutput {
+	s.BackupDetails = v
+	return s
+}
+
 // Represents a new global secondary index to be added to an existing table.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/CreateGlobalSecondaryIndexAction
 type CreateGlobalSecondaryIndexAction struct {
@@ -3441,6 +4725,126 @@ func (s *CreateGlobalSecondaryIndexAction) SetProjection(v *Projection) *CreateG
 // SetProvisionedThroughput sets the ProvisionedThroughput field's value.
 func (s *CreateGlobalSecondaryIndexAction) SetProvisionedThroughput(v *ProvisionedThroughput) *CreateGlobalSecondaryIndexAction {
 	s.ProvisionedThroughput = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/CreateGlobalTableInput
+type CreateGlobalTableInput struct {
+	_ struct{} `type:"structure"`
+
+	// The global table name.
+	//
+	// GlobalTableName is a required field
+	GlobalTableName *string `min:"3" type:"string" required:"true"`
+
+	// The regions where the global table needs to be created.
+	//
+	// ReplicationGroup is a required field
+	ReplicationGroup []*Replica `type:"list" required:"true"`
+}
+
+// String returns the string representation
+func (s CreateGlobalTableInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateGlobalTableInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateGlobalTableInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateGlobalTableInput"}
+	if s.GlobalTableName == nil {
+		invalidParams.Add(request.NewErrParamRequired("GlobalTableName"))
+	}
+	if s.GlobalTableName != nil && len(*s.GlobalTableName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("GlobalTableName", 3))
+	}
+	if s.ReplicationGroup == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReplicationGroup"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetGlobalTableName sets the GlobalTableName field's value.
+func (s *CreateGlobalTableInput) SetGlobalTableName(v string) *CreateGlobalTableInput {
+	s.GlobalTableName = &v
+	return s
+}
+
+// SetReplicationGroup sets the ReplicationGroup field's value.
+func (s *CreateGlobalTableInput) SetReplicationGroup(v []*Replica) *CreateGlobalTableInput {
+	s.ReplicationGroup = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/CreateGlobalTableOutput
+type CreateGlobalTableOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Contains the details of the global table.
+	GlobalTableDescription *GlobalTableDescription `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateGlobalTableOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateGlobalTableOutput) GoString() string {
+	return s.String()
+}
+
+// SetGlobalTableDescription sets the GlobalTableDescription field's value.
+func (s *CreateGlobalTableOutput) SetGlobalTableDescription(v *GlobalTableDescription) *CreateGlobalTableOutput {
+	s.GlobalTableDescription = v
+	return s
+}
+
+// Represents a replica to be added.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/CreateReplicaAction
+type CreateReplicaAction struct {
+	_ struct{} `type:"structure"`
+
+	// The region of the replica to be added.
+	//
+	// RegionName is a required field
+	RegionName *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s CreateReplicaAction) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateReplicaAction) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateReplicaAction) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateReplicaAction"}
+	if s.RegionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RegionName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetRegionName sets the RegionName field's value.
+func (s *CreateReplicaAction) SetRegionName(v string) *CreateReplicaAction {
+	s.RegionName = &v
 	return s
 }
 
@@ -3742,6 +5146,72 @@ func (s CreateTableOutput) GoString() string {
 // SetTableDescription sets the TableDescription field's value.
 func (s *CreateTableOutput) SetTableDescription(v *TableDescription) *CreateTableOutput {
 	s.TableDescription = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/DeleteBackupInput
+type DeleteBackupInput struct {
+	_ struct{} `type:"structure"`
+
+	// The ARN associated with the backup.
+	//
+	// BackupArn is a required field
+	BackupArn *string `min:"37" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DeleteBackupInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteBackupInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteBackupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteBackupInput"}
+	if s.BackupArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("BackupArn"))
+	}
+	if s.BackupArn != nil && len(*s.BackupArn) < 37 {
+		invalidParams.Add(request.NewErrParamMinLen("BackupArn", 37))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetBackupArn sets the BackupArn field's value.
+func (s *DeleteBackupInput) SetBackupArn(v string) *DeleteBackupInput {
+	s.BackupArn = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/DeleteBackupOutput
+type DeleteBackupOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Contains the description of the backup created for the table.
+	BackupDescription *BackupDescription `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteBackupOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteBackupOutput) GoString() string {
+	return s.String()
+}
+
+// SetBackupDescription sets the BackupDescription field's value.
+func (s *DeleteBackupOutput) SetBackupDescription(v *BackupDescription) *DeleteBackupOutput {
+	s.BackupDescription = v
 	return s
 }
 
@@ -4050,7 +5520,7 @@ type DeleteItemOutput struct {
 	//    * ItemCollectionKey - The partition key value of the item collection.
 	//    This is the same as the partition key value of the item itself.
 	//
-	//    * SizeEstimateRange - An estimate of item collection size, in gigabytes.
+	//    * SizeEstimateRangeGB - An estimate of item collection size, in gigabytes.
 	//    This value is a two-element array containing a lower bound and an upper
 	//    bound for the estimate. The estimate includes the size of all the items
 	//    in the table, plus the size of all attributes projected into all of the
@@ -4087,6 +5557,46 @@ func (s *DeleteItemOutput) SetConsumedCapacity(v *ConsumedCapacity) *DeleteItemO
 // SetItemCollectionMetrics sets the ItemCollectionMetrics field's value.
 func (s *DeleteItemOutput) SetItemCollectionMetrics(v *ItemCollectionMetrics) *DeleteItemOutput {
 	s.ItemCollectionMetrics = v
+	return s
+}
+
+// Represents a replica to be removed.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/DeleteReplicaAction
+type DeleteReplicaAction struct {
+	_ struct{} `type:"structure"`
+
+	// The region of the replica to be removed.
+	//
+	// RegionName is a required field
+	RegionName *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DeleteReplicaAction) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteReplicaAction) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteReplicaAction) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteReplicaAction"}
+	if s.RegionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RegionName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetRegionName sets the RegionName field's value.
+func (s *DeleteReplicaAction) SetRegionName(v string) *DeleteReplicaAction {
+	s.RegionName = &v
 	return s
 }
 
@@ -4184,6 +5694,205 @@ func (s DeleteTableOutput) GoString() string {
 // SetTableDescription sets the TableDescription field's value.
 func (s *DeleteTableOutput) SetTableDescription(v *TableDescription) *DeleteTableOutput {
 	s.TableDescription = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/DescribeBackupInput
+type DescribeBackupInput struct {
+	_ struct{} `type:"structure"`
+
+	// The ARN associated with the backup.
+	//
+	// BackupArn is a required field
+	BackupArn *string `min:"37" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DescribeBackupInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeBackupInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeBackupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeBackupInput"}
+	if s.BackupArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("BackupArn"))
+	}
+	if s.BackupArn != nil && len(*s.BackupArn) < 37 {
+		invalidParams.Add(request.NewErrParamMinLen("BackupArn", 37))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetBackupArn sets the BackupArn field's value.
+func (s *DescribeBackupInput) SetBackupArn(v string) *DescribeBackupInput {
+	s.BackupArn = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/DescribeBackupOutput
+type DescribeBackupOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Contains the description of the backup created for the table.
+	BackupDescription *BackupDescription `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeBackupOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeBackupOutput) GoString() string {
+	return s.String()
+}
+
+// SetBackupDescription sets the BackupDescription field's value.
+func (s *DescribeBackupOutput) SetBackupDescription(v *BackupDescription) *DescribeBackupOutput {
+	s.BackupDescription = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/DescribeContinuousBackupsInput
+type DescribeContinuousBackupsInput struct {
+	_ struct{} `type:"structure"`
+
+	// Name of the table for which the customer wants to check the backup and restore
+	// settings.
+	//
+	// TableName is a required field
+	TableName *string `min:"3" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DescribeContinuousBackupsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeContinuousBackupsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeContinuousBackupsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeContinuousBackupsInput"}
+	if s.TableName == nil {
+		invalidParams.Add(request.NewErrParamRequired("TableName"))
+	}
+	if s.TableName != nil && len(*s.TableName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("TableName", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetTableName sets the TableName field's value.
+func (s *DescribeContinuousBackupsInput) SetTableName(v string) *DescribeContinuousBackupsInput {
+	s.TableName = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/DescribeContinuousBackupsOutput
+type DescribeContinuousBackupsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// ContinuousBackupsDescription can be one of the following : ENABLED, DISABLED.
+	ContinuousBackupsDescription *ContinuousBackupsDescription `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeContinuousBackupsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeContinuousBackupsOutput) GoString() string {
+	return s.String()
+}
+
+// SetContinuousBackupsDescription sets the ContinuousBackupsDescription field's value.
+func (s *DescribeContinuousBackupsOutput) SetContinuousBackupsDescription(v *ContinuousBackupsDescription) *DescribeContinuousBackupsOutput {
+	s.ContinuousBackupsDescription = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/DescribeGlobalTableInput
+type DescribeGlobalTableInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the global table.
+	//
+	// GlobalTableName is a required field
+	GlobalTableName *string `min:"3" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DescribeGlobalTableInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeGlobalTableInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeGlobalTableInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeGlobalTableInput"}
+	if s.GlobalTableName == nil {
+		invalidParams.Add(request.NewErrParamRequired("GlobalTableName"))
+	}
+	if s.GlobalTableName != nil && len(*s.GlobalTableName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("GlobalTableName", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetGlobalTableName sets the GlobalTableName field's value.
+func (s *DescribeGlobalTableInput) SetGlobalTableName(v string) *DescribeGlobalTableInput {
+	s.GlobalTableName = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/DescribeGlobalTableOutput
+type DescribeGlobalTableOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Contains the details of the global table.
+	GlobalTableDescription *GlobalTableDescription `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeGlobalTableOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeGlobalTableOutput) GoString() string {
+	return s.String()
+}
+
+// SetGlobalTableDescription sets the GlobalTableDescription field's value.
+func (s *DescribeGlobalTableOutput) SetGlobalTableDescription(v *GlobalTableDescription) *DescribeGlobalTableOutput {
+	s.GlobalTableDescription = v
 	return s
 }
 
@@ -5025,6 +6734,76 @@ func (s *GlobalSecondaryIndexDescription) SetProvisionedThroughput(v *Provisione
 	return s
 }
 
+// Represents the properties of a global secondary index for the table when
+// the backup was created.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/GlobalSecondaryIndexInfo
+type GlobalSecondaryIndexInfo struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the global secondary index.
+	IndexName *string `min:"3" type:"string"`
+
+	// The complete key schema for a global secondary index, which consists of one
+	// or more pairs of attribute names and key types:
+	//
+	//    * HASH - partition key
+	//
+	//    * RANGE - sort key
+	//
+	// The partition key of an item is also known as its hash attribute. The term
+	// "hash attribute" derives from DynamoDB' usage of an internal hash function
+	// to evenly distribute data items across partitions, based on their partition
+	// key values.
+	//
+	// The sort key of an item is also known as its range attribute. The term "range
+	// attribute" derives from the way DynamoDB stores items with the same partition
+	// key physically close together, in sorted order by the sort key value.
+	KeySchema []*KeySchemaElement `min:"1" type:"list"`
+
+	// Represents attributes that are copied (projected) from the table into the
+	// global secondary index. These are in addition to the primary key attributes
+	// and index key attributes, which are automatically projected.
+	Projection *Projection `type:"structure"`
+
+	// Represents the provisioned throughput settings for the specified global secondary
+	// index.
+	ProvisionedThroughput *ProvisionedThroughput `type:"structure"`
+}
+
+// String returns the string representation
+func (s GlobalSecondaryIndexInfo) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GlobalSecondaryIndexInfo) GoString() string {
+	return s.String()
+}
+
+// SetIndexName sets the IndexName field's value.
+func (s *GlobalSecondaryIndexInfo) SetIndexName(v string) *GlobalSecondaryIndexInfo {
+	s.IndexName = &v
+	return s
+}
+
+// SetKeySchema sets the KeySchema field's value.
+func (s *GlobalSecondaryIndexInfo) SetKeySchema(v []*KeySchemaElement) *GlobalSecondaryIndexInfo {
+	s.KeySchema = v
+	return s
+}
+
+// SetProjection sets the Projection field's value.
+func (s *GlobalSecondaryIndexInfo) SetProjection(v *Projection) *GlobalSecondaryIndexInfo {
+	s.Projection = v
+	return s
+}
+
+// SetProvisionedThroughput sets the ProvisionedThroughput field's value.
+func (s *GlobalSecondaryIndexInfo) SetProvisionedThroughput(v *ProvisionedThroughput) *GlobalSecondaryIndexInfo {
+	s.ProvisionedThroughput = v
+	return s
+}
+
 // Represents one of the following:
 //
 //    * A new global secondary index to be added to an existing table.
@@ -5109,6 +6888,109 @@ func (s *GlobalSecondaryIndexUpdate) SetDelete(v *DeleteGlobalSecondaryIndexActi
 // SetUpdate sets the Update field's value.
 func (s *GlobalSecondaryIndexUpdate) SetUpdate(v *UpdateGlobalSecondaryIndexAction) *GlobalSecondaryIndexUpdate {
 	s.Update = v
+	return s
+}
+
+// Represents the properties of a global table.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/GlobalTable
+type GlobalTable struct {
+	_ struct{} `type:"structure"`
+
+	// The global table name.
+	GlobalTableName *string `min:"3" type:"string"`
+
+	// The regions where the global table has replicas.
+	ReplicationGroup []*Replica `type:"list"`
+}
+
+// String returns the string representation
+func (s GlobalTable) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GlobalTable) GoString() string {
+	return s.String()
+}
+
+// SetGlobalTableName sets the GlobalTableName field's value.
+func (s *GlobalTable) SetGlobalTableName(v string) *GlobalTable {
+	s.GlobalTableName = &v
+	return s
+}
+
+// SetReplicationGroup sets the ReplicationGroup field's value.
+func (s *GlobalTable) SetReplicationGroup(v []*Replica) *GlobalTable {
+	s.ReplicationGroup = v
+	return s
+}
+
+// Contains details about the global table.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/GlobalTableDescription
+type GlobalTableDescription struct {
+	_ struct{} `type:"structure"`
+
+	// The creation time of the global table.
+	CreationDateTime *time.Time `type:"timestamp" timestampFormat:"unix"`
+
+	// The unique identifier of the global table.
+	GlobalTableArn *string `type:"string"`
+
+	// The global table name.
+	GlobalTableName *string `min:"3" type:"string"`
+
+	// The current state of the global table:
+	//
+	//    * CREATING - The global table is being created.
+	//
+	//    * UPDATING - The global table is being updated.
+	//
+	//    * DELETING - The global table is being deleted.
+	//
+	//    * ACTIVE - The global table is ready for use.
+	GlobalTableStatus *string `type:"string" enum:"GlobalTableStatus"`
+
+	// The regions where the global table has replicas.
+	ReplicationGroup []*ReplicaDescription `type:"list"`
+}
+
+// String returns the string representation
+func (s GlobalTableDescription) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GlobalTableDescription) GoString() string {
+	return s.String()
+}
+
+// SetCreationDateTime sets the CreationDateTime field's value.
+func (s *GlobalTableDescription) SetCreationDateTime(v time.Time) *GlobalTableDescription {
+	s.CreationDateTime = &v
+	return s
+}
+
+// SetGlobalTableArn sets the GlobalTableArn field's value.
+func (s *GlobalTableDescription) SetGlobalTableArn(v string) *GlobalTableDescription {
+	s.GlobalTableArn = &v
+	return s
+}
+
+// SetGlobalTableName sets the GlobalTableName field's value.
+func (s *GlobalTableDescription) SetGlobalTableName(v string) *GlobalTableDescription {
+	s.GlobalTableName = &v
+	return s
+}
+
+// SetGlobalTableStatus sets the GlobalTableStatus field's value.
+func (s *GlobalTableDescription) SetGlobalTableStatus(v string) *GlobalTableDescription {
+	s.GlobalTableStatus = &v
+	return s
+}
+
+// SetReplicationGroup sets the ReplicationGroup field's value.
+func (s *GlobalTableDescription) SetReplicationGroup(v []*ReplicaDescription) *GlobalTableDescription {
+	s.ReplicationGroup = v
 	return s
 }
 
@@ -5370,6 +7252,210 @@ func (s *KeysAndAttributes) SetKeys(v []map[string]*AttributeValue) *KeysAndAttr
 // SetProjectionExpression sets the ProjectionExpression field's value.
 func (s *KeysAndAttributes) SetProjectionExpression(v string) *KeysAndAttributes {
 	s.ProjectionExpression = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/ListBackupsInput
+type ListBackupsInput struct {
+	_ struct{} `type:"structure"`
+
+	// LastEvaluatedBackupARN returned by the previous ListBackups call.
+	ExclusiveStartBackupArn *string `min:"37" type:"string"`
+
+	// Maximum number of backups to return at once.
+	Limit *int64 `min:"1" type:"integer"`
+
+	// The backups from the table specified by TableName are listed.
+	TableName *string `min:"3" type:"string"`
+
+	// Only backups created after this time are listed. TimeRangeLowerBound is inclusive.
+	TimeRangeLowerBound *time.Time `type:"timestamp" timestampFormat:"unix"`
+
+	// Only backups created before this time are listed. TimeRangeUpperBound is
+	// exclusive.
+	TimeRangeUpperBound *time.Time `type:"timestamp" timestampFormat:"unix"`
+}
+
+// String returns the string representation
+func (s ListBackupsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListBackupsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListBackupsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListBackupsInput"}
+	if s.ExclusiveStartBackupArn != nil && len(*s.ExclusiveStartBackupArn) < 37 {
+		invalidParams.Add(request.NewErrParamMinLen("ExclusiveStartBackupArn", 37))
+	}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+	if s.TableName != nil && len(*s.TableName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("TableName", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetExclusiveStartBackupArn sets the ExclusiveStartBackupArn field's value.
+func (s *ListBackupsInput) SetExclusiveStartBackupArn(v string) *ListBackupsInput {
+	s.ExclusiveStartBackupArn = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *ListBackupsInput) SetLimit(v int64) *ListBackupsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetTableName sets the TableName field's value.
+func (s *ListBackupsInput) SetTableName(v string) *ListBackupsInput {
+	s.TableName = &v
+	return s
+}
+
+// SetTimeRangeLowerBound sets the TimeRangeLowerBound field's value.
+func (s *ListBackupsInput) SetTimeRangeLowerBound(v time.Time) *ListBackupsInput {
+	s.TimeRangeLowerBound = &v
+	return s
+}
+
+// SetTimeRangeUpperBound sets the TimeRangeUpperBound field's value.
+func (s *ListBackupsInput) SetTimeRangeUpperBound(v time.Time) *ListBackupsInput {
+	s.TimeRangeUpperBound = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/ListBackupsOutput
+type ListBackupsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// List of BackupSummary objects.
+	BackupSummaries []*BackupSummary `type:"list"`
+
+	// Last evaluated BackupARN.
+	LastEvaluatedBackupArn *string `min:"37" type:"string"`
+}
+
+// String returns the string representation
+func (s ListBackupsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListBackupsOutput) GoString() string {
+	return s.String()
+}
+
+// SetBackupSummaries sets the BackupSummaries field's value.
+func (s *ListBackupsOutput) SetBackupSummaries(v []*BackupSummary) *ListBackupsOutput {
+	s.BackupSummaries = v
+	return s
+}
+
+// SetLastEvaluatedBackupArn sets the LastEvaluatedBackupArn field's value.
+func (s *ListBackupsOutput) SetLastEvaluatedBackupArn(v string) *ListBackupsOutput {
+	s.LastEvaluatedBackupArn = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/ListGlobalTablesInput
+type ListGlobalTablesInput struct {
+	_ struct{} `type:"structure"`
+
+	// The first global table name that this operation will evaluate.
+	ExclusiveStartGlobalTableName *string `min:"3" type:"string"`
+
+	// The maximum number of table names to return.
+	Limit *int64 `min:"1" type:"integer"`
+
+	// Lists the global tables in a specific region.
+	RegionName *string `type:"string"`
+}
+
+// String returns the string representation
+func (s ListGlobalTablesInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListGlobalTablesInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListGlobalTablesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListGlobalTablesInput"}
+	if s.ExclusiveStartGlobalTableName != nil && len(*s.ExclusiveStartGlobalTableName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("ExclusiveStartGlobalTableName", 3))
+	}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetExclusiveStartGlobalTableName sets the ExclusiveStartGlobalTableName field's value.
+func (s *ListGlobalTablesInput) SetExclusiveStartGlobalTableName(v string) *ListGlobalTablesInput {
+	s.ExclusiveStartGlobalTableName = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *ListGlobalTablesInput) SetLimit(v int64) *ListGlobalTablesInput {
+	s.Limit = &v
+	return s
+}
+
+// SetRegionName sets the RegionName field's value.
+func (s *ListGlobalTablesInput) SetRegionName(v string) *ListGlobalTablesInput {
+	s.RegionName = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/ListGlobalTablesOutput
+type ListGlobalTablesOutput struct {
+	_ struct{} `type:"structure"`
+
+	// List of global table names.
+	GlobalTables []*GlobalTable `type:"list"`
+
+	// Last evaluated global table name.
+	LastEvaluatedGlobalTableName *string `min:"3" type:"string"`
+}
+
+// String returns the string representation
+func (s ListGlobalTablesOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListGlobalTablesOutput) GoString() string {
+	return s.String()
+}
+
+// SetGlobalTables sets the GlobalTables field's value.
+func (s *ListGlobalTablesOutput) SetGlobalTables(v []*GlobalTable) *ListGlobalTablesOutput {
+	s.GlobalTables = v
+	return s
+}
+
+// SetLastEvaluatedGlobalTableName sets the LastEvaluatedGlobalTableName field's value.
+func (s *ListGlobalTablesOutput) SetLastEvaluatedGlobalTableName(v string) *ListGlobalTablesOutput {
+	s.LastEvaluatedGlobalTableName = &v
 	return s
 }
 
@@ -5750,6 +7836,66 @@ func (s *LocalSecondaryIndexDescription) SetKeySchema(v []*KeySchemaElement) *Lo
 
 // SetProjection sets the Projection field's value.
 func (s *LocalSecondaryIndexDescription) SetProjection(v *Projection) *LocalSecondaryIndexDescription {
+	s.Projection = v
+	return s
+}
+
+// Represents the properties of a local secondary index for the table when the
+// backup was created.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/LocalSecondaryIndexInfo
+type LocalSecondaryIndexInfo struct {
+	_ struct{} `type:"structure"`
+
+	// Represents the name of the local secondary index.
+	IndexName *string `min:"3" type:"string"`
+
+	// The complete key schema for a local secondary index, which consists of one
+	// or more pairs of attribute names and key types:
+	//
+	//    * HASH - partition key
+	//
+	//    * RANGE - sort key
+	//
+	// The partition key of an item is also known as its hash attribute. The term
+	// "hash attribute" derives from DynamoDB' usage of an internal hash function
+	// to evenly distribute data items across partitions, based on their partition
+	// key values.
+	//
+	// The sort key of an item is also known as its range attribute. The term "range
+	// attribute" derives from the way DynamoDB stores items with the same partition
+	// key physically close together, in sorted order by the sort key value.
+	KeySchema []*KeySchemaElement `min:"1" type:"list"`
+
+	// Represents attributes that are copied (projected) from the table into the
+	// global secondary index. These are in addition to the primary key attributes
+	// and index key attributes, which are automatically projected.
+	Projection *Projection `type:"structure"`
+}
+
+// String returns the string representation
+func (s LocalSecondaryIndexInfo) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s LocalSecondaryIndexInfo) GoString() string {
+	return s.String()
+}
+
+// SetIndexName sets the IndexName field's value.
+func (s *LocalSecondaryIndexInfo) SetIndexName(v string) *LocalSecondaryIndexInfo {
+	s.IndexName = &v
+	return s
+}
+
+// SetKeySchema sets the KeySchema field's value.
+func (s *LocalSecondaryIndexInfo) SetKeySchema(v []*KeySchemaElement) *LocalSecondaryIndexInfo {
+	s.KeySchema = v
+	return s
+}
+
+// SetProjection sets the Projection field's value.
+func (s *LocalSecondaryIndexInfo) SetProjection(v *Projection) *LocalSecondaryIndexInfo {
 	s.Projection = v
 	return s
 }
@@ -6229,7 +8375,7 @@ type PutItemOutput struct {
 	//    * ItemCollectionKey - The partition key value of the item collection.
 	//    This is the same as the partition key value of the item itself.
 	//
-	//    * SizeEstimateRange - An estimate of item collection size, in gigabytes.
+	//    * SizeEstimateRangeGB - An estimate of item collection size, in gigabytes.
 	//    This value is a two-element array containing a lower bound and an upper
 	//    bound for the estimate. The estimate includes the size of all the items
 	//    in the table, plus the size of all attributes projected into all of the
@@ -6842,6 +8988,255 @@ func (s *QueryOutput) SetScannedCount(v int64) *QueryOutput {
 	return s
 }
 
+// Represents the properties of a replica.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/Replica
+type Replica struct {
+	_ struct{} `type:"structure"`
+
+	// The region where the replica needs to be created.
+	RegionName *string `type:"string"`
+}
+
+// String returns the string representation
+func (s Replica) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s Replica) GoString() string {
+	return s.String()
+}
+
+// SetRegionName sets the RegionName field's value.
+func (s *Replica) SetRegionName(v string) *Replica {
+	s.RegionName = &v
+	return s
+}
+
+// Contains the details of the replica.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/ReplicaDescription
+type ReplicaDescription struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the region.
+	RegionName *string `type:"string"`
+}
+
+// String returns the string representation
+func (s ReplicaDescription) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ReplicaDescription) GoString() string {
+	return s.String()
+}
+
+// SetRegionName sets the RegionName field's value.
+func (s *ReplicaDescription) SetRegionName(v string) *ReplicaDescription {
+	s.RegionName = &v
+	return s
+}
+
+// Represents one of the following:
+//
+//    * A new replica to be added to an existing global table.
+//
+//    * New parameters for an existing replica.
+//
+//    * An existing replica to be removed from an existing global table.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/ReplicaUpdate
+type ReplicaUpdate struct {
+	_ struct{} `type:"structure"`
+
+	// The parameters required for creating a replica on an existing global table.
+	Create *CreateReplicaAction `type:"structure"`
+
+	// The name of the existing replica to be removed.
+	Delete *DeleteReplicaAction `type:"structure"`
+}
+
+// String returns the string representation
+func (s ReplicaUpdate) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ReplicaUpdate) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ReplicaUpdate) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ReplicaUpdate"}
+	if s.Create != nil {
+		if err := s.Create.Validate(); err != nil {
+			invalidParams.AddNested("Create", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Delete != nil {
+		if err := s.Delete.Validate(); err != nil {
+			invalidParams.AddNested("Delete", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetCreate sets the Create field's value.
+func (s *ReplicaUpdate) SetCreate(v *CreateReplicaAction) *ReplicaUpdate {
+	s.Create = v
+	return s
+}
+
+// SetDelete sets the Delete field's value.
+func (s *ReplicaUpdate) SetDelete(v *DeleteReplicaAction) *ReplicaUpdate {
+	s.Delete = v
+	return s
+}
+
+// Contains details for the restore.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/RestoreSummary
+type RestoreSummary struct {
+	_ struct{} `type:"structure"`
+
+	// Point in time or source backup time.
+	//
+	// RestoreDateTime is a required field
+	RestoreDateTime *time.Time `type:"timestamp" timestampFormat:"unix" required:"true"`
+
+	// Indicates if a restore is in progress or not.
+	//
+	// RestoreInProgress is a required field
+	RestoreInProgress *bool `type:"boolean" required:"true"`
+
+	// ARN of the backup from which the table was restored.
+	SourceBackupArn *string `min:"37" type:"string"`
+
+	// ARN of the source table of the backup that is being restored.
+	SourceTableArn *string `type:"string"`
+}
+
+// String returns the string representation
+func (s RestoreSummary) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s RestoreSummary) GoString() string {
+	return s.String()
+}
+
+// SetRestoreDateTime sets the RestoreDateTime field's value.
+func (s *RestoreSummary) SetRestoreDateTime(v time.Time) *RestoreSummary {
+	s.RestoreDateTime = &v
+	return s
+}
+
+// SetRestoreInProgress sets the RestoreInProgress field's value.
+func (s *RestoreSummary) SetRestoreInProgress(v bool) *RestoreSummary {
+	s.RestoreInProgress = &v
+	return s
+}
+
+// SetSourceBackupArn sets the SourceBackupArn field's value.
+func (s *RestoreSummary) SetSourceBackupArn(v string) *RestoreSummary {
+	s.SourceBackupArn = &v
+	return s
+}
+
+// SetSourceTableArn sets the SourceTableArn field's value.
+func (s *RestoreSummary) SetSourceTableArn(v string) *RestoreSummary {
+	s.SourceTableArn = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/RestoreTableFromBackupInput
+type RestoreTableFromBackupInput struct {
+	_ struct{} `type:"structure"`
+
+	// The ARN associated with the backup.
+	//
+	// BackupArn is a required field
+	BackupArn *string `min:"37" type:"string" required:"true"`
+
+	// The name of the new table to which the backup must be restored.
+	//
+	// TargetTableName is a required field
+	TargetTableName *string `min:"3" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s RestoreTableFromBackupInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s RestoreTableFromBackupInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RestoreTableFromBackupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RestoreTableFromBackupInput"}
+	if s.BackupArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("BackupArn"))
+	}
+	if s.BackupArn != nil && len(*s.BackupArn) < 37 {
+		invalidParams.Add(request.NewErrParamMinLen("BackupArn", 37))
+	}
+	if s.TargetTableName == nil {
+		invalidParams.Add(request.NewErrParamRequired("TargetTableName"))
+	}
+	if s.TargetTableName != nil && len(*s.TargetTableName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("TargetTableName", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetBackupArn sets the BackupArn field's value.
+func (s *RestoreTableFromBackupInput) SetBackupArn(v string) *RestoreTableFromBackupInput {
+	s.BackupArn = &v
+	return s
+}
+
+// SetTargetTableName sets the TargetTableName field's value.
+func (s *RestoreTableFromBackupInput) SetTargetTableName(v string) *RestoreTableFromBackupInput {
+	s.TargetTableName = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/RestoreTableFromBackupOutput
+type RestoreTableFromBackupOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The description of the table created from an existing backup.
+	TableDescription *TableDescription `type:"structure"`
+}
+
+// String returns the string representation
+func (s RestoreTableFromBackupOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s RestoreTableFromBackupOutput) GoString() string {
+	return s.String()
+}
+
+// SetTableDescription sets the TableDescription field's value.
+func (s *RestoreTableFromBackupOutput) SetTableDescription(v *TableDescription) *RestoreTableFromBackupOutput {
+	s.TableDescription = v
+	return s
+}
+
 // Represents the input of a Scan operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/ScanInput
 type ScanInput struct {
@@ -7321,6 +9716,161 @@ func (s *ScanOutput) SetScannedCount(v int64) *ScanOutput {
 	return s
 }
 
+// Contains the details of the table when the backup was created.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/SourceTableDetails
+type SourceTableDetails struct {
+	_ struct{} `type:"structure"`
+
+	// Number of items in the table. Please note this is an approximate value.
+	ItemCount *int64 `type:"long"`
+
+	// Schema of the table.
+	//
+	// KeySchema is a required field
+	KeySchema []*KeySchemaElement `min:"1" type:"list" required:"true"`
+
+	// Read IOPs and Write IOPS on the table when the backup was created.
+	//
+	// ProvisionedThroughput is a required field
+	ProvisionedThroughput *ProvisionedThroughput `type:"structure" required:"true"`
+
+	// ARN of the table for which backup was created.
+	TableArn *string `type:"string"`
+
+	// Time when the source table was created.
+	//
+	// TableCreationDateTime is a required field
+	TableCreationDateTime *time.Time `type:"timestamp" timestampFormat:"unix" required:"true"`
+
+	// Unique identifier for the table for which the backup was created.
+	//
+	// TableId is a required field
+	TableId *string `type:"string" required:"true"`
+
+	// The name of the table for which the backup was created.
+	//
+	// TableName is a required field
+	TableName *string `min:"3" type:"string" required:"true"`
+
+	// Size of the table in bytes. Please note this is an approximate value.
+	TableSizeBytes *int64 `type:"long"`
+}
+
+// String returns the string representation
+func (s SourceTableDetails) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SourceTableDetails) GoString() string {
+	return s.String()
+}
+
+// SetItemCount sets the ItemCount field's value.
+func (s *SourceTableDetails) SetItemCount(v int64) *SourceTableDetails {
+	s.ItemCount = &v
+	return s
+}
+
+// SetKeySchema sets the KeySchema field's value.
+func (s *SourceTableDetails) SetKeySchema(v []*KeySchemaElement) *SourceTableDetails {
+	s.KeySchema = v
+	return s
+}
+
+// SetProvisionedThroughput sets the ProvisionedThroughput field's value.
+func (s *SourceTableDetails) SetProvisionedThroughput(v *ProvisionedThroughput) *SourceTableDetails {
+	s.ProvisionedThroughput = v
+	return s
+}
+
+// SetTableArn sets the TableArn field's value.
+func (s *SourceTableDetails) SetTableArn(v string) *SourceTableDetails {
+	s.TableArn = &v
+	return s
+}
+
+// SetTableCreationDateTime sets the TableCreationDateTime field's value.
+func (s *SourceTableDetails) SetTableCreationDateTime(v time.Time) *SourceTableDetails {
+	s.TableCreationDateTime = &v
+	return s
+}
+
+// SetTableId sets the TableId field's value.
+func (s *SourceTableDetails) SetTableId(v string) *SourceTableDetails {
+	s.TableId = &v
+	return s
+}
+
+// SetTableName sets the TableName field's value.
+func (s *SourceTableDetails) SetTableName(v string) *SourceTableDetails {
+	s.TableName = &v
+	return s
+}
+
+// SetTableSizeBytes sets the TableSizeBytes field's value.
+func (s *SourceTableDetails) SetTableSizeBytes(v int64) *SourceTableDetails {
+	s.TableSizeBytes = &v
+	return s
+}
+
+// Contains the details of the features enabled on the table when the backup
+// was created. For example, LSIs, GSIs, streams, TTL.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/SourceTableFeatureDetails
+type SourceTableFeatureDetails struct {
+	_ struct{} `type:"structure"`
+
+	// Represents the GSI properties for the table when the backup was created.
+	// It includes the IndexName, KeySchema, Projection and ProvisionedThroughput
+	// for the GSIs on the table at the time of backup.
+	GlobalSecondaryIndexes []*GlobalSecondaryIndexInfo `type:"list"`
+
+	// Represents the LSI properties for the table when the backup was created.
+	// It includes the IndexName, KeySchema and Projection for the LSIs on the table
+	// at the time of backup.
+	LocalSecondaryIndexes []*LocalSecondaryIndexInfo `type:"list"`
+
+	// Stream settings on the table when the backup was created.
+	StreamDescription *StreamSpecification `type:"structure"`
+
+	// Time to Live settings on the table when the backup was created.
+	TimeToLiveDescription *TimeToLiveDescription `type:"structure"`
+}
+
+// String returns the string representation
+func (s SourceTableFeatureDetails) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SourceTableFeatureDetails) GoString() string {
+	return s.String()
+}
+
+// SetGlobalSecondaryIndexes sets the GlobalSecondaryIndexes field's value.
+func (s *SourceTableFeatureDetails) SetGlobalSecondaryIndexes(v []*GlobalSecondaryIndexInfo) *SourceTableFeatureDetails {
+	s.GlobalSecondaryIndexes = v
+	return s
+}
+
+// SetLocalSecondaryIndexes sets the LocalSecondaryIndexes field's value.
+func (s *SourceTableFeatureDetails) SetLocalSecondaryIndexes(v []*LocalSecondaryIndexInfo) *SourceTableFeatureDetails {
+	s.LocalSecondaryIndexes = v
+	return s
+}
+
+// SetStreamDescription sets the StreamDescription field's value.
+func (s *SourceTableFeatureDetails) SetStreamDescription(v *StreamSpecification) *SourceTableFeatureDetails {
+	s.StreamDescription = v
+	return s
+}
+
+// SetTimeToLiveDescription sets the TimeToLiveDescription field's value.
+func (s *SourceTableFeatureDetails) SetTimeToLiveDescription(v *TimeToLiveDescription) *SourceTableFeatureDetails {
+	s.TimeToLiveDescription = v
+	return s
+}
+
 // Represents the DynamoDB Streams configuration for a table in DynamoDB.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/StreamSpecification
 type StreamSpecification struct {
@@ -7543,11 +10093,17 @@ type TableDescription struct {
 	// write capacity units, along with data about increases and decreases.
 	ProvisionedThroughput *ProvisionedThroughputDescription `type:"structure"`
 
+	// Contains details for the restore.
+	RestoreSummary *RestoreSummary `type:"structure"`
+
 	// The current DynamoDB Streams configuration for the table.
 	StreamSpecification *StreamSpecification `type:"structure"`
 
 	// The Amazon Resource Name (ARN) that uniquely identifies the table.
 	TableArn *string `type:"string"`
+
+	// Unique identifier for the table for which the backup was created.
+	TableId *string `type:"string"`
 
 	// The name of the table.
 	TableName *string `min:"3" type:"string"`
@@ -7633,6 +10189,12 @@ func (s *TableDescription) SetProvisionedThroughput(v *ProvisionedThroughputDesc
 	return s
 }
 
+// SetRestoreSummary sets the RestoreSummary field's value.
+func (s *TableDescription) SetRestoreSummary(v *RestoreSummary) *TableDescription {
+	s.RestoreSummary = v
+	return s
+}
+
 // SetStreamSpecification sets the StreamSpecification field's value.
 func (s *TableDescription) SetStreamSpecification(v *StreamSpecification) *TableDescription {
 	s.StreamSpecification = v
@@ -7642,6 +10204,12 @@ func (s *TableDescription) SetStreamSpecification(v *StreamSpecification) *Table
 // SetTableArn sets the TableArn field's value.
 func (s *TableDescription) SetTableArn(v string) *TableDescription {
 	s.TableArn = &v
+	return s
+}
+
+// SetTableId sets the TableId field's value.
+func (s *TableDescription) SetTableId(v string) *TableDescription {
+	s.TableId = &v
 	return s
 }
 
@@ -8048,6 +10616,96 @@ func (s *UpdateGlobalSecondaryIndexAction) SetProvisionedThroughput(v *Provision
 	return s
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/UpdateGlobalTableInput
+type UpdateGlobalTableInput struct {
+	_ struct{} `type:"structure"`
+
+	// The global table name.
+	//
+	// GlobalTableName is a required field
+	GlobalTableName *string `min:"3" type:"string" required:"true"`
+
+	// A list of regions that should be added or removed from the global table.
+	//
+	// ReplicaUpdates is a required field
+	ReplicaUpdates []*ReplicaUpdate `type:"list" required:"true"`
+}
+
+// String returns the string representation
+func (s UpdateGlobalTableInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateGlobalTableInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateGlobalTableInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateGlobalTableInput"}
+	if s.GlobalTableName == nil {
+		invalidParams.Add(request.NewErrParamRequired("GlobalTableName"))
+	}
+	if s.GlobalTableName != nil && len(*s.GlobalTableName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("GlobalTableName", 3))
+	}
+	if s.ReplicaUpdates == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReplicaUpdates"))
+	}
+	if s.ReplicaUpdates != nil {
+		for i, v := range s.ReplicaUpdates {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "ReplicaUpdates", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetGlobalTableName sets the GlobalTableName field's value.
+func (s *UpdateGlobalTableInput) SetGlobalTableName(v string) *UpdateGlobalTableInput {
+	s.GlobalTableName = &v
+	return s
+}
+
+// SetReplicaUpdates sets the ReplicaUpdates field's value.
+func (s *UpdateGlobalTableInput) SetReplicaUpdates(v []*ReplicaUpdate) *UpdateGlobalTableInput {
+	s.ReplicaUpdates = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/UpdateGlobalTableOutput
+type UpdateGlobalTableOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Contains the details of the global table.
+	GlobalTableDescription *GlobalTableDescription `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateGlobalTableOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateGlobalTableOutput) GoString() string {
+	return s.String()
+}
+
+// SetGlobalTableDescription sets the GlobalTableDescription field's value.
+func (s *UpdateGlobalTableOutput) SetGlobalTableDescription(v *GlobalTableDescription) *UpdateGlobalTableOutput {
+	s.GlobalTableDescription = v
+	return s
+}
+
 // Represents the input of an UpdateItem operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/dynamodb-2012-08-10/UpdateItemInput
 type UpdateItemInput struct {
@@ -8416,7 +11074,7 @@ type UpdateItemOutput struct {
 	//    * ItemCollectionKey - The partition key value of the item collection.
 	//    This is the same as the partition key value of the item itself.
 	//
-	//    * SizeEstimateRange - An estimate of item collection size, in gigabytes.
+	//    * SizeEstimateRangeGB - An estimate of item collection size, in gigabytes.
 	//    This value is a two-element array containing a lower bound and an upper
 	//    bound for the estimate. The estimate includes the size of all the items
 	//    in the table, plus the size of all attributes projected into all of the
@@ -8738,6 +11396,17 @@ const (
 )
 
 const (
+	// BackupStatusCreating is a BackupStatus enum value
+	BackupStatusCreating = "CREATING"
+
+	// BackupStatusDeleted is a BackupStatus enum value
+	BackupStatusDeleted = "DELETED"
+
+	// BackupStatusAvailable is a BackupStatus enum value
+	BackupStatusAvailable = "AVAILABLE"
+)
+
+const (
 	// ComparisonOperatorEq is a ComparisonOperator enum value
 	ComparisonOperatorEq = "EQ"
 
@@ -8784,6 +11453,28 @@ const (
 
 	// ConditionalOperatorOr is a ConditionalOperator enum value
 	ConditionalOperatorOr = "OR"
+)
+
+const (
+	// ContinuousBackupsStatusEnabled is a ContinuousBackupsStatus enum value
+	ContinuousBackupsStatusEnabled = "ENABLED"
+
+	// ContinuousBackupsStatusDisabled is a ContinuousBackupsStatus enum value
+	ContinuousBackupsStatusDisabled = "DISABLED"
+)
+
+const (
+	// GlobalTableStatusCreating is a GlobalTableStatus enum value
+	GlobalTableStatusCreating = "CREATING"
+
+	// GlobalTableStatusActive is a GlobalTableStatus enum value
+	GlobalTableStatusActive = "ACTIVE"
+
+	// GlobalTableStatusDeleting is a GlobalTableStatus enum value
+	GlobalTableStatusDeleting = "DELETING"
+
+	// GlobalTableStatusUpdating is a GlobalTableStatus enum value
+	GlobalTableStatusUpdating = "UPDATING"
 )
 
 const (

--- a/vendor/github.com/aws/aws-sdk-go/service/dynamodb/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/dynamodb/errors.go
@@ -4,11 +4,42 @@ package dynamodb
 
 const (
 
+	// ErrCodeBackupInUseException for service response error code
+	// "BackupInUseException".
+	//
+	// There is another ongoing conflicting backup control plane operation on the
+	// table. The backups is either being created, deleted or restored to a table.
+	ErrCodeBackupInUseException = "BackupInUseException"
+
+	// ErrCodeBackupNotFoundException for service response error code
+	// "BackupNotFoundException".
+	//
+	// Backup not found for the given BackupARN.
+	ErrCodeBackupNotFoundException = "BackupNotFoundException"
+
 	// ErrCodeConditionalCheckFailedException for service response error code
 	// "ConditionalCheckFailedException".
 	//
 	// A condition specified in the operation could not be evaluated.
 	ErrCodeConditionalCheckFailedException = "ConditionalCheckFailedException"
+
+	// ErrCodeContinuousBackupsUnavailableException for service response error code
+	// "ContinuousBackupsUnavailableException".
+	//
+	// Backups have not yet been enabled for this table.
+	ErrCodeContinuousBackupsUnavailableException = "ContinuousBackupsUnavailableException"
+
+	// ErrCodeGlobalTableAlreadyExistsException for service response error code
+	// "GlobalTableAlreadyExistsException".
+	//
+	// The specified global table already exists.
+	ErrCodeGlobalTableAlreadyExistsException = "GlobalTableAlreadyExistsException"
+
+	// ErrCodeGlobalTableNotFoundException for service response error code
+	// "GlobalTableNotFoundException".
+	//
+	// The specified global table does not exist.
+	ErrCodeGlobalTableNotFoundException = "GlobalTableNotFoundException"
 
 	// ErrCodeInternalServerError for service response error code
 	// "InternalServerError".
@@ -47,6 +78,18 @@ const (
 	// in the Amazon DynamoDB Developer Guide.
 	ErrCodeProvisionedThroughputExceededException = "ProvisionedThroughputExceededException"
 
+	// ErrCodeReplicaAlreadyExistsException for service response error code
+	// "ReplicaAlreadyExistsException".
+	//
+	// The specified replica is already part of the global table.
+	ErrCodeReplicaAlreadyExistsException = "ReplicaAlreadyExistsException"
+
+	// ErrCodeReplicaNotFoundException for service response error code
+	// "ReplicaNotFoundException".
+	//
+	// The specified replica is no longer part of the global table.
+	ErrCodeReplicaNotFoundException = "ReplicaNotFoundException"
+
 	// ErrCodeResourceInUseException for service response error code
 	// "ResourceInUseException".
 	//
@@ -61,4 +104,23 @@ const (
 	// The operation tried to access a nonexistent table or index. The resource
 	// might not be specified correctly, or its status might not be ACTIVE.
 	ErrCodeResourceNotFoundException = "ResourceNotFoundException"
+
+	// ErrCodeTableAlreadyExistsException for service response error code
+	// "TableAlreadyExistsException".
+	//
+	// A table with the name already exists.
+	ErrCodeTableAlreadyExistsException = "TableAlreadyExistsException"
+
+	// ErrCodeTableInUseException for service response error code
+	// "TableInUseException".
+	//
+	// A table by that name is either being created or deleted.
+	ErrCodeTableInUseException = "TableInUseException"
+
+	// ErrCodeTableNotFoundException for service response error code
+	// "TableNotFoundException".
+	//
+	// A table with the name TableName does not currently exist within the subscriber's
+	// account.
+	ErrCodeTableNotFoundException = "TableNotFoundException"
 )

--- a/vendor/github.com/aws/aws-sdk-go/service/ec2/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ec2/api.go
@@ -10160,6 +10160,98 @@ func (c *EC2) DescribeInstanceAttributeWithContext(ctx aws.Context, input *Descr
 	return out, req.Send()
 }
 
+const opDescribeInstanceCreditSpecifications = "DescribeInstanceCreditSpecifications"
+
+// DescribeInstanceCreditSpecificationsRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeInstanceCreditSpecifications operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeInstanceCreditSpecifications for more information on using the DescribeInstanceCreditSpecifications
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeInstanceCreditSpecificationsRequest method.
+//    req, resp := client.DescribeInstanceCreditSpecificationsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DescribeInstanceCreditSpecifications
+func (c *EC2) DescribeInstanceCreditSpecificationsRequest(input *DescribeInstanceCreditSpecificationsInput) (req *request.Request, output *DescribeInstanceCreditSpecificationsOutput) {
+	op := &request.Operation{
+		Name:       opDescribeInstanceCreditSpecifications,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DescribeInstanceCreditSpecificationsInput{}
+	}
+
+	output = &DescribeInstanceCreditSpecificationsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeInstanceCreditSpecifications API operation for Amazon Elastic Compute Cloud.
+//
+// Describes the credit option for CPU usage of one or more of your T2 instances.
+// The credit options are standard and unlimited.
+//
+// If you do not specify an instance ID, Amazon EC2 returns only the T2 instances
+// with the unlimited credit option. If you specify one or more instance IDs,
+// Amazon EC2 returns the credit option (standard or unlimited) of those instances.
+// If you specify an instance ID that is not valid, such as an instance that
+// is not a T2 instance, an error is returned.
+//
+// Recently terminated instances might appear in the returned results. This
+// interval is usually less than one hour.
+//
+// If an Availability Zone is experiencing a service disruption and you specify
+// instance IDs in the affected zone, or do not specify any instance IDs at
+// all, the call fails. If you specify only instance IDs in an unaffected zone,
+// the call works normally.
+//
+// For more information, see T2 Instances (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-instances.html)
+// in the Amazon Elastic Compute Cloud User Guide.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation DescribeInstanceCreditSpecifications for usage and error information.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DescribeInstanceCreditSpecifications
+func (c *EC2) DescribeInstanceCreditSpecifications(input *DescribeInstanceCreditSpecificationsInput) (*DescribeInstanceCreditSpecificationsOutput, error) {
+	req, out := c.DescribeInstanceCreditSpecificationsRequest(input)
+	return out, req.Send()
+}
+
+// DescribeInstanceCreditSpecificationsWithContext is the same as DescribeInstanceCreditSpecifications with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeInstanceCreditSpecifications for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) DescribeInstanceCreditSpecificationsWithContext(ctx aws.Context, input *DescribeInstanceCreditSpecificationsInput, opts ...request.Option) (*DescribeInstanceCreditSpecificationsOutput, error) {
+	req, out := c.DescribeInstanceCreditSpecificationsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opDescribeInstanceStatus = "DescribeInstanceStatus"
 
 // DescribeInstanceStatusRequest generates a "aws/request.Request" representing the
@@ -17625,6 +17717,84 @@ func (c *EC2) ModifyInstanceAttribute(input *ModifyInstanceAttributeInput) (*Mod
 // for more information on using Contexts.
 func (c *EC2) ModifyInstanceAttributeWithContext(ctx aws.Context, input *ModifyInstanceAttributeInput, opts ...request.Option) (*ModifyInstanceAttributeOutput, error) {
 	req, out := c.ModifyInstanceAttributeRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opModifyInstanceCreditSpecification = "ModifyInstanceCreditSpecification"
+
+// ModifyInstanceCreditSpecificationRequest generates a "aws/request.Request" representing the
+// client's request for the ModifyInstanceCreditSpecification operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ModifyInstanceCreditSpecification for more information on using the ModifyInstanceCreditSpecification
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ModifyInstanceCreditSpecificationRequest method.
+//    req, resp := client.ModifyInstanceCreditSpecificationRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/ModifyInstanceCreditSpecification
+func (c *EC2) ModifyInstanceCreditSpecificationRequest(input *ModifyInstanceCreditSpecificationInput) (req *request.Request, output *ModifyInstanceCreditSpecificationOutput) {
+	op := &request.Operation{
+		Name:       opModifyInstanceCreditSpecification,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &ModifyInstanceCreditSpecificationInput{}
+	}
+
+	output = &ModifyInstanceCreditSpecificationOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ModifyInstanceCreditSpecification API operation for Amazon Elastic Compute Cloud.
+//
+// Modifies the credit option for CPU usage on a running or stopped T2 instance.
+// The credit options are standard and unlimited.
+//
+// For more information, see T2 Instances (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-instances.html)
+// in the Amazon Elastic Compute Cloud User Guide.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic Compute Cloud's
+// API operation ModifyInstanceCreditSpecification for usage and error information.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/ModifyInstanceCreditSpecification
+func (c *EC2) ModifyInstanceCreditSpecification(input *ModifyInstanceCreditSpecificationInput) (*ModifyInstanceCreditSpecificationOutput, error) {
+	req, out := c.ModifyInstanceCreditSpecificationRequest(input)
+	return out, req.Send()
+}
+
+// ModifyInstanceCreditSpecificationWithContext is the same as ModifyInstanceCreditSpecification with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ModifyInstanceCreditSpecification for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EC2) ModifyInstanceCreditSpecificationWithContext(ctx aws.Context, input *ModifyInstanceCreditSpecificationInput, opts ...request.Option) (*ModifyInstanceCreditSpecificationOutput, error) {
+	req, out := c.ModifyInstanceCreditSpecificationRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -30343,7 +30513,9 @@ type CreditSpecificationRequest struct {
 
 	// The credit option for CPU usage of a T2 instance. Valid values are standard
 	// and unlimited.
-	CpuCredits *string `type:"string"`
+	//
+	// CpuCredits is a required field
+	CpuCredits *string `type:"string" required:"true"`
 }
 
 // String returns the string representation
@@ -30354,6 +30526,19 @@ func (s CreditSpecificationRequest) String() string {
 // GoString returns the string representation
 func (s CreditSpecificationRequest) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreditSpecificationRequest) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreditSpecificationRequest"}
+	if s.CpuCredits == nil {
+		invalidParams.Add(request.NewErrParamRequired("CpuCredits"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // SetCpuCredits sets the CpuCredits field's value.
@@ -35481,6 +35666,112 @@ func (s *DescribeInstanceAttributeOutput) SetSriovNetSupport(v *AttributeValue) 
 // SetUserData sets the UserData field's value.
 func (s *DescribeInstanceAttributeOutput) SetUserData(v *AttributeValue) *DescribeInstanceAttributeOutput {
 	s.UserData = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DescribeInstanceCreditSpecificationsRequest
+type DescribeInstanceCreditSpecificationsInput struct {
+	_ struct{} `type:"structure"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// One or more filters.
+	//
+	//    * instance-id - The ID of the instance.
+	Filters []*Filter `locationName:"Filter" locationNameList:"Filter" type:"list"`
+
+	// One or more instance IDs.
+	//
+	// Default: Describes all your instances.
+	//
+	// Constraints: Maximum 1000 explicitly specified instance IDs.
+	InstanceIds []*string `locationName:"InstanceId" locationNameList:"InstanceId" type:"list"`
+
+	// The maximum number of results to return in a single call. To retrieve the
+	// remaining results, make another call with the returned NextToken value. This
+	// value can be between 5 and 1000. You cannot specify this parameter and the
+	// instance IDs parameter in the same call.
+	MaxResults *int64 `type:"integer"`
+
+	// The token to retrieve the next page of results.
+	NextToken *string `type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeInstanceCreditSpecificationsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeInstanceCreditSpecificationsInput) GoString() string {
+	return s.String()
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *DescribeInstanceCreditSpecificationsInput) SetDryRun(v bool) *DescribeInstanceCreditSpecificationsInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeInstanceCreditSpecificationsInput) SetFilters(v []*Filter) *DescribeInstanceCreditSpecificationsInput {
+	s.Filters = v
+	return s
+}
+
+// SetInstanceIds sets the InstanceIds field's value.
+func (s *DescribeInstanceCreditSpecificationsInput) SetInstanceIds(v []*string) *DescribeInstanceCreditSpecificationsInput {
+	s.InstanceIds = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeInstanceCreditSpecificationsInput) SetMaxResults(v int64) *DescribeInstanceCreditSpecificationsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeInstanceCreditSpecificationsInput) SetNextToken(v string) *DescribeInstanceCreditSpecificationsInput {
+	s.NextToken = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/DescribeInstanceCreditSpecificationsResult
+type DescribeInstanceCreditSpecificationsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the credit option for CPU usage of an instance.
+	InstanceCreditSpecifications []*InstanceCreditSpecification `locationName:"instanceCreditSpecificationSet" locationNameList:"item" type:"list"`
+
+	// The token to use to retrieve the next page of results. This value is null
+	// when there are no more results to return.
+	NextToken *string `locationName:"nextToken" type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeInstanceCreditSpecificationsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeInstanceCreditSpecificationsOutput) GoString() string {
+	return s.String()
+}
+
+// SetInstanceCreditSpecifications sets the InstanceCreditSpecifications field's value.
+func (s *DescribeInstanceCreditSpecificationsOutput) SetInstanceCreditSpecifications(v []*InstanceCreditSpecification) *DescribeInstanceCreditSpecificationsOutput {
+	s.InstanceCreditSpecifications = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeInstanceCreditSpecificationsOutput) SetNextToken(v string) *DescribeInstanceCreditSpecificationsOutput {
+	s.NextToken = &v
 	return s
 }
 
@@ -48161,6 +48452,76 @@ func (s *InstanceCount) SetState(v string) *InstanceCount {
 	return s
 }
 
+// Describes the credit option for CPU usage of a T2 instance.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/InstanceCreditSpecification
+type InstanceCreditSpecification struct {
+	_ struct{} `type:"structure"`
+
+	// The credit option for CPU usage of the instance. Valid values are standard
+	// and unlimited.
+	CpuCredits *string `locationName:"cpuCredits" type:"string"`
+
+	// The ID of the instance.
+	InstanceId *string `locationName:"instanceId" type:"string"`
+}
+
+// String returns the string representation
+func (s InstanceCreditSpecification) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s InstanceCreditSpecification) GoString() string {
+	return s.String()
+}
+
+// SetCpuCredits sets the CpuCredits field's value.
+func (s *InstanceCreditSpecification) SetCpuCredits(v string) *InstanceCreditSpecification {
+	s.CpuCredits = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *InstanceCreditSpecification) SetInstanceId(v string) *InstanceCreditSpecification {
+	s.InstanceId = &v
+	return s
+}
+
+// Describes the credit option for CPU usage of a T2 instance.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/InstanceCreditSpecificationRequest
+type InstanceCreditSpecificationRequest struct {
+	_ struct{} `type:"structure"`
+
+	// The credit option for CPU usage of the instance. Valid values are standard
+	// and unlimited.
+	CpuCredits *string `type:"string"`
+
+	// The ID of the instance.
+	InstanceId *string `type:"string"`
+}
+
+// String returns the string representation
+func (s InstanceCreditSpecificationRequest) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s InstanceCreditSpecificationRequest) GoString() string {
+	return s.String()
+}
+
+// SetCpuCredits sets the CpuCredits field's value.
+func (s *InstanceCreditSpecificationRequest) SetCpuCredits(v string) *InstanceCreditSpecificationRequest {
+	s.CpuCredits = &v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *InstanceCreditSpecificationRequest) SetInstanceId(v string) *InstanceCreditSpecificationRequest {
+	s.InstanceId = &v
+	return s
+}
+
 // Describes an instance to export.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/InstanceExportDetails
 type InstanceExportDetails struct {
@@ -51969,6 +52330,103 @@ func (s ModifyInstanceAttributeOutput) String() string {
 // GoString returns the string representation
 func (s ModifyInstanceAttributeOutput) GoString() string {
 	return s.String()
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/ModifyInstanceCreditSpecificationRequest
+type ModifyInstanceCreditSpecificationInput struct {
+	_ struct{} `type:"structure"`
+
+	// A unique, case-sensitive token that you provide to ensure idempotency of
+	// your modification request. For more information, see Ensuring Idempotency
+	// (http://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html).
+	ClientToken *string `type:"string"`
+
+	// Checks whether you have the required permissions for the action, without
+	// actually making the request, and provides an error response. If you have
+	// the required permissions, the error response is DryRunOperation. Otherwise,
+	// it is UnauthorizedOperation.
+	DryRun *bool `type:"boolean"`
+
+	// Information about the credit option for CPU usage.
+	//
+	// InstanceCreditSpecifications is a required field
+	InstanceCreditSpecifications []*InstanceCreditSpecificationRequest `locationName:"InstanceCreditSpecification" locationNameList:"item" type:"list" required:"true"`
+}
+
+// String returns the string representation
+func (s ModifyInstanceCreditSpecificationInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ModifyInstanceCreditSpecificationInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyInstanceCreditSpecificationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyInstanceCreditSpecificationInput"}
+	if s.InstanceCreditSpecifications == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceCreditSpecifications"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetClientToken sets the ClientToken field's value.
+func (s *ModifyInstanceCreditSpecificationInput) SetClientToken(v string) *ModifyInstanceCreditSpecificationInput {
+	s.ClientToken = &v
+	return s
+}
+
+// SetDryRun sets the DryRun field's value.
+func (s *ModifyInstanceCreditSpecificationInput) SetDryRun(v bool) *ModifyInstanceCreditSpecificationInput {
+	s.DryRun = &v
+	return s
+}
+
+// SetInstanceCreditSpecifications sets the InstanceCreditSpecifications field's value.
+func (s *ModifyInstanceCreditSpecificationInput) SetInstanceCreditSpecifications(v []*InstanceCreditSpecificationRequest) *ModifyInstanceCreditSpecificationInput {
+	s.InstanceCreditSpecifications = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/ModifyInstanceCreditSpecificationResult
+type ModifyInstanceCreditSpecificationOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the instances whose credit option for CPU usage was successfully
+	// modified.
+	SuccessfulInstanceCreditSpecifications []*SuccessfulInstanceCreditSpecificationItem `locationName:"successfulInstanceCreditSpecificationSet" locationNameList:"item" type:"list"`
+
+	// Information about the instances whose credit option for CPU usage was not
+	// modified.
+	UnsuccessfulInstanceCreditSpecifications []*UnsuccessfulInstanceCreditSpecificationItem `locationName:"unsuccessfulInstanceCreditSpecificationSet" locationNameList:"item" type:"list"`
+}
+
+// String returns the string representation
+func (s ModifyInstanceCreditSpecificationOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ModifyInstanceCreditSpecificationOutput) GoString() string {
+	return s.String()
+}
+
+// SetSuccessfulInstanceCreditSpecifications sets the SuccessfulInstanceCreditSpecifications field's value.
+func (s *ModifyInstanceCreditSpecificationOutput) SetSuccessfulInstanceCreditSpecifications(v []*SuccessfulInstanceCreditSpecificationItem) *ModifyInstanceCreditSpecificationOutput {
+	s.SuccessfulInstanceCreditSpecifications = v
+	return s
+}
+
+// SetUnsuccessfulInstanceCreditSpecifications sets the UnsuccessfulInstanceCreditSpecifications field's value.
+func (s *ModifyInstanceCreditSpecificationOutput) SetUnsuccessfulInstanceCreditSpecifications(v []*UnsuccessfulInstanceCreditSpecificationItem) *ModifyInstanceCreditSpecificationOutput {
+	s.UnsuccessfulInstanceCreditSpecifications = v
+	return s
 }
 
 // Contains the parameters for ModifyInstancePlacement.
@@ -57460,6 +57918,11 @@ func (s RequestLaunchTemplateData) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *RequestLaunchTemplateData) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "RequestLaunchTemplateData"}
+	if s.CreditSpecification != nil {
+		if err := s.CreditSpecification.Validate(); err != nil {
+			invalidParams.AddNested("CreditSpecification", err.(request.ErrInvalidParams))
+		}
+	}
 	if s.ElasticGpuSpecifications != nil {
 		for i, v := range s.ElasticGpuSpecifications {
 			if v == nil {
@@ -60228,6 +60691,14 @@ type RunInstancesInput struct {
 	// Constraints: Maximum 64 ASCII characters
 	ClientToken *string `locationName:"clientToken" type:"string"`
 
+	// The credit option for CPU usage of the instance. Valid values are standard
+	// and unlimited. To change this attribute after launch, use ModifyInstanceCreditSpecification.
+	// For more information, see T2 Instances (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-instances.html)
+	// in the Amazon Elastic Compute Cloud User Guide.
+	//
+	// Default: standard
+	CreditSpecification *CreditSpecificationRequest `type:"structure"`
+
 	// If you set this parameter to true, you can't terminate the instance using
 	// the Amazon EC2 console, CLI, or API; otherwise, you can. To change this attribute
 	// to false after launch, use ModifyInstanceAttribute. Alternatively, if you
@@ -60404,6 +60875,11 @@ func (s *RunInstancesInput) Validate() error {
 	if s.MinCount == nil {
 		invalidParams.Add(request.NewErrParamRequired("MinCount"))
 	}
+	if s.CreditSpecification != nil {
+		if err := s.CreditSpecification.Validate(); err != nil {
+			invalidParams.AddNested("CreditSpecification", err.(request.ErrInvalidParams))
+		}
+	}
 	if s.ElasticGpuSpecification != nil {
 		for i, v := range s.ElasticGpuSpecification {
 			if v == nil {
@@ -60451,6 +60927,12 @@ func (s *RunInstancesInput) SetBlockDeviceMappings(v []*BlockDeviceMapping) *Run
 // SetClientToken sets the ClientToken field's value.
 func (s *RunInstancesInput) SetClientToken(v string) *RunInstancesInput {
 	s.ClientToken = &v
+	return s
+}
+
+// SetCreditSpecification sets the CreditSpecification field's value.
+func (s *RunInstancesInput) SetCreditSpecification(v *CreditSpecificationRequest) *RunInstancesInput {
+	s.CreditSpecification = v
 	return s
 }
 
@@ -64497,6 +64979,32 @@ func (s *SubnetIpv6CidrBlockAssociation) SetIpv6CidrBlockState(v *SubnetCidrBloc
 	return s
 }
 
+// Describes the T2 instance whose credit option for CPU usage was successfully
+// modified.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/SuccessfulInstanceCreditSpecificationItem
+type SuccessfulInstanceCreditSpecificationItem struct {
+	_ struct{} `type:"structure"`
+
+	// The ID of the instance.
+	InstanceId *string `locationName:"instanceId" type:"string"`
+}
+
+// String returns the string representation
+func (s SuccessfulInstanceCreditSpecificationItem) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SuccessfulInstanceCreditSpecificationItem) GoString() string {
+	return s.String()
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *SuccessfulInstanceCreditSpecificationItem) SetInstanceId(v string) *SuccessfulInstanceCreditSpecificationItem {
+	s.InstanceId = &v
+	return s
+}
+
 // Describes a tag.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/Tag
 type Tag struct {
@@ -65150,6 +65658,76 @@ func (s UnmonitorInstancesOutput) GoString() string {
 // SetInstanceMonitorings sets the InstanceMonitorings field's value.
 func (s *UnmonitorInstancesOutput) SetInstanceMonitorings(v []*InstanceMonitoring) *UnmonitorInstancesOutput {
 	s.InstanceMonitorings = v
+	return s
+}
+
+// Describes the T2 instance whose credit option for CPU usage was not modified.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/UnsuccessfulInstanceCreditSpecificationItem
+type UnsuccessfulInstanceCreditSpecificationItem struct {
+	_ struct{} `type:"structure"`
+
+	// The applicable error for the T2 instance whose credit option for CPU usage
+	// was not modified.
+	Error *UnsuccessfulInstanceCreditSpecificationItemError `locationName:"error" type:"structure"`
+
+	// The ID of the instance.
+	InstanceId *string `locationName:"instanceId" type:"string"`
+}
+
+// String returns the string representation
+func (s UnsuccessfulInstanceCreditSpecificationItem) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UnsuccessfulInstanceCreditSpecificationItem) GoString() string {
+	return s.String()
+}
+
+// SetError sets the Error field's value.
+func (s *UnsuccessfulInstanceCreditSpecificationItem) SetError(v *UnsuccessfulInstanceCreditSpecificationItemError) *UnsuccessfulInstanceCreditSpecificationItem {
+	s.Error = v
+	return s
+}
+
+// SetInstanceId sets the InstanceId field's value.
+func (s *UnsuccessfulInstanceCreditSpecificationItem) SetInstanceId(v string) *UnsuccessfulInstanceCreditSpecificationItem {
+	s.InstanceId = &v
+	return s
+}
+
+// Information about the error for the T2 instance whose credit option for CPU
+// usage was not modified.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/UnsuccessfulInstanceCreditSpecificationItemError
+type UnsuccessfulInstanceCreditSpecificationItemError struct {
+	_ struct{} `type:"structure"`
+
+	// The error code.
+	Code *string `locationName:"code" type:"string" enum:"UnsuccessfulInstanceCreditSpecificationErrorCode"`
+
+	// The applicable error message.
+	Message *string `locationName:"message" type:"string"`
+}
+
+// String returns the string representation
+func (s UnsuccessfulInstanceCreditSpecificationItemError) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UnsuccessfulInstanceCreditSpecificationItemError) GoString() string {
+	return s.String()
+}
+
+// SetCode sets the Code field's value.
+func (s *UnsuccessfulInstanceCreditSpecificationItemError) SetCode(v string) *UnsuccessfulInstanceCreditSpecificationItemError {
+	s.Code = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *UnsuccessfulInstanceCreditSpecificationItemError) SetMessage(v string) *UnsuccessfulInstanceCreditSpecificationItemError {
+	s.Message = &v
 	return s
 }
 
@@ -68204,6 +68782,36 @@ const (
 
 	// InstanceTypeF116xlarge is a InstanceType enum value
 	InstanceTypeF116xlarge = "f1.16xlarge"
+
+	// InstanceTypeM5Large is a InstanceType enum value
+	InstanceTypeM5Large = "m5.large"
+
+	// InstanceTypeM5Xlarge is a InstanceType enum value
+	InstanceTypeM5Xlarge = "m5.xlarge"
+
+	// InstanceTypeM52xlarge is a InstanceType enum value
+	InstanceTypeM52xlarge = "m5.2xlarge"
+
+	// InstanceTypeM54xlarge is a InstanceType enum value
+	InstanceTypeM54xlarge = "m5.4xlarge"
+
+	// InstanceTypeM512xlarge is a InstanceType enum value
+	InstanceTypeM512xlarge = "m5.12xlarge"
+
+	// InstanceTypeM524xlarge is a InstanceType enum value
+	InstanceTypeM524xlarge = "m5.24xlarge"
+
+	// InstanceTypeH12xlarge is a InstanceType enum value
+	InstanceTypeH12xlarge = "h1.2xlarge"
+
+	// InstanceTypeH14xlarge is a InstanceType enum value
+	InstanceTypeH14xlarge = "h1.4xlarge"
+
+	// InstanceTypeH18xlarge is a InstanceType enum value
+	InstanceTypeH18xlarge = "h1.8xlarge"
+
+	// InstanceTypeH116xlarge is a InstanceType enum value
+	InstanceTypeH116xlarge = "h1.16xlarge"
 )
 
 const (
@@ -68840,6 +69448,20 @@ const (
 
 	// TrafficTypeAll is a TrafficType enum value
 	TrafficTypeAll = "ALL"
+)
+
+const (
+	// UnsuccessfulInstanceCreditSpecificationErrorCodeInvalidInstanceIdMalformed is a UnsuccessfulInstanceCreditSpecificationErrorCode enum value
+	UnsuccessfulInstanceCreditSpecificationErrorCodeInvalidInstanceIdMalformed = "InvalidInstanceID.Malformed"
+
+	// UnsuccessfulInstanceCreditSpecificationErrorCodeInvalidInstanceIdNotFound is a UnsuccessfulInstanceCreditSpecificationErrorCode enum value
+	UnsuccessfulInstanceCreditSpecificationErrorCodeInvalidInstanceIdNotFound = "InvalidInstanceID.NotFound"
+
+	// UnsuccessfulInstanceCreditSpecificationErrorCodeIncorrectInstanceState is a UnsuccessfulInstanceCreditSpecificationErrorCode enum value
+	UnsuccessfulInstanceCreditSpecificationErrorCodeIncorrectInstanceState = "IncorrectInstanceState"
+
+	// UnsuccessfulInstanceCreditSpecificationErrorCodeInstanceCreditSpecificationNotSupported is a UnsuccessfulInstanceCreditSpecificationErrorCode enum value
+	UnsuccessfulInstanceCreditSpecificationErrorCodeInstanceCreditSpecificationNotSupported = "InstanceCreditSpecification.NotSupported"
 )
 
 const (

--- a/vendor/github.com/aws/aws-sdk-go/service/ecs/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ecs/api.go
@@ -64,8 +64,8 @@ func (c *ECS) CreateClusterRequest(input *CreateClusterInput) (req *request.Requ
 // AWS services can be managed on your behalf. However, if the IAM user that
 // makes the call does not have permissions to create the service-linked role,
 // it is not created. For more information, see Using Service-Linked Roles for
-// Amazon ECS (http://docs.aws.amazon.com/AmazonECS/latest/developerguideusing-service-linked-roles.html)
-// in the Amazon EC2 Container Service Developer Guide.
+// Amazon ECS (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/using-service-linked-roles.html)
+// in the Amazon Elastic Container Service Developer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -80,8 +80,8 @@ func (c *ECS) CreateClusterRequest(input *CreateClusterInput) (req *request.Requ
 //
 //   * ErrCodeClientException "ClientException"
 //   These errors are usually caused by a client action, such as using an action
-//   or resource on behalf of a user that doesn't have permission to use the action
-//   or resource, or specifying an identifier that is not valid.
+//   or resource on behalf of a user that doesn't have permissions to use the
+//   action or resource, or specifying an identifier that is not valid.
 //
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
 //   The specified parameter is invalid. Review the available parameters for the
@@ -162,13 +162,13 @@ func (c *ECS) CreateServiceRequest(input *CreateServiceInput) (req *request.Requ
 // can optionally run your service behind a load balancer. The load balancer
 // distributes traffic across the tasks that are associated with the service.
 // For more information, see Service Load Balancing (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-load-balancing.html)
-// in the Amazon EC2 Container Service Developer Guide.
+// in the Amazon Elastic Container Service Developer Guide.
 //
 // You can optionally specify a deployment configuration for your service. During
-// a deployment (which is triggered by changing the task definition or the desired
-// count of a service with an UpdateService operation), the service scheduler
-// uses the minimumHealthyPercent and maximumPercent parameters to determine
-// the deployment strategy.
+// a deployment, the service scheduler uses the minimumHealthyPercent and maximumPercent
+// parameters to determine the deployment strategy. The deployment is triggered
+// by changing the task definition or the desired count of a service with an
+// UpdateService operation.
 //
 // The minimumHealthyPercent represents a lower limit on the number of your
 // service's tasks that must remain in the RUNNING state during a deployment,
@@ -226,8 +226,8 @@ func (c *ECS) CreateServiceRequest(input *CreateServiceInput) (req *request.Requ
 //
 //   * ErrCodeClientException "ClientException"
 //   These errors are usually caused by a client action, such as using an action
-//   or resource on behalf of a user that doesn't have permission to use the action
-//   or resource, or specifying an identifier that is not valid.
+//   or resource on behalf of a user that doesn't have permissions to use the
+//   action or resource, or specifying an identifier that is not valid.
 //
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
 //   The specified parameter is invalid. Review the available parameters for the
@@ -236,6 +236,19 @@ func (c *ECS) CreateServiceRequest(input *CreateServiceInput) (req *request.Requ
 //   * ErrCodeClusterNotFoundException "ClusterNotFoundException"
 //   The specified cluster could not be found. You can view your available clusters
 //   with ListClusters. Amazon ECS clusters are region-specific.
+//
+//   * ErrCodeUnsupportedFeatureException "UnsupportedFeatureException"
+//   The specified task is not supported in this region.
+//
+//   * ErrCodePlatformUnknownException "PlatformUnknownException"
+//   The specified platform version does not exist.
+//
+//   * ErrCodePlatformTaskDefinitionIncompatibilityException "PlatformTaskDefinitionIncompatibilityException"
+//   The specified platform version does not satisfy the task definition’s required
+//   capabilities.
+//
+//   * ErrCodeAccessDeniedException "AccessDeniedException"
+//   You do not have authorization to perform the requested action.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/CreateService
 func (c *ECS) CreateService(input *CreateServiceInput) (*CreateServiceOutput, error) {
@@ -409,8 +422,8 @@ func (c *ECS) DeleteClusterRequest(input *DeleteClusterInput) (req *request.Requ
 //
 //   * ErrCodeClientException "ClientException"
 //   These errors are usually caused by a client action, such as using an action
-//   or resource on behalf of a user that doesn't have permission to use the action
-//   or resource, or specifying an identifier that is not valid.
+//   or resource on behalf of a user that doesn't have permissions to use the
+//   action or resource, or specifying an identifier that is not valid.
 //
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
 //   The specified parameter is invalid. Review the available parameters for the
@@ -429,6 +442,9 @@ func (c *ECS) DeleteClusterRequest(input *DeleteClusterInput) (req *request.Requ
 //   You cannot delete a cluster that contains services. You must first update
 //   the service to reduce its desired task count to 0 and then delete the service.
 //   For more information, see UpdateService and DeleteService.
+//
+//   * ErrCodeClusterContainsTasksException "ClusterContainsTasksException"
+//   You cannot delete a cluster that has active tasks.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/DeleteCluster
 func (c *ECS) DeleteCluster(input *DeleteClusterInput) (*DeleteClusterOutput, error) {
@@ -507,9 +523,9 @@ func (c *ECS) DeleteServiceRequest(input *DeleteServiceInput) (req *request.Requ
 // is no longer visible in the console or in ListServices API operations. After
 // the tasks have stopped, then the service status moves from DRAINING to INACTIVE.
 // Services in the DRAINING or INACTIVE status can still be viewed with DescribeServices
-// API operations; however, in the future, INACTIVE services may be cleaned
+// API operations. However, in the future, INACTIVE services may be cleaned
 // up and purged from Amazon ECS record keeping, and DescribeServices API operations
-// on those services will return a ServiceNotFoundException error.
+// on those services return a ServiceNotFoundException error.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -524,8 +540,8 @@ func (c *ECS) DeleteServiceRequest(input *DeleteServiceInput) (req *request.Requ
 //
 //   * ErrCodeClientException "ClientException"
 //   These errors are usually caused by a client action, such as using an action
-//   or resource on behalf of a user that doesn't have permission to use the action
-//   or resource, or specifying an identifier that is not valid.
+//   or resource on behalf of a user that doesn't have permissions to use the
+//   action or resource, or specifying an identifier that is not valid.
 //
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
 //   The specified parameter is invalid. Review the available parameters for the
@@ -610,7 +626,7 @@ func (c *ECS) DeregisterContainerInstanceRequest(input *DeregisterContainerInsta
 //
 // If you intend to use the container instance for some other purpose after
 // deregistration, you should stop all of the tasks running on the container
-// instance before deregistration to avoid any orphaned tasks from consuming
+// instance before deregistration. That prevents any orphaned tasks from consuming
 // resources.
 //
 // Deregistering a container instance removes the instance from a cluster, but
@@ -634,8 +650,8 @@ func (c *ECS) DeregisterContainerInstanceRequest(input *DeregisterContainerInsta
 //
 //   * ErrCodeClientException "ClientException"
 //   These errors are usually caused by a client action, such as using an action
-//   or resource on behalf of a user that doesn't have permission to use the action
-//   or resource, or specifying an identifier that is not valid.
+//   or resource on behalf of a user that doesn't have permissions to use the
+//   action or resource, or specifying an identifier that is not valid.
 //
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
 //   The specified parameter is invalid. Review the available parameters for the
@@ -719,13 +735,13 @@ func (c *ECS) DeregisterTaskDefinitionRequest(input *DeregisterTaskDefinitionInp
 //
 // You cannot use an INACTIVE task definition to run new tasks or create new
 // services, and you cannot update an existing service to reference an INACTIVE
-// task definition (although there may be up to a 10 minute window following
+// task definition (although there may be up to a 10-minute window following
 // deregistration where these restrictions have not yet taken effect).
 //
 // At this time, INACTIVE task definitions remain discoverable in your account
 // indefinitely; however, this behavior is subject to change in the future,
 // so you should not rely on INACTIVE task definitions persisting beyond the
-// life cycle of any associated tasks and services.
+// lifecycle of any associated tasks and services.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -740,8 +756,8 @@ func (c *ECS) DeregisterTaskDefinitionRequest(input *DeregisterTaskDefinitionInp
 //
 //   * ErrCodeClientException "ClientException"
 //   These errors are usually caused by a client action, such as using an action
-//   or resource on behalf of a user that doesn't have permission to use the action
-//   or resource, or specifying an identifier that is not valid.
+//   or resource on behalf of a user that doesn't have permissions to use the
+//   action or resource, or specifying an identifier that is not valid.
 //
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
 //   The specified parameter is invalid. Review the available parameters for the
@@ -828,8 +844,8 @@ func (c *ECS) DescribeClustersRequest(input *DescribeClustersInput) (req *reques
 //
 //   * ErrCodeClientException "ClientException"
 //   These errors are usually caused by a client action, such as using an action
-//   or resource on behalf of a user that doesn't have permission to use the action
-//   or resource, or specifying an identifier that is not valid.
+//   or resource on behalf of a user that doesn't have permissions to use the
+//   action or resource, or specifying an identifier that is not valid.
 //
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
 //   The specified parameter is invalid. Review the available parameters for the
@@ -901,7 +917,7 @@ func (c *ECS) DescribeContainerInstancesRequest(input *DescribeContainerInstance
 
 // DescribeContainerInstances API operation for Amazon EC2 Container Service.
 //
-// Describes Amazon EC2 Container Service container instances. Returns metadata
+// Describes Amazon Elastic Container Service container instances. Returns metadata
 // about registered and remaining resources on each container instance requested.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -917,8 +933,8 @@ func (c *ECS) DescribeContainerInstancesRequest(input *DescribeContainerInstance
 //
 //   * ErrCodeClientException "ClientException"
 //   These errors are usually caused by a client action, such as using an action
-//   or resource on behalf of a user that doesn't have permission to use the action
-//   or resource, or specifying an identifier that is not valid.
+//   or resource on behalf of a user that doesn't have permissions to use the
+//   action or resource, or specifying an identifier that is not valid.
 //
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
 //   The specified parameter is invalid. Review the available parameters for the
@@ -1009,8 +1025,8 @@ func (c *ECS) DescribeServicesRequest(input *DescribeServicesInput) (req *reques
 //
 //   * ErrCodeClientException "ClientException"
 //   These errors are usually caused by a client action, such as using an action
-//   or resource on behalf of a user that doesn't have permission to use the action
-//   or resource, or specifying an identifier that is not valid.
+//   or resource on behalf of a user that doesn't have permissions to use the
+//   action or resource, or specifying an identifier that is not valid.
 //
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
 //   The specified parameter is invalid. Review the available parameters for the
@@ -1106,8 +1122,8 @@ func (c *ECS) DescribeTaskDefinitionRequest(input *DescribeTaskDefinitionInput) 
 //
 //   * ErrCodeClientException "ClientException"
 //   These errors are usually caused by a client action, such as using an action
-//   or resource on behalf of a user that doesn't have permission to use the action
-//   or resource, or specifying an identifier that is not valid.
+//   or resource on behalf of a user that doesn't have permissions to use the
+//   action or resource, or specifying an identifier that is not valid.
 //
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
 //   The specified parameter is invalid. Review the available parameters for the
@@ -1194,8 +1210,8 @@ func (c *ECS) DescribeTasksRequest(input *DescribeTasksInput) (req *request.Requ
 //
 //   * ErrCodeClientException "ClientException"
 //   These errors are usually caused by a client action, such as using an action
-//   or resource on behalf of a user that doesn't have permission to use the action
-//   or resource, or specifying an identifier that is not valid.
+//   or resource on behalf of a user that doesn't have permissions to use the
+//   action or resource, or specifying an identifier that is not valid.
 //
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
 //   The specified parameter is invalid. Review the available parameters for the
@@ -1271,11 +1287,10 @@ func (c *ECS) DiscoverPollEndpointRequest(input *DiscoverPollEndpointInput) (req
 
 // DiscoverPollEndpoint API operation for Amazon EC2 Container Service.
 //
-// This action is only used by the Amazon EC2 Container Service agent, and it
-// is not intended for use outside of the agent.
+// This action is only used by the Amazon ECS agent, and it is not intended
+// for use outside of the agent.
 //
-// Returns an endpoint for the Amazon EC2 Container Service agent to poll for
-// updates.
+// Returns an endpoint for the Amazon ECS agent to poll for updates.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1290,8 +1305,8 @@ func (c *ECS) DiscoverPollEndpointRequest(input *DiscoverPollEndpointInput) (req
 //
 //   * ErrCodeClientException "ClientException"
 //   These errors are usually caused by a client action, such as using an action
-//   or resource on behalf of a user that doesn't have permission to use the action
-//   or resource, or specifying an identifier that is not valid.
+//   or resource on behalf of a user that doesn't have permissions to use the
+//   action or resource, or specifying an identifier that is not valid.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/DiscoverPollEndpoint
 func (c *ECS) DiscoverPollEndpoint(input *DiscoverPollEndpointInput) (*DiscoverPollEndpointOutput, error) {
@@ -1470,8 +1485,8 @@ func (c *ECS) ListClustersRequest(input *ListClustersInput) (req *request.Reques
 //
 //   * ErrCodeClientException "ClientException"
 //   These errors are usually caused by a client action, such as using an action
-//   or resource on behalf of a user that doesn't have permission to use the action
-//   or resource, or specifying an identifier that is not valid.
+//   or resource on behalf of a user that doesn't have permissions to use the
+//   action or resource, or specifying an identifier that is not valid.
 //
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
 //   The specified parameter is invalid. Review the available parameters for the
@@ -1603,7 +1618,7 @@ func (c *ECS) ListContainerInstancesRequest(input *ListContainerInstancesInput) 
 // the results of a ListContainerInstances operation with cluster query language
 // statements inside the filter parameter. For more information, see Cluster
 // Query Language (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-query-language.html)
-// in the Amazon EC2 Container Service Developer Guide.
+// in the Amazon Elastic Container Service Developer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1618,8 +1633,8 @@ func (c *ECS) ListContainerInstancesRequest(input *ListContainerInstancesInput) 
 //
 //   * ErrCodeClientException "ClientException"
 //   These errors are usually caused by a client action, such as using an action
-//   or resource on behalf of a user that doesn't have permission to use the action
-//   or resource, or specifying an identifier that is not valid.
+//   or resource on behalf of a user that doesn't have permissions to use the
+//   action or resource, or specifying an identifier that is not valid.
 //
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
 //   The specified parameter is invalid. Review the available parameters for the
@@ -1766,8 +1781,8 @@ func (c *ECS) ListServicesRequest(input *ListServicesInput) (req *request.Reques
 //
 //   * ErrCodeClientException "ClientException"
 //   These errors are usually caused by a client action, such as using an action
-//   or resource on behalf of a user that doesn't have permission to use the action
-//   or resource, or specifying an identifier that is not valid.
+//   or resource on behalf of a user that doesn't have permissions to use the
+//   action or resource, or specifying an identifier that is not valid.
 //
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
 //   The specified parameter is invalid. Review the available parameters for the
@@ -1920,8 +1935,8 @@ func (c *ECS) ListTaskDefinitionFamiliesRequest(input *ListTaskDefinitionFamilie
 //
 //   * ErrCodeClientException "ClientException"
 //   These errors are usually caused by a client action, such as using an action
-//   or resource on behalf of a user that doesn't have permission to use the action
-//   or resource, or specifying an identifier that is not valid.
+//   or resource on behalf of a user that doesn't have permissions to use the
+//   action or resource, or specifying an identifier that is not valid.
 //
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
 //   The specified parameter is invalid. Review the available parameters for the
@@ -2066,8 +2081,8 @@ func (c *ECS) ListTaskDefinitionsRequest(input *ListTaskDefinitionsInput) (req *
 //
 //   * ErrCodeClientException "ClientException"
 //   These errors are usually caused by a client action, such as using an action
-//   or resource on behalf of a user that doesn't have permission to use the action
-//   or resource, or specifying an identifier that is not valid.
+//   or resource on behalf of a user that doesn't have permissions to use the
+//   action or resource, or specifying an identifier that is not valid.
 //
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
 //   The specified parameter is invalid. Review the available parameters for the
@@ -2199,7 +2214,7 @@ func (c *ECS) ListTasksRequest(input *ListTasksInput) (req *request.Request, out
 // by family name, by a particular container instance, or by the desired status
 // of the task with the family, containerInstance, and desiredStatus parameters.
 //
-// Recently-stopped tasks might appear in the returned results. Currently, stopped
+// Recently stopped tasks might appear in the returned results. Currently, stopped
 // tasks appear in the returned results for at least one hour.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -2215,8 +2230,8 @@ func (c *ECS) ListTasksRequest(input *ListTasksInput) (req *request.Request, out
 //
 //   * ErrCodeClientException "ClientException"
 //   These errors are usually caused by a client action, such as using an action
-//   or resource on behalf of a user that doesn't have permission to use the action
-//   or resource, or specifying an identifier that is not valid.
+//   or resource on behalf of a user that doesn't have permissions to use the
+//   action or resource, or specifying an identifier that is not valid.
 //
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
 //   The specified parameter is invalid. Review the available parameters for the
@@ -2350,7 +2365,7 @@ func (c *ECS) PutAttributesRequest(input *PutAttributesInput) (req *request.Requ
 // does not exist, it is created. If the attribute exists, its value is replaced
 // with the specified value. To delete an attribute, use DeleteAttributes. For
 // more information, see Attributes (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-constraints.html#attributes)
-// in the Amazon EC2 Container Service Developer Guide.
+// in the Amazon Elastic Container Service Developer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2444,8 +2459,8 @@ func (c *ECS) RegisterContainerInstanceRequest(input *RegisterContainerInstanceI
 
 // RegisterContainerInstance API operation for Amazon EC2 Container Service.
 //
-// This action is only used by the Amazon EC2 Container Service agent, and it
-// is not intended for use outside of the agent.
+// This action is only used by the Amazon ECS agent, and it is not intended
+// for use outside of the agent.
 //
 // Registers an EC2 instance into the specified cluster. This instance becomes
 // available to place containers on.
@@ -2463,8 +2478,12 @@ func (c *ECS) RegisterContainerInstanceRequest(input *RegisterContainerInstanceI
 //
 //   * ErrCodeClientException "ClientException"
 //   These errors are usually caused by a client action, such as using an action
-//   or resource on behalf of a user that doesn't have permission to use the action
-//   or resource, or specifying an identifier that is not valid.
+//   or resource on behalf of a user that doesn't have permissions to use the
+//   action or resource, or specifying an identifier that is not valid.
+//
+//   * ErrCodeInvalidParameterException "InvalidParameterException"
+//   The specified parameter is invalid. Review the available parameters for the
+//   API request.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/RegisterContainerInstance
 func (c *ECS) RegisterContainerInstance(input *RegisterContainerInstanceInput) (*RegisterContainerInstanceOutput, error) {
@@ -2536,19 +2555,23 @@ func (c *ECS) RegisterTaskDefinitionRequest(input *RegisterTaskDefinitionInput) 
 // Optionally, you can add data volumes to your containers with the volumes
 // parameter. For more information about task definition parameters and defaults,
 // see Amazon ECS Task Definitions (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_defintions.html)
-// in the Amazon EC2 Container Service Developer Guide.
+// in the Amazon Elastic Container Service Developer Guide.
 //
 // You can specify an IAM role for your task with the taskRoleArn parameter.
 // When you specify an IAM role for a task, its containers can then use the
 // latest versions of the AWS CLI or SDKs to make API requests to the AWS services
 // that are specified in the IAM policy associated with the role. For more information,
 // see IAM Roles for Tasks (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html)
-// in the Amazon EC2 Container Service Developer Guide.
+// in the Amazon Elastic Container Service Developer Guide.
 //
 // You can specify a Docker networking mode for the containers in your task
 // definition with the networkMode parameter. The available network modes correspond
 // to those described in Network settings (https://docs.docker.com/engine/reference/run/#/network-settings)
-// in the Docker run reference.
+// in the Docker run reference. If you specify the awsvpc network mode, the
+// task is allocated an Elastic Network Interface, and you must specify a NetworkConfiguration
+// when you create a service or run a task with the task definition. For more
+// information, see Task Networking (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-networking.html)
+// in the Amazon Elastic Container Service Developer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2563,8 +2586,8 @@ func (c *ECS) RegisterTaskDefinitionRequest(input *RegisterTaskDefinitionInput) 
 //
 //   * ErrCodeClientException "ClientException"
 //   These errors are usually caused by a client action, such as using an action
-//   or resource on behalf of a user that doesn't have permission to use the action
-//   or resource, or specifying an identifier that is not valid.
+//   or resource on behalf of a user that doesn't have permissions to use the
+//   action or resource, or specifying an identifier that is not valid.
 //
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
 //   The specified parameter is invalid. Review the available parameters for the
@@ -2641,7 +2664,7 @@ func (c *ECS) RunTaskRequest(input *RunTaskInput) (req *request.Request, output 
 // You can allow Amazon ECS to place tasks for you, or you can customize how
 // Amazon ECS places tasks using placement constraints and placement strategies.
 // For more information, see Scheduling Tasks (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/scheduling_tasks.html)
-// in the Amazon EC2 Container Service Developer Guide.
+// in the Amazon Elastic Container Service Developer Guide.
 //
 // Alternatively, you can use StartTask to use your own scheduler or place tasks
 // manually on specific container instances.
@@ -2659,8 +2682,8 @@ func (c *ECS) RunTaskRequest(input *RunTaskInput) (req *request.Request, output 
 //
 //   * ErrCodeClientException "ClientException"
 //   These errors are usually caused by a client action, such as using an action
-//   or resource on behalf of a user that doesn't have permission to use the action
-//   or resource, or specifying an identifier that is not valid.
+//   or resource on behalf of a user that doesn't have permissions to use the
+//   action or resource, or specifying an identifier that is not valid.
 //
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
 //   The specified parameter is invalid. Review the available parameters for the
@@ -2669,6 +2692,23 @@ func (c *ECS) RunTaskRequest(input *RunTaskInput) (req *request.Request, output 
 //   * ErrCodeClusterNotFoundException "ClusterNotFoundException"
 //   The specified cluster could not be found. You can view your available clusters
 //   with ListClusters. Amazon ECS clusters are region-specific.
+//
+//   * ErrCodeUnsupportedFeatureException "UnsupportedFeatureException"
+//   The specified task is not supported in this region.
+//
+//   * ErrCodePlatformUnknownException "PlatformUnknownException"
+//   The specified platform version does not exist.
+//
+//   * ErrCodePlatformTaskDefinitionIncompatibilityException "PlatformTaskDefinitionIncompatibilityException"
+//   The specified platform version does not satisfy the task definition’s required
+//   capabilities.
+//
+//   * ErrCodeAccessDeniedException "AccessDeniedException"
+//   You do not have authorization to perform the requested action.
+//
+//   * ErrCodeBlockedException "BlockedException"
+//   Your AWS account has been blocked. Contact AWS Customer Support (http://aws.amazon.com/contact-us/)
+//   for more information.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/RunTask
 func (c *ECS) RunTask(input *RunTaskInput) (*RunTaskOutput, error) {
@@ -2741,7 +2781,7 @@ func (c *ECS) StartTaskRequest(input *StartTaskInput) (req *request.Request, out
 //
 // Alternatively, you can use RunTask to place tasks for you. For more information,
 // see Scheduling Tasks (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/scheduling_tasks.html)
-// in the Amazon EC2 Container Service Developer Guide.
+// in the Amazon Elastic Container Service Developer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2756,8 +2796,8 @@ func (c *ECS) StartTaskRequest(input *StartTaskInput) (req *request.Request, out
 //
 //   * ErrCodeClientException "ClientException"
 //   These errors are usually caused by a client action, such as using an action
-//   or resource on behalf of a user that doesn't have permission to use the action
-//   or resource, or specifying an identifier that is not valid.
+//   or resource on behalf of a user that doesn't have permissions to use the
+//   action or resource, or specifying an identifier that is not valid.
 //
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
 //   The specified parameter is invalid. Review the available parameters for the
@@ -2844,7 +2884,7 @@ func (c *ECS) StopTaskRequest(input *StopTaskInput) (req *request.Request, outpu
 // The default 30-second timeout can be configured on the Amazon ECS container
 // agent with the ECS_CONTAINER_STOP_TIMEOUT variable. For more information,
 // see Amazon ECS Container Agent Configuration (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html)
-// in the Amazon EC2 Container Service Developer Guide.
+// in the Amazon Elastic Container Service Developer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2859,8 +2899,8 @@ func (c *ECS) StopTaskRequest(input *StopTaskInput) (req *request.Request, outpu
 //
 //   * ErrCodeClientException "ClientException"
 //   These errors are usually caused by a client action, such as using an action
-//   or resource on behalf of a user that doesn't have permission to use the action
-//   or resource, or specifying an identifier that is not valid.
+//   or resource on behalf of a user that doesn't have permissions to use the
+//   action or resource, or specifying an identifier that is not valid.
 //
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
 //   The specified parameter is invalid. Review the available parameters for the
@@ -2936,8 +2976,8 @@ func (c *ECS) SubmitContainerStateChangeRequest(input *SubmitContainerStateChang
 
 // SubmitContainerStateChange API operation for Amazon EC2 Container Service.
 //
-// This action is only used by the Amazon EC2 Container Service agent, and it
-// is not intended for use outside of the agent.
+// This action is only used by the Amazon ECS agent, and it is not intended
+// for use outside of the agent.
 //
 // Sent to acknowledge that a container changed states.
 //
@@ -2954,8 +2994,11 @@ func (c *ECS) SubmitContainerStateChangeRequest(input *SubmitContainerStateChang
 //
 //   * ErrCodeClientException "ClientException"
 //   These errors are usually caused by a client action, such as using an action
-//   or resource on behalf of a user that doesn't have permission to use the action
-//   or resource, or specifying an identifier that is not valid.
+//   or resource on behalf of a user that doesn't have permissions to use the
+//   action or resource, or specifying an identifier that is not valid.
+//
+//   * ErrCodeAccessDeniedException "AccessDeniedException"
+//   You do not have authorization to perform the requested action.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/SubmitContainerStateChange
 func (c *ECS) SubmitContainerStateChange(input *SubmitContainerStateChangeInput) (*SubmitContainerStateChangeOutput, error) {
@@ -3023,8 +3066,8 @@ func (c *ECS) SubmitTaskStateChangeRequest(input *SubmitTaskStateChangeInput) (r
 
 // SubmitTaskStateChange API operation for Amazon EC2 Container Service.
 //
-// This action is only used by the Amazon EC2 Container Service agent, and it
-// is not intended for use outside of the agent.
+// This action is only used by the Amazon ECS agent, and it is not intended
+// for use outside of the agent.
 //
 // Sent to acknowledge that a task changed states.
 //
@@ -3041,8 +3084,11 @@ func (c *ECS) SubmitTaskStateChangeRequest(input *SubmitTaskStateChangeInput) (r
 //
 //   * ErrCodeClientException "ClientException"
 //   These errors are usually caused by a client action, such as using an action
-//   or resource on behalf of a user that doesn't have permission to use the action
-//   or resource, or specifying an identifier that is not valid.
+//   or resource on behalf of a user that doesn't have permissions to use the
+//   action or resource, or specifying an identifier that is not valid.
+//
+//   * ErrCodeAccessDeniedException "AccessDeniedException"
+//   You do not have authorization to perform the requested action.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/SubmitTaskStateChange
 func (c *ECS) SubmitTaskStateChange(input *SubmitTaskStateChangeInput) (*SubmitTaskStateChangeOutput, error) {
@@ -3120,7 +3166,7 @@ func (c *ECS) UpdateContainerAgentRequest(input *UpdateContainerAgentInput) (req
 // with the ecs-init service installed and running. For help updating the Amazon
 // ECS container agent on other operating systems, see Manually Updating the
 // Amazon ECS Container Agent (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-update.html#manually_update_agent)
-// in the Amazon EC2 Container Service Developer Guide.
+// in the Amazon Elastic Container Service Developer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3135,8 +3181,8 @@ func (c *ECS) UpdateContainerAgentRequest(input *UpdateContainerAgentInput) (req
 //
 //   * ErrCodeClientException "ClientException"
 //   These errors are usually caused by a client action, such as using an action
-//   or resource on behalf of a user that doesn't have permission to use the action
-//   or resource, or specifying an identifier that is not valid.
+//   or resource on behalf of a user that doesn't have permissions to use the
+//   action or resource, or specifying an identifier that is not valid.
 //
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
 //   The specified parameter is invalid. Review the available parameters for the
@@ -3243,9 +3289,9 @@ func (c *ECS) UpdateContainerInstancesStateRequest(input *UpdateContainerInstanc
 // are in the PENDING state are stopped immediately.
 //
 // Service tasks on the container instance that are in the RUNNING state are
-// stopped and replaced according the service's deployment configuration parameters,
-// minimumHealthyPercent and maximumPercent. Note that you can change the deployment
-// configuration of your service using UpdateService.
+// stopped and replaced according to the service's deployment configuration
+// parameters, minimumHealthyPercent and maximumPercent. You can change the
+// deployment configuration of your service using UpdateService.
 //
 //    * If minimumHealthyPercent is below 100%, the scheduler can ignore desiredCount
 //    temporarily during task replacement. For example, desiredCount is four
@@ -3288,8 +3334,8 @@ func (c *ECS) UpdateContainerInstancesStateRequest(input *UpdateContainerInstanc
 //
 //   * ErrCodeClientException "ClientException"
 //   These errors are usually caused by a client action, such as using an action
-//   or resource on behalf of a user that doesn't have permission to use the action
-//   or resource, or specifying an identifier that is not valid.
+//   or resource on behalf of a user that doesn't have permissions to use the
+//   action or resource, or specifying an identifier that is not valid.
 //
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
 //   The specified parameter is invalid. Review the available parameters for the
@@ -3446,8 +3492,8 @@ func (c *ECS) UpdateServiceRequest(input *UpdateServiceInput) (req *request.Requ
 //
 //   * ErrCodeClientException "ClientException"
 //   These errors are usually caused by a client action, such as using an action
-//   or resource on behalf of a user that doesn't have permission to use the action
-//   or resource, or specifying an identifier that is not valid.
+//   or resource on behalf of a user that doesn't have permissions to use the
+//   action or resource, or specifying an identifier that is not valid.
 //
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
 //   The specified parameter is invalid. Review the available parameters for the
@@ -3462,9 +3508,18 @@ func (c *ECS) UpdateServiceRequest(input *UpdateServiceInput) (req *request.Requ
 //   with ListServices. Amazon ECS services are cluster-specific and region-specific.
 //
 //   * ErrCodeServiceNotActiveException "ServiceNotActiveException"
-//   The specified service is not active. You cannot update a service that is
-//   not active. If you have previously deleted a service, you can re-create it
-//   with CreateService.
+//   The specified service is not active. You can't update a service that is inactive.
+//   If you have previously deleted a service, you can re-create it with CreateService.
+//
+//   * ErrCodePlatformUnknownException "PlatformUnknownException"
+//   The specified platform version does not exist.
+//
+//   * ErrCodePlatformTaskDefinitionIncompatibilityException "PlatformTaskDefinitionIncompatibilityException"
+//   The specified platform version does not satisfy the task definition’s required
+//   capabilities.
+//
+//   * ErrCodeAccessDeniedException "AccessDeniedException"
+//   You do not have authorization to perform the requested action.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/UpdateService
 func (c *ECS) UpdateService(input *UpdateServiceInput) (*UpdateServiceOutput, error) {
@@ -3600,7 +3655,7 @@ func (s *AttachmentStateChange) SetStatus(v string) *AttachmentStateChange {
 // An attribute is a name-value pair associated with an Amazon ECS object. Attributes
 // enable you to extend the Amazon ECS data model by adding custom metadata
 // to your resources. For more information, see Attributes (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-constraints.html#attributes)
-// in the Amazon EC2 Container Service Developer Guide.
+// in the Amazon Elastic Container Service Developer Guide.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/Attribute
 type Attribute struct {
 	_ struct{} `type:"structure"`
@@ -3617,7 +3672,7 @@ type Attribute struct {
 
 	// The type of the target with which to attach the attribute. This parameter
 	// is required if you use the short form ID for a resource instead of the full
-	// Amazon Resource Name (ARN).
+	// ARN.
 	TargetType *string `locationName:"targetType" type:"string" enum:"TargetType"`
 
 	// The value of the attribute. Up to 128 letters (uppercase and lowercase),
@@ -3673,10 +3728,14 @@ func (s *Attribute) SetValue(v string) *Attribute {
 	return s
 }
 
-// An object representing the subnets and security groups for a task or service.
+// An object representing the networking details for a task or service.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/AwsVpcConfiguration
 type AwsVpcConfiguration struct {
 	_ struct{} `type:"structure"`
+
+	// Specifies whether or not the task's elastic network interface receives a
+	// public IP address.
+	AssignPublicIp *string `locationName:"assignPublicIp" type:"string" enum:"AssignPublicIp"`
 
 	// The security groups associated with the task or service. If you do not specify
 	// a security group, the default security group for the VPC is used.
@@ -3709,6 +3768,12 @@ func (s *AwsVpcConfiguration) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetAssignPublicIp sets the AssignPublicIp field's value.
+func (s *AwsVpcConfiguration) SetAssignPublicIp(v string) *AwsVpcConfiguration {
+	s.AssignPublicIp = &v
+	return s
 }
 
 // SetSecurityGroups sets the SecurityGroups field's value.
@@ -3752,6 +3817,26 @@ type Cluster struct {
 
 	// The number of tasks in the cluster that are in the RUNNING state.
 	RunningTasksCount *int64 `locationName:"runningTasksCount" type:"integer"`
+
+	// Additional information about your clusters that are separated by launch type,
+	// including:
+	//
+	//    * runningEC2TasksCount
+	//
+	//    * RunningFargateTasksCount
+	//
+	//    * pendingEC2TasksCount
+	//
+	//    * pendingFargateTasksCount
+	//
+	//    * activeEC2ServiceCount
+	//
+	//    * activeFargateServiceCount
+	//
+	//    * drainingEC2ServiceCount
+	//
+	//    * drainingFargateServiceCount
+	Statistics []*KeyValuePair `locationName:"statistics" type:"list"`
 
 	// The status of the cluster. The valid values are ACTIVE or INACTIVE. ACTIVE
 	// indicates that you can register container instances with the cluster and
@@ -3805,6 +3890,12 @@ func (s *Cluster) SetRunningTasksCount(v int64) *Cluster {
 	return s
 }
 
+// SetStatistics sets the Statistics field's value.
+func (s *Cluster) SetStatistics(v []*KeyValuePair) *Cluster {
+	s.Statistics = v
+	return s
+}
+
 // SetStatus sets the Status field's value.
 func (s *Cluster) SetStatus(v string) *Cluster {
 	s.Status = &v
@@ -3838,7 +3929,7 @@ type Container struct {
 	// details about a running or stopped container.
 	Reason *string `locationName:"reason" type:"string"`
 
-	// The Amazon Resource Name (ARN) of the task.
+	// The ARN of the task.
 	TaskArn *string `locationName:"taskArn" type:"string"`
 }
 
@@ -3914,12 +4005,17 @@ type ContainerDefinition struct {
 	// (https://docs.docker.com/engine/reference/builder/#cmd).
 	Command []*string `locationName:"command" type:"list"`
 
-	// The number of cpu units reserved for the container. A container instance
-	// has 1,024 cpu units for every CPU core. This parameter specifies the minimum
-	// amount of CPU to reserve for a container, and containers share unallocated
-	// CPU units with other containers on the instance with the same ratio as their
-	// allocated amount. This parameter maps to CpuShares in the Create a container
-	// (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
+	// The number of cpu units reserved for the container. If your containers will
+	// be part of a task using the Fargate launch type, this field is optional and
+	// the only requirement is that the total amount of CPU reserved for all containers
+	// within a task be lower than the task cpu value.
+	//
+	// For containers that will be part of a task using the EC2 launch type, a container
+	// instance has 1,024 cpu units for every CPU core. This parameter specifies
+	// the minimum amount of CPU to reserve for a container, and containers share
+	// unallocated CPU units with other containers on the instance with the same
+	// ratio as their allocated amount. This parameter maps to CpuShares in the
+	// Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
 	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
 	// and the --cpu-shares option to docker run (https://docs.docker.com/engine/reference/run/).
 	//
@@ -3978,13 +4074,15 @@ type ContainerDefinition struct {
 	// and the --label option to docker run (https://docs.docker.com/engine/reference/run/).
 	// This parameter requires version 1.18 of the Docker Remote API or greater
 	// on your container instance. To check the Docker Remote API version on your
-	// container instance, log into your container instance and run the following
+	// container instance, log in to your container instance and run the following
 	// command: sudo docker version | grep "Server API version"
 	DockerLabels map[string]*string `locationName:"dockerLabels" type:"map"`
 
 	// A list of strings to provide custom labels for SELinux and AppArmor multi-level
-	// security systems. This parameter maps to SecurityOpt in the Create a container
-	// (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
+	// security systems. This field is not valid for containers in tasks using the
+	// Fargate launch type.
+	//
+	// This parameter maps to SecurityOpt in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
 	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
 	// and the --security-opt option to docker run (https://docs.docker.com/engine/reference/run/).
 	//
@@ -3993,7 +4091,7 @@ type ContainerDefinition struct {
 	// variables before containers placed on that instance can use these security
 	// options. For more information, see Amazon ECS Container Agent Configuration
 	// (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html)
-	// in the Amazon EC2 Container Service Developer Guide.
+	// in the Amazon Elastic Container Service Developer Guide.
 	DockerSecurityOptions []*string `locationName:"dockerSecurityOptions" type:"list"`
 
 	// Early versions of the Amazon ECS container agent do not properly handle entryPoint
@@ -4013,8 +4111,8 @@ type ContainerDefinition struct {
 	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
 	// and the --env option to docker run (https://docs.docker.com/engine/reference/run/).
 	//
-	// We do not recommend using plain text environment variables for sensitive
-	// information, such as credential data.
+	// We do not recommend using plaintext environment variables for sensitive information,
+	// such as credential data.
 	Environment []*KeyValuePair `locationName:"environment" type:"list"`
 
 	// If the essential parameter of a container is marked as true, and that container
@@ -4028,12 +4126,13 @@ type ContainerDefinition struct {
 	// are used for a common purpose into components, and separate the different
 	// components into multiple task definitions. For more information, see Application
 	// Architecture (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/application_architecture.html)
-	// in the Amazon EC2 Container Service Developer Guide.
+	// in the Amazon Elastic Container Service Developer Guide.
 	Essential *bool `locationName:"essential" type:"boolean"`
 
 	// A list of hostnames and IP address mappings to append to the /etc/hosts file
-	// on the container. This parameter maps to ExtraHosts in the Create a container
-	// (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
+	// on the container. If using the Fargate launch type, this may be used to list
+	// non-Fargate hosts you want the container to talk to. This parameter maps
+	// to ExtraHosts in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
 	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
 	// and the --add-host option to docker run (https://docs.docker.com/engine/reference/run/).
 	ExtraHosts []*HostEntry `locationName:"extraHosts" type:"list"`
@@ -4073,9 +4172,10 @@ type ContainerDefinition struct {
 	// The link parameter allows containers to communicate with each other without
 	// the need for port mappings, using the name parameter and optionally, an alias
 	// for the link. This construct is analogous to name:alias in Docker links.
-	// Up to 255 letters (uppercase and lowercase), numbers, hyphens, and underscores
-	// are allowed for each name and alias. For more information on linking Docker
-	// containers, see https://docs.docker.com/engine/userguide/networking/default_network/dockerlinks/
+	// This field is not valid for containers in tasks using the Fargate launch
+	// type. Up to 255 letters (uppercase and lowercase), numbers, hyphens, and
+	// underscores are allowed for each name and alias. For more information on
+	// linking Docker containers, see https://docs.docker.com/engine/userguide/networking/default_network/dockerlinks/
 	// (https://docs.docker.com/engine/userguide/networking/default_network/dockerlinks/).
 	// This parameter maps to Links in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
 	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
@@ -4088,11 +4188,15 @@ type ContainerDefinition struct {
 	Links []*string `locationName:"links" type:"list"`
 
 	// Linux-specific modifications that are applied to the container, such as Linux
-	// KernelCapabilities.
+	// KernelCapabilities. This field is not valid for containers in tasks using
+	// the Fargate launch type.
 	LinuxParameters *LinuxParameters `locationName:"linuxParameters" type:"structure"`
 
-	// The log configuration specification for the container. This parameter maps
-	// to LogConfig in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
+	// The log configuration specification for the container.
+	//
+	// If using the Fargate launch type, the only supported value is awslogs.
+	//
+	// This parameter maps to LogConfig in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
 	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
 	// and the --log-driver option to docker run (https://docs.docker.com/engine/reference/run/).
 	// By default, containers use the same logging driver that the Docker daemon
@@ -4110,7 +4214,7 @@ type ContainerDefinition struct {
 	//
 	// This parameter requires version 1.18 of the Docker Remote API or greater
 	// on your container instance. To check the Docker Remote API version on your
-	// container instance, log into your container instance and run the following
+	// container instance, log in to your container instance and run the following
 	// command: sudo docker version | grep "Server API version"
 	//
 	// The Amazon ECS container agent running on a container instance must register
@@ -4118,7 +4222,7 @@ type ContainerDefinition struct {
 	// environment variable before containers placed on that instance can use these
 	// log configuration options. For more information, see Amazon ECS Container
 	// Agent Configuration (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html)
-	// in the Amazon EC2 Container Service Developer Guide.
+	// in the Amazon Elastic Container Service Developer Guide.
 	LogConfiguration *LogConfiguration `locationName:"logConfiguration" type:"structure"`
 
 	// The hard limit (in MiB) of memory to present to the container. If your container
@@ -4127,7 +4231,13 @@ type ContainerDefinition struct {
 	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
 	// and the --memory option to docker run (https://docs.docker.com/engine/reference/run/).
 	//
-	// You must specify a non-zero integer for one or both of memory or memoryReservation
+	// If your containers will be part of a task using the Fargate launch type,
+	// this field is optional and the only requirement is that the total amount
+	// of memory reserved for all containers within a task be lower than the task
+	// memory value.
+	//
+	// For containers that will be part of a task using the EC2 launch type, you
+	// must specify a non-zero integer for one or both of memory or memoryReservation
 	// in container definitions. If you specify both, memory must be greater than
 	// memoryReservation. If you specify memoryReservation, then that value is subtracted
 	// from the available memory resources for the container instance on which the
@@ -4161,8 +4271,11 @@ type ContainerDefinition struct {
 	// more memory resources when needed.
 	MemoryReservation *int64 `locationName:"memoryReservation" type:"integer"`
 
-	// The mount points for data volumes in your container. This parameter maps
-	// to Volumes in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
+	// The mount points for data volumes in your container.
+	//
+	// If using the Fargate launch type, the sourceVolume parameter is not supported.
+	//
+	// This parameter maps to Volumes in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
 	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
 	// and the --volume option to docker run (https://docs.docker.com/engine/reference/run/).
 	MountPoints []*MountPoint `locationName:"mountPoints" type:"list"`
@@ -4178,17 +4291,22 @@ type ContainerDefinition struct {
 
 	// The list of port mappings for the container. Port mappings allow containers
 	// to access ports on the host container instance to send or receive traffic.
+	//
+	// If using containers in a task with the Fargate, exposed ports should be specified
+	// using containerPort. The hostPort can be left blank or it must be the same
+	// value as the containerPort.
+	//
 	// This parameter maps to PortBindings in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
 	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
 	// and the --publish option to docker run (https://docs.docker.com/engine/reference/run/).
-	// If the network mode of a task definition is set to none, then you cannot
-	// specify port mappings. If the network mode of a task definition is set to
-	// host, then host ports must either be undefined or they must match the container
-	// port in the port mapping.
+	// If the network mode of a task definition is set to none, then you can't specify
+	// port mappings. If the network mode of a task definition is set to host, then
+	// host ports must either be undefined or they must match the container port
+	// in the port mapping.
 	//
 	// After a task reaches the RUNNING status, manual and automatic host and container
 	// port assignments are visible in the Network Bindings section of a container
-	// description of a selected task in the Amazon ECS console, or the networkBindings
+	// description for a selected task in the Amazon ECS console, or the networkBindings
 	// section DescribeTasks responses.
 	PortMappings []*PortMapping `locationName:"portMappings" type:"list"`
 
@@ -4213,7 +4331,7 @@ type ContainerDefinition struct {
 	// Valid naming values are displayed in the Ulimit data type. This parameter
 	// requires version 1.18 of the Docker Remote API or greater on your container
 	// instance. To check the Docker Remote API version on your container instance,
-	// log into your container instance and run the following command: sudo docker
+	// log in to your container instance and run the following command: sudo docker
 	// version | grep "Server API version"
 	Ulimits []*Ulimit `locationName:"ulimits" type:"list"`
 
@@ -4454,10 +4572,9 @@ func (s *ContainerDefinition) SetWorkingDirectory(v string) *ContainerDefinition
 type ContainerInstance struct {
 	_ struct{} `type:"structure"`
 
-	// This parameter returns true if the agent is actually connected to Amazon
-	// ECS. Registered instances with an agent that may be unhealthy or stopped
-	// return false, and instances without a connected agent cannot accept placement
-	// requests.
+	// This parameter returns true if the agent is connected to Amazon ECS. Registered
+	// instances with an agent that may be unhealthy or stopped return false. Instances
+	// without a connected agent can't accept placement requests.
 	AgentConnected *bool `locationName:"agentConnected" type:"boolean"`
 
 	// The status of the most recent agent update. If an update has never been requested,
@@ -4483,7 +4600,7 @@ type ContainerInstance struct {
 	// The number of tasks on the container instance that are in the PENDING status.
 	PendingTasksCount *int64 `locationName:"pendingTasksCount" type:"integer"`
 
-	// The Unix timestamp for when the container instance was registered.
+	// The Unix time stamp for when the container instance was registered.
 	RegisteredAt *time.Time `locationName:"registeredAt" type:"timestamp" timestampFormat:"unix"`
 
 	// For most resource types, this parameter describes the registered resources
@@ -4508,15 +4625,15 @@ type ContainerInstance struct {
 	// DRAINING indicates that new tasks are not placed on the container instance
 	// and any service tasks running on the container instance are removed if possible.
 	// For more information, see Container Instance Draining (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-instance-draining.html)
-	// in the Amazon EC2 Container Service Developer Guide.
+	// in the Amazon Elastic Container Service Developer Guide.
 	Status *string `locationName:"status" type:"string"`
 
 	// The version counter for the container instance. Every time a container instance
 	// experiences a change that triggers a CloudWatch event, the version counter
 	// is incremented. If you are replicating your Amazon ECS container instance
-	// state with CloudWatch events, you can compare the version of a container
+	// state with CloudWatch Events, you can compare the version of a container
 	// instance reported by the Amazon ECS APIs with the version reported in CloudWatch
-	// events for the container instance (inside the detail object) to verify that
+	// Events for the container instance (inside the detail object) to verify that
 	// the version in your event stream is current.
 	Version *int64 `locationName:"version" type:"long"`
 
@@ -4836,6 +4953,9 @@ type CreateServiceInput struct {
 	// DesiredCount is a required field
 	DesiredCount *int64 `locationName:"desiredCount" type:"integer" required:"true"`
 
+	// The launch type on which to run your service.
+	LaunchType *string `locationName:"launchType" type:"string" enum:"LaunchType"`
+
 	// A load balancer object representing the load balancer to use with your service.
 	// Currently, you are limited to one load balancer or target group per service.
 	// After you create a service, the load balancer name or target group ARN, container
@@ -4858,8 +4978,8 @@ type CreateServiceInput struct {
 	// The network configuration for the service. This parameter is required for
 	// task definitions that use the awsvpc network mode to receive their own Elastic
 	// Network Interface, and it is not supported for other network modes. For more
-	// information, see Task Networking (http://docs.aws.amazon.com/AmazonECS/latest/developerguidetask-networking.html)
-	// in the Amazon EC2 Container Service Developer Guide.
+	// information, see Task Networking (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-networking.html)
+	// in the Amazon Elastic Container Service Developer Guide.
 	NetworkConfiguration *NetworkConfiguration `locationName:"networkConfiguration" type:"structure"`
 
 	// An array of placement constraint objects to use for tasks in your service.
@@ -4868,8 +4988,12 @@ type CreateServiceInput struct {
 	PlacementConstraints []*PlacementConstraint `locationName:"placementConstraints" type:"list"`
 
 	// The placement strategy objects to use for tasks in your service. You can
-	// specify a maximum of 5 strategy rules per service.
+	// specify a maximum of five strategy rules per service.
 	PlacementStrategy []*PlacementStrategy `locationName:"placementStrategy" type:"list"`
+
+	// The platform version on which to run your service. If one is not specified,
+	// the latest version is used by default.
+	PlatformVersion *string `locationName:"platformVersion" type:"string"`
 
 	// The name or full Amazon Resource Name (ARN) of the IAM role that allows Amazon
 	// ECS to make calls to your load balancer on your behalf. This parameter is
@@ -4882,8 +5006,8 @@ type CreateServiceInput struct {
 	// role is used by default for your service unless you specify a role here.
 	// The service-linked role is required if your task definition uses the awsvpc
 	// network mode, in which case you should not specify a role here. For more
-	// information, see Using Service-Linked Roles for Amazon ECS (http://docs.aws.amazon.com/AmazonECS/latest/developerguideusing-service-linked-roles.html)
-	// in the Amazon EC2 Container Service Developer Guide.
+	// information, see Using Service-Linked Roles for Amazon ECS (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/using-service-linked-roles.html)
+	// in the Amazon Elastic Container Service Developer Guide.
 	//
 	// If your specified role has a path other than /, then you must either specify
 	// the full role ARN (this is recommended) or prefix the role name with the
@@ -4901,9 +5025,9 @@ type CreateServiceInput struct {
 	// ServiceName is a required field
 	ServiceName *string `locationName:"serviceName" type:"string" required:"true"`
 
-	// The family and revision (family:revision) or full Amazon Resource Name (ARN)
-	// of the task definition to run in your service. If a revision is not specified,
-	// the latest ACTIVE revision is used.
+	// The family and revision (family:revision) or full ARN of the task definition
+	// to run in your service. If a revision is not specified, the latest ACTIVE
+	// revision is used.
 	//
 	// TaskDefinition is a required field
 	TaskDefinition *string `locationName:"taskDefinition" type:"string" required:"true"`
@@ -4967,6 +5091,12 @@ func (s *CreateServiceInput) SetDesiredCount(v int64) *CreateServiceInput {
 	return s
 }
 
+// SetLaunchType sets the LaunchType field's value.
+func (s *CreateServiceInput) SetLaunchType(v string) *CreateServiceInput {
+	s.LaunchType = &v
+	return s
+}
+
 // SetLoadBalancers sets the LoadBalancers field's value.
 func (s *CreateServiceInput) SetLoadBalancers(v []*LoadBalancer) *CreateServiceInput {
 	s.LoadBalancers = v
@@ -4988,6 +5118,12 @@ func (s *CreateServiceInput) SetPlacementConstraints(v []*PlacementConstraint) *
 // SetPlacementStrategy sets the PlacementStrategy field's value.
 func (s *CreateServiceInput) SetPlacementStrategy(v []*PlacementStrategy) *CreateServiceInput {
 	s.PlacementStrategy = v
+	return s
+}
+
+// SetPlatformVersion sets the PlatformVersion field's value.
+func (s *CreateServiceInput) SetPlatformVersion(v string) *CreateServiceInput {
+	s.PlatformVersion = &v
 	return s
 }
 
@@ -5262,7 +5398,7 @@ func (s *DeleteServiceOutput) SetService(v *Service) *DeleteServiceOutput {
 type Deployment struct {
 	_ struct{} `type:"structure"`
 
-	// The Unix timestamp for when the service was created.
+	// The Unix time stamp for when the service was created.
 	CreatedAt *time.Time `locationName:"createdAt" type:"timestamp" timestampFormat:"unix"`
 
 	// The most recent desired count of tasks that was specified for the service
@@ -5272,12 +5408,18 @@ type Deployment struct {
 	// The ID of the deployment.
 	Id *string `locationName:"id" type:"string"`
 
+	// The launch type on which your service is running.
+	LaunchType *string `locationName:"launchType" type:"string" enum:"LaunchType"`
+
 	// The VPC subnet and security group configuration for tasks that receive their
 	// own Elastic Network Interface by using the awsvpc networking mode.
 	NetworkConfiguration *NetworkConfiguration `locationName:"networkConfiguration" type:"structure"`
 
 	// The number of tasks in the deployment that are in the PENDING status.
 	PendingCount *int64 `locationName:"pendingCount" type:"integer"`
+
+	// The platform version on which your service is running.
+	PlatformVersion *string `locationName:"platformVersion" type:"string"`
 
 	// The number of tasks in the deployment that are in the RUNNING status.
 	RunningCount *int64 `locationName:"runningCount" type:"integer"`
@@ -5291,7 +5433,7 @@ type Deployment struct {
 	// The most recent task definition that was specified for the service to use.
 	TaskDefinition *string `locationName:"taskDefinition" type:"string"`
 
-	// The Unix timestamp for when the service was last updated.
+	// The Unix time stamp for when the service was last updated.
 	UpdatedAt *time.Time `locationName:"updatedAt" type:"timestamp" timestampFormat:"unix"`
 }
 
@@ -5323,6 +5465,12 @@ func (s *Deployment) SetId(v string) *Deployment {
 	return s
 }
 
+// SetLaunchType sets the LaunchType field's value.
+func (s *Deployment) SetLaunchType(v string) *Deployment {
+	s.LaunchType = &v
+	return s
+}
+
 // SetNetworkConfiguration sets the NetworkConfiguration field's value.
 func (s *Deployment) SetNetworkConfiguration(v *NetworkConfiguration) *Deployment {
 	s.NetworkConfiguration = v
@@ -5332,6 +5480,12 @@ func (s *Deployment) SetNetworkConfiguration(v *NetworkConfiguration) *Deploymen
 // SetPendingCount sets the PendingCount field's value.
 func (s *Deployment) SetPendingCount(v int64) *Deployment {
 	s.PendingCount = &v
+	return s
+}
+
+// SetPlatformVersion sets the PlatformVersion field's value.
+func (s *Deployment) SetPlatformVersion(v string) *Deployment {
+	s.PlatformVersion = &v
 	return s
 }
 
@@ -5373,9 +5527,9 @@ type DeploymentConfiguration struct {
 
 	// The lower limit (as a percentage of the service's desiredCount) of the number
 	// of running tasks that must remain in the RUNNING state in a service during
-	// a deployment. The minimum healthy tasks during a deployment is the desiredCount
-	// multiplied by minimumHealthyPercent/100, rounded up to the nearest integer
-	// value.
+	// a deployment. The minimum number of healthy tasks during a deployment is
+	// the desiredCount multiplied by minimumHealthyPercent/100, rounded up to the
+	// nearest integer value.
 	MinimumHealthyPercent *int64 `locationName:"minimumHealthyPercent" type:"integer"`
 }
 
@@ -5410,11 +5564,11 @@ type DeregisterContainerInstanceInput struct {
 	// default cluster is assumed.
 	Cluster *string `locationName:"cluster" type:"string"`
 
-	// The container instance ID or full Amazon Resource Name (ARN) of the container
-	// instance to deregister. The ARN contains the arn:aws:ecs namespace, followed
-	// by the region of the container instance, the AWS account ID of the container
-	// instance owner, the container-instance namespace, and then the container
-	// instance ID. For example, arn:aws:ecs:region:aws_account_id:container-instance/container_instance_ID.
+	// The container instance ID or full ARN of the container instance to deregister.
+	// The ARN contains the arn:aws:ecs namespace, followed by the region of the
+	// container instance, the AWS account ID of the container instance owner, the
+	// container-instance namespace, and then the container instance ID. For example,
+	// arn:aws:ecs:region:aws_account_id:container-instance/container_instance_ID.
 	//
 	// ContainerInstance is a required field
 	ContainerInstance *string `locationName:"containerInstance" type:"string" required:"true"`
@@ -5428,9 +5582,9 @@ type DeregisterContainerInstanceInput struct {
 	// of that task, on a different container instance if possible.
 	//
 	// Any containers in orphaned service tasks that are registered with a Classic
-	// Load Balancer or an Application Load Balancer target group are deregistered,
-	// and they will begin connection draining according to the settings on the
-	// load balancer or target group.
+	// Load Balancer or an Application Load Balancer target group are deregistered.
+	// They begin connection draining according to the settings on the load balancer
+	// or target group.
 	Force *bool `locationName:"force" type:"boolean"`
 }
 
@@ -5570,6 +5724,26 @@ type DescribeClustersInput struct {
 	// A list of up to 100 cluster names or full cluster Amazon Resource Name (ARN)
 	// entries. If you do not specify a cluster, the default cluster is assumed.
 	Clusters []*string `locationName:"clusters" type:"list"`
+
+	// Additional information about your clusters to be separated by launch type,
+	// including:
+	//
+	//    * runningEC2TasksCount
+	//
+	//    * RunningFargateTasksCount
+	//
+	//    * pendingEC2TasksCount
+	//
+	//    * pendingFargateTasksCount
+	//
+	//    * activeEC2ServiceCount
+	//
+	//    * activeFargateServiceCount
+	//
+	//    * drainingEC2ServiceCount
+	//
+	//    * drainingFargateServiceCount
+	Include []*string `locationName:"include" type:"list"`
 }
 
 // String returns the string representation
@@ -5585,6 +5759,12 @@ func (s DescribeClustersInput) GoString() string {
 // SetClusters sets the Clusters field's value.
 func (s *DescribeClustersInput) SetClusters(v []*string) *DescribeClustersInput {
 	s.Clusters = v
+	return s
+}
+
+// SetInclude sets the Include field's value.
+func (s *DescribeClustersInput) SetInclude(v []*string) *DescribeClustersInput {
+	s.Include = v
 	return s
 }
 
@@ -5630,7 +5810,7 @@ type DescribeContainerInstancesInput struct {
 	// default cluster is assumed.
 	Cluster *string `locationName:"cluster" type:"string"`
 
-	// A list of container instance IDs or full Amazon Resource Name (ARN) entries.
+	// A list of container instance IDs or full ARN entries.
 	//
 	// ContainerInstances is a required field
 	ContainerInstances []*string `locationName:"containerInstances" type:"list" required:"true"`
@@ -5862,7 +6042,7 @@ type DescribeTasksInput struct {
 	// is assumed.
 	Cluster *string `locationName:"cluster" type:"string"`
 
-	// A list of up to 100 task IDs or full Amazon Resource Name (ARN) entries.
+	// A list of up to 100 task IDs or full ARN entries.
 	//
 	// Tasks is a required field
 	Tasks []*string `locationName:"tasks" type:"list" required:"true"`
@@ -5950,7 +6130,7 @@ type Device struct {
 	HostPath *string `locationName:"hostPath" type:"string" required:"true"`
 
 	// The explicit permissions to provide to the container for the device. By default,
-	// the container will be able to read, write, and mknod the device.
+	// the container has permissions for read, write, and mknod for the device.
 	Permissions []*string `locationName:"permissions" type:"list"`
 }
 
@@ -6003,11 +6183,10 @@ type DiscoverPollEndpointInput struct {
 	// container instance belongs to.
 	Cluster *string `locationName:"cluster" type:"string"`
 
-	// The container instance ID or full Amazon Resource Name (ARN) of the container
-	// instance. The ARN contains the arn:aws:ecs namespace, followed by the region
-	// of the container instance, the AWS account ID of the container instance owner,
-	// the container-instance namespace, and then the container instance ID. For
-	// example, arn:aws:ecs:region:aws_account_id:container-instance/container_instance_ID.
+	// The container instance ID or full ARN of the container instance. The ARN
+	// contains the arn:aws:ecs namespace, followed by the region of the container
+	// instance, the AWS account ID of the container instance owner, the container-instance
+	// namespace, and then the container instance ID. For example, arn:aws:ecs:region:aws_account_id:container-instance/container_instance_ID.
 	ContainerInstance *string `locationName:"containerInstance" type:"string"`
 }
 
@@ -6167,6 +6346,8 @@ type HostVolumeProperties struct {
 	// instance until you delete it manually. If the sourcePath value does not exist
 	// on the host container instance, the Docker daemon creates it. If the location
 	// does exist, the contents of the source path folder are exported.
+	//
+	// If you are using the Fargate launch type, the host parameter is not supported.
 	SourcePath *string `locationName:"sourcePath" type:"string"`
 }
 
@@ -6307,7 +6488,7 @@ type LinuxParameters struct {
 	// processes. This parameter maps to the --init option to docker run (https://docs.docker.com/engine/reference/run/).
 	// This parameter requires version 1.25 of the Docker Remote API or greater
 	// on your container instance. To check the Docker Remote API version on your
-	// container instance, log into your container instance and run the following
+	// container instance, log in to your container instance and run the following
 	// command: sudo docker version | grep "Server API version"
 	InitProcessEnabled *bool `locationName:"initProcessEnabled" type:"boolean"`
 }
@@ -6387,7 +6568,7 @@ type ListAttributesInput struct {
 	// The nextToken value returned from a previous paginated ListAttributes request
 	// where maxResults was used and the results exceeded the value of that parameter.
 	// Pagination continues from the end of the previous results that returned the
-	// nextToken value. This value is null when there are no more results to return.
+	// nextToken value.
 	//
 	// This token should be treated as an opaque identifier that is only used to
 	// retrieve the next items in a list and not for other programmatic purposes.
@@ -6510,7 +6691,7 @@ type ListClustersInput struct {
 	// The nextToken value returned from a previous paginated ListClusters request
 	// where maxResults was used and the results exceeded the value of that parameter.
 	// Pagination continues from the end of the previous results that returned the
-	// nextToken value. This value is null when there are no more results to return.
+	// nextToken value.
 	//
 	// This token should be treated as an opaque identifier that is only used to
 	// retrieve the next items in a list and not for other programmatic purposes.
@@ -6588,7 +6769,7 @@ type ListContainerInstancesInput struct {
 	// You can filter the results of a ListContainerInstances operation with cluster
 	// query language statements. For more information, see Cluster Query Language
 	// (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-query-language.html)
-	// in the Amazon EC2 Container Service Developer Guide.
+	// in the Amazon Elastic Container Service Developer Guide.
 	Filter *string `locationName:"filter" type:"string"`
 
 	// The maximum number of container instance results returned by ListContainerInstances
@@ -6604,8 +6785,7 @@ type ListContainerInstancesInput struct {
 	// The nextToken value returned from a previous paginated ListContainerInstances
 	// request where maxResults was used and the results exceeded the value of that
 	// parameter. Pagination continues from the end of the previous results that
-	// returned the nextToken value. This value is null when there are no more results
-	// to return.
+	// returned the nextToken value.
 	//
 	// This token should be treated as an opaque identifier that is only used to
 	// retrieve the next items in a list and not for other programmatic purposes.
@@ -6663,8 +6843,8 @@ func (s *ListContainerInstancesInput) SetStatus(v string) *ListContainerInstance
 type ListContainerInstancesOutput struct {
 	_ struct{} `type:"structure"`
 
-	// The list of container instances with full Amazon Resource Name (ARN) entries
-	// for each container instance associated with the specified cluster.
+	// The list of container instances with full ARN entries for each container
+	// instance associated with the specified cluster.
 	ContainerInstanceArns []*string `locationName:"containerInstanceArns" type:"list"`
 
 	// The nextToken value to include in a future ListContainerInstances request.
@@ -6705,6 +6885,9 @@ type ListServicesInput struct {
 	// is assumed.
 	Cluster *string `locationName:"cluster" type:"string"`
 
+	// The launch type for services you want to list.
+	LaunchType *string `locationName:"launchType" type:"string" enum:"LaunchType"`
+
 	// The maximum number of service results returned by ListServices in paginated
 	// output. When this parameter is used, ListServices only returns maxResults
 	// results in a single page along with a nextToken response element. The remaining
@@ -6717,7 +6900,7 @@ type ListServicesInput struct {
 	// The nextToken value returned from a previous paginated ListServices request
 	// where maxResults was used and the results exceeded the value of that parameter.
 	// Pagination continues from the end of the previous results that returned the
-	// nextToken value. This value is null when there are no more results to return.
+	// nextToken value.
 	//
 	// This token should be treated as an opaque identifier that is only used to
 	// retrieve the next items in a list and not for other programmatic purposes.
@@ -6737,6 +6920,12 @@ func (s ListServicesInput) GoString() string {
 // SetCluster sets the Cluster field's value.
 func (s *ListServicesInput) SetCluster(v string) *ListServicesInput {
 	s.Cluster = &v
+	return s
+}
+
+// SetLaunchType sets the LaunchType field's value.
+func (s *ListServicesInput) SetLaunchType(v string) *ListServicesInput {
+	s.LaunchType = &v
 	return s
 }
 
@@ -6762,8 +6951,8 @@ type ListServicesOutput struct {
 	// more results to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	// The list of full Amazon Resource Name (ARN) entries for each service associated
-	// with the specified cluster.
+	// The list of full ARN entries for each service associated with the specified
+	// cluster.
 	ServiceArns []*string `locationName:"serviceArns" type:"list"`
 }
 
@@ -6811,8 +7000,7 @@ type ListTaskDefinitionFamiliesInput struct {
 	// The nextToken value returned from a previous paginated ListTaskDefinitionFamilies
 	// request where maxResults was used and the results exceeded the value of that
 	// parameter. Pagination continues from the end of the previous results that
-	// returned the nextToken value. This value is null when there are no more results
-	// to return.
+	// returned the nextToken value.
 	//
 	// This token should be treated as an opaque identifier that is only used to
 	// retrieve the next items in a list and not for other programmatic purposes.
@@ -6920,8 +7108,7 @@ type ListTaskDefinitionsInput struct {
 	// The nextToken value returned from a previous paginated ListTaskDefinitions
 	// request where maxResults was used and the results exceeded the value of that
 	// parameter. Pagination continues from the end of the previous results that
-	// returned the nextToken value. This value is null when there are no more results
-	// to return.
+	// returned the nextToken value.
 	//
 	// This token should be treated as an opaque identifier that is only used to
 	// retrieve the next items in a list and not for other programmatic purposes.
@@ -7029,25 +7216,29 @@ type ListTasksInput struct {
 	// assumed.
 	Cluster *string `locationName:"cluster" type:"string"`
 
-	// The container instance ID or full Amazon Resource Name (ARN) of the container
-	// instance with which to filter the ListTasks results. Specifying a containerInstance
-	// limits the results to tasks that belong to that container instance.
+	// The container instance ID or full ARN of the container instance with which
+	// to filter the ListTasks results. Specifying a containerInstance limits the
+	// results to tasks that belong to that container instance.
 	ContainerInstance *string `locationName:"containerInstance" type:"string"`
 
 	// The task desired status with which to filter the ListTasks results. Specifying
-	// a desiredStatus of STOPPED limits the results to tasks that ECS has set the
-	// desired status to STOPPED, which can be useful for debugging tasks that are
-	// not starting properly or have died or finished. The default status filter
-	// is RUNNING, which shows tasks that ECS has set the desired status to RUNNING.
+	// a desiredStatus of STOPPED limits the results to tasks that Amazon ECS has
+	// set the desired status to STOPPED, which can be useful for debugging tasks
+	// that are not starting properly or have died or finished. The default status
+	// filter is RUNNING, which shows tasks that Amazon ECS has set the desired
+	// status to RUNNING.
 	//
 	// Although you can filter results based on a desired status of PENDING, this
-	// will not return any results because ECS never sets the desired status of
-	// a task to that value (only a task's lastStatus may have a value of PENDING).
+	// does not return any results because Amazon ECS never sets the desired status
+	// of a task to that value (only a task's lastStatus may have a value of PENDING).
 	DesiredStatus *string `locationName:"desiredStatus" type:"string" enum:"DesiredStatus"`
 
 	// The name of the family with which to filter the ListTasks results. Specifying
 	// a family limits the results to tasks that belong to that family.
 	Family *string `locationName:"family" type:"string"`
+
+	// The launch type for services you want to list.
+	LaunchType *string `locationName:"launchType" type:"string" enum:"LaunchType"`
 
 	// The maximum number of task results returned by ListTasks in paginated output.
 	// When this parameter is used, ListTasks only returns maxResults results in
@@ -7061,7 +7252,7 @@ type ListTasksInput struct {
 	// The nextToken value returned from a previous paginated ListTasks request
 	// where maxResults was used and the results exceeded the value of that parameter.
 	// Pagination continues from the end of the previous results that returned the
-	// nextToken value. This value is null when there are no more results to return.
+	// nextToken value.
 	//
 	// This token should be treated as an opaque identifier that is only used to
 	// retrieve the next items in a list and not for other programmatic purposes.
@@ -7110,6 +7301,12 @@ func (s *ListTasksInput) SetFamily(v string) *ListTasksInput {
 	return s
 }
 
+// SetLaunchType sets the LaunchType field's value.
+func (s *ListTasksInput) SetLaunchType(v string) *ListTasksInput {
+	s.LaunchType = &v
+	return s
+}
+
 // SetMaxResults sets the MaxResults field's value.
 func (s *ListTasksInput) SetMaxResults(v int64) *ListTasksInput {
 	s.MaxResults = &v
@@ -7144,7 +7341,7 @@ type ListTasksOutput struct {
 	// to return.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	// The list of task Amazon Resource Name (ARN) entries for the ListTasks request.
+	// The list of task ARN entries for the ListTasks request.
 	TaskArns []*string `locationName:"taskArns" type:"list"`
 }
 
@@ -7234,19 +7431,21 @@ type LogConfiguration struct {
 
 	// The log driver to use for the container. The valid values listed for this
 	// parameter are log drivers that the Amazon ECS container agent can communicate
-	// with by default.
+	// with by default. If using the Fargate launch type, the only supported value
+	// is awslogs. For more information about using the awslogs driver, see Using
+	// the awslogs Log Driver (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_awslogs.html)
+	// in the Amazon Elastic Container Service Developer Guide.
 	//
 	// If you have a custom driver that is not listed above that you would like
 	// to work with the Amazon ECS container agent, you can fork the Amazon ECS
 	// container agent project that is available on GitHub (https://github.com/aws/amazon-ecs-agent)
 	// and customize it to work with that driver. We encourage you to submit pull
 	// requests for changes that you would like to have included. However, Amazon
-	// Web Services does not currently provide support for running modified copies
-	// of this software.
+	// Web Services does not currently support running modified copies of this software.
 	//
 	// This parameter requires version 1.18 of the Docker Remote API or greater
 	// on your container instance. To check the Docker Remote API version on your
-	// container instance, log into your container instance and run the following
+	// container instance, log in to your container instance and run the following
 	// command: sudo docker version | grep "Server API version"
 	//
 	// LogDriver is a required field
@@ -7254,8 +7453,8 @@ type LogConfiguration struct {
 
 	// The configuration options to send to the log driver. This parameter requires
 	// version 1.19 of the Docker Remote API or greater on your container instance.
-	// To check the Docker Remote API version on your container instance, log into
-	// your container instance and run the following command: sudo docker version
+	// To check the Docker Remote API version on your container instance, log in
+	// to your container instance and run the following command: sudo docker version
 	// | grep "Server API version"
 	Options map[string]*string `locationName:"options" type:"map"`
 }
@@ -7308,7 +7507,8 @@ type MountPoint struct {
 	// value is false.
 	ReadOnly *bool `locationName:"readOnly" type:"boolean"`
 
-	// The name of the volume to mount.
+	// The name of the volume to mount. If using the Fargate launch type, the sourceVolume
+	// parameter is not supported.
 	SourceVolume *string `locationName:"sourceVolume" type:"string"`
 }
 
@@ -7351,7 +7551,7 @@ type NetworkBinding struct {
 	// The IP address that the container is bound to on the container instance.
 	BindIP *string `locationName:"bindIP" type:"string"`
 
-	// The port number on the container that is be used with the network binding.
+	// The port number on the container that is used with the network binding.
 	ContainerPort *int64 `locationName:"containerPort" type:"integer"`
 
 	// The port number on the host that is used with the network binding.
@@ -7481,7 +7681,7 @@ func (s *NetworkInterface) SetPrivateIpv4Address(v string) *NetworkInterface {
 
 // An object representing a constraint on task placement. For more information,
 // see Task Placement Constraints (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-constraints.html)
-// in the Amazon EC2 Container Service Developer Guide.
+// in the Amazon Elastic Container Service Developer Guide.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/PlacementConstraint
 type PlacementConstraint struct {
 	_ struct{} `type:"structure"`
@@ -7489,12 +7689,12 @@ type PlacementConstraint struct {
 	// A cluster query language expression to apply to the constraint. Note you
 	// cannot specify an expression if the constraint type is distinctInstance.
 	// For more information, see Cluster Query Language (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-query-language.html)
-	// in the Amazon EC2 Container Service Developer Guide.
+	// in the Amazon Elastic Container Service Developer Guide.
 	Expression *string `locationName:"expression" type:"string"`
 
 	// The type of constraint. Use distinctInstance to ensure that each task in
 	// a particular group is running on a different container instance. Use memberOf
-	// to restrict selection to a group of valid candidates. Note that distinctInstance
+	// to restrict the selection to a group of valid candidates. The value distinctInstance
 	// is not supported in task definitions.
 	Type *string `locationName:"type" type:"string" enum:"PlacementConstraintType"`
 }
@@ -7523,7 +7723,7 @@ func (s *PlacementConstraint) SetType(v string) *PlacementConstraint {
 
 // The task placement strategy for a task or service. For more information,
 // see Task Placement Strategies (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-strategies.html)
-// in the Amazon EC2 Container Service Developer Guide.
+// in the Amazon Elastic Container Service Developer Guide.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/PlacementStrategy
 type PlacementStrategy struct {
 	_ struct{} `type:"structure"`
@@ -7570,41 +7770,57 @@ func (s *PlacementStrategy) SetType(v string) *PlacementStrategy {
 
 // Port mappings allow containers to access ports on the host container instance
 // to send or receive traffic. Port mappings are specified as part of the container
-// definition. After a task reaches the RUNNING status, manual and automatic
-// host and container port assignments are visible in the networkBindings section
-// of DescribeTasks API responses.
+// definition.
+//
+// If using containers in a task with the Fargate launch type, exposed ports
+// should be specified using containerPort. The hostPort can be left blank or
+// it must be the same value as the containerPort.
+//
+// After a task reaches the RUNNING status, manual and automatic host and container
+// port assignments are visible in the networkBindings section of DescribeTasks
+// API responses.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/PortMapping
 type PortMapping struct {
 	_ struct{} `type:"structure"`
 
 	// The port number on the container that is bound to the user-specified or automatically
-	// assigned host port. If you specify a container port and not a host port,
-	// your container automatically receives a host port in the ephemeral port range
-	// (for more information, see hostPort). Port mappings that are automatically
-	// assigned in this way do not count toward the 100 reserved ports limit of
-	// a container instance.
+	// assigned host port.
+	//
+	// If using containers in a task with the Fargate launch type, exposed ports
+	// should be specified using containerPort.
+	//
+	// If using containers in a task with the EC2 launch type and you specify a
+	// container port and not a host port, your container automatically receives
+	// a host port in the ephemeral port range (for more information, see hostPort).
+	// Port mappings that are automatically assigned in this way do not count toward
+	// the 100 reserved ports limit of a container instance.
 	ContainerPort *int64 `locationName:"containerPort" type:"integer"`
 
 	// The port number on the container instance to reserve for your container.
-	// You can specify a non-reserved host port for your container port mapping,
-	// or you can omit the hostPort (or set it to 0) while specifying a containerPort
-	// and your container automatically receives a port in the ephemeral port range
-	// for your container instance operating system and Docker version.
+	//
+	// If using containers in a task with the Fargate launch type, the hostPort
+	// can either be left blank or needs to be the same value as the containerPort.
+	//
+	// If using containers in a task with the EC2 launch type, you can specify a
+	// non-reserved host port for your container port mapping, or you can omit the
+	// hostPort (or set it to 0) while specifying a containerPort and your container
+	// automatically receives a port in the ephemeral port range for your container
+	// instance operating system and Docker version.
 	//
 	// The default ephemeral port range for Docker version 1.6.0 and later is listed
 	// on the instance under /proc/sys/net/ipv4/ip_local_port_range; if this kernel
-	// parameter is unavailable, the default ephemeral port range of 49153 to 65535
-	// is used. You should not attempt to specify a host port in the ephemeral port
-	// range as these are reserved for automatic assignment. In general, ports below
-	// 32768 are outside of the ephemeral port range.
+	// parameter is unavailable, the default ephemeral port range from 49153 through
+	// 65535 is used. You should not attempt to specify a host port in the ephemeral
+	// port range as these are reserved for automatic assignment. In general, ports
+	// below 32768 are outside of the ephemeral port range.
 	//
-	// The default ephemeral port range of 49153 to 65535 will always be used for
-	// Docker versions prior to 1.6.0.
+	// The default ephemeral port range from 49153 through 65535 is always used
+	// for Docker versions before 1.6.0.
 	//
 	// The default reserved ports are 22 for SSH, the Docker ports 2375 and 2376,
 	// and the Amazon ECS container agent ports 51678 and 51679. Any host port that
 	// was previously specified in a running task is also reserved while the task
-	// is running (after a task stops, the host port is released).The current reserved
+	// is running (after a task stops, the host port is released). The current reserved
 	// ports are displayed in the remainingResources of DescribeContainerInstances
 	// output, and a container instance may have up to 100 reserved ports at a time,
 	// including the default reserved ports (automatically assigned ports do not
@@ -7742,8 +7958,7 @@ type RegisterContainerInstanceInput struct {
 	// default cluster is assumed.
 	Cluster *string `locationName:"cluster" type:"string"`
 
-	// The Amazon Resource Name (ARN) of the container instance (if it was previously
-	// registered).
+	// The ARN of the container instance (if it was previously registered).
 	ContainerInstanceArn *string `locationName:"containerInstanceArn" type:"string"`
 
 	// The instance identity document for the EC2 instance to register. This document
@@ -7869,6 +8084,29 @@ type RegisterTaskDefinitionInput struct {
 	// ContainerDefinitions is a required field
 	ContainerDefinitions []*ContainerDefinition `locationName:"containerDefinitions" type:"list" required:"true"`
 
+	// The number of cpu units used by the task. If using the EC2 launch type, this
+	// field is optional and any value can be used. If you are using the Fargate
+	// launch type, this field is required and you must use one of the following
+	// values, which determines your range of valid values for the memory parameter:
+	//
+	//    * 256 (.25 vCPU) - Available memory values: 512MB, 1GB, 2GB
+	//
+	//    * 512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB
+	//
+	//    * 1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB,
+	//    8GB
+	//
+	//    * 2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB
+	//    increments
+	//
+	//    * 4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB
+	//    increments
+	Cpu *string `locationName:"cpu" type:"string"`
+
+	// The Amazon Resource Name (ARN) of the task execution role that the Amazon
+	// ECS container agent and the Docker daemon can assume.
+	ExecutionRoleArn *string `locationName:"executionRoleArn" type:"string"`
+
 	// You must specify a family for a task definition, which allows you to track
 	// multiple versions of the same task definition. The family is used as a name
 	// for your task definition. Up to 255 letters (uppercase and lowercase), numbers,
@@ -7877,26 +8115,46 @@ type RegisterTaskDefinitionInput struct {
 	// Family is a required field
 	Family *string `locationName:"family" type:"string" required:"true"`
 
+	// The amount (in MiB) of memory used by the task. If using the EC2 launch type,
+	// this field is optional and any value can be used. If you are using the Fargate
+	// launch type, this field is required and you must use one of the following
+	// values, which determines your range of valid values for the cpu parameter:
+	//
+	//    * 512MB, 1GB, 2GB - Available cpu values: 256 (.25 vCPU)
+	//
+	//    * 1GB, 2GB, 3GB, 4GB - Available cpu values: 512 (.5 vCPU)
+	//
+	//    * 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB - Available cpu values: 1024 (1 vCPU)
+	//
+	//    * Between 4GB and 16GB in 1GB increments - Available cpu values: 2048
+	//    (2 vCPU)
+	//
+	//    * Between 8GB and 30GB in 1GB increments - Available cpu values: 4096
+	//    (4 vCPU)
+	Memory *string `locationName:"memory" type:"string"`
+
 	// The Docker networking mode to use for the containers in the task. The valid
 	// values are none, bridge, awsvpc, and host. The default Docker network mode
-	// is bridge. If the network mode is set to none, you cannot specify port mappings
-	// in your container definitions, and the task's containers do not have external
-	// connectivity. The host and awsvpc network modes offer the highest networking
-	// performance for containers because they use the EC2 network stack instead
-	// of the virtualized network stack provided by the bridge mode.
+	// is bridge. If using the Fargate launch type, the awsvpc network mode is required.
+	// If using the EC2 launch type, any network mode can be used. If the network
+	// mode is set to none, you can't specify port mappings in your container definitions,
+	// and the task's containers do not have external connectivity. The host and
+	// awsvpc network modes offer the highest networking performance for containers
+	// because they use the EC2 network stack instead of the virtualized network
+	// stack provided by the bridge mode.
 	//
 	// With the host and awsvpc network modes, exposed container ports are mapped
 	// directly to the corresponding host port (for the host network mode) or the
-	// attached ENI port (for the awsvpc network mode), so you cannot take advantage
-	// of dynamic host port mappings.
+	// attached elastic network interface port (for the awsvpc network mode), so
+	// you cannot take advantage of dynamic host port mappings.
 	//
 	// If the network mode is awsvpc, the task is allocated an Elastic Network Interface,
 	// and you must specify a NetworkConfiguration when you create a service or
 	// run a task with the task definition. For more information, see Task Networking
-	// (http://docs.aws.amazon.com/AmazonECS/latest/developerguidetask-networking.html)
-	// in the Amazon EC2 Container Service Developer Guide.
+	// (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-networking.html)
+	// in the Amazon Elastic Container Service Developer Guide.
 	//
-	// If the network mode is host, you can not run multiple instantiations of the
+	// If the network mode is host, you can't run multiple instantiations of the
 	// same task on a single container instance when port mappings are used.
 	//
 	// For more information, see Network settings (https://docs.docker.com/engine/reference/run/#network-settings)
@@ -7908,11 +8166,15 @@ type RegisterTaskDefinitionInput struct {
 	// the task definition and those specified at run time).
 	PlacementConstraints []*TaskDefinitionPlacementConstraint `locationName:"placementConstraints" type:"list"`
 
+	// The launch type required by the task. If no value is specified, it defaults
+	// to EC2.
+	RequiresCompatibilities []*string `locationName:"requiresCompatibilities" type:"list"`
+
 	// The short name or full Amazon Resource Name (ARN) of the IAM role that containers
 	// in this task can assume. All containers in this task are granted the permissions
 	// that are specified in this role. For more information, see IAM Roles for
 	// Tasks (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html)
-	// in the Amazon EC2 Container Service Developer Guide.
+	// in the Amazon Elastic Container Service Developer Guide.
 	TaskRoleArn *string `locationName:"taskRoleArn" type:"string"`
 
 	// A list of volume definitions in JSON format that containers in your task
@@ -7962,9 +8224,27 @@ func (s *RegisterTaskDefinitionInput) SetContainerDefinitions(v []*ContainerDefi
 	return s
 }
 
+// SetCpu sets the Cpu field's value.
+func (s *RegisterTaskDefinitionInput) SetCpu(v string) *RegisterTaskDefinitionInput {
+	s.Cpu = &v
+	return s
+}
+
+// SetExecutionRoleArn sets the ExecutionRoleArn field's value.
+func (s *RegisterTaskDefinitionInput) SetExecutionRoleArn(v string) *RegisterTaskDefinitionInput {
+	s.ExecutionRoleArn = &v
+	return s
+}
+
 // SetFamily sets the Family field's value.
 func (s *RegisterTaskDefinitionInput) SetFamily(v string) *RegisterTaskDefinitionInput {
 	s.Family = &v
+	return s
+}
+
+// SetMemory sets the Memory field's value.
+func (s *RegisterTaskDefinitionInput) SetMemory(v string) *RegisterTaskDefinitionInput {
+	s.Memory = &v
 	return s
 }
 
@@ -7977,6 +8257,12 @@ func (s *RegisterTaskDefinitionInput) SetNetworkMode(v string) *RegisterTaskDefi
 // SetPlacementConstraints sets the PlacementConstraints field's value.
 func (s *RegisterTaskDefinitionInput) SetPlacementConstraints(v []*TaskDefinitionPlacementConstraint) *RegisterTaskDefinitionInput {
 	s.PlacementConstraints = v
+	return s
+}
+
+// SetRequiresCompatibilities sets the RequiresCompatibilities field's value.
+func (s *RegisterTaskDefinitionInput) SetRequiresCompatibilities(v []*string) *RegisterTaskDefinitionInput {
+	s.RequiresCompatibilities = v
 	return s
 }
 
@@ -8106,11 +8392,14 @@ type RunTaskInput struct {
 	// is the family name of the task definition (for example, family:my-family-name).
 	Group *string `locationName:"group" type:"string"`
 
+	// The launch type on which to run your task.
+	LaunchType *string `locationName:"launchType" type:"string" enum:"LaunchType"`
+
 	// The network configuration for the task. This parameter is required for task
 	// definitions that use the awsvpc network mode to receive their own Elastic
 	// Network Interface, and it is not supported for other network modes. For more
-	// information, see Task Networking (http://docs.aws.amazon.com/AmazonECS/latest/developerguidetask-networking.html)
-	// in the Amazon EC2 Container Service Developer Guide.
+	// information, see Task Networking (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-networking.html)
+	// in the Amazon Elastic Container Service Developer Guide.
 	NetworkConfiguration *NetworkConfiguration `locationName:"networkConfiguration" type:"structure"`
 
 	// A list of container overrides in JSON format that specify the name of a container
@@ -8131,8 +8420,12 @@ type RunTaskInput struct {
 	PlacementConstraints []*PlacementConstraint `locationName:"placementConstraints" type:"list"`
 
 	// The placement strategy objects to use for the task. You can specify a maximum
-	// of 5 strategy rules per task.
+	// of five strategy rules per task.
 	PlacementStrategy []*PlacementStrategy `locationName:"placementStrategy" type:"list"`
+
+	// The platform version on which to run your task. If one is not specified,
+	// the latest version is used by default.
+	PlatformVersion *string `locationName:"platformVersion" type:"string"`
 
 	// An optional tag specified when a task is started. For example if you automatically
 	// trigger a task to run a batch process job, you could apply a unique identifier
@@ -8145,9 +8438,8 @@ type RunTaskInput struct {
 	// contains the deployment ID of the service that starts it.
 	StartedBy *string `locationName:"startedBy" type:"string"`
 
-	// The family and revision (family:revision) or full Amazon Resource Name (ARN)
-	// of the task definition to run. If a revision is not specified, the latest
-	// ACTIVE revision is used.
+	// The family and revision (family:revision) or full ARN of the task definition
+	// to run. If a revision is not specified, the latest ACTIVE revision is used.
 	//
 	// TaskDefinition is a required field
 	TaskDefinition *string `locationName:"taskDefinition" type:"string" required:"true"`
@@ -8199,6 +8491,12 @@ func (s *RunTaskInput) SetGroup(v string) *RunTaskInput {
 	return s
 }
 
+// SetLaunchType sets the LaunchType field's value.
+func (s *RunTaskInput) SetLaunchType(v string) *RunTaskInput {
+	s.LaunchType = &v
+	return s
+}
+
 // SetNetworkConfiguration sets the NetworkConfiguration field's value.
 func (s *RunTaskInput) SetNetworkConfiguration(v *NetworkConfiguration) *RunTaskInput {
 	s.NetworkConfiguration = v
@@ -8223,6 +8521,12 @@ func (s *RunTaskInput) SetPlacementStrategy(v []*PlacementStrategy) *RunTaskInpu
 	return s
 }
 
+// SetPlatformVersion sets the PlatformVersion field's value.
+func (s *RunTaskInput) SetPlatformVersion(v string) *RunTaskInput {
+	s.PlatformVersion = &v
+	return s
+}
+
 // SetStartedBy sets the StartedBy field's value.
 func (s *RunTaskInput) SetStartedBy(v string) *RunTaskInput {
 	s.StartedBy = &v
@@ -8242,7 +8546,7 @@ type RunTaskOutput struct {
 	// Any failures associated with the call.
 	Failures []*Failure `locationName:"failures" type:"list"`
 
-	// A full description of the tasks that were run. Each task that was successfully
+	// A full description of the tasks that were run. The tasks that were successfully
 	// placed on your cluster are described here.
 	Tasks []*Task `locationName:"tasks" type:"list"`
 }
@@ -8277,7 +8581,7 @@ type Service struct {
 	// The Amazon Resource Name (ARN) of the cluster that hosts the service.
 	ClusterArn *string `locationName:"clusterArn" type:"string"`
 
-	// The Unix timestamp for when the service was created.
+	// The Unix time stamp for when the service was created.
 	CreatedAt *time.Time `locationName:"createdAt" type:"timestamp" timestampFormat:"unix"`
 
 	// Optional deployment parameters that control how many tasks run during the
@@ -8295,6 +8599,9 @@ type Service struct {
 	// The event stream for your service. A maximum of 100 of the latest events
 	// are displayed.
 	Events []*ServiceEvent `locationName:"events" type:"list"`
+
+	// The launch type on which your service is running.
+	LaunchType *string `locationName:"launchType" type:"string" enum:"LaunchType"`
 
 	// A list of Elastic Load Balancing load balancer objects, containing the load
 	// balancer name, the container name (as it appears in a container definition),
@@ -8314,18 +8621,22 @@ type Service struct {
 	// The placement strategy that determines how tasks for the service are placed.
 	PlacementStrategy []*PlacementStrategy `locationName:"placementStrategy" type:"list"`
 
-	// The Amazon Resource Name (ARN) of the IAM role associated with the service
-	// that allows the Amazon ECS container agent to register container instances
-	// with an Elastic Load Balancing load balancer.
+	// The platform version on which your task is running. For more information,
+	// see AWS Fargate Platform Versions (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html)
+	// in the Amazon Elastic Container Service Developer Guide.
+	PlatformVersion *string `locationName:"platformVersion" type:"string"`
+
+	// The ARN of the IAM role associated with the service that allows the Amazon
+	// ECS container agent to register container instances with an Elastic Load
+	// Balancing load balancer.
 	RoleArn *string `locationName:"roleArn" type:"string"`
 
 	// The number of tasks in the cluster that are in the RUNNING state.
 	RunningCount *int64 `locationName:"runningCount" type:"integer"`
 
-	// The Amazon Resource Name (ARN) that identifies the service. The ARN contains
-	// the arn:aws:ecs namespace, followed by the region of the service, the AWS
-	// account ID of the service owner, the service namespace, and then the service
-	// name. For example, arn:aws:ecs:region:012345678910:service/my-service.
+	// The ARN that identifies the service. The ARN contains the arn:aws:ecs namespace,
+	// followed by the region of the service, the AWS account ID of the service
+	// owner, the service namespace, and then the service name. For example, arn:aws:ecs:region:012345678910:service/my-service.
 	ServiceArn *string `locationName:"serviceArn" type:"string"`
 
 	// The name of your service. Up to 255 letters (uppercase and lowercase), numbers,
@@ -8389,6 +8700,12 @@ func (s *Service) SetEvents(v []*ServiceEvent) *Service {
 	return s
 }
 
+// SetLaunchType sets the LaunchType field's value.
+func (s *Service) SetLaunchType(v string) *Service {
+	s.LaunchType = &v
+	return s
+}
+
 // SetLoadBalancers sets the LoadBalancers field's value.
 func (s *Service) SetLoadBalancers(v []*LoadBalancer) *Service {
 	s.LoadBalancers = v
@@ -8416,6 +8733,12 @@ func (s *Service) SetPlacementConstraints(v []*PlacementConstraint) *Service {
 // SetPlacementStrategy sets the PlacementStrategy field's value.
 func (s *Service) SetPlacementStrategy(v []*PlacementStrategy) *Service {
 	s.PlacementStrategy = v
+	return s
+}
+
+// SetPlatformVersion sets the PlatformVersion field's value.
+func (s *Service) SetPlatformVersion(v string) *Service {
+	s.PlatformVersion = &v
 	return s
 }
 
@@ -8460,7 +8783,7 @@ func (s *Service) SetTaskDefinition(v string) *Service {
 type ServiceEvent struct {
 	_ struct{} `type:"structure"`
 
-	// The Unix timestamp for when the event was triggered.
+	// The Unix time stamp for when the event was triggered.
 	CreatedAt *time.Time `locationName:"createdAt" type:"timestamp" timestampFormat:"unix"`
 
 	// The ID string of the event.
@@ -8507,9 +8830,9 @@ type StartTaskInput struct {
 	// is assumed.
 	Cluster *string `locationName:"cluster" type:"string"`
 
-	// The container instance IDs or full Amazon Resource Name (ARN) entries for
-	// the container instances on which you would like to place your task. You can
-	// specify up to 10 container instances.
+	// The container instance IDs or full ARN entries for the container instances
+	// on which you would like to place your task. You can specify up to 10 container
+	// instances.
 	//
 	// ContainerInstances is a required field
 	ContainerInstances []*string `locationName:"containerInstances" type:"list" required:"true"`
@@ -8545,9 +8868,8 @@ type StartTaskInput struct {
 	// contains the deployment ID of the service that starts it.
 	StartedBy *string `locationName:"startedBy" type:"string"`
 
-	// The family and revision (family:revision) or full Amazon Resource Name (ARN)
-	// of the task definition to start. If a revision is not specified, the latest
-	// ACTIVE revision is used.
+	// The family and revision (family:revision) or full ARN of the task definition
+	// to start. If a revision is not specified, the latest ACTIVE revision is used.
 	//
 	// TaskDefinition is a required field
 	TaskDefinition *string `locationName:"taskDefinition" type:"string" required:"true"`
@@ -8634,7 +8956,7 @@ type StartTaskOutput struct {
 	Failures []*Failure `locationName:"failures" type:"list"`
 
 	// A full description of the tasks that were started. Each task that was successfully
-	// placed on your container instances are described here.
+	// placed on your container instances is described.
 	Tasks []*Task `locationName:"tasks" type:"list"`
 }
 
@@ -8671,11 +8993,11 @@ type StopTaskInput struct {
 
 	// An optional message specified when a task is stopped. For example, if you
 	// are using a custom scheduler, you can use this parameter to specify the reason
-	// for stopping the task here, and the message will appear in subsequent DescribeTasks
+	// for stopping the task here, and the message appears in subsequent DescribeTasks
 	// API operations on this task. Up to 255 characters are allowed in this message.
 	Reason *string `locationName:"reason" type:"string"`
 
-	// The task ID or full Amazon Resource Name (ARN) entry of the task to stop.
+	// The task ID or full ARN entry of the task to stop.
 	//
 	// Task is a required field
 	Task *string `locationName:"task" type:"string" required:"true"`
@@ -8750,8 +9072,7 @@ func (s *StopTaskOutput) SetTask(v *Task) *StopTaskOutput {
 type SubmitContainerStateChangeInput struct {
 	_ struct{} `type:"structure"`
 
-	// The short name or full Amazon Resource Name (ARN) of the cluster that hosts
-	// the container.
+	// The short name or full ARN of the cluster that hosts the container.
 	Cluster *string `locationName:"cluster" type:"string"`
 
 	// The name of the container.
@@ -8864,14 +9185,22 @@ type SubmitTaskStateChangeInput struct {
 	// Any containers associated with the state change request.
 	Containers []*ContainerStateChange `locationName:"containers" type:"list"`
 
+	// The Unix timestamp for when the task execution stopped.
+	ExecutionStoppedAt *time.Time `locationName:"executionStoppedAt" type:"timestamp" timestampFormat:"unix"`
+
+	// The Unix time stamp for when the container image pull began.
+	PullStartedAt *time.Time `locationName:"pullStartedAt" type:"timestamp" timestampFormat:"unix"`
+
+	// The Unix time stamp for when the container image pull completed.
+	PullStoppedAt *time.Time `locationName:"pullStoppedAt" type:"timestamp" timestampFormat:"unix"`
+
 	// The reason for the state change request.
 	Reason *string `locationName:"reason" type:"string"`
 
 	// The status of the state change request.
 	Status *string `locationName:"status" type:"string"`
 
-	// The task ID or full Amazon Resource Name (ARN) of the task in the state change
-	// request.
+	// The task ID or full ARN of the task in the state change request.
 	Task *string `locationName:"task" type:"string"`
 }
 
@@ -8920,6 +9249,24 @@ func (s *SubmitTaskStateChangeInput) SetCluster(v string) *SubmitTaskStateChange
 // SetContainers sets the Containers field's value.
 func (s *SubmitTaskStateChangeInput) SetContainers(v []*ContainerStateChange) *SubmitTaskStateChangeInput {
 	s.Containers = v
+	return s
+}
+
+// SetExecutionStoppedAt sets the ExecutionStoppedAt field's value.
+func (s *SubmitTaskStateChangeInput) SetExecutionStoppedAt(v time.Time) *SubmitTaskStateChangeInput {
+	s.ExecutionStoppedAt = &v
+	return s
+}
+
+// SetPullStartedAt sets the PullStartedAt field's value.
+func (s *SubmitTaskStateChangeInput) SetPullStartedAt(v time.Time) *SubmitTaskStateChangeInput {
+	s.PullStartedAt = &v
+	return s
+}
+
+// SetPullStoppedAt sets the PullStoppedAt field's value.
+func (s *SubmitTaskStateChangeInput) SetPullStoppedAt(v time.Time) *SubmitTaskStateChangeInput {
+	s.PullStoppedAt = &v
 	return s
 }
 
@@ -8974,21 +9321,49 @@ type Task struct {
 	// awsvpc network mode.
 	Attachments []*Attachment `locationName:"attachments" type:"list"`
 
-	// The Amazon Resource Name (ARN) of the cluster that hosts the task.
+	// The ARN of the cluster that hosts the task.
 	ClusterArn *string `locationName:"clusterArn" type:"string"`
 
-	// The Amazon Resource Name (ARN) of the container instances that host the task.
+	// The connectivity status of a task.
+	Connectivity *string `locationName:"connectivity" type:"string" enum:"Connectivity"`
+
+	// The Unix time stamp for when the task last went into CONNECTED status.
+	ConnectivityAt *time.Time `locationName:"connectivityAt" type:"timestamp" timestampFormat:"unix"`
+
+	// The ARN of the container instances that host the task.
 	ContainerInstanceArn *string `locationName:"containerInstanceArn" type:"string"`
 
 	// The containers associated with the task.
 	Containers []*Container `locationName:"containers" type:"list"`
 
-	// The Unix timestamp for when the task was created (the task entered the PENDING
+	// The number of cpu units used by the task. If using the EC2 launch type, this
+	// field is optional and any value can be used. If using the Fargate launch
+	// type, this field is required and you must use one of the following values,
+	// which determines your range of valid values for the memory parameter:
+	//
+	//    * 256 (.25 vCPU) - Available memory values: 512MB, 1GB, 2GB
+	//
+	//    * 512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB
+	//
+	//    * 1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB,
+	//    8GB
+	//
+	//    * 2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB
+	//    increments
+	//
+	//    * 4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB
+	//    increments
+	Cpu *string `locationName:"cpu" type:"string"`
+
+	// The Unix time stamp for when the task was created (the task entered the PENDING
 	// state).
 	CreatedAt *time.Time `locationName:"createdAt" type:"timestamp" timestampFormat:"unix"`
 
 	// The desired status of the task.
 	DesiredStatus *string `locationName:"desiredStatus" type:"string"`
+
+	// The Unix timestamp for when the task execution stopped.
+	ExecutionStoppedAt *time.Time `locationName:"executionStoppedAt" type:"timestamp" timestampFormat:"unix"`
 
 	// The name of the task group associated with the task.
 	Group *string `locationName:"group" type:"string"`
@@ -8996,10 +9371,42 @@ type Task struct {
 	// The last known status of the task.
 	LastStatus *string `locationName:"lastStatus" type:"string"`
 
+	// The launch type on which your task is running.
+	LaunchType *string `locationName:"launchType" type:"string" enum:"LaunchType"`
+
+	// The amount (in MiB) of memory used by the task. If using the EC2 launch type,
+	// this field is optional and any value can be used. If using the Fargate launch
+	// type, this field is required and you must use one of the following values,
+	// which determines your range of valid values for the cpu parameter:
+	//
+	//    * 512MB, 1GB, 2GB - Available cpu values: 256 (.25 vCPU)
+	//
+	//    * 1GB, 2GB, 3GB, 4GB - Available cpu values: 512 (.5 vCPU)
+	//
+	//    * 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB - Available cpu values: 1024 (1 vCPU)
+	//
+	//    * Between 4GB and 16GB in 1GB increments - Available cpu values: 2048
+	//    (2 vCPU)
+	//
+	//    * Between 8GB and 30GB in 1GB increments - Available cpu values: 4096
+	//    (4 vCPU)
+	Memory *string `locationName:"memory" type:"string"`
+
 	// One or more container overrides.
 	Overrides *TaskOverride `locationName:"overrides" type:"structure"`
 
-	// The Unix timestamp for when the task was started (the task transitioned from
+	// The platform version on which your task is running. For more information,
+	// see AWS Fargate Platform Versions (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html)
+	// in the Amazon Elastic Container Service Developer Guide.
+	PlatformVersion *string `locationName:"platformVersion" type:"string"`
+
+	// The Unix time stamp for when the container image pull began.
+	PullStartedAt *time.Time `locationName:"pullStartedAt" type:"timestamp" timestampFormat:"unix"`
+
+	// The Unix time stamp for when the container image pull completed.
+	PullStoppedAt *time.Time `locationName:"pullStoppedAt" type:"timestamp" timestampFormat:"unix"`
+
+	// The Unix time stamp for when the task started (the task transitioned from
 	// the PENDING state to the RUNNING state).
 	StartedAt *time.Time `locationName:"startedAt" type:"timestamp" timestampFormat:"unix"`
 
@@ -9008,24 +9415,28 @@ type Task struct {
 	// service that starts it.
 	StartedBy *string `locationName:"startedBy" type:"string"`
 
-	// The Unix timestamp for when the task was stopped (the task transitioned from
-	// the RUNNING state to the STOPPED state).
+	// The Unix time stamp for when the task was stopped (the task transitioned
+	// from the RUNNING state to the STOPPED state).
 	StoppedAt *time.Time `locationName:"stoppedAt" type:"timestamp" timestampFormat:"unix"`
 
 	// The reason the task was stopped.
 	StoppedReason *string `locationName:"stoppedReason" type:"string"`
 
+	// The Unix time stamp for when the task will stop (the task transitioned from
+	// the RUNNING state to the STOPPED state).
+	StoppingAt *time.Time `locationName:"stoppingAt" type:"timestamp" timestampFormat:"unix"`
+
 	// The Amazon Resource Name (ARN) of the task.
 	TaskArn *string `locationName:"taskArn" type:"string"`
 
-	// The Amazon Resource Name (ARN) of the task definition that creates the task.
+	// The ARN of the task definition that creates the task.
 	TaskDefinitionArn *string `locationName:"taskDefinitionArn" type:"string"`
 
 	// The version counter for the task. Every time a task experiences a change
 	// that triggers a CloudWatch event, the version counter is incremented. If
-	// you are replicating your Amazon ECS task state with CloudWatch events, you
+	// you are replicating your Amazon ECS task state with CloudWatch Events, you
 	// can compare the version of a task reported by the Amazon ECS APIs with the
-	// version reported in CloudWatch events for the task (inside the detail object)
+	// version reported in CloudWatch Events for the task (inside the detail object)
 	// to verify that the version in your event stream is current.
 	Version *int64 `locationName:"version" type:"long"`
 }
@@ -9052,6 +9463,18 @@ func (s *Task) SetClusterArn(v string) *Task {
 	return s
 }
 
+// SetConnectivity sets the Connectivity field's value.
+func (s *Task) SetConnectivity(v string) *Task {
+	s.Connectivity = &v
+	return s
+}
+
+// SetConnectivityAt sets the ConnectivityAt field's value.
+func (s *Task) SetConnectivityAt(v time.Time) *Task {
+	s.ConnectivityAt = &v
+	return s
+}
+
 // SetContainerInstanceArn sets the ContainerInstanceArn field's value.
 func (s *Task) SetContainerInstanceArn(v string) *Task {
 	s.ContainerInstanceArn = &v
@@ -9061,6 +9484,12 @@ func (s *Task) SetContainerInstanceArn(v string) *Task {
 // SetContainers sets the Containers field's value.
 func (s *Task) SetContainers(v []*Container) *Task {
 	s.Containers = v
+	return s
+}
+
+// SetCpu sets the Cpu field's value.
+func (s *Task) SetCpu(v string) *Task {
+	s.Cpu = &v
 	return s
 }
 
@@ -9076,6 +9505,12 @@ func (s *Task) SetDesiredStatus(v string) *Task {
 	return s
 }
 
+// SetExecutionStoppedAt sets the ExecutionStoppedAt field's value.
+func (s *Task) SetExecutionStoppedAt(v time.Time) *Task {
+	s.ExecutionStoppedAt = &v
+	return s
+}
+
 // SetGroup sets the Group field's value.
 func (s *Task) SetGroup(v string) *Task {
 	s.Group = &v
@@ -9088,9 +9523,39 @@ func (s *Task) SetLastStatus(v string) *Task {
 	return s
 }
 
+// SetLaunchType sets the LaunchType field's value.
+func (s *Task) SetLaunchType(v string) *Task {
+	s.LaunchType = &v
+	return s
+}
+
+// SetMemory sets the Memory field's value.
+func (s *Task) SetMemory(v string) *Task {
+	s.Memory = &v
+	return s
+}
+
 // SetOverrides sets the Overrides field's value.
 func (s *Task) SetOverrides(v *TaskOverride) *Task {
 	s.Overrides = v
+	return s
+}
+
+// SetPlatformVersion sets the PlatformVersion field's value.
+func (s *Task) SetPlatformVersion(v string) *Task {
+	s.PlatformVersion = &v
+	return s
+}
+
+// SetPullStartedAt sets the PullStartedAt field's value.
+func (s *Task) SetPullStartedAt(v time.Time) *Task {
+	s.PullStartedAt = &v
+	return s
+}
+
+// SetPullStoppedAt sets the PullStoppedAt field's value.
+func (s *Task) SetPullStoppedAt(v time.Time) *Task {
+	s.PullStoppedAt = &v
 	return s
 }
 
@@ -9118,6 +9583,12 @@ func (s *Task) SetStoppedReason(v string) *Task {
 	return s
 }
 
+// SetStoppingAt sets the StoppingAt field's value.
+func (s *Task) SetStoppingAt(v time.Time) *Task {
+	s.StoppingAt = &v
+	return s
+}
+
 // SetTaskArn sets the TaskArn field's value.
 func (s *Task) SetTaskArn(v string) *Task {
 	s.TaskArn = &v
@@ -9141,34 +9612,99 @@ func (s *Task) SetVersion(v int64) *Task {
 type TaskDefinition struct {
 	_ struct{} `type:"structure"`
 
+	// The launch type to use with your task. For more information, see Amazon ECS
+	// Launch Types (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_types.html)
+	// in the Amazon Elastic Container Service Developer Guide.
+	Compatibilities []*string `locationName:"compatibilities" type:"list"`
+
 	// A list of container definitions in JSON format that describe the different
 	// containers that make up your task. For more information about container definition
 	// parameters and defaults, see Amazon ECS Task Definitions (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_defintions.html)
-	// in the Amazon EC2 Container Service Developer Guide.
+	// in the Amazon Elastic Container Service Developer Guide.
 	ContainerDefinitions []*ContainerDefinition `locationName:"containerDefinitions" type:"list"`
+
+	// The number of cpu units used by the task. If using the EC2 launch type, this
+	// field is optional and any value can be used. If using the Fargate launch
+	// type, this field is required and you must use one of the following values,
+	// which determines your range of valid values for the memory parameter:
+	//
+	//    * 256 (.25 vCPU) - Available memory values: 512MB, 1GB, 2GB
+	//
+	//    * 512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB
+	//
+	//    * 1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB,
+	//    8GB
+	//
+	//    * 2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB
+	//    increments
+	//
+	//    * 4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB
+	//    increments
+	Cpu *string `locationName:"cpu" type:"string"`
+
+	// The Amazon Resource Name (ARN) of the task execution role that the Amazon
+	// ECS container agent and the Docker daemon can assume.
+	ExecutionRoleArn *string `locationName:"executionRoleArn" type:"string"`
 
 	// The family of your task definition, used as the definition name.
 	Family *string `locationName:"family" type:"string"`
 
-	// The Docker networking mode to use for the containers in the task. The valid
-	// values are none, bridge, awsvpc, and host.
+	// The amount (in MiB) of memory used by the task. If using the EC2 launch type,
+	// this field is optional and any value can be used. If using the Fargate launch
+	// type, this field is required and you must use one of the following values,
+	// which determines your range of valid values for the cpu parameter:
 	//
-	// If the network mode is none, the containers do not have external connectivity.
-	// The default Docker network mode is bridge. If the network mode is awsvpc,
-	// the task is allocated an Elastic Network Interface. The host and awsvpc network
-	// modes offer the highest networking performance for containers because they
-	// use the EC2 network stack instead of the virtualized network stack provided
-	// by the bridge mode.
+	//    * 512MB, 1GB, 2GB - Available cpu values: 256 (.25 vCPU)
+	//
+	//    * 1GB, 2GB, 3GB, 4GB - Available cpu values: 512 (.5 vCPU)
+	//
+	//    * 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB - Available cpu values: 1024 (1 vCPU)
+	//
+	//    * Between 4GB and 16GB in 1GB increments - Available cpu values: 2048
+	//    (2 vCPU)
+	//
+	//    * Between 8GB and 30GB in 1GB increments - Available cpu values: 4096
+	//    (4 vCPU)
+	Memory *string `locationName:"memory" type:"string"`
+
+	// The Docker networking mode to use for the containers in the task. The valid
+	// values are none, bridge, awsvpc, and host. The default Docker network mode
+	// is bridge. If using the Fargate launch type, the awsvpc network mode is required.
+	// If using the EC2 launch type, any network mode can be used. If the network
+	// mode is set to none, you can't specify port mappings in your container definitions,
+	// and the task's containers do not have external connectivity. The host and
+	// awsvpc network modes offer the highest networking performance for containers
+	// because they use the EC2 network stack instead of the virtualized network
+	// stack provided by the bridge mode.
+	//
+	// With the host and awsvpc network modes, exposed container ports are mapped
+	// directly to the corresponding host port (for the host network mode) or the
+	// attached elastic network interface port (for the awsvpc network mode), so
+	// you cannot take advantage of dynamic host port mappings.
+	//
+	// If the network mode is awsvpc, the task is allocated an Elastic Network Interface,
+	// and you must specify a NetworkConfiguration when you create a service or
+	// run a task with the task definition. For more information, see Task Networking
+	// (http://docs.aws.amazon.com/AmazonECS/latest/developerguidetask-networking.html)
+	// in the Amazon Elastic Container Service Developer Guide.
+	//
+	// If the network mode is host, you can't run multiple instantiations of the
+	// same task on a single container instance when port mappings are used.
 	//
 	// For more information, see Network settings (https://docs.docker.com/engine/reference/run/#network-settings)
 	// in the Docker run reference.
 	NetworkMode *string `locationName:"networkMode" type:"string" enum:"NetworkMode"`
 
-	// An array of placement constraint objects to use for tasks.
+	// An array of placement constraint objects to use for tasks. This field is
+	// not valid if using the Fargate launch type for your task.
 	PlacementConstraints []*TaskDefinitionPlacementConstraint `locationName:"placementConstraints" type:"list"`
 
-	// The container instance attributes required by your task.
+	// The container instance attributes required by your task. This field is not
+	// valid if using the Fargate launch type for your task.
 	RequiresAttributes []*Attribute `locationName:"requiresAttributes" type:"list"`
+
+	// The launch type the task is using.
+	RequiresCompatibilities []*string `locationName:"requiresCompatibilities" type:"list"`
 
 	// The revision of the task in a particular family. The revision is a version
 	// number of a task definition in a family. When you register a task definition
@@ -9183,14 +9719,18 @@ type TaskDefinition struct {
 	// The full Amazon Resource Name (ARN) of the task definition.
 	TaskDefinitionArn *string `locationName:"taskDefinitionArn" type:"string"`
 
-	// The Amazon Resource Name (ARN) of the IAM role that containers in this task
-	// can assume. All containers in this task are granted the permissions that
-	// are specified in this role.
+	// The ARN of the IAM role that containers in this task can assume. All containers
+	// in this task are granted the permissions that are specified in this role.
 	TaskRoleArn *string `locationName:"taskRoleArn" type:"string"`
 
-	// The list of volumes in a task. For more information about volume definition
-	// parameters and defaults, see Amazon ECS Task Definitions (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_defintions.html)
-	// in the Amazon EC2 Container Service Developer Guide.
+	// The list of volumes in a task.
+	//
+	// If you are using the Fargate launch type, the host and sourcePath parameters
+	// are not supported.
+	//
+	// For more information about volume definition parameters and defaults, see
+	// Amazon ECS Task Definitions (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definitions.html)
+	// in the Amazon Elastic Container Service Developer Guide.
 	Volumes []*Volume `locationName:"volumes" type:"list"`
 }
 
@@ -9204,15 +9744,39 @@ func (s TaskDefinition) GoString() string {
 	return s.String()
 }
 
+// SetCompatibilities sets the Compatibilities field's value.
+func (s *TaskDefinition) SetCompatibilities(v []*string) *TaskDefinition {
+	s.Compatibilities = v
+	return s
+}
+
 // SetContainerDefinitions sets the ContainerDefinitions field's value.
 func (s *TaskDefinition) SetContainerDefinitions(v []*ContainerDefinition) *TaskDefinition {
 	s.ContainerDefinitions = v
 	return s
 }
 
+// SetCpu sets the Cpu field's value.
+func (s *TaskDefinition) SetCpu(v string) *TaskDefinition {
+	s.Cpu = &v
+	return s
+}
+
+// SetExecutionRoleArn sets the ExecutionRoleArn field's value.
+func (s *TaskDefinition) SetExecutionRoleArn(v string) *TaskDefinition {
+	s.ExecutionRoleArn = &v
+	return s
+}
+
 // SetFamily sets the Family field's value.
 func (s *TaskDefinition) SetFamily(v string) *TaskDefinition {
 	s.Family = &v
+	return s
+}
+
+// SetMemory sets the Memory field's value.
+func (s *TaskDefinition) SetMemory(v string) *TaskDefinition {
+	s.Memory = &v
 	return s
 }
 
@@ -9231,6 +9795,12 @@ func (s *TaskDefinition) SetPlacementConstraints(v []*TaskDefinitionPlacementCon
 // SetRequiresAttributes sets the RequiresAttributes field's value.
 func (s *TaskDefinition) SetRequiresAttributes(v []*Attribute) *TaskDefinition {
 	s.RequiresAttributes = v
+	return s
+}
+
+// SetRequiresCompatibilities sets the RequiresCompatibilities field's value.
+func (s *TaskDefinition) SetRequiresCompatibilities(v []*string) *TaskDefinition {
+	s.RequiresCompatibilities = v
 	return s
 }
 
@@ -9265,15 +9835,19 @@ func (s *TaskDefinition) SetVolumes(v []*Volume) *TaskDefinition {
 }
 
 // An object representing a constraint on task placement in the task definition.
+//
+// If you are using the Fargate launch type, task placement contraints are not
+// supported.
+//
 // For more information, see Task Placement Constraints (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-constraints.html)
-// in the Amazon EC2 Container Service Developer Guide.
+// in the Amazon Elastic Container Service Developer Guide.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13/TaskDefinitionPlacementConstraint
 type TaskDefinitionPlacementConstraint struct {
 	_ struct{} `type:"structure"`
 
 	// A cluster query language expression to apply to the constraint. For more
 	// information, see Cluster Query Language (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-query-language.html)
-	// in the Amazon EC2 Container Service Developer Guide.
+	// in the Amazon Elastic Container Service Developer Guide.
 	Expression *string `locationName:"expression" type:"string"`
 
 	// The type of constraint. The DistinctInstance constraint ensures that each
@@ -9312,6 +9886,10 @@ type TaskOverride struct {
 	// One or more container overrides sent to a task.
 	ContainerOverrides []*ContainerOverride `locationName:"containerOverrides" type:"list"`
 
+	// The Amazon Resource Name (ARN) of the task execution role that the Amazon
+	// ECS container agent and the Docker daemon can assume.
+	ExecutionRoleArn *string `locationName:"executionRoleArn" type:"string"`
+
 	// The Amazon Resource Name (ARN) of the IAM role that containers in this task
 	// can assume. All containers in this task are granted the permissions that
 	// are specified in this role.
@@ -9331,6 +9909,12 @@ func (s TaskOverride) GoString() string {
 // SetContainerOverrides sets the ContainerOverrides field's value.
 func (s *TaskOverride) SetContainerOverrides(v []*ContainerOverride) *TaskOverride {
 	s.ContainerOverrides = v
+	return s
+}
+
+// SetExecutionRoleArn sets the ExecutionRoleArn field's value.
+func (s *TaskOverride) SetExecutionRoleArn(v string) *TaskOverride {
+	s.ExecutionRoleArn = &v
 	return s
 }
 
@@ -9417,9 +10001,8 @@ type UpdateContainerAgentInput struct {
 	// cluster is assumed.
 	Cluster *string `locationName:"cluster" type:"string"`
 
-	// The container instance ID or full Amazon Resource Name (ARN) entries for
-	// the container instance on which you would like to update the Amazon ECS container
-	// agent.
+	// The container instance ID or full ARN entries for the container instance
+	// on which you would like to update the Amazon ECS container agent.
 	//
 	// ContainerInstance is a required field
 	ContainerInstance *string `locationName:"containerInstance" type:"string" required:"true"`
@@ -9493,7 +10076,7 @@ type UpdateContainerInstancesStateInput struct {
 	// cluster is assumed.
 	Cluster *string `locationName:"cluster" type:"string"`
 
-	// A list of container instance IDs or full Amazon Resource Name (ARN) entries.
+	// A list of container instance IDs or full ARN entries.
 	//
 	// ContainerInstances is a required field
 	ContainerInstances []*string `locationName:"containerInstances" type:"list" required:"true"`
@@ -9598,11 +10181,14 @@ type UpdateServiceInput struct {
 	// service.
 	DesiredCount *int64 `locationName:"desiredCount" type:"integer"`
 
+	// Whether or not to force a new deployment of the service.
+	ForceNewDeployment *bool `locationName:"forceNewDeployment" type:"boolean"`
+
 	// The network configuration for the service. This parameter is required for
 	// task definitions that use the awsvpc network mode to receive their own Elastic
 	// Network Interface, and it is not supported for other network modes. For more
-	// information, see Task Networking (http://docs.aws.amazon.com/AmazonECS/latest/developerguidetask-networking.html)
-	// in the Amazon EC2 Container Service Developer Guide.
+	// information, see Task Networking (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-networking.html)
+	// in the Amazon Elastic Container Service Developer Guide.
 	//
 	// Updating a service to add a subnet to a list of existing subnets does not
 	// trigger a service deployment. For example, if your network configuration
@@ -9610,16 +10196,19 @@ type UpdateServiceInput struct {
 	// network configuration, this does not trigger a new service deployment.
 	NetworkConfiguration *NetworkConfiguration `locationName:"networkConfiguration" type:"structure"`
 
+	// The platform version you want to update your service to run.
+	PlatformVersion *string `locationName:"platformVersion" type:"string"`
+
 	// The name of the service to update.
 	//
 	// Service is a required field
 	Service *string `locationName:"service" type:"string" required:"true"`
 
-	// The family and revision (family:revision) or full Amazon Resource Name (ARN)
-	// of the task definition to run in your service. If a revision is not specified,
-	// the latest ACTIVE revision is used. If you modify the task definition with
-	// UpdateService, Amazon ECS spawns a task with the new version of the task
-	// definition and then stops an old task after the new version is running.
+	// The family and revision (family:revision) or full ARN of the task definition
+	// to run in your service. If a revision is not specified, the latest ACTIVE
+	// revision is used. If you modify the task definition with UpdateService, Amazon
+	// ECS spawns a task with the new version of the task definition and then stops
+	// an old task after the new version is running.
 	TaskDefinition *string `locationName:"taskDefinition" type:"string"`
 }
 
@@ -9669,9 +10258,21 @@ func (s *UpdateServiceInput) SetDesiredCount(v int64) *UpdateServiceInput {
 	return s
 }
 
+// SetForceNewDeployment sets the ForceNewDeployment field's value.
+func (s *UpdateServiceInput) SetForceNewDeployment(v bool) *UpdateServiceInput {
+	s.ForceNewDeployment = &v
+	return s
+}
+
 // SetNetworkConfiguration sets the NetworkConfiguration field's value.
 func (s *UpdateServiceInput) SetNetworkConfiguration(v *NetworkConfiguration) *UpdateServiceInput {
 	s.NetworkConfiguration = v
+	return s
+}
+
+// SetPlatformVersion sets the PlatformVersion field's value.
+func (s *UpdateServiceInput) SetPlatformVersion(v string) *UpdateServiceInput {
+	s.PlatformVersion = &v
 	return s
 }
 
@@ -9766,6 +10367,8 @@ type Volume struct {
 	// is empty, then the Docker daemon assigns a host path for your data volume,
 	// but the data is not guaranteed to persist after the containers associated
 	// with it stop running.
+	//
+	// If you are using the Fargate launch type, the host parameter is not supported.
 	Host *HostVolumeProperties `locationName:"host" type:"structure"`
 
 	// The name of the volume. Up to 255 letters (uppercase and lowercase), numbers,
@@ -9854,6 +10457,35 @@ const (
 )
 
 const (
+	// AssignPublicIpEnabled is a AssignPublicIp enum value
+	AssignPublicIpEnabled = "ENABLED"
+
+	// AssignPublicIpDisabled is a AssignPublicIp enum value
+	AssignPublicIpDisabled = "DISABLED"
+)
+
+const (
+	// ClusterFieldStatistics is a ClusterField enum value
+	ClusterFieldStatistics = "STATISTICS"
+)
+
+const (
+	// CompatibilityEc2 is a Compatibility enum value
+	CompatibilityEc2 = "EC2"
+
+	// CompatibilityFargate is a Compatibility enum value
+	CompatibilityFargate = "FARGATE"
+)
+
+const (
+	// ConnectivityConnected is a Connectivity enum value
+	ConnectivityConnected = "CONNECTED"
+
+	// ConnectivityDisconnected is a Connectivity enum value
+	ConnectivityDisconnected = "DISCONNECTED"
+)
+
+const (
 	// ContainerInstanceStatusActive is a ContainerInstanceStatus enum value
 	ContainerInstanceStatusActive = "ACTIVE"
 
@@ -9881,6 +10513,14 @@ const (
 
 	// DeviceCgroupPermissionMknod is a DeviceCgroupPermission enum value
 	DeviceCgroupPermissionMknod = "mknod"
+)
+
+const (
+	// LaunchTypeEc2 is a LaunchType enum value
+	LaunchTypeEc2 = "EC2"
+
+	// LaunchTypeFargate is a LaunchType enum value
+	LaunchTypeFargate = "FARGATE"
 )
 
 const (

--- a/vendor/github.com/aws/aws-sdk-go/service/ecs/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ecs/doc.go
@@ -3,18 +3,24 @@
 // Package ecs provides the client and types for making API
 // requests to Amazon EC2 Container Service.
 //
-// Amazon EC2 Container Service (Amazon ECS) is a highly scalable, fast, container
-// management service that makes it easy to run, stop, and manage Docker containers
-// on a cluster of EC2 instances. Amazon ECS lets you launch and stop container-enabled
-// applications with simple API calls, allows you to get the state of your cluster
-// from a centralized service, and gives you access to many familiar Amazon
-// EC2 features like security groups, Amazon EBS volumes, and IAM roles.
+// Amazon Elastic Container Service (Amazon ECS) is a highly scalable, fast,
+// container management service that makes it easy to run, stop, and manage
+// Docker containers on a cluster. You can host your cluster on a serverless
+// infrastructure that is managed by Amazon ECS by launching your services or
+// tasks using the Fargate launch type. For more control, you can host your
+// tasks on a cluster of Amazon Elastic Compute Cloud (Amazon EC2) instances
+// that you manage by using the EC2 launch type. For more information about
+// launch types, see Amazon ECS Launch Types (http://docs.aws.amazon.com/AmazonECS/latest/developerguidelaunch_types.html).
+//
+// Amazon ECS lets you launch and stop container-based applications with simple
+// API calls, allows you to get the state of your cluster from a centralized
+// service, and gives you access to many familiar Amazon EC2 features.
 //
 // You can use Amazon ECS to schedule the placement of containers across your
 // cluster based on your resource needs, isolation policies, and availability
-// requirements. Amazon EC2 Container Service eliminates the need for you to
-// operate your own cluster management and configuration management systems
-// or worry about scaling your management infrastructure.
+// requirements. Amazon ECS eliminates the need for you to operate your own
+// cluster management and configuration management systems or worry about scaling
+// your management infrastructure.
 //
 // See https://docs.aws.amazon.com/goto/WebAPI/ecs-2014-11-13 for more information on this service.
 //

--- a/vendor/github.com/aws/aws-sdk-go/service/ecs/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ecs/errors.go
@@ -4,6 +4,12 @@ package ecs
 
 const (
 
+	// ErrCodeAccessDeniedException for service response error code
+	// "AccessDeniedException".
+	//
+	// You do not have authorization to perform the requested action.
+	ErrCodeAccessDeniedException = "AccessDeniedException"
+
 	// ErrCodeAttributeLimitExceededException for service response error code
 	// "AttributeLimitExceededException".
 	//
@@ -12,12 +18,19 @@ const (
 	// a resource with DeleteAttributes.
 	ErrCodeAttributeLimitExceededException = "AttributeLimitExceededException"
 
+	// ErrCodeBlockedException for service response error code
+	// "BlockedException".
+	//
+	// Your AWS account has been blocked. Contact AWS Customer Support (http://aws.amazon.com/contact-us/)
+	// for more information.
+	ErrCodeBlockedException = "BlockedException"
+
 	// ErrCodeClientException for service response error code
 	// "ClientException".
 	//
 	// These errors are usually caused by a client action, such as using an action
-	// or resource on behalf of a user that doesn't have permission to use the action
-	// or resource, or specifying an identifier that is not valid.
+	// or resource on behalf of a user that doesn't have permissions to use the
+	// action or resource, or specifying an identifier that is not valid.
 	ErrCodeClientException = "ClientException"
 
 	// ErrCodeClusterContainsContainerInstancesException for service response error code
@@ -35,6 +48,12 @@ const (
 	// the service to reduce its desired task count to 0 and then delete the service.
 	// For more information, see UpdateService and DeleteService.
 	ErrCodeClusterContainsServicesException = "ClusterContainsServicesException"
+
+	// ErrCodeClusterContainsTasksException for service response error code
+	// "ClusterContainsTasksException".
+	//
+	// You cannot delete a cluster that has active tasks.
+	ErrCodeClusterContainsTasksException = "ClusterContainsTasksException"
 
 	// ErrCodeClusterNotFoundException for service response error code
 	// "ClusterNotFoundException".
@@ -67,6 +86,19 @@ const (
 	// that there is no update path to the current version.
 	ErrCodeNoUpdateAvailableException = "NoUpdateAvailableException"
 
+	// ErrCodePlatformTaskDefinitionIncompatibilityException for service response error code
+	// "PlatformTaskDefinitionIncompatibilityException".
+	//
+	// The specified platform version does not satisfy the task definition’s required
+	// capabilities.
+	ErrCodePlatformTaskDefinitionIncompatibilityException = "PlatformTaskDefinitionIncompatibilityException"
+
+	// ErrCodePlatformUnknownException for service response error code
+	// "PlatformUnknownException".
+	//
+	// The specified platform version does not exist.
+	ErrCodePlatformUnknownException = "PlatformUnknownException"
+
 	// ErrCodeServerException for service response error code
 	// "ServerException".
 	//
@@ -76,9 +108,8 @@ const (
 	// ErrCodeServiceNotActiveException for service response error code
 	// "ServiceNotActiveException".
 	//
-	// The specified service is not active. You cannot update a service that is
-	// not active. If you have previously deleted a service, you can re-create it
-	// with CreateService.
+	// The specified service is not active. You can't update a service that is inactive.
+	// If you have previously deleted a service, you can re-create it with CreateService.
 	ErrCodeServiceNotActiveException = "ServiceNotActiveException"
 
 	// ErrCodeServiceNotFoundException for service response error code
@@ -95,6 +126,12 @@ const (
 	// instances with ListContainerInstances. Amazon ECS container instances are
 	// cluster-specific and region-specific.
 	ErrCodeTargetNotFoundException = "TargetNotFoundException"
+
+	// ErrCodeUnsupportedFeatureException for service response error code
+	// "UnsupportedFeatureException".
+	//
+	// The specified task is not supported in this region.
+	ErrCodeUnsupportedFeatureException = "UnsupportedFeatureException"
 
 	// ErrCodeUpdateInProgressException for service response error code
 	// "UpdateInProgressException".

--- a/vendor/github.com/aws/aws-sdk-go/service/glacier/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/glacier/api.go
@@ -3,6 +3,7 @@
 package glacier
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -1139,8 +1140,8 @@ func (c *Glacier) DescribeJobRequest(input *DescribeJobInput) (req *request.Requ
 // For more information, see Access Control Using AWS Identity and Access Management
 // (IAM) (http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html).
 //
-// For information about the underlying REST API, see Working with Archives
-// in Amazon Glacier (http://docs.aws.amazon.com/amazonglacier/latest/dev/api-describe-job-get.html)
+// For more information about using this operation, see the documentation for
+// the underlying REST API Describe Job (http://docs.aws.amazon.com/amazonglacier/latest/dev/api-describe-job-get.html)
 // in the Amazon Glacier Developer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -1845,142 +1846,10 @@ func (c *Glacier) InitiateJobRequest(input *InitiateJobInput) (req *request.Requ
 
 // InitiateJob API operation for Amazon Glacier.
 //
-// This operation initiates a job of the specified type. In this release, you
-// can initiate a job to retrieve either an archive or a vault inventory (a
-// list of archives in a vault).
-//
-// Retrieving data from Amazon Glacier is a two-step process:
-//
-// Initiate a retrieval job.
-//
-// A data retrieval policy can cause your initiate retrieval job request to
-// fail with a PolicyEnforcedException exception. For more information about
-// data retrieval policies, see Amazon Glacier Data Retrieval Policies (http://docs.aws.amazon.com/amazonglacier/latest/dev/data-retrieval-policy.html).
-// For more information about the PolicyEnforcedException exception, see Error
-// Responses (http://docs.aws.amazon.com/amazonglacier/latest/dev/api-error-responses.html).
-//
-// After the job completes, download the bytes.
-//
-// The retrieval request is executed asynchronously. When you initiate a retrieval
-// job, Amazon Glacier creates a job and returns a job ID in the response. When
-// Amazon Glacier completes the job, you can get the job output (archive or
-// inventory data). For information about getting job output, see GetJobOutput
-// operation.
-//
-// The job must complete before you can get its output. To determine when a
-// job is complete, you have the following options:
-//
-//    * Use Amazon SNS Notification You can specify an Amazon Simple Notification
-//    Service (Amazon SNS) topic to which Amazon Glacier can post a notification
-//    after the job is completed. You can specify an SNS topic per job request.
-//    The notification is sent only after Amazon Glacier completes the job.
-//    In addition to specifying an SNS topic per job request, you can configure
-//    vault notifications for a vault so that job notifications are always sent.
-//    For more information, see SetVaultNotifications.
-//
-//    * Get job details You can make a DescribeJob request to obtain job status
-//    information while a job is in progress. However, it is more efficient
-//    to use an Amazon SNS notification to determine when a job is complete.
-//
-// The information you get via notification is same that you get by calling
-// DescribeJob.
-//
-// If for a specific event, you add both the notification configuration on the
-// vault and also specify an SNS topic in your initiate job request, Amazon
-// Glacier sends both notifications. For more information, see SetVaultNotifications.
-//
-// An AWS account has full permission to perform all operations (actions). However,
-// AWS Identity and Access Management (IAM) users don't have any permissions
-// by default. You must grant them explicit permission to perform specific actions.
-// For more information, see Access Control Using AWS Identity and Access Management
-// (IAM) (http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html).
-//
-// About the Vault Inventory
-//
-// Amazon Glacier prepares an inventory for each vault periodically, every 24
-// hours. When you initiate a job for a vault inventory, Amazon Glacier returns
-// the last inventory for the vault. The inventory data you get might be up
-// to a day or two days old. Also, the initiate inventory job might take some
-// time to complete before you can download the vault inventory. So you do not
-// want to retrieve a vault inventory for each vault operation. However, in
-// some scenarios, you might find the vault inventory useful. For example, when
-// you upload an archive, you can provide an archive description but not an
-// archive name. Amazon Glacier provides you a unique archive ID, an opaque
-// string of characters. So, you might maintain your own database that maps
-// archive names to their corresponding Amazon Glacier assigned archive IDs.
-// You might find the vault inventory useful in the event you need to reconcile
-// information in your database with the actual vault inventory.
-//
-// Range Inventory Retrieval
-//
-// You can limit the number of inventory items retrieved by filtering on the
-// archive creation date or by setting a limit.
-//
-// Filtering by Archive Creation Date
-//
-// You can retrieve inventory items for archives created between StartDate and
-// EndDate by specifying values for these parameters in the InitiateJob request.
-// Archives created on or after the StartDate and before the EndDate will be
-// returned. If you only provide the StartDate without the EndDate, you will
-// retrieve the inventory for all archives created on or after the StartDate.
-// If you only provide the EndDate without the StartDate, you will get back
-// the inventory for all archives created before the EndDate.
-//
-// Limiting Inventory Items per Retrieval
-//
-// You can limit the number of inventory items returned by setting the Limit
-// parameter in the InitiateJob request. The inventory job output will contain
-// inventory items up to the specified Limit. If there are more inventory items
-// available, the result is paginated. After a job is complete you can use the
-// DescribeJob operation to get a marker that you use in a subsequent InitiateJob
-// request. The marker will indicate the starting point to retrieve the next
-// set of inventory items. You can page through your entire inventory by repeatedly
-// making InitiateJob requests with the marker from the previous DescribeJob
-// output, until you get a marker from DescribeJob that returns null, indicating
-// that there are no more inventory items available.
-//
-// You can use the Limit parameter together with the date range parameters.
-//
-// About Ranged Archive Retrieval
-//
-// You can initiate an archive retrieval for the whole archive or a range of
-// the archive. In the case of ranged archive retrieval, you specify a byte
-// range to return or the whole archive. The range specified must be megabyte
-// (MB) aligned, that is the range start value must be divisible by 1 MB and
-// range end value plus 1 must be divisible by 1 MB or equal the end of the
-// archive. If the ranged archive retrieval is not megabyte aligned, this operation
-// returns a 400 response. Furthermore, to ensure you get checksum values for
-// data you download using Get Job Output API, the range must be tree hash aligned.
-//
-// An AWS account has full permission to perform all operations (actions). However,
-// AWS Identity and Access Management (IAM) users don't have any permissions
-// by default. You must grant them explicit permission to perform specific actions.
-// For more information, see Access Control Using AWS Identity and Access Management
-// (IAM) (http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html).
-//
-// For conceptual information and the underlying REST API, see Initiate a Job
-// (http://docs.aws.amazon.com/amazonglacier/latest/dev/api-initiate-job-post.html)
-// and Downloading a Vault Inventory (http://docs.aws.amazon.com/amazonglacier/latest/dev/vault-inventory.html)
-//
-// Expedited and Bulk Archive Retrievals
-//
-// When retrieving an archive, you can specify one of the following options
-// in the Tier field of the request body:
-//
-//    * Standard The default type of retrieval, which allows access to any of
-//    your archives within several hours. Standard retrievals typically complete
-//    within 3–5 hours.
-//
-//    * Bulk Amazon Glacier’s lowest-cost retrieval option, which enables you
-//    to retrieve large amounts of data inexpensively in a day. Bulk retrieval
-//    requests typically complete within 5–12 hours.
-//
-//    * Expedited Amazon Glacier’s option for the fastest retrievals. Archives
-//    requested using the expedited retrievals typically become accessible within
-//    1–5 minutes.
-//
-// For more information about expedited and bulk retrievals, see Retrieving
-// Amazon Glacier Archives (http://docs.aws.amazon.com/amazonglacier/latest/dev/downloading-an-archive-two-steps.html).
+// This operation initiates a job of the specified type, which can be a select,
+// an archival retrieval, or a vault retrieval. For more information about using
+// this operation, see the documentation for the underlying REST API Initiate
+// a Job (http://docs.aws.amazon.com/amazonglacier/latest/dev/api-initiate-job-post.html).
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2316,7 +2185,8 @@ func (c *Glacier) ListJobsRequest(input *ListJobsInput) (req *request.Request, o
 // ListJobs API operation for Amazon Glacier.
 //
 // This operation lists jobs for a vault, including jobs that are in-progress
-// and jobs that have recently finished.
+// and jobs that have recently finished. The List Job operation returns a list
+// of these jobs sorted by job initiation time.
 //
 // Amazon Glacier retains recently completed jobs for a period before deleting
 // them; however, it eventually removes completed jobs. The output of completed
@@ -2327,12 +2197,6 @@ func (c *Glacier) ListJobsRequest(input *ListJobsInput) (req *request.Request, o
 // After the job completes, you start to download the archive but encounter
 // a network error. In this scenario, you can retry and download the archive
 // while the job exists.
-//
-// To retrieve an archive or retrieve a vault inventory from Amazon Glacier,
-// you first initiate a job, and after the job completes, you download the data.
-// For an archive retrieval, the output is the archive data. For an inventory
-// retrieval, it is the inventory list. The List Job operation returns a list
-// of these jobs sorted by job initiation time.
 //
 // The List Jobs operation supports pagination. You should always check the
 // response Marker field. If there are no more jobs to list, the Marker field
@@ -2354,7 +2218,8 @@ func (c *Glacier) ListJobsRequest(input *ListJobsInput) (req *request.Request, o
 // to return only jobs that were completed (true) or jobs that were not completed
 // (false).
 //
-// For the underlying REST API, see List Jobs (http://docs.aws.amazon.com/amazonglacier/latest/dev/api-jobs-get.html).
+// For more information about using this operation, see the documentation for
+// the underlying REST API List Jobs (http://docs.aws.amazon.com/amazonglacier/latest/dev/api-jobs-get.html).
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2826,7 +2691,8 @@ func (c *Glacier) ListProvisionedCapacityRequest(input *ListProvisionedCapacityI
 
 // ListProvisionedCapacity API operation for Amazon Glacier.
 //
-// This operation lists the provisioned capacity for the specified AWS account.
+// This operation lists the provisioned capacity units for the specified AWS
+// account.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -4143,6 +4009,143 @@ func (s *ArchiveCreationOutput) SetLocation(v string) *ArchiveCreationOutput {
 	return s
 }
 
+// Contains information about the comma-separated value (CSV) file to select
+// from.
+type CSVInput struct {
+	_ struct{} `type:"structure"`
+
+	// A single character used to indicate that a row should be ignored when the
+	// character is present at the start of that row.
+	Comments *string `type:"string"`
+
+	// A value used to separate individual fields from each other within a record.
+	FieldDelimiter *string `type:"string"`
+
+	// Describes the first line of input. Valid values are None, Ignore, and Use.
+	FileHeaderInfo *string `type:"string" enum:"FileHeaderInfo"`
+
+	// A value used as an escape character where the field delimiter is part of
+	// the value.
+	QuoteCharacter *string `type:"string"`
+
+	// A single character used for escaping the quotation-mark character inside
+	// an already escaped value.
+	QuoteEscapeCharacter *string `type:"string"`
+
+	// A value used to separate individual records from each other.
+	RecordDelimiter *string `type:"string"`
+}
+
+// String returns the string representation
+func (s CSVInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CSVInput) GoString() string {
+	return s.String()
+}
+
+// SetComments sets the Comments field's value.
+func (s *CSVInput) SetComments(v string) *CSVInput {
+	s.Comments = &v
+	return s
+}
+
+// SetFieldDelimiter sets the FieldDelimiter field's value.
+func (s *CSVInput) SetFieldDelimiter(v string) *CSVInput {
+	s.FieldDelimiter = &v
+	return s
+}
+
+// SetFileHeaderInfo sets the FileHeaderInfo field's value.
+func (s *CSVInput) SetFileHeaderInfo(v string) *CSVInput {
+	s.FileHeaderInfo = &v
+	return s
+}
+
+// SetQuoteCharacter sets the QuoteCharacter field's value.
+func (s *CSVInput) SetQuoteCharacter(v string) *CSVInput {
+	s.QuoteCharacter = &v
+	return s
+}
+
+// SetQuoteEscapeCharacter sets the QuoteEscapeCharacter field's value.
+func (s *CSVInput) SetQuoteEscapeCharacter(v string) *CSVInput {
+	s.QuoteEscapeCharacter = &v
+	return s
+}
+
+// SetRecordDelimiter sets the RecordDelimiter field's value.
+func (s *CSVInput) SetRecordDelimiter(v string) *CSVInput {
+	s.RecordDelimiter = &v
+	return s
+}
+
+// Contains information about the comma-separated value (CSV) file that the
+// job results are stored in.
+type CSVOutput struct {
+	_ struct{} `type:"structure"`
+
+	// A value used to separate individual fields from each other within a record.
+	FieldDelimiter *string `type:"string"`
+
+	// A value used as an escape character where the field delimiter is part of
+	// the value.
+	QuoteCharacter *string `type:"string"`
+
+	// A single character used for escaping the quotation-mark character inside
+	// an already escaped value.
+	QuoteEscapeCharacter *string `type:"string"`
+
+	// A value that indicates whether all output fields should be contained within
+	// quotation marks.
+	QuoteFields *string `type:"string" enum:"QuoteFields"`
+
+	// A value used to separate individual records from each other.
+	RecordDelimiter *string `type:"string"`
+}
+
+// String returns the string representation
+func (s CSVOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CSVOutput) GoString() string {
+	return s.String()
+}
+
+// SetFieldDelimiter sets the FieldDelimiter field's value.
+func (s *CSVOutput) SetFieldDelimiter(v string) *CSVOutput {
+	s.FieldDelimiter = &v
+	return s
+}
+
+// SetQuoteCharacter sets the QuoteCharacter field's value.
+func (s *CSVOutput) SetQuoteCharacter(v string) *CSVOutput {
+	s.QuoteCharacter = &v
+	return s
+}
+
+// SetQuoteEscapeCharacter sets the QuoteEscapeCharacter field's value.
+func (s *CSVOutput) SetQuoteEscapeCharacter(v string) *CSVOutput {
+	s.QuoteEscapeCharacter = &v
+	return s
+}
+
+// SetQuoteFields sets the QuoteFields field's value.
+func (s *CSVOutput) SetQuoteFields(v string) *CSVOutput {
+	s.QuoteFields = &v
+	return s
+}
+
+// SetRecordDelimiter sets the RecordDelimiter field's value.
+func (s *CSVOutput) SetRecordDelimiter(v string) *CSVOutput {
+	s.RecordDelimiter = &v
+	return s
+}
+
 // Provides options to complete a multipart upload operation. This informs Amazon
 // Glacier that all the archive parts have been uploaded and Amazon Glacier
 // can now assemble the archive from the uploaded parts. After assembling and
@@ -4975,6 +4978,53 @@ func (s *DescribeVaultOutput) SetVaultName(v string) *DescribeVaultOutput {
 	return s
 }
 
+// Contains information about the encryption used to store the job results in
+// Amazon S3.
+type Encryption struct {
+	_ struct{} `type:"structure"`
+
+	// The server-side encryption algorithm used when storing job results in Amazon
+	// S3, for example AES256 or aws:kms.
+	EncryptionType *string `type:"string" enum:"EncryptionType"`
+
+	// Optional. If the encryption type is aws:kms, you can use this value to specify
+	// the encryption context for the restore results.
+	KMSContext *string `type:"string"`
+
+	// The AWS KMS key ID to use for object encryption. All GET and PUT requests
+	// for an object protected by AWS KMS fail if not made by using Secure Sockets
+	// Layer (SSL) or Signature Version 4.
+	KMSKeyId *string `type:"string"`
+}
+
+// String returns the string representation
+func (s Encryption) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s Encryption) GoString() string {
+	return s.String()
+}
+
+// SetEncryptionType sets the EncryptionType field's value.
+func (s *Encryption) SetEncryptionType(v string) *Encryption {
+	s.EncryptionType = &v
+	return s
+}
+
+// SetKMSContext sets the KMSContext field's value.
+func (s *Encryption) SetKMSContext(v string) *Encryption {
+	s.KMSContext = &v
+	return s
+}
+
+// SetKMSKeyId sets the KMSKeyId field's value.
+func (s *Encryption) SetKMSKeyId(v string) *Encryption {
+	s.KMSKeyId = &v
+	return s
+}
+
 // Input for GetDataRetrievalPolicy.
 type GetDataRetrievalPolicyInput struct {
 	_ struct{} `type:"structure"`
@@ -5524,6 +5574,129 @@ func (s *GetVaultNotificationsOutput) SetVaultNotificationConfig(v *VaultNotific
 	return s
 }
 
+// Contains information about a grant.
+type Grant struct {
+	_ struct{} `type:"structure"`
+
+	// The grantee.
+	Grantee *Grantee `type:"structure"`
+
+	// Specifies the permission given to the grantee.
+	Permission *string `type:"string" enum:"Permission"`
+}
+
+// String returns the string representation
+func (s Grant) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s Grant) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Grant) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Grant"}
+	if s.Grantee != nil {
+		if err := s.Grantee.Validate(); err != nil {
+			invalidParams.AddNested("Grantee", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetGrantee sets the Grantee field's value.
+func (s *Grant) SetGrantee(v *Grantee) *Grant {
+	s.Grantee = v
+	return s
+}
+
+// SetPermission sets the Permission field's value.
+func (s *Grant) SetPermission(v string) *Grant {
+	s.Permission = &v
+	return s
+}
+
+// Contains information about the grantee.
+type Grantee struct {
+	_ struct{} `type:"structure"`
+
+	// Screen name of the grantee.
+	DisplayName *string `type:"string"`
+
+	// Email address of the grantee.
+	EmailAddress *string `type:"string"`
+
+	// The canonical user ID of the grantee.
+	ID *string `type:"string"`
+
+	// Type of grantee
+	//
+	// Type is a required field
+	Type *string `type:"string" required:"true" enum:"Type"`
+
+	// URI of the grantee group.
+	URI *string `type:"string"`
+}
+
+// String returns the string representation
+func (s Grantee) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s Grantee) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Grantee) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Grantee"}
+	if s.Type == nil {
+		invalidParams.Add(request.NewErrParamRequired("Type"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDisplayName sets the DisplayName field's value.
+func (s *Grantee) SetDisplayName(v string) *Grantee {
+	s.DisplayName = &v
+	return s
+}
+
+// SetEmailAddress sets the EmailAddress field's value.
+func (s *Grantee) SetEmailAddress(v string) *Grantee {
+	s.EmailAddress = &v
+	return s
+}
+
+// SetID sets the ID field's value.
+func (s *Grantee) SetID(v string) *Grantee {
+	s.ID = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *Grantee) SetType(v string) *Grantee {
+	s.Type = &v
+	return s
+}
+
+// SetURI sets the URI field's value.
+func (s *Grantee) SetURI(v string) *Grantee {
+	s.URI = &v
+	return s
+}
+
 // Provides options for initiating an Amazon Glacier job.
 type InitiateJobInput struct {
 	_ struct{} `type:"structure" payload:"JobParameters"`
@@ -5565,6 +5738,11 @@ func (s *InitiateJobInput) Validate() error {
 	if s.VaultName == nil {
 		invalidParams.Add(request.NewErrParamRequired("VaultName"))
 	}
+	if s.JobParameters != nil {
+		if err := s.JobParameters.Validate(); err != nil {
+			invalidParams.AddNested("JobParameters", err.(request.ErrInvalidParams))
+		}
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -5597,6 +5775,9 @@ type InitiateJobOutput struct {
 	// The ID of the job.
 	JobId *string `location:"header" locationName:"x-amz-job-id" type:"string"`
 
+	// The path to the location of where the select results are stored.
+	JobOutputPath *string `location:"header" locationName:"x-amz-job-output-path" type:"string"`
+
 	// The relative URI path of the job.
 	Location *string `location:"header" locationName:"Location" type:"string"`
 }
@@ -5614,6 +5795,12 @@ func (s InitiateJobOutput) GoString() string {
 // SetJobId sets the JobId field's value.
 func (s *InitiateJobOutput) SetJobId(v string) *InitiateJobOutput {
 	s.JobId = &v
+	return s
+}
+
+// SetJobOutputPath sets the JobOutputPath field's value.
+func (s *InitiateJobOutput) SetJobOutputPath(v string) *InitiateJobOutput {
+	s.JobOutputPath = &v
 	return s
 }
 
@@ -5829,6 +6016,30 @@ func (s *InitiateVaultLockOutput) SetLockId(v string) *InitiateVaultLockOutput {
 	return s
 }
 
+// Describes how the archive is serialized.
+type InputSerialization struct {
+	_ struct{} `type:"structure"`
+
+	// Describes the serialization of a CSV-encoded object.
+	Csv *CSVInput `locationName:"csv" type:"structure"`
+}
+
+// String returns the string representation
+func (s InputSerialization) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s InputSerialization) GoString() string {
+	return s.String()
+}
+
+// SetCsv sets the Csv field's value.
+func (s *InputSerialization) SetCsv(v *CSVInput) *InputSerialization {
+	s.Csv = v
+	return s
+}
+
 // Describes the options for a range inventory retrieval job.
 type InventoryRetrievalJobDescription struct {
 	_ struct{} `type:"structure"`
@@ -5960,77 +6171,93 @@ func (s *InventoryRetrievalJobInput) SetStartDate(v string) *InventoryRetrievalJ
 	return s
 }
 
-// Describes an Amazon Glacier job.
+// Contains the description of an Amazon Glacier job.
 type JobDescription struct {
 	_ struct{} `type:"structure"`
 
-	// The job type. It is either ArchiveRetrieval or InventoryRetrieval.
+	// The job type. This value is either ArchiveRetrieval, InventoryRetrieval,
+	// or Select.
 	Action *string `type:"string" enum:"ActionCode"`
 
-	// For an ArchiveRetrieval job, this is the archive ID requested for download.
-	// Otherwise, this field is null.
+	// The archive ID requested for a select job or archive retrieval. Otherwise,
+	// this field is null.
 	ArchiveId *string `type:"string"`
 
 	// The SHA256 tree hash of the entire archive for an archive retrieval. For
-	// inventory retrieval jobs, this field is null.
+	// inventory retrieval or select jobs, this field is null.
 	ArchiveSHA256TreeHash *string `type:"string"`
 
-	// For an ArchiveRetrieval job, this is the size in bytes of the archive being
-	// requested for download. For the InventoryRetrieval job, the value is null.
+	// For an archive retrieval job, this value is the size in bytes of the archive
+	// being requested for download. For an inventory retrieval or select job, this
+	// value is null.
 	ArchiveSizeInBytes *int64 `type:"long"`
 
-	// The job status. When a job is completed, you get the job's output.
+	// The job status. When a job is completed, you get the job's output using Get
+	// Job Output (GET output).
 	Completed *bool `type:"boolean"`
 
-	// The UTC time that the archive retrieval request completed. While the job
-	// is in progress, the value will be null.
+	// The UTC time that the job request completed. While the job is in progress,
+	// the value is null.
 	CompletionDate *string `type:"string"`
 
-	// The UTC date when the job was created. A string representation of ISO 8601
-	// date format, for example, "2012-03-20T17:03:43.221Z".
+	// The UTC date when the job was created. This value is a string representation
+	// of ISO 8601 date format, for example "2012-03-20T17:03:43.221Z".
 	CreationDate *string `type:"string"`
 
 	// Parameters used for range inventory retrieval.
 	InventoryRetrievalParameters *InventoryRetrievalJobDescription `type:"structure"`
 
-	// For an InventoryRetrieval job, this is the size in bytes of the inventory
-	// requested for download. For the ArchiveRetrieval job, the value is null.
+	// For an inventory retrieval job, this value is the size in bytes of the inventory
+	// requested for download. For an archive retrieval or select job, this value
+	// is null.
 	InventorySizeInBytes *int64 `type:"long"`
 
-	// The job description you provided when you initiated the job.
+	// The job description provided when initiating the job.
 	JobDescription *string `type:"string"`
 
 	// An opaque string that identifies an Amazon Glacier job.
 	JobId *string `type:"string"`
 
-	// The retrieved byte range for archive retrieval jobs in the form "StartByteValue-EndByteValue"
+	// Contains the job output location.
+	JobOutputPath *string `type:"string"`
+
+	// Contains the location where the data from the select job is stored.
+	OutputLocation *OutputLocation `type:"structure"`
+
+	// The retrieved byte range for archive retrieval jobs in the form StartByteValue-EndByteValue.
 	// If no range was specified in the archive retrieval, then the whole archive
-	// is retrieved and StartByteValue equals 0 and EndByteValue equals the size
-	// of the archive minus 1. For inventory retrieval jobs this field is null.
+	// is retrieved. In this case, StartByteValue equals 0 and EndByteValue equals
+	// the size of the archive minus 1. For inventory retrieval or select jobs,
+	// this field is null.
 	RetrievalByteRange *string `type:"string"`
 
-	// For an ArchiveRetrieval job, it is the checksum of the archive. Otherwise,
-	// the value is null.
+	// For an archive retrieval job, this value is the checksum of the archive.
+	// Otherwise, this value is null.
 	//
 	// The SHA256 tree hash value for the requested range of an archive. If the
-	// Initiate a Job request for an archive specified a tree-hash aligned range,
-	// then this field returns a value.
+	// InitiateJob request for an archive specified a tree-hash aligned range, then
+	// this field returns a value.
 	//
-	// For the specific case when the whole archive is retrieved, this value is
-	// the same as the ArchiveSHA256TreeHash value.
+	// If the whole archive is retrieved, this value is the same as the ArchiveSHA256TreeHash
+	// value.
 	//
-	// This field is null in the following situations:
+	// This field is null for the following:
 	//
-	//    * Archive retrieval jobs that specify a range that is not tree-hash aligned.
+	//    * Archive retrieval jobs that specify a range that is not tree-hash aligned
 	//
-	//    * Archival jobs that specify a range that is equal to the whole archive
-	//    and the job status is InProgress.
+	//    * Archival jobs that specify a range that is equal to the whole archive,
+	//    when the job status is InProgress
 	//
-	//    * Inventory jobs.
+	//    * Inventory jobs
+	//
+	//    * Select jobs
 	SHA256TreeHash *string `type:"string"`
 
-	// An Amazon Simple Notification Service (Amazon SNS) topic that receives notification.
+	// An Amazon SNS topic that receives notification.
 	SNSTopic *string `type:"string"`
+
+	// Contains the parameters that define a select job.
+	SelectParameters *SelectParameters `type:"structure"`
 
 	// The status code can be InProgress, Succeeded, or Failed, and indicates the
 	// status of the job.
@@ -6043,7 +6270,7 @@ type JobDescription struct {
 	// Standard, or Bulk. Standard is the default.
 	Tier *string `type:"string"`
 
-	// The Amazon Resource Name (ARN) of the vault from which the archive retrieval
+	// The Amazon Resource Name (ARN) of the vault from which an archive retrieval
 	// was requested.
 	VaultARN *string `type:"string"`
 }
@@ -6124,6 +6351,18 @@ func (s *JobDescription) SetJobId(v string) *JobDescription {
 	return s
 }
 
+// SetJobOutputPath sets the JobOutputPath field's value.
+func (s *JobDescription) SetJobOutputPath(v string) *JobDescription {
+	s.JobOutputPath = &v
+	return s
+}
+
+// SetOutputLocation sets the OutputLocation field's value.
+func (s *JobDescription) SetOutputLocation(v *OutputLocation) *JobDescription {
+	s.OutputLocation = v
+	return s
+}
+
 // SetRetrievalByteRange sets the RetrievalByteRange field's value.
 func (s *JobDescription) SetRetrievalByteRange(v string) *JobDescription {
 	s.RetrievalByteRange = &v
@@ -6139,6 +6378,12 @@ func (s *JobDescription) SetSHA256TreeHash(v string) *JobDescription {
 // SetSNSTopic sets the SNSTopic field's value.
 func (s *JobDescription) SetSNSTopic(v string) *JobDescription {
 	s.SNSTopic = &v
+	return s
+}
+
+// SetSelectParameters sets the SelectParameters field's value.
+func (s *JobDescription) SetSelectParameters(v *SelectParameters) *JobDescription {
+	s.SelectParameters = v
 	return s
 }
 
@@ -6171,8 +6416,8 @@ type JobParameters struct {
 	_ struct{} `type:"structure"`
 
 	// The ID of the archive that you want to retrieve. This field is required only
-	// if Type is set to archive-retrieval. An error occurs if you specify this
-	// request parameter for an inventory retrieval job request.
+	// if Type is set to select or archive-retrievalcode>. An error occurs if you
+	// specify this request parameter for an inventory retrieval job request.
 	ArchiveId *string `type:"string"`
 
 	// The optional description for the job. The description must be less than or
@@ -6188,6 +6433,10 @@ type JobParameters struct {
 
 	// Input parameters used for range inventory retrieval.
 	InventoryRetrievalParameters *InventoryRetrievalJobInput `type:"structure"`
+
+	// Contains information about the location where the select job results are
+	// stored.
+	OutputLocation *OutputLocation `type:"structure"`
 
 	// The byte range to retrieve for an archive retrieval. in the form "StartByteValue-EndByteValue"
 	// If not specified, the whole archive is retrieved. If specified, the byte
@@ -6206,12 +6455,16 @@ type JobParameters struct {
 	// topic publishes the notification to its subscribers. The SNS topic must exist.
 	SNSTopic *string `type:"string"`
 
-	// The retrieval option to use for the archive retrieval. Valid values are Expedited,
-	// Standard, or Bulk. Standard is the default.
+	// Contains the parameters that define a job.
+	SelectParameters *SelectParameters `type:"structure"`
+
+	// The retrieval option to use for a select or archive retrieval job. Valid
+	// values are Expedited, Standard, or Bulk. Standard is the default.
 	Tier *string `type:"string"`
 
-	// The job type. You can initiate a job to retrieve an archive or get an inventory
-	// of a vault. Valid values are "archive-retrieval" and "inventory-retrieval".
+	// The job type. You can initiate a job to perform a select query on an archive,
+	// retrieve an archive, or get an inventory of a vault. Valid values are "select",
+	// "archive-retrieval" and "inventory-retrieval".
 	Type *string `type:"string"`
 }
 
@@ -6223,6 +6476,21 @@ func (s JobParameters) String() string {
 // GoString returns the string representation
 func (s JobParameters) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *JobParameters) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "JobParameters"}
+	if s.OutputLocation != nil {
+		if err := s.OutputLocation.Validate(); err != nil {
+			invalidParams.AddNested("OutputLocation", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // SetArchiveId sets the ArchiveId field's value.
@@ -6249,6 +6517,12 @@ func (s *JobParameters) SetInventoryRetrievalParameters(v *InventoryRetrievalJob
 	return s
 }
 
+// SetOutputLocation sets the OutputLocation field's value.
+func (s *JobParameters) SetOutputLocation(v *OutputLocation) *JobParameters {
+	s.OutputLocation = v
+	return s
+}
+
 // SetRetrievalByteRange sets the RetrievalByteRange field's value.
 func (s *JobParameters) SetRetrievalByteRange(v string) *JobParameters {
 	s.RetrievalByteRange = &v
@@ -6258,6 +6532,12 @@ func (s *JobParameters) SetRetrievalByteRange(v string) *JobParameters {
 // SetSNSTopic sets the SNSTopic field's value.
 func (s *JobParameters) SetSNSTopic(v string) *JobParameters {
 	s.SNSTopic = &v
+	return s
+}
+
+// SetSelectParameters sets the SelectParameters field's value.
+func (s *JobParameters) SetSelectParameters(v *SelectParameters) *JobParameters {
+	s.SelectParameters = v
 	return s
 }
 
@@ -6707,11 +6987,11 @@ func (s *ListPartsOutput) SetVaultARN(v string) *ListPartsOutput {
 type ListProvisionedCapacityInput struct {
 	_ struct{} `type:"structure"`
 
-	// The AccountId value is the AWS account ID of the account that owns the vault.
-	// You can either specify an AWS account ID or optionally a single '-' (hyphen),
-	// in which case Amazon Glacier uses the AWS account ID associated with the
-	// credentials used to sign the request. If you use an account ID, don't include
-	// any hyphens ('-') in the ID.
+	// The AWS account ID of the account that owns the vault. You can either specify
+	// an AWS account ID or optionally a single '-' (hyphen), in which case Amazon
+	// Glacier uses the AWS account ID associated with the credentials used to sign
+	// the request. If you use an account ID, don't include any hyphens ('-') in
+	// the ID.
 	//
 	// AccountId is a required field
 	AccountId *string `location:"uri" locationName:"accountId" type:"string" required:"true"`
@@ -6950,6 +7230,70 @@ func (s *ListVaultsOutput) SetVaultList(v []*DescribeVaultOutput) *ListVaultsOut
 	return s
 }
 
+// Contains information about the location where the select job results are
+// stored.
+type OutputLocation struct {
+	_ struct{} `type:"structure"`
+
+	// Describes an S3 location that will receive the results of the restore request.
+	S3 *S3Location `type:"structure"`
+}
+
+// String returns the string representation
+func (s OutputLocation) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s OutputLocation) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *OutputLocation) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "OutputLocation"}
+	if s.S3 != nil {
+		if err := s.S3.Validate(); err != nil {
+			invalidParams.AddNested("S3", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetS3 sets the S3 field's value.
+func (s *OutputLocation) SetS3(v *S3Location) *OutputLocation {
+	s.S3 = v
+	return s
+}
+
+// Describes how the select output is serialized.
+type OutputSerialization struct {
+	_ struct{} `type:"structure"`
+
+	// Describes the serialization of CSV-encoded query results.
+	Csv *CSVOutput `locationName:"csv" type:"structure"`
+}
+
+// String returns the string representation
+func (s OutputSerialization) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s OutputSerialization) GoString() string {
+	return s.String()
+}
+
+// SetCsv sets the Csv field's value.
+func (s *OutputSerialization) SetCsv(v *CSVOutput) *OutputSerialization {
+	s.Csv = v
+	return s
+}
+
 // A list of the part sizes of the multipart upload.
 type PartListElement struct {
 	_ struct{} `type:"structure"`
@@ -7171,6 +7515,166 @@ func (s RemoveTagsFromVaultOutput) String() string {
 // GoString returns the string representation
 func (s RemoveTagsFromVaultOutput) GoString() string {
 	return s.String()
+}
+
+// Contains information about the location in Amazon S3 where the select job
+// results are stored.
+type S3Location struct {
+	_ struct{} `type:"structure"`
+
+	// A list of grants that control access to the staged results.
+	AccessControlList []*Grant `type:"list"`
+
+	// The name of the bucket where the restore results are stored.
+	BucketName *string `type:"string"`
+
+	// The canned ACL to apply to the restore results.
+	CannedACL *string `type:"string" enum:"CannedACL"`
+
+	// Contains information about the encryption used to store the job results in
+	// Amazon S3.
+	Encryption *Encryption `type:"structure"`
+
+	// The prefix that is prepended to the restore results for this request.
+	Prefix *string `type:"string"`
+
+	// The storage class used to store the restore results.
+	StorageClass *string `type:"string" enum:"StorageClass"`
+
+	// The tag-set that is applied to the restore results.
+	Tagging map[string]*string `type:"map"`
+
+	// A map of metadata to store with the restore results in Amazon S3.
+	UserMetadata map[string]*string `type:"map"`
+}
+
+// String returns the string representation
+func (s S3Location) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s S3Location) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *S3Location) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "S3Location"}
+	if s.AccessControlList != nil {
+		for i, v := range s.AccessControlList {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "AccessControlList", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAccessControlList sets the AccessControlList field's value.
+func (s *S3Location) SetAccessControlList(v []*Grant) *S3Location {
+	s.AccessControlList = v
+	return s
+}
+
+// SetBucketName sets the BucketName field's value.
+func (s *S3Location) SetBucketName(v string) *S3Location {
+	s.BucketName = &v
+	return s
+}
+
+// SetCannedACL sets the CannedACL field's value.
+func (s *S3Location) SetCannedACL(v string) *S3Location {
+	s.CannedACL = &v
+	return s
+}
+
+// SetEncryption sets the Encryption field's value.
+func (s *S3Location) SetEncryption(v *Encryption) *S3Location {
+	s.Encryption = v
+	return s
+}
+
+// SetPrefix sets the Prefix field's value.
+func (s *S3Location) SetPrefix(v string) *S3Location {
+	s.Prefix = &v
+	return s
+}
+
+// SetStorageClass sets the StorageClass field's value.
+func (s *S3Location) SetStorageClass(v string) *S3Location {
+	s.StorageClass = &v
+	return s
+}
+
+// SetTagging sets the Tagging field's value.
+func (s *S3Location) SetTagging(v map[string]*string) *S3Location {
+	s.Tagging = v
+	return s
+}
+
+// SetUserMetadata sets the UserMetadata field's value.
+func (s *S3Location) SetUserMetadata(v map[string]*string) *S3Location {
+	s.UserMetadata = v
+	return s
+}
+
+// Contains information about the parameters used for a select.
+type SelectParameters struct {
+	_ struct{} `type:"structure"`
+
+	// The expression that is used to select the object.
+	Expression *string `type:"string"`
+
+	// The type of the provided expression, for example SQL.
+	ExpressionType *string `type:"string" enum:"ExpressionType"`
+
+	// Describes the serialization format of the object.
+	InputSerialization *InputSerialization `type:"structure"`
+
+	// Describes how the results of the select job are serialized.
+	OutputSerialization *OutputSerialization `type:"structure"`
+}
+
+// String returns the string representation
+func (s SelectParameters) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SelectParameters) GoString() string {
+	return s.String()
+}
+
+// SetExpression sets the Expression field's value.
+func (s *SelectParameters) SetExpression(v string) *SelectParameters {
+	s.Expression = &v
+	return s
+}
+
+// SetExpressionType sets the ExpressionType field's value.
+func (s *SelectParameters) SetExpressionType(v string) *SelectParameters {
+	s.ExpressionType = &v
+	return s
+}
+
+// SetInputSerialization sets the InputSerialization field's value.
+func (s *SelectParameters) SetInputSerialization(v *InputSerialization) *SelectParameters {
+	s.InputSerialization = v
+	return s
+}
+
+// SetOutputSerialization sets the OutputSerialization field's value.
+func (s *SelectParameters) SetOutputSerialization(v *OutputSerialization) *SelectParameters {
+	s.OutputSerialization = v
+	return s
 }
 
 // SetDataRetrievalPolicy input.
@@ -7762,6 +8266,81 @@ const (
 
 	// ActionCodeInventoryRetrieval is a ActionCode enum value
 	ActionCodeInventoryRetrieval = "InventoryRetrieval"
+
+	// ActionCodeSelect is a ActionCode enum value
+	ActionCodeSelect = "Select"
+)
+
+const (
+	// CannedACLPrivate is a CannedACL enum value
+	CannedACLPrivate = "private"
+
+	// CannedACLPublicRead is a CannedACL enum value
+	CannedACLPublicRead = "public-read"
+
+	// CannedACLPublicReadWrite is a CannedACL enum value
+	CannedACLPublicReadWrite = "public-read-write"
+
+	// CannedACLAwsExecRead is a CannedACL enum value
+	CannedACLAwsExecRead = "aws-exec-read"
+
+	// CannedACLAuthenticatedRead is a CannedACL enum value
+	CannedACLAuthenticatedRead = "authenticated-read"
+
+	// CannedACLBucketOwnerRead is a CannedACL enum value
+	CannedACLBucketOwnerRead = "bucket-owner-read"
+
+	// CannedACLBucketOwnerFullControl is a CannedACL enum value
+	CannedACLBucketOwnerFullControl = "bucket-owner-full-control"
+)
+
+const (
+	// EncryptionTypeAwsKms is a EncryptionType enum value
+	EncryptionTypeAwsKms = "aws:kms"
+
+	// EncryptionTypeAes256 is a EncryptionType enum value
+	EncryptionTypeAes256 = "AES256"
+)
+
+const (
+	// ExpressionTypeSql is a ExpressionType enum value
+	ExpressionTypeSql = "SQL"
+)
+
+const (
+	// FileHeaderInfoUse is a FileHeaderInfo enum value
+	FileHeaderInfoUse = "USE"
+
+	// FileHeaderInfoIgnore is a FileHeaderInfo enum value
+	FileHeaderInfoIgnore = "IGNORE"
+
+	// FileHeaderInfoNone is a FileHeaderInfo enum value
+	FileHeaderInfoNone = "NONE"
+)
+
+const (
+	// PermissionFullControl is a Permission enum value
+	PermissionFullControl = "FULL_CONTROL"
+
+	// PermissionWrite is a Permission enum value
+	PermissionWrite = "WRITE"
+
+	// PermissionWriteAcp is a Permission enum value
+	PermissionWriteAcp = "WRITE_ACP"
+
+	// PermissionRead is a Permission enum value
+	PermissionRead = "READ"
+
+	// PermissionReadAcp is a Permission enum value
+	PermissionReadAcp = "READ_ACP"
+)
+
+const (
+	// QuoteFieldsAlways is a QuoteFields enum value
+	QuoteFieldsAlways = "ALWAYS"
+
+	// QuoteFieldsAsneeded is a QuoteFields enum value
+	QuoteFieldsAsneeded = "ASNEEDED"
 )
 
 const (
@@ -7773,4 +8352,26 @@ const (
 
 	// StatusCodeFailed is a StatusCode enum value
 	StatusCodeFailed = "Failed"
+)
+
+const (
+	// StorageClassStandard is a StorageClass enum value
+	StorageClassStandard = "STANDARD"
+
+	// StorageClassReducedRedundancy is a StorageClass enum value
+	StorageClassReducedRedundancy = "REDUCED_REDUNDANCY"
+
+	// StorageClassStandardIa is a StorageClass enum value
+	StorageClassStandardIa = "STANDARD_IA"
+)
+
+const (
+	// TypeAmazonCustomerByEmail is a Type enum value
+	TypeAmazonCustomerByEmail = "AmazonCustomerByEmail"
+
+	// TypeCanonicalUser is a Type enum value
+	TypeCanonicalUser = "CanonicalUser"
+
+	// TypeGroup is a Type enum value
+	TypeGroup = "Group"
 )

--- a/vendor/github.com/aws/aws-sdk-go/service/iot/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/iot/api.go
@@ -114,6 +114,283 @@ func (c *IoT) AcceptCertificateTransferWithContext(ctx aws.Context, input *Accep
 	return out, req.Send()
 }
 
+const opAddThingToThingGroup = "AddThingToThingGroup"
+
+// AddThingToThingGroupRequest generates a "aws/request.Request" representing the
+// client's request for the AddThingToThingGroup operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See AddThingToThingGroup for more information on using the AddThingToThingGroup
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the AddThingToThingGroupRequest method.
+//    req, resp := client.AddThingToThingGroupRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) AddThingToThingGroupRequest(input *AddThingToThingGroupInput) (req *request.Request, output *AddThingToThingGroupOutput) {
+	op := &request.Operation{
+		Name:       opAddThingToThingGroup,
+		HTTPMethod: "PUT",
+		HTTPPath:   "/thing-groups/addThingToThingGroup",
+	}
+
+	if input == nil {
+		input = &AddThingToThingGroupInput{}
+	}
+
+	output = &AddThingToThingGroupOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// AddThingToThingGroup API operation for AWS IoT.
+//
+// Adds a thing to a thing group.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation AddThingToThingGroup for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+func (c *IoT) AddThingToThingGroup(input *AddThingToThingGroupInput) (*AddThingToThingGroupOutput, error) {
+	req, out := c.AddThingToThingGroupRequest(input)
+	return out, req.Send()
+}
+
+// AddThingToThingGroupWithContext is the same as AddThingToThingGroup with the addition of
+// the ability to pass a context and additional request options.
+//
+// See AddThingToThingGroup for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) AddThingToThingGroupWithContext(ctx aws.Context, input *AddThingToThingGroupInput, opts ...request.Option) (*AddThingToThingGroupOutput, error) {
+	req, out := c.AddThingToThingGroupRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opAssociateTargetsWithJob = "AssociateTargetsWithJob"
+
+// AssociateTargetsWithJobRequest generates a "aws/request.Request" representing the
+// client's request for the AssociateTargetsWithJob operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See AssociateTargetsWithJob for more information on using the AssociateTargetsWithJob
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the AssociateTargetsWithJobRequest method.
+//    req, resp := client.AssociateTargetsWithJobRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) AssociateTargetsWithJobRequest(input *AssociateTargetsWithJobInput) (req *request.Request, output *AssociateTargetsWithJobOutput) {
+	op := &request.Operation{
+		Name:       opAssociateTargetsWithJob,
+		HTTPMethod: "POST",
+		HTTPPath:   "/jobs/{jobId}/targets",
+	}
+
+	if input == nil {
+		input = &AssociateTargetsWithJobInput{}
+	}
+
+	output = &AssociateTargetsWithJobOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// AssociateTargetsWithJob API operation for AWS IoT.
+//
+// Associates a group with a continuous job. The following criteria must be
+// met:
+//
+//    * The job must have been created with the targetSelection field set to
+//    "CONTINUOUS".
+//
+//    * The job status must currently be "IN_PROGRESS".
+//
+//    * The total number of targets associated with a job must not exceed 100.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation AssociateTargetsWithJob for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   The number of attached entities exceeds the limit.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+func (c *IoT) AssociateTargetsWithJob(input *AssociateTargetsWithJobInput) (*AssociateTargetsWithJobOutput, error) {
+	req, out := c.AssociateTargetsWithJobRequest(input)
+	return out, req.Send()
+}
+
+// AssociateTargetsWithJobWithContext is the same as AssociateTargetsWithJob with the addition of
+// the ability to pass a context and additional request options.
+//
+// See AssociateTargetsWithJob for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) AssociateTargetsWithJobWithContext(ctx aws.Context, input *AssociateTargetsWithJobInput, opts ...request.Option) (*AssociateTargetsWithJobOutput, error) {
+	req, out := c.AssociateTargetsWithJobRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opAttachPolicy = "AttachPolicy"
+
+// AttachPolicyRequest generates a "aws/request.Request" representing the
+// client's request for the AttachPolicy operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See AttachPolicy for more information on using the AttachPolicy
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the AttachPolicyRequest method.
+//    req, resp := client.AttachPolicyRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) AttachPolicyRequest(input *AttachPolicyInput) (req *request.Request, output *AttachPolicyOutput) {
+	op := &request.Operation{
+		Name:       opAttachPolicy,
+		HTTPMethod: "PUT",
+		HTTPPath:   "/target-policies/{policyName}",
+	}
+
+	if input == nil {
+		input = &AttachPolicyInput{}
+	}
+
+	output = &AttachPolicyOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restjson.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// AttachPolicy API operation for AWS IoT.
+//
+// Attaches a policy to the specified target.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation AttachPolicy for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeUnauthorizedException "UnauthorizedException"
+//   You are not authorized to perform this operation.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   The number of attached entities exceeds the limit.
+//
+func (c *IoT) AttachPolicy(input *AttachPolicyInput) (*AttachPolicyOutput, error) {
+	req, out := c.AttachPolicyRequest(input)
+	return out, req.Send()
+}
+
+// AttachPolicyWithContext is the same as AttachPolicy with the addition of
+// the ability to pass a context and additional request options.
+//
+// See AttachPolicy for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) AttachPolicyWithContext(ctx aws.Context, input *AttachPolicyInput, opts ...request.Option) (*AttachPolicyOutput, error) {
+	req, out := c.AttachPolicyRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opAttachPrincipalPolicy = "AttachPrincipalPolicy"
 
 // AttachPrincipalPolicyRequest generates a "aws/request.Request" representing the
@@ -139,6 +416,9 @@ const opAttachPrincipalPolicy = "AttachPrincipalPolicy"
 //        fmt.Println(resp)
 //    }
 func (c *IoT) AttachPrincipalPolicyRequest(input *AttachPrincipalPolicyInput) (req *request.Request, output *AttachPrincipalPolicyOutput) {
+	if c.Client.Config.Logger != nil {
+		c.Client.Config.Logger.Log("This operation, AttachPrincipalPolicy, has been deprecated")
+	}
 	op := &request.Operation{
 		Name:       opAttachPrincipalPolicy,
 		HTTPMethod: "PUT",
@@ -160,6 +440,8 @@ func (c *IoT) AttachPrincipalPolicyRequest(input *AttachPrincipalPolicyInput) (r
 //
 // Attaches the specified policy to the specified principal (certificate or
 // other credential).
+//
+// Note: This API is deprecated. Please use AttachPolicy instead.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -408,6 +690,276 @@ func (c *IoT) CancelCertificateTransferWithContext(ctx aws.Context, input *Cance
 	return out, req.Send()
 }
 
+const opCancelJob = "CancelJob"
+
+// CancelJobRequest generates a "aws/request.Request" representing the
+// client's request for the CancelJob operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See CancelJob for more information on using the CancelJob
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the CancelJobRequest method.
+//    req, resp := client.CancelJobRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) CancelJobRequest(input *CancelJobInput) (req *request.Request, output *CancelJobOutput) {
+	op := &request.Operation{
+		Name:       opCancelJob,
+		HTTPMethod: "PUT",
+		HTTPPath:   "/jobs/{jobId}/cancel",
+	}
+
+	if input == nil {
+		input = &CancelJobInput{}
+	}
+
+	output = &CancelJobOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// CancelJob API operation for AWS IoT.
+//
+// Cancels a job.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation CancelJob for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+func (c *IoT) CancelJob(input *CancelJobInput) (*CancelJobOutput, error) {
+	req, out := c.CancelJobRequest(input)
+	return out, req.Send()
+}
+
+// CancelJobWithContext is the same as CancelJob with the addition of
+// the ability to pass a context and additional request options.
+//
+// See CancelJob for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) CancelJobWithContext(ctx aws.Context, input *CancelJobInput, opts ...request.Option) (*CancelJobOutput, error) {
+	req, out := c.CancelJobRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opClearDefaultAuthorizer = "ClearDefaultAuthorizer"
+
+// ClearDefaultAuthorizerRequest generates a "aws/request.Request" representing the
+// client's request for the ClearDefaultAuthorizer operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ClearDefaultAuthorizer for more information on using the ClearDefaultAuthorizer
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ClearDefaultAuthorizerRequest method.
+//    req, resp := client.ClearDefaultAuthorizerRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) ClearDefaultAuthorizerRequest(input *ClearDefaultAuthorizerInput) (req *request.Request, output *ClearDefaultAuthorizerOutput) {
+	op := &request.Operation{
+		Name:       opClearDefaultAuthorizer,
+		HTTPMethod: "DELETE",
+		HTTPPath:   "/default-authorizer",
+	}
+
+	if input == nil {
+		input = &ClearDefaultAuthorizerInput{}
+	}
+
+	output = &ClearDefaultAuthorizerOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ClearDefaultAuthorizer API operation for AWS IoT.
+//
+// Clears the default authorizer.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation ClearDefaultAuthorizer for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeUnauthorizedException "UnauthorizedException"
+//   You are not authorized to perform this operation.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+func (c *IoT) ClearDefaultAuthorizer(input *ClearDefaultAuthorizerInput) (*ClearDefaultAuthorizerOutput, error) {
+	req, out := c.ClearDefaultAuthorizerRequest(input)
+	return out, req.Send()
+}
+
+// ClearDefaultAuthorizerWithContext is the same as ClearDefaultAuthorizer with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ClearDefaultAuthorizer for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) ClearDefaultAuthorizerWithContext(ctx aws.Context, input *ClearDefaultAuthorizerInput, opts ...request.Option) (*ClearDefaultAuthorizerOutput, error) {
+	req, out := c.ClearDefaultAuthorizerRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opCreateAuthorizer = "CreateAuthorizer"
+
+// CreateAuthorizerRequest generates a "aws/request.Request" representing the
+// client's request for the CreateAuthorizer operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See CreateAuthorizer for more information on using the CreateAuthorizer
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the CreateAuthorizerRequest method.
+//    req, resp := client.CreateAuthorizerRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) CreateAuthorizerRequest(input *CreateAuthorizerInput) (req *request.Request, output *CreateAuthorizerOutput) {
+	op := &request.Operation{
+		Name:       opCreateAuthorizer,
+		HTTPMethod: "POST",
+		HTTPPath:   "/authorizer/{authorizerName}",
+	}
+
+	if input == nil {
+		input = &CreateAuthorizerInput{}
+	}
+
+	output = &CreateAuthorizerOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// CreateAuthorizer API operation for AWS IoT.
+//
+// Creates an authorizer.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation CreateAuthorizer for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceAlreadyExistsException "ResourceAlreadyExistsException"
+//   The resource already exists.
+//
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   The number of attached entities exceeds the limit.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeUnauthorizedException "UnauthorizedException"
+//   You are not authorized to perform this operation.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+func (c *IoT) CreateAuthorizer(input *CreateAuthorizerInput) (*CreateAuthorizerOutput, error) {
+	req, out := c.CreateAuthorizerRequest(input)
+	return out, req.Send()
+}
+
+// CreateAuthorizerWithContext is the same as CreateAuthorizer with the addition of
+// the ability to pass a context and additional request options.
+//
+// See CreateAuthorizer for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) CreateAuthorizerWithContext(ctx aws.Context, input *CreateAuthorizerInput, opts ...request.Option) (*CreateAuthorizerOutput, error) {
+	req, out := c.CreateAuthorizerRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opCreateCertificateFromCsr = "CreateCertificateFromCsr"
 
 // CreateCertificateFromCsrRequest generates a "aws/request.Request" representing the
@@ -532,6 +1084,97 @@ func (c *IoT) CreateCertificateFromCsr(input *CreateCertificateFromCsrInput) (*C
 // for more information on using Contexts.
 func (c *IoT) CreateCertificateFromCsrWithContext(ctx aws.Context, input *CreateCertificateFromCsrInput, opts ...request.Option) (*CreateCertificateFromCsrOutput, error) {
 	req, out := c.CreateCertificateFromCsrRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opCreateJob = "CreateJob"
+
+// CreateJobRequest generates a "aws/request.Request" representing the
+// client's request for the CreateJob operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See CreateJob for more information on using the CreateJob
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the CreateJobRequest method.
+//    req, resp := client.CreateJobRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) CreateJobRequest(input *CreateJobInput) (req *request.Request, output *CreateJobOutput) {
+	op := &request.Operation{
+		Name:       opCreateJob,
+		HTTPMethod: "PUT",
+		HTTPPath:   "/jobs/{jobId}",
+	}
+
+	if input == nil {
+		input = &CreateJobInput{}
+	}
+
+	output = &CreateJobOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// CreateJob API operation for AWS IoT.
+//
+// Creates a job.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation CreateJob for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+//   * ErrCodeResourceAlreadyExistsException "ResourceAlreadyExistsException"
+//   The resource already exists.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   The number of attached entities exceeds the limit.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+func (c *IoT) CreateJob(input *CreateJobInput) (*CreateJobOutput, error) {
+	req, out := c.CreateJobRequest(input)
+	return out, req.Send()
+}
+
+// CreateJobWithContext is the same as CreateJob with the addition of
+// the ability to pass a context and additional request options.
+//
+// See CreateJob for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) CreateJobWithContext(ctx aws.Context, input *CreateJobInput, opts ...request.Option) (*CreateJobOutput, error) {
+	req, out := c.CreateJobRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -831,6 +1474,100 @@ func (c *IoT) CreatePolicyVersionWithContext(ctx aws.Context, input *CreatePolic
 	return out, req.Send()
 }
 
+const opCreateRoleAlias = "CreateRoleAlias"
+
+// CreateRoleAliasRequest generates a "aws/request.Request" representing the
+// client's request for the CreateRoleAlias operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See CreateRoleAlias for more information on using the CreateRoleAlias
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the CreateRoleAliasRequest method.
+//    req, resp := client.CreateRoleAliasRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) CreateRoleAliasRequest(input *CreateRoleAliasInput) (req *request.Request, output *CreateRoleAliasOutput) {
+	op := &request.Operation{
+		Name:       opCreateRoleAlias,
+		HTTPMethod: "POST",
+		HTTPPath:   "/role-aliases/{roleAlias}",
+	}
+
+	if input == nil {
+		input = &CreateRoleAliasInput{}
+	}
+
+	output = &CreateRoleAliasOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// CreateRoleAlias API operation for AWS IoT.
+//
+// Creates a role alias.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation CreateRoleAlias for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceAlreadyExistsException "ResourceAlreadyExistsException"
+//   The resource already exists.
+//
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   The number of attached entities exceeds the limit.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeUnauthorizedException "UnauthorizedException"
+//   You are not authorized to perform this operation.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+func (c *IoT) CreateRoleAlias(input *CreateRoleAliasInput) (*CreateRoleAliasOutput, error) {
+	req, out := c.CreateRoleAliasRequest(input)
+	return out, req.Send()
+}
+
+// CreateRoleAliasWithContext is the same as CreateRoleAlias with the addition of
+// the ability to pass a context and additional request options.
+//
+// See CreateRoleAlias for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) CreateRoleAliasWithContext(ctx aws.Context, input *CreateRoleAliasInput, opts ...request.Option) (*CreateRoleAliasOutput, error) {
+	req, out := c.CreateRoleAliasRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opCreateThing = "CreateThing"
 
 // CreateThingRequest generates a "aws/request.Request" representing the
@@ -920,6 +1657,91 @@ func (c *IoT) CreateThing(input *CreateThingInput) (*CreateThingOutput, error) {
 // for more information on using Contexts.
 func (c *IoT) CreateThingWithContext(ctx aws.Context, input *CreateThingInput, opts ...request.Option) (*CreateThingOutput, error) {
 	req, out := c.CreateThingRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opCreateThingGroup = "CreateThingGroup"
+
+// CreateThingGroupRequest generates a "aws/request.Request" representing the
+// client's request for the CreateThingGroup operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See CreateThingGroup for more information on using the CreateThingGroup
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the CreateThingGroupRequest method.
+//    req, resp := client.CreateThingGroupRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) CreateThingGroupRequest(input *CreateThingGroupInput) (req *request.Request, output *CreateThingGroupOutput) {
+	op := &request.Operation{
+		Name:       opCreateThingGroup,
+		HTTPMethod: "POST",
+		HTTPPath:   "/thing-groups/{thingGroupName}",
+	}
+
+	if input == nil {
+		input = &CreateThingGroupInput{}
+	}
+
+	output = &CreateThingGroupOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// CreateThingGroup API operation for AWS IoT.
+//
+// Create a thing group.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation CreateThingGroup for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeResourceAlreadyExistsException "ResourceAlreadyExistsException"
+//   The resource already exists.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+func (c *IoT) CreateThingGroup(input *CreateThingGroupInput) (*CreateThingGroupOutput, error) {
+	req, out := c.CreateThingGroupRequest(input)
+	return out, req.Send()
+}
+
+// CreateThingGroupWithContext is the same as CreateThingGroup with the addition of
+// the ability to pass a context and additional request options.
+//
+// See CreateThingGroup for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) CreateThingGroupWithContext(ctx aws.Context, input *CreateThingGroupInput, opts ...request.Option) (*CreateThingGroupOutput, error) {
+	req, out := c.CreateThingGroupRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -1103,6 +1925,100 @@ func (c *IoT) CreateTopicRule(input *CreateTopicRuleInput) (*CreateTopicRuleOutp
 // for more information on using Contexts.
 func (c *IoT) CreateTopicRuleWithContext(ctx aws.Context, input *CreateTopicRuleInput, opts ...request.Option) (*CreateTopicRuleOutput, error) {
 	req, out := c.CreateTopicRuleRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDeleteAuthorizer = "DeleteAuthorizer"
+
+// DeleteAuthorizerRequest generates a "aws/request.Request" representing the
+// client's request for the DeleteAuthorizer operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DeleteAuthorizer for more information on using the DeleteAuthorizer
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DeleteAuthorizerRequest method.
+//    req, resp := client.DeleteAuthorizerRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) DeleteAuthorizerRequest(input *DeleteAuthorizerInput) (req *request.Request, output *DeleteAuthorizerOutput) {
+	op := &request.Operation{
+		Name:       opDeleteAuthorizer,
+		HTTPMethod: "DELETE",
+		HTTPPath:   "/authorizer/{authorizerName}",
+	}
+
+	if input == nil {
+		input = &DeleteAuthorizerInput{}
+	}
+
+	output = &DeleteAuthorizerOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DeleteAuthorizer API operation for AWS IoT.
+//
+// Deletes an authorizer.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation DeleteAuthorizer for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeDeleteConflictException "DeleteConflictException"
+//   You can't delete the resource because it is attached to one or more resources.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeUnauthorizedException "UnauthorizedException"
+//   You are not authorized to perform this operation.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+func (c *IoT) DeleteAuthorizer(input *DeleteAuthorizerInput) (*DeleteAuthorizerOutput, error) {
+	req, out := c.DeleteAuthorizerRequest(input)
+	return out, req.Send()
+}
+
+// DeleteAuthorizerWithContext is the same as DeleteAuthorizer with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeleteAuthorizer for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) DeleteAuthorizerWithContext(ctx aws.Context, input *DeleteAuthorizerInput, opts ...request.Option) (*DeleteAuthorizerOutput, error) {
+	req, out := c.DeleteAuthorizerRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -1599,6 +2515,100 @@ func (c *IoT) DeleteRegistrationCodeWithContext(ctx aws.Context, input *DeleteRe
 	return out, req.Send()
 }
 
+const opDeleteRoleAlias = "DeleteRoleAlias"
+
+// DeleteRoleAliasRequest generates a "aws/request.Request" representing the
+// client's request for the DeleteRoleAlias operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DeleteRoleAlias for more information on using the DeleteRoleAlias
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DeleteRoleAliasRequest method.
+//    req, resp := client.DeleteRoleAliasRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) DeleteRoleAliasRequest(input *DeleteRoleAliasInput) (req *request.Request, output *DeleteRoleAliasOutput) {
+	op := &request.Operation{
+		Name:       opDeleteRoleAlias,
+		HTTPMethod: "DELETE",
+		HTTPPath:   "/role-aliases/{roleAlias}",
+	}
+
+	if input == nil {
+		input = &DeleteRoleAliasInput{}
+	}
+
+	output = &DeleteRoleAliasOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DeleteRoleAlias API operation for AWS IoT.
+//
+// Deletes a role alias
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation DeleteRoleAlias for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeDeleteConflictException "DeleteConflictException"
+//   You can't delete the resource because it is attached to one or more resources.
+//
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeUnauthorizedException "UnauthorizedException"
+//   You are not authorized to perform this operation.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+func (c *IoT) DeleteRoleAlias(input *DeleteRoleAliasInput) (*DeleteRoleAliasOutput, error) {
+	req, out := c.DeleteRoleAliasRequest(input)
+	return out, req.Send()
+}
+
+// DeleteRoleAliasWithContext is the same as DeleteRoleAlias with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeleteRoleAlias for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) DeleteRoleAliasWithContext(ctx aws.Context, input *DeleteRoleAliasInput, opts ...request.Option) (*DeleteRoleAliasOutput, error) {
+	req, out := c.DeleteRoleAliasRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opDeleteThing = "DeleteThing"
 
 // DeleteThingRequest generates a "aws/request.Request" representing the
@@ -1689,6 +2699,92 @@ func (c *IoT) DeleteThing(input *DeleteThingInput) (*DeleteThingOutput, error) {
 // for more information on using Contexts.
 func (c *IoT) DeleteThingWithContext(ctx aws.Context, input *DeleteThingInput, opts ...request.Option) (*DeleteThingOutput, error) {
 	req, out := c.DeleteThingRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDeleteThingGroup = "DeleteThingGroup"
+
+// DeleteThingGroupRequest generates a "aws/request.Request" representing the
+// client's request for the DeleteThingGroup operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DeleteThingGroup for more information on using the DeleteThingGroup
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DeleteThingGroupRequest method.
+//    req, resp := client.DeleteThingGroupRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) DeleteThingGroupRequest(input *DeleteThingGroupInput) (req *request.Request, output *DeleteThingGroupOutput) {
+	op := &request.Operation{
+		Name:       opDeleteThingGroup,
+		HTTPMethod: "DELETE",
+		HTTPPath:   "/thing-groups/{thingGroupName}",
+	}
+
+	if input == nil {
+		input = &DeleteThingGroupInput{}
+	}
+
+	output = &DeleteThingGroupOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DeleteThingGroup API operation for AWS IoT.
+//
+// Deletes a thing group.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation DeleteThingGroup for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeVersionConflictException "VersionConflictException"
+//   An exception thrown when the version of a thing passed to a command is different
+//   than the version specified with the --version parameter.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+func (c *IoT) DeleteThingGroup(input *DeleteThingGroupInput) (*DeleteThingGroupOutput, error) {
+	req, out := c.DeleteThingGroupRequest(input)
+	return out, req.Send()
+}
+
+// DeleteThingGroupWithContext is the same as DeleteThingGroup with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeleteThingGroup for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) DeleteThingGroupWithContext(ctx aws.Context, input *DeleteThingGroupInput, opts ...request.Option) (*DeleteThingGroupOutput, error) {
+	req, out := c.DeleteThingGroupRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -1833,7 +2929,7 @@ func (c *IoT) DeleteTopicRuleRequest(input *DeleteTopicRuleInput) (req *request.
 
 // DeleteTopicRule API operation for AWS IoT.
 //
-// Deletes the specified rule.
+// Deletes the rule.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1871,6 +2967,90 @@ func (c *IoT) DeleteTopicRule(input *DeleteTopicRuleInput) (*DeleteTopicRuleOutp
 // for more information on using Contexts.
 func (c *IoT) DeleteTopicRuleWithContext(ctx aws.Context, input *DeleteTopicRuleInput, opts ...request.Option) (*DeleteTopicRuleOutput, error) {
 	req, out := c.DeleteTopicRuleRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDeleteV2LoggingLevel = "DeleteV2LoggingLevel"
+
+// DeleteV2LoggingLevelRequest generates a "aws/request.Request" representing the
+// client's request for the DeleteV2LoggingLevel operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DeleteV2LoggingLevel for more information on using the DeleteV2LoggingLevel
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DeleteV2LoggingLevelRequest method.
+//    req, resp := client.DeleteV2LoggingLevelRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) DeleteV2LoggingLevelRequest(input *DeleteV2LoggingLevelInput) (req *request.Request, output *DeleteV2LoggingLevelOutput) {
+	op := &request.Operation{
+		Name:       opDeleteV2LoggingLevel,
+		HTTPMethod: "DELETE",
+		HTTPPath:   "/v2LoggingLevel",
+	}
+
+	if input == nil {
+		input = &DeleteV2LoggingLevelInput{}
+	}
+
+	output = &DeleteV2LoggingLevelOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restjson.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// DeleteV2LoggingLevel API operation for AWS IoT.
+//
+// Deletes a logging level.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation DeleteV2LoggingLevel for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalException "InternalException"
+//   An unexpected error has occurred.
+//
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+func (c *IoT) DeleteV2LoggingLevel(input *DeleteV2LoggingLevelInput) (*DeleteV2LoggingLevelOutput, error) {
+	req, out := c.DeleteV2LoggingLevelRequest(input)
+	return out, req.Send()
+}
+
+// DeleteV2LoggingLevelWithContext is the same as DeleteV2LoggingLevel with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeleteV2LoggingLevel for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) DeleteV2LoggingLevelWithContext(ctx aws.Context, input *DeleteV2LoggingLevelInput, opts ...request.Option) (*DeleteV2LoggingLevelOutput, error) {
+	req, out := c.DeleteV2LoggingLevelRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -1963,6 +3143,97 @@ func (c *IoT) DeprecateThingType(input *DeprecateThingTypeInput) (*DeprecateThin
 // for more information on using Contexts.
 func (c *IoT) DeprecateThingTypeWithContext(ctx aws.Context, input *DeprecateThingTypeInput, opts ...request.Option) (*DeprecateThingTypeOutput, error) {
 	req, out := c.DeprecateThingTypeRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDescribeAuthorizer = "DescribeAuthorizer"
+
+// DescribeAuthorizerRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeAuthorizer operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeAuthorizer for more information on using the DescribeAuthorizer
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeAuthorizerRequest method.
+//    req, resp := client.DescribeAuthorizerRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) DescribeAuthorizerRequest(input *DescribeAuthorizerInput) (req *request.Request, output *DescribeAuthorizerOutput) {
+	op := &request.Operation{
+		Name:       opDescribeAuthorizer,
+		HTTPMethod: "GET",
+		HTTPPath:   "/authorizer/{authorizerName}",
+	}
+
+	if input == nil {
+		input = &DescribeAuthorizerInput{}
+	}
+
+	output = &DescribeAuthorizerOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeAuthorizer API operation for AWS IoT.
+//
+// Describes an authorizer.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation DescribeAuthorizer for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeUnauthorizedException "UnauthorizedException"
+//   You are not authorized to perform this operation.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+func (c *IoT) DescribeAuthorizer(input *DescribeAuthorizerInput) (*DescribeAuthorizerOutput, error) {
+	req, out := c.DescribeAuthorizerRequest(input)
+	return out, req.Send()
+}
+
+// DescribeAuthorizerWithContext is the same as DescribeAuthorizer with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeAuthorizer for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) DescribeAuthorizerWithContext(ctx aws.Context, input *DescribeAuthorizerInput, opts ...request.Option) (*DescribeAuthorizerOutput, error) {
+	req, out := c.DescribeAuthorizerRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -2101,7 +3372,8 @@ func (c *IoT) DescribeCertificateRequest(input *DescribeCertificateInput) (req *
 
 // DescribeCertificate API operation for AWS IoT.
 //
-// Gets information about the specified certificate.
+// Gets information about the specified certificate. You may specify the certificate
+// using either its ID or PEM.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2145,6 +3417,97 @@ func (c *IoT) DescribeCertificate(input *DescribeCertificateInput) (*DescribeCer
 // for more information on using Contexts.
 func (c *IoT) DescribeCertificateWithContext(ctx aws.Context, input *DescribeCertificateInput, opts ...request.Option) (*DescribeCertificateOutput, error) {
 	req, out := c.DescribeCertificateRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDescribeDefaultAuthorizer = "DescribeDefaultAuthorizer"
+
+// DescribeDefaultAuthorizerRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeDefaultAuthorizer operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeDefaultAuthorizer for more information on using the DescribeDefaultAuthorizer
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeDefaultAuthorizerRequest method.
+//    req, resp := client.DescribeDefaultAuthorizerRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) DescribeDefaultAuthorizerRequest(input *DescribeDefaultAuthorizerInput) (req *request.Request, output *DescribeDefaultAuthorizerOutput) {
+	op := &request.Operation{
+		Name:       opDescribeDefaultAuthorizer,
+		HTTPMethod: "GET",
+		HTTPPath:   "/default-authorizer",
+	}
+
+	if input == nil {
+		input = &DescribeDefaultAuthorizerInput{}
+	}
+
+	output = &DescribeDefaultAuthorizerOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeDefaultAuthorizer API operation for AWS IoT.
+//
+// Describes the default authorizer.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation DescribeDefaultAuthorizer for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeUnauthorizedException "UnauthorizedException"
+//   You are not authorized to perform this operation.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+func (c *IoT) DescribeDefaultAuthorizer(input *DescribeDefaultAuthorizerInput) (*DescribeDefaultAuthorizerOutput, error) {
+	req, out := c.DescribeDefaultAuthorizerRequest(input)
+	return out, req.Send()
+}
+
+// DescribeDefaultAuthorizerWithContext is the same as DescribeDefaultAuthorizer with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeDefaultAuthorizer for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) DescribeDefaultAuthorizerWithContext(ctx aws.Context, input *DescribeDefaultAuthorizerInput, opts ...request.Option) (*DescribeDefaultAuthorizerOutput, error) {
+	req, out := c.DescribeDefaultAuthorizerRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -2205,6 +3568,9 @@ func (c *IoT) DescribeEndpointRequest(input *DescribeEndpointInput) (req *reques
 //   * ErrCodeInternalFailureException "InternalFailureException"
 //   An unexpected error has occurred.
 //
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
 //   * ErrCodeUnauthorizedException "UnauthorizedException"
 //   You are not authorized to perform this operation.
 //
@@ -2227,6 +3593,437 @@ func (c *IoT) DescribeEndpoint(input *DescribeEndpointInput) (*DescribeEndpointO
 // for more information on using Contexts.
 func (c *IoT) DescribeEndpointWithContext(ctx aws.Context, input *DescribeEndpointInput, opts ...request.Option) (*DescribeEndpointOutput, error) {
 	req, out := c.DescribeEndpointRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDescribeEventConfigurations = "DescribeEventConfigurations"
+
+// DescribeEventConfigurationsRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeEventConfigurations operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeEventConfigurations for more information on using the DescribeEventConfigurations
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeEventConfigurationsRequest method.
+//    req, resp := client.DescribeEventConfigurationsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) DescribeEventConfigurationsRequest(input *DescribeEventConfigurationsInput) (req *request.Request, output *DescribeEventConfigurationsOutput) {
+	op := &request.Operation{
+		Name:       opDescribeEventConfigurations,
+		HTTPMethod: "GET",
+		HTTPPath:   "/event-configurations",
+	}
+
+	if input == nil {
+		input = &DescribeEventConfigurationsInput{}
+	}
+
+	output = &DescribeEventConfigurationsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeEventConfigurations API operation for AWS IoT.
+//
+// Describes event configurations.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation DescribeEventConfigurations for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+func (c *IoT) DescribeEventConfigurations(input *DescribeEventConfigurationsInput) (*DescribeEventConfigurationsOutput, error) {
+	req, out := c.DescribeEventConfigurationsRequest(input)
+	return out, req.Send()
+}
+
+// DescribeEventConfigurationsWithContext is the same as DescribeEventConfigurations with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeEventConfigurations for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) DescribeEventConfigurationsWithContext(ctx aws.Context, input *DescribeEventConfigurationsInput, opts ...request.Option) (*DescribeEventConfigurationsOutput, error) {
+	req, out := c.DescribeEventConfigurationsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDescribeIndex = "DescribeIndex"
+
+// DescribeIndexRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeIndex operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeIndex for more information on using the DescribeIndex
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeIndexRequest method.
+//    req, resp := client.DescribeIndexRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) DescribeIndexRequest(input *DescribeIndexInput) (req *request.Request, output *DescribeIndexOutput) {
+	op := &request.Operation{
+		Name:       opDescribeIndex,
+		HTTPMethod: "GET",
+		HTTPPath:   "/indices/{indexName}",
+	}
+
+	if input == nil {
+		input = &DescribeIndexInput{}
+	}
+
+	output = &DescribeIndexOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeIndex API operation for AWS IoT.
+//
+// Describes a search index.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation DescribeIndex for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeUnauthorizedException "UnauthorizedException"
+//   You are not authorized to perform this operation.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+func (c *IoT) DescribeIndex(input *DescribeIndexInput) (*DescribeIndexOutput, error) {
+	req, out := c.DescribeIndexRequest(input)
+	return out, req.Send()
+}
+
+// DescribeIndexWithContext is the same as DescribeIndex with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeIndex for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) DescribeIndexWithContext(ctx aws.Context, input *DescribeIndexInput, opts ...request.Option) (*DescribeIndexOutput, error) {
+	req, out := c.DescribeIndexRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDescribeJob = "DescribeJob"
+
+// DescribeJobRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeJob operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeJob for more information on using the DescribeJob
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeJobRequest method.
+//    req, resp := client.DescribeJobRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) DescribeJobRequest(input *DescribeJobInput) (req *request.Request, output *DescribeJobOutput) {
+	op := &request.Operation{
+		Name:       opDescribeJob,
+		HTTPMethod: "GET",
+		HTTPPath:   "/jobs/{jobId}",
+	}
+
+	if input == nil {
+		input = &DescribeJobInput{}
+	}
+
+	output = &DescribeJobOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeJob API operation for AWS IoT.
+//
+// Describes a job.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation DescribeJob for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+func (c *IoT) DescribeJob(input *DescribeJobInput) (*DescribeJobOutput, error) {
+	req, out := c.DescribeJobRequest(input)
+	return out, req.Send()
+}
+
+// DescribeJobWithContext is the same as DescribeJob with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeJob for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) DescribeJobWithContext(ctx aws.Context, input *DescribeJobInput, opts ...request.Option) (*DescribeJobOutput, error) {
+	req, out := c.DescribeJobRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDescribeJobExecution = "DescribeJobExecution"
+
+// DescribeJobExecutionRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeJobExecution operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeJobExecution for more information on using the DescribeJobExecution
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeJobExecutionRequest method.
+//    req, resp := client.DescribeJobExecutionRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) DescribeJobExecutionRequest(input *DescribeJobExecutionInput) (req *request.Request, output *DescribeJobExecutionOutput) {
+	op := &request.Operation{
+		Name:       opDescribeJobExecution,
+		HTTPMethod: "GET",
+		HTTPPath:   "/things/{thingName}/jobs/{jobId}",
+	}
+
+	if input == nil {
+		input = &DescribeJobExecutionInput{}
+	}
+
+	output = &DescribeJobExecutionOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeJobExecution API operation for AWS IoT.
+//
+// Describes a job execution.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation DescribeJobExecution for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+func (c *IoT) DescribeJobExecution(input *DescribeJobExecutionInput) (*DescribeJobExecutionOutput, error) {
+	req, out := c.DescribeJobExecutionRequest(input)
+	return out, req.Send()
+}
+
+// DescribeJobExecutionWithContext is the same as DescribeJobExecution with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeJobExecution for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) DescribeJobExecutionWithContext(ctx aws.Context, input *DescribeJobExecutionInput, opts ...request.Option) (*DescribeJobExecutionOutput, error) {
+	req, out := c.DescribeJobExecutionRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDescribeRoleAlias = "DescribeRoleAlias"
+
+// DescribeRoleAliasRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeRoleAlias operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeRoleAlias for more information on using the DescribeRoleAlias
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeRoleAliasRequest method.
+//    req, resp := client.DescribeRoleAliasRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) DescribeRoleAliasRequest(input *DescribeRoleAliasInput) (req *request.Request, output *DescribeRoleAliasOutput) {
+	op := &request.Operation{
+		Name:       opDescribeRoleAlias,
+		HTTPMethod: "GET",
+		HTTPPath:   "/role-aliases/{roleAlias}",
+	}
+
+	if input == nil {
+		input = &DescribeRoleAliasInput{}
+	}
+
+	output = &DescribeRoleAliasOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeRoleAlias API operation for AWS IoT.
+//
+// Describes a role alias.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation DescribeRoleAlias for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeUnauthorizedException "UnauthorizedException"
+//   You are not authorized to perform this operation.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+func (c *IoT) DescribeRoleAlias(input *DescribeRoleAliasInput) (*DescribeRoleAliasOutput, error) {
+	req, out := c.DescribeRoleAliasRequest(input)
+	return out, req.Send()
+}
+
+// DescribeRoleAliasWithContext is the same as DescribeRoleAlias with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeRoleAlias for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) DescribeRoleAliasWithContext(ctx aws.Context, input *DescribeRoleAliasInput, opts ...request.Option) (*DescribeRoleAliasOutput, error) {
+	req, out := c.DescribeRoleAliasRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -2323,6 +4120,179 @@ func (c *IoT) DescribeThingWithContext(ctx aws.Context, input *DescribeThingInpu
 	return out, req.Send()
 }
 
+const opDescribeThingGroup = "DescribeThingGroup"
+
+// DescribeThingGroupRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeThingGroup operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeThingGroup for more information on using the DescribeThingGroup
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeThingGroupRequest method.
+//    req, resp := client.DescribeThingGroupRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) DescribeThingGroupRequest(input *DescribeThingGroupInput) (req *request.Request, output *DescribeThingGroupOutput) {
+	op := &request.Operation{
+		Name:       opDescribeThingGroup,
+		HTTPMethod: "GET",
+		HTTPPath:   "/thing-groups/{thingGroupName}",
+	}
+
+	if input == nil {
+		input = &DescribeThingGroupInput{}
+	}
+
+	output = &DescribeThingGroupOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeThingGroup API operation for AWS IoT.
+//
+// Describe a thing group.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation DescribeThingGroup for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+func (c *IoT) DescribeThingGroup(input *DescribeThingGroupInput) (*DescribeThingGroupOutput, error) {
+	req, out := c.DescribeThingGroupRequest(input)
+	return out, req.Send()
+}
+
+// DescribeThingGroupWithContext is the same as DescribeThingGroup with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeThingGroup for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) DescribeThingGroupWithContext(ctx aws.Context, input *DescribeThingGroupInput, opts ...request.Option) (*DescribeThingGroupOutput, error) {
+	req, out := c.DescribeThingGroupRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDescribeThingRegistrationTask = "DescribeThingRegistrationTask"
+
+// DescribeThingRegistrationTaskRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeThingRegistrationTask operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeThingRegistrationTask for more information on using the DescribeThingRegistrationTask
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeThingRegistrationTaskRequest method.
+//    req, resp := client.DescribeThingRegistrationTaskRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) DescribeThingRegistrationTaskRequest(input *DescribeThingRegistrationTaskInput) (req *request.Request, output *DescribeThingRegistrationTaskOutput) {
+	op := &request.Operation{
+		Name:       opDescribeThingRegistrationTask,
+		HTTPMethod: "GET",
+		HTTPPath:   "/thing-registration-tasks/{taskId}",
+	}
+
+	if input == nil {
+		input = &DescribeThingRegistrationTaskInput{}
+	}
+
+	output = &DescribeThingRegistrationTaskOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeThingRegistrationTask API operation for AWS IoT.
+//
+// Describes a bulk thing provisioning task.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation DescribeThingRegistrationTask for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeUnauthorizedException "UnauthorizedException"
+//   You are not authorized to perform this operation.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+func (c *IoT) DescribeThingRegistrationTask(input *DescribeThingRegistrationTaskInput) (*DescribeThingRegistrationTaskOutput, error) {
+	req, out := c.DescribeThingRegistrationTaskRequest(input)
+	return out, req.Send()
+}
+
+// DescribeThingRegistrationTaskWithContext is the same as DescribeThingRegistrationTask with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeThingRegistrationTask for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) DescribeThingRegistrationTaskWithContext(ctx aws.Context, input *DescribeThingRegistrationTaskInput, opts ...request.Option) (*DescribeThingRegistrationTaskOutput, error) {
+	req, out := c.DescribeThingRegistrationTaskRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opDescribeThingType = "DescribeThingType"
 
 // DescribeThingTypeRequest generates a "aws/request.Request" representing the
@@ -2414,6 +4384,99 @@ func (c *IoT) DescribeThingTypeWithContext(ctx aws.Context, input *DescribeThing
 	return out, req.Send()
 }
 
+const opDetachPolicy = "DetachPolicy"
+
+// DetachPolicyRequest generates a "aws/request.Request" representing the
+// client's request for the DetachPolicy operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DetachPolicy for more information on using the DetachPolicy
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DetachPolicyRequest method.
+//    req, resp := client.DetachPolicyRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) DetachPolicyRequest(input *DetachPolicyInput) (req *request.Request, output *DetachPolicyOutput) {
+	op := &request.Operation{
+		Name:       opDetachPolicy,
+		HTTPMethod: "POST",
+		HTTPPath:   "/target-policies/{policyName}",
+	}
+
+	if input == nil {
+		input = &DetachPolicyInput{}
+	}
+
+	output = &DetachPolicyOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restjson.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// DetachPolicy API operation for AWS IoT.
+//
+// Detaches a policy from the specified target.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation DetachPolicy for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeUnauthorizedException "UnauthorizedException"
+//   You are not authorized to perform this operation.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   The number of attached entities exceeds the limit.
+//
+func (c *IoT) DetachPolicy(input *DetachPolicyInput) (*DetachPolicyOutput, error) {
+	req, out := c.DetachPolicyRequest(input)
+	return out, req.Send()
+}
+
+// DetachPolicyWithContext is the same as DetachPolicy with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DetachPolicy for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) DetachPolicyWithContext(ctx aws.Context, input *DetachPolicyInput, opts ...request.Option) (*DetachPolicyOutput, error) {
+	req, out := c.DetachPolicyRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opDetachPrincipalPolicy = "DetachPrincipalPolicy"
 
 // DetachPrincipalPolicyRequest generates a "aws/request.Request" representing the
@@ -2439,6 +4502,9 @@ const opDetachPrincipalPolicy = "DetachPrincipalPolicy"
 //        fmt.Println(resp)
 //    }
 func (c *IoT) DetachPrincipalPolicyRequest(input *DetachPrincipalPolicyInput) (req *request.Request, output *DetachPrincipalPolicyOutput) {
+	if c.Client.Config.Logger != nil {
+		c.Client.Config.Logger.Log("This operation, DetachPrincipalPolicy, has been deprecated")
+	}
 	op := &request.Operation{
 		Name:       opDetachPrincipalPolicy,
 		HTTPMethod: "DELETE",
@@ -2459,6 +4525,8 @@ func (c *IoT) DetachPrincipalPolicyRequest(input *DetachPrincipalPolicyInput) (r
 // DetachPrincipalPolicy API operation for AWS IoT.
 //
 // Removes the specified policy from the specified certificate.
+//
+// Note: This API is deprecated. Please use DetachPolicy instead.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2642,7 +4710,7 @@ func (c *IoT) DisableTopicRuleRequest(input *DisableTopicRuleInput) (req *reques
 
 // DisableTopicRule API operation for AWS IoT.
 //
-// Disables the specified rule.
+// Disables the rule.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2729,7 +4797,7 @@ func (c *IoT) EnableTopicRuleRequest(input *EnableTopicRuleInput) (req *request.
 
 // EnableTopicRule API operation for AWS IoT.
 //
-// Enables the specified rule.
+// Enables the rule.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2767,6 +4835,273 @@ func (c *IoT) EnableTopicRule(input *EnableTopicRuleInput) (*EnableTopicRuleOutp
 // for more information on using Contexts.
 func (c *IoT) EnableTopicRuleWithContext(ctx aws.Context, input *EnableTopicRuleInput, opts ...request.Option) (*EnableTopicRuleOutput, error) {
 	req, out := c.EnableTopicRuleRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opGetEffectivePolicies = "GetEffectivePolicies"
+
+// GetEffectivePoliciesRequest generates a "aws/request.Request" representing the
+// client's request for the GetEffectivePolicies operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See GetEffectivePolicies for more information on using the GetEffectivePolicies
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the GetEffectivePoliciesRequest method.
+//    req, resp := client.GetEffectivePoliciesRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) GetEffectivePoliciesRequest(input *GetEffectivePoliciesInput) (req *request.Request, output *GetEffectivePoliciesOutput) {
+	op := &request.Operation{
+		Name:       opGetEffectivePolicies,
+		HTTPMethod: "POST",
+		HTTPPath:   "/effective-policies",
+	}
+
+	if input == nil {
+		input = &GetEffectivePoliciesInput{}
+	}
+
+	output = &GetEffectivePoliciesOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// GetEffectivePolicies API operation for AWS IoT.
+//
+// Gets effective policies.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation GetEffectivePolicies for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeUnauthorizedException "UnauthorizedException"
+//   You are not authorized to perform this operation.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   The number of attached entities exceeds the limit.
+//
+func (c *IoT) GetEffectivePolicies(input *GetEffectivePoliciesInput) (*GetEffectivePoliciesOutput, error) {
+	req, out := c.GetEffectivePoliciesRequest(input)
+	return out, req.Send()
+}
+
+// GetEffectivePoliciesWithContext is the same as GetEffectivePolicies with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetEffectivePolicies for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) GetEffectivePoliciesWithContext(ctx aws.Context, input *GetEffectivePoliciesInput, opts ...request.Option) (*GetEffectivePoliciesOutput, error) {
+	req, out := c.GetEffectivePoliciesRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opGetIndexingConfiguration = "GetIndexingConfiguration"
+
+// GetIndexingConfigurationRequest generates a "aws/request.Request" representing the
+// client's request for the GetIndexingConfiguration operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See GetIndexingConfiguration for more information on using the GetIndexingConfiguration
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the GetIndexingConfigurationRequest method.
+//    req, resp := client.GetIndexingConfigurationRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) GetIndexingConfigurationRequest(input *GetIndexingConfigurationInput) (req *request.Request, output *GetIndexingConfigurationOutput) {
+	op := &request.Operation{
+		Name:       opGetIndexingConfiguration,
+		HTTPMethod: "GET",
+		HTTPPath:   "/indexing/config",
+	}
+
+	if input == nil {
+		input = &GetIndexingConfigurationInput{}
+	}
+
+	output = &GetIndexingConfigurationOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// GetIndexingConfiguration API operation for AWS IoT.
+//
+// Gets the search configuration.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation GetIndexingConfiguration for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeUnauthorizedException "UnauthorizedException"
+//   You are not authorized to perform this operation.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+func (c *IoT) GetIndexingConfiguration(input *GetIndexingConfigurationInput) (*GetIndexingConfigurationOutput, error) {
+	req, out := c.GetIndexingConfigurationRequest(input)
+	return out, req.Send()
+}
+
+// GetIndexingConfigurationWithContext is the same as GetIndexingConfiguration with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetIndexingConfiguration for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) GetIndexingConfigurationWithContext(ctx aws.Context, input *GetIndexingConfigurationInput, opts ...request.Option) (*GetIndexingConfigurationOutput, error) {
+	req, out := c.GetIndexingConfigurationRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opGetJobDocument = "GetJobDocument"
+
+// GetJobDocumentRequest generates a "aws/request.Request" representing the
+// client's request for the GetJobDocument operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See GetJobDocument for more information on using the GetJobDocument
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the GetJobDocumentRequest method.
+//    req, resp := client.GetJobDocumentRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) GetJobDocumentRequest(input *GetJobDocumentInput) (req *request.Request, output *GetJobDocumentOutput) {
+	op := &request.Operation{
+		Name:       opGetJobDocument,
+		HTTPMethod: "GET",
+		HTTPPath:   "/jobs/{jobId}/job-document",
+	}
+
+	if input == nil {
+		input = &GetJobDocumentInput{}
+	}
+
+	output = &GetJobDocumentOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// GetJobDocument API operation for AWS IoT.
+//
+// Gets a job document.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation GetJobDocument for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+func (c *IoT) GetJobDocument(input *GetJobDocumentInput) (*GetJobDocumentOutput, error) {
+	req, out := c.GetJobDocumentRequest(input)
+	return out, req.Send()
+}
+
+// GetJobDocumentWithContext is the same as GetJobDocument with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetJobDocument for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) GetJobDocumentWithContext(ctx aws.Context, input *GetJobDocumentInput, opts ...request.Option) (*GetJobDocumentOutput, error) {
+	req, out := c.GetJobDocumentRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -3167,7 +5502,7 @@ func (c *IoT) GetTopicRuleRequest(input *GetTopicRuleInput) (req *request.Reques
 
 // GetTopicRule API operation for AWS IoT.
 //
-// Gets information about the specified rule.
+// Gets information about the rule.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3205,6 +5540,270 @@ func (c *IoT) GetTopicRule(input *GetTopicRuleInput) (*GetTopicRuleOutput, error
 // for more information on using Contexts.
 func (c *IoT) GetTopicRuleWithContext(ctx aws.Context, input *GetTopicRuleInput, opts ...request.Option) (*GetTopicRuleOutput, error) {
 	req, out := c.GetTopicRuleRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opGetV2LoggingOptions = "GetV2LoggingOptions"
+
+// GetV2LoggingOptionsRequest generates a "aws/request.Request" representing the
+// client's request for the GetV2LoggingOptions operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See GetV2LoggingOptions for more information on using the GetV2LoggingOptions
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the GetV2LoggingOptionsRequest method.
+//    req, resp := client.GetV2LoggingOptionsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) GetV2LoggingOptionsRequest(input *GetV2LoggingOptionsInput) (req *request.Request, output *GetV2LoggingOptionsOutput) {
+	op := &request.Operation{
+		Name:       opGetV2LoggingOptions,
+		HTTPMethod: "GET",
+		HTTPPath:   "/v2LoggingOptions",
+	}
+
+	if input == nil {
+		input = &GetV2LoggingOptionsInput{}
+	}
+
+	output = &GetV2LoggingOptionsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// GetV2LoggingOptions API operation for AWS IoT.
+//
+// Gets the fine grained logging options.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation GetV2LoggingOptions for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalException "InternalException"
+//   An unexpected error has occurred.
+//
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+func (c *IoT) GetV2LoggingOptions(input *GetV2LoggingOptionsInput) (*GetV2LoggingOptionsOutput, error) {
+	req, out := c.GetV2LoggingOptionsRequest(input)
+	return out, req.Send()
+}
+
+// GetV2LoggingOptionsWithContext is the same as GetV2LoggingOptions with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetV2LoggingOptions for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) GetV2LoggingOptionsWithContext(ctx aws.Context, input *GetV2LoggingOptionsInput, opts ...request.Option) (*GetV2LoggingOptionsOutput, error) {
+	req, out := c.GetV2LoggingOptionsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opListAttachedPolicies = "ListAttachedPolicies"
+
+// ListAttachedPoliciesRequest generates a "aws/request.Request" representing the
+// client's request for the ListAttachedPolicies operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ListAttachedPolicies for more information on using the ListAttachedPolicies
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ListAttachedPoliciesRequest method.
+//    req, resp := client.ListAttachedPoliciesRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) ListAttachedPoliciesRequest(input *ListAttachedPoliciesInput) (req *request.Request, output *ListAttachedPoliciesOutput) {
+	op := &request.Operation{
+		Name:       opListAttachedPolicies,
+		HTTPMethod: "POST",
+		HTTPPath:   "/attached-policies/{target}",
+	}
+
+	if input == nil {
+		input = &ListAttachedPoliciesInput{}
+	}
+
+	output = &ListAttachedPoliciesOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListAttachedPolicies API operation for AWS IoT.
+//
+// Lists the policies attached to the specified thing group.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation ListAttachedPolicies for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeUnauthorizedException "UnauthorizedException"
+//   You are not authorized to perform this operation.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   The number of attached entities exceeds the limit.
+//
+func (c *IoT) ListAttachedPolicies(input *ListAttachedPoliciesInput) (*ListAttachedPoliciesOutput, error) {
+	req, out := c.ListAttachedPoliciesRequest(input)
+	return out, req.Send()
+}
+
+// ListAttachedPoliciesWithContext is the same as ListAttachedPolicies with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListAttachedPolicies for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) ListAttachedPoliciesWithContext(ctx aws.Context, input *ListAttachedPoliciesInput, opts ...request.Option) (*ListAttachedPoliciesOutput, error) {
+	req, out := c.ListAttachedPoliciesRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opListAuthorizers = "ListAuthorizers"
+
+// ListAuthorizersRequest generates a "aws/request.Request" representing the
+// client's request for the ListAuthorizers operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ListAuthorizers for more information on using the ListAuthorizers
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ListAuthorizersRequest method.
+//    req, resp := client.ListAuthorizersRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) ListAuthorizersRequest(input *ListAuthorizersInput) (req *request.Request, output *ListAuthorizersOutput) {
+	op := &request.Operation{
+		Name:       opListAuthorizers,
+		HTTPMethod: "GET",
+		HTTPPath:   "/authorizers/",
+	}
+
+	if input == nil {
+		input = &ListAuthorizersInput{}
+	}
+
+	output = &ListAuthorizersOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListAuthorizers API operation for AWS IoT.
+//
+// Lists the authorizers registered in your account.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation ListAuthorizers for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeUnauthorizedException "UnauthorizedException"
+//   You are not authorized to perform this operation.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+func (c *IoT) ListAuthorizers(input *ListAuthorizersInput) (*ListAuthorizersOutput, error) {
+	req, out := c.ListAuthorizersRequest(input)
+	return out, req.Send()
+}
+
+// ListAuthorizersWithContext is the same as ListAuthorizers with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListAuthorizers for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) ListAuthorizersWithContext(ctx aws.Context, input *ListAuthorizersInput, opts ...request.Option) (*ListAuthorizersOutput, error) {
+	req, out := c.ListAuthorizersRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -3480,6 +6079,349 @@ func (c *IoT) ListCertificatesByCAWithContext(ctx aws.Context, input *ListCertif
 	return out, req.Send()
 }
 
+const opListIndices = "ListIndices"
+
+// ListIndicesRequest generates a "aws/request.Request" representing the
+// client's request for the ListIndices operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ListIndices for more information on using the ListIndices
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ListIndicesRequest method.
+//    req, resp := client.ListIndicesRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) ListIndicesRequest(input *ListIndicesInput) (req *request.Request, output *ListIndicesOutput) {
+	op := &request.Operation{
+		Name:       opListIndices,
+		HTTPMethod: "GET",
+		HTTPPath:   "/indices",
+	}
+
+	if input == nil {
+		input = &ListIndicesInput{}
+	}
+
+	output = &ListIndicesOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListIndices API operation for AWS IoT.
+//
+// Lists the search indices.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation ListIndices for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeUnauthorizedException "UnauthorizedException"
+//   You are not authorized to perform this operation.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+func (c *IoT) ListIndices(input *ListIndicesInput) (*ListIndicesOutput, error) {
+	req, out := c.ListIndicesRequest(input)
+	return out, req.Send()
+}
+
+// ListIndicesWithContext is the same as ListIndices with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListIndices for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) ListIndicesWithContext(ctx aws.Context, input *ListIndicesInput, opts ...request.Option) (*ListIndicesOutput, error) {
+	req, out := c.ListIndicesRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opListJobExecutionsForJob = "ListJobExecutionsForJob"
+
+// ListJobExecutionsForJobRequest generates a "aws/request.Request" representing the
+// client's request for the ListJobExecutionsForJob operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ListJobExecutionsForJob for more information on using the ListJobExecutionsForJob
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ListJobExecutionsForJobRequest method.
+//    req, resp := client.ListJobExecutionsForJobRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) ListJobExecutionsForJobRequest(input *ListJobExecutionsForJobInput) (req *request.Request, output *ListJobExecutionsForJobOutput) {
+	op := &request.Operation{
+		Name:       opListJobExecutionsForJob,
+		HTTPMethod: "GET",
+		HTTPPath:   "/jobs/{jobId}/things",
+	}
+
+	if input == nil {
+		input = &ListJobExecutionsForJobInput{}
+	}
+
+	output = &ListJobExecutionsForJobOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListJobExecutionsForJob API operation for AWS IoT.
+//
+// Lists the job executions for a job.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation ListJobExecutionsForJob for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+func (c *IoT) ListJobExecutionsForJob(input *ListJobExecutionsForJobInput) (*ListJobExecutionsForJobOutput, error) {
+	req, out := c.ListJobExecutionsForJobRequest(input)
+	return out, req.Send()
+}
+
+// ListJobExecutionsForJobWithContext is the same as ListJobExecutionsForJob with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListJobExecutionsForJob for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) ListJobExecutionsForJobWithContext(ctx aws.Context, input *ListJobExecutionsForJobInput, opts ...request.Option) (*ListJobExecutionsForJobOutput, error) {
+	req, out := c.ListJobExecutionsForJobRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opListJobExecutionsForThing = "ListJobExecutionsForThing"
+
+// ListJobExecutionsForThingRequest generates a "aws/request.Request" representing the
+// client's request for the ListJobExecutionsForThing operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ListJobExecutionsForThing for more information on using the ListJobExecutionsForThing
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ListJobExecutionsForThingRequest method.
+//    req, resp := client.ListJobExecutionsForThingRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) ListJobExecutionsForThingRequest(input *ListJobExecutionsForThingInput) (req *request.Request, output *ListJobExecutionsForThingOutput) {
+	op := &request.Operation{
+		Name:       opListJobExecutionsForThing,
+		HTTPMethod: "GET",
+		HTTPPath:   "/things/{thingName}/jobs",
+	}
+
+	if input == nil {
+		input = &ListJobExecutionsForThingInput{}
+	}
+
+	output = &ListJobExecutionsForThingOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListJobExecutionsForThing API operation for AWS IoT.
+//
+// Lists the job executions for the specified thing.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation ListJobExecutionsForThing for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+func (c *IoT) ListJobExecutionsForThing(input *ListJobExecutionsForThingInput) (*ListJobExecutionsForThingOutput, error) {
+	req, out := c.ListJobExecutionsForThingRequest(input)
+	return out, req.Send()
+}
+
+// ListJobExecutionsForThingWithContext is the same as ListJobExecutionsForThing with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListJobExecutionsForThing for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) ListJobExecutionsForThingWithContext(ctx aws.Context, input *ListJobExecutionsForThingInput, opts ...request.Option) (*ListJobExecutionsForThingOutput, error) {
+	req, out := c.ListJobExecutionsForThingRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opListJobs = "ListJobs"
+
+// ListJobsRequest generates a "aws/request.Request" representing the
+// client's request for the ListJobs operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ListJobs for more information on using the ListJobs
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ListJobsRequest method.
+//    req, resp := client.ListJobsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) ListJobsRequest(input *ListJobsInput) (req *request.Request, output *ListJobsOutput) {
+	op := &request.Operation{
+		Name:       opListJobs,
+		HTTPMethod: "GET",
+		HTTPPath:   "/jobs",
+	}
+
+	if input == nil {
+		input = &ListJobsInput{}
+	}
+
+	output = &ListJobsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListJobs API operation for AWS IoT.
+//
+// Lists jobs.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation ListJobs for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+func (c *IoT) ListJobs(input *ListJobsInput) (*ListJobsOutput, error) {
+	req, out := c.ListJobsRequest(input)
+	return out, req.Send()
+}
+
+// ListJobsWithContext is the same as ListJobs with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListJobs for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) ListJobsWithContext(ctx aws.Context, input *ListJobsInput, opts ...request.Option) (*ListJobsOutput, error) {
+	req, out := c.ListJobsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opListOutgoingCertificates = "ListOutgoingCertificates"
 
 // ListOutgoingCertificatesRequest generates a "aws/request.Request" representing the
@@ -3522,7 +6464,7 @@ func (c *IoT) ListOutgoingCertificatesRequest(input *ListOutgoingCertificatesInp
 
 // ListOutgoingCertificates API operation for AWS IoT.
 //
-// Lists certificates that are being transfered but not yet accepted.
+// Lists certificates that are being transferred but not yet accepted.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3681,6 +6623,9 @@ const opListPolicyPrincipals = "ListPolicyPrincipals"
 //        fmt.Println(resp)
 //    }
 func (c *IoT) ListPolicyPrincipalsRequest(input *ListPolicyPrincipalsInput) (req *request.Request, output *ListPolicyPrincipalsOutput) {
+	if c.Client.Config.Logger != nil {
+		c.Client.Config.Logger.Log("This operation, ListPolicyPrincipals, has been deprecated")
+	}
 	op := &request.Operation{
 		Name:       opListPolicyPrincipals,
 		HTTPMethod: "GET",
@@ -3699,6 +6644,8 @@ func (c *IoT) ListPolicyPrincipalsRequest(input *ListPolicyPrincipalsInput) (req
 // ListPolicyPrincipals API operation for AWS IoT.
 //
 // Lists the principals associated with the specified policy.
+//
+// Note: This API is deprecated. Please use ListTargetsForPolicy instead.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3863,6 +6810,9 @@ const opListPrincipalPolicies = "ListPrincipalPolicies"
 //        fmt.Println(resp)
 //    }
 func (c *IoT) ListPrincipalPoliciesRequest(input *ListPrincipalPoliciesInput) (req *request.Request, output *ListPrincipalPoliciesOutput) {
+	if c.Client.Config.Logger != nil {
+		c.Client.Config.Logger.Log("This operation, ListPrincipalPolicies, has been deprecated")
+	}
 	op := &request.Operation{
 		Name:       opListPrincipalPolicies,
 		HTTPMethod: "GET",
@@ -3882,6 +6832,8 @@ func (c *IoT) ListPrincipalPoliciesRequest(input *ListPrincipalPoliciesInput) (r
 //
 // Lists the policies attached to the specified principal. If you use an Cognito
 // identity, the ID must be in AmazonCognito Identity format (http://docs.aws.amazon.com/cognitoidentity/latest/APIReference/API_GetCredentialsForIdentity.html#API_GetCredentialsForIdentity_RequestSyntax).
+//
+// Note: This API is deprecated. Please use ListAttachedPolicies instead.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -4021,6 +6973,352 @@ func (c *IoT) ListPrincipalThingsWithContext(ctx aws.Context, input *ListPrincip
 	return out, req.Send()
 }
 
+const opListRoleAliases = "ListRoleAliases"
+
+// ListRoleAliasesRequest generates a "aws/request.Request" representing the
+// client's request for the ListRoleAliases operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ListRoleAliases for more information on using the ListRoleAliases
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ListRoleAliasesRequest method.
+//    req, resp := client.ListRoleAliasesRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) ListRoleAliasesRequest(input *ListRoleAliasesInput) (req *request.Request, output *ListRoleAliasesOutput) {
+	op := &request.Operation{
+		Name:       opListRoleAliases,
+		HTTPMethod: "GET",
+		HTTPPath:   "/role-aliases",
+	}
+
+	if input == nil {
+		input = &ListRoleAliasesInput{}
+	}
+
+	output = &ListRoleAliasesOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListRoleAliases API operation for AWS IoT.
+//
+// Lists the role aliases registered in your account.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation ListRoleAliases for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeUnauthorizedException "UnauthorizedException"
+//   You are not authorized to perform this operation.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+func (c *IoT) ListRoleAliases(input *ListRoleAliasesInput) (*ListRoleAliasesOutput, error) {
+	req, out := c.ListRoleAliasesRequest(input)
+	return out, req.Send()
+}
+
+// ListRoleAliasesWithContext is the same as ListRoleAliases with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListRoleAliases for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) ListRoleAliasesWithContext(ctx aws.Context, input *ListRoleAliasesInput, opts ...request.Option) (*ListRoleAliasesOutput, error) {
+	req, out := c.ListRoleAliasesRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opListTargetsForPolicy = "ListTargetsForPolicy"
+
+// ListTargetsForPolicyRequest generates a "aws/request.Request" representing the
+// client's request for the ListTargetsForPolicy operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ListTargetsForPolicy for more information on using the ListTargetsForPolicy
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ListTargetsForPolicyRequest method.
+//    req, resp := client.ListTargetsForPolicyRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) ListTargetsForPolicyRequest(input *ListTargetsForPolicyInput) (req *request.Request, output *ListTargetsForPolicyOutput) {
+	op := &request.Operation{
+		Name:       opListTargetsForPolicy,
+		HTTPMethod: "POST",
+		HTTPPath:   "/policy-targets/{policyName}",
+	}
+
+	if input == nil {
+		input = &ListTargetsForPolicyInput{}
+	}
+
+	output = &ListTargetsForPolicyOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListTargetsForPolicy API operation for AWS IoT.
+//
+// List targets for the specified policy.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation ListTargetsForPolicy for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeUnauthorizedException "UnauthorizedException"
+//   You are not authorized to perform this operation.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   The number of attached entities exceeds the limit.
+//
+func (c *IoT) ListTargetsForPolicy(input *ListTargetsForPolicyInput) (*ListTargetsForPolicyOutput, error) {
+	req, out := c.ListTargetsForPolicyRequest(input)
+	return out, req.Send()
+}
+
+// ListTargetsForPolicyWithContext is the same as ListTargetsForPolicy with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListTargetsForPolicy for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) ListTargetsForPolicyWithContext(ctx aws.Context, input *ListTargetsForPolicyInput, opts ...request.Option) (*ListTargetsForPolicyOutput, error) {
+	req, out := c.ListTargetsForPolicyRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opListThingGroups = "ListThingGroups"
+
+// ListThingGroupsRequest generates a "aws/request.Request" representing the
+// client's request for the ListThingGroups operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ListThingGroups for more information on using the ListThingGroups
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ListThingGroupsRequest method.
+//    req, resp := client.ListThingGroupsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) ListThingGroupsRequest(input *ListThingGroupsInput) (req *request.Request, output *ListThingGroupsOutput) {
+	op := &request.Operation{
+		Name:       opListThingGroups,
+		HTTPMethod: "GET",
+		HTTPPath:   "/thing-groups",
+	}
+
+	if input == nil {
+		input = &ListThingGroupsInput{}
+	}
+
+	output = &ListThingGroupsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListThingGroups API operation for AWS IoT.
+//
+// List the thing groups in your account.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation ListThingGroups for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+func (c *IoT) ListThingGroups(input *ListThingGroupsInput) (*ListThingGroupsOutput, error) {
+	req, out := c.ListThingGroupsRequest(input)
+	return out, req.Send()
+}
+
+// ListThingGroupsWithContext is the same as ListThingGroups with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListThingGroups for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) ListThingGroupsWithContext(ctx aws.Context, input *ListThingGroupsInput, opts ...request.Option) (*ListThingGroupsOutput, error) {
+	req, out := c.ListThingGroupsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opListThingGroupsForThing = "ListThingGroupsForThing"
+
+// ListThingGroupsForThingRequest generates a "aws/request.Request" representing the
+// client's request for the ListThingGroupsForThing operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ListThingGroupsForThing for more information on using the ListThingGroupsForThing
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ListThingGroupsForThingRequest method.
+//    req, resp := client.ListThingGroupsForThingRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) ListThingGroupsForThingRequest(input *ListThingGroupsForThingInput) (req *request.Request, output *ListThingGroupsForThingOutput) {
+	op := &request.Operation{
+		Name:       opListThingGroupsForThing,
+		HTTPMethod: "GET",
+		HTTPPath:   "/things/{thingName}/thing-groups",
+	}
+
+	if input == nil {
+		input = &ListThingGroupsForThingInput{}
+	}
+
+	output = &ListThingGroupsForThingOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListThingGroupsForThing API operation for AWS IoT.
+//
+// List the thing groups to which the specified thing belongs.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation ListThingGroupsForThing for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+func (c *IoT) ListThingGroupsForThing(input *ListThingGroupsForThingInput) (*ListThingGroupsForThingOutput, error) {
+	req, out := c.ListThingGroupsForThingRequest(input)
+	return out, req.Send()
+}
+
+// ListThingGroupsForThingWithContext is the same as ListThingGroupsForThing with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListThingGroupsForThing for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) ListThingGroupsForThingWithContext(ctx aws.Context, input *ListThingGroupsForThingInput, opts ...request.Option) (*ListThingGroupsForThingOutput, error) {
+	req, out := c.ListThingGroupsForThingRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opListThingPrincipals = "ListThingPrincipals"
 
 // ListThingPrincipalsRequest generates a "aws/request.Request" representing the
@@ -4107,6 +7405,176 @@ func (c *IoT) ListThingPrincipals(input *ListThingPrincipalsInput) (*ListThingPr
 // for more information on using Contexts.
 func (c *IoT) ListThingPrincipalsWithContext(ctx aws.Context, input *ListThingPrincipalsInput, opts ...request.Option) (*ListThingPrincipalsOutput, error) {
 	req, out := c.ListThingPrincipalsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opListThingRegistrationTaskReports = "ListThingRegistrationTaskReports"
+
+// ListThingRegistrationTaskReportsRequest generates a "aws/request.Request" representing the
+// client's request for the ListThingRegistrationTaskReports operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ListThingRegistrationTaskReports for more information on using the ListThingRegistrationTaskReports
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ListThingRegistrationTaskReportsRequest method.
+//    req, resp := client.ListThingRegistrationTaskReportsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) ListThingRegistrationTaskReportsRequest(input *ListThingRegistrationTaskReportsInput) (req *request.Request, output *ListThingRegistrationTaskReportsOutput) {
+	op := &request.Operation{
+		Name:       opListThingRegistrationTaskReports,
+		HTTPMethod: "GET",
+		HTTPPath:   "/thing-registration-tasks/{taskId}/reports",
+	}
+
+	if input == nil {
+		input = &ListThingRegistrationTaskReportsInput{}
+	}
+
+	output = &ListThingRegistrationTaskReportsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListThingRegistrationTaskReports API operation for AWS IoT.
+//
+// Information about the thing registration tasks.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation ListThingRegistrationTaskReports for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeUnauthorizedException "UnauthorizedException"
+//   You are not authorized to perform this operation.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+func (c *IoT) ListThingRegistrationTaskReports(input *ListThingRegistrationTaskReportsInput) (*ListThingRegistrationTaskReportsOutput, error) {
+	req, out := c.ListThingRegistrationTaskReportsRequest(input)
+	return out, req.Send()
+}
+
+// ListThingRegistrationTaskReportsWithContext is the same as ListThingRegistrationTaskReports with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListThingRegistrationTaskReports for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) ListThingRegistrationTaskReportsWithContext(ctx aws.Context, input *ListThingRegistrationTaskReportsInput, opts ...request.Option) (*ListThingRegistrationTaskReportsOutput, error) {
+	req, out := c.ListThingRegistrationTaskReportsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opListThingRegistrationTasks = "ListThingRegistrationTasks"
+
+// ListThingRegistrationTasksRequest generates a "aws/request.Request" representing the
+// client's request for the ListThingRegistrationTasks operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ListThingRegistrationTasks for more information on using the ListThingRegistrationTasks
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ListThingRegistrationTasksRequest method.
+//    req, resp := client.ListThingRegistrationTasksRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) ListThingRegistrationTasksRequest(input *ListThingRegistrationTasksInput) (req *request.Request, output *ListThingRegistrationTasksOutput) {
+	op := &request.Operation{
+		Name:       opListThingRegistrationTasks,
+		HTTPMethod: "GET",
+		HTTPPath:   "/thing-registration-tasks",
+	}
+
+	if input == nil {
+		input = &ListThingRegistrationTasksInput{}
+	}
+
+	output = &ListThingRegistrationTasksOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListThingRegistrationTasks API operation for AWS IoT.
+//
+// List bulk thing provisioning tasks.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation ListThingRegistrationTasks for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeUnauthorizedException "UnauthorizedException"
+//   You are not authorized to perform this operation.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+func (c *IoT) ListThingRegistrationTasks(input *ListThingRegistrationTasksInput) (*ListThingRegistrationTasksOutput, error) {
+	req, out := c.ListThingRegistrationTasksRequest(input)
+	return out, req.Send()
+}
+
+// ListThingRegistrationTasksWithContext is the same as ListThingRegistrationTasks with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListThingRegistrationTasks for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) ListThingRegistrationTasksWithContext(ctx aws.Context, input *ListThingRegistrationTasksInput, opts ...request.Option) (*ListThingRegistrationTasksOutput, error) {
+	req, out := c.ListThingRegistrationTasksRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -4291,6 +7759,88 @@ func (c *IoT) ListThingsWithContext(ctx aws.Context, input *ListThingsInput, opt
 	return out, req.Send()
 }
 
+const opListThingsInThingGroup = "ListThingsInThingGroup"
+
+// ListThingsInThingGroupRequest generates a "aws/request.Request" representing the
+// client's request for the ListThingsInThingGroup operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ListThingsInThingGroup for more information on using the ListThingsInThingGroup
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ListThingsInThingGroupRequest method.
+//    req, resp := client.ListThingsInThingGroupRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) ListThingsInThingGroupRequest(input *ListThingsInThingGroupInput) (req *request.Request, output *ListThingsInThingGroupOutput) {
+	op := &request.Operation{
+		Name:       opListThingsInThingGroup,
+		HTTPMethod: "GET",
+		HTTPPath:   "/thing-groups/{thingGroupName}/things",
+	}
+
+	if input == nil {
+		input = &ListThingsInThingGroupInput{}
+	}
+
+	output = &ListThingsInThingGroupOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListThingsInThingGroup API operation for AWS IoT.
+//
+// Lists the things in the specified group.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation ListThingsInThingGroup for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+func (c *IoT) ListThingsInThingGroup(input *ListThingsInThingGroupInput) (*ListThingsInThingGroupOutput, error) {
+	req, out := c.ListThingsInThingGroupRequest(input)
+	return out, req.Send()
+}
+
+// ListThingsInThingGroupWithContext is the same as ListThingsInThingGroup with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListThingsInThingGroup for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) ListThingsInThingGroupWithContext(ctx aws.Context, input *ListThingsInThingGroupInput, opts ...request.Option) (*ListThingsInThingGroupOutput, error) {
+	req, out := c.ListThingsInThingGroupRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opListTopicRules = "ListTopicRules"
 
 // ListTopicRulesRequest generates a "aws/request.Request" representing the
@@ -4368,6 +7918,91 @@ func (c *IoT) ListTopicRules(input *ListTopicRulesInput) (*ListTopicRulesOutput,
 // for more information on using Contexts.
 func (c *IoT) ListTopicRulesWithContext(ctx aws.Context, input *ListTopicRulesInput, opts ...request.Option) (*ListTopicRulesOutput, error) {
 	req, out := c.ListTopicRulesRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opListV2LoggingLevels = "ListV2LoggingLevels"
+
+// ListV2LoggingLevelsRequest generates a "aws/request.Request" representing the
+// client's request for the ListV2LoggingLevels operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ListV2LoggingLevels for more information on using the ListV2LoggingLevels
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ListV2LoggingLevelsRequest method.
+//    req, resp := client.ListV2LoggingLevelsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) ListV2LoggingLevelsRequest(input *ListV2LoggingLevelsInput) (req *request.Request, output *ListV2LoggingLevelsOutput) {
+	op := &request.Operation{
+		Name:       opListV2LoggingLevels,
+		HTTPMethod: "GET",
+		HTTPPath:   "/v2LoggingLevel",
+	}
+
+	if input == nil {
+		input = &ListV2LoggingLevelsInput{}
+	}
+
+	output = &ListV2LoggingLevelsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListV2LoggingLevels API operation for AWS IoT.
+//
+// Lists logging levels.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation ListV2LoggingLevels for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalException "InternalException"
+//   An unexpected error has occurred.
+//
+//   * ErrCodeNotConfiguredException "NotConfiguredException"
+//   The resource is not configured.
+//
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+func (c *IoT) ListV2LoggingLevels(input *ListV2LoggingLevelsInput) (*ListV2LoggingLevelsOutput, error) {
+	req, out := c.ListV2LoggingLevelsRequest(input)
+	return out, req.Send()
+}
+
+// ListV2LoggingLevelsWithContext is the same as ListV2LoggingLevels with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListV2LoggingLevels for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) ListV2LoggingLevelsWithContext(ctx aws.Context, input *ListV2LoggingLevelsInput, opts ...request.Option) (*ListV2LoggingLevelsOutput, error) {
+	req, out := c.ListV2LoggingLevelsRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -4583,6 +8218,101 @@ func (c *IoT) RegisterCertificateWithContext(ctx aws.Context, input *RegisterCer
 	return out, req.Send()
 }
 
+const opRegisterThing = "RegisterThing"
+
+// RegisterThingRequest generates a "aws/request.Request" representing the
+// client's request for the RegisterThing operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See RegisterThing for more information on using the RegisterThing
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the RegisterThingRequest method.
+//    req, resp := client.RegisterThingRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) RegisterThingRequest(input *RegisterThingInput) (req *request.Request, output *RegisterThingOutput) {
+	op := &request.Operation{
+		Name:       opRegisterThing,
+		HTTPMethod: "POST",
+		HTTPPath:   "/things",
+	}
+
+	if input == nil {
+		input = &RegisterThingInput{}
+	}
+
+	output = &RegisterThingOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// RegisterThing API operation for AWS IoT.
+//
+// Provisions a thing.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation RegisterThing for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeUnauthorizedException "UnauthorizedException"
+//   You are not authorized to perform this operation.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeConflictingResourceUpdateException "ConflictingResourceUpdateException"
+//   A conflicting resource update exception. This exception is thrown when two
+//   pending updates cause a conflict.
+//
+//   * ErrCodeResourceRegistrationFailureException "ResourceRegistrationFailureException"
+//   The resource registration failed.
+//
+func (c *IoT) RegisterThing(input *RegisterThingInput) (*RegisterThingOutput, error) {
+	req, out := c.RegisterThingRequest(input)
+	return out, req.Send()
+}
+
+// RegisterThingWithContext is the same as RegisterThing with the addition of
+// the ability to pass a context and additional request options.
+//
+// See RegisterThing for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) RegisterThingWithContext(ctx aws.Context, input *RegisterThingInput, opts ...request.Option) (*RegisterThingOutput, error) {
+	req, out := c.RegisterThingRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opRejectCertificateTransfer = "RejectCertificateTransfer"
 
 // RejectCertificateTransferRequest generates a "aws/request.Request" representing the
@@ -4688,6 +8418,91 @@ func (c *IoT) RejectCertificateTransferWithContext(ctx aws.Context, input *Rejec
 	return out, req.Send()
 }
 
+const opRemoveThingFromThingGroup = "RemoveThingFromThingGroup"
+
+// RemoveThingFromThingGroupRequest generates a "aws/request.Request" representing the
+// client's request for the RemoveThingFromThingGroup operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See RemoveThingFromThingGroup for more information on using the RemoveThingFromThingGroup
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the RemoveThingFromThingGroupRequest method.
+//    req, resp := client.RemoveThingFromThingGroupRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) RemoveThingFromThingGroupRequest(input *RemoveThingFromThingGroupInput) (req *request.Request, output *RemoveThingFromThingGroupOutput) {
+	op := &request.Operation{
+		Name:       opRemoveThingFromThingGroup,
+		HTTPMethod: "PUT",
+		HTTPPath:   "/thing-groups/removeThingFromThingGroup",
+	}
+
+	if input == nil {
+		input = &RemoveThingFromThingGroupInput{}
+	}
+
+	output = &RemoveThingFromThingGroupOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// RemoveThingFromThingGroup API operation for AWS IoT.
+//
+// Remove the specified thing from the specified group.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation RemoveThingFromThingGroup for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+func (c *IoT) RemoveThingFromThingGroup(input *RemoveThingFromThingGroupInput) (*RemoveThingFromThingGroupOutput, error) {
+	req, out := c.RemoveThingFromThingGroupRequest(input)
+	return out, req.Send()
+}
+
+// RemoveThingFromThingGroupWithContext is the same as RemoveThingFromThingGroup with the addition of
+// the ability to pass a context and additional request options.
+//
+// See RemoveThingFromThingGroup for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) RemoveThingFromThingGroupWithContext(ctx aws.Context, input *RemoveThingFromThingGroupInput, opts ...request.Option) (*RemoveThingFromThingGroupOutput, error) {
+	req, out := c.RemoveThingFromThingGroupRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opReplaceTopicRule = "ReplaceTopicRule"
 
 // ReplaceTopicRuleRequest generates a "aws/request.Request" representing the
@@ -4732,9 +8547,9 @@ func (c *IoT) ReplaceTopicRuleRequest(input *ReplaceTopicRuleInput) (req *reques
 
 // ReplaceTopicRule API operation for AWS IoT.
 //
-// Replaces the specified rule. You must specify all parameters for the new
-// rule. Creating rules is an administrator-level action. Any user who has permission
-// to create rules will be able to access data processed by the rule.
+// Replaces the rule. You must specify all parameters for the new rule. Creating
+// rules is an administrator-level action. Any user who has permission to create
+// rules will be able to access data processed by the rule.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -4775,6 +8590,195 @@ func (c *IoT) ReplaceTopicRule(input *ReplaceTopicRuleInput) (*ReplaceTopicRuleO
 // for more information on using Contexts.
 func (c *IoT) ReplaceTopicRuleWithContext(ctx aws.Context, input *ReplaceTopicRuleInput, opts ...request.Option) (*ReplaceTopicRuleOutput, error) {
 	req, out := c.ReplaceTopicRuleRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opSearchIndex = "SearchIndex"
+
+// SearchIndexRequest generates a "aws/request.Request" representing the
+// client's request for the SearchIndex operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See SearchIndex for more information on using the SearchIndex
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the SearchIndexRequest method.
+//    req, resp := client.SearchIndexRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) SearchIndexRequest(input *SearchIndexInput) (req *request.Request, output *SearchIndexOutput) {
+	op := &request.Operation{
+		Name:       opSearchIndex,
+		HTTPMethod: "POST",
+		HTTPPath:   "/indices/search",
+	}
+
+	if input == nil {
+		input = &SearchIndexInput{}
+	}
+
+	output = &SearchIndexOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// SearchIndex API operation for AWS IoT.
+//
+// The query search index.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation SearchIndex for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeUnauthorizedException "UnauthorizedException"
+//   You are not authorized to perform this operation.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+//   * ErrCodeInvalidQueryException "InvalidQueryException"
+//   The query is invalid.
+//
+//   * ErrCodeIndexNotReadyException "IndexNotReadyException"
+//   The index is not ready.
+//
+func (c *IoT) SearchIndex(input *SearchIndexInput) (*SearchIndexOutput, error) {
+	req, out := c.SearchIndexRequest(input)
+	return out, req.Send()
+}
+
+// SearchIndexWithContext is the same as SearchIndex with the addition of
+// the ability to pass a context and additional request options.
+//
+// See SearchIndex for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) SearchIndexWithContext(ctx aws.Context, input *SearchIndexInput, opts ...request.Option) (*SearchIndexOutput, error) {
+	req, out := c.SearchIndexRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opSetDefaultAuthorizer = "SetDefaultAuthorizer"
+
+// SetDefaultAuthorizerRequest generates a "aws/request.Request" representing the
+// client's request for the SetDefaultAuthorizer operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See SetDefaultAuthorizer for more information on using the SetDefaultAuthorizer
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the SetDefaultAuthorizerRequest method.
+//    req, resp := client.SetDefaultAuthorizerRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) SetDefaultAuthorizerRequest(input *SetDefaultAuthorizerInput) (req *request.Request, output *SetDefaultAuthorizerOutput) {
+	op := &request.Operation{
+		Name:       opSetDefaultAuthorizer,
+		HTTPMethod: "POST",
+		HTTPPath:   "/default-authorizer",
+	}
+
+	if input == nil {
+		input = &SetDefaultAuthorizerInput{}
+	}
+
+	output = &SetDefaultAuthorizerOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// SetDefaultAuthorizer API operation for AWS IoT.
+//
+// Sets the default authorizer. This will be used if a websocket connection
+// is made without specifying an authorizer.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation SetDefaultAuthorizer for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeUnauthorizedException "UnauthorizedException"
+//   You are not authorized to perform this operation.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+func (c *IoT) SetDefaultAuthorizer(input *SetDefaultAuthorizerInput) (*SetDefaultAuthorizerOutput, error) {
+	req, out := c.SetDefaultAuthorizerRequest(input)
+	return out, req.Send()
+}
+
+// SetDefaultAuthorizerWithContext is the same as SetDefaultAuthorizer with the addition of
+// the ability to pass a context and additional request options.
+//
+// See SetDefaultAuthorizer for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) SetDefaultAuthorizerWithContext(ctx aws.Context, input *SetDefaultAuthorizerInput, opts ...request.Option) (*SetDefaultAuthorizerOutput, error) {
+	req, out := c.SetDefaultAuthorizerRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -4960,6 +8964,538 @@ func (c *IoT) SetLoggingOptionsWithContext(ctx aws.Context, input *SetLoggingOpt
 	return out, req.Send()
 }
 
+const opSetV2LoggingLevel = "SetV2LoggingLevel"
+
+// SetV2LoggingLevelRequest generates a "aws/request.Request" representing the
+// client's request for the SetV2LoggingLevel operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See SetV2LoggingLevel for more information on using the SetV2LoggingLevel
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the SetV2LoggingLevelRequest method.
+//    req, resp := client.SetV2LoggingLevelRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) SetV2LoggingLevelRequest(input *SetV2LoggingLevelInput) (req *request.Request, output *SetV2LoggingLevelOutput) {
+	op := &request.Operation{
+		Name:       opSetV2LoggingLevel,
+		HTTPMethod: "POST",
+		HTTPPath:   "/v2LoggingLevel",
+	}
+
+	if input == nil {
+		input = &SetV2LoggingLevelInput{}
+	}
+
+	output = &SetV2LoggingLevelOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restjson.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// SetV2LoggingLevel API operation for AWS IoT.
+//
+// Sets the logging level.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation SetV2LoggingLevel for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalException "InternalException"
+//   An unexpected error has occurred.
+//
+//   * ErrCodeNotConfiguredException "NotConfiguredException"
+//   The resource is not configured.
+//
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+func (c *IoT) SetV2LoggingLevel(input *SetV2LoggingLevelInput) (*SetV2LoggingLevelOutput, error) {
+	req, out := c.SetV2LoggingLevelRequest(input)
+	return out, req.Send()
+}
+
+// SetV2LoggingLevelWithContext is the same as SetV2LoggingLevel with the addition of
+// the ability to pass a context and additional request options.
+//
+// See SetV2LoggingLevel for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) SetV2LoggingLevelWithContext(ctx aws.Context, input *SetV2LoggingLevelInput, opts ...request.Option) (*SetV2LoggingLevelOutput, error) {
+	req, out := c.SetV2LoggingLevelRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opSetV2LoggingOptions = "SetV2LoggingOptions"
+
+// SetV2LoggingOptionsRequest generates a "aws/request.Request" representing the
+// client's request for the SetV2LoggingOptions operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See SetV2LoggingOptions for more information on using the SetV2LoggingOptions
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the SetV2LoggingOptionsRequest method.
+//    req, resp := client.SetV2LoggingOptionsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) SetV2LoggingOptionsRequest(input *SetV2LoggingOptionsInput) (req *request.Request, output *SetV2LoggingOptionsOutput) {
+	op := &request.Operation{
+		Name:       opSetV2LoggingOptions,
+		HTTPMethod: "POST",
+		HTTPPath:   "/v2LoggingOptions",
+	}
+
+	if input == nil {
+		input = &SetV2LoggingOptionsInput{}
+	}
+
+	output = &SetV2LoggingOptionsOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restjson.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// SetV2LoggingOptions API operation for AWS IoT.
+//
+// Sets the logging options for the V2 logging service.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation SetV2LoggingOptions for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalException "InternalException"
+//   An unexpected error has occurred.
+//
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+func (c *IoT) SetV2LoggingOptions(input *SetV2LoggingOptionsInput) (*SetV2LoggingOptionsOutput, error) {
+	req, out := c.SetV2LoggingOptionsRequest(input)
+	return out, req.Send()
+}
+
+// SetV2LoggingOptionsWithContext is the same as SetV2LoggingOptions with the addition of
+// the ability to pass a context and additional request options.
+//
+// See SetV2LoggingOptions for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) SetV2LoggingOptionsWithContext(ctx aws.Context, input *SetV2LoggingOptionsInput, opts ...request.Option) (*SetV2LoggingOptionsOutput, error) {
+	req, out := c.SetV2LoggingOptionsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opStartThingRegistrationTask = "StartThingRegistrationTask"
+
+// StartThingRegistrationTaskRequest generates a "aws/request.Request" representing the
+// client's request for the StartThingRegistrationTask operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See StartThingRegistrationTask for more information on using the StartThingRegistrationTask
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the StartThingRegistrationTaskRequest method.
+//    req, resp := client.StartThingRegistrationTaskRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) StartThingRegistrationTaskRequest(input *StartThingRegistrationTaskInput) (req *request.Request, output *StartThingRegistrationTaskOutput) {
+	op := &request.Operation{
+		Name:       opStartThingRegistrationTask,
+		HTTPMethod: "POST",
+		HTTPPath:   "/thing-registration-tasks",
+	}
+
+	if input == nil {
+		input = &StartThingRegistrationTaskInput{}
+	}
+
+	output = &StartThingRegistrationTaskOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// StartThingRegistrationTask API operation for AWS IoT.
+//
+// Creates a bulk thing provisioning task.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation StartThingRegistrationTask for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeUnauthorizedException "UnauthorizedException"
+//   You are not authorized to perform this operation.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+func (c *IoT) StartThingRegistrationTask(input *StartThingRegistrationTaskInput) (*StartThingRegistrationTaskOutput, error) {
+	req, out := c.StartThingRegistrationTaskRequest(input)
+	return out, req.Send()
+}
+
+// StartThingRegistrationTaskWithContext is the same as StartThingRegistrationTask with the addition of
+// the ability to pass a context and additional request options.
+//
+// See StartThingRegistrationTask for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) StartThingRegistrationTaskWithContext(ctx aws.Context, input *StartThingRegistrationTaskInput, opts ...request.Option) (*StartThingRegistrationTaskOutput, error) {
+	req, out := c.StartThingRegistrationTaskRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opStopThingRegistrationTask = "StopThingRegistrationTask"
+
+// StopThingRegistrationTaskRequest generates a "aws/request.Request" representing the
+// client's request for the StopThingRegistrationTask operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See StopThingRegistrationTask for more information on using the StopThingRegistrationTask
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the StopThingRegistrationTaskRequest method.
+//    req, resp := client.StopThingRegistrationTaskRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) StopThingRegistrationTaskRequest(input *StopThingRegistrationTaskInput) (req *request.Request, output *StopThingRegistrationTaskOutput) {
+	op := &request.Operation{
+		Name:       opStopThingRegistrationTask,
+		HTTPMethod: "PUT",
+		HTTPPath:   "/thing-registration-tasks/{taskId}/cancel",
+	}
+
+	if input == nil {
+		input = &StopThingRegistrationTaskInput{}
+	}
+
+	output = &StopThingRegistrationTaskOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// StopThingRegistrationTask API operation for AWS IoT.
+//
+// Cancels a bulk thing provisioning task.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation StopThingRegistrationTask for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeUnauthorizedException "UnauthorizedException"
+//   You are not authorized to perform this operation.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+func (c *IoT) StopThingRegistrationTask(input *StopThingRegistrationTaskInput) (*StopThingRegistrationTaskOutput, error) {
+	req, out := c.StopThingRegistrationTaskRequest(input)
+	return out, req.Send()
+}
+
+// StopThingRegistrationTaskWithContext is the same as StopThingRegistrationTask with the addition of
+// the ability to pass a context and additional request options.
+//
+// See StopThingRegistrationTask for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) StopThingRegistrationTaskWithContext(ctx aws.Context, input *StopThingRegistrationTaskInput, opts ...request.Option) (*StopThingRegistrationTaskOutput, error) {
+	req, out := c.StopThingRegistrationTaskRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opTestAuthorization = "TestAuthorization"
+
+// TestAuthorizationRequest generates a "aws/request.Request" representing the
+// client's request for the TestAuthorization operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See TestAuthorization for more information on using the TestAuthorization
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the TestAuthorizationRequest method.
+//    req, resp := client.TestAuthorizationRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) TestAuthorizationRequest(input *TestAuthorizationInput) (req *request.Request, output *TestAuthorizationOutput) {
+	op := &request.Operation{
+		Name:       opTestAuthorization,
+		HTTPMethod: "POST",
+		HTTPPath:   "/test-authorization",
+	}
+
+	if input == nil {
+		input = &TestAuthorizationInput{}
+	}
+
+	output = &TestAuthorizationOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// TestAuthorization API operation for AWS IoT.
+//
+// Test custom authorization.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation TestAuthorization for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeUnauthorizedException "UnauthorizedException"
+//   You are not authorized to perform this operation.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   The number of attached entities exceeds the limit.
+//
+func (c *IoT) TestAuthorization(input *TestAuthorizationInput) (*TestAuthorizationOutput, error) {
+	req, out := c.TestAuthorizationRequest(input)
+	return out, req.Send()
+}
+
+// TestAuthorizationWithContext is the same as TestAuthorization with the addition of
+// the ability to pass a context and additional request options.
+//
+// See TestAuthorization for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) TestAuthorizationWithContext(ctx aws.Context, input *TestAuthorizationInput, opts ...request.Option) (*TestAuthorizationOutput, error) {
+	req, out := c.TestAuthorizationRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opTestInvokeAuthorizer = "TestInvokeAuthorizer"
+
+// TestInvokeAuthorizerRequest generates a "aws/request.Request" representing the
+// client's request for the TestInvokeAuthorizer operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See TestInvokeAuthorizer for more information on using the TestInvokeAuthorizer
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the TestInvokeAuthorizerRequest method.
+//    req, resp := client.TestInvokeAuthorizerRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) TestInvokeAuthorizerRequest(input *TestInvokeAuthorizerInput) (req *request.Request, output *TestInvokeAuthorizerOutput) {
+	op := &request.Operation{
+		Name:       opTestInvokeAuthorizer,
+		HTTPMethod: "POST",
+		HTTPPath:   "/authorizer/{authorizerName}/test",
+	}
+
+	if input == nil {
+		input = &TestInvokeAuthorizerInput{}
+	}
+
+	output = &TestInvokeAuthorizerOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// TestInvokeAuthorizer API operation for AWS IoT.
+//
+// Invoke the specified custom authorizer for testing purposes.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation TestInvokeAuthorizer for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeUnauthorizedException "UnauthorizedException"
+//   You are not authorized to perform this operation.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+//   * ErrCodeInvalidResponseException "InvalidResponseException"
+//   The response is invalid.
+//
+func (c *IoT) TestInvokeAuthorizer(input *TestInvokeAuthorizerInput) (*TestInvokeAuthorizerOutput, error) {
+	req, out := c.TestInvokeAuthorizerRequest(input)
+	return out, req.Send()
+}
+
+// TestInvokeAuthorizerWithContext is the same as TestInvokeAuthorizer with the addition of
+// the ability to pass a context and additional request options.
+//
+// See TestInvokeAuthorizer for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) TestInvokeAuthorizerWithContext(ctx aws.Context, input *TestInvokeAuthorizerInput, opts ...request.Option) (*TestInvokeAuthorizerOutput, error) {
+	req, out := c.TestInvokeAuthorizerRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opTransferCertificate = "TransferCertificate"
 
 // TransferCertificateRequest generates a "aws/request.Request" representing the
@@ -5064,6 +9600,100 @@ func (c *IoT) TransferCertificate(input *TransferCertificateInput) (*TransferCer
 // for more information on using Contexts.
 func (c *IoT) TransferCertificateWithContext(ctx aws.Context, input *TransferCertificateInput, opts ...request.Option) (*TransferCertificateOutput, error) {
 	req, out := c.TransferCertificateRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opUpdateAuthorizer = "UpdateAuthorizer"
+
+// UpdateAuthorizerRequest generates a "aws/request.Request" representing the
+// client's request for the UpdateAuthorizer operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See UpdateAuthorizer for more information on using the UpdateAuthorizer
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the UpdateAuthorizerRequest method.
+//    req, resp := client.UpdateAuthorizerRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) UpdateAuthorizerRequest(input *UpdateAuthorizerInput) (req *request.Request, output *UpdateAuthorizerOutput) {
+	op := &request.Operation{
+		Name:       opUpdateAuthorizer,
+		HTTPMethod: "PUT",
+		HTTPPath:   "/authorizer/{authorizerName}",
+	}
+
+	if input == nil {
+		input = &UpdateAuthorizerInput{}
+	}
+
+	output = &UpdateAuthorizerOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// UpdateAuthorizer API operation for AWS IoT.
+//
+// Updates an authorizer.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation UpdateAuthorizer for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   The number of attached entities exceeds the limit.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeUnauthorizedException "UnauthorizedException"
+//   You are not authorized to perform this operation.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+func (c *IoT) UpdateAuthorizer(input *UpdateAuthorizerInput) (*UpdateAuthorizerOutput, error) {
+	req, out := c.UpdateAuthorizerRequest(input)
+	return out, req.Send()
+}
+
+// UpdateAuthorizerWithContext is the same as UpdateAuthorizer with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UpdateAuthorizer for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) UpdateAuthorizerWithContext(ctx aws.Context, input *UpdateAuthorizerInput, opts ...request.Option) (*UpdateAuthorizerOutput, error) {
+	req, out := c.UpdateAuthorizerRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -5264,6 +9894,267 @@ func (c *IoT) UpdateCertificateWithContext(ctx aws.Context, input *UpdateCertifi
 	return out, req.Send()
 }
 
+const opUpdateEventConfigurations = "UpdateEventConfigurations"
+
+// UpdateEventConfigurationsRequest generates a "aws/request.Request" representing the
+// client's request for the UpdateEventConfigurations operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See UpdateEventConfigurations for more information on using the UpdateEventConfigurations
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the UpdateEventConfigurationsRequest method.
+//    req, resp := client.UpdateEventConfigurationsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) UpdateEventConfigurationsRequest(input *UpdateEventConfigurationsInput) (req *request.Request, output *UpdateEventConfigurationsOutput) {
+	op := &request.Operation{
+		Name:       opUpdateEventConfigurations,
+		HTTPMethod: "PATCH",
+		HTTPPath:   "/event-configurations",
+	}
+
+	if input == nil {
+		input = &UpdateEventConfigurationsInput{}
+	}
+
+	output = &UpdateEventConfigurationsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// UpdateEventConfigurations API operation for AWS IoT.
+//
+// Updates the event configurations.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation UpdateEventConfigurations for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+func (c *IoT) UpdateEventConfigurations(input *UpdateEventConfigurationsInput) (*UpdateEventConfigurationsOutput, error) {
+	req, out := c.UpdateEventConfigurationsRequest(input)
+	return out, req.Send()
+}
+
+// UpdateEventConfigurationsWithContext is the same as UpdateEventConfigurations with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UpdateEventConfigurations for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) UpdateEventConfigurationsWithContext(ctx aws.Context, input *UpdateEventConfigurationsInput, opts ...request.Option) (*UpdateEventConfigurationsOutput, error) {
+	req, out := c.UpdateEventConfigurationsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opUpdateIndexingConfiguration = "UpdateIndexingConfiguration"
+
+// UpdateIndexingConfigurationRequest generates a "aws/request.Request" representing the
+// client's request for the UpdateIndexingConfiguration operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See UpdateIndexingConfiguration for more information on using the UpdateIndexingConfiguration
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the UpdateIndexingConfigurationRequest method.
+//    req, resp := client.UpdateIndexingConfigurationRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) UpdateIndexingConfigurationRequest(input *UpdateIndexingConfigurationInput) (req *request.Request, output *UpdateIndexingConfigurationOutput) {
+	op := &request.Operation{
+		Name:       opUpdateIndexingConfiguration,
+		HTTPMethod: "POST",
+		HTTPPath:   "/indexing/config",
+	}
+
+	if input == nil {
+		input = &UpdateIndexingConfigurationInput{}
+	}
+
+	output = &UpdateIndexingConfigurationOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// UpdateIndexingConfiguration API operation for AWS IoT.
+//
+// Updates the search configuration.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation UpdateIndexingConfiguration for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeUnauthorizedException "UnauthorizedException"
+//   You are not authorized to perform this operation.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+func (c *IoT) UpdateIndexingConfiguration(input *UpdateIndexingConfigurationInput) (*UpdateIndexingConfigurationOutput, error) {
+	req, out := c.UpdateIndexingConfigurationRequest(input)
+	return out, req.Send()
+}
+
+// UpdateIndexingConfigurationWithContext is the same as UpdateIndexingConfiguration with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UpdateIndexingConfiguration for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) UpdateIndexingConfigurationWithContext(ctx aws.Context, input *UpdateIndexingConfigurationInput, opts ...request.Option) (*UpdateIndexingConfigurationOutput, error) {
+	req, out := c.UpdateIndexingConfigurationRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opUpdateRoleAlias = "UpdateRoleAlias"
+
+// UpdateRoleAliasRequest generates a "aws/request.Request" representing the
+// client's request for the UpdateRoleAlias operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See UpdateRoleAlias for more information on using the UpdateRoleAlias
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the UpdateRoleAliasRequest method.
+//    req, resp := client.UpdateRoleAliasRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) UpdateRoleAliasRequest(input *UpdateRoleAliasInput) (req *request.Request, output *UpdateRoleAliasOutput) {
+	op := &request.Operation{
+		Name:       opUpdateRoleAlias,
+		HTTPMethod: "PUT",
+		HTTPPath:   "/role-aliases/{roleAlias}",
+	}
+
+	if input == nil {
+		input = &UpdateRoleAliasInput{}
+	}
+
+	output = &UpdateRoleAliasOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// UpdateRoleAlias API operation for AWS IoT.
+//
+// Updates a role alias.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation UpdateRoleAlias for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeUnauthorizedException "UnauthorizedException"
+//   You are not authorized to perform this operation.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+func (c *IoT) UpdateRoleAlias(input *UpdateRoleAliasInput) (*UpdateRoleAliasOutput, error) {
+	req, out := c.UpdateRoleAliasRequest(input)
+	return out, req.Send()
+}
+
+// UpdateRoleAliasWithContext is the same as UpdateRoleAlias with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UpdateRoleAlias for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) UpdateRoleAliasWithContext(ctx aws.Context, input *UpdateRoleAliasInput, opts ...request.Option) (*UpdateRoleAliasOutput, error) {
+	req, out := c.UpdateRoleAliasRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opUpdateThing = "UpdateThing"
 
 // UpdateThingRequest generates a "aws/request.Request" representing the
@@ -5354,6 +10245,180 @@ func (c *IoT) UpdateThing(input *UpdateThingInput) (*UpdateThingOutput, error) {
 // for more information on using Contexts.
 func (c *IoT) UpdateThingWithContext(ctx aws.Context, input *UpdateThingInput, opts ...request.Option) (*UpdateThingOutput, error) {
 	req, out := c.UpdateThingRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opUpdateThingGroup = "UpdateThingGroup"
+
+// UpdateThingGroupRequest generates a "aws/request.Request" representing the
+// client's request for the UpdateThingGroup operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See UpdateThingGroup for more information on using the UpdateThingGroup
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the UpdateThingGroupRequest method.
+//    req, resp := client.UpdateThingGroupRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) UpdateThingGroupRequest(input *UpdateThingGroupInput) (req *request.Request, output *UpdateThingGroupOutput) {
+	op := &request.Operation{
+		Name:       opUpdateThingGroup,
+		HTTPMethod: "PATCH",
+		HTTPPath:   "/thing-groups/{thingGroupName}",
+	}
+
+	if input == nil {
+		input = &UpdateThingGroupInput{}
+	}
+
+	output = &UpdateThingGroupOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// UpdateThingGroup API operation for AWS IoT.
+//
+// Update a thing group.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation UpdateThingGroup for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeVersionConflictException "VersionConflictException"
+//   An exception thrown when the version of a thing passed to a command is different
+//   than the version specified with the --version parameter.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+func (c *IoT) UpdateThingGroup(input *UpdateThingGroupInput) (*UpdateThingGroupOutput, error) {
+	req, out := c.UpdateThingGroupRequest(input)
+	return out, req.Send()
+}
+
+// UpdateThingGroupWithContext is the same as UpdateThingGroup with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UpdateThingGroup for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) UpdateThingGroupWithContext(ctx aws.Context, input *UpdateThingGroupInput, opts ...request.Option) (*UpdateThingGroupOutput, error) {
+	req, out := c.UpdateThingGroupRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opUpdateThingGroupsForThing = "UpdateThingGroupsForThing"
+
+// UpdateThingGroupsForThingRequest generates a "aws/request.Request" representing the
+// client's request for the UpdateThingGroupsForThing operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See UpdateThingGroupsForThing for more information on using the UpdateThingGroupsForThing
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the UpdateThingGroupsForThingRequest method.
+//    req, resp := client.UpdateThingGroupsForThingRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) UpdateThingGroupsForThingRequest(input *UpdateThingGroupsForThingInput) (req *request.Request, output *UpdateThingGroupsForThingOutput) {
+	op := &request.Operation{
+		Name:       opUpdateThingGroupsForThing,
+		HTTPMethod: "PUT",
+		HTTPPath:   "/thing-groups/updateThingGroupsForThing",
+	}
+
+	if input == nil {
+		input = &UpdateThingGroupsForThingInput{}
+	}
+
+	output = &UpdateThingGroupsForThingOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// UpdateThingGroupsForThing API operation for AWS IoT.
+//
+// Updates the groups to which the thing belongs.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation UpdateThingGroupsForThing for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An unexpected error has occurred.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+func (c *IoT) UpdateThingGroupsForThing(input *UpdateThingGroupsForThingInput) (*UpdateThingGroupsForThingOutput, error) {
+	req, out := c.UpdateThingGroupsForThingRequest(input)
+	return out, req.Send()
+}
+
+// UpdateThingGroupsForThingWithContext is the same as UpdateThingGroupsForThing with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UpdateThingGroupsForThing for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) UpdateThingGroupsForThingWithContext(ctx aws.Context, input *UpdateThingGroupsForThingInput, opts ...request.Option) (*UpdateThingGroupsForThingOutput, error) {
+	req, out := c.UpdateThingGroupsForThingRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -5633,6 +10698,288 @@ func (s *Action) SetSqs(v *SqsAction) *Action {
 	return s
 }
 
+type AddThingToThingGroupInput struct {
+	_ struct{} `type:"structure"`
+
+	// The ARN of the thing to add to a group.
+	ThingArn *string `locationName:"thingArn" type:"string"`
+
+	// The ARN of the group to which you are adding a thing.
+	ThingGroupArn *string `locationName:"thingGroupArn" type:"string"`
+
+	// The name of the group to which you are adding a thing.
+	ThingGroupName *string `locationName:"thingGroupName" min:"1" type:"string"`
+
+	// The name of the thing to add to a group.
+	ThingName *string `locationName:"thingName" min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s AddThingToThingGroupInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AddThingToThingGroupInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AddThingToThingGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AddThingToThingGroupInput"}
+	if s.ThingGroupName != nil && len(*s.ThingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ThingGroupName", 1))
+	}
+	if s.ThingName != nil && len(*s.ThingName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ThingName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetThingArn sets the ThingArn field's value.
+func (s *AddThingToThingGroupInput) SetThingArn(v string) *AddThingToThingGroupInput {
+	s.ThingArn = &v
+	return s
+}
+
+// SetThingGroupArn sets the ThingGroupArn field's value.
+func (s *AddThingToThingGroupInput) SetThingGroupArn(v string) *AddThingToThingGroupInput {
+	s.ThingGroupArn = &v
+	return s
+}
+
+// SetThingGroupName sets the ThingGroupName field's value.
+func (s *AddThingToThingGroupInput) SetThingGroupName(v string) *AddThingToThingGroupInput {
+	s.ThingGroupName = &v
+	return s
+}
+
+// SetThingName sets the ThingName field's value.
+func (s *AddThingToThingGroupInput) SetThingName(v string) *AddThingToThingGroupInput {
+	s.ThingName = &v
+	return s
+}
+
+type AddThingToThingGroupOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s AddThingToThingGroupOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AddThingToThingGroupOutput) GoString() string {
+	return s.String()
+}
+
+// Contains information that allowed the authorization.
+type Allowed struct {
+	_ struct{} `type:"structure"`
+
+	// A list of policies that allowed the authentication.
+	Policies []*Policy `locationName:"policies" type:"list"`
+}
+
+// String returns the string representation
+func (s Allowed) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s Allowed) GoString() string {
+	return s.String()
+}
+
+// SetPolicies sets the Policies field's value.
+func (s *Allowed) SetPolicies(v []*Policy) *Allowed {
+	s.Policies = v
+	return s
+}
+
+type AssociateTargetsWithJobInput struct {
+	_ struct{} `type:"structure"`
+
+	// An optional comment string describing why the job was associated with the
+	// targets.
+	Comment *string `locationName:"comment" type:"string"`
+
+	// The unique identifier you assigned to this job when it was created.
+	//
+	// JobId is a required field
+	JobId *string `location:"uri" locationName:"jobId" min:"1" type:"string" required:"true"`
+
+	// A list of thing group ARNs that define the targets of the job.
+	//
+	// Targets is a required field
+	Targets []*string `locationName:"targets" min:"1" type:"list" required:"true"`
+}
+
+// String returns the string representation
+func (s AssociateTargetsWithJobInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AssociateTargetsWithJobInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AssociateTargetsWithJobInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AssociateTargetsWithJobInput"}
+	if s.JobId == nil {
+		invalidParams.Add(request.NewErrParamRequired("JobId"))
+	}
+	if s.JobId != nil && len(*s.JobId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("JobId", 1))
+	}
+	if s.Targets == nil {
+		invalidParams.Add(request.NewErrParamRequired("Targets"))
+	}
+	if s.Targets != nil && len(s.Targets) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Targets", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetComment sets the Comment field's value.
+func (s *AssociateTargetsWithJobInput) SetComment(v string) *AssociateTargetsWithJobInput {
+	s.Comment = &v
+	return s
+}
+
+// SetJobId sets the JobId field's value.
+func (s *AssociateTargetsWithJobInput) SetJobId(v string) *AssociateTargetsWithJobInput {
+	s.JobId = &v
+	return s
+}
+
+// SetTargets sets the Targets field's value.
+func (s *AssociateTargetsWithJobInput) SetTargets(v []*string) *AssociateTargetsWithJobInput {
+	s.Targets = v
+	return s
+}
+
+type AssociateTargetsWithJobOutput struct {
+	_ struct{} `type:"structure"`
+
+	// A short text description of the job.
+	Description *string `locationName:"description" type:"string"`
+
+	// An ARN identifying the job.
+	JobArn *string `locationName:"jobArn" type:"string"`
+
+	// The unique identifier you assigned to this job when it was created.
+	JobId *string `locationName:"jobId" min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s AssociateTargetsWithJobOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AssociateTargetsWithJobOutput) GoString() string {
+	return s.String()
+}
+
+// SetDescription sets the Description field's value.
+func (s *AssociateTargetsWithJobOutput) SetDescription(v string) *AssociateTargetsWithJobOutput {
+	s.Description = &v
+	return s
+}
+
+// SetJobArn sets the JobArn field's value.
+func (s *AssociateTargetsWithJobOutput) SetJobArn(v string) *AssociateTargetsWithJobOutput {
+	s.JobArn = &v
+	return s
+}
+
+// SetJobId sets the JobId field's value.
+func (s *AssociateTargetsWithJobOutput) SetJobId(v string) *AssociateTargetsWithJobOutput {
+	s.JobId = &v
+	return s
+}
+
+type AttachPolicyInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the policy to attach.
+	//
+	// PolicyName is a required field
+	PolicyName *string `location:"uri" locationName:"policyName" min:"1" type:"string" required:"true"`
+
+	// The identity to which the policy is attached.
+	//
+	// Target is a required field
+	Target *string `locationName:"target" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s AttachPolicyInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AttachPolicyInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AttachPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AttachPolicyInput"}
+	if s.PolicyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyName"))
+	}
+	if s.PolicyName != nil && len(*s.PolicyName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyName", 1))
+	}
+	if s.Target == nil {
+		invalidParams.Add(request.NewErrParamRequired("Target"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *AttachPolicyInput) SetPolicyName(v string) *AttachPolicyInput {
+	s.PolicyName = &v
+	return s
+}
+
+// SetTarget sets the Target field's value.
+func (s *AttachPolicyInput) SetTarget(v string) *AttachPolicyInput {
+	s.Target = &v
+	return s
+}
+
+type AttachPolicyOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s AttachPolicyOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AttachPolicyOutput) GoString() string {
+	return s.String()
+}
+
 // The input for the AttachPrincipalPolicy operation.
 type AttachPrincipalPolicyInput struct {
 	_ struct{} `type:"structure"`
@@ -5813,6 +11160,223 @@ func (s *AttributePayload) SetAttributes(v map[string]*string) *AttributePayload
 // SetMerge sets the Merge field's value.
 func (s *AttributePayload) SetMerge(v bool) *AttributePayload {
 	s.Merge = &v
+	return s
+}
+
+// A collection of authorization information.
+type AuthInfo struct {
+	_ struct{} `type:"structure"`
+
+	// The type of action for which the principal is being authorized.
+	ActionType *string `locationName:"actionType" type:"string" enum:"ActionType"`
+
+	// The resources for which the principal is being authorized to perform the
+	// specified action.
+	Resources []*string `locationName:"resources" type:"list"`
+}
+
+// String returns the string representation
+func (s AuthInfo) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AuthInfo) GoString() string {
+	return s.String()
+}
+
+// SetActionType sets the ActionType field's value.
+func (s *AuthInfo) SetActionType(v string) *AuthInfo {
+	s.ActionType = &v
+	return s
+}
+
+// SetResources sets the Resources field's value.
+func (s *AuthInfo) SetResources(v []*string) *AuthInfo {
+	s.Resources = v
+	return s
+}
+
+// The authorizer result.
+type AuthResult struct {
+	_ struct{} `type:"structure"`
+
+	// The policies and statements that allowed the specified action.
+	Allowed *Allowed `locationName:"allowed" type:"structure"`
+
+	// The final authorization decision of this scenario. Multiple statements are
+	// taken into account when determining the authorization decision. An explicit
+	// deny statement can override multiple allow statements.
+	AuthDecision *string `locationName:"authDecision" type:"string" enum:"AuthDecision"`
+
+	// Authorization information.
+	AuthInfo *AuthInfo `locationName:"authInfo" type:"structure"`
+
+	// The policies and statements that denied the specified action.
+	Denied *Denied `locationName:"denied" type:"structure"`
+
+	// Contains any missing context values found while evaluating policy.
+	MissingContextValues []*string `locationName:"missingContextValues" type:"list"`
+}
+
+// String returns the string representation
+func (s AuthResult) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AuthResult) GoString() string {
+	return s.String()
+}
+
+// SetAllowed sets the Allowed field's value.
+func (s *AuthResult) SetAllowed(v *Allowed) *AuthResult {
+	s.Allowed = v
+	return s
+}
+
+// SetAuthDecision sets the AuthDecision field's value.
+func (s *AuthResult) SetAuthDecision(v string) *AuthResult {
+	s.AuthDecision = &v
+	return s
+}
+
+// SetAuthInfo sets the AuthInfo field's value.
+func (s *AuthResult) SetAuthInfo(v *AuthInfo) *AuthResult {
+	s.AuthInfo = v
+	return s
+}
+
+// SetDenied sets the Denied field's value.
+func (s *AuthResult) SetDenied(v *Denied) *AuthResult {
+	s.Denied = v
+	return s
+}
+
+// SetMissingContextValues sets the MissingContextValues field's value.
+func (s *AuthResult) SetMissingContextValues(v []*string) *AuthResult {
+	s.MissingContextValues = v
+	return s
+}
+
+// The authorizer description.
+type AuthorizerDescription struct {
+	_ struct{} `type:"structure"`
+
+	// The authorizer ARN.
+	AuthorizerArn *string `locationName:"authorizerArn" type:"string"`
+
+	// The authorizer's Lambda function ARN.
+	AuthorizerFunctionArn *string `locationName:"authorizerFunctionArn" type:"string"`
+
+	// The authorizer name.
+	AuthorizerName *string `locationName:"authorizerName" min:"1" type:"string"`
+
+	// The UNIX timestamp of when the authorizer was created.
+	CreationDate *time.Time `locationName:"creationDate" type:"timestamp" timestampFormat:"unix"`
+
+	// The UNIX timestamp of when the authorizer was last updated.
+	LastModifiedDate *time.Time `locationName:"lastModifiedDate" type:"timestamp" timestampFormat:"unix"`
+
+	// The status of the authorizer.
+	Status *string `locationName:"status" type:"string" enum:"AuthorizerStatus"`
+
+	// The key used to extract the token from the HTTP headers.
+	TokenKeyName *string `locationName:"tokenKeyName" min:"1" type:"string"`
+
+	// The public keys used to validate the token signature returned by your custom
+	// authentication service.
+	TokenSigningPublicKeys map[string]*string `locationName:"tokenSigningPublicKeys" type:"map"`
+}
+
+// String returns the string representation
+func (s AuthorizerDescription) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AuthorizerDescription) GoString() string {
+	return s.String()
+}
+
+// SetAuthorizerArn sets the AuthorizerArn field's value.
+func (s *AuthorizerDescription) SetAuthorizerArn(v string) *AuthorizerDescription {
+	s.AuthorizerArn = &v
+	return s
+}
+
+// SetAuthorizerFunctionArn sets the AuthorizerFunctionArn field's value.
+func (s *AuthorizerDescription) SetAuthorizerFunctionArn(v string) *AuthorizerDescription {
+	s.AuthorizerFunctionArn = &v
+	return s
+}
+
+// SetAuthorizerName sets the AuthorizerName field's value.
+func (s *AuthorizerDescription) SetAuthorizerName(v string) *AuthorizerDescription {
+	s.AuthorizerName = &v
+	return s
+}
+
+// SetCreationDate sets the CreationDate field's value.
+func (s *AuthorizerDescription) SetCreationDate(v time.Time) *AuthorizerDescription {
+	s.CreationDate = &v
+	return s
+}
+
+// SetLastModifiedDate sets the LastModifiedDate field's value.
+func (s *AuthorizerDescription) SetLastModifiedDate(v time.Time) *AuthorizerDescription {
+	s.LastModifiedDate = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *AuthorizerDescription) SetStatus(v string) *AuthorizerDescription {
+	s.Status = &v
+	return s
+}
+
+// SetTokenKeyName sets the TokenKeyName field's value.
+func (s *AuthorizerDescription) SetTokenKeyName(v string) *AuthorizerDescription {
+	s.TokenKeyName = &v
+	return s
+}
+
+// SetTokenSigningPublicKeys sets the TokenSigningPublicKeys field's value.
+func (s *AuthorizerDescription) SetTokenSigningPublicKeys(v map[string]*string) *AuthorizerDescription {
+	s.TokenSigningPublicKeys = v
+	return s
+}
+
+// The authorizer summary.
+type AuthorizerSummary struct {
+	_ struct{} `type:"structure"`
+
+	// The authorizer ARN.
+	AuthorizerArn *string `locationName:"authorizerArn" type:"string"`
+
+	// The authorizer name.
+	AuthorizerName *string `locationName:"authorizerName" min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s AuthorizerSummary) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AuthorizerSummary) GoString() string {
+	return s.String()
+}
+
+// SetAuthorizerArn sets the AuthorizerArn field's value.
+func (s *AuthorizerSummary) SetAuthorizerArn(v string) *AuthorizerSummary {
+	s.AuthorizerArn = &v
+	return s
+}
+
+// SetAuthorizerName sets the AuthorizerName field's value.
+func (s *AuthorizerSummary) SetAuthorizerName(v string) *AuthorizerSummary {
+	s.AuthorizerName = &v
 	return s
 }
 
@@ -6004,6 +11568,97 @@ func (s CancelCertificateTransferOutput) GoString() string {
 	return s.String()
 }
 
+type CancelJobInput struct {
+	_ struct{} `type:"structure"`
+
+	// An optional comment string describing why the job was canceled.
+	Comment *string `locationName:"comment" type:"string"`
+
+	// The unique identifier you assigned to this job when it was created.
+	//
+	// JobId is a required field
+	JobId *string `location:"uri" locationName:"jobId" min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s CancelJobInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CancelJobInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CancelJobInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CancelJobInput"}
+	if s.JobId == nil {
+		invalidParams.Add(request.NewErrParamRequired("JobId"))
+	}
+	if s.JobId != nil && len(*s.JobId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("JobId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetComment sets the Comment field's value.
+func (s *CancelJobInput) SetComment(v string) *CancelJobInput {
+	s.Comment = &v
+	return s
+}
+
+// SetJobId sets the JobId field's value.
+func (s *CancelJobInput) SetJobId(v string) *CancelJobInput {
+	s.JobId = &v
+	return s
+}
+
+type CancelJobOutput struct {
+	_ struct{} `type:"structure"`
+
+	// A short text description of the job.
+	Description *string `locationName:"description" type:"string"`
+
+	// The job ARN.
+	JobArn *string `locationName:"jobArn" type:"string"`
+
+	// The unique identifier you assigned to this job when it was created.
+	JobId *string `locationName:"jobId" min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s CancelJobOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CancelJobOutput) GoString() string {
+	return s.String()
+}
+
+// SetDescription sets the Description field's value.
+func (s *CancelJobOutput) SetDescription(v string) *CancelJobOutput {
+	s.Description = &v
+	return s
+}
+
+// SetJobArn sets the JobArn field's value.
+func (s *CancelJobOutput) SetJobArn(v string) *CancelJobOutput {
+	s.JobArn = &v
+	return s
+}
+
+// SetJobId sets the JobId field's value.
+func (s *CancelJobOutput) SetJobId(v string) *CancelJobOutput {
+	s.JobId = &v
+	return s
+}
+
 // Information about a certificate.
 type Certificate struct {
 	_ struct{} `type:"structure"`
@@ -6160,6 +11815,34 @@ func (s *CertificateDescription) SetStatus(v string) *CertificateDescription {
 func (s *CertificateDescription) SetTransferData(v *TransferData) *CertificateDescription {
 	s.TransferData = v
 	return s
+}
+
+type ClearDefaultAuthorizerInput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s ClearDefaultAuthorizerInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ClearDefaultAuthorizerInput) GoString() string {
+	return s.String()
+}
+
+type ClearDefaultAuthorizerOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s ClearDefaultAuthorizerOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ClearDefaultAuthorizerOutput) GoString() string {
+	return s.String()
 }
 
 // Describes an action that updates a CloudWatch alarm.
@@ -6348,6 +12031,158 @@ func (s *CloudwatchMetricAction) SetRoleArn(v string) *CloudwatchMetricAction {
 	return s
 }
 
+// Configuration.
+type Configuration struct {
+	_ struct{} `type:"structure"`
+
+	// True to enable the configuration.
+	Enabled *bool `type:"boolean"`
+}
+
+// String returns the string representation
+func (s Configuration) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s Configuration) GoString() string {
+	return s.String()
+}
+
+// SetEnabled sets the Enabled field's value.
+func (s *Configuration) SetEnabled(v bool) *Configuration {
+	s.Enabled = &v
+	return s
+}
+
+type CreateAuthorizerInput struct {
+	_ struct{} `type:"structure"`
+
+	// The ARN of the authorizer's Lambda function.
+	//
+	// AuthorizerFunctionArn is a required field
+	AuthorizerFunctionArn *string `locationName:"authorizerFunctionArn" type:"string" required:"true"`
+
+	// The authorizer name.
+	//
+	// AuthorizerName is a required field
+	AuthorizerName *string `location:"uri" locationName:"authorizerName" min:"1" type:"string" required:"true"`
+
+	// The status of the create authorizer request.
+	Status *string `locationName:"status" type:"string" enum:"AuthorizerStatus"`
+
+	// The name of the token key used to extract the token from the HTTP headers.
+	//
+	// TokenKeyName is a required field
+	TokenKeyName *string `locationName:"tokenKeyName" min:"1" type:"string" required:"true"`
+
+	// The public keys used to verify the digital signature returned by your custom
+	// authentication service.
+	//
+	// TokenSigningPublicKeys is a required field
+	TokenSigningPublicKeys map[string]*string `locationName:"tokenSigningPublicKeys" type:"map" required:"true"`
+}
+
+// String returns the string representation
+func (s CreateAuthorizerInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateAuthorizerInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateAuthorizerInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateAuthorizerInput"}
+	if s.AuthorizerFunctionArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("AuthorizerFunctionArn"))
+	}
+	if s.AuthorizerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AuthorizerName"))
+	}
+	if s.AuthorizerName != nil && len(*s.AuthorizerName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AuthorizerName", 1))
+	}
+	if s.TokenKeyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("TokenKeyName"))
+	}
+	if s.TokenKeyName != nil && len(*s.TokenKeyName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TokenKeyName", 1))
+	}
+	if s.TokenSigningPublicKeys == nil {
+		invalidParams.Add(request.NewErrParamRequired("TokenSigningPublicKeys"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAuthorizerFunctionArn sets the AuthorizerFunctionArn field's value.
+func (s *CreateAuthorizerInput) SetAuthorizerFunctionArn(v string) *CreateAuthorizerInput {
+	s.AuthorizerFunctionArn = &v
+	return s
+}
+
+// SetAuthorizerName sets the AuthorizerName field's value.
+func (s *CreateAuthorizerInput) SetAuthorizerName(v string) *CreateAuthorizerInput {
+	s.AuthorizerName = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *CreateAuthorizerInput) SetStatus(v string) *CreateAuthorizerInput {
+	s.Status = &v
+	return s
+}
+
+// SetTokenKeyName sets the TokenKeyName field's value.
+func (s *CreateAuthorizerInput) SetTokenKeyName(v string) *CreateAuthorizerInput {
+	s.TokenKeyName = &v
+	return s
+}
+
+// SetTokenSigningPublicKeys sets the TokenSigningPublicKeys field's value.
+func (s *CreateAuthorizerInput) SetTokenSigningPublicKeys(v map[string]*string) *CreateAuthorizerInput {
+	s.TokenSigningPublicKeys = v
+	return s
+}
+
+type CreateAuthorizerOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The authorizer ARN.
+	AuthorizerArn *string `locationName:"authorizerArn" type:"string"`
+
+	// The authorizer's name.
+	AuthorizerName *string `locationName:"authorizerName" min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s CreateAuthorizerOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateAuthorizerOutput) GoString() string {
+	return s.String()
+}
+
+// SetAuthorizerArn sets the AuthorizerArn field's value.
+func (s *CreateAuthorizerOutput) SetAuthorizerArn(v string) *CreateAuthorizerOutput {
+	s.AuthorizerArn = &v
+	return s
+}
+
+// SetAuthorizerName sets the AuthorizerName field's value.
+func (s *CreateAuthorizerOutput) SetAuthorizerName(v string) *CreateAuthorizerOutput {
+	s.AuthorizerName = &v
+	return s
+}
+
 // The input for the CreateCertificateFromCsr operation.
 type CreateCertificateFromCsrInput struct {
 	_ struct{} `type:"structure"`
@@ -6440,6 +12275,187 @@ func (s *CreateCertificateFromCsrOutput) SetCertificateId(v string) *CreateCerti
 // SetCertificatePem sets the CertificatePem field's value.
 func (s *CreateCertificateFromCsrOutput) SetCertificatePem(v string) *CreateCertificateFromCsrOutput {
 	s.CertificatePem = &v
+	return s
+}
+
+type CreateJobInput struct {
+	_ struct{} `type:"structure"`
+
+	// A short text description of the job.
+	Description *string `locationName:"description" type:"string"`
+
+	// The job document.
+	Document *string `locationName:"document" type:"string"`
+
+	// Parameters for the job document.
+	DocumentParameters map[string]*string `locationName:"documentParameters" type:"map"`
+
+	// An S3 link to the job document.
+	DocumentSource *string `locationName:"documentSource" min:"1" type:"string"`
+
+	// Allows you to create a staged rollout of the job.
+	JobExecutionsRolloutConfig *JobExecutionsRolloutConfig `locationName:"jobExecutionsRolloutConfig" type:"structure"`
+
+	// A job identifier which must be unique for your AWS account. We recommend
+	// using a UUID. Alpha-numeric characters, "-" and "_" are valid for use here.
+	//
+	// JobId is a required field
+	JobId *string `location:"uri" locationName:"jobId" min:"1" type:"string" required:"true"`
+
+	// Configuration information for pre-signed S3 URLs.
+	PresignedUrlConfig *PresignedUrlConfig `locationName:"presignedUrlConfig" type:"structure"`
+
+	// Specifies whether the job will continue to run (CONTINUOUS), or will be complete
+	// after all those things specified as targets have completed the job (SNAPSHOT).
+	// If continuous, the job may also be run on a thing when a change is detected
+	// in a target. For example, a job will run on a thing when the thing is added
+	// to a target group, even after the job was completed by all things originally
+	// in the group.
+	TargetSelection *string `locationName:"targetSelection" type:"string" enum:"TargetSelection"`
+
+	// A list of things and thing groups to which the job should be sent.
+	//
+	// Targets is a required field
+	Targets []*string `locationName:"targets" min:"1" type:"list" required:"true"`
+}
+
+// String returns the string representation
+func (s CreateJobInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateJobInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateJobInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateJobInput"}
+	if s.DocumentSource != nil && len(*s.DocumentSource) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DocumentSource", 1))
+	}
+	if s.JobId == nil {
+		invalidParams.Add(request.NewErrParamRequired("JobId"))
+	}
+	if s.JobId != nil && len(*s.JobId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("JobId", 1))
+	}
+	if s.Targets == nil {
+		invalidParams.Add(request.NewErrParamRequired("Targets"))
+	}
+	if s.Targets != nil && len(s.Targets) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Targets", 1))
+	}
+	if s.JobExecutionsRolloutConfig != nil {
+		if err := s.JobExecutionsRolloutConfig.Validate(); err != nil {
+			invalidParams.AddNested("JobExecutionsRolloutConfig", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.PresignedUrlConfig != nil {
+		if err := s.PresignedUrlConfig.Validate(); err != nil {
+			invalidParams.AddNested("PresignedUrlConfig", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDescription sets the Description field's value.
+func (s *CreateJobInput) SetDescription(v string) *CreateJobInput {
+	s.Description = &v
+	return s
+}
+
+// SetDocument sets the Document field's value.
+func (s *CreateJobInput) SetDocument(v string) *CreateJobInput {
+	s.Document = &v
+	return s
+}
+
+// SetDocumentParameters sets the DocumentParameters field's value.
+func (s *CreateJobInput) SetDocumentParameters(v map[string]*string) *CreateJobInput {
+	s.DocumentParameters = v
+	return s
+}
+
+// SetDocumentSource sets the DocumentSource field's value.
+func (s *CreateJobInput) SetDocumentSource(v string) *CreateJobInput {
+	s.DocumentSource = &v
+	return s
+}
+
+// SetJobExecutionsRolloutConfig sets the JobExecutionsRolloutConfig field's value.
+func (s *CreateJobInput) SetJobExecutionsRolloutConfig(v *JobExecutionsRolloutConfig) *CreateJobInput {
+	s.JobExecutionsRolloutConfig = v
+	return s
+}
+
+// SetJobId sets the JobId field's value.
+func (s *CreateJobInput) SetJobId(v string) *CreateJobInput {
+	s.JobId = &v
+	return s
+}
+
+// SetPresignedUrlConfig sets the PresignedUrlConfig field's value.
+func (s *CreateJobInput) SetPresignedUrlConfig(v *PresignedUrlConfig) *CreateJobInput {
+	s.PresignedUrlConfig = v
+	return s
+}
+
+// SetTargetSelection sets the TargetSelection field's value.
+func (s *CreateJobInput) SetTargetSelection(v string) *CreateJobInput {
+	s.TargetSelection = &v
+	return s
+}
+
+// SetTargets sets the Targets field's value.
+func (s *CreateJobInput) SetTargets(v []*string) *CreateJobInput {
+	s.Targets = v
+	return s
+}
+
+type CreateJobOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The job description.
+	Description *string `locationName:"description" type:"string"`
+
+	// The job ARN.
+	JobArn *string `locationName:"jobArn" type:"string"`
+
+	// The unique identifier you assigned to this job.
+	JobId *string `locationName:"jobId" min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s CreateJobOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateJobOutput) GoString() string {
+	return s.String()
+}
+
+// SetDescription sets the Description field's value.
+func (s *CreateJobOutput) SetDescription(v string) *CreateJobOutput {
+	s.Description = &v
+	return s
+}
+
+// SetJobArn sets the JobArn field's value.
+func (s *CreateJobOutput) SetJobArn(v string) *CreateJobOutput {
+	s.JobArn = &v
+	return s
+}
+
+// SetJobId sets the JobId field's value.
+func (s *CreateJobOutput) SetJobId(v string) *CreateJobOutput {
+	s.JobId = &v
 	return s
 }
 
@@ -6632,7 +12648,7 @@ type CreatePolicyVersionInput struct {
 	_ struct{} `type:"structure"`
 
 	// The JSON document that describes the policy. Minimum length of 1. Maximum
-	// length of 2048, excluding whitespaces
+	// length of 2048, excluding whitespace.
 	//
 	// PolicyDocument is a required field
 	PolicyDocument *string `locationName:"policyDocument" type:"string" required:"true"`
@@ -6746,6 +12762,212 @@ func (s *CreatePolicyVersionOutput) SetPolicyVersionId(v string) *CreatePolicyVe
 	return s
 }
 
+type CreateRoleAliasInput struct {
+	_ struct{} `type:"structure"`
+
+	// How long (in seconds) the credentials will be valid.
+	CredentialDurationSeconds *int64 `locationName:"credentialDurationSeconds" min:"900" type:"integer"`
+
+	// The role alias that points to a role ARN. This allows you to change the role
+	// without having to update the device.
+	//
+	// RoleAlias is a required field
+	RoleAlias *string `location:"uri" locationName:"roleAlias" min:"1" type:"string" required:"true"`
+
+	// The role ARN.
+	//
+	// RoleArn is a required field
+	RoleArn *string `locationName:"roleArn" min:"20" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s CreateRoleAliasInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateRoleAliasInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateRoleAliasInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateRoleAliasInput"}
+	if s.CredentialDurationSeconds != nil && *s.CredentialDurationSeconds < 900 {
+		invalidParams.Add(request.NewErrParamMinValue("CredentialDurationSeconds", 900))
+	}
+	if s.RoleAlias == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleAlias"))
+	}
+	if s.RoleAlias != nil && len(*s.RoleAlias) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleAlias", 1))
+	}
+	if s.RoleArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleArn"))
+	}
+	if s.RoleArn != nil && len(*s.RoleArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleArn", 20))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetCredentialDurationSeconds sets the CredentialDurationSeconds field's value.
+func (s *CreateRoleAliasInput) SetCredentialDurationSeconds(v int64) *CreateRoleAliasInput {
+	s.CredentialDurationSeconds = &v
+	return s
+}
+
+// SetRoleAlias sets the RoleAlias field's value.
+func (s *CreateRoleAliasInput) SetRoleAlias(v string) *CreateRoleAliasInput {
+	s.RoleAlias = &v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *CreateRoleAliasInput) SetRoleArn(v string) *CreateRoleAliasInput {
+	s.RoleArn = &v
+	return s
+}
+
+type CreateRoleAliasOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The role alias.
+	RoleAlias *string `locationName:"roleAlias" min:"1" type:"string"`
+
+	// The role alias ARN.
+	RoleAliasArn *string `locationName:"roleAliasArn" type:"string"`
+}
+
+// String returns the string representation
+func (s CreateRoleAliasOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateRoleAliasOutput) GoString() string {
+	return s.String()
+}
+
+// SetRoleAlias sets the RoleAlias field's value.
+func (s *CreateRoleAliasOutput) SetRoleAlias(v string) *CreateRoleAliasOutput {
+	s.RoleAlias = &v
+	return s
+}
+
+// SetRoleAliasArn sets the RoleAliasArn field's value.
+func (s *CreateRoleAliasOutput) SetRoleAliasArn(v string) *CreateRoleAliasOutput {
+	s.RoleAliasArn = &v
+	return s
+}
+
+type CreateThingGroupInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the parent thing group.
+	ParentGroupName *string `locationName:"parentGroupName" min:"1" type:"string"`
+
+	// The thing group name to create.
+	//
+	// ThingGroupName is a required field
+	ThingGroupName *string `location:"uri" locationName:"thingGroupName" min:"1" type:"string" required:"true"`
+
+	// The thing group properties.
+	ThingGroupProperties *ThingGroupProperties `locationName:"thingGroupProperties" type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateThingGroupInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateThingGroupInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateThingGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateThingGroupInput"}
+	if s.ParentGroupName != nil && len(*s.ParentGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ParentGroupName", 1))
+	}
+	if s.ThingGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ThingGroupName"))
+	}
+	if s.ThingGroupName != nil && len(*s.ThingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ThingGroupName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetParentGroupName sets the ParentGroupName field's value.
+func (s *CreateThingGroupInput) SetParentGroupName(v string) *CreateThingGroupInput {
+	s.ParentGroupName = &v
+	return s
+}
+
+// SetThingGroupName sets the ThingGroupName field's value.
+func (s *CreateThingGroupInput) SetThingGroupName(v string) *CreateThingGroupInput {
+	s.ThingGroupName = &v
+	return s
+}
+
+// SetThingGroupProperties sets the ThingGroupProperties field's value.
+func (s *CreateThingGroupInput) SetThingGroupProperties(v *ThingGroupProperties) *CreateThingGroupInput {
+	s.ThingGroupProperties = v
+	return s
+}
+
+type CreateThingGroupOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The thing group ARN.
+	ThingGroupArn *string `locationName:"thingGroupArn" type:"string"`
+
+	// The thing group ID.
+	ThingGroupId *string `locationName:"thingGroupId" min:"1" type:"string"`
+
+	// The thing group name.
+	ThingGroupName *string `locationName:"thingGroupName" min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s CreateThingGroupOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateThingGroupOutput) GoString() string {
+	return s.String()
+}
+
+// SetThingGroupArn sets the ThingGroupArn field's value.
+func (s *CreateThingGroupOutput) SetThingGroupArn(v string) *CreateThingGroupOutput {
+	s.ThingGroupArn = &v
+	return s
+}
+
+// SetThingGroupId sets the ThingGroupId field's value.
+func (s *CreateThingGroupOutput) SetThingGroupId(v string) *CreateThingGroupOutput {
+	s.ThingGroupId = &v
+	return s
+}
+
+// SetThingGroupName sets the ThingGroupName field's value.
+func (s *CreateThingGroupOutput) SetThingGroupName(v string) *CreateThingGroupOutput {
+	s.ThingGroupName = &v
+	return s
+}
+
 // The input for the CreateThing operation.
 type CreateThingInput struct {
 	_ struct{} `type:"structure"`
@@ -6819,6 +13041,9 @@ type CreateThingOutput struct {
 	// The ARN of the new thing.
 	ThingArn *string `locationName:"thingArn" type:"string"`
 
+	// The thing ID.
+	ThingId *string `locationName:"thingId" type:"string"`
+
 	// The name of the new thing.
 	ThingName *string `locationName:"thingName" min:"1" type:"string"`
 }
@@ -6836,6 +13061,12 @@ func (s CreateThingOutput) GoString() string {
 // SetThingArn sets the ThingArn field's value.
 func (s *CreateThingOutput) SetThingArn(v string) *CreateThingOutput {
 	s.ThingArn = &v
+	return s
+}
+
+// SetThingId sets the ThingId field's value.
+func (s *CreateThingOutput) SetThingId(v string) *CreateThingOutput {
+	s.ThingId = &v
 	return s
 }
 
@@ -6905,6 +13136,9 @@ type CreateThingTypeOutput struct {
 	// The Amazon Resource Name (ARN) of the thing type.
 	ThingTypeArn *string `locationName:"thingTypeArn" type:"string"`
 
+	// The thing type ID.
+	ThingTypeId *string `locationName:"thingTypeId" type:"string"`
+
 	// The name of the thing type.
 	ThingTypeName *string `locationName:"thingTypeName" min:"1" type:"string"`
 }
@@ -6922,6 +13156,12 @@ func (s CreateThingTypeOutput) GoString() string {
 // SetThingTypeArn sets the ThingTypeArn field's value.
 func (s *CreateThingTypeOutput) SetThingTypeArn(v string) *CreateThingTypeOutput {
 	s.ThingTypeArn = &v
+	return s
+}
+
+// SetThingTypeId sets the ThingTypeId field's value.
+func (s *CreateThingTypeOutput) SetThingTypeId(v string) *CreateThingTypeOutput {
+	s.ThingTypeId = &v
 	return s
 }
 
@@ -7006,6 +13246,61 @@ func (s CreateTopicRuleOutput) GoString() string {
 	return s.String()
 }
 
+type DeleteAuthorizerInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the authorizer to delete.
+	//
+	// AuthorizerName is a required field
+	AuthorizerName *string `location:"uri" locationName:"authorizerName" min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DeleteAuthorizerInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteAuthorizerInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteAuthorizerInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteAuthorizerInput"}
+	if s.AuthorizerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AuthorizerName"))
+	}
+	if s.AuthorizerName != nil && len(*s.AuthorizerName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AuthorizerName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAuthorizerName sets the AuthorizerName field's value.
+func (s *DeleteAuthorizerInput) SetAuthorizerName(v string) *DeleteAuthorizerInput {
+	s.AuthorizerName = &v
+	return s
+}
+
+type DeleteAuthorizerOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteAuthorizerOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteAuthorizerOutput) GoString() string {
+	return s.String()
+}
+
 // Input for the DeleteCACertificate operation.
 type DeleteCACertificateInput struct {
 	_ struct{} `type:"structure"`
@@ -7071,6 +13366,9 @@ type DeleteCertificateInput struct {
 	//
 	// CertificateId is a required field
 	CertificateId *string `location:"uri" locationName:"certificateId" min:"64" type:"string" required:"true"`
+
+	// Forces a certificate request to be deleted.
+	ForceDelete *bool `location:"querystring" locationName:"forceDelete" type:"boolean"`
 }
 
 // String returns the string representation
@@ -7102,6 +13400,12 @@ func (s *DeleteCertificateInput) Validate() error {
 // SetCertificateId sets the CertificateId field's value.
 func (s *DeleteCertificateInput) SetCertificateId(v string) *DeleteCertificateInput {
 	s.CertificateId = &v
+	return s
+}
+
+// SetForceDelete sets the ForceDelete field's value.
+func (s *DeleteCertificateInput) SetForceDelete(v bool) *DeleteCertificateInput {
+	s.ForceDelete = &v
 	return s
 }
 
@@ -7272,6 +13576,125 @@ func (s DeleteRegistrationCodeOutput) String() string {
 
 // GoString returns the string representation
 func (s DeleteRegistrationCodeOutput) GoString() string {
+	return s.String()
+}
+
+type DeleteRoleAliasInput struct {
+	_ struct{} `type:"structure"`
+
+	// The role alias to delete.
+	//
+	// RoleAlias is a required field
+	RoleAlias *string `location:"uri" locationName:"roleAlias" min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DeleteRoleAliasInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteRoleAliasInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteRoleAliasInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteRoleAliasInput"}
+	if s.RoleAlias == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleAlias"))
+	}
+	if s.RoleAlias != nil && len(*s.RoleAlias) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleAlias", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetRoleAlias sets the RoleAlias field's value.
+func (s *DeleteRoleAliasInput) SetRoleAlias(v string) *DeleteRoleAliasInput {
+	s.RoleAlias = &v
+	return s
+}
+
+type DeleteRoleAliasOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteRoleAliasOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteRoleAliasOutput) GoString() string {
+	return s.String()
+}
+
+type DeleteThingGroupInput struct {
+	_ struct{} `type:"structure"`
+
+	// The expected version of the thing group to delete.
+	ExpectedVersion *int64 `location:"querystring" locationName:"expectedVersion" type:"long"`
+
+	// The name of the thing group to delete.
+	//
+	// ThingGroupName is a required field
+	ThingGroupName *string `location:"uri" locationName:"thingGroupName" min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DeleteThingGroupInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteThingGroupInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteThingGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteThingGroupInput"}
+	if s.ThingGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ThingGroupName"))
+	}
+	if s.ThingGroupName != nil && len(*s.ThingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ThingGroupName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetExpectedVersion sets the ExpectedVersion field's value.
+func (s *DeleteThingGroupInput) SetExpectedVersion(v int64) *DeleteThingGroupInput {
+	s.ExpectedVersion = &v
+	return s
+}
+
+// SetThingGroupName sets the ThingGroupName field's value.
+func (s *DeleteThingGroupInput) SetThingGroupName(v string) *DeleteThingGroupInput {
+	s.ThingGroupName = &v
+	return s
+}
+
+type DeleteThingGroupOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteThingGroupOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteThingGroupOutput) GoString() string {
 	return s.String()
 }
 
@@ -7456,6 +13879,107 @@ func (s DeleteTopicRuleOutput) GoString() string {
 	return s.String()
 }
 
+type DeleteV2LoggingLevelInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the resource for which you are configuring logging.
+	//
+	// TargetName is a required field
+	TargetName *string `location:"querystring" locationName:"targetName" type:"string" required:"true"`
+
+	// The type of resource for which you are configuring logging. Must be THING_Group.
+	//
+	// TargetType is a required field
+	TargetType *string `location:"querystring" locationName:"targetType" type:"string" required:"true" enum:"LogTargetType"`
+}
+
+// String returns the string representation
+func (s DeleteV2LoggingLevelInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteV2LoggingLevelInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteV2LoggingLevelInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteV2LoggingLevelInput"}
+	if s.TargetName == nil {
+		invalidParams.Add(request.NewErrParamRequired("TargetName"))
+	}
+	if s.TargetType == nil {
+		invalidParams.Add(request.NewErrParamRequired("TargetType"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetTargetName sets the TargetName field's value.
+func (s *DeleteV2LoggingLevelInput) SetTargetName(v string) *DeleteV2LoggingLevelInput {
+	s.TargetName = &v
+	return s
+}
+
+// SetTargetType sets the TargetType field's value.
+func (s *DeleteV2LoggingLevelInput) SetTargetType(v string) *DeleteV2LoggingLevelInput {
+	s.TargetType = &v
+	return s
+}
+
+type DeleteV2LoggingLevelOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteV2LoggingLevelOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteV2LoggingLevelOutput) GoString() string {
+	return s.String()
+}
+
+// Contains information that denied the authorization.
+type Denied struct {
+	_ struct{} `type:"structure"`
+
+	// Information that explicitly denies the authorization.
+	ExplicitDeny *ExplicitDeny `locationName:"explicitDeny" type:"structure"`
+
+	// Information that implicitly denies the authorization. When a policy doesn't
+	// explicitly deny or allow an action on a resource it is considered an implicit
+	// deny.
+	ImplicitDeny *ImplicitDeny `locationName:"implicitDeny" type:"structure"`
+}
+
+// String returns the string representation
+func (s Denied) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s Denied) GoString() string {
+	return s.String()
+}
+
+// SetExplicitDeny sets the ExplicitDeny field's value.
+func (s *Denied) SetExplicitDeny(v *ExplicitDeny) *Denied {
+	s.ExplicitDeny = v
+	return s
+}
+
+// SetImplicitDeny sets the ImplicitDeny field's value.
+func (s *Denied) SetImplicitDeny(v *ImplicitDeny) *Denied {
+	s.ImplicitDeny = v
+	return s
+}
+
 // The input for the DeprecateThingType operation.
 type DeprecateThingTypeInput struct {
 	_ struct{} `type:"structure"`
@@ -7523,6 +14047,70 @@ func (s DeprecateThingTypeOutput) GoString() string {
 	return s.String()
 }
 
+type DescribeAuthorizerInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the authorizer to describe.
+	//
+	// AuthorizerName is a required field
+	AuthorizerName *string `location:"uri" locationName:"authorizerName" min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DescribeAuthorizerInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAuthorizerInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeAuthorizerInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeAuthorizerInput"}
+	if s.AuthorizerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AuthorizerName"))
+	}
+	if s.AuthorizerName != nil && len(*s.AuthorizerName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AuthorizerName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAuthorizerName sets the AuthorizerName field's value.
+func (s *DescribeAuthorizerInput) SetAuthorizerName(v string) *DescribeAuthorizerInput {
+	s.AuthorizerName = &v
+	return s
+}
+
+type DescribeAuthorizerOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The authorizer description.
+	AuthorizerDescription *AuthorizerDescription `locationName:"authorizerDescription" type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeAuthorizerOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAuthorizerOutput) GoString() string {
+	return s.String()
+}
+
+// SetAuthorizerDescription sets the AuthorizerDescription field's value.
+func (s *DescribeAuthorizerOutput) SetAuthorizerDescription(v *AuthorizerDescription) *DescribeAuthorizerOutput {
+	s.AuthorizerDescription = v
+	return s
+}
+
 // The input for the DescribeCACertificate operation.
 type DescribeCACertificateInput struct {
 	_ struct{} `type:"structure"`
@@ -7571,6 +14159,9 @@ type DescribeCACertificateOutput struct {
 
 	// The CA certificate description.
 	CertificateDescription *CACertificateDescription `locationName:"certificateDescription" type:"structure"`
+
+	// Information about the registration configuration.
+	RegistrationConfig *RegistrationConfig `locationName:"registrationConfig" type:"structure"`
 }
 
 // String returns the string representation
@@ -7586,6 +14177,12 @@ func (s DescribeCACertificateOutput) GoString() string {
 // SetCertificateDescription sets the CertificateDescription field's value.
 func (s *DescribeCACertificateOutput) SetCertificateDescription(v *CACertificateDescription) *DescribeCACertificateOutput {
 	s.CertificateDescription = v
+	return s
+}
+
+// SetRegistrationConfig sets the RegistrationConfig field's value.
+func (s *DescribeCACertificateOutput) SetRegistrationConfig(v *RegistrationConfig) *DescribeCACertificateOutput {
+	s.RegistrationConfig = v
 	return s
 }
 
@@ -7655,9 +14252,49 @@ func (s *DescribeCertificateOutput) SetCertificateDescription(v *CertificateDesc
 	return s
 }
 
+type DescribeDefaultAuthorizerInput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeDefaultAuthorizerInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDefaultAuthorizerInput) GoString() string {
+	return s.String()
+}
+
+type DescribeDefaultAuthorizerOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The default authorizer's description.
+	AuthorizerDescription *AuthorizerDescription `locationName:"authorizerDescription" type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeDefaultAuthorizerOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDefaultAuthorizerOutput) GoString() string {
+	return s.String()
+}
+
+// SetAuthorizerDescription sets the AuthorizerDescription field's value.
+func (s *DescribeDefaultAuthorizerOutput) SetAuthorizerDescription(v *AuthorizerDescription) *DescribeDefaultAuthorizerOutput {
+	s.AuthorizerDescription = v
+	return s
+}
+
 // The input for the DescribeEndpoint operation.
 type DescribeEndpointInput struct {
 	_ struct{} `type:"structure"`
+
+	// The endpoint type.
+	EndpointType *string `location:"querystring" locationName:"endpointType" type:"string"`
 }
 
 // String returns the string representation
@@ -7668,6 +14305,12 @@ func (s DescribeEndpointInput) String() string {
 // GoString returns the string representation
 func (s DescribeEndpointInput) GoString() string {
 	return s.String()
+}
+
+// SetEndpointType sets the EndpointType field's value.
+func (s *DescribeEndpointInput) SetEndpointType(v string) *DescribeEndpointInput {
+	s.EndpointType = &v
+	return s
 }
 
 // The output from the DescribeEndpoint operation.
@@ -7691,6 +14334,485 @@ func (s DescribeEndpointOutput) GoString() string {
 // SetEndpointAddress sets the EndpointAddress field's value.
 func (s *DescribeEndpointOutput) SetEndpointAddress(v string) *DescribeEndpointOutput {
 	s.EndpointAddress = &v
+	return s
+}
+
+type DescribeEventConfigurationsInput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeEventConfigurationsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeEventConfigurationsInput) GoString() string {
+	return s.String()
+}
+
+type DescribeEventConfigurationsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The creation date of the event configuration.
+	CreationDate *time.Time `locationName:"creationDate" type:"timestamp" timestampFormat:"unix"`
+
+	// The event configurations.
+	EventConfigurations map[string]*Configuration `locationName:"eventConfigurations" type:"map"`
+
+	// The date the event configurations were last modified.
+	LastModifiedDate *time.Time `locationName:"lastModifiedDate" type:"timestamp" timestampFormat:"unix"`
+}
+
+// String returns the string representation
+func (s DescribeEventConfigurationsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeEventConfigurationsOutput) GoString() string {
+	return s.String()
+}
+
+// SetCreationDate sets the CreationDate field's value.
+func (s *DescribeEventConfigurationsOutput) SetCreationDate(v time.Time) *DescribeEventConfigurationsOutput {
+	s.CreationDate = &v
+	return s
+}
+
+// SetEventConfigurations sets the EventConfigurations field's value.
+func (s *DescribeEventConfigurationsOutput) SetEventConfigurations(v map[string]*Configuration) *DescribeEventConfigurationsOutput {
+	s.EventConfigurations = v
+	return s
+}
+
+// SetLastModifiedDate sets the LastModifiedDate field's value.
+func (s *DescribeEventConfigurationsOutput) SetLastModifiedDate(v time.Time) *DescribeEventConfigurationsOutput {
+	s.LastModifiedDate = &v
+	return s
+}
+
+type DescribeIndexInput struct {
+	_ struct{} `type:"structure"`
+
+	// The index name.
+	//
+	// IndexName is a required field
+	IndexName *string `location:"uri" locationName:"indexName" min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DescribeIndexInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeIndexInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeIndexInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeIndexInput"}
+	if s.IndexName == nil {
+		invalidParams.Add(request.NewErrParamRequired("IndexName"))
+	}
+	if s.IndexName != nil && len(*s.IndexName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IndexName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetIndexName sets the IndexName field's value.
+func (s *DescribeIndexInput) SetIndexName(v string) *DescribeIndexInput {
+	s.IndexName = &v
+	return s
+}
+
+type DescribeIndexOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The index name.
+	IndexName *string `locationName:"indexName" min:"1" type:"string"`
+
+	// The index status.
+	IndexStatus *string `locationName:"indexStatus" type:"string" enum:"IndexStatus"`
+
+	// Contains a value that specifies the type of indexing performed. Valid values
+	// are:
+	//
+	// REGISTRY – Your thing index will contain only registry data.
+	//
+	// REGISTRY_AND_SHADOW - Your thing index will contain registry and shadow data.
+	Schema *string `locationName:"schema" type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeIndexOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeIndexOutput) GoString() string {
+	return s.String()
+}
+
+// SetIndexName sets the IndexName field's value.
+func (s *DescribeIndexOutput) SetIndexName(v string) *DescribeIndexOutput {
+	s.IndexName = &v
+	return s
+}
+
+// SetIndexStatus sets the IndexStatus field's value.
+func (s *DescribeIndexOutput) SetIndexStatus(v string) *DescribeIndexOutput {
+	s.IndexStatus = &v
+	return s
+}
+
+// SetSchema sets the Schema field's value.
+func (s *DescribeIndexOutput) SetSchema(v string) *DescribeIndexOutput {
+	s.Schema = &v
+	return s
+}
+
+type DescribeJobExecutionInput struct {
+	_ struct{} `type:"structure"`
+
+	// A string (consisting of the digits "0" through "9" which is used to specify
+	// a particular job execution on a particular device.
+	ExecutionNumber *int64 `location:"querystring" locationName:"executionNumber" type:"long"`
+
+	// The unique identifier you assigned to this job when it was created.
+	//
+	// JobId is a required field
+	JobId *string `location:"uri" locationName:"jobId" min:"1" type:"string" required:"true"`
+
+	// The name of the thing on which the job execution is running.
+	//
+	// ThingName is a required field
+	ThingName *string `location:"uri" locationName:"thingName" min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DescribeJobExecutionInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeJobExecutionInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeJobExecutionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeJobExecutionInput"}
+	if s.JobId == nil {
+		invalidParams.Add(request.NewErrParamRequired("JobId"))
+	}
+	if s.JobId != nil && len(*s.JobId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("JobId", 1))
+	}
+	if s.ThingName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ThingName"))
+	}
+	if s.ThingName != nil && len(*s.ThingName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ThingName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetExecutionNumber sets the ExecutionNumber field's value.
+func (s *DescribeJobExecutionInput) SetExecutionNumber(v int64) *DescribeJobExecutionInput {
+	s.ExecutionNumber = &v
+	return s
+}
+
+// SetJobId sets the JobId field's value.
+func (s *DescribeJobExecutionInput) SetJobId(v string) *DescribeJobExecutionInput {
+	s.JobId = &v
+	return s
+}
+
+// SetThingName sets the ThingName field's value.
+func (s *DescribeJobExecutionInput) SetThingName(v string) *DescribeJobExecutionInput {
+	s.ThingName = &v
+	return s
+}
+
+type DescribeJobExecutionOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the job execution.
+	Execution *JobExecution `locationName:"execution" type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeJobExecutionOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeJobExecutionOutput) GoString() string {
+	return s.String()
+}
+
+// SetExecution sets the Execution field's value.
+func (s *DescribeJobExecutionOutput) SetExecution(v *JobExecution) *DescribeJobExecutionOutput {
+	s.Execution = v
+	return s
+}
+
+type DescribeJobInput struct {
+	_ struct{} `type:"structure"`
+
+	// The unique identifier you assigned to this job when it was created.
+	//
+	// JobId is a required field
+	JobId *string `location:"uri" locationName:"jobId" min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DescribeJobInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeJobInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeJobInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeJobInput"}
+	if s.JobId == nil {
+		invalidParams.Add(request.NewErrParamRequired("JobId"))
+	}
+	if s.JobId != nil && len(*s.JobId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("JobId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetJobId sets the JobId field's value.
+func (s *DescribeJobInput) SetJobId(v string) *DescribeJobInput {
+	s.JobId = &v
+	return s
+}
+
+type DescribeJobOutput struct {
+	_ struct{} `type:"structure"`
+
+	// An S3 link to the job document.
+	DocumentSource *string `locationName:"documentSource" min:"1" type:"string"`
+
+	// Information about the job.
+	Job *Job `locationName:"job" type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeJobOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeJobOutput) GoString() string {
+	return s.String()
+}
+
+// SetDocumentSource sets the DocumentSource field's value.
+func (s *DescribeJobOutput) SetDocumentSource(v string) *DescribeJobOutput {
+	s.DocumentSource = &v
+	return s
+}
+
+// SetJob sets the Job field's value.
+func (s *DescribeJobOutput) SetJob(v *Job) *DescribeJobOutput {
+	s.Job = v
+	return s
+}
+
+type DescribeRoleAliasInput struct {
+	_ struct{} `type:"structure"`
+
+	// The role alias to describe.
+	//
+	// RoleAlias is a required field
+	RoleAlias *string `location:"uri" locationName:"roleAlias" min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DescribeRoleAliasInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeRoleAliasInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeRoleAliasInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeRoleAliasInput"}
+	if s.RoleAlias == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleAlias"))
+	}
+	if s.RoleAlias != nil && len(*s.RoleAlias) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleAlias", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetRoleAlias sets the RoleAlias field's value.
+func (s *DescribeRoleAliasInput) SetRoleAlias(v string) *DescribeRoleAliasInput {
+	s.RoleAlias = &v
+	return s
+}
+
+type DescribeRoleAliasOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The role alias description.
+	RoleAliasDescription *RoleAliasDescription `locationName:"roleAliasDescription" type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeRoleAliasOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeRoleAliasOutput) GoString() string {
+	return s.String()
+}
+
+// SetRoleAliasDescription sets the RoleAliasDescription field's value.
+func (s *DescribeRoleAliasOutput) SetRoleAliasDescription(v *RoleAliasDescription) *DescribeRoleAliasOutput {
+	s.RoleAliasDescription = v
+	return s
+}
+
+type DescribeThingGroupInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the thing group.
+	//
+	// ThingGroupName is a required field
+	ThingGroupName *string `location:"uri" locationName:"thingGroupName" min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DescribeThingGroupInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeThingGroupInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeThingGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeThingGroupInput"}
+	if s.ThingGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ThingGroupName"))
+	}
+	if s.ThingGroupName != nil && len(*s.ThingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ThingGroupName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetThingGroupName sets the ThingGroupName field's value.
+func (s *DescribeThingGroupInput) SetThingGroupName(v string) *DescribeThingGroupInput {
+	s.ThingGroupName = &v
+	return s
+}
+
+type DescribeThingGroupOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The thing group ARN.
+	ThingGroupArn *string `locationName:"thingGroupArn" type:"string"`
+
+	// The thing group ID.
+	ThingGroupId *string `locationName:"thingGroupId" min:"1" type:"string"`
+
+	// Thing group metadata.
+	ThingGroupMetadata *ThingGroupMetadata `locationName:"thingGroupMetadata" type:"structure"`
+
+	// The name of the thing group.
+	ThingGroupName *string `locationName:"thingGroupName" min:"1" type:"string"`
+
+	// The thing group properties.
+	ThingGroupProperties *ThingGroupProperties `locationName:"thingGroupProperties" type:"structure"`
+
+	// The version of the thing group.
+	Version *int64 `locationName:"version" type:"long"`
+}
+
+// String returns the string representation
+func (s DescribeThingGroupOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeThingGroupOutput) GoString() string {
+	return s.String()
+}
+
+// SetThingGroupArn sets the ThingGroupArn field's value.
+func (s *DescribeThingGroupOutput) SetThingGroupArn(v string) *DescribeThingGroupOutput {
+	s.ThingGroupArn = &v
+	return s
+}
+
+// SetThingGroupId sets the ThingGroupId field's value.
+func (s *DescribeThingGroupOutput) SetThingGroupId(v string) *DescribeThingGroupOutput {
+	s.ThingGroupId = &v
+	return s
+}
+
+// SetThingGroupMetadata sets the ThingGroupMetadata field's value.
+func (s *DescribeThingGroupOutput) SetThingGroupMetadata(v *ThingGroupMetadata) *DescribeThingGroupOutput {
+	s.ThingGroupMetadata = v
+	return s
+}
+
+// SetThingGroupName sets the ThingGroupName field's value.
+func (s *DescribeThingGroupOutput) SetThingGroupName(v string) *DescribeThingGroupOutput {
+	s.ThingGroupName = &v
+	return s
+}
+
+// SetThingGroupProperties sets the ThingGroupProperties field's value.
+func (s *DescribeThingGroupOutput) SetThingGroupProperties(v *ThingGroupProperties) *DescribeThingGroupOutput {
+	s.ThingGroupProperties = v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *DescribeThingGroupOutput) SetVersion(v int64) *DescribeThingGroupOutput {
+	s.Version = &v
 	return s
 }
 
@@ -7746,6 +14868,12 @@ type DescribeThingOutput struct {
 	// The default client ID.
 	DefaultClientId *string `locationName:"defaultClientId" type:"string"`
 
+	// The ARN of the thing to describe.
+	ThingArn *string `locationName:"thingArn" type:"string"`
+
+	// The ID of the thing to describe.
+	ThingId *string `locationName:"thingId" type:"string"`
+
 	// The name of the thing.
 	ThingName *string `locationName:"thingName" min:"1" type:"string"`
 
@@ -7782,6 +14910,18 @@ func (s *DescribeThingOutput) SetDefaultClientId(v string) *DescribeThingOutput 
 	return s
 }
 
+// SetThingArn sets the ThingArn field's value.
+func (s *DescribeThingOutput) SetThingArn(v string) *DescribeThingOutput {
+	s.ThingArn = &v
+	return s
+}
+
+// SetThingId sets the ThingId field's value.
+func (s *DescribeThingOutput) SetThingId(v string) *DescribeThingOutput {
+	s.ThingId = &v
+	return s
+}
+
 // SetThingName sets the ThingName field's value.
 func (s *DescribeThingOutput) SetThingName(v string) *DescribeThingOutput {
 	s.ThingName = &v
@@ -7797,6 +14937,166 @@ func (s *DescribeThingOutput) SetThingTypeName(v string) *DescribeThingOutput {
 // SetVersion sets the Version field's value.
 func (s *DescribeThingOutput) SetVersion(v int64) *DescribeThingOutput {
 	s.Version = &v
+	return s
+}
+
+type DescribeThingRegistrationTaskInput struct {
+	_ struct{} `type:"structure"`
+
+	// The task ID.
+	//
+	// TaskId is a required field
+	TaskId *string `location:"uri" locationName:"taskId" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DescribeThingRegistrationTaskInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeThingRegistrationTaskInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeThingRegistrationTaskInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeThingRegistrationTaskInput"}
+	if s.TaskId == nil {
+		invalidParams.Add(request.NewErrParamRequired("TaskId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetTaskId sets the TaskId field's value.
+func (s *DescribeThingRegistrationTaskInput) SetTaskId(v string) *DescribeThingRegistrationTaskInput {
+	s.TaskId = &v
+	return s
+}
+
+type DescribeThingRegistrationTaskOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The task creation date.
+	CreationDate *time.Time `locationName:"creationDate" type:"timestamp" timestampFormat:"unix"`
+
+	// The number of things that failed to be provisioned.
+	FailureCount *int64 `locationName:"failureCount" type:"integer"`
+
+	// The S3 bucket that contains the input file.
+	InputFileBucket *string `locationName:"inputFileBucket" min:"3" type:"string"`
+
+	// The input file key.
+	InputFileKey *string `locationName:"inputFileKey" min:"1" type:"string"`
+
+	// The date when the task was last modified.
+	LastModifiedDate *time.Time `locationName:"lastModifiedDate" type:"timestamp" timestampFormat:"unix"`
+
+	// The message.
+	Message *string `locationName:"message" type:"string"`
+
+	// The progress of the bulk provisioning task expressed as a percentage.
+	PercentageProgress *int64 `locationName:"percentageProgress" type:"integer"`
+
+	// The role ARN that grants access to the input file bucket.
+	RoleArn *string `locationName:"roleArn" min:"20" type:"string"`
+
+	// The status of the bulk thing provisioning task.
+	Status *string `locationName:"status" type:"string" enum:"Status"`
+
+	// The number of things successfully provisioned.
+	SuccessCount *int64 `locationName:"successCount" type:"integer"`
+
+	// The task ID.
+	TaskId *string `locationName:"taskId" type:"string"`
+
+	// The task's template.
+	TemplateBody *string `locationName:"templateBody" type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeThingRegistrationTaskOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeThingRegistrationTaskOutput) GoString() string {
+	return s.String()
+}
+
+// SetCreationDate sets the CreationDate field's value.
+func (s *DescribeThingRegistrationTaskOutput) SetCreationDate(v time.Time) *DescribeThingRegistrationTaskOutput {
+	s.CreationDate = &v
+	return s
+}
+
+// SetFailureCount sets the FailureCount field's value.
+func (s *DescribeThingRegistrationTaskOutput) SetFailureCount(v int64) *DescribeThingRegistrationTaskOutput {
+	s.FailureCount = &v
+	return s
+}
+
+// SetInputFileBucket sets the InputFileBucket field's value.
+func (s *DescribeThingRegistrationTaskOutput) SetInputFileBucket(v string) *DescribeThingRegistrationTaskOutput {
+	s.InputFileBucket = &v
+	return s
+}
+
+// SetInputFileKey sets the InputFileKey field's value.
+func (s *DescribeThingRegistrationTaskOutput) SetInputFileKey(v string) *DescribeThingRegistrationTaskOutput {
+	s.InputFileKey = &v
+	return s
+}
+
+// SetLastModifiedDate sets the LastModifiedDate field's value.
+func (s *DescribeThingRegistrationTaskOutput) SetLastModifiedDate(v time.Time) *DescribeThingRegistrationTaskOutput {
+	s.LastModifiedDate = &v
+	return s
+}
+
+// SetMessage sets the Message field's value.
+func (s *DescribeThingRegistrationTaskOutput) SetMessage(v string) *DescribeThingRegistrationTaskOutput {
+	s.Message = &v
+	return s
+}
+
+// SetPercentageProgress sets the PercentageProgress field's value.
+func (s *DescribeThingRegistrationTaskOutput) SetPercentageProgress(v int64) *DescribeThingRegistrationTaskOutput {
+	s.PercentageProgress = &v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *DescribeThingRegistrationTaskOutput) SetRoleArn(v string) *DescribeThingRegistrationTaskOutput {
+	s.RoleArn = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *DescribeThingRegistrationTaskOutput) SetStatus(v string) *DescribeThingRegistrationTaskOutput {
+	s.Status = &v
+	return s
+}
+
+// SetSuccessCount sets the SuccessCount field's value.
+func (s *DescribeThingRegistrationTaskOutput) SetSuccessCount(v int64) *DescribeThingRegistrationTaskOutput {
+	s.SuccessCount = &v
+	return s
+}
+
+// SetTaskId sets the TaskId field's value.
+func (s *DescribeThingRegistrationTaskOutput) SetTaskId(v string) *DescribeThingRegistrationTaskOutput {
+	s.TaskId = &v
+	return s
+}
+
+// SetTemplateBody sets the TemplateBody field's value.
+func (s *DescribeThingRegistrationTaskOutput) SetTemplateBody(v string) *DescribeThingRegistrationTaskOutput {
+	s.TemplateBody = &v
 	return s
 }
 
@@ -7846,6 +15146,12 @@ func (s *DescribeThingTypeInput) SetThingTypeName(v string) *DescribeThingTypeIn
 type DescribeThingTypeOutput struct {
 	_ struct{} `type:"structure"`
 
+	// The thing type ARN.
+	ThingTypeArn *string `locationName:"thingTypeArn" type:"string"`
+
+	// The thing type ID.
+	ThingTypeId *string `locationName:"thingTypeId" type:"string"`
+
 	// The ThingTypeMetadata contains additional information about the thing type
 	// including: creation date and time, a value indicating whether the thing type
 	// is deprecated, and a date and time when it was deprecated.
@@ -7869,6 +15175,18 @@ func (s DescribeThingTypeOutput) GoString() string {
 	return s.String()
 }
 
+// SetThingTypeArn sets the ThingTypeArn field's value.
+func (s *DescribeThingTypeOutput) SetThingTypeArn(v string) *DescribeThingTypeOutput {
+	s.ThingTypeArn = &v
+	return s
+}
+
+// SetThingTypeId sets the ThingTypeId field's value.
+func (s *DescribeThingTypeOutput) SetThingTypeId(v string) *DescribeThingTypeOutput {
+	s.ThingTypeId = &v
+	return s
+}
+
 // SetThingTypeMetadata sets the ThingTypeMetadata field's value.
 func (s *DescribeThingTypeOutput) SetThingTypeMetadata(v *ThingTypeMetadata) *DescribeThingTypeOutput {
 	s.ThingTypeMetadata = v
@@ -7885,6 +15203,75 @@ func (s *DescribeThingTypeOutput) SetThingTypeName(v string) *DescribeThingTypeO
 func (s *DescribeThingTypeOutput) SetThingTypeProperties(v *ThingTypeProperties) *DescribeThingTypeOutput {
 	s.ThingTypeProperties = v
 	return s
+}
+
+type DetachPolicyInput struct {
+	_ struct{} `type:"structure"`
+
+	// The policy to detach.
+	//
+	// PolicyName is a required field
+	PolicyName *string `location:"uri" locationName:"policyName" min:"1" type:"string" required:"true"`
+
+	// The target from which the policy will be detached.
+	//
+	// Target is a required field
+	Target *string `locationName:"target" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DetachPolicyInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DetachPolicyInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DetachPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DetachPolicyInput"}
+	if s.PolicyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyName"))
+	}
+	if s.PolicyName != nil && len(*s.PolicyName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyName", 1))
+	}
+	if s.Target == nil {
+		invalidParams.Add(request.NewErrParamRequired("Target"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *DetachPolicyInput) SetPolicyName(v string) *DetachPolicyInput {
+	s.PolicyName = &v
+	return s
+}
+
+// SetTarget sets the Target field's value.
+func (s *DetachPolicyInput) SetTarget(v string) *DetachPolicyInput {
+	s.Target = &v
+	return s
+}
+
+type DetachPolicyOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s DetachPolicyOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DetachPolicyOutput) GoString() string {
+	return s.String()
 }
 
 // The input for the DetachPrincipalPolicy operation.
@@ -8300,6 +15687,48 @@ func (s *DynamoDBv2Action) SetRoleArn(v string) *DynamoDBv2Action {
 	return s
 }
 
+// The policy that has the effect on the authorization results.
+type EffectivePolicy struct {
+	_ struct{} `type:"structure"`
+
+	// The policy ARN.
+	PolicyArn *string `locationName:"policyArn" type:"string"`
+
+	// The IAM policy document.
+	PolicyDocument *string `locationName:"policyDocument" type:"string"`
+
+	// The policy name.
+	PolicyName *string `locationName:"policyName" min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s EffectivePolicy) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s EffectivePolicy) GoString() string {
+	return s.String()
+}
+
+// SetPolicyArn sets the PolicyArn field's value.
+func (s *EffectivePolicy) SetPolicyArn(v string) *EffectivePolicy {
+	s.PolicyArn = &v
+	return s
+}
+
+// SetPolicyDocument sets the PolicyDocument field's value.
+func (s *EffectivePolicy) SetPolicyDocument(v string) *EffectivePolicy {
+	s.PolicyDocument = &v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *EffectivePolicy) SetPolicyName(v string) *EffectivePolicy {
+	s.PolicyName = &v
+	return s
+}
+
 // Describes an action that writes data to an Amazon Elasticsearch Service domain.
 type ElasticsearchAction struct {
 	_ struct{} `type:"structure"`
@@ -8451,6 +15880,30 @@ func (s EnableTopicRuleOutput) GoString() string {
 	return s.String()
 }
 
+// Information that explicitly denies authorization.
+type ExplicitDeny struct {
+	_ struct{} `type:"structure"`
+
+	// The policies that denied the authorization.
+	Policies []*Policy `locationName:"policies" type:"list"`
+}
+
+// String returns the string representation
+func (s ExplicitDeny) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ExplicitDeny) GoString() string {
+	return s.String()
+}
+
+// SetPolicies sets the Policies field's value.
+func (s *ExplicitDeny) SetPolicies(v []*Policy) *ExplicitDeny {
+	s.Policies = v
+	return s
+}
+
 // Describes an action that writes data to an Amazon Kinesis Firehose stream.
 type FirehoseAction struct {
 	_ struct{} `type:"structure"`
@@ -8460,7 +15913,7 @@ type FirehoseAction struct {
 	// DeliveryStreamName is a required field
 	DeliveryStreamName *string `locationName:"deliveryStreamName" type:"string" required:"true"`
 
-	// The IAM role that grants access to the Amazon Kinesis Firehost stream.
+	// The IAM role that grants access to the Amazon Kinesis Firehose stream.
 	//
 	// RoleArn is a required field
 	RoleArn *string `locationName:"roleArn" type:"string" required:"true"`
@@ -8512,6 +15965,184 @@ func (s *FirehoseAction) SetRoleArn(v string) *FirehoseAction {
 // SetSeparator sets the Separator field's value.
 func (s *FirehoseAction) SetSeparator(v string) *FirehoseAction {
 	s.Separator = &v
+	return s
+}
+
+type GetEffectivePoliciesInput struct {
+	_ struct{} `type:"structure"`
+
+	// The Cognito identity pool ID.
+	CognitoIdentityPoolId *string `locationName:"cognitoIdentityPoolId" type:"string"`
+
+	// The principal.
+	Principal *string `locationName:"principal" type:"string"`
+
+	// The thing name.
+	ThingName *string `location:"querystring" locationName:"thingName" min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s GetEffectivePoliciesInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetEffectivePoliciesInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetEffectivePoliciesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetEffectivePoliciesInput"}
+	if s.ThingName != nil && len(*s.ThingName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ThingName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetCognitoIdentityPoolId sets the CognitoIdentityPoolId field's value.
+func (s *GetEffectivePoliciesInput) SetCognitoIdentityPoolId(v string) *GetEffectivePoliciesInput {
+	s.CognitoIdentityPoolId = &v
+	return s
+}
+
+// SetPrincipal sets the Principal field's value.
+func (s *GetEffectivePoliciesInput) SetPrincipal(v string) *GetEffectivePoliciesInput {
+	s.Principal = &v
+	return s
+}
+
+// SetThingName sets the ThingName field's value.
+func (s *GetEffectivePoliciesInput) SetThingName(v string) *GetEffectivePoliciesInput {
+	s.ThingName = &v
+	return s
+}
+
+type GetEffectivePoliciesOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The effective policies.
+	EffectivePolicies []*EffectivePolicy `locationName:"effectivePolicies" type:"list"`
+}
+
+// String returns the string representation
+func (s GetEffectivePoliciesOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetEffectivePoliciesOutput) GoString() string {
+	return s.String()
+}
+
+// SetEffectivePolicies sets the EffectivePolicies field's value.
+func (s *GetEffectivePoliciesOutput) SetEffectivePolicies(v []*EffectivePolicy) *GetEffectivePoliciesOutput {
+	s.EffectivePolicies = v
+	return s
+}
+
+type GetIndexingConfigurationInput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetIndexingConfigurationInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetIndexingConfigurationInput) GoString() string {
+	return s.String()
+}
+
+type GetIndexingConfigurationOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Thing indexing configuration.
+	ThingIndexingConfiguration *ThingIndexingConfiguration `locationName:"thingIndexingConfiguration" type:"structure"`
+}
+
+// String returns the string representation
+func (s GetIndexingConfigurationOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetIndexingConfigurationOutput) GoString() string {
+	return s.String()
+}
+
+// SetThingIndexingConfiguration sets the ThingIndexingConfiguration field's value.
+func (s *GetIndexingConfigurationOutput) SetThingIndexingConfiguration(v *ThingIndexingConfiguration) *GetIndexingConfigurationOutput {
+	s.ThingIndexingConfiguration = v
+	return s
+}
+
+type GetJobDocumentInput struct {
+	_ struct{} `type:"structure"`
+
+	// The unique identifier you assigned to this job when it was created.
+	//
+	// JobId is a required field
+	JobId *string `location:"uri" locationName:"jobId" min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s GetJobDocumentInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetJobDocumentInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetJobDocumentInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetJobDocumentInput"}
+	if s.JobId == nil {
+		invalidParams.Add(request.NewErrParamRequired("JobId"))
+	}
+	if s.JobId != nil && len(*s.JobId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("JobId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetJobId sets the JobId field's value.
+func (s *GetJobDocumentInput) SetJobId(v string) *GetJobDocumentInput {
+	s.JobId = &v
+	return s
+}
+
+type GetJobDocumentOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The job document content.
+	Document *string `locationName:"document" type:"string"`
+}
+
+// String returns the string representation
+func (s GetJobDocumentOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetJobDocumentOutput) GoString() string {
+	return s.String()
+}
+
+// SetDocument sets the Document field's value.
+func (s *GetJobDocumentOutput) SetDocument(v string) *GetJobDocumentOutput {
+	s.Document = &v
 	return s
 }
 
@@ -8886,6 +16517,730 @@ func (s *GetTopicRuleOutput) SetRuleArn(v string) *GetTopicRuleOutput {
 	return s
 }
 
+type GetV2LoggingOptionsInput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetV2LoggingOptionsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetV2LoggingOptionsInput) GoString() string {
+	return s.String()
+}
+
+type GetV2LoggingOptionsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The default log level.
+	DefaultLogLevel *string `locationName:"defaultLogLevel" type:"string" enum:"LogLevel"`
+
+	// Disables all logs.
+	DisableAllLogs *bool `locationName:"disableAllLogs" type:"boolean"`
+
+	// The IAM role ARN AWS IoT uses to write to your CloudWatch logs.
+	RoleArn *string `locationName:"roleArn" type:"string"`
+}
+
+// String returns the string representation
+func (s GetV2LoggingOptionsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetV2LoggingOptionsOutput) GoString() string {
+	return s.String()
+}
+
+// SetDefaultLogLevel sets the DefaultLogLevel field's value.
+func (s *GetV2LoggingOptionsOutput) SetDefaultLogLevel(v string) *GetV2LoggingOptionsOutput {
+	s.DefaultLogLevel = &v
+	return s
+}
+
+// SetDisableAllLogs sets the DisableAllLogs field's value.
+func (s *GetV2LoggingOptionsOutput) SetDisableAllLogs(v bool) *GetV2LoggingOptionsOutput {
+	s.DisableAllLogs = &v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *GetV2LoggingOptionsOutput) SetRoleArn(v string) *GetV2LoggingOptionsOutput {
+	s.RoleArn = &v
+	return s
+}
+
+// The name and ARN of a group.
+type GroupNameAndArn struct {
+	_ struct{} `type:"structure"`
+
+	// The group ARN.
+	GroupArn *string `locationName:"groupArn" type:"string"`
+
+	// The group name.
+	GroupName *string `locationName:"groupName" min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s GroupNameAndArn) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GroupNameAndArn) GoString() string {
+	return s.String()
+}
+
+// SetGroupArn sets the GroupArn field's value.
+func (s *GroupNameAndArn) SetGroupArn(v string) *GroupNameAndArn {
+	s.GroupArn = &v
+	return s
+}
+
+// SetGroupName sets the GroupName field's value.
+func (s *GroupNameAndArn) SetGroupName(v string) *GroupNameAndArn {
+	s.GroupName = &v
+	return s
+}
+
+// Information that implicitly denies authorization. When policy doesn't explicitly
+// deny or allow an action on a resource it is considered an implicit deny.
+type ImplicitDeny struct {
+	_ struct{} `type:"structure"`
+
+	// Policies that don't contain a matching allow or deny statement for the specified
+	// action on the specified resource.
+	Policies []*Policy `locationName:"policies" type:"list"`
+}
+
+// String returns the string representation
+func (s ImplicitDeny) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ImplicitDeny) GoString() string {
+	return s.String()
+}
+
+// SetPolicies sets the Policies field's value.
+func (s *ImplicitDeny) SetPolicies(v []*Policy) *ImplicitDeny {
+	s.Policies = v
+	return s
+}
+
+// The Job object contains details about a job.
+type Job struct {
+	_ struct{} `type:"structure"`
+
+	// If the job was updated, describes the reason for the update.
+	Comment *string `locationName:"comment" type:"string"`
+
+	// The time, in milliseconds since the epoch, when the job was completed.
+	CompletedAt *time.Time `locationName:"completedAt" type:"timestamp" timestampFormat:"unix"`
+
+	// The time, in milliseconds since the epoch, when the job was created.
+	CreatedAt *time.Time `locationName:"createdAt" type:"timestamp" timestampFormat:"unix"`
+
+	// A short text description of the job.
+	Description *string `locationName:"description" type:"string"`
+
+	// The parameters specified for the job document.
+	DocumentParameters map[string]*string `locationName:"documentParameters" type:"map"`
+
+	// An ARN identifying the job with format "arn:aws:iot:region:account:job/jobId".
+	JobArn *string `locationName:"jobArn" type:"string"`
+
+	// Allows you to create a staged rollout of a job.
+	JobExecutionsRolloutConfig *JobExecutionsRolloutConfig `locationName:"jobExecutionsRolloutConfig" type:"structure"`
+
+	// The unique identifier you assigned to this job when it was created.
+	JobId *string `locationName:"jobId" min:"1" type:"string"`
+
+	// Details about the job process.
+	JobProcessDetails *JobProcessDetails `locationName:"jobProcessDetails" type:"structure"`
+
+	// The time, in milliseconds since the epoch, when the job was last updated.
+	LastUpdatedAt *time.Time `locationName:"lastUpdatedAt" type:"timestamp" timestampFormat:"unix"`
+
+	// Configuration for pre-signed S3 URLs.
+	PresignedUrlConfig *PresignedUrlConfig `locationName:"presignedUrlConfig" type:"structure"`
+
+	// The status of the job, one of IN_PROGRESS, CANCELED, or COMPLETED.
+	Status *string `locationName:"status" type:"string" enum:"JobStatus"`
+
+	// Specifies whether the job will continue to run (CONTINUOUS), or will be complete
+	// after all those things specified as targets have completed the job (SNAPSHOT).
+	// If continuous, the job may also be run on a thing when a change is detected
+	// in a target. For example, a job will run on a device when the thing representing
+	// the device is added to a target group, even after the job was completed by
+	// all things originally in the group.
+	TargetSelection *string `locationName:"targetSelection" type:"string" enum:"TargetSelection"`
+
+	// A list of IoT things and thing groups to which the job should be sent.
+	Targets []*string `locationName:"targets" min:"1" type:"list"`
+}
+
+// String returns the string representation
+func (s Job) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s Job) GoString() string {
+	return s.String()
+}
+
+// SetComment sets the Comment field's value.
+func (s *Job) SetComment(v string) *Job {
+	s.Comment = &v
+	return s
+}
+
+// SetCompletedAt sets the CompletedAt field's value.
+func (s *Job) SetCompletedAt(v time.Time) *Job {
+	s.CompletedAt = &v
+	return s
+}
+
+// SetCreatedAt sets the CreatedAt field's value.
+func (s *Job) SetCreatedAt(v time.Time) *Job {
+	s.CreatedAt = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *Job) SetDescription(v string) *Job {
+	s.Description = &v
+	return s
+}
+
+// SetDocumentParameters sets the DocumentParameters field's value.
+func (s *Job) SetDocumentParameters(v map[string]*string) *Job {
+	s.DocumentParameters = v
+	return s
+}
+
+// SetJobArn sets the JobArn field's value.
+func (s *Job) SetJobArn(v string) *Job {
+	s.JobArn = &v
+	return s
+}
+
+// SetJobExecutionsRolloutConfig sets the JobExecutionsRolloutConfig field's value.
+func (s *Job) SetJobExecutionsRolloutConfig(v *JobExecutionsRolloutConfig) *Job {
+	s.JobExecutionsRolloutConfig = v
+	return s
+}
+
+// SetJobId sets the JobId field's value.
+func (s *Job) SetJobId(v string) *Job {
+	s.JobId = &v
+	return s
+}
+
+// SetJobProcessDetails sets the JobProcessDetails field's value.
+func (s *Job) SetJobProcessDetails(v *JobProcessDetails) *Job {
+	s.JobProcessDetails = v
+	return s
+}
+
+// SetLastUpdatedAt sets the LastUpdatedAt field's value.
+func (s *Job) SetLastUpdatedAt(v time.Time) *Job {
+	s.LastUpdatedAt = &v
+	return s
+}
+
+// SetPresignedUrlConfig sets the PresignedUrlConfig field's value.
+func (s *Job) SetPresignedUrlConfig(v *PresignedUrlConfig) *Job {
+	s.PresignedUrlConfig = v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *Job) SetStatus(v string) *Job {
+	s.Status = &v
+	return s
+}
+
+// SetTargetSelection sets the TargetSelection field's value.
+func (s *Job) SetTargetSelection(v string) *Job {
+	s.TargetSelection = &v
+	return s
+}
+
+// SetTargets sets the Targets field's value.
+func (s *Job) SetTargets(v []*string) *Job {
+	s.Targets = v
+	return s
+}
+
+// The job execution object represents the execution of a job on a particular
+// device.
+type JobExecution struct {
+	_ struct{} `type:"structure"`
+
+	// A string (consisting of the digits "0" through "9") which identifies this
+	// particular job execution on this particular device. It can be used in commands
+	// which return or update job execution information.
+	ExecutionNumber *int64 `locationName:"executionNumber" type:"long"`
+
+	// The unique identifier you assigned to the job when it was created.
+	JobId *string `locationName:"jobId" min:"1" type:"string"`
+
+	// The time, in milliseconds since the epoch, when the job execution was last
+	// updated.
+	LastUpdatedAt *time.Time `locationName:"lastUpdatedAt" type:"timestamp" timestampFormat:"unix"`
+
+	// The time, in milliseconds since the epoch, when the job execution was queued.
+	QueuedAt *time.Time `locationName:"queuedAt" type:"timestamp" timestampFormat:"unix"`
+
+	// The time, in milliseconds since the epoch, when the job execution started.
+	StartedAt *time.Time `locationName:"startedAt" type:"timestamp" timestampFormat:"unix"`
+
+	// The status of the job execution (IN_PROGRESS, QUEUED, FAILED, SUCCESS, CANCELED,
+	// or REJECTED).
+	Status *string `locationName:"status" type:"string" enum:"JobExecutionStatus"`
+
+	// A collection of name/value pairs that describe the status of the job execution.
+	StatusDetails *JobExecutionStatusDetails `locationName:"statusDetails" type:"structure"`
+
+	// The ARN of the thing on which the job execution is running.
+	ThingArn *string `locationName:"thingArn" type:"string"`
+}
+
+// String returns the string representation
+func (s JobExecution) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s JobExecution) GoString() string {
+	return s.String()
+}
+
+// SetExecutionNumber sets the ExecutionNumber field's value.
+func (s *JobExecution) SetExecutionNumber(v int64) *JobExecution {
+	s.ExecutionNumber = &v
+	return s
+}
+
+// SetJobId sets the JobId field's value.
+func (s *JobExecution) SetJobId(v string) *JobExecution {
+	s.JobId = &v
+	return s
+}
+
+// SetLastUpdatedAt sets the LastUpdatedAt field's value.
+func (s *JobExecution) SetLastUpdatedAt(v time.Time) *JobExecution {
+	s.LastUpdatedAt = &v
+	return s
+}
+
+// SetQueuedAt sets the QueuedAt field's value.
+func (s *JobExecution) SetQueuedAt(v time.Time) *JobExecution {
+	s.QueuedAt = &v
+	return s
+}
+
+// SetStartedAt sets the StartedAt field's value.
+func (s *JobExecution) SetStartedAt(v time.Time) *JobExecution {
+	s.StartedAt = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *JobExecution) SetStatus(v string) *JobExecution {
+	s.Status = &v
+	return s
+}
+
+// SetStatusDetails sets the StatusDetails field's value.
+func (s *JobExecution) SetStatusDetails(v *JobExecutionStatusDetails) *JobExecution {
+	s.StatusDetails = v
+	return s
+}
+
+// SetThingArn sets the ThingArn field's value.
+func (s *JobExecution) SetThingArn(v string) *JobExecution {
+	s.ThingArn = &v
+	return s
+}
+
+// Details of the job execution status.
+type JobExecutionStatusDetails struct {
+	_ struct{} `type:"structure"`
+
+	// The job execution status.
+	DetailsMap map[string]*string `locationName:"detailsMap" type:"map"`
+}
+
+// String returns the string representation
+func (s JobExecutionStatusDetails) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s JobExecutionStatusDetails) GoString() string {
+	return s.String()
+}
+
+// SetDetailsMap sets the DetailsMap field's value.
+func (s *JobExecutionStatusDetails) SetDetailsMap(v map[string]*string) *JobExecutionStatusDetails {
+	s.DetailsMap = v
+	return s
+}
+
+// The job execution summary.
+type JobExecutionSummary struct {
+	_ struct{} `type:"structure"`
+
+	// A string (consisting of the digits "0" through "9") which identifies this
+	// particular job execution on this particular device. It can be used later
+	// in commands which return or update job execution information.
+	ExecutionNumber *int64 `locationName:"executionNumber" type:"long"`
+
+	// The time, in milliseconds since the epoch, when the job execution was last
+	// updated.
+	LastUpdatedAt *time.Time `locationName:"lastUpdatedAt" type:"timestamp" timestampFormat:"unix"`
+
+	// The time, in milliseconds since the epoch, when the job execution was queued.
+	QueuedAt *time.Time `locationName:"queuedAt" type:"timestamp" timestampFormat:"unix"`
+
+	// The time, in milliseconds since the epoch, when the job execution started.
+	StartedAt *time.Time `locationName:"startedAt" type:"timestamp" timestampFormat:"unix"`
+
+	// The status of the job execution.
+	Status *string `locationName:"status" type:"string" enum:"JobExecutionStatus"`
+}
+
+// String returns the string representation
+func (s JobExecutionSummary) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s JobExecutionSummary) GoString() string {
+	return s.String()
+}
+
+// SetExecutionNumber sets the ExecutionNumber field's value.
+func (s *JobExecutionSummary) SetExecutionNumber(v int64) *JobExecutionSummary {
+	s.ExecutionNumber = &v
+	return s
+}
+
+// SetLastUpdatedAt sets the LastUpdatedAt field's value.
+func (s *JobExecutionSummary) SetLastUpdatedAt(v time.Time) *JobExecutionSummary {
+	s.LastUpdatedAt = &v
+	return s
+}
+
+// SetQueuedAt sets the QueuedAt field's value.
+func (s *JobExecutionSummary) SetQueuedAt(v time.Time) *JobExecutionSummary {
+	s.QueuedAt = &v
+	return s
+}
+
+// SetStartedAt sets the StartedAt field's value.
+func (s *JobExecutionSummary) SetStartedAt(v time.Time) *JobExecutionSummary {
+	s.StartedAt = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *JobExecutionSummary) SetStatus(v string) *JobExecutionSummary {
+	s.Status = &v
+	return s
+}
+
+// Contains a summary of information about job executions for a specific job.
+type JobExecutionSummaryForJob struct {
+	_ struct{} `type:"structure"`
+
+	// Contains a subset of information about a job execution.
+	JobExecutionSummary *JobExecutionSummary `locationName:"jobExecutionSummary" type:"structure"`
+
+	// The ARN of the thing on which the job execution is running.
+	ThingArn *string `locationName:"thingArn" type:"string"`
+}
+
+// String returns the string representation
+func (s JobExecutionSummaryForJob) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s JobExecutionSummaryForJob) GoString() string {
+	return s.String()
+}
+
+// SetJobExecutionSummary sets the JobExecutionSummary field's value.
+func (s *JobExecutionSummaryForJob) SetJobExecutionSummary(v *JobExecutionSummary) *JobExecutionSummaryForJob {
+	s.JobExecutionSummary = v
+	return s
+}
+
+// SetThingArn sets the ThingArn field's value.
+func (s *JobExecutionSummaryForJob) SetThingArn(v string) *JobExecutionSummaryForJob {
+	s.ThingArn = &v
+	return s
+}
+
+// The job execution summary for a thing.
+type JobExecutionSummaryForThing struct {
+	_ struct{} `type:"structure"`
+
+	// Contains a subset of information about a job execution.
+	JobExecutionSummary *JobExecutionSummary `locationName:"jobExecutionSummary" type:"structure"`
+
+	// The unique identifier you assigned to this job when it was created.
+	JobId *string `locationName:"jobId" min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s JobExecutionSummaryForThing) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s JobExecutionSummaryForThing) GoString() string {
+	return s.String()
+}
+
+// SetJobExecutionSummary sets the JobExecutionSummary field's value.
+func (s *JobExecutionSummaryForThing) SetJobExecutionSummary(v *JobExecutionSummary) *JobExecutionSummaryForThing {
+	s.JobExecutionSummary = v
+	return s
+}
+
+// SetJobId sets the JobId field's value.
+func (s *JobExecutionSummaryForThing) SetJobId(v string) *JobExecutionSummaryForThing {
+	s.JobId = &v
+	return s
+}
+
+// Allows you to create a staged rollout of a job.
+type JobExecutionsRolloutConfig struct {
+	_ struct{} `type:"structure"`
+
+	// The maximum number of things that will be notified of a pending job, per
+	// minute. This parameter allows you to create a staged rollout.
+	MaximumPerMinute *int64 `locationName:"maximumPerMinute" min:"1" type:"integer"`
+}
+
+// String returns the string representation
+func (s JobExecutionsRolloutConfig) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s JobExecutionsRolloutConfig) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *JobExecutionsRolloutConfig) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "JobExecutionsRolloutConfig"}
+	if s.MaximumPerMinute != nil && *s.MaximumPerMinute < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaximumPerMinute", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetMaximumPerMinute sets the MaximumPerMinute field's value.
+func (s *JobExecutionsRolloutConfig) SetMaximumPerMinute(v int64) *JobExecutionsRolloutConfig {
+	s.MaximumPerMinute = &v
+	return s
+}
+
+// The job process details.
+type JobProcessDetails struct {
+	_ struct{} `type:"structure"`
+
+	// The number of things that cancelled the job.
+	NumberOfCanceledThings *int64 `locationName:"numberOfCanceledThings" type:"integer"`
+
+	// The number of things that failed executing the job.
+	NumberOfFailedThings *int64 `locationName:"numberOfFailedThings" type:"integer"`
+
+	// The number of things currently executing the job.
+	NumberOfInProgressThings *int64 `locationName:"numberOfInProgressThings" type:"integer"`
+
+	// The number of things that are awaiting execution of the job.
+	NumberOfQueuedThings *int64 `locationName:"numberOfQueuedThings" type:"integer"`
+
+	// The number of things that rejected the job.
+	NumberOfRejectedThings *int64 `locationName:"numberOfRejectedThings" type:"integer"`
+
+	// The number of things that are no longer scheduled to execute the job because
+	// they have been deleted or have been removed from the group that was a target
+	// of the job.
+	NumberOfRemovedThings *int64 `locationName:"numberOfRemovedThings" type:"integer"`
+
+	// The number of things which successfully completed the job.
+	NumberOfSucceededThings *int64 `locationName:"numberOfSucceededThings" type:"integer"`
+
+	// The devices on which the job is executing.
+	ProcessingTargets []*string `locationName:"processingTargets" type:"list"`
+}
+
+// String returns the string representation
+func (s JobProcessDetails) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s JobProcessDetails) GoString() string {
+	return s.String()
+}
+
+// SetNumberOfCanceledThings sets the NumberOfCanceledThings field's value.
+func (s *JobProcessDetails) SetNumberOfCanceledThings(v int64) *JobProcessDetails {
+	s.NumberOfCanceledThings = &v
+	return s
+}
+
+// SetNumberOfFailedThings sets the NumberOfFailedThings field's value.
+func (s *JobProcessDetails) SetNumberOfFailedThings(v int64) *JobProcessDetails {
+	s.NumberOfFailedThings = &v
+	return s
+}
+
+// SetNumberOfInProgressThings sets the NumberOfInProgressThings field's value.
+func (s *JobProcessDetails) SetNumberOfInProgressThings(v int64) *JobProcessDetails {
+	s.NumberOfInProgressThings = &v
+	return s
+}
+
+// SetNumberOfQueuedThings sets the NumberOfQueuedThings field's value.
+func (s *JobProcessDetails) SetNumberOfQueuedThings(v int64) *JobProcessDetails {
+	s.NumberOfQueuedThings = &v
+	return s
+}
+
+// SetNumberOfRejectedThings sets the NumberOfRejectedThings field's value.
+func (s *JobProcessDetails) SetNumberOfRejectedThings(v int64) *JobProcessDetails {
+	s.NumberOfRejectedThings = &v
+	return s
+}
+
+// SetNumberOfRemovedThings sets the NumberOfRemovedThings field's value.
+func (s *JobProcessDetails) SetNumberOfRemovedThings(v int64) *JobProcessDetails {
+	s.NumberOfRemovedThings = &v
+	return s
+}
+
+// SetNumberOfSucceededThings sets the NumberOfSucceededThings field's value.
+func (s *JobProcessDetails) SetNumberOfSucceededThings(v int64) *JobProcessDetails {
+	s.NumberOfSucceededThings = &v
+	return s
+}
+
+// SetProcessingTargets sets the ProcessingTargets field's value.
+func (s *JobProcessDetails) SetProcessingTargets(v []*string) *JobProcessDetails {
+	s.ProcessingTargets = v
+	return s
+}
+
+// The job summary.
+type JobSummary struct {
+	_ struct{} `type:"structure"`
+
+	// The time, in milliseconds since the epoch, when the job completed.
+	CompletedAt *time.Time `locationName:"completedAt" type:"timestamp" timestampFormat:"unix"`
+
+	// The time, in milliseconds since the epoch, when the job was created.
+	CreatedAt *time.Time `locationName:"createdAt" type:"timestamp" timestampFormat:"unix"`
+
+	// The job ARN.
+	JobArn *string `locationName:"jobArn" type:"string"`
+
+	// The unique identifier you assigned to this job when it was created.
+	JobId *string `locationName:"jobId" min:"1" type:"string"`
+
+	// The time, in milliseconds since the epoch, when the job was last updated.
+	LastUpdatedAt *time.Time `locationName:"lastUpdatedAt" type:"timestamp" timestampFormat:"unix"`
+
+	// The job summary status.
+	Status *string `locationName:"status" type:"string" enum:"JobStatus"`
+
+	// Specifies whether the job will continue to run (CONTINUOUS), or will be complete
+	// after all those things specified as targets have completed the job (SNAPSHOT).
+	// If continuous, the job may also be run on a thing when a change is detected
+	// in a target. For example, a job will run on a thing when the thing is added
+	// to a target group, even after the job was completed by all things originally
+	// in the group.
+	TargetSelection *string `locationName:"targetSelection" type:"string" enum:"TargetSelection"`
+
+	// The ID of the thing group.
+	ThingGroupId *string `locationName:"thingGroupId" min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s JobSummary) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s JobSummary) GoString() string {
+	return s.String()
+}
+
+// SetCompletedAt sets the CompletedAt field's value.
+func (s *JobSummary) SetCompletedAt(v time.Time) *JobSummary {
+	s.CompletedAt = &v
+	return s
+}
+
+// SetCreatedAt sets the CreatedAt field's value.
+func (s *JobSummary) SetCreatedAt(v time.Time) *JobSummary {
+	s.CreatedAt = &v
+	return s
+}
+
+// SetJobArn sets the JobArn field's value.
+func (s *JobSummary) SetJobArn(v string) *JobSummary {
+	s.JobArn = &v
+	return s
+}
+
+// SetJobId sets the JobId field's value.
+func (s *JobSummary) SetJobId(v string) *JobSummary {
+	s.JobId = &v
+	return s
+}
+
+// SetLastUpdatedAt sets the LastUpdatedAt field's value.
+func (s *JobSummary) SetLastUpdatedAt(v time.Time) *JobSummary {
+	s.LastUpdatedAt = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *JobSummary) SetStatus(v string) *JobSummary {
+	s.Status = &v
+	return s
+}
+
+// SetTargetSelection sets the TargetSelection field's value.
+func (s *JobSummary) SetTargetSelection(v string) *JobSummary {
+	s.TargetSelection = &v
+	return s
+}
+
+// SetThingGroupId sets the ThingGroupId field's value.
+func (s *JobSummary) SetThingGroupId(v string) *JobSummary {
+	s.ThingGroupId = &v
+	return s
+}
+
 // Describes a key pair.
 type KeyPair struct {
 	_ struct{} `type:"structure"`
@@ -9017,6 +17372,202 @@ func (s *LambdaAction) Validate() error {
 // SetFunctionArn sets the FunctionArn field's value.
 func (s *LambdaAction) SetFunctionArn(v string) *LambdaAction {
 	s.FunctionArn = &v
+	return s
+}
+
+type ListAttachedPoliciesInput struct {
+	_ struct{} `type:"structure"`
+
+	// The token to retrieve the next set of results.
+	Marker *string `location:"querystring" locationName:"marker" type:"string"`
+
+	// The maximum number of results to be returned per request.
+	PageSize *int64 `location:"querystring" locationName:"pageSize" min:"1" type:"integer"`
+
+	// When true, recursively list attached policies.
+	Recursive *bool `location:"querystring" locationName:"recursive" type:"boolean"`
+
+	// The group for which the policies will be listed.
+	//
+	// Target is a required field
+	Target *string `location:"uri" locationName:"target" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s ListAttachedPoliciesInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListAttachedPoliciesInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListAttachedPoliciesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListAttachedPoliciesInput"}
+	if s.PageSize != nil && *s.PageSize < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("PageSize", 1))
+	}
+	if s.Target == nil {
+		invalidParams.Add(request.NewErrParamRequired("Target"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListAttachedPoliciesInput) SetMarker(v string) *ListAttachedPoliciesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetPageSize sets the PageSize field's value.
+func (s *ListAttachedPoliciesInput) SetPageSize(v int64) *ListAttachedPoliciesInput {
+	s.PageSize = &v
+	return s
+}
+
+// SetRecursive sets the Recursive field's value.
+func (s *ListAttachedPoliciesInput) SetRecursive(v bool) *ListAttachedPoliciesInput {
+	s.Recursive = &v
+	return s
+}
+
+// SetTarget sets the Target field's value.
+func (s *ListAttachedPoliciesInput) SetTarget(v string) *ListAttachedPoliciesInput {
+	s.Target = &v
+	return s
+}
+
+type ListAttachedPoliciesOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The token to retrieve the next set of results, or ``null`` if there are no
+	// more results.
+	NextMarker *string `locationName:"nextMarker" type:"string"`
+
+	// The policies.
+	Policies []*Policy `locationName:"policies" type:"list"`
+}
+
+// String returns the string representation
+func (s ListAttachedPoliciesOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListAttachedPoliciesOutput) GoString() string {
+	return s.String()
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListAttachedPoliciesOutput) SetNextMarker(v string) *ListAttachedPoliciesOutput {
+	s.NextMarker = &v
+	return s
+}
+
+// SetPolicies sets the Policies field's value.
+func (s *ListAttachedPoliciesOutput) SetPolicies(v []*Policy) *ListAttachedPoliciesOutput {
+	s.Policies = v
+	return s
+}
+
+type ListAuthorizersInput struct {
+	_ struct{} `type:"structure"`
+
+	// Return the list of authorizers in ascending alphabetical order.
+	AscendingOrder *bool `location:"querystring" locationName:"isAscendingOrder" type:"boolean"`
+
+	// A marker used to get the next set of results.
+	Marker *string `location:"querystring" locationName:"marker" type:"string"`
+
+	// The maximum number of results to return at one time.
+	PageSize *int64 `location:"querystring" locationName:"pageSize" min:"1" type:"integer"`
+
+	// The status of the list authorizers request.
+	Status *string `location:"querystring" locationName:"status" type:"string" enum:"AuthorizerStatus"`
+}
+
+// String returns the string representation
+func (s ListAuthorizersInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListAuthorizersInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListAuthorizersInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListAuthorizersInput"}
+	if s.PageSize != nil && *s.PageSize < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("PageSize", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAscendingOrder sets the AscendingOrder field's value.
+func (s *ListAuthorizersInput) SetAscendingOrder(v bool) *ListAuthorizersInput {
+	s.AscendingOrder = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListAuthorizersInput) SetMarker(v string) *ListAuthorizersInput {
+	s.Marker = &v
+	return s
+}
+
+// SetPageSize sets the PageSize field's value.
+func (s *ListAuthorizersInput) SetPageSize(v int64) *ListAuthorizersInput {
+	s.PageSize = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ListAuthorizersInput) SetStatus(v string) *ListAuthorizersInput {
+	s.Status = &v
+	return s
+}
+
+type ListAuthorizersOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The authorizers.
+	Authorizers []*AuthorizerSummary `locationName:"authorizers" type:"list"`
+
+	// A marker used to get the next set of results.
+	NextMarker *string `locationName:"nextMarker" type:"string"`
+}
+
+// String returns the string representation
+func (s ListAuthorizersOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListAuthorizersOutput) GoString() string {
+	return s.String()
+}
+
+// SetAuthorizers sets the Authorizers field's value.
+func (s *ListAuthorizersOutput) SetAuthorizers(v []*AuthorizerSummary) *ListAuthorizersOutput {
+	s.Authorizers = v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListAuthorizersOutput) SetNextMarker(v string) *ListAuthorizersOutput {
+	s.NextMarker = &v
 	return s
 }
 
@@ -9306,6 +17857,420 @@ func (s *ListCertificatesOutput) SetNextMarker(v string) *ListCertificatesOutput
 	return s
 }
 
+type ListIndicesInput struct {
+	_ struct{} `type:"structure"`
+
+	// The maximum number of results to return at one time.
+	MaxResults *int64 `location:"querystring" locationName:"maxResults" min:"1" type:"integer"`
+
+	// The token used to get the next set of results, or null if there are no additional
+	// results.
+	NextToken *string `location:"querystring" locationName:"nextToken" type:"string"`
+}
+
+// String returns the string representation
+func (s ListIndicesInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListIndicesInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListIndicesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListIndicesInput"}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListIndicesInput) SetMaxResults(v int64) *ListIndicesInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListIndicesInput) SetNextToken(v string) *ListIndicesInput {
+	s.NextToken = &v
+	return s
+}
+
+type ListIndicesOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The index names.
+	IndexNames []*string `locationName:"indexNames" type:"list"`
+
+	// The token used to get the next set of results, or null if there are no additional
+	// results.
+	NextToken *string `locationName:"nextToken" type:"string"`
+}
+
+// String returns the string representation
+func (s ListIndicesOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListIndicesOutput) GoString() string {
+	return s.String()
+}
+
+// SetIndexNames sets the IndexNames field's value.
+func (s *ListIndicesOutput) SetIndexNames(v []*string) *ListIndicesOutput {
+	s.IndexNames = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListIndicesOutput) SetNextToken(v string) *ListIndicesOutput {
+	s.NextToken = &v
+	return s
+}
+
+type ListJobExecutionsForJobInput struct {
+	_ struct{} `type:"structure"`
+
+	// The unique identifier you assigned to this job when it was created.
+	//
+	// JobId is a required field
+	JobId *string `location:"uri" locationName:"jobId" min:"1" type:"string" required:"true"`
+
+	// The maximum number of results to be returned per request.
+	MaxResults *int64 `location:"querystring" locationName:"maxResults" min:"1" type:"integer"`
+
+	// The token to retrieve the next set of results.
+	NextToken *string `location:"querystring" locationName:"nextToken" type:"string"`
+
+	// The status of the job.
+	Status *string `location:"querystring" locationName:"status" type:"string" enum:"JobExecutionStatus"`
+}
+
+// String returns the string representation
+func (s ListJobExecutionsForJobInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListJobExecutionsForJobInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListJobExecutionsForJobInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListJobExecutionsForJobInput"}
+	if s.JobId == nil {
+		invalidParams.Add(request.NewErrParamRequired("JobId"))
+	}
+	if s.JobId != nil && len(*s.JobId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("JobId", 1))
+	}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetJobId sets the JobId field's value.
+func (s *ListJobExecutionsForJobInput) SetJobId(v string) *ListJobExecutionsForJobInput {
+	s.JobId = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListJobExecutionsForJobInput) SetMaxResults(v int64) *ListJobExecutionsForJobInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListJobExecutionsForJobInput) SetNextToken(v string) *ListJobExecutionsForJobInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ListJobExecutionsForJobInput) SetStatus(v string) *ListJobExecutionsForJobInput {
+	s.Status = &v
+	return s
+}
+
+type ListJobExecutionsForJobOutput struct {
+	_ struct{} `type:"structure"`
+
+	// A list of job execution summaries.
+	ExecutionSummaries []*JobExecutionSummaryForJob `locationName:"executionSummaries" type:"list"`
+
+	// The token for the next set of results, or null if there are no additional
+	// results.
+	NextToken *string `locationName:"nextToken" type:"string"`
+}
+
+// String returns the string representation
+func (s ListJobExecutionsForJobOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListJobExecutionsForJobOutput) GoString() string {
+	return s.String()
+}
+
+// SetExecutionSummaries sets the ExecutionSummaries field's value.
+func (s *ListJobExecutionsForJobOutput) SetExecutionSummaries(v []*JobExecutionSummaryForJob) *ListJobExecutionsForJobOutput {
+	s.ExecutionSummaries = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListJobExecutionsForJobOutput) SetNextToken(v string) *ListJobExecutionsForJobOutput {
+	s.NextToken = &v
+	return s
+}
+
+type ListJobExecutionsForThingInput struct {
+	_ struct{} `type:"structure"`
+
+	// The maximum number of results to be returned per request.
+	MaxResults *int64 `location:"querystring" locationName:"maxResults" min:"1" type:"integer"`
+
+	// The token to retrieve the next set of results.
+	NextToken *string `location:"querystring" locationName:"nextToken" type:"string"`
+
+	// An optional filter that lets you search for jobs that have the specified
+	// status.
+	Status *string `location:"querystring" locationName:"status" type:"string" enum:"JobExecutionStatus"`
+
+	// The thing name.
+	//
+	// ThingName is a required field
+	ThingName *string `location:"uri" locationName:"thingName" min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s ListJobExecutionsForThingInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListJobExecutionsForThingInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListJobExecutionsForThingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListJobExecutionsForThingInput"}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+	if s.ThingName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ThingName"))
+	}
+	if s.ThingName != nil && len(*s.ThingName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ThingName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListJobExecutionsForThingInput) SetMaxResults(v int64) *ListJobExecutionsForThingInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListJobExecutionsForThingInput) SetNextToken(v string) *ListJobExecutionsForThingInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ListJobExecutionsForThingInput) SetStatus(v string) *ListJobExecutionsForThingInput {
+	s.Status = &v
+	return s
+}
+
+// SetThingName sets the ThingName field's value.
+func (s *ListJobExecutionsForThingInput) SetThingName(v string) *ListJobExecutionsForThingInput {
+	s.ThingName = &v
+	return s
+}
+
+type ListJobExecutionsForThingOutput struct {
+	_ struct{} `type:"structure"`
+
+	// A list of job execution summaries.
+	ExecutionSummaries []*JobExecutionSummaryForThing `locationName:"executionSummaries" type:"list"`
+
+	// The token for the next set of results, or null if there are no additional
+	// results.
+	NextToken *string `locationName:"nextToken" type:"string"`
+}
+
+// String returns the string representation
+func (s ListJobExecutionsForThingOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListJobExecutionsForThingOutput) GoString() string {
+	return s.String()
+}
+
+// SetExecutionSummaries sets the ExecutionSummaries field's value.
+func (s *ListJobExecutionsForThingOutput) SetExecutionSummaries(v []*JobExecutionSummaryForThing) *ListJobExecutionsForThingOutput {
+	s.ExecutionSummaries = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListJobExecutionsForThingOutput) SetNextToken(v string) *ListJobExecutionsForThingOutput {
+	s.NextToken = &v
+	return s
+}
+
+type ListJobsInput struct {
+	_ struct{} `type:"structure"`
+
+	// The maximum number of results to return per request.
+	MaxResults *int64 `location:"querystring" locationName:"maxResults" min:"1" type:"integer"`
+
+	// The token to retrieve the next set of results.
+	NextToken *string `location:"querystring" locationName:"nextToken" type:"string"`
+
+	// An optional filter that lets you search for jobs that have the specified
+	// status.
+	Status *string `location:"querystring" locationName:"status" type:"string" enum:"JobStatus"`
+
+	// Specifies whether the job will continue to run (CONTINUOUS), or will be complete
+	// after all those things specified as targets have completed the job (SNAPSHOT).
+	// If continuous, the job may also be run on a thing when a change is detected
+	// in a target. For example, a job will run on a thing when the thing is added
+	// to a target group, even after the job was completed by all things originally
+	// in the group.
+	TargetSelection *string `location:"querystring" locationName:"targetSelection" type:"string" enum:"TargetSelection"`
+
+	// A filter that limits the returned jobs to those for the specified group.
+	ThingGroupId *string `location:"querystring" locationName:"thingGroupId" min:"1" type:"string"`
+
+	// A filter that limits the returned jobs to those for the specified group.
+	ThingGroupName *string `location:"querystring" locationName:"thingGroupName" min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s ListJobsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListJobsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListJobsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListJobsInput"}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+	if s.ThingGroupId != nil && len(*s.ThingGroupId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ThingGroupId", 1))
+	}
+	if s.ThingGroupName != nil && len(*s.ThingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ThingGroupName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListJobsInput) SetMaxResults(v int64) *ListJobsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListJobsInput) SetNextToken(v string) *ListJobsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ListJobsInput) SetStatus(v string) *ListJobsInput {
+	s.Status = &v
+	return s
+}
+
+// SetTargetSelection sets the TargetSelection field's value.
+func (s *ListJobsInput) SetTargetSelection(v string) *ListJobsInput {
+	s.TargetSelection = &v
+	return s
+}
+
+// SetThingGroupId sets the ThingGroupId field's value.
+func (s *ListJobsInput) SetThingGroupId(v string) *ListJobsInput {
+	s.ThingGroupId = &v
+	return s
+}
+
+// SetThingGroupName sets the ThingGroupName field's value.
+func (s *ListJobsInput) SetThingGroupName(v string) *ListJobsInput {
+	s.ThingGroupName = &v
+	return s
+}
+
+type ListJobsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// A list of jobs.
+	Jobs []*JobSummary `locationName:"jobs" type:"list"`
+
+	// The token for the next set of results, or null if there are no additional
+	// results.
+	NextToken *string `locationName:"nextToken" type:"string"`
+}
+
+// String returns the string representation
+func (s ListJobsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListJobsOutput) GoString() string {
+	return s.String()
+}
+
+// SetJobs sets the Jobs field's value.
+func (s *ListJobsOutput) SetJobs(v []*JobSummary) *ListJobsOutput {
+	s.Jobs = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListJobsOutput) SetNextToken(v string) *ListJobsOutput {
+	s.NextToken = &v
+	return s
+}
+
 // The input to the ListOutgoingCertificates operation.
 type ListOutgoingCertificatesInput struct {
 	_ struct{} `type:"structure"`
@@ -9369,7 +18334,7 @@ type ListOutgoingCertificatesOutput struct {
 	// The marker for the next set of results.
 	NextMarker *string `locationName:"nextMarker" type:"string"`
 
-	// The certificates that are being transfered but not yet accepted.
+	// The certificates that are being transferred but not yet accepted.
 	OutgoingCertificates []*OutgoingCertificate `locationName:"outgoingCertificates" type:"list"`
 }
 
@@ -9769,7 +18734,7 @@ type ListPrincipalThingsInput struct {
 	// The maximum number of results to return in this operation.
 	MaxResults *int64 `location:"querystring" locationName:"maxResults" min:"1" type:"integer"`
 
-	// The token for the next set of results, or null if there are no additional
+	// The token used to get the next set of results, or null if there are no additional
 	// results.
 	NextToken *string `location:"querystring" locationName:"nextToken" type:"string"`
 
@@ -9827,7 +18792,7 @@ func (s *ListPrincipalThingsInput) SetPrincipal(v string) *ListPrincipalThingsIn
 type ListPrincipalThingsOutput struct {
 	_ struct{} `type:"structure"`
 
-	// The token for the next set of results, or null if there are no additional
+	// The token used to get the next set of results, or null if there are no additional
 	// results.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
@@ -9854,6 +18819,394 @@ func (s *ListPrincipalThingsOutput) SetNextToken(v string) *ListPrincipalThingsO
 // SetThings sets the Things field's value.
 func (s *ListPrincipalThingsOutput) SetThings(v []*string) *ListPrincipalThingsOutput {
 	s.Things = v
+	return s
+}
+
+type ListRoleAliasesInput struct {
+	_ struct{} `type:"structure"`
+
+	// Return the list of role aliases in ascending alphabetical order.
+	AscendingOrder *bool `location:"querystring" locationName:"isAscendingOrder" type:"boolean"`
+
+	// A marker used to get the next set of results.
+	Marker *string `location:"querystring" locationName:"marker" type:"string"`
+
+	// The maximum number of results to return at one time.
+	PageSize *int64 `location:"querystring" locationName:"pageSize" min:"1" type:"integer"`
+}
+
+// String returns the string representation
+func (s ListRoleAliasesInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListRoleAliasesInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListRoleAliasesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListRoleAliasesInput"}
+	if s.PageSize != nil && *s.PageSize < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("PageSize", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAscendingOrder sets the AscendingOrder field's value.
+func (s *ListRoleAliasesInput) SetAscendingOrder(v bool) *ListRoleAliasesInput {
+	s.AscendingOrder = &v
+	return s
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListRoleAliasesInput) SetMarker(v string) *ListRoleAliasesInput {
+	s.Marker = &v
+	return s
+}
+
+// SetPageSize sets the PageSize field's value.
+func (s *ListRoleAliasesInput) SetPageSize(v int64) *ListRoleAliasesInput {
+	s.PageSize = &v
+	return s
+}
+
+type ListRoleAliasesOutput struct {
+	_ struct{} `type:"structure"`
+
+	// A marker used to get the next set of results.
+	NextMarker *string `locationName:"nextMarker" type:"string"`
+
+	// The role aliases.
+	RoleAliases []*string `locationName:"roleAliases" type:"list"`
+}
+
+// String returns the string representation
+func (s ListRoleAliasesOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListRoleAliasesOutput) GoString() string {
+	return s.String()
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListRoleAliasesOutput) SetNextMarker(v string) *ListRoleAliasesOutput {
+	s.NextMarker = &v
+	return s
+}
+
+// SetRoleAliases sets the RoleAliases field's value.
+func (s *ListRoleAliasesOutput) SetRoleAliases(v []*string) *ListRoleAliasesOutput {
+	s.RoleAliases = v
+	return s
+}
+
+type ListTargetsForPolicyInput struct {
+	_ struct{} `type:"structure"`
+
+	// A marker used to get the next set of results.
+	Marker *string `location:"querystring" locationName:"marker" type:"string"`
+
+	// The maximum number of results to return at one time.
+	PageSize *int64 `location:"querystring" locationName:"pageSize" min:"1" type:"integer"`
+
+	// The policy name.
+	//
+	// PolicyName is a required field
+	PolicyName *string `location:"uri" locationName:"policyName" min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s ListTargetsForPolicyInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListTargetsForPolicyInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListTargetsForPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListTargetsForPolicyInput"}
+	if s.PageSize != nil && *s.PageSize < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("PageSize", 1))
+	}
+	if s.PolicyName == nil {
+		invalidParams.Add(request.NewErrParamRequired("PolicyName"))
+	}
+	if s.PolicyName != nil && len(*s.PolicyName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetMarker sets the Marker field's value.
+func (s *ListTargetsForPolicyInput) SetMarker(v string) *ListTargetsForPolicyInput {
+	s.Marker = &v
+	return s
+}
+
+// SetPageSize sets the PageSize field's value.
+func (s *ListTargetsForPolicyInput) SetPageSize(v int64) *ListTargetsForPolicyInput {
+	s.PageSize = &v
+	return s
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *ListTargetsForPolicyInput) SetPolicyName(v string) *ListTargetsForPolicyInput {
+	s.PolicyName = &v
+	return s
+}
+
+type ListTargetsForPolicyOutput struct {
+	_ struct{} `type:"structure"`
+
+	// A marker used to get the next set of results.
+	NextMarker *string `locationName:"nextMarker" type:"string"`
+
+	// The policy targets.
+	Targets []*string `locationName:"targets" type:"list"`
+}
+
+// String returns the string representation
+func (s ListTargetsForPolicyOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListTargetsForPolicyOutput) GoString() string {
+	return s.String()
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListTargetsForPolicyOutput) SetNextMarker(v string) *ListTargetsForPolicyOutput {
+	s.NextMarker = &v
+	return s
+}
+
+// SetTargets sets the Targets field's value.
+func (s *ListTargetsForPolicyOutput) SetTargets(v []*string) *ListTargetsForPolicyOutput {
+	s.Targets = v
+	return s
+}
+
+type ListThingGroupsForThingInput struct {
+	_ struct{} `type:"structure"`
+
+	// The maximum number of results to return at one time.
+	MaxResults *int64 `location:"querystring" locationName:"maxResults" min:"1" type:"integer"`
+
+	// The token used to get the next set of results, or null if there are no additional
+	// results.
+	NextToken *string `location:"querystring" locationName:"nextToken" type:"string"`
+
+	// The thing name.
+	//
+	// ThingName is a required field
+	ThingName *string `location:"uri" locationName:"thingName" min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s ListThingGroupsForThingInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListThingGroupsForThingInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListThingGroupsForThingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListThingGroupsForThingInput"}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+	if s.ThingName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ThingName"))
+	}
+	if s.ThingName != nil && len(*s.ThingName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ThingName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListThingGroupsForThingInput) SetMaxResults(v int64) *ListThingGroupsForThingInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListThingGroupsForThingInput) SetNextToken(v string) *ListThingGroupsForThingInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetThingName sets the ThingName field's value.
+func (s *ListThingGroupsForThingInput) SetThingName(v string) *ListThingGroupsForThingInput {
+	s.ThingName = &v
+	return s
+}
+
+type ListThingGroupsForThingOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The token used to get the next set of results, or null if there are no additional
+	// results.
+	NextToken *string `locationName:"nextToken" type:"string"`
+
+	// The thing groups.
+	ThingGroups []*GroupNameAndArn `locationName:"thingGroups" type:"list"`
+}
+
+// String returns the string representation
+func (s ListThingGroupsForThingOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListThingGroupsForThingOutput) GoString() string {
+	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListThingGroupsForThingOutput) SetNextToken(v string) *ListThingGroupsForThingOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetThingGroups sets the ThingGroups field's value.
+func (s *ListThingGroupsForThingOutput) SetThingGroups(v []*GroupNameAndArn) *ListThingGroupsForThingOutput {
+	s.ThingGroups = v
+	return s
+}
+
+type ListThingGroupsInput struct {
+	_ struct{} `type:"structure"`
+
+	// The maximum number of results to return at one time.
+	MaxResults *int64 `location:"querystring" locationName:"maxResults" min:"1" type:"integer"`
+
+	// A filter that limits the results to those with the specified name prefix.
+	NamePrefixFilter *string `location:"querystring" locationName:"namePrefixFilter" min:"1" type:"string"`
+
+	// The token used to get the next set of results, or null if there are no additional
+	// results.
+	NextToken *string `location:"querystring" locationName:"nextToken" type:"string"`
+
+	// A filter that limits the results to those with the specified parent group.
+	ParentGroup *string `location:"querystring" locationName:"parentGroup" min:"1" type:"string"`
+
+	// If true, return child groups as well.
+	Recursive *bool `location:"querystring" locationName:"recursive" type:"boolean"`
+}
+
+// String returns the string representation
+func (s ListThingGroupsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListThingGroupsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListThingGroupsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListThingGroupsInput"}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+	if s.NamePrefixFilter != nil && len(*s.NamePrefixFilter) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NamePrefixFilter", 1))
+	}
+	if s.ParentGroup != nil && len(*s.ParentGroup) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ParentGroup", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListThingGroupsInput) SetMaxResults(v int64) *ListThingGroupsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNamePrefixFilter sets the NamePrefixFilter field's value.
+func (s *ListThingGroupsInput) SetNamePrefixFilter(v string) *ListThingGroupsInput {
+	s.NamePrefixFilter = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListThingGroupsInput) SetNextToken(v string) *ListThingGroupsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetParentGroup sets the ParentGroup field's value.
+func (s *ListThingGroupsInput) SetParentGroup(v string) *ListThingGroupsInput {
+	s.ParentGroup = &v
+	return s
+}
+
+// SetRecursive sets the Recursive field's value.
+func (s *ListThingGroupsInput) SetRecursive(v bool) *ListThingGroupsInput {
+	s.Recursive = &v
+	return s
+}
+
+type ListThingGroupsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The token used to get the next set of results, or null if there are no additional
+	// results.
+	NextToken *string `locationName:"nextToken" type:"string"`
+
+	// The thing groups.
+	ThingGroups []*GroupNameAndArn `locationName:"thingGroups" type:"list"`
+}
+
+// String returns the string representation
+func (s ListThingGroupsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListThingGroupsOutput) GoString() string {
+	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListThingGroupsOutput) SetNextToken(v string) *ListThingGroupsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetThingGroups sets the ThingGroups field's value.
+func (s *ListThingGroupsOutput) SetThingGroups(v []*GroupNameAndArn) *ListThingGroupsOutput {
+	s.ThingGroups = v
 	return s
 }
 
@@ -9920,6 +19273,208 @@ func (s ListThingPrincipalsOutput) GoString() string {
 // SetPrincipals sets the Principals field's value.
 func (s *ListThingPrincipalsOutput) SetPrincipals(v []*string) *ListThingPrincipalsOutput {
 	s.Principals = v
+	return s
+}
+
+type ListThingRegistrationTaskReportsInput struct {
+	_ struct{} `type:"structure"`
+
+	// The maximum number of results to return per request.
+	MaxResults *int64 `location:"querystring" locationName:"maxResults" min:"1" type:"integer"`
+
+	// The token to retrieve the next set of results.
+	NextToken *string `location:"querystring" locationName:"nextToken" type:"string"`
+
+	// The type of task report.
+	//
+	// ReportType is a required field
+	ReportType *string `location:"querystring" locationName:"reportType" type:"string" required:"true" enum:"ReportType"`
+
+	// The id of the task.
+	//
+	// TaskId is a required field
+	TaskId *string `location:"uri" locationName:"taskId" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s ListThingRegistrationTaskReportsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListThingRegistrationTaskReportsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListThingRegistrationTaskReportsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListThingRegistrationTaskReportsInput"}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+	if s.ReportType == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReportType"))
+	}
+	if s.TaskId == nil {
+		invalidParams.Add(request.NewErrParamRequired("TaskId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListThingRegistrationTaskReportsInput) SetMaxResults(v int64) *ListThingRegistrationTaskReportsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListThingRegistrationTaskReportsInput) SetNextToken(v string) *ListThingRegistrationTaskReportsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetReportType sets the ReportType field's value.
+func (s *ListThingRegistrationTaskReportsInput) SetReportType(v string) *ListThingRegistrationTaskReportsInput {
+	s.ReportType = &v
+	return s
+}
+
+// SetTaskId sets the TaskId field's value.
+func (s *ListThingRegistrationTaskReportsInput) SetTaskId(v string) *ListThingRegistrationTaskReportsInput {
+	s.TaskId = &v
+	return s
+}
+
+type ListThingRegistrationTaskReportsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The token to retrieve the next set of results.
+	NextToken *string `locationName:"nextToken" type:"string"`
+
+	// The type of task report.
+	ReportType *string `locationName:"reportType" type:"string" enum:"ReportType"`
+
+	// Links to the task resources.
+	ResourceLinks []*string `locationName:"resourceLinks" type:"list"`
+}
+
+// String returns the string representation
+func (s ListThingRegistrationTaskReportsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListThingRegistrationTaskReportsOutput) GoString() string {
+	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListThingRegistrationTaskReportsOutput) SetNextToken(v string) *ListThingRegistrationTaskReportsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetReportType sets the ReportType field's value.
+func (s *ListThingRegistrationTaskReportsOutput) SetReportType(v string) *ListThingRegistrationTaskReportsOutput {
+	s.ReportType = &v
+	return s
+}
+
+// SetResourceLinks sets the ResourceLinks field's value.
+func (s *ListThingRegistrationTaskReportsOutput) SetResourceLinks(v []*string) *ListThingRegistrationTaskReportsOutput {
+	s.ResourceLinks = v
+	return s
+}
+
+type ListThingRegistrationTasksInput struct {
+	_ struct{} `type:"structure"`
+
+	// The maximum number of results to return at one time.
+	MaxResults *int64 `location:"querystring" locationName:"maxResults" min:"1" type:"integer"`
+
+	// The token used to get the next set of results, or null if there are no additional
+	// results.
+	NextToken *string `location:"querystring" locationName:"nextToken" type:"string"`
+
+	// The status of the bulk thing provisioning task.
+	Status *string `location:"querystring" locationName:"status" type:"string" enum:"Status"`
+}
+
+// String returns the string representation
+func (s ListThingRegistrationTasksInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListThingRegistrationTasksInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListThingRegistrationTasksInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListThingRegistrationTasksInput"}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListThingRegistrationTasksInput) SetMaxResults(v int64) *ListThingRegistrationTasksInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListThingRegistrationTasksInput) SetNextToken(v string) *ListThingRegistrationTasksInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ListThingRegistrationTasksInput) SetStatus(v string) *ListThingRegistrationTasksInput {
+	s.Status = &v
+	return s
+}
+
+type ListThingRegistrationTasksOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The token used to get the next set of results, or null if there are no additional
+	// results.
+	NextToken *string `locationName:"nextToken" type:"string"`
+
+	// A list of bulk thing provisioning task IDs.
+	TaskIds []*string `locationName:"taskIds" type:"list"`
+}
+
+// String returns the string representation
+func (s ListThingRegistrationTasksOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListThingRegistrationTasksOutput) GoString() string {
+	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListThingRegistrationTasksOutput) SetNextToken(v string) *ListThingRegistrationTasksOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetTaskIds sets the TaskIds field's value.
+func (s *ListThingRegistrationTasksOutput) SetTaskIds(v []*string) *ListThingRegistrationTasksOutput {
+	s.TaskIds = v
 	return s
 }
 
@@ -10016,6 +19571,111 @@ func (s *ListThingTypesOutput) SetThingTypes(v []*ThingTypeDefinition) *ListThin
 	return s
 }
 
+type ListThingsInThingGroupInput struct {
+	_ struct{} `type:"structure"`
+
+	// The maximum number of results to return at one time.
+	MaxResults *int64 `location:"querystring" locationName:"maxResults" min:"1" type:"integer"`
+
+	// The token used to get the next set of results, or null if there are no additional
+	// results.
+	NextToken *string `location:"querystring" locationName:"nextToken" type:"string"`
+
+	// When true, list things in this thing group and in all child groups as well.
+	Recursive *bool `location:"querystring" locationName:"recursive" type:"boolean"`
+
+	// The thing group name.
+	//
+	// ThingGroupName is a required field
+	ThingGroupName *string `location:"uri" locationName:"thingGroupName" min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s ListThingsInThingGroupInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListThingsInThingGroupInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListThingsInThingGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListThingsInThingGroupInput"}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+	if s.ThingGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ThingGroupName"))
+	}
+	if s.ThingGroupName != nil && len(*s.ThingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ThingGroupName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListThingsInThingGroupInput) SetMaxResults(v int64) *ListThingsInThingGroupInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListThingsInThingGroupInput) SetNextToken(v string) *ListThingsInThingGroupInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetRecursive sets the Recursive field's value.
+func (s *ListThingsInThingGroupInput) SetRecursive(v bool) *ListThingsInThingGroupInput {
+	s.Recursive = &v
+	return s
+}
+
+// SetThingGroupName sets the ThingGroupName field's value.
+func (s *ListThingsInThingGroupInput) SetThingGroupName(v string) *ListThingsInThingGroupInput {
+	s.ThingGroupName = &v
+	return s
+}
+
+type ListThingsInThingGroupOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The token used to get the next set of results, or null if there are no additional
+	// results.
+	NextToken *string `locationName:"nextToken" type:"string"`
+
+	// The things in the specified thing group.
+	Things []*string `locationName:"things" type:"list"`
+}
+
+// String returns the string representation
+func (s ListThingsInThingGroupOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListThingsInThingGroupOutput) GoString() string {
+	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListThingsInThingGroupOutput) SetNextToken(v string) *ListThingsInThingGroupOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetThings sets the Things field's value.
+func (s *ListThingsInThingGroupOutput) SetThings(v []*string) *ListThingsInThingGroupOutput {
+	s.Things = v
+	return s
+}
+
 // The input for the ListThings operation.
 type ListThingsInput struct {
 	_ struct{} `type:"structure"`
@@ -10029,7 +19689,7 @@ type ListThingsInput struct {
 	// The maximum number of results to return in this operation.
 	MaxResults *int64 `location:"querystring" locationName:"maxResults" min:"1" type:"integer"`
 
-	// The token for the next set of results, or null if there are no additional
+	// The token used to get the next set of results, or null if there are no additional
 	// results.
 	NextToken *string `location:"querystring" locationName:"nextToken" type:"string"`
 
@@ -10097,7 +19757,7 @@ func (s *ListThingsInput) SetThingTypeName(v string) *ListThingsInput {
 type ListThingsOutput struct {
 	_ struct{} `type:"structure"`
 
-	// The token for the next set of results, or null if there are no additional
+	// The token used to get the next set of results, or null if there are no additional
 	// results.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
@@ -10224,11 +19884,180 @@ func (s *ListTopicRulesOutput) SetRules(v []*TopicRuleListItem) *ListTopicRulesO
 	return s
 }
 
+type ListV2LoggingLevelsInput struct {
+	_ struct{} `type:"structure"`
+
+	// The maximum number of results to return at one time.
+	MaxResults *int64 `location:"querystring" locationName:"maxResults" min:"1" type:"integer"`
+
+	// The token used to get the next set of results, or null if there are no additional
+	// results.
+	NextToken *string `location:"querystring" locationName:"nextToken" type:"string"`
+
+	// The type of resource for which you are configuring logging. Must be THING_Group.
+	TargetType *string `location:"querystring" locationName:"targetType" type:"string" enum:"LogTargetType"`
+}
+
+// String returns the string representation
+func (s ListV2LoggingLevelsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListV2LoggingLevelsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListV2LoggingLevelsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListV2LoggingLevelsInput"}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListV2LoggingLevelsInput) SetMaxResults(v int64) *ListV2LoggingLevelsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListV2LoggingLevelsInput) SetNextToken(v string) *ListV2LoggingLevelsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetTargetType sets the TargetType field's value.
+func (s *ListV2LoggingLevelsInput) SetTargetType(v string) *ListV2LoggingLevelsInput {
+	s.TargetType = &v
+	return s
+}
+
+type ListV2LoggingLevelsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The logging configuration for a target.
+	LogTargetConfigurations []*LogTargetConfiguration `locationName:"logTargetConfigurations" type:"list"`
+
+	// The token used to get the next set of results, or null if there are no additional
+	// results.
+	NextToken *string `locationName:"nextToken" type:"string"`
+}
+
+// String returns the string representation
+func (s ListV2LoggingLevelsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListV2LoggingLevelsOutput) GoString() string {
+	return s.String()
+}
+
+// SetLogTargetConfigurations sets the LogTargetConfigurations field's value.
+func (s *ListV2LoggingLevelsOutput) SetLogTargetConfigurations(v []*LogTargetConfiguration) *ListV2LoggingLevelsOutput {
+	s.LogTargetConfigurations = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListV2LoggingLevelsOutput) SetNextToken(v string) *ListV2LoggingLevelsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// A log target.
+type LogTarget struct {
+	_ struct{} `type:"structure"`
+
+	// The target name.
+	TargetName *string `locationName:"targetName" type:"string"`
+
+	// The target type.
+	//
+	// TargetType is a required field
+	TargetType *string `locationName:"targetType" type:"string" required:"true" enum:"LogTargetType"`
+}
+
+// String returns the string representation
+func (s LogTarget) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s LogTarget) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *LogTarget) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "LogTarget"}
+	if s.TargetType == nil {
+		invalidParams.Add(request.NewErrParamRequired("TargetType"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetTargetName sets the TargetName field's value.
+func (s *LogTarget) SetTargetName(v string) *LogTarget {
+	s.TargetName = &v
+	return s
+}
+
+// SetTargetType sets the TargetType field's value.
+func (s *LogTarget) SetTargetType(v string) *LogTarget {
+	s.TargetType = &v
+	return s
+}
+
+// The target configuration.
+type LogTargetConfiguration struct {
+	_ struct{} `type:"structure"`
+
+	// The logging level.
+	LogLevel *string `locationName:"logLevel" type:"string" enum:"LogLevel"`
+
+	// A log target
+	LogTarget *LogTarget `locationName:"logTarget" type:"structure"`
+}
+
+// String returns the string representation
+func (s LogTargetConfiguration) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s LogTargetConfiguration) GoString() string {
+	return s.String()
+}
+
+// SetLogLevel sets the LogLevel field's value.
+func (s *LogTargetConfiguration) SetLogLevel(v string) *LogTargetConfiguration {
+	s.LogLevel = &v
+	return s
+}
+
+// SetLogTarget sets the LogTarget field's value.
+func (s *LogTargetConfiguration) SetLogTarget(v *LogTarget) *LogTargetConfiguration {
+	s.LogTarget = v
+	return s
+}
+
 // Describes the logging options payload.
 type LoggingOptionsPayload struct {
 	_ struct{} `type:"structure"`
 
-	// The logging level.
+	// The log level.
 	LogLevel *string `locationName:"logLevel" type:"string" enum:"LogLevel"`
 
 	// The ARN of the IAM role that grants access.
@@ -10272,7 +20101,7 @@ func (s *LoggingOptionsPayload) SetRoleArn(v string) *LoggingOptionsPayload {
 	return s
 }
 
-// A certificate that has been transfered but not yet accepted.
+// A certificate that has been transferred but not yet accepted.
 type OutgoingCertificate struct {
 	_ struct{} `type:"structure"`
 
@@ -10416,6 +20245,59 @@ func (s *PolicyVersion) SetVersionId(v string) *PolicyVersion {
 	return s
 }
 
+// Configuration for pre-signed S3 URLs.
+type PresignedUrlConfig struct {
+	_ struct{} `type:"structure"`
+
+	// How long (in seconds) pre-signed URLs are valid. Valid values are 60 - 3600,
+	// the default value is 3600 seconds. Pre-signed URLs are generated when Jobs
+	// receives an MQTT request for the job document.
+	ExpiresInSec *int64 `locationName:"expiresInSec" min:"60" type:"long"`
+
+	// The ARN of an IAM role that grants grants permission to download files from
+	// the S3 bucket where the job data/updates are stored. The role must also grant
+	// permission for IoT to download the files.
+	RoleArn *string `locationName:"roleArn" min:"20" type:"string"`
+}
+
+// String returns the string representation
+func (s PresignedUrlConfig) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PresignedUrlConfig) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PresignedUrlConfig) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PresignedUrlConfig"}
+	if s.ExpiresInSec != nil && *s.ExpiresInSec < 60 {
+		invalidParams.Add(request.NewErrParamMinValue("ExpiresInSec", 60))
+	}
+	if s.RoleArn != nil && len(*s.RoleArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleArn", 20))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetExpiresInSec sets the ExpiresInSec field's value.
+func (s *PresignedUrlConfig) SetExpiresInSec(v int64) *PresignedUrlConfig {
+	s.ExpiresInSec = &v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *PresignedUrlConfig) SetRoleArn(v string) *PresignedUrlConfig {
+	s.RoleArn = &v
+	return s
+}
+
 // The input for the DynamoActionVS action that specifies the DynamoDB table
 // to which the message data will be written.
 type PutItemInput struct {
@@ -10468,6 +20350,9 @@ type RegisterCACertificateInput struct {
 	// CaCertificate is a required field
 	CaCertificate *string `locationName:"caCertificate" min:"1" type:"string" required:"true"`
 
+	// Information about the registration configuration.
+	RegistrationConfig *RegistrationConfig `locationName:"registrationConfig" type:"structure"`
+
 	// A boolean value that specifies if the CA certificate is set to active.
 	SetAsActive *bool `location:"querystring" locationName:"setAsActive" type:"boolean"`
 
@@ -10502,6 +20387,11 @@ func (s *RegisterCACertificateInput) Validate() error {
 	if s.VerificationCertificate != nil && len(*s.VerificationCertificate) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("VerificationCertificate", 1))
 	}
+	if s.RegistrationConfig != nil {
+		if err := s.RegistrationConfig.Validate(); err != nil {
+			invalidParams.AddNested("RegistrationConfig", err.(request.ErrInvalidParams))
+		}
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -10518,6 +20408,12 @@ func (s *RegisterCACertificateInput) SetAllowAutoRegistration(v bool) *RegisterC
 // SetCaCertificate sets the CaCertificate field's value.
 func (s *RegisterCACertificateInput) SetCaCertificate(v string) *RegisterCACertificateInput {
 	s.CaCertificate = &v
+	return s
+}
+
+// SetRegistrationConfig sets the RegistrationConfig field's value.
+func (s *RegisterCACertificateInput) SetRegistrationConfig(v *RegistrationConfig) *RegisterCACertificateInput {
+	s.RegistrationConfig = v
 	return s
 }
 
@@ -10671,6 +20567,131 @@ func (s *RegisterCertificateOutput) SetCertificateId(v string) *RegisterCertific
 	return s
 }
 
+type RegisterThingInput struct {
+	_ struct{} `type:"structure"`
+
+	// The parameters for provisioning a thing.
+	Parameters map[string]*string `locationName:"parameters" type:"map"`
+
+	// The provisioning template.
+	//
+	// TemplateBody is a required field
+	TemplateBody *string `locationName:"templateBody" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s RegisterThingInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s RegisterThingInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RegisterThingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RegisterThingInput"}
+	if s.TemplateBody == nil {
+		invalidParams.Add(request.NewErrParamRequired("TemplateBody"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetParameters sets the Parameters field's value.
+func (s *RegisterThingInput) SetParameters(v map[string]*string) *RegisterThingInput {
+	s.Parameters = v
+	return s
+}
+
+// SetTemplateBody sets the TemplateBody field's value.
+func (s *RegisterThingInput) SetTemplateBody(v string) *RegisterThingInput {
+	s.TemplateBody = &v
+	return s
+}
+
+type RegisterThingOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The PEM of a certificate.
+	CertificatePem *string `locationName:"certificatePem" min:"1" type:"string"`
+
+	// ARNs for the generated resources.
+	ResourceArns map[string]*string `locationName:"resourceArns" type:"map"`
+}
+
+// String returns the string representation
+func (s RegisterThingOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s RegisterThingOutput) GoString() string {
+	return s.String()
+}
+
+// SetCertificatePem sets the CertificatePem field's value.
+func (s *RegisterThingOutput) SetCertificatePem(v string) *RegisterThingOutput {
+	s.CertificatePem = &v
+	return s
+}
+
+// SetResourceArns sets the ResourceArns field's value.
+func (s *RegisterThingOutput) SetResourceArns(v map[string]*string) *RegisterThingOutput {
+	s.ResourceArns = v
+	return s
+}
+
+// The registration configuration.
+type RegistrationConfig struct {
+	_ struct{} `type:"structure"`
+
+	// The ARN of the role.
+	RoleArn *string `locationName:"roleArn" min:"20" type:"string"`
+
+	// The template body.
+	TemplateBody *string `locationName:"templateBody" type:"string"`
+}
+
+// String returns the string representation
+func (s RegistrationConfig) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s RegistrationConfig) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RegistrationConfig) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RegistrationConfig"}
+	if s.RoleArn != nil && len(*s.RoleArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleArn", 20))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *RegistrationConfig) SetRoleArn(v string) *RegistrationConfig {
+	s.RoleArn = &v
+	return s
+}
+
+// SetTemplateBody sets the TemplateBody field's value.
+func (s *RegistrationConfig) SetTemplateBody(v string) *RegistrationConfig {
+	s.TemplateBody = &v
+	return s
+}
+
 // The input for the RejectCertificateTransfer operation.
 type RejectCertificateTransferInput struct {
 	_ struct{} `type:"structure"`
@@ -10733,6 +20754,86 @@ func (s RejectCertificateTransferOutput) String() string {
 
 // GoString returns the string representation
 func (s RejectCertificateTransferOutput) GoString() string {
+	return s.String()
+}
+
+type RemoveThingFromThingGroupInput struct {
+	_ struct{} `type:"structure"`
+
+	// The ARN of the thing to remove from the group.
+	ThingArn *string `locationName:"thingArn" type:"string"`
+
+	// The group ARN.
+	ThingGroupArn *string `locationName:"thingGroupArn" type:"string"`
+
+	// The group name.
+	ThingGroupName *string `locationName:"thingGroupName" min:"1" type:"string"`
+
+	// The name of the thing to remove from the group.
+	ThingName *string `locationName:"thingName" min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s RemoveThingFromThingGroupInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s RemoveThingFromThingGroupInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RemoveThingFromThingGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RemoveThingFromThingGroupInput"}
+	if s.ThingGroupName != nil && len(*s.ThingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ThingGroupName", 1))
+	}
+	if s.ThingName != nil && len(*s.ThingName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ThingName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetThingArn sets the ThingArn field's value.
+func (s *RemoveThingFromThingGroupInput) SetThingArn(v string) *RemoveThingFromThingGroupInput {
+	s.ThingArn = &v
+	return s
+}
+
+// SetThingGroupArn sets the ThingGroupArn field's value.
+func (s *RemoveThingFromThingGroupInput) SetThingGroupArn(v string) *RemoveThingFromThingGroupInput {
+	s.ThingGroupArn = &v
+	return s
+}
+
+// SetThingGroupName sets the ThingGroupName field's value.
+func (s *RemoveThingFromThingGroupInput) SetThingGroupName(v string) *RemoveThingFromThingGroupInput {
+	s.ThingGroupName = &v
+	return s
+}
+
+// SetThingName sets the ThingName field's value.
+func (s *RemoveThingFromThingGroupInput) SetThingName(v string) *RemoveThingFromThingGroupInput {
+	s.ThingName = &v
+	return s
+}
+
+type RemoveThingFromThingGroupOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s RemoveThingFromThingGroupOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s RemoveThingFromThingGroupOutput) GoString() string {
 	return s.String()
 }
 
@@ -10861,6 +20962,75 @@ func (s *RepublishAction) SetRoleArn(v string) *RepublishAction {
 // SetTopic sets the Topic field's value.
 func (s *RepublishAction) SetTopic(v string) *RepublishAction {
 	s.Topic = &v
+	return s
+}
+
+// Role alias description.
+type RoleAliasDescription struct {
+	_ struct{} `type:"structure"`
+
+	// The UNIX timestamp of when the role alias was created.
+	CreationDate *time.Time `locationName:"creationDate" type:"timestamp" timestampFormat:"unix"`
+
+	// The number of seconds for which the credential is valid.
+	CredentialDurationSeconds *int64 `locationName:"credentialDurationSeconds" min:"900" type:"integer"`
+
+	// The UNIX timestamp of when the role alias was last modified.
+	LastModifiedDate *time.Time `locationName:"lastModifiedDate" type:"timestamp" timestampFormat:"unix"`
+
+	// The role alias owner.
+	Owner *string `locationName:"owner" type:"string"`
+
+	// The role alias.
+	RoleAlias *string `locationName:"roleAlias" min:"1" type:"string"`
+
+	// The role ARN.
+	RoleArn *string `locationName:"roleArn" min:"20" type:"string"`
+}
+
+// String returns the string representation
+func (s RoleAliasDescription) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s RoleAliasDescription) GoString() string {
+	return s.String()
+}
+
+// SetCreationDate sets the CreationDate field's value.
+func (s *RoleAliasDescription) SetCreationDate(v time.Time) *RoleAliasDescription {
+	s.CreationDate = &v
+	return s
+}
+
+// SetCredentialDurationSeconds sets the CredentialDurationSeconds field's value.
+func (s *RoleAliasDescription) SetCredentialDurationSeconds(v int64) *RoleAliasDescription {
+	s.CredentialDurationSeconds = &v
+	return s
+}
+
+// SetLastModifiedDate sets the LastModifiedDate field's value.
+func (s *RoleAliasDescription) SetLastModifiedDate(v time.Time) *RoleAliasDescription {
+	s.LastModifiedDate = &v
+	return s
+}
+
+// SetOwner sets the Owner field's value.
+func (s *RoleAliasDescription) SetOwner(v string) *RoleAliasDescription {
+	s.Owner = &v
+	return s
+}
+
+// SetRoleAlias sets the RoleAlias field's value.
+func (s *RoleAliasDescription) SetRoleAlias(v string) *RoleAliasDescription {
+	s.RoleAlias = &v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *RoleAliasDescription) SetRoleArn(v string) *RoleAliasDescription {
+	s.RoleArn = &v
 	return s
 }
 
@@ -11000,6 +21170,196 @@ func (s *SalesforceAction) SetUrl(v string) *SalesforceAction {
 	return s
 }
 
+type SearchIndexInput struct {
+	_ struct{} `type:"structure"`
+
+	// The search index name.
+	IndexName *string `locationName:"indexName" min:"1" type:"string"`
+
+	// The maximum number of results to return at one time.
+	MaxResults *int64 `locationName:"maxResults" min:"1" type:"integer"`
+
+	// The token used to get the next set of results, or null if there are no additional
+	// results.
+	NextToken *string `locationName:"nextToken" type:"string"`
+
+	// The search query string.
+	//
+	// QueryString is a required field
+	QueryString *string `locationName:"queryString" min:"1" type:"string" required:"true"`
+
+	// The query version.
+	QueryVersion *string `locationName:"queryVersion" type:"string"`
+}
+
+// String returns the string representation
+func (s SearchIndexInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SearchIndexInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SearchIndexInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SearchIndexInput"}
+	if s.IndexName != nil && len(*s.IndexName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IndexName", 1))
+	}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+	if s.QueryString == nil {
+		invalidParams.Add(request.NewErrParamRequired("QueryString"))
+	}
+	if s.QueryString != nil && len(*s.QueryString) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("QueryString", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetIndexName sets the IndexName field's value.
+func (s *SearchIndexInput) SetIndexName(v string) *SearchIndexInput {
+	s.IndexName = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *SearchIndexInput) SetMaxResults(v int64) *SearchIndexInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *SearchIndexInput) SetNextToken(v string) *SearchIndexInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetQueryString sets the QueryString field's value.
+func (s *SearchIndexInput) SetQueryString(v string) *SearchIndexInput {
+	s.QueryString = &v
+	return s
+}
+
+// SetQueryVersion sets the QueryVersion field's value.
+func (s *SearchIndexInput) SetQueryVersion(v string) *SearchIndexInput {
+	s.QueryVersion = &v
+	return s
+}
+
+type SearchIndexOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The token used to get the next set of results, or null if there are no additional
+	// results.
+	NextToken *string `locationName:"nextToken" type:"string"`
+
+	// The things that match the search query.
+	Things []*ThingDocument `locationName:"things" type:"list"`
+}
+
+// String returns the string representation
+func (s SearchIndexOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SearchIndexOutput) GoString() string {
+	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *SearchIndexOutput) SetNextToken(v string) *SearchIndexOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetThings sets the Things field's value.
+func (s *SearchIndexOutput) SetThings(v []*ThingDocument) *SearchIndexOutput {
+	s.Things = v
+	return s
+}
+
+type SetDefaultAuthorizerInput struct {
+	_ struct{} `type:"structure"`
+
+	// The authorizer name.
+	//
+	// AuthorizerName is a required field
+	AuthorizerName *string `locationName:"authorizerName" min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s SetDefaultAuthorizerInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SetDefaultAuthorizerInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetDefaultAuthorizerInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetDefaultAuthorizerInput"}
+	if s.AuthorizerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AuthorizerName"))
+	}
+	if s.AuthorizerName != nil && len(*s.AuthorizerName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AuthorizerName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAuthorizerName sets the AuthorizerName field's value.
+func (s *SetDefaultAuthorizerInput) SetAuthorizerName(v string) *SetDefaultAuthorizerInput {
+	s.AuthorizerName = &v
+	return s
+}
+
+type SetDefaultAuthorizerOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The authorizer ARN.
+	AuthorizerArn *string `locationName:"authorizerArn" type:"string"`
+
+	// The authorizer name.
+	AuthorizerName *string `locationName:"authorizerName" min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s SetDefaultAuthorizerOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SetDefaultAuthorizerOutput) GoString() string {
+	return s.String()
+}
+
+// SetAuthorizerArn sets the AuthorizerArn field's value.
+func (s *SetDefaultAuthorizerOutput) SetAuthorizerArn(v string) *SetDefaultAuthorizerOutput {
+	s.AuthorizerArn = &v
+	return s
+}
+
+// SetAuthorizerName sets the AuthorizerName field's value.
+func (s *SetDefaultAuthorizerOutput) SetAuthorizerName(v string) *SetDefaultAuthorizerOutput {
+	s.AuthorizerName = &v
+	return s
+}
+
 // The input for the SetDefaultPolicyVersion operation.
 type SetDefaultPolicyVersionInput struct {
 	_ struct{} `type:"structure"`
@@ -11125,6 +21485,132 @@ func (s SetLoggingOptionsOutput) String() string {
 
 // GoString returns the string representation
 func (s SetLoggingOptionsOutput) GoString() string {
+	return s.String()
+}
+
+type SetV2LoggingLevelInput struct {
+	_ struct{} `type:"structure"`
+
+	// The log level.
+	//
+	// LogLevel is a required field
+	LogLevel *string `locationName:"logLevel" type:"string" required:"true" enum:"LogLevel"`
+
+	// The log target.
+	//
+	// LogTarget is a required field
+	LogTarget *LogTarget `locationName:"logTarget" type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s SetV2LoggingLevelInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SetV2LoggingLevelInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SetV2LoggingLevelInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SetV2LoggingLevelInput"}
+	if s.LogLevel == nil {
+		invalidParams.Add(request.NewErrParamRequired("LogLevel"))
+	}
+	if s.LogTarget == nil {
+		invalidParams.Add(request.NewErrParamRequired("LogTarget"))
+	}
+	if s.LogTarget != nil {
+		if err := s.LogTarget.Validate(); err != nil {
+			invalidParams.AddNested("LogTarget", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetLogLevel sets the LogLevel field's value.
+func (s *SetV2LoggingLevelInput) SetLogLevel(v string) *SetV2LoggingLevelInput {
+	s.LogLevel = &v
+	return s
+}
+
+// SetLogTarget sets the LogTarget field's value.
+func (s *SetV2LoggingLevelInput) SetLogTarget(v *LogTarget) *SetV2LoggingLevelInput {
+	s.LogTarget = v
+	return s
+}
+
+type SetV2LoggingLevelOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s SetV2LoggingLevelOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SetV2LoggingLevelOutput) GoString() string {
+	return s.String()
+}
+
+type SetV2LoggingOptionsInput struct {
+	_ struct{} `type:"structure"`
+
+	// The default logging level.
+	DefaultLogLevel *string `locationName:"defaultLogLevel" type:"string" enum:"LogLevel"`
+
+	// Set to true to disable all logs, otherwise set to false.
+	DisableAllLogs *bool `locationName:"disableAllLogs" type:"boolean"`
+
+	// The role ARN that allows IoT to write to Cloudwatch logs.
+	RoleArn *string `locationName:"roleArn" type:"string"`
+}
+
+// String returns the string representation
+func (s SetV2LoggingOptionsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SetV2LoggingOptionsInput) GoString() string {
+	return s.String()
+}
+
+// SetDefaultLogLevel sets the DefaultLogLevel field's value.
+func (s *SetV2LoggingOptionsInput) SetDefaultLogLevel(v string) *SetV2LoggingOptionsInput {
+	s.DefaultLogLevel = &v
+	return s
+}
+
+// SetDisableAllLogs sets the DisableAllLogs field's value.
+func (s *SetV2LoggingOptionsInput) SetDisableAllLogs(v bool) *SetV2LoggingOptionsInput {
+	s.DisableAllLogs = &v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *SetV2LoggingOptionsInput) SetRoleArn(v string) *SetV2LoggingOptionsInput {
+	s.RoleArn = &v
+	return s
+}
+
+type SetV2LoggingOptionsOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s SetV2LoggingOptionsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SetV2LoggingOptionsOutput) GoString() string {
 	return s.String()
 }
 
@@ -11257,6 +21743,419 @@ func (s *SqsAction) SetUseBase64(v bool) *SqsAction {
 	return s
 }
 
+type StartThingRegistrationTaskInput struct {
+	_ struct{} `type:"structure"`
+
+	// The S3 bucket that contains the input file.
+	//
+	// InputFileBucket is a required field
+	InputFileBucket *string `locationName:"inputFileBucket" min:"3" type:"string" required:"true"`
+
+	// The name of input file within the S3 bucket. This file contains a newline
+	// delimited JSON file. Each line contains the parameter values to provision
+	// one device (thing).
+	//
+	// InputFileKey is a required field
+	InputFileKey *string `locationName:"inputFileKey" min:"1" type:"string" required:"true"`
+
+	// The IAM role ARN that grants permission the input file.
+	//
+	// RoleArn is a required field
+	RoleArn *string `locationName:"roleArn" min:"20" type:"string" required:"true"`
+
+	// The provisioning template.
+	//
+	// TemplateBody is a required field
+	TemplateBody *string `locationName:"templateBody" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s StartThingRegistrationTaskInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s StartThingRegistrationTaskInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StartThingRegistrationTaskInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StartThingRegistrationTaskInput"}
+	if s.InputFileBucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("InputFileBucket"))
+	}
+	if s.InputFileBucket != nil && len(*s.InputFileBucket) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("InputFileBucket", 3))
+	}
+	if s.InputFileKey == nil {
+		invalidParams.Add(request.NewErrParamRequired("InputFileKey"))
+	}
+	if s.InputFileKey != nil && len(*s.InputFileKey) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("InputFileKey", 1))
+	}
+	if s.RoleArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleArn"))
+	}
+	if s.RoleArn != nil && len(*s.RoleArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleArn", 20))
+	}
+	if s.TemplateBody == nil {
+		invalidParams.Add(request.NewErrParamRequired("TemplateBody"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetInputFileBucket sets the InputFileBucket field's value.
+func (s *StartThingRegistrationTaskInput) SetInputFileBucket(v string) *StartThingRegistrationTaskInput {
+	s.InputFileBucket = &v
+	return s
+}
+
+// SetInputFileKey sets the InputFileKey field's value.
+func (s *StartThingRegistrationTaskInput) SetInputFileKey(v string) *StartThingRegistrationTaskInput {
+	s.InputFileKey = &v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *StartThingRegistrationTaskInput) SetRoleArn(v string) *StartThingRegistrationTaskInput {
+	s.RoleArn = &v
+	return s
+}
+
+// SetTemplateBody sets the TemplateBody field's value.
+func (s *StartThingRegistrationTaskInput) SetTemplateBody(v string) *StartThingRegistrationTaskInput {
+	s.TemplateBody = &v
+	return s
+}
+
+type StartThingRegistrationTaskOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The bulk thing provisioning task ID.
+	TaskId *string `locationName:"taskId" type:"string"`
+}
+
+// String returns the string representation
+func (s StartThingRegistrationTaskOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s StartThingRegistrationTaskOutput) GoString() string {
+	return s.String()
+}
+
+// SetTaskId sets the TaskId field's value.
+func (s *StartThingRegistrationTaskOutput) SetTaskId(v string) *StartThingRegistrationTaskOutput {
+	s.TaskId = &v
+	return s
+}
+
+type StopThingRegistrationTaskInput struct {
+	_ struct{} `type:"structure"`
+
+	// The bulk thing provisioning task ID.
+	//
+	// TaskId is a required field
+	TaskId *string `location:"uri" locationName:"taskId" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s StopThingRegistrationTaskInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s StopThingRegistrationTaskInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StopThingRegistrationTaskInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StopThingRegistrationTaskInput"}
+	if s.TaskId == nil {
+		invalidParams.Add(request.NewErrParamRequired("TaskId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetTaskId sets the TaskId field's value.
+func (s *StopThingRegistrationTaskInput) SetTaskId(v string) *StopThingRegistrationTaskInput {
+	s.TaskId = &v
+	return s
+}
+
+type StopThingRegistrationTaskOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s StopThingRegistrationTaskOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s StopThingRegistrationTaskOutput) GoString() string {
+	return s.String()
+}
+
+type TestAuthorizationInput struct {
+	_ struct{} `type:"structure"`
+
+	// A list of authorization info objects. Simulating authorization will create
+	// a response for each authInfo object in the list.
+	//
+	// AuthInfos is a required field
+	AuthInfos []*AuthInfo `locationName:"authInfos" min:"1" type:"list" required:"true"`
+
+	// The MQTT client ID.
+	ClientId *string `location:"querystring" locationName:"clientId" type:"string"`
+
+	// The Cognito identity pool ID.
+	CognitoIdentityPoolId *string `locationName:"cognitoIdentityPoolId" type:"string"`
+
+	// When testing custom authorization, the policies specified here are treated
+	// as if they are attached to the principal being authorized.
+	PolicyNamesToAdd []*string `locationName:"policyNamesToAdd" type:"list"`
+
+	// When testing custom authorization, the policies specified here are treated
+	// as if they are not attached to the principal being authorized.
+	PolicyNamesToSkip []*string `locationName:"policyNamesToSkip" type:"list"`
+
+	// The principal.
+	Principal *string `locationName:"principal" type:"string"`
+}
+
+// String returns the string representation
+func (s TestAuthorizationInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TestAuthorizationInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TestAuthorizationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TestAuthorizationInput"}
+	if s.AuthInfos == nil {
+		invalidParams.Add(request.NewErrParamRequired("AuthInfos"))
+	}
+	if s.AuthInfos != nil && len(s.AuthInfos) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AuthInfos", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAuthInfos sets the AuthInfos field's value.
+func (s *TestAuthorizationInput) SetAuthInfos(v []*AuthInfo) *TestAuthorizationInput {
+	s.AuthInfos = v
+	return s
+}
+
+// SetClientId sets the ClientId field's value.
+func (s *TestAuthorizationInput) SetClientId(v string) *TestAuthorizationInput {
+	s.ClientId = &v
+	return s
+}
+
+// SetCognitoIdentityPoolId sets the CognitoIdentityPoolId field's value.
+func (s *TestAuthorizationInput) SetCognitoIdentityPoolId(v string) *TestAuthorizationInput {
+	s.CognitoIdentityPoolId = &v
+	return s
+}
+
+// SetPolicyNamesToAdd sets the PolicyNamesToAdd field's value.
+func (s *TestAuthorizationInput) SetPolicyNamesToAdd(v []*string) *TestAuthorizationInput {
+	s.PolicyNamesToAdd = v
+	return s
+}
+
+// SetPolicyNamesToSkip sets the PolicyNamesToSkip field's value.
+func (s *TestAuthorizationInput) SetPolicyNamesToSkip(v []*string) *TestAuthorizationInput {
+	s.PolicyNamesToSkip = v
+	return s
+}
+
+// SetPrincipal sets the Principal field's value.
+func (s *TestAuthorizationInput) SetPrincipal(v string) *TestAuthorizationInput {
+	s.Principal = &v
+	return s
+}
+
+type TestAuthorizationOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The authentication results.
+	AuthResults []*AuthResult `locationName:"authResults" type:"list"`
+}
+
+// String returns the string representation
+func (s TestAuthorizationOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TestAuthorizationOutput) GoString() string {
+	return s.String()
+}
+
+// SetAuthResults sets the AuthResults field's value.
+func (s *TestAuthorizationOutput) SetAuthResults(v []*AuthResult) *TestAuthorizationOutput {
+	s.AuthResults = v
+	return s
+}
+
+type TestInvokeAuthorizerInput struct {
+	_ struct{} `type:"structure"`
+
+	// The custom authorizer name.
+	//
+	// AuthorizerName is a required field
+	AuthorizerName *string `location:"uri" locationName:"authorizerName" min:"1" type:"string" required:"true"`
+
+	// The token returned by your custom authentication service.
+	//
+	// Token is a required field
+	Token *string `locationName:"token" min:"1" type:"string" required:"true"`
+
+	// The signature made with the token and your custom authentication service's
+	// private key.
+	//
+	// TokenSignature is a required field
+	TokenSignature *string `locationName:"tokenSignature" min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s TestInvokeAuthorizerInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TestInvokeAuthorizerInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TestInvokeAuthorizerInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TestInvokeAuthorizerInput"}
+	if s.AuthorizerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AuthorizerName"))
+	}
+	if s.AuthorizerName != nil && len(*s.AuthorizerName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AuthorizerName", 1))
+	}
+	if s.Token == nil {
+		invalidParams.Add(request.NewErrParamRequired("Token"))
+	}
+	if s.Token != nil && len(*s.Token) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Token", 1))
+	}
+	if s.TokenSignature == nil {
+		invalidParams.Add(request.NewErrParamRequired("TokenSignature"))
+	}
+	if s.TokenSignature != nil && len(*s.TokenSignature) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TokenSignature", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAuthorizerName sets the AuthorizerName field's value.
+func (s *TestInvokeAuthorizerInput) SetAuthorizerName(v string) *TestInvokeAuthorizerInput {
+	s.AuthorizerName = &v
+	return s
+}
+
+// SetToken sets the Token field's value.
+func (s *TestInvokeAuthorizerInput) SetToken(v string) *TestInvokeAuthorizerInput {
+	s.Token = &v
+	return s
+}
+
+// SetTokenSignature sets the TokenSignature field's value.
+func (s *TestInvokeAuthorizerInput) SetTokenSignature(v string) *TestInvokeAuthorizerInput {
+	s.TokenSignature = &v
+	return s
+}
+
+type TestInvokeAuthorizerOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The number of seconds after which the connection is terminated.
+	DisconnectAfterInSeconds *int64 `locationName:"disconnectAfterInSeconds" type:"integer"`
+
+	// True if the token is authenticated, otherwise false.
+	IsAuthenticated *bool `locationName:"isAuthenticated" type:"boolean"`
+
+	// IAM policy documents.
+	PolicyDocuments []*string `locationName:"policyDocuments" type:"list"`
+
+	// The principal ID.
+	PrincipalId *string `locationName:"principalId" min:"1" type:"string"`
+
+	// The number of seconds after which the temporary credentials are refreshed.
+	RefreshAfterInSeconds *int64 `locationName:"refreshAfterInSeconds" type:"integer"`
+}
+
+// String returns the string representation
+func (s TestInvokeAuthorizerOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TestInvokeAuthorizerOutput) GoString() string {
+	return s.String()
+}
+
+// SetDisconnectAfterInSeconds sets the DisconnectAfterInSeconds field's value.
+func (s *TestInvokeAuthorizerOutput) SetDisconnectAfterInSeconds(v int64) *TestInvokeAuthorizerOutput {
+	s.DisconnectAfterInSeconds = &v
+	return s
+}
+
+// SetIsAuthenticated sets the IsAuthenticated field's value.
+func (s *TestInvokeAuthorizerOutput) SetIsAuthenticated(v bool) *TestInvokeAuthorizerOutput {
+	s.IsAuthenticated = &v
+	return s
+}
+
+// SetPolicyDocuments sets the PolicyDocuments field's value.
+func (s *TestInvokeAuthorizerOutput) SetPolicyDocuments(v []*string) *TestInvokeAuthorizerOutput {
+	s.PolicyDocuments = v
+	return s
+}
+
+// SetPrincipalId sets the PrincipalId field's value.
+func (s *TestInvokeAuthorizerOutput) SetPrincipalId(v string) *TestInvokeAuthorizerOutput {
+	s.PrincipalId = &v
+	return s
+}
+
+// SetRefreshAfterInSeconds sets the RefreshAfterInSeconds field's value.
+func (s *TestInvokeAuthorizerOutput) SetRefreshAfterInSeconds(v int64) *TestInvokeAuthorizerOutput {
+	s.RefreshAfterInSeconds = &v
+	return s
+}
+
 // The properties of the thing, including thing name, thing type name, and a
 // list of thing attributes.
 type ThingAttribute struct {
@@ -11264,6 +22163,9 @@ type ThingAttribute struct {
 
 	// A list of thing attributes which are name-value pairs.
 	Attributes map[string]*string `locationName:"attributes" type:"map"`
+
+	// The thing ARN.
+	ThingArn *string `locationName:"thingArn" type:"string"`
 
 	// The name of the thing.
 	ThingName *string `locationName:"thingName" min:"1" type:"string"`
@@ -11291,6 +22193,12 @@ func (s *ThingAttribute) SetAttributes(v map[string]*string) *ThingAttribute {
 	return s
 }
 
+// SetThingArn sets the ThingArn field's value.
+func (s *ThingAttribute) SetThingArn(v string) *ThingAttribute {
+	s.ThingArn = &v
+	return s
+}
+
 // SetThingName sets the ThingName field's value.
 func (s *ThingAttribute) SetThingName(v string) *ThingAttribute {
 	s.ThingName = &v
@@ -11309,9 +22217,187 @@ func (s *ThingAttribute) SetVersion(v int64) *ThingAttribute {
 	return s
 }
 
+// The thing search index document.
+type ThingDocument struct {
+	_ struct{} `type:"structure"`
+
+	// The attributes.
+	Attributes map[string]*string `locationName:"attributes" type:"map"`
+
+	// The thing shadow.
+	Shadow *string `locationName:"shadow" type:"string"`
+
+	// Thing group names.
+	ThingGroupNames []*string `locationName:"thingGroupNames" type:"list"`
+
+	// The thing ID.
+	ThingId *string `locationName:"thingId" type:"string"`
+
+	// The thing name.
+	ThingName *string `locationName:"thingName" min:"1" type:"string"`
+
+	// The thing type name.
+	ThingTypeName *string `locationName:"thingTypeName" min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s ThingDocument) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ThingDocument) GoString() string {
+	return s.String()
+}
+
+// SetAttributes sets the Attributes field's value.
+func (s *ThingDocument) SetAttributes(v map[string]*string) *ThingDocument {
+	s.Attributes = v
+	return s
+}
+
+// SetShadow sets the Shadow field's value.
+func (s *ThingDocument) SetShadow(v string) *ThingDocument {
+	s.Shadow = &v
+	return s
+}
+
+// SetThingGroupNames sets the ThingGroupNames field's value.
+func (s *ThingDocument) SetThingGroupNames(v []*string) *ThingDocument {
+	s.ThingGroupNames = v
+	return s
+}
+
+// SetThingId sets the ThingId field's value.
+func (s *ThingDocument) SetThingId(v string) *ThingDocument {
+	s.ThingId = &v
+	return s
+}
+
+// SetThingName sets the ThingName field's value.
+func (s *ThingDocument) SetThingName(v string) *ThingDocument {
+	s.ThingName = &v
+	return s
+}
+
+// SetThingTypeName sets the ThingTypeName field's value.
+func (s *ThingDocument) SetThingTypeName(v string) *ThingDocument {
+	s.ThingTypeName = &v
+	return s
+}
+
+// Thing group metadata.
+type ThingGroupMetadata struct {
+	_ struct{} `type:"structure"`
+
+	// The UNIX timestamp of when the thing group was created.
+	CreationDate *time.Time `locationName:"creationDate" type:"timestamp" timestampFormat:"unix"`
+
+	// The parent thing group name.
+	ParentGroupName *string `locationName:"parentGroupName" min:"1" type:"string"`
+
+	// The root parent thing group.
+	RootToParentThingGroups []*GroupNameAndArn `locationName:"rootToParentThingGroups" type:"list"`
+}
+
+// String returns the string representation
+func (s ThingGroupMetadata) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ThingGroupMetadata) GoString() string {
+	return s.String()
+}
+
+// SetCreationDate sets the CreationDate field's value.
+func (s *ThingGroupMetadata) SetCreationDate(v time.Time) *ThingGroupMetadata {
+	s.CreationDate = &v
+	return s
+}
+
+// SetParentGroupName sets the ParentGroupName field's value.
+func (s *ThingGroupMetadata) SetParentGroupName(v string) *ThingGroupMetadata {
+	s.ParentGroupName = &v
+	return s
+}
+
+// SetRootToParentThingGroups sets the RootToParentThingGroups field's value.
+func (s *ThingGroupMetadata) SetRootToParentThingGroups(v []*GroupNameAndArn) *ThingGroupMetadata {
+	s.RootToParentThingGroups = v
+	return s
+}
+
+// Thing group properties.
+type ThingGroupProperties struct {
+	_ struct{} `type:"structure"`
+
+	// The thing group attributes in JSON format.
+	AttributePayload *AttributePayload `locationName:"attributePayload" type:"structure"`
+
+	// The thing group description.
+	ThingGroupDescription *string `locationName:"thingGroupDescription" type:"string"`
+}
+
+// String returns the string representation
+func (s ThingGroupProperties) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ThingGroupProperties) GoString() string {
+	return s.String()
+}
+
+// SetAttributePayload sets the AttributePayload field's value.
+func (s *ThingGroupProperties) SetAttributePayload(v *AttributePayload) *ThingGroupProperties {
+	s.AttributePayload = v
+	return s
+}
+
+// SetThingGroupDescription sets the ThingGroupDescription field's value.
+func (s *ThingGroupProperties) SetThingGroupDescription(v string) *ThingGroupProperties {
+	s.ThingGroupDescription = &v
+	return s
+}
+
+// Thing indexing configuration.
+type ThingIndexingConfiguration struct {
+	_ struct{} `type:"structure"`
+
+	// Thing indexing mode. Valid values are:
+	//
+	//    * REGISTRY – Your thing index will contain only registry data.
+	//
+	//    * REGISTRY_AND_SHADOW - Your thing index will contain registry and shadow
+	//    data.
+	//
+	//    * OFF - Thing indexing is disabled.
+	ThingIndexingMode *string `locationName:"thingIndexingMode" type:"string" enum:"ThingIndexingMode"`
+}
+
+// String returns the string representation
+func (s ThingIndexingConfiguration) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ThingIndexingConfiguration) GoString() string {
+	return s.String()
+}
+
+// SetThingIndexingMode sets the ThingIndexingMode field's value.
+func (s *ThingIndexingConfiguration) SetThingIndexingMode(v string) *ThingIndexingConfiguration {
+	s.ThingIndexingMode = &v
+	return s
+}
+
 // The definition of the thing type, including thing type name and description.
 type ThingTypeDefinition struct {
 	_ struct{} `type:"structure"`
+
+	// The thing type ARN.
+	ThingTypeArn *string `locationName:"thingTypeArn" type:"string"`
 
 	// The ThingTypeMetadata contains additional information about the thing type
 	// including: creation date and time, a value indicating whether the thing type
@@ -11333,6 +22419,12 @@ func (s ThingTypeDefinition) String() string {
 // GoString returns the string representation
 func (s ThingTypeDefinition) GoString() string {
 	return s.String()
+}
+
+// SetThingTypeArn sets the ThingTypeArn field's value.
+func (s *ThingTypeDefinition) SetThingTypeArn(v string) *ThingTypeDefinition {
+	s.ThingTypeArn = &v
+	return s
 }
 
 // SetThingTypeMetadata sets the ThingTypeMetadata field's value.
@@ -11812,6 +22904,118 @@ func (s *TransferData) SetTransferMessage(v string) *TransferData {
 	return s
 }
 
+type UpdateAuthorizerInput struct {
+	_ struct{} `type:"structure"`
+
+	// The ARN of the authorizer's Lambda function.
+	AuthorizerFunctionArn *string `locationName:"authorizerFunctionArn" type:"string"`
+
+	// The authorizer name.
+	//
+	// AuthorizerName is a required field
+	AuthorizerName *string `location:"uri" locationName:"authorizerName" min:"1" type:"string" required:"true"`
+
+	// The status of the update authorizer request.
+	Status *string `locationName:"status" type:"string" enum:"AuthorizerStatus"`
+
+	// The key used to extract the token from the HTTP headers.
+	TokenKeyName *string `locationName:"tokenKeyName" min:"1" type:"string"`
+
+	// The public keys used to verify the token signature.
+	TokenSigningPublicKeys map[string]*string `locationName:"tokenSigningPublicKeys" type:"map"`
+}
+
+// String returns the string representation
+func (s UpdateAuthorizerInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateAuthorizerInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateAuthorizerInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateAuthorizerInput"}
+	if s.AuthorizerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AuthorizerName"))
+	}
+	if s.AuthorizerName != nil && len(*s.AuthorizerName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AuthorizerName", 1))
+	}
+	if s.TokenKeyName != nil && len(*s.TokenKeyName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TokenKeyName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAuthorizerFunctionArn sets the AuthorizerFunctionArn field's value.
+func (s *UpdateAuthorizerInput) SetAuthorizerFunctionArn(v string) *UpdateAuthorizerInput {
+	s.AuthorizerFunctionArn = &v
+	return s
+}
+
+// SetAuthorizerName sets the AuthorizerName field's value.
+func (s *UpdateAuthorizerInput) SetAuthorizerName(v string) *UpdateAuthorizerInput {
+	s.AuthorizerName = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *UpdateAuthorizerInput) SetStatus(v string) *UpdateAuthorizerInput {
+	s.Status = &v
+	return s
+}
+
+// SetTokenKeyName sets the TokenKeyName field's value.
+func (s *UpdateAuthorizerInput) SetTokenKeyName(v string) *UpdateAuthorizerInput {
+	s.TokenKeyName = &v
+	return s
+}
+
+// SetTokenSigningPublicKeys sets the TokenSigningPublicKeys field's value.
+func (s *UpdateAuthorizerInput) SetTokenSigningPublicKeys(v map[string]*string) *UpdateAuthorizerInput {
+	s.TokenSigningPublicKeys = v
+	return s
+}
+
+type UpdateAuthorizerOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The authorizer ARN.
+	AuthorizerArn *string `locationName:"authorizerArn" type:"string"`
+
+	// The authorizer name.
+	AuthorizerName *string `locationName:"authorizerName" min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s UpdateAuthorizerOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateAuthorizerOutput) GoString() string {
+	return s.String()
+}
+
+// SetAuthorizerArn sets the AuthorizerArn field's value.
+func (s *UpdateAuthorizerOutput) SetAuthorizerArn(v string) *UpdateAuthorizerOutput {
+	s.AuthorizerArn = &v
+	return s
+}
+
+// SetAuthorizerName sets the AuthorizerName field's value.
+func (s *UpdateAuthorizerOutput) SetAuthorizerName(v string) *UpdateAuthorizerOutput {
+	s.AuthorizerName = &v
+	return s
+}
+
 // The input to the UpdateCACertificate operation.
 type UpdateCACertificateInput struct {
 	_ struct{} `type:"structure"`
@@ -11830,6 +23034,12 @@ type UpdateCACertificateInput struct {
 	// Note: The status value REGISTER_INACTIVE is deprecated and should not be
 	// used.
 	NewStatus *string `location:"querystring" locationName:"newStatus" type:"string" enum:"CACertificateStatus"`
+
+	// Information about the registration configuration.
+	RegistrationConfig *RegistrationConfig `locationName:"registrationConfig" type:"structure"`
+
+	// If true, remove auto registration.
+	RemoveAutoRegistration *bool `locationName:"removeAutoRegistration" type:"boolean"`
 }
 
 // String returns the string representation
@@ -11850,6 +23060,11 @@ func (s *UpdateCACertificateInput) Validate() error {
 	}
 	if s.CertificateId != nil && len(*s.CertificateId) < 64 {
 		invalidParams.Add(request.NewErrParamMinLen("CertificateId", 64))
+	}
+	if s.RegistrationConfig != nil {
+		if err := s.RegistrationConfig.Validate(); err != nil {
+			invalidParams.AddNested("RegistrationConfig", err.(request.ErrInvalidParams))
+		}
 	}
 
 	if invalidParams.Len() > 0 {
@@ -11873,6 +23088,18 @@ func (s *UpdateCACertificateInput) SetNewAutoRegistrationStatus(v string) *Updat
 // SetNewStatus sets the NewStatus field's value.
 func (s *UpdateCACertificateInput) SetNewStatus(v string) *UpdateCACertificateInput {
 	s.NewStatus = &v
+	return s
+}
+
+// SetRegistrationConfig sets the RegistrationConfig field's value.
+func (s *UpdateCACertificateInput) SetRegistrationConfig(v *RegistrationConfig) *UpdateCACertificateInput {
+	s.RegistrationConfig = v
+	return s
+}
+
+// SetRemoveAutoRegistration sets the RemoveAutoRegistration field's value.
+func (s *UpdateCACertificateInput) SetRemoveAutoRegistration(v bool) *UpdateCACertificateInput {
+	s.RemoveAutoRegistration = &v
 	return s
 }
 
@@ -11967,6 +23194,333 @@ func (s UpdateCertificateOutput) GoString() string {
 	return s.String()
 }
 
+type UpdateEventConfigurationsInput struct {
+	_ struct{} `type:"structure"`
+
+	// The new event configuration values.
+	EventConfigurations map[string]*Configuration `locationName:"eventConfigurations" type:"map"`
+}
+
+// String returns the string representation
+func (s UpdateEventConfigurationsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateEventConfigurationsInput) GoString() string {
+	return s.String()
+}
+
+// SetEventConfigurations sets the EventConfigurations field's value.
+func (s *UpdateEventConfigurationsInput) SetEventConfigurations(v map[string]*Configuration) *UpdateEventConfigurationsInput {
+	s.EventConfigurations = v
+	return s
+}
+
+type UpdateEventConfigurationsOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateEventConfigurationsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateEventConfigurationsOutput) GoString() string {
+	return s.String()
+}
+
+type UpdateIndexingConfigurationInput struct {
+	_ struct{} `type:"structure"`
+
+	// Thing indexing configuration.
+	ThingIndexingConfiguration *ThingIndexingConfiguration `locationName:"thingIndexingConfiguration" type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateIndexingConfigurationInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateIndexingConfigurationInput) GoString() string {
+	return s.String()
+}
+
+// SetThingIndexingConfiguration sets the ThingIndexingConfiguration field's value.
+func (s *UpdateIndexingConfigurationInput) SetThingIndexingConfiguration(v *ThingIndexingConfiguration) *UpdateIndexingConfigurationInput {
+	s.ThingIndexingConfiguration = v
+	return s
+}
+
+type UpdateIndexingConfigurationOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateIndexingConfigurationOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateIndexingConfigurationOutput) GoString() string {
+	return s.String()
+}
+
+type UpdateRoleAliasInput struct {
+	_ struct{} `type:"structure"`
+
+	// The number of seconds the credential will be valid.
+	CredentialDurationSeconds *int64 `locationName:"credentialDurationSeconds" min:"900" type:"integer"`
+
+	// The role alias to update.
+	//
+	// RoleAlias is a required field
+	RoleAlias *string `location:"uri" locationName:"roleAlias" min:"1" type:"string" required:"true"`
+
+	// The role ARN.
+	RoleArn *string `locationName:"roleArn" min:"20" type:"string"`
+}
+
+// String returns the string representation
+func (s UpdateRoleAliasInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateRoleAliasInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateRoleAliasInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateRoleAliasInput"}
+	if s.CredentialDurationSeconds != nil && *s.CredentialDurationSeconds < 900 {
+		invalidParams.Add(request.NewErrParamMinValue("CredentialDurationSeconds", 900))
+	}
+	if s.RoleAlias == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleAlias"))
+	}
+	if s.RoleAlias != nil && len(*s.RoleAlias) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleAlias", 1))
+	}
+	if s.RoleArn != nil && len(*s.RoleArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleArn", 20))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetCredentialDurationSeconds sets the CredentialDurationSeconds field's value.
+func (s *UpdateRoleAliasInput) SetCredentialDurationSeconds(v int64) *UpdateRoleAliasInput {
+	s.CredentialDurationSeconds = &v
+	return s
+}
+
+// SetRoleAlias sets the RoleAlias field's value.
+func (s *UpdateRoleAliasInput) SetRoleAlias(v string) *UpdateRoleAliasInput {
+	s.RoleAlias = &v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *UpdateRoleAliasInput) SetRoleArn(v string) *UpdateRoleAliasInput {
+	s.RoleArn = &v
+	return s
+}
+
+type UpdateRoleAliasOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The role alias.
+	RoleAlias *string `locationName:"roleAlias" min:"1" type:"string"`
+
+	// The role alias ARN.
+	RoleAliasArn *string `locationName:"roleAliasArn" type:"string"`
+}
+
+// String returns the string representation
+func (s UpdateRoleAliasOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateRoleAliasOutput) GoString() string {
+	return s.String()
+}
+
+// SetRoleAlias sets the RoleAlias field's value.
+func (s *UpdateRoleAliasOutput) SetRoleAlias(v string) *UpdateRoleAliasOutput {
+	s.RoleAlias = &v
+	return s
+}
+
+// SetRoleAliasArn sets the RoleAliasArn field's value.
+func (s *UpdateRoleAliasOutput) SetRoleAliasArn(v string) *UpdateRoleAliasOutput {
+	s.RoleAliasArn = &v
+	return s
+}
+
+type UpdateThingGroupInput struct {
+	_ struct{} `type:"structure"`
+
+	// The expected version of the thing group. If this does not match the version
+	// of the thing group being updated, the update will fail.
+	ExpectedVersion *int64 `locationName:"expectedVersion" type:"long"`
+
+	// The thing group to update.
+	//
+	// ThingGroupName is a required field
+	ThingGroupName *string `location:"uri" locationName:"thingGroupName" min:"1" type:"string" required:"true"`
+
+	// The thing group properties.
+	//
+	// ThingGroupProperties is a required field
+	ThingGroupProperties *ThingGroupProperties `locationName:"thingGroupProperties" type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s UpdateThingGroupInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateThingGroupInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateThingGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateThingGroupInput"}
+	if s.ThingGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ThingGroupName"))
+	}
+	if s.ThingGroupName != nil && len(*s.ThingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ThingGroupName", 1))
+	}
+	if s.ThingGroupProperties == nil {
+		invalidParams.Add(request.NewErrParamRequired("ThingGroupProperties"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetExpectedVersion sets the ExpectedVersion field's value.
+func (s *UpdateThingGroupInput) SetExpectedVersion(v int64) *UpdateThingGroupInput {
+	s.ExpectedVersion = &v
+	return s
+}
+
+// SetThingGroupName sets the ThingGroupName field's value.
+func (s *UpdateThingGroupInput) SetThingGroupName(v string) *UpdateThingGroupInput {
+	s.ThingGroupName = &v
+	return s
+}
+
+// SetThingGroupProperties sets the ThingGroupProperties field's value.
+func (s *UpdateThingGroupInput) SetThingGroupProperties(v *ThingGroupProperties) *UpdateThingGroupInput {
+	s.ThingGroupProperties = v
+	return s
+}
+
+type UpdateThingGroupOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The version of the updated thing group.
+	Version *int64 `locationName:"version" type:"long"`
+}
+
+// String returns the string representation
+func (s UpdateThingGroupOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateThingGroupOutput) GoString() string {
+	return s.String()
+}
+
+// SetVersion sets the Version field's value.
+func (s *UpdateThingGroupOutput) SetVersion(v int64) *UpdateThingGroupOutput {
+	s.Version = &v
+	return s
+}
+
+type UpdateThingGroupsForThingInput struct {
+	_ struct{} `type:"structure"`
+
+	// The groups to which the thing will be added.
+	ThingGroupsToAdd []*string `locationName:"thingGroupsToAdd" type:"list"`
+
+	// The groups from which the thing will be removed.
+	ThingGroupsToRemove []*string `locationName:"thingGroupsToRemove" type:"list"`
+
+	// The thing whose group memberships will be updated.
+	ThingName *string `locationName:"thingName" min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s UpdateThingGroupsForThingInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateThingGroupsForThingInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateThingGroupsForThingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateThingGroupsForThingInput"}
+	if s.ThingName != nil && len(*s.ThingName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ThingName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetThingGroupsToAdd sets the ThingGroupsToAdd field's value.
+func (s *UpdateThingGroupsForThingInput) SetThingGroupsToAdd(v []*string) *UpdateThingGroupsForThingInput {
+	s.ThingGroupsToAdd = v
+	return s
+}
+
+// SetThingGroupsToRemove sets the ThingGroupsToRemove field's value.
+func (s *UpdateThingGroupsForThingInput) SetThingGroupsToRemove(v []*string) *UpdateThingGroupsForThingInput {
+	s.ThingGroupsToRemove = v
+	return s
+}
+
+// SetThingName sets the ThingName field's value.
+func (s *UpdateThingGroupsForThingInput) SetThingName(v string) *UpdateThingGroupsForThingInput {
+	s.ThingName = &v
+	return s
+}
+
+type UpdateThingGroupsForThingOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateThingGroupsForThingOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateThingGroupsForThingOutput) GoString() string {
+	return s.String()
+}
+
 // The input for the UpdateThing operation.
 type UpdateThingInput struct {
 	_ struct{} `type:"structure"`
@@ -11984,7 +23538,7 @@ type UpdateThingInput struct {
 	// in the request, the UpdateThing request is rejected with a VersionConflictException.
 	ExpectedVersion *int64 `locationName:"expectedVersion" type:"long"`
 
-	// Remove a thing type association. If true, the assocation is removed.
+	// Remove a thing type association. If true, the association is removed.
 	RemoveThingType *bool `locationName:"removeThingType" type:"boolean"`
 
 	// The name of the thing to update.
@@ -12071,6 +23625,39 @@ func (s UpdateThingOutput) GoString() string {
 }
 
 const (
+	// ActionTypePublish is a ActionType enum value
+	ActionTypePublish = "PUBLISH"
+
+	// ActionTypeSubscribe is a ActionType enum value
+	ActionTypeSubscribe = "SUBSCRIBE"
+
+	// ActionTypeReceive is a ActionType enum value
+	ActionTypeReceive = "RECEIVE"
+
+	// ActionTypeConnect is a ActionType enum value
+	ActionTypeConnect = "CONNECT"
+)
+
+const (
+	// AuthDecisionAllowed is a AuthDecision enum value
+	AuthDecisionAllowed = "ALLOWED"
+
+	// AuthDecisionExplicitDeny is a AuthDecision enum value
+	AuthDecisionExplicitDeny = "EXPLICIT_DENY"
+
+	// AuthDecisionImplicitDeny is a AuthDecision enum value
+	AuthDecisionImplicitDeny = "IMPLICIT_DENY"
+)
+
+const (
+	// AuthorizerStatusActive is a AuthorizerStatus enum value
+	AuthorizerStatusActive = "ACTIVE"
+
+	// AuthorizerStatusInactive is a AuthorizerStatus enum value
+	AuthorizerStatusInactive = "INACTIVE"
+)
+
+const (
 	// AutoRegistrationStatusEnable is a AutoRegistrationStatus enum value
 	AutoRegistrationStatusEnable = "ENABLE"
 
@@ -12141,6 +23728,77 @@ const (
 )
 
 const (
+	// EventTypeThing is a EventType enum value
+	EventTypeThing = "THING"
+
+	// EventTypeThingGroup is a EventType enum value
+	EventTypeThingGroup = "THING_GROUP"
+
+	// EventTypeThingType is a EventType enum value
+	EventTypeThingType = "THING_TYPE"
+
+	// EventTypeThingGroupMembership is a EventType enum value
+	EventTypeThingGroupMembership = "THING_GROUP_MEMBERSHIP"
+
+	// EventTypeThingGroupHierarchy is a EventType enum value
+	EventTypeThingGroupHierarchy = "THING_GROUP_HIERARCHY"
+
+	// EventTypeThingTypeAssociation is a EventType enum value
+	EventTypeThingTypeAssociation = "THING_TYPE_ASSOCIATION"
+
+	// EventTypeJob is a EventType enum value
+	EventTypeJob = "JOB"
+
+	// EventTypeJobExecution is a EventType enum value
+	EventTypeJobExecution = "JOB_EXECUTION"
+)
+
+const (
+	// IndexStatusActive is a IndexStatus enum value
+	IndexStatusActive = "ACTIVE"
+
+	// IndexStatusBuilding is a IndexStatus enum value
+	IndexStatusBuilding = "BUILDING"
+
+	// IndexStatusRebuilding is a IndexStatus enum value
+	IndexStatusRebuilding = "REBUILDING"
+)
+
+const (
+	// JobExecutionStatusQueued is a JobExecutionStatus enum value
+	JobExecutionStatusQueued = "QUEUED"
+
+	// JobExecutionStatusInProgress is a JobExecutionStatus enum value
+	JobExecutionStatusInProgress = "IN_PROGRESS"
+
+	// JobExecutionStatusSucceeded is a JobExecutionStatus enum value
+	JobExecutionStatusSucceeded = "SUCCEEDED"
+
+	// JobExecutionStatusFailed is a JobExecutionStatus enum value
+	JobExecutionStatusFailed = "FAILED"
+
+	// JobExecutionStatusRejected is a JobExecutionStatus enum value
+	JobExecutionStatusRejected = "REJECTED"
+
+	// JobExecutionStatusRemoved is a JobExecutionStatus enum value
+	JobExecutionStatusRemoved = "REMOVED"
+
+	// JobExecutionStatusCanceled is a JobExecutionStatus enum value
+	JobExecutionStatusCanceled = "CANCELED"
+)
+
+const (
+	// JobStatusInProgress is a JobStatus enum value
+	JobStatusInProgress = "IN_PROGRESS"
+
+	// JobStatusCanceled is a JobStatus enum value
+	JobStatusCanceled = "CANCELED"
+
+	// JobStatusCompleted is a JobStatus enum value
+	JobStatusCompleted = "COMPLETED"
+)
+
+const (
 	// LogLevelDebug is a LogLevel enum value
 	LogLevelDebug = "DEBUG"
 
@@ -12158,9 +23816,61 @@ const (
 )
 
 const (
+	// LogTargetTypeDefault is a LogTargetType enum value
+	LogTargetTypeDefault = "DEFAULT"
+
+	// LogTargetTypeThingGroup is a LogTargetType enum value
+	LogTargetTypeThingGroup = "THING_GROUP"
+)
+
+const (
 	// MessageFormatRaw is a MessageFormat enum value
 	MessageFormatRaw = "RAW"
 
 	// MessageFormatJson is a MessageFormat enum value
 	MessageFormatJson = "JSON"
+)
+
+const (
+	// ReportTypeErrors is a ReportType enum value
+	ReportTypeErrors = "ERRORS"
+
+	// ReportTypeResults is a ReportType enum value
+	ReportTypeResults = "RESULTS"
+)
+
+const (
+	// StatusInProgress is a Status enum value
+	StatusInProgress = "InProgress"
+
+	// StatusCompleted is a Status enum value
+	StatusCompleted = "Completed"
+
+	// StatusFailed is a Status enum value
+	StatusFailed = "Failed"
+
+	// StatusCancelled is a Status enum value
+	StatusCancelled = "Cancelled"
+
+	// StatusCancelling is a Status enum value
+	StatusCancelling = "Cancelling"
+)
+
+const (
+	// TargetSelectionContinuous is a TargetSelection enum value
+	TargetSelectionContinuous = "CONTINUOUS"
+
+	// TargetSelectionSnapshot is a TargetSelection enum value
+	TargetSelectionSnapshot = "SNAPSHOT"
+)
+
+const (
+	// ThingIndexingModeOff is a ThingIndexingMode enum value
+	ThingIndexingModeOff = "OFF"
+
+	// ThingIndexingModeRegistry is a ThingIndexingMode enum value
+	ThingIndexingModeRegistry = "REGISTRY"
+
+	// ThingIndexingModeRegistryAndShadow is a ThingIndexingMode enum value
+	ThingIndexingModeRegistryAndShadow = "REGISTRY_AND_SHADOW"
 )

--- a/vendor/github.com/aws/aws-sdk-go/service/iot/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/iot/errors.go
@@ -24,11 +24,24 @@ const (
 	// The certificate is invalid.
 	ErrCodeCertificateValidationException = "CertificateValidationException"
 
+	// ErrCodeConflictingResourceUpdateException for service response error code
+	// "ConflictingResourceUpdateException".
+	//
+	// A conflicting resource update exception. This exception is thrown when two
+	// pending updates cause a conflict.
+	ErrCodeConflictingResourceUpdateException = "ConflictingResourceUpdateException"
+
 	// ErrCodeDeleteConflictException for service response error code
 	// "DeleteConflictException".
 	//
 	// You can't delete the resource because it is attached to one or more resources.
 	ErrCodeDeleteConflictException = "DeleteConflictException"
+
+	// ErrCodeIndexNotReadyException for service response error code
+	// "IndexNotReadyException".
+	//
+	// The index is not ready.
+	ErrCodeIndexNotReadyException = "IndexNotReadyException"
 
 	// ErrCodeInternalException for service response error code
 	// "InternalException".
@@ -42,11 +55,23 @@ const (
 	// An unexpected error has occurred.
 	ErrCodeInternalFailureException = "InternalFailureException"
 
+	// ErrCodeInvalidQueryException for service response error code
+	// "InvalidQueryException".
+	//
+	// The query is invalid.
+	ErrCodeInvalidQueryException = "InvalidQueryException"
+
 	// ErrCodeInvalidRequestException for service response error code
 	// "InvalidRequestException".
 	//
 	// The request is not valid.
 	ErrCodeInvalidRequestException = "InvalidRequestException"
+
+	// ErrCodeInvalidResponseException for service response error code
+	// "InvalidResponseException".
+	//
+	// The response is invalid.
+	ErrCodeInvalidResponseException = "InvalidResponseException"
 
 	// ErrCodeLimitExceededException for service response error code
 	// "LimitExceededException".
@@ -59,6 +84,12 @@ const (
 	//
 	// The policy documentation is not valid.
 	ErrCodeMalformedPolicyException = "MalformedPolicyException"
+
+	// ErrCodeNotConfiguredException for service response error code
+	// "NotConfiguredException".
+	//
+	// The resource is not configured.
+	ErrCodeNotConfiguredException = "NotConfiguredException"
 
 	// ErrCodeRegistrationCodeValidationException for service response error code
 	// "RegistrationCodeValidationException".
@@ -77,6 +108,12 @@ const (
 	//
 	// The specified resource does not exist.
 	ErrCodeResourceNotFoundException = "ResourceNotFoundException"
+
+	// ErrCodeResourceRegistrationFailureException for service response error code
+	// "ResourceRegistrationFailureException".
+	//
+	// The resource registration failed.
+	ErrCodeResourceRegistrationFailureException = "ResourceRegistrationFailureException"
 
 	// ErrCodeServiceUnavailableException for service response error code
 	// "ServiceUnavailableException".

--- a/vendor/github.com/aws/aws-sdk-go/service/lightsail/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/lightsail/api.go
@@ -219,6 +219,216 @@ func (c *Lightsail) AttachDiskWithContext(ctx aws.Context, input *AttachDiskInpu
 	return out, req.Send()
 }
 
+const opAttachInstancesToLoadBalancer = "AttachInstancesToLoadBalancer"
+
+// AttachInstancesToLoadBalancerRequest generates a "aws/request.Request" representing the
+// client's request for the AttachInstancesToLoadBalancer operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See AttachInstancesToLoadBalancer for more information on using the AttachInstancesToLoadBalancer
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the AttachInstancesToLoadBalancerRequest method.
+//    req, resp := client.AttachInstancesToLoadBalancerRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/AttachInstancesToLoadBalancer
+func (c *Lightsail) AttachInstancesToLoadBalancerRequest(input *AttachInstancesToLoadBalancerInput) (req *request.Request, output *AttachInstancesToLoadBalancerOutput) {
+	op := &request.Operation{
+		Name:       opAttachInstancesToLoadBalancer,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &AttachInstancesToLoadBalancerInput{}
+	}
+
+	output = &AttachInstancesToLoadBalancerOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// AttachInstancesToLoadBalancer API operation for Amazon Lightsail.
+//
+// Attaches one or more Lightsail instances to a load balancer.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Lightsail's
+// API operation AttachInstancesToLoadBalancer for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeServiceException "ServiceException"
+//   A general service exception.
+//
+//   * ErrCodeInvalidInputException "InvalidInputException"
+//   Lightsail throws this exception when user input does not conform to the validation
+//   rules of an input field.
+//
+//   Domain-related APIs are only available in the N. Virginia (us-east-1) Region.
+//   Please set your Region configuration to us-east-1 to create, view, or edit
+//   these resources.
+//
+//   * ErrCodeNotFoundException "NotFoundException"
+//   Lightsail throws this exception when it cannot find a resource.
+//
+//   * ErrCodeOperationFailureException "OperationFailureException"
+//   Lightsail throws this exception when an operation fails to execute.
+//
+//   * ErrCodeAccessDeniedException "AccessDeniedException"
+//   Lightsail throws this exception when the user cannot be authenticated or
+//   uses invalid credentials to access a resource.
+//
+//   * ErrCodeAccountSetupInProgressException "AccountSetupInProgressException"
+//   Lightsail throws this exception when an account is still in the setup in
+//   progress state.
+//
+//   * ErrCodeUnauthenticatedException "UnauthenticatedException"
+//   Lightsail throws this exception when the user has not been authenticated.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/AttachInstancesToLoadBalancer
+func (c *Lightsail) AttachInstancesToLoadBalancer(input *AttachInstancesToLoadBalancerInput) (*AttachInstancesToLoadBalancerOutput, error) {
+	req, out := c.AttachInstancesToLoadBalancerRequest(input)
+	return out, req.Send()
+}
+
+// AttachInstancesToLoadBalancerWithContext is the same as AttachInstancesToLoadBalancer with the addition of
+// the ability to pass a context and additional request options.
+//
+// See AttachInstancesToLoadBalancer for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Lightsail) AttachInstancesToLoadBalancerWithContext(ctx aws.Context, input *AttachInstancesToLoadBalancerInput, opts ...request.Option) (*AttachInstancesToLoadBalancerOutput, error) {
+	req, out := c.AttachInstancesToLoadBalancerRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opAttachLoadBalancerTlsCertificate = "AttachLoadBalancerTlsCertificate"
+
+// AttachLoadBalancerTlsCertificateRequest generates a "aws/request.Request" representing the
+// client's request for the AttachLoadBalancerTlsCertificate operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See AttachLoadBalancerTlsCertificate for more information on using the AttachLoadBalancerTlsCertificate
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the AttachLoadBalancerTlsCertificateRequest method.
+//    req, resp := client.AttachLoadBalancerTlsCertificateRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/AttachLoadBalancerTlsCertificate
+func (c *Lightsail) AttachLoadBalancerTlsCertificateRequest(input *AttachLoadBalancerTlsCertificateInput) (req *request.Request, output *AttachLoadBalancerTlsCertificateOutput) {
+	op := &request.Operation{
+		Name:       opAttachLoadBalancerTlsCertificate,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &AttachLoadBalancerTlsCertificateInput{}
+	}
+
+	output = &AttachLoadBalancerTlsCertificateOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// AttachLoadBalancerTlsCertificate API operation for Amazon Lightsail.
+//
+// Attaches a Transport Layer Security (TLS) certificate to your load balancer.
+//
+// TLS is just an updated, more secure version of Secure Socket Layer (SSL).
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Lightsail's
+// API operation AttachLoadBalancerTlsCertificate for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeServiceException "ServiceException"
+//   A general service exception.
+//
+//   * ErrCodeInvalidInputException "InvalidInputException"
+//   Lightsail throws this exception when user input does not conform to the validation
+//   rules of an input field.
+//
+//   Domain-related APIs are only available in the N. Virginia (us-east-1) Region.
+//   Please set your Region configuration to us-east-1 to create, view, or edit
+//   these resources.
+//
+//   * ErrCodeNotFoundException "NotFoundException"
+//   Lightsail throws this exception when it cannot find a resource.
+//
+//   * ErrCodeOperationFailureException "OperationFailureException"
+//   Lightsail throws this exception when an operation fails to execute.
+//
+//   * ErrCodeAccessDeniedException "AccessDeniedException"
+//   Lightsail throws this exception when the user cannot be authenticated or
+//   uses invalid credentials to access a resource.
+//
+//   * ErrCodeAccountSetupInProgressException "AccountSetupInProgressException"
+//   Lightsail throws this exception when an account is still in the setup in
+//   progress state.
+//
+//   * ErrCodeUnauthenticatedException "UnauthenticatedException"
+//   Lightsail throws this exception when the user has not been authenticated.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/AttachLoadBalancerTlsCertificate
+func (c *Lightsail) AttachLoadBalancerTlsCertificate(input *AttachLoadBalancerTlsCertificateInput) (*AttachLoadBalancerTlsCertificateOutput, error) {
+	req, out := c.AttachLoadBalancerTlsCertificateRequest(input)
+	return out, req.Send()
+}
+
+// AttachLoadBalancerTlsCertificateWithContext is the same as AttachLoadBalancerTlsCertificate with the addition of
+// the ability to pass a context and additional request options.
+//
+// See AttachLoadBalancerTlsCertificate for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Lightsail) AttachLoadBalancerTlsCertificateWithContext(ctx aws.Context, input *AttachLoadBalancerTlsCertificateInput, opts ...request.Option) (*AttachLoadBalancerTlsCertificateOutput, error) {
+	req, out := c.AttachLoadBalancerTlsCertificateRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opAttachStaticIp = "AttachStaticIp"
 
 // AttachStaticIpRequest generates a "aws/request.Request" representing the
@@ -1385,6 +1595,219 @@ func (c *Lightsail) CreateKeyPairWithContext(ctx aws.Context, input *CreateKeyPa
 	return out, req.Send()
 }
 
+const opCreateLoadBalancer = "CreateLoadBalancer"
+
+// CreateLoadBalancerRequest generates a "aws/request.Request" representing the
+// client's request for the CreateLoadBalancer operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See CreateLoadBalancer for more information on using the CreateLoadBalancer
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the CreateLoadBalancerRequest method.
+//    req, resp := client.CreateLoadBalancerRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/CreateLoadBalancer
+func (c *Lightsail) CreateLoadBalancerRequest(input *CreateLoadBalancerInput) (req *request.Request, output *CreateLoadBalancerOutput) {
+	op := &request.Operation{
+		Name:       opCreateLoadBalancer,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &CreateLoadBalancerInput{}
+	}
+
+	output = &CreateLoadBalancerOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// CreateLoadBalancer API operation for Amazon Lightsail.
+//
+// Creates a Lightsail load balancer.
+//
+// When you create a load balancer, you can specify certificates and port settings.
+// You can create up to 5 load balancers per AWS Region in your account.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Lightsail's
+// API operation CreateLoadBalancer for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeServiceException "ServiceException"
+//   A general service exception.
+//
+//   * ErrCodeInvalidInputException "InvalidInputException"
+//   Lightsail throws this exception when user input does not conform to the validation
+//   rules of an input field.
+//
+//   Domain-related APIs are only available in the N. Virginia (us-east-1) Region.
+//   Please set your Region configuration to us-east-1 to create, view, or edit
+//   these resources.
+//
+//   * ErrCodeNotFoundException "NotFoundException"
+//   Lightsail throws this exception when it cannot find a resource.
+//
+//   * ErrCodeOperationFailureException "OperationFailureException"
+//   Lightsail throws this exception when an operation fails to execute.
+//
+//   * ErrCodeAccessDeniedException "AccessDeniedException"
+//   Lightsail throws this exception when the user cannot be authenticated or
+//   uses invalid credentials to access a resource.
+//
+//   * ErrCodeAccountSetupInProgressException "AccountSetupInProgressException"
+//   Lightsail throws this exception when an account is still in the setup in
+//   progress state.
+//
+//   * ErrCodeUnauthenticatedException "UnauthenticatedException"
+//   Lightsail throws this exception when the user has not been authenticated.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/CreateLoadBalancer
+func (c *Lightsail) CreateLoadBalancer(input *CreateLoadBalancerInput) (*CreateLoadBalancerOutput, error) {
+	req, out := c.CreateLoadBalancerRequest(input)
+	return out, req.Send()
+}
+
+// CreateLoadBalancerWithContext is the same as CreateLoadBalancer with the addition of
+// the ability to pass a context and additional request options.
+//
+// See CreateLoadBalancer for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Lightsail) CreateLoadBalancerWithContext(ctx aws.Context, input *CreateLoadBalancerInput, opts ...request.Option) (*CreateLoadBalancerOutput, error) {
+	req, out := c.CreateLoadBalancerRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opCreateLoadBalancerTlsCertificate = "CreateLoadBalancerTlsCertificate"
+
+// CreateLoadBalancerTlsCertificateRequest generates a "aws/request.Request" representing the
+// client's request for the CreateLoadBalancerTlsCertificate operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See CreateLoadBalancerTlsCertificate for more information on using the CreateLoadBalancerTlsCertificate
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the CreateLoadBalancerTlsCertificateRequest method.
+//    req, resp := client.CreateLoadBalancerTlsCertificateRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/CreateLoadBalancerTlsCertificate
+func (c *Lightsail) CreateLoadBalancerTlsCertificateRequest(input *CreateLoadBalancerTlsCertificateInput) (req *request.Request, output *CreateLoadBalancerTlsCertificateOutput) {
+	op := &request.Operation{
+		Name:       opCreateLoadBalancerTlsCertificate,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &CreateLoadBalancerTlsCertificateInput{}
+	}
+
+	output = &CreateLoadBalancerTlsCertificateOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// CreateLoadBalancerTlsCertificate API operation for Amazon Lightsail.
+//
+// Creates a Lightsail load balancer TLS certificate.
+//
+// TLS is just an updated, more secure version of Secure Socket Layer (SSL).
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Lightsail's
+// API operation CreateLoadBalancerTlsCertificate for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeServiceException "ServiceException"
+//   A general service exception.
+//
+//   * ErrCodeInvalidInputException "InvalidInputException"
+//   Lightsail throws this exception when user input does not conform to the validation
+//   rules of an input field.
+//
+//   Domain-related APIs are only available in the N. Virginia (us-east-1) Region.
+//   Please set your Region configuration to us-east-1 to create, view, or edit
+//   these resources.
+//
+//   * ErrCodeNotFoundException "NotFoundException"
+//   Lightsail throws this exception when it cannot find a resource.
+//
+//   * ErrCodeOperationFailureException "OperationFailureException"
+//   Lightsail throws this exception when an operation fails to execute.
+//
+//   * ErrCodeAccessDeniedException "AccessDeniedException"
+//   Lightsail throws this exception when the user cannot be authenticated or
+//   uses invalid credentials to access a resource.
+//
+//   * ErrCodeAccountSetupInProgressException "AccountSetupInProgressException"
+//   Lightsail throws this exception when an account is still in the setup in
+//   progress state.
+//
+//   * ErrCodeUnauthenticatedException "UnauthenticatedException"
+//   Lightsail throws this exception when the user has not been authenticated.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/CreateLoadBalancerTlsCertificate
+func (c *Lightsail) CreateLoadBalancerTlsCertificate(input *CreateLoadBalancerTlsCertificateInput) (*CreateLoadBalancerTlsCertificateOutput, error) {
+	req, out := c.CreateLoadBalancerTlsCertificateRequest(input)
+	return out, req.Send()
+}
+
+// CreateLoadBalancerTlsCertificateWithContext is the same as CreateLoadBalancerTlsCertificate with the addition of
+// the ability to pass a context and additional request options.
+//
+// See CreateLoadBalancerTlsCertificate for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Lightsail) CreateLoadBalancerTlsCertificateWithContext(ctx aws.Context, input *CreateLoadBalancerTlsCertificateInput, opts ...request.Option) (*CreateLoadBalancerTlsCertificateOutput, error) {
+	req, out := c.CreateLoadBalancerTlsCertificateRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opDeleteDisk = "DeleteDisk"
 
 // DeleteDiskRequest generates a "aws/request.Request" representing the
@@ -2123,6 +2546,214 @@ func (c *Lightsail) DeleteKeyPairWithContext(ctx aws.Context, input *DeleteKeyPa
 	return out, req.Send()
 }
 
+const opDeleteLoadBalancer = "DeleteLoadBalancer"
+
+// DeleteLoadBalancerRequest generates a "aws/request.Request" representing the
+// client's request for the DeleteLoadBalancer operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DeleteLoadBalancer for more information on using the DeleteLoadBalancer
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DeleteLoadBalancerRequest method.
+//    req, resp := client.DeleteLoadBalancerRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/DeleteLoadBalancer
+func (c *Lightsail) DeleteLoadBalancerRequest(input *DeleteLoadBalancerInput) (req *request.Request, output *DeleteLoadBalancerOutput) {
+	op := &request.Operation{
+		Name:       opDeleteLoadBalancer,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DeleteLoadBalancerInput{}
+	}
+
+	output = &DeleteLoadBalancerOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DeleteLoadBalancer API operation for Amazon Lightsail.
+//
+// Deletes a Lightsail load balancer.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Lightsail's
+// API operation DeleteLoadBalancer for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeServiceException "ServiceException"
+//   A general service exception.
+//
+//   * ErrCodeInvalidInputException "InvalidInputException"
+//   Lightsail throws this exception when user input does not conform to the validation
+//   rules of an input field.
+//
+//   Domain-related APIs are only available in the N. Virginia (us-east-1) Region.
+//   Please set your Region configuration to us-east-1 to create, view, or edit
+//   these resources.
+//
+//   * ErrCodeNotFoundException "NotFoundException"
+//   Lightsail throws this exception when it cannot find a resource.
+//
+//   * ErrCodeOperationFailureException "OperationFailureException"
+//   Lightsail throws this exception when an operation fails to execute.
+//
+//   * ErrCodeAccessDeniedException "AccessDeniedException"
+//   Lightsail throws this exception when the user cannot be authenticated or
+//   uses invalid credentials to access a resource.
+//
+//   * ErrCodeAccountSetupInProgressException "AccountSetupInProgressException"
+//   Lightsail throws this exception when an account is still in the setup in
+//   progress state.
+//
+//   * ErrCodeUnauthenticatedException "UnauthenticatedException"
+//   Lightsail throws this exception when the user has not been authenticated.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/DeleteLoadBalancer
+func (c *Lightsail) DeleteLoadBalancer(input *DeleteLoadBalancerInput) (*DeleteLoadBalancerOutput, error) {
+	req, out := c.DeleteLoadBalancerRequest(input)
+	return out, req.Send()
+}
+
+// DeleteLoadBalancerWithContext is the same as DeleteLoadBalancer with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeleteLoadBalancer for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Lightsail) DeleteLoadBalancerWithContext(ctx aws.Context, input *DeleteLoadBalancerInput, opts ...request.Option) (*DeleteLoadBalancerOutput, error) {
+	req, out := c.DeleteLoadBalancerRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDeleteLoadBalancerTlsCertificate = "DeleteLoadBalancerTlsCertificate"
+
+// DeleteLoadBalancerTlsCertificateRequest generates a "aws/request.Request" representing the
+// client's request for the DeleteLoadBalancerTlsCertificate operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DeleteLoadBalancerTlsCertificate for more information on using the DeleteLoadBalancerTlsCertificate
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DeleteLoadBalancerTlsCertificateRequest method.
+//    req, resp := client.DeleteLoadBalancerTlsCertificateRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/DeleteLoadBalancerTlsCertificate
+func (c *Lightsail) DeleteLoadBalancerTlsCertificateRequest(input *DeleteLoadBalancerTlsCertificateInput) (req *request.Request, output *DeleteLoadBalancerTlsCertificateOutput) {
+	op := &request.Operation{
+		Name:       opDeleteLoadBalancerTlsCertificate,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DeleteLoadBalancerTlsCertificateInput{}
+	}
+
+	output = &DeleteLoadBalancerTlsCertificateOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DeleteLoadBalancerTlsCertificate API operation for Amazon Lightsail.
+//
+// Deletes a TLS/SSL certificate associated with a Lightsail load balancer.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Lightsail's
+// API operation DeleteLoadBalancerTlsCertificate for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeServiceException "ServiceException"
+//   A general service exception.
+//
+//   * ErrCodeInvalidInputException "InvalidInputException"
+//   Lightsail throws this exception when user input does not conform to the validation
+//   rules of an input field.
+//
+//   Domain-related APIs are only available in the N. Virginia (us-east-1) Region.
+//   Please set your Region configuration to us-east-1 to create, view, or edit
+//   these resources.
+//
+//   * ErrCodeNotFoundException "NotFoundException"
+//   Lightsail throws this exception when it cannot find a resource.
+//
+//   * ErrCodeOperationFailureException "OperationFailureException"
+//   Lightsail throws this exception when an operation fails to execute.
+//
+//   * ErrCodeAccessDeniedException "AccessDeniedException"
+//   Lightsail throws this exception when the user cannot be authenticated or
+//   uses invalid credentials to access a resource.
+//
+//   * ErrCodeAccountSetupInProgressException "AccountSetupInProgressException"
+//   Lightsail throws this exception when an account is still in the setup in
+//   progress state.
+//
+//   * ErrCodeUnauthenticatedException "UnauthenticatedException"
+//   Lightsail throws this exception when the user has not been authenticated.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/DeleteLoadBalancerTlsCertificate
+func (c *Lightsail) DeleteLoadBalancerTlsCertificate(input *DeleteLoadBalancerTlsCertificateInput) (*DeleteLoadBalancerTlsCertificateOutput, error) {
+	req, out := c.DeleteLoadBalancerTlsCertificateRequest(input)
+	return out, req.Send()
+}
+
+// DeleteLoadBalancerTlsCertificateWithContext is the same as DeleteLoadBalancerTlsCertificate with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeleteLoadBalancerTlsCertificate for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Lightsail) DeleteLoadBalancerTlsCertificateWithContext(ctx aws.Context, input *DeleteLoadBalancerTlsCertificateInput, opts ...request.Option) (*DeleteLoadBalancerTlsCertificateOutput, error) {
+	req, out := c.DeleteLoadBalancerTlsCertificateRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opDetachDisk = "DetachDisk"
 
 // DetachDiskRequest generates a "aws/request.Request" representing the
@@ -2224,6 +2855,110 @@ func (c *Lightsail) DetachDisk(input *DetachDiskInput) (*DetachDiskOutput, error
 // for more information on using Contexts.
 func (c *Lightsail) DetachDiskWithContext(ctx aws.Context, input *DetachDiskInput, opts ...request.Option) (*DetachDiskOutput, error) {
 	req, out := c.DetachDiskRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDetachInstancesFromLoadBalancer = "DetachInstancesFromLoadBalancer"
+
+// DetachInstancesFromLoadBalancerRequest generates a "aws/request.Request" representing the
+// client's request for the DetachInstancesFromLoadBalancer operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DetachInstancesFromLoadBalancer for more information on using the DetachInstancesFromLoadBalancer
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DetachInstancesFromLoadBalancerRequest method.
+//    req, resp := client.DetachInstancesFromLoadBalancerRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/DetachInstancesFromLoadBalancer
+func (c *Lightsail) DetachInstancesFromLoadBalancerRequest(input *DetachInstancesFromLoadBalancerInput) (req *request.Request, output *DetachInstancesFromLoadBalancerOutput) {
+	op := &request.Operation{
+		Name:       opDetachInstancesFromLoadBalancer,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DetachInstancesFromLoadBalancerInput{}
+	}
+
+	output = &DetachInstancesFromLoadBalancerOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DetachInstancesFromLoadBalancer API operation for Amazon Lightsail.
+//
+// Detaches the specified instances from a Lightsail load balancer.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Lightsail's
+// API operation DetachInstancesFromLoadBalancer for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeServiceException "ServiceException"
+//   A general service exception.
+//
+//   * ErrCodeInvalidInputException "InvalidInputException"
+//   Lightsail throws this exception when user input does not conform to the validation
+//   rules of an input field.
+//
+//   Domain-related APIs are only available in the N. Virginia (us-east-1) Region.
+//   Please set your Region configuration to us-east-1 to create, view, or edit
+//   these resources.
+//
+//   * ErrCodeNotFoundException "NotFoundException"
+//   Lightsail throws this exception when it cannot find a resource.
+//
+//   * ErrCodeOperationFailureException "OperationFailureException"
+//   Lightsail throws this exception when an operation fails to execute.
+//
+//   * ErrCodeAccessDeniedException "AccessDeniedException"
+//   Lightsail throws this exception when the user cannot be authenticated or
+//   uses invalid credentials to access a resource.
+//
+//   * ErrCodeAccountSetupInProgressException "AccountSetupInProgressException"
+//   Lightsail throws this exception when an account is still in the setup in
+//   progress state.
+//
+//   * ErrCodeUnauthenticatedException "UnauthenticatedException"
+//   Lightsail throws this exception when the user has not been authenticated.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/DetachInstancesFromLoadBalancer
+func (c *Lightsail) DetachInstancesFromLoadBalancer(input *DetachInstancesFromLoadBalancerInput) (*DetachInstancesFromLoadBalancerOutput, error) {
+	req, out := c.DetachInstancesFromLoadBalancerRequest(input)
+	return out, req.Send()
+}
+
+// DetachInstancesFromLoadBalancerWithContext is the same as DetachInstancesFromLoadBalancer with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DetachInstancesFromLoadBalancer for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Lightsail) DetachInstancesFromLoadBalancerWithContext(ctx aws.Context, input *DetachInstancesFromLoadBalancerInput, opts ...request.Option) (*DetachInstancesFromLoadBalancerOutput, error) {
+	req, out := c.DetachInstancesFromLoadBalancerRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -4431,6 +5166,429 @@ func (c *Lightsail) GetKeyPairsWithContext(ctx aws.Context, input *GetKeyPairsIn
 	return out, req.Send()
 }
 
+const opGetLoadBalancer = "GetLoadBalancer"
+
+// GetLoadBalancerRequest generates a "aws/request.Request" representing the
+// client's request for the GetLoadBalancer operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See GetLoadBalancer for more information on using the GetLoadBalancer
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the GetLoadBalancerRequest method.
+//    req, resp := client.GetLoadBalancerRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/GetLoadBalancer
+func (c *Lightsail) GetLoadBalancerRequest(input *GetLoadBalancerInput) (req *request.Request, output *GetLoadBalancerOutput) {
+	op := &request.Operation{
+		Name:       opGetLoadBalancer,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &GetLoadBalancerInput{}
+	}
+
+	output = &GetLoadBalancerOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// GetLoadBalancer API operation for Amazon Lightsail.
+//
+// Returns information about the specified Lightsail load balancer.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Lightsail's
+// API operation GetLoadBalancer for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeServiceException "ServiceException"
+//   A general service exception.
+//
+//   * ErrCodeInvalidInputException "InvalidInputException"
+//   Lightsail throws this exception when user input does not conform to the validation
+//   rules of an input field.
+//
+//   Domain-related APIs are only available in the N. Virginia (us-east-1) Region.
+//   Please set your Region configuration to us-east-1 to create, view, or edit
+//   these resources.
+//
+//   * ErrCodeNotFoundException "NotFoundException"
+//   Lightsail throws this exception when it cannot find a resource.
+//
+//   * ErrCodeOperationFailureException "OperationFailureException"
+//   Lightsail throws this exception when an operation fails to execute.
+//
+//   * ErrCodeAccessDeniedException "AccessDeniedException"
+//   Lightsail throws this exception when the user cannot be authenticated or
+//   uses invalid credentials to access a resource.
+//
+//   * ErrCodeAccountSetupInProgressException "AccountSetupInProgressException"
+//   Lightsail throws this exception when an account is still in the setup in
+//   progress state.
+//
+//   * ErrCodeUnauthenticatedException "UnauthenticatedException"
+//   Lightsail throws this exception when the user has not been authenticated.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/GetLoadBalancer
+func (c *Lightsail) GetLoadBalancer(input *GetLoadBalancerInput) (*GetLoadBalancerOutput, error) {
+	req, out := c.GetLoadBalancerRequest(input)
+	return out, req.Send()
+}
+
+// GetLoadBalancerWithContext is the same as GetLoadBalancer with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetLoadBalancer for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Lightsail) GetLoadBalancerWithContext(ctx aws.Context, input *GetLoadBalancerInput, opts ...request.Option) (*GetLoadBalancerOutput, error) {
+	req, out := c.GetLoadBalancerRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opGetLoadBalancerMetricData = "GetLoadBalancerMetricData"
+
+// GetLoadBalancerMetricDataRequest generates a "aws/request.Request" representing the
+// client's request for the GetLoadBalancerMetricData operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See GetLoadBalancerMetricData for more information on using the GetLoadBalancerMetricData
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the GetLoadBalancerMetricDataRequest method.
+//    req, resp := client.GetLoadBalancerMetricDataRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/GetLoadBalancerMetricData
+func (c *Lightsail) GetLoadBalancerMetricDataRequest(input *GetLoadBalancerMetricDataInput) (req *request.Request, output *GetLoadBalancerMetricDataOutput) {
+	op := &request.Operation{
+		Name:       opGetLoadBalancerMetricData,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &GetLoadBalancerMetricDataInput{}
+	}
+
+	output = &GetLoadBalancerMetricDataOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// GetLoadBalancerMetricData API operation for Amazon Lightsail.
+//
+// Returns information about health metrics for your Lightsail load balancer.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Lightsail's
+// API operation GetLoadBalancerMetricData for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeServiceException "ServiceException"
+//   A general service exception.
+//
+//   * ErrCodeInvalidInputException "InvalidInputException"
+//   Lightsail throws this exception when user input does not conform to the validation
+//   rules of an input field.
+//
+//   Domain-related APIs are only available in the N. Virginia (us-east-1) Region.
+//   Please set your Region configuration to us-east-1 to create, view, or edit
+//   these resources.
+//
+//   * ErrCodeNotFoundException "NotFoundException"
+//   Lightsail throws this exception when it cannot find a resource.
+//
+//   * ErrCodeOperationFailureException "OperationFailureException"
+//   Lightsail throws this exception when an operation fails to execute.
+//
+//   * ErrCodeAccessDeniedException "AccessDeniedException"
+//   Lightsail throws this exception when the user cannot be authenticated or
+//   uses invalid credentials to access a resource.
+//
+//   * ErrCodeAccountSetupInProgressException "AccountSetupInProgressException"
+//   Lightsail throws this exception when an account is still in the setup in
+//   progress state.
+//
+//   * ErrCodeUnauthenticatedException "UnauthenticatedException"
+//   Lightsail throws this exception when the user has not been authenticated.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/GetLoadBalancerMetricData
+func (c *Lightsail) GetLoadBalancerMetricData(input *GetLoadBalancerMetricDataInput) (*GetLoadBalancerMetricDataOutput, error) {
+	req, out := c.GetLoadBalancerMetricDataRequest(input)
+	return out, req.Send()
+}
+
+// GetLoadBalancerMetricDataWithContext is the same as GetLoadBalancerMetricData with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetLoadBalancerMetricData for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Lightsail) GetLoadBalancerMetricDataWithContext(ctx aws.Context, input *GetLoadBalancerMetricDataInput, opts ...request.Option) (*GetLoadBalancerMetricDataOutput, error) {
+	req, out := c.GetLoadBalancerMetricDataRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opGetLoadBalancerTlsCertificates = "GetLoadBalancerTlsCertificates"
+
+// GetLoadBalancerTlsCertificatesRequest generates a "aws/request.Request" representing the
+// client's request for the GetLoadBalancerTlsCertificates operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See GetLoadBalancerTlsCertificates for more information on using the GetLoadBalancerTlsCertificates
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the GetLoadBalancerTlsCertificatesRequest method.
+//    req, resp := client.GetLoadBalancerTlsCertificatesRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/GetLoadBalancerTlsCertificates
+func (c *Lightsail) GetLoadBalancerTlsCertificatesRequest(input *GetLoadBalancerTlsCertificatesInput) (req *request.Request, output *GetLoadBalancerTlsCertificatesOutput) {
+	op := &request.Operation{
+		Name:       opGetLoadBalancerTlsCertificates,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &GetLoadBalancerTlsCertificatesInput{}
+	}
+
+	output = &GetLoadBalancerTlsCertificatesOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// GetLoadBalancerTlsCertificates API operation for Amazon Lightsail.
+//
+// Returns information about the TLS certificates that are associated with the
+// specified Lightsail load balancer.
+//
+// TLS is just an updated, more secure version of Secure Socket Layer (SSL).
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Lightsail's
+// API operation GetLoadBalancerTlsCertificates for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeServiceException "ServiceException"
+//   A general service exception.
+//
+//   * ErrCodeInvalidInputException "InvalidInputException"
+//   Lightsail throws this exception when user input does not conform to the validation
+//   rules of an input field.
+//
+//   Domain-related APIs are only available in the N. Virginia (us-east-1) Region.
+//   Please set your Region configuration to us-east-1 to create, view, or edit
+//   these resources.
+//
+//   * ErrCodeNotFoundException "NotFoundException"
+//   Lightsail throws this exception when it cannot find a resource.
+//
+//   * ErrCodeOperationFailureException "OperationFailureException"
+//   Lightsail throws this exception when an operation fails to execute.
+//
+//   * ErrCodeAccessDeniedException "AccessDeniedException"
+//   Lightsail throws this exception when the user cannot be authenticated or
+//   uses invalid credentials to access a resource.
+//
+//   * ErrCodeAccountSetupInProgressException "AccountSetupInProgressException"
+//   Lightsail throws this exception when an account is still in the setup in
+//   progress state.
+//
+//   * ErrCodeUnauthenticatedException "UnauthenticatedException"
+//   Lightsail throws this exception when the user has not been authenticated.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/GetLoadBalancerTlsCertificates
+func (c *Lightsail) GetLoadBalancerTlsCertificates(input *GetLoadBalancerTlsCertificatesInput) (*GetLoadBalancerTlsCertificatesOutput, error) {
+	req, out := c.GetLoadBalancerTlsCertificatesRequest(input)
+	return out, req.Send()
+}
+
+// GetLoadBalancerTlsCertificatesWithContext is the same as GetLoadBalancerTlsCertificates with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetLoadBalancerTlsCertificates for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Lightsail) GetLoadBalancerTlsCertificatesWithContext(ctx aws.Context, input *GetLoadBalancerTlsCertificatesInput, opts ...request.Option) (*GetLoadBalancerTlsCertificatesOutput, error) {
+	req, out := c.GetLoadBalancerTlsCertificatesRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opGetLoadBalancers = "GetLoadBalancers"
+
+// GetLoadBalancersRequest generates a "aws/request.Request" representing the
+// client's request for the GetLoadBalancers operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See GetLoadBalancers for more information on using the GetLoadBalancers
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the GetLoadBalancersRequest method.
+//    req, resp := client.GetLoadBalancersRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/GetLoadBalancers
+func (c *Lightsail) GetLoadBalancersRequest(input *GetLoadBalancersInput) (req *request.Request, output *GetLoadBalancersOutput) {
+	op := &request.Operation{
+		Name:       opGetLoadBalancers,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &GetLoadBalancersInput{}
+	}
+
+	output = &GetLoadBalancersOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// GetLoadBalancers API operation for Amazon Lightsail.
+//
+// Returns information about all load balancers in an account.
+//
+// If you are describing a long list of load balancers, you can paginate the
+// output to make the list more manageable. You can use the pageToken and nextPageToken
+// values to retrieve the next items in the list.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Lightsail's
+// API operation GetLoadBalancers for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeServiceException "ServiceException"
+//   A general service exception.
+//
+//   * ErrCodeInvalidInputException "InvalidInputException"
+//   Lightsail throws this exception when user input does not conform to the validation
+//   rules of an input field.
+//
+//   Domain-related APIs are only available in the N. Virginia (us-east-1) Region.
+//   Please set your Region configuration to us-east-1 to create, view, or edit
+//   these resources.
+//
+//   * ErrCodeNotFoundException "NotFoundException"
+//   Lightsail throws this exception when it cannot find a resource.
+//
+//   * ErrCodeOperationFailureException "OperationFailureException"
+//   Lightsail throws this exception when an operation fails to execute.
+//
+//   * ErrCodeAccessDeniedException "AccessDeniedException"
+//   Lightsail throws this exception when the user cannot be authenticated or
+//   uses invalid credentials to access a resource.
+//
+//   * ErrCodeAccountSetupInProgressException "AccountSetupInProgressException"
+//   Lightsail throws this exception when an account is still in the setup in
+//   progress state.
+//
+//   * ErrCodeUnauthenticatedException "UnauthenticatedException"
+//   Lightsail throws this exception when the user has not been authenticated.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/GetLoadBalancers
+func (c *Lightsail) GetLoadBalancers(input *GetLoadBalancersInput) (*GetLoadBalancersOutput, error) {
+	req, out := c.GetLoadBalancersRequest(input)
+	return out, req.Send()
+}
+
+// GetLoadBalancersWithContext is the same as GetLoadBalancers with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetLoadBalancers for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Lightsail) GetLoadBalancersWithContext(ctx aws.Context, input *GetLoadBalancersInput, opts ...request.Option) (*GetLoadBalancersOutput, error) {
+	req, out := c.GetLoadBalancersRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opGetOperation = "GetOperation"
 
 // GetOperationRequest generates a "aws/request.Request" representing the
@@ -6211,6 +7369,110 @@ func (c *Lightsail) UpdateDomainEntryWithContext(ctx aws.Context, input *UpdateD
 	return out, req.Send()
 }
 
+const opUpdateLoadBalancerAttribute = "UpdateLoadBalancerAttribute"
+
+// UpdateLoadBalancerAttributeRequest generates a "aws/request.Request" representing the
+// client's request for the UpdateLoadBalancerAttribute operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See UpdateLoadBalancerAttribute for more information on using the UpdateLoadBalancerAttribute
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the UpdateLoadBalancerAttributeRequest method.
+//    req, resp := client.UpdateLoadBalancerAttributeRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/UpdateLoadBalancerAttribute
+func (c *Lightsail) UpdateLoadBalancerAttributeRequest(input *UpdateLoadBalancerAttributeInput) (req *request.Request, output *UpdateLoadBalancerAttributeOutput) {
+	op := &request.Operation{
+		Name:       opUpdateLoadBalancerAttribute,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &UpdateLoadBalancerAttributeInput{}
+	}
+
+	output = &UpdateLoadBalancerAttributeOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// UpdateLoadBalancerAttribute API operation for Amazon Lightsail.
+//
+// Updates the specified attribute for a load balancer.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Lightsail's
+// API operation UpdateLoadBalancerAttribute for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeServiceException "ServiceException"
+//   A general service exception.
+//
+//   * ErrCodeInvalidInputException "InvalidInputException"
+//   Lightsail throws this exception when user input does not conform to the validation
+//   rules of an input field.
+//
+//   Domain-related APIs are only available in the N. Virginia (us-east-1) Region.
+//   Please set your Region configuration to us-east-1 to create, view, or edit
+//   these resources.
+//
+//   * ErrCodeNotFoundException "NotFoundException"
+//   Lightsail throws this exception when it cannot find a resource.
+//
+//   * ErrCodeOperationFailureException "OperationFailureException"
+//   Lightsail throws this exception when an operation fails to execute.
+//
+//   * ErrCodeAccessDeniedException "AccessDeniedException"
+//   Lightsail throws this exception when the user cannot be authenticated or
+//   uses invalid credentials to access a resource.
+//
+//   * ErrCodeAccountSetupInProgressException "AccountSetupInProgressException"
+//   Lightsail throws this exception when an account is still in the setup in
+//   progress state.
+//
+//   * ErrCodeUnauthenticatedException "UnauthenticatedException"
+//   Lightsail throws this exception when the user has not been authenticated.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/UpdateLoadBalancerAttribute
+func (c *Lightsail) UpdateLoadBalancerAttribute(input *UpdateLoadBalancerAttributeInput) (*UpdateLoadBalancerAttributeOutput, error) {
+	req, out := c.UpdateLoadBalancerAttributeRequest(input)
+	return out, req.Send()
+}
+
+// UpdateLoadBalancerAttributeWithContext is the same as UpdateLoadBalancerAttribute with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UpdateLoadBalancerAttribute for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Lightsail) UpdateLoadBalancerAttributeWithContext(ctx aws.Context, input *UpdateLoadBalancerAttributeInput, opts ...request.Option) (*UpdateLoadBalancerAttributeOutput, error) {
+	req, out := c.UpdateLoadBalancerAttributeRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/AllocateStaticIpRequest
 type AllocateStaticIpInput struct {
 	_ struct{} `type:"structure"`
@@ -6347,7 +7609,7 @@ func (s *AttachDiskInput) SetInstanceName(v string) *AttachDiskInput {
 type AttachDiskOutput struct {
 	_ struct{} `type:"structure"`
 
-	// An object describing the API operation.
+	// An object describing the API operations.
 	Operations []*Operation `locationName:"operations" type:"list"`
 }
 
@@ -6363,6 +7625,162 @@ func (s AttachDiskOutput) GoString() string {
 
 // SetOperations sets the Operations field's value.
 func (s *AttachDiskOutput) SetOperations(v []*Operation) *AttachDiskOutput {
+	s.Operations = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/AttachInstancesToLoadBalancerRequest
+type AttachInstancesToLoadBalancerInput struct {
+	_ struct{} `type:"structure"`
+
+	// An array of strings representing the instance name(s) you want to attach
+	// to your load balancer.
+	//
+	// InstanceNames is a required field
+	InstanceNames []*string `locationName:"instanceNames" type:"list" required:"true"`
+
+	// The name of the load balancer.
+	//
+	// LoadBalancerName is a required field
+	LoadBalancerName *string `locationName:"loadBalancerName" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s AttachInstancesToLoadBalancerInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AttachInstancesToLoadBalancerInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AttachInstancesToLoadBalancerInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AttachInstancesToLoadBalancerInput"}
+	if s.InstanceNames == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceNames"))
+	}
+	if s.LoadBalancerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetInstanceNames sets the InstanceNames field's value.
+func (s *AttachInstancesToLoadBalancerInput) SetInstanceNames(v []*string) *AttachInstancesToLoadBalancerInput {
+	s.InstanceNames = v
+	return s
+}
+
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *AttachInstancesToLoadBalancerInput) SetLoadBalancerName(v string) *AttachInstancesToLoadBalancerInput {
+	s.LoadBalancerName = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/AttachInstancesToLoadBalancerResult
+type AttachInstancesToLoadBalancerOutput struct {
+	_ struct{} `type:"structure"`
+
+	// An object representing the API operations.
+	Operations []*Operation `locationName:"operations" type:"list"`
+}
+
+// String returns the string representation
+func (s AttachInstancesToLoadBalancerOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AttachInstancesToLoadBalancerOutput) GoString() string {
+	return s.String()
+}
+
+// SetOperations sets the Operations field's value.
+func (s *AttachInstancesToLoadBalancerOutput) SetOperations(v []*Operation) *AttachInstancesToLoadBalancerOutput {
+	s.Operations = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/AttachLoadBalancerTlsCertificateRequest
+type AttachLoadBalancerTlsCertificateInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of your TLS/SSL certificate.
+	//
+	// CertificateName is a required field
+	CertificateName *string `locationName:"certificateName" type:"string" required:"true"`
+
+	// The name of the load balancer to which you want to associate the TLS/SSL
+	// certificate.
+	//
+	// LoadBalancerName is a required field
+	LoadBalancerName *string `locationName:"loadBalancerName" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s AttachLoadBalancerTlsCertificateInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AttachLoadBalancerTlsCertificateInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AttachLoadBalancerTlsCertificateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AttachLoadBalancerTlsCertificateInput"}
+	if s.CertificateName == nil {
+		invalidParams.Add(request.NewErrParamRequired("CertificateName"))
+	}
+	if s.LoadBalancerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetCertificateName sets the CertificateName field's value.
+func (s *AttachLoadBalancerTlsCertificateInput) SetCertificateName(v string) *AttachLoadBalancerTlsCertificateInput {
+	s.CertificateName = &v
+	return s
+}
+
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *AttachLoadBalancerTlsCertificateInput) SetLoadBalancerName(v string) *AttachLoadBalancerTlsCertificateInput {
+	s.LoadBalancerName = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/AttachLoadBalancerTlsCertificateResult
+type AttachLoadBalancerTlsCertificateOutput struct {
+	_ struct{} `type:"structure"`
+
+	// An object representing the API operations.
+	Operations []*Operation `locationName:"operations" type:"list"`
+}
+
+// String returns the string representation
+func (s AttachLoadBalancerTlsCertificateOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AttachLoadBalancerTlsCertificateOutput) GoString() string {
+	return s.String()
+}
+
+// SetOperations sets the Operations field's value.
+func (s *AttachLoadBalancerTlsCertificateOutput) SetOperations(v []*Operation) *AttachLoadBalancerTlsCertificateOutput {
 	s.Operations = v
 	return s
 }
@@ -7358,7 +8776,7 @@ type CreateInstancesFromSnapshotInput struct {
 	KeyPairName *string `locationName:"keyPairName" type:"string"`
 
 	// You can create a launch script that configures a server with additional user
-	// data. For example, apt-get –y update.
+	// data. For example, apt-get -y update.
 	//
 	// Depending on the machine image you choose, the command to get software on
 	// your instance varies. Amazon Linux and CentOS use yum, Debian and Ubuntu
@@ -7508,7 +8926,7 @@ type CreateInstancesInput struct {
 	KeyPairName *string `locationName:"keyPairName" type:"string"`
 
 	// A launch script you can create that configures a server with additional user
-	// data. For example, you might want to run apt-get –y update.
+	// data. For example, you might want to run apt-get -y update.
 	//
 	// Depending on the machine image you choose, the command to get software on
 	// your instance varies. Amazon Linux and CentOS use yum, Debian and Ubuntu
@@ -7705,6 +9123,228 @@ func (s *CreateKeyPairOutput) SetPrivateKeyBase64(v string) *CreateKeyPairOutput
 // SetPublicKeyBase64 sets the PublicKeyBase64 field's value.
 func (s *CreateKeyPairOutput) SetPublicKeyBase64(v string) *CreateKeyPairOutput {
 	s.PublicKeyBase64 = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/CreateLoadBalancerRequest
+type CreateLoadBalancerInput struct {
+	_ struct{} `type:"structure"`
+
+	// The alternative domain names to use with your TLS/SSL certificate (e.g.,
+	// www.example.com, www.ejemplo.com, ejemplo.com).
+	CertificateAlternativeNames []*string `locationName:"certificateAlternativeNames" type:"list"`
+
+	// The domain name with which your certificate is associated (e.g., example.com).
+	//
+	// If you specify certificateDomainName, then certificateName is required (and
+	// vice-versa).
+	CertificateDomainName *string `locationName:"certificateDomainName" type:"string"`
+
+	// The name of the TLS/SSL certificate.
+	//
+	// If you specify certificateName, then certificateDomainName is required (and
+	// vice-versa).
+	CertificateName *string `locationName:"certificateName" type:"string"`
+
+	// The path you provided to perform the load balancer health check. If you didn't
+	// specify a health check path, Lightsail uses the root path of your website
+	// (e.g., "/").
+	HealthCheckPath *string `locationName:"healthCheckPath" type:"string"`
+
+	// The instance port where you're creating your load balancer.
+	//
+	// InstancePort is a required field
+	InstancePort *int64 `locationName:"instancePort" type:"integer" required:"true"`
+
+	// The name of your load balancer.
+	//
+	// LoadBalancerName is a required field
+	LoadBalancerName *string `locationName:"loadBalancerName" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s CreateLoadBalancerInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateLoadBalancerInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateLoadBalancerInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateLoadBalancerInput"}
+	if s.InstancePort == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstancePort"))
+	}
+	if s.LoadBalancerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetCertificateAlternativeNames sets the CertificateAlternativeNames field's value.
+func (s *CreateLoadBalancerInput) SetCertificateAlternativeNames(v []*string) *CreateLoadBalancerInput {
+	s.CertificateAlternativeNames = v
+	return s
+}
+
+// SetCertificateDomainName sets the CertificateDomainName field's value.
+func (s *CreateLoadBalancerInput) SetCertificateDomainName(v string) *CreateLoadBalancerInput {
+	s.CertificateDomainName = &v
+	return s
+}
+
+// SetCertificateName sets the CertificateName field's value.
+func (s *CreateLoadBalancerInput) SetCertificateName(v string) *CreateLoadBalancerInput {
+	s.CertificateName = &v
+	return s
+}
+
+// SetHealthCheckPath sets the HealthCheckPath field's value.
+func (s *CreateLoadBalancerInput) SetHealthCheckPath(v string) *CreateLoadBalancerInput {
+	s.HealthCheckPath = &v
+	return s
+}
+
+// SetInstancePort sets the InstancePort field's value.
+func (s *CreateLoadBalancerInput) SetInstancePort(v int64) *CreateLoadBalancerInput {
+	s.InstancePort = &v
+	return s
+}
+
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *CreateLoadBalancerInput) SetLoadBalancerName(v string) *CreateLoadBalancerInput {
+	s.LoadBalancerName = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/CreateLoadBalancerResult
+type CreateLoadBalancerOutput struct {
+	_ struct{} `type:"structure"`
+
+	// An object containing information about the API operations.
+	Operations []*Operation `locationName:"operations" type:"list"`
+}
+
+// String returns the string representation
+func (s CreateLoadBalancerOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateLoadBalancerOutput) GoString() string {
+	return s.String()
+}
+
+// SetOperations sets the Operations field's value.
+func (s *CreateLoadBalancerOutput) SetOperations(v []*Operation) *CreateLoadBalancerOutput {
+	s.Operations = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/CreateLoadBalancerTlsCertificateRequest
+type CreateLoadBalancerTlsCertificateInput struct {
+	_ struct{} `type:"structure"`
+
+	// An array of strings listing alternative domain names for your TLS/SSL certificate.
+	CertificateAlternativeNames []*string `locationName:"certificateAlternativeNames" type:"list"`
+
+	// The domain name (e.g., example.com) for your TLS/SSL certificate.
+	//
+	// CertificateDomainName is a required field
+	CertificateDomainName *string `locationName:"certificateDomainName" type:"string" required:"true"`
+
+	// The TLS/SSL certificate name.
+	//
+	// CertificateName is a required field
+	CertificateName *string `locationName:"certificateName" type:"string" required:"true"`
+
+	// The load balancer name where you want to create the TLS/SSL certificate.
+	//
+	// LoadBalancerName is a required field
+	LoadBalancerName *string `locationName:"loadBalancerName" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s CreateLoadBalancerTlsCertificateInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateLoadBalancerTlsCertificateInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateLoadBalancerTlsCertificateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateLoadBalancerTlsCertificateInput"}
+	if s.CertificateDomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("CertificateDomainName"))
+	}
+	if s.CertificateName == nil {
+		invalidParams.Add(request.NewErrParamRequired("CertificateName"))
+	}
+	if s.LoadBalancerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetCertificateAlternativeNames sets the CertificateAlternativeNames field's value.
+func (s *CreateLoadBalancerTlsCertificateInput) SetCertificateAlternativeNames(v []*string) *CreateLoadBalancerTlsCertificateInput {
+	s.CertificateAlternativeNames = v
+	return s
+}
+
+// SetCertificateDomainName sets the CertificateDomainName field's value.
+func (s *CreateLoadBalancerTlsCertificateInput) SetCertificateDomainName(v string) *CreateLoadBalancerTlsCertificateInput {
+	s.CertificateDomainName = &v
+	return s
+}
+
+// SetCertificateName sets the CertificateName field's value.
+func (s *CreateLoadBalancerTlsCertificateInput) SetCertificateName(v string) *CreateLoadBalancerTlsCertificateInput {
+	s.CertificateName = &v
+	return s
+}
+
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *CreateLoadBalancerTlsCertificateInput) SetLoadBalancerName(v string) *CreateLoadBalancerTlsCertificateInput {
+	s.LoadBalancerName = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/CreateLoadBalancerTlsCertificateResult
+type CreateLoadBalancerTlsCertificateOutput struct {
+	_ struct{} `type:"structure"`
+
+	// An object containing information about the API operations.
+	Operations []*Operation `locationName:"operations" type:"list"`
+}
+
+// String returns the string representation
+func (s CreateLoadBalancerTlsCertificateOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateLoadBalancerTlsCertificateOutput) GoString() string {
+	return s.String()
+}
+
+// SetOperations sets the Operations field's value.
+func (s *CreateLoadBalancerTlsCertificateOutput) SetOperations(v []*Operation) *CreateLoadBalancerTlsCertificateOutput {
+	s.Operations = v
 	return s
 }
 
@@ -8168,6 +9808,155 @@ func (s *DeleteKeyPairOutput) SetOperation(v *Operation) *DeleteKeyPairOutput {
 	return s
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/DeleteLoadBalancerRequest
+type DeleteLoadBalancerInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the load balancer you want to delete.
+	//
+	// LoadBalancerName is a required field
+	LoadBalancerName *string `locationName:"loadBalancerName" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DeleteLoadBalancerInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteLoadBalancerInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteLoadBalancerInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteLoadBalancerInput"}
+	if s.LoadBalancerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *DeleteLoadBalancerInput) SetLoadBalancerName(v string) *DeleteLoadBalancerInput {
+	s.LoadBalancerName = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/DeleteLoadBalancerResult
+type DeleteLoadBalancerOutput struct {
+	_ struct{} `type:"structure"`
+
+	// An object describing the API operations.
+	Operations []*Operation `locationName:"operations" type:"list"`
+}
+
+// String returns the string representation
+func (s DeleteLoadBalancerOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteLoadBalancerOutput) GoString() string {
+	return s.String()
+}
+
+// SetOperations sets the Operations field's value.
+func (s *DeleteLoadBalancerOutput) SetOperations(v []*Operation) *DeleteLoadBalancerOutput {
+	s.Operations = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/DeleteLoadBalancerTlsCertificateRequest
+type DeleteLoadBalancerTlsCertificateInput struct {
+	_ struct{} `type:"structure"`
+
+	// The TLS/SSL certificate name.
+	//
+	// CertificateName is a required field
+	CertificateName *string `locationName:"certificateName" type:"string" required:"true"`
+
+	// When true, forces the deletion of a TLS/SSL certificate.
+	Force *bool `locationName:"force" type:"boolean"`
+
+	// The load balancer name.
+	//
+	// LoadBalancerName is a required field
+	LoadBalancerName *string `locationName:"loadBalancerName" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DeleteLoadBalancerTlsCertificateInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteLoadBalancerTlsCertificateInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteLoadBalancerTlsCertificateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteLoadBalancerTlsCertificateInput"}
+	if s.CertificateName == nil {
+		invalidParams.Add(request.NewErrParamRequired("CertificateName"))
+	}
+	if s.LoadBalancerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetCertificateName sets the CertificateName field's value.
+func (s *DeleteLoadBalancerTlsCertificateInput) SetCertificateName(v string) *DeleteLoadBalancerTlsCertificateInput {
+	s.CertificateName = &v
+	return s
+}
+
+// SetForce sets the Force field's value.
+func (s *DeleteLoadBalancerTlsCertificateInput) SetForce(v bool) *DeleteLoadBalancerTlsCertificateInput {
+	s.Force = &v
+	return s
+}
+
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *DeleteLoadBalancerTlsCertificateInput) SetLoadBalancerName(v string) *DeleteLoadBalancerTlsCertificateInput {
+	s.LoadBalancerName = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/DeleteLoadBalancerTlsCertificateResult
+type DeleteLoadBalancerTlsCertificateOutput struct {
+	_ struct{} `type:"structure"`
+
+	// An object describing the API operations.
+	Operations []*Operation `locationName:"operations" type:"list"`
+}
+
+// String returns the string representation
+func (s DeleteLoadBalancerTlsCertificateOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteLoadBalancerTlsCertificateOutput) GoString() string {
+	return s.String()
+}
+
+// SetOperations sets the Operations field's value.
+func (s *DeleteLoadBalancerTlsCertificateOutput) SetOperations(v []*Operation) *DeleteLoadBalancerTlsCertificateOutput {
+	s.Operations = v
+	return s
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/DetachDiskRequest
 type DetachDiskInput struct {
 	_ struct{} `type:"structure"`
@@ -8228,6 +10017,84 @@ func (s DetachDiskOutput) GoString() string {
 
 // SetOperations sets the Operations field's value.
 func (s *DetachDiskOutput) SetOperations(v []*Operation) *DetachDiskOutput {
+	s.Operations = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/DetachInstancesFromLoadBalancerRequest
+type DetachInstancesFromLoadBalancerInput struct {
+	_ struct{} `type:"structure"`
+
+	// An array of strings containing the names of the instances you want to detach
+	// from the load balancer.
+	//
+	// InstanceNames is a required field
+	InstanceNames []*string `locationName:"instanceNames" type:"list" required:"true"`
+
+	// The name of the Lightsail load balancer.
+	//
+	// LoadBalancerName is a required field
+	LoadBalancerName *string `locationName:"loadBalancerName" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DetachInstancesFromLoadBalancerInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DetachInstancesFromLoadBalancerInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DetachInstancesFromLoadBalancerInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DetachInstancesFromLoadBalancerInput"}
+	if s.InstanceNames == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceNames"))
+	}
+	if s.LoadBalancerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetInstanceNames sets the InstanceNames field's value.
+func (s *DetachInstancesFromLoadBalancerInput) SetInstanceNames(v []*string) *DetachInstancesFromLoadBalancerInput {
+	s.InstanceNames = v
+	return s
+}
+
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *DetachInstancesFromLoadBalancerInput) SetLoadBalancerName(v string) *DetachInstancesFromLoadBalancerInput {
+	s.LoadBalancerName = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/DetachInstancesFromLoadBalancerResult
+type DetachInstancesFromLoadBalancerOutput struct {
+	_ struct{} `type:"structure"`
+
+	// An object describing the API operations.
+	Operations []*Operation `locationName:"operations" type:"list"`
+}
+
+// String returns the string representation
+func (s DetachInstancesFromLoadBalancerOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DetachInstancesFromLoadBalancerOutput) GoString() string {
+	return s.String()
+}
+
+// SetOperations sets the Operations field's value.
+func (s *DetachInstancesFromLoadBalancerOutput) SetOperations(v []*Operation) *DetachInstancesFromLoadBalancerOutput {
 	s.Operations = v
 	return s
 }
@@ -8309,8 +10176,8 @@ type Disk struct {
 
 	// (Deprecated) The attachment state of the disk.
 	//
-	// In releases prior to November 9, 2017, this parameter returned attached for
-	// system disks in the API response. It is now deprecated, but still included
+	// In releases prior to November 14, 2017, this parameter returned attached
+	// for system disks in the API response. It is now deprecated, but still included
 	// in the response. Use isAttached instead.
 	AttachmentState *string `locationName:"attachmentState" deprecated:"true" type:"string"`
 
@@ -8319,7 +10186,7 @@ type Disk struct {
 
 	// (Deprecated) The number of GB in use by the disk.
 	//
-	// In releases prior to November 9, 2017, this parameter was not included in
+	// In releases prior to November 14, 2017, this parameter was not included in
 	// the API response. It is now deprecated.
 	GbInUse *int64 `locationName:"gbInUse" deprecated:"true" type:"integer"`
 
@@ -8698,11 +10565,18 @@ type DomainEntry struct {
 	// The ID of the domain recordset entry.
 	Id *string `locationName:"id" type:"string"`
 
+	// When true, specifies whether the domain entry is an alias used by the Lightsail
+	// load balancer.
+	IsAlias *bool `locationName:"isAlias" type:"boolean"`
+
 	// The name of the domain.
 	Name *string `locationName:"name" type:"string"`
 
-	// The options for the domain entry.
-	Options map[string]*string `locationName:"options" type:"map"`
+	// (Deprecated) The options for the domain entry.
+	//
+	// In releases prior to November 29, 2017, this parameter was not included in
+	// the API response. It is now deprecated.
+	Options map[string]*string `locationName:"options" deprecated:"true" type:"map"`
 
 	// The target AWS name server (e.g., ns-111.awsdns-22.com.).
 	Target *string `locationName:"target" type:"string"`
@@ -8724,6 +10598,12 @@ func (s DomainEntry) GoString() string {
 // SetId sets the Id field's value.
 func (s *DomainEntry) SetId(v string) *DomainEntry {
 	s.Id = &v
+	return s
+}
+
+// SetIsAlias sets the IsAlias field's value.
+func (s *DomainEntry) SetIsAlias(v bool) *DomainEntry {
+	s.IsAlias = &v
 	return s
 }
 
@@ -10091,6 +11971,431 @@ func (s *GetKeyPairsOutput) SetNextPageToken(v string) *GetKeyPairsOutput {
 	return s
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/GetLoadBalancerRequest
+type GetLoadBalancerInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the load balancer.
+	//
+	// LoadBalancerName is a required field
+	LoadBalancerName *string `locationName:"loadBalancerName" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s GetLoadBalancerInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetLoadBalancerInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetLoadBalancerInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetLoadBalancerInput"}
+	if s.LoadBalancerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *GetLoadBalancerInput) SetLoadBalancerName(v string) *GetLoadBalancerInput {
+	s.LoadBalancerName = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/GetLoadBalancerMetricDataRequest
+type GetLoadBalancerMetricDataInput struct {
+	_ struct{} `type:"structure"`
+
+	// The end time of the period.
+	//
+	// EndTime is a required field
+	EndTime *time.Time `locationName:"endTime" type:"timestamp" timestampFormat:"unix" required:"true"`
+
+	// The name of the load balancer.
+	//
+	// LoadBalancerName is a required field
+	LoadBalancerName *string `locationName:"loadBalancerName" type:"string" required:"true"`
+
+	// The metric about which you want to return information. Valid values are listed
+	// below, along with the most useful statistics to include in your request.
+	//
+	//    * ClientTLSNegotiationErrorCount - The number of TLS connections initiated
+	//    by the client that did not establish a session with the load balancer.
+	//    Possible causes include a mismatch of ciphers or protocols.
+	//
+	// Statistics: The most useful statistic is Sum.
+	//
+	//    * HealthyHostCount - The number of target instances that are considered
+	//    healthy.
+	//
+	// Statistics: The most useful statistic are Average, Minimum, and Maximum.
+	//
+	//    * UnhealthyHostCount - The number of target instances that are considered
+	//    unhealthy.
+	//
+	// Statistics: The most useful statistic are Average, Minimum, and Maximum.
+	//
+	//    * HTTPCode_LB_4XX_Count - The number of HTTP 4XX client error codes that
+	//    originate from the load balancer. Client errors are generated when requests
+	//    are malformed or incomplete. These requests have not been received by
+	//    the target instance. This count does not include any response codes generated
+	//    by the target instances.
+	//
+	// Statistics: The most useful statistic is Sum. Note that Minimum, Maximum,
+	//    and Average all return 1.
+	//
+	//    * HTTPCode_LB_5XX_Count - The number of HTTP 5XX server error codes that
+	//    originate from the load balancer. This count does not include any response
+	//    codes generated by the target instances.
+	//
+	// Statistics: The most useful statistic is Sum. Note that Minimum, Maximum,
+	//    and Average all return 1. Note that Minimum, Maximum, and Average all
+	//    return 1.
+	//
+	//    * HTTPCode_Instance_2XX_Count - The number of HTTP response codes generated
+	//    by the target instances. This does not include any response codes generated
+	//    by the load balancer.
+	//
+	// Statistics: The most useful statistic is Sum. Note that Minimum, Maximum,
+	//    and Average all return 1.
+	//
+	//    * HTTPCode_Instance_3XX_Count - The number of HTTP response codes generated
+	//    by the target instances. This does not include any response codes generated
+	//    by the load balancer.
+	//
+	// Statistics: The most useful statistic is Sum. Note that Minimum, Maximum,
+	//    and Average all return 1.
+	//
+	//    * HTTPCode_Instance_4XX_Count - The number of HTTP response codes generated
+	//    by the target instances. This does not include any response codes generated
+	//    by the load balancer.
+	//
+	// Statistics: The most useful statistic is Sum. Note that Minimum, Maximum,
+	//    and Average all return 1.
+	//
+	//    * HTTPCode_Instance_5XX_Count - The number of HTTP response codes generated
+	//    by the target instances. This does not include any response codes generated
+	//    by the load balancer.
+	//
+	// Statistics: The most useful statistic is Sum. Note that Minimum, Maximum,
+	//    and Average all return 1.
+	//
+	//    * InstanceResponseTime - The time elapsed, in seconds, after the request
+	//    leaves the load balancer until a response from the target instance is
+	//    received.
+	//
+	// Statistics: The most useful statistic is Average.
+	//
+	//    * RejectedConnectionCount - The number of connections that were rejected
+	//    because the load balancer had reached its maximum number of connections.
+	//
+	// Statistics: The most useful statistic is Sum.
+	//
+	//    * RequestCount - The number of requests processed over IPv4. This count
+	//    includes only the requests with a response generated by a target instance
+	//    of the load balancer.
+	//
+	// Statistics: The most useful statistic is Sum. Note that Minimum, Maximum,
+	//    and Average all return 1.
+	//
+	// MetricName is a required field
+	MetricName *string `locationName:"metricName" type:"string" required:"true" enum:"LoadBalancerMetricName"`
+
+	// The time period duration for your health data request.
+	//
+	// Period is a required field
+	Period *int64 `locationName:"period" min:"60" type:"integer" required:"true"`
+
+	// The start time of the period.
+	//
+	// StartTime is a required field
+	StartTime *time.Time `locationName:"startTime" type:"timestamp" timestampFormat:"unix" required:"true"`
+
+	// An array of statistics that you want to request metrics for. Valid values
+	// are listed below.
+	//
+	// Statistics is a required field
+	Statistics []*string `locationName:"statistics" type:"list" required:"true"`
+
+	// The unit for the time period request. Valid values are listed below.
+	//
+	// Unit is a required field
+	Unit *string `locationName:"unit" type:"string" required:"true" enum:"MetricUnit"`
+}
+
+// String returns the string representation
+func (s GetLoadBalancerMetricDataInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetLoadBalancerMetricDataInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetLoadBalancerMetricDataInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetLoadBalancerMetricDataInput"}
+	if s.EndTime == nil {
+		invalidParams.Add(request.NewErrParamRequired("EndTime"))
+	}
+	if s.LoadBalancerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerName"))
+	}
+	if s.MetricName == nil {
+		invalidParams.Add(request.NewErrParamRequired("MetricName"))
+	}
+	if s.Period == nil {
+		invalidParams.Add(request.NewErrParamRequired("Period"))
+	}
+	if s.Period != nil && *s.Period < 60 {
+		invalidParams.Add(request.NewErrParamMinValue("Period", 60))
+	}
+	if s.StartTime == nil {
+		invalidParams.Add(request.NewErrParamRequired("StartTime"))
+	}
+	if s.Statistics == nil {
+		invalidParams.Add(request.NewErrParamRequired("Statistics"))
+	}
+	if s.Unit == nil {
+		invalidParams.Add(request.NewErrParamRequired("Unit"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetEndTime sets the EndTime field's value.
+func (s *GetLoadBalancerMetricDataInput) SetEndTime(v time.Time) *GetLoadBalancerMetricDataInput {
+	s.EndTime = &v
+	return s
+}
+
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *GetLoadBalancerMetricDataInput) SetLoadBalancerName(v string) *GetLoadBalancerMetricDataInput {
+	s.LoadBalancerName = &v
+	return s
+}
+
+// SetMetricName sets the MetricName field's value.
+func (s *GetLoadBalancerMetricDataInput) SetMetricName(v string) *GetLoadBalancerMetricDataInput {
+	s.MetricName = &v
+	return s
+}
+
+// SetPeriod sets the Period field's value.
+func (s *GetLoadBalancerMetricDataInput) SetPeriod(v int64) *GetLoadBalancerMetricDataInput {
+	s.Period = &v
+	return s
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *GetLoadBalancerMetricDataInput) SetStartTime(v time.Time) *GetLoadBalancerMetricDataInput {
+	s.StartTime = &v
+	return s
+}
+
+// SetStatistics sets the Statistics field's value.
+func (s *GetLoadBalancerMetricDataInput) SetStatistics(v []*string) *GetLoadBalancerMetricDataInput {
+	s.Statistics = v
+	return s
+}
+
+// SetUnit sets the Unit field's value.
+func (s *GetLoadBalancerMetricDataInput) SetUnit(v string) *GetLoadBalancerMetricDataInput {
+	s.Unit = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/GetLoadBalancerMetricDataResult
+type GetLoadBalancerMetricDataOutput struct {
+	_ struct{} `type:"structure"`
+
+	// An array of metric datapoint objects.
+	MetricData []*MetricDatapoint `locationName:"metricData" type:"list"`
+
+	// The metric about which you are receiving information. Valid values are listed
+	// below.
+	MetricName *string `locationName:"metricName" type:"string" enum:"LoadBalancerMetricName"`
+}
+
+// String returns the string representation
+func (s GetLoadBalancerMetricDataOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetLoadBalancerMetricDataOutput) GoString() string {
+	return s.String()
+}
+
+// SetMetricData sets the MetricData field's value.
+func (s *GetLoadBalancerMetricDataOutput) SetMetricData(v []*MetricDatapoint) *GetLoadBalancerMetricDataOutput {
+	s.MetricData = v
+	return s
+}
+
+// SetMetricName sets the MetricName field's value.
+func (s *GetLoadBalancerMetricDataOutput) SetMetricName(v string) *GetLoadBalancerMetricDataOutput {
+	s.MetricName = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/GetLoadBalancerResult
+type GetLoadBalancerOutput struct {
+	_ struct{} `type:"structure"`
+
+	// An object containing information about your load balancer.
+	LoadBalancer *LoadBalancer `locationName:"loadBalancer" type:"structure"`
+}
+
+// String returns the string representation
+func (s GetLoadBalancerOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetLoadBalancerOutput) GoString() string {
+	return s.String()
+}
+
+// SetLoadBalancer sets the LoadBalancer field's value.
+func (s *GetLoadBalancerOutput) SetLoadBalancer(v *LoadBalancer) *GetLoadBalancerOutput {
+	s.LoadBalancer = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/GetLoadBalancerTlsCertificatesRequest
+type GetLoadBalancerTlsCertificatesInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the load balancer where you stored your TLS/SSL certificate.
+	//
+	// LoadBalancerName is a required field
+	LoadBalancerName *string `locationName:"loadBalancerName" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s GetLoadBalancerTlsCertificatesInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetLoadBalancerTlsCertificatesInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetLoadBalancerTlsCertificatesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetLoadBalancerTlsCertificatesInput"}
+	if s.LoadBalancerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *GetLoadBalancerTlsCertificatesInput) SetLoadBalancerName(v string) *GetLoadBalancerTlsCertificatesInput {
+	s.LoadBalancerName = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/GetLoadBalancerTlsCertificatesResult
+type GetLoadBalancerTlsCertificatesOutput struct {
+	_ struct{} `type:"structure"`
+
+	// An array of LoadBalancerTlsCertificate objects describing your TLS/SSL certificates.
+	TlsCertificates []*LoadBalancerTlsCertificate `locationName:"tlsCertificates" type:"list"`
+}
+
+// String returns the string representation
+func (s GetLoadBalancerTlsCertificatesOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetLoadBalancerTlsCertificatesOutput) GoString() string {
+	return s.String()
+}
+
+// SetTlsCertificates sets the TlsCertificates field's value.
+func (s *GetLoadBalancerTlsCertificatesOutput) SetTlsCertificates(v []*LoadBalancerTlsCertificate) *GetLoadBalancerTlsCertificatesOutput {
+	s.TlsCertificates = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/GetLoadBalancersRequest
+type GetLoadBalancersInput struct {
+	_ struct{} `type:"structure"`
+
+	// A token used for paginating the results from your GetLoadBalancers request.
+	PageToken *string `locationName:"pageToken" type:"string"`
+}
+
+// String returns the string representation
+func (s GetLoadBalancersInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetLoadBalancersInput) GoString() string {
+	return s.String()
+}
+
+// SetPageToken sets the PageToken field's value.
+func (s *GetLoadBalancersInput) SetPageToken(v string) *GetLoadBalancersInput {
+	s.PageToken = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/GetLoadBalancersResult
+type GetLoadBalancersOutput struct {
+	_ struct{} `type:"structure"`
+
+	// An array of LoadBalancer objects describing your load balancers.
+	LoadBalancers []*LoadBalancer `locationName:"loadBalancers" type:"list"`
+
+	// A token used for advancing to the next page of results from your GetLoadBalancers
+	// request.
+	NextPageToken *string `locationName:"nextPageToken" type:"string"`
+}
+
+// String returns the string representation
+func (s GetLoadBalancersOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetLoadBalancersOutput) GoString() string {
+	return s.String()
+}
+
+// SetLoadBalancers sets the LoadBalancers field's value.
+func (s *GetLoadBalancersOutput) SetLoadBalancers(v []*LoadBalancer) *GetLoadBalancersOutput {
+	s.LoadBalancers = v
+	return s
+}
+
+// SetNextPageToken sets the NextPageToken field's value.
+func (s *GetLoadBalancersOutput) SetNextPageToken(v string) *GetLoadBalancersOutput {
+	s.NextPageToken = &v
+	return s
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/GetOperationRequest
 type GetOperationInput struct {
 	_ struct{} `type:"structure"`
@@ -10902,6 +13207,50 @@ func (s *InstanceHardware) SetRamSizeInGb(v float64) *InstanceHardware {
 	return s
 }
 
+// Describes information about the health of the instance.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/InstanceHealthSummary
+type InstanceHealthSummary struct {
+	_ struct{} `type:"structure"`
+
+	// Describes the overall instance health. Valid values are below.
+	InstanceHealth *string `locationName:"instanceHealth" type:"string" enum:"InstanceHealthState"`
+
+	// More information about the instance health. Valid values are below.
+	InstanceHealthReason *string `locationName:"instanceHealthReason" type:"string" enum:"InstanceHealthReason"`
+
+	// The name of the Lightsail instance for which you are requesting health check
+	// data.
+	InstanceName *string `locationName:"instanceName" type:"string"`
+}
+
+// String returns the string representation
+func (s InstanceHealthSummary) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s InstanceHealthSummary) GoString() string {
+	return s.String()
+}
+
+// SetInstanceHealth sets the InstanceHealth field's value.
+func (s *InstanceHealthSummary) SetInstanceHealth(v string) *InstanceHealthSummary {
+	s.InstanceHealth = &v
+	return s
+}
+
+// SetInstanceHealthReason sets the InstanceHealthReason field's value.
+func (s *InstanceHealthSummary) SetInstanceHealthReason(v string) *InstanceHealthSummary {
+	s.InstanceHealthReason = &v
+	return s
+}
+
+// SetInstanceName sets the InstanceName field's value.
+func (s *InstanceHealthSummary) SetInstanceName(v string) *InstanceHealthSummary {
+	s.InstanceName = &v
+	return s
+}
+
 // Describes monthly data transfer rates and port information for an instance.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/InstanceNetworking
 type InstanceNetworking struct {
@@ -11400,6 +13749,577 @@ func (s *KeyPair) SetResourceType(v string) *KeyPair {
 // SetSupportCode sets the SupportCode field's value.
 func (s *KeyPair) SetSupportCode(v string) *KeyPair {
 	s.SupportCode = &v
+	return s
+}
+
+// Describes the Lightsail load balancer.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/LoadBalancer
+type LoadBalancer struct {
+	_ struct{} `type:"structure"`
+
+	// The Amazon Resource Name (ARN) of the load balancer.
+	Arn *string `locationName:"arn" type:"string"`
+
+	// A string to string map of the configuration options for your load balancer.
+	// Valid values are listed below.
+	ConfigurationOptions map[string]*string `locationName:"configurationOptions" type:"map"`
+
+	// The date when your load balancer was created.
+	CreatedAt *time.Time `locationName:"createdAt" type:"timestamp" timestampFormat:"unix"`
+
+	// The DNS name of your Lightsail load balancer.
+	DnsName *string `locationName:"dnsName" type:"string"`
+
+	// The path you specified to perform your health checks. If no path is specified,
+	// the load balancer tries to make a request to the default (root) page.
+	HealthCheckPath *string `locationName:"healthCheckPath" type:"string"`
+
+	// An array of InstanceHealthSummary objects describing the health of the load
+	// balancer.
+	InstanceHealthSummary []*InstanceHealthSummary `locationName:"instanceHealthSummary" type:"list"`
+
+	// The instance port where the load balancer is listening.
+	InstancePort *int64 `locationName:"instancePort" type:"integer"`
+
+	// The AWS Region and Availability Zone where your load balancer was created
+	// (e.g., us-east-2a).
+	Location *ResourceLocation `locationName:"location" type:"structure"`
+
+	// The name of the load balancer (e.g., my-load-balancer).
+	Name *string `locationName:"name" type:"string"`
+
+	// The protocol you have enabled for your load balancer. Valid values are below.
+	Protocol *string `locationName:"protocol" type:"string" enum:"LoadBalancerProtocol"`
+
+	// An array of public port settings for your load balancer.
+	PublicPorts []*int64 `locationName:"publicPorts" type:"list"`
+
+	// The resource type (e.g., LoadBalancer.
+	ResourceType *string `locationName:"resourceType" type:"string" enum:"ResourceType"`
+
+	// The status of your load balancer. Valid values are below.
+	State *string `locationName:"state" type:"string" enum:"LoadBalancerState"`
+
+	// The support code. Include this code in your email to support when you have
+	// questions about your Lightsail load balancer. This code enables our support
+	// team to look up your Lightsail information more easily.
+	SupportCode *string `locationName:"supportCode" type:"string"`
+
+	// An array of LoadBalancerTlsCertificateSummary objects that provide additional
+	// information about the TLS/SSL certificates.
+	TlsCertificateSummaries []*LoadBalancerTlsCertificateSummary `locationName:"tlsCertificateSummaries" type:"list"`
+}
+
+// String returns the string representation
+func (s LoadBalancer) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s LoadBalancer) GoString() string {
+	return s.String()
+}
+
+// SetArn sets the Arn field's value.
+func (s *LoadBalancer) SetArn(v string) *LoadBalancer {
+	s.Arn = &v
+	return s
+}
+
+// SetConfigurationOptions sets the ConfigurationOptions field's value.
+func (s *LoadBalancer) SetConfigurationOptions(v map[string]*string) *LoadBalancer {
+	s.ConfigurationOptions = v
+	return s
+}
+
+// SetCreatedAt sets the CreatedAt field's value.
+func (s *LoadBalancer) SetCreatedAt(v time.Time) *LoadBalancer {
+	s.CreatedAt = &v
+	return s
+}
+
+// SetDnsName sets the DnsName field's value.
+func (s *LoadBalancer) SetDnsName(v string) *LoadBalancer {
+	s.DnsName = &v
+	return s
+}
+
+// SetHealthCheckPath sets the HealthCheckPath field's value.
+func (s *LoadBalancer) SetHealthCheckPath(v string) *LoadBalancer {
+	s.HealthCheckPath = &v
+	return s
+}
+
+// SetInstanceHealthSummary sets the InstanceHealthSummary field's value.
+func (s *LoadBalancer) SetInstanceHealthSummary(v []*InstanceHealthSummary) *LoadBalancer {
+	s.InstanceHealthSummary = v
+	return s
+}
+
+// SetInstancePort sets the InstancePort field's value.
+func (s *LoadBalancer) SetInstancePort(v int64) *LoadBalancer {
+	s.InstancePort = &v
+	return s
+}
+
+// SetLocation sets the Location field's value.
+func (s *LoadBalancer) SetLocation(v *ResourceLocation) *LoadBalancer {
+	s.Location = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *LoadBalancer) SetName(v string) *LoadBalancer {
+	s.Name = &v
+	return s
+}
+
+// SetProtocol sets the Protocol field's value.
+func (s *LoadBalancer) SetProtocol(v string) *LoadBalancer {
+	s.Protocol = &v
+	return s
+}
+
+// SetPublicPorts sets the PublicPorts field's value.
+func (s *LoadBalancer) SetPublicPorts(v []*int64) *LoadBalancer {
+	s.PublicPorts = v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *LoadBalancer) SetResourceType(v string) *LoadBalancer {
+	s.ResourceType = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *LoadBalancer) SetState(v string) *LoadBalancer {
+	s.State = &v
+	return s
+}
+
+// SetSupportCode sets the SupportCode field's value.
+func (s *LoadBalancer) SetSupportCode(v string) *LoadBalancer {
+	s.SupportCode = &v
+	return s
+}
+
+// SetTlsCertificateSummaries sets the TlsCertificateSummaries field's value.
+func (s *LoadBalancer) SetTlsCertificateSummaries(v []*LoadBalancerTlsCertificateSummary) *LoadBalancer {
+	s.TlsCertificateSummaries = v
+	return s
+}
+
+// Describes a load balancer TLS/SSL certificate.
+//
+// TLS is just an updated, more secure version of Secure Socket Layer (SSL).
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/LoadBalancerTlsCertificate
+type LoadBalancerTlsCertificate struct {
+	_ struct{} `type:"structure"`
+
+	// The Amazon Resource Name (ARN) of the TLS/SSL certificate.
+	Arn *string `locationName:"arn" type:"string"`
+
+	// The time when you created your TLS/SSL certificate.
+	CreatedAt *time.Time `locationName:"createdAt" type:"timestamp" timestampFormat:"unix"`
+
+	// The domain name for your TLS/SSL certificate.
+	DomainName *string `locationName:"domainName" type:"string"`
+
+	// An array of LoadBalancerTlsCertificateDomainValidationRecord objects describing
+	// the records.
+	DomainValidationRecords []*LoadBalancerTlsCertificateDomainValidationRecord `locationName:"domainValidationRecords" type:"list"`
+
+	// The reason for the TLS/SSL certificate validation failure.
+	FailureReason *string `locationName:"failureReason" type:"string" enum:"LoadBalancerTlsCertificateFailureReason"`
+
+	// When true, the TLS/SSL certificate is attached to the Lightsail load balancer.
+	IsAttached *bool `locationName:"isAttached" type:"boolean"`
+
+	// The time when the TLS/SSL certificate was issued.
+	IssuedAt *time.Time `locationName:"issuedAt" type:"timestamp" timestampFormat:"unix"`
+
+	// The issuer of the certificate.
+	Issuer *string `locationName:"issuer" type:"string"`
+
+	// The algorithm that was used to generate the key pair (the public and private
+	// key).
+	KeyAlgorithm *string `locationName:"keyAlgorithm" type:"string"`
+
+	// The load balancer name where your TLS/SSL certificate is attached.
+	LoadBalancerName *string `locationName:"loadBalancerName" type:"string"`
+
+	// The AWS Region and Availability Zone where you created your certificate.
+	Location *ResourceLocation `locationName:"location" type:"structure"`
+
+	// The name of the TLS/SSL certificate (e.g., my-certificate).
+	Name *string `locationName:"name" type:"string"`
+
+	// The timestamp when the TLS/SSL certificate expires.
+	NotAfter *time.Time `locationName:"notAfter" type:"timestamp" timestampFormat:"unix"`
+
+	// The timestamp when the TLS/SSL certificate is first valid.
+	NotBefore *time.Time `locationName:"notBefore" type:"timestamp" timestampFormat:"unix"`
+
+	// An object containing information about the status of Lightsail's managed
+	// renewal for the certificate.
+	RenewalSummary *LoadBalancerTlsCertificateRenewalSummary `locationName:"renewalSummary" type:"structure"`
+
+	// The resource type (e.g., LoadBalancerTlsCertificate.
+	ResourceType *string `locationName:"resourceType" type:"string" enum:"ResourceType"`
+
+	// The reason the certificate was revoked. Valid values are below.
+	RevocationReason *string `locationName:"revocationReason" type:"string" enum:"LoadBalancerTlsCertificateRevocationReason"`
+
+	// The timestamp when the TLS/SSL certificate was revoked.
+	RevokedAt *time.Time `locationName:"revokedAt" type:"timestamp" timestampFormat:"unix"`
+
+	// The serial number of the certificate.
+	Serial *string `locationName:"serial" type:"string"`
+
+	// The algorithm that was used to sign the certificate.
+	SignatureAlgorithm *string `locationName:"signatureAlgorithm" type:"string"`
+
+	// The status of the TLS/SSL certificate. Valid values are below.
+	Status *string `locationName:"status" type:"string" enum:"LoadBalancerTlsCertificateStatus"`
+
+	// The name of the entity that is associated with the public key contained in
+	// the certificate.
+	Subject *string `locationName:"subject" type:"string"`
+
+	// One or more domain names (subject alternative names) included in the certificate.
+	// This list contains the domain names that are bound to the public key that
+	// is contained in the certificate. The subject alternative names include the
+	// canonical domain name (CN) of the certificate and additional domain names
+	// that can be used to connect to the website.
+	SubjectAlternativeNames []*string `locationName:"subjectAlternativeNames" type:"list"`
+
+	// The support code. Include this code in your email to support when you have
+	// questions about your Lightsail load balancer or TLS/SSL certificate. This
+	// code enables our support team to look up your Lightsail information more
+	// easily.
+	SupportCode *string `locationName:"supportCode" type:"string"`
+}
+
+// String returns the string representation
+func (s LoadBalancerTlsCertificate) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s LoadBalancerTlsCertificate) GoString() string {
+	return s.String()
+}
+
+// SetArn sets the Arn field's value.
+func (s *LoadBalancerTlsCertificate) SetArn(v string) *LoadBalancerTlsCertificate {
+	s.Arn = &v
+	return s
+}
+
+// SetCreatedAt sets the CreatedAt field's value.
+func (s *LoadBalancerTlsCertificate) SetCreatedAt(v time.Time) *LoadBalancerTlsCertificate {
+	s.CreatedAt = &v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *LoadBalancerTlsCertificate) SetDomainName(v string) *LoadBalancerTlsCertificate {
+	s.DomainName = &v
+	return s
+}
+
+// SetDomainValidationRecords sets the DomainValidationRecords field's value.
+func (s *LoadBalancerTlsCertificate) SetDomainValidationRecords(v []*LoadBalancerTlsCertificateDomainValidationRecord) *LoadBalancerTlsCertificate {
+	s.DomainValidationRecords = v
+	return s
+}
+
+// SetFailureReason sets the FailureReason field's value.
+func (s *LoadBalancerTlsCertificate) SetFailureReason(v string) *LoadBalancerTlsCertificate {
+	s.FailureReason = &v
+	return s
+}
+
+// SetIsAttached sets the IsAttached field's value.
+func (s *LoadBalancerTlsCertificate) SetIsAttached(v bool) *LoadBalancerTlsCertificate {
+	s.IsAttached = &v
+	return s
+}
+
+// SetIssuedAt sets the IssuedAt field's value.
+func (s *LoadBalancerTlsCertificate) SetIssuedAt(v time.Time) *LoadBalancerTlsCertificate {
+	s.IssuedAt = &v
+	return s
+}
+
+// SetIssuer sets the Issuer field's value.
+func (s *LoadBalancerTlsCertificate) SetIssuer(v string) *LoadBalancerTlsCertificate {
+	s.Issuer = &v
+	return s
+}
+
+// SetKeyAlgorithm sets the KeyAlgorithm field's value.
+func (s *LoadBalancerTlsCertificate) SetKeyAlgorithm(v string) *LoadBalancerTlsCertificate {
+	s.KeyAlgorithm = &v
+	return s
+}
+
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *LoadBalancerTlsCertificate) SetLoadBalancerName(v string) *LoadBalancerTlsCertificate {
+	s.LoadBalancerName = &v
+	return s
+}
+
+// SetLocation sets the Location field's value.
+func (s *LoadBalancerTlsCertificate) SetLocation(v *ResourceLocation) *LoadBalancerTlsCertificate {
+	s.Location = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *LoadBalancerTlsCertificate) SetName(v string) *LoadBalancerTlsCertificate {
+	s.Name = &v
+	return s
+}
+
+// SetNotAfter sets the NotAfter field's value.
+func (s *LoadBalancerTlsCertificate) SetNotAfter(v time.Time) *LoadBalancerTlsCertificate {
+	s.NotAfter = &v
+	return s
+}
+
+// SetNotBefore sets the NotBefore field's value.
+func (s *LoadBalancerTlsCertificate) SetNotBefore(v time.Time) *LoadBalancerTlsCertificate {
+	s.NotBefore = &v
+	return s
+}
+
+// SetRenewalSummary sets the RenewalSummary field's value.
+func (s *LoadBalancerTlsCertificate) SetRenewalSummary(v *LoadBalancerTlsCertificateRenewalSummary) *LoadBalancerTlsCertificate {
+	s.RenewalSummary = v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *LoadBalancerTlsCertificate) SetResourceType(v string) *LoadBalancerTlsCertificate {
+	s.ResourceType = &v
+	return s
+}
+
+// SetRevocationReason sets the RevocationReason field's value.
+func (s *LoadBalancerTlsCertificate) SetRevocationReason(v string) *LoadBalancerTlsCertificate {
+	s.RevocationReason = &v
+	return s
+}
+
+// SetRevokedAt sets the RevokedAt field's value.
+func (s *LoadBalancerTlsCertificate) SetRevokedAt(v time.Time) *LoadBalancerTlsCertificate {
+	s.RevokedAt = &v
+	return s
+}
+
+// SetSerial sets the Serial field's value.
+func (s *LoadBalancerTlsCertificate) SetSerial(v string) *LoadBalancerTlsCertificate {
+	s.Serial = &v
+	return s
+}
+
+// SetSignatureAlgorithm sets the SignatureAlgorithm field's value.
+func (s *LoadBalancerTlsCertificate) SetSignatureAlgorithm(v string) *LoadBalancerTlsCertificate {
+	s.SignatureAlgorithm = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *LoadBalancerTlsCertificate) SetStatus(v string) *LoadBalancerTlsCertificate {
+	s.Status = &v
+	return s
+}
+
+// SetSubject sets the Subject field's value.
+func (s *LoadBalancerTlsCertificate) SetSubject(v string) *LoadBalancerTlsCertificate {
+	s.Subject = &v
+	return s
+}
+
+// SetSubjectAlternativeNames sets the SubjectAlternativeNames field's value.
+func (s *LoadBalancerTlsCertificate) SetSubjectAlternativeNames(v []*string) *LoadBalancerTlsCertificate {
+	s.SubjectAlternativeNames = v
+	return s
+}
+
+// SetSupportCode sets the SupportCode field's value.
+func (s *LoadBalancerTlsCertificate) SetSupportCode(v string) *LoadBalancerTlsCertificate {
+	s.SupportCode = &v
+	return s
+}
+
+// Contains information about the domain names on a TLS/SSL certificate that
+// you will use to validate domain ownership.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/LoadBalancerTlsCertificateDomainValidationOption
+type LoadBalancerTlsCertificateDomainValidationOption struct {
+	_ struct{} `type:"structure"`
+
+	// A fully qualified domain name in the certificate request.
+	DomainName *string `locationName:"domainName" type:"string"`
+
+	// The status of the domain validation. Valid values are listed below.
+	ValidationStatus *string `locationName:"validationStatus" type:"string" enum:"LoadBalancerTlsCertificateDomainStatus"`
+}
+
+// String returns the string representation
+func (s LoadBalancerTlsCertificateDomainValidationOption) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s LoadBalancerTlsCertificateDomainValidationOption) GoString() string {
+	return s.String()
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *LoadBalancerTlsCertificateDomainValidationOption) SetDomainName(v string) *LoadBalancerTlsCertificateDomainValidationOption {
+	s.DomainName = &v
+	return s
+}
+
+// SetValidationStatus sets the ValidationStatus field's value.
+func (s *LoadBalancerTlsCertificateDomainValidationOption) SetValidationStatus(v string) *LoadBalancerTlsCertificateDomainValidationOption {
+	s.ValidationStatus = &v
+	return s
+}
+
+// Describes the validation record of each domain name in the TLS/SSL certificate.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/LoadBalancerTlsCertificateDomainValidationRecord
+type LoadBalancerTlsCertificateDomainValidationRecord struct {
+	_ struct{} `type:"structure"`
+
+	// The domain name against which your TLS/SSL certificate was validated.
+	DomainName *string `locationName:"domainName" type:"string"`
+
+	// A fully qualified domain name in the certificate. For example, example.com.
+	Name *string `locationName:"name" type:"string"`
+
+	// The type of validation record. For example, CNAME for domain validation.
+	Type *string `locationName:"type" type:"string"`
+
+	// The validation status. Valid values are listed below.
+	ValidationStatus *string `locationName:"validationStatus" type:"string" enum:"LoadBalancerTlsCertificateDomainStatus"`
+
+	// The value for that type.
+	Value *string `locationName:"value" type:"string"`
+}
+
+// String returns the string representation
+func (s LoadBalancerTlsCertificateDomainValidationRecord) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s LoadBalancerTlsCertificateDomainValidationRecord) GoString() string {
+	return s.String()
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *LoadBalancerTlsCertificateDomainValidationRecord) SetDomainName(v string) *LoadBalancerTlsCertificateDomainValidationRecord {
+	s.DomainName = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *LoadBalancerTlsCertificateDomainValidationRecord) SetName(v string) *LoadBalancerTlsCertificateDomainValidationRecord {
+	s.Name = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *LoadBalancerTlsCertificateDomainValidationRecord) SetType(v string) *LoadBalancerTlsCertificateDomainValidationRecord {
+	s.Type = &v
+	return s
+}
+
+// SetValidationStatus sets the ValidationStatus field's value.
+func (s *LoadBalancerTlsCertificateDomainValidationRecord) SetValidationStatus(v string) *LoadBalancerTlsCertificateDomainValidationRecord {
+	s.ValidationStatus = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *LoadBalancerTlsCertificateDomainValidationRecord) SetValue(v string) *LoadBalancerTlsCertificateDomainValidationRecord {
+	s.Value = &v
+	return s
+}
+
+// Contains information about the status of Lightsail's managed renewal for
+// the certificate.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/LoadBalancerTlsCertificateRenewalSummary
+type LoadBalancerTlsCertificateRenewalSummary struct {
+	_ struct{} `type:"structure"`
+
+	// Contains information about the validation of each domain name in the certificate,
+	// as it pertains to Lightsail's managed renewal. This is different from the
+	// initial validation that occurs as a result of the RequestCertificate request.
+	DomainValidationOptions []*LoadBalancerTlsCertificateDomainValidationOption `locationName:"domainValidationOptions" type:"list"`
+
+	// The status of Lightsail's managed renewal of the certificate. Valid values
+	// are listed below.
+	RenewalStatus *string `locationName:"renewalStatus" type:"string" enum:"LoadBalancerTlsCertificateRenewalStatus"`
+}
+
+// String returns the string representation
+func (s LoadBalancerTlsCertificateRenewalSummary) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s LoadBalancerTlsCertificateRenewalSummary) GoString() string {
+	return s.String()
+}
+
+// SetDomainValidationOptions sets the DomainValidationOptions field's value.
+func (s *LoadBalancerTlsCertificateRenewalSummary) SetDomainValidationOptions(v []*LoadBalancerTlsCertificateDomainValidationOption) *LoadBalancerTlsCertificateRenewalSummary {
+	s.DomainValidationOptions = v
+	return s
+}
+
+// SetRenewalStatus sets the RenewalStatus field's value.
+func (s *LoadBalancerTlsCertificateRenewalSummary) SetRenewalStatus(v string) *LoadBalancerTlsCertificateRenewalSummary {
+	s.RenewalStatus = &v
+	return s
+}
+
+// Provides a summary of TLS/SSL certificate metadata.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/LoadBalancerTlsCertificateSummary
+type LoadBalancerTlsCertificateSummary struct {
+	_ struct{} `type:"structure"`
+
+	// When true, the TLS/SSL certificate is attached to the Lightsail load balancer.
+	IsAttached *bool `locationName:"isAttached" type:"boolean"`
+
+	// The name of the TLS/SSL certificate.
+	Name *string `locationName:"name" type:"string"`
+}
+
+// String returns the string representation
+func (s LoadBalancerTlsCertificateSummary) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s LoadBalancerTlsCertificateSummary) GoString() string {
+	return s.String()
+}
+
+// SetIsAttached sets the IsAttached field's value.
+func (s *LoadBalancerTlsCertificateSummary) SetIsAttached(v bool) *LoadBalancerTlsCertificateSummary {
+	s.IsAttached = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *LoadBalancerTlsCertificateSummary) SetName(v string) *LoadBalancerTlsCertificateSummary {
+	s.Name = &v
 	return s
 }
 
@@ -12499,6 +15419,100 @@ func (s *UpdateDomainEntryOutput) SetOperations(v []*Operation) *UpdateDomainEnt
 	return s
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/UpdateLoadBalancerAttributeRequest
+type UpdateLoadBalancerAttributeInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the attribute you want to update. Valid values are below.
+	//
+	// AttributeName is a required field
+	AttributeName *string `locationName:"attributeName" type:"string" required:"true" enum:"LoadBalancerAttributeName"`
+
+	// The value that you want to specify for the attribute name.
+	//
+	// AttributeValue is a required field
+	AttributeValue *string `locationName:"attributeValue" min:"1" type:"string" required:"true"`
+
+	// The name of the load balancer that you want to modify.
+	//
+	// LoadBalancerName is a required field
+	LoadBalancerName *string `locationName:"loadBalancerName" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s UpdateLoadBalancerAttributeInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateLoadBalancerAttributeInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateLoadBalancerAttributeInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateLoadBalancerAttributeInput"}
+	if s.AttributeName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AttributeName"))
+	}
+	if s.AttributeValue == nil {
+		invalidParams.Add(request.NewErrParamRequired("AttributeValue"))
+	}
+	if s.AttributeValue != nil && len(*s.AttributeValue) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AttributeValue", 1))
+	}
+	if s.LoadBalancerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("LoadBalancerName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAttributeName sets the AttributeName field's value.
+func (s *UpdateLoadBalancerAttributeInput) SetAttributeName(v string) *UpdateLoadBalancerAttributeInput {
+	s.AttributeName = &v
+	return s
+}
+
+// SetAttributeValue sets the AttributeValue field's value.
+func (s *UpdateLoadBalancerAttributeInput) SetAttributeValue(v string) *UpdateLoadBalancerAttributeInput {
+	s.AttributeValue = &v
+	return s
+}
+
+// SetLoadBalancerName sets the LoadBalancerName field's value.
+func (s *UpdateLoadBalancerAttributeInput) SetLoadBalancerName(v string) *UpdateLoadBalancerAttributeInput {
+	s.LoadBalancerName = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/lightsail-2016-11-28/UpdateLoadBalancerAttributeResult
+type UpdateLoadBalancerAttributeOutput struct {
+	_ struct{} `type:"structure"`
+
+	// An object describing the API operations.
+	Operations []*Operation `locationName:"operations" type:"list"`
+}
+
+// String returns the string representation
+func (s UpdateLoadBalancerAttributeOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateLoadBalancerAttributeOutput) GoString() string {
+	return s.String()
+}
+
+// SetOperations sets the Operations field's value.
+func (s *UpdateLoadBalancerAttributeOutput) SetOperations(v []*Operation) *UpdateLoadBalancerAttributeOutput {
+	s.Operations = v
+	return s
+}
+
 const (
 	// AccessDirectionInbound is a AccessDirection enum value
 	AccessDirectionInbound = "inbound"
@@ -12555,6 +15569,61 @@ const (
 )
 
 const (
+	// InstanceHealthReasonLbRegistrationInProgress is a InstanceHealthReason enum value
+	InstanceHealthReasonLbRegistrationInProgress = "Lb.RegistrationInProgress"
+
+	// InstanceHealthReasonLbInitialHealthChecking is a InstanceHealthReason enum value
+	InstanceHealthReasonLbInitialHealthChecking = "Lb.InitialHealthChecking"
+
+	// InstanceHealthReasonLbInternalError is a InstanceHealthReason enum value
+	InstanceHealthReasonLbInternalError = "Lb.InternalError"
+
+	// InstanceHealthReasonInstanceResponseCodeMismatch is a InstanceHealthReason enum value
+	InstanceHealthReasonInstanceResponseCodeMismatch = "Instance.ResponseCodeMismatch"
+
+	// InstanceHealthReasonInstanceTimeout is a InstanceHealthReason enum value
+	InstanceHealthReasonInstanceTimeout = "Instance.Timeout"
+
+	// InstanceHealthReasonInstanceFailedHealthChecks is a InstanceHealthReason enum value
+	InstanceHealthReasonInstanceFailedHealthChecks = "Instance.FailedHealthChecks"
+
+	// InstanceHealthReasonInstanceNotRegistered is a InstanceHealthReason enum value
+	InstanceHealthReasonInstanceNotRegistered = "Instance.NotRegistered"
+
+	// InstanceHealthReasonInstanceNotInUse is a InstanceHealthReason enum value
+	InstanceHealthReasonInstanceNotInUse = "Instance.NotInUse"
+
+	// InstanceHealthReasonInstanceDeregistrationInProgress is a InstanceHealthReason enum value
+	InstanceHealthReasonInstanceDeregistrationInProgress = "Instance.DeregistrationInProgress"
+
+	// InstanceHealthReasonInstanceInvalidState is a InstanceHealthReason enum value
+	InstanceHealthReasonInstanceInvalidState = "Instance.InvalidState"
+
+	// InstanceHealthReasonInstanceIpUnusable is a InstanceHealthReason enum value
+	InstanceHealthReasonInstanceIpUnusable = "Instance.IpUnusable"
+)
+
+const (
+	// InstanceHealthStateInitial is a InstanceHealthState enum value
+	InstanceHealthStateInitial = "initial"
+
+	// InstanceHealthStateHealthy is a InstanceHealthState enum value
+	InstanceHealthStateHealthy = "healthy"
+
+	// InstanceHealthStateUnhealthy is a InstanceHealthState enum value
+	InstanceHealthStateUnhealthy = "unhealthy"
+
+	// InstanceHealthStateUnused is a InstanceHealthState enum value
+	InstanceHealthStateUnused = "unused"
+
+	// InstanceHealthStateDraining is a InstanceHealthState enum value
+	InstanceHealthStateDraining = "draining"
+
+	// InstanceHealthStateUnavailable is a InstanceHealthState enum value
+	InstanceHealthStateUnavailable = "unavailable"
+)
+
+const (
 	// InstanceMetricNameCpuutilization is a InstanceMetricName enum value
 	InstanceMetricNameCpuutilization = "CPUUtilization"
 
@@ -12591,6 +15660,180 @@ const (
 
 	// InstanceSnapshotStateAvailable is a InstanceSnapshotState enum value
 	InstanceSnapshotStateAvailable = "available"
+)
+
+const (
+	// LoadBalancerAttributeNameHealthCheckPath is a LoadBalancerAttributeName enum value
+	LoadBalancerAttributeNameHealthCheckPath = "HealthCheckPath"
+
+	// LoadBalancerAttributeNameSessionStickinessEnabled is a LoadBalancerAttributeName enum value
+	LoadBalancerAttributeNameSessionStickinessEnabled = "SessionStickinessEnabled"
+
+	// LoadBalancerAttributeNameSessionStickinessLbCookieDurationSeconds is a LoadBalancerAttributeName enum value
+	LoadBalancerAttributeNameSessionStickinessLbCookieDurationSeconds = "SessionStickiness_LB_CookieDurationSeconds"
+)
+
+const (
+	// LoadBalancerMetricNameClientTlsnegotiationErrorCount is a LoadBalancerMetricName enum value
+	LoadBalancerMetricNameClientTlsnegotiationErrorCount = "ClientTLSNegotiationErrorCount"
+
+	// LoadBalancerMetricNameHealthyHostCount is a LoadBalancerMetricName enum value
+	LoadBalancerMetricNameHealthyHostCount = "HealthyHostCount"
+
+	// LoadBalancerMetricNameUnhealthyHostCount is a LoadBalancerMetricName enum value
+	LoadBalancerMetricNameUnhealthyHostCount = "UnhealthyHostCount"
+
+	// LoadBalancerMetricNameHttpcodeLb4xxCount is a LoadBalancerMetricName enum value
+	LoadBalancerMetricNameHttpcodeLb4xxCount = "HTTPCode_LB_4XX_Count"
+
+	// LoadBalancerMetricNameHttpcodeLb5xxCount is a LoadBalancerMetricName enum value
+	LoadBalancerMetricNameHttpcodeLb5xxCount = "HTTPCode_LB_5XX_Count"
+
+	// LoadBalancerMetricNameHttpcodeInstance2xxCount is a LoadBalancerMetricName enum value
+	LoadBalancerMetricNameHttpcodeInstance2xxCount = "HTTPCode_Instance_2XX_Count"
+
+	// LoadBalancerMetricNameHttpcodeInstance3xxCount is a LoadBalancerMetricName enum value
+	LoadBalancerMetricNameHttpcodeInstance3xxCount = "HTTPCode_Instance_3XX_Count"
+
+	// LoadBalancerMetricNameHttpcodeInstance4xxCount is a LoadBalancerMetricName enum value
+	LoadBalancerMetricNameHttpcodeInstance4xxCount = "HTTPCode_Instance_4XX_Count"
+
+	// LoadBalancerMetricNameHttpcodeInstance5xxCount is a LoadBalancerMetricName enum value
+	LoadBalancerMetricNameHttpcodeInstance5xxCount = "HTTPCode_Instance_5XX_Count"
+
+	// LoadBalancerMetricNameInstanceResponseTime is a LoadBalancerMetricName enum value
+	LoadBalancerMetricNameInstanceResponseTime = "InstanceResponseTime"
+
+	// LoadBalancerMetricNameRejectedConnectionCount is a LoadBalancerMetricName enum value
+	LoadBalancerMetricNameRejectedConnectionCount = "RejectedConnectionCount"
+
+	// LoadBalancerMetricNameRequestCount is a LoadBalancerMetricName enum value
+	LoadBalancerMetricNameRequestCount = "RequestCount"
+)
+
+const (
+	// LoadBalancerProtocolHttpHttps is a LoadBalancerProtocol enum value
+	LoadBalancerProtocolHttpHttps = "HTTP_HTTPS"
+
+	// LoadBalancerProtocolHttp is a LoadBalancerProtocol enum value
+	LoadBalancerProtocolHttp = "HTTP"
+)
+
+const (
+	// LoadBalancerStateActive is a LoadBalancerState enum value
+	LoadBalancerStateActive = "active"
+
+	// LoadBalancerStateProvisioning is a LoadBalancerState enum value
+	LoadBalancerStateProvisioning = "provisioning"
+
+	// LoadBalancerStateActiveImpaired is a LoadBalancerState enum value
+	LoadBalancerStateActiveImpaired = "active_impaired"
+
+	// LoadBalancerStateFailed is a LoadBalancerState enum value
+	LoadBalancerStateFailed = "failed"
+
+	// LoadBalancerStateUnknown is a LoadBalancerState enum value
+	LoadBalancerStateUnknown = "unknown"
+)
+
+const (
+	// LoadBalancerTlsCertificateDomainStatusPendingValidation is a LoadBalancerTlsCertificateDomainStatus enum value
+	LoadBalancerTlsCertificateDomainStatusPendingValidation = "PENDING_VALIDATION"
+
+	// LoadBalancerTlsCertificateDomainStatusFailed is a LoadBalancerTlsCertificateDomainStatus enum value
+	LoadBalancerTlsCertificateDomainStatusFailed = "FAILED"
+
+	// LoadBalancerTlsCertificateDomainStatusSuccess is a LoadBalancerTlsCertificateDomainStatus enum value
+	LoadBalancerTlsCertificateDomainStatusSuccess = "SUCCESS"
+)
+
+const (
+	// LoadBalancerTlsCertificateFailureReasonNoAvailableContacts is a LoadBalancerTlsCertificateFailureReason enum value
+	LoadBalancerTlsCertificateFailureReasonNoAvailableContacts = "NO_AVAILABLE_CONTACTS"
+
+	// LoadBalancerTlsCertificateFailureReasonAdditionalVerificationRequired is a LoadBalancerTlsCertificateFailureReason enum value
+	LoadBalancerTlsCertificateFailureReasonAdditionalVerificationRequired = "ADDITIONAL_VERIFICATION_REQUIRED"
+
+	// LoadBalancerTlsCertificateFailureReasonDomainNotAllowed is a LoadBalancerTlsCertificateFailureReason enum value
+	LoadBalancerTlsCertificateFailureReasonDomainNotAllowed = "DOMAIN_NOT_ALLOWED"
+
+	// LoadBalancerTlsCertificateFailureReasonInvalidPublicDomain is a LoadBalancerTlsCertificateFailureReason enum value
+	LoadBalancerTlsCertificateFailureReasonInvalidPublicDomain = "INVALID_PUBLIC_DOMAIN"
+
+	// LoadBalancerTlsCertificateFailureReasonOther is a LoadBalancerTlsCertificateFailureReason enum value
+	LoadBalancerTlsCertificateFailureReasonOther = "OTHER"
+)
+
+const (
+	// LoadBalancerTlsCertificateRenewalStatusPendingAutoRenewal is a LoadBalancerTlsCertificateRenewalStatus enum value
+	LoadBalancerTlsCertificateRenewalStatusPendingAutoRenewal = "PENDING_AUTO_RENEWAL"
+
+	// LoadBalancerTlsCertificateRenewalStatusPendingValidation is a LoadBalancerTlsCertificateRenewalStatus enum value
+	LoadBalancerTlsCertificateRenewalStatusPendingValidation = "PENDING_VALIDATION"
+
+	// LoadBalancerTlsCertificateRenewalStatusSuccess is a LoadBalancerTlsCertificateRenewalStatus enum value
+	LoadBalancerTlsCertificateRenewalStatusSuccess = "SUCCESS"
+
+	// LoadBalancerTlsCertificateRenewalStatusFailed is a LoadBalancerTlsCertificateRenewalStatus enum value
+	LoadBalancerTlsCertificateRenewalStatusFailed = "FAILED"
+)
+
+const (
+	// LoadBalancerTlsCertificateRevocationReasonUnspecified is a LoadBalancerTlsCertificateRevocationReason enum value
+	LoadBalancerTlsCertificateRevocationReasonUnspecified = "UNSPECIFIED"
+
+	// LoadBalancerTlsCertificateRevocationReasonKeyCompromise is a LoadBalancerTlsCertificateRevocationReason enum value
+	LoadBalancerTlsCertificateRevocationReasonKeyCompromise = "KEY_COMPROMISE"
+
+	// LoadBalancerTlsCertificateRevocationReasonCaCompromise is a LoadBalancerTlsCertificateRevocationReason enum value
+	LoadBalancerTlsCertificateRevocationReasonCaCompromise = "CA_COMPROMISE"
+
+	// LoadBalancerTlsCertificateRevocationReasonAffiliationChanged is a LoadBalancerTlsCertificateRevocationReason enum value
+	LoadBalancerTlsCertificateRevocationReasonAffiliationChanged = "AFFILIATION_CHANGED"
+
+	// LoadBalancerTlsCertificateRevocationReasonSuperceded is a LoadBalancerTlsCertificateRevocationReason enum value
+	LoadBalancerTlsCertificateRevocationReasonSuperceded = "SUPERCEDED"
+
+	// LoadBalancerTlsCertificateRevocationReasonCessationOfOperation is a LoadBalancerTlsCertificateRevocationReason enum value
+	LoadBalancerTlsCertificateRevocationReasonCessationOfOperation = "CESSATION_OF_OPERATION"
+
+	// LoadBalancerTlsCertificateRevocationReasonCertificateHold is a LoadBalancerTlsCertificateRevocationReason enum value
+	LoadBalancerTlsCertificateRevocationReasonCertificateHold = "CERTIFICATE_HOLD"
+
+	// LoadBalancerTlsCertificateRevocationReasonRemoveFromCrl is a LoadBalancerTlsCertificateRevocationReason enum value
+	LoadBalancerTlsCertificateRevocationReasonRemoveFromCrl = "REMOVE_FROM_CRL"
+
+	// LoadBalancerTlsCertificateRevocationReasonPrivilegeWithdrawn is a LoadBalancerTlsCertificateRevocationReason enum value
+	LoadBalancerTlsCertificateRevocationReasonPrivilegeWithdrawn = "PRIVILEGE_WITHDRAWN"
+
+	// LoadBalancerTlsCertificateRevocationReasonAACompromise is a LoadBalancerTlsCertificateRevocationReason enum value
+	LoadBalancerTlsCertificateRevocationReasonAACompromise = "A_A_COMPROMISE"
+)
+
+const (
+	// LoadBalancerTlsCertificateStatusPendingValidation is a LoadBalancerTlsCertificateStatus enum value
+	LoadBalancerTlsCertificateStatusPendingValidation = "PENDING_VALIDATION"
+
+	// LoadBalancerTlsCertificateStatusIssued is a LoadBalancerTlsCertificateStatus enum value
+	LoadBalancerTlsCertificateStatusIssued = "ISSUED"
+
+	// LoadBalancerTlsCertificateStatusInactive is a LoadBalancerTlsCertificateStatus enum value
+	LoadBalancerTlsCertificateStatusInactive = "INACTIVE"
+
+	// LoadBalancerTlsCertificateStatusExpired is a LoadBalancerTlsCertificateStatus enum value
+	LoadBalancerTlsCertificateStatusExpired = "EXPIRED"
+
+	// LoadBalancerTlsCertificateStatusValidationTimedOut is a LoadBalancerTlsCertificateStatus enum value
+	LoadBalancerTlsCertificateStatusValidationTimedOut = "VALIDATION_TIMED_OUT"
+
+	// LoadBalancerTlsCertificateStatusRevoked is a LoadBalancerTlsCertificateStatus enum value
+	LoadBalancerTlsCertificateStatusRevoked = "REVOKED"
+
+	// LoadBalancerTlsCertificateStatusFailed is a LoadBalancerTlsCertificateStatus enum value
+	LoadBalancerTlsCertificateStatusFailed = "FAILED"
+
+	// LoadBalancerTlsCertificateStatusUnknown is a LoadBalancerTlsCertificateStatus enum value
+	LoadBalancerTlsCertificateStatusUnknown = "UNKNOWN"
 )
 
 const (
@@ -12776,6 +16019,30 @@ const (
 	// OperationTypeCreateInstancesFromSnapshot is a OperationType enum value
 	OperationTypeCreateInstancesFromSnapshot = "CreateInstancesFromSnapshot"
 
+	// OperationTypeCreateLoadBalancer is a OperationType enum value
+	OperationTypeCreateLoadBalancer = "CreateLoadBalancer"
+
+	// OperationTypeDeleteLoadBalancer is a OperationType enum value
+	OperationTypeDeleteLoadBalancer = "DeleteLoadBalancer"
+
+	// OperationTypeAttachInstancesToLoadBalancer is a OperationType enum value
+	OperationTypeAttachInstancesToLoadBalancer = "AttachInstancesToLoadBalancer"
+
+	// OperationTypeDetachInstancesFromLoadBalancer is a OperationType enum value
+	OperationTypeDetachInstancesFromLoadBalancer = "DetachInstancesFromLoadBalancer"
+
+	// OperationTypeUpdateLoadBalancerAttribute is a OperationType enum value
+	OperationTypeUpdateLoadBalancerAttribute = "UpdateLoadBalancerAttribute"
+
+	// OperationTypeCreateLoadBalancerTlsCertificate is a OperationType enum value
+	OperationTypeCreateLoadBalancerTlsCertificate = "CreateLoadBalancerTlsCertificate"
+
+	// OperationTypeDeleteLoadBalancerTlsCertificate is a OperationType enum value
+	OperationTypeDeleteLoadBalancerTlsCertificate = "DeleteLoadBalancerTlsCertificate"
+
+	// OperationTypeAttachLoadBalancerTlsCertificate is a OperationType enum value
+	OperationTypeAttachLoadBalancerTlsCertificate = "AttachLoadBalancerTlsCertificate"
+
 	// OperationTypeCreateDisk is a OperationType enum value
 	OperationTypeCreateDisk = "CreateDisk"
 
@@ -12867,6 +16134,12 @@ const (
 
 	// ResourceTypePeeredVpc is a ResourceType enum value
 	ResourceTypePeeredVpc = "PeeredVpc"
+
+	// ResourceTypeLoadBalancer is a ResourceType enum value
+	ResourceTypeLoadBalancer = "LoadBalancer"
+
+	// ResourceTypeLoadBalancerTlsCertificate is a ResourceType enum value
+	ResourceTypeLoadBalancerTlsCertificate = "LoadBalancerTlsCertificate"
 
 	// ResourceTypeDisk is a ResourceType enum value
 	ResourceTypeDisk = "Disk"

--- a/vendor/github.com/aws/aws-sdk-go/service/s3/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/s3/api.go
@@ -6986,6 +6986,140 @@ func (s *CORSRule) SetMaxAgeSeconds(v int64) *CORSRule {
 	return s
 }
 
+// Describes how a CSV-formatted input object is formatted.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CSVInput
+type CSVInput struct {
+	_ struct{} `type:"structure"`
+
+	// Single character used to indicate a row should be ignored when present at
+	// the start of a row.
+	Comments *string `type:"string"`
+
+	// Value used to separate individual fields in a record.
+	FieldDelimiter *string `type:"string"`
+
+	// Describes the first line of input. Valid values: None, Ignore, Use.
+	FileHeaderInfo *string `type:"string" enum:"FileHeaderInfo"`
+
+	// Value used for escaping where the field delimiter is part of the value.
+	QuoteCharacter *string `type:"string"`
+
+	// Single character used for escaping the quote character inside an already
+	// escaped value.
+	QuoteEscapeCharacter *string `type:"string"`
+
+	// Value used to separate individual records.
+	RecordDelimiter *string `type:"string"`
+}
+
+// String returns the string representation
+func (s CSVInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CSVInput) GoString() string {
+	return s.String()
+}
+
+// SetComments sets the Comments field's value.
+func (s *CSVInput) SetComments(v string) *CSVInput {
+	s.Comments = &v
+	return s
+}
+
+// SetFieldDelimiter sets the FieldDelimiter field's value.
+func (s *CSVInput) SetFieldDelimiter(v string) *CSVInput {
+	s.FieldDelimiter = &v
+	return s
+}
+
+// SetFileHeaderInfo sets the FileHeaderInfo field's value.
+func (s *CSVInput) SetFileHeaderInfo(v string) *CSVInput {
+	s.FileHeaderInfo = &v
+	return s
+}
+
+// SetQuoteCharacter sets the QuoteCharacter field's value.
+func (s *CSVInput) SetQuoteCharacter(v string) *CSVInput {
+	s.QuoteCharacter = &v
+	return s
+}
+
+// SetQuoteEscapeCharacter sets the QuoteEscapeCharacter field's value.
+func (s *CSVInput) SetQuoteEscapeCharacter(v string) *CSVInput {
+	s.QuoteEscapeCharacter = &v
+	return s
+}
+
+// SetRecordDelimiter sets the RecordDelimiter field's value.
+func (s *CSVInput) SetRecordDelimiter(v string) *CSVInput {
+	s.RecordDelimiter = &v
+	return s
+}
+
+// Describes how CSV-formatted results are formatted.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CSVOutput
+type CSVOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Value used to separate individual fields in a record.
+	FieldDelimiter *string `type:"string"`
+
+	// Value used for escaping where the field delimiter is part of the value.
+	QuoteCharacter *string `type:"string"`
+
+	// Single character used for escaping the quote character inside an already
+	// escaped value.
+	QuoteEscapeCharacter *string `type:"string"`
+
+	// Indicates whether or not all output fields should be quoted.
+	QuoteFields *string `type:"string" enum:"QuoteFields"`
+
+	// Value used to separate individual records.
+	RecordDelimiter *string `type:"string"`
+}
+
+// String returns the string representation
+func (s CSVOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CSVOutput) GoString() string {
+	return s.String()
+}
+
+// SetFieldDelimiter sets the FieldDelimiter field's value.
+func (s *CSVOutput) SetFieldDelimiter(v string) *CSVOutput {
+	s.FieldDelimiter = &v
+	return s
+}
+
+// SetQuoteCharacter sets the QuoteCharacter field's value.
+func (s *CSVOutput) SetQuoteCharacter(v string) *CSVOutput {
+	s.QuoteCharacter = &v
+	return s
+}
+
+// SetQuoteEscapeCharacter sets the QuoteEscapeCharacter field's value.
+func (s *CSVOutput) SetQuoteEscapeCharacter(v string) *CSVOutput {
+	s.QuoteEscapeCharacter = &v
+	return s
+}
+
+// SetQuoteFields sets the QuoteFields field's value.
+func (s *CSVOutput) SetQuoteFields(v string) *CSVOutput {
+	s.QuoteFields = &v
+	return s
+}
+
+// SetRecordDelimiter sets the RecordDelimiter field's value.
+func (s *CSVOutput) SetRecordDelimiter(v string) *CSVOutput {
+	s.RecordDelimiter = &v
+	return s
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CloudFunctionConfiguration
 type CloudFunctionConfiguration struct {
 	_ struct{} `type:"structure"`
@@ -9760,6 +9894,68 @@ func (s *Destination) SetEncryptionConfiguration(v *EncryptionConfiguration) *De
 // SetStorageClass sets the StorageClass field's value.
 func (s *Destination) SetStorageClass(v string) *Destination {
 	s.StorageClass = &v
+	return s
+}
+
+// Describes the server-side encryption that will be applied to the restore
+// results.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/Encryption
+type Encryption struct {
+	_ struct{} `type:"structure"`
+
+	// The server-side encryption algorithm used when storing job results in Amazon
+	// S3 (e.g., AES256, aws:kms).
+	//
+	// EncryptionType is a required field
+	EncryptionType *string `type:"string" required:"true" enum:"ServerSideEncryption"`
+
+	// If the encryption type is aws:kms, this optional value can be used to specify
+	// the encryption context for the restore results.
+	KMSContext *string `type:"string"`
+
+	// If the encryption type is aws:kms, this optional value specifies the AWS
+	// KMS key ID to use for encryption of job results.
+	KMSKeyId *string `type:"string"`
+}
+
+// String returns the string representation
+func (s Encryption) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s Encryption) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Encryption) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Encryption"}
+	if s.EncryptionType == nil {
+		invalidParams.Add(request.NewErrParamRequired("EncryptionType"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetEncryptionType sets the EncryptionType field's value.
+func (s *Encryption) SetEncryptionType(v string) *Encryption {
+	s.EncryptionType = &v
+	return s
+}
+
+// SetKMSContext sets the KMSContext field's value.
+func (s *Encryption) SetKMSContext(v string) *Encryption {
+	s.KMSContext = &v
+	return s
+}
+
+// SetKMSKeyId sets the KMSKeyId field's value.
+func (s *Encryption) SetKMSKeyId(v string) *Encryption {
+	s.KMSKeyId = &v
 	return s
 }
 
@@ -12786,6 +12982,31 @@ func (s *Initiator) SetID(v string) *Initiator {
 	return s
 }
 
+// Describes the serialization format of the object.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/InputSerialization
+type InputSerialization struct {
+	_ struct{} `type:"structure"`
+
+	// Describes the serialization of a CSV-encoded object.
+	CSV *CSVInput `type:"structure"`
+}
+
+// String returns the string representation
+func (s InputSerialization) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s InputSerialization) GoString() string {
+	return s.String()
+}
+
+// SetCSV sets the CSV field's value.
+func (s *InputSerialization) SetCSV(v *CSVInput) *InputSerialization {
+	s.CSV = v
+	return s
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/InventoryConfiguration
 type InventoryConfiguration struct {
 	_ struct{} `type:"structure"`
@@ -15203,6 +15424,135 @@ func (s *ListPartsOutput) SetUploadId(v string) *ListPartsOutput {
 	return s
 }
 
+// Describes an S3 location that will receive the results of the restore request.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/S3Location
+type Location struct {
+	_ struct{} `type:"structure"`
+
+	// A list of grants that control access to the staged results.
+	AccessControlList []*Grant `locationNameList:"Grant" type:"list"`
+
+	// The name of the bucket where the restore results will be placed.
+	//
+	// BucketName is a required field
+	BucketName *string `type:"string" required:"true"`
+
+	// The canned ACL to apply to the restore results.
+	CannedACL *string `type:"string" enum:"ObjectCannedACL"`
+
+	// Describes the server-side encryption that will be applied to the restore
+	// results.
+	Encryption *Encryption `type:"structure"`
+
+	// The prefix that is prepended to the restore results for this request.
+	//
+	// Prefix is a required field
+	Prefix *string `type:"string" required:"true"`
+
+	// The class of storage used to store the restore results.
+	StorageClass *string `type:"string" enum:"StorageClass"`
+
+	// The tag-set that is applied to the restore results.
+	Tagging *Tagging `type:"structure"`
+
+	// A list of metadata to store with the restore results in S3.
+	UserMetadata []*MetadataEntry `locationNameList:"MetadataEntry" type:"list"`
+}
+
+// String returns the string representation
+func (s Location) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s Location) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Location) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Location"}
+	if s.BucketName == nil {
+		invalidParams.Add(request.NewErrParamRequired("BucketName"))
+	}
+	if s.Prefix == nil {
+		invalidParams.Add(request.NewErrParamRequired("Prefix"))
+	}
+	if s.AccessControlList != nil {
+		for i, v := range s.AccessControlList {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "AccessControlList", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.Encryption != nil {
+		if err := s.Encryption.Validate(); err != nil {
+			invalidParams.AddNested("Encryption", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Tagging != nil {
+		if err := s.Tagging.Validate(); err != nil {
+			invalidParams.AddNested("Tagging", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAccessControlList sets the AccessControlList field's value.
+func (s *Location) SetAccessControlList(v []*Grant) *Location {
+	s.AccessControlList = v
+	return s
+}
+
+// SetBucketName sets the BucketName field's value.
+func (s *Location) SetBucketName(v string) *Location {
+	s.BucketName = &v
+	return s
+}
+
+// SetCannedACL sets the CannedACL field's value.
+func (s *Location) SetCannedACL(v string) *Location {
+	s.CannedACL = &v
+	return s
+}
+
+// SetEncryption sets the Encryption field's value.
+func (s *Location) SetEncryption(v *Encryption) *Location {
+	s.Encryption = v
+	return s
+}
+
+// SetPrefix sets the Prefix field's value.
+func (s *Location) SetPrefix(v string) *Location {
+	s.Prefix = &v
+	return s
+}
+
+// SetStorageClass sets the StorageClass field's value.
+func (s *Location) SetStorageClass(v string) *Location {
+	s.StorageClass = &v
+	return s
+}
+
+// SetTagging sets the Tagging field's value.
+func (s *Location) SetTagging(v *Tagging) *Location {
+	s.Tagging = v
+	return s
+}
+
+// SetUserMetadata sets the UserMetadata field's value.
+func (s *Location) SetUserMetadata(v []*MetadataEntry) *Location {
+	s.UserMetadata = v
+	return s
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/LoggingEnabled
 type LoggingEnabled struct {
 	_ struct{} `type:"structure"`
@@ -15267,6 +15617,38 @@ func (s *LoggingEnabled) SetTargetGrants(v []*TargetGrant) *LoggingEnabled {
 // SetTargetPrefix sets the TargetPrefix field's value.
 func (s *LoggingEnabled) SetTargetPrefix(v string) *LoggingEnabled {
 	s.TargetPrefix = &v
+	return s
+}
+
+// A metadata key-value pair to store with an object.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/MetadataEntry
+type MetadataEntry struct {
+	_ struct{} `type:"structure"`
+
+	Name *string `type:"string"`
+
+	Value *string `type:"string"`
+}
+
+// String returns the string representation
+func (s MetadataEntry) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s MetadataEntry) GoString() string {
+	return s.String()
+}
+
+// SetName sets the Name field's value.
+func (s *MetadataEntry) SetName(v string) *MetadataEntry {
+	s.Name = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *MetadataEntry) SetValue(v string) *MetadataEntry {
+	s.Value = &v
 	return s
 }
 
@@ -15927,6 +16309,71 @@ func (s *ObjectVersion) SetStorageClass(v string) *ObjectVersion {
 // SetVersionId sets the VersionId field's value.
 func (s *ObjectVersion) SetVersionId(v string) *ObjectVersion {
 	s.VersionId = &v
+	return s
+}
+
+// Describes the location where the restore job's output is stored.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/OutputLocation
+type OutputLocation struct {
+	_ struct{} `type:"structure"`
+
+	// Describes an S3 location that will receive the results of the restore request.
+	S3 *Location `type:"structure"`
+}
+
+// String returns the string representation
+func (s OutputLocation) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s OutputLocation) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *OutputLocation) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "OutputLocation"}
+	if s.S3 != nil {
+		if err := s.S3.Validate(); err != nil {
+			invalidParams.AddNested("S3", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetS3 sets the S3 field's value.
+func (s *OutputLocation) SetS3(v *Location) *OutputLocation {
+	s.S3 = v
+	return s
+}
+
+// Describes how results of the Select job are serialized.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/OutputSerialization
+type OutputSerialization struct {
+	_ struct{} `type:"structure"`
+
+	// Describes the serialization of CSV-encoded Select results.
+	CSV *CSVOutput `type:"structure"`
+}
+
+// String returns the string representation
+func (s OutputSerialization) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s OutputSerialization) GoString() string {
+	return s.String()
+}
+
+// SetCSV sets the CSV field's value.
+func (s *OutputSerialization) SetCSV(v *CSVOutput) *OutputSerialization {
+	s.CSV = v
 	return s
 }
 
@@ -18637,6 +19084,7 @@ type RestoreObjectInput struct {
 	// at http://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html
 	RequestPayer *string `location:"header" locationName:"x-amz-request-payer" type:"string" enum:"RequestPayer"`
 
+	// Container for restore job parameters.
 	RestoreRequest *RestoreRequest `locationName:"RestoreRequest" type:"structure" xmlURI:"http://s3.amazonaws.com/doc/2006-03-01/"`
 
 	VersionId *string `location:"querystring" locationName:"versionId" type:"string"`
@@ -18720,6 +19168,10 @@ type RestoreObjectOutput struct {
 	// If present, indicates that the requester was successfully charged for the
 	// request.
 	RequestCharged *string `location:"header" locationName:"x-amz-request-charged" type:"string" enum:"RequestCharged"`
+
+	// Indicates the path in the provided S3 output location where Select results
+	// will be restored to.
+	RestoreOutputPath *string `location:"header" locationName:"x-amz-restore-output-path" type:"string"`
 }
 
 // String returns the string representation
@@ -18738,17 +19190,39 @@ func (s *RestoreObjectOutput) SetRequestCharged(v string) *RestoreObjectOutput {
 	return s
 }
 
+// SetRestoreOutputPath sets the RestoreOutputPath field's value.
+func (s *RestoreObjectOutput) SetRestoreOutputPath(v string) *RestoreObjectOutput {
+	s.RestoreOutputPath = &v
+	return s
+}
+
+// Container for restore job parameters.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/RestoreRequest
 type RestoreRequest struct {
 	_ struct{} `type:"structure"`
 
-	// Lifetime of the active copy in days
-	//
-	// Days is a required field
-	Days *int64 `type:"integer" required:"true"`
+	// Lifetime of the active copy in days. Do not use with restores that specify
+	// OutputLocation.
+	Days *int64 `type:"integer"`
 
-	// Glacier related prameters pertaining to this job.
+	// The optional description for the job.
+	Description *string `type:"string"`
+
+	// Glacier related parameters pertaining to this job. Do not use with restores
+	// that specify OutputLocation.
 	GlacierJobParameters *GlacierJobParameters `type:"structure"`
+
+	// Describes the location where the restore job's output is stored.
+	OutputLocation *OutputLocation `type:"structure"`
+
+	// Describes the parameters for Select job types.
+	SelectParameters *SelectParameters `type:"structure"`
+
+	// Glacier retrieval tier at which the restore will be processed.
+	Tier *string `type:"string" enum:"Tier"`
+
+	// Type of restore request.
+	Type *string `type:"string" enum:"RestoreRequestType"`
 }
 
 // String returns the string representation
@@ -18764,12 +19238,19 @@ func (s RestoreRequest) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *RestoreRequest) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "RestoreRequest"}
-	if s.Days == nil {
-		invalidParams.Add(request.NewErrParamRequired("Days"))
-	}
 	if s.GlacierJobParameters != nil {
 		if err := s.GlacierJobParameters.Validate(); err != nil {
 			invalidParams.AddNested("GlacierJobParameters", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.OutputLocation != nil {
+		if err := s.OutputLocation.Validate(); err != nil {
+			invalidParams.AddNested("OutputLocation", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.SelectParameters != nil {
+		if err := s.SelectParameters.Validate(); err != nil {
+			invalidParams.AddNested("SelectParameters", err.(request.ErrInvalidParams))
 		}
 	}
 
@@ -18785,9 +19266,39 @@ func (s *RestoreRequest) SetDays(v int64) *RestoreRequest {
 	return s
 }
 
+// SetDescription sets the Description field's value.
+func (s *RestoreRequest) SetDescription(v string) *RestoreRequest {
+	s.Description = &v
+	return s
+}
+
 // SetGlacierJobParameters sets the GlacierJobParameters field's value.
 func (s *RestoreRequest) SetGlacierJobParameters(v *GlacierJobParameters) *RestoreRequest {
 	s.GlacierJobParameters = v
+	return s
+}
+
+// SetOutputLocation sets the OutputLocation field's value.
+func (s *RestoreRequest) SetOutputLocation(v *OutputLocation) *RestoreRequest {
+	s.OutputLocation = v
+	return s
+}
+
+// SetSelectParameters sets the SelectParameters field's value.
+func (s *RestoreRequest) SetSelectParameters(v *SelectParameters) *RestoreRequest {
+	s.SelectParameters = v
+	return s
+}
+
+// SetTier sets the Tier field's value.
+func (s *RestoreRequest) SetTier(v string) *RestoreRequest {
+	s.Tier = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *RestoreRequest) SetType(v string) *RestoreRequest {
+	s.Type = &v
 	return s
 }
 
@@ -19014,6 +19525,88 @@ func (s SSES3) String() string {
 // GoString returns the string representation
 func (s SSES3) GoString() string {
 	return s.String()
+}
+
+// Describes the parameters for Select job types.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/SelectParameters
+type SelectParameters struct {
+	_ struct{} `type:"structure"`
+
+	// The expression that is used to query the object.
+	//
+	// Expression is a required field
+	Expression *string `type:"string" required:"true"`
+
+	// The type of the provided expression (e.g., SQL).
+	//
+	// ExpressionType is a required field
+	ExpressionType *string `type:"string" required:"true" enum:"ExpressionType"`
+
+	// Describes the serialization format of the object.
+	//
+	// InputSerialization is a required field
+	InputSerialization *InputSerialization `type:"structure" required:"true"`
+
+	// Describes how the results of the Select job are serialized.
+	//
+	// OutputSerialization is a required field
+	OutputSerialization *OutputSerialization `type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s SelectParameters) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SelectParameters) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SelectParameters) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SelectParameters"}
+	if s.Expression == nil {
+		invalidParams.Add(request.NewErrParamRequired("Expression"))
+	}
+	if s.ExpressionType == nil {
+		invalidParams.Add(request.NewErrParamRequired("ExpressionType"))
+	}
+	if s.InputSerialization == nil {
+		invalidParams.Add(request.NewErrParamRequired("InputSerialization"))
+	}
+	if s.OutputSerialization == nil {
+		invalidParams.Add(request.NewErrParamRequired("OutputSerialization"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetExpression sets the Expression field's value.
+func (s *SelectParameters) SetExpression(v string) *SelectParameters {
+	s.Expression = &v
+	return s
+}
+
+// SetExpressionType sets the ExpressionType field's value.
+func (s *SelectParameters) SetExpressionType(v string) *SelectParameters {
+	s.ExpressionType = &v
+	return s
+}
+
+// SetInputSerialization sets the InputSerialization field's value.
+func (s *SelectParameters) SetInputSerialization(v *InputSerialization) *SelectParameters {
+	s.InputSerialization = v
+	return s
+}
+
+// SetOutputSerialization sets the OutputSerialization field's value.
+func (s *SelectParameters) SetOutputSerialization(v *OutputSerialization) *SelectParameters {
+	s.OutputSerialization = v
+	return s
 }
 
 // Describes the default server-side encryption to apply to new objects in the
@@ -20488,6 +21081,22 @@ const (
 )
 
 const (
+	// ExpressionTypeSql is a ExpressionType enum value
+	ExpressionTypeSql = "SQL"
+)
+
+const (
+	// FileHeaderInfoUse is a FileHeaderInfo enum value
+	FileHeaderInfoUse = "USE"
+
+	// FileHeaderInfoIgnore is a FileHeaderInfo enum value
+	FileHeaderInfoIgnore = "IGNORE"
+
+	// FileHeaderInfoNone is a FileHeaderInfo enum value
+	FileHeaderInfoNone = "NONE"
+)
+
+const (
 	// FilterRuleNamePrefix is a FilterRuleName enum value
 	FilterRuleNamePrefix = "prefix"
 
@@ -20644,6 +21253,14 @@ const (
 )
 
 const (
+	// QuoteFieldsAlways is a QuoteFields enum value
+	QuoteFieldsAlways = "ALWAYS"
+
+	// QuoteFieldsAsneeded is a QuoteFields enum value
+	QuoteFieldsAsneeded = "ASNEEDED"
+)
+
+const (
 	// ReplicationRuleStatusEnabled is a ReplicationRuleStatus enum value
 	ReplicationRuleStatusEnabled = "Enabled"
 
@@ -20679,6 +21296,11 @@ const (
 const (
 	// RequestPayerRequester is a RequestPayer enum value
 	RequestPayerRequester = "requester"
+)
+
+const (
+	// RestoreRequestTypeSelect is a RestoreRequestType enum value
+	RestoreRequestTypeSelect = "SELECT"
 )
 
 const (

--- a/vendor/github.com/aws/aws-sdk-go/service/ssm/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ssm/api.go
@@ -2301,6 +2301,12 @@ func (c *SSM) DescribeAutomationExecutionsRequest(input *DescribeAutomationExecu
 // API operation DescribeAutomationExecutions for usage and error information.
 //
 // Returned Error Codes:
+//   * ErrCodeInvalidFilterKey "InvalidFilterKey"
+//   The specified key is not valid.
+//
+//   * ErrCodeInvalidFilterValue "InvalidFilterValue"
+//   The filter value is not valid. Verify the value and try again.
+//
 //   * ErrCodeInvalidNextToken "InvalidNextToken"
 //   The specified token is not valid.
 //
@@ -2324,6 +2330,99 @@ func (c *SSM) DescribeAutomationExecutions(input *DescribeAutomationExecutionsIn
 // for more information on using Contexts.
 func (c *SSM) DescribeAutomationExecutionsWithContext(ctx aws.Context, input *DescribeAutomationExecutionsInput, opts ...request.Option) (*DescribeAutomationExecutionsOutput, error) {
 	req, out := c.DescribeAutomationExecutionsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDescribeAutomationStepExecutions = "DescribeAutomationStepExecutions"
+
+// DescribeAutomationStepExecutionsRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeAutomationStepExecutions operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeAutomationStepExecutions for more information on using the DescribeAutomationStepExecutions
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeAutomationStepExecutionsRequest method.
+//    req, resp := client.DescribeAutomationStepExecutionsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/DescribeAutomationStepExecutions
+func (c *SSM) DescribeAutomationStepExecutionsRequest(input *DescribeAutomationStepExecutionsInput) (req *request.Request, output *DescribeAutomationStepExecutionsOutput) {
+	op := &request.Operation{
+		Name:       opDescribeAutomationStepExecutions,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DescribeAutomationStepExecutionsInput{}
+	}
+
+	output = &DescribeAutomationStepExecutionsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeAutomationStepExecutions API operation for Amazon Simple Systems Manager (SSM).
+//
+// Information about all active and terminated step executions in an Automation
+// workflow.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Simple Systems Manager (SSM)'s
+// API operation DescribeAutomationStepExecutions for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeAutomationExecutionNotFoundException "AutomationExecutionNotFoundException"
+//   There is no automation execution information for the requested automation
+//   execution ID.
+//
+//   * ErrCodeInvalidNextToken "InvalidNextToken"
+//   The specified token is not valid.
+//
+//   * ErrCodeInvalidFilterKey "InvalidFilterKey"
+//   The specified key is not valid.
+//
+//   * ErrCodeInvalidFilterValue "InvalidFilterValue"
+//   The filter value is not valid. Verify the value and try again.
+//
+//   * ErrCodeInternalServerError "InternalServerError"
+//   An error occurred on the server side.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/DescribeAutomationStepExecutions
+func (c *SSM) DescribeAutomationStepExecutions(input *DescribeAutomationStepExecutionsInput) (*DescribeAutomationStepExecutionsOutput, error) {
+	req, out := c.DescribeAutomationStepExecutionsRequest(input)
+	return out, req.Send()
+}
+
+// DescribeAutomationStepExecutionsWithContext is the same as DescribeAutomationStepExecutions with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeAutomationStepExecutions for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *SSM) DescribeAutomationStepExecutionsWithContext(ctx aws.Context, input *DescribeAutomationStepExecutionsInput, opts ...request.Option) (*DescribeAutomationStepExecutionsOutput, error) {
+	req, out := c.DescribeAutomationStepExecutionsRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -8157,6 +8256,10 @@ func (c *SSM) SendAutomationSignalRequest(input *SendAutomationSignalInput) (req
 //   There is no automation execution information for the requested automation
 //   execution ID.
 //
+//   * ErrCodeAutomationStepNotFoundException "AutomationStepNotFoundException"
+//   The specified step name and execution ID don't exist. Verify the information
+//   and try again.
+//
 //   * ErrCodeInvalidAutomationSignalException "InvalidAutomationSignalException"
 //   The signal is not valid for the current Automation execution.
 //
@@ -8283,7 +8386,7 @@ func (c *SSM) SendCommandRequest(input *SendCommandInput) (req *request.Request,
 //   an IAM role for notifications that includes the required trust policy. For
 //   information about configuring the IAM role for Run Command notifications,
 //   see Configuring Amazon SNS Notifications for Run Command (http://docs.aws.amazon.com/systems-manager/latest/userguide/rc-sns-notifications.html)
-//   in the Amazon EC2 Systems Manager User Guide.
+//   in the AWS Systems Manager User Guide.
 //
 //   * ErrCodeInvalidNotificationConfig "InvalidNotificationConfig"
 //   One or more configuration items is not valid. Verify that a valid Amazon
@@ -8384,6 +8487,10 @@ func (c *SSM) StartAutomationExecutionRequest(input *StartAutomationExecutionInp
 //   Error returned when an idempotent operation is retried and the parameters
 //   don't match the original call to the API with the same idempotency token.
 //
+//   * ErrCodeInvalidTarget "InvalidTarget"
+//   The target is not valid or does not exist. It might not be configured for
+//   EC2 Systems Manager or you might not have permission to perform the operation.
+//
 //   * ErrCodeInternalServerError "InternalServerError"
 //   An error occurred on the server side.
 //
@@ -8466,6 +8573,9 @@ func (c *SSM) StopAutomationExecutionRequest(input *StopAutomationExecutionInput
 //   * ErrCodeAutomationExecutionNotFoundException "AutomationExecutionNotFoundException"
 //   There is no automation execution information for the requested automation
 //   execution ID.
+//
+//   * ErrCodeInvalidAutomationStatusUpdateException "InvalidAutomationStatusUpdateException"
+//   The specified update status operation is not valid.
 //
 //   * ErrCodeInternalServerError "InternalServerError"
 //   An error occurred on the server side.
@@ -10145,11 +10255,20 @@ type AutomationExecution struct {
 	// The execution status of the Automation.
 	AutomationExecutionStatus *string `type:"string" enum:"AutomationExecutionStatus"`
 
+	// The action of the currently executing step.
+	CurrentAction *string `type:"string"`
+
+	// The name of the currently executing step.
+	CurrentStepName *string `type:"string"`
+
 	// The name of the Automation document used during the execution.
 	DocumentName *string `type:"string"`
 
 	// The version of the document to use during execution.
 	DocumentVersion *string `type:"string"`
+
+	// The Amazon Resource Name (ARN) of the user who executed the automation.
+	ExecutedBy *string `type:"string"`
 
 	// The time the execution finished.
 	ExecutionEndTime *time.Time `type:"timestamp" timestampFormat:"unix"`
@@ -10161,6 +10280,15 @@ type AutomationExecution struct {
 	// Failed.
 	FailureMessage *string `type:"string"`
 
+	// The MaxConcurrency value specified by the user when the execution started.
+	MaxConcurrency *string `min:"1" type:"string"`
+
+	// The MaxErrors value specified by the user when the execution started.
+	MaxErrors *string `min:"1" type:"string"`
+
+	// The automation execution mode.
+	Mode *string `type:"string" enum:"ExecutionMode"`
+
 	// The list of execution outputs as defined in the automation document.
 	Outputs map[string][]*string `min:"1" type:"map"`
 
@@ -10168,9 +10296,29 @@ type AutomationExecution struct {
 	// StartAutomationExecution.
 	Parameters map[string][]*string `min:"1" type:"map"`
 
+	// The AutomationExecutionId of the parent automation.
+	ParentAutomationExecutionId *string `min:"36" type:"string"`
+
+	// A list of resolved targets in the rate control execution.
+	ResolvedTargets *ResolvedTargets `type:"structure"`
+
 	// A list of details about the current state of all steps that comprise an execution.
 	// An Automation document contains a list of steps that are executed in order.
 	StepExecutions []*StepExecution `type:"list"`
+
+	// A boolean value that indicates if the response contains the full list of
+	// the Automation step executions. If true, use the DescribeAutomationStepExecutions
+	// API action to get the full list of step executions.
+	StepExecutionsTruncated *bool `type:"boolean"`
+
+	// The target of the execution.
+	Target *string `type:"string"`
+
+	// The parameter name.
+	TargetParameterName *string `min:"1" type:"string"`
+
+	// The specified targets.
+	Targets []*Target `type:"list"`
 }
 
 // String returns the string representation
@@ -10195,6 +10343,18 @@ func (s *AutomationExecution) SetAutomationExecutionStatus(v string) *Automation
 	return s
 }
 
+// SetCurrentAction sets the CurrentAction field's value.
+func (s *AutomationExecution) SetCurrentAction(v string) *AutomationExecution {
+	s.CurrentAction = &v
+	return s
+}
+
+// SetCurrentStepName sets the CurrentStepName field's value.
+func (s *AutomationExecution) SetCurrentStepName(v string) *AutomationExecution {
+	s.CurrentStepName = &v
+	return s
+}
+
 // SetDocumentName sets the DocumentName field's value.
 func (s *AutomationExecution) SetDocumentName(v string) *AutomationExecution {
 	s.DocumentName = &v
@@ -10204,6 +10364,12 @@ func (s *AutomationExecution) SetDocumentName(v string) *AutomationExecution {
 // SetDocumentVersion sets the DocumentVersion field's value.
 func (s *AutomationExecution) SetDocumentVersion(v string) *AutomationExecution {
 	s.DocumentVersion = &v
+	return s
+}
+
+// SetExecutedBy sets the ExecutedBy field's value.
+func (s *AutomationExecution) SetExecutedBy(v string) *AutomationExecution {
+	s.ExecutedBy = &v
 	return s
 }
 
@@ -10225,6 +10391,24 @@ func (s *AutomationExecution) SetFailureMessage(v string) *AutomationExecution {
 	return s
 }
 
+// SetMaxConcurrency sets the MaxConcurrency field's value.
+func (s *AutomationExecution) SetMaxConcurrency(v string) *AutomationExecution {
+	s.MaxConcurrency = &v
+	return s
+}
+
+// SetMaxErrors sets the MaxErrors field's value.
+func (s *AutomationExecution) SetMaxErrors(v string) *AutomationExecution {
+	s.MaxErrors = &v
+	return s
+}
+
+// SetMode sets the Mode field's value.
+func (s *AutomationExecution) SetMode(v string) *AutomationExecution {
+	s.Mode = &v
+	return s
+}
+
 // SetOutputs sets the Outputs field's value.
 func (s *AutomationExecution) SetOutputs(v map[string][]*string) *AutomationExecution {
 	s.Outputs = v
@@ -10237,9 +10421,45 @@ func (s *AutomationExecution) SetParameters(v map[string][]*string) *AutomationE
 	return s
 }
 
+// SetParentAutomationExecutionId sets the ParentAutomationExecutionId field's value.
+func (s *AutomationExecution) SetParentAutomationExecutionId(v string) *AutomationExecution {
+	s.ParentAutomationExecutionId = &v
+	return s
+}
+
+// SetResolvedTargets sets the ResolvedTargets field's value.
+func (s *AutomationExecution) SetResolvedTargets(v *ResolvedTargets) *AutomationExecution {
+	s.ResolvedTargets = v
+	return s
+}
+
 // SetStepExecutions sets the StepExecutions field's value.
 func (s *AutomationExecution) SetStepExecutions(v []*StepExecution) *AutomationExecution {
 	s.StepExecutions = v
+	return s
+}
+
+// SetStepExecutionsTruncated sets the StepExecutionsTruncated field's value.
+func (s *AutomationExecution) SetStepExecutionsTruncated(v bool) *AutomationExecution {
+	s.StepExecutionsTruncated = &v
+	return s
+}
+
+// SetTarget sets the Target field's value.
+func (s *AutomationExecution) SetTarget(v string) *AutomationExecution {
+	s.Target = &v
+	return s
+}
+
+// SetTargetParameterName sets the TargetParameterName field's value.
+func (s *AutomationExecution) SetTargetParameterName(v string) *AutomationExecution {
+	s.TargetParameterName = &v
+	return s
+}
+
+// SetTargets sets the Targets field's value.
+func (s *AutomationExecution) SetTargets(v []*Target) *AutomationExecution {
+	s.Targets = v
 	return s
 }
 
@@ -10249,7 +10469,9 @@ func (s *AutomationExecution) SetStepExecutions(v []*StepExecution) *AutomationE
 type AutomationExecutionFilter struct {
 	_ struct{} `type:"structure"`
 
-	// The aspect of the Automation execution information that should be limited.
+	// One or more keys to limit the results. Valid filter keys include the following:
+	// DocumentNamePrefix, ExecutionStatus, ExecutionId, ParentExecutionId, CurrentAction,
+	// StartTimeBefore, StartTimeAfter.
 	//
 	// Key is a required field
 	Key *string `type:"string" required:"true" enum:"AutomationExecutionFilterKey"`
@@ -10314,6 +10536,12 @@ type AutomationExecutionMetadata struct {
 	// Timed out, or Cancelled.
 	AutomationExecutionStatus *string `type:"string" enum:"AutomationExecutionStatus"`
 
+	// The action of the currently executing step.
+	CurrentAction *string `type:"string"`
+
+	// The name of the currently executing step.
+	CurrentStepName *string `type:"string"`
+
 	// The name of the Automation document used during execution.
 	DocumentName *string `type:"string"`
 
@@ -10330,11 +10558,38 @@ type AutomationExecutionMetadata struct {
 	// The time the execution started.>
 	ExecutionStartTime *time.Time `type:"timestamp" timestampFormat:"unix"`
 
+	// The list of execution outputs as defined in the Automation document.
+	FailureMessage *string `type:"string"`
+
 	// An Amazon S3 bucket where execution information is stored.
 	LogFile *string `type:"string"`
 
+	// The MaxConcurrency value specified by the user when starting the Automation.
+	MaxConcurrency *string `min:"1" type:"string"`
+
+	// The MaxErrors value specified by the user when starting the Automation.
+	MaxErrors *string `min:"1" type:"string"`
+
+	// The Automation execution mode.
+	Mode *string `type:"string" enum:"ExecutionMode"`
+
 	// The list of execution outputs as defined in the Automation document.
 	Outputs map[string][]*string `min:"1" type:"map"`
+
+	// The ExecutionId of the parent Automation.
+	ParentAutomationExecutionId *string `min:"36" type:"string"`
+
+	// A list of targets that resolved during the execution.
+	ResolvedTargets *ResolvedTargets `type:"structure"`
+
+	// The list of execution outputs as defined in the Automation document.
+	Target *string `type:"string"`
+
+	// The list of execution outputs as defined in the Automation document.
+	TargetParameterName *string `min:"1" type:"string"`
+
+	// The targets defined by the user when starting the Automation.
+	Targets []*Target `type:"list"`
 }
 
 // String returns the string representation
@@ -10356,6 +10611,18 @@ func (s *AutomationExecutionMetadata) SetAutomationExecutionId(v string) *Automa
 // SetAutomationExecutionStatus sets the AutomationExecutionStatus field's value.
 func (s *AutomationExecutionMetadata) SetAutomationExecutionStatus(v string) *AutomationExecutionMetadata {
 	s.AutomationExecutionStatus = &v
+	return s
+}
+
+// SetCurrentAction sets the CurrentAction field's value.
+func (s *AutomationExecutionMetadata) SetCurrentAction(v string) *AutomationExecutionMetadata {
+	s.CurrentAction = &v
+	return s
+}
+
+// SetCurrentStepName sets the CurrentStepName field's value.
+func (s *AutomationExecutionMetadata) SetCurrentStepName(v string) *AutomationExecutionMetadata {
+	s.CurrentStepName = &v
 	return s
 }
 
@@ -10389,15 +10656,69 @@ func (s *AutomationExecutionMetadata) SetExecutionStartTime(v time.Time) *Automa
 	return s
 }
 
+// SetFailureMessage sets the FailureMessage field's value.
+func (s *AutomationExecutionMetadata) SetFailureMessage(v string) *AutomationExecutionMetadata {
+	s.FailureMessage = &v
+	return s
+}
+
 // SetLogFile sets the LogFile field's value.
 func (s *AutomationExecutionMetadata) SetLogFile(v string) *AutomationExecutionMetadata {
 	s.LogFile = &v
 	return s
 }
 
+// SetMaxConcurrency sets the MaxConcurrency field's value.
+func (s *AutomationExecutionMetadata) SetMaxConcurrency(v string) *AutomationExecutionMetadata {
+	s.MaxConcurrency = &v
+	return s
+}
+
+// SetMaxErrors sets the MaxErrors field's value.
+func (s *AutomationExecutionMetadata) SetMaxErrors(v string) *AutomationExecutionMetadata {
+	s.MaxErrors = &v
+	return s
+}
+
+// SetMode sets the Mode field's value.
+func (s *AutomationExecutionMetadata) SetMode(v string) *AutomationExecutionMetadata {
+	s.Mode = &v
+	return s
+}
+
 // SetOutputs sets the Outputs field's value.
 func (s *AutomationExecutionMetadata) SetOutputs(v map[string][]*string) *AutomationExecutionMetadata {
 	s.Outputs = v
+	return s
+}
+
+// SetParentAutomationExecutionId sets the ParentAutomationExecutionId field's value.
+func (s *AutomationExecutionMetadata) SetParentAutomationExecutionId(v string) *AutomationExecutionMetadata {
+	s.ParentAutomationExecutionId = &v
+	return s
+}
+
+// SetResolvedTargets sets the ResolvedTargets field's value.
+func (s *AutomationExecutionMetadata) SetResolvedTargets(v *ResolvedTargets) *AutomationExecutionMetadata {
+	s.ResolvedTargets = v
+	return s
+}
+
+// SetTarget sets the Target field's value.
+func (s *AutomationExecutionMetadata) SetTarget(v string) *AutomationExecutionMetadata {
+	s.Target = &v
+	return s
+}
+
+// SetTargetParameterName sets the TargetParameterName field's value.
+func (s *AutomationExecutionMetadata) SetTargetParameterName(v string) *AutomationExecutionMetadata {
+	s.TargetParameterName = &v
+	return s
+}
+
+// SetTargets sets the Targets field's value.
+func (s *AutomationExecutionMetadata) SetTargets(v []*Target) *AutomationExecutionMetadata {
+	s.Targets = v
 	return s
 }
 
@@ -12037,10 +12358,14 @@ func (s *CreateAssociationOutput) SetAssociationDescription(v *AssociationDescri
 type CreateDocumentInput struct {
 	_ struct{} `type:"structure"`
 
-	// A valid JSON string.
+	// A valid JSON or YAML string.
 	//
 	// Content is a required field
 	Content *string `min:"1" type:"string" required:"true"`
+
+	// Specify the document format for the request. The document format can be either
+	// JSON or YAML. JSON is the default format.
+	DocumentFormat *string `type:"string" enum:"DocumentFormat"`
 
 	// The type of document to create. Valid document types include: Policy, Automation,
 	// and Command.
@@ -12050,6 +12375,15 @@ type CreateDocumentInput struct {
 	//
 	// Name is a required field
 	Name *string `type:"string" required:"true"`
+
+	// Specify a target type to define the kinds of resources the document can run
+	// on. For example, to run a document on EC2 instances, specify the following
+	// value: /AWS::EC2::Instance. If you specify a value of '/' the document can
+	// run on all types of resources. If you don't specify a value, the document
+	// can't run on any resources. For a list of valid resource types, see AWS Resource
+	// Types Reference (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html)
+	// in the AWS CloudFormation User Guide.
+	TargetType *string `type:"string"`
 }
 
 // String returns the string representation
@@ -12087,6 +12421,12 @@ func (s *CreateDocumentInput) SetContent(v string) *CreateDocumentInput {
 	return s
 }
 
+// SetDocumentFormat sets the DocumentFormat field's value.
+func (s *CreateDocumentInput) SetDocumentFormat(v string) *CreateDocumentInput {
+	s.DocumentFormat = &v
+	return s
+}
+
 // SetDocumentType sets the DocumentType field's value.
 func (s *CreateDocumentInput) SetDocumentType(v string) *CreateDocumentInput {
 	s.DocumentType = &v
@@ -12096,6 +12436,12 @@ func (s *CreateDocumentInput) SetDocumentType(v string) *CreateDocumentInput {
 // SetName sets the Name field's value.
 func (s *CreateDocumentInput) SetName(v string) *CreateDocumentInput {
 	s.Name = &v
+	return s
+}
+
+// SetTargetType sets the TargetType field's value.
+func (s *CreateDocumentInput) SetTargetType(v string) *CreateDocumentInput {
+	s.TargetType = &v
 	return s
 }
 
@@ -13652,6 +13998,139 @@ func (s *DescribeAutomationExecutionsOutput) SetAutomationExecutionMetadataList(
 // SetNextToken sets the NextToken field's value.
 func (s *DescribeAutomationExecutionsOutput) SetNextToken(v string) *DescribeAutomationExecutionsOutput {
 	s.NextToken = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/DescribeAutomationStepExecutionsRequest
+type DescribeAutomationStepExecutionsInput struct {
+	_ struct{} `type:"structure"`
+
+	// The Automation execution ID for which you want step execution descriptions.
+	//
+	// AutomationExecutionId is a required field
+	AutomationExecutionId *string `min:"36" type:"string" required:"true"`
+
+	// One or more filters to limit the number of step executions returned by the
+	// request.
+	Filters []*StepExecutionFilter `min:"1" type:"list"`
+
+	// The maximum number of items to return for this call. The call also returns
+	// a token that you can specify in a subsequent call to get the next set of
+	// results.
+	MaxResults *int64 `min:"1" type:"integer"`
+
+	// The token for the next set of items to return. (You received this token from
+	// a previous call.)
+	NextToken *string `type:"string"`
+
+	// A boolean that indicates whether to list step executions in reverse order
+	// by start time. The default value is false.
+	ReverseOrder *bool `type:"boolean"`
+}
+
+// String returns the string representation
+func (s DescribeAutomationStepExecutionsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAutomationStepExecutionsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeAutomationStepExecutionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeAutomationStepExecutionsInput"}
+	if s.AutomationExecutionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AutomationExecutionId"))
+	}
+	if s.AutomationExecutionId != nil && len(*s.AutomationExecutionId) < 36 {
+		invalidParams.Add(request.NewErrParamMinLen("AutomationExecutionId", 36))
+	}
+	if s.Filters != nil && len(s.Filters) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Filters", 1))
+	}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+	if s.Filters != nil {
+		for i, v := range s.Filters {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Filters", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAutomationExecutionId sets the AutomationExecutionId field's value.
+func (s *DescribeAutomationStepExecutionsInput) SetAutomationExecutionId(v string) *DescribeAutomationStepExecutionsInput {
+	s.AutomationExecutionId = &v
+	return s
+}
+
+// SetFilters sets the Filters field's value.
+func (s *DescribeAutomationStepExecutionsInput) SetFilters(v []*StepExecutionFilter) *DescribeAutomationStepExecutionsInput {
+	s.Filters = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeAutomationStepExecutionsInput) SetMaxResults(v int64) *DescribeAutomationStepExecutionsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeAutomationStepExecutionsInput) SetNextToken(v string) *DescribeAutomationStepExecutionsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetReverseOrder sets the ReverseOrder field's value.
+func (s *DescribeAutomationStepExecutionsInput) SetReverseOrder(v bool) *DescribeAutomationStepExecutionsInput {
+	s.ReverseOrder = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/DescribeAutomationStepExecutionsResult
+type DescribeAutomationStepExecutionsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The token to use when requesting the next set of items. If there are no additional
+	// items to return, the string is empty.
+	NextToken *string `type:"string"`
+
+	// A list of details about the current state of all steps that make up an execution.
+	StepExecutions []*StepExecution `type:"list"`
+}
+
+// String returns the string representation
+func (s DescribeAutomationStepExecutionsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAutomationStepExecutionsOutput) GoString() string {
+	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeAutomationStepExecutionsOutput) SetNextToken(v string) *DescribeAutomationStepExecutionsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetStepExecutions sets the StepExecutions field's value.
+func (s *DescribeAutomationStepExecutionsOutput) SetStepExecutions(v []*StepExecution) *DescribeAutomationStepExecutionsOutput {
+	s.StepExecutions = v
 	return s
 }
 
@@ -15891,6 +16370,9 @@ type DocumentDescription struct {
 	// A description of the document.
 	Description *string `type:"string"`
 
+	// The document format, either JSON or YAML.
+	DocumentFormat *string `type:"string" enum:"DocumentFormat"`
+
 	// The type of document.
 	DocumentType *string `type:"string" enum:"DocumentType"`
 
@@ -15933,6 +16415,12 @@ type DocumentDescription struct {
 
 	// The tags, or metadata, that have been applied to the document.
 	Tags []*Tag `type:"list"`
+
+	// The target type which defines the kinds of resources the document can run
+	// on. For example, /AWS::EC2::Instance. For a list of valid resource types,
+	// see AWS Resource Types Reference (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html)
+	// in the AWS CloudFormation User Guide.
+	TargetType *string `type:"string"`
 }
 
 // String returns the string representation
@@ -15960,6 +16448,12 @@ func (s *DocumentDescription) SetDefaultVersion(v string) *DocumentDescription {
 // SetDescription sets the Description field's value.
 func (s *DocumentDescription) SetDescription(v string) *DocumentDescription {
 	s.Description = &v
+	return s
+}
+
+// SetDocumentFormat sets the DocumentFormat field's value.
+func (s *DocumentDescription) SetDocumentFormat(v string) *DocumentDescription {
+	s.DocumentFormat = &v
 	return s
 }
 
@@ -16041,6 +16535,12 @@ func (s *DocumentDescription) SetTags(v []*Tag) *DocumentDescription {
 	return s
 }
 
+// SetTargetType sets the TargetType field's value.
+func (s *DocumentDescription) SetTargetType(v string) *DocumentDescription {
+	s.TargetType = &v
+	return s
+}
+
 // Describes a filter.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/DocumentFilter
 type DocumentFilter struct {
@@ -16103,6 +16603,9 @@ func (s *DocumentFilter) SetValue(v string) *DocumentFilter {
 type DocumentIdentifier struct {
 	_ struct{} `type:"structure"`
 
+	// The document format, either JSON or YAML.
+	DocumentFormat *string `type:"string" enum:"DocumentFormat"`
+
 	// The document type.
 	DocumentType *string `type:"string" enum:"DocumentType"`
 
@@ -16123,6 +16626,12 @@ type DocumentIdentifier struct {
 
 	// The tags, or metadata, that have been applied to the document.
 	Tags []*Tag `type:"list"`
+
+	// The target type which defines the kinds of resources the document can run
+	// on. For example, /AWS::EC2::Instance. For a list of valid resource types,
+	// see AWS Resource Types Reference (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html)
+	// in the AWS CloudFormation User Guide.
+	TargetType *string `type:"string"`
 }
 
 // String returns the string representation
@@ -16133,6 +16642,12 @@ func (s DocumentIdentifier) String() string {
 // GoString returns the string representation
 func (s DocumentIdentifier) GoString() string {
 	return s.String()
+}
+
+// SetDocumentFormat sets the DocumentFormat field's value.
+func (s *DocumentIdentifier) SetDocumentFormat(v string) *DocumentIdentifier {
+	s.DocumentFormat = &v
+	return s
 }
 
 // SetDocumentType sets the DocumentType field's value.
@@ -16174,6 +16689,12 @@ func (s *DocumentIdentifier) SetSchemaVersion(v string) *DocumentIdentifier {
 // SetTags sets the Tags field's value.
 func (s *DocumentIdentifier) SetTags(v []*Tag) *DocumentIdentifier {
 	s.Tags = v
+	return s
+}
+
+// SetTargetType sets the TargetType field's value.
+func (s *DocumentIdentifier) SetTargetType(v string) *DocumentIdentifier {
+	s.TargetType = &v
 	return s
 }
 
@@ -16311,6 +16832,9 @@ type DocumentVersionInfo struct {
 	// The date the document was created.
 	CreatedDate *time.Time `type:"timestamp" timestampFormat:"unix"`
 
+	// The document format, either JSON or YAML.
+	DocumentFormat *string `type:"string" enum:"DocumentFormat"`
+
 	// The document version.
 	DocumentVersion *string `type:"string"`
 
@@ -16334,6 +16858,12 @@ func (s DocumentVersionInfo) GoString() string {
 // SetCreatedDate sets the CreatedDate field's value.
 func (s *DocumentVersionInfo) SetCreatedDate(v time.Time) *DocumentVersionInfo {
 	s.CreatedDate = &v
+	return s
+}
+
+// SetDocumentFormat sets the DocumentFormat field's value.
+func (s *DocumentVersionInfo) SetDocumentFormat(v string) *DocumentVersionInfo {
+	s.DocumentFormat = &v
 	return s
 }
 
@@ -17014,6 +17544,10 @@ func (s *GetDeployablePatchSnapshotForInstanceOutput) SetSnapshotId(v string) *G
 type GetDocumentInput struct {
 	_ struct{} `type:"structure"`
 
+	// Returns the document in the specified format. The document format can be
+	// either JSON or YAML. JSON is the default format.
+	DocumentFormat *string `type:"string" enum:"DocumentFormat"`
+
 	// The document version for which you want information.
 	DocumentVersion *string `type:"string"`
 
@@ -17046,6 +17580,12 @@ func (s *GetDocumentInput) Validate() error {
 	return nil
 }
 
+// SetDocumentFormat sets the DocumentFormat field's value.
+func (s *GetDocumentInput) SetDocumentFormat(v string) *GetDocumentInput {
+	s.DocumentFormat = &v
+	return s
+}
+
 // SetDocumentVersion sets the DocumentVersion field's value.
 func (s *GetDocumentInput) SetDocumentVersion(v string) *GetDocumentInput {
 	s.DocumentVersion = &v
@@ -17064,6 +17604,9 @@ type GetDocumentOutput struct {
 
 	// The contents of the Systems Manager document.
 	Content *string `min:"1" type:"string"`
+
+	// The document format, either JSON or YAML.
+	DocumentFormat *string `type:"string" enum:"DocumentFormat"`
 
 	// The document type.
 	DocumentType *string `type:"string" enum:"DocumentType"`
@@ -17088,6 +17631,12 @@ func (s GetDocumentOutput) GoString() string {
 // SetContent sets the Content field's value.
 func (s *GetDocumentOutput) SetContent(v string) *GetDocumentOutput {
 	s.Content = &v
+	return s
+}
+
+// SetDocumentFormat sets the DocumentFormat field's value.
+func (s *GetDocumentOutput) SetDocumentFormat(v string) *GetDocumentOutput {
+	s.DocumentFormat = &v
 	return s
 }
 
@@ -20071,7 +20620,7 @@ func (s *InventoryItemSchema) SetVersion(v string) *InventoryItemSchema {
 type InventoryResultEntity struct {
 	_ struct{} `type:"structure"`
 
-	// The data section in the inventory result entity json.
+	// The data section in the inventory result entity JSON.
 	Data map[string]*InventoryResultItem `type:"map"`
 
 	// ID of the inventory result entity. For example, for managed instance inventory
@@ -22746,7 +23295,7 @@ type NotificationConfig struct {
 	// include the following: All (events), InProgress, Success, TimedOut, Cancelled,
 	// Failed. To learn more about these events, see Setting Up Events and Notifications
 	// (http://docs.aws.amazon.com/systems-manager/latest/userguide/monitor-commands.html)
-	// in the Amazon EC2 Systems Manager User Guide.
+	// in the AWS Systems Manager User Guide.
 	NotificationEvents []*string `type:"list"`
 
 	// Command: Receive notification when the status of a command changes. Invocation:
@@ -24823,6 +25372,41 @@ func (s RemoveTagsFromResourceOutput) GoString() string {
 	return s.String()
 }
 
+// Information about targets that resolved during the Automation execution.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/ResolvedTargets
+type ResolvedTargets struct {
+	_ struct{} `type:"structure"`
+
+	// A list of parameter values sent to targets that resolved during the Automation
+	// execution.
+	ParameterValues []*string `type:"list"`
+
+	// A boolean value indicating whether the resolved target list is truncated.
+	Truncated *bool `type:"boolean"`
+}
+
+// String returns the string representation
+func (s ResolvedTargets) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ResolvedTargets) GoString() string {
+	return s.String()
+}
+
+// SetParameterValues sets the ParameterValues field's value.
+func (s *ResolvedTargets) SetParameterValues(v []*string) *ResolvedTargets {
+	s.ParameterValues = v
+	return s
+}
+
+// SetTruncated sets the Truncated field's value.
+func (s *ResolvedTargets) SetTruncated(v bool) *ResolvedTargets {
+	s.Truncated = &v
+	return s
+}
+
 // Compliance summary information for a specific resource.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/ResourceComplianceSummaryItem
 type ResourceComplianceSummaryItem struct {
@@ -25638,9 +26222,41 @@ type StartAutomationExecutionInput struct {
 	// The version of the Automation document to use for this execution.
 	DocumentVersion *string `type:"string"`
 
+	// The maximum number of targets allowed to run this task in parallel. You can
+	// specify a number, such as 10, or a percentage, such as 10%. The default value
+	// is 10.
+	MaxConcurrency *string `min:"1" type:"string"`
+
+	// The number of errors that are allowed before the system stops running the
+	// automation on additional targets. You can specify either an absolute number
+	// of errors, for example 10, or a percentage of the target set, for example
+	// 10%. If you specify 3, for example, the system stops running the automation
+	// when the fourth error is received. If you specify 0, then the system stops
+	// running the automation on additional targets after the first error result
+	// is returned. If you run an automation on 50 resources and set max-errors
+	// to 10%, then the system stops running the automation on additional targets
+	// when the sixth error is received.
+	//
+	// Executions that are already running an automation when max-errors is reached
+	// are allowed to complete, but some of these executions may fail as well. If
+	// you need to ensure that there won't be more than max-errors failed executions,
+	// set max-concurrency to 1 so the executions proceed one at a time.
+	MaxErrors *string `min:"1" type:"string"`
+
+	// The execution mode of the automation. Valid modes include the following:
+	// Auto and Interactive. The default mode is Auto.
+	Mode *string `type:"string" enum:"ExecutionMode"`
+
 	// A key-value map of execution parameters, which match the declared parameters
 	// in the Automation document.
 	Parameters map[string][]*string `min:"1" type:"map"`
+
+	// The name of the parameter used as the target resource for the rate-controlled
+	// execution. Required if you specify Targets.
+	TargetParameterName *string `min:"1" type:"string"`
+
+	// A key-value mapping to target resources. Required if you specify TargetParameterName.
+	Targets []*Target `type:"list"`
 }
 
 // String returns the string representation
@@ -25662,8 +26278,27 @@ func (s *StartAutomationExecutionInput) Validate() error {
 	if s.DocumentName == nil {
 		invalidParams.Add(request.NewErrParamRequired("DocumentName"))
 	}
+	if s.MaxConcurrency != nil && len(*s.MaxConcurrency) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("MaxConcurrency", 1))
+	}
+	if s.MaxErrors != nil && len(*s.MaxErrors) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("MaxErrors", 1))
+	}
 	if s.Parameters != nil && len(s.Parameters) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("Parameters", 1))
+	}
+	if s.TargetParameterName != nil && len(*s.TargetParameterName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TargetParameterName", 1))
+	}
+	if s.Targets != nil {
+		for i, v := range s.Targets {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Targets", i), err.(request.ErrInvalidParams))
+			}
+		}
 	}
 
 	if invalidParams.Len() > 0 {
@@ -25690,9 +26325,39 @@ func (s *StartAutomationExecutionInput) SetDocumentVersion(v string) *StartAutom
 	return s
 }
 
+// SetMaxConcurrency sets the MaxConcurrency field's value.
+func (s *StartAutomationExecutionInput) SetMaxConcurrency(v string) *StartAutomationExecutionInput {
+	s.MaxConcurrency = &v
+	return s
+}
+
+// SetMaxErrors sets the MaxErrors field's value.
+func (s *StartAutomationExecutionInput) SetMaxErrors(v string) *StartAutomationExecutionInput {
+	s.MaxErrors = &v
+	return s
+}
+
+// SetMode sets the Mode field's value.
+func (s *StartAutomationExecutionInput) SetMode(v string) *StartAutomationExecutionInput {
+	s.Mode = &v
+	return s
+}
+
 // SetParameters sets the Parameters field's value.
 func (s *StartAutomationExecutionInput) SetParameters(v map[string][]*string) *StartAutomationExecutionInput {
 	s.Parameters = v
+	return s
+}
+
+// SetTargetParameterName sets the TargetParameterName field's value.
+func (s *StartAutomationExecutionInput) SetTargetParameterName(v string) *StartAutomationExecutionInput {
+	s.TargetParameterName = &v
+	return s
+}
+
+// SetTargets sets the Targets field's value.
+func (s *StartAutomationExecutionInput) SetTargets(v []*Target) *StartAutomationExecutionInput {
+	s.Targets = v
 	return s
 }
 
@@ -25746,8 +26411,18 @@ type StepExecution struct {
 	// Fully-resolved values passed into the step before execution.
 	Inputs map[string]*string `type:"map"`
 
+	// The maximum number of tries to run the action of the step. The default value
+	// is 1.
+	MaxAttempts *int64 `type:"integer"`
+
+	// The action to take if the step fails. The default value is Abort.
+	OnFailure *string `type:"string"`
+
 	// Returned values from the execution of the step.
 	Outputs map[string][]*string `min:"1" type:"map"`
+
+	// A user-specified list of parameters to override when executing a step.
+	OverriddenParameters map[string][]*string `min:"1" type:"map"`
 
 	// A message associated with the response code for an execution.
 	Response *string `type:"string"`
@@ -25755,12 +26430,18 @@ type StepExecution struct {
 	// The response code returned by the execution of the step.
 	ResponseCode *string `type:"string"`
 
+	// The unique ID of a step execution.
+	StepExecutionId *string `type:"string"`
+
 	// The name of this execution step.
 	StepName *string `type:"string"`
 
 	// The execution status for this step. Valid values include: Pending, InProgress,
 	// Success, Cancelled, Failed, and TimedOut.
 	StepStatus *string `type:"string" enum:"AutomationExecutionStatus"`
+
+	// The timeout seconds of the step.
+	TimeoutSeconds *int64 `type:"long"`
 }
 
 // String returns the string representation
@@ -25809,9 +26490,27 @@ func (s *StepExecution) SetInputs(v map[string]*string) *StepExecution {
 	return s
 }
 
+// SetMaxAttempts sets the MaxAttempts field's value.
+func (s *StepExecution) SetMaxAttempts(v int64) *StepExecution {
+	s.MaxAttempts = &v
+	return s
+}
+
+// SetOnFailure sets the OnFailure field's value.
+func (s *StepExecution) SetOnFailure(v string) *StepExecution {
+	s.OnFailure = &v
+	return s
+}
+
 // SetOutputs sets the Outputs field's value.
 func (s *StepExecution) SetOutputs(v map[string][]*string) *StepExecution {
 	s.Outputs = v
+	return s
+}
+
+// SetOverriddenParameters sets the OverriddenParameters field's value.
+func (s *StepExecution) SetOverriddenParameters(v map[string][]*string) *StepExecution {
+	s.OverriddenParameters = v
 	return s
 }
 
@@ -25827,6 +26526,12 @@ func (s *StepExecution) SetResponseCode(v string) *StepExecution {
 	return s
 }
 
+// SetStepExecutionId sets the StepExecutionId field's value.
+func (s *StepExecution) SetStepExecutionId(v string) *StepExecution {
+	s.StepExecutionId = &v
+	return s
+}
+
 // SetStepName sets the StepName field's value.
 func (s *StepExecution) SetStepName(v string) *StepExecution {
 	s.StepName = &v
@@ -25839,6 +26544,72 @@ func (s *StepExecution) SetStepStatus(v string) *StepExecution {
 	return s
 }
 
+// SetTimeoutSeconds sets the TimeoutSeconds field's value.
+func (s *StepExecution) SetTimeoutSeconds(v int64) *StepExecution {
+	s.TimeoutSeconds = &v
+	return s
+}
+
+// A filter to limit the amount of step execution information returned by the
+// call.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/StepExecutionFilter
+type StepExecutionFilter struct {
+	_ struct{} `type:"structure"`
+
+	// One or more keys to limit the results. Valid filter keys include the following:
+	// StepName, Action, StepExecutionId, StepExecutionStatus, StartTimeBefore,
+	// StartTimeAfter.
+	//
+	// Key is a required field
+	Key *string `type:"string" required:"true" enum:"StepExecutionFilterKey"`
+
+	// The values of the filter key.
+	//
+	// Values is a required field
+	Values []*string `min:"1" type:"list" required:"true"`
+}
+
+// String returns the string representation
+func (s StepExecutionFilter) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s StepExecutionFilter) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StepExecutionFilter) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StepExecutionFilter"}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Values == nil {
+		invalidParams.Add(request.NewErrParamRequired("Values"))
+	}
+	if s.Values != nil && len(s.Values) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Values", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetKey sets the Key field's value.
+func (s *StepExecutionFilter) SetKey(v string) *StepExecutionFilter {
+	s.Key = &v
+	return s
+}
+
+// SetValues sets the Values field's value.
+func (s *StepExecutionFilter) SetValues(v []*string) *StepExecutionFilter {
+	s.Values = v
+	return s
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/StopAutomationExecutionRequest
 type StopAutomationExecutionInput struct {
 	_ struct{} `type:"structure"`
@@ -25847,6 +26618,10 @@ type StopAutomationExecutionInput struct {
 	//
 	// AutomationExecutionId is a required field
 	AutomationExecutionId *string `min:"36" type:"string" required:"true"`
+
+	// The stop request type. Valid types include the following: Cancel and Complete.
+	// The default type is Cancel.
+	Type *string `type:"string" enum:"StopType"`
 }
 
 // String returns the string representation
@@ -25878,6 +26653,12 @@ func (s *StopAutomationExecutionInput) Validate() error {
 // SetAutomationExecutionId sets the AutomationExecutionId field's value.
 func (s *StopAutomationExecutionInput) SetAutomationExecutionId(v string) *StopAutomationExecutionInput {
 	s.AutomationExecutionId = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *StopAutomationExecutionInput) SetType(v string) *StopAutomationExecutionInput {
+	s.Type = &v
 	return s
 }
 
@@ -26354,6 +27135,10 @@ type UpdateDocumentInput struct {
 	// Content is a required field
 	Content *string `min:"1" type:"string" required:"true"`
 
+	// Specify the document format for the new document version. Systems Manager
+	// supports JSON and YAML documents. JSON is the default format.
+	DocumentFormat *string `type:"string" enum:"DocumentFormat"`
+
 	// The version of the document that you want to update.
 	DocumentVersion *string `type:"string"`
 
@@ -26361,6 +27146,9 @@ type UpdateDocumentInput struct {
 	//
 	// Name is a required field
 	Name *string `type:"string" required:"true"`
+
+	// Specify a new target type for the document.
+	TargetType *string `type:"string"`
 }
 
 // String returns the string representation
@@ -26398,6 +27186,12 @@ func (s *UpdateDocumentInput) SetContent(v string) *UpdateDocumentInput {
 	return s
 }
 
+// SetDocumentFormat sets the DocumentFormat field's value.
+func (s *UpdateDocumentInput) SetDocumentFormat(v string) *UpdateDocumentInput {
+	s.DocumentFormat = &v
+	return s
+}
+
 // SetDocumentVersion sets the DocumentVersion field's value.
 func (s *UpdateDocumentInput) SetDocumentVersion(v string) *UpdateDocumentInput {
 	s.DocumentVersion = &v
@@ -26407,6 +27201,12 @@ func (s *UpdateDocumentInput) SetDocumentVersion(v string) *UpdateDocumentInput 
 // SetName sets the Name field's value.
 func (s *UpdateDocumentInput) SetName(v string) *UpdateDocumentInput {
 	s.Name = &v
+	return s
+}
+
+// SetTargetType sets the TargetType field's value.
+func (s *UpdateDocumentInput) SetTargetType(v string) *UpdateDocumentInput {
+	s.TargetType = &v
 	return s
 }
 
@@ -27539,6 +28339,21 @@ const (
 
 	// AutomationExecutionFilterKeyExecutionStatus is a AutomationExecutionFilterKey enum value
 	AutomationExecutionFilterKeyExecutionStatus = "ExecutionStatus"
+
+	// AutomationExecutionFilterKeyExecutionId is a AutomationExecutionFilterKey enum value
+	AutomationExecutionFilterKeyExecutionId = "ExecutionId"
+
+	// AutomationExecutionFilterKeyParentExecutionId is a AutomationExecutionFilterKey enum value
+	AutomationExecutionFilterKeyParentExecutionId = "ParentExecutionId"
+
+	// AutomationExecutionFilterKeyCurrentAction is a AutomationExecutionFilterKey enum value
+	AutomationExecutionFilterKeyCurrentAction = "CurrentAction"
+
+	// AutomationExecutionFilterKeyStartTimeBefore is a AutomationExecutionFilterKey enum value
+	AutomationExecutionFilterKeyStartTimeBefore = "StartTimeBefore"
+
+	// AutomationExecutionFilterKeyStartTimeAfter is a AutomationExecutionFilterKey enum value
+	AutomationExecutionFilterKeyStartTimeAfter = "StartTimeAfter"
 )
 
 const (
@@ -27556,6 +28371,9 @@ const (
 
 	// AutomationExecutionStatusTimedOut is a AutomationExecutionStatus enum value
 	AutomationExecutionStatusTimedOut = "TimedOut"
+
+	// AutomationExecutionStatusCancelling is a AutomationExecutionStatus enum value
+	AutomationExecutionStatusCancelling = "Cancelling"
 
 	// AutomationExecutionStatusCancelled is a AutomationExecutionStatus enum value
 	AutomationExecutionStatusCancelled = "Cancelled"
@@ -27715,6 +28533,14 @@ const (
 )
 
 const (
+	// DocumentFormatYaml is a DocumentFormat enum value
+	DocumentFormatYaml = "YAML"
+
+	// DocumentFormatJson is a DocumentFormat enum value
+	DocumentFormatJson = "JSON"
+)
+
+const (
 	// DocumentHashTypeSha256 is a DocumentHashType enum value
 	DocumentHashTypeSha256 = "Sha256"
 
@@ -27758,6 +28584,14 @@ const (
 
 	// DocumentTypeAutomation is a DocumentType enum value
 	DocumentTypeAutomation = "Automation"
+)
+
+const (
+	// ExecutionModeAuto is a ExecutionMode enum value
+	ExecutionModeAuto = "Auto"
+
+	// ExecutionModeInteractive is a ExecutionMode enum value
+	ExecutionModeInteractive = "Interactive"
 )
 
 const (
@@ -28096,4 +28930,41 @@ const (
 
 	// SignalTypeReject is a SignalType enum value
 	SignalTypeReject = "Reject"
+
+	// SignalTypeStartStep is a SignalType enum value
+	SignalTypeStartStep = "StartStep"
+
+	// SignalTypeStopStep is a SignalType enum value
+	SignalTypeStopStep = "StopStep"
+
+	// SignalTypeResume is a SignalType enum value
+	SignalTypeResume = "Resume"
+)
+
+const (
+	// StepExecutionFilterKeyStartTimeBefore is a StepExecutionFilterKey enum value
+	StepExecutionFilterKeyStartTimeBefore = "StartTimeBefore"
+
+	// StepExecutionFilterKeyStartTimeAfter is a StepExecutionFilterKey enum value
+	StepExecutionFilterKeyStartTimeAfter = "StartTimeAfter"
+
+	// StepExecutionFilterKeyStepExecutionStatus is a StepExecutionFilterKey enum value
+	StepExecutionFilterKeyStepExecutionStatus = "StepExecutionStatus"
+
+	// StepExecutionFilterKeyStepExecutionId is a StepExecutionFilterKey enum value
+	StepExecutionFilterKeyStepExecutionId = "StepExecutionId"
+
+	// StepExecutionFilterKeyStepName is a StepExecutionFilterKey enum value
+	StepExecutionFilterKeyStepName = "StepName"
+
+	// StepExecutionFilterKeyAction is a StepExecutionFilterKey enum value
+	StepExecutionFilterKeyAction = "Action"
+)
+
+const (
+	// StopTypeComplete is a StopType enum value
+	StopTypeComplete = "Complete"
+
+	// StopTypeCancel is a StopType enum value
+	StopTypeCancel = "Cancel"
 )

--- a/vendor/github.com/aws/aws-sdk-go/service/ssm/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ssm/doc.go
@@ -3,16 +3,16 @@
 // Package ssm provides the client and types for making API
 // requests to Amazon Simple Systems Manager (SSM).
 //
-// Amazon EC2 Systems Manager is a collection of capabilities that helps you
-// automate management tasks such as collecting system inventory, applying operating
+// AWS Systems Manager is a collection of capabilities that helps you automate
+// management tasks such as collecting system inventory, applying operating
 // system (OS) patches, automating the creation of Amazon Machine Images (AMIs),
 // and configuring operating systems (OSs) and applications at scale. Systems
 // Manager lets you remotely and securely manage the configuration of your managed
 // instances. A managed instance is any Amazon EC2 instance or on-premises machine
 // in your hybrid environment that has been configured for Systems Manager.
 //
-// This reference is intended to be used with the Amazon EC2 Systems Manager
-// User Guide (http://docs.aws.amazon.com/systems-manager/latest/userguide/).
+// This reference is intended to be used with the AWS Systems Manager User Guide
+// (http://docs.aws.amazon.com/systems-manager/latest/userguide/).
 //
 // To get started, verify prerequisites and configure managed instances. For
 // more information, see Systems Manager Prerequisites (http://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up.html).

--- a/vendor/github.com/aws/aws-sdk-go/service/ssm/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ssm/errors.go
@@ -69,6 +69,13 @@ const (
 	// execution ID.
 	ErrCodeAutomationExecutionNotFoundException = "AutomationExecutionNotFoundException"
 
+	// ErrCodeAutomationStepNotFoundException for service response error code
+	// "AutomationStepNotFoundException".
+	//
+	// The specified step name and execution ID don't exist. Verify the information
+	// and try again.
+	ErrCodeAutomationStepNotFoundException = "AutomationStepNotFoundException"
+
 	// ErrCodeComplianceTypeCountLimitExceededException for service response error code
 	// "ComplianceTypeCountLimitExceededException".
 	//
@@ -209,6 +216,12 @@ const (
 	//
 	// The signal is not valid for the current Automation execution.
 	ErrCodeInvalidAutomationSignalException = "InvalidAutomationSignalException"
+
+	// ErrCodeInvalidAutomationStatusUpdateException for service response error code
+	// "InvalidAutomationStatusUpdateException".
+	//
+	// The specified update status operation is not valid.
+	ErrCodeInvalidAutomationStatusUpdateException = "InvalidAutomationStatusUpdateException"
 
 	// ErrCodeInvalidCommandId for service response error code
 	// "InvalidCommandId".
@@ -387,7 +400,7 @@ const (
 	// an IAM role for notifications that includes the required trust policy. For
 	// information about configuring the IAM role for Run Command notifications,
 	// see Configuring Amazon SNS Notifications for Run Command (http://docs.aws.amazon.com/systems-manager/latest/userguide/rc-sns-notifications.html)
-	// in the Amazon EC2 Systems Manager User Guide.
+	// in the AWS Systems Manager User Guide.
 	ErrCodeInvalidRole = "InvalidRole"
 
 	// ErrCodeInvalidSchedule for service response error code

--- a/vendor/github.com/aws/aws-sdk-go/service/waf/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/waf/api.go
@@ -1016,6 +1016,112 @@ func (c *WAF) CreateRuleWithContext(ctx aws.Context, input *CreateRuleInput, opt
 	return out, req.Send()
 }
 
+const opCreateRuleGroup = "CreateRuleGroup"
+
+// CreateRuleGroupRequest generates a "aws/request.Request" representing the
+// client's request for the CreateRuleGroup operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See CreateRuleGroup for more information on using the CreateRuleGroup
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the CreateRuleGroupRequest method.
+//    req, resp := client.CreateRuleGroupRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/CreateRuleGroup
+func (c *WAF) CreateRuleGroupRequest(input *CreateRuleGroupInput) (req *request.Request, output *CreateRuleGroupOutput) {
+	op := &request.Operation{
+		Name:       opCreateRuleGroup,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &CreateRuleGroupInput{}
+	}
+
+	output = &CreateRuleGroupOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// CreateRuleGroup API operation for AWS WAF.
+//
+// Creates a RuleGroup. A rule group is a collection of predefined rules that
+// you add to a web ACL. You use UpdateRuleGroup to add rules to the rule group.
+//
+// Rule groups are subject to the following limits:
+//
+//    * Three rule groups per account. You can request an increase to this limit
+//    by contacting customer support.
+//
+//    * One rule group per web ACL.
+//
+//    * Ten rules per rule group.
+//
+// For more information about how to use the AWS WAF API to allow or block HTTP
+// requests, see the AWS WAF Developer Guide (http://docs.aws.amazon.com/waf/latest/developerguide/).
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS WAF's
+// API operation CreateRuleGroup for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeStaleDataException "StaleDataException"
+//   The operation failed because you tried to create, update, or delete an object
+//   by using a change token that has already been used.
+//
+//   * ErrCodeInternalErrorException "InternalErrorException"
+//   The operation failed because of a system problem, even though the request
+//   was valid. Retry your request.
+//
+//   * ErrCodeDisallowedNameException "DisallowedNameException"
+//   The name specified is invalid.
+//
+//   * ErrCodeLimitsExceededException "LimitsExceededException"
+//   The operation exceeds a resource limit, for example, the maximum number of
+//   WebACL objects that you can create for an AWS account. For more information,
+//   see Limits (http://docs.aws.amazon.com/waf/latest/developerguide/limits.html)
+//   in the AWS WAF Developer Guide.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/CreateRuleGroup
+func (c *WAF) CreateRuleGroup(input *CreateRuleGroupInput) (*CreateRuleGroupOutput, error) {
+	req, out := c.CreateRuleGroupRequest(input)
+	return out, req.Send()
+}
+
+// CreateRuleGroupWithContext is the same as CreateRuleGroup with the addition of
+// the ability to pass a context and additional request options.
+//
+// See CreateRuleGroup for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *WAF) CreateRuleGroupWithContext(ctx aws.Context, input *CreateRuleGroupInput, opts ...request.Option) (*CreateRuleGroupOutput, error) {
+	req, out := c.CreateRuleGroupRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opCreateSizeConstraintSet = "CreateSizeConstraintSet"
 
 // CreateSizeConstraintSetRequest generates a "aws/request.Request" representing the
@@ -2484,6 +2590,127 @@ func (c *WAF) DeleteRuleWithContext(ctx aws.Context, input *DeleteRuleInput, opt
 	return out, req.Send()
 }
 
+const opDeleteRuleGroup = "DeleteRuleGroup"
+
+// DeleteRuleGroupRequest generates a "aws/request.Request" representing the
+// client's request for the DeleteRuleGroup operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DeleteRuleGroup for more information on using the DeleteRuleGroup
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DeleteRuleGroupRequest method.
+//    req, resp := client.DeleteRuleGroupRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/DeleteRuleGroup
+func (c *WAF) DeleteRuleGroupRequest(input *DeleteRuleGroupInput) (req *request.Request, output *DeleteRuleGroupOutput) {
+	op := &request.Operation{
+		Name:       opDeleteRuleGroup,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DeleteRuleGroupInput{}
+	}
+
+	output = &DeleteRuleGroupOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DeleteRuleGroup API operation for AWS WAF.
+//
+// Permanently deletes a RuleGroup. You can't delete a RuleGroup if it's still
+// used in any WebACL objects or if it still includes any rules.
+//
+// If you just want to remove a RuleGroup from a WebACL, use UpdateWebACL.
+//
+// To permanently delete a RuleGroup from AWS WAF, perform the following steps:
+//
+// Update the RuleGroup to remove rules, if any. For more information, see UpdateRuleGroup.
+//
+// Use GetChangeToken to get the change token that you provide in the ChangeToken
+// parameter of a DeleteRuleGroup request.
+//
+// Submit a DeleteRuleGroup request.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS WAF's
+// API operation DeleteRuleGroup for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeStaleDataException "StaleDataException"
+//   The operation failed because you tried to create, update, or delete an object
+//   by using a change token that has already been used.
+//
+//   * ErrCodeInternalErrorException "InternalErrorException"
+//   The operation failed because of a system problem, even though the request
+//   was valid. Retry your request.
+//
+//   * ErrCodeNonexistentItemException "NonexistentItemException"
+//   The operation failed because the referenced object doesn't exist.
+//
+//   * ErrCodeReferencedItemException "ReferencedItemException"
+//   The operation failed because you tried to delete an object that is still
+//   in use. For example:
+//
+//      * You tried to delete a ByteMatchSet that is still referenced by a Rule.
+//
+//      * You tried to delete a Rule that is still referenced by a WebACL.
+//
+//   * ErrCodeNonEmptyEntityException "NonEmptyEntityException"
+//   The operation failed because you tried to delete an object that isn't empty.
+//   For example:
+//
+//      * You tried to delete a WebACL that still contains one or more Rule objects.
+//
+//      * You tried to delete a Rule that still contains one or more ByteMatchSet
+//      objects or other predicates.
+//
+//      * You tried to delete a ByteMatchSet that contains one or more ByteMatchTuple
+//      objects.
+//
+//      * You tried to delete an IPSet that references one or more IP addresses.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/DeleteRuleGroup
+func (c *WAF) DeleteRuleGroup(input *DeleteRuleGroupInput) (*DeleteRuleGroupOutput, error) {
+	req, out := c.DeleteRuleGroupRequest(input)
+	return out, req.Send()
+}
+
+// DeleteRuleGroupWithContext is the same as DeleteRuleGroup with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeleteRuleGroup for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *WAF) DeleteRuleGroupWithContext(ctx aws.Context, input *DeleteRuleGroupInput, opts ...request.Option) (*DeleteRuleGroupOutput, error) {
+	req, out := c.DeleteRuleGroupRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opDeleteSizeConstraintSet = "DeleteSizeConstraintSet"
 
 // DeleteSizeConstraintSetRequest generates a "aws/request.Request" representing the
@@ -3906,6 +4133,92 @@ func (c *WAF) GetRuleWithContext(ctx aws.Context, input *GetRuleInput, opts ...r
 	return out, req.Send()
 }
 
+const opGetRuleGroup = "GetRuleGroup"
+
+// GetRuleGroupRequest generates a "aws/request.Request" representing the
+// client's request for the GetRuleGroup operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See GetRuleGroup for more information on using the GetRuleGroup
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the GetRuleGroupRequest method.
+//    req, resp := client.GetRuleGroupRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/GetRuleGroup
+func (c *WAF) GetRuleGroupRequest(input *GetRuleGroupInput) (req *request.Request, output *GetRuleGroupOutput) {
+	op := &request.Operation{
+		Name:       opGetRuleGroup,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &GetRuleGroupInput{}
+	}
+
+	output = &GetRuleGroupOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// GetRuleGroup API operation for AWS WAF.
+//
+// Returns the RuleGroup that is specified by the RuleGroupId that you included
+// in the GetRuleGroup request.
+//
+// To view the rules in a rule group, use ListActivatedRulesInRuleGroup.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS WAF's
+// API operation GetRuleGroup for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalErrorException "InternalErrorException"
+//   The operation failed because of a system problem, even though the request
+//   was valid. Retry your request.
+//
+//   * ErrCodeNonexistentItemException "NonexistentItemException"
+//   The operation failed because the referenced object doesn't exist.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/GetRuleGroup
+func (c *WAF) GetRuleGroup(input *GetRuleGroupInput) (*GetRuleGroupOutput, error) {
+	req, out := c.GetRuleGroupRequest(input)
+	return out, req.Send()
+}
+
+// GetRuleGroupWithContext is the same as GetRuleGroup with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetRuleGroup for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *WAF) GetRuleGroupWithContext(ctx aws.Context, input *GetRuleGroupInput, opts ...request.Option) (*GetRuleGroupOutput, error) {
+	req, out := c.GetRuleGroupRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opGetSampledRequests = "GetSampledRequests"
 
 // GetSampledRequestsRequest generates a "aws/request.Request" representing the
@@ -4342,6 +4655,118 @@ func (c *WAF) GetXssMatchSet(input *GetXssMatchSetInput) (*GetXssMatchSetOutput,
 // for more information on using Contexts.
 func (c *WAF) GetXssMatchSetWithContext(ctx aws.Context, input *GetXssMatchSetInput, opts ...request.Option) (*GetXssMatchSetOutput, error) {
 	req, out := c.GetXssMatchSetRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opListActivatedRulesInRuleGroup = "ListActivatedRulesInRuleGroup"
+
+// ListActivatedRulesInRuleGroupRequest generates a "aws/request.Request" representing the
+// client's request for the ListActivatedRulesInRuleGroup operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ListActivatedRulesInRuleGroup for more information on using the ListActivatedRulesInRuleGroup
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ListActivatedRulesInRuleGroupRequest method.
+//    req, resp := client.ListActivatedRulesInRuleGroupRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/ListActivatedRulesInRuleGroup
+func (c *WAF) ListActivatedRulesInRuleGroupRequest(input *ListActivatedRulesInRuleGroupInput) (req *request.Request, output *ListActivatedRulesInRuleGroupOutput) {
+	op := &request.Operation{
+		Name:       opListActivatedRulesInRuleGroup,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &ListActivatedRulesInRuleGroupInput{}
+	}
+
+	output = &ListActivatedRulesInRuleGroupOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListActivatedRulesInRuleGroup API operation for AWS WAF.
+//
+// Returns an array of ActivatedRule objects.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS WAF's
+// API operation ListActivatedRulesInRuleGroup for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalErrorException "InternalErrorException"
+//   The operation failed because of a system problem, even though the request
+//   was valid. Retry your request.
+//
+//   * ErrCodeNonexistentItemException "NonexistentItemException"
+//   The operation failed because the referenced object doesn't exist.
+//
+//   * ErrCodeInvalidParameterException "InvalidParameterException"
+//   The operation failed because AWS WAF didn't recognize a parameter in the
+//   request. For example:
+//
+//      * You specified an invalid parameter name.
+//
+//      * You specified an invalid value.
+//
+//      * You tried to update an object (ByteMatchSet, IPSet, Rule, or WebACL)
+//      using an action other than INSERT or DELETE.
+//
+//      * You tried to create a WebACL with a DefaultActionType other than ALLOW,
+//      BLOCK, or COUNT.
+//
+//      * You tried to create a RateBasedRule with a RateKey value other than
+//      IP.
+//
+//      * You tried to update a WebACL with a WafActionType other than ALLOW,
+//      BLOCK, or COUNT.
+//
+//      * You tried to update a ByteMatchSet with a FieldToMatchType other than
+//      HEADER, METHOD, QUERY_STRING, URI, or BODY.
+//
+//      * You tried to update a ByteMatchSet with a Field of HEADER but no value
+//      for Data.
+//
+//      * Your request references an ARN that is malformed, or corresponds to
+//      a resource with which a web ACL cannot be associated.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/ListActivatedRulesInRuleGroup
+func (c *WAF) ListActivatedRulesInRuleGroup(input *ListActivatedRulesInRuleGroupInput) (*ListActivatedRulesInRuleGroupOutput, error) {
+	req, out := c.ListActivatedRulesInRuleGroupRequest(input)
+	return out, req.Send()
+}
+
+// ListActivatedRulesInRuleGroupWithContext is the same as ListActivatedRulesInRuleGroup with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListActivatedRulesInRuleGroup for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *WAF) ListActivatedRulesInRuleGroupWithContext(ctx aws.Context, input *ListActivatedRulesInRuleGroupInput, opts ...request.Option) (*ListActivatedRulesInRuleGroupOutput, error) {
+	req, out := c.ListActivatedRulesInRuleGroupRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -4851,6 +5276,86 @@ func (c *WAF) ListRegexPatternSetsWithContext(ctx aws.Context, input *ListRegexP
 	return out, req.Send()
 }
 
+const opListRuleGroups = "ListRuleGroups"
+
+// ListRuleGroupsRequest generates a "aws/request.Request" representing the
+// client's request for the ListRuleGroups operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ListRuleGroups for more information on using the ListRuleGroups
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ListRuleGroupsRequest method.
+//    req, resp := client.ListRuleGroupsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/ListRuleGroups
+func (c *WAF) ListRuleGroupsRequest(input *ListRuleGroupsInput) (req *request.Request, output *ListRuleGroupsOutput) {
+	op := &request.Operation{
+		Name:       opListRuleGroups,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &ListRuleGroupsInput{}
+	}
+
+	output = &ListRuleGroupsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListRuleGroups API operation for AWS WAF.
+//
+// Returns an array of RuleGroup objects.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS WAF's
+// API operation ListRuleGroups for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalErrorException "InternalErrorException"
+//   The operation failed because of a system problem, even though the request
+//   was valid. Retry your request.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/ListRuleGroups
+func (c *WAF) ListRuleGroups(input *ListRuleGroupsInput) (*ListRuleGroupsOutput, error) {
+	req, out := c.ListRuleGroupsRequest(input)
+	return out, req.Send()
+}
+
+// ListRuleGroupsWithContext is the same as ListRuleGroups with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListRuleGroups for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *WAF) ListRuleGroupsWithContext(ctx aws.Context, input *ListRuleGroupsInput, opts ...request.Option) (*ListRuleGroupsOutput, error) {
+	req, out := c.ListRuleGroupsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opListRules = "ListRules"
 
 // ListRulesRequest generates a "aws/request.Request" representing the
@@ -5098,6 +5603,89 @@ func (c *WAF) ListSqlInjectionMatchSets(input *ListSqlInjectionMatchSetsInput) (
 // for more information on using Contexts.
 func (c *WAF) ListSqlInjectionMatchSetsWithContext(ctx aws.Context, input *ListSqlInjectionMatchSetsInput, opts ...request.Option) (*ListSqlInjectionMatchSetsOutput, error) {
 	req, out := c.ListSqlInjectionMatchSetsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opListSubscribedRuleGroups = "ListSubscribedRuleGroups"
+
+// ListSubscribedRuleGroupsRequest generates a "aws/request.Request" representing the
+// client's request for the ListSubscribedRuleGroups operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ListSubscribedRuleGroups for more information on using the ListSubscribedRuleGroups
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ListSubscribedRuleGroupsRequest method.
+//    req, resp := client.ListSubscribedRuleGroupsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/ListSubscribedRuleGroups
+func (c *WAF) ListSubscribedRuleGroupsRequest(input *ListSubscribedRuleGroupsInput) (req *request.Request, output *ListSubscribedRuleGroupsOutput) {
+	op := &request.Operation{
+		Name:       opListSubscribedRuleGroups,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &ListSubscribedRuleGroupsInput{}
+	}
+
+	output = &ListSubscribedRuleGroupsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListSubscribedRuleGroups API operation for AWS WAF.
+//
+// Returns an array of RuleGroup objects that you are subscribed to.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS WAF's
+// API operation ListSubscribedRuleGroups for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeNonexistentItemException "NonexistentItemException"
+//   The operation failed because the referenced object doesn't exist.
+//
+//   * ErrCodeInternalErrorException "InternalErrorException"
+//   The operation failed because of a system problem, even though the request
+//   was valid. Retry your request.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/ListSubscribedRuleGroups
+func (c *WAF) ListSubscribedRuleGroups(input *ListSubscribedRuleGroupsInput) (*ListSubscribedRuleGroupsOutput, error) {
+	req, out := c.ListSubscribedRuleGroupsRequest(input)
+	return out, req.Send()
+}
+
+// ListSubscribedRuleGroupsWithContext is the same as ListSubscribedRuleGroups with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListSubscribedRuleGroups for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *WAF) ListSubscribedRuleGroupsWithContext(ctx aws.Context, input *ListSubscribedRuleGroupsInput, opts ...request.Option) (*ListSubscribedRuleGroupsOutput, error) {
+	req, out := c.ListSubscribedRuleGroupsRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -6139,15 +6727,15 @@ func (c *WAF) UpdateRegexMatchSetRequest(input *UpdateRegexMatchSetInput) (req *
 
 // UpdateRegexMatchSet API operation for AWS WAF.
 //
-// Inserts or deletes RegexMatchSetUpdate objects (filters) in a RegexMatchSet.
+// Inserts or deletes RegexMatchTuple objects (filters) in a RegexMatchSet.
 // For each RegexMatchSetUpdate object, you specify the following values:
 //
 //    * Whether to insert or delete the object from the array. If you want to
 //    change a RegexMatchSetUpdate object, you delete the existing object and
 //    add a new one.
 //
-//    * The part of a web request that you want AWS WAF to inspect, such as
-//    a query string or the value of the User-Agent header.
+//    * The part of a web request that you want AWS WAF to inspectupdate, such
+//    as a query string or the value of the User-Agent header.
 //
 //    * The identifier of the pattern (a regular expression) that you want AWS
 //    WAF to look for. For more information, see RegexPatternSet.
@@ -6309,14 +6897,12 @@ func (c *WAF) UpdateRegexPatternSetRequest(input *UpdateRegexPatternSetInput) (r
 
 // UpdateRegexPatternSet API operation for AWS WAF.
 //
-// Inserts or deletes RegexMatchSetUpdate objects (filters) in a RegexPatternSet.
-// For each RegexPatternSet object, you specify the following values:
+// Inserts or deletes RegexPatternString objects in a RegexPatternSet. For each
+// RegexPatternString object, you specify the following values:
 //
-//    * Whether to insert or delete the object from the array. If you want to
-//    change a RegexPatternSet object, you delete the existing object and add
-//    a new one.
+//    * Whether to insert or delete the RegexPatternString.
 //
-//    * The regular expression pattern that you want AWS WAF to look for. For
+//    * The regular expression pattern that you want to insert or delete. For
 //    more information, see RegexPatternSet.
 //
 // For example, you can create a RegexPatternString such as B[a@]dB[o0]t. AWS
@@ -6364,6 +6950,9 @@ func (c *WAF) UpdateRegexPatternSetRequest(input *UpdateRegexPatternSetInput) (r
 //   WebACL objects that you can create for an AWS account. For more information,
 //   see Limits (http://docs.aws.amazon.com/waf/latest/developerguide/limits.html)
 //   in the AWS WAF Developer Guide.
+//
+//   * ErrCodeNonexistentItemException "NonexistentItemException"
+//   The operation failed because the referenced object doesn't exist.
 //
 //   * ErrCodeNonexistentContainerException "NonexistentContainerException"
 //   The operation failed because you tried to add an object to or delete an object
@@ -6629,6 +7218,187 @@ func (c *WAF) UpdateRule(input *UpdateRuleInput) (*UpdateRuleOutput, error) {
 // for more information on using Contexts.
 func (c *WAF) UpdateRuleWithContext(ctx aws.Context, input *UpdateRuleInput, opts ...request.Option) (*UpdateRuleOutput, error) {
 	req, out := c.UpdateRuleRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opUpdateRuleGroup = "UpdateRuleGroup"
+
+// UpdateRuleGroupRequest generates a "aws/request.Request" representing the
+// client's request for the UpdateRuleGroup operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See UpdateRuleGroup for more information on using the UpdateRuleGroup
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the UpdateRuleGroupRequest method.
+//    req, resp := client.UpdateRuleGroupRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/UpdateRuleGroup
+func (c *WAF) UpdateRuleGroupRequest(input *UpdateRuleGroupInput) (req *request.Request, output *UpdateRuleGroupOutput) {
+	op := &request.Operation{
+		Name:       opUpdateRuleGroup,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &UpdateRuleGroupInput{}
+	}
+
+	output = &UpdateRuleGroupOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// UpdateRuleGroup API operation for AWS WAF.
+//
+// Inserts or deletes ActivatedRule objects in a RuleGroup.
+//
+// You can only insert REGULAR rules into a rule group.
+//
+// You can have a maximum of ten rules per rule group.
+//
+// To create and configure a RuleGroup, perform the following steps:
+//
+// Create and update the Rules that you want to include in the RuleGroup. See
+// CreateRule.
+//
+// Use GetChangeToken to get the change token that you provide in the ChangeToken
+// parameter of an UpdateRuleGroup request.
+//
+// Submit an UpdateRuleGroup request to add Rules to the RuleGroup.
+//
+// Create and update a WebACL that contains the RuleGroup. See CreateWebACL.
+//
+// If you want to replace one Rule with another, you delete the existing one
+// and add the new one.
+//
+// For more information about how to use the AWS WAF API to allow or block HTTP
+// requests, see the AWS WAF Developer Guide (http://docs.aws.amazon.com/waf/latest/developerguide/).
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS WAF's
+// API operation UpdateRuleGroup for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeStaleDataException "StaleDataException"
+//   The operation failed because you tried to create, update, or delete an object
+//   by using a change token that has already been used.
+//
+//   * ErrCodeInternalErrorException "InternalErrorException"
+//   The operation failed because of a system problem, even though the request
+//   was valid. Retry your request.
+//
+//   * ErrCodeNonexistentContainerException "NonexistentContainerException"
+//   The operation failed because you tried to add an object to or delete an object
+//   from another object that doesn't exist. For example:
+//
+//      * You tried to add a Rule to or delete a Rule from a WebACL that doesn't
+//      exist.
+//
+//      * You tried to add a ByteMatchSet to or delete a ByteMatchSet from a Rule
+//      that doesn't exist.
+//
+//      * You tried to add an IP address to or delete an IP address from an IPSet
+//      that doesn't exist.
+//
+//      * You tried to add a ByteMatchTuple to or delete a ByteMatchTuple from
+//      a ByteMatchSet that doesn't exist.
+//
+//   * ErrCodeNonexistentItemException "NonexistentItemException"
+//   The operation failed because the referenced object doesn't exist.
+//
+//   * ErrCodeInvalidOperationException "InvalidOperationException"
+//   The operation failed because there was nothing to do. For example:
+//
+//      * You tried to remove a Rule from a WebACL, but the Rule isn't in the
+//      specified WebACL.
+//
+//      * You tried to remove an IP address from an IPSet, but the IP address
+//      isn't in the specified IPSet.
+//
+//      * You tried to remove a ByteMatchTuple from a ByteMatchSet, but the ByteMatchTuple
+//      isn't in the specified WebACL.
+//
+//      * You tried to add a Rule to a WebACL, but the Rule already exists in
+//      the specified WebACL.
+//
+//      * You tried to add an IP address to an IPSet, but the IP address already
+//      exists in the specified IPSet.
+//
+//      * You tried to add a ByteMatchTuple to a ByteMatchSet, but the ByteMatchTuple
+//      already exists in the specified WebACL.
+//
+//   * ErrCodeLimitsExceededException "LimitsExceededException"
+//   The operation exceeds a resource limit, for example, the maximum number of
+//   WebACL objects that you can create for an AWS account. For more information,
+//   see Limits (http://docs.aws.amazon.com/waf/latest/developerguide/limits.html)
+//   in the AWS WAF Developer Guide.
+//
+//   * ErrCodeInvalidParameterException "InvalidParameterException"
+//   The operation failed because AWS WAF didn't recognize a parameter in the
+//   request. For example:
+//
+//      * You specified an invalid parameter name.
+//
+//      * You specified an invalid value.
+//
+//      * You tried to update an object (ByteMatchSet, IPSet, Rule, or WebACL)
+//      using an action other than INSERT or DELETE.
+//
+//      * You tried to create a WebACL with a DefaultActionType other than ALLOW,
+//      BLOCK, or COUNT.
+//
+//      * You tried to create a RateBasedRule with a RateKey value other than
+//      IP.
+//
+//      * You tried to update a WebACL with a WafActionType other than ALLOW,
+//      BLOCK, or COUNT.
+//
+//      * You tried to update a ByteMatchSet with a FieldToMatchType other than
+//      HEADER, METHOD, QUERY_STRING, URI, or BODY.
+//
+//      * You tried to update a ByteMatchSet with a Field of HEADER but no value
+//      for Data.
+//
+//      * Your request references an ARN that is malformed, or corresponds to
+//      a resource with which a web ACL cannot be associated.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/UpdateRuleGroup
+func (c *WAF) UpdateRuleGroup(input *UpdateRuleGroupInput) (*UpdateRuleGroupOutput, error) {
+	req, out := c.UpdateRuleGroupRequest(input)
+	return out, req.Send()
+}
+
+// UpdateRuleGroupWithContext is the same as UpdateRuleGroup with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UpdateRuleGroup for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *WAF) UpdateRuleGroupWithContext(ctx aws.Context, input *UpdateRuleGroupInput, opts ...request.Option) (*UpdateRuleGroupOutput, error) {
+	req, out := c.UpdateRuleGroupRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -7233,6 +8003,9 @@ func (c *WAF) UpdateWebACLRequest(input *UpdateWebACLInput) (req *request.Reques
 //   see Limits (http://docs.aws.amazon.com/waf/latest/developerguide/limits.html)
 //   in the AWS WAF Developer Guide.
 //
+//   * ErrCodeSubscriptionNotFoundException "SubscriptionNotFoundException"
+//   The specified subscription does not exist.
+//
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/UpdateWebACL
 func (c *WAF) UpdateWebACL(input *UpdateWebACLInput) (*UpdateWebACLOutput, error) {
 	req, out := c.UpdateWebACLRequest(input)
@@ -7471,8 +8244,26 @@ type ActivatedRule struct {
 	//    in the rule and then continues to inspect the web request based on the
 	//    remaining rules in the web ACL.
 	//
-	// Action is a required field
-	Action *WafAction `type:"structure" required:"true"`
+	// The Action data type within ActivatedRule is used only when submitting an
+	// UpdateWebACL request. ActivatedRule|Action is not applicable and therefore
+	// not available for UpdateRuleGroup.
+	Action *WafAction `type:"structure"`
+
+	// Use the OverrideAction to test your RuleGroup.
+	//
+	// Any rule in a RuleGroup can potentially block a request. If you set the OverrideAction
+	// to None, the RuleGroup will block a request if any individual rule in the
+	// RuleGroup matches the request and is configured to block that request. However
+	// if you first want to test the RuleGroup, set the OverrideAction to Count.
+	// The RuleGroup will then override any block action specified by individual
+	// rules contained within the group. Instead of blocking matching requests,
+	// those requests will be counted. You can view a record of counted requests
+	// using GetSampledRequests.
+	//
+	// The OverrideAction data type within ActivatedRule is used only when submitting
+	// an UpdateRuleGroup request. ActivatedRule|OverrideAction is not applicable
+	// and therefore not available for UpdateWebACL.
+	OverrideAction *WafOverrideAction `type:"structure"`
 
 	// Specifies the order in which the Rules in a WebACL are evaluated. Rules with
 	// a lower value for Priority are evaluated before Rules with a higher value.
@@ -7492,11 +8283,12 @@ type ActivatedRule struct {
 	// RuleId is a required field
 	RuleId *string `min:"1" type:"string" required:"true"`
 
-	// The rule type, either REGULAR, as defined by Rule, or RATE_BASED, as defined
-	// by RateBasedRule. The default is REGULAR. Although this field is optional,
-	// be aware that if you try to add a RATE_BASED rule to a web ACL without setting
-	// the type, the UpdateWebACL request will fail because the request tries to
-	// add a REGULAR rule with the specified ID, which does not exist.
+	// The rule type, either REGULAR, as defined by Rule, RATE_BASED, as defined
+	// by RateBasedRule, or GROUP, as defined by RuleGroup. The default is REGULAR.
+	// Although this field is optional, be aware that if you try to add a RATE_BASED
+	// rule to a web ACL without setting the type, the UpdateWebACL request will
+	// fail because the request tries to add a REGULAR rule with the specified ID,
+	// which does not exist.
 	Type *string `type:"string" enum:"WafRuleType"`
 }
 
@@ -7513,9 +8305,6 @@ func (s ActivatedRule) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *ActivatedRule) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "ActivatedRule"}
-	if s.Action == nil {
-		invalidParams.Add(request.NewErrParamRequired("Action"))
-	}
 	if s.Priority == nil {
 		invalidParams.Add(request.NewErrParamRequired("Priority"))
 	}
@@ -7530,6 +8319,11 @@ func (s *ActivatedRule) Validate() error {
 			invalidParams.AddNested("Action", err.(request.ErrInvalidParams))
 		}
 	}
+	if s.OverrideAction != nil {
+		if err := s.OverrideAction.Validate(); err != nil {
+			invalidParams.AddNested("OverrideAction", err.(request.ErrInvalidParams))
+		}
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -7540,6 +8334,12 @@ func (s *ActivatedRule) Validate() error {
 // SetAction sets the Action field's value.
 func (s *ActivatedRule) SetAction(v *WafAction) *ActivatedRule {
 	s.Action = v
+	return s
+}
+
+// SetOverrideAction sets the OverrideAction field's value.
+func (s *ActivatedRule) SetOverrideAction(v *WafOverrideAction) *ActivatedRule {
+	s.OverrideAction = v
 	return s
 }
 
@@ -8608,6 +9408,118 @@ func (s *CreateRegexPatternSetOutput) SetRegexPatternSet(v *RegexPatternSet) *Cr
 	return s
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/CreateRuleGroupRequest
+type CreateRuleGroupInput struct {
+	_ struct{} `type:"structure"`
+
+	// The value returned by the most recent call to GetChangeToken.
+	//
+	// ChangeToken is a required field
+	ChangeToken *string `min:"1" type:"string" required:"true"`
+
+	// A friendly name or description for the metrics for this RuleGroup. The name
+	// can contain only alphanumeric characters (A-Z, a-z, 0-9); the name can't
+	// contain whitespace. You can't change the name of the metric after you create
+	// the RuleGroup.
+	//
+	// MetricName is a required field
+	MetricName *string `type:"string" required:"true"`
+
+	// A friendly name or description of the RuleGroup. You can't change Name after
+	// you create a RuleGroup.
+	//
+	// Name is a required field
+	Name *string `min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s CreateRuleGroupInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateRuleGroupInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateRuleGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateRuleGroupInput"}
+	if s.ChangeToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("ChangeToken"))
+	}
+	if s.ChangeToken != nil && len(*s.ChangeToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ChangeToken", 1))
+	}
+	if s.MetricName == nil {
+		invalidParams.Add(request.NewErrParamRequired("MetricName"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetChangeToken sets the ChangeToken field's value.
+func (s *CreateRuleGroupInput) SetChangeToken(v string) *CreateRuleGroupInput {
+	s.ChangeToken = &v
+	return s
+}
+
+// SetMetricName sets the MetricName field's value.
+func (s *CreateRuleGroupInput) SetMetricName(v string) *CreateRuleGroupInput {
+	s.MetricName = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateRuleGroupInput) SetName(v string) *CreateRuleGroupInput {
+	s.Name = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/CreateRuleGroupResponse
+type CreateRuleGroupOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The ChangeToken that you used to submit the CreateRuleGroup request. You
+	// can also use this value to query the status of the request. For more information,
+	// see GetChangeTokenStatus.
+	ChangeToken *string `min:"1" type:"string"`
+
+	// An empty RuleGroup.
+	RuleGroup *RuleGroup `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateRuleGroupOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateRuleGroupOutput) GoString() string {
+	return s.String()
+}
+
+// SetChangeToken sets the ChangeToken field's value.
+func (s *CreateRuleGroupOutput) SetChangeToken(v string) *CreateRuleGroupOutput {
+	s.ChangeToken = &v
+	return s
+}
+
+// SetRuleGroup sets the RuleGroup field's value.
+func (s *CreateRuleGroupOutput) SetRuleGroup(v *RuleGroup) *CreateRuleGroupOutput {
+	s.RuleGroup = v
+	return s
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/CreateRuleRequest
 type CreateRuleInput struct {
 	_ struct{} `type:"structure"`
@@ -9653,6 +10565,92 @@ func (s DeleteRegexPatternSetOutput) GoString() string {
 
 // SetChangeToken sets the ChangeToken field's value.
 func (s *DeleteRegexPatternSetOutput) SetChangeToken(v string) *DeleteRegexPatternSetOutput {
+	s.ChangeToken = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/DeleteRuleGroupRequest
+type DeleteRuleGroupInput struct {
+	_ struct{} `type:"structure"`
+
+	// The value returned by the most recent call to GetChangeToken.
+	//
+	// ChangeToken is a required field
+	ChangeToken *string `min:"1" type:"string" required:"true"`
+
+	// The RuleGroupId of the RuleGroup that you want to delete. RuleGroupId is
+	// returned by CreateRuleGroup and by ListRuleGroups.
+	//
+	// RuleGroupId is a required field
+	RuleGroupId *string `min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DeleteRuleGroupInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteRuleGroupInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteRuleGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteRuleGroupInput"}
+	if s.ChangeToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("ChangeToken"))
+	}
+	if s.ChangeToken != nil && len(*s.ChangeToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ChangeToken", 1))
+	}
+	if s.RuleGroupId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RuleGroupId"))
+	}
+	if s.RuleGroupId != nil && len(*s.RuleGroupId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RuleGroupId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetChangeToken sets the ChangeToken field's value.
+func (s *DeleteRuleGroupInput) SetChangeToken(v string) *DeleteRuleGroupInput {
+	s.ChangeToken = &v
+	return s
+}
+
+// SetRuleGroupId sets the RuleGroupId field's value.
+func (s *DeleteRuleGroupInput) SetRuleGroupId(v string) *DeleteRuleGroupInput {
+	s.RuleGroupId = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/DeleteRuleGroupResponse
+type DeleteRuleGroupOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The ChangeToken that you used to submit the DeleteRuleGroup request. You
+	// can also use this value to query the status of the request. For more information,
+	// see GetChangeTokenStatus.
+	ChangeToken *string `min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s DeleteRuleGroupOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteRuleGroupOutput) GoString() string {
+	return s.String()
+}
+
+// SetChangeToken sets the ChangeToken field's value.
+func (s *DeleteRuleGroupOutput) SetChangeToken(v string) *DeleteRuleGroupOutput {
 	s.ChangeToken = &v
 	return s
 }
@@ -10995,6 +11993,73 @@ func (s *GetRegexPatternSetOutput) SetRegexPatternSet(v *RegexPatternSet) *GetRe
 	return s
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/GetRuleGroupRequest
+type GetRuleGroupInput struct {
+	_ struct{} `type:"structure"`
+
+	// The RuleGroupId of the RuleGroup that you want to get. RuleGroupId is returned
+	// by CreateRuleGroup and by ListRuleGroups.
+	//
+	// RuleGroupId is a required field
+	RuleGroupId *string `min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s GetRuleGroupInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetRuleGroupInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetRuleGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetRuleGroupInput"}
+	if s.RuleGroupId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RuleGroupId"))
+	}
+	if s.RuleGroupId != nil && len(*s.RuleGroupId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RuleGroupId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetRuleGroupId sets the RuleGroupId field's value.
+func (s *GetRuleGroupInput) SetRuleGroupId(v string) *GetRuleGroupInput {
+	s.RuleGroupId = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/GetRuleGroupResponse
+type GetRuleGroupOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the RuleGroup that you specified in the GetRuleGroup request.
+	RuleGroup *RuleGroup `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetRuleGroupOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetRuleGroupOutput) GoString() string {
+	return s.String()
+}
+
+// SetRuleGroup sets the RuleGroup field's value.
+func (s *GetRuleGroupOutput) SetRuleGroup(v *RuleGroup) *GetRuleGroupOutput {
+	s.RuleGroup = v
+	return s
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/GetRuleRequest
 type GetRuleInput struct {
 	_ struct{} `type:"structure"`
@@ -11080,10 +12145,10 @@ type GetSampledRequestsInput struct {
 	// MaxItems is a required field
 	MaxItems *int64 `min:"1" type:"long" required:"true"`
 
-	// RuleId is one of two values:
+	// RuleId is one of three values:
 	//
-	//    * The RuleId of the Rule for which you want GetSampledRequests to return
-	//    a sample of requests.
+	//    * The RuleId of the Rule or the RuleGroupId of the RuleGroup for which
+	//    you want GetSampledRequests to return a sample of requests.
 	//
 	//    * Default_Action, which causes GetSampledRequests to return a sample of
 	//    the requests that didn't match any of the rules in the specified WebACL.
@@ -11894,6 +12959,108 @@ func (s *IPSetUpdate) SetIPSetDescriptor(v *IPSetDescriptor) *IPSetUpdate {
 	return s
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/ListActivatedRulesInRuleGroupRequest
+type ListActivatedRulesInRuleGroupInput struct {
+	_ struct{} `type:"structure"`
+
+	// Specifies the number of ActivatedRules that you want AWS WAF to return for
+	// this request. If you have more ActivatedRules than the number that you specify
+	// for Limit, the response includes a NextMarker value that you can use to get
+	// another batch of ActivatedRules.
+	Limit *int64 `type:"integer"`
+
+	// If you specify a value for Limit and you have more ActivatedRules than the
+	// value of Limit, AWS WAF returns a NextMarker value in the response that allows
+	// you to list another group of ActivatedRules. For the second and subsequent
+	// ListActivatedRulesInRuleGroup requests, specify the value of NextMarker from
+	// the previous response to get information about another batch of ActivatedRules.
+	NextMarker *string `min:"1" type:"string"`
+
+	// The RuleGroupId of the RuleGroup for which you want to get a list of ActivatedRule
+	// objects.
+	RuleGroupId *string `min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s ListActivatedRulesInRuleGroupInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListActivatedRulesInRuleGroupInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListActivatedRulesInRuleGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListActivatedRulesInRuleGroupInput"}
+	if s.NextMarker != nil && len(*s.NextMarker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextMarker", 1))
+	}
+	if s.RuleGroupId != nil && len(*s.RuleGroupId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RuleGroupId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetLimit sets the Limit field's value.
+func (s *ListActivatedRulesInRuleGroupInput) SetLimit(v int64) *ListActivatedRulesInRuleGroupInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListActivatedRulesInRuleGroupInput) SetNextMarker(v string) *ListActivatedRulesInRuleGroupInput {
+	s.NextMarker = &v
+	return s
+}
+
+// SetRuleGroupId sets the RuleGroupId field's value.
+func (s *ListActivatedRulesInRuleGroupInput) SetRuleGroupId(v string) *ListActivatedRulesInRuleGroupInput {
+	s.RuleGroupId = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/ListActivatedRulesInRuleGroupResponse
+type ListActivatedRulesInRuleGroupOutput struct {
+	_ struct{} `type:"structure"`
+
+	// An array of ActivatedRules objects.
+	ActivatedRules []*ActivatedRule `type:"list"`
+
+	// If you have more ActivatedRules than the number that you specified for Limit
+	// in the request, the response includes a NextMarker value. To list more ActivatedRules,
+	// submit another ListActivatedRulesInRuleGroup request, and specify the NextMarker
+	// value from the response in the NextMarker value in the next request.
+	NextMarker *string `min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s ListActivatedRulesInRuleGroupOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListActivatedRulesInRuleGroupOutput) GoString() string {
+	return s.String()
+}
+
+// SetActivatedRules sets the ActivatedRules field's value.
+func (s *ListActivatedRulesInRuleGroupOutput) SetActivatedRules(v []*ActivatedRule) *ListActivatedRulesInRuleGroupOutput {
+	s.ActivatedRules = v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListActivatedRulesInRuleGroupOutput) SetNextMarker(v string) *ListActivatedRulesInRuleGroupOutput {
+	s.NextMarker = &v
+	return s
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/ListByteMatchSetsRequest
 type ListByteMatchSetsInput struct {
 	_ struct{} `type:"structure"`
@@ -12433,6 +13600,95 @@ func (s *ListRegexPatternSetsOutput) SetRegexPatternSets(v []*RegexPatternSetSum
 	return s
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/ListRuleGroupsRequest
+type ListRuleGroupsInput struct {
+	_ struct{} `type:"structure"`
+
+	// Specifies the number of RuleGroups that you want AWS WAF to return for this
+	// request. If you have more RuleGroups than the number that you specify for
+	// Limit, the response includes a NextMarker value that you can use to get another
+	// batch of RuleGroups.
+	Limit *int64 `type:"integer"`
+
+	// If you specify a value for Limit and you have more RuleGroups than the value
+	// of Limit, AWS WAF returns a NextMarker value in the response that allows
+	// you to list another group of RuleGroups. For the second and subsequent ListRuleGroups
+	// requests, specify the value of NextMarker from the previous response to get
+	// information about another batch of RuleGroups.
+	NextMarker *string `min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s ListRuleGroupsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListRuleGroupsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListRuleGroupsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListRuleGroupsInput"}
+	if s.NextMarker != nil && len(*s.NextMarker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextMarker", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetLimit sets the Limit field's value.
+func (s *ListRuleGroupsInput) SetLimit(v int64) *ListRuleGroupsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListRuleGroupsInput) SetNextMarker(v string) *ListRuleGroupsInput {
+	s.NextMarker = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/ListRuleGroupsResponse
+type ListRuleGroupsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// If you have more RuleGroups than the number that you specified for Limit
+	// in the request, the response includes a NextMarker value. To list more RuleGroups,
+	// submit another ListRuleGroups request, and specify the NextMarker value from
+	// the response in the NextMarker value in the next request.
+	NextMarker *string `min:"1" type:"string"`
+
+	// An array of RuleGroup objects.
+	RuleGroups []*RuleGroupSummary `type:"list"`
+}
+
+// String returns the string representation
+func (s ListRuleGroupsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListRuleGroupsOutput) GoString() string {
+	return s.String()
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListRuleGroupsOutput) SetNextMarker(v string) *ListRuleGroupsOutput {
+	s.NextMarker = &v
+	return s
+}
+
+// SetRuleGroups sets the RuleGroups field's value.
+func (s *ListRuleGroupsOutput) SetRuleGroups(v []*RuleGroupSummary) *ListRuleGroupsOutput {
+	s.RuleGroups = v
+	return s
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/ListRulesRequest
 type ListRulesInput struct {
 	_ struct{} `type:"structure"`
@@ -12701,6 +13957,96 @@ func (s *ListSqlInjectionMatchSetsOutput) SetNextMarker(v string) *ListSqlInject
 // SetSqlInjectionMatchSets sets the SqlInjectionMatchSets field's value.
 func (s *ListSqlInjectionMatchSetsOutput) SetSqlInjectionMatchSets(v []*SqlInjectionMatchSetSummary) *ListSqlInjectionMatchSetsOutput {
 	s.SqlInjectionMatchSets = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/ListSubscribedRuleGroupsRequest
+type ListSubscribedRuleGroupsInput struct {
+	_ struct{} `type:"structure"`
+
+	// Specifies the number of subscribed rule groups that you want AWS WAF to return
+	// for this request. If you have more objects than the number you specify for
+	// Limit, the response includes a NextMarker value that you can use to get another
+	// batch of objects.
+	Limit *int64 `type:"integer"`
+
+	// If you specify a value for Limit and you have more ByteMatchSetssubscribed
+	// rule groups than the value of Limit, AWS WAF returns a NextMarker value in
+	// the response that allows you to list another group of subscribed rule groups.
+	// For the second and subsequent ListSubscribedRuleGroupsRequest requests, specify
+	// the value of NextMarker from the previous response to get information about
+	// another batch of subscribed rule groups.
+	NextMarker *string `min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s ListSubscribedRuleGroupsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListSubscribedRuleGroupsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListSubscribedRuleGroupsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListSubscribedRuleGroupsInput"}
+	if s.NextMarker != nil && len(*s.NextMarker) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextMarker", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetLimit sets the Limit field's value.
+func (s *ListSubscribedRuleGroupsInput) SetLimit(v int64) *ListSubscribedRuleGroupsInput {
+	s.Limit = &v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListSubscribedRuleGroupsInput) SetNextMarker(v string) *ListSubscribedRuleGroupsInput {
+	s.NextMarker = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/ListSubscribedRuleGroupsResponse
+type ListSubscribedRuleGroupsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// If you have more objects than the number that you specified for Limit in
+	// the request, the response includes a NextMarker value. To list more objects,
+	// submit another ListSubscribedRuleGroups request, and specify the NextMarker
+	// value from the response in the NextMarker value in the next request.
+	NextMarker *string `min:"1" type:"string"`
+
+	// An array of RuleGroup objects.
+	RuleGroups []*SubscribedRuleGroupSummary `type:"list"`
+}
+
+// String returns the string representation
+func (s ListSubscribedRuleGroupsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListSubscribedRuleGroupsOutput) GoString() string {
+	return s.String()
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *ListSubscribedRuleGroupsOutput) SetNextMarker(v string) *ListSubscribedRuleGroupsOutput {
+	s.NextMarker = &v
+	return s
+}
+
+// SetRuleGroups sets the RuleGroups field's value.
+func (s *ListSubscribedRuleGroupsOutput) SetRuleGroups(v []*SubscribedRuleGroupSummary) *ListSubscribedRuleGroupsOutput {
+	s.RuleGroups = v
 	return s
 }
 
@@ -13652,6 +14998,176 @@ func (s *Rule) SetRuleId(v string) *Rule {
 	return s
 }
 
+// A collection of predefined rules that you can add to a web ACL.
+//
+// Rule groups are subject to the following limits:
+//
+//    * Three rule groups per account. You can request an increase to this limit
+//    by contacting customer support.
+//
+//    * One rule group per web ACL.
+//
+//    * Ten rules per rule group.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/RuleGroup
+type RuleGroup struct {
+	_ struct{} `type:"structure"`
+
+	// A friendly name or description for the metrics for this RuleGroup. The name
+	// can contain only alphanumeric characters (A-Z, a-z, 0-9); the name can't
+	// contain whitespace. You can't change the name of the metric after you create
+	// the RuleGroup.
+	MetricName *string `type:"string"`
+
+	// The friendly name or description for the RuleGroup. You can't change the
+	// name of a RuleGroup after you create it.
+	Name *string `min:"1" type:"string"`
+
+	// A unique identifier for a RuleGroup. You use RuleGroupId to get more information
+	// about a RuleGroup (see GetRuleGroup), update a RuleGroup (see UpdateRuleGroup),
+	// insert a RuleGroup into a WebACL or delete a one from a WebACL (see UpdateWebACL),
+	// or delete a RuleGroup from AWS WAF (see DeleteRuleGroup).
+	//
+	// RuleGroupId is returned by CreateRuleGroup and by ListRuleGroups.
+	//
+	// RuleGroupId is a required field
+	RuleGroupId *string `min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s RuleGroup) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s RuleGroup) GoString() string {
+	return s.String()
+}
+
+// SetMetricName sets the MetricName field's value.
+func (s *RuleGroup) SetMetricName(v string) *RuleGroup {
+	s.MetricName = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *RuleGroup) SetName(v string) *RuleGroup {
+	s.Name = &v
+	return s
+}
+
+// SetRuleGroupId sets the RuleGroupId field's value.
+func (s *RuleGroup) SetRuleGroupId(v string) *RuleGroup {
+	s.RuleGroupId = &v
+	return s
+}
+
+// Contains the identifier and the friendly name or description of the RuleGroup.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/RuleGroupSummary
+type RuleGroupSummary struct {
+	_ struct{} `type:"structure"`
+
+	// A friendly name or description of the RuleGroup. You can't change the name
+	// of a RuleGroup after you create it.
+	//
+	// Name is a required field
+	Name *string `min:"1" type:"string" required:"true"`
+
+	// A unique identifier for a RuleGroup. You use RuleGroupId to get more information
+	// about a RuleGroup (see GetRuleGroup), update a RuleGroup (see UpdateRuleGroup),
+	// insert a RuleGroup into a WebACL or delete one from a WebACL (see UpdateWebACL),
+	// or delete a RuleGroup from AWS WAF (see DeleteRuleGroup).
+	//
+	// RuleGroupId is returned by CreateRuleGroup and by ListRuleGroups.
+	//
+	// RuleGroupId is a required field
+	RuleGroupId *string `min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s RuleGroupSummary) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s RuleGroupSummary) GoString() string {
+	return s.String()
+}
+
+// SetName sets the Name field's value.
+func (s *RuleGroupSummary) SetName(v string) *RuleGroupSummary {
+	s.Name = &v
+	return s
+}
+
+// SetRuleGroupId sets the RuleGroupId field's value.
+func (s *RuleGroupSummary) SetRuleGroupId(v string) *RuleGroupSummary {
+	s.RuleGroupId = &v
+	return s
+}
+
+// Specifies an ActivatedRule and indicates whether you want to add it to a
+// RuleGroup or delete it from a RuleGroup.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/RuleGroupUpdate
+type RuleGroupUpdate struct {
+	_ struct{} `type:"structure"`
+
+	// Specify INSERT to add an ActivatedRule to a RuleGroup. Use DELETE to remove
+	// an ActivatedRule from a RuleGroup.
+	//
+	// Action is a required field
+	Action *string `type:"string" required:"true" enum:"ChangeAction"`
+
+	// The ActivatedRule object specifies a Rule that you want to insert or delete,
+	// the priority of the Rule in the WebACL, and the action that you want AWS
+	// WAF to take when a web request matches the Rule (ALLOW, BLOCK, or COUNT).
+	//
+	// ActivatedRule is a required field
+	ActivatedRule *ActivatedRule `type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s RuleGroupUpdate) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s RuleGroupUpdate) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RuleGroupUpdate) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RuleGroupUpdate"}
+	if s.Action == nil {
+		invalidParams.Add(request.NewErrParamRequired("Action"))
+	}
+	if s.ActivatedRule == nil {
+		invalidParams.Add(request.NewErrParamRequired("ActivatedRule"))
+	}
+	if s.ActivatedRule != nil {
+		if err := s.ActivatedRule.Validate(); err != nil {
+			invalidParams.AddNested("ActivatedRule", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAction sets the Action field's value.
+func (s *RuleGroupUpdate) SetAction(v string) *RuleGroupUpdate {
+	s.Action = &v
+	return s
+}
+
+// SetActivatedRule sets the ActivatedRule field's value.
+func (s *RuleGroupUpdate) SetActivatedRule(v *ActivatedRule) *RuleGroupUpdate {
+	s.ActivatedRule = v
+	return s
+}
+
 // Contains the identifier and the friendly name or description of the Rule.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/RuleSummary
 type RuleSummary struct {
@@ -13773,6 +15289,12 @@ type SampledHTTPRequest struct {
 	// Request is a required field
 	Request *HTTPRequest `type:"structure" required:"true"`
 
+	// This value is returned if the GetSampledRequests request specifies the ID
+	// of a RuleGroup rather than the ID of an individual rule. RuleWithinRuleGroup
+	// is the rule within the specified RuleGroup that matched the request listed
+	// in the response.
+	RuleWithinRuleGroup *string `min:"1" type:"string"`
+
 	// The time at which AWS WAF received the request from your AWS resource, in
 	// Unix time format (in seconds).
 	Timestamp *time.Time `type:"timestamp" timestampFormat:"unix"`
@@ -13805,6 +15327,12 @@ func (s *SampledHTTPRequest) SetAction(v string) *SampledHTTPRequest {
 // SetRequest sets the Request field's value.
 func (s *SampledHTTPRequest) SetRequest(v *HTTPRequest) *SampledHTTPRequest {
 	s.Request = v
+	return s
+}
+
+// SetRuleWithinRuleGroup sets the RuleWithinRuleGroup field's value.
+func (s *SampledHTTPRequest) SetRuleWithinRuleGroup(v string) *SampledHTTPRequest {
+	s.RuleWithinRuleGroup = &v
 	return s
 }
 
@@ -14467,6 +15995,59 @@ func (s *SqlInjectionMatchTuple) SetFieldToMatch(v *FieldToMatch) *SqlInjectionM
 // SetTextTransformation sets the TextTransformation field's value.
 func (s *SqlInjectionMatchTuple) SetTextTransformation(v string) *SqlInjectionMatchTuple {
 	s.TextTransformation = &v
+	return s
+}
+
+// A summary of the rule groups you are subscribed to.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/SubscribedRuleGroupSummary
+type SubscribedRuleGroupSummary struct {
+	_ struct{} `type:"structure"`
+
+	// A friendly name or description for the metrics for this RuleGroup. The name
+	// can contain only alphanumeric characters (A-Z, a-z, 0-9); the name can't
+	// contain whitespace. You can't change the name of the metric after you create
+	// the RuleGroup.
+	//
+	// MetricName is a required field
+	MetricName *string `type:"string" required:"true"`
+
+	// A friendly name or description of the RuleGroup. You can't change the name
+	// of a RuleGroup after you create it.
+	//
+	// Name is a required field
+	Name *string `min:"1" type:"string" required:"true"`
+
+	// A unique identifier for a RuleGroup.
+	//
+	// RuleGroupId is a required field
+	RuleGroupId *string `min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s SubscribedRuleGroupSummary) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SubscribedRuleGroupSummary) GoString() string {
+	return s.String()
+}
+
+// SetMetricName sets the MetricName field's value.
+func (s *SubscribedRuleGroupSummary) SetMetricName(v string) *SubscribedRuleGroupSummary {
+	s.MetricName = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *SubscribedRuleGroupSummary) SetName(v string) *SubscribedRuleGroupSummary {
+	s.Name = &v
+	return s
+}
+
+// SetRuleGroupId sets the RuleGroupId field's value.
+func (s *SubscribedRuleGroupSummary) SetRuleGroupId(v string) *SubscribedRuleGroupSummary {
+	s.RuleGroupId = &v
 	return s
 }
 
@@ -15259,6 +16840,126 @@ func (s *UpdateRegexPatternSetOutput) SetChangeToken(v string) *UpdateRegexPatte
 	return s
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/UpdateRuleGroupRequest
+type UpdateRuleGroupInput struct {
+	_ struct{} `type:"structure"`
+
+	// The value returned by the most recent call to GetChangeToken.
+	//
+	// ChangeToken is a required field
+	ChangeToken *string `min:"1" type:"string" required:"true"`
+
+	// The RuleGroupId of the RuleGroup that you want to update. RuleGroupId is
+	// returned by CreateRuleGroup and by ListRuleGroups.
+	//
+	// RuleGroupId is a required field
+	RuleGroupId *string `min:"1" type:"string" required:"true"`
+
+	// An array of RuleGroupUpdate objects that you want to insert into or delete
+	// from a RuleGroup.
+	//
+	// You can only insert REGULAR rules into a rule group.
+	//
+	// The Action data type within ActivatedRule is used only when submitting an
+	// UpdateWebACL request. ActivatedRule|Action is not applicable and therefore
+	// not available for UpdateRuleGroup.
+	//
+	// Updates is a required field
+	Updates []*RuleGroupUpdate `min:"1" type:"list" required:"true"`
+}
+
+// String returns the string representation
+func (s UpdateRuleGroupInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateRuleGroupInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateRuleGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateRuleGroupInput"}
+	if s.ChangeToken == nil {
+		invalidParams.Add(request.NewErrParamRequired("ChangeToken"))
+	}
+	if s.ChangeToken != nil && len(*s.ChangeToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ChangeToken", 1))
+	}
+	if s.RuleGroupId == nil {
+		invalidParams.Add(request.NewErrParamRequired("RuleGroupId"))
+	}
+	if s.RuleGroupId != nil && len(*s.RuleGroupId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RuleGroupId", 1))
+	}
+	if s.Updates == nil {
+		invalidParams.Add(request.NewErrParamRequired("Updates"))
+	}
+	if s.Updates != nil && len(s.Updates) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Updates", 1))
+	}
+	if s.Updates != nil {
+		for i, v := range s.Updates {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Updates", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetChangeToken sets the ChangeToken field's value.
+func (s *UpdateRuleGroupInput) SetChangeToken(v string) *UpdateRuleGroupInput {
+	s.ChangeToken = &v
+	return s
+}
+
+// SetRuleGroupId sets the RuleGroupId field's value.
+func (s *UpdateRuleGroupInput) SetRuleGroupId(v string) *UpdateRuleGroupInput {
+	s.RuleGroupId = &v
+	return s
+}
+
+// SetUpdates sets the Updates field's value.
+func (s *UpdateRuleGroupInput) SetUpdates(v []*RuleGroupUpdate) *UpdateRuleGroupInput {
+	s.Updates = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/UpdateRuleGroupResponse
+type UpdateRuleGroupOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The ChangeToken that you used to submit the UpdateRuleGroup request. You
+	// can also use this value to query the status of the request. For more information,
+	// see GetChangeTokenStatus.
+	ChangeToken *string `min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s UpdateRuleGroupOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateRuleGroupOutput) GoString() string {
+	return s.String()
+}
+
+// SetChangeToken sets the ChangeToken field's value.
+func (s *UpdateRuleGroupOutput) SetChangeToken(v string) *UpdateRuleGroupOutput {
+	s.ChangeToken = &v
+	return s
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/UpdateRuleRequest
 type UpdateRuleInput struct {
 	_ struct{} `type:"structure"`
@@ -15642,7 +17343,10 @@ type UpdateWebACLInput struct {
 	//
 	//    * WebACLUpdate: Contains Action and ActivatedRule
 	//
-	//    * ActivatedRule: Contains Action, Priority, RuleId, and Type
+	//    * ActivatedRule: Contains Action, Priority, RuleId, and Type. The OverrideAction
+	//    data type within ActivatedRule is used only when submitting an UpdateRuleGroup
+	//    request. ActivatedRule|OverrideAction is not applicable and therefore
+	//    not available for UpdateWebACL.
 	//
 	//    * WafAction: Contains Type
 	Updates []*WebACLUpdate `type:"list"`
@@ -15923,6 +17627,47 @@ func (s *WafAction) Validate() error {
 
 // SetType sets the Type field's value.
 func (s *WafAction) SetType(v string) *WafAction {
+	s.Type = &v
+	return s
+}
+
+// The action to take if any rule within the RuleGroup matches a request.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/WafOverrideAction
+type WafOverrideAction struct {
+	_ struct{} `type:"structure"`
+
+	// COUNT overrides the action specified by the individual rule within a RuleGroup
+	// . If set to NONE, the rule's action will take place.
+	//
+	// Type is a required field
+	Type *string `type:"string" required:"true" enum:"WafOverrideActionType"`
+}
+
+// String returns the string representation
+func (s WafOverrideAction) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s WafOverrideAction) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *WafOverrideAction) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "WafOverrideAction"}
+	if s.Type == nil {
+		invalidParams.Add(request.NewErrParamRequired("Type"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetType sets the Type field's value.
+func (s *WafOverrideAction) SetType(v string) *WafOverrideAction {
 	s.Type = &v
 	return s
 }
@@ -17235,6 +18980,9 @@ const (
 	// ParameterExceptionFieldWafAction is a ParameterExceptionField enum value
 	ParameterExceptionFieldWafAction = "WAF_ACTION"
 
+	// ParameterExceptionFieldWafOverrideAction is a ParameterExceptionField enum value
+	ParameterExceptionFieldWafOverrideAction = "WAF_OVERRIDE_ACTION"
+
 	// ParameterExceptionFieldPredicateType is a ParameterExceptionField enum value
 	ParameterExceptionFieldPredicateType = "PREDICATE_TYPE"
 
@@ -17357,9 +19105,20 @@ const (
 )
 
 const (
+	// WafOverrideActionTypeNone is a WafOverrideActionType enum value
+	WafOverrideActionTypeNone = "NONE"
+
+	// WafOverrideActionTypeCount is a WafOverrideActionType enum value
+	WafOverrideActionTypeCount = "COUNT"
+)
+
+const (
 	// WafRuleTypeRegular is a WafRuleType enum value
 	WafRuleTypeRegular = "REGULAR"
 
 	// WafRuleTypeRateBased is a WafRuleType enum value
 	WafRuleTypeRateBased = "RATE_BASED"
+
+	// WafRuleTypeGroup is a WafRuleType enum value
+	WafRuleTypeGroup = "GROUP"
 )

--- a/vendor/github.com/aws/aws-sdk-go/service/waf/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/waf/errors.go
@@ -154,4 +154,10 @@ const (
 	// The operation failed because you tried to create, update, or delete an object
 	// by using a change token that has already been used.
 	ErrCodeStaleDataException = "StaleDataException"
+
+	// ErrCodeSubscriptionNotFoundException for service response error code
+	// "SubscriptionNotFoundException".
+	//
+	// The specified subscription does not exist.
+	ErrCodeSubscriptionNotFoundException = "SubscriptionNotFoundException"
 )

--- a/vendor/github.com/aws/aws-sdk-go/service/wafregional/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/wafregional/api.go
@@ -1134,6 +1134,112 @@ func (c *WAFRegional) CreateRuleWithContext(ctx aws.Context, input *waf.CreateRu
 	return out, req.Send()
 }
 
+const opCreateRuleGroup = "CreateRuleGroup"
+
+// CreateRuleGroupRequest generates a "aws/request.Request" representing the
+// client's request for the CreateRuleGroup operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See CreateRuleGroup for more information on using the CreateRuleGroup
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the CreateRuleGroupRequest method.
+//    req, resp := client.CreateRuleGroupRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-regional-2016-11-28/CreateRuleGroup
+func (c *WAFRegional) CreateRuleGroupRequest(input *waf.CreateRuleGroupInput) (req *request.Request, output *waf.CreateRuleGroupOutput) {
+	op := &request.Operation{
+		Name:       opCreateRuleGroup,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &waf.CreateRuleGroupInput{}
+	}
+
+	output = &waf.CreateRuleGroupOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// CreateRuleGroup API operation for AWS WAF Regional.
+//
+// Creates a RuleGroup. A rule group is a collection of predefined rules that
+// you add to a web ACL. You use UpdateRuleGroup to add rules to the rule group.
+//
+// Rule groups are subject to the following limits:
+//
+//    * Three rule groups per account. You can request an increase to this limit
+//    by contacting customer support.
+//
+//    * One rule group per web ACL.
+//
+//    * Ten rules per rule group.
+//
+// For more information about how to use the AWS WAF API to allow or block HTTP
+// requests, see the AWS WAF Developer Guide (http://docs.aws.amazon.com/waf/latest/developerguide/).
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS WAF Regional's
+// API operation CreateRuleGroup for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeWAFStaleDataException "WAFStaleDataException"
+//   The operation failed because you tried to create, update, or delete an object
+//   by using a change token that has already been used.
+//
+//   * ErrCodeWAFInternalErrorException "WAFInternalErrorException"
+//   The operation failed because of a system problem, even though the request
+//   was valid. Retry your request.
+//
+//   * ErrCodeWAFDisallowedNameException "WAFDisallowedNameException"
+//   The name specified is invalid.
+//
+//   * ErrCodeWAFLimitsExceededException "WAFLimitsExceededException"
+//   The operation exceeds a resource limit, for example, the maximum number of
+//   WebACL objects that you can create for an AWS account. For more information,
+//   see Limits (http://docs.aws.amazon.com/waf/latest/developerguide/limits.html)
+//   in the AWS WAF Developer Guide.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-regional-2016-11-28/CreateRuleGroup
+func (c *WAFRegional) CreateRuleGroup(input *waf.CreateRuleGroupInput) (*waf.CreateRuleGroupOutput, error) {
+	req, out := c.CreateRuleGroupRequest(input)
+	return out, req.Send()
+}
+
+// CreateRuleGroupWithContext is the same as CreateRuleGroup with the addition of
+// the ability to pass a context and additional request options.
+//
+// See CreateRuleGroup for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *WAFRegional) CreateRuleGroupWithContext(ctx aws.Context, input *waf.CreateRuleGroupInput, opts ...request.Option) (*waf.CreateRuleGroupOutput, error) {
+	req, out := c.CreateRuleGroupRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opCreateSizeConstraintSet = "CreateSizeConstraintSet"
 
 // CreateSizeConstraintSetRequest generates a "aws/request.Request" representing the
@@ -2597,6 +2703,127 @@ func (c *WAFRegional) DeleteRule(input *waf.DeleteRuleInput) (*waf.DeleteRuleOut
 // for more information on using Contexts.
 func (c *WAFRegional) DeleteRuleWithContext(ctx aws.Context, input *waf.DeleteRuleInput, opts ...request.Option) (*waf.DeleteRuleOutput, error) {
 	req, out := c.DeleteRuleRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDeleteRuleGroup = "DeleteRuleGroup"
+
+// DeleteRuleGroupRequest generates a "aws/request.Request" representing the
+// client's request for the DeleteRuleGroup operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DeleteRuleGroup for more information on using the DeleteRuleGroup
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DeleteRuleGroupRequest method.
+//    req, resp := client.DeleteRuleGroupRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-regional-2016-11-28/DeleteRuleGroup
+func (c *WAFRegional) DeleteRuleGroupRequest(input *waf.DeleteRuleGroupInput) (req *request.Request, output *waf.DeleteRuleGroupOutput) {
+	op := &request.Operation{
+		Name:       opDeleteRuleGroup,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &waf.DeleteRuleGroupInput{}
+	}
+
+	output = &waf.DeleteRuleGroupOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DeleteRuleGroup API operation for AWS WAF Regional.
+//
+// Permanently deletes a RuleGroup. You can't delete a RuleGroup if it's still
+// used in any WebACL objects or if it still includes any rules.
+//
+// If you just want to remove a RuleGroup from a WebACL, use UpdateWebACL.
+//
+// To permanently delete a RuleGroup from AWS WAF, perform the following steps:
+//
+// Update the RuleGroup to remove rules, if any. For more information, see UpdateRuleGroup.
+//
+// Use GetChangeToken to get the change token that you provide in the ChangeToken
+// parameter of a DeleteRuleGroup request.
+//
+// Submit a DeleteRuleGroup request.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS WAF Regional's
+// API operation DeleteRuleGroup for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeWAFStaleDataException "WAFStaleDataException"
+//   The operation failed because you tried to create, update, or delete an object
+//   by using a change token that has already been used.
+//
+//   * ErrCodeWAFInternalErrorException "WAFInternalErrorException"
+//   The operation failed because of a system problem, even though the request
+//   was valid. Retry your request.
+//
+//   * ErrCodeWAFNonexistentItemException "WAFNonexistentItemException"
+//   The operation failed because the referenced object doesn't exist.
+//
+//   * ErrCodeWAFReferencedItemException "WAFReferencedItemException"
+//   The operation failed because you tried to delete an object that is still
+//   in use. For example:
+//
+//      * You tried to delete a ByteMatchSet that is still referenced by a Rule.
+//
+//      * You tried to delete a Rule that is still referenced by a WebACL.
+//
+//   * ErrCodeWAFNonEmptyEntityException "WAFNonEmptyEntityException"
+//   The operation failed because you tried to delete an object that isn't empty.
+//   For example:
+//
+//      * You tried to delete a WebACL that still contains one or more Rule objects.
+//
+//      * You tried to delete a Rule that still contains one or more ByteMatchSet
+//      objects or other predicates.
+//
+//      * You tried to delete a ByteMatchSet that contains one or more ByteMatchTuple
+//      objects.
+//
+//      * You tried to delete an IPSet that references one or more IP addresses.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-regional-2016-11-28/DeleteRuleGroup
+func (c *WAFRegional) DeleteRuleGroup(input *waf.DeleteRuleGroupInput) (*waf.DeleteRuleGroupOutput, error) {
+	req, out := c.DeleteRuleGroupRequest(input)
+	return out, req.Send()
+}
+
+// DeleteRuleGroupWithContext is the same as DeleteRuleGroup with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeleteRuleGroup for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *WAFRegional) DeleteRuleGroupWithContext(ctx aws.Context, input *waf.DeleteRuleGroupInput, opts ...request.Option) (*waf.DeleteRuleGroupOutput, error) {
+	req, out := c.DeleteRuleGroupRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -4140,6 +4367,92 @@ func (c *WAFRegional) GetRuleWithContext(ctx aws.Context, input *waf.GetRuleInpu
 	return out, req.Send()
 }
 
+const opGetRuleGroup = "GetRuleGroup"
+
+// GetRuleGroupRequest generates a "aws/request.Request" representing the
+// client's request for the GetRuleGroup operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See GetRuleGroup for more information on using the GetRuleGroup
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the GetRuleGroupRequest method.
+//    req, resp := client.GetRuleGroupRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-regional-2016-11-28/GetRuleGroup
+func (c *WAFRegional) GetRuleGroupRequest(input *waf.GetRuleGroupInput) (req *request.Request, output *waf.GetRuleGroupOutput) {
+	op := &request.Operation{
+		Name:       opGetRuleGroup,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &waf.GetRuleGroupInput{}
+	}
+
+	output = &waf.GetRuleGroupOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// GetRuleGroup API operation for AWS WAF Regional.
+//
+// Returns the RuleGroup that is specified by the RuleGroupId that you included
+// in the GetRuleGroup request.
+//
+// To view the rules in a rule group, use ListActivatedRulesInRuleGroup.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS WAF Regional's
+// API operation GetRuleGroup for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeWAFInternalErrorException "WAFInternalErrorException"
+//   The operation failed because of a system problem, even though the request
+//   was valid. Retry your request.
+//
+//   * ErrCodeWAFNonexistentItemException "WAFNonexistentItemException"
+//   The operation failed because the referenced object doesn't exist.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-regional-2016-11-28/GetRuleGroup
+func (c *WAFRegional) GetRuleGroup(input *waf.GetRuleGroupInput) (*waf.GetRuleGroupOutput, error) {
+	req, out := c.GetRuleGroupRequest(input)
+	return out, req.Send()
+}
+
+// GetRuleGroupWithContext is the same as GetRuleGroup with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetRuleGroup for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *WAFRegional) GetRuleGroupWithContext(ctx aws.Context, input *waf.GetRuleGroupInput, opts ...request.Option) (*waf.GetRuleGroupOutput, error) {
+	req, out := c.GetRuleGroupRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opGetSampledRequests = "GetSampledRequests"
 
 // GetSampledRequestsRequest generates a "aws/request.Request" representing the
@@ -4696,6 +5009,118 @@ func (c *WAFRegional) GetXssMatchSet(input *waf.GetXssMatchSetInput) (*waf.GetXs
 // for more information on using Contexts.
 func (c *WAFRegional) GetXssMatchSetWithContext(ctx aws.Context, input *waf.GetXssMatchSetInput, opts ...request.Option) (*waf.GetXssMatchSetOutput, error) {
 	req, out := c.GetXssMatchSetRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opListActivatedRulesInRuleGroup = "ListActivatedRulesInRuleGroup"
+
+// ListActivatedRulesInRuleGroupRequest generates a "aws/request.Request" representing the
+// client's request for the ListActivatedRulesInRuleGroup operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ListActivatedRulesInRuleGroup for more information on using the ListActivatedRulesInRuleGroup
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ListActivatedRulesInRuleGroupRequest method.
+//    req, resp := client.ListActivatedRulesInRuleGroupRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-regional-2016-11-28/ListActivatedRulesInRuleGroup
+func (c *WAFRegional) ListActivatedRulesInRuleGroupRequest(input *waf.ListActivatedRulesInRuleGroupInput) (req *request.Request, output *waf.ListActivatedRulesInRuleGroupOutput) {
+	op := &request.Operation{
+		Name:       opListActivatedRulesInRuleGroup,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &waf.ListActivatedRulesInRuleGroupInput{}
+	}
+
+	output = &waf.ListActivatedRulesInRuleGroupOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListActivatedRulesInRuleGroup API operation for AWS WAF Regional.
+//
+// Returns an array of ActivatedRule objects.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS WAF Regional's
+// API operation ListActivatedRulesInRuleGroup for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeWAFInternalErrorException "WAFInternalErrorException"
+//   The operation failed because of a system problem, even though the request
+//   was valid. Retry your request.
+//
+//   * ErrCodeWAFNonexistentItemException "WAFNonexistentItemException"
+//   The operation failed because the referenced object doesn't exist.
+//
+//   * ErrCodeWAFInvalidParameterException "WAFInvalidParameterException"
+//   The operation failed because AWS WAF didn't recognize a parameter in the
+//   request. For example:
+//
+//      * You specified an invalid parameter name.
+//
+//      * You specified an invalid value.
+//
+//      * You tried to update an object (ByteMatchSet, IPSet, Rule, or WebACL)
+//      using an action other than INSERT or DELETE.
+//
+//      * You tried to create a WebACL with a DefaultActionType other than ALLOW,
+//      BLOCK, or COUNT.
+//
+//      * You tried to create a RateBasedRule with a RateKey value other than
+//      IP.
+//
+//      * You tried to update a WebACL with a WafActionType other than ALLOW,
+//      BLOCK, or COUNT.
+//
+//      * You tried to update a ByteMatchSet with a FieldToMatchType other than
+//      HEADER, METHOD, QUERY_STRING, URI, or BODY.
+//
+//      * You tried to update a ByteMatchSet with a Field of HEADER but no value
+//      for Data.
+//
+//      * Your request references an ARN that is malformed, or corresponds to
+//      a resource with which a web ACL cannot be associated.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-regional-2016-11-28/ListActivatedRulesInRuleGroup
+func (c *WAFRegional) ListActivatedRulesInRuleGroup(input *waf.ListActivatedRulesInRuleGroupInput) (*waf.ListActivatedRulesInRuleGroupOutput, error) {
+	req, out := c.ListActivatedRulesInRuleGroupRequest(input)
+	return out, req.Send()
+}
+
+// ListActivatedRulesInRuleGroupWithContext is the same as ListActivatedRulesInRuleGroup with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListActivatedRulesInRuleGroup for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *WAFRegional) ListActivatedRulesInRuleGroupWithContext(ctx aws.Context, input *waf.ListActivatedRulesInRuleGroupInput, opts ...request.Option) (*waf.ListActivatedRulesInRuleGroupOutput, error) {
+	req, out := c.ListActivatedRulesInRuleGroupRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -5292,6 +5717,86 @@ func (c *WAFRegional) ListResourcesForWebACLWithContext(ctx aws.Context, input *
 	return out, req.Send()
 }
 
+const opListRuleGroups = "ListRuleGroups"
+
+// ListRuleGroupsRequest generates a "aws/request.Request" representing the
+// client's request for the ListRuleGroups operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ListRuleGroups for more information on using the ListRuleGroups
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ListRuleGroupsRequest method.
+//    req, resp := client.ListRuleGroupsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-regional-2016-11-28/ListRuleGroups
+func (c *WAFRegional) ListRuleGroupsRequest(input *waf.ListRuleGroupsInput) (req *request.Request, output *waf.ListRuleGroupsOutput) {
+	op := &request.Operation{
+		Name:       opListRuleGroups,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &waf.ListRuleGroupsInput{}
+	}
+
+	output = &waf.ListRuleGroupsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListRuleGroups API operation for AWS WAF Regional.
+//
+// Returns an array of RuleGroup objects.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS WAF Regional's
+// API operation ListRuleGroups for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeWAFInternalErrorException "WAFInternalErrorException"
+//   The operation failed because of a system problem, even though the request
+//   was valid. Retry your request.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-regional-2016-11-28/ListRuleGroups
+func (c *WAFRegional) ListRuleGroups(input *waf.ListRuleGroupsInput) (*waf.ListRuleGroupsOutput, error) {
+	req, out := c.ListRuleGroupsRequest(input)
+	return out, req.Send()
+}
+
+// ListRuleGroupsWithContext is the same as ListRuleGroups with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListRuleGroups for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *WAFRegional) ListRuleGroupsWithContext(ctx aws.Context, input *waf.ListRuleGroupsInput, opts ...request.Option) (*waf.ListRuleGroupsOutput, error) {
+	req, out := c.ListRuleGroupsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opListRules = "ListRules"
 
 // ListRulesRequest generates a "aws/request.Request" representing the
@@ -5539,6 +6044,89 @@ func (c *WAFRegional) ListSqlInjectionMatchSets(input *waf.ListSqlInjectionMatch
 // for more information on using Contexts.
 func (c *WAFRegional) ListSqlInjectionMatchSetsWithContext(ctx aws.Context, input *waf.ListSqlInjectionMatchSetsInput, opts ...request.Option) (*waf.ListSqlInjectionMatchSetsOutput, error) {
 	req, out := c.ListSqlInjectionMatchSetsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opListSubscribedRuleGroups = "ListSubscribedRuleGroups"
+
+// ListSubscribedRuleGroupsRequest generates a "aws/request.Request" representing the
+// client's request for the ListSubscribedRuleGroups operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ListSubscribedRuleGroups for more information on using the ListSubscribedRuleGroups
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ListSubscribedRuleGroupsRequest method.
+//    req, resp := client.ListSubscribedRuleGroupsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-regional-2016-11-28/ListSubscribedRuleGroups
+func (c *WAFRegional) ListSubscribedRuleGroupsRequest(input *waf.ListSubscribedRuleGroupsInput) (req *request.Request, output *waf.ListSubscribedRuleGroupsOutput) {
+	op := &request.Operation{
+		Name:       opListSubscribedRuleGroups,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &waf.ListSubscribedRuleGroupsInput{}
+	}
+
+	output = &waf.ListSubscribedRuleGroupsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListSubscribedRuleGroups API operation for AWS WAF Regional.
+//
+// Returns an array of RuleGroup objects that you are subscribed to.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS WAF Regional's
+// API operation ListSubscribedRuleGroups for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeWAFNonexistentItemException "WAFNonexistentItemException"
+//   The operation failed because the referenced object doesn't exist.
+//
+//   * ErrCodeWAFInternalErrorException "WAFInternalErrorException"
+//   The operation failed because of a system problem, even though the request
+//   was valid. Retry your request.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-regional-2016-11-28/ListSubscribedRuleGroups
+func (c *WAFRegional) ListSubscribedRuleGroups(input *waf.ListSubscribedRuleGroupsInput) (*waf.ListSubscribedRuleGroupsOutput, error) {
+	req, out := c.ListSubscribedRuleGroupsRequest(input)
+	return out, req.Send()
+}
+
+// ListSubscribedRuleGroupsWithContext is the same as ListSubscribedRuleGroups with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListSubscribedRuleGroups for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *WAFRegional) ListSubscribedRuleGroupsWithContext(ctx aws.Context, input *waf.ListSubscribedRuleGroupsInput, opts ...request.Option) (*waf.ListSubscribedRuleGroupsOutput, error) {
+	req, out := c.ListSubscribedRuleGroupsRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -6580,15 +7168,15 @@ func (c *WAFRegional) UpdateRegexMatchSetRequest(input *waf.UpdateRegexMatchSetI
 
 // UpdateRegexMatchSet API operation for AWS WAF Regional.
 //
-// Inserts or deletes RegexMatchSetUpdate objects (filters) in a RegexMatchSet.
+// Inserts or deletes RegexMatchTuple objects (filters) in a RegexMatchSet.
 // For each RegexMatchSetUpdate object, you specify the following values:
 //
 //    * Whether to insert or delete the object from the array. If you want to
 //    change a RegexMatchSetUpdate object, you delete the existing object and
 //    add a new one.
 //
-//    * The part of a web request that you want AWS WAF to inspect, such as
-//    a query string or the value of the User-Agent header.
+//    * The part of a web request that you want AWS WAF to inspectupdate, such
+//    as a query string or the value of the User-Agent header.
 //
 //    * The identifier of the pattern (a regular expression) that you want AWS
 //    WAF to look for. For more information, see RegexPatternSet.
@@ -6750,14 +7338,12 @@ func (c *WAFRegional) UpdateRegexPatternSetRequest(input *waf.UpdateRegexPattern
 
 // UpdateRegexPatternSet API operation for AWS WAF Regional.
 //
-// Inserts or deletes RegexMatchSetUpdate objects (filters) in a RegexPatternSet.
-// For each RegexPatternSet object, you specify the following values:
+// Inserts or deletes RegexPatternString objects in a RegexPatternSet. For each
+// RegexPatternString object, you specify the following values:
 //
-//    * Whether to insert or delete the object from the array. If you want to
-//    change a RegexPatternSet object, you delete the existing object and add
-//    a new one.
+//    * Whether to insert or delete the RegexPatternString.
 //
-//    * The regular expression pattern that you want AWS WAF to look for. For
+//    * The regular expression pattern that you want to insert or delete. For
 //    more information, see RegexPatternSet.
 //
 // For example, you can create a RegexPatternString such as B[a@]dB[o0]t. AWS
@@ -6805,6 +7391,9 @@ func (c *WAFRegional) UpdateRegexPatternSetRequest(input *waf.UpdateRegexPattern
 //   WebACL objects that you can create for an AWS account. For more information,
 //   see Limits (http://docs.aws.amazon.com/waf/latest/developerguide/limits.html)
 //   in the AWS WAF Developer Guide.
+//
+//   * ErrCodeWAFNonexistentItemException "WAFNonexistentItemException"
+//   The operation failed because the referenced object doesn't exist.
 //
 //   * ErrCodeWAFNonexistentContainerException "WAFNonexistentContainerException"
 //   The operation failed because you tried to add an object to or delete an object
@@ -7070,6 +7659,187 @@ func (c *WAFRegional) UpdateRule(input *waf.UpdateRuleInput) (*waf.UpdateRuleOut
 // for more information on using Contexts.
 func (c *WAFRegional) UpdateRuleWithContext(ctx aws.Context, input *waf.UpdateRuleInput, opts ...request.Option) (*waf.UpdateRuleOutput, error) {
 	req, out := c.UpdateRuleRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opUpdateRuleGroup = "UpdateRuleGroup"
+
+// UpdateRuleGroupRequest generates a "aws/request.Request" representing the
+// client's request for the UpdateRuleGroup operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See UpdateRuleGroup for more information on using the UpdateRuleGroup
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the UpdateRuleGroupRequest method.
+//    req, resp := client.UpdateRuleGroupRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-regional-2016-11-28/UpdateRuleGroup
+func (c *WAFRegional) UpdateRuleGroupRequest(input *waf.UpdateRuleGroupInput) (req *request.Request, output *waf.UpdateRuleGroupOutput) {
+	op := &request.Operation{
+		Name:       opUpdateRuleGroup,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &waf.UpdateRuleGroupInput{}
+	}
+
+	output = &waf.UpdateRuleGroupOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// UpdateRuleGroup API operation for AWS WAF Regional.
+//
+// Inserts or deletes ActivatedRule objects in a RuleGroup.
+//
+// You can only insert REGULAR rules into a rule group.
+//
+// You can have a maximum of ten rules per rule group.
+//
+// To create and configure a RuleGroup, perform the following steps:
+//
+// Create and update the Rules that you want to include in the RuleGroup. See
+// CreateRule.
+//
+// Use GetChangeToken to get the change token that you provide in the ChangeToken
+// parameter of an UpdateRuleGroup request.
+//
+// Submit an UpdateRuleGroup request to add Rules to the RuleGroup.
+//
+// Create and update a WebACL that contains the RuleGroup. See CreateWebACL.
+//
+// If you want to replace one Rule with another, you delete the existing one
+// and add the new one.
+//
+// For more information about how to use the AWS WAF API to allow or block HTTP
+// requests, see the AWS WAF Developer Guide (http://docs.aws.amazon.com/waf/latest/developerguide/).
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS WAF Regional's
+// API operation UpdateRuleGroup for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeWAFStaleDataException "WAFStaleDataException"
+//   The operation failed because you tried to create, update, or delete an object
+//   by using a change token that has already been used.
+//
+//   * ErrCodeWAFInternalErrorException "WAFInternalErrorException"
+//   The operation failed because of a system problem, even though the request
+//   was valid. Retry your request.
+//
+//   * ErrCodeWAFNonexistentContainerException "WAFNonexistentContainerException"
+//   The operation failed because you tried to add an object to or delete an object
+//   from another object that doesn't exist. For example:
+//
+//      * You tried to add a Rule to or delete a Rule from a WebACL that doesn't
+//      exist.
+//
+//      * You tried to add a ByteMatchSet to or delete a ByteMatchSet from a Rule
+//      that doesn't exist.
+//
+//      * You tried to add an IP address to or delete an IP address from an IPSet
+//      that doesn't exist.
+//
+//      * You tried to add a ByteMatchTuple to or delete a ByteMatchTuple from
+//      a ByteMatchSet that doesn't exist.
+//
+//   * ErrCodeWAFNonexistentItemException "WAFNonexistentItemException"
+//   The operation failed because the referenced object doesn't exist.
+//
+//   * ErrCodeWAFInvalidOperationException "WAFInvalidOperationException"
+//   The operation failed because there was nothing to do. For example:
+//
+//      * You tried to remove a Rule from a WebACL, but the Rule isn't in the
+//      specified WebACL.
+//
+//      * You tried to remove an IP address from an IPSet, but the IP address
+//      isn't in the specified IPSet.
+//
+//      * You tried to remove a ByteMatchTuple from a ByteMatchSet, but the ByteMatchTuple
+//      isn't in the specified WebACL.
+//
+//      * You tried to add a Rule to a WebACL, but the Rule already exists in
+//      the specified WebACL.
+//
+//      * You tried to add an IP address to an IPSet, but the IP address already
+//      exists in the specified IPSet.
+//
+//      * You tried to add a ByteMatchTuple to a ByteMatchSet, but the ByteMatchTuple
+//      already exists in the specified WebACL.
+//
+//   * ErrCodeWAFLimitsExceededException "WAFLimitsExceededException"
+//   The operation exceeds a resource limit, for example, the maximum number of
+//   WebACL objects that you can create for an AWS account. For more information,
+//   see Limits (http://docs.aws.amazon.com/waf/latest/developerguide/limits.html)
+//   in the AWS WAF Developer Guide.
+//
+//   * ErrCodeWAFInvalidParameterException "WAFInvalidParameterException"
+//   The operation failed because AWS WAF didn't recognize a parameter in the
+//   request. For example:
+//
+//      * You specified an invalid parameter name.
+//
+//      * You specified an invalid value.
+//
+//      * You tried to update an object (ByteMatchSet, IPSet, Rule, or WebACL)
+//      using an action other than INSERT or DELETE.
+//
+//      * You tried to create a WebACL with a DefaultActionType other than ALLOW,
+//      BLOCK, or COUNT.
+//
+//      * You tried to create a RateBasedRule with a RateKey value other than
+//      IP.
+//
+//      * You tried to update a WebACL with a WafActionType other than ALLOW,
+//      BLOCK, or COUNT.
+//
+//      * You tried to update a ByteMatchSet with a FieldToMatchType other than
+//      HEADER, METHOD, QUERY_STRING, URI, or BODY.
+//
+//      * You tried to update a ByteMatchSet with a Field of HEADER but no value
+//      for Data.
+//
+//      * Your request references an ARN that is malformed, or corresponds to
+//      a resource with which a web ACL cannot be associated.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-regional-2016-11-28/UpdateRuleGroup
+func (c *WAFRegional) UpdateRuleGroup(input *waf.UpdateRuleGroupInput) (*waf.UpdateRuleGroupOutput, error) {
+	req, out := c.UpdateRuleGroupRequest(input)
+	return out, req.Send()
+}
+
+// UpdateRuleGroupWithContext is the same as UpdateRuleGroup with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UpdateRuleGroup for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *WAFRegional) UpdateRuleGroupWithContext(ctx aws.Context, input *waf.UpdateRuleGroupInput, opts ...request.Option) (*waf.UpdateRuleGroupOutput, error) {
+	req, out := c.UpdateRuleGroupRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -7673,6 +8443,9 @@ func (c *WAFRegional) UpdateWebACLRequest(input *waf.UpdateWebACLInput) (req *re
 //   WebACL objects that you can create for an AWS account. For more information,
 //   see Limits (http://docs.aws.amazon.com/waf/latest/developerguide/limits.html)
 //   in the AWS WAF Developer Guide.
+//
+//   * ErrCodeWAFSubscriptionNotFoundException "WAFSubscriptionNotFoundException"
+//   The specified subscription does not exist.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/waf-regional-2016-11-28/UpdateWebACL
 func (c *WAFRegional) UpdateWebACL(input *waf.UpdateWebACLInput) (*waf.UpdateWebACLOutput, error) {
@@ -8983,6 +9756,9 @@ const (
 	// ParameterExceptionFieldWafAction is a ParameterExceptionField enum value
 	ParameterExceptionFieldWafAction = "WAF_ACTION"
 
+	// ParameterExceptionFieldWafOverrideAction is a ParameterExceptionField enum value
+	ParameterExceptionFieldWafOverrideAction = "WAF_OVERRIDE_ACTION"
+
 	// ParameterExceptionFieldPredicateType is a ParameterExceptionField enum value
 	ParameterExceptionFieldPredicateType = "PREDICATE_TYPE"
 
@@ -9105,9 +9881,20 @@ const (
 )
 
 const (
+	// WafOverrideActionTypeNone is a WafOverrideActionType enum value
+	WafOverrideActionTypeNone = "NONE"
+
+	// WafOverrideActionTypeCount is a WafOverrideActionType enum value
+	WafOverrideActionTypeCount = "COUNT"
+)
+
+const (
 	// WafRuleTypeRegular is a WafRuleType enum value
 	WafRuleTypeRegular = "REGULAR"
 
 	// WafRuleTypeRateBased is a WafRuleType enum value
 	WafRuleTypeRateBased = "RATE_BASED"
+
+	// WafRuleTypeGroup is a WafRuleType enum value
+	WafRuleTypeGroup = "GROUP"
 )

--- a/vendor/github.com/aws/aws-sdk-go/service/wafregional/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/wafregional/errors.go
@@ -155,6 +155,12 @@ const (
 	// by using a change token that has already been used.
 	ErrCodeWAFStaleDataException = "WAFStaleDataException"
 
+	// ErrCodeWAFSubscriptionNotFoundException for service response error code
+	// "WAFSubscriptionNotFoundException".
+	//
+	// The specified subscription does not exist.
+	ErrCodeWAFSubscriptionNotFoundException = "WAFSubscriptionNotFoundException"
+
 	// ErrCodeWAFUnavailableEntityException for service response error code
 	// "WAFUnavailableEntityException".
 	//

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -141,756 +141,756 @@
 			"revisionTime": "2017-07-27T15:54:43Z"
 		},
 		{
-			"checksumSHA1": "h/m5SH4paAbQZ/2fttRwEVt/JzE=",
+			"checksumSHA1": "sApdWt8nEtaTapjFMDHLRo/8zUs=",
 			"path": "github.com/aws/aws-sdk-go/aws",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "DtuTqKH29YnLjrIJkRYX0HQtXY0=",
 			"path": "github.com/aws/aws-sdk-go/aws/arn",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "Y9W+4GimK4Fuxq+vyIskVYFRnX4=",
 			"path": "github.com/aws/aws-sdk-go/aws/awserr",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "yyYr41HZ1Aq0hWc3J5ijXwYEcac=",
 			"path": "github.com/aws/aws-sdk-go/aws/awsutil",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "9nE/FjZ4pYrT883KtV2/aI+Gayo=",
 			"path": "github.com/aws/aws-sdk-go/aws/client",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "ieAJ+Cvp/PKv1LpUEnUXpc3OI6E=",
 			"path": "github.com/aws/aws-sdk-go/aws/client/metadata",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "7/8j/q0TWtOgXyvEcv4B2Dhl00o=",
 			"path": "github.com/aws/aws-sdk-go/aws/corehandlers",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "Y+cPwQL0dZMyqp3wI+KJWmA9KQ8=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "u3GOAJLmdvbuNUeUEcZSEAOeL/0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "NUJUTWlc1sV8b7WjfiYc4JZbXl0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/endpointcreds",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "JEYqmF83O5n5bHkupAzA6STm0no=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "ZdtYh3ZHSgP/WEIaqwJHTEhpkbs=",
 			"path": "github.com/aws/aws-sdk-go/aws/defaults",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "/EXbk/z2TWjWc1Hvb4QYs3Wmhb8=",
 			"path": "github.com/aws/aws-sdk-go/aws/ec2metadata",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "2Rcu4ZCsQkoBFN0NpveADCcES8Q=",
 			"path": "github.com/aws/aws-sdk-go/aws/endpoints",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "9GvAyILJ7g+VUg8Ef5DsT5GuYsg=",
 			"path": "github.com/aws/aws-sdk-go/aws/request",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "HcGL4e6Uep4/80eCUI5xkcWjpQ0=",
 			"path": "github.com/aws/aws-sdk-go/aws/session",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "iU00ZjhAml/13g+1YXT21IqoXqg=",
 			"path": "github.com/aws/aws-sdk-go/aws/signer/v4",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "04ypv4x12l4q0TksA1zEVsmgpvw=",
 			"path": "github.com/aws/aws-sdk-go/internal/shareddefaults",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "NStHCXEvYqG72GknZyv1jaKaeH0=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "1QmQ3FqV37w0Zi44qv8pA1GeR0A=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/ec2query",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "yHfT5DTbeCLs4NE2Rgnqrhe15ls=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/json/jsonutil",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "R00RL5jJXRYq1iiK1+PGvMfvXyM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/jsonrpc",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "ZqY5RWavBLWTo6j9xqdyBEaNFRk=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "9V1PvtFQ9MObZTc3sa86WcuOtOU=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "pkeoOfZpHRvFG/AOZeTf0lwtsFg=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/rest",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "Rpu8KBtHZgvhkwHxUfaky+qW+G4=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restjson",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "ODo+ko8D6unAxZuN1jGzMcN4QCc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restxml",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "0qYPUga28aQVkxZgBR3Z86AbGUQ=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "F6mth+G7dXN1GI+nktaGo8Lx8aE=",
 			"path": "github.com/aws/aws-sdk-go/private/signer/v2",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "2CNaABTsz1Dl+cRpvKKhSS2Udgk=",
 			"path": "github.com/aws/aws-sdk-go/service/acm",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "C4vMftQYHGigucKljPRM6m6iko4=",
 			"path": "github.com/aws/aws-sdk-go/service/apigateway",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "s+mt8VBjyMOBCZbr4/uOhUGZdYY=",
 			"path": "github.com/aws/aws-sdk-go/service/applicationautoscaling",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "1/p8oChMJW38gBTOA8AUCWkHuM8=",
 			"path": "github.com/aws/aws-sdk-go/service/athena",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
-			"checksumSHA1": "ILLTTjBCwDHKcx6D/Ja5k4Nn5Ww=",
+			"checksumSHA1": "dsq+AB+U9PQG+2KGa5wDQNJaqHE=",
 			"path": "github.com/aws/aws-sdk-go/service/autoscaling",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "DTKp8JsJ4NvsSoeLVp72lPPT2jc=",
 			"path": "github.com/aws/aws-sdk-go/service/batch",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "86Gd/aNE5+OAAibFQg6YWh7YKU0=",
 			"path": "github.com/aws/aws-sdk-go/service/budgets",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "NTUkkfytXTRTbjLiiZrHS0FO9A4=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudformation",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "vbSfNKXjDDYLLAYafrD37T5xBFk=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudfront",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "V5UO7ojp8/EuLhPIS4OOOurke3M=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudtrail",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "Rx8tIQPEmYZhy1zbRpDmMBmGfvg=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatch",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "UlNtqtd2PcKoWqqXmOj4kfu8hyc=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchevents",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "7SPaq0IXgoe1Cqph7ws9vFYr3zg=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "iOGHSGv16gPEKX+DHoOoXIeGm70=",
 			"path": "github.com/aws/aws-sdk-go/service/codebuild",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "B8CSJW3k+VJ6neD1ddrSJJ/5TF8=",
 			"path": "github.com/aws/aws-sdk-go/service/codecommit",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "8T1UkQcbxF08m5xJL16lsWLdT6k=",
 			"path": "github.com/aws/aws-sdk-go/service/codedeploy",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "EEVCD+xa8rnlVXoFULjc9fWcVzY=",
 			"path": "github.com/aws/aws-sdk-go/service/codepipeline",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "GHaVqY5f85olNwlO5J4f160D+mI=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentity",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "00Mr7fjKuKIzfjNkNA7b7psEseI=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentityprovider",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "YONbbZXdr13qIiKYzqk4cptd2XE=",
 			"path": "github.com/aws/aws-sdk-go/service/configservice",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "3EkRSF6NzJkEuZUvOt3TdpABXYc=",
 			"path": "github.com/aws/aws-sdk-go/service/databasemigrationservice",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "TSYWqKDCe6RaR2kYrExoDIC+7LU=",
 			"path": "github.com/aws/aws-sdk-go/service/devicefarm",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "2139YRKSqXN9N49CFTopzwftCDw=",
 			"path": "github.com/aws/aws-sdk-go/service/directconnect",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "0T4esELn9yJKr3D7b1/apnu1ZOA=",
 			"path": "github.com/aws/aws-sdk-go/service/directoryservice",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
-			"checksumSHA1": "kEGGjvoqrbTSX3Kno7GJrV7UflY=",
+			"checksumSHA1": "kxsEfXt3Laq9lcZz0+3BHz7XMW0=",
 			"path": "github.com/aws/aws-sdk-go/service/dynamodb",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
-			"checksumSHA1": "+0rHsZmOR2E3suixKJGHRGAmWqg=",
+			"checksumSHA1": "PvOIz7Ar599RTwzaCYAwOYdMwpU=",
 			"path": "github.com/aws/aws-sdk-go/service/ec2",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "tvxhxL5w10Qau4eUabsLK4L60iA=",
 			"path": "github.com/aws/aws-sdk-go/service/ecr",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
-			"checksumSHA1": "vIOUiTgp58sppu4baTu5VxXKs/s=",
+			"checksumSHA1": "4ah7g2O2CGVs/a3UWEAuVNd/f30=",
 			"path": "github.com/aws/aws-sdk-go/service/ecs",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "9I1RdgcMUEYJlyNIqdtSgFTdWKM=",
 			"path": "github.com/aws/aws-sdk-go/service/efs",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "jmTYmZVr8dw9kPDYlBhe4oG556U=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticache",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "xylCApLVAqLTW6uTYCziTDxgRMI=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticbeanstalk",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "RmVY7K2zivKjDe0ad8Grd+81J/M=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticsearchservice",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "SZ7yLDZ6RvMhpWe0Goyem64kgyA=",
 			"path": "github.com/aws/aws-sdk-go/service/elastictranscoder",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "i+zp7see74G8qx251yfQiTvbz4U=",
 			"path": "github.com/aws/aws-sdk-go/service/elb",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "i9eKrHV2n3LuYoMVnMpNjF34ih8=",
 			"path": "github.com/aws/aws-sdk-go/service/elbv2",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "LJrVm902tsUu83HoxW5+twvlMSA=",
 			"path": "github.com/aws/aws-sdk-go/service/emr",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "cEKm/PVdmVyoRD1wu9jDHIh52G4=",
 			"path": "github.com/aws/aws-sdk-go/service/firehose",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
-			"checksumSHA1": "+gED8OQZsY/taXgjkGbBJlx1hnY=",
+			"checksumSHA1": "oDoGvSfmO2Z099ixV2HXn+SDeHE=",
 			"path": "github.com/aws/aws-sdk-go/service/glacier",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "GEw6g6/GwkskwL5bGj/KYJ8BENY=",
 			"path": "github.com/aws/aws-sdk-go/service/glue",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "HBlNyNP2zLI589MIX82zMvANmLY=",
 			"path": "github.com/aws/aws-sdk-go/service/iam",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "WoIsJOP3M2BAhZ5p46LJNd9FQPk=",
 			"path": "github.com/aws/aws-sdk-go/service/inspector",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
-			"checksumSHA1": "jWoHNr5dOtwUmlC5bi5kRcW30wE=",
+			"checksumSHA1": "WCQ76H7tI4wkQ9if4HL2qJpGGr4=",
 			"path": "github.com/aws/aws-sdk-go/service/iot",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "yrji9KybkQLQBcP0ti5X6FrEXoc=",
 			"path": "github.com/aws/aws-sdk-go/service/kinesis",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "CqvUs/OKC5GYojf8InoQpTWUI30=",
 			"path": "github.com/aws/aws-sdk-go/service/kms",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "bOgniixFKS4I8P0jg6GKOK34iB0=",
 			"path": "github.com/aws/aws-sdk-go/service/lambda",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
-			"checksumSHA1": "c51LPR75+eskzYq8cj9zdKd3DXk=",
+			"checksumSHA1": "N7F39+vn1EaZZpfThaFExQcGfhI=",
 			"path": "github.com/aws/aws-sdk-go/service/lightsail",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "75LM8oENH3zGsQhNKuwIfEjXRDw=",
 			"path": "github.com/aws/aws-sdk-go/service/mq",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "xkNWwN2rw+szg+zXAxCun34zxhs=",
 			"path": "github.com/aws/aws-sdk-go/service/opsworks",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "saFo2jqsWU43Lax6lL8PhQKRl8s=",
 			"path": "github.com/aws/aws-sdk-go/service/rds",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "BwFxr+n+xU7TOQxxONFxdtrWjG4=",
 			"path": "github.com/aws/aws-sdk-go/service/redshift",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "S1md3W8h4/TLxScptLYbD5ukfrM=",
 			"path": "github.com/aws/aws-sdk-go/service/route53",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
-			"checksumSHA1": "soLaAo4O4kxArCMP1r3ctgwhmC4=",
+			"checksumSHA1": "TFFdPTzKEzgc1jNP27gJmEU/cOk=",
 			"path": "github.com/aws/aws-sdk-go/service/s3",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "Tz5NbDa/SGUINmuFD8KQLh1HDOI=",
 			"path": "github.com/aws/aws-sdk-go/service/servicecatalog",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "/ztCHg70ElmJqzKYIRwDB6TiBOc=",
 			"path": "github.com/aws/aws-sdk-go/service/ses",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "4fkXdvKPVnJvu6yUBc+MHkN4t20=",
 			"path": "github.com/aws/aws-sdk-go/service/sfn",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "rrsHusPbMvyKM0WvbZyYjDgKG00=",
 			"path": "github.com/aws/aws-sdk-go/service/shield",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "B3CgAFSREebpsFoFOo4vrQ6u04w=",
 			"path": "github.com/aws/aws-sdk-go/service/simpledb",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "rwSNHPn9iLEaoDx6vX0KbWefcHY=",
 			"path": "github.com/aws/aws-sdk-go/service/sns",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "aWWSD60GhNwldZ7mxL9Z8Q+fiXo=",
 			"path": "github.com/aws/aws-sdk-go/service/sqs",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
-			"checksumSHA1": "U1lCM+/AZ5khvQcsgZy1c/qp86Q=",
+			"checksumSHA1": "1wkJ4xq3qTqlHTkAADIdBZ6OWvI=",
 			"path": "github.com/aws/aws-sdk-go/service/ssm",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "d9vR1rl8kmJxJBwe00byziVFR/o=",
 			"path": "github.com/aws/aws-sdk-go/service/sts",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "Uw4pOUxSMbx4xBHUcOUkNhtnywE=",
 			"path": "github.com/aws/aws-sdk-go/service/swf",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
-			"checksumSHA1": "sjZeBzVjWM2tWSIOr7p13Kx2iNU=",
+			"checksumSHA1": "eVLbU/Ep3lSJXgHZvSGb6HsxRUY=",
 			"path": "github.com/aws/aws-sdk-go/service/waf",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
-			"checksumSHA1": "rM51Xn6MSt2XJzSF1p51m6G4u/8=",
+			"checksumSHA1": "wq/SHXPytoKkPtXDBu/1WbS0L5A=",
 			"path": "github.com/aws/aws-sdk-go/service/wafregional",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "AUwsvYff1GCOYtCgB6wd0doC9kc=",
 			"path": "github.com/aws/aws-sdk-go/service/workspaces",
-			"revision": "80bf27afd5602f55c398d43621b9900583df3661",
-			"revisionTime": "2017-11-29T07:44:19Z",
-			"version": "v1.12.35",
-			"versionExact": "v1.12.35"
+			"revision": "83e491e1ee74c797ee52c228b654601ba6702c31",
+			"revisionTime": "2017-11-30T02:37:06Z",
+			"version": "v1.12.37",
+			"versionExact": "v1.12.37"
 		},
 		{
 			"checksumSHA1": "usT4LCSQItkFvFOQT7cBlkCuGaE=",


### PR DESCRIPTION
closes #2474 unless of course v1.12.36 is specifically needed

```
govendor v1.0.9
govendor fetch github.com/aws/aws-sdk-go/...@v1.12.37
```

[`aws-sdk-go` Release notes](https://github.com/aws/aws-sdk-go/blob/v1.12.37/CHANGELOG.md)