### PR TITLE
resource/aws_autoscaling_policy: Add support for target_tracking_configuration

### DIFF
--- a/aws/resource_aws_autoscaling_policy.go
+++ b/aws/resource_aws_autoscaling_policy.go
@@ -93,6 +93,81 @@ func resourceAwsAutoscalingPolicy() *schema.Resource {
 				},
 				Set: resourceAwsAutoscalingScalingAdjustmentHash,
 			},
+			"target_tracking_configuration": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"predefined_metric_specification": &schema.Schema{
+							Type:          schema.TypeSet,
+							Optional:      true,
+							ConflictsWith: []string{"customized_metric_specification"},
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"predefined_metric_type": &schema.Schema{
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"resource_label": &schema.Schema{
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"customized_metric_specification": &schema.Schema{
+							Type:          schema.TypeSet,
+							Optional:      true,
+							ConflictsWith: []string{"predefined_metric_specification"},
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"metric_dimension": &schema.Schema{
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"name": &schema.Schema{
+													Type:     schema.TypeString,
+													Required: true,
+												},
+												"value": &schema.Schema{
+													Type:     schema.TypeString,
+													Required: true,
+												},
+											},
+										},
+									},
+									"metric_name": &schema.Schema{
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"namespace": &schema.Schema{
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"statistic": &schema.Schema{
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"unit": &schema.Schema{
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"target_value": &schema.Schema{
+							Type:     schema.TypeFloat,
+							Required: true,
+						},
+						"disable_scale_in": &schema.Schema{
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -146,6 +221,7 @@ func resourceAwsAutoscalingPolicyRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("name", p.PolicyName)
 	d.Set("scaling_adjustment", p.ScalingAdjustment)
 	d.Set("step_adjustment", flattenStepAdjustments(p.StepAdjustments))
+	d.Set("target_tracking_configuration", flattenTargetTrackingConfiguration(p.TargetTrackingConfiguration))
 
 	return nil
 }
@@ -240,6 +316,10 @@ func getAwsAutoscalingPutScalingPolicyInput(d *schema.ResourceData) (autoscaling
 		params.MinAdjustmentStep = aws.Int64(int64(v.(int)))
 	}
 
+	if v, ok := d.GetOk("target_tracking_configuration"); ok {
+		params.TargetTrackingConfiguration = expandTargetTrackingConfiguration(v.(*schema.Set).List()[0].(map[string]interface{}))
+	}
+
 	// Validate our final input to confirm it won't error when sent to AWS.
 	// First, SimpleScaling policy types...
 	if *params.PolicyType == "SimpleScaling" && params.StepAdjustments != nil {
@@ -251,6 +331,9 @@ func getAwsAutoscalingPutScalingPolicyInput(d *schema.ResourceData) (autoscaling
 	if *params.PolicyType == "SimpleScaling" && params.EstimatedInstanceWarmup != nil {
 		return params, fmt.Errorf("SimpleScaling policy types cannot use estimated_instance_warmup!")
 	}
+	if *params.PolicyType == "SimpleScaling" && params.TargetTrackingConfiguration != nil {
+		return params, fmt.Errorf("SimpleScaling policy types cannot use target_tracking_configuration!")
+	}
 
 	// Second, StepScaling policy types...
 	if *params.PolicyType == "StepScaling" && params.ScalingAdjustment != nil {
@@ -258,6 +341,29 @@ func getAwsAutoscalingPutScalingPolicyInput(d *schema.ResourceData) (autoscaling
 	}
 	if *params.PolicyType == "StepScaling" && params.Cooldown != nil {
 		return params, fmt.Errorf("StepScaling policy types cannot use cooldown!")
+	}
+	if *params.PolicyType == "StepScaling" && params.TargetTrackingConfiguration != nil {
+		return params, fmt.Errorf("StepScaling policy types cannot use target_tracking_configuration!")
+	}
+
+	// Third, TargetTrackingScaling policy types...
+	if *params.PolicyType == "TargetTrackingScaling" && params.AdjustmentType != nil {
+		return params, fmt.Errorf("TargetTrackingScaling policy types cannot use adjustment_type!")
+	}
+	if *params.PolicyType == "TargetTrackingScaling" && params.Cooldown != nil {
+		return params, fmt.Errorf("TargetTrackingScaling policy types cannot use cooldown!")
+	}
+	if *params.PolicyType == "TargetTrackingScaling" && params.MetricAggregationType != nil {
+		return params, fmt.Errorf("TargetTrackingScaling policy types cannot use metric_aggregation_type!")
+	}
+	if *params.PolicyType == "TargetTrackingScaling" && params.MinAdjustmentMagnitude != nil {
+		return params, fmt.Errorf("TargetTrackingScaling policy types cannot use min_adjustment_magnitude!")
+	}
+	if *params.PolicyType == "TargetTrackingScaling" && params.ScalingAdjustment != nil {
+		return params, fmt.Errorf("TargetTrackingScaling policy types cannot use scaling_adjustment!")
+	}
+	if *params.PolicyType == "TargetTrackingScaling" && params.StepAdjustments != nil {
+		return params, fmt.Errorf("TargetTrackingScaling policy types cannot use step_adjustments!")
 	}
 
 	return params, nil
@@ -308,4 +414,85 @@ func resourceAwsAutoscalingScalingAdjustmentHash(v interface{}) int {
 	buf.WriteString(fmt.Sprintf("%d-", m["scaling_adjustment"].(int)))
 
 	return hashcode.String(buf.String())
+}
+
+func expandTargetTrackingConfiguration(config map[string]interface{}) *autoscaling.TargetTrackingConfiguration {
+	result := &autoscaling.TargetTrackingConfiguration{}
+
+	result.TargetValue = aws.Float64(config["target_value"].(float64))
+	if v, ok := config["disable_scale_in"]; ok {
+		result.DisableScaleIn = aws.Bool(v.(bool))
+	}
+	if v, ok := config["predefined_metric_specification"]; ok {
+		spec := v.(*schema.Set).List()[0].(map[string]interface{})
+		predSpec := &autoscaling.PredefinedMetricSpecification{
+			PredefinedMetricType: aws.String(spec["predefined_metric_type"].(string)),
+		}
+		if val, ok := spec["resource_label"]; ok {
+			predSpec.ResourceLabel = aws.String(val.(string))
+		}
+		result.PredefinedMetricSpecification = predSpec
+	}
+	if v, ok := config["customized_metric_specification"]; ok {
+		spec := v.(*schema.Set).List()[0].(map[string]interface{})
+		customSpec := &autoscaling.CustomizedMetricSpecification{
+			Namespace:  aws.String(spec["namespace"].(string)),
+			MetricName: aws.String(spec["metric_name"].(string)),
+			Statistic:  aws.String(spec["statistic"].(string)),
+		}
+		if val, ok := spec["unit"]; ok {
+			customSpec.Unit = aws.String(val.(string))
+		}
+		if val, ok := spec["metric_dimension"]; ok {
+			dims := val.([]interface{})
+			metDimList := make([]*autoscaling.MetricDimension, len(dims))
+			for i := range metDimList {
+				dim := dims[i].(map[string]interface{})
+				md := &autoscaling.MetricDimension{
+					Name:  aws.String(dim["name"].(string)),
+					Value: aws.String(dim["value"].(string)),
+				}
+				metDimList[i] = md
+			}
+			customSpec.Dimensions = metDimList
+		}
+		result.CustomizedMetricSpecification = customSpec
+	}
+	return result
+}
+
+func flattenTargetTrackingConfiguration(config *autoscaling.TargetTrackingConfiguration) []map[string]interface{} {
+	result := map[string]interface{}{}
+	result["disable_scale_in"] = *config.DisableScaleIn
+	result["target_value"] = *config.TargetValue
+	if config.PredefinedMetricSpecification != nil {
+		spec := map[string]interface{}{}
+		spec["predefined_metric_type"] = *config.PredefinedMetricSpecification.PredefinedMetricType
+		if config.PredefinedMetricSpecification.ResourceLabel != nil {
+			spec["resource_label"] = *config.PredefinedMetricSpecification.ResourceLabel
+		}
+		result["predefined_metric_specification"] = []map[string]interface{}{spec}
+	}
+	if config.CustomizedMetricSpecification != nil {
+		spec := map[string]interface{}{}
+		spec["metric_name"] = *config.CustomizedMetricSpecification.MetricName
+		spec["namespace"] = *config.CustomizedMetricSpecification.Namespace
+		spec["statistic"] = *config.CustomizedMetricSpecification.Statistic
+		if config.CustomizedMetricSpecification.Unit != nil {
+			spec["unit"] = *config.CustomizedMetricSpecification.Unit
+		}
+		if config.CustomizedMetricSpecification.Dimensions != nil {
+			dimSpec := make([]interface{}, len(config.CustomizedMetricSpecification.Dimensions))
+			for i := range dimSpec {
+				dim := map[string]interface{}{}
+				rawDim := config.CustomizedMetricSpecification.Dimensions[i]
+				dim["name"] = *rawDim.Name
+				dim["value"] = *rawDim.Value
+				dimSpec[i] = dim
+			}
+			spec["metric_dimension"] = dimSpec
+		}
+		result["customized_metric_specification"] = []map[string]interface{}{spec}
+	}
+	return []map[string]interface{}{result}
 }

--- a/aws/resource_aws_autoscaling_policy_test.go
+++ b/aws/resource_aws_autoscaling_policy_test.go
@@ -418,14 +418,26 @@ resource "aws_autoscaling_policy" "foobar_simple" {
 
 func testAccAwsAutoscalingPolicyConfig_TargetTracking_Predefined(rName string) string {
 	return fmt.Sprintf(`
+data "aws_ami" "amzn" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn-ami-hvm-*-x86_64-gp2"]
+  }
+}
+
+data "aws_availability_zones" "test" {}
+
 resource "aws_launch_configuration" "test" {
   name          = "tf-test-%s"
-  image_id      = "ami-21f78e11"
-  instance_type = "t1.micro"
+  image_id      = "${data.aws_ami.amzn.id}"
+  instance_type = "t2.micro"
 }
 
 resource "aws_autoscaling_group" "test" {
-  availability_zones        = ["us-west-2a"]
+  availability_zones        = ["${data.aws_availability_zones.test.names[0]}"]
   name                      = "tf-test-%s"
   max_size                  = 5
   min_size                  = 0
@@ -453,14 +465,26 @@ resource "aws_autoscaling_policy" "test" {
 
 func testAccAwsAutoscalingPolicyConfig_TargetTracking_Custom(rName string) string {
 	return fmt.Sprintf(`
+data "aws_ami" "amzn" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn-ami-hvm-*-x86_64-gp2"]
+  }
+}
+
+data "aws_availability_zones" "test" {}
+
 resource "aws_launch_configuration" "test" {
   name          = "tf-test-%s"
-  image_id      = "ami-21f78e11"
-  instance_type = "t1.micro"
+  image_id      = "${data.aws_ami.amzn.id}"
+  instance_type = "t2.micro"
 }
 
 resource "aws_autoscaling_group" "test" {
-  availability_zones        = ["us-west-2a"]
+  availability_zones        = ["${data.aws_availability_zones.test.names[0]}"]
   name                      = "tf-test-%s"
   max_size                  = 5
   min_size                  = 0

--- a/aws/resource_aws_autoscaling_policy_test.go
+++ b/aws/resource_aws_autoscaling_policy_test.go
@@ -140,6 +140,46 @@ func TestAccAWSAutoscalingPolicy_upgrade(t *testing.T) {
 	})
 }
 
+func TestAccAWSAutoscalingPolicy_TargetTrack_Predefined(t *testing.T) {
+	var policy autoscaling.ScalingPolicy
+
+	name := acctest.RandString(5)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAutoscalingPolicyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAwsAutoscalingPolicyConfig_TargetTracking_Predefined(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalingPolicyExists("aws_autoscaling_policy.test", &policy),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAutoscalingPolicy_TargetTrack_Custom(t *testing.T) {
+	var policy autoscaling.ScalingPolicy
+
+	name := acctest.RandString(5)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAutoscalingPolicyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAwsAutoscalingPolicyConfig_TargetTracking_Custom(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalingPolicyExists("aws_autoscaling_policy.test", &policy),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckScalingPolicyExists(n string, policy *autoscaling.ScalingPolicy) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -374,4 +414,80 @@ resource "aws_autoscaling_policy" "foobar_simple" {
   autoscaling_group_name   = "${aws_autoscaling_group.foobar.name}"
 }
 `, name, name, name)
+}
+
+func testAccAwsAutoscalingPolicyConfig_TargetTracking_Predefined(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_launch_configuration" "test" {
+  name          = "tf-test-%s"
+  image_id      = "ami-21f78e11"
+  instance_type = "t1.micro"
+}
+
+resource "aws_autoscaling_group" "test" {
+  availability_zones        = ["us-west-2a"]
+  name                      = "tf-test-%s"
+  max_size                  = 5
+  min_size                  = 0
+  health_check_grace_period = 300
+  health_check_type         = "ELB"
+  force_delete              = true
+  termination_policies      = ["OldestInstance"]
+  launch_configuration      = "${aws_launch_configuration.test.name}"
+}
+
+resource "aws_autoscaling_policy" "test" {
+  name                     = "tf-as-%s"
+  policy_type              = "TargetTrackingScaling"
+  autoscaling_group_name   = "${aws_autoscaling_group.test.name}"
+
+  target_tracking_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ASGAverageCPUUtilization"
+    }
+    target_value = 40.0
+  }
+}
+`, rName, rName, rName)
+}
+
+func testAccAwsAutoscalingPolicyConfig_TargetTracking_Custom(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_launch_configuration" "test" {
+  name          = "tf-test-%s"
+  image_id      = "ami-21f78e11"
+  instance_type = "t1.micro"
+}
+
+resource "aws_autoscaling_group" "test" {
+  availability_zones        = ["us-west-2a"]
+  name                      = "tf-test-%s"
+  max_size                  = 5
+  min_size                  = 0
+  health_check_grace_period = 300
+  health_check_type         = "ELB"
+  force_delete              = true
+  termination_policies      = ["OldestInstance"]
+  launch_configuration      = "${aws_launch_configuration.test.name}"
+}
+
+resource "aws_autoscaling_policy" "test" {
+  name                     = "tf-as-%s"
+  policy_type              = "TargetTrackingScaling"
+  autoscaling_group_name   = "${aws_autoscaling_group.test.name}"
+
+  target_tracking_configuration {
+    customized_metric_specification {
+      metric_dimension {
+        name = "fuga"
+        value = "fuga"
+      }
+      metric_name = "hoge"
+      namespace = "hoge"
+      statistic = "Average"
+    }
+    target_value = 40.0
+  }
+}
+`, rName, rName, rName)
 }

--- a/website/docs/r/autoscaling_policy.html.markdown
+++ b/website/docs/r/autoscaling_policy.html.markdown
@@ -45,8 +45,8 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the policy.
 * `autoscaling_group_name` - (Required) The name of the autoscaling group.
-* `adjustment_type` - (Required) Specifies whether the adjustment is an absolute number or a percentage of the current capacity. Valid values are `ChangeInCapacity`, `ExactCapacity`, and `PercentChangeInCapacity`.
-* `policy_type` - (Optional) The policy type, either "SimpleScaling" or "StepScaling". If this value isn't provided, AWS will default to "SimpleScaling."
+* `adjustment_type` - (Optional) Specifies whether the adjustment is an absolute number or a percentage of the current capacity. Valid values are `ChangeInCapacity`, `ExactCapacity`, and `PercentChangeInCapacity`.
+* `policy_type` - (Optional) The policy type, either "SimpleScaling", "StepScaling" or "TargetTrackingScaling". If this value isn't provided, AWS will default to "SimpleScaling."
 
 The following arguments are only available to "SimpleScaling" type policies:
 
@@ -85,6 +85,62 @@ Without a value, AWS will treat this bound as infinity.
 difference between the alarm threshold and the CloudWatch metric.
 Without a value, AWS will treat this bound as infinity. The upper bound
 must be greater than the lower bound.
+
+The following arguments are only available to "TargetTrackingScaling" type policies:
+
+* `target_tracking_configuration` - (Optional) A target tracking policy. These have the following structure:
+
+```hcl
+target_tracking_configuration {
+  predefined_metric_specification {
+    predefined_metric_type = "ASGAverageCPUUtilization"
+  }
+  target_value = 40.0
+}
+target_tracking_configuration {
+  customized_metric_specification {
+    metric_dimension {
+      name = "fuga"
+      value = "fuga"
+    }
+    metric_name = "hoge"
+    namespace = "hoge"
+    statistic = "Average"
+  }
+  target_value = 40.0
+}
+```
+
+The following fields are available in target tracking configuration:
+
+* `predefined_metric_specification` - (Optional) A predefined metric. Conflicts with `customized_metric_specification`.
+* `customized_metric_specification` - (Optional) A customized metric. Conflicts with `predefined_metric_specification`.
+* `target_value` - (Required) The target value for the metric.
+* `disable_scale_in` - (Optional, Default: false) Indicates whether scale in by the target tracking policy is disabled.
+
+### predefined_metric_specification
+
+The following arguments are supported:
+
+* `predefined_metric_type` - (Required) The metric type.
+* `resource_label` - (Optional) Identifies the resource associated with the metric type.
+
+### customized_metric_specification
+
+The following arguments are supported:
+
+* `metric_dimension` - (Optional) The dimensions of the metric.
+* `metric_name` - (Required) The name of the metric.
+* `namespace` - (Required) The namespace of the metric.
+* `statistic` - (Required) The statistic of the metric.
+* `unit` - (Optional) The unit of the metric.
+
+#### metric_dimension
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the dimension.
+* `value` - (Required) The value of the dimension.
 
 The following arguments are supported for backwards compatibility but should not be used:
 


### PR DESCRIPTION
Support: #1156 
```
TF_ACC=1 go test ./aws -v -run=TestAccAWSAutoscalingPolicy_TargetTrack -timeout 120m
=== RUN   TestAccAWSAutoscalingPolicy_TargetTrack_Predefined
--- PASS: TestAccAWSAutoscalingPolicy_TargetTrack_Predefined (87.74s)
=== RUN   TestAccAWSAutoscalingPolicy_TargetTrack_Custom
--- PASS: TestAccAWSAutoscalingPolicy_TargetTrack_Custom (82.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	169.792s
```

`adjustment_type` isn't supported if the policy type is TargetTrackingScaling so I changed Optional