### PR TITLE
New Resource: aws_gamelift_build

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -50,6 +50,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/aws/aws-sdk-go/service/emr"
 	"github.com/aws/aws-sdk-go/service/firehose"
+	"github.com/aws/aws-sdk-go/service/gamelift"
 	"github.com/aws/aws-sdk-go/service/glacier"
 	"github.com/aws/aws-sdk-go/service/glue"
 	"github.com/aws/aws-sdk-go/service/guardduty"
@@ -177,6 +178,7 @@ type AWSClient struct {
 	iamconn               *iam.IAM
 	kinesisconn           *kinesis.Kinesis
 	kmsconn               *kms.KMS
+	gameliftconn          *gamelift.GameLift
 	firehoseconn          *firehose.Firehose
 	inspectorconn         *inspector.Inspector
 	elasticacheconn       *elasticache.ElastiCache
@@ -423,6 +425,7 @@ func (c *Config) Client() (interface{}, error) {
 	client.esconn = elasticsearch.New(sess)
 	client.firehoseconn = firehose.New(sess)
 	client.inspectorconn = inspector.New(sess)
+	client.gameliftconn = gamelift.New(sess)
 	client.glacierconn = glacier.New(sess)
 	client.guarddutyconn = guardduty.New(sess)
 	client.iotconn = iot.New(sess)

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -358,6 +358,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_emr_instance_group":                       resourceAwsEMRInstanceGroup(),
 			"aws_emr_security_configuration":               resourceAwsEMRSecurityConfiguration(),
 			"aws_flow_log":                                 resourceAwsFlowLog(),
+			"aws_gamelift_build":                           resourceAwsGameliftBuild(),
 			"aws_glacier_vault":                            resourceAwsGlacierVault(),
 			"aws_glue_catalog_database":                    resourceAwsGlueCatalogDatabase(),
 			"aws_guardduty_detector":                       resourceAwsGuardDutyDetector(),

--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -51,14 +51,23 @@ func testAccPreCheck(t *testing.T) {
 			t.Fatal("AWS_SECRET_ACCESS_KEY must be set for acceptance tests")
 		}
 	}
-	if v := os.Getenv("AWS_DEFAULT_REGION"); v == "" {
-		log.Println("[INFO] Test: Using us-west-2 as test region")
-		os.Setenv("AWS_DEFAULT_REGION", "us-west-2")
-	}
+
+	region := testAccGetRegion()
+	log.Printf("[INFO] Test: Using %s as test region", region)
+	os.Setenv("AWS_DEFAULT_REGION", region)
+
 	err := testAccProvider.Configure(terraform.NewResourceConfig(nil))
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+func testAccGetRegion() string {
+	v := os.Getenv("AWS_DEFAULT_REGION")
+	if v == "" {
+		return "us-west-2"
+	}
+	return v
 }
 
 func testAccEC2ClassicPreCheck(t *testing.T) {

--- a/aws/resource_aws_gamelift_build.go
+++ b/aws/resource_aws_gamelift_build.go
@@ -1,0 +1,187 @@
+package aws
+
+import (
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/gamelift"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func resourceAwsGameliftBuild() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsGameliftBuildCreate,
+		Read:   resourceAwsGameliftBuildRead,
+		Update: resourceAwsGameliftBuildUpdate,
+		Delete: resourceAwsGameliftBuildDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, 1024),
+			},
+			"operating_system": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateGameliftOperatingSystem,
+			},
+			"storage_location": {
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"bucket": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"key": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"role_arn": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validateArn,
+						},
+					},
+				},
+			},
+			"version": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 1024),
+			},
+		},
+	}
+}
+
+func resourceAwsGameliftBuildCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).gameliftconn
+
+	sl := expandGameliftStorageLocation(d.Get("storage_location").([]interface{}))
+	input := gamelift.CreateBuildInput{
+		Name:            aws.String(d.Get("name").(string)),
+		OperatingSystem: aws.String(d.Get("operating_system").(string)),
+		StorageLocation: sl,
+	}
+	if v, ok := d.GetOk("version"); ok {
+		input.Version = aws.String(v.(string))
+	}
+	log.Printf("[INFO] Creating Gamelift Build: %s", input)
+	var out *gamelift.CreateBuildOutput
+	err := resource.Retry(30*time.Second, func() *resource.RetryError {
+		var err error
+		out, err = conn.CreateBuild(&input)
+		if err != nil {
+			if isAWSErr(err, gamelift.ErrCodeInvalidRequestException, "Provided build is not accessible.") {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	d.SetId(*out.Build.BuildId)
+
+	stateConf := resource.StateChangeConf{
+		Pending: []string{gamelift.BuildStatusInitialized},
+		Target:  []string{gamelift.BuildStatusReady},
+		Timeout: 1 * time.Minute,
+		Refresh: func() (interface{}, string, error) {
+			out, err := conn.DescribeBuild(&gamelift.DescribeBuildInput{
+				BuildId: aws.String(d.Id()),
+			})
+			if err != nil {
+				return 42, "", err
+			}
+
+			return out, *out.Build.Status, nil
+		},
+	}
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return err
+	}
+
+	return resourceAwsGameliftBuildRead(d, meta)
+}
+
+func resourceAwsGameliftBuildRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).gameliftconn
+
+	log.Printf("[INFO] Reading Gamelift Build: %s", d.Id())
+	out, err := conn.DescribeBuild(&gamelift.DescribeBuildInput{
+		BuildId: aws.String(d.Id()),
+	})
+	if err != nil {
+		if isAWSErr(err, gamelift.ErrCodeNotFoundException, "") {
+			log.Printf("[WARN] Gamelift Build (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+	b := out.Build
+
+	d.Set("name", b.Name)
+	d.Set("operating_system", b.OperatingSystem)
+	d.Set("version", b.Version)
+
+	return nil
+}
+
+func resourceAwsGameliftBuildUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).gameliftconn
+
+	log.Printf("[INFO] Updating Gamelift Build: %s", d.Id())
+	input := gamelift.UpdateBuildInput{
+		BuildId: aws.String(d.Id()),
+		Name:    aws.String(d.Get("name").(string)),
+	}
+	if v, ok := d.GetOk("version"); ok {
+		input.Version = aws.String(v.(string))
+	}
+
+	_, err := conn.UpdateBuild(&input)
+	if err != nil {
+		return err
+	}
+
+	return resourceAwsGameliftBuildRead(d, meta)
+}
+
+func resourceAwsGameliftBuildDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).gameliftconn
+
+	log.Printf("[INFO] Deleting Gamelift Build: %s", d.Id())
+	_, err := conn.DeleteBuild(&gamelift.DeleteBuildInput{
+		BuildId: aws.String(d.Id()),
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func expandGameliftStorageLocation(cfg []interface{}) *gamelift.S3Location {
+	loc := cfg[0].(map[string]interface{})
+	return &gamelift.S3Location{
+		Bucket:  aws.String(loc["bucket"].(string)),
+		Key:     aws.String(loc["key"].(string)),
+		RoleArn: aws.String(loc["role_arn"].(string)),
+	}
+}

--- a/aws/resource_aws_gamelift_build_test.go
+++ b/aws/resource_aws_gamelift_build_test.go
@@ -1,0 +1,230 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/gamelift"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+const testAccGameliftPrefix = "tf_acc_build_"
+
+func init() {
+	resource.AddTestSweepers("aws_gamelift_build", &resource.Sweeper{
+		Name: "aws_gamelift_build",
+		F:    testSweepGameliftBuilds,
+	})
+}
+
+func testSweepGameliftBuilds(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).gameliftconn
+
+	resp, err := conn.ListBuilds(&gamelift.ListBuildsInput{})
+	if err != nil {
+		return fmt.Errorf("Error listing Gamelift Builds: %s", err)
+	}
+
+	if len(resp.Builds) == 0 {
+		log.Print("[DEBUG] No Gamelift Builds to sweep")
+		return nil
+	}
+
+	log.Printf("[INFO] Found %d Gamelift Builds", len(resp.Builds))
+
+	for _, build := range resp.Builds {
+		if !strings.HasPrefix(*build.Name, testAccGameliftPrefix) {
+			continue
+		}
+
+		log.Printf("[INFO] Deleting Gamelift Build %q", *build.BuildId)
+		_, err := conn.DeleteBuild(&gamelift.DeleteBuildInput{
+			BuildId: build.BuildId,
+		})
+		if err != nil {
+			return fmt.Errorf("Error deleting Gamelift Build (%s): %s",
+				*build.BuildId, err)
+		}
+	}
+
+	return nil
+}
+
+func TestAccAWSGameliftBuild_basic(t *testing.T) {
+	var conf gamelift.Build
+
+	rString := acctest.RandString(8)
+
+	buildName := fmt.Sprintf("%s_%s", testAccGameliftPrefix, rString)
+	uBuildName := fmt.Sprintf("%s_updated_%s", testAccGameliftPrefix, rString)
+
+	region := testAccGetRegion()
+	loc, err := testAccAWSGameliftSampleGameLocation(region)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bucketName := *loc.Bucket
+	roleArn := *loc.RoleArn
+	key := *loc.Key
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGameliftBuildDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGameliftBuildBasicConfig(buildName, bucketName, key, roleArn),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGameliftBuildExists("aws_gamelift_build.test", &conf),
+					resource.TestCheckResourceAttr("aws_gamelift_build.test", "name", buildName),
+					resource.TestCheckResourceAttr("aws_gamelift_build.test", "operating_system", "WINDOWS_2012"),
+					resource.TestCheckResourceAttr("aws_gamelift_build.test", "storage_location.#", "1"),
+					resource.TestCheckResourceAttr("aws_gamelift_build.test", "storage_location.0.bucket", bucketName),
+					resource.TestCheckResourceAttr("aws_gamelift_build.test", "storage_location.0.key", key),
+					resource.TestCheckResourceAttr("aws_gamelift_build.test", "storage_location.0.role_arn", roleArn),
+				),
+			},
+			{
+				Config: testAccAWSGameliftBuildBasicConfig(uBuildName, bucketName, key, roleArn),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGameliftBuildExists("aws_gamelift_build.test", &conf),
+					resource.TestCheckResourceAttr("aws_gamelift_build.test", "name", uBuildName),
+					resource.TestCheckResourceAttr("aws_gamelift_build.test", "operating_system", "WINDOWS_2012"),
+					resource.TestCheckResourceAttr("aws_gamelift_build.test", "storage_location.#", "1"),
+					resource.TestCheckResourceAttr("aws_gamelift_build.test", "storage_location.0.bucket", bucketName),
+					resource.TestCheckResourceAttr("aws_gamelift_build.test", "storage_location.0.key", key),
+					resource.TestCheckResourceAttr("aws_gamelift_build.test", "storage_location.0.role_arn", roleArn),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSGameliftBuildExists(n string, res *gamelift.Build) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Gamelift Build ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).gameliftconn
+
+		req := &gamelift.DescribeBuildInput{
+			BuildId: aws.String(rs.Primary.ID),
+		}
+		out, err := conn.DescribeBuild(req)
+		if err != nil {
+			return err
+		}
+
+		b := out.Build
+
+		if *b.BuildId != rs.Primary.ID {
+			return fmt.Errorf("Gamelift Build not found")
+		}
+
+		*res = *b
+
+		return nil
+	}
+}
+
+func testAccCheckAWSGameliftBuildDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).gameliftconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_gamelift_build" {
+			continue
+		}
+
+		req := gamelift.DescribeBuildInput{
+			BuildId: aws.String(rs.Primary.ID),
+		}
+		out, err := conn.DescribeBuild(&req)
+		if err == nil {
+			if *out.Build.BuildId == rs.Primary.ID {
+				return fmt.Errorf("Gamelift Build still exists")
+			}
+		}
+		if isAWSErr(err, gamelift.ErrCodeNotFoundException, "") {
+			return nil
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+// Location found from CloudTrail event after finishing tutorial
+// e.g. https://us-west-2.console.aws.amazon.com/gamelift/home?region=us-west-2#/r/fleets/sample
+func testAccAWSGameliftSampleGameLocation(region string) (*gamelift.S3Location, error) {
+	version := "v1.2.0.0"
+	accId, err := testAccGameliftAccountIdByRegion(region)
+	if err != nil {
+		return nil, err
+	}
+	bucket := fmt.Sprintf("gamelift-sample-builds-prod-%s", region)
+	key := fmt.Sprintf("%s/server/sample_build_%s", version, version)
+	roleArn := fmt.Sprintf("arn:aws:iam::%s:role/sample-build-upload-role-%s", accId, region)
+
+	return &gamelift.S3Location{
+		Bucket:  aws.String(bucket),
+		Key:     aws.String(key),
+		RoleArn: aws.String(roleArn),
+	}, nil
+}
+
+// Account ID found from CloudTrail event (role ARN) after finishing tutorial in given region
+func testAccGameliftAccountIdByRegion(region string) (string, error) {
+	m := map[string]string{
+		"ap-northeast-1": "120069834884",
+		"ap-northeast-2": "805673136642",
+		"ap-south-1":     "134975661615",
+		"ap-southeast-1": "077577004113",
+		"ap-southeast-2": "112188327105",
+		"ca-central-1":   "800535022691",
+		"eu-central-1":   "797584052317",
+		"eu-west-1":      "319803218673",
+		"eu-west-2":      "937342764187",
+		"sa-east-1":      "028872612690",
+		"us-east-1":      "783764748367",
+		"us-east-2":      "415729564621",
+		"us-west-1":      "715879310420",
+		"us-west-2":      "741061592171",
+	}
+
+	if accId, ok := m[region]; ok {
+		return accId, nil
+	}
+
+	return "", fmt.Errorf("Account ID not found for region %q", region)
+}
+
+func testAccAWSGameliftBuildBasicConfig(buildName, bucketName, key, roleArn string) string {
+	return fmt.Sprintf(`
+resource "aws_gamelift_build" "test" {
+  name = "%s"
+  operating_system = "WINDOWS_2012"
+  storage_location {
+    bucket = "%s"
+    key = "%s"
+    role_arn = "%s"
+  }
+}
+`, buildName, bucketName, key, roleArn)
+}

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/apigateway"
 	"github.com/aws/aws-sdk-go/service/cognitoidentity"
 	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
+	"github.com/aws/aws-sdk-go/service/gamelift"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/structure"
@@ -2108,5 +2109,18 @@ func validateServiceDiscoveryServiceHealthCheckConfigType(v interface{}, k strin
 		}
 	}
 	errors = append(errors, fmt.Errorf("expected %s to be one of %v, got %s", k, validType, value))
+	return
+}
+
+func validateGameliftOperatingSystem(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	operatingSystems := map[string]bool{
+		gamelift.OperatingSystemAmazonLinux: true,
+		gamelift.OperatingSystemWindows2012: true,
+	}
+
+	if !operatingSystems[value] {
+		errors = append(errors, fmt.Errorf("%q must be a valid operating system value: %q", k, value))
+	}
 	return
 }

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -924,6 +924,15 @@
                     </ul>
                 </li>
 
+                <li<%= sidebar_current("docs-aws-resource-gamelift") %>>
+                    <a href="#">Gamelift Resources</a>
+                    <ul class="nav nav-visible">
+                        <li<%= sidebar_current("docs-aws-resource-gamelift-build") %>>
+                            <a href="/docs/providers/aws/r/gamelift_build.html">aws_gamelift_build</a>
+                        </li>
+                    </ul>
+                 </li>
+                
                 <li<%= sidebar_current("docs-aws-resource-glacier") %>>
                     <a href="#">Glacier Resources</a>
                     <ul class="nav nav-visible">

--- a/website/docs/r/gamelift_build.html.markdown
+++ b/website/docs/r/gamelift_build.html.markdown
@@ -1,0 +1,53 @@
+---
+layout: "aws"
+page_title: "AWS: aws_gamelift_build"
+sidebar_current: "docs-aws-resource-gamelift-build"
+description: |-
+  Provides a Gamelift Build resource.
+---
+
+# aws_gamelift_build
+
+Provides an Gamelift Build resource.
+
+## Example Usage
+
+```hcl
+resource "aws_gamelift_build" "test" {
+  name = "example-build"
+  operating_system = "WINDOWS_2012"
+  storage_location {
+    bucket = "${aws_s3_bucket.test.bucket}"
+    key = "${aws_s3_bucket_object.test.key}"
+    role_arn = "${aws_iam_role.test.arn}"
+  }
+  depends_on = ["aws_iam_role_policy.test"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name of the build
+* `operating_system` - (Required) Operating system that the game server binaries are built to run on. e.g. `WINDOWS_2012` or `AMAZON_LINUX`.
+* `storage_location` - (Required) Information indicating where your game build files are stored. See below.
+* `version` - (Optional) Version that is associated with this build.
+
+### Nested Fields
+
+#### `storage_location`
+
+* `bucket` - (Required) Name of your S3 bucket.
+* `key` - (Required) Name of the zip file containing your build files.
+* `role_arn` - (Required) ARN of the access role that allows Amazon GameLift to access your S3 bucket.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - Build ID.
+
+## Import
+
+Gamelift Builds cannot be imported at this time.


### PR DESCRIPTION
I want to take a look into the ZIP file to see if there's any way to bring the size down from 15M, but otherwise this is ready for review.

The ZIP file was basically created by following steps in https://github.com/awslabs/aws-gamelift-sample/blob/master/deployment/deployment.md#gamelift----game-server-build--fleet-creation
and it unfortunately contains a few binaries which practically can't be compressed.

The build resource here practically doesn't require a ZIP file with fully working game, but `aws_gamelift_fleet` (for which I already have a PR in a queue) will.

## Import

The main reason I decided not to implement import is because `DescribeBuild` doesn't return `storage_location` which is `ForceNew`, so having such empty field in the state would result in recreation.

## Test Results

```
$ make testacc TESTARGS='-run=TestAccAWSGamelift'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccAWSGamelift -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSGameliftBuild_basic
--- PASS: TestAccAWSGameliftBuild_basic (313.15s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	313.202s
```

  