### PR TITLE
r/aws_eip: Support tags

### DIFF
--- a/website/docs/r/eip.html.markdown
+++ b/website/docs/r/eip.html.markdown
@@ -92,6 +92,7 @@ The following arguments are supported:
 * `associate_with_private_ip` - (Optional) A user specified primary or secondary private IP address to
   associate with the Elastic IP address. If no private IP address is specified,
   the Elastic IP address is associated with the primary private IP address.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ~> **NOTE:** You can specify either the `instance` ID or the `network_interface` ID,
 but not both. Including both will **not** return an error from the AWS API, but will
@@ -100,7 +101,7 @@ more information.
 
 ## Attributes Reference
 
-The following attributes are exported:
+The following additional attributes are exported:
 
 * `id` - Contains the EIP allocation ID.
 * `private_ip` - Contains the private IP address (if in VPC).
@@ -109,7 +110,6 @@ The following attributes are exported:
 * `public_ip` - Contains the public IP address.
 * `instance` - Contains the ID of the attached instance.
 * `network_interface` - Contains the ID of the attached network interface.
-
 
 ## Import
 


### PR DESCRIPTION
Prerequisite: AWS SDK v1.12.53 (#2767)
Closes #2744 

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSEIP'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSEIP -timeout 120m
=== RUN   TestAccAWSEIPAssociation_basic
--- PASS: TestAccAWSEIPAssociation_basic (122.43s)
=== RUN   TestAccAWSEIPAssociation_ec2Classic
--- SKIP: TestAccAWSEIPAssociation_ec2Classic (1.37s)
	provider_test.go:69: This test can only run in EC2 Classic, platforms available in us-east-1: ["VPC"]
=== RUN   TestAccAWSEIPAssociation_disappears
--- PASS: TestAccAWSEIPAssociation_disappears (107.66s)
=== RUN   TestAccAWSEIP_importEc2Classic
--- SKIP: TestAccAWSEIP_importEc2Classic (1.21s)
	provider_test.go:69: This test can only run in EC2 Classic, platforms available in us-east-1: ["VPC"]
=== RUN   TestAccAWSEIP_importVpc
--- PASS: TestAccAWSEIP_importVpc (40.88s)
=== RUN   TestAccAWSEIP_basic
--- PASS: TestAccAWSEIP_basic (9.62s)
=== RUN   TestAccAWSEIP_instance
--- PASS: TestAccAWSEIP_instance (187.87s)
=== RUN   TestAccAWSEIP_network_interface
--- PASS: TestAccAWSEIP_network_interface (41.78s)
=== RUN   TestAccAWSEIP_twoEIPsOneNetworkInterface
--- PASS: TestAccAWSEIP_twoEIPsOneNetworkInterface (41.54s)
=== RUN   TestAccAWSEIP_associated_user_private_ip
--- PASS: TestAccAWSEIP_associated_user_private_ip (147.79s)
=== RUN   TestAccAWSEIP_classic_disassociate
--- SKIP: TestAccAWSEIP_classic_disassociate (1.44s)
	provider_test.go:69: This test can only run in EC2 Classic, platforms available in us-west-2: ["VPC"]
=== RUN   TestAccAWSEIP_disappears
--- PASS: TestAccAWSEIP_disappears (8.32s)
=== RUN   TestAccAWSEIPAssociate_not_associated
--- PASS: TestAccAWSEIPAssociate_not_associated (124.13s)
=== RUN   TestAccAWSEIP_tags
--- PASS: TestAccAWSEIP_tags (19.26s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	855.340s
```