### PR TITLE
resource/aws_s3_bucket: Mark replication_configuration rules id attribute as required

### DIFF
--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -351,7 +351,7 @@ func resourceAwsS3Bucket() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"id": {
 										Type:         schema.TypeString,
-										Optional:     true,
+										Required:     true,
 										ValidateFunc: validateS3BucketReplicationRuleId,
 									},
 									"destination": {

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -381,7 +381,7 @@ The `replication_configuration` object supports the following:
 
 The `rules` object supports the following:
 
-* `id` - (Optional) Unique identifier for the rule.
+* `id` - (Required) Unique identifier for the rule.
 * `destination` - (Required) Specifies the destination for the rule (documented below).
 * `prefix` - (Required) Object keyname prefix identifying one or more objects to which the rule applies. Set as an empty string to replicate the whole bucket.
 * `status` - (Required) The status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.


### PR DESCRIPTION
Closes #665 

The `rules` under `replication_configuration` are currently TypeSet with the hash computed including the ID attribute when available. However, when creating a rule that omits the ID attribute (allowing AWS to generate the ID), the plan will always show a difference due to the hash changing. Rather than deal with a state migration to TypeList on a critical resource for seemingly little benefit, set this attribute as `Required` as the least effort option to make the resource configuration less surprising.

I do not believe this needs to be marked as a breaking change, due to the current behavior.

If there are better ways to handle this via the `Set` function or some other way, please let me know!