### PR TITLE
r/aws_appautoscaling_target: Support updating max_capacity, min_capacity, and role_arn attributes

### DIFF
--- a/aws/resource_aws_appautoscaling_target_test.go
+++ b/aws/resource_aws_appautoscaling_target_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -27,6 +28,8 @@ func TestAccAWSAppautoScalingTarget_basic(t *testing.T) {
 				Config: testAccAWSAppautoscalingTargetConfig(randClusterName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAppautoscalingTargetExists("aws_appautoscaling_target.bar", &target),
+					resource.TestMatchResourceAttr("aws_appautoscaling_target.bar", "role_arn",
+						regexp.MustCompile(fmt.Sprintf("^arn:aws:iam::[0-9]{12}:role/autoscalerole%s$", randClusterName))),
 					resource.TestCheckResourceAttr("aws_appautoscaling_target.bar", "service_namespace", "ecs"),
 					resource.TestCheckResourceAttr("aws_appautoscaling_target.bar", "scalable_dimension", "ecs:service:DesiredCount"),
 					resource.TestCheckResourceAttr("aws_appautoscaling_target.bar", "min_capacity", "1"),
@@ -40,6 +43,8 @@ func TestAccAWSAppautoScalingTarget_basic(t *testing.T) {
 					testAccCheckAWSAppautoscalingTargetExists("aws_appautoscaling_target.bar", &target),
 					resource.TestCheckResourceAttr("aws_appautoscaling_target.bar", "min_capacity", "2"),
 					resource.TestCheckResourceAttr("aws_appautoscaling_target.bar", "max_capacity", "8"),
+					resource.TestMatchResourceAttr("aws_appautoscaling_target.bar", "role_arn",
+						regexp.MustCompile(fmt.Sprintf("^arn:aws:iam::[0-9]{12}:role/autoscaleroleupdate%s$", randClusterName))),
 				),
 			},
 		},
@@ -288,7 +293,7 @@ func testAccAWSAppautoscalingTargetConfigUpdate(
 	randClusterName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "autoscale_role" {
-	name = "autoscalerole%s"
+	name = "autoscaleroleupdate%s"
 	path = "/"
 
 	assume_role_policy = <<EOF


### PR DESCRIPTION
The [RegisterScalableTarget](http://docs.aws.amazon.com/sdk-for-go/api/service/applicationautoscaling/#ApplicationAutoScaling.RegisterScalableTarget) API call supports updating attributes on existing targets.

Closes #240 and potentially #968 

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSAppautoScalingTarget'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSAppautoScalingTarget -timeout 120m
=== RUN   TestAccAWSAppautoScalingTarget_basic
--- PASS: TestAccAWSAppautoScalingTarget_basic (67.34s)
=== RUN   TestAccAWSAppautoScalingTarget_spotFleetRequest
--- PASS: TestAccAWSAppautoScalingTarget_spotFleetRequest (69.89s)
=== RUN   TestAccAWSAppautoScalingTarget_emrCluster
--- PASS: TestAccAWSAppautoScalingTarget_emrCluster (556.08s)
=== RUN   TestAccAWSAppautoScalingTarget_multipleTargets
--- PASS: TestAccAWSAppautoScalingTarget_multipleTargets (32.41s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws   725.772s
```
