### PR TITLE
r/aws_instance: validate user data size during plan

### DIFF
--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -116,6 +116,7 @@ func resourceAwsInstance() *schema.Resource {
 						return ""
 					}
 				},
+				ValidateFunc: validateInstanceUserDataSize,
 			},
 
 			"user_data_base64": {

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -15,6 +15,15 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
+func validateInstanceUserDataSize(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+
+	if len(value) > 16384 {
+		errors = append(errors, fmt.Errorf("%q cannot be longer than 16384 bytes", k))
+	}
+	return
+}
+
 func validateRdsIdentifier(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if !regexp.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -9,6 +9,30 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 )
 
+func TestValidateInstanceUserDataSize(t *testing.T) {
+	validValues := []string{
+		"#!/bin/bash",
+		"#!/bin/bash\n" + strings.Repeat("#", 16372), // = 16384
+	}
+
+	for _, s := range validValues {
+		_, errors := validateInstanceUserDataSize(s, "user_data")
+		if len(errors) > 0 {
+			t.Fatalf("%q should be valid user data with limited size: %v", s, errors)
+		}
+	}
+
+	invalidValues := []string{
+		"#!/bin/bash\n" + strings.Repeat("#", 16373), // = 16385
+	}
+
+	for _, s := range invalidValues {
+		_, errors := validateInstanceUserDataSize(s, "user_data")
+		if len(errors) == 0 {
+			t.Fatalf("%q should not be valid user data with limited size: %v", s, errors)
+		}
+	}
+}
 func TestValidateEcrRepositoryName(t *testing.T) {
 	validNames := []string{
 		"nginx-web-app",


### PR DESCRIPTION
Related issue: #97

Clear error message is returned during `terraform apply`.
```
Error: Error applying plan:

1 error(s) occurred:

* aws_instance.this: 1 error(s) occurred:

* aws_instance.this: Error launching source instance: InvalidParameterValue: User data is limited to 16384 bytes
	status code: 400, request id: f87cabb3-e79b-4bba-81a0-632c95e54891
```
However, it might still help to validate user data size during `terraform plan`.
