### PR TITLE
r/aws_instance: add T2 unlimited to aws instance resources

### DIFF
--- a/aws/data_source_aws_instance.go
+++ b/aws/data_source_aws_instance.go
@@ -222,6 +222,18 @@ func dataSourceAwsInstance() *schema.Resource {
 					},
 				},
 			},
+			"credit_specification": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cpu_credits": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -388,6 +400,13 @@ func instanceDescriptionAttributes(d *schema.ResourceData, instance *ec2.Instanc
 		if attr.UserData.Value != nil {
 			d.Set("user_data", userDataHashSum(*attr.UserData.Value))
 		}
+	}
+	{
+		creditSpecifications, err := getCreditSpecifications(conn, d.Id())
+		if err != nil {
+			return err
+		}
+		d.Set("credit_specification", creditSpecifications)
 	}
 
 	return nil

--- a/aws/data_source_aws_instance.go
+++ b/aws/data_source_aws_instance.go
@@ -406,7 +406,9 @@ func instanceDescriptionAttributes(d *schema.ResourceData, instance *ec2.Instanc
 		if err != nil {
 			return err
 		}
-		d.Set("credit_specification", creditSpecifications)
+		if err := d.Set("credit_specification", creditSpecifications); err != nil {
+			return fmt.Errorf("error setting credit_specification: %s", err)
+		}
 	}
 
 	return nil

--- a/aws/data_source_aws_instance_test.go
+++ b/aws/data_source_aws_instance_test.go
@@ -283,6 +283,24 @@ func TestAccAWSInstanceDataSource_getPasswordData_falseToTrue(t *testing.T) {
 	})
 }
 
+func TestAccAWSInstanceDataSource_creditSpecification(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+
+				Config: testAccInstanceDataSourceConfig_creditSpecification,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_instance.foo", "instance_type", "t2.micro"),
+					resource.TestCheckResourceAttr("data.aws_instance.foo", "credit_specification.#", "1"),
+					resource.TestCheckResourceAttr("data.aws_instance.foo", "credit_specification.0.cpu_credits", "unlimited"),
+				),
+			},
+		},
+	})
+}
+
 // Lookup based on InstanceID
 const testAccInstanceDataSourceConfig = `
 resource "aws_instance" "web" {
@@ -658,3 +676,27 @@ func testAccInstanceDataSourceConfig_getPasswordData(val bool, rInt int) string 
 	}
 	`, rInt, val)
 }
+
+const testAccInstanceDataSourceConfig_creditSpecification = `
+resource "aws_vpc" "foo" {
+  cidr_block = "10.1.0.0/16"
+}
+
+resource "aws_subnet" "foo" {
+  cidr_block = "10.1.1.0/24"
+  vpc_id = "${aws_vpc.foo.id}"
+}
+
+resource "aws_instance" "foo" {
+  ami = "ami-bf4193c7"
+  instance_type = "t2.micro"
+  subnet_id = "${aws_subnet.foo.id}"
+  credit_specification {
+    cpu_credits = "unlimited"
+  }
+}
+
+data "aws_instance" "foo" {
+  instance_id = "${aws_instance.foo.id}"
+}
+`

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -1397,6 +1397,78 @@ func TestAccAWSInstance_getPasswordData_trueToFalse(t *testing.T) {
 	})
 }
 
+func TestAccAWSInstance_creditSpecification_standardCpuCredits(t *testing.T) {
+	var instance ec2.Instance
+	resName := "aws_instance.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_creditSpecification_standardCpuCredits(acctest.RandInt()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(resName, &instance),
+					resource.TestCheckResourceAttr(resName, "credit_specification.#", "1"),
+					resource.TestCheckResourceAttr(resName, "credit_specification.0.cpu_credits", "standard"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSInstance_creditSpecification_unlimitedCpuCredits(t *testing.T) {
+	var instance ec2.Instance
+	resName := "aws_instance.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_creditSpecification_unlimitedCpuCredits(acctest.RandInt()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(resName, &instance),
+					resource.TestCheckResourceAttr(resName, "credit_specification.#", "1"),
+					resource.TestCheckResourceAttr(resName, "credit_specification.0.cpu_credits", "unlimited"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSInstance_creditSpecification_updateCpuCredits(t *testing.T) {
+	var before ec2.Instance
+	var after ec2.Instance
+	resName := "aws_instance.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_creditSpecification_standardCpuCredits(acctest.RandInt()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(resName, &before),
+					resource.TestCheckResourceAttr(resName, "credit_specification.#", "1"),
+					resource.TestCheckResourceAttr(resName, "credit_specification.0.cpu_credits", "standard"),
+				),
+			},
+			{
+				Config: testAccInstanceConfig_creditSpecification_unlimitedCpuCredits(acctest.RandInt()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(resName, &after),
+					resource.TestCheckResourceAttr(resName, "credit_specification.#", "1"),
+					resource.TestCheckResourceAttr(resName, "credit_specification.0.cpu_credits", "unlimited"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckInstanceNotRecreated(t *testing.T,
 	before, after *ec2.Instance) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -2969,4 +3041,56 @@ func testAccInstanceConfig_getPasswordData(val bool, rInt int) string {
 		get_password_data = %t
 	}
 	`, rInt, val)
+}
+
+func testAccInstanceConfig_creditSpecification_standardCpuCredits(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "my_vpc" {
+  cidr_block = "172.16.0.0/16"
+  tags {
+    Name = "tf-acctest-%d"
+  }
+}
+
+resource "aws_subnet" "my_subnet" {
+  vpc_id = "${aws_vpc.my_vpc.id}"
+  cidr_block = "172.16.20.0/24"
+  availability_zone = "us-west-2a"
+}
+
+resource "aws_instance" "foo" {
+  ami = "ami-22b9a343" # us-west-2
+  instance_type = "t2.micro"
+  subnet_id = "${aws_subnet.my_subnet.id}"
+  credit_specification {
+    cpu_credits = "standard"
+  }
+}
+`, rInt)
+}
+
+func testAccInstanceConfig_creditSpecification_unlimitedCpuCredits(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "my_vpc" {
+  cidr_block = "172.16.0.0/16"
+  tags {
+    Name = "tf-acctest-%d"
+  }
+}
+
+resource "aws_subnet" "my_subnet" {
+  vpc_id = "${aws_vpc.my_vpc.id}"
+  cidr_block = "172.16.20.0/24"
+  availability_zone = "us-west-2a"
+}
+
+resource "aws_instance" "foo" {
+  ami = "ami-22b9a343" # us-west-2
+  instance_type = "t2.micro"
+  subnet_id = "${aws_subnet.my_subnet.id}"
+  credit_specification {
+    cpu_credits = "unlimited"
+  }
+}
+`, rInt)
 }

--- a/website/docs/d/instance.html.markdown
+++ b/website/docs/d/instance.html.markdown
@@ -102,5 +102,6 @@ interpolation.
 * `tags` - A mapping of tags assigned to the Instance.
 * `tenancy` - The tenancy of the instance: `dedicated`, `default`, `host`.
 * `vpc_security_group_ids` - The associated security groups in a non-default VPC.
+* `credit_specification` - The credit specification of the Instance.
 
 [1]: http://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instances.html

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -90,6 +90,7 @@ instances. See [Shutdown Behavior](https://docs.aws.amazon.com/AWSEC2/latest/Use
 * `ephemeral_block_device` - (Optional) Customize Ephemeral (also known as
   "Instance Store") volumes on the instance. See [Block Devices](#block-devices) below for details.
 * `network_interface` - (Optional) Customize network interfaces to be attached at instance boot time. See [Network Interfaces](#network-interfaces) below for more details.
+* `credit_specification` - (Optional) Customize the credit specification of the instance. See [Credit Specification](#credit-specification) below for more details.
 
 ### Timeouts
 
@@ -176,6 +177,14 @@ Each `network_interface` block supports the following:
 * `network_interface_id` - (Required) The ID of the network interface to attach.
 * `delete_on_termination` - (Optional) Whether or not to delete the network interface on instance termination. Defaults to `false`.
 
+### Credit Specification
+
+Credit specification can be applied/modified to the EC2 Instance at any time.
+
+The `credit_specification` block supports the following:
+
+* `cpu_credits` - (Optional) The credit option for CPU usage.
+
 ### Example
 
 ```hcl
@@ -239,6 +248,7 @@ The following attributes are exported:
 * `security_groups` - The associated security groups.
 * `vpc_security_group_ids` - The associated security groups in non-default VPC
 * `subnet_id` - The VPC subnet ID.
+* `credit_specification` - Credit specification of instance.
 
 For any `root_block_device` and `ebs_block_device` the `volume_id` is exported.
 e.g. `aws_instance.web.root_block_device.0.volume_id`


### PR DESCRIPTION
I think this should cover: https://github.com/terraform-providers/terraform-provider-aws/issues/2491

```bash
make testacc TEST=./aws TESTARGS='-run=TestAccAWSInstance_t2Unlimited'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSInstance_t2Unlimited -timeout 120m
=== RUN   TestAccAWSInstance_t2Unlimited_invalidInstanceType
--- PASS: TestAccAWSInstance_t2Unlimited_invalidInstanceType (24.21s)
=== RUN   TestAccAWSInstance_t2Unlimited_unlimitedCredits
--- PASS: TestAccAWSInstance_t2Unlimited_unlimitedCredits (127.75s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	151.986s

make testacc TEST=./aws TESTARGS='-run=TestAccAWSInstanceDataSource_t2Unlimited'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSInstanceDataSource_t2Unlimited -timeout 120m
=== RUN   TestAccAWSInstanceDataSource_t2Unlimited
--- PASS: TestAccAWSInstanceDataSource_t2Unlimited (147.84s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	147.866s
```