### PR TITLE
Update formatting of networking_configuration

### DIFF
--- a/website/docs/r/ecs_service.html.markdown
+++ b/website/docs/r/ecs_service.html.markdown
@@ -98,6 +98,7 @@ Guide](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-query-
 ## network_configuration
 
 `network_configuration` support the following:
+
 * `subnets` - (Required) The subnets associated with the task or service.
 * `security_groups` - (Optional) The security groups associated with the task or service. If you do not specify a security group, the default security group for the VPC is used.
 For more information, see [Task Networking](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-networking.html)


### PR DESCRIPTION
A missing new line makes the rendered markdown to be on the same line.

<img width="873" alt="aws aws_ecs_service - terraform by hashicorp 2017-12-21 20-47-32" src="https://user-images.githubusercontent.com/24556/34272337-2fb0b460-e690-11e7-9443-ea6bad49164b.png">

I'm unsure how to build the website, so I was unable to test it myself.