### PR TITLE
feat(region): support eu-west-3 region

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -487,6 +487,7 @@ func (c *Config) ValidateRegion() error {
 		"eu-central-1",
 		"eu-west-1",
 		"eu-west-2",
+		"eu-west-3",
 		"sa-east-1",
 		"us-east-1",
 		"us-east-2",

--- a/aws/data_source_aws_cloudtrail_service_account.go
+++ b/aws/data_source_aws_cloudtrail_service_account.go
@@ -21,6 +21,7 @@ var cloudTrailServiceAccountPerRegionMap = map[string]string{
 	"eu-central-1":   "035351147821",
 	"eu-west-1":      "859597730677",
 	"eu-west-2":      "282025262664",
+	"eu-west-3":      "262312530599",
 	"sa-east-1":      "814480443879",
 }
 

--- a/aws/data_source_aws_elb_hosted_zone_id.go
+++ b/aws/data_source_aws_elb_hosted_zone_id.go
@@ -6,9 +6,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
-// See https://github.com/fog/fog-aws/pull/332/files
-// This list isn't exposed by AWS - it's been found through
-// trouble solving
+// See http://docs.aws.amazon.com/general/latest/gr/rande.html#elb_region
 var elbHostedZoneIdPerRegionMap = map[string]string{
 	"ap-northeast-1": "Z14GRHDCWA56QT",
 	"ap-northeast-2": "ZWKZPGTI48KDX",
@@ -19,6 +17,7 @@ var elbHostedZoneIdPerRegionMap = map[string]string{
 	"eu-central-1":   "Z215JYRZR1TBD5",
 	"eu-west-1":      "Z32O12XQLNTSW2",
 	"eu-west-2":      "ZHURV8PSTC4K8",
+	"eu-west-3":      "Z3Q77PNBQS71R4",
 	"us-east-1":      "Z35SXDOTRQ7X7K",
 	"us-east-2":      "Z3AADJGX6KTTL2",
 	"us-west-1":      "Z368ELLRRE2KJ0",

--- a/aws/data_source_aws_elb_service_account.go
+++ b/aws/data_source_aws_elb_service_account.go
@@ -18,6 +18,7 @@ var elbAccountIdPerRegionMap = map[string]string{
 	"eu-central-1":   "054676820928",
 	"eu-west-1":      "156460612806",
 	"eu-west-2":      "652711504416",
+	"eu-west-3":      "", // aws doc not updated
 	"sa-east-1":      "507241528517",
 	"us-east-1":      "127311923021",
 	"us-east-2":      "033677994240",

--- a/aws/data_source_aws_redshift_service_account.go
+++ b/aws/data_source_aws_redshift_service_account.go
@@ -21,6 +21,7 @@ var redshiftServiceAccountPerRegionMap = map[string]string{
 	"eu-central-1":   "053454850223",
 	"eu-west-1":      "210876761215",
 	"eu-west-2":      "307160386991",
+	"eu-west-3":      "915173422425",
 	"sa-east-1":      "075028567923",
 }
 

--- a/aws/hosted_zones.go
+++ b/aws/hosted_zones.go
@@ -10,6 +10,7 @@ var hostedZoneIDsMap = map[string]string{
 	"us-west-1":      "Z2F56UZL2M1ACD",
 	"eu-west-1":      "Z1BKCTXD74EZPE",
 	"eu-west-2":      "Z3GKZC51ZF0DB4",
+	"eu-west-3":      "Z3R1K369G5AVDG",
 	"eu-central-1":   "Z21DNDUVLTQW6Q",
 	"ap-south-1":     "Z11RGJOFQNVJUP",
 	"ap-southeast-1": "Z3O0J2DXBE1FTB",

--- a/aws/website_endpoint_url_test.go
+++ b/aws/website_endpoint_url_test.go
@@ -11,6 +11,7 @@ var websiteEndpoints = []struct {
 	{"us-west-2", "bucket-name.s3-website-us-west-2.amazonaws.com"},
 	{"us-west-1", "bucket-name.s3-website-us-west-1.amazonaws.com"},
 	{"eu-west-1", "bucket-name.s3-website-eu-west-1.amazonaws.com"},
+	{"eu-west-3", "bucket-name.s3-website.eu-west-3.amazonaws.com"},
 	{"eu-central-1", "bucket-name.s3-website.eu-central-1.amazonaws.com"},
 	{"ap-south-1", "bucket-name.s3-website.ap-south-1.amazonaws.com"},
 	{"ap-southeast-1", "bucket-name.s3-website-ap-southeast-1.amazonaws.com"},


### PR DESCRIPTION
## Description

add support for `eu-west-3 (Paris)` region

## WIP
some ids are still missing from aws documentation, will update this PR when available

- [x] hosted zone id
- [x] cloudtrail service account
- [x] elb hosted zone id
- [x] redshift service account
- [x] elb account id

## Depends

- [x] #2706 Bump `aws-sdk-go` to v1.12.49
- [x] #2718 Bump `aws-sdk-go` to v1.12.50

## Resolve

resolves #2735