### PR TITLE
resource/aws_db_option_group: Add version field

### DIFF
--- a/aws/resource_aws_db_option_group.go
+++ b/aws/resource_aws_db_option_group.go
@@ -107,6 +107,10 @@ func resourceAwsDbOptionGroup() *schema.Resource {
 							Elem:     &schema.Schema{Type: schema.TypeString},
 							Set:      schema.HashString,
 						},
+						"version": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 					},
 				},
 				Set: resourceAwsDbOptionHash,
@@ -353,6 +357,11 @@ func resourceAwsDbOptionHash(v interface{}) int {
 	for _, sgRaw := range m["db_security_group_memberships"].(*schema.Set).List() {
 		buf.WriteString(fmt.Sprintf("%s-", sgRaw.(string)))
 	}
+
+	if _, ok := m["version"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", m["version"].(string)))
+	}
+
 	return hashcode.String(buf.String())
 }
 

--- a/aws/resource_aws_db_option_group_test.go
+++ b/aws/resource_aws_db_option_group_test.go
@@ -262,6 +262,44 @@ func TestAccAWSDBOptionGroup_sqlServerOptionsUpdate(t *testing.T) {
 	})
 }
 
+func TestAccAWSDBOptionGroup_OracleOptionsUpdate(t *testing.T) {
+	var v rds.OptionGroup
+	rName := fmt.Sprintf("option-group-test-terraform-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBOptionGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBOptionGroupOracleEEOptionSettings(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBOptionGroupExists("aws_db_option_group.bar", &v),
+					resource.TestCheckResourceAttr(
+						"aws_db_option_group.bar", "name", rName),
+					resource.TestCheckResourceAttr(
+						"aws_db_option_group.bar", "option.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_db_option_group.bar", "option.0.version", "12.1.0.4.v1"),
+				),
+			},
+
+			{
+				Config: testAccAWSDBOptionGroupOracleEEOptionSettings_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBOptionGroupExists("aws_db_option_group.bar", &v),
+					resource.TestCheckResourceAttr(
+						"aws_db_option_group.bar", "name", rName),
+					resource.TestCheckResourceAttr(
+						"aws_db_option_group.bar", "option.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_db_option_group.bar", "option.0.version", "12.1.0.5.v1"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSDBOptionGroup_multipleOptions(t *testing.T) {
 	var v rds.OptionGroup
 	rName := fmt.Sprintf("option-group-test-terraform-%s", acctest.RandString(5))
@@ -488,6 +526,84 @@ resource "aws_db_option_group" "bar" {
 
   option {
     option_name = "Mirroring"
+  }
+}
+`, r)
+}
+
+func testAccAWSDBOptionGroupOracleEEOptionSettings(r string) string {
+	return fmt.Sprintf(`
+resource "aws_security_group" "foo" {
+  name = "terraform-test-issue_748"
+  description = "SG for test of issue 748"
+}
+
+resource "aws_db_option_group" "bar" {
+  name                     = "%s"
+  option_group_description = "Test option group for terraform issue 748"
+  engine_name              = "oracle-ee"
+  major_engine_version     = "12.1"
+
+  option {
+    option_name = "OEM_AGENT"
+    port        = "3872"
+    version     = "12.1.0.4.v1"
+
+    vpc_security_group_memberships = ["${aws_security_group.foo.id}"]
+
+    option_settings {
+      name  = "OMS_PORT"
+      value = "4903"
+    }
+
+    option_settings {
+      name  = "OMS_HOST"
+      value = "oem.host.value"
+    }
+
+    option_settings {
+      name  = "AGENT_REGISTRATION_PASSWORD"
+      value = "password"
+    }
+  }
+}
+`, r)
+}
+
+func testAccAWSDBOptionGroupOracleEEOptionSettings_update(r string) string {
+	return fmt.Sprintf(`
+resource "aws_security_group" "foo" {
+  name = "terraform-test-issue_748"
+  description = "SG for test of issue 748"
+}
+
+resource "aws_db_option_group" "bar" {
+  name                     = "%s"
+  option_group_description = "Test option group for terraform issue 748"
+  engine_name              = "oracle-ee"
+  major_engine_version     = "12.1"
+
+  option {
+    option_name = "OEM_AGENT"
+    port        = "3872"
+    version     = "12.1.0.5.v1"
+
+    vpc_security_group_memberships = ["${aws_security_group.foo.id}"]
+
+    option_settings {
+      name  = "OMS_PORT"
+      value = "4903"
+    }
+
+    option_settings {
+      name  = "OMS_HOST"
+      value = "oem.host.value"
+    }
+
+    option_settings {
+      name  = "AGENT_REGISTRATION_PASSWORD"
+      value = "password"
+    }
   }
 }
 `, r)

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -341,6 +341,10 @@ func expandOptionConfiguration(configured []interface{}) ([]*rds.OptionConfigura
 			o.OptionSettings = expandOptionSetting(raw.(*schema.Set).List())
 		}
 
+		if raw, ok := data["version"]; ok && raw.(string) != "" {
+			o.OptionVersion = aws.String(raw.(string))
+		}
+
 		option = append(option, o)
 	}
 
@@ -634,6 +638,10 @@ func flattenOptions(list []*rds.Option) []map[string]interface{} {
 			r["port"] = ""
 			if i.Port != nil {
 				r["port"] = int(*i.Port)
+			}
+			r["version"] = ""
+			if i.OptionVersion != nil {
+				r["version"] = strings.ToLower(*i.OptionVersion)
 			}
 			if i.VpcSecurityGroupMemberships != nil {
 				vpcs := make([]string, 0, len(i.VpcSecurityGroupMemberships))

--- a/website/docs/r/db_option_group.html.markdown
+++ b/website/docs/r/db_option_group.html.markdown
@@ -51,6 +51,7 @@ Option blocks support the following:
 * `option_name` - (Required) The Name of the Option (e.g. MEMCACHED).
 * `option_settings` - (Optional) A list of option settings to apply.
 * `port` - (Optional) The Port number when connecting to the Option (e.g. 11211).
+* `version` - (Optional) The OptionVersion string when connecting to the Option (e.g. 13.1.0.0).
 * `db_security_group_memberships` - (Optional) A list of DB Security Groups for which the option is enabled.
 * `vpc_security_group_memberships` - (Optional) A list of VPC Security Groups for which the option is enabled.
 


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/748

Certain Oracle RDS options require a `version` attribute set, e.g. [OEM_AGENT](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Oracle.Options.OEMAgent.html). This change adds that attribute to the option.

The acceptance test is wrong since I'm not sure about how to get the correct option number (obviously not `option.0.version`) from state. If anyone can give me a steer it would be appreciated.