### PR TITLE
resource/aws_volume_attachment: Support update

### DIFF
--- a/aws/resource_aws_volume_attachment.go
+++ b/aws/resource_aws_volume_attachment.go
@@ -205,6 +205,7 @@ func resourceAwsVolumeAttachmentRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceAwsVolumeAttachmentUpdate(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] Attaching Volume (%s) is updating which does nothing but updates a few params in state", d.Id())
 	return nil
 }
 

--- a/aws/resource_aws_volume_attachment.go
+++ b/aws/resource_aws_volume_attachment.go
@@ -18,6 +18,7 @@ func resourceAwsVolumeAttachment() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsVolumeAttachmentCreate,
 		Read:   resourceAwsVolumeAttachmentRead,
+		Update: resourceAwsVolumeAttachmentUpdate,
 		Delete: resourceAwsVolumeAttachmentDelete,
 
 		Schema: map[string]*schema.Schema{
@@ -202,6 +203,10 @@ func resourceAwsVolumeAttachmentRead(d *schema.ResourceData, meta interface{}) e
 		d.SetId("")
 	}
 
+	return nil
+}
+
+func resourceAwsVolumeAttachmentUpdate(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 

--- a/aws/resource_aws_volume_attachment.go
+++ b/aws/resource_aws_volume_attachment.go
@@ -43,12 +43,10 @@ func resourceAwsVolumeAttachment() *schema.Resource {
 			"force_detach": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Computed: true,
 			},
 			"skip_destroy": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Computed: true,
 			},
 		},
 	}

--- a/aws/resource_aws_volume_attachment_test.go
+++ b/aws/resource_aws_volume_attachment_test.go
@@ -131,6 +131,8 @@ func TestAccAWSVolumeAttachment_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"aws_volume_attachment.ebs_att", "force_detach", "false"),
+					resource.TestCheckResourceAttr(
+						"aws_volume_attachment.ebs_att", "skip_destroy", "false"),
 				),
 			},
 			{
@@ -138,6 +140,8 @@ func TestAccAWSVolumeAttachment_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"aws_volume_attachment.ebs_att", "force_detach", "true"),
+					resource.TestCheckResourceAttr(
+						"aws_volume_attachment.ebs_att", "skip_destroy", "true"),
 				),
 			},
 		},
@@ -180,96 +184,97 @@ func testAccCheckVolumeAttachmentDestroy(s *terraform.State) error {
 
 const testAccVolumeAttachmentConfigInstanceOnly = `
 resource "aws_instance" "web" {
-	ami = "ami-21f78e11"
+  ami = "ami-21f78e11"
   availability_zone = "us-west-2a"
-	instance_type = "t1.micro"
-	tags {
-		Name = "HelloWorld"
-	}
+  instance_type = "t1.micro"
+  tags {
+    Name = "HelloWorld"
+  }
 }
 `
 
 const testAccVolumeAttachmentConfig = `
 resource "aws_instance" "web" {
-	ami = "ami-21f78e11"
+  ami = "ami-21f78e11"
   availability_zone = "us-west-2a"
-	instance_type = "t1.micro"
-	tags {
-		Name = "HelloWorld"
-	}
+  instance_type = "t1.micro"
+  tags {
+    Name = "HelloWorld"
+  }
 }
 
 resource "aws_ebs_volume" "example" {
   availability_zone = "us-west-2a"
-	size = 1
+  size = 1
 }
 
 resource "aws_volume_attachment" "ebs_att" {
   device_name = "/dev/sdh"
-	volume_id = "${aws_ebs_volume.example.id}"
-	instance_id = "${aws_instance.web.id}"
+  volume_id = "${aws_ebs_volume.example.id}"
+  instance_id = "${aws_instance.web.id}"
 }
 `
 
 const testAccVolumeAttachmentConfigSkipDestroy = `
 resource "aws_instance" "web" {
-	ami = "ami-21f78e11"
-  	availability_zone = "us-west-2a"
-	instance_type = "t1.micro"
-	tags {
-		Name = "HelloWorld"
-	}
+  ami = "ami-21f78e11"
+  availability_zone = "us-west-2a"
+  instance_type = "t1.micro"
+  tags {
+    Name = "HelloWorld"
+  }
 }
 
 resource "aws_ebs_volume" "example" {
-  	availability_zone = "us-west-2a"
-	size = 1
-	tags {
-		Name = "TestVolume"
-	}
+  availability_zone = "us-west-2a"
+  size = 1
+  tags {
+    Name = "TestVolume"
+  }
 }
 
 data "aws_ebs_volume" "ebs_volume" {
-    filter {
-	name = "size"
-	values = ["${aws_ebs_volume.example.size}"]
-    }
-    filter {
-	name = "availability-zone"
-	values = ["${aws_ebs_volume.example.availability_zone}"]
-    }
-    filter {
-	name = "tag:Name"
-	values = ["TestVolume"]
-    }
+  filter {
+    name = "size"
+    values = ["${aws_ebs_volume.example.size}"]
+  }
+  filter {
+    name = "availability-zone"
+    values = ["${aws_ebs_volume.example.availability_zone}"]
+  }
+  filter {
+    name = "tag:Name"
+    values = ["TestVolume"]
+  }
 }
 
 resource "aws_volume_attachment" "ebs_att" {
-  	device_name = "/dev/sdh"
-	volume_id = "${data.aws_ebs_volume.ebs_volume.id}"
-	instance_id = "${aws_instance.web.id}"
-	skip_destroy = true
+  device_name = "/dev/sdh"
+  volume_id = "${data.aws_ebs_volume.ebs_volume.id}"
+  instance_id = "${aws_instance.web.id}"
+  skip_destroy = true
 }
 `
 
 func testAccVolumeAttachmentConfig_update(detach bool) string {
 	return fmt.Sprintf(`
 resource "aws_instance" "web" {
-	ami = "ami-21f78e11"
+  ami = "ami-21f78e11"
   availability_zone = "us-west-2a"
-	instance_type = "t1.micro"
+  instance_type = "t1.micro"
 }
 
 resource "aws_ebs_volume" "example" {
   availability_zone = "us-west-2a"
-	size = 1
+  size = 1
 }
 
 resource "aws_volume_attachment" "ebs_att" {
   device_name = "/dev/sdh"
-	volume_id = "${aws_ebs_volume.example.id}"
-	instance_id = "${aws_instance.web.id}"
+  volume_id = "${aws_ebs_volume.example.id}"
+  instance_id = "${aws_instance.web.id}"
   force_detach = %t
+  skip_destroy = %t
 }
-`, detach)
+`, detach, detach)
 }


### PR DESCRIPTION
Fixes: #2520 
Fixes: #1211

Implement `resourceAwsVolumeAttachmentUpdate` which does nothing and removed computed.
```
TF_ACC=1 go test ./aws -v -run=TestAccAWSVolumeAttachment_ -timeout 120m
=== RUN   TestAccAWSVolumeAttachment_basic
--- PASS: TestAccAWSVolumeAttachment_basic (151.78s)
=== RUN   TestAccAWSVolumeAttachment_skipDestroy
--- PASS: TestAccAWSVolumeAttachment_skipDestroy (148.37s)
=== RUN   TestAccAWSVolumeAttachment_attachStopped
--- PASS: TestAccAWSVolumeAttachment_attachStopped (209.48s)
=== RUN   TestAccAWSVolumeAttachment_update
--- PASS: TestAccAWSVolumeAttachment_update (184.05s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	693.704s
```