### PR TITLE
New resources: aws_dx_gateway, aws_dx_gateway_assocation

### DIFF
--- a/aws/import_aws_dx_gateway.go
+++ b/aws/import_aws_dx_gateway.go
@@ -1,0 +1,48 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/directconnect"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// Direct Connect Gateway import also imports all assocations
+func resourceAwsDxGatewayImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	conn := meta.(*AWSClient).dxconn
+
+	id := d.Id()
+	resp, err := conn.DescribeDirectConnectGateways(&directconnect.DescribeDirectConnectGatewaysInput{
+		DirectConnectGatewayId: aws.String(id),
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(resp.DirectConnectGateways) < 1 || resp.DirectConnectGateways[0] == nil {
+		return nil, fmt.Errorf("Direct Connect Gateway %s was not found", id)
+	}
+	results := make([]*schema.ResourceData, 1)
+	results[0] = d
+
+	{
+		subResource := resourceAwsDxGatewayAssociation()
+		resp, err := conn.DescribeDirectConnectGatewayAssociations(&directconnect.DescribeDirectConnectGatewayAssociationsInput{
+			DirectConnectGatewayId: aws.String(id),
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		for _, assoc := range resp.DirectConnectGatewayAssociations {
+			d := subResource.Data(nil)
+			d.SetType("aws_dx_gateway_association")
+			d.Set("dx_gateway_id", assoc.DirectConnectGatewayId)
+			d.Set("virtual_gateway_id", assoc.VirtualGatewayId)
+			d.SetId(dxGatewayIdVgwIdHash(*assoc.DirectConnectGatewayId, *assoc.VirtualGatewayId))
+			results = append(results, d)
+		}
+	}
+
+	return results, nil
+}

--- a/aws/import_aws_dx_gateway_test.go
+++ b/aws/import_aws_dx_gateway_test.go
@@ -1,0 +1,93 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAwsDxGateway_importBasic(t *testing.T) {
+	resourceName := "aws_dx_gateway.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsDxGatewayDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDxGatewayConfig(acctest.RandString(5), acctest.RandIntRange(64512, 65534)),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsDxGateway_importComplex(t *testing.T) {
+	checkFn := func(s []*terraform.InstanceState) error {
+		if len(s) != 3 {
+			return fmt.Errorf("Got %d resources, expected 3. State: %#v", len(s), s)
+		}
+		return nil
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsDxGatewayDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDxGatewayConfig_complexImport(acctest.RandString(5), acctest.RandIntRange(64512, 65534)),
+			},
+
+			resource.TestStep{
+				ResourceName:      "aws_dx_gateway.test",
+				ImportState:       true,
+				ImportStateCheck:  checkFn,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccDxGatewayConfig_complexImport(rName string, rBgpAsn int) string {
+	return fmt.Sprintf(`
+resource "aws_dx_gateway" "test" {
+  name = "tf-dxg-%s"
+  amazon_side_asn = "%d"
+}
+
+resource "aws_vpc" "test1" {
+  cidr_block = "10.255.255.16/28"
+}
+
+resource "aws_vpc" "test2" {
+  cidr_block = "10.255.255.32/28"
+}
+
+resource "aws_vpn_gateway" "test1" {
+  vpc_id = "${aws_vpc.test1.id}"
+}
+
+resource "aws_vpn_gateway" "test2" {
+  vpc_id = "${aws_vpc.test2.id}"
+}
+
+resource "aws_dx_gateway_association" "test1" {
+  dx_gateway_id = "${aws_dx_gateway.test.id}"
+  virtual_gateway_id = "${aws_vpn_gateway.test1.id}"
+}
+
+resource "aws_dx_gateway_association" "test2" {
+  dx_gateway_id = "${aws_dx_gateway.test.id}"
+  virtual_gateway_id = "${aws_vpn_gateway.test2.id}"
+}
+`, rName, rBgpAsn)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -337,6 +337,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_dx_connection":                            resourceAwsDxConnection(),
 			"aws_dx_connection_association":                resourceAwsDxConnectionAssociation(),
 			"aws_dx_gateway":                               resourceAwsDxGateway(),
+			"aws_dx_gateway_association":                   resourceAwsDxGatewayAssociation(),
 			"aws_dynamodb_table":                           resourceAwsDynamoDbTable(),
 			"aws_dynamodb_table_item":                      resourceAwsDynamoDbTableItem(),
 			"aws_dynamodb_global_table":                    resourceAwsDynamoDbGlobalTable(),

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -336,6 +336,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_dx_lag":                                   resourceAwsDxLag(),
 			"aws_dx_connection":                            resourceAwsDxConnection(),
 			"aws_dx_connection_association":                resourceAwsDxConnectionAssociation(),
+			"aws_dx_gateway":                               resourceAwsDxGateway(),
 			"aws_dynamodb_table":                           resourceAwsDynamoDbTable(),
 			"aws_dynamodb_table_item":                      resourceAwsDynamoDbTableItem(),
 			"aws_dynamodb_global_table":                    resourceAwsDynamoDbGlobalTable(),

--- a/aws/resource_aws_dx_gateway.go
+++ b/aws/resource_aws_dx_gateway.go
@@ -1,0 +1,141 @@
+package aws
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/directconnect"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsDxGateway() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsDxGatewayCreate,
+		Read:   resourceAwsDxGatewayRead,
+		Delete: resourceAwsDxGatewayDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceAwsDxGatewayImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"amazon_side_asn": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateAmazonSideAsn,
+			},
+		},
+	}
+}
+
+func resourceAwsDxGatewayCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).dxconn
+
+	input := &directconnect.CreateDirectConnectGatewayInput{
+		DirectConnectGatewayName: aws.String(d.Get("name").(string)),
+	}
+
+	if asn, ok := d.GetOk("amazon_side_asn"); ok {
+		i, err := strconv.ParseInt(asn.(string), 10, 64)
+		if err != nil {
+			return err
+		}
+		input.AmazonSideAsn = aws.Int64(i)
+	}
+
+	resp, err := conn.CreateDirectConnectGateway(input)
+	if err != nil {
+		return err
+	}
+	gatewayId := aws.StringValue(resp.DirectConnectGateway.DirectConnectGatewayId)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{directconnect.GatewayStatePending},
+		Target:     []string{directconnect.GatewayStateAvailable},
+		Refresh:    dxGatewayRefreshStateFunc(conn, gatewayId),
+		Timeout:    10 * time.Minute,
+		Delay:      10 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error waiting for Direct Connect Gateway (%s) to become available: %s", gatewayId, err)
+	}
+
+	d.SetId(gatewayId)
+	return resourceAwsDxGatewayRead(d, meta)
+}
+
+func resourceAwsDxGatewayRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).dxconn
+
+	resp, err := conn.DescribeDirectConnectGateways(&directconnect.DescribeDirectConnectGatewaysInput{
+		DirectConnectGatewayId: aws.String(d.Id()),
+	})
+	if err != nil {
+		return err
+	}
+
+	if len(resp.DirectConnectGateways) < 1 {
+		d.SetId("")
+		return nil
+	}
+	if len(resp.DirectConnectGateways) != 1 {
+		return fmt.Errorf("[ERROR] Number of Direct Connect Gateways (%s) isn't one, got %d", d.Id(), len(resp.DirectConnectGateways))
+	}
+	gateway := resp.DirectConnectGateways[0]
+
+	if d.Id() != aws.StringValue(gateway.DirectConnectGatewayId) {
+		return fmt.Errorf("[ERROR] Direct Connect Gateway (%s) not found", d.Id())
+	}
+
+	d.Set("name", aws.StringValue(gateway.DirectConnectGatewayName))
+	d.Set("amazon_side_asn", strconv.FormatInt(aws.Int64Value(gateway.AmazonSideAsn), 10))
+
+	return nil
+}
+
+func resourceAwsDxGatewayDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).dxconn
+
+	_, err := conn.DeleteDirectConnectGateway(&directconnect.DeleteDirectConnectGatewayInput{
+		DirectConnectGatewayId: aws.String(d.Id()),
+	})
+	if err != nil {
+		return err
+	}
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{directconnect.GatewayStatePending, directconnect.GatewayStateAvailable, directconnect.GatewayStateDeleting},
+		Target:     []string{directconnect.GatewayStateDeleted},
+		Refresh:    dxGatewayRefreshStateFunc(conn, d.Id()),
+		Timeout:    10 * time.Minute,
+		Delay:      10 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error waiting for Direct Connect Gateway (%s) to be deleted: %s", d.Id(), err)
+	}
+	d.SetId("")
+	return nil
+}
+
+func dxGatewayRefreshStateFunc(conn *directconnect.DirectConnect, gatewayId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := conn.DescribeDirectConnectGateways(&directconnect.DescribeDirectConnectGatewaysInput{
+			DirectConnectGatewayId: aws.String(gatewayId),
+		})
+		if err != nil {
+			return nil, "failed", err
+		}
+		return resp, *resp.DirectConnectGateways[0].DirectConnectGatewayState, nil
+	}
+}

--- a/aws/resource_aws_dx_gateway_association.go
+++ b/aws/resource_aws_dx_gateway_association.go
@@ -1,0 +1,102 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/directconnect"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsDxGatewayAssociation() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsDxGatewayAssociationCreate,
+		Read:   resourceAwsDxGatewayAssociationRead,
+		Delete: resourceAwsDxGatewayAssociationDelete,
+
+		Schema: map[string]*schema.Schema{
+			"dx_gateway_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"virtual_gateway_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAwsDxGatewayAssociationCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).dxconn
+
+	dxGatewayId := d.Get("dx_gateway_id").(string)
+	vgwId := d.Get("virtual_gateway_id").(string)
+
+	_, err := conn.CreateDirectConnectGatewayAssociation(&directconnect.CreateDirectConnectGatewayAssociationInput{
+		DirectConnectGatewayId: aws.String(dxGatewayId),
+		VirtualGatewayId:       aws.String(vgwId),
+	})
+	if err != nil {
+		return err
+	}
+
+	d.SetId(dxGatewayIdVgwIdHash(dxGatewayId, vgwId))
+	return nil
+}
+
+func resourceAwsDxGatewayAssociationRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).dxconn
+
+	dxGatewayId := d.Get("dx_gateway_id").(string)
+	vgwId := d.Get("virtual_gateway_id").(string)
+
+	resp, err := conn.DescribeDirectConnectGatewayAssociations(&directconnect.DescribeDirectConnectGatewayAssociationsInput{
+		DirectConnectGatewayId: aws.String(dxGatewayId),
+		VirtualGatewayId:       aws.String(vgwId),
+	})
+
+	if err != nil {
+		return err
+	}
+	if len(resp.DirectConnectGatewayAssociations) < 1 {
+		d.SetId("")
+		return nil
+	}
+	if len(resp.DirectConnectGatewayAssociations) != 1 {
+		return fmt.Errorf("Found %d Direct Connect Gateway associations for %s, expected 1", len(resp.DirectConnectGatewayAssociations), d.Id())
+	}
+	if *resp.DirectConnectGatewayAssociations[0].VirtualGatewayId != d.Get("virtual_gateway_id").(string) {
+		log.Printf("[WARN] Direct Connect Gateway Association %s not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	return nil
+}
+
+func resourceAwsDxGatewayAssociationDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).dxconn
+
+	dxGatewayId := d.Get("dx_gateway_id").(string)
+	vgwId := d.Get("virtual_gateway_id").(string)
+
+	_, err := conn.DeleteDirectConnectGatewayAssociation(&directconnect.DeleteDirectConnectGatewayAssociationInput{
+		DirectConnectGatewayId: aws.String(dxGatewayId),
+		VirtualGatewayId:       aws.String(vgwId),
+	})
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func dxGatewayIdVgwIdHash(gatewayId, vgwId string) string {
+	return fmt.Sprintf("ga-%s%s", gatewayId, vgwId)
+}

--- a/aws/resource_aws_dx_gateway_association_test.go
+++ b/aws/resource_aws_dx_gateway_association_test.go
@@ -1,0 +1,133 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/directconnect"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAwsDxGatewayAssociation_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsDxGatewayAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDxGatewayAssociationConfig(acctest.RandString(5), acctest.RandIntRange(64512, 65534)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsDxGatewayAssociationExists("aws_dx_gateway_association.test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAwsDxGatewayAssociation_multiVgws(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsDxGatewayAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDxGatewayAssociationConfig_multiVgws(acctest.RandString(5), acctest.RandIntRange(64512, 65534)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsDxGatewayAssociationExists("aws_dx_gateway_association.test1"),
+					testAccCheckAwsDxGatewayAssociationExists("aws_dx_gateway_association.test2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsDxGatewayAssociationDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).dxconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_dx_gateway_association" {
+			continue
+		}
+
+		resp, _ := conn.DescribeDirectConnectGatewayAssociations(&directconnect.DescribeDirectConnectGatewayAssociationsInput{
+			DirectConnectGatewayId: aws.String(rs.Primary.Attributes["dx_gateway_id"]),
+			VirtualGatewayId:       aws.String(rs.Primary.Attributes["virtual_gateway_id"]),
+		})
+
+		if len(resp.DirectConnectGatewayAssociations) > 0 {
+			return fmt.Errorf("Direct Connect Gateway (%s) is not dissociated from VGW %s", rs.Primary.Attributes["dx_gateway_id"], rs.Primary.Attributes["virtual_gateway_id"])
+		}
+	}
+	return nil
+}
+
+func testAccCheckAwsDxGatewayAssociationExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		return nil
+	}
+}
+
+func testAccDxGatewayAssociationConfig(rName string, rBgpAsn int) string {
+	return fmt.Sprintf(`
+resource "aws_dx_gateway" "test" {
+  name = "tf-dxg-%s"
+  amazon_side_asn = "%d"
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.255.255.0/28"
+}
+
+resource "aws_vpn_gateway" "test" {
+  vpc_id = "${aws_vpc.test.id}"
+}
+
+resource "aws_dx_gateway_association" "test" {
+  dx_gateway_id = "${aws_dx_gateway.test.id}"
+  virtual_gateway_id = "${aws_vpn_gateway.test.id}"
+}
+`, rName, rBgpAsn)
+}
+
+func testAccDxGatewayAssociationConfig_multiVgws(rName string, rBgpAsn int) string {
+	return fmt.Sprintf(`
+resource "aws_dx_gateway" "test" {
+  name = "tf-dxg-%s"
+  amazon_side_asn = "%d"
+}
+
+resource "aws_vpc" "test1" {
+  cidr_block = "10.255.255.16/28"
+}
+
+resource "aws_vpc" "test2" {
+  cidr_block = "10.255.255.32/28"
+}
+
+resource "aws_vpn_gateway" "test1" {
+  vpc_id = "${aws_vpc.test1.id}"
+}
+
+resource "aws_vpn_gateway" "test2" {
+  vpc_id = "${aws_vpc.test2.id}"
+}
+
+resource "aws_dx_gateway_association" "test1" {
+  dx_gateway_id = "${aws_dx_gateway.test.id}"
+  virtual_gateway_id = "${aws_vpn_gateway.test1.id}"
+}
+
+resource "aws_dx_gateway_association" "test2" {
+  dx_gateway_id = "${aws_dx_gateway.test.id}"
+  virtual_gateway_id = "${aws_vpn_gateway.test2.id}"
+}
+`, rName, rBgpAsn)
+}

--- a/aws/resource_aws_dx_gateway_test.go
+++ b/aws/resource_aws_dx_gateway_test.go
@@ -1,0 +1,73 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/directconnect"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAwsDxGateway_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsDxGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDxGatewayConfig(acctest.RandString(5), acctest.RandIntRange(64512, 65534)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsDxGatewayExists("aws_dx_gateway.test"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsDxGatewayDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).dxconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_dx_gateway" {
+			continue
+		}
+
+		input := &directconnect.DescribeDirectConnectGatewaysInput{
+			DirectConnectGatewayId: aws.String(rs.Primary.ID),
+		}
+
+		resp, err := conn.DescribeDirectConnectGateways(input)
+		if err != nil {
+			return err
+		}
+		for _, v := range resp.DirectConnectGateways {
+			if *v.DirectConnectGatewayId == rs.Primary.ID && !(*v.DirectConnectGatewayState == directconnect.GatewayStateDeleted) {
+				return fmt.Errorf("[DESTROY ERROR] DX Gateway (%s) not deleted", rs.Primary.ID)
+			}
+		}
+	}
+	return nil
+}
+
+func testAccCheckAwsDxGatewayExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		return nil
+	}
+}
+
+func testAccDxGatewayConfig(rName string, rBgpAsn int) string {
+	return fmt.Sprintf(`
+    resource "aws_dx_gateway" "test" {
+      name = "tf-dxg-%s"
+      amazon_side_asn = "%d"
+    }
+    `, rName, rBgpAsn)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -644,6 +644,9 @@
                         <li<%= sidebar_current("docs-aws-resource-dx-connection-association") %>>
                             <a href="/docs/providers/aws/r/dx_connection_association.html">aws_dx_connection_association</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-resource-dx-gateway") %>>
+                            <a href="/docs/providers/aws/r/dx_gateway.html">aws_dx_gateway</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-resource-dx-lag") %>>
                             <a href="/docs/providers/aws/r/dx_lag.html">aws_dx_lag</a>
                         </li>

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -647,6 +647,9 @@
                         <li<%= sidebar_current("docs-aws-resource-dx-gateway") %>>
                             <a href="/docs/providers/aws/r/dx_gateway.html">aws_dx_gateway</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-resource-dx-gateway-association") %>>
+                            <a href="/docs/providers/aws/r/dx_gateway_association.html">aws_dx_gateway_association</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-resource-dx-lag") %>>
                             <a href="/docs/providers/aws/r/dx_lag.html">aws_dx_lag</a>
                         </li>

--- a/website/docs/r/dx_gateway.html.markdown
+++ b/website/docs/r/dx_gateway.html.markdown
@@ -1,0 +1,41 @@
+---
+layout: "aws"
+page_title: "AWS: aws_dx_gateway"
+sidebar_current: "docs-aws-resource-dx-gateway"
+description: |-
+  Provides a Direct Connect Gateway.
+---
+
+# aws_dx_gateway
+
+Provides a Direct Connect Gateway.
+
+## Example Usage
+
+```hcl
+resource "aws_dx_gateway" "example" {
+  name = "tf-dxg-example"
+  amazon_side_asn = "64512"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the connection.
+* `amazon_side_asn` - (Required) The ASN to be configured on the Amazon side of the connection. The ASN must be in the private range of 64,512 to 65,534 or 4,200,000,000 to 4,294,967,294.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the gateway.
+
+## Import
+
+Direct Connect Gateways can be imported using the `gateway id`, e.g.
+
+```
+$ terraform import aws_dx_gateway.test abcd1234-dcba-5678-be23-cdef9876ab45
+```

--- a/website/docs/r/dx_gateway_association.html.markdown
+++ b/website/docs/r/dx_gateway_association.html.markdown
@@ -1,0 +1,40 @@
+---
+layout: "aws"
+page_title: "AWS: aws_dx_gateway_association"
+sidebar_current: "docs-aws-resource-dx-gateway-association"
+description: |-
+  Associates a Direct Connect Gateway with a VGW.
+---
+
+# aws_dx_gateway_association
+
+Associates a Direct Connect Gateway with a VGW.
+
+## Example Usage
+
+```hcl
+resource "aws_dx_gateway" "example" {
+  name = "example"
+  amazon_side_asn = "64512"
+}
+
+resource "aws_vpc" "example" {
+  cidr_block = "10.255.255.0/28"
+}
+
+resource "aws_vpn_gateway" "example" {
+  vpc_id = "${aws_vpc.test.id}"
+}
+
+resource "aws_dx_gateway_association" "example" {
+  dx_gateway_id = "${aws_dx_gateway.example.id}"
+  virtual_gateway_id = "${aws_vpn_gateway.example.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `dx_gateway_id` - (Required) The ID of the Direct Connect Gateway.
+* `virtual_gateway_id` - (Required) The ID of the VGW with which to associate the gateway.


### PR DESCRIPTION
```
TF_ACC=1 go test ./aws/ -v -run=TestAccAwsDxGateway -timeout 120m
=== RUN   TestAccAwsDxGatewayAssociation_basic
--- PASS: TestAccAwsDxGatewayAssociation_basic (65.53s)
=== RUN   TestAccAwsDxGatewayAssociation_multiVgws
--- PASS: TestAccAwsDxGatewayAssociation_multiVgws (79.58s)
=== RUN   TestAccAwsDxGateway_basic
--- PASS: TestAccAwsDxGateway_basic (31.14s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	176.300s
```

I have used the same ASN validation code from #1888 to prove this works, but I suppose this blocks merging this PR until that is solved with the proposed addition of `TypeInt64` to Terraform.

Resolves #2140.