### PR TITLE
New resource: aws_guardduty_detector

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -51,6 +51,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/emr"
 	"github.com/aws/aws-sdk-go/service/firehose"
 	"github.com/aws/aws-sdk-go/service/glacier"
+	"github.com/aws/aws-sdk-go/service/guardduty"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/inspector"
 	"github.com/aws/aws-sdk-go/service/iot"
@@ -176,6 +177,7 @@ type AWSClient struct {
 	mqconn                *mq.MQ
 	opsworksconn          *opsworks.OpsWorks
 	glacierconn           *glacier.Glacier
+	guarddutyconn         *guardduty.GuardDuty
 	codebuildconn         *codebuild.CodeBuild
 	codedeployconn        *codedeploy.CodeDeploy
 	codecommitconn        *codecommit.CodeCommit
@@ -403,6 +405,7 @@ func (c *Config) Client() (interface{}, error) {
 	client.firehoseconn = firehose.New(sess)
 	client.inspectorconn = inspector.New(sess)
 	client.glacierconn = glacier.New(sess)
+	client.guarddutyconn = guardduty.New(sess)
 	client.iotconn = iot.New(sess)
 	client.kinesisconn = kinesis.New(awsKinesisSess)
 	client.kmsconn = kms.New(awsKmsSess)

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -349,6 +349,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_emr_security_configuration":               resourceAwsEMRSecurityConfiguration(),
 			"aws_flow_log":                                 resourceAwsFlowLog(),
 			"aws_glacier_vault":                            resourceAwsGlacierVault(),
+			"aws_guardduty_detector":                       resourceAwsGuardDutyDetector(),
 			"aws_iam_access_key":                           resourceAwsIamAccessKey(),
 			"aws_iam_account_alias":                        resourceAwsIamAccountAlias(),
 			"aws_iam_account_password_policy":              resourceAwsIamAccountPasswordPolicy(),

--- a/aws/resource_aws_guardduty_detector.go
+++ b/aws/resource_aws_guardduty_detector.go
@@ -41,7 +41,7 @@ func resourceAwsGuardDutyDetectorCreate(d *schema.ResourceData, meta interface{}
 		Enable: aws.Bool(d.Get("enable").(bool)),
 	}
 
-	log.Printf("[DEBUG] Creating GuardDuty Detector: %#v", input)
+	log.Printf("[DEBUG] Creating GuardDuty Detector: %s", input)
 	output, err := conn.CreateDetector(&input)
 	if err != nil {
 		return fmt.Errorf("Creating GuardDuty Detector failed: %s", err.Error())
@@ -57,10 +57,10 @@ func resourceAwsGuardDutyDetectorRead(d *schema.ResourceData, meta interface{}) 
 		DetectorId: aws.String(d.Id()),
 	}
 
-	log.Printf("[DEBUG] Reading GuardDuty Detector: %#v", input)
+	log.Printf("[DEBUG] Reading GuardDuty Detector: %s", input)
 	gdo, err := conn.GetDetector(&input)
 	if err != nil {
-		if isAWSErr(err, "NoSuchEntityException", "The request is rejected because the input detectorId is not owned by the current account.") {
+		if isAWSErr(err, guardduty.ErrCodeBadRequestException, "The request is rejected because the input detectorId is not owned by the current account.") {
 			log.Printf("[WARN] GuardDuty detector %q not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
@@ -69,12 +69,7 @@ func resourceAwsGuardDutyDetectorRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	d.Set("account_id", meta.(*AWSClient).accountid)
-
-	if *gdo.Status == guardduty.DetectorStatusEnabled {
-		d.Set("enable", true)
-	} else {
-		d.Set("enable", false)
-	}
+	d.Set("enable", *gdo.Status == guardduty.DetectorStatusEnabled)
 
 	return nil
 }
@@ -87,7 +82,7 @@ func resourceAwsGuardDutyDetectorUpdate(d *schema.ResourceData, meta interface{}
 		Enable:     aws.Bool(d.Get("enable").(bool)),
 	}
 
-	log.Printf("[DEBUG] Update GuardDuty Detector: %#v", input)
+	log.Printf("[DEBUG] Update GuardDuty Detector: %s", input)
 	_, err := conn.UpdateDetector(&input)
 	if err != nil {
 		return fmt.Errorf("Updating GuardDuty Detector '%s' failed: %s", d.Id(), err.Error())
@@ -102,7 +97,7 @@ func resourceAwsGuardDutyDetectorDelete(d *schema.ResourceData, meta interface{}
 		DetectorId: aws.String(d.Id()),
 	}
 
-	log.Printf("[DEBUG] Delete GuardDuty Detector: %#v", input)
+	log.Printf("[DEBUG] Delete GuardDuty Detector: %s", input)
 	_, err := conn.DeleteDetector(&input)
 	if err != nil {
 		return fmt.Errorf("Deleting GuardDuty Detector '%s' failed: %s", d.Id(), err.Error())

--- a/aws/resource_aws_guardduty_detector.go
+++ b/aws/resource_aws_guardduty_detector.go
@@ -1,0 +1,111 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/guardduty"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsGuardDutyDetector() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsGuardDutyDetectorCreate,
+		Read:   resourceAwsGuardDutyDetectorRead,
+		Update: resourceAwsGuardDutyDetectorUpdate,
+		Delete: resourceAwsGuardDutyDetectorDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"enable": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"account_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsGuardDutyDetectorCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).guarddutyconn
+
+	input := guardduty.CreateDetectorInput{
+		Enable: aws.Bool(d.Get("enable").(bool)),
+	}
+
+	log.Printf("[DEBUG] Creating GuardDuty Detector: %#v", input)
+	output, err := conn.CreateDetector(&input)
+	if err != nil {
+		return fmt.Errorf("Creating GuardDuty Detector failed: %s", err.Error())
+	}
+	d.SetId(*output.DetectorId)
+
+	return resourceAwsGuardDutyDetectorRead(d, meta)
+}
+
+func resourceAwsGuardDutyDetectorRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).guarddutyconn
+	input := guardduty.GetDetectorInput{
+		DetectorId: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Reading GuardDuty Detector: %#v", input)
+	gdo, err := conn.GetDetector(&input)
+	if err != nil {
+		if isAWSErr(err, "NoSuchEntityException", "The request is rejected because the input detectorId is not owned by the current account.") {
+			log.Printf("[WARN] GuardDuty detector %q not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Reading GuardDuty Detector '%s' failed: %s", d.Id(), err.Error())
+	}
+
+	d.Set("account_id", meta.(*AWSClient).accountid)
+
+	if *gdo.Status == guardduty.DetectorStatusEnabled {
+		d.Set("enable", true)
+	} else {
+		d.Set("enable", false)
+	}
+
+	return nil
+}
+
+func resourceAwsGuardDutyDetectorUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).guarddutyconn
+
+	input := guardduty.UpdateDetectorInput{
+		DetectorId: aws.String(d.Id()),
+		Enable:     aws.Bool(d.Get("enable").(bool)),
+	}
+
+	log.Printf("[DEBUG] Update GuardDuty Detector: %#v", input)
+	_, err := conn.UpdateDetector(&input)
+	if err != nil {
+		return fmt.Errorf("Updating GuardDuty Detector '%s' failed: %s", d.Id(), err.Error())
+	}
+
+	return resourceAwsGuardDutyDetectorRead(d, meta)
+}
+
+func resourceAwsGuardDutyDetectorDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).guarddutyconn
+	input := guardduty.DeleteDetectorInput{
+		DetectorId: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Delete GuardDuty Detector: %#v", input)
+	_, err := conn.DeleteDetector(&input)
+	if err != nil {
+		return fmt.Errorf("Deleting GuardDuty Detector '%s' failed: %s", d.Id(), err.Error())
+	}
+	return nil
+}

--- a/aws/resource_aws_guardduty_detector_test.go
+++ b/aws/resource_aws_guardduty_detector_test.go
@@ -1,0 +1,116 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/guardduty"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAwsGuardDutyDetector_basic(t *testing.T) {
+	resourceName := "aws_guardduty_detector.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsGuardDutyDetectorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGuardDutyDetectorConfig_basic1,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsGuardDutyDetectorExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "account_id"),
+					resource.TestCheckResourceAttr(resourceName, "enable", "true"),
+				),
+			},
+			{
+				Config: testAccGuardDutyDetectorConfig_basic2,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsGuardDutyDetectorExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "enable", "false"),
+				),
+			},
+			{
+				Config: testAccGuardDutyDetectorConfig_basic3,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsGuardDutyDetectorExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "enable", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAwsGuardDutyDetector_import(t *testing.T) {
+	resourceName := "aws_guardduty_detector.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSesTemplateDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccGuardDutyDetectorConfig_basic1,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAwsGuardDutyDetectorDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).guarddutyconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_guardduty_detector" {
+			continue
+		}
+
+		input := &guardduty.GetDetectorInput{
+			DetectorId: aws.String(rs.Primary.ID),
+		}
+
+		_, err := conn.GetDetector(input)
+		if err != nil {
+			if isAWSErr(err, "NoSuchEntityException", "The request is rejected because the input detectorId is not owned by the current account.") {
+				return nil
+			}
+			return err
+		}
+
+		return fmt.Errorf("Expected GuardDuty Detector to be destroyed, %s found", rs.Primary.ID)
+	}
+
+	return nil
+}
+
+func testAccCheckAwsGuardDutyDetectorExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		return nil
+	}
+}
+
+const testAccGuardDutyDetectorConfig_basic1 = `
+resource "aws_guardduty_detector" "test" {}`
+
+const testAccGuardDutyDetectorConfig_basic2 = `
+resource "aws_guardduty_detector" "test" {
+  enable = false
+}`
+
+const testAccGuardDutyDetectorConfig_basic3 = `
+resource "aws_guardduty_detector" "test" {
+  enable = true
+}`

--- a/aws/resource_aws_guardduty_detector_test.go
+++ b/aws/resource_aws_guardduty_detector_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAwsGuardDutyDetector_basic(t *testing.T) {
+func testAccAwsGuardDutyDetector_basic(t *testing.T) {
 	resourceName := "aws_guardduty_detector.test"
 
 	resource.Test(t, resource.TestCase{
@@ -44,7 +44,7 @@ func TestAccAwsGuardDutyDetector_basic(t *testing.T) {
 	})
 }
 
-func TestAccAwsGuardDutyDetector_import(t *testing.T) {
+func testAccAwsGuardDutyDetector_import(t *testing.T) {
 	resourceName := "aws_guardduty_detector.test"
 
 	resource.Test(t, resource.TestCase{
@@ -79,7 +79,7 @@ func testAccCheckAwsGuardDutyDetectorDestroy(s *terraform.State) error {
 
 		_, err := conn.GetDetector(input)
 		if err != nil {
-			if isAWSErr(err, "NoSuchEntityException", "The request is rejected because the input detectorId is not owned by the current account.") {
+			if isAWSErr(err, guardduty.ErrCodeBadRequestException, "The request is rejected because the input detectorId is not owned by the current account.") {
 				return nil
 			}
 			return err

--- a/aws/resource_aws_guardduty_test.go
+++ b/aws/resource_aws_guardduty_test.go
@@ -1,0 +1,26 @@
+package aws
+
+import (
+	"testing"
+)
+
+func TestAccAWSGuardDuty(t *testing.T) {
+	testCases := map[string]map[string]func(t *testing.T){
+		"Detector": {
+			"basic":  testAccAwsGuardDutyDetector_basic,
+			"import": testAccAwsGuardDutyDetector_import,
+		},
+	}
+
+	for group, m := range testCases {
+		m := m
+		t.Run(group, func(t *testing.T) {
+			for name, tc := range m {
+				tc := tc
+				t.Run(name, func(t *testing.T) {
+					tc(t)
+				})
+			}
+		})
+	}
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -900,6 +900,14 @@
                     </ul>
                  </li>
 
+                <li<%= sidebar_current("docs-aws-resource-guardduty") %>>
+                    <a href="#">GuardDuty Resources</a>
+                    <ul class="nav nav-visible">
+                        <li<%= sidebar_current("docs-aws-resource-guardduty-detector") %>>
+                            <a href="/docs/providers/aws/r/guardduty_detector.html">aws_guardduty_detector</a>
+                        </li>
+                    </ul>
+                 </li>
 
                 <li<%= sidebar_current("docs-aws-resource-iam") %>>
                     <a href="#">IAM Resources</a>

--- a/website/docs/r/guardduty_detector.html.markdown
+++ b/website/docs/r/guardduty_detector.html.markdown
@@ -1,0 +1,42 @@
+---
+layout: "aws"
+page_title: "AWS: aws_guardduty_detector"
+sidebar_current: "docs-aws-resource-guardduty-detector"
+description: |-
+  Provides a resource to manage a GuardDuty detector
+---
+
+# aws_guardduty_detector
+
+Provides a resource to manage a GuardDuty detector.
+
+~> **NOTE:** Deleting this resource is equivalent to "disabling" GuardDuty for an AWS region, which removes all existing findings. You can set the `enable` attribute to `false` to instead "suspend" monitoring and feedback reporting while keeping existing data. See the [Suspending or Disabling Amazon GuardDuty documentation](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_suspend-disable.html) for more information.
+
+## Example Usage
+
+```hcl
+resource "aws_guardduty_detector" "MyDetector" {
+  enable = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `enable` - (Optional) Enable monitoring and feedback reporting. Setting to `false` is equivalent to "suspending" GuardDuty. Defaults to `true`.
+
+## Attributes Reference
+
+The following additional attributes are exported:
+
+* `id` - The ID of the GuardDuty detector
+* `account_id` - The AWS account ID of the GuardDuty detector
+
+## Import
+
+GuardDuty detectors can be imported using the detector ID, e.g.
+
+```
+$ terraform import aws_guardduty_detector.MyDetector 00b00fd5aecc0ab60a708659477e9617
+```


### PR DESCRIPTION
First resource for AWS GuardDuty service, which is responsible for enabling/disabling/suspending GuardDuty for a specific region and provides an identifier for cross-account membership later on. Reference: #2489 

Aside: the `account_id` attribute is for later usage since we need it for cross-account membership. It seems like the AWS account ID and AWS region could potentially be made meta-attributes for all AWS resources, rather than depending on each resource to implement.

```
make testacc TEST=./aws TESTARGS='-run=TestAccAwsGuardDutyDetector'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAwsGuardDutyDetector -timeout 120m
=== RUN   TestAccAwsGuardDutyDetector_basic
--- PASS: TestAccAwsGuardDutyDetector_basic (23.87s)
=== RUN   TestAccAwsGuardDutyDetector_import
--- PASS: TestAccAwsGuardDutyDetector_import (10.98s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	34.882s
```