### PR TITLE
Normalize Not found resource log lines on-read

### DIFF
--- a/aws/resource_aws_app_cookie_stickiness_policy.go
+++ b/aws/resource_aws_app_cookie_stickiness_policy.go
@@ -102,6 +102,7 @@ func resourceAwsAppCookieStickinessPolicyRead(d *schema.ResourceData, meta inter
 	if err != nil {
 		if ec2err, ok := err.(awserr.Error); ok {
 			if ec2err.Code() == "PolicyNotFound" || ec2err.Code() == "LoadBalancerNotFound" {
+				log.Printf("[WARN] Load Balancer / Load Balancer Policy (%s) not found, removing from state", d.Id())
 				d.SetId("")
 			}
 			return nil
@@ -131,8 +132,8 @@ func resourceAwsAppCookieStickinessPolicyRead(d *schema.ResourceData, meta inter
 	if *cookieAttr.AttributeName != "CookieName" {
 		return fmt.Errorf("Unable to find cookie Name.")
 	}
-	d.Set("cookie_name", cookieAttr.AttributeValue)
 
+	d.Set("cookie_name", cookieAttr.AttributeValue)
 	d.Set("name", policyName)
 	d.Set("load_balancer", lbName)
 	d.Set("lb_port", lbPort)

--- a/aws/resource_aws_appautoscaling_policy.go
+++ b/aws/resource_aws_appautoscaling_policy.go
@@ -292,6 +292,7 @@ func resourceAwsAppautoscalingPolicyRead(d *schema.ResourceData, meta interface{
 		return err
 	}
 	if p == nil {
+		log.Printf("[WARN] Application AutoScaling Policy (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}

--- a/aws/resource_aws_appautoscaling_scheduled_action.go
+++ b/aws/resource_aws_appautoscaling_scheduled_action.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -154,6 +155,7 @@ func resourceAwsAppautoscalingScheduledActionRead(d *schema.ResourceData, meta i
 		return err
 	}
 	if len(resp.ScheduledActions) < 1 {
+		log.Printf("[WARN] Application Autoscaling Scheduled Action (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
@@ -181,6 +183,7 @@ func resourceAwsAppautoscalingScheduledActionDelete(d *schema.ResourceData, meta
 	_, err := conn.DeleteScheduledAction(input)
 	if err != nil {
 		if isAWSErr(err, applicationautoscaling.ErrCodeObjectNotFoundException, "") {
+			log.Printf("[WARN] Application Autoscaling Scheduled Action (%s) already gone, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}

--- a/aws/resource_aws_appautoscaling_target.go
+++ b/aws/resource_aws_appautoscaling_target.go
@@ -103,7 +103,7 @@ func resourceAwsAppautoscalingTargetRead(d *schema.ResourceData, meta interface{
 		return err
 	}
 	if t == nil {
-		log.Printf("[INFO] Application AutoScaling Target %q not found", d.Id())
+		log.Printf("[WARN] Application AutoScaling Target (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}

--- a/aws/resource_aws_athena_named_query.go
+++ b/aws/resource_aws_athena_named_query.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"log"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/athena"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -67,6 +69,7 @@ func resourceAwsAthenaNamedQueryRead(d *schema.ResourceData, meta interface{}) e
 	_, err := conn.GetNamedQuery(input)
 	if err != nil {
 		if isAWSErr(err, athena.ErrCodeInvalidRequestException, d.Id()) {
+			log.Printf("[WARN] Athena Named Query (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}

--- a/aws/resource_aws_autoscaling_attachment.go
+++ b/aws/resource_aws_autoscaling_attachment.go
@@ -85,7 +85,7 @@ func resourceAwsAutoscalingAttachmentRead(d *schema.ResourceData, meta interface
 		return err
 	}
 	if asg == nil {
-		log.Printf("[INFO] Autoscaling Group %q not found", asgName)
+		log.Printf("[WARN] Autoscaling Group (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}

--- a/aws/resource_aws_autoscaling_group.go
+++ b/aws/resource_aws_autoscaling_group.go
@@ -459,7 +459,7 @@ func resourceAwsAutoscalingGroupRead(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 	if g == nil {
-		log.Printf("[INFO] Autoscaling Group %q not found", d.Id())
+		log.Printf("[WARN] Autoscaling Group (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
@@ -743,7 +743,7 @@ func resourceAwsAutoscalingGroupDelete(d *schema.ResourceData, meta interface{})
 		return err
 	}
 	if g == nil {
-		log.Printf("[INFO] Autoscaling Group %q not found", d.Id())
+		log.Printf("[WARN] Autoscaling Group (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
@@ -850,7 +850,7 @@ func resourceAwsAutoscalingGroupDrain(d *schema.ResourceData, meta interface{}) 
 			return resource.NonRetryableError(err)
 		}
 		if g == nil {
-			log.Printf("[INFO] Autoscaling Group %q not found", d.Id())
+			log.Printf("[WARN] Autoscaling Group (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}

--- a/aws/resource_aws_autoscaling_group_waiting.go
+++ b/aws/resource_aws_autoscaling_group_waiting.go
@@ -41,7 +41,7 @@ func waitForASGCapacity(
 			return resource.NonRetryableError(err)
 		}
 		if g == nil {
-			log.Printf("[INFO] Autoscaling Group %q not found", d.Id())
+			log.Printf("[WARN] Autoscaling Group (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}

--- a/aws/resource_aws_autoscaling_lifecycle_hook.go
+++ b/aws/resource_aws_autoscaling_lifecycle_hook.go
@@ -95,6 +95,7 @@ func resourceAwsAutoscalingLifecycleHookRead(d *schema.ResourceData, meta interf
 		return err
 	}
 	if p == nil {
+		log.Printf("[WARN] Autoscaling Lifecycle Hook (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}

--- a/aws/resource_aws_autoscaling_policy.go
+++ b/aws/resource_aws_autoscaling_policy.go
@@ -124,6 +124,7 @@ func resourceAwsAutoscalingPolicyRead(d *schema.ResourceData, meta interface{}) 
 		return err
 	}
 	if p == nil {
+		log.Printf("[WARN] Autoscaling Policy (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
@@ -276,7 +277,7 @@ func getAwsAutoscalingPolicy(d *schema.ResourceData, meta interface{}) (*autosca
 	if err != nil {
 		//A ValidationError here can mean that either the Policy is missing OR the Autoscaling Group is missing
 		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "ValidationError" {
-			log.Printf("[WARNING] %s not found, removing from state", d.Id())
+			log.Printf("[WARN] Autoscaling Policy (%s) not found, removing from state", d.Id())
 			d.SetId("")
 
 			return nil, nil

--- a/aws/resource_aws_autoscaling_schedule.go
+++ b/aws/resource_aws_autoscaling_schedule.go
@@ -135,7 +135,7 @@ func resourceAwsAutoscalingScheduleRead(d *schema.ResourceData, meta interface{}
 	}
 
 	if !exists {
-		log.Printf("Error retrieving Autoscaling Scheduled Actions. Removing from state")
+		log.Printf("[WARN] Autoscaling Scheduled Action (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
@@ -202,7 +202,7 @@ func resourceAwsASGScheduledActionRetrieve(d *schema.ResourceData, meta interfac
 	if err != nil {
 		//A ValidationError here can mean that either the Schedule is missing OR the Autoscaling Group is missing
 		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "ValidationError" {
-			log.Printf("[WARNING] %s not found, removing from state", d.Id())
+			log.Printf("[WARN] Autoscaling Scheduled Action (%s) not found, removing from state", d.Id())
 			d.SetId("")
 
 			return nil, nil, false


### PR DESCRIPTION
This continues the normalization / cleaning of the code, pieces by pieces. This adds more debug lines when reading from AWS, in case resources do not exist.

Context: App / Autoscalings