### PR TITLE
d/aws_iam_server_certificate: add support for retrieving public key

### DIFF
--- a/aws/data_source_aws_iam_server_certificate.go
+++ b/aws/data_source_aws_iam_server_certificate.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
+	"time"
 )
 
 func dataSourceAwsIAMServerCertificate() *schema.Resource {
@@ -65,6 +66,21 @@ func dataSourceAwsIAMServerCertificate() *schema.Resource {
 			},
 
 			"expiration_date": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"upload_date": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"certificate_body": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"certificate_chain": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -129,8 +145,19 @@ func dataSourceAwsIAMServerCertificateRead(d *schema.ResourceData, meta interfac
 	d.Set("path", *metadata.Path)
 	d.Set("name", *metadata.ServerCertificateName)
 	if metadata.Expiration != nil {
-		d.Set("expiration_date", metadata.Expiration.Format("2006-01-02T15:04:05"))
+		d.Set("expiration_date", metadata.Expiration.Format(time.RFC3339))
 	}
+
+	log.Printf("[DEBUG] Get Public Key Certificate for %s", *metadata.ServerCertificateName)
+	serverCertificateResp, err := iamconn.GetServerCertificate(&iam.GetServerCertificateInput{
+		ServerCertificateName: metadata.ServerCertificateName,
+	})
+	if err != nil {
+		return err
+	}
+	d.Set("upload_date", serverCertificateResp.ServerCertificate.ServerCertificateMetadata.UploadDate.Format(time.RFC3339))
+	d.Set("certificate_body", aws.StringValue(serverCertificateResp.ServerCertificate.CertificateBody))
+	d.Set("certificate_chain", aws.StringValue(serverCertificateResp.ServerCertificate.CertificateChain))
 
 	return nil
 }

--- a/aws/data_source_aws_iam_server_certificate.go
+++ b/aws/data_source_aws_iam_server_certificate.go
@@ -5,12 +5,12 @@ import (
 	"log"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
-	"time"
 )
 
 func dataSourceAwsIAMServerCertificate() *schema.Resource {

--- a/aws/data_source_aws_iam_server_certificate_test.go
+++ b/aws/data_source_aws_iam_server_certificate_test.go
@@ -58,7 +58,7 @@ func TestAccAWSDataSourceIAMServerCertificate_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.aws_iam_server_certificate.test", "name"),
 					resource.TestCheckResourceAttrSet("data.aws_iam_server_certificate.test", "path"),
 					resource.TestCheckResourceAttrSet("data.aws_iam_server_certificate.test", "upload_date"),
-					resource.TestCheckResourceAttrSet("data.aws_iam_server_certificate.test", "certificate_chain"),
+					resource.TestCheckResourceAttr("data.aws_iam_server_certificate.test", "certificate_chain", ""),
 					resource.TestMatchResourceAttr("data.aws_iam_server_certificate.test", "certificate_body", regexp.MustCompile("^-----BEGIN CERTIFICATE-----")),
 				),
 			},

--- a/aws/data_source_aws_iam_server_certificate_test.go
+++ b/aws/data_source_aws_iam_server_certificate_test.go
@@ -58,7 +58,7 @@ func TestAccAWSDataSourceIAMServerCertificate_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.aws_iam_server_certificate.test", "name"),
 					resource.TestCheckResourceAttrSet("data.aws_iam_server_certificate.test", "path"),
 					resource.TestCheckResourceAttrSet("data.aws_iam_server_certificate.test", "upload_date"),
-					resource.TestCheckResourceAttrSet("data.aws_iam_server_certificate.test", "certificate_body"),
+					resource.TestCheckResourceAttrSet("data.aws_iam_server_certificate.test", "certificate_chain"),
 					resource.TestMatchResourceAttr("data.aws_iam_server_certificate.test", "certificate_body", regexp.MustCompile("^-----BEGIN CERTIFICATE-----")),
 				),
 			},

--- a/aws/data_source_aws_iam_server_certificate_test.go
+++ b/aws/data_source_aws_iam_server_certificate_test.go
@@ -57,6 +57,7 @@ func TestAccAWSDataSourceIAMServerCertificate_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.aws_iam_server_certificate.test", "id"),
 					resource.TestCheckResourceAttrSet("data.aws_iam_server_certificate.test", "name"),
 					resource.TestCheckResourceAttrSet("data.aws_iam_server_certificate.test", "path"),
+					resource.TestMatchResourceAttr("data.aws_iam_server_certificate.test", "certificate_body", regexp.MustCompile("^-----BEGIN CERTIFICATE-----")),
 				),
 			},
 		},

--- a/aws/data_source_aws_iam_server_certificate_test.go
+++ b/aws/data_source_aws_iam_server_certificate_test.go
@@ -57,6 +57,8 @@ func TestAccAWSDataSourceIAMServerCertificate_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.aws_iam_server_certificate.test", "id"),
 					resource.TestCheckResourceAttrSet("data.aws_iam_server_certificate.test", "name"),
 					resource.TestCheckResourceAttrSet("data.aws_iam_server_certificate.test", "path"),
+					resource.TestCheckResourceAttrSet("data.aws_iam_server_certificate.test", "upload_date"),
+					resource.TestCheckResourceAttrSet("data.aws_iam_server_certificate.test", "certificate_body"),
 					resource.TestMatchResourceAttr("data.aws_iam_server_certificate.test", "certificate_body", regexp.MustCompile("^-----BEGIN CERTIFICATE-----")),
 				),
 			},

--- a/website/docs/d/iam_server_certificate.html.markdown
+++ b/website/docs/d/iam_server_certificate.html.markdown
@@ -39,9 +39,12 @@ resource "aws_elb" "elb" {
 
 ## Attributes Reference
 
-`arn` is set to the ARN of the IAM Server Certificate
-`path` is set to the path of the IAM Server Certificate
-`expiration_date` is set to the expiration date of the IAM Server Certificate
+* `arn` is set to the ARN of the IAM Server Certificate
+* `path` is set to the path of the IAM Server Certificate
+* `expiration_date` is set to the expiration date of the IAM Server Certificate
+* `upload_date` is the date when the server certificate was uploaded
+* `certificate_body` is the public key certificate (PEM-encoded). This is useful when [configuring back-end instance authentication](http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-create-https-ssl-load-balancer.html) policy for load balancer
+* `certificate_chain` is the public key certificate chain (PEM-encoded) if exists, empty otherwise
 
 ## Import 
 


### PR DESCRIPTION
Invoke [API_GetServerCertificate](https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetServerCertificate.html) to obtain additional information for server certificate. Among which, `certificate_body` is useful when configuring back-end instance authentication with `aws_load_balancer_policy` and `aws_load_balancer_backend_server_policy`

Also fix the date format to be RFC-compliant

For #2742 
