### PR TITLE
Bump aws-sdk-go to v1.12.52

### DIFF
--- a/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
@@ -513,6 +513,7 @@ var awsPartition = partition{
 
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
+				"ap-northeast-2": endpoint{},
 				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
 				"ca-central-1":   endpoint{},

--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.12.51"
+const SDKVersion = "1.12.52"

--- a/vendor/github.com/aws/aws-sdk-go/service/codebuild/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/codebuild/api.go
@@ -2307,6 +2307,9 @@ type EnvironmentImage struct {
 
 	// The name of the Docker image.
 	Name *string `locationName:"name" type:"string"`
+
+	// A list of environment image versions.
+	Versions []*string `locationName:"versions" type:"list"`
 }
 
 // String returns the string representation
@@ -2328,6 +2331,12 @@ func (s *EnvironmentImage) SetDescription(v string) *EnvironmentImage {
 // SetName sets the Name field's value.
 func (s *EnvironmentImage) SetName(v string) *EnvironmentImage {
 	s.Name = &v
+	return s
+}
+
+// SetVersions sets the Versions field's value.
+func (s *EnvironmentImage) SetVersions(v []*string) *EnvironmentImage {
+	s.Versions = v
 	return s
 }
 
@@ -3044,10 +3053,7 @@ type Project struct {
 	// The default is 60 minutes.
 	TimeoutInMinutes *int64 `locationName:"timeoutInMinutes" min:"5" type:"integer"`
 
-	// If your AWS CodeBuild project accesses resources in an Amazon VPC, you provide
-	// this parameter that identifies the VPC ID and the list of security group
-	// IDs and subnet IDs. The security groups and subnets must belong to the same
-	// VPC. You must provide at least one security group and one subnet ID.
+	// Information about the VPC configuration that AWS CodeBuild will access.
 	VpcConfig *VpcConfig `locationName:"vpcConfig" type:"structure"`
 
 	// Information about a webhook in GitHub that connects repository events to
@@ -4220,10 +4226,7 @@ func (s *UpdateProjectOutput) SetProject(v *Project) *UpdateProjectOutput {
 	return s
 }
 
-// If your AWS CodeBuild project accesses resources in an Amazon VPC, you provide
-// this parameter that identifies the VPC ID and the list of security group
-// IDs and subnet IDs. The security groups and subnets must belong to the same
-// VPC. You must provide at least one security group and one subnet ID.
+// Information about the VPC configuration that AWS CodeBuild will access.
 // See also, https://docs.aws.amazon.com/goto/WebAPI/codebuild-2016-10-06/VpcConfig
 type VpcConfig struct {
 	_ struct{} `type:"structure"`

--- a/vendor/github.com/aws/aws-sdk-go/service/ec2/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ec2/api.go
@@ -20190,6 +20190,8 @@ func (c *EC2) ReplaceNetworkAclAssociationRequest(input *ReplaceNetworkAclAssoci
 // For more information about network ACLs, see Network ACLs (http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_ACLs.html)
 // in the Amazon Virtual Private Cloud User Guide.
 //
+// This is an idempotent operation.
+//
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
 // the error.
@@ -22652,6 +22654,9 @@ type Address struct {
 
 	// The Elastic IP address.
 	PublicIp *string `locationName:"publicIp" type:"string"`
+
+	// Any tags assigned to the Elastic IP address.
+	Tags []*Tag `locationName:"tags" locationNameList:"item" type:"list"`
 }
 
 // String returns the string representation
@@ -22709,6 +22714,12 @@ func (s *Address) SetPrivateIpAddress(v string) *Address {
 // SetPublicIp sets the PublicIp field's value.
 func (s *Address) SetPublicIp(v string) *Address {
 	s.PublicIp = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *Address) SetTags(v []*Tag) *Address {
+	s.Tags = v
 	return s
 }
 
@@ -41336,14 +41347,14 @@ type DescribeVpcEndpointConnectionsInput struct {
 
 	// One or more filters.
 	//
-	//    * customer-account-id - The AWS account number of the owner of the endpoint.
+	//    * service-id - The ID of the service.
 	//
-	//    * endpoint-connection-state - The state of the endpoint (PendingAcceptance
-	//    | Pending | Available | Deleting | Deleted | Rejected | Failed).
+	//    * vpc-endpoint-owner - The AWS account number of the owner of the endpoint.
+	//
+	//    * vpc-endpoint-state - The state of the endpoint (pendingAcceptance |
+	//    pending | available | deleting | deleted | rejected | failed).
 	//
 	//    * vpc-endpoint-id - The ID of the endpoint.
-	//
-	//    * vpc-endpoint-service-id - The ID of the service.
 	Filters []*Filter `locationName:"Filter" locationNameList:"Filter" type:"list"`
 
 	// The maximum number of results to return for the request in a single page.
@@ -41437,12 +41448,12 @@ type DescribeVpcEndpointServiceConfigurationsInput struct {
 
 	// One or more filters.
 	//
-	//    * service-name - The ARN of the service.
+	//    * service-name - The name of the service.
 	//
-	//    * vpc-endpoint-service-id - The ID of the service.
+	//    * service-id - The ID of the service.
 	//
-	//    * vpc-endpoint-service-state - The state of the service (Pending | Available
-	//    | Deleting | Deleted | Failed).
+	//    * service-state - The state of the service (Pending | Available | Deleting
+	//    | Deleted | Failed).
 	Filters []*Filter `locationName:"Filter" locationNameList:"Filter" type:"list"`
 
 	// The maximum number of results to return for the request in a single page.
@@ -49577,10 +49588,11 @@ type IpPermission struct {
 	// [EC2-VPC only] One or more IPv6 ranges.
 	Ipv6Ranges []*Ipv6Range `locationName:"ipv6Ranges" locationNameList:"item" type:"list"`
 
-	// (Valid for AuthorizeSecurityGroupEgress, RevokeSecurityGroupEgress and DescribeSecurityGroups
-	// only) One or more prefix list IDs for an AWS service. In an AuthorizeSecurityGroupEgress
-	// request, this is the AWS service that you want to access through a VPC endpoint
-	// from instances associated with the security group.
+	// (EC2-VPC only; valid for AuthorizeSecurityGroupEgress, RevokeSecurityGroupEgress
+	// and DescribeSecurityGroups only) One or more prefix list IDs for an AWS service.
+	// In an AuthorizeSecurityGroupEgress request, this is the AWS service that
+	// you want to access through a VPC endpoint from instances associated with
+	// the security group.
 	PrefixListIds []*PrefixListId `locationName:"prefixListIds" locationNameList:"item" type:"list"`
 
 	// The end of port range for the TCP and UDP protocols, or an ICMP/ICMPv6 code.
@@ -55613,7 +55625,7 @@ func (s *PrefixList) SetPrefixListName(v string) *PrefixList {
 	return s
 }
 
-// The ID of the prefix.
+// [EC2-VPC only] The ID of the prefix.
 // See also, https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/PrefixListId
 type PrefixListId struct {
 	_ struct{} `type:"structure"`

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -141,828 +141,828 @@
 			"revisionTime": "2017-07-27T15:54:43Z"
 		},
 		{
-			"checksumSHA1": "IARbiOsFuZg1G6v9wnl0RWyBMkY=",
+			"checksumSHA1": "zrW2b0liD5UpOFil/Nj7wa7Sp9A=",
 			"path": "github.com/aws/aws-sdk-go/aws",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "DtuTqKH29YnLjrIJkRYX0HQtXY0=",
 			"path": "github.com/aws/aws-sdk-go/aws/arn",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "Y9W+4GimK4Fuxq+vyIskVYFRnX4=",
 			"path": "github.com/aws/aws-sdk-go/aws/awserr",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "yyYr41HZ1Aq0hWc3J5ijXwYEcac=",
 			"path": "github.com/aws/aws-sdk-go/aws/awsutil",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "9nE/FjZ4pYrT883KtV2/aI+Gayo=",
 			"path": "github.com/aws/aws-sdk-go/aws/client",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "ieAJ+Cvp/PKv1LpUEnUXpc3OI6E=",
 			"path": "github.com/aws/aws-sdk-go/aws/client/metadata",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "7/8j/q0TWtOgXyvEcv4B2Dhl00o=",
 			"path": "github.com/aws/aws-sdk-go/aws/corehandlers",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "Y+cPwQL0dZMyqp3wI+KJWmA9KQ8=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "u3GOAJLmdvbuNUeUEcZSEAOeL/0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "NUJUTWlc1sV8b7WjfiYc4JZbXl0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/endpointcreds",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "JEYqmF83O5n5bHkupAzA6STm0no=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "OnU/n7R33oYXiB4SAGd5pK7I0Bs=",
 			"path": "github.com/aws/aws-sdk-go/aws/defaults",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "/EXbk/z2TWjWc1Hvb4QYs3Wmhb8=",
 			"path": "github.com/aws/aws-sdk-go/aws/ec2metadata",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
-			"checksumSHA1": "pkjsLFuKd1FMWJXFnsO1XX+JKPs=",
+			"checksumSHA1": "aOgB3+hNeX2svLhaX373ToSkhTg=",
 			"path": "github.com/aws/aws-sdk-go/aws/endpoints",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "9GvAyILJ7g+VUg8Ef5DsT5GuYsg=",
 			"path": "github.com/aws/aws-sdk-go/aws/request",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "HcGL4e6Uep4/80eCUI5xkcWjpQ0=",
 			"path": "github.com/aws/aws-sdk-go/aws/session",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "iU00ZjhAml/13g+1YXT21IqoXqg=",
 			"path": "github.com/aws/aws-sdk-go/aws/signer/v4",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "04ypv4x12l4q0TksA1zEVsmgpvw=",
 			"path": "github.com/aws/aws-sdk-go/internal/shareddefaults",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "NStHCXEvYqG72GknZyv1jaKaeH0=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "1QmQ3FqV37w0Zi44qv8pA1GeR0A=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/ec2query",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "yHfT5DTbeCLs4NE2Rgnqrhe15ls=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/json/jsonutil",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "R00RL5jJXRYq1iiK1+PGvMfvXyM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/jsonrpc",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "ZqY5RWavBLWTo6j9xqdyBEaNFRk=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "9V1PvtFQ9MObZTc3sa86WcuOtOU=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "pkeoOfZpHRvFG/AOZeTf0lwtsFg=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/rest",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "Rpu8KBtHZgvhkwHxUfaky+qW+G4=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restjson",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "ODo+ko8D6unAxZuN1jGzMcN4QCc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restxml",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "0qYPUga28aQVkxZgBR3Z86AbGUQ=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "F6mth+G7dXN1GI+nktaGo8Lx8aE=",
 			"path": "github.com/aws/aws-sdk-go/private/signer/v2",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "vnYDXA1NxJ7Hu+DMfXNk1UnmkWg=",
 			"path": "github.com/aws/aws-sdk-go/service/acm",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "DPl/OkvEUjrd+XKqX73l6nUNw3U=",
 			"path": "github.com/aws/aws-sdk-go/service/apigateway",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "X8tOI6i+RJwXIgg1qBjDNclyG/0=",
 			"path": "github.com/aws/aws-sdk-go/service/applicationautoscaling",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "aDAaH6YiA50IrJ5Smfg0fovrniA=",
 			"path": "github.com/aws/aws-sdk-go/service/appsync",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "oBXDw1zQTfxcKsK3ZjtKcS7gBLI=",
 			"path": "github.com/aws/aws-sdk-go/service/athena",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "ITAwWyJp4t9AGfUXm9M3pFWTHVA=",
 			"path": "github.com/aws/aws-sdk-go/service/autoscaling",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "Zz8qI6RloveM1zrXAglLxJZT1ZA=",
 			"path": "github.com/aws/aws-sdk-go/service/batch",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "/nO06EpnD22+Ex80gHi4UYrAvKc=",
 			"path": "github.com/aws/aws-sdk-go/service/budgets",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "6gM3CZZgiB0JvS7EK1c31Q8L09U=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudformation",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "T80IDetBz1hqJpq5Wqmx3MwCh8w=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudfront",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "bYrI9mxspB0xDFZEy3OIfWuez5g=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudtrail",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "oB+M+kOmYG28V0PuI75IF6E+/w8=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatch",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "Nc3vXlV7s309PprScYpRDPQWeDQ=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchevents",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "bPh7NF3mLpGMV0rIakolMPHqMyw=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
-			"checksumSHA1": "OqrWtx9iyIJ9roP2sEcmP9UCfXE=",
+			"checksumSHA1": "P6qyaFX9X6Nnvm3avLigjmjfYds=",
 			"path": "github.com/aws/aws-sdk-go/service/codebuild",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "7nW1Ho2X3RcUU8FaFBhJIUeuDNw=",
 			"path": "github.com/aws/aws-sdk-go/service/codecommit",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "m19PZt1B51QCWo1jxSbII2zzL6Q=",
 			"path": "github.com/aws/aws-sdk-go/service/codedeploy",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "LKw7fnNwq17Eqy0clzS/LK89vS4=",
 			"path": "github.com/aws/aws-sdk-go/service/codepipeline",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "aXh1KIbNX+g+tH+lh3pk++9lm3k=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentity",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "IWi9xZz+OncotjM/vJ87Iffg2Qk=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentityprovider",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "56F6Stg8hQ1kxiAEzqB0TDctW9k=",
 			"path": "github.com/aws/aws-sdk-go/service/configservice",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "hYCwLQdIjHj8rMHLGVyUVhecI4s=",
 			"path": "github.com/aws/aws-sdk-go/service/databasemigrationservice",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "26CWoHQP/dyL2VzE5ZNd8zNzhko=",
 			"path": "github.com/aws/aws-sdk-go/service/devicefarm",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "6g94rUHAgjcqMMTtMqKUbLU37wY=",
 			"path": "github.com/aws/aws-sdk-go/service/directconnect",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "oFnS6I0u7KqnxK0/r1uoz8rTkxI=",
 			"path": "github.com/aws/aws-sdk-go/service/directoryservice",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "0TXXUPjrbOCHpX555B6suH36Nnk=",
 			"path": "github.com/aws/aws-sdk-go/service/dynamodb",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
-			"checksumSHA1": "BOjSO1uO7Coj6o3oqpPUtEhQrPI=",
+			"checksumSHA1": "ygIRwuuaUwheg2sYJkChPRD2JME=",
 			"path": "github.com/aws/aws-sdk-go/service/ec2",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "uEv9kkBsVIjg7K4+Y8TVlU0Cc8o=",
 			"path": "github.com/aws/aws-sdk-go/service/ecr",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "sD9Urgwx7F3ImX+tJg2Q+ME/oFM=",
 			"path": "github.com/aws/aws-sdk-go/service/ecs",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "eoM9nF5iVMbuGOmkY33d19aHt8Y=",
 			"path": "github.com/aws/aws-sdk-go/service/efs",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "dU5MPXUUOYD/E9sNncpFZ/U86Cw=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticache",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "pj8mBWT3HE0Iid6HSmhw7lmyZDU=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticbeanstalk",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "VYGtTaSiajfKOVTbi9/SNmbiIac=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticsearchservice",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "SZ7yLDZ6RvMhpWe0Goyem64kgyA=",
 			"path": "github.com/aws/aws-sdk-go/service/elastictranscoder",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "WYqHhdRNsiGGBLWlBLbOItZf+zA=",
 			"path": "github.com/aws/aws-sdk-go/service/elb",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "ae7VWg/xuXpnSD6wGumN44qEd+Q=",
 			"path": "github.com/aws/aws-sdk-go/service/elbv2",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "NbkH6F+792jQ7BW4lGCb+vJVw58=",
 			"path": "github.com/aws/aws-sdk-go/service/emr",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "5btWHj2fZrPc/zfYdJLPaOcivxI=",
 			"path": "github.com/aws/aws-sdk-go/service/firehose",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "oDoGvSfmO2Z099ixV2HXn+SDeHE=",
 			"path": "github.com/aws/aws-sdk-go/service/glacier",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "HRmbBf3dUEBAfdC2xKaoWAGeM7Y=",
 			"path": "github.com/aws/aws-sdk-go/service/glue",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "6JlxJoy1JCArNK2qBkaJ5IV6qBc=",
 			"path": "github.com/aws/aws-sdk-go/service/guardduty",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "oZaxMqnwl2rA+V/W0tJ3uownORI=",
 			"path": "github.com/aws/aws-sdk-go/service/iam",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "dnNMSn5aHAtdOks+aWHLpwbi/VE=",
 			"path": "github.com/aws/aws-sdk-go/service/inspector",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "pZwCI4DpP5hcMa/ItKhiwo/ukd0=",
 			"path": "github.com/aws/aws-sdk-go/service/iot",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "IoSyRZhlL0petrB28nXk5jKM9YA=",
 			"path": "github.com/aws/aws-sdk-go/service/kinesis",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "oAFLgD0uJiVOZkFkL5dd/wUgBz4=",
 			"path": "github.com/aws/aws-sdk-go/service/kms",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "XDVse9fKF0RkAywzzgsO31AV4oc=",
 			"path": "github.com/aws/aws-sdk-go/service/lambda",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "HluEcyZNywrbKnj/aR3tXbu29d8=",
 			"path": "github.com/aws/aws-sdk-go/service/lexmodelbuildingservice",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "wjs9YBsHx0YQH0zKBA7Ibd1UV5Y=",
 			"path": "github.com/aws/aws-sdk-go/service/lightsail",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "4VfB5vMLNYs0y6K159YCBgo9T3c=",
 			"path": "github.com/aws/aws-sdk-go/service/mediaconvert",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "Ox3VWHYSQq0YKmlr0paUPdr5W/0=",
 			"path": "github.com/aws/aws-sdk-go/service/medialive",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "Rs7QtkcLl3XNPnKb8ss/AhF2X50=",
 			"path": "github.com/aws/aws-sdk-go/service/mediapackage",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "QjiIL8LrlhwrQw8FboF+wMNvUF0=",
 			"path": "github.com/aws/aws-sdk-go/service/mediastore",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "ZY1SJNE03I6NL2OBJD9hlwVsqO0=",
 			"path": "github.com/aws/aws-sdk-go/service/mediastoredata",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "ynB7Flcudp0VOqBVKZJ+23DtLHU=",
 			"path": "github.com/aws/aws-sdk-go/service/mq",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "fpsBu+F79ktlLRwal1GugVMUDo0=",
 			"path": "github.com/aws/aws-sdk-go/service/opsworks",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "Iqkgx2nafQPV7fjw+uP35jtF6t4=",
 			"path": "github.com/aws/aws-sdk-go/service/rds",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "vP1FcccUZbuUlin7ME89w1GVJtA=",
 			"path": "github.com/aws/aws-sdk-go/service/redshift",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "tKnVaKPOCiU6xl3/AYcdBCLtRdw=",
 			"path": "github.com/aws/aws-sdk-go/service/route53",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "sCaHoPWsJXRHFbilUKwN71qFTOI=",
 			"path": "github.com/aws/aws-sdk-go/service/s3",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "QZU8vR9cOIenYiH+Ywl4Gzfnlp0=",
 			"path": "github.com/aws/aws-sdk-go/service/servicecatalog",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "dk6ebvA0EYgdPyc5HPKLBPEtsm4=",
 			"path": "github.com/aws/aws-sdk-go/service/servicediscovery",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "Ex1Ma0SFGpqeNuPbeXZtsliZ3zo=",
 			"path": "github.com/aws/aws-sdk-go/service/ses",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "maVXeR3WDAkONlzf04e4mDgCYxo=",
 			"path": "github.com/aws/aws-sdk-go/service/sfn",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "ADoR4mlCW5usH8iOa6mPNSy49LM=",
 			"path": "github.com/aws/aws-sdk-go/service/shield",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "B3CgAFSREebpsFoFOo4vrQ6u04w=",
 			"path": "github.com/aws/aws-sdk-go/service/simpledb",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "FfY8w4DM8XIULdRnFhd3Um8Mj8c=",
 			"path": "github.com/aws/aws-sdk-go/service/sns",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "Wx189wAbIhWChx4kVbvsyqKMF4U=",
 			"path": "github.com/aws/aws-sdk-go/service/sqs",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "ijz0rBDeR6JP/06S+97k84FRYxc=",
 			"path": "github.com/aws/aws-sdk-go/service/ssm",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "W1oFtpaT4TWIIJrAvFcn/XdcT7g=",
 			"path": "github.com/aws/aws-sdk-go/service/sts",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "Uw4pOUxSMbx4xBHUcOUkNhtnywE=",
 			"path": "github.com/aws/aws-sdk-go/service/swf",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "on6d7Hydx2bM9jkFOf1JZcZZgeY=",
 			"path": "github.com/aws/aws-sdk-go/service/waf",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "rHqjsOndIR82gX5mSKybaRWf3UY=",
 			"path": "github.com/aws/aws-sdk-go/service/wafregional",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "5HDSvmMW7F3xzPAzughe4dEn6RM=",
 			"path": "github.com/aws/aws-sdk-go/service/workspaces",
-			"revision": "1cb9ce3dbddddab4a70e25ec1a5a60f1647b7e0b",
-			"revisionTime": "2017-12-21T00:21:33Z",
-			"version": "v1.12.51",
-			"versionExact": "v1.12.51"
+			"revision": "32d0e45c3f93cd20c25614183246d7e34bc7385c",
+			"revisionTime": "2017-12-21T23:11:03Z",
+			"version": "v1.12.52",
+			"versionExact": "v1.12.52"
 		},
 		{
 			"checksumSHA1": "usT4LCSQItkFvFOQT7cBlkCuGaE=",


### PR DESCRIPTION
required by #2744 

`govendor fetch github.com/aws/aws-sdk-go/...@v1.12.52`