### PR TITLE
Use s3 bucket "id" attribute for "aws_s3_bucket_object" docs

### DIFF
--- a/website/docs/r/s3_bucket_object.html.markdown
+++ b/website/docs/r/s3_bucket_object.html.markdown
@@ -38,7 +38,7 @@ resource "aws_s3_bucket" "examplebucket" {
 
 resource "aws_s3_bucket_object" "examplebucket_object" {
   key        = "someobject"
-  bucket     = "${aws_s3_bucket.examplebucket.bucket}"
+  bucket     = "${aws_s3_bucket.examplebucket.id}"
   source     = "index.html"
   kms_key_id = "${aws_kms_key.examplekms.arn}"
 }
@@ -54,7 +54,7 @@ resource "aws_s3_bucket" "examplebucket" {
 
 resource "aws_s3_bucket_object" "examplebucket_object" {
   key                    = "someobject"
-  bucket                 = "${aws_s3_bucket.examplebucket.bucket}"
+  bucket                 = "${aws_s3_bucket.examplebucket.id}"
   source                 = "index.html"
   server_side_encryption = "aws:kms"
 }


### PR DESCRIPTION
Reasoning for docs update:

Looks like the `s3_bucket_object` docs use the `bucket` attribute from the `aws_s3_bucket` resource. While it does look like the `bucket` attribute is sometimes exported (if I read the code correctly), it's not documented on the `aws_s3_bucket` page. Also, other pages use the `id` attribute, so this change might be good for the sake of consistency.