### PR TITLE
Make it possible to import Route53 records containing a wildcard

### DIFF
--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -618,7 +618,7 @@ func findRecord(d *schema.ResourceData, meta interface{}) (*route53.ResourceReco
 
 	for _, record := range resp.ResourceRecordSets {
 		name := cleanRecordName(*record.Name)
-		if FQDN(strings.ToLower(name)) != FQDN(strings.ToLower(*lopts.StartRecordName)) {
+		if FQDN(strings.ToLower(name)) != FQDN(strings.ToLower(cleanRecordName(*lopts.StartRecordName))) {
 			continue
 		}
 		if strings.ToUpper(*record.Type) != strings.ToUpper(*lopts.StartRecordType) {


### PR DESCRIPTION
Today, route 53 records can only be manually imported into Terraform if they do not contain a wildcard matcher ('*'). This PR consistently applies normalization of the record during import so that wildcard domains can also be imported.