### PR TITLE
Fixes skipped min_capacity argument in scalable_target_action

### DIFF
--- a/aws/resource_aws_appautoscaling_scheduled_action.go
+++ b/aws/resource_aws_appautoscaling_scheduled_action.go
@@ -104,7 +104,7 @@ func resourceAwsAppautoscalingScheduledActionPut(d *schema.ResourceData, meta in
 			sta.MaxCapacity = aws.Int64(int64(max.(int)))
 		}
 		if min, ok := raw["min_capacity"]; ok {
-			sta.MaxCapacity = aws.Int64(int64(min.(int)))
+			sta.MinCapacity = aws.Int64(int64(min.(int)))
 		}
 		input.ScalableTargetAction = sta
 	}


### PR DESCRIPTION
This simple PF fixes variable assignment.

The result of code: 
```
resource "aws_appautoscaling_target" "target" {
    ....
    scalable_target_action {
        min_capacity = 1
        max_capacity = 100
  }
}
```

was 

```
{
    "ScheduledActions": [
        {
           .... 
           "ScalableTargetAction": {
                "MaxCapacity": 1
            }
        }
    ]
}
```