### PR TITLE
Add peer_region to vpc peering connection

### DIFF
--- a/aws/data_source_aws_vpc_peering_connection.go
+++ b/aws/data_source_aws_vpc_peering_connection.go
@@ -39,6 +39,11 @@ func dataSourceAwsVpcPeeringConnection() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"peer_vpc_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -126,6 +131,7 @@ func dataSourceAwsVpcPeeringConnectionRead(d *schema.ResourceData, meta interfac
 	d.Set("vpc_id", pcx.RequesterVpcInfo.VpcId)
 	d.Set("owner_id", pcx.RequesterVpcInfo.OwnerId)
 	d.Set("cidr_block", pcx.RequesterVpcInfo.CidrBlock)
+	d.Set("region", pcx.RequesterVpcInfo.Region)
 	d.Set("peer_vpc_id", pcx.AccepterVpcInfo.VpcId)
 	d.Set("peer_owner_id", pcx.AccepterVpcInfo.OwnerId)
 	d.Set("peer_cidr_block", pcx.AccepterVpcInfo.CidrBlock)

--- a/aws/data_source_aws_vpc_peering_connection.go
+++ b/aws/data_source_aws_vpc_peering_connection.go
@@ -54,6 +54,11 @@ func dataSourceAwsVpcPeeringConnection() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"peer_region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"accepter": {
 				Type:     schema.TypeMap,
 				Computed: true,
@@ -124,6 +129,7 @@ func dataSourceAwsVpcPeeringConnectionRead(d *schema.ResourceData, meta interfac
 	d.Set("peer_vpc_id", pcx.AccepterVpcInfo.VpcId)
 	d.Set("peer_owner_id", pcx.AccepterVpcInfo.OwnerId)
 	d.Set("peer_cidr_block", pcx.AccepterVpcInfo.CidrBlock)
+	d.Set("peer_region", pcx.AccepterVpcInfo.Region)
 	d.Set("tags", tagsToMap(pcx.Tags))
 
 	if pcx.AccepterVpcInfo.PeeringOptions != nil {

--- a/aws/resource_aws_vpc_peering_connection.go
+++ b/aws/resource_aws_vpc_peering_connection.go
@@ -49,6 +49,12 @@ func resourceAwsVpcPeeringConnection() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"peer_region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
 			"accepter":  vpcPeeringConnectionOptionsSchema(),
 			"requester": vpcPeeringConnectionOptionsSchema(),
 			"tags":      tagsSchema(),
@@ -67,6 +73,10 @@ func resourceAwsVPCPeeringCreate(d *schema.ResourceData, meta interface{}) error
 
 	if v, ok := d.GetOk("peer_owner_id"); ok {
 		createOpts.PeerOwnerId = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("peer_region"); ok {
+		createOpts.SetPeerRegion(v.(string))
 	}
 
 	log.Printf("[DEBUG] VPC Peering Create options: %#v", createOpts)
@@ -152,6 +162,7 @@ func resourceAwsVPCPeeringRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("accept_status", pc.Status.Code)
+	d.Set("peer_region", pc.AccepterVpcInfo.Region)
 
 	// When the VPC Peering Connection is pending acceptance,
 	// the details about accepter and/or requester peering

--- a/aws/resource_aws_vpc_peering_connection.go
+++ b/aws/resource_aws_vpc_peering_connection.go
@@ -153,16 +153,15 @@ func resourceAwsVPCPeeringRead(d *schema.ResourceData, meta interface{}) error {
 		// We're the accepter
 		d.Set("peer_owner_id", pc.RequesterVpcInfo.OwnerId)
 		d.Set("peer_vpc_id", pc.RequesterVpcInfo.VpcId)
-		d.Set("peer_region", pc.RequesterVpcInfo.Region)
 		d.Set("vpc_id", pc.AccepterVpcInfo.VpcId)
 	} else {
 		// We're the requester
 		d.Set("peer_owner_id", pc.AccepterVpcInfo.OwnerId)
 		d.Set("peer_vpc_id", pc.AccepterVpcInfo.VpcId)
-		d.Set("peer_region", pc.AccepterVpcInfo.Region)
 		d.Set("vpc_id", pc.RequesterVpcInfo.VpcId)
 	}
 
+	d.Set("peer_region", pc.AccepterVpcInfo.Region)
 	d.Set("accept_status", pc.Status.Code)
 
 	// When the VPC Peering Connection is pending acceptance,

--- a/aws/resource_aws_vpc_peering_connection.go
+++ b/aws/resource_aws_vpc_peering_connection.go
@@ -79,7 +79,7 @@ func resourceAwsVPCPeeringCreate(d *schema.ResourceData, meta interface{}) error
 		if _, ok := d.GetOk("auto_accept"); ok {
 			return fmt.Errorf("peer_region cannot be set whilst auto_accept is true when creating a vpc peering connection")
 		}
-		createOpts.SetPeerRegion(v.(string))
+		createOpts.PeerRegion = aws.String(v.(string))
 	}
 
 	log.Printf("[DEBUG] VPC Peering Create options: %#v", createOpts)

--- a/aws/resource_aws_vpc_peering_connection.go
+++ b/aws/resource_aws_vpc_peering_connection.go
@@ -76,6 +76,9 @@ func resourceAwsVPCPeeringCreate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	if v, ok := d.GetOk("peer_region"); ok {
+		if _, ok := d.GetOk("auto_accept"); ok {
+			return fmt.Errorf("peer_region cannot be set whilst auto_accept is true when creating a vpc peering connection")
+		}
 		createOpts.SetPeerRegion(v.(string))
 	}
 

--- a/aws/resource_aws_vpc_peering_connection.go
+++ b/aws/resource_aws_vpc_peering_connection.go
@@ -153,16 +153,17 @@ func resourceAwsVPCPeeringRead(d *schema.ResourceData, meta interface{}) error {
 		// We're the accepter
 		d.Set("peer_owner_id", pc.RequesterVpcInfo.OwnerId)
 		d.Set("peer_vpc_id", pc.RequesterVpcInfo.VpcId)
+		d.Set("peer_region", pc.RequesterVpcInfo.Region)
 		d.Set("vpc_id", pc.AccepterVpcInfo.VpcId)
 	} else {
 		// We're the requester
 		d.Set("peer_owner_id", pc.AccepterVpcInfo.OwnerId)
 		d.Set("peer_vpc_id", pc.AccepterVpcInfo.VpcId)
+		d.Set("peer_region", pc.AccepterVpcInfo.Region)
 		d.Set("vpc_id", pc.RequesterVpcInfo.VpcId)
 	}
 
 	d.Set("accept_status", pc.Status.Code)
-	d.Set("peer_region", pc.AccepterVpcInfo.Region)
 
 	// When the VPC Peering Connection is pending acceptance,
 	// the details about accepter and/or requester peering

--- a/aws/resource_aws_vpc_peering_connection_accepter.go
+++ b/aws/resource_aws_vpc_peering_connection_accepter.go
@@ -43,6 +43,10 @@ func resourceAwsVpcPeeringConnectionAccepter() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"peer_region": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"accepter":  vpcPeeringConnectionOptionsSchema(),
 			"requester": vpcPeeringConnectionOptionsSchema(),
 			"tags":      tagsSchema(),

--- a/aws/resource_aws_vpc_peering_connection_accepter.go
+++ b/aws/resource_aws_vpc_peering_connection_accepter.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"errors"
 	"log"
 
 	"fmt"
@@ -63,11 +62,6 @@ func resourceAwsVPCPeeringAccepterCreate(d *schema.ResourceData, meta interface{
 	}
 	if d.Id() == "" {
 		return fmt.Errorf("VPC Peering Connection %q not found", id)
-	}
-
-	// Ensure that this IS as cross-account VPC peering connection.
-	if d.Get("peer_owner_id").(string) == meta.(*AWSClient).accountid {
-		return errors.New("aws_vpc_peering_connection_accepter can only adopt into management cross-account VPC peering connections")
 	}
 
 	return resourceAwsVPCPeeringUpdate(d, meta)

--- a/aws/resource_aws_vpc_peering_connection_accepter_test.go
+++ b/aws/resource_aws_vpc_peering_connection_accepter_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
 
@@ -34,10 +35,19 @@ func TestAccAWSVPCPeeringConnectionAccepter_sameRegion(t *testing.T) {
 func TestAccAWSVPCPeeringConnectionAccepter_differentRegion(t *testing.T) {
 	var connection ec2.VpcPeeringConnection
 
+	var providers []*schema.Provider
+	providerFactories := map[string]terraform.ResourceProviderFactory{
+		"aws": func() (terraform.ResourceProvider, error) {
+			p := Provider()
+			providers = append(providers, p.(*schema.Provider))
+			return p, nil
+		},
+	}
+
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccAwsVPCPeeringConnectionAccepterDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccAwsVPCPeeringConnectionAccepterDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccAwsVPCPeeringConnectionAccepterDifferentRegion,

--- a/aws/resource_aws_vpc_peering_connection_accepter_test.go
+++ b/aws/resource_aws_vpc_peering_connection_accepter_test.go
@@ -1,22 +1,54 @@
 package aws
 
 import (
-	"regexp"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAwsVPCPeeringConnectionAccepter_sameAccount(t *testing.T) {
+func TestAccAWSVPCPeeringConnectionAccepter_sameRegion(t *testing.T) {
+	var connection ec2.VpcPeeringConnection
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccAwsVPCPeeringConnectionAccepterDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config:      testAccAwsVPCPeeringConnectionAccepterSameAccountConfig,
-				ExpectError: regexp.MustCompile(`aws_vpc_peering_connection_accepter can only adopt into management cross-account VPC peering connections`),
+				Config: testAccAwsVPCPeeringConnectionAccepterSameRegion,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSVpcPeeringConnectionExists(
+						"aws_vpc_peering_connection_accepter.peer",
+						&connection),
+					resource.TestCheckResourceAttr(
+						"aws_vpc_peering_connection_accepter.peer",
+						"accept_status", "active"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSVPCPeeringConnectionAccepter_differentRegion(t *testing.T) {
+	var connection ec2.VpcPeeringConnection
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccAwsVPCPeeringConnectionAccepterDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAwsVPCPeeringConnectionAccepterDifferentRegion,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSVpcPeeringConnectionExists(
+						"aws_vpc_peering_connection_accepter.peer",
+						&connection),
+					resource.TestCheckResourceAttr(
+						"aws_vpc_peering_connection_accepter.peer",
+						"accept_status", "active"),
+				),
 			},
 		},
 	})
@@ -27,51 +59,75 @@ func testAccAwsVPCPeeringConnectionAccepterDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccAwsVPCPeeringConnectionAccepterSameAccountConfig = `
-provider "aws" {
-    region = "us-west-2"
-    // Requester's credentials.
-}
-
-provider "aws" {
-    alias = "peer"
-    region = "us-west-2"
-    // Accepter's credentials.
-}
-
+const testAccAwsVPCPeeringConnectionAccepterSameRegion = `
 resource "aws_vpc" "main" {
-    cidr_block = "10.0.0.0/16"
+	cidr_block = "10.0.0.0/16"
+	tags {
+		Name = "tf-acc-revoke-vpc-peering-connection-accepter-same-region"
+	}
 }
 
 resource "aws_vpc" "peer" {
-    provider = "aws.peer"
-    cidr_block = "10.1.0.0/16"
-}
-
-data "aws_caller_identity" "peer" {
-    provider = "aws.peer"
+	cidr_block = "10.1.0.0/16"
+	tags {
+		Name = "tf-acc-revoke-vpc-peering-connection-accepter-same-region"
+	}
 }
 
 // Requester's side of the connection.
 resource "aws_vpc_peering_connection" "peer" {
-    vpc_id = "${aws_vpc.main.id}"
-    peer_vpc_id = "${aws_vpc.peer.id}"
-    peer_owner_id = "${data.aws_caller_identity.peer.account_id}"
-    auto_accept = false
-
-    tags {
-      Side = "Requester"
-    }
+	vpc_id = "${aws_vpc.main.id}"
+	peer_vpc_id = "${aws_vpc.peer.id}"
+	auto_accept = false
 }
 
 // Accepter's side of the connection.
 resource "aws_vpc_peering_connection_accepter" "peer" {
-    provider = "aws.peer"
-    vpc_peering_connection_id = "${aws_vpc_peering_connection.peer.id}"
-    auto_accept = true
+	vpc_peering_connection_id = "${aws_vpc_peering_connection.peer.id}"
+	auto_accept = true
+}
+`
 
-    tags {
-       Side = "Accepter"
-    }
+const testAccAwsVPCPeeringConnectionAccepterDifferentRegion = `
+provider "aws" {
+	alias = "main"
+	region = "us-west-2"
+}
+
+provider "aws" {
+	alias = "peer"
+	region = "us-east-1"
+}
+
+resource "aws_vpc" "main" {
+	provider = "aws.main"
+	cidr_block = "10.0.0.0/16"
+	tags {
+		Name = "tf-acc-revoke-vpc-peering-connection-accepter-different-region"
+	}
+}
+
+resource "aws_vpc" "peer" {
+	provider = "aws.peer"
+	cidr_block = "10.1.0.0/16"
+	tags {
+		Name = "tf-acc-revoke-vpc-peering-connection-accepter-different-region"
+	}
+}
+
+// Requester's side of the connection.
+resource "aws_vpc_peering_connection" "peer" {
+	provider = "aws.main"
+	vpc_id = "${aws_vpc.main.id}"
+	peer_vpc_id = "${aws_vpc.peer.id}"
+	peer_region = "us-east-1"
+	auto_accept = false
+}
+
+// Accepter's side of the connection.
+resource "aws_vpc_peering_connection_accepter" "peer" {
+	provider = "aws.peer"
+	vpc_peering_connection_id = "${aws_vpc_peering_connection.peer.id}"
+	auto_accept = true
 }
 `

--- a/aws/resource_aws_vpc_peering_connection_test.go
+++ b/aws/resource_aws_vpc_peering_connection_test.go
@@ -437,7 +437,6 @@ provider "aws" {
 }
 
 resource "aws_vpc" "foo" {
-	provider = "aws"
 	cidr_block = "10.0.0.0/16"
 }
 
@@ -447,7 +446,6 @@ resource "aws_vpc" "bar" {
 }
 
 resource "aws_vpc_peering_connection" "foo" {
-	provider = "aws"
 	vpc_id = "${aws_vpc.foo.id}"
 	peer_vpc_id = "${aws_vpc.bar.id}"
 	peer_region = "us-east-1"

--- a/website/docs/d/vpc_peering_connection.html.markdown
+++ b/website/docs/d/vpc_peering_connection.html.markdown
@@ -48,6 +48,8 @@ The given filters must match exactly one VPC peering connection whose data will 
 
 * `cidr_block` - (Optional) The CIDR block of the requester VPC of the specific VPC Peering Connection to retrieve.
 
+* `region` - (Optional) The region of the requester VPC of the specific VPC Peering Connection to retrieve.
+
 * `peer_vpc_id` - (Optional) The ID of the accepter VPC of the specific VPC Peering Connection to retrieve.
 
 * `peer_owner_id` - (Optional) The AWS account ID of the owner of the accepter VPC of the specific VPC Peering Connection to retrieve.

--- a/website/docs/d/vpc_peering_connection.html.markdown
+++ b/website/docs/d/vpc_peering_connection.html.markdown
@@ -54,6 +54,8 @@ The given filters must match exactly one VPC peering connection whose data will 
 
 * `peer_cidr_block` - (Optional) The CIDR block of the accepter VPC of the specific VPC Peering Connection to retrieve.
 
+* `peer_region` - (Optional) The region of the accepter VPC of the specific VPC Peering Connection to retrieve.
+
 * `filter` - (Optional) Custom filter block as described below.
 
 * `tags` - (Optional) A mapping of tags, each pair of which must exactly match

--- a/website/docs/r/vpc_peering.html.markdown
+++ b/website/docs/r/vpc_peering.html.markdown
@@ -10,9 +10,9 @@ description: |-
 
 Provides a resource to manage a VPC Peering Connection resource.
 
--> **Note:** For cross-account (requester's AWS account differs from the accepter's AWS account) VPC Peering Connections
-use the `aws_vpc_peering_connection` resource to manage the requester's side of the connection and
-use the `aws_vpc_peering_connection_accepter` resource to manage the accepter's side of the connection.
+-> **Note:** For cross-account (requester's AWS account differs from the accepter's AWS account) or inter-region
+VPC Peering Connections use the `aws_vpc_peering_connection` resource to manage the requester's side of the
+connection and use the `aws_vpc_peering_connection_accepter` resource to manage the accepter's side of the connection.
 
 ## Example Usage
 
@@ -102,7 +102,8 @@ The following arguments are supported:
 * `peer_vpc_id` - (Required) The ID of the VPC with which you are creating the VPC Peering Connection.
 * `vpc_id` - (Required) The ID of the requester VPC.
 * `auto_accept` - (Optional) Accept the peering (both VPCs need to be in the same AWS account).
-* `peer_region` - (Optional) The region of the accepter VPC of the [VPC Peering Connection].
+* `peer_region` - (Optional) The region of the accepter VPC of the [VPC Peering Connection]. `auto_accept` must be `false`,
+and use the `aws_vpc_peering_connection_accepter` to manage the accepter side.
 * `accepter` (Optional) - An optional configuration block that allows for [VPC Peering Connection]
 (http://docs.aws.amazon.com/AmazonVPC/latest/PeeringGuide) options to be set for the VPC that accepts
 the peering connection (a maximum of one).

--- a/website/docs/r/vpc_peering.html.markdown
+++ b/website/docs/r/vpc_peering.html.markdown
@@ -65,6 +65,29 @@ resource "aws_vpc" "bar" {
 }
 ```
 
+Basic usage with region:
+
+
+```hcl
+resource "aws_vpc_peering_connection" "foo" {
+  peer_owner_id = "${var.peer_owner_id}"
+  peer_vpc_id   = "${aws_vpc.bar.id}"
+  vpc_id        = "${aws_vpc.foo.id}"
+  peer_region   = "us-east-1"
+  auto_accept   = true
+}
+
+resource "aws_vpc" "foo" {
+  provider   = "aws.us-west-2"
+  cidr_block = "10.1.0.0/16"
+}
+
+resource "aws_vpc" "bar" {
+  provider   = "aws.us-east-1"
+  cidr_block = "10.2.0.0/16"
+}
+```
+
 ## Argument Reference
 
 -> **Note:** Modifying the VPC Peering Connection options requires peering to be active. An automatic activation
@@ -79,6 +102,7 @@ The following arguments are supported:
 * `peer_vpc_id` - (Required) The ID of the VPC with which you are creating the VPC Peering Connection.
 * `vpc_id` - (Required) The ID of the requester VPC.
 * `auto_accept` - (Optional) Accept the peering (both VPCs need to be in the same AWS account).
+* `peer_region` - (Optional) The region of the accepter VPC of the [VPC Peering Connection].
 * `accepter` (Optional) - An optional configuration block that allows for [VPC Peering Connection]
 (http://docs.aws.amazon.com/AmazonVPC/latest/PeeringGuide) options to be set for the VPC that accepts
 the peering connection (a maximum of one).

--- a/website/docs/r/vpc_peering_accepter.html.markdown
+++ b/website/docs/r/vpc_peering_accepter.html.markdown
@@ -3,15 +3,16 @@ layout: "aws"
 page_title: "AWS: aws_vpc_peering_connection_accepter"
 sidebar_current: "docs-aws-resource-vpc-peering-accepter"
 description: |-
-  Manage the accepter's side of a cross-account VPC Peering Connection.
+  Manage the accepter's side of a VPC Peering Connection.
 ---
 
 # aws\_vpc\_peering\_connection\_accepter
 
-Provides a resource to manage the accepter's side of a cross-account VPC Peering Connection.
+Provides a resource to manage the accepter's side of a VPC Peering Connection.
 
-When a cross-account (requester's AWS account differs from the accepter's AWS account) VPC Peering Connection
-is created, a VPC Peering Connection resource is automatically created in the accepter's account.
+When a cross-account (requester's AWS account differs from the accepter's AWS account) or an inter-region
+VPC Peering Connection is created, a VPC Peering Connection resource is automatically created in the
+accepter's account.
 The requester can use the `aws_vpc_peering_connection` resource to manage its side of the connection
 and the accepter can use the `aws_vpc_peering_connection_accepter` resource to "adopt" its side of the
 connection into management.
@@ -20,11 +21,14 @@ connection into management.
 
 ```hcl
 provider "aws" {
+  region = "us-east-1"
+
   # Requester's credentials.
 }
 
 provider "aws" {
   alias = "peer"
+  region = "us-west-2"
 
   # Accepter's credentials.
 }
@@ -47,6 +51,7 @@ resource "aws_vpc_peering_connection" "peer" {
   vpc_id        = "${aws_vpc.main.id}"
   peer_vpc_id   = "${aws_vpc.peer.id}"
   peer_owner_id = "${data.aws_caller_identity.peer.account_id}"
+  peer_region   = "us-west-2"
   auto_accept   = false
 
   tags {
@@ -91,7 +96,7 @@ All of the argument attributes except `auto_accept` are also exported as result 
 * `vpc_id` - The ID of the accepter VPC.
 * `peer_vpc_id` - The ID of the requester VPC.
 * `peer_owner_id` - The AWS account ID of the owner of the requester VPC.
-* `peer_region` - The region of the requester VPC.
+* `peer_region` - The region of the accepter VPC.
 * `accepter` - A configuration block that describes [VPC Peering Connection]
 (http://docs.aws.amazon.com/AmazonVPC/latest/PeeringGuide) options set for the accepter VPC.
 * `requester` - A configuration block that describes [VPC Peering Connection]

--- a/website/docs/r/vpc_peering_accepter.html.markdown
+++ b/website/docs/r/vpc_peering_accepter.html.markdown
@@ -91,6 +91,7 @@ All of the argument attributes except `auto_accept` are also exported as result 
 * `vpc_id` - The ID of the accepter VPC.
 * `peer_vpc_id` - The ID of the requester VPC.
 * `peer_owner_id` - The AWS account ID of the owner of the requester VPC.
+* `peer_region` - The region of the requester VPC.
 * `accepter` - A configuration block that describes [VPC Peering Connection]
 (http://docs.aws.amazon.com/AmazonVPC/latest/PeeringGuide) options set for the accepter VPC.
 * `requester` - A configuration block that describes [VPC Peering Connection]


### PR DESCRIPTION
https://github.com/terraform-providers/terraform-provider-aws/issues/2484

```bash
TF_ACC=1 go test ./aws -v -run=TestAccAWSVPCPeeringConnection_region -timeout 120m                                                                                                                                     ~/D/k/r/g/s/g/t/terraform-provider-aws inter-region-vpc-peer
=== RUN   TestAccAWSVPCPeeringConnection_region
--- PASS: TestAccAWSVPCPeeringConnection_region (27.57s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	27.615s
```