### PR TITLE
r/aws_codepipeline: Add arn attribute

### DIFF
--- a/aws/resource_aws_codepipeline.go
+++ b/aws/resource_aws_codepipeline.go
@@ -24,6 +24,11 @@ func resourceAwsCodePipeline() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -459,6 +464,7 @@ func resourceAwsCodePipelineRead(d *schema.ResourceData, meta interface{}) error
 		}
 		return fmt.Errorf("[ERROR] Error retreiving Pipeline: %q", err)
 	}
+	metadata := resp.Metadata
 	pipeline := resp.Pipeline
 
 	if err := d.Set("artifact_store", flattenAwsCodePipelineArtifactStore(pipeline.ArtifactStore)); err != nil {
@@ -469,6 +475,7 @@ func resourceAwsCodePipelineRead(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
+	d.Set("arn", metadata.PipelineArn)
 	d.Set("name", pipeline.Name)
 	d.Set("role_arn", pipeline.RoleArn)
 	return nil

--- a/aws/resource_aws_codepipeline_test.go
+++ b/aws/resource_aws_codepipeline_test.go
@@ -29,6 +29,8 @@ func TestAccAWSCodePipeline_basic(t *testing.T) {
 				Config: testAccAWSCodePipelineConfig_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodePipelineExists("aws_codepipeline.bar"),
+					resource.TestMatchResourceAttr("aws_codepipeline.bar", "arn",
+						regexp.MustCompile(fmt.Sprintf("^arn:aws:codepipeline:[^:]+:[0-9]{12}:test-pipeline-%s", name))),
 					resource.TestCheckResourceAttr("aws_codepipeline.bar", "artifact_store.0.type", "S3"),
 					resource.TestCheckResourceAttr("aws_codepipeline.bar", "artifact_store.0.encryption_key.0.id", "1234"),
 					resource.TestCheckResourceAttr("aws_codepipeline.bar", "artifact_store.0.encryption_key.0.type", "KMS"),

--- a/website/docs/r/codepipeline.markdown
+++ b/website/docs/r/codepipeline.markdown
@@ -157,9 +157,10 @@ A `action` block supports the following arguments:
 
 ## Attributes Reference
 
-The following attributes are exported:
+The following additional attributes are exported:
 
 * `id` - The codepipeline ID.
+* `arn` - The codepipeline ARN.
 
 ## Import
 


### PR DESCRIPTION
Reference: http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-codepipeline
Closes #2714 

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSCodePipeline_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCodePipeline_basic -timeout 120m
=== RUN   TestAccAWSCodePipeline_basic
--- PASS: TestAccAWSCodePipeline_basic (49.59s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	49.626s
```