### PR TITLE
Fixes example

### DIFF
--- a/website/docs/r/iam_user_ssh_key.html.markdown
+++ b/website/docs/r/iam_user_ssh_key.html.markdown
@@ -20,7 +20,7 @@ resource "aws_iam_user" "user" {
 
 resource "aws_iam_user_ssh_key" "user" {
   username   = "${aws_iam_user.user.name}"
-  encoding   = "PEM"
+  encoding   = "SSH"
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 mytest@mydomain.com"
 }
 ```
@@ -30,7 +30,7 @@ resource "aws_iam_user_ssh_key" "user" {
 The following arguments are supported:
 
 * `username` - (Required) The name of the IAM user to associate the SSH public key with.
-* `encoding` - (Required) Specifies the public key encoding format to use in the response. To retrieve the public key in ssh-rsa format, use SSH . To retrieve the public key in PEM format, use PEM .
+* `encoding` - (Required) Specifies the public key encoding format to use in the response. To retrieve the public key in ssh-rsa format, use `SSH`. To retrieve the public key in PEM format, use `PEM`.
 * `public_key` - (Required) The SSH public key. The public key must be encoded in ssh-rsa format or PEM format.
 * `status` - (Optional) The status to assign to the SSH public key. Active means the key can be used for authentication with an AWS CodeCommit repository. Inactive means the key cannot be used. Default is `active`.
 


### PR DESCRIPTION
The example uses an `ssh-rsa` formatted key, but the `encoding` is set to `PEM`.