### PR TITLE
Do not treat DBParameterGroupNotFound as an error.

### DIFF
--- a/aws/resource_aws_db_parameter_group.go
+++ b/aws/resource_aws_db_parameter_group.go
@@ -134,6 +134,11 @@ func resourceAwsDbParameterGroupRead(d *schema.ResourceData, meta interface{}) e
 
 	describeResp, err := rdsconn.DescribeDBParameterGroups(&describeOpts)
 	if err != nil {
+		if isAWSErr(err, rds.ErrCodeDBParameterGroupNotFoundFault, "") {
+			log.Printf("[WARN] DB Parameter Group (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
It's expected that DB Parameter Groups will not exist in some cases,
e.g. they were manually deleted. Terraform should just plan to
re-create them instead of erroring.

Fixes #490