### PR TITLE
resource/aws_lambda_function: Make it possible to remove dead_letter_config

### DIFF
--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -565,13 +565,14 @@ func resourceAwsLambdaFunctionUpdate(d *schema.ResourceData, meta interface{}) e
 	}
 	if d.HasChange("dead_letter_config") {
 		dlcMaps := d.Get("dead_letter_config").([]interface{})
+		configReq.DeadLetterConfig = &lambda.DeadLetterConfig{
+			TargetArn: aws.String(""),
+		}
 		if len(dlcMaps) == 1 { // Schema guarantees either 0 or 1
 			dlcMap := dlcMaps[0].(map[string]interface{})
-			configReq.DeadLetterConfig = &lambda.DeadLetterConfig{
-				TargetArn: aws.String(dlcMap["target_arn"].(string)),
-			}
-			configUpdate = true
+			configReq.DeadLetterConfig.TargetArn = aws.String(dlcMap["target_arn"].(string))
 		}
+		configUpdate = true
 	}
 	if d.HasChange("tracing_config") {
 		tracingConfig := d.Get("tracing_config").([]interface{})


### PR DESCRIPTION
Make it possible to remove `dead_letter_config` by removing the block.

## Issue

Currently there is an issue removing `dead_letter_config` from a lambda function. The current work around is to:
1. Set `target_arn = ""`
2. Apply.
3. Remove `dead_letter_config` entirely.

If you don't do step 3, then you will get the following diff on subsequent plans:
```
  ~ aws_lambda_function.func
      dead_letter_config.#: "0" => "1"
```

With this change, you can just remove the whole `dead_letter_config` block and then apply.

## Tests

I tried looking into writing tests to cover this, but I don't have time to get up to speed on how to do that correctly right now. Feel free to add commits to this branch (edits from maintainers are allowed).

Thanks!!