### PR TITLE
Removing Duplicate State

### DIFF
--- a/website/docs/d/availability_zone.html.markdown
+++ b/website/docs/d/availability_zone.html.markdown
@@ -77,7 +77,7 @@ zone whose data will be exported as attributes.
 * `name` - (Optional) The full name of the availability zone to select.
 
 * `state` - (Optional) A specific availability zone state to require. May
-  be any of `"available"`, `"information"`, `"impaired"` or `"available"`.
+  be any of `"available"`, `"information"` or `"impaired"`.
 
 All reasonable uses of this data source will specify `name`, since `state`
 alone would match a single AZ only in a region that itself has only one AZ.


### PR DESCRIPTION
This PR looks to improve the AWS provider documentation. There is a duplicate `available` state in the documentation.