### PR TITLE
Fix the elasticache documentation about the endpoints

### DIFF
--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -104,8 +104,8 @@ Cluster Mode (`cluster_mode`) supports the following:
 The following attributes are exported:
 
 * `id` - The ID of the ElastiCache Replication Group.
-* `configuration_endpoint_address` - The address of the endpoint for the primary node in the replication group. If Redis, only present when cluster mode is disabled.
-* `primary_endpoint_address` - (Redis only) The address of the replication group configuration endpoint when cluster mode is enabled.
+* `configuration_endpoint_address` - The address of the replication group configuration endpoint when cluster mode is enabled.
+* `primary_endpoint_address` - (Redis only) The address of the endpoint for the primary node in the replication group, if the cluster mode is disabled.
 
 ## Import
 


### PR DESCRIPTION
The current documentation for Elasticache attributes looks wrong. The `configuration_endpoint_address` is available for Memcache and Clustered Redis and the `primary_endpoint_address` is available for Standalone Redis only

- Reference: http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Endpoints.html