### PR TITLE
r/aws_rds_cluster_instance: Set db_subnet_group_name in state on read if available

### DIFF
--- a/aws/resource_aws_rds_cluster_instance.go
+++ b/aws/resource_aws_rds_cluster_instance.go
@@ -312,6 +312,10 @@ func resourceAwsRDSClusterInstanceRead(d *schema.ResourceData, meta interface{})
 		d.Set("port", db.Endpoint.Port)
 	}
 
+	if db.DBSubnetGroup != nil {
+		d.Set("db_subnet_group_name", db.DBSubnetGroup.DBSubnetGroupName)
+	}
+
 	d.Set("publicly_accessible", db.PubliclyAccessible)
 	d.Set("cluster_identifier", db.DBClusterIdentifier)
 	d.Set("engine", db.Engine)

--- a/aws/resource_aws_rds_cluster_instance_test.go
+++ b/aws/resource_aws_rds_cluster_instance_test.go
@@ -52,6 +52,7 @@ func TestAccAWSRDSClusterInstance_basic(t *testing.T) {
 
 func TestAccAWSRDSClusterInstance_namePrefix(t *testing.T) {
 	var v rds.DBInstance
+	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -59,10 +60,12 @@ func TestAccAWSRDSClusterInstance_namePrefix(t *testing.T) {
 		CheckDestroy: testAccCheckAWSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSClusterInstanceConfig_namePrefix(acctest.RandInt()),
+				Config: testAccAWSClusterInstanceConfig_namePrefix(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterInstanceExists("aws_rds_cluster_instance.test", &v),
 					testAccCheckAWSDBClusterInstanceAttributes(&v),
+					resource.TestCheckResourceAttr(
+						"aws_rds_cluster_instance.test", "db_subnet_group_name", fmt.Sprintf("tf-test-%d", rInt)),
 					resource.TestMatchResourceAttr(
 						"aws_rds_cluster_instance.test", "identifier", regexp.MustCompile("^tf-cluster-instance-")),
 				),


### PR DESCRIPTION
Closes #2594 

Previously, when checking instance `db_subnet_group_name` attribute when only set in cluster configuration or similarly for instance import:
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSRDSClusterInstance_namePrefix'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSRDSClusterInstance_namePrefix -timeout 120m
=== RUN   TestAccAWSRDSClusterInstance_namePrefix
--- FAIL: TestAccAWSRDSClusterInstance_namePrefix (644.43s)
	testing.go:503: Step 0 error: Check failed: Check 3/4 error: aws_rds_cluster_instance.test: Attribute 'db_subnet_group_name' not found
FAIL
exit status 1
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	644.461s
make: *** [testacc] Error 1
```

Now:
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSRDSClusterInstance_namePrefix'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSRDSClusterInstance_namePrefix -timeout 120m
=== RUN   TestAccAWSRDSClusterInstance_namePrefix
--- PASS: TestAccAWSRDSClusterInstance_namePrefix (636.21s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	636.242s
```