### PR TITLE
Bump aws-sdk-go to v1.12.39

### DIFF
--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.12.38"
+const SDKVersion = "1.12.39"

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -141,812 +141,812 @@
 			"revisionTime": "2017-07-27T15:54:43Z"
 		},
 		{
-			"checksumSHA1": "n/GWI9xCa4UZa/TfIQrpJP30U8A=",
+			"checksumSHA1": "e8B73ptQ844aa/mzFsS3W4yoXtk=",
 			"path": "github.com/aws/aws-sdk-go/aws",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "DtuTqKH29YnLjrIJkRYX0HQtXY0=",
 			"path": "github.com/aws/aws-sdk-go/aws/arn",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "Y9W+4GimK4Fuxq+vyIskVYFRnX4=",
 			"path": "github.com/aws/aws-sdk-go/aws/awserr",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "yyYr41HZ1Aq0hWc3J5ijXwYEcac=",
 			"path": "github.com/aws/aws-sdk-go/aws/awsutil",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "9nE/FjZ4pYrT883KtV2/aI+Gayo=",
 			"path": "github.com/aws/aws-sdk-go/aws/client",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "ieAJ+Cvp/PKv1LpUEnUXpc3OI6E=",
 			"path": "github.com/aws/aws-sdk-go/aws/client/metadata",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "7/8j/q0TWtOgXyvEcv4B2Dhl00o=",
 			"path": "github.com/aws/aws-sdk-go/aws/corehandlers",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "Y+cPwQL0dZMyqp3wI+KJWmA9KQ8=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "u3GOAJLmdvbuNUeUEcZSEAOeL/0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "NUJUTWlc1sV8b7WjfiYc4JZbXl0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/endpointcreds",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "JEYqmF83O5n5bHkupAzA6STm0no=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "ZdtYh3ZHSgP/WEIaqwJHTEhpkbs=",
 			"path": "github.com/aws/aws-sdk-go/aws/defaults",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "/EXbk/z2TWjWc1Hvb4QYs3Wmhb8=",
 			"path": "github.com/aws/aws-sdk-go/aws/ec2metadata",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "2Rcu4ZCsQkoBFN0NpveADCcES8Q=",
 			"path": "github.com/aws/aws-sdk-go/aws/endpoints",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "9GvAyILJ7g+VUg8Ef5DsT5GuYsg=",
 			"path": "github.com/aws/aws-sdk-go/aws/request",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "HcGL4e6Uep4/80eCUI5xkcWjpQ0=",
 			"path": "github.com/aws/aws-sdk-go/aws/session",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "iU00ZjhAml/13g+1YXT21IqoXqg=",
 			"path": "github.com/aws/aws-sdk-go/aws/signer/v4",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "04ypv4x12l4q0TksA1zEVsmgpvw=",
 			"path": "github.com/aws/aws-sdk-go/internal/shareddefaults",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "NStHCXEvYqG72GknZyv1jaKaeH0=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "1QmQ3FqV37w0Zi44qv8pA1GeR0A=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/ec2query",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "yHfT5DTbeCLs4NE2Rgnqrhe15ls=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/json/jsonutil",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "R00RL5jJXRYq1iiK1+PGvMfvXyM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/jsonrpc",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "ZqY5RWavBLWTo6j9xqdyBEaNFRk=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "9V1PvtFQ9MObZTc3sa86WcuOtOU=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "pkeoOfZpHRvFG/AOZeTf0lwtsFg=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/rest",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "Rpu8KBtHZgvhkwHxUfaky+qW+G4=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restjson",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "ODo+ko8D6unAxZuN1jGzMcN4QCc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restxml",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "0qYPUga28aQVkxZgBR3Z86AbGUQ=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "F6mth+G7dXN1GI+nktaGo8Lx8aE=",
 			"path": "github.com/aws/aws-sdk-go/private/signer/v2",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "2CNaABTsz1Dl+cRpvKKhSS2Udgk=",
 			"path": "github.com/aws/aws-sdk-go/service/acm",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "1RJUtQledDNrJ50K4Oqbe/UY6fg=",
 			"path": "github.com/aws/aws-sdk-go/service/apigateway",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "s+mt8VBjyMOBCZbr4/uOhUGZdYY=",
 			"path": "github.com/aws/aws-sdk-go/service/applicationautoscaling",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "FjLBsCW1nIlajKKmON/gq5RCgHU=",
 			"path": "github.com/aws/aws-sdk-go/service/appsync",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "1/p8oChMJW38gBTOA8AUCWkHuM8=",
 			"path": "github.com/aws/aws-sdk-go/service/athena",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "dsq+AB+U9PQG+2KGa5wDQNJaqHE=",
 			"path": "github.com/aws/aws-sdk-go/service/autoscaling",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "DTKp8JsJ4NvsSoeLVp72lPPT2jc=",
 			"path": "github.com/aws/aws-sdk-go/service/batch",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "86Gd/aNE5+OAAibFQg6YWh7YKU0=",
 			"path": "github.com/aws/aws-sdk-go/service/budgets",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "NTUkkfytXTRTbjLiiZrHS0FO9A4=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudformation",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "vbSfNKXjDDYLLAYafrD37T5xBFk=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudfront",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "V5UO7ojp8/EuLhPIS4OOOurke3M=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudtrail",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "Rx8tIQPEmYZhy1zbRpDmMBmGfvg=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatch",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "UlNtqtd2PcKoWqqXmOj4kfu8hyc=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchevents",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "7SPaq0IXgoe1Cqph7ws9vFYr3zg=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "iOGHSGv16gPEKX+DHoOoXIeGm70=",
 			"path": "github.com/aws/aws-sdk-go/service/codebuild",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "B8CSJW3k+VJ6neD1ddrSJJ/5TF8=",
 			"path": "github.com/aws/aws-sdk-go/service/codecommit",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "8T1UkQcbxF08m5xJL16lsWLdT6k=",
 			"path": "github.com/aws/aws-sdk-go/service/codedeploy",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "EEVCD+xa8rnlVXoFULjc9fWcVzY=",
 			"path": "github.com/aws/aws-sdk-go/service/codepipeline",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "GHaVqY5f85olNwlO5J4f160D+mI=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentity",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "00Mr7fjKuKIzfjNkNA7b7psEseI=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentityprovider",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "YONbbZXdr13qIiKYzqk4cptd2XE=",
 			"path": "github.com/aws/aws-sdk-go/service/configservice",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "3EkRSF6NzJkEuZUvOt3TdpABXYc=",
 			"path": "github.com/aws/aws-sdk-go/service/databasemigrationservice",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "TSYWqKDCe6RaR2kYrExoDIC+7LU=",
 			"path": "github.com/aws/aws-sdk-go/service/devicefarm",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "2139YRKSqXN9N49CFTopzwftCDw=",
 			"path": "github.com/aws/aws-sdk-go/service/directconnect",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "0T4esELn9yJKr3D7b1/apnu1ZOA=",
 			"path": "github.com/aws/aws-sdk-go/service/directoryservice",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "kxsEfXt3Laq9lcZz0+3BHz7XMW0=",
 			"path": "github.com/aws/aws-sdk-go/service/dynamodb",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "5CSBr2ISv3GBYd56i3H+zjm4GQc=",
 			"path": "github.com/aws/aws-sdk-go/service/ec2",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "tvxhxL5w10Qau4eUabsLK4L60iA=",
 			"path": "github.com/aws/aws-sdk-go/service/ecr",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "4ah7g2O2CGVs/a3UWEAuVNd/f30=",
 			"path": "github.com/aws/aws-sdk-go/service/ecs",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "9I1RdgcMUEYJlyNIqdtSgFTdWKM=",
 			"path": "github.com/aws/aws-sdk-go/service/efs",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "jmTYmZVr8dw9kPDYlBhe4oG556U=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticache",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "xylCApLVAqLTW6uTYCziTDxgRMI=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticbeanstalk",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "RmVY7K2zivKjDe0ad8Grd+81J/M=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticsearchservice",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "SZ7yLDZ6RvMhpWe0Goyem64kgyA=",
 			"path": "github.com/aws/aws-sdk-go/service/elastictranscoder",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "i+zp7see74G8qx251yfQiTvbz4U=",
 			"path": "github.com/aws/aws-sdk-go/service/elb",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "i9eKrHV2n3LuYoMVnMpNjF34ih8=",
 			"path": "github.com/aws/aws-sdk-go/service/elbv2",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "LJrVm902tsUu83HoxW5+twvlMSA=",
 			"path": "github.com/aws/aws-sdk-go/service/emr",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "cEKm/PVdmVyoRD1wu9jDHIh52G4=",
 			"path": "github.com/aws/aws-sdk-go/service/firehose",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "oDoGvSfmO2Z099ixV2HXn+SDeHE=",
 			"path": "github.com/aws/aws-sdk-go/service/glacier",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "GEw6g6/GwkskwL5bGj/KYJ8BENY=",
 			"path": "github.com/aws/aws-sdk-go/service/glue",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "pUw08vq4ypW0qg5np1bZBPUdFhk=",
 			"path": "github.com/aws/aws-sdk-go/service/guardduty",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "HBlNyNP2zLI589MIX82zMvANmLY=",
 			"path": "github.com/aws/aws-sdk-go/service/iam",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "WoIsJOP3M2BAhZ5p46LJNd9FQPk=",
 			"path": "github.com/aws/aws-sdk-go/service/inspector",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "WCQ76H7tI4wkQ9if4HL2qJpGGr4=",
 			"path": "github.com/aws/aws-sdk-go/service/iot",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "yrji9KybkQLQBcP0ti5X6FrEXoc=",
 			"path": "github.com/aws/aws-sdk-go/service/kinesis",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "CqvUs/OKC5GYojf8InoQpTWUI30=",
 			"path": "github.com/aws/aws-sdk-go/service/kms",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "hMCDSOWlIT4Dr+ZG7PCMVM32IOI=",
 			"path": "github.com/aws/aws-sdk-go/service/lambda",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "N7F39+vn1EaZZpfThaFExQcGfhI=",
 			"path": "github.com/aws/aws-sdk-go/service/lightsail",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "gSpDdjt2R3cME3YZWOF4SZ/mrJ8=",
 			"path": "github.com/aws/aws-sdk-go/service/mediaconvert",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "42hWUchiIBN8VvWSPzi9QcHoDVk=",
 			"path": "github.com/aws/aws-sdk-go/service/medialive",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "tN30knTZ2ALjKm4IDU6jK+kYqtE=",
 			"path": "github.com/aws/aws-sdk-go/service/mediapackage",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "4Uq/ZoglG76ZQ16gLnnpO1Ga3Ak=",
 			"path": "github.com/aws/aws-sdk-go/service/mediastore",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "n+Jxsi0zhH+TYMTm+JIJfpVrJGQ=",
 			"path": "github.com/aws/aws-sdk-go/service/mediastoredata",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "75LM8oENH3zGsQhNKuwIfEjXRDw=",
 			"path": "github.com/aws/aws-sdk-go/service/mq",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "xkNWwN2rw+szg+zXAxCun34zxhs=",
 			"path": "github.com/aws/aws-sdk-go/service/opsworks",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "saFo2jqsWU43Lax6lL8PhQKRl8s=",
 			"path": "github.com/aws/aws-sdk-go/service/rds",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "BwFxr+n+xU7TOQxxONFxdtrWjG4=",
 			"path": "github.com/aws/aws-sdk-go/service/redshift",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "S1md3W8h4/TLxScptLYbD5ukfrM=",
 			"path": "github.com/aws/aws-sdk-go/service/route53",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "TFFdPTzKEzgc1jNP27gJmEU/cOk=",
 			"path": "github.com/aws/aws-sdk-go/service/s3",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "Tz5NbDa/SGUINmuFD8KQLh1HDOI=",
 			"path": "github.com/aws/aws-sdk-go/service/servicecatalog",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "/ztCHg70ElmJqzKYIRwDB6TiBOc=",
 			"path": "github.com/aws/aws-sdk-go/service/ses",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "4fkXdvKPVnJvu6yUBc+MHkN4t20=",
 			"path": "github.com/aws/aws-sdk-go/service/sfn",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "rrsHusPbMvyKM0WvbZyYjDgKG00=",
 			"path": "github.com/aws/aws-sdk-go/service/shield",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "B3CgAFSREebpsFoFOo4vrQ6u04w=",
 			"path": "github.com/aws/aws-sdk-go/service/simpledb",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "rwSNHPn9iLEaoDx6vX0KbWefcHY=",
 			"path": "github.com/aws/aws-sdk-go/service/sns",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "aWWSD60GhNwldZ7mxL9Z8Q+fiXo=",
 			"path": "github.com/aws/aws-sdk-go/service/sqs",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "1wkJ4xq3qTqlHTkAADIdBZ6OWvI=",
 			"path": "github.com/aws/aws-sdk-go/service/ssm",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "d9vR1rl8kmJxJBwe00byziVFR/o=",
 			"path": "github.com/aws/aws-sdk-go/service/sts",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "Uw4pOUxSMbx4xBHUcOUkNhtnywE=",
 			"path": "github.com/aws/aws-sdk-go/service/swf",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "eVLbU/Ep3lSJXgHZvSGb6HsxRUY=",
 			"path": "github.com/aws/aws-sdk-go/service/waf",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "wq/SHXPytoKkPtXDBu/1WbS0L5A=",
 			"path": "github.com/aws/aws-sdk-go/service/wafregional",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "AUwsvYff1GCOYtCgB6wd0doC9kc=",
 			"path": "github.com/aws/aws-sdk-go/service/workspaces",
-			"revision": "b00fb575f3373d28ad8b5d259e12f2314f3efa31",
-			"revisionTime": "2017-11-30T18:49:58Z",
-			"version": "v1.12.38",
-			"versionExact": "v1.12.38"
+			"revision": "388e6676807f5968ad5eaaec0c70002f80c20b84",
+			"revisionTime": "2017-12-01T21:16:35Z",
+			"version": "v1.12.39",
+			"versionExact": "v1.12.39"
 		},
 		{
 			"checksumSHA1": "usT4LCSQItkFvFOQT7cBlkCuGaE=",


### PR DESCRIPTION
[CHANGELOG](https://github.com/aws/aws-sdk-go/blob/v1.12.39/CHANGELOG.md)
```
go get -u github.com/kardianos/govendor
govendor --version v1.0.9
govendor fetch github.com/aws/aws-sdk-go/...@v1.12.39
```
relates to #2477 #2478 #2479 