### PR TITLE
r/aws_sqs_queue allow SQS name validation during terraform validate

### DIFF
--- a/aws/resource_aws_sqs_queue.go
+++ b/aws/resource_aws_sqs_queue.go
@@ -51,6 +51,7 @@ func resourceAwsSqsQueue() *schema.Resource {
 				ForceNew:      true,
 				Computed:      true,
 				ConflictsWith: []string{"name_prefix"},
+				ValidateFunc:  validateSQSQueueName,
 			},
 			"name_prefix": {
 				Type:     schema.TypeString,
@@ -147,7 +148,7 @@ func resourceAwsSqsQueueCreate(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("Error validating the FIFO queue name: %v", errors)
 		}
 	} else {
-		if errors := validateSQSQueueName(name, "name"); len(errors) > 0 {
+		if errors := validateSQSNonFifoQueueName(name, "name"); len(errors) > 0 {
 			return fmt.Errorf("Error validating SQS queue name: %v", errors)
 		}
 	}

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -758,7 +758,19 @@ func validateApiGatewayIntegrationContentHandling(v interface{}, k string) (ws [
 	return
 }
 
-func validateSQSQueueName(v interface{}, k string) (errors []error) {
+func validateSQSQueueName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if len(value) > 80 {
+		errors = append(errors, fmt.Errorf("%q cannot be longer than 80 characters", k))
+	}
+
+	if !regexp.MustCompile(`^[0-9A-Za-z-_]+(\.fifo)?$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf("only alphanumeric characters and hyphens allowed in %q", k))
+	}
+	return
+}
+
+func validateSQSNonFifoQueueName(v interface{}, k string) (errors []error) {
 	value := v.(string)
 	if len(value) > 80 {
 		errors = append(errors, fmt.Errorf("%q cannot be longer than 80 characters", k))

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -1061,8 +1061,12 @@ func TestValidateSQSQueueName(t *testing.T) {
 		strings.Repeat("W", 80),
 	}
 	for _, v := range validNames {
-		if errors := validateSQSQueueName(v, "name"); len(errors) > 0 {
+		if _, errors := validateSQSQueueName(v, "name"); len(errors) > 0 {
 			t.Fatalf("%q should be a valid SQS queue Name", v)
+		}
+
+		if errors := validateSQSNonFifoQueueName(v, "name"); len(errors) > 0 {
+			t.Fatalf("%q should be a valid SQS non-fifo queue Name", v)
 		}
 	}
 
@@ -1078,8 +1082,12 @@ func TestValidateSQSQueueName(t *testing.T) {
 		strings.Repeat("W", 81), // length > 80
 	}
 	for _, v := range invalidNames {
-		if errors := validateSQSQueueName(v, "name"); len(errors) == 0 {
+		if _, errors := validateSQSQueueName(v, "name"); len(errors) == 0 {
 			t.Fatalf("%q should be an invalid SQS queue Name", v)
+		}
+
+		if errors := validateSQSNonFifoQueueName(v, "name"); len(errors) == 0 {
+			t.Fatalf("%q should be an invalid SQS non-fifo queue Name", v)
 		}
 	}
 }
@@ -1097,6 +1105,10 @@ func TestValidateSQSFifoQueueName(t *testing.T) {
 		fmt.Sprintf("%s.fifo", strings.Repeat("W", 75)),
 	}
 	for _, v := range validNames {
+		if _, errors := validateSQSQueueName(v, "name"); len(errors) > 0 {
+			t.Fatalf("%q should be a valid SQS queue Name", v)
+		}
+
 		if errors := validateSQSFifoQueueName(v, "name"); len(errors) > 0 {
 			t.Fatalf("%q should be a valid SQS FIFO queue Name: %v", v, errors)
 		}
@@ -1115,6 +1127,10 @@ func TestValidateSQSFifoQueueName(t *testing.T) {
 		strings.Repeat("W", 81), // length > 80
 	}
 	for _, v := range invalidNames {
+		if _, errors := validateSQSQueueName(v, "name"); len(errors) == 0 {
+			t.Fatalf("%q should be an invalid SQS queue Name", v)
+		}
+
 		if errors := validateSQSFifoQueueName(v, "name"); len(errors) == 0 {
 			t.Fatalf("%q should be an invalid SQS FIFO queue Name: %v", v, errors)
 		}


### PR DESCRIPTION
Fixes #2835.

I have repurposed the validateSQSQueueName function to allow for both FIFO and non-FIFO queue names which therefore can be used in the Schema. I moved the old functionality to the new validateSQSNonFifoQueueName function. I also bumped the FIFO and non-FIFO tests to test against both relevant functions.