### PR TITLE
Add Support For New AWS Region (eu-west-3)

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -487,6 +487,7 @@ func (c *Config) ValidateRegion() error {
 		"eu-central-1",
 		"eu-west-1",
 		"eu-west-2",
+		"eu-west-3",
 		"sa-east-1",
 		"us-east-1",
 		"us-east-2",

--- a/aws/hosted_zones.go
+++ b/aws/hosted_zones.go
@@ -10,6 +10,7 @@ var hostedZoneIDsMap = map[string]string{
 	"us-west-1":      "Z2F56UZL2M1ACD",
 	"eu-west-1":      "Z1BKCTXD74EZPE",
 	"eu-west-2":      "Z3GKZC51ZF0DB4",
+	"eu-west-3":      "Z3R1K369G5AVDG",
 	"eu-central-1":   "Z21DNDUVLTQW6Q",
 	"ap-south-1":     "Z11RGJOFQNVJUP",
 	"ap-southeast-1": "Z3O0J2DXBE1FTB",


### PR DESCRIPTION
This commit adds support for the new EU (Paris) region.

The ELB service account number for eu-west-3 has not yet been published. 
Once the service account is known, the `aws_elb_service_account` data 
source should be updated accordingly. 