### PR TITLE
[WIP] New Resource: LB Listener Additional Certificates

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -527,6 +527,8 @@ func Provider() terraform.ResourceProvider {
 			"aws_lb":                          resourceAwsLb(),
 			"aws_alb_listener":                resourceAwsLbListener(),
 			"aws_lb_listener":                 resourceAwsLbListener(),
+			"aws_alb_listener_certificate":    resourceAwsLbListenerCertificate(),
+			"aws_lb_listener_certificate":     resourceAwsLbListenerCertificate(),
 			"aws_alb_listener_rule":           resourceAwsLbbListenerRule(),
 			"aws_lb_listener_rule":            resourceAwsLbbListenerRule(),
 			"aws_alb_target_group":            resourceAwsLbTargetGroup(),

--- a/aws/resource_aws_lb_listener_certificate.go
+++ b/aws/resource_aws_lb_listener_certificate.go
@@ -1,0 +1,119 @@
+package aws
+
+import (
+	"errors"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsLbListenerCertificate() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsLbListenerCertificateCreate,
+		Read:   resourceAwsLbListenerCertificateRead,
+		Delete: resourceAwsLbListenerCertificateDelete,
+
+		Schema: map[string]*schema.Schema{
+			"listener_arn": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"certificate_arn": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAwsLbListenerCertificateCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).elbv2conn
+	params := &elbv2.AddListenerCertificatesInput{
+		ListenerArn: aws.String(d.Get("listener_arn").(string)),
+		Certificates: []*elbv2.Certificate{
+			&elbv2.Certificate{
+				CertificateArn: aws.String(d.Get("certificate_arn").(string)),
+			},
+		},
+	}
+
+	resp, err := conn.AddListenerCertificates(params)
+	if err != nil {
+		return errwrap.Wrapf("Error creating LB Listener Certificate: {{err}}", err)
+	}
+
+	if len(resp.Certificates) == 0 {
+		return errors.New("Error creating LB Listener Certificate: no certificates returned in response")
+	}
+
+	d.SetId(d.Get("listener_arn").(string) + "_" + d.Get("certificate_arn").(string))
+
+	return resourceAwsLbListenerCertificateRead(d, meta)
+}
+
+func resourceAwsLbListenerCertificateRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).elbv2conn
+	params := &elbv2.DescribeListenerCertificatesInput{
+		ListenerArn: aws.String(d.Get("listener_arn").(string)),
+		PageSize:    aws.Int64(400),
+	}
+
+	morePages := true
+	found := false
+	for morePages && !found {
+		resp, err := conn.DescribeListenerCertificates(params)
+		if err != nil {
+			return errwrap.Wrapf("Error describing LB Listener Certificates: {{err}}", err)
+		}
+
+		for _, cert := range resp.Certificates {
+			// We don't care about the default certificate.
+			if *cert.IsDefault {
+				continue
+			}
+
+			if *cert.CertificateArn == d.Get("certificate_arn").(string) {
+				found = true
+			}
+		}
+
+		if *resp.NextMarker != "" {
+			params.Marker = resp.NextMarker
+		} else {
+			morePages = false
+		}
+	}
+
+	if !found {
+		log.Printf("[WARN] DescribeListenerCertificates - removing %s from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	return nil
+}
+
+func resourceAwsLbListenerCertificateDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).elbv2conn
+	params := &elbv2.RemoveListenerCertificatesInput{
+		ListenerArn: aws.String(d.Get("listener_arn").(string)),
+		Certificates: []*elbv2.Certificate{
+			&elbv2.Certificate{
+				CertificateArn: aws.String(d.Get("certificate_arn").(string)),
+			},
+		},
+	}
+
+	// Returns no useful response.
+	_, err := conn.RemoveListenerCertificates(params)
+	if err != nil {
+		return errwrap.Wrapf("Error removing LB Listener Certificate: {{err}}", err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_lb_listener_certificate_test.go
+++ b/aws/resource_aws_lb_listener_certificate_test.go
@@ -1,0 +1,226 @@
+package aws
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAwsLbListenerCertificate_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProvidersWithTLS,
+		CheckDestroy: testAccCheckAwsLbListenerCertificateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLbListenerCertificateConfig(acctest.RandString(5)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsLbListenerCertificateExists("aws_lb_listener_certificate.default"),
+					testAccCheckAwsLbListenerCertificateExists("aws_lb_listener_certificate.additional_1"),
+					testAccCheckAwsLbListenerCertificateExists("aws_lb_listener_certificate.additional_2"),
+					resource.TestCheckResourceAttrSet("aws_lb_listener_certificate.default", "listener_arn"),
+					resource.TestCheckResourceAttrSet("aws_lb_listener_certificate.default", "certificate_arn"),
+					resource.TestCheckResourceAttrSet("aws_lb_listener_certificate.additional_1", "listener_arn"),
+					resource.TestCheckResourceAttrSet("aws_lb_listener_certificate.additional_1", "certificate_arn"),
+					resource.TestCheckResourceAttrSet("aws_lb_listener_certificate.additional_2", "listener_arn"),
+					resource.TestCheckResourceAttrSet("aws_lb_listener_certificate.additional_2", "certificate_arn"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsLbListenerCertificateDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).elbv2conn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_lb_listener_certificate" {
+			continue
+		}
+
+		input := &elbv2.DescribeListenerCertificatesInput{
+			ListenerArn: aws.String(rs.Primary.Attributes["listener_arn"]),
+			PageSize:    aws.Int64(400),
+		}
+
+		resp, err := conn.DescribeListenerCertificates(input)
+		if err != nil {
+			return err
+		}
+
+		for _, cert := range resp.Certificates {
+			// We only care about additional certificates.
+			if *cert.IsDefault {
+				continue
+			}
+
+			if *cert.CertificateArn == rs.Primary.Attributes["certificate_arn"] {
+				return errors.New("LB listener certificate not destroyed")
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAwsLbListenerCertificateExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		return nil
+	}
+}
+
+func testAccLbListenerCertificateConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_lb_listener_certificate" "default" {
+  listener_arn    = "${aws_lb_listener.test.arn}"
+  certificate_arn = "${aws_iam_server_certificate.default.arn}"
+}
+
+resource "aws_lb_listener_certificate" "additional_1" {
+  listener_arn    = "${aws_lb_listener.test.arn}"
+  certificate_arn = "${aws_iam_server_certificate.additional_1.arn}"
+}
+
+resource "aws_lb_listener_certificate" "additional_2" {
+  listener_arn    = "${aws_lb_listener.test.arn}"
+  certificate_arn = "${aws_iam_server_certificate.additional_2.arn}"
+}
+
+resource "aws_lb" "test" {
+  name_prefix    = "%s"
+  subnets = ["${aws_subnet.test.*.id}"]
+  internal = true
+}
+
+resource "aws_lb_target_group" "test" {
+  port     = "443"
+  protocol = "HTTP"
+  vpc_id            = "${aws_vpc.test.id}"
+}
+
+resource "aws_lb_listener" "test" {
+  load_balancer_arn = "${aws_lb.test.arn}"
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-2015-05"
+  certificate_arn   = "${aws_iam_server_certificate.default.arn}"
+
+  default_action {
+    target_group_arn = "${aws_lb_target_group.test.arn}"
+    type             = "forward"
+  }
+}
+
+resource "aws_iam_server_certificate" "default" {
+  name             = "terraform-default-cert"
+  certificate_body = "${tls_self_signed_cert.default.cert_pem}"
+  private_key      = "${tls_private_key.default.private_key_pem}"
+}
+
+resource "tls_private_key" "default" {
+  algorithm = "RSA"
+}
+
+resource "tls_self_signed_cert" "default" {
+  key_algorithm   = "RSA"
+  private_key_pem = "${tls_private_key.default.private_key_pem}"
+
+  subject {
+    common_name  = "example.com"
+    organization = "ACME Examples, Inc"
+  }
+
+  validity_period_hours = 12
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+  ]
+}
+
+resource "aws_iam_server_certificate" "additional_1" {
+  name             = "terraform-additional-cert-1"
+  certificate_body = "${tls_self_signed_cert.additional_1.cert_pem}"
+  private_key      = "${tls_private_key.additional_1.private_key_pem}"
+}
+
+resource "tls_private_key" "additional_1" {
+  algorithm = "RSA"
+}
+
+resource "tls_self_signed_cert" "additional_1" {
+  key_algorithm   = "RSA"
+  private_key_pem = "${tls_private_key.additional_1.private_key_pem}"
+
+  subject {
+    common_name  = "one.example.com"
+    organization = "ACME Examples, Inc"
+  }
+
+  validity_period_hours = 12
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+  ]
+}
+
+resource "aws_iam_server_certificate" "additional_2" {
+  name             = "terraform-additional-cert-2"
+  certificate_body = "${tls_self_signed_cert.additional_2.cert_pem}"
+  private_key      = "${tls_private_key.additional_2.private_key_pem}"
+}
+
+resource "tls_private_key" "additional_2" {
+  algorithm = "RSA"
+}
+
+resource "tls_self_signed_cert" "additional_2" {
+  key_algorithm   = "RSA"
+  private_key_pem = "${tls_private_key.additional_2.private_key_pem}"
+
+  subject {
+    common_name  = "two.example.com"
+    organization = "ACME Examples, Inc"
+  }
+
+  validity_period_hours = 12
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+  ]
+}
+
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+}
+
+variable "subnets" {
+  default = ["10.0.1.0/24", "10.0.2.0/24"]
+}
+
+resource "aws_subnet" "test" {
+  count             = 2
+  vpc_id            = "${aws_vpc.test.id}"
+  cidr_block        = "${element(var.subnets, count.index)}"
+  availability_zone = "${element(data.aws_availability_zones.available.names, count.index)}"
+}
+`, rName)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -598,6 +598,10 @@
                             <a href="/docs/providers/aws/r/lb_listener.html">aws_alb_listener</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-elbv2-listener-certificate") %>>
+                          <a href="/docs/providers/aws/r/lb_listener_certificate.html">aws_alb_listener_certificate</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-aws-resource-elbv2-listener-rule") %>>
                           <a href="/docs/providers/aws/r/lb_listener_rule.html">aws_alb_listener_rule</a>
                         </li>
@@ -748,6 +752,10 @@
 
                         <li<%= sidebar_current("docs-aws-resource-elbv2-listener") %>>
                             <a href="/docs/providers/aws/r/lb_listener.html">aws_lb_listener</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-elbv2-listener-certificate") %>>
+                          <a href="/docs/providers/aws/r/lb_listener_certificate.html">aws_lb_listener_certificate</a>
                         </li>
 
                         <li<%= sidebar_current("docs-aws-resource-elbv2-listener-rule") %>>

--- a/website/docs/r/lb_listener.html.markdown
+++ b/website/docs/r/lb_listener.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
 * `port` - (Required) The port on which the load balancer is listening.
 * `protocol` - (Optional) The protocol for connections from clients to the load balancer. Valid values are `TCP`, `HTTP` and `HTTPS`. Defaults to `HTTP`.
 * `ssl_policy` - (Optional) The name of the SSL Policy for the listener. Required if `protocol` is `HTTPS`.
-* `certificate_arn` - (Optional) The ARN of the SSL server certificate. Exactly one certificate is required if the protocol is HTTPS.
+* `certificate_arn` - (Optional) The ARN of the default SSL server certificate. Exactly one certificate is required if the protocol is HTTPS.
 * `default_action` - (Required) An Action block. Action blocks are documented below.
 
 Action Blocks (for `default_action`) support the following:

--- a/website/docs/r/lb_listener_certificate.html.markdown
+++ b/website/docs/r/lb_listener_certificate.html.markdown
@@ -1,0 +1,44 @@
+---
+layout: "aws"
+page_title: "AWS: aws_lb_listener_certificate"
+sidebar_current: "docs-aws-resource-elbv2-listener-rule"
+description: |-
+  Provides a Load Balancer Listener Certificate resource.
+---
+
+# aws_lb_listener_certificate
+
+Provides a Load Balancer Listener Certificate resource.
+
+This resource is for additional certificates and does not replace the default certificate on the listener.
+
+~> **Note:** `aws_alb_listener_certificate` is known as `aws_lb_listener_certificate`. The functionality is identical.
+
+## Example Usage
+
+```hcl
+data "aws_acm_certificate" "example" {
+  domain   = "example.com"
+  statuses = ["ISSUED"]
+}
+
+resource "aws_lb" "front_end" {
+  # ...
+}
+
+resource "aws_lb_listener" "front_end" {
+  # ...
+}
+
+resource "aws_lb_listener_certificate" "example" {
+  listener_arn    = "${aws_lb_listener.front_end.arn}"
+  certificate_arn = "${aws_acm_certificate.example.arn}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `listener_arn` - (Required, Forces New Resource) The ARN of the listener to which to attach the certificate.
+* `certificate_arn` - (Required, Forces New Resource) The ARN of the certificate to attach to the listener.


### PR DESCRIPTION
This PR is for #1853 and is a second attempt of the PR #2203.

We create a new resource `aws_lb_listener_certificate` which is used to add additional certificates into an HTTPS load balancer listener. This does not effect the `certificate_arn` argument to `aws_lb_listener` as there must still be a default certificate assigned to the listener.

I need help with the acceptance tests currently. They currently fail in the destroy phase as I believe the listener resource is being destroyed before the listener certificate resource and therefore the listener cannot be found. This could fairly easily be worked around by allowing a `ListenerNotFound` error in the destroy test but I don't believe that'd be testing the destruction of this specific resource correctly. Maybe @radeksimko can be of assistance here (as he reviewed my previous PR).

Other than that failing test this is ready to go IMO.