### PR TITLE
Make depends_on consistent with note in aws_api_gateway_deployment

### DIFF
--- a/website/docs/r/api_gateway_deployment.html.markdown
+++ b/website/docs/r/api_gateway_deployment.html.markdown
@@ -42,7 +42,7 @@ resource "aws_api_gateway_integration" "MyDemoIntegration" {
 }
 
 resource "aws_api_gateway_deployment" "MyDemoDeployment" {
-  depends_on = ["aws_api_gateway_method.MyDemoMethod"]
+  depends_on = ["aws_api_gateway_integration.MyDemoIntegration"]
 
   rest_api_id = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
   stage_name  = "test"


### PR DESCRIPTION
At the top of the page the note says that the `aws_api_gateway_deployment` resource should include a `depends_on` for the `aws_api_gateway_integration.name` resource, yet the example depends on the `aws_api_gateway_method.MyDemoMethod` resource, which doesn't seem to fix the race condition.

Updating the example to match what the note says, so the example works out of the box.