### PR TITLE
Standardized log lines when WAF resources are not found on refresh

### DIFF
--- a/aws/resource_aws_waf_byte_match_set.go
+++ b/aws/resource_aws_waf_byte_match_set.go
@@ -98,7 +98,7 @@ func resourceAwsWafByteMatchSetRead(d *schema.ResourceData, meta interface{}) er
 	resp, err := conn.GetByteMatchSet(params)
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "WAFNonexistentItemException" {
-			log.Printf("[WARN] WAF IPSet (%s) not found, error code (404)", d.Id())
+			log.Printf("[WARN] WAF IPSet (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}

--- a/aws/resource_aws_waf_ipset.go
+++ b/aws/resource_aws_waf_ipset.go
@@ -72,7 +72,7 @@ func resourceAwsWafIPSetRead(d *schema.ResourceData, meta interface{}) error {
 	resp, err := conn.GetIPSet(params)
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "WAFNonexistentItemException" {
-			log.Printf("[WARN] WAF IPSet (%s) not found, error code (404)", d.Id())
+			log.Printf("[WARN] WAF IPSet (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}

--- a/aws/resource_aws_waf_rate_based_rule.go
+++ b/aws/resource_aws_waf_rate_based_rule.go
@@ -117,7 +117,7 @@ func resourceAwsWafRateBasedRuleRead(d *schema.ResourceData, meta interface{}) e
 	resp, err := conn.GetRateBasedRule(params)
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "WAFNonexistentItemException" {
-			log.Printf("[WARN] WAF Rate Based Rule (%s) not found, error code (404)", d.Id())
+			log.Printf("[WARN] WAF Rate Based Rule (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}

--- a/aws/resource_aws_waf_rule.go
+++ b/aws/resource_aws_waf_rule.go
@@ -100,7 +100,7 @@ func resourceAwsWafRuleRead(d *schema.ResourceData, meta interface{}) error {
 	resp, err := conn.GetRule(params)
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "WAFNonexistentItemException" {
-			log.Printf("[WARN] WAF Rule (%s) not found, error code (404)", d.Id())
+			log.Printf("[WARN] WAF Rule (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}

--- a/aws/resource_aws_waf_size_constraint_set.go
+++ b/aws/resource_aws_waf_size_constraint_set.go
@@ -98,7 +98,7 @@ func resourceAwsWafSizeConstraintSetRead(d *schema.ResourceData, meta interface{
 	resp, err := conn.GetSizeConstraintSet(params)
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "WAFNonexistentItemException" {
-			log.Printf("[WARN] WAF IPSet (%s) not found, error code (404)", d.Id())
+			log.Printf("[WARN] WAF IPSet (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}

--- a/aws/resource_aws_waf_sql_injection_match_set.go
+++ b/aws/resource_aws_waf_sql_injection_match_set.go
@@ -89,7 +89,7 @@ func resourceAwsWafSqlInjectionMatchSetRead(d *schema.ResourceData, meta interfa
 	resp, err := conn.GetSqlInjectionMatchSet(params)
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "WAFNonexistentItemException" {
-			log.Printf("[WARN] WAF IPSet (%s) not found, error code (404)", d.Id())
+			log.Printf("[WARN] WAF IPSet (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}

--- a/aws/resource_aws_waf_web_acl.go
+++ b/aws/resource_aws_waf_web_acl.go
@@ -119,7 +119,7 @@ func resourceAwsWafWebAclRead(d *schema.ResourceData, meta interface{}) error {
 	resp, err := conn.GetWebACL(params)
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "WAFNonexistentItemException" {
-			log.Printf("[WARN] WAF ACL (%s) not found, error code (404)", d.Id())
+			log.Printf("[WARN] WAF ACL (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}

--- a/aws/resource_aws_waf_xss_match_set.go
+++ b/aws/resource_aws_waf_xss_match_set.go
@@ -91,7 +91,7 @@ func resourceAwsWafXssMatchSetRead(d *schema.ResourceData, meta interface{}) err
 	resp, err := conn.GetXssMatchSet(params)
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "WAFNonexistentItemException" {
-			log.Printf("[WARN] WAF IPSet (%s) not found, error code (404)", d.Id())
+			log.Printf("[WARN] WAF IPSet (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}

--- a/aws/resource_aws_wafregional_byte_match_set.go
+++ b/aws/resource_aws_wafregional_byte_match_set.go
@@ -102,7 +102,7 @@ func resourceAwsWafRegionalByteMatchSetRead(d *schema.ResourceData, meta interfa
 	resp, err := conn.GetByteMatchSet(params)
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "WAFNonexistentItemException" {
-			log.Printf("[WARN] WAF IPSet (%s) not found, error code (404)", d.Id())
+			log.Printf("[WARN] WAF IPSet (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}

--- a/aws/resource_aws_wafregional_ipset.go
+++ b/aws/resource_aws_wafregional_ipset.go
@@ -74,7 +74,7 @@ func resourceAwsWafRegionalIPSetRead(d *schema.ResourceData, meta interface{}) e
 	resp, err := conn.GetIPSet(params)
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "WAFNonexistentItemException" {
-			log.Printf("[WARN] WAF IPSet (%s) not found, error code (404)", d.Id())
+			log.Printf("[WARN] WAF IPSet (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}


### PR DESCRIPTION
This just cleans the codebase by normalising message over resources. Part 1 on... many ones! 😄 