### PR TITLE
resource/aws_security_group: Allow empty rule description

### DIFF
--- a/aws/resource_aws_security_group_test.go
+++ b/aws/resource_aws_security_group_test.go
@@ -1420,6 +1420,28 @@ func TestAccAWSSecurityGroup_egressWithPrefixList(t *testing.T) {
 	})
 }
 
+func TestAccAWSSecurityGroup_emptyRuleDescription(t *testing.T) {
+	var group ec2.SecurityGroup
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSecurityGroupConfigEmptyRuleDescription,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSecurityGroupExists("aws_security_group.web", &group),
+					resource.TestCheckResourceAttr(
+						"aws_security_group.web", "egress.3629188364.description", ""),
+					resource.TestCheckResourceAttr(
+						"aws_security_group.web", "ingress.3629188364.description", ""),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSSecurityGroup_ipv4andipv6Egress(t *testing.T) {
 	var group ec2.SecurityGroup
 
@@ -1608,6 +1630,36 @@ func TestAccAWSSecurityGroup_failWithDiffMismatch(t *testing.T) {
 	})
 }
 
+const testAccAWSSecurityGroupConfigEmptyRuleDescription = `
+resource "aws_vpc" "foo" {
+  cidr_block = "10.1.0.0/16"
+}
+
+resource "aws_security_group" "web" {
+  name = "terraform_acceptance_test_desc_example"
+  description = "Used in the terraform acceptance tests"
+  vpc_id = "${aws_vpc.foo.id}"
+
+  ingress {
+    protocol = "6"
+    from_port = 80
+    to_port = 8000
+    cidr_blocks = ["10.0.0.0/8"]
+    description = ""
+  }
+
+  egress {
+    protocol = "tcp"
+    from_port = 80
+    to_port = 8000
+    cidr_blocks = ["10.0.0.0/8"]
+    description = ""
+  }
+
+  tags {
+    Name = "tf-acc-test"
+  }
+}`
 const testAccAWSSecurityGroupConfigForTagsOrdering = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"

--- a/aws/resource_aws_security_group_test.go
+++ b/aws/resource_aws_security_group_test.go
@@ -1633,6 +1633,9 @@ func TestAccAWSSecurityGroup_failWithDiffMismatch(t *testing.T) {
 const testAccAWSSecurityGroupConfigEmptyRuleDescription = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
+  tags {
+    Name = "terraform-testacc-security-group-empty-rule-description"
+  }
 }
 
 resource "aws_security_group" "web" {

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1891,8 +1891,9 @@ func validateSecurityGroupRuleDescription(v interface{}, k string) (ws []string,
 			"%q cannot be longer than 255 characters: %q", k, value))
 	}
 
-	// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IpRange.html
-	pattern := `^[A-Za-z0-9 \.\_\-\:\/\(\)\#\,\@\[\]\+\=\;\{\}\!\$\*]+$`
+	// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IpRange.html. Note that
+	// "" is an allowable description value.
+	pattern := `^[A-Za-z0-9 \.\_\-\:\/\(\)\#\,\@\[\]\+\=\;\{\}\!\$\*]*$`
 	if !regexp.MustCompile(pattern).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
 			"%q doesn't comply with restrictions (%q): %q",


### PR DESCRIPTION
```
❯ make testacc TESTARGS="-run TestAccAWSSecurityGroup_emptyRuleDescription"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccAWSSecurityGroup_emptyRuleDescription -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSSecurityGroup_emptyRuleDescription
--- PASS: TestAccAWSSecurityGroup_emptyRuleDescription (195.99s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	196.033s
```

Fixes #2831.