### PR TITLE
r/aws_ssm_parameter: Fix arn attribute for full path names and improve testing

### DIFF
--- a/aws/import_aws_ssm_parameter_test.go
+++ b/aws/import_aws_ssm_parameter_test.go
@@ -18,7 +18,7 @@ func TestAccAWSSSMParameter_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSSMParameterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSSMParameterBasicConfig(randName, randValue),
+				Config: testAccAWSSSMParameterBasicConfig(randName, "String", randValue),
 			},
 
 			{

--- a/aws/resource_aws_ssm_parameter.go
+++ b/aws/resource_aws_ssm_parameter.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
@@ -91,7 +92,7 @@ func resourceAwsSsmParameterRead(d *schema.ResourceData, meta interface{}) error
 		Region:    meta.(*AWSClient).region,
 		Service:   "ssm",
 		AccountID: meta.(*AWSClient).accountid,
-		Resource:  fmt.Sprintf("parameter/%s", d.Id()),
+		Resource:  fmt.Sprintf("parameter/%s", strings.TrimPrefix(d.Id(), "/")),
 	}
 	d.Set("arn", arn.String())
 

--- a/aws/resource_aws_ssm_parameter_test.go
+++ b/aws/resource_aws_ssm_parameter_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -13,17 +14,19 @@ import (
 
 func TestAccAWSSSMParameter_basic(t *testing.T) {
 	var param ssm.Parameter
-	name := acctest.RandString(10)
+	name := fmt.Sprintf("%s_%s", t.Name(), acctest.RandString(10))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSSMParameterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSSMParameterBasicConfig(name, "bar"),
+				Config: testAccAWSSSMParameterBasicConfig(name, "String", "bar"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMParameterExists("aws_ssm_parameter.foo", &param),
-					resource.TestCheckResourceAttrSet("aws_ssm_parameter.foo", "arn"),
+					resource.TestMatchResourceAttr("aws_ssm_parameter.foo", "arn",
+						regexp.MustCompile(fmt.Sprintf("^arn:aws:ssm:[a-z0-9-]+:[0-9]{12}:parameter/%s$", name))),
 					resource.TestCheckResourceAttr("aws_ssm_parameter.foo", "value", "bar"),
 					resource.TestCheckResourceAttr("aws_ssm_parameter.foo", "type", "String"),
 				),
@@ -34,14 +37,15 @@ func TestAccAWSSSMParameter_basic(t *testing.T) {
 
 func TestAccAWSSSMParameter_disappears(t *testing.T) {
 	var param ssm.Parameter
-	name := acctest.RandString(10)
+	name := fmt.Sprintf("%s_%s", t.Name(), acctest.RandString(10))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSSMParameterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSSMParameterBasicConfig(name, "bar"),
+				Config: testAccAWSSSMParameterBasicConfig(name, "String", "bar"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMParameterExists("aws_ssm_parameter.foo", &param),
 					testAccCheckAWSSSMParameterDisappears(&param),
@@ -54,17 +58,18 @@ func TestAccAWSSSMParameter_disappears(t *testing.T) {
 
 func TestAccAWSSSMParameter_update(t *testing.T) {
 	var param ssm.Parameter
-	name := acctest.RandString(10)
+	name := fmt.Sprintf("%s_%s", t.Name(), acctest.RandString(10))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSSMParameterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSSMParameterBasicConfig(name, "bar"),
+				Config: testAccAWSSSMParameterBasicConfig(name, "String", "bar"),
 			},
 			{
-				Config: testAccAWSSSMParameterBasicConfigOverwrite(name, "baz1"),
+				Config: testAccAWSSSMParameterBasicConfigOverwrite(name, "String", "baz1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMParameterExists("aws_ssm_parameter.foo", &param),
 					resource.TestCheckResourceAttr("aws_ssm_parameter.foo", "value", "baz1"),
@@ -77,21 +82,22 @@ func TestAccAWSSSMParameter_update(t *testing.T) {
 
 func TestAccAWSSSMParameter_changeNameForcesNew(t *testing.T) {
 	var beforeParam, afterParam ssm.Parameter
-	before := acctest.RandString(10)
-	after := acctest.RandString(10)
+	before := fmt.Sprintf("%s_%s", t.Name(), acctest.RandString(10))
+	after := fmt.Sprintf("%s_%s", t.Name(), acctest.RandString(10))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSSMParameterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSSMParameterBasicConfig(before, "bar"),
+				Config: testAccAWSSSMParameterBasicConfig(before, "String", "bar"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMParameterExists("aws_ssm_parameter.foo", &beforeParam),
 				),
 			},
 			{
-				Config: testAccAWSSSMParameterBasicConfig(after, "bar"),
+				Config: testAccAWSSSMParameterBasicConfig(after, "String", "bar"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMParameterExists("aws_ssm_parameter.foo", &afterParam),
 					testAccCheckAWSSSMParameterRecreated(t, &beforeParam, &afterParam),
@@ -101,20 +107,44 @@ func TestAccAWSSSMParameter_changeNameForcesNew(t *testing.T) {
 	})
 }
 
-func TestAccAWSSSMParameter_secure(t *testing.T) {
+func TestAccAWSSSMParameter_fullPath(t *testing.T) {
 	var param ssm.Parameter
-	name := acctest.RandString(10)
+	name := fmt.Sprintf("/path/%s_%s", t.Name(), acctest.RandString(10))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSSMParameterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSSMParameterSecureConfig(name, "secret"),
+				Config: testAccAWSSSMParameterBasicConfig(name, "String", "bar"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMParameterExists("aws_ssm_parameter.secret_foo", &param),
-					resource.TestCheckResourceAttr("aws_ssm_parameter.secret_foo", "value", "secret"),
-					resource.TestCheckResourceAttr("aws_ssm_parameter.secret_foo", "type", "SecureString"),
+					testAccCheckAWSSSMParameterExists("aws_ssm_parameter.foo", &param),
+					resource.TestMatchResourceAttr("aws_ssm_parameter.foo", "arn",
+						regexp.MustCompile(fmt.Sprintf("^arn:aws:ssm:[a-z0-9-]+:[0-9]{12}:parameter%s$", name))),
+					resource.TestCheckResourceAttr("aws_ssm_parameter.foo", "value", "bar"),
+					resource.TestCheckResourceAttr("aws_ssm_parameter.foo", "type", "String"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSSMParameter_secure(t *testing.T) {
+	var param ssm.Parameter
+	name := fmt.Sprintf("%s_%s", t.Name(), acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMParameterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSSMParameterBasicConfig(name, "SecureString", "secret"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMParameterExists("aws_ssm_parameter.foo", &param),
+					resource.TestCheckResourceAttr("aws_ssm_parameter.foo", "value", "secret"),
+					resource.TestCheckResourceAttr("aws_ssm_parameter.foo", "type", "SecureString"),
 				),
 			},
 		},
@@ -123,7 +153,8 @@ func TestAccAWSSSMParameter_secure(t *testing.T) {
 
 func TestAccAWSSSMParameter_secure_with_key(t *testing.T) {
 	var param ssm.Parameter
-	name := acctest.RandString(10)
+	name := fmt.Sprintf("%s_%s", t.Name(), acctest.RandString(10))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -229,35 +260,25 @@ func testAccCheckAWSSSMParameterDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAWSSSMParameterBasicConfig(rName string, value string) string {
+func testAccAWSSSMParameterBasicConfig(rName, pType, value string) string {
 	return fmt.Sprintf(`
 resource "aws_ssm_parameter" "foo" {
-  name  = "test_parameter-%s"
-  type  = "String"
+  name  = "%s"
+  type  = "%s"
   value = "%s"
 }
-`, rName, value)
+`, rName, pType, value)
 }
 
-func testAccAWSSSMParameterBasicConfigOverwrite(rName string, value string) string {
+func testAccAWSSSMParameterBasicConfigOverwrite(rName, pType, value string) string {
 	return fmt.Sprintf(`
 resource "aws_ssm_parameter" "foo" {
-  name  = "test_parameter-%s"
-  type  = "String"
+  name  = "%s"
+  type  = "%s"
   value = "%s"
   overwrite = true
 }
-`, rName, value)
-}
-
-func testAccAWSSSMParameterSecureConfig(rName string, value string) string {
-	return fmt.Sprintf(`
-resource "aws_ssm_parameter" "secret_foo" {
-  name  = "test_secure_parameter-%s"
-  type  = "SecureString"
-  value = "%s"
-}
-`, rName, value)
+`, rName, pType, value)
 }
 
 func testAccAWSSSMParameterSecureConfigWithKey(rName string, value string) string {


### PR DESCRIPTION
The AWS API allows zero path parameter names without the leading `/` (e.g. `myName`), but requires the leading `/` when placing a parameter under a path (e.g. `/path/to/myName`). When setting the name with a leading `/` it would put `//` in the ARN attribute (e.g. `parameter//path/to/myName`)

Previously, the testing only checked existence of `arn` attribute. This augments it to do regex matching for the full value for both the no leading `/` and with leading `/` scenarios. It also simplifies the testing configurations and adds the test names to the parameter names in the testing.

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSSSMParameter'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSSSMParameter -timeout 120m
=== RUN   TestAccAWSSSMParameter_importBasic
--- PASS: TestAccAWSSSMParameter_importBasic (11.81s)
=== RUN   TestAccAWSSSMParameter_basic
--- PASS: TestAccAWSSSMParameter_basic (9.18s)
=== RUN   TestAccAWSSSMParameter_disappears
--- PASS: TestAccAWSSSMParameter_disappears (8.29s)
=== RUN   TestAccAWSSSMParameter_update
--- PASS: TestAccAWSSSMParameter_update (15.91s)
=== RUN   TestAccAWSSSMParameter_changeNameForcesNew
--- PASS: TestAccAWSSSMParameter_changeNameForcesNew (17.95s)
=== RUN   TestAccAWSSSMParameter_fullPath
--- PASS: TestAccAWSSSMParameter_fullPath (9.65s)
=== RUN   TestAccAWSSSMParameter_secure
--- PASS: TestAccAWSSSMParameter_secure (11.27s)
=== RUN   TestAccAWSSSMParameter_secure_with_key
--- PASS: TestAccAWSSSMParameter_secure_with_key (38.33s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	122.423s
```