### PR TITLE
r/aws_cognito_user_pool: Add computed arn attribute

### DIFF
--- a/aws/resource_aws_cognito_user_pool.go
+++ b/aws/resource_aws_cognito_user_pool.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
 	"github.com/hashicorp/errwrap"
@@ -82,6 +83,11 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 					ValidateFunc: validateCognitoUserPoolAliasAttribute,
 				},
 				ConflictsWith: []string{"username_attributes"},
+			},
+
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 
 			"auto_verified_attributes": {
@@ -606,6 +612,14 @@ func resourceAwsCognitoUserPoolRead(d *schema.ResourceData, meta interface{}) er
 	if resp.UserPool.AliasAttributes != nil {
 		d.Set("alias_attributes", flattenStringList(resp.UserPool.AliasAttributes))
 	}
+	arn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Region:    meta.(*AWSClient).region,
+		Service:   "cognito-idp",
+		AccountID: meta.(*AWSClient).accountid,
+		Resource:  fmt.Sprintf("userpool/%s", d.Id()),
+	}
+	d.Set("arn", arn.String())
 	if resp.UserPool.AutoVerifiedAttributes != nil {
 		d.Set("auto_verified_attributes", flattenStringList(resp.UserPool.AutoVerifiedAttributes))
 	}

--- a/aws/resource_aws_cognito_user_pool_test.go
+++ b/aws/resource_aws_cognito_user_pool_test.go
@@ -26,6 +26,8 @@ func TestAccAWSCognitoUserPool_basic(t *testing.T) {
 				Config: testAccAWSCognitoUserPoolConfig_basic(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolExists("aws_cognito_user_pool.pool"),
+					resource.TestMatchResourceAttr("aws_cognito_user_pool.pool", "arn",
+						regexp.MustCompile("^arn:aws:cognito-idp:[^:]+:[0-9]{12}:userpool/[\\w-]+_[0-9a-zA-Z]+$")),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "name", "terraform-test-pool-"+name),
 					resource.TestCheckResourceAttrSet("aws_cognito_user_pool.pool", "creation_date"),
 					resource.TestCheckResourceAttrSet("aws_cognito_user_pool.pool", "last_modified_date"),

--- a/website/docs/r/cognito_user_pool.markdown
+++ b/website/docs/r/cognito_user_pool.markdown
@@ -120,9 +120,10 @@ The following arguments are supported:
 
 ## Attribute Reference
 
-The following attributes are exported:
+The following additional attributes are exported:
 
 * `id` - The id of the user pool.
+* `arn` - The ARN of the user pool.
 * `creation_date` - The date the user pool was created.
 * `last_modified_date` - The date the user pool was last modified.
 


### PR DESCRIPTION
The API does not provide this directly, so let's synthesize it for now. Closes #2657

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSCognitoUserPool_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCognitoUserPool_basic -timeout 120m
=== RUN   TestAccAWSCognitoUserPool_basic
--- PASS: TestAccAWSCognitoUserPool_basic (13.19s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	13.228s
```