### PR TITLE
Downsize EMR to save money

### DIFF
--- a/aws/resource_aws_appautoscaling_scheduled_action_test.go
+++ b/aws/resource_aws_appautoscaling_scheduled_action_test.go
@@ -299,8 +299,8 @@ resource "aws_emr_cluster" "hoge" {
     instance_profile                  = "${aws_iam_instance_profile.instance_profile.arn}"
   }
 
-  master_instance_type = "m4.large"
-  core_instance_type   = "m4.large"
+  master_instance_type = "c4.large"
+  core_instance_type   = "c4.large"
   core_instance_count  = 2
 
   tags {
@@ -329,7 +329,7 @@ resource "aws_emr_cluster" "hoge" {
 resource "aws_emr_instance_group" "hoge" {
   cluster_id     = "${aws_emr_cluster.hoge.id}"
   instance_count = 1
-  instance_type  = "m4.large"
+  instance_type  = "c4.large"
 }
 
 resource "aws_security_group" "hoge" {

--- a/aws/resource_aws_emr_cluster_test.go
+++ b/aws/resource_aws_emr_cluster_test.go
@@ -366,8 +366,8 @@ resource "aws_emr_cluster" "test" {
   release_label        = "emr-5.0.0"
   applications         = ["Hadoop", "Hive"]
   log_uri              = "s3n://terraform/testlog/"
-  master_instance_type = "m4.large"
-  core_instance_type   = "m1.small"
+  master_instance_type = "c4.large"
+  core_instance_type   = "c4.large"
   core_instance_count  = 1
   service_role         = "${aws_iam_role.iam_emr_default_role.arn}"
 
@@ -678,8 +678,8 @@ resource "aws_emr_cluster" "tf-test-cluster" {
     instance_profile                  = "${aws_iam_instance_profile.emr_profile.arn}"
   }
 
-  master_instance_type = "m3.xlarge"
-  core_instance_type   = "m3.xlarge"
+  master_instance_type = "c4.large"
+  core_instance_type   = "c4.large"
   core_instance_count  = 1
 
   tags {
@@ -985,8 +985,8 @@ resource "aws_emr_cluster" "tf-test-cluster" {
     instance_profile                  = "${aws_iam_instance_profile.emr_profile.arn}"
   }
 
-  master_instance_type = "m3.xlarge"
-  core_instance_type   = "m3.xlarge"
+  master_instance_type = "c4.large"
+  core_instance_type   = "c4.large"
   core_instance_count  = 1
 
   security_configuration = "${aws_emr_security_configuration.foo.name}"
@@ -1338,7 +1338,7 @@ resource "aws_emr_cluster" "tf-test-cluster" {
   instance_group = [
     {
       instance_role = "CORE"
-      instance_type = "m3.xlarge"
+      instance_type = "c4.large"
       instance_count = "1"
       ebs_config {
         size = "40"
@@ -1349,7 +1349,7 @@ resource "aws_emr_cluster" "tf-test-cluster" {
     },
     {
       instance_role = "MASTER"
-      instance_type = "m3.xlarge"
+      instance_type = "c4.large"
       instance_count = 1
     }
   ]
@@ -1657,8 +1657,8 @@ resource "aws_emr_cluster" "tf-test-cluster" {
     instance_profile                  = "${aws_iam_instance_profile.emr_profile.arn}"
   }
 
-  master_instance_type = "m3.xlarge"
-  core_instance_type   = "m3.xlarge"
+  master_instance_type = "c4.large"
+  core_instance_type   = "c4.large"
   core_instance_count  = 1
 
   tags {
@@ -1964,8 +1964,8 @@ resource "aws_emr_cluster" "tf-test-cluster" {
     instance_profile                  = "${aws_iam_instance_profile.emr_profile.arn}"
   }
 
-  master_instance_type = "m3.xlarge"
-  core_instance_type   = "m3.xlarge"
+  master_instance_type = "c4.large"
+  core_instance_type   = "c4.large"
   core_instance_count  = 1
 
   tags {
@@ -2271,8 +2271,8 @@ resource "aws_emr_cluster" "tf-test-cluster" {
     instance_profile                  = "${aws_iam_instance_profile.emr_profile.arn}"
   }
 
-  master_instance_type = "m3.xlarge"
-  core_instance_type   = "m3.xlarge"
+  master_instance_type = "c4.large"
+  core_instance_type   = "c4.large"
   core_instance_count  = 1
 
   tags {
@@ -2577,8 +2577,8 @@ resource "aws_emr_cluster" "tf-test-cluster" {
     instance_profile                  = "${aws_iam_instance_profile.emr_profile.arn}"
   }
 
-  master_instance_type = "m3.xlarge"
-  core_instance_type   = "m3.xlarge"
+  master_instance_type = "c4.large"
+  core_instance_type   = "c4.large"
   core_instance_count  = 1
 
   tags {
@@ -2920,8 +2920,8 @@ resource "aws_emr_cluster" "tf-test-cluster" {
   termination_protection = false
   keep_job_flow_alive_when_no_steps = true
 
-  master_instance_type = "m1.medium"
-  core_instance_type   = "m1.medium"
+  master_instance_type = "c4.large"
+  core_instance_type   = "c4.large"
   core_instance_count  = 1
 
   log_uri = "s3://${aws_s3_bucket.test.bucket}/"

--- a/aws/resource_aws_emr_instance_group_test.go
+++ b/aws/resource_aws_emr_instance_group_test.go
@@ -146,8 +146,8 @@ resource "aws_emr_cluster" "tf-test-cluster" {
     instance_profile                  = "${aws_iam_instance_profile.emr_profile.arn}"
   }
 
-  master_instance_type = "m3.xlarge"
-  core_instance_type   = "m3.xlarge"
+  master_instance_type = "c4.large"
+  core_instance_type   = "c4.large"
   core_instance_count  = 2
 
   tags {
@@ -401,7 +401,7 @@ func testAccAWSEmrInstanceGroupConfig(r int) string {
 	resource "aws_emr_instance_group" "task" {
     cluster_id     = "${aws_emr_cluster.tf-test-cluster.id}"
     instance_count = 1
-    instance_type  = "m1.small"
+    instance_type  = "c4.large"
   }
 	`, r, r, r, r, r, r)
 }
@@ -411,7 +411,7 @@ func testAccAWSEmrInstanceGroupConfig_zero_count(r int) string {
 	resource "aws_emr_instance_group" "task" {
     cluster_id     = "${aws_emr_cluster.tf-test-cluster.id}"
     instance_count = 0
-    instance_type  = "m1.small"
+    instance_type  = "c4.large"
   }
 	`, r, r, r, r, r, r)
 }
@@ -421,7 +421,7 @@ func testAccAWSEmrInstanceGroupConfig_ebsBasic(r int) string {
 		resource "aws_emr_instance_group" "task" {
     cluster_id     = "${aws_emr_cluster.tf-test-cluster.id}"
     instance_count = 1
-    instance_type  = "m3.xlarge"
+    instance_type  = "c4.large"
     ebs_optimized = true
     ebs_config {
       "size" = 10,


### PR DESCRIPTION
There's no need to use such expensive instance types in our tests, so I downgraded these to save some money. 💰 

`c4.large` is `$0.026` per Hour (the cheapest instance size available)

`m4.large` was `$0.030` per Hour
`m3.xlarge` was `$0.070` per Hour

https://aws.amazon.com/emr/pricing/

There was a few `m1.small` occurrences which I also replaced, because that instance type is obsolete and may become unavailable soon.

It's usually not a big deal, but it can make a significant difference on the bill if we have leaks.

## Test results

```
=== RUN   TestAccAWSEMRCluster_terminationProtected
--- PASS: TestAccAWSEMRCluster_terminationProtected (435.12s)
=== RUN   TestAccAWSEMRCluster_basic
--- PASS: TestAccAWSEMRCluster_basic (525.69s)
=== RUN   TestAccAWSEMRCluster_bootstrap_ordering
--- PASS: TestAccAWSEMRCluster_bootstrap_ordering (539.13s)
=== RUN   TestAccAWSEMRCluster_security_config
--- PASS: TestAccAWSEMRCluster_security_config (548.30s)
=== RUN   TestAccAWSEMRCluster_instance_group
--- PASS: TestAccAWSEMRCluster_instance_group (548.32s)
=== RUN   TestAccAWSEMRInstanceGroup_basic
--- PASS: TestAccAWSEMRInstanceGroup_basic (631.34s)
=== RUN   TestAccAWSEMRInstanceGroup_zero_count
--- PASS: TestAccAWSEMRInstanceGroup_zero_count (671.51s)
=== RUN   TestAccAWSEMRCluster_s3Logging
--- PASS: TestAccAWSEMRCluster_s3Logging (681.47s)
=== RUN   TestAccAWSEMRInstanceGroup_ebsBasic
--- PASS: TestAccAWSEMRInstanceGroup_ebsBasic (696.61s)
=== RUN   TestAccAWSEMRCluster_visibleToAllUsers
--- PASS: TestAccAWSEMRCluster_visibleToAllUsers (816.70s)
=== RUN   TestAccAWSEMRCluster_tags
--- PASS: TestAccAWSEMRCluster_tags (831.56s)
=== RUN   TestAccAWSEMRCluster_root_volume_size
--- PASS: TestAccAWSEMRCluster_root_volume_size (889.48s)
=== RUN   TestAccAwsAppautoscalingScheduledAction_EMR
--- PASS: TestAccAwsAppautoscalingScheduledAction_EMR (414.57s)
```