### PR TITLE
r/aws_placement_group: Update documentation to omit incorrect "The only supported value is cluster" for strategy

### DIFF
--- a/website/docs/r/placement_group.html.markdown
+++ b/website/docs/r/placement_group.html.markdown
@@ -25,7 +25,7 @@ resource "aws_placement_group" "web" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the placement group.
-* `strategy` - (Required) The placement strategy. The only supported value is `cluster`
+* `strategy` - (Required) The placement strategy.
 
 ## Attributes Reference
 


### PR DESCRIPTION
We do not limit the `strategy` attribute value, so do not say that we do in the documentation. 😄 

Closes #2492 