### PR TITLE
Wrap aws_lambda_function.environment.variables type in &schema.Schema

### DIFF
--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -170,7 +170,6 @@ func resourceAwsLambdaFunction() *schema.Resource {
 						"variables": {
 							Type:     schema.TypeMap,
 							Optional: true,
-							Elem:     schema.TypeString,
 						},
 					},
 				},

--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -170,6 +170,7 @@ func resourceAwsLambdaFunction() *schema.Resource {
 						"variables": {
 							Type:     schema.TypeMap,
 							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 					},
 				},


### PR DESCRIPTION
Wrap element type in &schema.Schema so that it conforms to the expected Terraform Schema structure