### PR TITLE
Fix Argument in Example Usage

### DIFF
--- a/website/docs/d/rds_cluster.html.markdown
+++ b/website/docs/d/rds_cluster.html.markdown
@@ -14,7 +14,7 @@ Provides information about a RDS cluster.
 
 ```hcl
 data "aws_rds_cluster" "clusterName" {
-  name = "clusterName"
+  cluster_identifier = "clusterName"
 }
 ```
 


### PR DESCRIPTION
Fix the argument name in `aws_rds_cluster` data source