### PR TITLE
New Resource: Service Discovery Service

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -469,6 +469,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_servicecatalog_portfolio":                 resourceAwsServiceCatalogPortfolio(),
 			"aws_service_discovery_private_dns_namespace":  resourceAwsServiceDiscoveryPrivateDnsNamespace(),
 			"aws_service_discovery_public_dns_namespace":   resourceAwsServiceDiscoveryPublicDnsNamespace(),
+			"aws_service_discovery_service":                resourceAwsServiceDiscoveryService(),
 			"aws_simpledb_domain":                          resourceAwsSimpleDBDomain(),
 			"aws_ssm_activation":                           resourceAwsSsmActivation(),
 			"aws_ssm_association":                          resourceAwsSsmAssociation(),

--- a/aws/resource_aws_service_discovery_service.go
+++ b/aws/resource_aws_service_discovery_service.go
@@ -1,0 +1,328 @@
+package aws
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/servicediscovery"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsServiceDiscoveryService() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsServiceDiscoveryServiceCreate,
+		Read:   resourceAwsServiceDiscoveryServiceRead,
+		Update: resourceAwsServiceDiscoveryServiceUpdate,
+		Delete: resourceAwsServiceDiscoveryServiceDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"dns_config": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"namespace_id": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"dns_records": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"ttl": {
+										Type:     schema.TypeInt,
+										Required: true,
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Required: true,
+										ForceNew: true,
+										ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+											value := v.(string)
+
+											validType := []string{"SRV", "A", "AAAA"}
+											for _, str := range validType {
+												if value == str {
+													return
+												}
+											}
+
+											errors = append(errors, fmt.Errorf("expected %s to be one of %v, got %s", k, validType, value))
+											return
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"health_check_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"failure_threshold": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"resource_path": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+							ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+								value := v.(string)
+
+								validType := []string{"HTTP", "HTTPS", "TCP"}
+								for _, str := range validType {
+									if value == str {
+										return
+									}
+								}
+
+								errors = append(errors, fmt.Errorf("expected %s to be one of %v, got %s", k, validType, value))
+								return
+							},
+						},
+					},
+				},
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsServiceDiscoveryServiceCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sdconn
+
+	input := &servicediscovery.CreateServiceInput{
+		Name:      aws.String(d.Get("name").(string)),
+		DnsConfig: expandServiceDiscoveryDnsConfig(d.Get("dns_config").([]interface{})[0].(map[string]interface{})),
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		input.Description = aws.String(v.(string))
+	}
+
+	hcconfig := d.Get("health_check_config").([]interface{})
+	if len(hcconfig) > 0 {
+		input.HealthCheckConfig = expandServiceDiscoveryHealthCheckConfig(hcconfig[0].(map[string]interface{}))
+	}
+
+	resp, err := conn.CreateService(input)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(*resp.Service.Id)
+	d.Set("arn", resp.Service.Arn)
+	return nil
+}
+
+func resourceAwsServiceDiscoveryServiceRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sdconn
+
+	input := &servicediscovery.GetServiceInput{
+		Id: aws.String(d.Id()),
+	}
+
+	resp, err := conn.GetService(input)
+	if err != nil {
+		if isAWSErr(err, servicediscovery.ErrCodeServiceNotFound, "") {
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	d.Set("arn", resp.Service.Arn)
+	d.Set("name", resp.Service.Name)
+	d.Set("description", resp.Service.Description)
+	d.Set("dns_config", flattenServiceDiscoveryDnsConfig(resp.Service.DnsConfig))
+	d.Set("health_check_config", flattenServiceDiscoveryHealthCheckConfig(resp.Service.HealthCheckConfig))
+	return nil
+}
+
+func resourceAwsServiceDiscoveryServiceUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sdconn
+
+	input := &servicediscovery.UpdateServiceInput{
+		Id: aws.String(d.Id()),
+	}
+
+	sc := &servicediscovery.ServiceChange{
+		DnsConfig: expandServiceDiscoveryDnsConfigChange(d.Get("dns_config").([]interface{})[0].(map[string]interface{})),
+	}
+
+	if d.HasChange("description") {
+		sc.Description = aws.String(d.Get("description").(string))
+	}
+	if d.HasChange("health_check_config") {
+		hcconfig := d.Get("health_check_config").([]interface{})
+		sc.HealthCheckConfig = expandServiceDiscoveryHealthCheckConfig(hcconfig[0].(map[string]interface{}))
+	}
+
+	input.Service = sc
+
+	resp, err := conn.UpdateService(input)
+	if err != nil {
+		if isAWSErr(err, servicediscovery.ErrCodeServiceNotFound, "") {
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{servicediscovery.OperationStatusSubmitted, servicediscovery.OperationStatusPending},
+		Target:     []string{servicediscovery.OperationStatusSuccess},
+		Refresh:    servicediscoveryOperationRefreshStatusFunc(conn, *resp.OperationId),
+		Timeout:    5 * time.Minute,
+		Delay:      10 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return err
+	}
+
+	return resourceAwsServiceDiscoveryServiceRead(d, meta)
+}
+
+func resourceAwsServiceDiscoveryServiceDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sdconn
+
+	input := &servicediscovery.DeleteServiceInput{
+		Id: aws.String(d.Id()),
+	}
+
+	_, err := conn.DeleteService(input)
+	if err != nil {
+		if isAWSErr(err, servicediscovery.ErrCodeServiceNotFound, "") {
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func expandServiceDiscoveryDnsConfig(configured map[string]interface{}) *servicediscovery.DnsConfig {
+	result := &servicediscovery.DnsConfig{}
+
+	result.NamespaceId = aws.String(configured["namespace_id"].(string))
+	dnsRecords := configured["dns_records"].([]interface{})
+	drs := make([]*servicediscovery.DnsRecord, len(dnsRecords))
+	for i := range drs {
+		raw := dnsRecords[i].(map[string]interface{})
+		dr := &servicediscovery.DnsRecord{
+			TTL:  aws.Int64(int64(raw["ttl"].(int))),
+			Type: aws.String(raw["type"].(string)),
+		}
+		drs[i] = dr
+	}
+	result.DnsRecords = drs
+
+	return result
+}
+
+func flattenServiceDiscoveryDnsConfig(config *servicediscovery.DnsConfig) []map[string]interface{} {
+	result := map[string]interface{}{}
+
+	result["namespace_id"] = *config.NamespaceId
+	drs := make([]map[string]interface{}, 0)
+	for _, v := range config.DnsRecords {
+		dr := map[string]interface{}{}
+		dr["ttl"] = *v.TTL
+		dr["type"] = *v.Type
+		drs = append(drs, dr)
+	}
+	result["dns_records"] = drs
+
+	return []map[string]interface{}{result}
+}
+
+func expandServiceDiscoveryDnsConfigChange(configured map[string]interface{}) *servicediscovery.DnsConfigChange {
+	result := &servicediscovery.DnsConfigChange{}
+
+	dnsRecords := configured["dns_records"].([]interface{})
+	drs := make([]*servicediscovery.DnsRecord, len(dnsRecords))
+	for i := range drs {
+		raw := dnsRecords[i].(map[string]interface{})
+		dr := &servicediscovery.DnsRecord{
+			TTL:  aws.Int64(int64(raw["ttl"].(int))),
+			Type: aws.String(raw["type"].(string)),
+		}
+		drs[i] = dr
+	}
+	result.DnsRecords = drs
+
+	return result
+}
+
+func expandServiceDiscoveryHealthCheckConfig(configured map[string]interface{}) *servicediscovery.HealthCheckConfig {
+	if len(configured) < 1 {
+		return nil
+	}
+	result := &servicediscovery.HealthCheckConfig{}
+
+	if v, ok := configured["failure_threshold"]; ok && v.(int) != 0 {
+		result.FailureThreshold = aws.Int64(int64(v.(int)))
+	}
+	if v, ok := configured["resource_path"]; ok && v.(string) != "" {
+		result.ResourcePath = aws.String(v.(string))
+	}
+	if v, ok := configured["type"]; ok && v.(string) != "" {
+		result.Type = aws.String(v.(string))
+	}
+
+	return result
+}
+
+func flattenServiceDiscoveryHealthCheckConfig(config *servicediscovery.HealthCheckConfig) []map[string]interface{} {
+	if config == nil {
+		return nil
+	}
+	result := map[string]interface{}{}
+
+	if config.FailureThreshold != nil {
+		result["failure_threshold"] = *config.FailureThreshold
+	}
+	if config.ResourcePath != nil {
+		result["resource_path"] = *config.ResourcePath
+	}
+	if config.Type != nil {
+		result["type"] = *config.Type
+	}
+
+	if len(result) < 1 {
+		return nil
+	}
+
+	return []map[string]interface{}{result}
+}

--- a/aws/resource_aws_service_discovery_service_test.go
+++ b/aws/resource_aws_service_discovery_service_test.go
@@ -154,7 +154,7 @@ resource "aws_service_discovery_service" "test" {
       ttl = 10
       type = "A"
     }
-		dns_records {
+    dns_records {
       ttl = 5
       type = "AAAA"
     }
@@ -179,7 +179,7 @@ resource "aws_service_discovery_service" "test" {
       type = "A"
     }
   }
-	health_check_config {
+  health_check_config {
     failure_threshold = %d
     resource_path = "%s"
     type = "HTTP"

--- a/aws/resource_aws_service_discovery_service_test.go
+++ b/aws/resource_aws_service_discovery_service_test.go
@@ -25,6 +25,7 @@ func TestAccAwsServiceDiscoveryService_private(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "dns_config.0.dns_records.#", "1"),
 					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "dns_config.0.dns_records.0.type", "A"),
 					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "dns_config.0.dns_records.0.ttl", "5"),
+					resource.TestCheckResourceAttrSet("aws_service_discovery_service.test", "arn"),
 				),
 			},
 			{
@@ -36,6 +37,7 @@ func TestAccAwsServiceDiscoveryService_private(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "dns_config.0.dns_records.0.ttl", "10"),
 					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "dns_config.0.dns_records.1.type", "AAAA"),
 					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "dns_config.0.dns_records.1.ttl", "5"),
+					resource.TestCheckResourceAttrSet("aws_service_discovery_service.test", "arn"),
 				),
 			},
 		},
@@ -56,6 +58,7 @@ func TestAccAwsServiceDiscoveryService_public(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "health_check_config.0.type", "HTTP"),
 					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "health_check_config.0.failure_threshold", "5"),
 					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "health_check_config.0.resource_path", "path"),
+					resource.TestCheckResourceAttrSet("aws_service_discovery_service.test", "arn"),
 				),
 			},
 			{
@@ -65,6 +68,7 @@ func TestAccAwsServiceDiscoveryService_public(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "health_check_config.0.type", "HTTP"),
 					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "health_check_config.0.failure_threshold", "3"),
 					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "health_check_config.0.resource_path", "update"),
+					resource.TestCheckResourceAttrSet("aws_service_discovery_service.test", "arn"),
 				),
 			},
 		},

--- a/aws/resource_aws_service_discovery_service_test.go
+++ b/aws/resource_aws_service_discovery_service_test.go
@@ -1,0 +1,185 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/servicediscovery"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAwsServiceDiscoveryService_private(t *testing.T) {
+	rName := acctest.RandString(5)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsServiceDiscoveryServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceDiscoveryServiceConfig_private(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceDiscoveryServiceExists("aws_service_discovery_service.test"),
+					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "dns_config.0.dns_records.#", "1"),
+					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "dns_config.0.dns_records.0.type", "A"),
+					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "dns_config.0.dns_records.0.ttl", "5"),
+				),
+			},
+			{
+				Config: testAccServiceDiscoveryServiceConfig_private_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceDiscoveryServiceExists("aws_service_discovery_service.test"),
+					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "dns_config.0.dns_records.#", "2"),
+					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "dns_config.0.dns_records.0.type", "A"),
+					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "dns_config.0.dns_records.0.ttl", "10"),
+					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "dns_config.0.dns_records.1.type", "AAAA"),
+					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "dns_config.0.dns_records.1.ttl", "5"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAwsServiceDiscoveryService_public(t *testing.T) {
+	rName := acctest.RandString(5)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsServiceDiscoveryServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceDiscoveryServiceConfig_public(rName, 5, "path"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceDiscoveryServiceExists("aws_service_discovery_service.test"),
+					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "health_check_config.0.type", "HTTP"),
+					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "health_check_config.0.failure_threshold", "5"),
+					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "health_check_config.0.resource_path", "path"),
+				),
+			},
+			{
+				Config: testAccServiceDiscoveryServiceConfig_public(rName, 3, "update"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceDiscoveryServiceExists("aws_service_discovery_service.test"),
+					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "health_check_config.0.type", "HTTP"),
+					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "health_check_config.0.failure_threshold", "3"),
+					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "health_check_config.0.resource_path", "update"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsServiceDiscoveryServiceDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).sdconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_service_discovery_service" {
+			continue
+		}
+
+		input := &servicediscovery.GetServiceInput{
+			Id: aws.String(rs.Primary.ID),
+		}
+
+		_, err := conn.GetService(input)
+		if err != nil {
+			if isAWSErr(err, servicediscovery.ErrCodeServiceNotFound, "") {
+				return nil
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+func testAccCheckAwsServiceDiscoveryServiceExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		return nil
+	}
+}
+
+func testAccServiceDiscoveryServiceConfig_private(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_service_discovery_private_dns_namespace" "test" {
+  name = "tf-sd-%s.terraform.local"
+  description = "test"
+  vpc = "${aws_vpc.test.id}"
+}
+
+resource "aws_service_discovery_service" "test" {
+  name = "tf-sd-%s"
+  dns_config {
+    namespace_id = "${aws_service_discovery_private_dns_namespace.test.id}"
+    dns_records {
+      ttl = 5
+      type = "A"
+    }
+  }
+}
+`, rName, rName)
+}
+
+func testAccServiceDiscoveryServiceConfig_private_update(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_service_discovery_private_dns_namespace" "test" {
+  name = "tf-sd-%s.terraform.local"
+  description = "test"
+  vpc = "${aws_vpc.test.id}"
+}
+
+resource "aws_service_discovery_service" "test" {
+  name = "tf-sd-%s"
+  dns_config {
+    namespace_id = "${aws_service_discovery_private_dns_namespace.test.id}"
+    dns_records {
+      ttl = 10
+      type = "A"
+    }
+		dns_records {
+      ttl = 5
+      type = "AAAA"
+    }
+  }
+}
+`, rName, rName)
+}
+
+func testAccServiceDiscoveryServiceConfig_public(rName string, th int, path string) string {
+	return fmt.Sprintf(`
+resource "aws_service_discovery_public_dns_namespace" "test" {
+  name = "tf-sd-%s.terraform.com"
+  description = "test"
+}
+
+resource "aws_service_discovery_service" "test" {
+  name = "tf-sd-%s"
+  dns_config {
+    namespace_id = "${aws_service_discovery_public_dns_namespace.test.id}"
+    dns_records {
+      ttl = 5
+      type = "A"
+    }
+  }
+	health_check_config {
+    failure_threshold = %d
+    resource_path = "%s"
+    type = "HTTP"
+  }
+}
+`, rName, rName, th, path)
+}

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -2025,3 +2025,27 @@ func validateAwsElastiCacheReplicationGroupAuthToken(v interface{}, k string) (w
 	}
 	return
 }
+
+func validateServiceDiscoveryServiceDnsRecordsType(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	validType := []string{"SRV", "A", "AAAA"}
+	for _, str := range validType {
+		if value == str {
+			return
+		}
+	}
+	errors = append(errors, fmt.Errorf("expected %s to be one of %v, got %s", k, validType, value))
+	return
+}
+
+func validateServiceDiscoveryServiceHealthCheckConfigType(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	validType := []string{"HTTP", "HTTPS", "TCP"}
+	for _, str := range validType {
+		if value == str {
+			return
+		}
+	}
+	errors = append(errors, fmt.Errorf("expected %s to be one of %v, got %s", k, validType, value))
+	return
+}

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -2890,3 +2890,53 @@ func TestValidateCognitoUserPoolDomain(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateServiceDiscoveryServiceDnsRecordsType(t *testing.T) {
+	validTypes := []string{
+		"SRV",
+		"A",
+		"AAAA",
+	}
+	for _, v := range validTypes {
+		_, errors := validateServiceDiscoveryServiceDnsRecordsType(v, "")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid Service Discovery DNS Records Type: %q", v, errors)
+		}
+	}
+
+	invalidTypes := []string{
+		"hoge",
+		"srv",
+	}
+	for _, v := range invalidTypes {
+		_, errors := validateServiceDiscoveryServiceDnsRecordsType(v, "")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be an invalid Service Discovery DNS Records Type", v)
+		}
+	}
+}
+
+func TestValidateServiceDiscoveryServiceHealthCheckConfigType(t *testing.T) {
+	validTypes := []string{
+		"HTTP",
+		"HTTPS",
+		"TCP",
+	}
+	for _, v := range validTypes {
+		_, errors := validateServiceDiscoveryServiceHealthCheckConfigType(v, "")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid Service Discovery Health Check Config Type: %q", v, errors)
+		}
+	}
+
+	invalidTypes := []string{
+		"hoge",
+		"tcp",
+	}
+	for _, v := range invalidTypes {
+		_, errors := validateServiceDiscoveryServiceHealthCheckConfigType(v, "")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be an invalid Service Discovery Health Check Config Type", v)
+		}
+	}
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1477,6 +1477,10 @@
                             <a href="/docs/providers/aws/r/service_discovery_public_dns_namespace.html">aws_service_discovery_public_dns_namespace</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-service-discovery-service") %>>
+                            <a href="/docs/providers/aws/r/service_discovery_service.html">aws_service_discovery_service</a>
+                        </li>
+
                     </ul>
                 </li>
 

--- a/website/docs/r/service_discovery_service.html.markdown
+++ b/website/docs/r/service_discovery_service.html.markdown
@@ -1,0 +1,97 @@
+---
+layout: "aws"
+page_title: "AWS: aws_service_discovery_service"
+sidebar_current: "docs-aws-resource-service-discovery-service"
+description: |-
+  Provides a Service Discovery Service resource.
+---
+
+# aws_service_discovery_service
+
+Provides a Service Discovery Service resource.
+
+## Example Usage
+
+```hcl
+resource "aws_vpc" "example" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_service_discovery_private_dns_namespace" "example" {
+  name = "example.terraform.local"
+  description = "example"
+  vpc = "${aws_vpc.example.id}"
+}
+
+resource "aws_service_discovery_service" "example" {
+  name = "example"
+  dns_config {
+    namespace_id = "${aws_service_discovery_private_dns_namespace.example.id}"
+    dns_records {
+      ttl = 10
+      type = "A"
+    }
+  }
+}
+```
+
+```hcl
+resource "aws_service_discovery_public_dns_namespace" "example" {
+  name = "example.terraform.com"
+  description = "example"
+}
+
+resource "aws_service_discovery_service" "example" {
+  name = "example"
+  dns_config {
+    namespace_id = "${aws_service_discovery_public_dns_namespace.example.id}"
+    dns_records {
+      ttl = 10
+      type = "A"
+    }
+  }
+  health_check_config {
+    failure_threshold = 100
+    resource_path = "path"
+    type = "HTTP"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, ForceNew) The name of the service.
+* `description` - (Optional) The description of the service.
+* `dns_config` - (Required) A complex type that contains information about the resource record sets that you want Amazon Route 53 to create when you register an instance.
+* `health_check_config` - (Optional) A complex type that contains settings for an optional health check. Only for Public DNS namespaces.
+
+### dns_config
+
+The following arguments are supported:
+
+* `namespace_id` - (Required, ForceNew) The ID of the namespace to use for DNS configuration.
+* `dns_records` - (Required) An array that contains one DnsRecord object for each resource record set.
+
+#### dns_records
+
+The following arguments are supported:
+
+* `ttl` - (Required) The amount of time, in seconds, that you want DNS resolvers to cache the settings for this resource record set.
+* `type` - (Required, ForceNew) The type of the resource, which indicates the value that Amazon Route 53 returns in response to DNS queries. Valid Values: A, AAAA, SRV
+
+### health_check_config
+
+The following arguments are supported:
+
+* `failure_threshold` - (Optional) The number of consecutive health checks. Maximum value of 10.
+* `resource_path` - (Optional) An array that contains one DnsRecord object for each resource record set.
+* `type` - (Optional, ForceNew) An array that contains one DnsRecord object for each resource record set.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the service.
+* `arn` - The ARN of the service.


### PR DESCRIPTION
Depend: #2569 #2589 
```
TF_ACC=1 go test ./aws -v -run=TestAccAwsServiceDiscoveryService_ -timeout 120m
=== RUN   TestAccAwsServiceDiscoveryService_private
--- PASS: TestAccAwsServiceDiscoveryService_private (172.04s)
=== RUN   TestAccAwsServiceDiscoveryService_public
--- PASS: TestAccAwsServiceDiscoveryService_public (120.92s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	293.039s
```

```
InvalidInput: The record types in the request must be the same as those present in the existing service. Records in the existing service are [A], but the records in the request are [AAAA]. The record types of a service cannot be changed.

InvalidInput: Type of health check cannot be changed
```
So `dns_records.type` and `health_check_config.type` are `ForceNew`.