### PR TITLE
r/aws_ecs_cluster: Add arn attribute

### DIFF
--- a/aws/resource_aws_ecs_cluster.go
+++ b/aws/resource_aws_ecs_cluster.go
@@ -19,10 +19,15 @@ func resourceAwsEcsCluster() *schema.Resource {
 		Delete: resourceAwsEcsClusterDelete,
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+			},
+
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 		},
 	}
@@ -43,6 +48,7 @@ func resourceAwsEcsClusterCreate(d *schema.ResourceData, meta interface{}) error
 	log.Printf("[DEBUG] ECS cluster %s created", *out.Cluster.ClusterArn)
 
 	d.SetId(*out.Cluster.ClusterArn)
+	d.Set("arn", out.Cluster.ClusterArn)
 	d.Set("name", out.Cluster.ClusterName)
 	return nil
 }
@@ -70,6 +76,7 @@ func resourceAwsEcsClusterRead(d *schema.ResourceData, meta interface{}) error {
 			}
 
 			d.SetId(*c.ClusterArn)
+			d.Set("arn", c.ClusterArn)
 			d.Set("name", c.ClusterName)
 			return nil
 		}

--- a/aws/resource_aws_ecs_cluster_test.go
+++ b/aws/resource_aws_ecs_cluster_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -20,6 +21,8 @@ func TestAccAWSEcsCluster_basic(t *testing.T) {
 				Config: testAccAWSEcsCluster,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsClusterExists("aws_ecs_cluster.foo"),
+					resource.TestMatchResourceAttr("aws_ecs_cluster.foo", "arn",
+						regexp.MustCompile("^arn:aws:ecs:[a-z0-9-]+:[0-9]{12}:cluster/red-grapes$")),
 				),
 			},
 		},

--- a/website/docs/r/ecs_cluster.html.markdown
+++ b/website/docs/r/ecs_cluster.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides an ECS cluster.
 ---
 
-# aws\_ecs\_cluster
+# aws_ecs_cluster
 
 Provides an ECS cluster.
 
@@ -26,7 +26,7 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-The following attributes are exported:
+The following additional attributes are exported:
 
-* `name` - The name of the cluster
 * `id` - The Amazon Resource Name (ARN) that identifies the cluster
+* `arn` - The Amazon Resource Name (ARN) that identifies the cluster


### PR DESCRIPTION
Closes #2539 

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSEcsCluster'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSEcsCluster -timeout 120m
=== RUN   TestAccAWSEcsCluster_basic
--- PASS: TestAccAWSEcsCluster_basic (10.39s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	10.425s
```