### PR TITLE
r/mq_broker: Fix crash in hashing function

### DIFF
--- a/aws/resource_aws_mq_broker.go
+++ b/aws/resource_aws_mq_broker.go
@@ -386,7 +386,11 @@ func resourceAwsMqUserHash(v interface{}) int {
 	var buf bytes.Buffer
 
 	m := v.(map[string]interface{})
-	buf.WriteString(fmt.Sprintf("%t-", m["console_access"].(bool)))
+	if ca, ok := m["console_access"]; ok {
+		buf.WriteString(fmt.Sprintf("%t-", ca.(bool)))
+	} else {
+		buf.WriteString("false-")
+	}
 	if g, ok := m["groups"]; ok {
 		buf.WriteString(fmt.Sprintf("%v-", g.(*schema.Set).List()))
 	}


### PR DESCRIPTION
This crash may occur when user is in "pending" state (typically happens after creation when broker reaches `CREATION_FAILED` state). There's practically no data about the user as it's pending.

## Example of response

_(we expect the `consoleAccess` and `groups` to be in the root level when user has no pending changes)_

```json
{
  "brokerId": "b-1e789f39-269d-4689-9f04-8dbe47181632",
  "username": "Test",
  "pending": {
    "pendingChange": "CREATE",
    "consoleAccess": false,
    "groups": []
  }
}
```

## Related test failure

```
=== RUN   TestAccAwsMqBroker_allFields

------- Stderr: -------
panic: interface conversion: interface {} is nil, not bool

goroutine 4280 [running]:
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsMqUserHash(0x2601760, 0xc42068bb60, 0xc4204e1c98)
    /opt/teamcity-agent/work/74d56ebce219706d/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_mq_broker.go:389 +0x5a1
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema.(*Set).hash(0xc4204e1c80, 0x2601760, 0xc42068bb60, 0x7fd44ab649b8, 0x0)
    /opt/teamcity-agent/work/74d56ebce219706d/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema/set.go:205 +0x3d
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema.(*Set).add(0xc4204e1c80, 0x2601760, 0xc42068bb60, 0x2875700, 0xc42059af01, 0xc4204e1c80)
    /opt/teamcity-agent/work/74d56ebce219706d/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema/set.go:192 +0x72
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema.(*Set).Add(0xc4204e1c80, 0x2601760, 0xc42068bb60)
    /opt/teamcity-agent/work/74d56ebce219706d/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema/set.go:69 +0x44
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema.NewSet(0x2d002a8, 0xc4204e1c60, 0x2, 0x2, 0x2)
    /opt/teamcity-agent/work/74d56ebce219706d/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema/set.go:56 +0x7a
github.com/terraform-providers/terraform-provider-aws/aws.flattenMqUsers(0xc42059a700, 0x2, 0x2, 0xc4204e1be0, 0x2, 0x2, 0x0)
    /opt/teamcity-agent/work/74d56ebce219706d/src/github.com/terraform-providers/terraform-provider-aws/aws/structure.go:2981 +0x745
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsMqBrokerRead(0xc4201f5ab0, 0x27683e0, 0xc42062a000, 0x0, 0x4870780)
    /opt/teamcity-agent/work/74d56ebce219706d/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_mq_broker.go:305 +0xf64
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema.(*Resource).Refresh(0xc4203c3180, 0xc42099bd10, 0x27683e0, 0xc42062a000, 0xc420460578, 0xc42060b801, 0xc4205aaab0)
    /opt/teamcity-agent/work/74d56ebce219706d/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema/resource.go:355 +0x199
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema.(*Provider).Refresh(0xc420447c70, 0xc4206f4aa0, 0xc42099bd10, 0x0, 0xbe82c6704afd620b, 0x18bc3b330d1)
    /opt/teamcity-agent/work/74d56ebce219706d/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema/provider.go:308 +0x9a
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/terraform.(*EvalRefresh).Eval(0xc420673620, 0x47dafc0, 0xc420792270, 0x2, 0x2, 0x2b2a28f, 0x4)
    /opt/teamcity-agent/work/74d56ebce219706d/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/terraform/eval_refresh.go:37 +0x149
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/terraform.EvalRaw(0x47cbb20, 0xc420673620, 0x47dafc0, 0xc420792270, 0x29a76c0, 0xc42099bd10, 0x0, 0x0)
    /opt/teamcity-agent/work/74d56ebce219706d/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/terraform/eval.go:53 +0x173
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/terraform.(*EvalSequence).Eval(0xc420673640, 0x47dafc0, 0xc420792270, 0x2, 0x2, 0x2b2a28f, 0x4)
    /opt/teamcity-agent/work/74d56ebce219706d/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/terraform/eval_sequence.go:14 +0x7e
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/terraform.EvalRaw(0x47cbbe0, 0xc420673640, 0x47dafc0, 0xc420792270, 0x25c22a0, 0x47dc005, 0x239a960, 0xc4204eb140)
    /opt/teamcity-agent/work/74d56ebce219706d/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/terraform/eval.go:53 +0x173
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/terraform.Eval(0x47cbbe0, 0xc420673640, 0x47dafc0, 0xc420792270, 0xc420673640, 0x47cbbe0, 0xc420673640, 0xc4206d7bb0)
    /opt/teamcity-agent/work/74d56ebce219706d/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/terraform/eval.go:34 +0x4d
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/terraform.(*Graph).walk.func1(0x2a97280, 0xc4209cac00, 0x0, 0x0)
    /opt/teamcity-agent/work/74d56ebce219706d/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/terraform/graph.go:126 +0xd0d
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/dag.(*Walker).walkVertex(0xc4201c9960, 0x2a97280, 0xc4209cac00, 0xc4206516c0)
    /opt/teamcity-agent/work/74d56ebce219706d/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/dag/walk.go:387 +0x3c1
created by github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/dag.(*Walker).Update
    /opt/teamcity-agent/work/74d56ebce219706d/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/dag/walk.go:310 +0x1364
```
