### PR TITLE
[WIP] New Resource: aws_acm_certificate (+ changes to data source to wait for certificate issuing)

### DIFF
--- a/aws/data_source_aws_acm_certificate.go
+++ b/aws/data_source_aws_acm_certificate.go
@@ -100,10 +100,7 @@ func dataSourceAwsAcmGetCertificate(d *schema.ResourceData, meta interface{}) *r
 		return true
 	})
 	if err != nil {
-		return &resource.RetryError{
-			Err:       errwrap.Wrapf("Error describing certificates: {{err}}", err),
-			Retryable: false,
-		}
+		return resource.NonRetryableError(errwrap.Wrapf("Error describing certificates: {{err}}", err))
 	}
 
 	// filter based on certificate type (imported or aws-issued)
@@ -117,10 +114,7 @@ func dataSourceAwsAcmGetCertificate(d *schema.ResourceData, meta interface{}) *r
 
 			description, err := conn.DescribeCertificate(params)
 			if err != nil {
-				return &resource.RetryError{
-					Err:       errwrap.Wrapf("Error describing certificates: {{err}}", err),
-					Retryable: false,
-				}
+				return resource.NonRetryableError(errwrap.Wrapf("Error describing certificates: {{err}}", err))
 			}
 
 			for _, certType := range typesStrings {
@@ -140,16 +134,10 @@ func dataSourceAwsAcmGetCertificate(d *schema.ResourceData, meta interface{}) *r
 	}
 
 	if len(arns) == 0 {
-		return &resource.RetryError{
-			Err:       fmt.Errorf("No certificate for domain %q found in this region.", targetValue),
-			Retryable: true,
-		}
+		return resource.RetryableError(fmt.Errorf("No certificate for domain %q found in this region.", targetValue))
 	}
 	if len(arns) > 1 {
-		return &resource.RetryError{
-			Err:       fmt.Errorf("Multiple certificates for domain %q found in this region.", targetValue),
-			Retryable: true,
-		}
+		return resource.NonRetryableError(fmt.Errorf("Multiple certificates for domain %q found in this region.", targetValue))
 	}
 
 	d.SetId(time.Now().UTC().String())

--- a/aws/data_source_aws_acm_certificate_test.go
+++ b/aws/data_source_aws_acm_certificate_test.go
@@ -32,6 +32,21 @@ func TestAccAwsAcmCertificateDataSource_noMatchReturnsError(t *testing.T) {
 	})
 }
 
+func TestAccAwsAcmCertificateDataSource_wait_until_issued(t *testing.T) {
+	domain := "certtest.hashicorp.com"
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAwsAcmCertificateDataSourceConfigWaitingForIssued(domain),
+			},
+		},
+	})
+}
+
 func testAccCheckAwsAcmCertificateDataSourceConfig(domain string) string {
 	return fmt.Sprintf(`
 data "aws_acm_certificate" "test" {
@@ -54,6 +69,17 @@ func testAccCheckAwsAcmCertificateDataSourceConfigWithTypes(domain string) strin
 data "aws_acm_certificate" "test" {
 	domain = "%s"
 	types = ["IMPORTED"]
+}
+`, domain)
+}
+
+func testAccCheckAwsAcmCertificateDataSourceConfigWaitingForIssued(domain string) string {
+	return fmt.Sprintf(`
+data "aws_acm_certificate" "test" {
+	domain = "%s"
+	statuses = ["ISSUED"]
+	wait_until_present = true
+	wait_until_present_timeout = "1m"
 }
 `, domain)
 }

--- a/aws/data_source_aws_acm_certificate_test.go
+++ b/aws/data_source_aws_acm_certificate_test.go
@@ -32,21 +32,6 @@ func TestAccAwsAcmCertificateDataSource_noMatchReturnsError(t *testing.T) {
 	})
 }
 
-func TestAccAwsAcmCertificateDataSource_wait_until_issued(t *testing.T) {
-	domain := "certtest.hashicorp.com"
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckAwsAcmCertificateDataSourceConfigWaitingForIssued(domain),
-			},
-		},
-	})
-}
-
 func testAccCheckAwsAcmCertificateDataSourceConfig(domain string) string {
 	return fmt.Sprintf(`
 data "aws_acm_certificate" "test" {
@@ -69,17 +54,6 @@ func testAccCheckAwsAcmCertificateDataSourceConfigWithTypes(domain string) strin
 data "aws_acm_certificate" "test" {
 	domain = "%s"
 	types = ["IMPORTED"]
-}
-`, domain)
-}
-
-func testAccCheckAwsAcmCertificateDataSourceConfigWaitingForIssued(domain string) string {
-	return fmt.Sprintf(`
-data "aws_acm_certificate" "test" {
-	domain = "%s"
-	statuses = ["ISSUED"]
-	wait_until_present = true
-	wait_until_present_timeout = "1m"
 }
 `, domain)
 }

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -237,6 +237,7 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
+			"aws_acm_certificate":                          resourceAwsAcmCertificate(),
 			"aws_ami":                                      resourceAwsAmi(),
 			"aws_ami_copy":                                 resourceAwsAmiCopy(),
 			"aws_ami_from_instance":                        resourceAwsAmiFromInstance(),

--- a/aws/resource_aws_acm_certificate.go
+++ b/aws/resource_aws_acm_certificate.go
@@ -109,39 +109,24 @@ func resourceAwsAcmCertificateRead(d *schema.ResourceData, meta interface{}) err
 		resp, err := acmconn.DescribeCertificate(params)
 
 		if err != nil {
-			return &resource.RetryError{
-				Err:       fmt.Errorf("Error describing certificate: %s", err),
-				Retryable: false,
-			}
+			return resource.NonRetryableError(fmt.Errorf("Error describing certificate: %s", err))
 		}
 
 		if err := d.Set("domain_name", resp.Certificate.DomainName); err != nil {
-			return &resource.RetryError{
-				Err:       err,
-				Retryable: false,
-			}
+			return resource.NonRetryableError(err)
 		}
 		if err := d.Set("subject_alternative_names", cleanUpSubjectAlternativeNames(resp.Certificate)); err != nil {
-			return &resource.RetryError{
-				Err:       err,
-				Retryable: false,
-			}
+			return resource.NonRetryableError(err)
 		}
 
 		domainValidationOptions, err := convertDomainValidationOptions(resp.Certificate.DomainValidationOptions)
 
 		if err != nil {
-			return &resource.RetryError{
-				Err:       err,
-				Retryable: true,
-			}
+			return resource.RetryableError(err)
 		}
 
 		if err := d.Set("domain_validation_options", domainValidationOptions); err != nil {
-			return &resource.RetryError{
-				Err:       err,
-				Retryable: false,
-			}
+			return resource.NonRetryableError(err)
 		}
 
 		return nil

--- a/aws/resource_aws_acm_certificate.go
+++ b/aws/resource_aws_acm_certificate.go
@@ -1,0 +1,251 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/acm"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"log"
+	"strings"
+	"time"
+)
+
+func resourceAwsAcmCertificate() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsAcmCertificateCreate,
+		Read:   resourceAwsAcmCertificateRead,
+		Delete: resourceAwsAcmCertificateDelete,
+
+		Schema: map[string]*schema.Schema{
+			"domain_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"subject_alternative_names": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"validation_method": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"certificate_arn": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+				ForceNew: true,
+			},
+			"domain_validation_options": &schema.Schema{
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"domain_name": &schema.Schema{
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_record_name": &schema.Schema{
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_record_type": &schema.Schema{
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_record_value": &schema.Schema{
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsAcmCertificateCreate(d *schema.ResourceData, meta interface{}) error {
+	acmconn := meta.(*AWSClient).acmconn
+	params := &acm.RequestCertificateInput{
+		DomainName:       aws.String(d.Get("domain_name").(string)),
+		ValidationMethod: aws.String("DNS"),
+	}
+
+	// TODO: check that validation method is DNS, nothing else supported at the moment
+
+	sans, ok := d.GetOk("subject_alternative_names")
+	if ok {
+		sanStrings := sans.([]interface{})
+		params.SubjectAlternativeNames = expandStringList(sanStrings)
+	}
+
+	log.Printf("[DEBUG] ACM Certificate Request: %#v", params)
+	resp, err := acmconn.RequestCertificate(params)
+
+	if err != nil {
+		return fmt.Errorf("Error requesting certificate: %s", err)
+	}
+
+	d.SetId(*resp.CertificateArn)
+	d.Set("certificate_arn", *resp.CertificateArn)
+
+	return resourceAwsAcmCertificateRead(d, meta)
+}
+
+func resourceAwsAcmCertificateRead(d *schema.ResourceData, meta interface{}) error {
+	acmconn := meta.(*AWSClient).acmconn
+
+	params := &acm.DescribeCertificateInput{
+		CertificateArn: aws.String(d.Id()),
+	}
+
+	return resource.Retry(time.Duration(1)*time.Minute, func() *resource.RetryError {
+		resp, err := acmconn.DescribeCertificate(params)
+
+		if err != nil {
+			return &resource.RetryError{
+				Err:       fmt.Errorf("Error describing certificate: %s", err),
+				Retryable: false,
+			}
+		}
+
+		if err := d.Set("domain_name", resp.Certificate.DomainName); err != nil {
+			return &resource.RetryError{
+				Err:       err,
+				Retryable: false,
+			}
+		}
+		if err := d.Set("subject_alternative_names", cleanUpSubjectAlternativeNames(resp.Certificate)); err != nil {
+			return &resource.RetryError{
+				Err:       err,
+				Retryable: false,
+			}
+		}
+
+		domainValidationOptions, err := convertDomainValidationOptions(resp.Certificate.DomainValidationOptions)
+
+		if err != nil {
+			return &resource.RetryError{
+				Err:       err,
+				Retryable: true,
+			}
+		}
+
+		if err := d.Set("domain_validation_options", domainValidationOptions); err != nil {
+			return &resource.RetryError{
+				Err:       err,
+				Retryable: false,
+			}
+		}
+
+		return nil
+	})
+
+}
+
+func cleanUpSubjectAlternativeNames(cert *acm.CertificateDetail) []string {
+	sans := cert.SubjectAlternativeNames
+	vs := make([]string, 0, len(sans)-1)
+	for _, v := range sans {
+		if *v != *cert.DomainName {
+			vs = append(vs, *v)
+		}
+	}
+	return vs
+
+}
+
+func convertDomainValidationOptions(validations []*acm.DomainValidation) ([]map[string]interface{}, error) {
+	result := make([]map[string]interface{}, 0, len(validations))
+
+	for _, o := range validations {
+		validationOption := make(map[string]interface{})
+		validationOption["domain_name"] = *o.DomainName
+		if o.ResourceRecord != nil {
+			validationOption["resource_record_name"] = *o.ResourceRecord.Name
+			validationOption["resource_record_type"] = *o.ResourceRecord.Type
+			validationOption["resource_record_value"] = *o.ResourceRecord.Value
+		} else {
+			log.Printf("[DEBUG] No resource record found in validation options, need to retry: %#v", o)
+			return nil, fmt.Errorf("No resource record found in DNS DomainValidationOptions: %v", o)
+		}
+
+		result = append(result, validationOption)
+	}
+
+	return result, nil
+}
+
+func resourceAwsAcmCertificateDelete(d *schema.ResourceData, meta interface{}) error {
+	acmconn := meta.(*AWSClient).acmconn
+
+	if err := resourceAwsAcmCertificateRead(d, meta); err != nil {
+		return err
+	}
+	if d.Id() == "" {
+		// This might happen from the read
+		return nil
+	}
+
+	params := &acm.DeleteCertificateInput{
+		CertificateArn: aws.String(d.Id()),
+	}
+
+	_, err := acmconn.DeleteCertificate(params)
+
+	if err != nil {
+		return fmt.Errorf("Error deleting certificate: %s", err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourceAwsAcmCertificateDomain(d *schema.ResourceData) string {
+	if v, ok := d.GetOk("domain"); ok {
+		return v.(string)
+	} else if strings.Contains(d.Id(), "eipalloc") {
+		// We have to do this for backwards compatibility since TF 0.1
+		// didn't have the "domain" computed attribute.
+		return "vpc"
+	}
+
+	return "standard"
+}
+
+func disassociateAcmCertificate(d *schema.ResourceData, meta interface{}) error {
+	ec2conn := meta.(*AWSClient).ec2conn
+	log.Printf("[DEBUG] Disassociating EIP: %s", d.Id())
+	var err error
+	switch resourceAwsAcmCertificateDomain(d) {
+	case "vpc":
+		associationID := d.Get("association_id").(string)
+		if associationID == "" {
+			// If assiciationID is empty, it means there's no association.
+			// Hence this disassociation can be skipped.
+			return nil
+		}
+		_, err = ec2conn.DisassociateAddress(&ec2.DisassociateAddressInput{
+			AssociationId: aws.String(associationID),
+		})
+	case "standard":
+		_, err = ec2conn.DisassociateAddress(&ec2.DisassociateAddressInput{
+			PublicIp: aws.String(d.Get("public_ip").(string)),
+		})
+	}
+
+	// First check if the association ID is not found. If this
+	// is the case, then it was already disassociated somehow,
+	// and that is okay. The most commmon reason for this is that
+	// the instance or ENI it was attached it was destroyed.
+	if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidAssociationID.NotFound" {
+		err = nil
+	}
+	return err
+}

--- a/aws/resource_aws_acm_certificate_test.go
+++ b/aws/resource_aws_acm_certificate_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAcmCertificateIssuingFlow(t *testing.T) {
+func TestAccAwsAcmResource_certificateIssuingFlow(t *testing.T) {
 	var conf acm.DescribeCertificateOutput
 
 	root_zone_domain := "sandbox.sellmayr.net"

--- a/aws/resource_aws_acm_certificate_test.go
+++ b/aws/resource_aws_acm_certificate_test.go
@@ -30,6 +30,7 @@ func TestAccAcmCertificateIssuingFlow(t *testing.T) {
 					testAccCheckAcmCertificateExists("aws_acm_certificate.cert", &conf),
 					testAccCheckAcmCertificateWasIssued(&conf),
 					testAccCheckAcmCertificateAttributes("aws_acm_certificate.cert", &conf, domain),
+					testAccCheckAcmDataSourceAttributes("data.aws_acm_certificate.cert", &conf, domain),
 				),
 			},
 		},
@@ -95,6 +96,26 @@ func testAccCheckAcmCertificateAttributes(n string, cert *acm.DescribeCertificat
 		}
 
 		// TODO: check other attributes?
+
+		return nil
+	}
+}
+
+func testAccCheckAcmDataSourceAttributes(n string, cert *acm.DescribeCertificateOutput, domain string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		attrs := rs.Primary.Attributes
+
+		if attrs["domain"] != domain {
+			return fmt.Errorf("Domain name in state is %s but expected %s", attrs["domain"], domain)
+		}
+
+		if attrs["arn"] != *cert.Certificate.CertificateArn {
+			return fmt.Errorf("Certificate ARN in state is %s but expected %s", attrs["arn"], *cert.Certificate.CertificateArn)
+		}
 
 		return nil
 	}

--- a/aws/resource_aws_acm_certificate_test.go
+++ b/aws/resource_aws_acm_certificate_test.go
@@ -1,0 +1,127 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/acm"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAcmCertificate_basic(t *testing.T) {
+	var conf acm.DescribeCertificateOutput
+
+	domain := "certtest.hashicorp.com"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAcmCertificateDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAcmCertificateConfig(domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAcmCertificateExists("aws_acm_certificate.cert", &conf),
+					testAccCheckAcmCertificateAttributes("aws_acm_certificate.cert", &conf, domain),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAcmCertificateExists(n string, res *acm.DescribeCertificateOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No id is set")
+		}
+
+		if rs.Primary.Attributes["certificate_arn"] == "" {
+			return fmt.Errorf("No certificate_arn is set")
+		}
+
+		if rs.Primary.Attributes["certificate_arn"] != rs.Primary.ID {
+			return fmt.Errorf("No certificate_arn and ID are different: %s %s", rs.Primary.Attributes["certificate_arn"], rs.Primary.ID)
+		}
+
+		acmconn := testAccProvider.Meta().(*AWSClient).acmconn
+
+		resp, err := acmconn.DescribeCertificate(&acm.DescribeCertificateInput{
+			CertificateArn: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		*res = *resp
+
+		return nil
+	}
+}
+
+func testAccCheckAcmCertificateAttributes(n string, cert *acm.DescribeCertificateOutput, domain string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		attrs := rs.Primary.Attributes
+
+		if *cert.Certificate.DomainName != domain {
+			return fmt.Errorf("Domain name is %s but expected %s", cert.Certificate.DomainName, domain)
+		}
+		if attrs["domain_name"] != domain {
+			return fmt.Errorf("Domain name in state is %s but expected %s", attrs["domain_name"], domain)
+		}
+
+		// TODO: check other attributes?
+
+		return nil
+	}
+}
+
+func testAccAcmCertificateConfig(domain string) string {
+	return fmt.Sprintf(`
+resource "aws_acm_certificate" "cert" {
+    domain_name = "%s"
+	validation_method = "DNS"
+}
+`, domain)
+}
+
+func testAccCheckAcmCertificateDestroy(s *terraform.State) error {
+	acmconn := testAccProvider.Meta().(*AWSClient).acmconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_acm_certificate" {
+			continue
+		}
+		_, err := acmconn.DescribeCertificate(&acm.DescribeCertificateInput{
+			CertificateArn: aws.String(rs.Primary.ID),
+		})
+
+		if err == nil {
+			return fmt.Errorf("Certificate still exists.")
+		}
+
+		// Verify the error is what we want
+		acmerr, ok := err.(awserr.Error)
+
+		if !ok {
+			return err
+		}
+		if acmerr.Code() != "ResourceNotFoundException" {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/aws/resource_aws_acm_certificate_test.go
+++ b/aws/resource_aws_acm_certificate_test.go
@@ -11,10 +11,11 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAcmCertificate_basic(t *testing.T) {
+func TestAccAcmCertificateIssuingFlow(t *testing.T) {
 	var conf acm.DescribeCertificateOutput
 
-	domain := "certtest.hashicorp.com"
+	root_zone_domain := "sandbox.sellmayr.net"
+	domain := "certtest.sandbox.sellmayr.net"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -22,14 +23,25 @@ func TestAccAcmCertificate_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAcmCertificateDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAcmCertificateConfig(domain),
+				Config: testAccAcmCertificateConfig(root_zone_domain, domain),
+				// expect non-empty plan that's triggered by the depends_on; see https://github.com/hashicorp/terraform/issues/11806
+				ExpectNonEmptyPlan: true,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAcmCertificateExists("aws_acm_certificate.cert", &conf),
+					testAccCheckAcmCertificateWasIssued(&conf),
 					testAccCheckAcmCertificateAttributes("aws_acm_certificate.cert", &conf, domain),
 				),
 			},
 		},
 	})
+}
+func testAccCheckAcmCertificateWasIssued(output *acm.DescribeCertificateOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if *output.Certificate.Status != "ISSUED" {
+			return fmt.Errorf("Expected certificate to be issued but was in status %s", output.Certificate.Status)
+		}
+		return nil
+	}
 }
 
 func testAccCheckAcmCertificateExists(n string, res *acm.DescribeCertificateOutput) resource.TestCheckFunc {
@@ -54,7 +66,7 @@ func testAccCheckAcmCertificateExists(n string, res *acm.DescribeCertificateOutp
 		acmconn := testAccProvider.Meta().(*AWSClient).acmconn
 
 		resp, err := acmconn.DescribeCertificate(&acm.DescribeCertificateInput{
-			CertificateArn: aws.String(rs.Primary.ID),
+			CertificateArn: aws.String(rs.Primary.Attributes["certificate_arn"]),
 		})
 
 		if err != nil {
@@ -76,7 +88,7 @@ func testAccCheckAcmCertificateAttributes(n string, cert *acm.DescribeCertificat
 		attrs := rs.Primary.Attributes
 
 		if *cert.Certificate.DomainName != domain {
-			return fmt.Errorf("Domain name is %s but expected %s", cert.Certificate.DomainName, domain)
+			return fmt.Errorf("Domain name is %s but expected %s", *cert.Certificate.DomainName, domain)
 		}
 		if attrs["domain_name"] != domain {
 			return fmt.Errorf("Domain name in state is %s but expected %s", attrs["domain_name"], domain)
@@ -88,13 +100,34 @@ func testAccCheckAcmCertificateAttributes(n string, cert *acm.DescribeCertificat
 	}
 }
 
-func testAccAcmCertificateConfig(domain string) string {
+func testAccAcmCertificateConfig(rootZoneDomain string, domain string) string {
 	return fmt.Sprintf(`
+
+data "aws_route53_zone" "zone" {
+  name = "%s."
+  private_zone = false
+}
+
 resource "aws_acm_certificate" "cert" {
     domain_name = "%s"
 	validation_method = "DNS"
 }
-`, domain)
+resource "aws_route53_record" "cert_validation" {
+  name = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_name}"
+  type = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_type}"
+  zone_id = "${data.aws_route53_zone.zone.id}"
+  records = ["${aws_acm_certificate.cert.domain_validation_options.0.resource_record_value}"]
+  ttl = 60
+}
+
+data "aws_acm_certificate" "cert" {
+  arn = "${aws_acm_certificate.cert.certificate_arn}"
+  statuses = ["ISSUED"]
+  wait_until_present = true
+  depends_on = ["aws_route53_record.cert_validation"]
+}
+
+`, rootZoneDomain, domain)
 }
 
 func testAccCheckAcmCertificateDestroy(s *terraform.State) error {

--- a/aws/resource_aws_acm_certificate_test.go
+++ b/aws/resource_aws_acm_certificate_test.go
@@ -39,7 +39,7 @@ func TestAccAwsAcmResource_certificateIssuingFlow(t *testing.T) {
 func testAccCheckAcmCertificateWasIssued(output *acm.DescribeCertificateOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if *output.Certificate.Status != "ISSUED" {
-			return fmt.Errorf("Expected certificate to be issued but was in status %s", output.Certificate.Status)
+			return fmt.Errorf("Expected certificate to be issued but was in status %s", *output.Certificate.Status)
 		}
 		return nil
 	}


### PR DESCRIPTION
This is a first draft trying to implement automated ACM certificate issuing based on my suggestions in #2418. 

Here is what it does: 

* Add a `aws_acm_certificate` resource that requests a new certificate and returns once `validationOptions` (the information what needs to be done to validate ownership of the domain) are available (for some reason, those aren't immediately available). Only supports DNS validation at this point
* Add an option to `aws_acm_certificate` data source to wait until a matching certificate can be found
* Add an option to `aws_acm_certificate` to search for `arn` instead of `domain` so we match exactly the certificate we requested from acm 
* Add an acceptance test that runs the whole certificate issuing flow (using route53 for DNS validation)

Here is what's still to do: 
* [ ] Add support for tagging
* [ ] Implement and test imports
* [ ] Update Documentation
* [ ] Support E-Mail validation

Here are a few things I'm unsure about: 
* Should `wait_until_present` and `wait_until_present_timeout` be two fields or one field where `0` means "don't wait"?
* The acceptance test needs a valid, publicly available domain to validate certificate requests. Is this a problem for CI? Should this be configurable and disabled by default so contributors aren't annoyed when working in unrelated parts? 
* Is it a good idea to model waiting for certificate issuing in a data source? If one is not careful (e.g. forgets the dependency on the route53 record), the data source starts polling in `terraform plan` without any chance of ever succeeding. If you have the dependency, it looks like terraform will always produce a non-empty plan for it (hashicorp/terraform#11806).
  As an alternative, waiting for certificate issuing could also be implemented as a separate resource: 
  ```terraform
  resource "aws_acm_certificate_validation" "cert" {
    certificate_arn = "${aws_acm_certificate.cert.certificate_arn}"
    validation_record = "${aws_route53_record.cert_validation.fqdn}" # This wouldn't strictly be necessary but it can enforce a dependency
  }
  ```
  This would also allow us to do additional checks (e.g. validating that the DNS record is correctly set) and would probably resolve the issues with the data source. It also introduces new ones though: It adds clutter to the resource-list and lead to confusion since it doesn't conform to any resource in AWS. E.g. which resource destroy will trigger certificate deletion: `acm_certificate_validation` or `acm_certificate`? 
* AWS does not expect `subject_alternative_names` to contain values when requesting a certificate but `DescribeCertificate` always includes the `domain_name` in `subject_alternative_names`. I'm currently filtering this so terraform doesn't detect this as a change. Is there a better way to do this?  

I'm not a golang or terraform provider expert so any feedback is welcome! 

