### PR TITLE
Downsize RDS to save money

### DIFF
--- a/aws/data_source_aws_db_instance_test.go
+++ b/aws/data_source_aws_db_instance_test.go
@@ -54,7 +54,7 @@ resource "aws_db_instance" "bar" {
 
 	allocated_storage = 10
 	engine = "MySQL"
-	instance_class = "db.m1.small"
+	instance_class = "db.t2.micro"
 	name = "baz"
 	password = "barbarbarbar"
 	username = "foo"

--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -933,12 +933,47 @@ EOF
 }
 
 resource "aws_iam_policy_attachment" "test-attach" {
-    name = "enhanced-monitoring-attachment"
+    name = "enhanced-monitoring-attachment-%s"
     roles = [
         "${aws_iam_role.enhanced_policy_role.name}",
     ]
 
-    policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
+    policy_arn = "${aws_iam_policy.test.arn}"
+}
+
+resource "aws_iam_policy" "test" {
+  name   = "tf-enhanced-monitoring-policy-%s"
+  policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "EnableCreationAndManagementOfRDSCloudwatchLogGroups",
+            "Effect": "Allow",
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:PutRetentionPolicy"
+            ],
+            "Resource": [
+                "arn:aws:logs:*:*:log-group:RDS*"
+            ]
+        },
+        {
+            "Sid": "EnableCreationAndManagementOfRDSCloudwatchLogStreams",
+            "Effect": "Allow",
+            "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+                "logs:DescribeLogStreams",
+                "logs:GetLogEvents"
+            ],
+            "Resource": [
+                "arn:aws:logs:*:*:log-group:RDS*:log-stream:*"
+            ]
+        }
+    ]
+}
+POLICY
 }
 
 resource "aws_db_instance" "enhanced_monitoring" {
@@ -960,7 +995,7 @@ resource "aws_db_instance" "enhanced_monitoring" {
 	monitoring_interval = "5"
 
 	skip_final_snapshot = true
-}`, rName, rName)
+}`, rName, rName, rName, rName)
 }
 
 func testAccSnapshotInstanceConfig_iopsUpdate(rName string, iops int) string {

--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -750,7 +750,7 @@ resource "aws_db_instance" "bar" {
 	allocated_storage = 10
 	engine = "MySQL"
 	engine_version = "5.6.35"
-	instance_class = "db.m3.medium"
+	instance_class = "db.t2.small"
 	name = "baz"
 	password = "barbarbarbar"
 	username = "foo"
@@ -785,7 +785,7 @@ resource "aws_db_instance" "bar" {
 
 	allocated_storage = 10
 	engine = "MySQL"
-	instance_class = "db.m1.small"
+	instance_class = "db.t2.micro"
 	name = "baz"
 	password = "barbarbarbar"
 	username = "foo"
@@ -864,7 +864,7 @@ resource "aws_db_instance" "snapshot" {
 	allocated_storage = 5
 	engine = "mysql"
 	engine_version = "5.6.35"
-	instance_class = "db.r3.large"
+	instance_class = "db.t2.micro"
 	name = "baz"
 	password = "barbarbarbar"
 	username = "foo"
@@ -891,7 +891,7 @@ resource "aws_db_instance" "snapshot" {
 	allocated_storage = 5
 	engine = "mysql"
 	engine_version = "5.6.35"
-	instance_class = "db.r3.large"
+	instance_class = "db.t2.micro"
 	name = "baz"
 	password = "barbarbarbar"
 	publicly_accessible = true
@@ -948,7 +948,7 @@ resource "aws_db_instance" "enhanced_monitoring" {
 	allocated_storage = 5
 	engine = "mysql"
 	engine_version = "5.6.35"
-	instance_class = "db.m3.medium"
+	instance_class = "db.t2.micro"
 	name = "baz"
 	password = "barbarbarbar"
 	username = "foo"

--- a/aws/resource_aws_rds_cluster_instance_test.go
+++ b/aws/resource_aws_rds_cluster_instance_test.go
@@ -243,7 +243,7 @@ resource "aws_rds_cluster" "default" {
 resource "aws_rds_cluster_instance" "cluster_instances" {
   identifier              = "tf-cluster-instance-%d"
   cluster_identifier      = "${aws_rds_cluster.default.id}"
-  instance_class          = "db.r3.large"
+  instance_class          = "db.t2.small"
   db_parameter_group_name = "${aws_db_parameter_group.bar.name}"
   promotion_tier          = "3"
 }
@@ -279,7 +279,7 @@ resource "aws_rds_cluster" "default" {
 resource "aws_rds_cluster_instance" "cluster_instances" {
   identifier                 = "tf-cluster-instance-%d"
   cluster_identifier         = "${aws_rds_cluster.default.id}"
-  instance_class             = "db.r3.large"
+  instance_class             = "db.t2.small"
   db_parameter_group_name    = "${aws_db_parameter_group.bar.name}"
   auto_minor_version_upgrade = false
   promotion_tier             = "3"
@@ -307,7 +307,7 @@ func testAccAWSClusterInstanceConfig_namePrefix(n int) string {
 resource "aws_rds_cluster_instance" "test" {
   identifier_prefix = "tf-cluster-instance-"
   cluster_identifier = "${aws_rds_cluster.test.id}"
-  instance_class = "db.r3.large"
+  instance_class = "db.t2.small"
 }
 
 resource "aws_rds_cluster" "test" {
@@ -348,7 +348,7 @@ func testAccAWSClusterInstanceConfig_generatedName(n int) string {
 	return fmt.Sprintf(`
 resource "aws_rds_cluster_instance" "test" {
   cluster_identifier = "${aws_rds_cluster.test.id}"
-  instance_class = "db.r3.large"
+  instance_class = "db.t2.small"
 }
 
 resource "aws_rds_cluster" "test" {
@@ -423,7 +423,7 @@ resource "aws_rds_cluster" "default" {
 resource "aws_rds_cluster_instance" "cluster_instances" {
   identifier              = "tf-cluster-instance-%d"
   cluster_identifier      = "${aws_rds_cluster.default.id}"
-  instance_class          = "db.r3.large"
+  instance_class          = "db.t2.small"
   db_parameter_group_name = "${aws_db_parameter_group.bar.name}"
 }
 
@@ -458,7 +458,7 @@ resource "aws_rds_cluster" "default" {
 resource "aws_rds_cluster_instance" "cluster_instances" {
   identifier              = "tf-cluster-instance-%d"
   cluster_identifier      = "${aws_rds_cluster.default.id}"
-  instance_class          = "db.r3.large"
+  instance_class          = "db.t2.small"
   db_parameter_group_name = "${aws_db_parameter_group.bar.name}"
   monitoring_interval     = "60"
   monitoring_role_arn     = "${aws_iam_role.tf_enhanced_monitor_role.arn}"

--- a/aws/resource_aws_rds_cluster_instance_test.go
+++ b/aws/resource_aws_rds_cluster_instance_test.go
@@ -484,9 +484,44 @@ EOF
 }
 
 resource "aws_iam_policy_attachment" "rds_m_attach" {
-    name = "AmazonRDSEnhancedMonitoringRole"
+    name = "tf-enhanced-monitoring-attachment-%d"
     roles = ["${aws_iam_role.tf_enhanced_monitor_role.name}"]
-    policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
+    policy_arn = "${aws_iam_policy.test.arn}"
+}
+
+resource "aws_iam_policy" "test" {
+  name   = "tf-enhanced-monitoring-policy-%d"
+  policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "EnableCreationAndManagementOfRDSCloudwatchLogGroups",
+            "Effect": "Allow",
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:PutRetentionPolicy"
+            ],
+            "Resource": [
+                "arn:aws:logs:*:*:log-group:RDS*"
+            ]
+        },
+        {
+            "Sid": "EnableCreationAndManagementOfRDSCloudwatchLogStreams",
+            "Effect": "Allow",
+            "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+                "logs:DescribeLogStreams",
+                "logs:GetLogEvents"
+            ],
+            "Resource": [
+                "arn:aws:logs:*:*:log-group:RDS*:log-stream:*"
+            ]
+        }
+    ]
+}
+POLICY
 }
 
 resource "aws_db_parameter_group" "bar" {
@@ -503,5 +538,5 @@ resource "aws_db_parameter_group" "bar" {
     foo = "bar"
   }
 }
-`, n, n, n, n)
+`, n, n, n, n, n, n)
 }


### PR DESCRIPTION
There's no need to use such expensive instance types in our tests, so I downgraded these to save some money. 💰 

`db.m3.medium` was `$0.09` per Hour
`db.r3.large` was `$0.24` per Hour

`db.t2.micro` is `$0.017` (MySQL) / `$0.018` (Postgres) per Hour (cheapest available)
`db.t2.small` is `$0.034` per Hour (cheapest available w/ encryption support)
`db.t2.small` (Aurora cluster) is `$0.041` (cheapest available)

https://aws.amazon.com/rds/mysql/pricing/
https://aws.amazon.com/rds/postgresql/pricing/
https://aws.amazon.com/rds/aurora/pricing/

There was a few `m1.*` occurrences which I also replaced, because that instance type is obsolete and may become unavailable soon.

I also patched 2 tests which were referring to a service role policy as these were intermittently failing due to `aws_iam_policy_attachment` treating policy ARN as point of truth (related to https://github.com/terraform-providers/terraform-provider-aws/issues/94).

## Test results

```
=== RUN   TestAccAWSDataDbInstance_endpoint
--- PASS: TestAccAWSDataDbInstance_endpoint (405.84s)
=== RUN   TestAccAWSDataDbInstance_basic
--- PASS: TestAccAWSDataDbInstance_basic (426.14s)

=== RUN   TestAccAWSRDSClusterInstance_namePrefix
--- PASS: TestAccAWSRDSClusterInstance_namePrefix (609.40s)
=== RUN   TestAccAWSRDSClusterInstance_generatedName
--- PASS: TestAccAWSRDSClusterInstance_generatedName (610.90s)
=== RUN   TestAccAWSRDSClusterInstance_withInstanceEnhancedMonitor
--- PASS: TestAccAWSRDSClusterInstance_withInstanceEnhancedMonitor (693.30s)
=== RUN   TestAccAWSRDSClusterInstance_kmsKey
--- PASS: TestAccAWSRDSClusterInstance_kmsKey (735.91s)
=== RUN   TestAccAWSRDSClusterInstance_importBasic
--- PASS: TestAccAWSRDSClusterInstance_importBasic (741.81s)
=== RUN   TestAccAWSRDSClusterInstance_disappears
--- PASS: TestAccAWSRDSClusterInstance_disappears (756.72s)
=== RUN   TestAccAWSRDSClusterInstance_basic
--- PASS: TestAccAWSRDSClusterInstance_basic (1409.17s)

=== RUN   TestAccAWSDBInstance_generatedName
--- PASS: TestAccAWSDBInstance_generatedName (426.06s)
=== RUN   TestAccAWSDBInstance_MinorVersion
--- PASS: TestAccAWSDBInstance_MinorVersion (436.20s)
=== RUN   TestAccAWSDBInstance_kmsKey
--- PASS: TestAccAWSDBInstance_kmsKey (445.41s)
=== RUN   TestAccAWSDBInstance_basic
--- PASS: TestAccAWSDBInstance_basic (486.92s)
=== RUN   TestAccAWSDBInstance_importBasic
--- PASS: TestAccAWSDBInstance_importBasic (498.04s)
=== RUN   TestAccAWSDBInstance_namePrefix
--- PASS: TestAccAWSDBInstance_namePrefix (517.62s)
=== RUN   TestAccAWSDBInstance_diffSuppressInitialState
--- PASS: TestAccAWSDBInstance_diffSuppressInitialState (517.71s)
=== RUN   TestAccAWSDBInstance_iamAuth
--- PASS: TestAccAWSDBInstance_iamAuth (557.78s)
=== RUN   TestAccAWSDBInstance_optionGroup
--- PASS: TestAccAWSDBInstance_optionGroup (557.90s)
=== RUN   TestAccAWSDBInstance_portUpdate
--- PASS: TestAccAWSDBInstance_portUpdate (561.84s)
=== RUN   TestAccAWSDBInstance_enhancedMonitoring
--- PASS: TestAccAWSDBInstance_enhancedMonitoring (804.19s)
=== RUN   TestAccAWSDBInstance_subnetGroup
--- PASS: TestAccAWSDBInstance_subnetGroup (868.35s)
```