### PR TITLE
Randomize names in Lambda-related tests

### DIFF
--- a/aws/import_aws_lambda_function_test.go
+++ b/aws/import_aws_lambda_function_test.go
@@ -38,7 +38,7 @@ func testSweepLambdaFunctions(region string) error {
 
 	for _, f := range resp.Functions {
 		var testOptGroup bool
-		for _, testName := range []string{"tf_test"} {
+		for _, testName := range []string{"tf_test", "tf_acc_"} {
 			if strings.HasPrefix(*f.FunctionName, testName) {
 				testOptGroup = true
 			}
@@ -63,8 +63,11 @@ func testSweepLambdaFunctions(region string) error {
 func TestAccAWSLambdaFunction_importLocalFile(t *testing.T) {
 	resourceName := "aws_lambda_function.lambda_function_test"
 
-	rSt := acctest.RandString(5)
-	rName := fmt.Sprintf("tf_test_%s", rSt)
+	rString := acctest.RandString(8)
+	funcName := fmt.Sprintf("tf_acc_lambda_func_import_local_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_import_local_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_import_local_%s", rString)
+	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_import_local_%s", rString)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -72,7 +75,7 @@ func TestAccAWSLambdaFunction_importLocalFile(t *testing.T) {
 		CheckDestroy: testAccCheckLambdaFunctionDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSLambdaConfigBasic(rName, rSt),
+				Config: testAccAWSLambdaConfigBasic(funcName, policyName, roleName, sgName),
 			},
 
 			resource.TestStep{
@@ -88,8 +91,11 @@ func TestAccAWSLambdaFunction_importLocalFile(t *testing.T) {
 func TestAccAWSLambdaFunction_importLocalFile_VPC(t *testing.T) {
 	resourceName := "aws_lambda_function.lambda_function_test"
 
-	rSt := acctest.RandString(5)
-	rName := fmt.Sprintf("tf_test_%s", rSt)
+	rString := acctest.RandString(8)
+	funcName := fmt.Sprintf("tf_acc_lambda_func_import_vpc_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_import_vpc_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_import_vpc_%s", rString)
+	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_import_vpc_%s", rString)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -97,7 +103,7 @@ func TestAccAWSLambdaFunction_importLocalFile_VPC(t *testing.T) {
 		CheckDestroy: testAccCheckLambdaFunctionDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSLambdaConfigWithVPC(rName, rSt),
+				Config: testAccAWSLambdaConfigWithVPC(funcName, policyName, roleName, sgName),
 			},
 
 			resource.TestStep{
@@ -113,8 +119,10 @@ func TestAccAWSLambdaFunction_importLocalFile_VPC(t *testing.T) {
 func TestAccAWSLambdaFunction_importS3(t *testing.T) {
 	resourceName := "aws_lambda_function.lambda_function_s3test"
 
-	rSt := acctest.RandString(5)
-	rName := fmt.Sprintf("tf_test_%s", rSt)
+	rString := acctest.RandString(8)
+	bucketName := fmt.Sprintf("tf-acc-bucket-lambda-func-import-s3-%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_import_s3_%s", rString)
+	funcName := fmt.Sprintf("tf_acc_lambda_func_import_s3_%s", rString)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -122,7 +130,7 @@ func TestAccAWSLambdaFunction_importS3(t *testing.T) {
 		CheckDestroy: testAccCheckLambdaFunctionDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSLambdaConfigS3(rName, rSt),
+				Config: testAccAWSLambdaConfigS3(bucketName, roleName, funcName),
 			},
 
 			resource.TestStep{

--- a/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
@@ -120,12 +120,14 @@ func TestAccAWSKinesisFirehoseDeliveryStream_s3ConfigUpdates(t *testing.T) {
 }
 
 func TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3basic(t *testing.T) {
-	rSt := acctest.RandString(5)
-	rName := fmt.Sprintf("aws_kinesis_firehose_delivery_stream_test_%s", rSt)
+	rString := acctest.RandString(8)
+	funcName := fmt.Sprintf("aws_kinesis_firehose_delivery_stream_test_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_%s", rString)
 
 	var stream firehose.DeliveryStreamDescription
 	ri := acctest.RandInt()
-	config := testAccFirehoseAWSLambdaConfigBasic(rName, rSt) +
+	config := testAccFirehoseAWSLambdaConfigBasic(funcName, policyName, roleName) +
 		fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_extendedS3basic,
 			ri, ri, ri, ri)
 
@@ -146,12 +148,13 @@ func TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3basic(t *testing.T) {
 }
 
 func TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidProcessorType(t *testing.T) {
-
-	rSt := acctest.RandString(5)
-	rName := fmt.Sprintf("aws_kinesis_firehose_delivery_stream_test_%s", rSt)
+	rString := acctest.RandString(8)
+	funcName := fmt.Sprintf("aws_kinesis_firehose_delivery_stream_test_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_%s", rString)
 
 	ri := acctest.RandInt()
-	config := testAccFirehoseAWSLambdaConfigBasic(rName, rSt) +
+	config := testAccFirehoseAWSLambdaConfigBasic(funcName, policyName, roleName) +
 		fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_extendedS3InvalidProcessorType,
 			ri, ri, ri, ri)
 
@@ -169,12 +172,13 @@ func TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidProcessorType(t *t
 }
 
 func TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidParameterName(t *testing.T) {
-
-	rSt := acctest.RandString(5)
-	rName := fmt.Sprintf("aws_kinesis_firehose_delivery_stream_test_%s", rSt)
+	rString := acctest.RandString(8)
+	funcName := fmt.Sprintf("aws_kinesis_firehose_delivery_stream_test_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_%s", rString)
 
 	ri := acctest.RandInt()
-	config := testAccFirehoseAWSLambdaConfigBasic(rName, rSt) +
+	config := testAccFirehoseAWSLambdaConfigBasic(funcName, policyName, roleName) +
 		fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_extendedS3InvalidParameterName,
 			ri, ri, ri, ri)
 
@@ -192,17 +196,18 @@ func TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidParameterName(t *t
 }
 
 func TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3Updates(t *testing.T) {
-
-	rSt := acctest.RandString(5)
-	rName := fmt.Sprintf("aws_kinesis_firehose_delivery_stream_test_%s", rSt)
+	rString := acctest.RandString(8)
+	funcName := fmt.Sprintf("aws_kinesis_firehose_delivery_stream_test_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_%s", rString)
 
 	var stream firehose.DeliveryStreamDescription
 	ri := acctest.RandInt()
 
-	preConfig := testAccFirehoseAWSLambdaConfigBasic(rName, rSt) +
+	preConfig := testAccFirehoseAWSLambdaConfigBasic(funcName, policyName, roleName) +
 		fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_extendedS3basic,
 			ri, ri, ri, ri)
-	postConfig := testAccFirehoseAWSLambdaConfigBasic(rName, rSt) +
+	postConfig := testAccFirehoseAWSLambdaConfigBasic(funcName, policyName, roleName) +
 		fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_extendedS3Updates,
 			ri, ri, ri, ri)
 
@@ -524,10 +529,10 @@ func testAccCheckFirehoseLambdaFunctionDestroy(s *terraform.State) error {
 	return nil
 }
 
-func baseAccFirehoseAWSLambdaConfig(rst string) string {
+func baseAccFirehoseAWSLambdaConfig(policyName, roleName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role_policy" "iam_policy_for_lambda" {
-    name = "iam_policy_for_lambda_%s"
+    name = "%s"
     role = "${aws_iam_role.iam_for_lambda.id}"
     policy = <<EOF
 {
@@ -557,7 +562,7 @@ EOF
 }
 
 resource "aws_iam_role" "iam_for_lambda" {
-    name = "iam_for_lambda_%s"
+    name = "%s"
     assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -574,11 +579,11 @@ resource "aws_iam_role" "iam_for_lambda" {
 }
 EOF
 }
-`, rst, rst)
+`, policyName, roleName)
 }
 
-func testAccFirehoseAWSLambdaConfigBasic(rName, rSt string) string {
-	return fmt.Sprintf(baseAccFirehoseAWSLambdaConfig(rSt)+`
+func testAccFirehoseAWSLambdaConfigBasic(funcName, policyName, roleName string) string {
+	return fmt.Sprintf(baseAccFirehoseAWSLambdaConfig(policyName, roleName)+`
 resource "aws_lambda_function" "lambda_function_test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
@@ -586,7 +591,7 @@ resource "aws_lambda_function" "lambda_function_test" {
     handler = "exports.example"
     runtime = "nodejs4.3"
 }
-`, rName)
+`, funcName)
 }
 
 const testAccKinesisFirehoseDeliveryStreamBaseConfig = `

--- a/aws/resource_aws_lambda_alias_test.go
+++ b/aws/resource_aws_lambda_alias_test.go
@@ -14,7 +14,13 @@ import (
 
 func TestAccAWSLambdaAlias_basic(t *testing.T) {
 	var conf lambda.AliasConfiguration
-	rInt := acctest.RandInt()
+
+	rString := acctest.RandString(8)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_alias_basic_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_lambda_alias_basic_%s", rString)
+	attachmentName := fmt.Sprintf("tf_acc_attachment_%s", rString)
+	funcName := fmt.Sprintf("tf_acc_lambda_func_alias_basic_%s", rString)
+	aliasName := fmt.Sprintf("tf_acc_lambda_alias_basic_%s", rString)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -22,11 +28,12 @@ func TestAccAWSLambdaAlias_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAwsLambdaAliasDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAwsLambdaAliasConfig(rInt),
+				Config: testAccAwsLambdaAliasConfig(roleName, policyName, attachmentName, funcName, aliasName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaAliasExists("aws_lambda_alias.lambda_alias_test", &conf),
 					testAccCheckAwsLambdaAttributes(&conf),
-					resource.TestMatchResourceAttr("aws_lambda_alias.lambda_alias_test", "arn", regexp.MustCompile(`^arn:aws:lambda:[a-z]+-[a-z]+-[0-9]+:\d{12}:function:example_lambda_name_create:testalias$`)),
+					resource.TestMatchResourceAttr("aws_lambda_alias.lambda_alias_test", "arn",
+						regexp.MustCompile(`^arn:aws:lambda:[a-z]+-[a-z]+-[0-9]+:\d{12}:function:`+funcName+`:`+aliasName+`$`)),
 				),
 			},
 		},
@@ -69,7 +76,7 @@ func testAccCheckAwsLambdaAliasExists(n string, mapping *lambda.AliasConfigurati
 
 		params := &lambda.GetAliasInput{
 			FunctionName: aws.String(rs.Primary.ID),
-			Name:         aws.String("testalias"),
+			Name:         aws.String(rs.Primary.Attributes["name"]),
 		}
 
 		getAliasConfiguration, err := conn.GetAlias(params)
@@ -97,10 +104,10 @@ func testAccCheckAwsLambdaAttributes(mapping *lambda.AliasConfiguration) resourc
 	}
 }
 
-func testAccAwsLambdaAliasConfig(rInt int) string {
+func testAccAwsLambdaAliasConfig(roleName, policyName, attachmentName, funcName, aliasName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "iam_for_lambda" {
-  name = "iam_for_lambda_%d"
+  name = "%s"
 
   assume_role_policy = <<EOF
 {
@@ -120,7 +127,7 @@ EOF
 }
 
 resource "aws_iam_policy" "policy_for_role" {
-  name        = "policy_for_role_%d"
+  name        = "%s"
   path        = "/"
   description = "IAM policy for for Lamda alias testing"
 
@@ -141,23 +148,23 @@ EOF
 }
 
 resource "aws_iam_policy_attachment" "policy_attachment_for_role" {
-  name       = "policy_attachment_for_role_%d"
+  name       = "%s"
   roles      = ["${aws_iam_role.iam_for_lambda.name}"]
   policy_arn = "${aws_iam_policy.policy_for_role.arn}"
 }
 
 resource "aws_lambda_function" "lambda_function_test_create" {
   filename      = "test-fixtures/lambdatest.zip"
-  function_name = "example_lambda_name_create"
+  function_name = "%s"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
   handler       = "exports.example"
   runtime       = "nodejs4.3"
 }
 
 resource "aws_lambda_alias" "lambda_alias_test" {
-  name             = "testalias"
+  name             = "%s"
   description      = "a sample description"
   function_name    = "${aws_lambda_function.lambda_function_test_create.arn}"
   function_version = "$LATEST"
-}`, rInt, rInt, rInt)
+}`, roleName, policyName, attachmentName, funcName, aliasName)
 }

--- a/aws/resource_aws_lambda_function_test.go
+++ b/aws/resource_aws_lambda_function_test.go
@@ -20,8 +20,11 @@ import (
 func TestAccAWSLambdaFunction_basic(t *testing.T) {
 	var conf lambda.GetFunctionOutput
 
-	rSt := acctest.RandString(5)
-	rName := fmt.Sprintf("tf_test_%s", rSt)
+	rString := acctest.RandString(8)
+	funcName := fmt.Sprintf("tf_acc_lambda_func_basic_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_basic_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_basic_%s", rString)
+	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_basic_%s", rString)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -29,11 +32,11 @@ func TestAccAWSLambdaFunction_basic(t *testing.T) {
 		CheckDestroy: testAccCheckLambdaFunctionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLambdaConfigBasic(rName, rSt),
+				Config: testAccAWSLambdaConfigBasic(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", rName, &conf),
-					testAccCheckAwsLambdaFunctionName(&conf, rName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+rName),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, funcName),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
 					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "reserved_concurrent_executions", "0"),
 				),
 			},
@@ -44,8 +47,11 @@ func TestAccAWSLambdaFunction_basic(t *testing.T) {
 func TestAccAWSLambdaFunction_concurrency(t *testing.T) {
 	var conf lambda.GetFunctionOutput
 
-	rSt := acctest.RandString(5)
-	rName := fmt.Sprintf("tf_test_%s", rSt)
+	rString := acctest.RandString(8)
+	funcName := fmt.Sprintf("tf_acc_lambda_func_concurrency_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_concurrency_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_concurrency_%s", rString)
+	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_concurrency_%s", rString)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -53,20 +59,20 @@ func TestAccAWSLambdaFunction_concurrency(t *testing.T) {
 		CheckDestroy: testAccCheckLambdaFunctionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLambdaConfigBasicConcurrency(rName, rSt),
+				Config: testAccAWSLambdaConfigBasicConcurrency(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", rName, &conf),
-					testAccCheckAwsLambdaFunctionName(&conf, rName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+rName),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, funcName),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
 					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "reserved_concurrent_executions", "111"),
 				),
 			},
 			{
-				Config: testAccAWSLambdaConfigConcurrencyUpdate(rName, rSt),
+				Config: testAccAWSLambdaConfigConcurrencyUpdate(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", rName, &conf),
-					testAccCheckAwsLambdaFunctionName(&conf, rName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+rName),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, funcName),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
 					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "reserved_concurrent_executions", "222"),
 				),
 			},
@@ -77,8 +83,11 @@ func TestAccAWSLambdaFunction_concurrency(t *testing.T) {
 func TestAccAWSLambdaFunction_concurrencyCycle(t *testing.T) {
 	var conf lambda.GetFunctionOutput
 
-	rSt := acctest.RandString(5)
-	rName := fmt.Sprintf("tf_test_%s", rSt)
+	rString := acctest.RandString(8)
+	funcName := fmt.Sprintf("tf_acc_lambda_func_concurrency_cycle_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_concurrency_cycle_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_concurrency_cycle_%s", rString)
+	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_concurrency_cycle_%s", rString)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -86,29 +95,29 @@ func TestAccAWSLambdaFunction_concurrencyCycle(t *testing.T) {
 		CheckDestroy: testAccCheckLambdaFunctionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLambdaConfigBasic(rName, rSt),
+				Config: testAccAWSLambdaConfigBasic(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", rName, &conf),
-					testAccCheckAwsLambdaFunctionName(&conf, rName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+rName),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, funcName),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
 					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "reserved_concurrent_executions", "0"),
 				),
 			},
 			{
-				Config: testAccAWSLambdaConfigConcurrencyUpdate(rName, rSt),
+				Config: testAccAWSLambdaConfigConcurrencyUpdate(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", rName, &conf),
-					testAccCheckAwsLambdaFunctionName(&conf, rName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+rName),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, funcName),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
 					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "reserved_concurrent_executions", "222"),
 				),
 			},
 			{
-				Config: testAccAWSLambdaConfigBasic(rName, rSt),
+				Config: testAccAWSLambdaConfigBasic(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", rName, &conf),
-					testAccCheckAwsLambdaFunctionName(&conf, rName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+rName),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, funcName),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
 					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "reserved_concurrent_executions", "0"),
 				),
 			},
@@ -119,8 +128,11 @@ func TestAccAWSLambdaFunction_concurrencyCycle(t *testing.T) {
 func TestAccAWSLambdaFunction_updateRuntime(t *testing.T) {
 	var conf lambda.GetFunctionOutput
 
-	rSt := acctest.RandString(5)
-	rName := fmt.Sprintf("tf_test_%s", rSt)
+	rString := acctest.RandString(8)
+	funcName := fmt.Sprintf("tf_acc_lambda_func_update_runtime_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_update_runtime_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_update_runtime_%s", rString)
+	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_update_runtime_%s", rString)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -128,16 +140,16 @@ func TestAccAWSLambdaFunction_updateRuntime(t *testing.T) {
 		CheckDestroy: testAccCheckLambdaFunctionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLambdaConfigBasic(rName, rSt),
+				Config: testAccAWSLambdaConfigBasic(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", rName, &conf),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
 					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "runtime", "nodejs4.3"),
 				),
 			},
 			{
-				Config: testAccAWSLambdaConfigBasicUpdateRuntime(rName, rSt),
+				Config: testAccAWSLambdaConfigBasicUpdateRuntime(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", rName, &conf),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
 					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "runtime", "nodejs4.3-edge"),
 				),
 			},
@@ -146,8 +158,11 @@ func TestAccAWSLambdaFunction_updateRuntime(t *testing.T) {
 }
 
 func TestAccAWSLambdaFunction_expectFilenameAndS3Attributes(t *testing.T) {
-	rSt := acctest.RandString(5)
-	rName := fmt.Sprintf("tf_test_%s", rSt)
+	rString := acctest.RandString(8)
+	funcName := fmt.Sprintf("tf_acc_lambda_func_expect_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_expect_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_expect_%s", rString)
+	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_expect_%s", rString)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -155,7 +170,7 @@ func TestAccAWSLambdaFunction_expectFilenameAndS3Attributes(t *testing.T) {
 		CheckDestroy: testAccCheckLambdaFunctionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccAWSLambdaConfigWithoutFilenameAndS3Attributes(rName, rSt),
+				Config:      testAccAWSLambdaConfigWithoutFilenameAndS3Attributes(funcName, policyName, roleName, sgName),
 				ExpectError: regexp.MustCompile(`filename or s3_\* attributes must be set`),
 			},
 		},
@@ -165,8 +180,11 @@ func TestAccAWSLambdaFunction_expectFilenameAndS3Attributes(t *testing.T) {
 func TestAccAWSLambdaFunction_envVariables(t *testing.T) {
 	var conf lambda.GetFunctionOutput
 
-	rSt := acctest.RandString(5)
-	rName := fmt.Sprintf("tf_test_%s", rSt)
+	rString := acctest.RandString(8)
+	funcName := fmt.Sprintf("tf_acc_lambda_func_env_vars_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_env_vars_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_env_vars_%s", rString)
+	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_env_vars_%s", rString)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -174,39 +192,39 @@ func TestAccAWSLambdaFunction_envVariables(t *testing.T) {
 		CheckDestroy: testAccCheckLambdaFunctionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLambdaConfigBasic(rName, rSt),
+				Config: testAccAWSLambdaConfigBasic(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", rName, &conf),
-					testAccCheckAwsLambdaFunctionName(&conf, rName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+rName),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, funcName),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
 					resource.TestCheckNoResourceAttr("aws_lambda_function.lambda_function_test", "environment"),
 				),
 			},
 			{
-				Config: testAccAWSLambdaConfigEnvVariables(rName, rSt),
+				Config: testAccAWSLambdaConfigEnvVariables(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", rName, &conf),
-					testAccCheckAwsLambdaFunctionName(&conf, rName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+rName),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, funcName),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
 					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "environment.0.variables.foo", "bar"),
 				),
 			},
 			{
-				Config: testAccAWSLambdaConfigEnvVariablesModified(rName, rSt),
+				Config: testAccAWSLambdaConfigEnvVariablesModified(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", rName, &conf),
-					testAccCheckAwsLambdaFunctionName(&conf, rName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+rName),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, funcName),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
 					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "environment.0.variables.foo", "baz"),
 					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "environment.0.variables.foo1", "bar1"),
 				),
 			},
 			{
-				Config: testAccAWSLambdaConfigEnvVariablesModifiedWithoutEnvironment(rName, rSt),
+				Config: testAccAWSLambdaConfigEnvVariablesModifiedWithoutEnvironment(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", rName, &conf),
-					testAccCheckAwsLambdaFunctionName(&conf, rName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+rName),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, funcName),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
 					resource.TestCheckNoResourceAttr("aws_lambda_function.lambda_function_test", "environment"),
 				),
 			},
@@ -217,8 +235,12 @@ func TestAccAWSLambdaFunction_envVariables(t *testing.T) {
 func TestAccAWSLambdaFunction_encryptedEnvVariables(t *testing.T) {
 	var conf lambda.GetFunctionOutput
 
-	rSt := acctest.RandString(5)
-	rName := fmt.Sprintf("tf_test_%s", rSt)
+	rString := acctest.RandString(8)
+	keyDesc := fmt.Sprintf("tf_acc_key_lambda_func_encrypted_env_%s", rString)
+	funcName := fmt.Sprintf("tf_acc_lambda_func_encrypted_env_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_encrypted_env_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_encrypted_env_%s", rString)
+	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_encrypted_env_%s", rString)
 	keyRegex := regexp.MustCompile("^arn:aws:kms:")
 
 	resource.Test(t, resource.TestCase{
@@ -227,21 +249,21 @@ func TestAccAWSLambdaFunction_encryptedEnvVariables(t *testing.T) {
 		CheckDestroy: testAccCheckLambdaFunctionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLambdaConfigEncryptedEnvVariables(rName, rSt),
+				Config: testAccAWSLambdaConfigEncryptedEnvVariables(keyDesc, funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", rName, &conf),
-					testAccCheckAwsLambdaFunctionName(&conf, rName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+rName),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, funcName),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
 					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "environment.0.variables.foo", "bar"),
 					resource.TestMatchResourceAttr("aws_lambda_function.lambda_function_test", "kms_key_arn", keyRegex),
 				),
 			},
 			{
-				Config: testAccAWSLambdaConfigEncryptedEnvVariablesModified(rName, rSt),
+				Config: testAccAWSLambdaConfigEncryptedEnvVariablesModified(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", rName, &conf),
-					testAccCheckAwsLambdaFunctionName(&conf, rName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+rName),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, funcName),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
 					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "environment.0.variables.foo", "bar"),
 					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "kms_key_arn", ""),
 				),
@@ -253,8 +275,11 @@ func TestAccAWSLambdaFunction_encryptedEnvVariables(t *testing.T) {
 func TestAccAWSLambdaFunction_versioned(t *testing.T) {
 	var conf lambda.GetFunctionOutput
 
-	rSt := acctest.RandString(5)
-	rName := fmt.Sprintf("tf_test_%s", rSt)
+	rString := acctest.RandString(8)
+	funcName := fmt.Sprintf("tf_acc_lambda_func_versioned_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_versioned_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_versioned_%s", rString)
+	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_versioned_%s", rString)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -262,15 +287,15 @@ func TestAccAWSLambdaFunction_versioned(t *testing.T) {
 		CheckDestroy: testAccCheckLambdaFunctionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLambdaConfigVersioned(rName, rSt),
+				Config: testAccAWSLambdaConfigVersioned(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", rName, &conf),
-					testAccCheckAwsLambdaFunctionName(&conf, rName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+rName),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, funcName),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
 					resource.TestMatchResourceAttr("aws_lambda_function.lambda_function_test", "version",
 						regexp.MustCompile("^[0-9]+$")),
 					resource.TestMatchResourceAttr("aws_lambda_function.lambda_function_test", "qualified_arn",
-						regexp.MustCompile(":"+rName+":[0-9]+$")),
+						regexp.MustCompile(":"+funcName+":[0-9]+$")),
 				),
 			},
 		},
@@ -280,8 +305,12 @@ func TestAccAWSLambdaFunction_versioned(t *testing.T) {
 func TestAccAWSLambdaFunction_DeadLetterConfig(t *testing.T) {
 	var conf lambda.GetFunctionOutput
 
-	rSt := acctest.RandString(5)
-	rName := fmt.Sprintf("tf_test_%s", rSt)
+	rString := acctest.RandString(8)
+	funcName := fmt.Sprintf("tf_acc_lambda_func_dlconfig_%s", rString)
+	topicName := fmt.Sprintf("tf_acc_topic_lambda_func_dlconfig_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_dlconfig_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_dlconfig_%s", rString)
+	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_dlconfig_%s", rString)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -289,15 +318,15 @@ func TestAccAWSLambdaFunction_DeadLetterConfig(t *testing.T) {
 		CheckDestroy: testAccCheckLambdaFunctionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLambdaConfigWithDeadLetterConfig(rName, rSt),
+				Config: testAccAWSLambdaConfigWithDeadLetterConfig(funcName, topicName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", rName, &conf),
-					testAccCheckAwsLambdaFunctionName(&conf, rName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+rName),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, funcName),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
 					func(s *terraform.State) error {
-						if !strings.HasSuffix(*conf.Configuration.DeadLetterConfig.TargetArn, ":"+rName) {
+						if !strings.HasSuffix(*conf.Configuration.DeadLetterConfig.TargetArn, ":"+topicName) {
 							return fmt.Errorf(
-								"Expected DeadLetterConfig.TargetArn %s to have suffix %s", *conf.Configuration.DeadLetterConfig.TargetArn, ":"+rName,
+								"Expected DeadLetterConfig.TargetArn %s to have suffix %s", *conf.Configuration.DeadLetterConfig.TargetArn, ":"+topicName,
 							)
 						}
 						return nil
@@ -311,9 +340,14 @@ func TestAccAWSLambdaFunction_DeadLetterConfig(t *testing.T) {
 func TestAccAWSLambdaFunction_DeadLetterConfigUpdated(t *testing.T) {
 	var conf lambda.GetFunctionOutput
 
-	rSt := acctest.RandString(5)
-	rName := fmt.Sprintf("tf_test_%s", rSt)
-	rNameUpdated := fmt.Sprintf("tf_test_%s_updated", rSt)
+	rString := acctest.RandString(8)
+	funcName := fmt.Sprintf("tf_acc_lambda_func_dlcfg_upd_%s", rString)
+	uFuncName := fmt.Sprintf("tf_acc_lambda_func_dlcfg_upd_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_dlcfg_upd_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_dlcfg_upd_%s", rString)
+	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_dlcfg_upd_%s", rString)
+	topic1Name := fmt.Sprintf("tf_acc_topic_lambda_func_dlcfg_upd_%s", rString)
+	topic2Name := fmt.Sprintf("tf_acc_topic_lambda_func_dlcfg_upd_2_%s", rString)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -321,16 +355,16 @@ func TestAccAWSLambdaFunction_DeadLetterConfigUpdated(t *testing.T) {
 		CheckDestroy: testAccCheckLambdaFunctionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLambdaConfigWithDeadLetterConfig(rName, rSt),
+				Config: testAccAWSLambdaConfigWithDeadLetterConfig(funcName, topic1Name, policyName, roleName, sgName),
 			},
 			{
-				Config: testAccAWSLambdaConfigWithDeadLetterConfigUpdated(rName, rSt, rNameUpdated),
+				Config: testAccAWSLambdaConfigWithDeadLetterConfigUpdated(funcName, topic1Name, topic2Name, policyName, roleName, sgName, uFuncName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", rName, &conf),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
 					func(s *terraform.State) error {
-						if !strings.HasSuffix(*conf.Configuration.DeadLetterConfig.TargetArn, ":"+rNameUpdated) {
+						if !strings.HasSuffix(*conf.Configuration.DeadLetterConfig.TargetArn, ":"+topic2Name) {
 							return fmt.Errorf(
-								"Expected DeadLetterConfig.TargetArn %s to have suffix %s", *conf.Configuration.DeadLetterConfig.TargetArn, ":"+rNameUpdated,
+								"Expected DeadLetterConfig.TargetArn %s to have suffix %s", *conf.Configuration.DeadLetterConfig.TargetArn, ":"+topic2Name,
 							)
 						}
 						return nil
@@ -342,8 +376,11 @@ func TestAccAWSLambdaFunction_DeadLetterConfigUpdated(t *testing.T) {
 }
 
 func TestAccAWSLambdaFunction_nilDeadLetterConfig(t *testing.T) {
-	rSt := acctest.RandString(5)
-	rName := fmt.Sprintf("tf_test_%s", rSt)
+	rString := acctest.RandString(8)
+	funcName := fmt.Sprintf("tf_acc_lambda_func_nil_dlcfg_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_nil_dlcfg_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_nil_dlcfg_%s", rString)
+	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_nil_dlcfg_%s", rString)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -351,9 +388,9 @@ func TestAccAWSLambdaFunction_nilDeadLetterConfig(t *testing.T) {
 		CheckDestroy: testAccCheckLambdaFunctionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLambdaConfigWithNilDeadLetterConfig(rName, rSt),
+				Config: testAccAWSLambdaConfigWithNilDeadLetterConfig(funcName, policyName, roleName, sgName),
 				ExpectError: regexp.MustCompile(
-					fmt.Sprintf("Nil dead_letter_config supplied for function: %s", rName)),
+					fmt.Sprintf("Nil dead_letter_config supplied for function: %s", funcName)),
 			},
 		},
 	})
@@ -362,8 +399,11 @@ func TestAccAWSLambdaFunction_nilDeadLetterConfig(t *testing.T) {
 func TestAccAWSLambdaFunction_tracingConfig(t *testing.T) {
 	var conf lambda.GetFunctionOutput
 
-	rSt := acctest.RandString(5)
-	rName := fmt.Sprintf("tf_test_%s", rSt)
+	rString := acctest.RandString(8)
+	funcName := fmt.Sprintf("tf_acc_lambda_func_tracing_cfg_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_tracing_cfg_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_tracing_cfg_%s", rString)
+	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_tracing_cfg_%s", rString)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -371,20 +411,20 @@ func TestAccAWSLambdaFunction_tracingConfig(t *testing.T) {
 		CheckDestroy: testAccCheckLambdaFunctionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLambdaConfigWithTracingConfig(rName, rSt),
+				Config: testAccAWSLambdaConfigWithTracingConfig(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", rName, &conf),
-					testAccCheckAwsLambdaFunctionName(&conf, rName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+rName),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, funcName),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
 					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "tracing_config.0.mode", "Active"),
 				),
 			},
 			{
-				Config: testAccAWSLambdaConfigWithTracingConfigUpdated(rName, rSt),
+				Config: testAccAWSLambdaConfigWithTracingConfigUpdated(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", rName, &conf),
-					testAccCheckAwsLambdaFunctionName(&conf, rName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+rName),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, funcName),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
 					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "tracing_config.0.mode", "PassThrough"),
 				),
 			},
@@ -395,8 +435,11 @@ func TestAccAWSLambdaFunction_tracingConfig(t *testing.T) {
 func TestAccAWSLambdaFunction_VPC(t *testing.T) {
 	var conf lambda.GetFunctionOutput
 
-	rSt := acctest.RandString(5)
-	rName := fmt.Sprintf("tf_test_%s", rSt)
+	rString := acctest.RandString(8)
+	funcName := fmt.Sprintf("tf_acc_lambda_func_vpc_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_vpc_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_vpc_%s", rString)
+	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_vpc_%s", rString)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -404,11 +447,11 @@ func TestAccAWSLambdaFunction_VPC(t *testing.T) {
 		CheckDestroy: testAccCheckLambdaFunctionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLambdaConfigWithVPC(rName, rSt),
+				Config: testAccAWSLambdaConfigWithVPC(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", rName, &conf),
-					testAccCheckAwsLambdaFunctionName(&conf, rName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+rName),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, funcName),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
 					testAccCheckAWSLambdaFunctionVersion(&conf, "$LATEST"),
 					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "vpc_config.#", "1"),
 					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "vpc_config.0.subnet_ids.#", "1"),
@@ -423,8 +466,12 @@ func TestAccAWSLambdaFunction_VPC(t *testing.T) {
 func TestAccAWSLambdaFunction_VPCUpdate(t *testing.T) {
 	var conf lambda.GetFunctionOutput
 
-	rSt := acctest.RandString(5)
-	rName := fmt.Sprintf("tf_test_%s", rSt)
+	rString := acctest.RandString(8)
+	funcName := fmt.Sprintf("tf_acc_lambda_func_vpc_upd_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_vpc_upd_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_vpc_upd_%s", rString)
+	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_vpc_upd_%s", rString)
+	sgName2 := fmt.Sprintf("tf_acc_sg_lambda_func_2nd_vpc_upd_%s", rString)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -432,11 +479,11 @@ func TestAccAWSLambdaFunction_VPCUpdate(t *testing.T) {
 		CheckDestroy: testAccCheckLambdaFunctionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLambdaConfigWithVPC(rName, rSt),
+				Config: testAccAWSLambdaConfigWithVPC(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", rName, &conf),
-					testAccCheckAwsLambdaFunctionName(&conf, rName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+rName),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, funcName),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
 					testAccCheckAWSLambdaFunctionVersion(&conf, "$LATEST"),
 					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "vpc_config.#", "1"),
 					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "vpc_config.0.subnet_ids.#", "1"),
@@ -444,11 +491,11 @@ func TestAccAWSLambdaFunction_VPCUpdate(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSLambdaConfigWithVPCUpdated(rName, rSt),
+				Config: testAccAWSLambdaConfigWithVPCUpdated(funcName, policyName, roleName, sgName, sgName2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", rName, &conf),
-					testAccCheckAwsLambdaFunctionName(&conf, rName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+rName),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, funcName),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
 					testAccCheckAWSLambdaFunctionVersion(&conf, "$LATEST"),
 					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "vpc_config.#", "1"),
 					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "vpc_config.0.subnet_ids.#", "2"),
@@ -464,8 +511,11 @@ func TestAccAWSLambdaFunction_VPCUpdate(t *testing.T) {
 func TestAccAWSLambdaFunction_VPC_withInvocation(t *testing.T) {
 	var conf lambda.GetFunctionOutput
 
-	rSt := acctest.RandString(5)
-	rName := fmt.Sprintf("tf_test_%s", rSt)
+	rString := acctest.RandString(8)
+	funcName := fmt.Sprintf("tf_acc_lambda_func_vpc_w_invc_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_vpc_w_invc_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_vpc_w_invc_%s", rString)
+	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_vpc_w_invc_%s", rString)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -473,9 +523,9 @@ func TestAccAWSLambdaFunction_VPC_withInvocation(t *testing.T) {
 		CheckDestroy: testAccCheckLambdaFunctionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLambdaConfigWithVPC(rName, rSt),
+				Config: testAccAWSLambdaConfigWithVPC(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", rName, &conf),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
 					testAccAwsInvokeLambdaFunction(&conf),
 				),
 			},
@@ -485,8 +535,11 @@ func TestAccAWSLambdaFunction_VPC_withInvocation(t *testing.T) {
 
 func TestAccAWSLambdaFunction_s3(t *testing.T) {
 	var conf lambda.GetFunctionOutput
-	rSt := acctest.RandString(5)
-	rName := fmt.Sprintf("tf_test_%s", rSt)
+
+	rString := acctest.RandString(8)
+	bucketName := fmt.Sprintf("tf-acc-bucket-lambda-func-s3-%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_s3_%s", rString)
+	funcName := fmt.Sprintf("tf_acc_lambda_func_s3_%s", rString)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -494,11 +547,11 @@ func TestAccAWSLambdaFunction_s3(t *testing.T) {
 		CheckDestroy: testAccCheckLambdaFunctionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLambdaConfigS3(rName, rSt),
+				Config: testAccAWSLambdaConfigS3(bucketName, roleName, funcName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_s3test", rName, &conf),
-					testAccCheckAwsLambdaFunctionName(&conf, rName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+rName),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_s3test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, funcName),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
 					testAccCheckAWSLambdaFunctionVersion(&conf, "$LATEST"),
 				),
 			},
@@ -515,8 +568,9 @@ func TestAccAWSLambdaFunction_localUpdate(t *testing.T) {
 	}
 	defer os.Remove(path)
 
-	rInt := acctest.RandInt()
-	rName := fmt.Sprintf("tf_acc_lambda_local_%d", rInt)
+	rString := acctest.RandString(8)
+	funcName := fmt.Sprintf("tf_acc_lambda_func_local_upd_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_local_upd_%s", rString)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -527,11 +581,11 @@ func TestAccAWSLambdaFunction_localUpdate(t *testing.T) {
 				PreConfig: func() {
 					testAccCreateZipFromFiles(map[string]string{"test-fixtures/lambda_func.js": "lambda.js"}, zipFile)
 				},
-				Config: genAWSLambdaFunctionConfig_local(path, rInt, rName),
+				Config: genAWSLambdaFunctionConfig_local(path, roleName, funcName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_local", rName, &conf),
-					testAccCheckAwsLambdaFunctionName(&conf, rName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, rName),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_local", funcName, &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, funcName),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, funcName),
 					testAccCheckAwsLambdaSourceCodeHash(&conf, "8DPiX+G1l2LQ8hjBkwRchQFf1TSCEvPrYGRKlM9UoyY="),
 				),
 			},
@@ -539,11 +593,11 @@ func TestAccAWSLambdaFunction_localUpdate(t *testing.T) {
 				PreConfig: func() {
 					testAccCreateZipFromFiles(map[string]string{"test-fixtures/lambda_func_modified.js": "lambda.js"}, zipFile)
 				},
-				Config: genAWSLambdaFunctionConfig_local(path, rInt, rName),
+				Config: genAWSLambdaFunctionConfig_local(path, roleName, funcName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_local", rName, &conf),
-					testAccCheckAwsLambdaFunctionName(&conf, rName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, rName),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_local", funcName, &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, funcName),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, funcName),
 					testAccCheckAwsLambdaSourceCodeHash(&conf, "0tdaP9H9hsk9c2CycSwOG/sa/x5JyAmSYunA/ce99Pg="),
 				),
 			},
@@ -554,7 +608,9 @@ func TestAccAWSLambdaFunction_localUpdate(t *testing.T) {
 func TestAccAWSLambdaFunction_localUpdate_nameOnly(t *testing.T) {
 	var conf lambda.GetFunctionOutput
 
-	rName := fmt.Sprintf("tf_test_iam_%d", acctest.RandInt())
+	rString := acctest.RandString(8)
+	funcName := fmt.Sprintf("tf_acc_lambda_func_local_upd_name_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_local_upd_name_%s", rString)
 
 	path, zipFile, err := createTempFile("lambda_localUpdate")
 	if err != nil {
@@ -577,11 +633,11 @@ func TestAccAWSLambdaFunction_localUpdate_nameOnly(t *testing.T) {
 				PreConfig: func() {
 					testAccCreateZipFromFiles(map[string]string{"test-fixtures/lambda_func.js": "lambda.js"}, zipFile)
 				},
-				Config: genAWSLambdaFunctionConfig_local_name_only(path, rName),
+				Config: genAWSLambdaFunctionConfig_local_name_only(path, roleName, funcName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_local", rName, &conf),
-					testAccCheckAwsLambdaFunctionName(&conf, rName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, rName),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_local", funcName, &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, funcName),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, funcName),
 					testAccCheckAwsLambdaSourceCodeHash(&conf, "8DPiX+G1l2LQ8hjBkwRchQFf1TSCEvPrYGRKlM9UoyY="),
 				),
 			},
@@ -589,11 +645,11 @@ func TestAccAWSLambdaFunction_localUpdate_nameOnly(t *testing.T) {
 				PreConfig: func() {
 					testAccCreateZipFromFiles(map[string]string{"test-fixtures/lambda_func_modified.js": "lambda.js"}, updatedZipFile)
 				},
-				Config: genAWSLambdaFunctionConfig_local_name_only(updatedPath, rName),
+				Config: genAWSLambdaFunctionConfig_local_name_only(updatedPath, roleName, funcName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_local", rName, &conf),
-					testAccCheckAwsLambdaFunctionName(&conf, rName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, rName),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_local", funcName, &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, funcName),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, funcName),
 					testAccCheckAwsLambdaSourceCodeHash(&conf, "0tdaP9H9hsk9c2CycSwOG/sa/x5JyAmSYunA/ce99Pg="),
 				),
 			},
@@ -610,12 +666,12 @@ func TestAccAWSLambdaFunction_s3Update_basic(t *testing.T) {
 	}
 	defer os.Remove(path)
 
-	bucketName := fmt.Sprintf("tf-acc-lambda-s3-deployments-%d", randomInteger)
+	rString := acctest.RandString(8)
+	bucketName := fmt.Sprintf("tf-acc-bucket-lambda-func-s3-upd-basic-%s", rString)
+	funcName := fmt.Sprintf("tf_acc_lambda_func_s3_upd_basic_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_s3_upd_basic_%s", rString)
+
 	key := "lambda-func.zip"
-
-	rInt := acctest.RandInt()
-
-	rName := fmt.Sprintf("tf_acc_lambda_%d", rInt)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -627,11 +683,11 @@ func TestAccAWSLambdaFunction_s3Update_basic(t *testing.T) {
 					// Upload 1st version
 					testAccCreateZipFromFiles(map[string]string{"test-fixtures/lambda_func.js": "lambda.js"}, zipFile)
 				},
-				Config: genAWSLambdaFunctionConfig_s3(bucketName, key, path, rInt, rName),
+				Config: genAWSLambdaFunctionConfig_s3(bucketName, key, path, roleName, funcName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_s3", rName, &conf),
-					testAccCheckAwsLambdaFunctionName(&conf, rName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, rName),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_s3", funcName, &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, funcName),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, funcName),
 					testAccCheckAwsLambdaSourceCodeHash(&conf, "8DPiX+G1l2LQ8hjBkwRchQFf1TSCEvPrYGRKlM9UoyY="),
 				),
 			},
@@ -641,16 +697,16 @@ func TestAccAWSLambdaFunction_s3Update_basic(t *testing.T) {
 					// Upload 2nd version
 					testAccCreateZipFromFiles(map[string]string{"test-fixtures/lambda_func_modified.js": "lambda.js"}, zipFile)
 				},
-				Config: genAWSLambdaFunctionConfig_s3(bucketName, key, path, rInt, rName),
+				Config: genAWSLambdaFunctionConfig_s3(bucketName, key, path, roleName, funcName),
 			},
 			// Extra step because of missing ComputedWhen
 			// See https://github.com/hashicorp/terraform/pull/4846 & https://github.com/hashicorp/terraform/pull/5330
 			{
-				Config: genAWSLambdaFunctionConfig_s3(bucketName, key, path, rInt, rName),
+				Config: genAWSLambdaFunctionConfig_s3(bucketName, key, path, roleName, funcName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_s3", rName, &conf),
-					testAccCheckAwsLambdaFunctionName(&conf, rName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, rName),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_s3", funcName, &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, funcName),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, funcName),
 					testAccCheckAwsLambdaSourceCodeHash(&conf, "0tdaP9H9hsk9c2CycSwOG/sa/x5JyAmSYunA/ce99Pg="),
 				),
 			},
@@ -661,15 +717,17 @@ func TestAccAWSLambdaFunction_s3Update_basic(t *testing.T) {
 func TestAccAWSLambdaFunction_s3Update_unversioned(t *testing.T) {
 	var conf lambda.GetFunctionOutput
 
-	rName := fmt.Sprintf("tf_iam_lambda_%d", acctest.RandInt())
-
 	path, zipFile, err := createTempFile("lambda_s3Update")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.Remove(path)
 
-	bucketName := fmt.Sprintf("tf-acc-lambda-s3-deployments-%d", randomInteger)
+	rString := acctest.RandString(8)
+	bucketName := fmt.Sprintf("tf-acc-bucket-lambda-func-s3-upd-unver-%s", rString)
+	funcName := fmt.Sprintf("tf_acc_lambda_func_s3_upd_unver_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_s3_upd_unver_%s", rString)
+
 	key := "lambda-func.zip"
 	key2 := "lambda-func-modified.zip"
 
@@ -683,11 +741,11 @@ func TestAccAWSLambdaFunction_s3Update_unversioned(t *testing.T) {
 					// Upload 1st version
 					testAccCreateZipFromFiles(map[string]string{"test-fixtures/lambda_func.js": "lambda.js"}, zipFile)
 				},
-				Config: testAccAWSLambdaFunctionConfig_s3_unversioned_tpl(rName, bucketName, key, path),
+				Config: testAccAWSLambdaFunctionConfig_s3_unversioned_tpl(bucketName, roleName, funcName, key, path),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_s3", "tf_acc_lambda_name_s3_unversioned", &conf),
-					testAccCheckAwsLambdaFunctionName(&conf, "tf_acc_lambda_name_s3_unversioned"),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, "tf_acc_lambda_name_s3_unversioned"),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_s3", funcName, &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, funcName),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, funcName),
 					testAccCheckAwsLambdaSourceCodeHash(&conf, "8DPiX+G1l2LQ8hjBkwRchQFf1TSCEvPrYGRKlM9UoyY="),
 				),
 			},
@@ -696,11 +754,11 @@ func TestAccAWSLambdaFunction_s3Update_unversioned(t *testing.T) {
 					// Upload 2nd version
 					testAccCreateZipFromFiles(map[string]string{"test-fixtures/lambda_func_modified.js": "lambda.js"}, zipFile)
 				},
-				Config: testAccAWSLambdaFunctionConfig_s3_unversioned_tpl(rName, bucketName, key2, path),
+				Config: testAccAWSLambdaFunctionConfig_s3_unversioned_tpl(bucketName, roleName, funcName, key2, path),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_s3", "tf_acc_lambda_name_s3_unversioned", &conf),
-					testAccCheckAwsLambdaFunctionName(&conf, "tf_acc_lambda_name_s3_unversioned"),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, "tf_acc_lambda_name_s3_unversioned"),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_s3", funcName, &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, funcName),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, funcName),
 					testAccCheckAwsLambdaSourceCodeHash(&conf, "0tdaP9H9hsk9c2CycSwOG/sa/x5JyAmSYunA/ce99Pg="),
 				),
 			},
@@ -709,8 +767,12 @@ func TestAccAWSLambdaFunction_s3Update_unversioned(t *testing.T) {
 }
 
 func TestAccAWSLambdaFunction_runtimeValidation_noRuntime(t *testing.T) {
-	rSt := acctest.RandString(5)
-	rName := fmt.Sprintf("tf_test_%s", rSt)
+	rString := acctest.RandString(8)
+
+	funcName := fmt.Sprintf("tf_acc_lambda_func_runtime_valid_no_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_runtime_valid_no_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_runtime_valid_no_%s", rString)
+	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_runtime_valid_no_%s", rString)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -718,7 +780,7 @@ func TestAccAWSLambdaFunction_runtimeValidation_noRuntime(t *testing.T) {
 		CheckDestroy: testAccCheckLambdaFunctionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccAWSLambdaConfigNoRuntime(rName, rSt),
+				Config:      testAccAWSLambdaConfigNoRuntime(funcName, policyName, roleName, sgName),
 				ExpectError: regexp.MustCompile(`\\"runtime\\": required field is not set`),
 			},
 		},
@@ -726,8 +788,12 @@ func TestAccAWSLambdaFunction_runtimeValidation_noRuntime(t *testing.T) {
 }
 
 func TestAccAWSLambdaFunction_runtimeValidation_nodeJs(t *testing.T) {
-	rSt := acctest.RandString(5)
-	rName := fmt.Sprintf("tf_test_%s", rSt)
+	rString := acctest.RandString(8)
+
+	funcName := fmt.Sprintf("tf_acc_lambda_func_runtime_valid_nodejs_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_runtime_valid_nodejs_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_runtime_valid_nodejs_%s", rString)
+	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_runtime_valid_nodejs_%s", rString)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -735,7 +801,7 @@ func TestAccAWSLambdaFunction_runtimeValidation_nodeJs(t *testing.T) {
 		CheckDestroy: testAccCheckLambdaFunctionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccAWSLambdaConfigNodeJsRuntime(rName, rSt),
+				Config:      testAccAWSLambdaConfigNodeJsRuntime(funcName, policyName, roleName, sgName),
 				ExpectError: regexp.MustCompile(fmt.Sprintf("%s has reached end of life since October 2016 and has been deprecated in favor of %s", lambda.RuntimeNodejs, lambda.RuntimeNodejs43)),
 			},
 		},
@@ -744,8 +810,13 @@ func TestAccAWSLambdaFunction_runtimeValidation_nodeJs(t *testing.T) {
 
 func TestAccAWSLambdaFunction_runtimeValidation_nodeJs43(t *testing.T) {
 	var conf lambda.GetFunctionOutput
-	rSt := acctest.RandString(5)
-	rName := fmt.Sprintf("tf_test_%s", rSt)
+
+	rString := acctest.RandString(8)
+
+	funcName := fmt.Sprintf("tf_acc_lambda_func_runtime_valid_node43_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_runtime_valid_node43_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_runtime_valid_node43_%s", rString)
+	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_runtime_valid_node43_%s", rString)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -753,9 +824,9 @@ func TestAccAWSLambdaFunction_runtimeValidation_nodeJs43(t *testing.T) {
 		CheckDestroy: testAccCheckLambdaFunctionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLambdaConfigNodeJs43Runtime(rName, rSt),
+				Config: testAccAWSLambdaConfigNodeJs43Runtime(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", rName, &conf),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
 					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "runtime", lambda.RuntimeNodejs43),
 				),
 			},
@@ -765,8 +836,13 @@ func TestAccAWSLambdaFunction_runtimeValidation_nodeJs43(t *testing.T) {
 
 func TestAccAWSLambdaFunction_runtimeValidation_python27(t *testing.T) {
 	var conf lambda.GetFunctionOutput
-	rSt := acctest.RandString(5)
-	rName := fmt.Sprintf("tf_test_%s", rSt)
+
+	rString := acctest.RandString(8)
+
+	funcName := fmt.Sprintf("tf_acc_lambda_func_runtime_valid_p27_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_runtime_valid_p27_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_runtime_valid_p27_%s", rString)
+	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_runtime_valid_p27_%s", rString)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -774,9 +850,9 @@ func TestAccAWSLambdaFunction_runtimeValidation_python27(t *testing.T) {
 		CheckDestroy: testAccCheckLambdaFunctionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLambdaConfigPython27Runtime(rName, rSt),
+				Config: testAccAWSLambdaConfigPython27Runtime(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", rName, &conf),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
 					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "runtime", lambda.RuntimePython27),
 				),
 			},
@@ -786,8 +862,13 @@ func TestAccAWSLambdaFunction_runtimeValidation_python27(t *testing.T) {
 
 func TestAccAWSLambdaFunction_runtimeValidation_java8(t *testing.T) {
 	var conf lambda.GetFunctionOutput
-	rSt := acctest.RandString(5)
-	rName := fmt.Sprintf("tf_test_%s", rSt)
+
+	rString := acctest.RandString(8)
+
+	funcName := fmt.Sprintf("tf_acc_lambda_func_runtime_valid_j8_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_runtime_valid_j8_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_runtime_valid_j8_%s", rString)
+	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_runtime_valid_j8_%s", rString)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -795,9 +876,9 @@ func TestAccAWSLambdaFunction_runtimeValidation_java8(t *testing.T) {
 		CheckDestroy: testAccCheckLambdaFunctionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLambdaConfigJava8Runtime(rName, rSt),
+				Config: testAccAWSLambdaConfigJava8Runtime(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", rName, &conf),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
 					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "runtime", lambda.RuntimeJava8),
 				),
 			},
@@ -808,8 +889,12 @@ func TestAccAWSLambdaFunction_runtimeValidation_java8(t *testing.T) {
 func TestAccAWSLambdaFunction_tags(t *testing.T) {
 	var conf lambda.GetFunctionOutput
 
-	rSt := acctest.RandString(5)
-	rName := fmt.Sprintf("tf_test_%s", rSt)
+	rString := acctest.RandString(8)
+
+	funcName := fmt.Sprintf("tf_acc_lambda_func_tags_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_tags_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_tags_%s", rString)
+	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_tags_%s", rString)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -817,31 +902,31 @@ func TestAccAWSLambdaFunction_tags(t *testing.T) {
 		CheckDestroy: testAccCheckLambdaFunctionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLambdaConfigBasic(rName, rSt),
+				Config: testAccAWSLambdaConfigBasic(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", rName, &conf),
-					testAccCheckAwsLambdaFunctionName(&conf, rName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+rName),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, funcName),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
 					resource.TestCheckNoResourceAttr("aws_lambda_function.lambda_function_test", "tags"),
 				),
 			},
 			{
-				Config: testAccAWSLambdaConfigTags(rName, rSt),
+				Config: testAccAWSLambdaConfigTags(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", rName, &conf),
-					testAccCheckAwsLambdaFunctionName(&conf, rName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+rName),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, funcName),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
 					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "tags.%", "2"),
 					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "tags.Key1", "Value One"),
 					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "tags.Description", "Very interesting"),
 				),
 			},
 			{
-				Config: testAccAWSLambdaConfigTagsModified(rName, rSt),
+				Config: testAccAWSLambdaConfigTagsModified(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", rName, &conf),
-					testAccCheckAwsLambdaFunctionName(&conf, rName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+rName),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, funcName),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
 					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "tags.%", "3"),
 					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "tags.Key1", "Value One Changed"),
 					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "tags.Key2", "Value Two"),
@@ -854,8 +939,13 @@ func TestAccAWSLambdaFunction_tags(t *testing.T) {
 
 func TestAccAWSLambdaFunction_runtimeValidation_python36(t *testing.T) {
 	var conf lambda.GetFunctionOutput
-	rSt := acctest.RandString(5)
-	rName := fmt.Sprintf("tf_test_%s", rSt)
+
+	rString := acctest.RandString(8)
+
+	funcName := fmt.Sprintf("tf_acc_lambda_func_runtime_valid_p36_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_runtime_valid_p36_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_runtime_valid_p36_%s", rString)
+	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_runtime_valid_p36_%s", rString)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -863,9 +953,9 @@ func TestAccAWSLambdaFunction_runtimeValidation_python36(t *testing.T) {
 		CheckDestroy: testAccCheckLambdaFunctionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLambdaConfigPython36Runtime(rName, rSt),
+				Config: testAccAWSLambdaConfigPython36Runtime(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", rName, &conf),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
 					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "runtime", lambda.RuntimePython36),
 				),
 			},
@@ -1025,10 +1115,10 @@ func createTempFile(prefix string) (string, *os.File, error) {
 	return pathToFile, f, nil
 }
 
-func baseAccAWSLambdaConfig(rst string) string {
+func baseAccAWSLambdaConfig(policyName, roleName, sgName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role_policy" "iam_policy_for_lambda" {
-    name = "iam_policy_for_lambda_%s"
+    name = "%s"
     role = "${aws_iam_role.iam_for_lambda.id}"
     policy = <<EOF
 {
@@ -1078,7 +1168,7 @@ EOF
 }
 
 resource "aws_iam_role" "iam_for_lambda" {
-    name = "iam_for_lambda_%s"
+    name = "%s"
     assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -1113,7 +1203,7 @@ resource "aws_subnet" "subnet_for_lambda" {
 }
 
 resource "aws_security_group" "sg_for_lambda" {
-  name = "sg_for_lambda_%s"
+  name = "%s"
   description = "Allow all inbound traffic for lambda test"
   vpc_id = "${aws_vpc.vpc_for_lambda.id}"
 
@@ -1130,11 +1220,11 @@ resource "aws_security_group" "sg_for_lambda" {
       protocol = "-1"
       cidr_blocks = ["0.0.0.0/0"]
   }
-}`, rst, rst, rst)
+}`, policyName, roleName, sgName)
 }
 
-func testAccAWSLambdaConfigBasic(rName, rSt string) string {
-	return fmt.Sprintf(baseAccAWSLambdaConfig(rSt)+`
+func testAccAWSLambdaConfigBasic(funcName, policyName, roleName, sgName string) string {
+	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
 resource "aws_lambda_function" "lambda_function_test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
@@ -1142,11 +1232,11 @@ resource "aws_lambda_function" "lambda_function_test" {
     handler = "exports.example"
     runtime = "nodejs4.3"
 }
-`, rName)
+`, funcName)
 }
 
-func testAccAWSLambdaConfigBasicConcurrency(rName, rSt string) string {
-	return fmt.Sprintf(baseAccAWSLambdaConfig(rSt)+`
+func testAccAWSLambdaConfigBasicConcurrency(funcName, policyName, roleName, sgName string) string {
+	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
 resource "aws_lambda_function" "lambda_function_test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
@@ -1155,11 +1245,11 @@ resource "aws_lambda_function" "lambda_function_test" {
     runtime = "nodejs4.3"
     reserved_concurrent_executions = 111
 }
-`, rName)
+`, funcName)
 }
 
-func testAccAWSLambdaConfigConcurrencyUpdate(rName, rSt string) string {
-	return fmt.Sprintf(baseAccAWSLambdaConfig(rSt)+`
+func testAccAWSLambdaConfigConcurrencyUpdate(funcName, policyName, roleName, sgName string) string {
+	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
 resource "aws_lambda_function" "lambda_function_test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
@@ -1168,11 +1258,11 @@ resource "aws_lambda_function" "lambda_function_test" {
     runtime = "nodejs4.3"
     reserved_concurrent_executions = 222
 }
-`, rName)
+`, funcName)
 }
 
-func testAccAWSLambdaConfigBasicUpdateRuntime(rName, rSt string) string {
-	return fmt.Sprintf(baseAccAWSLambdaConfig(rSt)+`
+func testAccAWSLambdaConfigBasicUpdateRuntime(funcName, policyName, roleName, sgName string) string {
+	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
 resource "aws_lambda_function" "lambda_function_test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
@@ -1180,22 +1270,22 @@ resource "aws_lambda_function" "lambda_function_test" {
     handler = "exports.example"
     runtime = "nodejs4.3-edge"
 }
-`, rName)
+`, funcName)
 }
 
-func testAccAWSLambdaConfigWithoutFilenameAndS3Attributes(rName, rSt string) string {
-	return fmt.Sprintf(baseAccAWSLambdaConfig(rSt)+`
+func testAccAWSLambdaConfigWithoutFilenameAndS3Attributes(funcName, policyName, roleName, sgName string) string {
+	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
 resource "aws_lambda_function" "lambda_function_test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
 		runtime = "nodejs4.3"
 }
-`, rName)
+`, funcName)
 }
 
-func testAccAWSLambdaConfigEnvVariables(rName, rSt string) string {
-	return fmt.Sprintf(baseAccAWSLambdaConfig(rSt)+`
+func testAccAWSLambdaConfigEnvVariables(funcName, policyName, roleName, sgName string) string {
+	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
 resource "aws_lambda_function" "lambda_function_test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
@@ -1208,11 +1298,11 @@ resource "aws_lambda_function" "lambda_function_test" {
         }
     }
 }
-`, rName)
+`, funcName)
 }
 
-func testAccAWSLambdaConfigEnvVariablesModified(rName, rSt string) string {
-	return fmt.Sprintf(baseAccAWSLambdaConfig(rSt)+`
+func testAccAWSLambdaConfigEnvVariablesModified(funcName, policyName, roleName, sgName string) string {
+	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
 resource "aws_lambda_function" "lambda_function_test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
@@ -1226,11 +1316,11 @@ resource "aws_lambda_function" "lambda_function_test" {
         }
     }
 }
-`, rName)
+`, funcName)
 }
 
-func testAccAWSLambdaConfigEnvVariablesModifiedWithoutEnvironment(rName, rSt string) string {
-	return fmt.Sprintf(baseAccAWSLambdaConfig(rSt)+`
+func testAccAWSLambdaConfigEnvVariablesModifiedWithoutEnvironment(funcName, policyName, roleName, sgName string) string {
+	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
 resource "aws_lambda_function" "lambda_function_test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
@@ -1238,13 +1328,13 @@ resource "aws_lambda_function" "lambda_function_test" {
     handler = "exports.example"
     runtime = "nodejs4.3"
 }
-`, rName)
+`, funcName)
 }
 
-func testAccAWSLambdaConfigEncryptedEnvVariables(rName, rSt string) string {
-	return fmt.Sprintf(baseAccAWSLambdaConfig(rSt)+`
+func testAccAWSLambdaConfigEncryptedEnvVariables(keyDesc, funcName, policyName, roleName, sgName string) string {
+	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
 resource "aws_kms_key" "foo" {
-    description = "Terraform acc test %s"
+    description = "%s"
     policy = <<POLICY
 {
   "Version": "2012-10-17",
@@ -1277,11 +1367,11 @@ resource "aws_lambda_function" "lambda_function_test" {
         }
     }
 }
-`, rName, rName)
+`, keyDesc, funcName)
 }
 
-func testAccAWSLambdaConfigEncryptedEnvVariablesModified(rName, rSt string) string {
-	return fmt.Sprintf(baseAccAWSLambdaConfig(rSt)+`
+func testAccAWSLambdaConfigEncryptedEnvVariablesModified(funcName, policyName, roleName, sgName string) string {
+	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
 resource "aws_lambda_function" "lambda_function_test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
@@ -1294,11 +1384,11 @@ resource "aws_lambda_function" "lambda_function_test" {
         }
     }
 }
-`, rName)
+`, funcName)
 }
 
-func testAccAWSLambdaConfigVersioned(rName, rSt string) string {
-	return fmt.Sprintf(baseAccAWSLambdaConfig(rSt)+`
+func testAccAWSLambdaConfigVersioned(funcName, policyName, roleName, sgName string) string {
+	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
 resource "aws_lambda_function" "lambda_function_test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
@@ -1307,11 +1397,11 @@ resource "aws_lambda_function" "lambda_function_test" {
     handler = "exports.example"
     runtime = "nodejs4.3"
 }
-`, rName)
+`, funcName)
 }
 
-func testAccAWSLambdaConfigWithTracingConfig(rName, rSt string) string {
-	return fmt.Sprintf(baseAccAWSLambdaConfig(rSt)+`
+func testAccAWSLambdaConfigWithTracingConfig(funcName, policyName, roleName, sgName string) string {
+	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
 resource "aws_lambda_function" "lambda_function_test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
@@ -1324,11 +1414,11 @@ resource "aws_lambda_function" "lambda_function_test" {
     }
 }
 
-`, rName)
+`, funcName)
 }
 
-func testAccAWSLambdaConfigWithTracingConfigUpdated(rName, rSt string) string {
-	return fmt.Sprintf(baseAccAWSLambdaConfig(rSt)+`
+func testAccAWSLambdaConfigWithTracingConfigUpdated(funcName, policyName, roleName, sgName string) string {
+	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
 resource "aws_lambda_function" "lambda_function_test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
@@ -1341,11 +1431,11 @@ resource "aws_lambda_function" "lambda_function_test" {
     }
 }
 
-`, rName)
+`, funcName)
 }
 
-func testAccAWSLambdaConfigWithDeadLetterConfig(rName, rSt string) string {
-	return fmt.Sprintf(baseAccAWSLambdaConfig(rSt)+`
+func testAccAWSLambdaConfigWithDeadLetterConfig(funcName, topicName, policyName, roleName, sgName string) string {
+	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
 resource "aws_lambda_function" "lambda_function_test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
@@ -1362,11 +1452,12 @@ resource "aws_sns_topic" "lambda_function_test" {
 	name = "%s"
 }
 
-`, rName, rName)
+`, funcName, topicName)
 }
 
-func testAccAWSLambdaConfigWithDeadLetterConfigUpdated(rName, rSt, rNameUpdated string) string {
-	return fmt.Sprintf(baseAccAWSLambdaConfig(rSt)+`
+func testAccAWSLambdaConfigWithDeadLetterConfigUpdated(funcName, topic1Name, topic2Name, policyName,
+	roleName, sgName, uFuncName string) string {
+	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
 resource "aws_lambda_function" "lambda_function_test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
@@ -1387,11 +1478,11 @@ resource "aws_sns_topic" "lambda_function_test_2" {
 	name = "%s"
 }
 
-`, rName, rName, rNameUpdated)
+`, uFuncName, topic1Name, topic2Name)
 }
 
-func testAccAWSLambdaConfigWithNilDeadLetterConfig(rName, rSt string) string {
-	return fmt.Sprintf(baseAccAWSLambdaConfig(rSt)+`
+func testAccAWSLambdaConfigWithNilDeadLetterConfig(funcName, policyName, roleName, sgName string) string {
+	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
 resource "aws_lambda_function" "lambda_function_test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
@@ -1403,11 +1494,11 @@ resource "aws_lambda_function" "lambda_function_test" {
         target_arn = ""
     }
 }
-`, rName)
+`, funcName)
 }
 
-func testAccAWSLambdaConfigWithVPC(rName, rSt string) string {
-	return fmt.Sprintf(baseAccAWSLambdaConfig(rSt)+`
+func testAccAWSLambdaConfigWithVPC(funcName, policyName, roleName, sgName string) string {
+	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
 resource "aws_lambda_function" "lambda_function_test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
@@ -1419,11 +1510,11 @@ resource "aws_lambda_function" "lambda_function_test" {
         subnet_ids = ["${aws_subnet.subnet_for_lambda.id}"]
         security_group_ids = ["${aws_security_group.sg_for_lambda.id}"]
     }
-}`, rName)
+}`, funcName)
 }
 
-func testAccAWSLambdaConfigWithVPCUpdated(rName, rSt string) string {
-	return fmt.Sprintf(baseAccAWSLambdaConfig(rSt)+`
+func testAccAWSLambdaConfigWithVPCUpdated(funcName, policyName, roleName, sgName, sgName2 string) string {
+	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
 resource "aws_lambda_function" "lambda_function_test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
@@ -1467,13 +1558,13 @@ resource "aws_security_group" "sg_for_lambda_2" {
 }
 
 
-`, rName, rName)
+`, funcName, sgName2)
 }
 
-func testAccAWSLambdaConfigS3(rName, rSt string) string {
+func testAccAWSLambdaConfigS3(bucketName, roleName, funcName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "lambda_bucket" {
-  bucket = "tf-test-bucket-%d"
+  bucket = "%s"
 }
 
 resource "aws_s3_bucket_object" "lambda_code" {
@@ -1483,7 +1574,7 @@ resource "aws_s3_bucket_object" "lambda_code" {
 }
 
 resource "aws_iam_role" "iam_for_lambda" {
-    name = "iam_for_lambda_%s"
+    name = "%s"
     assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -1509,11 +1600,11 @@ resource "aws_lambda_function" "lambda_function_s3test" {
     handler = "exports.example"
     runtime = "nodejs4.3"
 }
-`, acctest.RandInt(), rSt, rName)
+`, bucketName, roleName, funcName)
 }
 
-func testAccAWSLambdaConfigNoRuntime(rName, rSt string) string {
-	return fmt.Sprintf(baseAccAWSLambdaConfig(rSt)+`
+func testAccAWSLambdaConfigNoRuntime(funcName, policyName, roleName, sgName string) string {
+	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
 resource "aws_lambda_function" "lambda_function_test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
@@ -1521,11 +1612,11 @@ resource "aws_lambda_function" "lambda_function_test" {
     handler = "exports.example"
     runtime = "nodejs4.3"
 }
-`, rName)
+`, funcName)
 }
 
-func testAccAWSLambdaConfigNodeJsRuntime(rName, rSt string) string {
-	return fmt.Sprintf(baseAccAWSLambdaConfig(rSt)+`
+func testAccAWSLambdaConfigNodeJsRuntime(funcName, policyName, roleName, sgName string) string {
+	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
 resource "aws_lambda_function" "lambda_function_test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
@@ -1533,11 +1624,11 @@ resource "aws_lambda_function" "lambda_function_test" {
     handler = "exports.example"
     runtime = "nodejs4.3"
 }
-`, rName)
+`, funcName)
 }
 
-func testAccAWSLambdaConfigNodeJs43Runtime(rName, rSt string) string {
-	return fmt.Sprintf(baseAccAWSLambdaConfig(rSt)+`
+func testAccAWSLambdaConfigNodeJs43Runtime(funcName, policyName, roleName, sgName string) string {
+	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
 resource "aws_lambda_function" "lambda_function_test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
@@ -1545,11 +1636,11 @@ resource "aws_lambda_function" "lambda_function_test" {
     handler = "exports.example"
     runtime = "nodejs4.3"
 }
-`, rName)
+`, funcName)
 }
 
-func testAccAWSLambdaConfigPython27Runtime(rName, rSt string) string {
-	return fmt.Sprintf(baseAccAWSLambdaConfig(rSt)+`
+func testAccAWSLambdaConfigPython27Runtime(funcName, policyName, roleName, sgName string) string {
+	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
 resource "aws_lambda_function" "lambda_function_test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
@@ -1557,11 +1648,11 @@ resource "aws_lambda_function" "lambda_function_test" {
     handler = "exports.example"
     runtime = "python2.7"
 }
-`, rName)
+`, funcName)
 }
 
-func testAccAWSLambdaConfigJava8Runtime(rName, rSt string) string {
-	return fmt.Sprintf(baseAccAWSLambdaConfig(rSt)+`
+func testAccAWSLambdaConfigJava8Runtime(funcName, policyName, roleName, sgName string) string {
+	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
 resource "aws_lambda_function" "lambda_function_test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
@@ -1569,11 +1660,11 @@ resource "aws_lambda_function" "lambda_function_test" {
     handler = "exports.example"
     runtime = "java8"
 }
-`, rName)
+`, funcName)
 }
 
-func testAccAWSLambdaConfigTags(rName, rSt string) string {
-	return fmt.Sprintf(baseAccAWSLambdaConfig(rSt)+`
+func testAccAWSLambdaConfigTags(funcName, policyName, roleName, sgName string) string {
+	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
 resource "aws_lambda_function" "lambda_function_test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
@@ -1585,11 +1676,11 @@ resource "aws_lambda_function" "lambda_function_test" {
 		Description = "Very interesting"
     }
 }
-`, rName)
+`, funcName)
 }
 
-func testAccAWSLambdaConfigTagsModified(rName, rSt string) string {
-	return fmt.Sprintf(baseAccAWSLambdaConfig(rSt)+`
+func testAccAWSLambdaConfigTagsModified(funcName, policyName, roleName, sgName string) string {
+	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
 resource "aws_lambda_function" "lambda_function_test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
@@ -1602,11 +1693,11 @@ resource "aws_lambda_function" "lambda_function_test" {
 		Key3 = "Value Three"
     }
 }
-`, rName)
+`, funcName)
 }
 
-func testAccAWSLambdaConfigPython36Runtime(rName, rSt string) string {
-	return fmt.Sprintf(baseAccAWSLambdaConfig(rSt)+`
+func testAccAWSLambdaConfigPython36Runtime(funcName, policyName, roleName, sgName string) string {
+	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
 resource "aws_lambda_function" "lambda_function_test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
@@ -1614,12 +1705,13 @@ resource "aws_lambda_function" "lambda_function_test" {
     handler = "exports.example"
     runtime = "python3.6"
 }
-`, rName)
+`, funcName)
 }
 
-const testAccAWSLambdaFunctionConfig_local_tpl = `
+func genAWSLambdaFunctionConfig_local(filePath, roleName, funcName string) string {
+	return fmt.Sprintf(`
 resource "aws_iam_role" "iam_for_lambda" {
-    name = "iam_for_lambda_%d"
+    name = "%s"
     assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -1644,18 +1736,14 @@ resource "aws_lambda_function" "lambda_function_local" {
     handler = "exports.example"
     runtime = "nodejs4.3"
 }
-`
-
-func genAWSLambdaFunctionConfig_local(filePath string, rInt int, rName string) string {
-	return fmt.Sprintf(testAccAWSLambdaFunctionConfig_local_tpl, rInt,
-		filePath, filePath, rName)
+`, roleName, filePath, filePath, funcName)
 }
 
-func genAWSLambdaFunctionConfig_local_name_only(filePath, rName string) string {
-	return testAccAWSLambdaFunctionConfig_local_name_only_tpl(filePath, rName)
+func genAWSLambdaFunctionConfig_local_name_only(filePath, roleName, funcName string) string {
+	return testAccAWSLambdaFunctionConfig_local_name_only_tpl(filePath, roleName, funcName)
 }
 
-func testAccAWSLambdaFunctionConfig_local_name_only_tpl(filePath, rName string) string {
+func testAccAWSLambdaFunctionConfig_local_name_only_tpl(filePath, roleName, funcName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "iam_for_lambda" {
     name = "%s"
@@ -1681,10 +1769,11 @@ resource "aws_lambda_function" "lambda_function_local" {
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
     runtime = "nodejs4.3"
-}`, rName, filePath, rName)
+}`, roleName, filePath, funcName)
 }
 
-const testAccAWSLambdaFunctionConfig_s3_tpl = `
+func genAWSLambdaFunctionConfig_s3(bucketName, key, path, roleName, funcName string) string {
+	return fmt.Sprintf(`
 resource "aws_s3_bucket" "artifacts" {
     bucket = "%s"
     acl = "private"
@@ -1700,7 +1789,7 @@ resource "aws_s3_bucket_object" "o" {
     etag = "${md5(file("%s"))}"
 }
 resource "aws_iam_role" "iam_for_lambda" {
-    name = "iam_for_lambda_%d"
+    name = "%s"
     assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -1726,14 +1815,10 @@ resource "aws_lambda_function" "lambda_function_s3" {
     handler = "exports.example"
     runtime = "nodejs4.3"
 }
-`
-
-func genAWSLambdaFunctionConfig_s3(bucket, key, path string, rInt int, rName string) string {
-	return fmt.Sprintf(testAccAWSLambdaFunctionConfig_s3_tpl,
-		bucket, key, path, path, rInt, rName)
+`, bucketName, key, path, path, roleName, funcName)
 }
 
-func testAccAWSLambdaFunctionConfig_s3_unversioned_tpl(rName, bucketName, key, path string) string {
+func testAccAWSLambdaFunctionConfig_s3_unversioned_tpl(bucketName, roleName, funcName, key, path string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "artifacts" {
     bucket = "%s"
@@ -1747,7 +1832,7 @@ resource "aws_s3_bucket_object" "o" {
     etag = "${md5(file("%s"))}"
 }
 resource "aws_iam_role" "iam_for_lambda" {
-		name = "%s"
+	name = "%s"
     assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -1767,9 +1852,9 @@ EOF
 resource "aws_lambda_function" "lambda_function_s3" {
     s3_bucket = "${aws_s3_bucket_object.o.bucket}"
     s3_key = "${aws_s3_bucket_object.o.key}"
-    function_name = "tf_acc_lambda_name_s3_unversioned"
+    function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
     runtime = "nodejs4.3"
-}`, bucketName, key, path, path, rName)
+}`, bucketName, key, path, path, roleName, funcName)
 }


### PR DESCRIPTION
This is to standardize names in Lambda-related tests, some of which were not randomized and caused test failures in the past due to leaks.

## Test results

```
=== RUN   TestAccAWSLambdaFunction_importS3
--- PASS: TestAccAWSLambdaFunction_importS3 (30.81s)
=== RUN   TestAccAWSLambdaAlias_basic
--- PASS: TestAccAWSLambdaAlias_basic (39.84s)
=== RUN   TestAccAWSLambdaFunction_importLocalFile_VPC
--- PASS: TestAccAWSLambdaFunction_importLocalFile_VPC (58.44s)
=== RUN   TestAccAWSLambdaFunction_nilDeadLetterConfig
--- PASS: TestAccAWSLambdaFunction_nilDeadLetterConfig (64.64s)
=== RUN   TestAccAWSLambdaFunction_s3
--- PASS: TestAccAWSLambdaFunction_s3 (41.65s)
=== RUN   TestAccAWSLambdaFunction_importLocalFile
--- PASS: TestAccAWSLambdaFunction_importLocalFile (105.57s)
=== RUN   TestAccAWSLambdaFunction_localUpdate
--- PASS: TestAccAWSLambdaFunction_localUpdate (50.19s)
=== RUN   TestAccAWSLambdaEventSourceMapping_disappears
--- PASS: TestAccAWSLambdaEventSourceMapping_disappears (114.93s)
=== RUN   TestAccAWSLambdaEventSourceMapping_importBasic
--- PASS: TestAccAWSLambdaEventSourceMapping_importBasic (119.03s)
=== RUN   TestAccAWSLambdaEventSourceMapping_basic
--- PASS: TestAccAWSLambdaEventSourceMapping_basic (119.26s)
=== RUN   TestAccAWSLambdaFunction_expectFilenameAndS3Attributes
--- PASS: TestAccAWSLambdaFunction_expectFilenameAndS3Attributes (125.69s)
=== RUN   TestAccAWSLambdaFunction_VPC_withInvocation
--- PASS: TestAccAWSLambdaFunction_VPC_withInvocation (109.13s)
=== RUN   TestAccAWSLambdaFunction_s3Update_unversioned
--- PASS: TestAccAWSLambdaFunction_s3Update_unversioned (48.19s)
=== RUN   TestAccAWSLambdaFunction_s3Update_basic
--- PASS: TestAccAWSLambdaFunction_s3Update_basic (59.41s)
=== RUN   TestAccAWSLambdaFunction_localUpdate_nameOnly
--- PASS: TestAccAWSLambdaFunction_localUpdate_nameOnly (67.19s)
=== RUN   TestAccAWSLambdaPermission_basic
--- PASS: TestAccAWSLambdaPermission_basic (29.99s)
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_nodeJs
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_nodeJs (85.68s)
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_python27
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python27 (91.62s)
=== RUN   TestAccAWSLambdaFunction_encryptedEnvVariables
--- PASS: TestAccAWSLambdaFunction_encryptedEnvVariables (218.69s)
=== RUN   TestAccAWSLambdaPermission_withRawFunctionName
--- PASS: TestAccAWSLambdaPermission_withRawFunctionName (56.28s)
=== RUN   TestAccAWSLambdaPermission_multiplePerms
--- PASS: TestAccAWSLambdaPermission_multiplePerms (39.64s)
=== RUN   TestAccAWSLambdaFunction_VPC
--- PASS: TestAccAWSLambdaFunction_VPC (260.73s)
=== RUN   TestAccAWSLambdaFunction_DeadLetterConfig
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfig (261.56s)
=== RUN   TestAccAWSLambdaFunction_versioned
--- PASS: TestAccAWSLambdaFunction_versioned (267.23s)
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_python36
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python36 (102.96s)
=== RUN   TestAccAWSLambdaPermission_withS3
--- PASS: TestAccAWSLambdaPermission_withS3 (57.64s)
=== RUN   TestAccAWSLambdaPermission_withQualifier
--- PASS: TestAccAWSLambdaPermission_withQualifier (81.29s)
=== RUN   TestAccAWSLambdaPermission_withSNS
--- PASS: TestAccAWSLambdaPermission_withSNS (33.25s)
=== RUN   TestAccAWSLambdaFunction_concurrencyCycle
--- PASS: TestAccAWSLambdaFunction_concurrencyCycle (287.07s)
=== RUN   TestAccAWSLambdaPermission_withIAMRole
--- PASS: TestAccAWSLambdaPermission_withIAMRole (35.14s)
=== RUN   TestAccAWSLambdaFunction_basic
--- PASS: TestAccAWSLambdaFunction_basic (292.90s)
=== RUN   TestAccAWSLambdaFunction_tags
--- PASS: TestAccAWSLambdaFunction_tags (134.07s)
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_java8
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_java8 (163.73s)
=== RUN   TestAccAWSLambdaFunction_updateRuntime
--- PASS: TestAccAWSLambdaFunction_updateRuntime (314.64s)
=== RUN   TestAccAWSLambdaFunction_tracingConfig
--- PASS: TestAccAWSLambdaFunction_tracingConfig (319.53s)
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_noRuntime
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_noRuntime (235.09s)
=== RUN   TestAccAWSLambdaFunction_concurrency
--- PASS: TestAccAWSLambdaFunction_concurrency (351.06s)
=== RUN   TestAccAWSLambdaFunction_envVariables
--- PASS: TestAccAWSLambdaFunction_envVariables (401.16s)
=== RUN   TestAccAWSLambdaFunction_DeadLetterConfigUpdated
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfigUpdated (403.83s)
=== RUN   TestAccAWSLambdaFunction_VPCUpdate
--- PASS: TestAccAWSLambdaFunction_VPCUpdate (376.85s)
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_nodeJs43
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_nodeJs43 (310.78s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidParameterName
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidParameterName (0.94s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidProcessorType
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidProcessorType (1.06s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3basic
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3basic (257.76s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3Updates
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3Updates (263.86s)
```