### PR TITLE
Downsize ES domains to save money

### DIFF
--- a/aws/resource_aws_elasticsearch_domain_test.go
+++ b/aws/resource_aws_elasticsearch_domain_test.go
@@ -503,7 +503,7 @@ resource "aws_elasticsearch_domain" "example" {
   cluster_config {
     instance_count = 2
     zone_awareness_enabled = true
-    instance_type = "r3.large.elasticsearch"
+    instance_type = "m3.medium.elasticsearch"
   }
 
   snapshot_options {
@@ -570,7 +570,7 @@ resource "aws_elasticsearch_domain" "example" {
   cluster_config {
     instance_count = 2
     zone_awareness_enabled = true
-    instance_type = "r3.large.elasticsearch"
+    instance_type = "m3.medium.elasticsearch"
   }
 
   vpc_options {
@@ -642,7 +642,7 @@ resource "aws_elasticsearch_domain" "example" {
   cluster_config {
     instance_count = 2
     zone_awareness_enabled = true
-    instance_type = "r3.large.elasticsearch"
+    instance_type = "m3.medium.elasticsearch"
   }
 
   vpc_options {
@@ -694,7 +694,7 @@ resource "aws_elasticsearch_domain" "example" {
   cluster_config {
     instance_count = 2
     zone_awareness_enabled = true
-    instance_type = "r3.large.elasticsearch"
+    instance_type = "t2.micro.elasticsearch"
   }
 
   vpc_options {

--- a/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
@@ -995,7 +995,7 @@ var testAccKinesisFirehoseDeliveryStreamBaseElasticsearchConfig = testAccKinesis
 resource "aws_elasticsearch_domain" "test_cluster" {
   domain_name = "es-test-%d"
   cluster_config {
-    instance_type = "r3.large.elasticsearch"
+    instance_type = "m3.medium.elasticsearch"
   }
 
   access_policies = <<CONFIG


### PR DESCRIPTION
There's no need to use such expensive instance types in our tests, so I downgraded these to save some money. 💰 

`t2.micro.elasticsearch` is `$0.018` per Hour (the cheapest available w/out EBS)
`m3.medium.elasticsearch` is `$0.094` per Hour (the cheapest available w/ EBS)

`r3.large.elasticsearch` was `$0.245` per Hour

https://aws.amazon.com/elasticsearch-service/pricing/

ES is an expensive leak otherwise and was the most expensive part of our bill - so I'm just picking the low hanging fruit - there's a few other places where we can cut the unnecessary costs.

## Test results

```
=== RUN   TestAccAWSElasticSearchDomain_duplicate
--- PASS: TestAccAWSElasticSearchDomain_duplicate (595.89s)
=== RUN   TestAccAWSElasticSearchDomain_v23
--- PASS: TestAccAWSElasticSearchDomain_v23 (739.38s)
=== RUN   TestAccAWSElasticSearchDomain_policy
--- PASS: TestAccAWSElasticSearchDomain_policy (945.22s)
=== RUN   TestAccAWSElasticSearchDomain_tags
--- PASS: TestAccAWSElasticSearchDomain_tags (997.97s)
=== RUN   TestAccAWSElasticSearchDomain_importBasic
--- PASS: TestAccAWSElasticSearchDomain_importBasic (1029.03s)
=== RUN   TestAccAWSElasticSearchDomain_complex
--- PASS: TestAccAWSElasticSearchDomain_complex (1037.62s)
=== RUN   TestAccAWSElasticSearchDomain_vpc
--- PASS: TestAccAWSElasticSearchDomain_vpc (1373.16s)
=== RUN   TestAccAWSElasticSearchDomain_basic
--- PASS: TestAccAWSElasticSearchDomain_basic (1531.54s)
=== RUN   TestAccAWSElasticSearchDomain_update
--- PASS: TestAccAWSElasticSearchDomain_update (2129.23s)
=== RUN   TestAccAWSElasticSearchDomain_internetToVpcEndpoint
--- PASS: TestAccAWSElasticSearchDomain_internetToVpcEndpoint (2160.52s)
=== RUN   TestAccAWSElasticSearchDomainPolicy_basic
--- PASS: TestAccAWSElasticSearchDomainPolicy_basic (2765.69s)
=== RUN   TestAccAWSElasticSearchDomain_vpc_update
--- PASS: TestAccAWSElasticSearchDomain_vpc_update (2766.88s)
```