### PR TITLE
resource/aws_api_gateway_integration: Allow update of URI attributes 

### DIFF
--- a/aws/resource_aws_api_gateway_integration.go
+++ b/aws/resource_aws_api_gateway_integration.go
@@ -51,7 +51,6 @@ func resourceAwsApiGatewayIntegration() *schema.Resource {
 			"uri": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 			},
 
 			"credentials": {
@@ -367,6 +366,17 @@ func resourceAwsApiGatewayIntegrationUpdate(d *schema.ResourceData, meta interfa
 			Op:    aws.String("replace"),
 			Path:  aws.String("/cacheNamespace"),
 			Value: aws.String(d.Get("cache_namespace").(string)),
+		})
+	}
+
+	// The documentation https://docs.aws.amazon.com/apigateway/api-reference/link-relation/integration-update/ says
+	// that uri changes are only supported for non-mock types. Because the uri value is not used in mock
+	// resources, it means that the uri can always be updated
+	if d.HasChange("uri") {
+		operations = append(operations, &apigateway.PatchOperation{
+			Op:    aws.String("replace"),
+			Path:  aws.String("/uri"),
+			Value: aws.String(d.Get("uri").(string)),
 		})
 	}
 

--- a/aws/resource_aws_api_gateway_integration_test.go
+++ b/aws/resource_aws_api_gateway_integration_test.go
@@ -58,6 +58,25 @@ func TestAccAWSAPIGatewayIntegration_basic(t *testing.T) {
 			},
 
 			{
+				Config: testAccAWSAPIGatewayIntegrationConfigUpdateURI,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayIntegrationExists("aws_api_gateway_integration.test", &conf),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "type", "HTTP"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "integration_http_method", "GET"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "uri", "https://www.google.de/updated"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "passthrough_behavior", "WHEN_NO_MATCH"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "content_handling", "CONVERT_TO_TEXT"),
+					resource.TestCheckNoResourceAttr("aws_api_gateway_integration.test", "credentials"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.%", "2"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.integration.request.header.X-Authorization", "'static'"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.integration.request.header.X-Foo", "'Bar'"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.%", "2"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.application/json", ""),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.application/xml", "#set($inputRoot = $input.path('$'))\n{ }"),
+				),
+			},
+
+			{
 				Config: testAccAWSAPIGatewayIntegrationConfigUpdateNoTemplates,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayIntegrationExists("aws_api_gateway_integration.test", &conf),
@@ -273,6 +292,51 @@ resource "aws_api_gateway_integration" "test" {
 
   type = "HTTP"
   uri = "https://www.google.de"
+  integration_http_method = "GET"
+  passthrough_behavior = "WHEN_NO_MATCH"
+  content_handling = "CONVERT_TO_TEXT"
+}
+`
+
+const testAccAWSAPIGatewayIntegrationConfigUpdateURI = `
+resource "aws_api_gateway_rest_api" "test" {
+  name = "test"
+}
+
+resource "aws_api_gateway_resource" "test" {
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  parent_id = "${aws_api_gateway_rest_api.test.root_resource_id}"
+  path_part = "test"
+}
+
+resource "aws_api_gateway_method" "test" {
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  resource_id = "${aws_api_gateway_resource.test.id}"
+  http_method = "GET"
+  authorization = "NONE"
+
+  request_models = {
+    "application/json" = "Error"
+  }
+}
+
+resource "aws_api_gateway_integration" "test" {
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  resource_id = "${aws_api_gateway_resource.test.id}"
+  http_method = "${aws_api_gateway_method.test.http_method}"
+
+  request_templates = {
+    "application/json" = ""
+    "application/xml" = "#set($inputRoot = $input.path('$'))\n{ }"
+  }
+
+  request_parameters = {
+    "integration.request.header.X-Authorization" = "'static'"
+    "integration.request.header.X-Foo" = "'Bar'"
+  }
+
+  type = "HTTP"
+  uri = "https://www.google.de/updated"
   integration_http_method = "GET"
   passthrough_behavior = "WHEN_NO_MATCH"
   content_handling = "CONVERT_TO_TEXT"


### PR DESCRIPTION
Instead of always forcing a new resource creation for URI changes (like a Lambda function version update), the integration:update action allows for in place updates.