### PR TITLE
New Resource: aws_lightsail_domain_entry

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -393,6 +393,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_lambda_permission":                        resourceAwsLambdaPermission(),
 			"aws_launch_configuration":                     resourceAwsLaunchConfiguration(),
 			"aws_lightsail_domain":                         resourceAwsLightsailDomain(),
+			"aws_lightsail_domain_entry":                   resourceAwsLightsailDomainEntry(),
 			"aws_lightsail_instance":                       resourceAwsLightsailInstance(),
 			"aws_lightsail_key_pair":                       resourceAwsLightsailKeyPair(),
 			"aws_lightsail_static_ip":                      resourceAwsLightsailStaticIp(),

--- a/aws/resource_aws_lightsail_domain_entry.go
+++ b/aws/resource_aws_lightsail_domain_entry.go
@@ -1,0 +1,179 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/lightsail"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsLightsailDomainEntry() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsLightsailDomainEntryCreate,
+		Read:   resourceAwsLightsailDomainEntryRead,
+		Update: resourceAwsLightsailDomainEntryUpdate,
+		Delete: resourceAwsLightsailDomainEntryDelete,
+
+		Schema: map[string]*schema.Schema{
+			"domain_entry": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"is_alias": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"target": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"domain_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAwsLightsailDomainEntryCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).lightsailconn
+
+	domainName := d.Get("domain_name").(string)
+	domainEntry := d.Get("domain_entry").([]interface{})[0].(map[string]interface{})
+
+	input := &lightsail.CreateDomainEntryInput{
+		DomainEntry: &lightsail.DomainEntry{
+			Name:   aws.String(domainEntry["name"].(string)),
+			Target: aws.String(domainEntry["target"].(string)),
+			Type:   aws.String(domainEntry["type"].(string)),
+		},
+		DomainName: aws.String(domainName),
+	}
+
+	if domainEntry["is_alias"] != nil {
+		input.DomainEntry.IsAlias = aws.Bool(domainEntry["is_alias"].(bool))
+	}
+	log.Printf("[DEBUG] domain entry to create: %s", input)
+
+	_, err := conn.CreateDomainEntry(input)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(domainEntry["name"].(string))
+	return resourceAwsLightsailDomainEntryRead(d, meta)
+}
+
+func resourceAwsLightsailDomainEntryRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).lightsailconn
+
+	domainName := d.Get("domain_name").(string)
+	domainEntry := d.Get("domain_entry").([]interface{})[0].(map[string]interface{})
+
+	out, err := conn.GetDomain(&lightsail.GetDomainInput{
+		DomainName: aws.String(domainName),
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range out.Domain.DomainEntries {
+		if *entry.Name == domainEntry["name"].(string) {
+			log.Print("[DEBUG] matched entry:", entry)
+			d.Set("domain_entry", []interface{}{
+				map[string]interface{}{
+					"id":       *entry.Id,
+					"is_alias": *entry.IsAlias,
+					"name":     *entry.Name,
+					"target":   *entry.Target,
+					"type":     *entry.Type,
+				},
+			})
+			return nil
+		}
+	}
+	return fmt.Errorf("[WARN] Domain entry (%s) not found", domainEntry["name"].(string))
+}
+
+func resourceAwsLightsailDomainEntryUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).lightsailconn
+
+	domainName := d.Get("domain_name").(string)
+	input := &lightsail.UpdateDomainEntryInput{
+		DomainName: aws.String(domainName),
+	}
+
+	oldRaw, _ := d.GetChange("domain_entry")
+	oldEntry := oldRaw.([]interface{})[0].(map[string]interface{})
+	newEntry := d.Get("domain_entry").([]interface{})[0].(map[string]interface{})
+	input.DomainEntry = &lightsail.DomainEntry{
+		Id:     aws.String(oldEntry["id"].(string)),
+		Name:   aws.String(newEntry["name"].(string)),
+		Target: aws.String(newEntry["target"].(string)),
+		Type:   aws.String(newEntry["type"].(string)),
+	}
+	if newEntry["is_alias"] != nil {
+		input.DomainEntry.IsAlias = aws.Bool(newEntry["is_alias"].(bool))
+	}
+	log.Printf("[DEBUG] domain entry to update: %s", input)
+
+	_, err := conn.UpdateDomainEntry(input)
+
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == "NotFoundException" {
+				log.Printf("[WARN] Lightsail Domain Entry (%s) not found, removing from state", d.Id())
+				d.SetId("")
+				return nil
+			}
+			return err
+		}
+		return err
+	}
+	return resourceAwsLightsailDomainEntryRead(d, meta)
+}
+
+func resourceAwsLightsailDomainEntryDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).lightsailconn
+
+	domainEntry := d.Get("domain_entry").([]interface{})[0].(map[string]interface{})
+	input := &lightsail.DeleteDomainEntryInput{
+		DomainEntry: &lightsail.DomainEntry{
+			Id:      aws.String(domainEntry["id"].(string)),
+			IsAlias: aws.Bool(domainEntry["is_alias"].(bool)),
+			Name:    aws.String(domainEntry["name"].(string)),
+			Target:  aws.String(domainEntry["target"].(string)),
+			Type:    aws.String(domainEntry["type"].(string)),
+		},
+		DomainName: aws.String(d.Get("domain_name").(string)),
+	}
+	log.Print("[DEBUG] domain entry to delete:", input)
+	_, err := conn.DeleteDomainEntry(input)
+	if err != nil {
+		return err
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/aws/resource_aws_lightsail_domain_entry_test.go
+++ b/aws/resource_aws_lightsail_domain_entry_test.go
@@ -1,0 +1,124 @@
+package aws
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/lightsail"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSLightsailDomainEntry_basic(t *testing.T) {
+	var domainEntry lightsail.DomainEntry
+	domainName := fmt.Sprintf("tf-lightsail-domain-%s.com", acctest.RandString(5))
+	entryName := fmt.Sprintf("tf-lightsail-domain-entry-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLightsailDomainEntryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLightsailDomainEntryConfig(domainName, entryName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLightsailDomainEntryExists("aws_lightsail_domain_entry.example", &domainEntry),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSLightsailDomainEntryExists(n string, domainEntry *lightsail.DomainEntry) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("No Lightsail Domain Entry ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).lightsailconn
+		domainName := rs.Primary.Attributes["domain_name"]
+
+		resp, err := conn.GetDomain(&lightsail.GetDomainInput{
+			DomainName: aws.String(domainName),
+		})
+		if err != nil {
+			return err
+		}
+
+		if resp == nil || resp.Domain == nil {
+			return fmt.Errorf("Domain (%s) not found", domainName)
+		}
+
+		for _, entry := range resp.Domain.DomainEntries {
+			if *entry.Name == rs.Primary.ID {
+				return nil
+			}
+		}
+		return fmt.Errorf("No entry exists in domain %s", domainName)
+	}
+}
+
+func testAccCheckAWSLightsailDomainEntryDestroy(s *terraform.State) error {
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_lightsail_domain_entry" {
+			continue
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).lightsailconn
+		domainName := rs.Primary.Attributes["domain_name"]
+
+		resp, err := conn.GetDomain(&lightsail.GetDomainInput{
+			DomainName: aws.String(domainName),
+		})
+
+		if err == nil && resp.Domain != nil {
+			for _, entry := range resp.Domain.DomainEntries {
+				if *entry.Name == rs.Primary.ID {
+					return fmt.Errorf("Lightsail domain entry %s still exists", rs.Primary.ID)
+				}
+			}
+			return nil
+		}
+
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == "NotFoundException" {
+				return nil
+			}
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func testAccAWSLightsailDomainEntryConfig(domainName, entryName string) string {
+	return fmt.Sprintf(`
+provider "aws" {
+	region = "us-east-1"
+}
+
+resource "aws_lightsail_domain" "example" {
+	domain_name = "%s"
+}
+
+resource "aws_lightsail_domain_entry" "example" {
+	domain_name = "${aws_lightsail_domain.example.id}"
+	domain_entry = {
+		name = "%s.${aws_lightsail_domain.example.id}"
+		target = "1.2.3.4"
+		type = "A"
+	}
+}
+`, domainName, entryName)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1106,6 +1106,10 @@
                           <a href="/docs/providers/aws/r/lightsail_domain.html">aws_lightsail_domain</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-lightsail-domain-entry") %>>
+                          <a href="/docs/providers/aws/r/lightsail_domain_entry.html">aws_lightsail_domain_entry</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-aws-resource-lightsail-instance") %>>
                             <a href="/docs/providers/aws/r/lightsail_instance.html">aws_lightsail_instance</a>
                         </li>

--- a/website/docs/r/lightsail_domain_entry.html.markdown
+++ b/website/docs/r/lightsail_domain_entry.html.markdown
@@ -1,0 +1,52 @@
+---
+layout: "aws"
+page_title: "AWS: aws_lightsail_domain_entry"
+sidebar_current: "docs-aws-resource-lightsail-domain-entry"
+description: |-
+  Provides a Lightsail Domain Entry
+---
+
+# aws_lightsail_domain_entry
+
+Creates one of the following entry records associated with the domain:
+A record, CNAME record, TXT record, or MX record.
+The domain must have been created as lightsail domain.
+
+~> **Note:** Lightsail is currently only supported in a limited number of AWS Regions, please see ["Regions and Availability Zones in Amazon Lightsail"](https://lightsail.aws.amazon.com/ls/docs/overview/article/understanding-regions-and-availability-zones-in-amazon-lightsail) for more details
+
+## Example Usage, creating a new domain
+
+```hcl
+resource "aws_lightsail_domain" "example" {
+	domain_name = "example.com"
+}
+
+resource "aws_lightsail_domain_entry" "access" {
+	domain_name = "${aws_lightsail_domain.example.id}"
+	domain_entry = {
+		name = "access.${aws_lightsail_domain.example.id}"
+		target = "172.31.32.33"
+		type = "A"
+	}
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domain_name` - (Required) The name of the Lightsail domain to manage
+* `domain_entry` - (Required) Describes a domain recordset entry. Fields documented below. See [DomainEntry API Reference](https://docs.aws.amazon.com/lightsail/2016-11-28/api-reference/API_DomainEntry.html)
+
+**domain_entry** requires the following:
+
+* `is_alias` - (Optional) Specifies whether the domain entry is an alias used by the Lightsail load balancer. You can include an alias (A type) record in your request, which points to a load balancer DNS name and routes traffic to your load balancer.
+* `name` - (Required) The full FQDN name of the domain.
+* `target` - (Required) The target AWS name server. Be sure to also set `is_alias` to `true` when setting up an `A` record for a Lightsail load balancer.
+* `type` - (Required) The type of domain entry (e.g., A, CNAME, SOA or NS).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `id` - The name of domain entry.


### PR DESCRIPTION
lightsail domain entry for #2731 

This is my first attempt to implement a new resource. Comments and feedbacks are welcome.

The resource is at least working for now. But I do have a few questions about the implementation.

1. The resource schema follows the same schema as AWS API for [CreateDomainEntryInput](https://docs.aws.amazon.com/sdk-for-go/api/service/lightsail/#CreateDomainEntryInput),
 [UpdateDomainEntryInput](https://docs.aws.amazon.com/sdk-for-go/api/service/lightsail/#UpdateDomainEntryInput), [DeleteDomainEntryInput](https://docs.aws.amazon.com/sdk-for-go/api/service/lightsail/#DeleteDomainEntryInput). I'm not sure if it's good idea to flat all into common `TypeString`. In that case, it will make the implementation a bit easier but break the identical mapping between `terraform` and AWS API.

2. Name for the domain entry in AWS API is the full FQDN with domain name. From user perspective, it would be easier to just use a string without domain name.  We can append domain name before sending request to AWS. The same concern of identical mapping applies here as well. Still I'm following convention for AWS API.

3. In [AWS API DomainEntry](https://docs.aws.amazon.com/lightsail/2016-11-28/api-reference/API_DomainEntry.html), `options` is already marked as `Deprecated`. So I didn't add this parameter at all. 

4. I haven't fully figured out how import works, so support for import is not there yet.

5. I'd like to validate `target` argument based on `is_alias`. AFAIK, `ValidateFunc` works only for the current argument. I don't have it in mind where similar logic is implemented.
 