### PR TITLE
resource/aws_directory_service_directory: Add security_group_id field

### DIFF
--- a/aws/resource_aws_directory_service_directory.go
+++ b/aws/resource_aws_directory_service_directory.go
@@ -134,6 +134,10 @@ func resourceAwsDirectoryServiceDirectory() *schema.Resource {
 				Set:      schema.HashString,
 				Computed: true,
 			},
+			"security_group_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"type": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -445,6 +449,10 @@ func resourceAwsDirectoryServiceDirectoryRead(d *schema.ResourceData, meta inter
 	d.Set("vpc_settings", flattenDSVpcSettings(dir.VpcSettings))
 	d.Set("connect_settings", flattenDSConnectSettings(dir.DnsIpAddrs, dir.ConnectSettings))
 	d.Set("enable_sso", *dir.SsoEnabled)
+
+	if dir.VpcSettings != nil {
+		d.Set("security_group_id", *dir.VpcSettings.SecurityGroupId)
+	}
 
 	tagList, err := dsconn.ListTagsForResource(&directoryservice.ListTagsForResourceInput{
 		ResourceId: aws.String(d.Id()),

--- a/aws/resource_aws_directory_service_directory_test.go
+++ b/aws/resource_aws_directory_service_directory_test.go
@@ -98,6 +98,7 @@ func TestAccAWSDirectoryServiceDirectory_basic(t *testing.T) {
 				Config: testAccDirectoryServiceDirectoryConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceDirectoryExists("aws_directory_service_directory.bar"),
+					resource.TestCheckResourceAttrSet("aws_directory_service_directory.bar", "security_group_id"),
 				),
 			},
 		},

--- a/website/docs/r/directory_service_directory.html.markdown
+++ b/website/docs/r/directory_service_directory.html.markdown
@@ -83,6 +83,7 @@ The following attributes are exported:
 * `id` - The directory identifier.
 * `access_url` - The access URL for the directory, such as `http://alias.awsapps.com`.
 * `dns_ip_addresses` - A list of IP addresses of the DNS servers for the directory or connector.
+* `security_group_id` - The ID of the security group created by the directory (`SimpleAD` or `MicrosoftAD` only).
 
 
 ## Import


### PR DESCRIPTION
Resolves #112.

Added `security_group_id` as a root attribute, even though it's technically part of the `VpcSettings` returned by AWS. I couldn't find an example of a computed attribute as a "sub-attribute" in other resources, ie:
 `directory_service_directory.foo.vpc_settings.security_group_id`...

Test Results
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSDirectoryServiceDirectory_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSDirectoryServiceDirectory_ -timeout 120m
=== RUN   TestAccAWSDirectoryServiceDirectory_importBasic
--- PASS: TestAccAWSDirectoryServiceDirectory_importBasic (481.14s)
=== RUN   TestAccAWSDirectoryServiceDirectory_basic
--- PASS: TestAccAWSDirectoryServiceDirectory_basic (489.55s)
=== RUN   TestAccAWSDirectoryServiceDirectory_tags
--- PASS: TestAccAWSDirectoryServiceDirectory_tags (542.55s)
=== RUN   TestAccAWSDirectoryServiceDirectory_microsoft
--- PASS: TestAccAWSDirectoryServiceDirectory_microsoft (1729.79s)
=== RUN   TestAccAWSDirectoryServiceDirectory_connector
--- PASS: TestAccAWSDirectoryServiceDirectory_connector (1031.32s)
=== RUN   TestAccAWSDirectoryServiceDirectory_withAliasAndSso
--- PASS: TestAccAWSDirectoryServiceDirectory_withAliasAndSso (562.31s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	4836.697s
```