### PR TITLE
Makefile: Add sweep target

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,3 +1,4 @@
+SWEEP?=us-east-1,us-west-2
 TEST?=$$(go list ./... |grep -v 'vendor')
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 
@@ -5,6 +6,10 @@ default: build
 
 build: fmtcheck
 	go install
+
+sweep:
+	@echo "WARNING: This will destroy infrastructure. Use only in development accounts."
+	go test $(TEST) -v -sweep=$(SWEEP) $(SWEEPARGS)
 
 test: fmtcheck
 	go test -i $(TEST) || exit 1
@@ -43,5 +48,5 @@ test-compile:
 	fi
 	go test -c $(TEST) $(TESTARGS)
 
-.PHONY: build test testacc vet fmt fmtcheck errcheck vendor-status test-compile
+.PHONY: build sweep test testacc vet fmt fmtcheck errcheck vendor-status test-compile
 


### PR DESCRIPTION
Make (pardon the pun) sweeping more accessible. ♻️ 

```
make sweep
WARNING: This will destroy infrastructure. Use only in development accounts.
go test $(go list ./... |grep -v 'vendor') -v -sweep=us-east-1,us-west-2
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
2017/12/06 22:01:28 [DEBUG] Running Sweepers for region (us-east-1):
...
2017/12/06 22:01:38 Sweeper Tests ran:
	- aws_db_option_group
	- aws_beanstalk_environment
	- aws_lambda_function
	- aws_beanstalk_application
	- aws_mq_broker
	- aws_subnet
	- aws_vpn_gateway
	- aws_vpc
	- aws_kms_key
	- aws_autoscaling_group
	- aws_launch_configuration
	- aws_security_group
	- aws_key_pair
2017/12/06 22:01:38 [DEBUG] Running Sweepers for region (us-west-2):
...
2017/12/06 22:01:57 Sweeper Tests ran:
	- aws_lambda_function
	- aws_beanstalk_application
	- aws_security_group
	- aws_key_pair
	- aws_launch_configuration
	- aws_vpc
	- aws_subnet
	- aws_beanstalk_environment
	- aws_kms_key
	- aws_vpn_gateway
	- aws_autoscaling_group
	- aws_db_option_group
	- aws_mq_broker
ok  	github.com/terraform-providers/terraform-provider-aws/aws	29.761s
```