### PR TITLE
Minor fix for aws_default_security_group resource doc

### DIFF
--- a/website/docs/r/default_security_group.html.markdown
+++ b/website/docs/r/default_security_group.html.markdown
@@ -75,7 +75,7 @@ resource "aws_vpc" "mainvpc" {
 }
 
 resource "aws_default_security_group" "default" {
-  vpc_id = "${aws_vpc.mainvpc.vpc}"
+  vpc_id = "${aws_vpc.mainvpc.id}"
 
   ingress {
     protocol  = -1


### PR DESCRIPTION
Reasoning for Doc update:

I noticed a minor error in one of the examples on the docs website that had the security group pulling the `vpc_id` from `aws_vpc.mainvpc.vpc`. From what I've seen in the docs and code, it doesn't look like the `aws_vpc` resource exports a `vpc` attribute (unless I'm missing something). Also, the example above correctly uses the `id` attribute.