### PR TITLE
Support switching VPC tenancy from Dedicated to Default

### DIFF
--- a/aws/resource_aws_vpc.go
+++ b/aws/resource_aws_vpc.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsVpc() *schema.Resource {
@@ -21,6 +22,7 @@ func resourceAwsVpc() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: resourceAwsVpcInstanceImport,
 		},
+		CustomizeDiff: resourceAwsVpcCustomizeDiff,
 
 		SchemaVersion: 1,
 		MigrateState:  resourceAwsVpcMigrateState,
@@ -34,10 +36,10 @@ func resourceAwsVpc() *schema.Resource {
 			},
 
 			"instance_tenancy": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      ec2.TenancyDefault,
+				ValidateFunc: validation.StringInSlice([]string{ec2.TenancyDefault, ec2.TenancyDedicated}, false),
 			},
 
 			"enable_dns_hostnames": {
@@ -112,15 +114,11 @@ func resourceAwsVpc() *schema.Resource {
 
 func resourceAwsVpcCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
-	instance_tenancy := "default"
-	if v, ok := d.GetOk("instance_tenancy"); ok {
-		instance_tenancy = v.(string)
-	}
 
 	// Create the VPC
 	createOpts := &ec2.CreateVpcInput{
 		CidrBlock:                   aws.String(d.Get("cidr_block").(string)),
-		InstanceTenancy:             aws.String(instance_tenancy),
+		InstanceTenancy:             aws.String(d.Get("instance_tenancy").(string)),
 		AmazonProvidedIpv6CidrBlock: aws.Bool(d.Get("assign_generated_ipv6_cidr_block").(bool)),
 	}
 
@@ -452,6 +450,21 @@ func resourceAwsVpcUpdate(d *schema.ResourceData, meta interface{}) error {
 		d.SetPartial("assign_generated_ipv6_cidr_block")
 	}
 
+	if d.HasChange("instance_tenancy") && !d.IsNewResource() {
+		modifyOpts := &ec2.ModifyVpcTenancyInput{
+			VpcId:           aws.String(vpcid),
+			InstanceTenancy: aws.String(d.Get("instance_tenancy").(string)),
+		}
+		log.Printf(
+			"[INFO] Modifying instance_tenancy vpc attribute for %s: %#v",
+			d.Id(), modifyOpts)
+		if _, err := conn.ModifyVpcTenancy(modifyOpts); err != nil {
+			return err
+		}
+
+		d.SetPartial("instance_tenancy")
+	}
+
 	if err := setTags(conn, d); err != nil {
 		return err
 	} else {
@@ -490,6 +503,17 @@ func resourceAwsVpcDelete(d *schema.ResourceData, meta interface{}) error {
 
 		return resource.NonRetryableError(fmt.Errorf("Error deleting VPC: %s", err))
 	})
+}
+
+func resourceAwsVpcCustomizeDiff(diff *schema.ResourceDiff, v interface{}) error {
+	if diff.HasChange("instance_tenancy") {
+		old, new := diff.GetChange("instance_tenancy")
+		if old.(string) != ec2.TenancyDedicated || new.(string) != ec2.TenancyDefault {
+			diff.ForceNew("instance_tenancy")
+		}
+	}
+
+	return nil
 }
 
 // VPCStateRefreshFunc returns a resource.StateRefreshFunc that is used to watch


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/1955.
N.B. This adds a requirement on the IAM ec2:ModifyVpcTenancy action.