### PR TITLE
New resource: aws_dx_gateway_association

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -324,6 +324,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_dx_lag":                                   resourceAwsDxLag(),
 			"aws_dx_connection":                            resourceAwsDxConnection(),
 			"aws_dx_connection_association":                resourceAwsDxConnectionAssociation(),
+			"aws_dx_gateway_association":                   resourceAwsDxGatewayAssociation(),
 			"aws_dynamodb_table":                           resourceAwsDynamoDbTable(),
 			"aws_ebs_snapshot":                             resourceAwsEbsSnapshot(),
 			"aws_ebs_volume":                               resourceAwsEbsVolume(),

--- a/aws/resource_aws_dx_gateway_association.go
+++ b/aws/resource_aws_dx_gateway_association.go
@@ -1,0 +1,104 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/directconnect"
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsDxGatewayAssociation() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsDxGatewayAssociationCreate,
+		Read:   resourceAwsDxGatewayAssociationRead,
+		Delete: resourceAwsDxGatewayAssociationDelete,
+
+		Schema: map[string]*schema.Schema{
+			"dx_gateway_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"virtual_gateway_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAwsDxGatewayAssociationCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).dxconn
+
+	dxGatewayId := d.Get("dx_gateway_id").(string)
+	vgwId := d.Get("virtual_gateway_id").(string)
+
+	input := &directconnect.CreateDirectConnectGatewayAssociationInput{
+		DirectConnectGatewayId: aws.String(dxGatewayId),
+		VirtualGatewayId:       aws.String(vgwId),
+	}
+	_, err := conn.CreateDirectConnectGatewayAssociation(input)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(dxGatewayIdVgwIdHash(dxGatewayId, vgwId))
+	return nil
+}
+
+func resourceAwsDxGatewayAssociationRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).dxconn
+
+	dxGatewayId := d.Get("dx_gateway_id").(string)
+	vgwId := d.Get("virtual_gateway_id").(string)
+
+	input := &directconnect.DescribeDirectConnectGatewayAssociationsInput{
+		DirectConnectGatewayId: aws.String(dxGatewayId),
+		VirtualGatewayId:       aws.String(vgwId),
+	}
+
+	resp, err := conn.DescribeDirectConnectGatewayAssociations(input)
+	if err != nil {
+		return err
+	}
+	if len(resp.DirectConnectGatewayAssociations) < 1 {
+		d.SetId("")
+		return nil
+	}
+	if len(resp.DirectConnectGatewayAssociations) != 1 {
+		return fmt.Errorf("Found %d Direct Connect Gateway associations for %s, expected 1", len(resp.DirectConnectGatewayAssociations), d.Id())
+	}
+	if *resp.DirectConnectGatewayAssociations[0].VirtualGatewayId != d.Get("virtual_gateway_id").(string) {
+		d.SetId("")
+		return nil
+	}
+
+	return nil
+}
+
+func resourceAwsDxGatewayAssociationDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).dxconn
+
+	dxGatewayId := d.Get("dx_gateway_id").(string)
+	vgwId := d.Get("virtual_gateway_id").(string)
+
+	input := &directconnect.DeleteDirectConnectGatewayAssociationInput{
+		DirectConnectGatewayId: aws.String(dxGatewayId),
+		VirtualGatewayId:       aws.String(vgwId),
+	}
+
+	_, err := conn.DeleteDirectConnectGatewayAssociation(input)
+	if err != nil {
+		return err
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func dxGatewayIdVgwIdHash(gatewayId, vgwId string) string {
+	return fmt.Sprintf("ga-%s%d", gatewayId, hashcode.String(vgwId))
+}

--- a/aws/resource_aws_dx_gateway_association_test.go
+++ b/aws/resource_aws_dx_gateway_association_test.go
@@ -1,0 +1,134 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/directconnect"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAwsDxGatewayAssociation_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsDxGatewayAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDxGatewayAssociationConfig(acctest.RandString(5)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsDxGatewayAssociationExists("aws_dx_gateway_association.test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAwsDxGatewayAssociation_multiVgws(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsDxGatewayAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDxGatewayAssociationConfig_multiVgws(acctest.RandString(5)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsDxGatewayAssociationExists("aws_dx_gateway_association.test1"),
+					testAccCheckAwsDxGatewayAssociationExists("aws_dx_gateway_association.test2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsDxGatewayAssociationDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).dxconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_dx_gateway_association" {
+			continue
+		}
+
+		input := &directconnect.DescribeDirectConnectGatewayAssociationsInput{
+			DirectConnectGatewayId: aws.String(rs.Primary.Attributes["dx_gateway_id"]),
+			VirtualGatewayId:       aws.String(rs.Primary.Attributes["virtual_gateway_id"]),
+		}
+		resp, _ := conn.DescribeDirectConnectGatewayAssociations(input)
+
+		if len(resp.DirectConnectGatewayAssociations) > 0 {
+			return fmt.Errorf("Direct Connect Gateway (%s) is not dissociated with VGW %s", rs.Primary.Attributes["dx_gateway_id"], rs.Primary.Attributes["virtual_gateway_id"])
+		}
+	}
+	return nil
+}
+
+func testAccCheckAwsDxGatewayAssociationExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		return nil
+	}
+}
+
+func testAccDxGatewayAssociationConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_dx_gateway" "test" {
+  name = "tf-dxg-%s"
+  amazon_side_asn = "64512"
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.255.255.0/28"
+}
+
+resource "aws_vpn_gateway" "test" {
+  vpc_id = "${aws_vpc.test.id}"
+}
+
+resource "aws_dx_gateway_association" "test" {
+  dx_gateway_id = "${aws_dx_gateway.test.id}"
+  virtual_gateway_id = "${aws_vpn_gateway.test.id}"
+}
+`, rName)
+}
+
+func testAccDxGatewayAssociationConfig_multiVgws(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_dx_gateway" "test" {
+  name = "tf-dxg-%s"
+  amazon_side_asn = "64512"
+}
+
+resource "aws_vpc" "test1" {
+  cidr_block = "10.255.255.16/28"
+}
+
+resource "aws_vpc" "test2" {
+  cidr_block = "10.255.255.32/28"
+}
+
+resource "aws_vpn_gateway" "test1" {
+  vpc_id = "${aws_vpc.test1.id}"
+}
+
+resource "aws_vpn_gateway" "test2" {
+  vpc_id = "${aws_vpc.test2.id}"
+}
+
+resource "aws_dx_gateway_association" "test1" {
+  dx_gateway_id = "${aws_dx_gateway.test.id}"
+  virtual_gateway_id = "${aws_vpn_gateway.test1.id}"
+}
+
+resource "aws_dx_gateway_association" "test2" {
+  dx_gateway_id = "${aws_dx_gateway.test.id}"
+  virtual_gateway_id = "${aws_vpn_gateway.test2.id}"
+}
+`, rName)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -582,6 +582,9 @@
                         <li<%= sidebar_current("docs-aws-resource-dx-connection-association") %>>
                             <a href="/docs/providers/aws/r/dx_connection_association.html">aws_dx_connection_association</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-resource-dx-gateway-association") %>>
+                            <a href="/docs/providers/aws/r/dx_gateway_association.html">aws_dx_gateway_association</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-resource-dx-lag") %>>
                             <a href="/docs/providers/aws/r/dx_lag.html">aws_dx_lag</a>
                         </li>

--- a/website/docs/r/dx_gateway_association.html.markdown
+++ b/website/docs/r/dx_gateway_association.html.markdown
@@ -1,0 +1,40 @@
+---
+layout: "aws"
+page_title: "AWS: aws_dx_gateway_association"
+sidebar_current: "docs-aws-resource-dx-gateway-association"
+description: |-
+  Associates a Direct Connect Gateway with a VGW.
+---
+
+# aws_dx_gateway_association
+
+Associates a Direct Connect Gateway with a VGW.
+
+## Example Usage
+
+```hcl
+resource "aws_dx_gateway" "example" {
+  name = "example"
+  amazon_side_asn = "64512"
+}
+
+resource "aws_vpc" "example" {
+  cidr_block = "10.255.255.0/28"
+}
+
+resource "aws_vpn_gateway" "example" {
+  vpc_id = "${aws_vpc.test.id}"
+}
+
+resource "aws_dx_gateway_association" "example" {
+  dx_gateway_id = "${aws_dx_gateway.example.id}"
+  virtual_gateway_id = "${aws_vpn_gateway.example.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `dx_gateway_id` - (Required) The ID of the Direct Connect Gateway.
+* `virtual_gateway_id` - (Required) The ID of the VGW with which to associate the gateway.


### PR DESCRIPTION
```
TF_ACC=1 go test ./aws/ -v -run=TestAccAwsDxGateway -timeout 120m
=== RUN   TestAccAwsDxGatewayAssociation_basic
--- PASS: TestAccAwsDxGatewayAssociation_basic (65.53s)
=== RUN   TestAccAwsDxGatewayAssociation_multiVgws
--- PASS: TestAccAwsDxGatewayAssociation_multiVgws (79.58s)
=== RUN   TestAccAwsDxGateway_basic
--- PASS: TestAccAwsDxGateway_basic (31.14s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	176.300s
```

This depends on #2861, but I have split it into separate PRs to ease review at the request of @Ninir. I have duplicated the acceptance test output above from that same PR as testing them independently is not possible (`aws_dx_gateway_association` depends on the resource `aws_dx_gateway` existing).