### PR TITLE
resource/aws_lambda_function: Validate the function name

### DIFF
--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -78,6 +78,7 @@ func resourceAwsLambdaFunction() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				ValidateFunc: validateLambdaFunctionName,
 			},
 			"handler": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -75,9 +75,9 @@ func resourceAwsLambdaFunction() *schema.Resource {
 				},
 			},
 			"function_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: validateLambdaFunctionName,
 			},
 			"handler": {

--- a/aws/resource_aws_lambda_permission.go
+++ b/aws/resource_aws_lambda_permission.go
@@ -34,7 +34,7 @@ func resourceAwsLambdaPermission() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validateLambdaFunctionName,
+				ValidateFunc: validateLambdaFunctionNameArn,
 			},
 			"principal": {
 				Type:     schema.TypeString,

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -349,6 +349,23 @@ func validateCloudWatchEventTargetId(v interface{}, k string) (ws []string, erro
 
 func validateLambdaFunctionName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
+	if len(value) > 64 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be longer than 140 characters: %q", k, value))
+	}
+	// http://docs.aws.amazon.com/lambda/latest/dg/API_AddPermission.html
+	pattern := `^[a-zA-Z0-9-_]+$`
+	if !regexp.MustCompile(pattern).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q doesn't comply with restrictions (%q): %q",
+			k, pattern, value))
+	}
+
+	return
+}
+
+func validateLambdaFunctionNameArn(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
 	if len(value) > 140 {
 		errors = append(errors, fmt.Errorf(
 			"%q cannot be longer than 140 characters: %q", k, value))

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -351,7 +351,7 @@ func validateLambdaFunctionName(v interface{}, k string) (ws []string, errors []
 	value := v.(string)
 	if len(value) > 64 {
 		errors = append(errors, fmt.Errorf(
-			"%q cannot be longer than 140 characters: %q", k, value))
+			"%q cannot be longer than 64 characters: %q", k, value))
 	}
 	// http://docs.aws.amazon.com/lambda/latest/dg/API_AddPermission.html
 	pattern := `^[a-zA-Z0-9-_]+$`

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -129,6 +129,35 @@ func TestValidateCloudWatchEventRuleName(t *testing.T) {
 
 func TestValidateLambdaFunctionName(t *testing.T) {
 	validNames := []string{
+		"FunctionName",
+		"function-name",
+		"function_name",
+	}
+	for _, v := range validNames {
+		_, errors := validateLambdaFunctionName(v, "name")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid Lambda function name: %q", v, errors)
+		}
+	}
+
+	invalidNames := []string{
+		"/FunctionNameWithSlash",
+		":FunctionNameWithSlash",
+		"arn:aws:lambda:us-west-2:123456789012:function:ARNFunctionName",
+		// length > 64
+		"TooLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo" +
+			"ooooooooooooooooongFunctionName",
+	}
+	for _, v := range invalidNames {
+		_, errors := validateLambdaFunctionName(v, "name")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be an invalid Lambda function name", v)
+		}
+	}
+}
+
+func TestValidateLambdaFunctionNameArn(t *testing.T) {
+	validNames := []string{
 		"arn:aws:lambda:us-west-2:123456789012:function:ThumbNail",
 		"arn:aws-us-gov:lambda:us-west-2:123456789012:function:ThumbNail",
 		"arn:aws-us-gov:lambda:us-gov-west-1:123456789012:function:ThumbNail",
@@ -136,7 +165,7 @@ func TestValidateLambdaFunctionName(t *testing.T) {
 		"function-name",
 	}
 	for _, v := range validNames {
-		_, errors := validateLambdaFunctionName(v, "name")
+		_, errors := validateLambdaFunctionNameArn(v, "name")
 		if len(errors) != 0 {
 			t.Fatalf("%q should be a valid Lambda function name: %q", v, errors)
 		}
@@ -151,7 +180,7 @@ func TestValidateLambdaFunctionName(t *testing.T) {
 			"ooooooooooooooooongFunctionName",
 	}
 	for _, v := range invalidNames {
-		_, errors := validateLambdaFunctionName(v, "name")
+		_, errors := validateLambdaFunctionNameArn(v, "name")
 		if len(errors) == 0 {
 			t.Fatalf("%q should be an invalid Lambda function name", v)
 		}

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -142,7 +142,6 @@ func TestValidateLambdaFunctionName(t *testing.T) {
 
 	invalidNames := []string{
 		"/FunctionNameWithSlash",
-		":FunctionNameWithSlash",
 		"arn:aws:lambda:us-west-2:123456789012:function:ARNFunctionName",
 		// length > 64
 		"TooLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo" +


### PR DESCRIPTION
Lambda function names (not the ARN, the actual name) has a restriction of 64 characters and alphanum with dash and underscore. (https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html)

> Note that the length constraint applies only to the ARN. If you specify only the function name, it is limited to 64 characters in length.

This adds a validator for those and rename the existing validator for function names that takes ARNs.

<img width="976" alt="screen shot 2017-12-28 at 9 28 23 am" src="https://user-images.githubusercontent.com/232139/34405080-85516308-ebb1-11e7-85e2-72b74e2765a2.png">
<img width="974" alt="screen shot 2017-12-28 at 9 28 36 am" src="https://user-images.githubusercontent.com/232139/34405083-872930de-ebb1-11e7-8556-646f8c96b633.png">
