### PR TITLE
r/aws_lambda_function AWS Lambda Concurrency

### DIFF
--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -78,6 +78,7 @@ large files efficiently.
 * `memory_size` - (Optional) Amount of memory in MB your Lambda Function can use at runtime. Defaults to `128`. See [Limits][5]
 * `runtime` - (Required) See [Runtimes][6] for valid values.
 * `timeout` - (Optional) The amount of time your Lambda Function has to run in seconds. Defaults to `3`. See [Limits][5]
+* `reserved_concurrent_executions` - (Optional) The amount of reserved concurrent executions for this lambda function. Defaults to Unreserved Concurrency Limits. See [Managing Concurrency][9]
 * `publish` - (Optional) Whether to publish creation/change as new Lambda Function Version. Defaults to `false`.
 * `vpc_config` - (Optional) Provide this to allow your function to access your VPC. Fields documented below. See [Lambda in VPC][7]
 * `environment` - (Optional) The Lambda environment's configuration settings. Fields documented below.
@@ -131,6 +132,7 @@ For **environment** the following attributes are supported:
 [6]: https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime
 [7]: http://docs.aws.amazon.com/lambda/latest/dg/vpc.html
 [8]: https://docs.aws.amazon.com/lambda/latest/dg/deployment-package-v2.html
+[9]: https://docs.aws.amazon.com/lambda/latest/dg/concurrent-executions.html
 
 ## Import
 


### PR DESCRIPTION
Support AWS Lambda concurrency: https://docs.aws.amazon.com/lambda/latest/dg/concurrent-executions.html

relates to #2501
requires #2500

- [x] Basic acceptance tests
- [x] Complex acceptance tests
- [x] Update README


```
make testacc TESTARGS='-run=TestAccAWSLambdaFunction_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccAWSLambdaFunction_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSLambdaFunction_basic
--- PASS: TestAccAWSLambdaFunction_basic (39.94s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	39.967s

make testacc TESTARGS='-run=TestAccAWSLambdaFunction_concurrency'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccAWSLambdaFunction_concurrency -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSLambdaFunction_concurrency
--- PASS: TestAccAWSLambdaFunction_concurrency (65.70s)
=== RUN   TestAccAWSLambdaFunction_concurrencyCycle
--- PASS: TestAccAWSLambdaFunction_concurrencyCycle (83.12s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	148.837s
```