### PR TITLE
Support CodeBuild within VPC

### DIFF
--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -258,6 +258,10 @@ func resourceAwsCodeBuildProjectCreate(d *schema.ResourceData, meta interface{})
 				return resource.RetryableError(err)
 			}
 
+			if isAWSErr(err, "InvalidInputException", "Not authorized to perform DescribeSecurityGroups") {
+				return resource.RetryableError(err)
+			}
+
 			return resource.NonRetryableError(err)
 		}
 

--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -324,6 +324,19 @@ func testAccCheckAWSCodeBuildProjectDestroy(s *terraform.State) error {
 
 func testAccAWSCodeBuildProjectConfig_basic(rName string) string {
 	return fmt.Sprintf(`
+resource "aws_vpc" "codebuild_vpc" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "codebuild_subnet" {
+  vpc_id     = "${aws_vpc.codebuild_vpc.id}"
+  cidr_block = "10.0.0.0/24"
+}
+
+resource "aws_security_group" "codebuild_security_group" {
+  vpc_id = "${aws_vpc.codebuild_vpc.id}"
+}
+
 resource "aws_iam_role" "codebuild_role" {
   name = "codebuild-role-%s"
   assume_role_policy = <<EOF
@@ -343,10 +356,10 @@ EOF
 }
 
 resource "aws_iam_policy" "codebuild_policy" {
-    name        = "codebuild-policy-%s"
-    path        = "/service-role/"
-    description = "Policy used in trust relationship with CodeBuild"
-    policy      = <<POLICY
+  name        = "codebuild-policy-%s"
+  path        = "/service-role/"
+  description = "Policy used in trust relationship with CodeBuild"
+  policy      = <<POLICY
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -360,6 +373,34 @@ resource "aws_iam_policy" "codebuild_policy" {
         "logs:CreateLogStream",
         "logs:PutLogEvents"
       ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateNetworkInterface",
+        "ec2:DescribeDhcpOptions",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DeleteNetworkInterface",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeVpcs"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateNetworkInterfacePermission"
+      ],
+      "Resource": "arn:aws:ec2::*:network-interface/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:Subnet": [
+            "arn:aws:ec2::*:subnet/${aws_subnet.codebuild_subnet.id}"
+          ],
+          "ec2:AuthorizedService": "codebuild.amazonaws.com"
+        }
+      }
     }
   ]
 }
@@ -373,10 +414,10 @@ resource "aws_iam_policy_attachment" "codebuild_policy_attachment" {
 }
 
 resource "aws_codebuild_project" "foo" {
-  name         = "test-project-%s"
-  description  = "test_codebuild_project"
-  build_timeout      = "5"
-  service_role = "${aws_iam_role.codebuild_role.arn}"
+  name          = "test-project-%s"
+  description   = "test_codebuild_project"
+  build_timeout = "5"
+  service_role  = "${aws_iam_role.codebuild_role.arn}"
 
   artifacts {
     type = "NO_ARTIFACTS"
@@ -401,6 +442,20 @@ resource "aws_codebuild_project" "foo" {
   tags {
     "Environment" = "Test"
   }
+
+  vpc_config {
+    vpc_id = "${aws_vpc.codebuild_vpc.id}"
+
+    subnets = [
+      "${aws_subnet.codebuild_subnet.id}"
+    ]
+
+    security_group_ids = [
+      "${aws_security_group.codebuild_security_group.id}"
+    ]
+  }
+
+  depends_on = ["aws_iam_policy_attachment.codebuild_policy_attachment"]
 }
 `, rName, rName, rName, rName)
 }

--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -454,8 +454,6 @@ resource "aws_codebuild_project" "foo" {
       "${aws_security_group.codebuild_security_group.id}"
     ]
   }
-
-  depends_on = ["aws_iam_policy_attachment.codebuild_policy_attachment"]
 }
 `, rName, rName, rName, rName)
 }

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -94,6 +94,20 @@ resource "aws_codebuild_project" "foo" {
     location = "https://github.com/mitchellh/packer.git"
   }
 
+  vpc_config {
+    vpc_id = "vpc-725fca"
+
+    subnets = [
+      "subnet-ba35d2e0",
+      "subnet-ab129af1",
+    ]
+
+    security_group_ids = [
+      "sg-f9f27d91",
+      "sg-e4f48g23",
+    ]
+  }
+
   tags {
     "Environment" = "Test"
   }
@@ -113,6 +127,7 @@ The following arguments are supported:
 * `artifacts` - (Required) Information about the project's build output artifacts. Artifact blocks are documented below.
 * `environment` - (Required) Information about the project's build environment. Environment blocks are documented below.
 * `source` - (Required) Information about the project's input source code. Source blocks are documented below.
+* `vpc_config` - (Optional) Configuration for the builds to run inside a VPC. VPC config blocks are documented below.
 
 `artifacts` supports the following:
 
@@ -147,6 +162,12 @@ The following arguments are supported:
 * `type` - (Required) The authorization type to use. The only valid value is `OAUTH`
 * `resource` - (Optional) The resource value that applies to the specified authorization type.
 
+`vpc_config` supports the following:
+
+* `vpc_id` - (Required) The ID of the VPC within which to run builds.
+* `subnets` - (Required) The subnet IDs within which to run builds.
+* `security_group_ids` - (Required) The security group IDs to assign to running builds.
+
 ## Attributes Reference
 
 The following attributes are exported:
@@ -156,4 +177,3 @@ The following attributes are exported:
 * `encryption_key` - The AWS Key Management Service (AWS KMS) customer master key (CMK) that was used for encrypting the build project's build output artifacts.
 * `name` - The projects name.
 * `service_role` - The ARN of the IAM service role.
-

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -147,6 +147,7 @@ The following arguments are supported:
 * `environment_variable` - (Optional) A set of environment variables to make available to builds for this build project.
 
 `environment_variable` supports the following:
+
 * `name` - (Required) The environment variable's name or key.
 * `value` - (Required) The environment variable's value.
 


### PR DESCRIPTION
Fixes #2495 

First attempt at a go contribution, happy to implement any suggestions.

- [x] Update `aws_codebuild_project`.
- [x] Acceptance test.
- [x] Documentation.

There is an issue with the acceptance test (hence WIP). Creation of the CodeBuild project requires the DescribeSecurityGroups permission. This is added to the IAM role, but there is a race condition between the policy actually being applied and the creation of the CodeBuild project, meaning that it can fail. I've added a `depends_on = ["aws_iam_policy_attachment.codebuild_policy_attachment"]` clause to the `aws_codebuild_policy` resource, but this doesn't help. I guess it is the natural lag in applying IAM policies. Any ideas? Edit: **this is fixed now**.