### PR TITLE
t/db_instance: Run acceptance tests in default region

### DIFF
--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -411,6 +411,25 @@ func TestAccAWSDBInstance_diffSuppressInitialState(t *testing.T) {
 	})
 }
 
+func TestAccAWSDBInstance_ec2Classic(t *testing.T) {
+	var v rds.DBInstance
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBInstanceConfigEc2Classic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBInstanceExists("aws_db_instance.bar", &v),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSDBInstanceDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).rdsconn
 
@@ -1337,6 +1356,29 @@ resource "aws_db_instance" "bar" {
 	skip_final_snapshot = true
 }
 `, acctest.RandInt())
+
+func testAccAWSDBInstanceConfigEc2Classic(rInt int) string {
+	return fmt.Sprintf(`
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_db_instance" "bar" {
+  identifier = "foobarbaz-test-terraform-%d"
+  allocated_storage = 10
+  engine = "mysql"
+  engine_version = "5.6"
+  instance_class = "db.m3.medium"
+  name = "baz"
+  password = "barbarbarbar"
+  username = "foo"
+  publicly_accessible = true
+  security_group_names = ["default"]
+  parameter_group_name = "default.mysql5.6"
+  skip_final_snapshot = true
+}
+`, rInt)
+}
 
 func testAccAWSDBInstanceConfigSuppressInitialState(rInt int) string {
 	return fmt.Sprintf(`

--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -855,9 +855,6 @@ func testAccReplicaInstanceConfig(val int) string {
 
 func testAccSnapshotInstanceConfig() string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
 resource "aws_db_instance" "snapshot" {
 	identifier = "tf-test-%d"
 
@@ -868,7 +865,6 @@ resource "aws_db_instance" "snapshot" {
 	name = "baz"
 	password = "barbarbarbar"
 	username = "foo"
-	security_group_names = ["default"]
 	backup_retention_period = 1
 
 	publicly_accessible = true
@@ -882,9 +878,6 @@ resource "aws_db_instance" "snapshot" {
 
 func testAccSnapshotInstanceConfigWithSnapshot(rInt int) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
 resource "aws_db_instance" "snapshot" {
 	identifier = "tf-snapshot-%d"
 
@@ -896,7 +889,6 @@ resource "aws_db_instance" "snapshot" {
 	password = "barbarbarbar"
 	publicly_accessible = true
 	username = "foo"
-    	security_group_names = ["default"]
 	backup_retention_period = 1
 
 	parameter_group_name = "default.mysql5.6"

--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -194,7 +194,7 @@ func TestAccAWSDBInstance_iamAuth(t *testing.T) {
 	})
 }
 
-func TestAccAWSDBInstanceReplica(t *testing.T) {
+func TestAccAWSDBInstance_replica(t *testing.T) {
 	var s, r rds.DBInstance
 
 	resource.Test(t, resource.TestCase{
@@ -214,7 +214,7 @@ func TestAccAWSDBInstanceReplica(t *testing.T) {
 	})
 }
 
-func TestAccAWSDBInstanceNoSnapshot(t *testing.T) {
+func TestAccAWSDBInstance_noSnapshot(t *testing.T) {
 	var snap rds.DBInstance
 
 	resource.Test(t, resource.TestCase{
@@ -232,7 +232,7 @@ func TestAccAWSDBInstanceNoSnapshot(t *testing.T) {
 	})
 }
 
-func TestAccAWSDBInstanceSnapshot(t *testing.T) {
+func TestAccAWSDBInstance_snapshot(t *testing.T) {
 	var snap rds.DBInstance
 	rInt := acctest.RandInt()
 


### PR DESCRIPTION
The tests were pinned to `us-east-1` for (IMO) no particular reason in https://github.com/hashicorp/terraform/pull/3853

This is to address the following test failures:

```
=== RUN   TestAccAWSDBInstanceNoSnapshot
--- FAIL: TestAccAWSDBInstanceNoSnapshot (6.84s)
    testing.go:503: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_db_instance.snapshot: 1 error(s) occurred:
        
        * aws_db_instance.snapshot: Error creating DB Instance: InsufficientDBInstanceCapacity: Cannot create a db.t2.micro database instance because there are no availability zones with sufficient capacity for non-VPC and storage type : standard for db.t2.micro. Please try the request again at a later time.
            status code: 400, request id: 7f3d6248-2bfc-427a-8e26-57037084c33e
=== RUN   TestAccAWSDBInstanceSnapshot
--- FAIL: TestAccAWSDBInstanceSnapshot (6.64s)
    testing.go:503: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_db_instance.snapshot: 1 error(s) occurred:
        
        * aws_db_instance.snapshot: Error creating DB Instance: InsufficientDBInstanceCapacity: Cannot create a db.t2.micro database instance because there are no availability zones with sufficient capacity for non-VPC and storage type : standard for db.t2.micro. Please try the request again at a later time.
            status code: 400, request id: 9f67a929-1e4a-4883-b33b-ad0bc73d353b
```

I also added one test which still runs in `us-east-1` but only tests basic functionality in that region and doesn't overlap with tests which are supposed to test something else. I had to choose `db.m3.medium` as it was the cheapest size from `m3` family available in that region. `t2` seems to be constantly unavailable in the region.

## Test results

```
=== RUN   TestAccAWSDBInstance_ec2Classic
--- PASS: TestAccAWSDBInstance_ec2Classic (448.96s)
=== RUN   TestAccAWSDBInstance_generatedName
--- PASS: TestAccAWSDBInstance_generatedName (398.72s)
=== RUN   TestAccAWSDBInstance_MinorVersion
--- PASS: TestAccAWSDBInstance_MinorVersion (417.60s)
=== RUN   TestAccAWSDBInstance_namePrefix
--- PASS: TestAccAWSDBInstance_namePrefix (418.55s)
=== RUN   TestAccAWSDBInstance_diffSuppressInitialState
--- PASS: TestAccAWSDBInstance_diffSuppressInitialState (418.55s)
=== RUN   TestAccAWSDBInstance_iamAuth
--- PASS: TestAccAWSDBInstance_iamAuth (470.62s)
=== RUN   TestAccAWSDBInstance_importBasic
--- PASS: TestAccAWSDBInstance_importBasic (470.84s)
=== RUN   TestAccAWSDBInstance_basic
--- PASS: TestAccAWSDBInstance_basic (478.79s)
=== RUN   TestAccAWSDBInstance_portUpdate
--- PASS: TestAccAWSDBInstance_portUpdate (513.97s)
=== RUN   TestAccAWSDBInstance_kmsKey
--- PASS: TestAccAWSDBInstance_kmsKey (520.18s)
=== RUN   TestAccAWSDBInstance_optionGroup
--- PASS: TestAccAWSDBInstance_optionGroup (553.10s)
=== RUN   TestAccAWSDBInstance_noSnapshot
--- PASS: TestAccAWSDBInstance_noSnapshot (571.47s)
=== RUN   TestAccAWSDBInstance_enhancedMonitoring
--- PASS: TestAccAWSDBInstance_enhancedMonitoring (583.22s)
=== RUN   TestAccAWSDBInstance_subnetGroup
--- PASS: TestAccAWSDBInstance_subnetGroup (785.42s)
=== RUN   TestAccAWSDBInstance_snapshot
--- PASS: TestAccAWSDBInstance_snapshot (965.69s)
=== RUN   TestAccAWSDBInstance_replica
--- PASS: TestAccAWSDBInstance_replica (1411.09s)
=== RUN   TestAccAWSDBInstance_MSSQL_TZ
--- PASS: TestAccAWSDBInstance_MSSQL_TZ (2299.56s)
```