### PR TITLE
r/aws_sqs_queue_policy: Support import by queue URL

### DIFF
--- a/aws/resource_aws_sqs_queue_policy_migrate.go
+++ b/aws/resource_aws_sqs_queue_policy_migrate.go
@@ -1,0 +1,38 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func resourceAwsSqsQueuePolicyMigrateState(
+	v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	switch v {
+	case 0:
+		log.Println("[INFO] Found AWS SQS Query Policy State v0; migrating to v1")
+		return migrateSqsQueuePolicyStateV0toV1(is)
+	default:
+		return is, fmt.Errorf("Unexpected schema version: %d", v)
+	}
+}
+
+func migrateSqsQueuePolicyStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
+
+	if is.Empty() {
+		log.Println("[DEBUG] Empty InstanceState; nothing to migrate.")
+
+		return is, nil
+	}
+
+	log.Printf("[DEBUG] Attributes before migration: %#v", is.Attributes)
+
+	is.Attributes["id"] = is.Attributes["queue_url"]
+	is.ID = is.Attributes["queue_url"]
+
+	log.Printf("[DEBUG] Attributes after migration: %#v, new id: %s", is.Attributes, is.Attributes["queue_url"])
+
+	return is, nil
+
+}

--- a/aws/resource_aws_sqs_queue_policy_migrate_test.go
+++ b/aws/resource_aws_sqs_queue_policy_migrate_test.go
@@ -1,0 +1,45 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAWSSqsQueuePolicyMigrateState(t *testing.T) {
+
+	cases := map[string]struct {
+		StateVersion int
+		ID           string
+		Attributes   map[string]string
+		Expected     string
+		Meta         interface{}
+	}{
+		"v0_1": {
+			StateVersion: 0,
+			ID:           "sqs-policy-https://queue.amazonaws.com/0123456789012/myqueue",
+			Attributes: map[string]string{
+				"policy":    "{}",
+				"queue_url": "https://queue.amazonaws.com/0123456789012/myqueue",
+			},
+			Expected: "https://queue.amazonaws.com/0123456789012/myqueue",
+		},
+	}
+
+	for tn, tc := range cases {
+		is := &terraform.InstanceState{
+			ID:         tc.ID,
+			Attributes: tc.Attributes,
+		}
+		is, err := resourceAwsSqsQueuePolicyMigrateState(
+			tc.StateVersion, is, tc.Meta)
+
+		if err != nil {
+			t.Fatalf("bad: %s, err: %#v", tn, err)
+		}
+
+		if is.ID != tc.Expected {
+			t.Fatalf("bad sqs queue policy id: %s\n\n expected: %s", is.ID, tc.Expected)
+		}
+	}
+}

--- a/aws/resource_aws_sqs_queue_policy_test.go
+++ b/aws/resource_aws_sqs_queue_policy_test.go
@@ -28,6 +28,28 @@ func TestAccAWSSQSQueuePolicy_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSSQSQueuePolicy_import(t *testing.T) {
+	queueName := fmt.Sprintf("sqs-queue-%s", acctest.RandString(5))
+	resourceName := "aws_sqs_queue_policy.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSSQSPolicyConfig_basic(queueName),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccAWSSQSPolicyConfig_basic(r string) string {
 	return fmt.Sprintf(testAccAWSSQSPolicyConfig_basic_tpl, r)
 }

--- a/website/docs/r/sqs_queue_policy.html.markdown
+++ b/website/docs/r/sqs_queue_policy.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides a SQS Queue Policy resource.
 ---
 
-# aws\_sqs\_queue\_policy
+# aws_sqs_queue_policy
 
 Allows you to set a policy of an SQS Queue
 while referencing ARN of the queue within the policy.
@@ -50,3 +50,11 @@ The following arguments are supported:
 
 * `queue_url` - (Required) The URL of the SQS Queue to which to attach the policy
 * `policy` - (Required) The JSON policy for the SQS queue
+
+## Import
+
+SQS Queue Policies can be imported using the queue URL, e.g.
+
+```
+$ terraform import aws_sqs_queue_policy.test https://queue.amazonaws.com/0123456789012/myqueue
+```


### PR DESCRIPTION
Via migrating the ID to remove the `sqs-policy-` prefix. Includes some other minor cleanup.

Closes #1501

```
make testacc TEST=./aws TESTARGS='-run=\(TestAWSSqsQueuePolicyMigrateState\|TestAccAWSSQSQueuePolicy\)'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=\(TestAWSSqsQueuePolicyMigrateState\|TestAccAWSSQSQueuePolicy\) -timeout 120m
=== RUN   TestAWSSqsQueuePolicyMigrateState
2017/12/05 01:50:46 [INFO] Found AWS SQS Query Policy State v0; migrating to v1
2017/12/05 01:50:46 [DEBUG] Attributes before migration: map[string]string{"policy":"{}", "queue_url":"https://queue.amazonaws.com/0123456789012/myqueue"}
2017/12/05 01:50:46 [DEBUG] Attributes after migration: map[string]string{"queue_url":"https://queue.amazonaws.com/0123456789012/myqueue", "id":"https://queue.amazonaws.com/0123456789012/myqueue", "policy":"{}"}, new id: https://queue.amazonaws.com/0123456789012/myqueue
--- PASS: TestAWSSqsQueuePolicyMigrateState (0.00s)
=== RUN   TestAccAWSSQSQueuePolicy_basic
--- PASS: TestAccAWSSQSQueuePolicy_basic (15.93s)
=== RUN   TestAccAWSSQSQueuePolicy_import
--- PASS: TestAccAWSSQSQueuePolicy_import (16.23s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	32.198s
```