### PR TITLE
resource/aws_instance: Ensure at least one security group is being attached

### DIFF
--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -893,6 +893,10 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 				groups = append(groups, aws.String(v.(string)))
 			}
 		}
+
+		if len(groups) < 1 {
+			return fmt.Errorf("At least one security group needs to be attached!")
+		}
 		// If a user has multiple network interface attachments on the target EC2 instance, simply modifying the
 		// instance attributes via a `ModifyInstanceAttributes()` request would fail with the following error message:
 		// "There are multiple interfaces attached to instance 'i-XX'. Please specify an interface ID for the operation instead."

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -895,7 +895,7 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if len(groups) < 1 {
-			return fmt.Errorf("At least one security group needs to be attached!")
+			return fmt.Errorf("VPC-based instances require at least one security group to be attached.")
 		}
 		// If a user has multiple network interface attachments on the target EC2 instance, simply modifying the
 		// instance attributes via a `ModifyInstanceAttributes()` request would fail with the following error message:

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -733,6 +733,7 @@ func TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_instance.foo_instance", "vpc_security_group_ids.#", "1"),
 				),
+				ExpectError: regexp.MustCompile(`VPC-based instances require at least one security group to be attached`),
 			},
 		},
 	})


### PR DESCRIPTION
VPC-EC2 instances require at least 1 security group be attached. I was able to run apply and try to remove all security groups from an instance and it fails silently. terraform apply says that it is modifying the aws_instance resource but never finishes.
  