### PR TITLE
New Resource: aws_dynamodb_global_table

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -316,6 +316,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_dx_lag":                                   resourceAwsDxLag(),
 			"aws_dx_connection":                            resourceAwsDxConnection(),
 			"aws_dynamodb_table":                           resourceAwsDynamoDbTable(),
+			"aws_dynamodb_global_table":                    resourceAwsDynamoDbGlobalTable(),
 			"aws_ebs_snapshot":                             resourceAwsEbsSnapshot(),
 			"aws_ebs_volume":                               resourceAwsEbsVolume(),
 			"aws_ecr_lifecycle_policy":                     resourceAwsEcrLifecyclePolicy(),

--- a/aws/resource_aws_dynamodb_global_table.go
+++ b/aws/resource_aws_dynamodb_global_table.go
@@ -1,14 +1,12 @@
 package aws
 
 import (
-	"bytes"
 	"fmt"
 	"log"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
-	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -48,7 +46,6 @@ func resourceAwsDynamoDbGlobalTable() *schema.Resource {
 						},
 					},
 				},
-				Set: resourceAwsDynamoDbGlobalTableReplicaHash,
 			},
 
 			"arn": {
@@ -243,13 +240,6 @@ func resourceAwsDynamoDbGlobalTableStateRefreshFunc(
 	}
 }
 
-func resourceAwsDynamoDbGlobalTableReplicaHash(v interface{}) int {
-	var buf bytes.Buffer
-	m := v.(map[string]interface{})
-	buf.WriteString(fmt.Sprintf("%s-", m["region_name"].(string)))
-	return hashcode.String(buf.String())
-}
-
 func flattenAwsDynamoDbGlobalTable(d *schema.ResourceData, globalTableDescription *dynamodb.GlobalTableDescription) error {
 	var err error
 
@@ -316,12 +306,12 @@ func expandAwsDynamoDbReplica(configuredReplica map[string]interface{}) *dynamod
 	return replica
 }
 
-func flattenAwsDynamoDbReplicas(replicaDescriptions []*dynamodb.ReplicaDescription) *schema.Set {
+func flattenAwsDynamoDbReplicas(replicaDescriptions []*dynamodb.ReplicaDescription) []interface{} {
 	replicas := []interface{}{}
 	for _, replicaDescription := range replicaDescriptions {
 		replicas = append(replicas, flattenAwsDynamoDbReplica(replicaDescription))
 	}
-	return schema.NewSet(resourceAwsDynamoDbGlobalTableReplicaHash, replicas)
+	return replicas
 }
 
 func flattenAwsDynamoDbReplica(replicaDescription *dynamodb.ReplicaDescription) map[string]interface{} {

--- a/aws/resource_aws_dynamodb_global_table.go
+++ b/aws/resource_aws_dynamodb_global_table.go
@@ -88,7 +88,7 @@ func resourceAwsDynamoDbGlobalTableCreate(d *schema.ResourceData, meta interface
 			dynamodb.GlobalTableStatusActive,
 		},
 		Refresh:    resourceAwsDynamoDbGlobalTableStateRefreshFunc(d, meta),
-		Timeout:    d.Timeout(schema.TimeoutUpdate),
+		Timeout:    d.Timeout(schema.TimeoutCreate),
 		MinTimeout: 10 * time.Second,
 	}
 	_, err = stateConf.WaitForState()
@@ -106,6 +106,7 @@ func resourceAwsDynamoDbGlobalTableRead(d *schema.ResourceData, meta interface{}
 		return err
 	}
 	if globalTableDescription == nil {
+		log.Printf("[WARN] DynamoDB Global Table %q not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}

--- a/aws/resource_aws_dynamodb_global_table.go
+++ b/aws/resource_aws_dynamodb_global_table.go
@@ -1,0 +1,330 @@
+package aws
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsDynamoDbGlobalTable() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsDynamoDbGlobalTableCreate,
+		Read:   resourceAwsDynamoDbGlobalTableRead,
+		Update: resourceAwsDynamoDbGlobalTableUpdate,
+		Delete: resourceAwsDynamoDbGlobalTableDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(1 * time.Minute),
+			Update: schema.DefaultTimeout(1 * time.Minute),
+			Delete: schema.DefaultTimeout(1 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateAwsDynamoDbGlobalTableName,
+			},
+
+			"replica": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"region_name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+				Set: resourceAwsDynamoDbGlobalTableReplicaHash,
+			},
+
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsDynamoDbGlobalTableCreate(d *schema.ResourceData, meta interface{}) error {
+	dynamodbconn := meta.(*AWSClient).dynamodbconn
+
+	globalTableName := d.Get("name").(string)
+
+	input := &dynamodb.CreateGlobalTableInput{
+		GlobalTableName:  aws.String(globalTableName),
+		ReplicationGroup: expandAwsDynamoDbReplicas(d.Get("replica").(*schema.Set).List()),
+	}
+
+	log.Printf("[DEBUG] Creating DynamoDB Global Table: %#v", input)
+	_, err := dynamodbconn.CreateGlobalTable(input)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(globalTableName)
+
+	log.Println("[INFO] Waiting for DynamoDB Global Table to be created")
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{
+			dynamodb.GlobalTableStatusCreating,
+			dynamodb.GlobalTableStatusDeleting,
+			dynamodb.GlobalTableStatusUpdating,
+		},
+		Target: []string{
+			dynamodb.GlobalTableStatusActive,
+		},
+		Refresh:    resourceAwsDynamoDbGlobalTableStateRefreshFunc(d, meta),
+		Timeout:    d.Timeout(schema.TimeoutUpdate),
+		MinTimeout: 10 * time.Second,
+	}
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return err
+	}
+
+	return resourceAwsDynamoDbGlobalTableRead(d, meta)
+}
+
+func resourceAwsDynamoDbGlobalTableRead(d *schema.ResourceData, meta interface{}) error {
+	globalTableDescription, err := resourceAwsDynamoDbGlobalTableRetrieve(d, meta)
+
+	if err != nil {
+		return err
+	}
+	if globalTableDescription == nil {
+		d.SetId("")
+		return nil
+	}
+
+	return flattenAwsDynamoDbGlobalTable(d, globalTableDescription)
+}
+
+func resourceAwsDynamoDbGlobalTableUpdate(d *schema.ResourceData, meta interface{}) error {
+	dynamodbconn := meta.(*AWSClient).dynamodbconn
+
+	if d.HasChange("replica") {
+		o, n := d.GetChange("replica")
+		if o == nil {
+			o = new(schema.Set)
+		}
+		if n == nil {
+			n = new(schema.Set)
+		}
+
+		os := o.(*schema.Set)
+		ns := n.(*schema.Set)
+		replicaUpdateCreateReplicas := expandAwsDynamoDbReplicaUpdateCreateReplicas(ns.Difference(os).List())
+		replicaUpdateDeleteReplicas := expandAwsDynamoDbReplicaUpdateDeleteReplicas(os.Difference(ns).List())
+
+		replicaUpdates := make([]*dynamodb.ReplicaUpdate, 0, (len(replicaUpdateCreateReplicas) + len(replicaUpdateDeleteReplicas)))
+		for _, replicaUpdate := range replicaUpdateCreateReplicas {
+			replicaUpdates = append(replicaUpdates, replicaUpdate)
+		}
+		for _, replicaUpdate := range replicaUpdateDeleteReplicas {
+			replicaUpdates = append(replicaUpdates, replicaUpdate)
+		}
+
+		input := &dynamodb.UpdateGlobalTableInput{
+			GlobalTableName: aws.String(d.Id()),
+			ReplicaUpdates:  replicaUpdates,
+		}
+		log.Printf("[DEBUG] Updating DynamoDB Global Table: %#v", input)
+		if _, err := dynamodbconn.UpdateGlobalTable(input); err != nil {
+			return err
+		}
+
+		log.Println("[INFO] Waiting for DynamoDB Global Table to be updated")
+		stateConf := &resource.StateChangeConf{
+			Pending: []string{
+				dynamodb.GlobalTableStatusCreating,
+				dynamodb.GlobalTableStatusDeleting,
+				dynamodb.GlobalTableStatusUpdating,
+			},
+			Target: []string{
+				dynamodb.GlobalTableStatusActive,
+			},
+			Refresh:    resourceAwsDynamoDbGlobalTableStateRefreshFunc(d, meta),
+			Timeout:    d.Timeout(schema.TimeoutUpdate),
+			MinTimeout: 10 * time.Second,
+		}
+		_, err := stateConf.WaitForState()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Deleting a DynamoDB Global Table is represented by removing all replicas.
+func resourceAwsDynamoDbGlobalTableDelete(d *schema.ResourceData, meta interface{}) error {
+	dynamodbconn := meta.(*AWSClient).dynamodbconn
+
+	input := &dynamodb.UpdateGlobalTableInput{
+		GlobalTableName: aws.String(d.Id()),
+		ReplicaUpdates:  expandAwsDynamoDbReplicaUpdateDeleteReplicas(d.Get("replica").(*schema.Set).List()),
+	}
+	log.Printf("[DEBUG] Deleting DynamoDB Global Table: %#v", input)
+	if _, err := dynamodbconn.UpdateGlobalTable(input); err != nil {
+		return err
+	}
+
+	log.Println("[INFO] Waiting for DynamoDB Global Table to be destroyed")
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{
+			dynamodb.GlobalTableStatusActive,
+			dynamodb.GlobalTableStatusCreating,
+			dynamodb.GlobalTableStatusDeleting,
+			dynamodb.GlobalTableStatusUpdating,
+		},
+		Target:     []string{},
+		Refresh:    resourceAwsDynamoDbGlobalTableStateRefreshFunc(d, meta),
+		Timeout:    d.Timeout(schema.TimeoutDelete),
+		MinTimeout: 10 * time.Second,
+	}
+	_, err := stateConf.WaitForState()
+	return err
+}
+
+func resourceAwsDynamoDbGlobalTableRetrieve(d *schema.ResourceData, meta interface{}) (*dynamodb.GlobalTableDescription, error) {
+	dynamodbconn := meta.(*AWSClient).dynamodbconn
+
+	input := &dynamodb.DescribeGlobalTableInput{
+		GlobalTableName: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Retrieving DynamoDB Global Table: %#v", input)
+
+	output, err := dynamodbconn.DescribeGlobalTable(input)
+	if err != nil {
+		if isAWSErr(err, dynamodb.ErrCodeGlobalTableNotFoundException, "") {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("Error retrieving DynamoDB Global Table: %s", err)
+	}
+
+	return output.GlobalTableDescription, nil
+}
+
+func resourceAwsDynamoDbGlobalTableStateRefreshFunc(
+	d *schema.ResourceData, meta interface{}) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		gtd, err := resourceAwsDynamoDbGlobalTableRetrieve(d, meta)
+
+		if err != nil {
+			log.Printf("Error on retrieving DynamoDB Global Table when waiting: %s", err)
+			return nil, "", err
+		}
+
+		if gtd == nil {
+			return nil, "", nil
+		}
+
+		if gtd.GlobalTableStatus != nil {
+			log.Printf("[DEBUG] Status for DynamoDB Global Table %s: %s", d.Id(), *gtd.GlobalTableStatus)
+		}
+
+		return gtd, *gtd.GlobalTableStatus, nil
+	}
+}
+
+func resourceAwsDynamoDbGlobalTableReplicaHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	buf.WriteString(fmt.Sprintf("%s-", m["region_name"].(string)))
+	return hashcode.String(buf.String())
+}
+
+func flattenAwsDynamoDbGlobalTable(d *schema.ResourceData, globalTableDescription *dynamodb.GlobalTableDescription) error {
+	var err error
+
+	d.Set("arn", globalTableDescription.GlobalTableArn)
+	d.Set("name", globalTableDescription.GlobalTableName)
+
+	err = d.Set("replica", flattenAwsDynamoDbReplicas(globalTableDescription.ReplicationGroup))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func expandAwsDynamoDbReplicaUpdateCreateReplicas(configuredReplicas []interface{}) []*dynamodb.ReplicaUpdate {
+	replicaUpdates := make([]*dynamodb.ReplicaUpdate, 0, len(configuredReplicas))
+	for _, replicaRaw := range configuredReplicas {
+		replica := replicaRaw.(map[string]interface{})
+		replicaUpdates = append(replicaUpdates, expandAwsDynamoDbReplicaUpdateCreateReplica(replica))
+	}
+	return replicaUpdates
+}
+
+func expandAwsDynamoDbReplicaUpdateCreateReplica(configuredReplica map[string]interface{}) *dynamodb.ReplicaUpdate {
+	replicaUpdate := &dynamodb.ReplicaUpdate{
+		Create: &dynamodb.CreateReplicaAction{
+			RegionName: aws.String(configuredReplica["region_name"].(string)),
+		},
+	}
+	return replicaUpdate
+}
+
+func expandAwsDynamoDbReplicaUpdateDeleteReplicas(configuredReplicas []interface{}) []*dynamodb.ReplicaUpdate {
+	replicaUpdates := make([]*dynamodb.ReplicaUpdate, 0, len(configuredReplicas))
+	for _, replicaRaw := range configuredReplicas {
+		replica := replicaRaw.(map[string]interface{})
+		replicaUpdates = append(replicaUpdates, expandAwsDynamoDbReplicaUpdateDeleteReplica(replica))
+	}
+	return replicaUpdates
+}
+
+func expandAwsDynamoDbReplicaUpdateDeleteReplica(configuredReplica map[string]interface{}) *dynamodb.ReplicaUpdate {
+	replicaUpdate := &dynamodb.ReplicaUpdate{
+		Delete: &dynamodb.DeleteReplicaAction{
+			RegionName: aws.String(configuredReplica["region_name"].(string)),
+		},
+	}
+	return replicaUpdate
+}
+
+func expandAwsDynamoDbReplicas(configuredReplicas []interface{}) []*dynamodb.Replica {
+	replicas := make([]*dynamodb.Replica, 0, len(configuredReplicas))
+	for _, replicaRaw := range configuredReplicas {
+		replica := replicaRaw.(map[string]interface{})
+		replicas = append(replicas, expandAwsDynamoDbReplica(replica))
+	}
+	return replicas
+}
+
+func expandAwsDynamoDbReplica(configuredReplica map[string]interface{}) *dynamodb.Replica {
+	replica := &dynamodb.Replica{
+		RegionName: aws.String(configuredReplica["region_name"].(string)),
+	}
+	return replica
+}
+
+func flattenAwsDynamoDbReplicas(replicaDescriptions []*dynamodb.ReplicaDescription) *schema.Set {
+	replicas := []interface{}{}
+	for _, replicaDescription := range replicaDescriptions {
+		replicas = append(replicas, flattenAwsDynamoDbReplica(replicaDescription))
+	}
+	return schema.NewSet(resourceAwsDynamoDbGlobalTableReplicaHash, replicas)
+}
+
+func flattenAwsDynamoDbReplica(replicaDescription *dynamodb.ReplicaDescription) map[string]interface{} {
+	replica := make(map[string]interface{})
+	replica["region_name"] = *replicaDescription.RegionName
+	return replica
+}

--- a/aws/resource_aws_dynamodb_global_table_test.go
+++ b/aws/resource_aws_dynamodb_global_table_test.go
@@ -102,7 +102,7 @@ func testAccCheckAwsDynamoDbGlobalTableDestroy(s *terraform.State) error {
 
 		_, err := conn.DescribeGlobalTable(input)
 		if err != nil {
-			if isAWSErr(err, "GlobalTableNotFoundException", "") {
+			if isAWSErr(err, dynamodb.ErrCodeGlobalTableNotFoundException, "") {
 				return nil
 			}
 			return err
@@ -196,7 +196,7 @@ func testAccDynamoDbGlobalTableConfig_basic1(tableName string) string {
 %s
 
 resource "aws_dynamodb_global_table" "test" {
-	depends_on = ["aws_dynamodb_table.us-east-1"]
+  depends_on = ["aws_dynamodb_table.us-east-1"]
   provider = "aws.us-east-1"
 
   name = "%s"

--- a/aws/resource_aws_dynamodb_global_table_test.go
+++ b/aws/resource_aws_dynamodb_global_table_test.go
@@ -39,7 +39,7 @@ func TestAccAwsDynamoDbGlobalTable_basic(t *testing.T) {
 					testAccCheckAwsDynamoDbGlobalTableExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", tableName),
 					resource.TestCheckResourceAttr(resourceName, "replica.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "replica.2879992352.region_name", "us-east-1"),
+					resource.TestCheckResourceAttr(resourceName, "replica.2896117718.region_name", "us-east-1"),
 					resource.TestMatchResourceAttr(resourceName, "arn",
 						regexp.MustCompile("^arn:aws:dynamodb::[0-9]{12}:global-table/[a-z0-9-]+$")),
 				),
@@ -49,8 +49,8 @@ func TestAccAwsDynamoDbGlobalTable_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsDynamoDbGlobalTableExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "replica.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "replica.2879992352.region_name", "us-east-1"),
-					resource.TestCheckResourceAttr(resourceName, "replica.2156159459.region_name", "us-east-2"),
+					resource.TestCheckResourceAttr(resourceName, "replica.2896117718.region_name", "us-east-1"),
+					resource.TestCheckResourceAttr(resourceName, "replica.2276617237.region_name", "us-east-2"),
 				),
 			},
 			{
@@ -58,8 +58,8 @@ func TestAccAwsDynamoDbGlobalTable_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsDynamoDbGlobalTableExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "replica.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "replica.2879992352.region_name", "us-east-1"),
-					resource.TestCheckResourceAttr(resourceName, "replica.3948195346.region_name", "us-west-2"),
+					resource.TestCheckResourceAttr(resourceName, "replica.2896117718.region_name", "us-east-1"),
+					resource.TestCheckResourceAttr(resourceName, "replica.3965887460.region_name", "us-west-2"),
 				),
 			},
 		},

--- a/aws/resource_aws_dynamodb_global_table_test.go
+++ b/aws/resource_aws_dynamodb_global_table_test.go
@@ -201,9 +201,9 @@ resource "aws_dynamodb_global_table" "test" {
 
   name = "%s"
 
-	replica {
+  replica {
     region_name = "us-east-1"
-	}
+  }
 }`, testAccDynamoDbGlobalTableConfig_basic_dynamodb_tables(tableName), tableName)
 }
 
@@ -212,18 +212,18 @@ func testAccDynamoDbGlobalTableConfig_basic2(tableName string) string {
 %s
 
 resource "aws_dynamodb_global_table" "test" {
-	depends_on = ["aws_dynamodb_table.us-east-1", "aws_dynamodb_table.us-east-2"]
+  depends_on = ["aws_dynamodb_table.us-east-1", "aws_dynamodb_table.us-east-2"]
   provider = "aws.us-east-1"
 
   name = "%s"
 
-	replica {
+  replica {
     region_name = "us-east-1"
-	}
+  }
 
-	replica {
+  replica {
     region_name = "us-east-2"
-	}
+  }
 }`, testAccDynamoDbGlobalTableConfig_basic_dynamodb_tables(tableName), tableName)
 }
 
@@ -232,18 +232,18 @@ func testAccDynamoDbGlobalTableConfig_basic3(tableName string) string {
 %s
 
 resource "aws_dynamodb_global_table" "test" {
-	depends_on = ["aws_dynamodb_table.us-east-1", "aws_dynamodb_table.us-west-2"]
+  depends_on = ["aws_dynamodb_table.us-east-1", "aws_dynamodb_table.us-west-2"]
   provider = "aws.us-east-1"
 
   name = "%s"
 
-	replica {
+  replica {
     region_name = "us-east-1"
-	}
+  }
 
-	replica {
+  replica {
     region_name = "us-west-2"
-	}
+  }
 }`, testAccDynamoDbGlobalTableConfig_basic_dynamodb_tables(tableName), tableName)
 }
 
@@ -252,8 +252,8 @@ func testAccDynamoDbGlobalTableConfig_invalidName(tableName string) string {
 resource "aws_dynamodb_global_table" "test" {
   name = "%s"
 
-	replica {
+  replica {
     region_name = "us-east-1"
-	}
+  }
 }`, tableName)
 }

--- a/aws/resource_aws_dynamodb_global_table_test.go
+++ b/aws/resource_aws_dynamodb_global_table_test.go
@@ -1,0 +1,259 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAwsDynamoDbGlobalTable_basic(t *testing.T) {
+	resourceName := "aws_dynamodb_global_table.test"
+	tableName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsDynamoDbGlobalTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDynamoDbGlobalTableConfig_invalidName(acctest.RandString(2)),
+				ExpectError: regexp.MustCompile("name length must be between 3 and 255 characters"),
+			},
+			{
+				Config:      testAccDynamoDbGlobalTableConfig_invalidName(acctest.RandString(256)),
+				ExpectError: regexp.MustCompile("name length must be between 3 and 255 characters"),
+			},
+			{
+				Config:      testAccDynamoDbGlobalTableConfig_invalidName("!!!!"),
+				ExpectError: regexp.MustCompile("name must only include alphanumeric, underscore, period, or hyphen characters"),
+			},
+			{
+				Config: testAccDynamoDbGlobalTableConfig_basic1(tableName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsDynamoDbGlobalTableExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", tableName),
+					resource.TestCheckResourceAttr(resourceName, "replica.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "replica.2879992352.region_name", "us-east-1"),
+					resource.TestMatchResourceAttr(resourceName, "arn",
+						regexp.MustCompile("^arn:aws:dynamodb::[0-9]{12}:global-table/[a-z0-9-]+$")),
+				),
+			},
+			{
+				Config: testAccDynamoDbGlobalTableConfig_basic2(tableName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsDynamoDbGlobalTableExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "replica.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "replica.2879992352.region_name", "us-east-1"),
+					resource.TestCheckResourceAttr(resourceName, "replica.2156159459.region_name", "us-east-2"),
+				),
+			},
+			{
+				Config: testAccDynamoDbGlobalTableConfig_basic3(tableName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsDynamoDbGlobalTableExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "replica.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "replica.2879992352.region_name", "us-east-1"),
+					resource.TestCheckResourceAttr(resourceName, "replica.3948195346.region_name", "us-west-2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAwsDynamoDbGlobalTable_import(t *testing.T) {
+	resourceName := "aws_dynamodb_global_table.test"
+	tableName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSesTemplateDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDynamoDbGlobalTableConfig_basic1(tableName),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAwsDynamoDbGlobalTableDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).dynamodbconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_dynamodb_global_table" {
+			continue
+		}
+
+		input := &dynamodb.DescribeGlobalTableInput{
+			GlobalTableName: aws.String(rs.Primary.ID),
+		}
+
+		_, err := conn.DescribeGlobalTable(input)
+		if err != nil {
+			if isAWSErr(err, "GlobalTableNotFoundException", "") {
+				return nil
+			}
+			return err
+		}
+
+		return fmt.Errorf("Expected DynamoDB Global Table to be destroyed, %s found", rs.Primary.ID)
+	}
+
+	return nil
+}
+
+func testAccCheckAwsDynamoDbGlobalTableExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		return nil
+	}
+}
+
+func testAccDynamoDbGlobalTableConfig_basic_dynamodb_tables(tableName string) string {
+	return fmt.Sprintf(`
+provider "aws" {
+  alias  = "us-east-1"
+  region = "us-east-1"
+}
+
+provider "aws" {
+  alias  = "us-east-2"
+  region = "us-east-2"
+}
+
+provider "aws" {
+  alias  = "us-west-2"
+  region = "us-west-2"
+}
+
+resource "aws_dynamodb_table" "us-east-1" {
+  provider = "aws.us-east-1"
+
+  hash_key         = "myAttribute"
+  name             = "%s"
+  stream_enabled   = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
+  read_capacity    = 1
+  write_capacity   = 1
+
+  attribute {
+    name = "myAttribute"
+    type = "S"
+  }
+}
+
+resource "aws_dynamodb_table" "us-east-2" {
+  provider = "aws.us-east-2"
+
+  hash_key         = "myAttribute"
+  name             = "%s"
+  stream_enabled   = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
+  read_capacity    = 1
+  write_capacity   = 1
+
+  attribute {
+    name = "myAttribute"
+    type = "S"
+  }
+}
+
+resource "aws_dynamodb_table" "us-west-2" {
+  provider = "aws.us-west-2"
+
+  hash_key         = "myAttribute"
+  name             = "%s"
+  stream_enabled   = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
+  read_capacity    = 1
+  write_capacity   = 1
+
+  attribute {
+    name = "myAttribute"
+    type = "S"
+  }
+}`, tableName, tableName, tableName)
+}
+
+func testAccDynamoDbGlobalTableConfig_basic1(tableName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "aws_dynamodb_global_table" "test" {
+	depends_on = ["aws_dynamodb_table.us-east-1"]
+  provider = "aws.us-east-1"
+
+  name = "%s"
+
+	replica {
+    region_name = "us-east-1"
+	}
+}`, testAccDynamoDbGlobalTableConfig_basic_dynamodb_tables(tableName), tableName)
+}
+
+func testAccDynamoDbGlobalTableConfig_basic2(tableName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "aws_dynamodb_global_table" "test" {
+	depends_on = ["aws_dynamodb_table.us-east-1", "aws_dynamodb_table.us-east-2"]
+  provider = "aws.us-east-1"
+
+  name = "%s"
+
+	replica {
+    region_name = "us-east-1"
+	}
+
+	replica {
+    region_name = "us-east-2"
+	}
+}`, testAccDynamoDbGlobalTableConfig_basic_dynamodb_tables(tableName), tableName)
+}
+
+func testAccDynamoDbGlobalTableConfig_basic3(tableName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "aws_dynamodb_global_table" "test" {
+	depends_on = ["aws_dynamodb_table.us-east-1", "aws_dynamodb_table.us-west-2"]
+  provider = "aws.us-east-1"
+
+  name = "%s"
+
+	replica {
+    region_name = "us-east-1"
+	}
+
+	replica {
+    region_name = "us-west-2"
+	}
+}`, testAccDynamoDbGlobalTableConfig_basic_dynamodb_tables(tableName), tableName)
+}
+
+func testAccDynamoDbGlobalTableConfig_invalidName(tableName string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_global_table" "test" {
+  name = "%s"
+
+	replica {
+    region_name = "us-east-1"
+	}
+}`, tableName)
+}

--- a/aws/resource_aws_dynamodb_table.go
+++ b/aws/resource_aws_dynamodb_table.go
@@ -39,6 +39,11 @@ func resourceAwsDynamoDbTable() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		Timeouts: &schema.ResourceTimeout{
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+		},
+
 		SchemaVersion: 1,
 		MigrateState:  resourceAwsDynamoDbTableMigrateState,
 
@@ -840,42 +845,30 @@ func flattenAwsDynamoDbTableResource(d *schema.ResourceData, meta interface{}, t
 func resourceAwsDynamoDbTableDelete(d *schema.ResourceData, meta interface{}) error {
 	dynamodbconn := meta.(*AWSClient).dynamodbconn
 
-	if err := waitForTableToBeActive(d.Id(), meta); err != nil {
-		return errwrap.Wrapf("Error waiting for Dynamo DB Table update: {{err}}", err)
-	}
-
 	log.Printf("[DEBUG] DynamoDB delete table: %s", d.Id())
 
-	_, err := dynamodbconn.DeleteTable(&dynamodb.DeleteTableInput{
-		TableName: aws.String(d.Id()),
-	})
-	if err != nil {
-		return err
-	}
-
-	params := &dynamodb.DescribeTableInput{
-		TableName: aws.String(d.Id()),
-	}
-
-	err = resource.Retry(10*time.Minute, func() *resource.RetryError {
-		t, err := dynamodbconn.DescribeTable(params)
+	err := resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		_, err := dynamodbconn.DeleteTable(&dynamodb.DeleteTableInput{
+			TableName: aws.String(d.Id()),
+		})
 		if err != nil {
-			if awserr, ok := err.(awserr.Error); ok && awserr.Code() == "ResourceNotFoundException" {
+			// Table is already deleted
+			if isAWSErr(err, dynamodb.ErrCodeResourceNotFoundException, "Requested resource not found: Table: ") {
 				return nil
 			}
-			// Didn't recognize the error, so shouldn't retry.
+			// This logic handles multiple scenarios in the DynamoDB API:
+			// 1. Updating a table immediately before deletion may return:
+			//    ResourceInUseException: Attempt to change a resource which is still in use: Table is being updated:
+			// 2. Removing a table from a DynamoDB global table may return:
+			//    ResourceInUseException: Attempt to change a resource which is still in use: Table is being deleted:
+			if isAWSErr(err, dynamodb.ErrCodeResourceInUseException, "") {
+				return resource.RetryableError(err)
+			}
+			// Unknown error
 			return resource.NonRetryableError(err)
 		}
 
-		if t != nil {
-			if t.Table.TableStatus != nil && strings.ToLower(*t.Table.TableStatus) == "deleting" {
-				log.Printf("[DEBUG] AWS Dynamo DB table (%s) is still deleting", d.Id())
-				return resource.RetryableError(fmt.Errorf("still deleting"))
-			}
-		}
-
-		// we should be not found or deleting, so error here
-		return resource.NonRetryableError(err)
+		return nil
 	})
 
 	// check error from retry
@@ -883,7 +876,63 @@ func resourceAwsDynamoDbTableDelete(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	return nil
+	log.Println("[INFO] Waiting for DynamoDB Table to be destroyed")
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{
+			dynamodb.TableStatusActive,
+			dynamodb.TableStatusCreating,
+			dynamodb.TableStatusDeleting,
+			dynamodb.TableStatusUpdating,
+		},
+		Target:     []string{},
+		Refresh:    resourceAwsDynamoDbTableStateRefreshFunc(d, meta),
+		Timeout:    d.Timeout(schema.TimeoutDelete),
+		MinTimeout: 10 * time.Second,
+	}
+	_, err = stateConf.WaitForState()
+	return err
+}
+
+func resourceAwsDynamoDbTableRetrieve(d *schema.ResourceData, meta interface{}) (*dynamodb.TableDescription, error) {
+	dynamodbconn := meta.(*AWSClient).dynamodbconn
+
+	input := &dynamodb.DescribeTableInput{
+		TableName: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Retrieving DynamoDB Table: %#v", input)
+
+	output, err := dynamodbconn.DescribeTable(input)
+	if err != nil {
+		if isAWSErr(err, dynamodb.ErrCodeResourceNotFoundException, "") {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("Error retrieving DynamoDB Table: %s", err)
+	}
+
+	return output.Table, nil
+}
+
+func resourceAwsDynamoDbTableStateRefreshFunc(
+	d *schema.ResourceData, meta interface{}) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		td, err := resourceAwsDynamoDbTableRetrieve(d, meta)
+
+		if err != nil {
+			log.Printf("Error on retrieving DynamoDB Table when waiting: %s", err)
+			return nil, "", err
+		}
+
+		if td == nil {
+			return nil, "", nil
+		}
+
+		if td.TableStatus != nil {
+			log.Printf("[DEBUG] Status for DynamoDB Table %s: %s", d.Id(), *td.TableStatus)
+		}
+
+		return td, *td.TableStatus, nil
+	}
 }
 
 func createGSIFromData(data *map[string]interface{}) dynamodb.GlobalSecondaryIndex {

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -860,6 +860,19 @@ func validateAwsEcsPlacementConstraint(constType, constExpr string) error {
 	return nil
 }
 
+// http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_CreateGlobalTable.html
+func validateAwsDynamoDbGlobalTableName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if (len(value) > 255) || (len(value) < 3) {
+		errors = append(errors, fmt.Errorf("%s length must be between 3 and 255 characters: %q", k, value))
+	}
+	pattern := `^[a-zA-Z0-9_.-]+$`
+	if !regexp.MustCompile(pattern).MatchString(value) {
+		errors = append(errors, fmt.Errorf("%s must only include alphanumeric, underscore, period, or hyphen characters: %q", k, value))
+	}
+	return
+}
+
 // Validates that an Ecs placement strategy is set correctly
 // Takes type, and field as strings
 func validateAwsEcsPlacementStrategy(stratType, stratField string) error {

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -563,6 +563,10 @@
                     <a href="#">DynamoDB Resources</a>
                     <ul class="nav nav-visible">
 
+                        <li<%= sidebar_current("docs-aws-resource-dynamodb-global-table") %>>
+                            <a href="/docs/providers/aws/r/dynamodb_global_table.html">aws_dynamodb_global_table</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-aws-resource-dynamodb-table") %>>
                             <a href="/docs/providers/aws/r/dynamodb_table.html">aws_dynamodb_table</a>
                         </li>

--- a/website/docs/r/dynamodb_global_table.html.markdown
+++ b/website/docs/r/dynamodb_global_table.html.markdown
@@ -58,18 +58,18 @@ resource "aws_dynamodb_table" "us-west-2" {
 }
 
 resource "aws_dynamodb_global_table" "myTable" {
-	depends_on = ["aws_dynamodb_table.us-east-1", "aws_dynamodb_table.us-west-2"]
+  depends_on = ["aws_dynamodb_table.us-east-1", "aws_dynamodb_table.us-west-2"]
   provider   = "aws.us-east-1"
 
   name = "myTable"
 
-	replica {
+  replica {
     region_name = "us-east-1"
-	}
+  }
 
-	replica {
+  replica {
     region_name = "us-west-2"
-	}
+  }
 }
 ```
 

--- a/website/docs/r/dynamodb_global_table.html.markdown
+++ b/website/docs/r/dynamodb_global_table.html.markdown
@@ -1,0 +1,102 @@
+---
+layout: "aws"
+page_title: "AWS: aws_dynamodb_global_table"
+sidebar_current: "docs-aws-resource-dynamodb-global-table"
+description: |-
+  Provides a resource to create a DynamoDB Global Table
+---
+
+# aws_dynamodb_global_table
+
+Provides a resource to manage a DynamoDB Global Table. These are layered on top of existing DynamoDB Tables.
+
+~> Note: There are many restrictions before you can properly create DynamoDB Global Tables in multiple regions. See the [AWS DynamoDB Global Table Requirements](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables_reqs_bestpractices.html) for more information.
+
+## Example Usage
+
+```hcl
+provider "aws" {
+  alias  = "us-east-1"
+  region = "us-east-1"
+}
+
+provider "aws" {
+  alias  = "us-west-2"
+  region = "us-west-2"
+}
+
+resource "aws_dynamodb_table" "us-east-1" {
+  provider = "aws.us-east-1"
+
+  hash_key         = "myAttribute"
+  name             = "myTable"
+  stream_enabled   = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
+  read_capacity    = 1
+  write_capacity   = 1
+
+  attribute {
+    name = "myAttribute"
+    type = "S"
+  }
+}
+
+resource "aws_dynamodb_table" "us-west-2" {
+  provider = "aws.us-west-2"
+
+  hash_key         = "myAttribute"
+  name             = "myTable"
+  stream_enabled   = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
+  read_capacity    = 1
+  write_capacity   = 1
+
+  attribute {
+    name = "myAttribute"
+    type = "S"
+  }
+}
+
+resource "aws_dynamodb_global_table" "myTable" {
+	depends_on = ["aws_dynamodb_table.us-east-1", "aws_dynamodb_table.us-west-2"]
+  provider   = "aws.us-east-1"
+
+  name = "myTable"
+
+	replica {
+    region_name = "us-east-1"
+	}
+
+	replica {
+    region_name = "us-west-2"
+	}
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the global table. Must match underlying DynamoDB Table names in all regions.
+* `replica` - (Required) Underlying DynamoDB Table. At least 1 replica must be defined. See below.
+
+### Nested Fields
+
+#### `replica`
+
+* `region_name` - (Required) AWS region name of replica DynamoDB Table. e.g. `us-east-1`
+
+## Attributes Reference
+
+The following additional attributes are exported:
+
+* `id` - The name of the DynamoDB Global Table
+* `arn` - The ARN of the DynamoDB Global Table
+
+## Import
+
+DynamoDB Global Tables can be imported using the global table name, e.g.
+
+```
+$ terraform import aws_dynamodb_global_table.MyTable MyTable
+```


### PR DESCRIPTION
Closes #2482 

Sorry for the additional changes inside `aws_dynamodb_table`, however I was receiving these errors and decided to clean up the deletion logic a little.
```
# Consistently after first implementing global table deletion

        * aws_dynamodb_table.us-east-1 (destroy): 1 error(s) occurred:

        * aws_dynamodb_table.us-east-1: ResourceInUseException: Attempt to change a resource which is still in use: Table is being deleted: tf-acc-test-k9l0s
            status code: 400, request id: E45O0ASHK3HNUP8KMU11L75D3FVV4KQNSO5AEMVJF66Q9ASUAAJG

# Consistently after fixing the above

        * aws_dynamodb_table.us-east-1 (destroy): 1 error(s) occurred:

        * aws_dynamodb_table.us-east-1: Error waiting for Dynamo DB Table update: ResourceNotFoundException: Requested resource not found: Table: tf-acc-test-khj7g not found
            status code: 400, request id: RRD7G8M109TJFBH3F8L6JFMHKRVV4KQNSO5AEMVJF66Q9ASUAAJG
```

Passes testing for me:
```
make testacc TEST=./aws TESTARGS='-run=TestAccAwsDynamoDbGlobalTable'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAwsDynamoDbGlobalTable -timeout 120m
=== RUN   TestAccAwsDynamoDbGlobalTable_basic
--- PASS: TestAccAwsDynamoDbGlobalTable_basic (92.97s)
=== RUN   TestAccAwsDynamoDbGlobalTable_import
--- PASS: TestAccAwsDynamoDbGlobalTable_import (55.70s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	148.715s

make testacc TEST=./aws TESTARGS='-run=TestAccAWSDynamoDbTable'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSDynamoDbTable -timeout 120m
=== RUN   TestAccAWSDynamoDbTable_importBasic
--- PASS: TestAccAWSDynamoDbTable_importBasic (71.61s)
=== RUN   TestAccAWSDynamoDbTable_importTags
--- PASS: TestAccAWSDynamoDbTable_importTags (76.10s)
=== RUN   TestAccAWSDynamoDbTable_basic
--- PASS: TestAccAWSDynamoDbTable_basic (287.11s)
=== RUN   TestAccAWSDynamoDbTable_streamSpecification
--- PASS: TestAccAWSDynamoDbTable_streamSpecification (72.92s)
=== RUN   TestAccAWSDynamoDbTable_tags
--- PASS: TestAccAWSDynamoDbTable_tags (69.01s)
=== RUN   TestAccAWSDynamoDbTable_gsiUpdate
--- PASS: TestAccAWSDynamoDbTable_gsiUpdate (182.58s)
=== RUN   TestAccAWSDynamoDbTable_ttl
--- PASS: TestAccAWSDynamoDbTable_ttl (91.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	850.376s
```