### PR TITLE
r/db event subscription: set source type when updating categories

### DIFF
--- a/aws/resource_aws_db_event_subscription.go
+++ b/aws/resource_aws_db_event_subscription.go
@@ -215,6 +215,7 @@ func resourceAwsDbEventSubscriptionUpdate(d *schema.ResourceData, meta interface
 		for i, eventCategory := range eventCategoriesSet.List() {
 			req.EventCategories[i] = aws.String(eventCategory.(string))
 		}
+		req.SourceType = aws.String(d.Get("source_type").(string))
 		requestUpdate = true
 	}
 


### PR DESCRIPTION
Resolves #1817

SourceType needs to be included when updating categories.

Test Results:
```$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDBEventSubscription_categoryUpdate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSDBEventSubscription_categoryUpdate -timeout 120m
=== RUN   TestAccAWSDBEventSubscription_categoryUpdate
--- PASS: TestAccAWSDBEventSubscription_categoryUpdate (1228.67s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1229.136s
