### PR TITLE
New Data Source: aws_lambda_function

### DIFF
--- a/aws/data_source_aws_lambda_function.go
+++ b/aws/data_source_aws_lambda_function.go
@@ -1,0 +1,65 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsLambdaFunction() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsLambdaFunctionRead,
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"function_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"role": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"qualifier": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "$LATEST",
+			},
+			"version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsLambdaFunctionRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).lambdaconn
+	function_name := d.Get("function_name")
+
+	log.Printf("[DEBUG] Fetching Lambda Function: %s", function_name)
+
+	params := &lambda.GetFunctionInput{
+		FunctionName: aws.String(function_name.(string)),
+		Qualifier:    aws.String(d.Get("qualifier").(string)),
+	}
+
+	getFunctionOutput, err := conn.GetFunction(params)
+	if err != nil {
+		return fmt.Errorf("Failed getting Lambda Function \"%s\": %s", function_name, err)
+	}
+
+	function := getFunctionOutput.Configuration
+	d.SetId(function_name.(string))
+	d.Set("arn", function.FunctionArn)
+	d.Set("role", function.Role)
+	d.Set("version", function.Version)
+
+	return nil
+}

--- a/aws/data_source_aws_lambda_function_test.go
+++ b/aws/data_source_aws_lambda_function_test.go
@@ -10,8 +10,11 @@ import (
 )
 
 func TestAccDataSourceLambdaFunction_basic(t *testing.T) {
-	rSt := acctest.RandString(5)
-	rName := fmt.Sprintf("tf_test_%s", rSt)
+	rString := acctest.RandString(5)
+	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_data_source_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_data_source_%s", rString)
+	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_data_source_%s", rString)
+	rName := fmt.Sprintf("tf_test_%s", rString)
 	arnRegexp := regexp.MustCompile("^arn:aws:lambda:")
 
 	resource.Test(t, resource.TestCase{
@@ -20,7 +23,7 @@ func TestAccDataSourceLambdaFunction_basic(t *testing.T) {
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDataSourceLambdaFunctionConfig_basic(rName, rSt),
+				Config: testAccAWSDataSourceLambdaFunctionConfig_basic(rName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.aws_lambda_function.func", "arn"),
 					resource.TestMatchResourceAttr("data.aws_lambda_function.func", "arn", arnRegexp),
@@ -32,8 +35,11 @@ func TestAccDataSourceLambdaFunction_basic(t *testing.T) {
 }
 
 func TestAccDataSourceLambdaFunction_alias(t *testing.T) {
-	rSt := acctest.RandString(5)
-	rName := fmt.Sprintf("tf_test_%s", rSt)
+	rString := acctest.RandString(5)
+	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_data_source_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_data_source_%s", rString)
+	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_data_source_%s", rString)
+	rName := fmt.Sprintf("tf_test_%s", rString)
 	arnRegexp := regexp.MustCompile("^arn:aws:lambda:")
 
 	resource.Test(t, resource.TestCase{
@@ -42,7 +48,7 @@ func TestAccDataSourceLambdaFunction_alias(t *testing.T) {
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDataSourceLambdaFunctionConfig_alias(rName, rSt),
+				Config: testAccAWSDataSourceLambdaFunctionConfig_alias(rName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.aws_lambda_function.func", "arn"),
 					resource.TestMatchResourceAttr("data.aws_lambda_function.func", "arn", arnRegexp),
@@ -54,8 +60,8 @@ func TestAccDataSourceLambdaFunction_alias(t *testing.T) {
 	})
 }
 
-func testAccAWSDataSourceLambdaFunctionConfig_basic(rName, rSt string) string {
-	return fmt.Sprintf(baseAccAWSLambdaConfig(rSt)+`
+func testAccAWSDataSourceLambdaFunctionConfig_basic(rName, policyName, roleName, sgName string) string {
+	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
 resource "aws_lambda_function" "lambda_function_test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
@@ -71,8 +77,8 @@ data "aws_lambda_function" "func" {
 `, rName)
 }
 
-func testAccAWSDataSourceLambdaFunctionConfig_alias(rName, rSt string) string {
-	return fmt.Sprintf(baseAccAWSLambdaConfig(rSt)+`
+func testAccAWSDataSourceLambdaFunctionConfig_alias(rName, policyName, roleName, sgName string) string {
+	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
 resource "aws_lambda_function" "lambda_function_test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"

--- a/aws/data_source_aws_lambda_function_test.go
+++ b/aws/data_source_aws_lambda_function_test.go
@@ -1,0 +1,98 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceLambdaFunction_basic(t *testing.T) {
+	rSt := acctest.RandString(5)
+	rName := fmt.Sprintf("tf_test_%s", rSt)
+	arnRegexp := regexp.MustCompile("^arn:aws:lambda:")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                  func() { testAccPreCheck(t) },
+		Providers:                 testAccProviders,
+		PreventPostDestroyRefresh: true,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDataSourceLambdaFunctionConfig_basic(rName, rSt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.aws_lambda_function.func", "arn"),
+					resource.TestMatchResourceAttr("data.aws_lambda_function.func", "arn", arnRegexp),
+					resource.TestCheckResourceAttr("data.aws_lambda_function.func", "function_name", rName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceLambdaFunction_alias(t *testing.T) {
+	rSt := acctest.RandString(5)
+	rName := fmt.Sprintf("tf_test_%s", rSt)
+	arnRegexp := regexp.MustCompile("^arn:aws:lambda:")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                  func() { testAccPreCheck(t) },
+		Providers:                 testAccProviders,
+		PreventPostDestroyRefresh: true,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDataSourceLambdaFunctionConfig_alias(rName, rSt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.aws_lambda_function.func", "arn"),
+					resource.TestMatchResourceAttr("data.aws_lambda_function.func", "arn", arnRegexp),
+					resource.TestCheckResourceAttr("data.aws_lambda_function.func", "function_name", rName),
+					resource.TestCheckResourceAttr("data.aws_lambda_function.func", "version", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAWSDataSourceLambdaFunctionConfig_basic(rName, rSt string) string {
+	return fmt.Sprintf(baseAccAWSLambdaConfig(rSt)+`
+resource "aws_lambda_function" "lambda_function_test" {
+    filename = "test-fixtures/lambdatest.zip"
+    function_name = "%s"
+    role = "${aws_iam_role.iam_for_lambda.arn}"
+    handler = "exports.example"
+    runtime = "nodejs4.3"
+}
+
+data "aws_lambda_function" "func" {
+	function_name = "${aws_lambda_function.lambda_function_test.function_name}"
+	qualifier = "${aws_lambda_function.lambda_function_test.version}"
+}
+`, rName)
+}
+
+func testAccAWSDataSourceLambdaFunctionConfig_alias(rName, rSt string) string {
+	return fmt.Sprintf(baseAccAWSLambdaConfig(rSt)+`
+resource "aws_lambda_function" "lambda_function_test" {
+    filename = "test-fixtures/lambdatest.zip"
+    function_name = "%s"
+    role = "${aws_iam_role.iam_for_lambda.arn}"
+		publish = true
+    handler = "exports.example"
+    runtime = "nodejs4.3"
+}
+
+resource "aws_lambda_alias" "lambda_alias" {
+  name             = "testalias"
+  function_name    = "${aws_lambda_function.lambda_function_test.arn}"
+  function_version = "1"
+
+  depends_on       = ["aws_lambda_function.lambda_function_test"]
+}
+
+data "aws_lambda_function" "func" {
+	function_name = "${aws_lambda_function.lambda_function_test.function_name}"
+	qualifier = "${aws_lambda_alias.lambda_alias.name}"
+}
+`, rName)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -205,6 +205,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_kms_alias":                        dataSourceAwsKmsAlias(),
 			"aws_kms_ciphertext":                   dataSourceAwsKmsCiphertext(),
 			"aws_kms_secret":                       dataSourceAwsKmsSecret(),
+			"aws_lambda_function":                  dataSourceAwsLambdaFunction(),
 			"aws_nat_gateway":                      dataSourceAwsNatGateway(),
 			"aws_network_interface":                dataSourceAwsNetworkInterface(),
 			"aws_partition":                        dataSourceAwsPartition(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -164,6 +164,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-network-interface") %>>
                             <a href="/docs/providers/aws/d/network_interface.html">aws_network_interface</a>
                          </li>
+                        <li<%= sidebar_current("docs-aws-datasource-lambda-function") %>>
+                           <a href="/docs/providers/aws/d/lambda_function.html">aws_lambda_function</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-lb-x") %>>
                             <a href="/docs/providers/aws/d/lb.html">aws_lb</a>
                         </li>

--- a/website/docs/d/lambda_function.html.markdown
+++ b/website/docs/d/lambda_function.html.markdown
@@ -1,0 +1,45 @@
+---
+layout: "aws"
+page_title: "AWS: aws_lambda_function"
+sidebar_current: "docs-aws-datasource-lambda-function"
+description: |-
+    Provides details about a specific Lambda function.
+---
+
+# aws_lambda_function
+
+Provides details about a specific Lambda function.
+
+This resource may prove useful when functions are built with external libraries or
+otherwise managed outside of Terraform.
+
+## Example Usage
+
+variable "function_name" {
+  type = "string"
+}
+
+variable "function_alias" {
+  type = "string"
+}
+
+data "aws_lambda_function" "function" {
+  function_name = "${var.function_name}"
+  version       = "${var.function_alias}"
+}
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `function_name` - (Required) Either the short name of the function or the _unqualified_ function ARN (ARN without version number or alias).
+* `qualifier` - (Optional) The version or alias of the function. Defaults to `$LATEST`.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `arn` - The fully-qualified ARN of the function.
+* `function_name` - The "short" function name.
+* `role` - The ARN of the IAM role that the function assumes on execution.
+* `version` - The version of the function. This will be set to the actual version number if `qualifier` argument was an alias. If no qualifier was set this will be set to `$LATEST`.


### PR DESCRIPTION
Resolves #2578.

Took a stab at creating the new `aws_lambda_function` data source. The `qualifier` property is a bit weird, but it's because of the way the AWS SDK handles it. If you supply an alias you get the actual version number back as `Version`. If you supply nothing you get `$LATEST`. So the resulting `version` property of the data source may end up being a version number or `$LATEST`.

```
make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceLambdaFunction'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccDataSourceLambdaFunction -timeout 120m
=== RUN   TestAccDataSourceLambdaFunction_basic
--- PASS: TestAccDataSourceLambdaFunction_basic (37.71s)
=== RUN   TestAccDataSourceLambdaFunction_alias
--- PASS: TestAccDataSourceLambdaFunction_alias (35.50s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	73.246s
```