### PR TITLE
d/aws_kms_alias: Add target_key_arn attribute

### DIFF
--- a/aws/data_source_aws_kms_alias_test.go
+++ b/aws/data_source_aws_kms_alias_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -44,6 +45,15 @@ func testAccDataSourceAwsKmsAliasCheck(name string) resource.TestCheckFunc {
 				"arn is %s; want %s",
 				attr["arn"],
 				kmsKeyRs.Primary.Attributes["arn"],
+			)
+		}
+
+		expectedTargetKeyArnSuffix := fmt.Sprintf("key/%s", kmsKeyRs.Primary.Attributes["target_key_id"])
+		if !strings.HasSuffix(attr["target_key_arn"], expectedTargetKeyArnSuffix) {
+			return fmt.Errorf(
+				"target_key_arn is %s; want suffix %s",
+				attr["target_key_arn"],
+				expectedTargetKeyArnSuffix,
 			)
 		}
 

--- a/website/docs/d/kms_alias.html.markdown
+++ b/website/docs/d/kms_alias.html.markdown
@@ -28,3 +28,4 @@ data "aws_kms_alias" "s3" {
 
 * `arn` - The Amazon Resource Name(ARN) of the key alias.
 * `target_key_id` - Key identifier pointed to by the alias.
+* `target_key_arn` - ARN pointed to by the alias.


### PR DESCRIPTION
This is an alternate implementation to #2224. Closes #2009. 

KMS keys and aliases are bound to the same AWS partition, account, and region so it is safe to assemble the target key ARN from the alias ARN and target key ID. Reference: http://docs.aws.amazon.com/sdk-for-go/api/service/kms/#KMS.CreateAlias

> The alias and the CMK it is mapped to must be in the same AWS account and the same region. You cannot perform this operation on an alias in a different AWS account.

```
make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsKmsAlias'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccDataSourceAwsKmsAlias -timeout 120m
=== RUN   TestAccDataSourceAwsKmsAlias
--- PASS: TestAccDataSourceAwsKmsAlias (41.76s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	41.791s
```