### PR TITLE
New Resources: aws_acm_certificate and aws_acm_certificate_validation

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -238,6 +238,7 @@ func Provider() terraform.ResourceProvider {
 
 		ResourcesMap: map[string]*schema.Resource{
 			"aws_acm_certificate":                          resourceAwsAcmCertificate(),
+			"aws_acm_certificate_validation":               resourceAwsAcmCertificateValidation(),
 			"aws_ami":                                      resourceAwsAmi(),
 			"aws_ami_copy":                                 resourceAwsAmiCopy(),
 			"aws_ami_from_instance":                        resourceAwsAmiFromInstance(),

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -237,6 +237,7 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
+			"aws_acm_certificate":                          resourceAwsAcmCertificate(),
 			"aws_ami":                                      resourceAwsAmi(),
 			"aws_ami_copy":                                 resourceAwsAmiCopy(),
 			"aws_ami_from_instance":                        resourceAwsAmiFromInstance(),

--- a/aws/resource_aws_acm_certificate.go
+++ b/aws/resource_aws_acm_certificate.go
@@ -35,6 +35,12 @@ func resourceAwsAcmCertificate() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					if v.(string) != "DNS" {
+						errors = append(errors, fmt.Errorf("only validation_method DNS is supported at the moment"))
+					}
+					return
+				},
 			},
 			"certificate_arn": &schema.Schema{
 				Type:     schema.TypeString,
@@ -75,8 +81,6 @@ func resourceAwsAcmCertificateCreate(d *schema.ResourceData, meta interface{}) e
 		DomainName:       aws.String(d.Get("domain_name").(string)),
 		ValidationMethod: aws.String("DNS"),
 	}
-
-	// TODO: check that validation method is DNS, nothing else supported at the moment
 
 	sans, ok := d.GetOk("subject_alternative_names")
 	if ok {

--- a/aws/resource_aws_acm_certificate.go
+++ b/aws/resource_aws_acm_certificate.go
@@ -209,21 +209,13 @@ func convertDomainValidationOptions(validations []*acm.DomainValidation) ([]map[
 func resourceAwsAcmCertificateDelete(d *schema.ResourceData, meta interface{}) error {
 	acmconn := meta.(*AWSClient).acmconn
 
-	if err := resourceAwsAcmCertificateRead(d, meta); err != nil {
-		return err
-	}
-	if d.Id() == "" {
-		// This might happen from the read
-		return nil
-	}
-
 	params := &acm.DeleteCertificateInput{
 		CertificateArn: aws.String(d.Id()),
 	}
 
 	_, err := acmconn.DeleteCertificate(params)
 
-	if err != nil {
+	if err != nil && !isAWSErr(err, acm.ErrCodeResourceNotFoundException, "") {
 		return fmt.Errorf("Error deleting certificate: %s", err)
 	}
 

--- a/aws/resource_aws_acm_certificate.go
+++ b/aws/resource_aws_acm_certificate.go
@@ -44,7 +44,7 @@ func resourceAwsAcmCertificate() *schema.Resource {
 					return
 				},
 			},
-			"certificate_arn": {
+			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -134,7 +134,7 @@ func resourceAwsAcmCertificateRead(d *schema.ResourceData, meta interface{}) err
 		if err := d.Set("domain_name", resp.Certificate.DomainName); err != nil {
 			return resource.NonRetryableError(err)
 		}
-		if err := d.Set("certificate_arn", resp.Certificate.CertificateArn); err != nil {
+		if err := d.Set("arn", resp.Certificate.CertificateArn); err != nil {
 			return resource.NonRetryableError(err)
 		}
 		if err := d.Set("validation_method", resp.Certificate.DomainValidationOptions[0].ValidationMethod); err != nil {

--- a/aws/resource_aws_acm_certificate.go
+++ b/aws/resource_aws_acm_certificate.go
@@ -96,7 +96,6 @@ func resourceAwsAcmCertificateCreate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	d.SetId(*resp.CertificateArn)
-	d.Set("certificate_arn", *resp.CertificateArn)
 
 	return resourceAwsAcmCertificateRead(d, meta)
 }

--- a/aws/resource_aws_acm_certificate.go
+++ b/aws/resource_aws_acm_certificate.go
@@ -123,7 +123,10 @@ func resourceAwsAcmCertificateRead(d *schema.ResourceData, meta interface{}) err
 	return resource.Retry(time.Duration(1)*time.Minute, func() *resource.RetryError {
 		resp, err := acmconn.DescribeCertificate(params)
 
-		if err != nil {
+		if err != nil && isAWSErr(err, acm.ErrCodeResourceNotFoundException, "") {
+			d.SetId("")
+			return nil
+		} else if err != nil {
 			return resource.NonRetryableError(fmt.Errorf("Error describing certificate: %s", err))
 		}
 

--- a/aws/resource_aws_acm_certificate.go
+++ b/aws/resource_aws_acm_certificate.go
@@ -122,10 +122,11 @@ func resourceAwsAcmCertificateRead(d *schema.ResourceData, meta interface{}) err
 	return resource.Retry(time.Duration(1)*time.Minute, func() *resource.RetryError {
 		resp, err := acmconn.DescribeCertificate(params)
 
-		if err != nil && isAWSErr(err, acm.ErrCodeResourceNotFoundException, "") {
-			d.SetId("")
-			return nil
-		} else if err != nil {
+		if err != nil {
+			if isAWSErr(err, acm.ErrCodeResourceNotFoundException, "") {
+				d.SetId("")
+				return nil
+			}
 			return resource.NonRetryableError(fmt.Errorf("Error describing certificate: %s", err))
 		}
 

--- a/aws/resource_aws_acm_certificate.go
+++ b/aws/resource_aws_acm_certificate.go
@@ -131,15 +131,10 @@ func resourceAwsAcmCertificateRead(d *schema.ResourceData, meta interface{}) err
 			return resource.NonRetryableError(fmt.Errorf("Certificate has type %s, only AMAZON_ISSUED is supported at the moment", *resp.Certificate.Type))
 		}
 
-		if err := d.Set("domain_name", resp.Certificate.DomainName); err != nil {
-			return resource.NonRetryableError(err)
-		}
-		if err := d.Set("arn", resp.Certificate.CertificateArn); err != nil {
-			return resource.NonRetryableError(err)
-		}
-		if err := d.Set("validation_method", resp.Certificate.DomainValidationOptions[0].ValidationMethod); err != nil {
-			return resource.NonRetryableError(err)
-		}
+		d.Set("domain_name", resp.Certificate.DomainName)
+		d.Set("arn", resp.Certificate.CertificateArn)
+		d.Set("validation_method", resp.Certificate.DomainValidationOptions[0].ValidationMethod)
+
 		if err := d.Set("subject_alternative_names", cleanUpSubjectAlternativeNames(resp.Certificate)); err != nil {
 			return resource.NonRetryableError(err)
 		}

--- a/aws/resource_aws_acm_certificate.go
+++ b/aws/resource_aws_acm_certificate.go
@@ -1,0 +1,190 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/acm"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"log"
+	"time"
+)
+
+func resourceAwsAcmCertificate() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsAcmCertificateCreate,
+		Read:   resourceAwsAcmCertificateRead,
+		Delete: resourceAwsAcmCertificateDelete,
+
+		Schema: map[string]*schema.Schema{
+			"domain_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"subject_alternative_names": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"validation_method": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"certificate_arn": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+				ForceNew: true,
+			},
+			"domain_validation_options": &schema.Schema{
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"domain_name": &schema.Schema{
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_record_name": &schema.Schema{
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_record_type": &schema.Schema{
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_record_value": &schema.Schema{
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsAcmCertificateCreate(d *schema.ResourceData, meta interface{}) error {
+	acmconn := meta.(*AWSClient).acmconn
+	params := &acm.RequestCertificateInput{
+		DomainName:       aws.String(d.Get("domain_name").(string)),
+		ValidationMethod: aws.String("DNS"),
+	}
+
+	// TODO: check that validation method is DNS, nothing else supported at the moment
+
+	sans, ok := d.GetOk("subject_alternative_names")
+	if ok {
+		sanStrings := sans.([]interface{})
+		params.SubjectAlternativeNames = expandStringList(sanStrings)
+	}
+
+	log.Printf("[DEBUG] ACM Certificate Request: %#v", params)
+	resp, err := acmconn.RequestCertificate(params)
+
+	if err != nil {
+		return fmt.Errorf("Error requesting certificate: %s", err)
+	}
+
+	d.SetId(*resp.CertificateArn)
+	d.Set("certificate_arn", *resp.CertificateArn)
+
+	return resourceAwsAcmCertificateRead(d, meta)
+}
+
+func resourceAwsAcmCertificateRead(d *schema.ResourceData, meta interface{}) error {
+	acmconn := meta.(*AWSClient).acmconn
+
+	params := &acm.DescribeCertificateInput{
+		CertificateArn: aws.String(d.Id()),
+	}
+
+	return resource.Retry(time.Duration(1)*time.Minute, func() *resource.RetryError {
+		resp, err := acmconn.DescribeCertificate(params)
+
+		if err != nil {
+			return resource.NonRetryableError(fmt.Errorf("Error describing certificate: %s", err))
+		}
+
+		if err := d.Set("domain_name", resp.Certificate.DomainName); err != nil {
+			return resource.NonRetryableError(err)
+		}
+		if err := d.Set("subject_alternative_names", cleanUpSubjectAlternativeNames(resp.Certificate)); err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		domainValidationOptions, err := convertDomainValidationOptions(resp.Certificate.DomainValidationOptions)
+
+		if err != nil {
+			return resource.RetryableError(err)
+		}
+
+		if err := d.Set("domain_validation_options", domainValidationOptions); err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+}
+
+func cleanUpSubjectAlternativeNames(cert *acm.CertificateDetail) []string {
+	sans := cert.SubjectAlternativeNames
+	vs := make([]string, 0, len(sans)-1)
+	for _, v := range sans {
+		if *v != *cert.DomainName {
+			vs = append(vs, *v)
+		}
+	}
+	return vs
+
+}
+
+func convertDomainValidationOptions(validations []*acm.DomainValidation) ([]map[string]interface{}, error) {
+	result := make([]map[string]interface{}, 0, len(validations))
+
+	for _, o := range validations {
+		validationOption := make(map[string]interface{})
+		validationOption["domain_name"] = *o.DomainName
+		if o.ResourceRecord != nil {
+			validationOption["resource_record_name"] = *o.ResourceRecord.Name
+			validationOption["resource_record_type"] = *o.ResourceRecord.Type
+			validationOption["resource_record_value"] = *o.ResourceRecord.Value
+		} else {
+			log.Printf("[DEBUG] No resource record found in validation options, need to retry: %#v", o)
+			return nil, fmt.Errorf("No resource record found in DNS DomainValidationOptions: %v", o)
+		}
+
+		result = append(result, validationOption)
+	}
+
+	return result, nil
+}
+
+func resourceAwsAcmCertificateDelete(d *schema.ResourceData, meta interface{}) error {
+	acmconn := meta.(*AWSClient).acmconn
+
+	if err := resourceAwsAcmCertificateRead(d, meta); err != nil {
+		return err
+	}
+	if d.Id() == "" {
+		// This might happen from the read
+		return nil
+	}
+
+	params := &acm.DeleteCertificateInput{
+		CertificateArn: aws.String(d.Id()),
+	}
+
+	_, err := acmconn.DeleteCertificate(params)
+
+	if err != nil {
+		return fmt.Errorf("Error deleting certificate: %s", err)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/aws/resource_aws_acm_certificate.go
+++ b/aws/resource_aws_acm_certificate.go
@@ -22,7 +22,6 @@ func resourceAwsAcmCertificate() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-
 			"subject_alternative_names": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
@@ -144,21 +143,21 @@ func cleanUpSubjectAlternativeNames(cert *acm.CertificateDetail) []string {
 }
 
 func convertDomainValidationOptions(validations []*acm.DomainValidation) ([]map[string]interface{}, error) {
-	result := make([]map[string]interface{}, 0, len(validations))
+	var result []map[string]interface{}
 
 	for _, o := range validations {
-		validationOption := make(map[string]interface{})
-		validationOption["domain_name"] = *o.DomainName
 		if o.ResourceRecord != nil {
-			validationOption["resource_record_name"] = *o.ResourceRecord.Name
-			validationOption["resource_record_type"] = *o.ResourceRecord.Type
-			validationOption["resource_record_value"] = *o.ResourceRecord.Value
+			validationOption := map[string]interface{}{
+				"domain_name":           *o.DomainName,
+				"resource_record_name":  *o.ResourceRecord.Name,
+				"resource_record_type":  *o.ResourceRecord.Type,
+				"resource_record_value": *o.ResourceRecord.Value,
+			}
+			result = append(result, validationOption)
 		} else {
 			log.Printf("[DEBUG] No resource record found in validation options, need to retry: %#v", o)
 			return nil, fmt.Errorf("No resource record found in DNS DomainValidationOptions: %v", o)
 		}
-
-		result = append(result, validationOption)
 	}
 
 	return result, nil

--- a/aws/resource_aws_acm_certificate_test.go
+++ b/aws/resource_aws_acm_certificate_test.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"testing"
 
+	"os"
+	"regexp"
+
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/acm"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"os"
-	"regexp"
 )
 
 func TestAccAwsAcmResource_certificateIssuingFlow(t *testing.T) {
@@ -297,12 +297,7 @@ func testAccCheckAcmCertificateDestroy(s *terraform.State) error {
 		}
 
 		// Verify the error is what we want
-		acmerr, ok := err.(awserr.Error)
-
-		if !ok {
-			return err
-		}
-		if acmerr.Code() != "ResourceNotFoundException" {
+		if !isAWSErr(err, acm.ErrCodeResourceNotFoundException, "") {
 			return err
 		}
 	}

--- a/aws/resource_aws_acm_certificate_test.go
+++ b/aws/resource_aws_acm_certificate_test.go
@@ -123,7 +123,7 @@ resource "aws_acm_certificate" "cert" {
 
 
 resource "aws_acm_certificate_validation" "cert" {
-  certificate_arn = "${aws_acm_certificate.cert.certificate_arn}"
+  certificate_arn = "${aws_acm_certificate.cert.arn}"
   timeout = "20s"
 }
 `, domain, sanDomain)
@@ -144,7 +144,7 @@ resource "aws_acm_certificate" "cert" {
 
 
 resource "aws_acm_certificate_validation" "cert" {
-  certificate_arn = "${aws_acm_certificate.cert.certificate_arn}"
+  certificate_arn = "${aws_acm_certificate.cert.arn}"
   validation_record_fqdns = ["some-wrong-fqdn.example.com"]
   timeout = "20s"
 }
@@ -187,7 +187,7 @@ resource "aws_route53_record" "cert_validation_san" {
 }
 
 resource "aws_acm_certificate_validation" "cert" {
-  certificate_arn = "${aws_acm_certificate.cert.certificate_arn}"
+  certificate_arn = "${aws_acm_certificate.cert.arn}"
   validation_record_fqdns = [
 	"${aws_route53_record.cert_validation.fqdn}",
 	"${aws_route53_record.cert_validation_san.fqdn}"
@@ -207,18 +207,18 @@ func testAccCheckAcmCertificateExists(n string, res *acm.DescribeCertificateOutp
 			return fmt.Errorf("No id is set")
 		}
 
-		if rs.Primary.Attributes["certificate_arn"] == "" {
-			return fmt.Errorf("No certificate_arn is set")
+		if rs.Primary.Attributes["arn"] == "" {
+			return fmt.Errorf("No arn is set")
 		}
 
-		if rs.Primary.Attributes["certificate_arn"] != rs.Primary.ID {
-			return fmt.Errorf("No certificate_arn and ID are different: %s %s", rs.Primary.Attributes["certificate_arn"], rs.Primary.ID)
+		if rs.Primary.Attributes["arn"] != rs.Primary.ID {
+			return fmt.Errorf("No arn and ID are different: %s %s", rs.Primary.Attributes["arn"], rs.Primary.ID)
 		}
 
 		acmconn := testAccProvider.Meta().(*AWSClient).acmconn
 
 		resp, err := acmconn.DescribeCertificate(&acm.DescribeCertificateInput{
-			CertificateArn: aws.String(rs.Primary.Attributes["certificate_arn"]),
+			CertificateArn: aws.String(rs.Primary.Attributes["arn"]),
 		})
 
 		if err != nil {
@@ -226,7 +226,7 @@ func testAccCheckAcmCertificateExists(n string, res *acm.DescribeCertificateOutp
 		}
 
 		tagsResp, err := acmconn.ListTagsForCertificate(&acm.ListTagsForCertificateInput{
-			CertificateArn: aws.String(rs.Primary.Attributes["certificate_arn"]),
+			CertificateArn: aws.String(rs.Primary.Attributes["arn"]),
 		})
 
 		if err != nil {

--- a/aws/resource_aws_acm_certificate_test.go
+++ b/aws/resource_aws_acm_certificate_test.go
@@ -70,7 +70,10 @@ func TestAccAwsAcmResource_certificateIssuingFlow(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Test that we can request a certificate
 			resource.TestStep{
-				Config: testAccAcmCertificateConfig(domain, sanDomain),
+				Config: testAccAcmCertificateConfig(
+					domain, sanDomain,
+					"Hello", "World",
+					"Foo", "Bar"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("aws_acm_certificate.cert", "arn", certificateArnRegex),
 					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_name", domain),
@@ -83,7 +86,10 @@ func TestAccAwsAcmResource_certificateIssuingFlow(t *testing.T) {
 			},
 			// Test that we can change the tags
 			resource.TestStep{
-				Config: testAccAcmCertificateConfigWithChangedTags(domain, sanDomain),
+				Config: testAccAcmCertificateConfig(
+					domain, sanDomain,
+					"Environment", "Test",
+					"Foo", "Baz"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "tags.%", "2"),
 					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "tags.Environment", "Test"),
@@ -126,7 +132,7 @@ resource "aws_acm_certificate" "cert" {
 
 }
 
-func testAccAcmCertificateConfig(domain string, sanDomain string) string {
+func testAccAcmCertificateConfig(domain string, sanDomain string, tag1Key, tag1Value, tag2Key, tag2Value string) string {
 	return fmt.Sprintf(`
 resource "aws_acm_certificate" "cert" {
   domain_name = "%s"
@@ -134,26 +140,11 @@ resource "aws_acm_certificate" "cert" {
   subject_alternative_names = ["%s"]
 
   tags {
-    "Hello" = "World"
-    "Foo" = "Bar"
+    "%s" = "%s"
+    "%s" = "%s"
   }
 }
-`, domain, sanDomain)
-}
-
-func testAccAcmCertificateConfigWithChangedTags(domain string, sanDomain string) string {
-	return fmt.Sprintf(`
-resource "aws_acm_certificate" "cert" {
-  domain_name = "%s"
-  validation_method = "DNS"
-  subject_alternative_names = ["%s"]
-
-  tags {
-    "Environment" = "Test"
-    "Foo" = "Baz"
-  }
-}
-`, domain, sanDomain)
+`, domain, sanDomain, tag1Key, tag1Value, tag2Key, tag2Value)
 }
 
 func testAccAcmCertificateWithValidationConfig(domain string, sanDomain string) string {

--- a/aws/resource_aws_acm_certificate_test.go
+++ b/aws/resource_aws_acm_certificate_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/acm"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -22,8 +23,11 @@ func TestAccAwsAcmResource_certificateIssuingFlow(t *testing.T) {
 	}
 
 	root_zone_domain := os.Getenv("ACM_CERTIFICATE_ROOT_DOMAIN")
-	domain := fmt.Sprintf("certtest.%s", root_zone_domain)
-	sanDomain := fmt.Sprintf("certtest2.%s", root_zone_domain)
+
+	rInt1 := acctest.RandInt()
+
+	domain := fmt.Sprintf("tf-acc-%d.%s", rInt1, root_zone_domain)
+	sanDomain := fmt.Sprintf("tf-acc-%d-san.%s", rInt1, root_zone_domain)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/aws/resource_aws_acm_certificate_test.go
+++ b/aws/resource_aws_acm_certificate_test.go
@@ -51,7 +51,8 @@ func TestAccAwsAcmResource_emailValidation(t *testing.T) {
 	})
 
 }
-func TestAccAwsAcmResource_certificateIssuingFlow(t *testing.T) {
+
+func TestAccAwsAcmResource_dnsValidationAndTagging(t *testing.T) {
 	if os.Getenv("ACM_CERTIFICATE_ROOT_DOMAIN") == "" {
 		t.Skip("Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set")
 	}
@@ -96,23 +97,6 @@ func TestAccAwsAcmResource_certificateIssuingFlow(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "tags.Foo", "Baz"),
 				),
 			},
-			// Test that validation times out if certificate can't be validated
-			resource.TestStep{
-				Config:      testAccAcmCertificateWithValidationConfig(domain, sanDomain),
-				ExpectError: regexp.MustCompile("Expected certificate to be issued but was in state PENDING_VALIDATION"),
-			},
-			// Test that validation fails if given validation_fqdns don't match
-			resource.TestStep{
-				Config:      testAccAcmCertificateWithValidationConfigAndWrongFQDN(domain, sanDomain),
-				ExpectError: regexp.MustCompile("Certificate needs .* to be set but only .* was passed to validation_record_fqdns"),
-			},
-			// Test that validation succeeds once we provide the right DNS validation records
-			resource.TestStep{
-				Config: testAccAcmCertificateWithValidationAndRecordsConfig(root_zone_domain, domain, sanDomain),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr("aws_acm_certificate_validation.cert", "certificate_arn", certificateArnRegex),
-				),
-			},
 			resource.TestStep{
 				ResourceName:      "aws_acm_certificate.cert",
 				ImportState:       true,
@@ -145,94 +129,6 @@ resource "aws_acm_certificate" "cert" {
   }
 }
 `, domain, sanDomain, tag1Key, tag1Value, tag2Key, tag2Value)
-}
-
-func testAccAcmCertificateWithValidationConfig(domain string, sanDomain string) string {
-	return fmt.Sprintf(`
-resource "aws_acm_certificate" "cert" {
-  domain_name = "%s"
-  validation_method = "DNS"
-  subject_alternative_names = ["%s"]
-
-  tags {
-    "Environment" = "Test"
-    "Foo" = "Baz"
-  }
-}
-
-
-resource "aws_acm_certificate_validation" "cert" {
-  certificate_arn = "${aws_acm_certificate.cert.arn}"
-  timeout = "20s"
-}
-`, domain, sanDomain)
-}
-
-func testAccAcmCertificateWithValidationConfigAndWrongFQDN(domain string, sanDomain string) string {
-	return fmt.Sprintf(`
-resource "aws_acm_certificate" "cert" {
-  domain_name = "%s"
-  validation_method = "DNS"
-  subject_alternative_names = ["%s"]
-
-  tags {
-    "Environment" = "Test"
-    "Foo" = "Baz"
-  }
-}
-
-
-resource "aws_acm_certificate_validation" "cert" {
-  certificate_arn = "${aws_acm_certificate.cert.arn}"
-  validation_record_fqdns = ["some-wrong-fqdn.example.com"]
-  timeout = "20s"
-}
-`, domain, sanDomain)
-}
-
-func testAccAcmCertificateWithValidationAndRecordsConfig(rootZoneDomain string, domain string, sanDomain string) string {
-	return fmt.Sprintf(`
-resource "aws_acm_certificate" "cert" {
-  domain_name = "%s"
-  validation_method = "DNS"
-  subject_alternative_names = ["%s"]
-
-  tags {
-    "Environment" = "Test"
-    "Foo" = "Baz"
-  }
-}
-
-
-data "aws_route53_zone" "zone" {
-  name = "%s."
-  private_zone = false
-}
-
-resource "aws_route53_record" "cert_validation" {
-  name = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_name}"
-  type = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_type}"
-  zone_id = "${data.aws_route53_zone.zone.id}"
-  records = ["${aws_acm_certificate.cert.domain_validation_options.0.resource_record_value}"]
-  ttl = 60
-}
-
-resource "aws_route53_record" "cert_validation_san" {
-  name = "${aws_acm_certificate.cert.domain_validation_options.1.resource_record_name}"
-  type = "${aws_acm_certificate.cert.domain_validation_options.1.resource_record_type}"
-  zone_id = "${data.aws_route53_zone.zone.id}"
-  records = ["${aws_acm_certificate.cert.domain_validation_options.1.resource_record_value}"]
-  ttl = 60
-}
-
-resource "aws_acm_certificate_validation" "cert" {
-  certificate_arn = "${aws_acm_certificate.cert.arn}"
-  validation_record_fqdns = [
-	"${aws_route53_record.cert_validation.fqdn}",
-	"${aws_route53_record.cert_validation_san.fqdn}"
-  ]
-}
-`, domain, sanDomain, rootZoneDomain)
 }
 
 func testAccCheckAcmCertificateDestroy(s *terraform.State) error {

--- a/aws/resource_aws_acm_certificate_test.go
+++ b/aws/resource_aws_acm_certificate_test.go
@@ -52,6 +52,11 @@ func TestAccAwsAcmResource_certificateIssuingFlow(t *testing.T) {
 					testAccCheckAcmCertificateValidationAttributes("aws_acm_certificate_validation.cert", &confAfterValidation),
 				),
 			},
+			resource.TestStep{
+				ResourceName:      "aws_acm_certificate.cert",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/aws/resource_aws_acm_certificate_test.go
+++ b/aws/resource_aws_acm_certificate_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/acm"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	"os"
 	"regexp"
 )
 
@@ -16,10 +17,13 @@ func TestAccAwsAcmResource_certificateIssuingFlow(t *testing.T) {
 	var conf acm.DescribeCertificateOutput
 	var tags acm.ListTagsForCertificateOutput
 	var confAfterValidation acm.DescribeCertificateOutput
+	if os.Getenv("ACM_CERTIFICATE_ROOT_DOMAIN") == "" {
+		t.Skip("Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set")
+	}
 
-	root_zone_domain := "sandbox.sellmayr.net"
-	domain := "certtest.sandbox.sellmayr.net"
-	sanDomain := "certtest2.sandbox.sellmayr.net"
+	root_zone_domain := os.Getenv("ACM_CERTIFICATE_ROOT_DOMAIN")
+	domain := fmt.Sprintf("certtest.%s", root_zone_domain)
+	sanDomain := fmt.Sprintf("certtest2.%s", root_zone_domain)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/aws/resource_aws_acm_certificate_test.go
+++ b/aws/resource_aws_acm_certificate_test.go
@@ -40,8 +40,17 @@ func TestAccAwsAcmResource_certificateIssuingFlow(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAcmCertificateExists("aws_acm_certificate.cert", &conf, &tags),
 					testAccCheckAcmCertificateAttributes("aws_acm_certificate.cert", &conf, domain, sanDomain, "PENDING_VALIDATION"),
+
 					testAccCheckTagsACM(&tags.Tags, "Hello", "World"),
 					testAccCheckTagsACM(&tags.Tags, "Foo", "Bar"),
+
+					resource.TestMatchResourceAttr("aws_acm_certificate.cert", "arn", regexp.MustCompile(`^arn:aws:acm:[^:]+:[^:]+:certificate/.+$`)),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_name", domain),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "subject_alternative_names.#", "1"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "subject_alternative_names.0", sanDomain),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "tags.%", "2"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "tags.Hello", "World"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "tags.Foo", "Bar"),
 				),
 			},
 			// Test that we can change the tags
@@ -50,8 +59,13 @@ func TestAccAwsAcmResource_certificateIssuingFlow(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAcmCertificateExists("aws_acm_certificate.cert", &conf, &tags),
 					testAccCheckAcmCertificateAttributes("aws_acm_certificate.cert", &conf, domain, sanDomain, "PENDING_VALIDATION"),
+
 					testAccCheckTagsACM(&tags.Tags, "Environment", "Test"),
 					testAccCheckTagsACM(&tags.Tags, "Foo", "Baz"),
+
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "tags.%", "2"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "tags.Environment", "Test"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "tags.Foo", "Baz"),
 				),
 			},
 			// Test that validation times out if certificate can't be validated

--- a/aws/resource_aws_acm_certificate_test.go
+++ b/aws/resource_aws_acm_certificate_test.go
@@ -9,11 +9,14 @@ import (
 	"github.com/aws/aws-sdk-go/service/acm"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	"regexp"
 )
 
 func TestAccAwsAcmResource_certificateIssuingFlow(t *testing.T) {
 	var conf acm.DescribeCertificateOutput
+	var confAfterValidation acm.DescribeCertificateOutput
 
+	root_zone_domain := "sandbox.sellmayr.net"
 	domain := "certtest.sandbox.sellmayr.net"
 
 	resource.Test(t, resource.TestCase{
@@ -21,11 +24,26 @@ func TestAccAwsAcmResource_certificateIssuingFlow(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAcmCertificateDestroy,
 		Steps: []resource.TestStep{
+			// Test that we can request a certificate
 			resource.TestStep{
 				Config: testAccAcmCertificateConfig(domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAcmCertificateExists("aws_acm_certificate.cert", &conf),
 					testAccCheckAcmCertificateAttributes("aws_acm_certificate.cert", &conf, domain, "PENDING_VALIDATION"),
+				),
+			},
+			// Test that validation times out if certificate can't be validated
+			resource.TestStep{
+				Config:      testAccAcmCertificateWithValidationConfig(domain),
+				ExpectError: regexp.MustCompile("Expected certificate to be issued but was in state PENDING_VALIDATION"),
+			},
+			// Test that validation succeeds once we provide the right DNS validation records
+			resource.TestStep{
+				Config: testAccAcmCertificateWithValidationAndRecordsConfig(root_zone_domain, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAcmCertificateExists("aws_acm_certificate.cert", &confAfterValidation),
+					testAccCheckAcmCertificateAttributes("aws_acm_certificate.cert", &confAfterValidation, domain, "ISSUED"),
+					testAccCheckAcmCertificateValidationAttributes("aws_acm_certificate_validation.cert", &confAfterValidation),
 				),
 			},
 		},
@@ -39,6 +57,47 @@ resource "aws_acm_certificate" "cert" {
 	validation_method = "DNS"
 }
 `, domain)
+}
+
+func testAccAcmCertificateWithValidationConfig(domain string) string {
+	return fmt.Sprintf(`
+resource "aws_acm_certificate" "cert" {
+    domain_name = "%s"
+	validation_method = "DNS"
+}
+
+resource "aws_acm_certificate_validation" "cert" {
+  certificate_arn = "${aws_acm_certificate.cert.certificate_arn}"
+  timeout = "20s"
+}
+`, domain)
+}
+
+func testAccAcmCertificateWithValidationAndRecordsConfig(rootZoneDomain string, domain string) string {
+	return fmt.Sprintf(`
+resource "aws_acm_certificate" "cert" {
+    domain_name = "%s"
+	validation_method = "DNS"
+}
+
+data "aws_route53_zone" "zone" {
+  name = "%s."
+  private_zone = false
+}
+
+resource "aws_route53_record" "cert_validation" {
+  name = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_name}"
+  type = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_type}"
+  zone_id = "${data.aws_route53_zone.zone.id}"
+  records = ["${aws_acm_certificate.cert.domain_validation_options.0.resource_record_value}"]
+  ttl = 60
+}
+
+resource "aws_acm_certificate_validation" "cert" {
+  certificate_arn = "${aws_acm_certificate.cert.certificate_arn}"
+  validation_record_fqdn = "${aws_route53_record.cert_validation.fqdn}" # This wouldn't strictly be necessary but it can enforce a dependency
+}
+`, domain, rootZoneDomain)
 }
 
 func testAccCheckAcmCertificateExists(n string, res *acm.DescribeCertificateOutput) resource.TestCheckFunc {
@@ -95,6 +154,22 @@ func testAccCheckAcmCertificateAttributes(n string, cert *acm.DescribeCertificat
 		}
 
 		// TODO: check other attributes?
+
+		return nil
+	}
+}
+
+func testAccCheckAcmCertificateValidationAttributes(n string, cert *acm.DescribeCertificateOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s.", n)
+		}
+		attrs := rs.Primary.Attributes
+
+		if attrs["certificate_arn"] != *cert.Certificate.CertificateArn {
+			return fmt.Errorf("Certificate ARN in state is %s but expected %s", attrs["arn"], *cert.Certificate.CertificateArn)
+		}
 
 		return nil
 	}

--- a/aws/resource_aws_acm_certificate_test.go
+++ b/aws/resource_aws_acm_certificate_test.go
@@ -1,0 +1,130 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/acm"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAwsAcmResource_certificateIssuingFlow(t *testing.T) {
+	var conf acm.DescribeCertificateOutput
+
+	domain := "certtest.sandbox.sellmayr.net"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAcmCertificateDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAcmCertificateConfig(domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAcmCertificateExists("aws_acm_certificate.cert", &conf),
+					testAccCheckAcmCertificateAttributes("aws_acm_certificate.cert", &conf, domain, "PENDING_VALIDATION"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAcmCertificateConfig(domain string) string {
+	return fmt.Sprintf(`
+resource "aws_acm_certificate" "cert" {
+    domain_name = "%s"
+	validation_method = "DNS"
+}
+`, domain)
+}
+
+func testAccCheckAcmCertificateExists(n string, res *acm.DescribeCertificateOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No id is set")
+		}
+
+		if rs.Primary.Attributes["certificate_arn"] == "" {
+			return fmt.Errorf("No certificate_arn is set")
+		}
+
+		if rs.Primary.Attributes["certificate_arn"] != rs.Primary.ID {
+			return fmt.Errorf("No certificate_arn and ID are different: %s %s", rs.Primary.Attributes["certificate_arn"], rs.Primary.ID)
+		}
+
+		acmconn := testAccProvider.Meta().(*AWSClient).acmconn
+
+		resp, err := acmconn.DescribeCertificate(&acm.DescribeCertificateInput{
+			CertificateArn: aws.String(rs.Primary.Attributes["certificate_arn"]),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		*res = *resp
+
+		return nil
+	}
+}
+
+func testAccCheckAcmCertificateAttributes(n string, cert *acm.DescribeCertificateOutput, domain string, status string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		attrs := rs.Primary.Attributes
+
+		if *cert.Certificate.DomainName != domain {
+			return fmt.Errorf("Domain name is %s but expected %s", *cert.Certificate.DomainName, domain)
+		}
+		if *cert.Certificate.Status != status {
+			return fmt.Errorf("Status is %s but expected %s", *cert.Certificate.Status, status)
+		}
+		if attrs["domain_name"] != domain {
+			return fmt.Errorf("Domain name in state is %s but expected %s", attrs["domain_name"], domain)
+		}
+
+		// TODO: check other attributes?
+
+		return nil
+	}
+}
+
+func testAccCheckAcmCertificateDestroy(s *terraform.State) error {
+	acmconn := testAccProvider.Meta().(*AWSClient).acmconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_acm_certificate" {
+			continue
+		}
+		_, err := acmconn.DescribeCertificate(&acm.DescribeCertificateInput{
+			CertificateArn: aws.String(rs.Primary.ID),
+		})
+
+		if err == nil {
+			return fmt.Errorf("Certificate still exists.")
+		}
+
+		// Verify the error is what we want
+		acmerr, ok := err.(awserr.Error)
+
+		if !ok {
+			return err
+		}
+		if acmerr.Code() != "ResourceNotFoundException" {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/aws/resource_aws_acm_certificate_validation.go
+++ b/aws/resource_aws_acm_certificate_validation.go
@@ -127,7 +127,10 @@ func resourceAwsAcmCertificateValidationRead(d *schema.ResourceData, meta interf
 
 	resp, err := acmconn.DescribeCertificate(params)
 
-	if err != nil {
+	if err != nil && isAWSErr(err, acm.ErrCodeResourceNotFoundException, "") {
+		d.SetId("")
+		return nil
+	} else if err != nil {
 		return fmt.Errorf("Error describing certificate: %s", err)
 	}
 

--- a/aws/resource_aws_acm_certificate_validation.go
+++ b/aws/resource_aws_acm_certificate_validation.go
@@ -2,15 +2,16 @@ package aws
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/acm"
-	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/helper/schema"
 	"log"
 	"reflect"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/acm"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
 )
 
 func resourceAwsAcmCertificateValidation() *schema.Resource {
@@ -93,7 +94,7 @@ func resourceAwsAcmCertificateValidationCreate(d *schema.ResourceData, meta inte
 func resourceAwsAcmCertificateCheckValidationRecords(validation_record_fqdns []interface{}, cert *acm.CertificateDetail) error {
 	expected_fqdns := make([]string, len(cert.DomainValidationOptions))
 	for i, v := range cert.DomainValidationOptions {
-		if *v.ValidationMethod == "DNS" {
+		if *v.ValidationMethod == acm.ValidationMethodDns {
 			expected_fqdns[i] = strings.TrimSuffix(*v.ResourceRecord.Name, ".")
 		}
 	}

--- a/aws/resource_aws_acm_certificate_validation.go
+++ b/aws/resource_aws_acm_certificate_validation.go
@@ -33,22 +33,14 @@ func resourceAwsAcmCertificateValidation() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
-			"timeout": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  "45m",
-			},
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(45 * time.Minute),
 		},
 	}
 }
 
 func resourceAwsAcmCertificateValidationCreate(d *schema.ResourceData, meta interface{}) error {
-	timeout, err := time.ParseDuration(d.Get("timeout").(string))
-	if err != nil {
-		return err
-	}
-
 	certificate_arn := d.Get("certificate_arn").(string)
 
 	acmconn := meta.(*AWSClient).acmconn
@@ -75,7 +67,7 @@ func resourceAwsAcmCertificateValidationCreate(d *schema.ResourceData, meta inte
 		log.Printf("[INFO] No validation_record_fqdns set, skipping check")
 	}
 
-	return resource.Retry(timeout, func() *resource.RetryError {
+	return resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 		resp, err := acmconn.DescribeCertificate(params)
 
 		if err != nil {

--- a/aws/resource_aws_acm_certificate_validation.go
+++ b/aws/resource_aws_acm_certificate_validation.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"reflect"
 	"sort"
+	"strings"
 	"time"
 )
 
@@ -93,7 +94,7 @@ func resourceAwsAcmCertificateCheckValidationRecords(validation_record_fqdns []i
 	expected_fqdns := make([]string, len(cert.DomainValidationOptions))
 	for i, v := range cert.DomainValidationOptions {
 		if *v.ValidationMethod == "DNS" {
-			expected_fqdns[i] = *v.ResourceRecord.Name
+			expected_fqdns[i] = strings.TrimSuffix(*v.ResourceRecord.Name, ".")
 		}
 	}
 
@@ -101,7 +102,7 @@ func resourceAwsAcmCertificateCheckValidationRecords(validation_record_fqdns []i
 
 	for _, v := range validation_record_fqdns {
 		val := v.(string)
-		actual_validation_record_fqdns = append(actual_validation_record_fqdns, val)
+		actual_validation_record_fqdns = append(actual_validation_record_fqdns, strings.TrimSuffix(val, "."))
 	}
 
 	sort.Strings(expected_fqdns)

--- a/aws/resource_aws_acm_certificate_validation.go
+++ b/aws/resource_aws_acm_certificate_validation.go
@@ -1,0 +1,98 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/acm"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"log"
+	"time"
+)
+
+func resourceAwsAcmCertificateValidation() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsAcmCertificateValidationCreate,
+		Read:   resourceAwsAcmCertificateValidationRead,
+		Delete: resourceAwsAcmCertificateValidationDelete,
+
+		Schema: map[string]*schema.Schema{
+			"certificate_arn": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"validation_record_fqdn": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"timeout": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "45m",
+			},
+		},
+	}
+}
+
+func resourceAwsAcmCertificateValidationCreate(d *schema.ResourceData, meta interface{}) error {
+	// TODO: check that validation_record_fqdn (if set) matches the domain validation information for cert
+	// TODO: check that certificate is AMAZON_ISSUED and has Domain Validation enabled (should we also allow to wait for E-Mail validation?)
+
+	timeout, err := time.ParseDuration(d.Get("timeout").(string))
+	if err != nil {
+		return err
+	}
+
+	return resource.Retry(timeout, func() *resource.RetryError {
+		acmconn := meta.(*AWSClient).acmconn
+
+		certificate_arn := d.Get("certificate_arn").(string)
+		params := &acm.DescribeCertificateInput{
+			CertificateArn: aws.String(certificate_arn),
+		}
+
+		resp, err := acmconn.DescribeCertificate(params)
+
+		if err != nil {
+			return resource.NonRetryableError(fmt.Errorf("Error describing certificate: %s", err))
+		}
+
+		if *resp.Certificate.Status != "ISSUED" {
+			return resource.RetryableError(fmt.Errorf("Expected certificate to be issued but was in state %s", *resp.Certificate.Status))
+		}
+
+		log.Printf("[INFO] ACM Certificate validation for %s done, certificate was issued", certificate_arn)
+		return resource.NonRetryableError(resourceAwsAcmCertificateValidationRead(d, meta))
+	})
+}
+
+func resourceAwsAcmCertificateValidationRead(d *schema.ResourceData, meta interface{}) error {
+	acmconn := meta.(*AWSClient).acmconn
+
+	params := &acm.DescribeCertificateInput{
+		CertificateArn: aws.String(d.Get("certificate_arn").(string)),
+	}
+
+	resp, err := acmconn.DescribeCertificate(params)
+
+	if err != nil {
+		return fmt.Errorf("Error describing certificate: %s", err)
+	}
+
+	if *resp.Certificate.Status != "ISSUED" {
+		log.Printf("[INFO] Certificate status not issued, was %s, tainting validation", *resp.Certificate.Status)
+		d.SetId("")
+	} else {
+		d.SetId((*resp.Certificate.IssuedAt).String())
+	}
+	return nil
+}
+
+func resourceAwsAcmCertificateValidationDelete(d *schema.ResourceData, meta interface{}) error {
+	// No need to do anything, certificate will be deleted when acm_certificate is deleted
+	d.SetId("")
+	return nil
+}

--- a/aws/resource_aws_acm_certificate_validation_test.go
+++ b/aws/resource_aws_acm_certificate_validation_test.go
@@ -1,0 +1,124 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"os"
+	"regexp"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAwsAcmResource_certificateIssuingAndValidationFlow(t *testing.T) {
+	if os.Getenv("ACM_CERTIFICATE_ROOT_DOMAIN") == "" {
+		t.Skip("Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set")
+	}
+
+	root_zone_domain := os.Getenv("ACM_CERTIFICATE_ROOT_DOMAIN")
+
+	rInt1 := acctest.RandInt()
+
+	domain := fmt.Sprintf("tf-acc-%d.%s", rInt1, root_zone_domain)
+	sanDomain := fmt.Sprintf("tf-acc-%d-san.%s", rInt1, root_zone_domain)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAcmCertificateDestroy,
+		Steps: []resource.TestStep{
+			// Test that validation times out if certificate can't be validated
+			resource.TestStep{
+				Config:      testAccAcmCertificateWithValidationConfig(domain, sanDomain),
+				ExpectError: regexp.MustCompile("Expected certificate to be issued but was in state PENDING_VALIDATION"),
+			},
+			// Test that validation fails if given validation_fqdns don't match
+			resource.TestStep{
+				Config:      testAccAcmCertificateWithValidationConfigAndWrongFQDN(domain, sanDomain),
+				ExpectError: regexp.MustCompile("Certificate needs .* to be set but only .* was passed to validation_record_fqdns"),
+			},
+			// Test that validation succeeds once we provide the right DNS validation records
+			resource.TestStep{
+				Config: testAccAcmCertificateWithValidationAndRecordsConfig(root_zone_domain, domain, sanDomain),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("aws_acm_certificate_validation.cert", "certificate_arn", certificateArnRegex),
+				),
+			},
+			// Test that we can import a validated certificate
+			resource.TestStep{
+				ResourceName:      "aws_acm_certificate.cert",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccAcmCertificateWithValidationConfig(domain string, sanDomain string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "aws_acm_certificate_validation" "cert" {
+  certificate_arn = "${aws_acm_certificate.cert.arn}"
+  timeout = "20s"
+}
+`, testAccAcmCertificateConfig(
+		domain, sanDomain,
+		"Environment", "Test",
+		"Foo", "Baz"))
+}
+
+func testAccAcmCertificateWithValidationConfigAndWrongFQDN(domain string, sanDomain string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "aws_acm_certificate_validation" "cert" {
+  certificate_arn = "${aws_acm_certificate.cert.arn}"
+  validation_record_fqdns = ["some-wrong-fqdn.example.com"]
+  timeout = "20s"
+}
+`, testAccAcmCertificateConfig(
+		domain, sanDomain,
+		"Environment", "Test",
+		"Foo", "Baz"))
+}
+
+func testAccAcmCertificateWithValidationAndRecordsConfig(rootZoneDomain string, domain string, sanDomain string) string {
+	return fmt.Sprintf(`
+%s
+
+data "aws_route53_zone" "zone" {
+  name = "%s."
+  private_zone = false
+}
+
+resource "aws_route53_record" "cert_validation" {
+  name = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_name}"
+  type = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_type}"
+  zone_id = "${data.aws_route53_zone.zone.id}"
+  records = ["${aws_acm_certificate.cert.domain_validation_options.0.resource_record_value}"]
+  ttl = 60
+}
+
+resource "aws_route53_record" "cert_validation_san" {
+  name = "${aws_acm_certificate.cert.domain_validation_options.1.resource_record_name}"
+  type = "${aws_acm_certificate.cert.domain_validation_options.1.resource_record_type}"
+  zone_id = "${data.aws_route53_zone.zone.id}"
+  records = ["${aws_acm_certificate.cert.domain_validation_options.1.resource_record_value}"]
+  ttl = 60
+}
+
+resource "aws_acm_certificate_validation" "cert" {
+  certificate_arn = "${aws_acm_certificate.cert.arn}"
+  validation_record_fqdns = [
+	"${aws_route53_record.cert_validation.fqdn}",
+	"${aws_route53_record.cert_validation_san.fqdn}"
+  ]
+}
+`, testAccAcmCertificateConfig(
+		domain, sanDomain,
+		"Environment", "Test",
+		"Foo", "Baz"),
+		rootZoneDomain)
+}

--- a/aws/resource_aws_acm_certificate_validation_test.go
+++ b/aws/resource_aws_acm_certificate_validation_test.go
@@ -61,7 +61,9 @@ func testAccAcmCertificateWithValidationConfig(domain string, sanDomain string) 
 
 resource "aws_acm_certificate_validation" "cert" {
   certificate_arn = "${aws_acm_certificate.cert.arn}"
-  timeout = "20s"
+  timeouts {
+    create = "20s"
+  }
 }
 `, testAccAcmCertificateConfig(
 		domain, sanDomain,
@@ -76,7 +78,9 @@ func testAccAcmCertificateWithValidationConfigAndWrongFQDN(domain string, sanDom
 resource "aws_acm_certificate_validation" "cert" {
   certificate_arn = "${aws_acm_certificate.cert.arn}"
   validation_record_fqdns = ["some-wrong-fqdn.example.com"]
-  timeout = "20s"
+  timeouts {
+    create = "20s"
+  }
 }
 `, testAccAcmCertificateConfig(
 		domain, sanDomain,

--- a/aws/tagsACM.go
+++ b/aws/tagsACM.go
@@ -1,0 +1,103 @@
+package aws
+
+import (
+	"log"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/acm"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func setTagsACM(conn *acm.ACM, d *schema.ResourceData) error {
+	if d.HasChange("tags") {
+		oraw, nraw := d.GetChange("tags")
+		o := oraw.(map[string]interface{})
+		n := nraw.(map[string]interface{})
+		create, remove := diffTagsACM(tagsFromMapACM(o), tagsFromMapACM(n))
+
+		// Set tags
+		if len(remove) > 0 {
+			input := acm.RemoveTagsFromCertificateInput{
+				CertificateArn: aws.String(d.Get("certificate_arn").(string)),
+				Tags:           remove,
+			}
+			log.Printf("[DEBUG] Removing ACM tags: %s", input)
+			_, err := conn.RemoveTagsFromCertificate(&input)
+			if err != nil {
+				return err
+			}
+		}
+		if len(create) > 0 {
+			input := acm.AddTagsToCertificateInput{
+				CertificateArn: aws.String(d.Get("certificate_arn").(string)),
+				Tags:           create,
+			}
+			log.Printf("[DEBUG] Adding ACM tags: %s", input)
+			_, err := conn.AddTagsToCertificate(&input)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// diffTags takes our tags locally and the ones remotely and returns
+// the set of tags that must be created, and the set of tags that must
+// be destroyed.
+func diffTagsACM(oldTags, newTags []*acm.Tag) ([]*acm.Tag, []*acm.Tag) {
+	// First, we're creating everything we have
+	create := make(map[string]interface{})
+	for _, t := range newTags {
+		create[*t.Key] = *t.Value
+	}
+
+	// Build the list of what to remove
+	var remove []*acm.Tag
+	for _, t := range oldTags {
+		old, ok := create[*t.Key]
+		if !ok || old != *t.Value {
+			// Delete it!
+			remove = append(remove, t)
+		}
+	}
+
+	return tagsFromMapACM(create), remove
+}
+
+func tagsFromMapACM(m map[string]interface{}) []*acm.Tag {
+	result := []*acm.Tag{}
+	for k, v := range m {
+		result = append(result, &acm.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v.(string)),
+		})
+	}
+
+	return result
+}
+
+func tagsToMapACM(ts []*acm.Tag) map[string]string {
+	result := map[string]string{}
+	for _, t := range ts {
+		result[*t.Key] = *t.Value
+	}
+
+	return result
+}
+
+// compare a tag against a list of strings and checks if it should
+// be ignored or not
+func tagIgnoredACM(t *acm.Tag) bool {
+	filter := []string{"^aws:"}
+	for _, v := range filter {
+		log.Printf("[DEBUG] Matching %v with %v\n", v, *t.Key)
+		if r, _ := regexp.MatchString(v, *t.Key); r == true {
+			log.Printf("[DEBUG] Found AWS specific tag %s (val: %s), ignoring.\n", *t.Key, *t.Value)
+			return true
+		}
+	}
+	return false
+}

--- a/aws/tagsACM.go
+++ b/aws/tagsACM.go
@@ -19,7 +19,7 @@ func setTagsACM(conn *acm.ACM, d *schema.ResourceData) error {
 		// Set tags
 		if len(remove) > 0 {
 			input := acm.RemoveTagsFromCertificateInput{
-				CertificateArn: aws.String(d.Get("certificate_arn").(string)),
+				CertificateArn: aws.String(d.Get("arn").(string)),
 				Tags:           remove,
 			}
 			log.Printf("[DEBUG] Removing ACM tags: %s", input)
@@ -30,7 +30,7 @@ func setTagsACM(conn *acm.ACM, d *schema.ResourceData) error {
 		}
 		if len(create) > 0 {
 			input := acm.AddTagsToCertificateInput{
-				CertificateArn: aws.String(d.Get("certificate_arn").(string)),
+				CertificateArn: aws.String(d.Get("arn").(string)),
 				Tags:           create,
 			}
 			log.Printf("[DEBUG] Adding ACM tags: %s", input)

--- a/aws/tagsACM_test.go
+++ b/aws/tagsACM_test.go
@@ -1,14 +1,11 @@
 package aws
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/acm"
-	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestDiffTagsACM(t *testing.T) {
@@ -76,28 +73,5 @@ func TestIgnoringTagsACM(t *testing.T) {
 		if !tagIgnoredACM(tag) {
 			t.Fatalf("Tag %v with value %v not ignored, but should be!", *tag.Key, *tag.Value)
 		}
-	}
-}
-
-// testAccCheckTags can be used to check the tags on a resource.
-func testAccCheckTagsACM(
-	ts *[]*acm.Tag, key string, value string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		m := tagsToMapACM(*ts)
-		v, ok := m[key]
-		if value != "" && !ok {
-			return fmt.Errorf("Missing tag: %s", key)
-		} else if value == "" && ok {
-			return fmt.Errorf("Extra tag: %s", key)
-		}
-		if value == "" {
-			return nil
-		}
-
-		if v != value {
-			return fmt.Errorf("%s: bad value: %s", key, v)
-		}
-
-		return nil
 	}
 }

--- a/aws/tagsACM_test.go
+++ b/aws/tagsACM_test.go
@@ -1,0 +1,103 @@
+package aws
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/acm"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestDiffTagsACM(t *testing.T) {
+	cases := []struct {
+		Old, New       map[string]interface{}
+		Create, Remove map[string]string
+	}{
+		// Basic add/remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"bar": "baz",
+			},
+			Create: map[string]string{
+				"bar": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Modify
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"foo": "baz",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		c, r := diffTagsACM(tagsFromMapACM(tc.Old), tagsFromMapACM(tc.New))
+		cm := tagsToMapACM(c)
+		rm := tagsToMapACM(r)
+		if !reflect.DeepEqual(cm, tc.Create) {
+			t.Fatalf("%d: bad create: %#v", i, cm)
+		}
+		if !reflect.DeepEqual(rm, tc.Remove) {
+			t.Fatalf("%d: bad remove: %#v", i, rm)
+		}
+	}
+}
+
+func TestIgnoringTagsACM(t *testing.T) {
+	var ignoredTags []*acm.Tag
+	ignoredTags = append(ignoredTags, &acm.Tag{
+		Key:   aws.String("aws:cloudformation:logical-id"),
+		Value: aws.String("foo"),
+	})
+	ignoredTags = append(ignoredTags, &acm.Tag{
+		Key:   aws.String("aws:foo:bar"),
+		Value: aws.String("baz"),
+	})
+	for _, tag := range ignoredTags {
+		if !tagIgnoredACM(tag) {
+			t.Fatalf("Tag %v with value %v not ignored, but should be!", *tag.Key, *tag.Value)
+		}
+	}
+}
+
+// testAccCheckTags can be used to check the tags on a resource.
+func testAccCheckTagsACM(
+	ts *[]*acm.Tag, key string, value string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		m := tagsToMapACM(*ts)
+		v, ok := m[key]
+		if value != "" && !ok {
+			return fmt.Errorf("Missing tag: %s", key)
+		} else if value == "" && ok {
+			return fmt.Errorf("Extra tag: %s", key)
+		}
+		if value == "" {
+			return nil
+		}
+
+		if v != value {
+			return fmt.Errorf("%s: bad value: %s", key, v)
+		}
+
+		return nil
+	}
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -233,6 +233,18 @@
                     </ul>
                 </li>
 
+                <li<%= sidebar_current("docs-aws-resource-acm") %>>
+                  <a href="#">ACM Resources</a>
+                  <ul class="nav nav-visible">
+                    <li<%= sidebar_current("docs-aws-resource-acm-certificate") %>>
+                      <a href="/docs/providers/aws/r/acm_certificate.html">aws_acm_certificate</a>
+                    </li>
+                    <li<%= sidebar_current("docs-aws-resource-acm-certificate-validation") %>>
+                      <a href="/docs/providers/aws/r/acm_certificate_validation.html">aws_acm_certificate_validation</a>
+                    </li>
+                  </ul>
+                </li>
+
                 <li<%= sidebar_current("docs-aws-resource-api-gateway") %>>
                     <a href="#">API Gateway Resources</a>
                     <ul class="nav nav-visible">

--- a/website/docs/r/acm_certificate.html.markdown
+++ b/website/docs/r/acm_certificate.html.markdown
@@ -45,7 +45,7 @@ resource "aws_route53_record" "cert_validation" {
 }
 
 resource "aws_acm_certificate_validation" "cert" {
-  certificate_arn = "${aws_acm_certificate.cert.certificate_arn}"
+  certificate_arn = "${aws_acm_certificate.cert.arn}"
   validation_record_fqdns = ["${aws_route53_record.cert_validation.fqdn}"]
 }
 
@@ -68,7 +68,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `certificate_arn` - The ARN of the certificate
+* `arn` - The ARN of the certificate
 * `domain_validation_options` - A list of attributes to feed into other resources to complete certificate validation. Can have more than one element, e.g. if SANs are defined
 
 Domain validation objects export the following attributes:

--- a/website/docs/r/acm_certificate.html.markdown
+++ b/website/docs/r/acm_certificate.html.markdown
@@ -46,7 +46,7 @@ resource "aws_route53_record" "cert_validation" {
 
 resource "aws_acm_certificate_validation" "cert" {
   certificate_arn = "${aws_acm_certificate.cert.certificate_arn}"
-  validation_record_fqdn = "${aws_route53_record.cert_validation.fqdn}"
+  validation_record_fqdns = ["${aws_route53_record.cert_validation.fqdn}"]
 }
 
 resource "aws_lb_listener" "front_end" {

--- a/website/docs/r/acm_certificate.html.markdown
+++ b/website/docs/r/acm_certificate.html.markdown
@@ -30,29 +30,6 @@ resource "aws_acm_certificate" "cert" {
     Environment = "test"
   }
 }
-
-data "aws_route53_zone" "zone" {
-  name = "example.com."
-  private_zone = false
-}
-
-resource "aws_route53_record" "cert_validation" {
-  name = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_name}"
-  type = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_type}"
-  zone_id = "${data.aws_route53_zone.zone.id}"
-  records = ["${aws_acm_certificate.cert.domain_validation_options.0.resource_record_value}"]
-  ttl = 60
-}
-
-resource "aws_acm_certificate_validation" "cert" {
-  certificate_arn = "${aws_acm_certificate.cert.arn}"
-  validation_record_fqdns = ["${aws_route53_record.cert_validation.fqdn}"]
-}
-
-resource "aws_lb_listener" "front_end" {
-  # [...]
-  certificate_arn   = "${aws_acm_certificate_validation.cert.certificate_arn}"
-}
 ```
 
 ## Argument Reference
@@ -66,8 +43,9 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-The following attributes are exported:
+The following additional attributes are exported:
 
+* `id` - The ARN of the certificate
 * `arn` - The ARN of the certificate
 * `domain_validation_options` - A list of attributes to feed into other resources to complete certificate validation. Can have more than one element, e.g. if SANs are defined
 

--- a/website/docs/r/acm_certificate.html.markdown
+++ b/website/docs/r/acm_certificate.html.markdown
@@ -24,8 +24,11 @@ deploy the required validation records and wait for validation to complete.
 
 ```hcl
 resource "aws_acm_certificate" "cert" {
-    domain_name = "example.com"
-	validation_method = "DNS"
+  domain_name = "example.com"
+  validation_method = "DNS"
+  tags {
+    Environment = "test"
+  }
 }
 
 data "aws_route53_zone" "zone" {
@@ -59,6 +62,7 @@ The following arguments are supported:
 * `domain_name` - (Required) A domain name for which the certificate should be issued
 * `subject_alternative_names` - (Optional) A list of domains that should be SANs in the issued certificate
 * `validation_method` - (Required) Which method to use for validation (only `DNS` is supported at the moment)
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference
 

--- a/website/docs/r/acm_certificate.html.markdown
+++ b/website/docs/r/acm_certificate.html.markdown
@@ -67,3 +67,5 @@ Certificates can be imported using their ARN, e.g.
 ```
 $ terraform import aws_acm_certificate.cert arn:aws:acm:eu-central-1:123456789012:certificate/7e7a28d2-163f-4b8f-b9cd-822f96c08d6a
 ```
+
+~> **WARNING:** Importing certificates that are not `AMAZON_ISSUED` is supported but may lead to fragile terraform projects: Once such a resource is destroyed, it can't be recreated.

--- a/website/docs/r/acm_certificate.html.markdown
+++ b/website/docs/r/acm_certificate.html.markdown
@@ -74,4 +74,10 @@ Domain validation objects export the following attributes:
 * `resource_record_type` - The type of DNS record to create
 * `resource_record_value` - The value the DNS record needs to have
 
+## Import
 
+Certificates can be imported using their ARN, e.g.
+
+```
+$ terraform import aws_acm_certificate.cert aws_acm_certificate.cert arn:aws:acm:eu-central-1:123456789012:certificate/7e7a28d2-163f-4b8f-b9cd-822f96c08d6a
+```

--- a/website/docs/r/acm_certificate.html.markdown
+++ b/website/docs/r/acm_certificate.html.markdown
@@ -41,7 +41,7 @@ The following arguments are supported:
 
 * `domain_name` - (Required) A domain name for which the certificate should be issued
 * `subject_alternative_names` - (Optional) A list of domains that should be SANs in the issued certificate
-* `validation_method` - (Required) Which method to use for validation (`DNS` or `EMAIL`)
+* `validation_method` - (Required) Which method to use for validation. `DNS` or `EMAIL` are valid, `NONE` can be used for certificates that were imported into ACM and then into Terraform.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference
@@ -65,5 +65,5 @@ Domain validation objects export the following attributes:
 Certificates can be imported using their ARN, e.g.
 
 ```
-$ terraform import aws_acm_certificate.cert aws_acm_certificate.cert arn:aws:acm:eu-central-1:123456789012:certificate/7e7a28d2-163f-4b8f-b9cd-822f96c08d6a
+$ terraform import aws_acm_certificate.cert arn:aws:acm:eu-central-1:123456789012:certificate/7e7a28d2-163f-4b8f-b9cd-822f96c08d6a
 ```

--- a/website/docs/r/acm_certificate.html.markdown
+++ b/website/docs/r/acm_certificate.html.markdown
@@ -20,6 +20,9 @@ Most commonly, this resource is used to together with [`aws_route53_record`](rou
 [`aws_acm_certificate_validation`](acm_certificate_validation.html) to request a DNS validated certificate,
 deploy the required validation records and wait for validation to complete.
 
+Domain validation through E-Mail is also supported but should be avoided as it requires a manual step outside
+of Terraform.
+
 ## Example Usage
 
 ```hcl
@@ -38,7 +41,7 @@ The following arguments are supported:
 
 * `domain_name` - (Required) A domain name for which the certificate should be issued
 * `subject_alternative_names` - (Optional) A list of domains that should be SANs in the issued certificate
-* `validation_method` - (Required) Which method to use for validation (only `DNS` is supported at the moment)
+* `validation_method` - (Required) Which method to use for validation (`DNS` or `EMAIL`)
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference
@@ -47,7 +50,8 @@ The following additional attributes are exported:
 
 * `id` - The ARN of the certificate
 * `arn` - The ARN of the certificate
-* `domain_validation_options` - A list of attributes to feed into other resources to complete certificate validation. Can have more than one element, e.g. if SANs are defined
+* `domain_validation_options` - A list of attributes to feed into other resources to complete certificate validation. Can have more than one element, e.g. if SANs are defined. Only set if `DNS`-validation was used.
+* `validation_emails` - A list of addresses that received a validation E-Mail. Only set if `EMAIL`-validation was used.
 
 Domain validation objects export the following attributes:
 

--- a/website/docs/r/acm_certificate_validation.html.markdown
+++ b/website/docs/r/acm_certificate_validation.html.markdown
@@ -57,9 +57,3 @@ The following arguments are supported:
 * `certificate_arn` - (Required) The ARN of the certificate that is being validated.
 * `validation_record_fqdns` - (Optional) List of FQDNs that implement the validation. If this is set, the resource can implement additional sanity checks and has an explicit dependency on the resource that is implementing the validation
 * `timeout` - (Optional) How long to wait for a certificate to be issued. Defaults to `"45m"` but ACM usually validates certificates much faster.
-
-## Attributes Reference
-
-The following attributes are exported:
-
-* `certificate_arn` - The ARN of the certificate that was validated. The same as the input but once this resouce completes, consumers can assume the certificate was issued successfully

--- a/website/docs/r/acm_certificate_validation.html.markdown
+++ b/website/docs/r/acm_certificate_validation.html.markdown
@@ -56,4 +56,10 @@ The following arguments are supported:
 
 * `certificate_arn` - (Required) The ARN of the certificate that is being validated.
 * `validation_record_fqdns` - (Optional) List of FQDNs that implement the validation. If this is set, the resource can implement additional sanity checks and has an explicit dependency on the resource that is implementing the validation
-* `timeout` - (Optional) How long to wait for a certificate to be issued. Defaults to `"45m"` but ACM usually validates certificates much faster.
+
+## Timeouts
+
+`acm_certificate_validation` provides the following [Timeouts](/docs/configuration/resources.html#timeouts)
+configuration options:
+
+- `create` - (Default `45m`) How long to wait for a certificate to be issued.

--- a/website/docs/r/acm_certificate_validation.html.markdown
+++ b/website/docs/r/acm_certificate_validation.html.markdown
@@ -22,8 +22,8 @@ deploy the required validation records and wait for validation to complete.
 
 ```hcl
 resource "aws_acm_certificate" "cert" {
-    domain_name = "example.com"
-	validation_method = "DNS"
+  domain_name = "example.com"
+  validation_method = "DNS"
 }
 
 data "aws_route53_zone" "zone" {

--- a/website/docs/r/acm_certificate_validation.html.markdown
+++ b/website/docs/r/acm_certificate_validation.html.markdown
@@ -40,7 +40,7 @@ resource "aws_route53_record" "cert_validation" {
 }
 
 resource "aws_acm_certificate_validation" "cert" {
-  certificate_arn = "${aws_acm_certificate.cert.certificate_arn}"
+  certificate_arn = "${aws_acm_certificate.cert.arn}"
   validation_record_fqdns = ["${aws_route53_record.cert_validation.fqdn}"]
 }
 

--- a/website/docs/r/acm_certificate_validation.html.markdown
+++ b/website/docs/r/acm_certificate_validation.html.markdown
@@ -41,7 +41,7 @@ resource "aws_route53_record" "cert_validation" {
 
 resource "aws_acm_certificate_validation" "cert" {
   certificate_arn = "${aws_acm_certificate.cert.certificate_arn}"
-  validation_record_fqdn = "${aws_route53_record.cert_validation.fqdn}"
+  validation_record_fqdns = ["${aws_route53_record.cert_validation.fqdn}"]
 }
 
 resource "aws_lb_listener" "front_end" {
@@ -55,7 +55,7 @@ resource "aws_lb_listener" "front_end" {
 The following arguments are supported:
 
 * `certificate_arn` - (Required) The ARN of the certificate that is being validated.
-* `validation_record_fqdn` - (Optional) The FQDN of the record that implements the validation. If this is set, the resource can implement additional sanity checks and has an explicit dependency on the resource that is implementing the validation
+* `validation_record_fqdns` - (Optional) List of FQDNs that implement the validation. If this is set, the resource can implement additional sanity checks and has an explicit dependency on the resource that is implementing the validation
 * `timeout` - (Optional) How long to wait for a certificate to be issued. Defaults to `"45m"` but ACM usually validates certificates much faster.
 
 ## Attributes Reference


### PR DESCRIPTION
This is a second draft trying to implement automated ACM certificate issuing based on my suggestions in #2418. It's similar to PR #2801 but uses a resource instead of a data source to implement polling for certificate issuing as a data source implementation seems to have a few pitfalls for the users. 

Here is what it does: 

* Add a `aws_acm_certificate` resource that requests a new certificate and returns once `validationOptions` (the information what needs to be done to validate ownership of the domain) are available (for some reason, those aren't immediately available). Only supports DNS validation at this point
* Add a `aws_acm_certificate_validation` resource that does some basic sanity checks and then waits for the given certificate to be issued
* Add an acceptance test that runs the whole certificate issuing flow (using route53 for DNS validation)

Current Limitations: 

* Only supports DNS validation: E-Mail validation is hard to completely automate and test (and already discussed at length in hashicorp/terraform#4782) so I did not invest time here. It shouldn't be a problem to add this later if there is demand for it
* Only supports certificates that are` AMAZON_ISSUED`: Importing existing certificate data could be added later if there is demand for it

Test considerations: 

Acceptance Tests need a publicly resolvable Route53 zone to make certificate validation work. To run tests, set the `ACM_CERTIFICATE_ROOT_DOMAIN` environment variable to the domain name of the Route53 zone. The test will use data-providers to look up the zone-id and add CNAMES to allow ACM to validate ownership of the domain: 

```
ACM_CERTIFICATE_ROOT_DOMAIN="sandbox.sellmayr.net" make testacc TEST=./aws TESTARGS='-run=TestAccAwsAcm'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAwsAcm -timeout 120m
=== RUN   TestAccAwsAcmCertificateDataSource_noMatchReturnsError
--- PASS: TestAccAwsAcmCertificateDataSource_noMatchReturnsError (20.45s)
=== RUN   TestAccAwsAcmResource_certificateIssuingFlow
--- PASS: TestAccAwsAcmResource_certificateIssuingFlow (324.23s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	344.721s
```

Here are a few things I'm unsure about: 

* Is it a good idea to model waiting for certificate issuing in a resource? I feel it's harder for the user to shoot himself in the foot this way but it's also a bit unintuitive to have a resource that doesn't correspond to any resource in AWS, especially when destroying it: Does destroying a validation destroy the certificate? It doesn't but is that obvious to the user? 
* AWS does not expect `subject_alternative_names` to contain values when requesting a certificate but `DescribeCertificate` always includes the `domain_name` in `subject_alternative_names`. I'm currently filtering this so terraform doesn't detect this as a change. Is there a better way to do this?  
* Should we have the `validation_method` property? It currently only allows `DNS` as a value so we could do without. However, it probably makes adding new validation methods easier

