### PR TITLE
Add SNS subscription filter

### DIFF
--- a/aws/resource_aws_sns_topic_subscription.go
+++ b/aws/resource_aws_sns_topic_subscription.go
@@ -167,7 +167,7 @@ func resourceAwsSnsTopicSubscriptionUpdate(d *schema.ResourceData, meta interfac
 		_, err := snsconn.SetSubscriptionAttributes(req)
 
 		if err != nil {
-			return fmt.Errorf("Unable to set filter policy attribute on subscription")
+			return fmt.Errorf("Unable to set filter policy attribute on subscription: %s", err)
 		}
 	}
 	return resourceAwsSnsTopicSubscriptionRead(d, meta)

--- a/aws/resource_aws_sns_topic_subscription.go
+++ b/aws/resource_aws_sns_topic_subscription.go
@@ -82,7 +82,7 @@ func resourceAwsSnsTopicSubscription() *schema.Resource {
 				ValidateFunc:     validateJsonString,
 				DiffSuppressFunc: suppressEquivalentJsonDiffs,
 				StateFunc: func(v interface{}) string {
-					json, _ := structure.normalizeJsonString(v)
+					json, _ := structure.NormalizeJsonString(v)
 					return json
 				},
 			},

--- a/aws/resource_aws_sns_topic_subscription.go
+++ b/aws/resource_aws_sns_topic_subscription.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/structure"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -81,7 +82,7 @@ func resourceAwsSnsTopicSubscription() *schema.Resource {
 				ValidateFunc:     validateJsonString,
 				DiffSuppressFunc: suppressEquivalentJsonDiffs,
 				StateFunc: func(v interface{}) string {
-					json, _ := normalizeJsonString(v)
+					json, _ := structure.normalizeJsonString(v)
 					return json
 				},
 			},

--- a/aws/resource_aws_sns_topic_subscription.go
+++ b/aws/resource_aws_sns_topic_subscription.go
@@ -76,8 +76,14 @@ func resourceAwsSnsTopicSubscription() *schema.Resource {
 				Computed: true,
 			},
 			"filter_policy": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateFunc:     validateJsonString,
+				DiffSuppressFunc: suppressEquivalentJsonDiffs,
+				StateFunc: func(v interface{}) string {
+					json, _ := normalizeJsonString(v)
+					return json
+				},
 			},
 		},
 	}

--- a/aws/resource_aws_sns_topic_subscription.go
+++ b/aws/resource_aws_sns_topic_subscription.go
@@ -24,6 +24,7 @@ var SNSSubscriptionAttributeMap = map[string]string{
 	"endpoint":             "Endpoint",
 	"protocol":             "Protocol",
 	"raw_message_delivery": "RawMessageDelivery",
+	"filter_policy":        "FilterPolicy",
 }
 
 func resourceAwsSnsTopicSubscription() *schema.Resource {
@@ -73,6 +74,10 @@ func resourceAwsSnsTopicSubscription() *schema.Resource {
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+			"filter_policy": {
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 		},
 	}
@@ -143,6 +148,22 @@ func resourceAwsSnsTopicSubscriptionUpdate(d *schema.ResourceData, meta interfac
 		}
 	}
 
+	if d.HasChange("filter_policy") {
+		_, n := d.GetChange("filter_policy")
+
+		attrValue := n.(string)
+
+		req := &sns.SetSubscriptionAttributesInput{
+			SubscriptionArn: aws.String(d.Id()),
+			AttributeName:   aws.String("FilterPolicy"),
+			AttributeValue:  aws.String(attrValue),
+		}
+		_, err := snsconn.SetSubscriptionAttributes(req)
+
+		if err != nil {
+			return fmt.Errorf("Unable to set filter policy attribute on subscription")
+		}
+	}
 	return resourceAwsSnsTopicSubscriptionRead(d, meta)
 }
 

--- a/aws/resource_aws_sns_topic_subscription_test.go
+++ b/aws/resource_aws_sns_topic_subscription_test.go
@@ -160,18 +160,14 @@ func testAccCheckAWSSNSTopicSubscriptionAttributesExists(n string) resource.Test
 			SubscriptionArn: aws.String(rs.Primary.ID),
 		}
 		out, err := conn.GetSubscriptionAttributes(params)
-
 		if err != nil {
 			return err
 		}
 
-		expected := map[string]string{
-			"FilterPolicy": "{\"key1\": [\"val1\"], \"key2\": [\"val2\"]}",
-		}
-		for key, actualVal := range out.Attributes {
-			if *actualVal != expected[key] {
-				return fmt.Errorf("Expected %v, got %v", expected[key], actualVal)
-			}
+		expected := "{\"key1\": [\"val1\"], \"key2\": [\"val2\"]}"
+		actual := *out.Attributes["FilterPolicy"]
+		if expected != actual {
+			return fmt.Errorf("Expected %v, got %v", expected, actual)
 		}
 
 		return nil
@@ -225,7 +221,7 @@ resource "aws_sns_topic_subscription" "test_subscription" {
     topic_arn = "${aws_sns_topic.test_topic.arn}"
     protocol = "sqs"
     endpoint = "${aws_sqs_queue.test_queue.arn}"
-    filter=_policy = "{"key1": ["val1"], "key2": ["val2"]}"
+    filter_policy = "{\"key1\": [\"val1\"], \"key2\": [\"val2\"]}"
   }
 `, i, i)
 }

--- a/aws/resource_aws_sns_topic_subscription_test.go
+++ b/aws/resource_aws_sns_topic_subscription_test.go
@@ -225,7 +225,7 @@ resource "aws_sns_topic_subscription" "test_subscription" {
     topic_arn = "${aws_sns_topic.test_topic.arn}"
     protocol = "sqs"
     endpoint = "${aws_sqs_queue.test_queue.arn}"
-    filter=_policy = "{\"key1\": [\"val1\"], \"key2\": [\"val2\"]}"
+    filter=_policy = "{"key1": ["val1"], "key2": ["val2"]}"
   }
 `, i, i)
 }


### PR DESCRIPTION
fixes #2554

https://docs.aws.amazon.com/sns/latest/dg/message-filtering.html

Applying a Filter Policy with the AWS CLI

```
$ aws sns set-subscription-attributes --subscription-arn arn:aws:sns: ... --attribute-name FilterPolicy --attribute-value '{"store":["example_corp"],"event":["order_placed"]}'
$ aws sns get-subscription-attributes --subscription-arn arn:aws:sns: ...
{
    "Attributes": {
        "Endpoint": "endpoint . . .", 
        "Protocol": "https",
        "RawMessageDelivery": "false", 
        "EffectiveDeliveryPolicy": "delivery policy . . .",
        "ConfirmationWasAuthenticated": "true", 
        "FilterPolicy": "{\"store\": [\"example_corp\"], \"event\": [\"order_placed\"]}", 
        "Owner": "111122223333", 
        "SubscriptionArn": "arn:aws:sns: . . .", 
        "TopicArn": "arn:aws:sns: . . ."
    }
}
```

Acceptance test for this has passed.

```
$ make testacc TESTARGS="-run=TestAccAWSSNSTopicSubscription_attributes"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccAWSSNSTopicSubscription_attributes -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSSNSTopicSubscription_attributes
--- PASS: TestAccAWSSNSTopicSubscription_attributes (41.49s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       41.526s
```
  