### PR TITLE
r/aws_s3_bucket_policy: set the resource ID after successful creation

### DIFF
--- a/aws/resource_aws_s3_bucket_policy.go
+++ b/aws/resource_aws_s3_bucket_policy.go
@@ -42,8 +42,6 @@ func resourceAwsS3BucketPolicyPut(d *schema.ResourceData, meta interface{}) erro
 	bucket := d.Get("bucket").(string)
 	policy := d.Get("policy").(string)
 
-	d.SetId(bucket)
-
 	log.Printf("[DEBUG] S3 bucket: %s, put policy: %s", bucket, policy)
 
 	params := &s3.PutBucketPolicyInput{
@@ -66,6 +64,8 @@ func resourceAwsS3BucketPolicyPut(d *schema.ResourceData, meta interface{}) erro
 	if err != nil {
 		return fmt.Errorf("Error putting S3 policy: %s", err)
 	}
+
+	d.SetId(bucket)
 
 	return nil
 }


### PR DESCRIPTION
Fixes #2819 
```
.../terraform-provider-aws % TF_ACC=1 go test -v ./... -run TestAccAWSS3BucketPolicy
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSS3BucketPolicy_basic
--- PASS: TestAccAWSS3BucketPolicy_basic (76.41s)
=== RUN   TestAccAWSS3BucketPolicy_policyUpdate
--- PASS: TestAccAWSS3BucketPolicy_policyUpdate (119.79s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	196.242s
```