### PR TITLE
r/aws_ecs_service: Add health_check_grace_period_seconds attribute

### DIFF
--- a/aws/resource_aws_ecs_service_test.go
+++ b/aws/resource_aws_ecs_service_test.go
@@ -739,9 +739,9 @@ data "aws_availability_zones" "available" {}
 
 resource "aws_vpc" "main" {
   cidr_block = "10.10.0.0/16"
-	tags {
-		Name = "%[2]s"
-	}
+  tags {
+    Name = "%[2]s"
+  }
 }
 
 resource "aws_subnet" "main" {
@@ -777,8 +777,8 @@ DEFINITION
 }
 
 resource "aws_iam_role" "ecs_service" {
-    name = "%[1]s"
-    assume_role_policy = <<EOF
+  name = "%[1]s"
+  assume_role_policy = <<EOF
 {
   "Version": "2008-10-17",
   "Statement": [
@@ -796,9 +796,9 @@ EOF
 }
 
 resource "aws_iam_role_policy" "ecs_service" {
-    name = "%[1]s"
-    role = "${aws_iam_role.ecs_service.name}"
-    policy = <<EOF
+  name = "%[1]s"
+  role = "${aws_iam_role.ecs_service.name}"
+  policy = <<EOF
 {
   "Version": "2012-10-17",
   "Statement": [

--- a/website/docs/r/ecs_service.html.markdown
+++ b/website/docs/r/ecs_service.html.markdown
@@ -58,6 +58,7 @@ The following arguments are supported:
 * `placement_strategy` - (Optional) Service level strategy rules that are taken
 into consideration during task placement. The maximum number of
 `placement_strategy` blocks is `5`. Defined below.
+* `health_check_grace_period_seconds` - (Optional) Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 1800. Only valid for services configured to use load balancers.
 * `load_balancer` - (Optional) A load balancer block. Load balancers documented below.
 * `placement_constraints` - (Optional) rules that are taken into consideration during task placement. Maximum number of
 `placement_constraints` is `10`. Defined below.


### PR DESCRIPTION
Closes #2786 

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSEcsService'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSEcsService -timeout 120m
=== RUN   TestAccAWSEcsServiceWithARN
--- PASS: TestAccAWSEcsServiceWithARN (37.76s)
=== RUN   TestAccAWSEcsServiceWithUnnormalizedPlacementStrategy
--- PASS: TestAccAWSEcsServiceWithUnnormalizedPlacementStrategy (52.09s)
=== RUN   TestAccAWSEcsServiceWithFamilyAndRevision
--- PASS: TestAccAWSEcsServiceWithFamilyAndRevision (46.97s)
=== RUN   TestAccAWSEcsServiceWithRenamedCluster
--- PASS: TestAccAWSEcsServiceWithRenamedCluster (69.47s)
=== RUN   TestAccAWSEcsService_healthCheckGracePeriodSeconds
--- PASS: TestAccAWSEcsService_healthCheckGracePeriodSeconds (246.37s)
=== RUN   TestAccAWSEcsService_withIamRole
--- PASS: TestAccAWSEcsService_withIamRole (152.77s)
=== RUN   TestAccAWSEcsService_withDeploymentValues
--- PASS: TestAccAWSEcsService_withDeploymentValues (30.58s)
=== RUN   TestAccAWSEcsService_withLbChanges
--- PASS: TestAccAWSEcsService_withLbChanges (245.83s)
=== RUN   TestAccAWSEcsService_withEcsClusterName
--- PASS: TestAccAWSEcsService_withEcsClusterName (41.16s)
=== RUN   TestAccAWSEcsService_withAlb
--- PASS: TestAccAWSEcsService_withAlb (234.73s)
=== RUN   TestAccAWSEcsServiceWithPlacementStrategy
--- PASS: TestAccAWSEcsServiceWithPlacementStrategy (61.25s)
=== RUN   TestAccAWSEcsServiceWithPlacementConstraints
--- PASS: TestAccAWSEcsServiceWithPlacementConstraints (24.35s)
=== RUN   TestAccAWSEcsServiceWithPlacementConstraints_emptyExpression
--- PASS: TestAccAWSEcsServiceWithPlacementConstraints_emptyExpression (14.97s)
=== RUN   TestAccAWSEcsServiceWithLaunchTypeFargate
--- PASS: TestAccAWSEcsServiceWithLaunchTypeFargate (19.69s)
=== RUN   TestAccAWSEcsServiceWithNetworkConfiguration
--- PASS: TestAccAWSEcsServiceWithNetworkConfiguration (46.66s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1324.682s
```