### PR TITLE
resource/aws_ssm_association: Allow updating targets

### DIFF
--- a/aws/resource_aws_ssm_association.go
+++ b/aws/resource_aws_ssm_association.go
@@ -73,7 +73,6 @@ func resourceAwsSsmAssociation() *schema.Resource {
 			"targets": {
 				Type:     schema.TypeList,
 				Optional: true,
-				ForceNew: true,
 				Computed: true,
 				MaxItems: 5,
 				Elem: &schema.Resource{

--- a/aws/resource_aws_ssm_association.go
+++ b/aws/resource_aws_ssm_association.go
@@ -213,6 +213,10 @@ func resourceAwsSsmAssocationUpdate(d *schema.ResourceData, meta interface{}) er
 		associationInput.OutputLocation = expandSSMAssociationOutputLocation(d.Get("output_location").([]interface{}))
 	}
 
+	if d.HasChange("targets") {
+		associationInput.Targets = expandAwsSsmTargets(d)
+	}
+
 	_, err := ssmconn.UpdateAssociation(associationInput)
 	if err != nil {
 		return errwrap.Wrapf("[ERROR] Error updating SSM association: {{err}}", err)

--- a/aws/resource_aws_ssm_association_test.go
+++ b/aws/resource_aws_ssm_association_test.go
@@ -391,6 +391,10 @@ resource "aws_ssm_association" "foo" {
     key = "tag:Name"
     values = ["acceptanceTest"]
   }
+  targets {
+    key = "tag:ExtraName"
+    values = ["acceptanceTest"]
+  }
 }`, rName)
 }
 

--- a/aws/resource_aws_ssm_association_test.go
+++ b/aws/resource_aws_ssm_association_test.go
@@ -31,12 +31,12 @@ func TestAccAWSSSMAssociation_basic(t *testing.T) {
 
 func TestAccAWSSSMAssociation_withTargets(t *testing.T) {
 	name := acctest.RandString(10)
-	onetarget := `
+	oneTarget := `
 	targets {
     key = "tag:Name"
     values = ["acceptanceTest"]
   }`
-	twotarget := `
+	twoTargets := `
 	targets {
     key = "tag:Name"
     values = ["acceptanceTest"]
@@ -51,7 +51,7 @@ func TestAccAWSSSMAssociation_withTargets(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSSMAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSSMAssociationBasicConfigWithTargets(name, onetarget),
+				Config: testAccAWSSSMAssociationBasicConfigWithTargets(name, oneTarget),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMAssociationExists("aws_ssm_association.foo"),
 					resource.TestCheckResourceAttr(
@@ -63,7 +63,7 @@ func TestAccAWSSSMAssociation_withTargets(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSSSMAssociationBasicConfigWithTargets(name, twotarget),
+				Config: testAccAWSSSMAssociationBasicConfigWithTargets(name, twoTargets),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMAssociationExists("aws_ssm_association.foo"),
 					resource.TestCheckResourceAttr(
@@ -79,7 +79,7 @@ func TestAccAWSSSMAssociation_withTargets(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSSSMAssociationBasicConfigWithTargets(name, onetarget),
+				Config: testAccAWSSSMAssociationBasicConfigWithTargets(name, oneTarget),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMAssociationExists("aws_ssm_association.foo"),
 					resource.TestCheckResourceAttr(


### PR DESCRIPTION
Fixed: #2536 
Update MaxItems of targets. [ref](https://docs.aws.amazon.com/ja_jp/systems-manager/latest/APIReference/API_CreateAssociation.html#EC2-CreateAssociation-request-Targets)

```
TF_ACC=1 go test ./aws -v -run=TestAccAWSSSMAssociation_withTargets -timeout 120m
=== RUN   TestAccAWSSSMAssociation_withTargets
--- PASS: TestAccAWSSSMAssociation_withTargets (41.74s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	41.774s
```