### PR TITLE
d/aws_ssm_parameter: Support returning raw encrypted SecureString value.

### DIFF
--- a/aws/data_source_aws_ssm_parameter.go
+++ b/aws/data_source_aws_ssm_parameter.go
@@ -32,6 +32,11 @@ func dataSourceAwsSsmParameter() *schema.Resource {
 				Computed:  true,
 				Sensitive: true,
 			},
+			"with_decryption": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
 		},
 	}
 }
@@ -45,7 +50,7 @@ func dataAwsSsmParameterRead(d *schema.ResourceData, meta interface{}) error {
 		Names: []*string{
 			aws.String(name),
 		},
-		WithDecryption: aws.Bool(true),
+		WithDecryption: aws.Bool(d.Get("with_decryption").(bool)),
 	}
 
 	log.Printf("[DEBUG] Reading SSM Parameter: %s", paramInput)

--- a/aws/data_source_aws_ssm_parameter_test.go
+++ b/aws/data_source_aws_ssm_parameter_test.go
@@ -16,19 +16,30 @@ func TestAccAwsSsmParameterDataSource_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAwsSsmParameterDataSourceConfig(name),
+				Config: testAccCheckAwsSsmParameterDataSourceConfig(name, "true"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.aws_ssm_parameter.test", "arn"),
 					resource.TestCheckResourceAttr("data.aws_ssm_parameter.test", "name", name),
 					resource.TestCheckResourceAttr("data.aws_ssm_parameter.test", "type", "String"),
 					resource.TestCheckResourceAttr("data.aws_ssm_parameter.test", "value", "TestValue"),
+					resource.TestCheckResourceAttr("data.aws_ssm_parameter.test", "with_decryption", "true"),
+				),
+			},
+			{
+				Config: testAccCheckAwsSsmParameterDataSourceConfig(name, "false"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.aws_ssm_parameter.test", "arn"),
+					resource.TestCheckResourceAttr("data.aws_ssm_parameter.test", "name", name),
+					resource.TestCheckResourceAttr("data.aws_ssm_parameter.test", "type", "String"),
+					resource.TestCheckResourceAttr("data.aws_ssm_parameter.test", "value", "TestValue"),
+					resource.TestCheckResourceAttr("data.aws_ssm_parameter.test", "with_decryption", "false"),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckAwsSsmParameterDataSourceConfig(name string) string {
+func testAccCheckAwsSsmParameterDataSourceConfig(name string, with_decryption string) string {
 	return fmt.Sprintf(`
 resource "aws_ssm_parameter" "test" {
 	name = "%s"
@@ -38,6 +49,7 @@ resource "aws_ssm_parameter" "test" {
 
 data "aws_ssm_parameter" "test" {
 	name = "${aws_ssm_parameter.test.name}"
+	with_decryption = %s
 }
-`, name)
+`, name, with_decryption)
 }

--- a/aws/data_source_aws_ssm_parameter_test.go
+++ b/aws/data_source_aws_ssm_parameter_test.go
@@ -4,13 +4,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccAwsSsmParameterDataSource_basic(t *testing.T) {
 	name := "test.parameter"
-	with_decryption := []string{"true", "false"}[acctest.RandIntRange(0, 2)]
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -18,20 +17,30 @@ func TestAccAwsSsmParameterDataSource_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAwsSsmParameterDataSourceConfig(name, with_decryption),
+				Config: testAccCheckAwsSsmParameterDataSourceConfig(name, "false"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.aws_ssm_parameter.test", "arn"),
 					resource.TestCheckResourceAttr("data.aws_ssm_parameter.test", "name", name),
 					resource.TestCheckResourceAttr("data.aws_ssm_parameter.test", "type", "String"),
 					resource.TestCheckResourceAttr("data.aws_ssm_parameter.test", "value", "TestValue"),
-					resource.TestCheckResourceAttr("data.aws_ssm_parameter.test", "with_decryption", with_decryption),
+					resource.TestCheckResourceAttr("data.aws_ssm_parameter.test", "with_decryption", "false"),
+				),
+			},
+			{
+				Config: testAccCheckAwsSsmParameterDataSourceConfig(name, "true"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.aws_ssm_parameter.test", "arn"),
+					resource.TestCheckResourceAttr("data.aws_ssm_parameter.test", "name", name),
+					resource.TestCheckResourceAttr("data.aws_ssm_parameter.test", "type", "String"),
+					resource.TestCheckResourceAttr("data.aws_ssm_parameter.test", "value", "TestValue"),
+					resource.TestCheckResourceAttr("data.aws_ssm_parameter.test", "with_decryption", "true"),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckAwsSsmParameterDataSourceConfig(name string, with_decryption string) string {
+func testAccCheckAwsSsmParameterDataSourceConfig(name string, withDecryption string) string {
 	return fmt.Sprintf(`
 resource "aws_ssm_parameter" "test" {
 	name = "%s"
@@ -43,5 +52,5 @@ data "aws_ssm_parameter" "test" {
 	name = "${aws_ssm_parameter.test.name}"
 	with_decryption = %s
 }
-`, name, with_decryption)
+`, name, withDecryption)
 }

--- a/aws/data_source_aws_ssm_parameter_test.go
+++ b/aws/data_source_aws_ssm_parameter_test.go
@@ -4,11 +4,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccAwsSsmParameterDataSource_basic(t *testing.T) {
 	name := "test.parameter"
+	with_decryption := []string{"true", "false"}[acctest.RandIntRange(0, 2)]
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -16,23 +18,13 @@ func TestAccAwsSsmParameterDataSource_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAwsSsmParameterDataSourceConfig(name, "true"),
+				Config: testAccCheckAwsSsmParameterDataSourceConfig(name, with_decryption),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.aws_ssm_parameter.test", "arn"),
 					resource.TestCheckResourceAttr("data.aws_ssm_parameter.test", "name", name),
 					resource.TestCheckResourceAttr("data.aws_ssm_parameter.test", "type", "String"),
 					resource.TestCheckResourceAttr("data.aws_ssm_parameter.test", "value", "TestValue"),
-					resource.TestCheckResourceAttr("data.aws_ssm_parameter.test", "with_decryption", "true"),
-				),
-			},
-			{
-				Config: testAccCheckAwsSsmParameterDataSourceConfig(name, "false"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.aws_ssm_parameter.test", "arn"),
-					resource.TestCheckResourceAttr("data.aws_ssm_parameter.test", "name", name),
-					resource.TestCheckResourceAttr("data.aws_ssm_parameter.test", "type", "String"),
-					resource.TestCheckResourceAttr("data.aws_ssm_parameter.test", "value", "TestValue"),
-					resource.TestCheckResourceAttr("data.aws_ssm_parameter.test", "with_decryption", "false"),
+					resource.TestCheckResourceAttr("data.aws_ssm_parameter.test", "with_decryption", with_decryption),
 				),
 			},
 		},

--- a/website/docs/d/ssm_parameter.html.markdown
+++ b/website/docs/d/ssm_parameter.html.markdown
@@ -28,6 +28,7 @@ data "aws_ssm_parameter" "foo" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the parameter.
+* `with_decryption` - (Optional) Whether to return decrypted `SecureString` value. Defaults to `true`.
 
 
 The following attributes are exported:


### PR DESCRIPTION
It is useful to have it for triggers or other purposes. Defaults to
returning decrypted value as before.

```
$ make testacc TESTARGS="-run 'TestAccAwsSsmParameterDataSource_'"                                                                                                                                                                                                                 148 ↵
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run 'TestAccAwsSsmParameterDataSource_' -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAwsSsmParameterDataSource_basic
--- PASS: TestAccAwsSsmParameterDataSource_basic (55.34s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       55.363s
```