### PR TITLE
test/aws_config_delivery_channel: Add missing dependencies

### DIFF
--- a/aws/resource_aws_config_delivery_channel_test.go
+++ b/aws/resource_aws_config_delivery_channel_test.go
@@ -205,8 +205,9 @@ resource "aws_s3_bucket" "b" {
 }
 
 resource "aws_config_delivery_channel" "foo" {
-  name = "tf-acc-test-awsconfig-%d"
+  name           = "tf-acc-test-awsconfig-%d"
   s3_bucket_name = "${aws_s3_bucket.b.bucket}"
+  depends_on     = ["aws_config_configuration_recorder.foo"]
 }`, randInt, randInt, randInt, randInt, randInt)
 }
 
@@ -268,12 +269,13 @@ resource "aws_sns_topic" "t" {
 }
 
 resource "aws_config_delivery_channel" "foo" {
-  name = "tf-acc-test-awsconfig-%d"
+  name           = "tf-acc-test-awsconfig-%d"
   s3_bucket_name = "${aws_s3_bucket.b.bucket}"
-  s3_key_prefix = "one/two/three"
-  sns_topic_arn = "${aws_sns_topic.t.arn}"
+  s3_key_prefix  = "one/two/three"
+  sns_topic_arn  = "${aws_sns_topic.t.arn}"
   snapshot_delivery_properties {
   	delivery_frequency = "Six_Hours"
   }
+  depends_on     = ["aws_config_configuration_recorder.foo"]
 }`, randInt, randInt, randInt, randInt, randInt, randInt)
 }


### PR DESCRIPTION
This is to prevent the following test failure which occurred recently due to a missing `depends_on`:

```
--- FAIL: TestAccAWSConfig/ConfigurationRecorderStatus/importBasic (29.83s)
            testing.go:563: Error destroying resource! WARNING: Dangling resources
                may exist. The full state and error is shown below.
                
                Error: Error applying: 1 error(s) occurred:
                
                * aws_config_delivery_channel.foo (destroy): 1 error(s) occurred:
                
                * aws_config_delivery_channel.foo: Unable to delete delivery channel: LastDeliveryChannelDeleteFailedException: Failed to delete last specified delivery channel with name 'tf-acc-test-awsconfig-342213420515241046', because there is a running configuration recorder.
                    status code: 400, request id: a4c2e086-d401-11e7-8941-9b8006137ac6
```

In other words our own tests didn't follow the recommendation in the docs 🤦‍♂️  https://www.terraform.io/docs/providers/aws/r/config_delivery_channel.html

## Test results

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSConfig'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSConfig -timeout 120m
=== RUN   TestAccAWSConfig
=== RUN   TestAccAWSConfig/DeliveryChannel
=== RUN   TestAccAWSConfig/DeliveryChannel/importBasic
=== RUN   TestAccAWSConfig/DeliveryChannel/basic
=== RUN   TestAccAWSConfig/DeliveryChannel/allParams
=== RUN   TestAccAWSConfig/Config
=== RUN   TestAccAWSConfig/Config/basic
=== RUN   TestAccAWSConfig/Config/ownerAws
=== RUN   TestAccAWSConfig/Config/customlambda
=== RUN   TestAccAWSConfig/Config/importAws
=== RUN   TestAccAWSConfig/Config/importLambda
=== RUN   TestAccAWSConfig/ConfigurationRecorderStatus
=== RUN   TestAccAWSConfig/ConfigurationRecorderStatus/basic
=== RUN   TestAccAWSConfig/ConfigurationRecorderStatus/startEnabled
=== RUN   TestAccAWSConfig/ConfigurationRecorderStatus/importBasic
=== RUN   TestAccAWSConfig/ConfigurationRecorder
=== RUN   TestAccAWSConfig/ConfigurationRecorder/basic
=== RUN   TestAccAWSConfig/ConfigurationRecorder/allParams
=== RUN   TestAccAWSConfig/ConfigurationRecorder/importBasic
--- PASS: TestAccAWSConfig (1644.48s)
    --- PASS: TestAccAWSConfig/DeliveryChannel (269.93s)
        --- PASS: TestAccAWSConfig/DeliveryChannel/importBasic (94.49s)
        --- PASS: TestAccAWSConfig/DeliveryChannel/basic (86.76s)
        --- PASS: TestAccAWSConfig/DeliveryChannel/allParams (88.69s)
    --- PASS: TestAccAWSConfig/Config (681.46s)
        --- PASS: TestAccAWSConfig/Config/basic (117.44s)
        --- PASS: TestAccAWSConfig/Config/ownerAws (120.42s)
        --- PASS: TestAccAWSConfig/Config/customlambda (161.59s)
        --- PASS: TestAccAWSConfig/Config/importAws (122.04s)
        --- PASS: TestAccAWSConfig/Config/importLambda (159.96s)
    --- PASS: TestAccAWSConfig/ConfigurationRecorderStatus (413.18s)
        --- PASS: TestAccAWSConfig/ConfigurationRecorderStatus/basic (105.68s)
        --- PASS: TestAccAWSConfig/ConfigurationRecorderStatus/startEnabled (210.35s)
        --- PASS: TestAccAWSConfig/ConfigurationRecorderStatus/importBasic (97.16s)
    --- PASS: TestAccAWSConfig/ConfigurationRecorder (279.90s)
        --- PASS: TestAccAWSConfig/ConfigurationRecorder/basic (101.68s)
        --- PASS: TestAccAWSConfig/ConfigurationRecorder/allParams (94.31s)
        --- PASS: TestAccAWSConfig/ConfigurationRecorder/importBasic (83.91s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1644.516s
```