### PR TITLE
New resource: aws_cognito_user_pool_app_client

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -292,6 +292,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_cognito_identity_pool":                    resourceAwsCognitoIdentityPool(),
 			"aws_cognito_identity_pool_roles_attachment":   resourceAwsCognitoIdentityPoolRolesAttachment(),
 			"aws_cognito_user_pool":                        resourceAwsCognitoUserPool(),
+			"aws_cognito_user_pool_app_client":             resourceAwsCognitoUserPoolAppClient(),
 			"aws_cognito_user_pool_domain":                 resourceAwsCognitoUserPoolDomain(),
 			"aws_autoscaling_lifecycle_hook":               resourceAwsAutoscalingLifecycleHook(),
 			"aws_cloudwatch_metric_alarm":                  resourceAwsCloudWatchMetricAlarm(),

--- a/aws/resource_aws_cognito_user_pool_app_client.go
+++ b/aws/resource_aws_cognito_user_pool_app_client.go
@@ -1,0 +1,182 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/schema"
+	"log"
+)
+
+func resourceAwsCognitoUserPoolAppClient() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsCognitoUserPoolAppClientCreate,
+		Read:   resourceAwsCognitoUserPoolAppClientRead,
+		Update: resourceAwsCognitoUserPoolAppClientUpdate,
+		Delete: resourceAwsCognitoUserPoolAppClientDelete,
+
+		Schema: map[string]*schema.Schema{
+			"client_secret": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"generate_secret": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				// Check this
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"read_attributes": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"refresh_token_validity": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  30,
+			},
+			"user_pool_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"write_attributes": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsCognitoUserPoolAppClientCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cognitoidpconn
+
+	params := &cognitoidentityprovider.CreateUserPoolClientInput{
+		ClientName: aws.String(d.Get("name").(string)),
+		UserPoolId: aws.String(d.Get("user_pool_id").(string)),
+	}
+
+	if v, ok := d.GetOk("generate_secret"); ok {
+		params.GenerateSecret = aws.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOk("refresh_token_validity"); ok {
+		params.RefreshTokenValidity = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("read_attributes"); ok {
+		params.ReadAttributes = expandStringList(v.(*schema.Set).List())
+	}
+
+	if v, ok := d.GetOk("write_attributes"); ok {
+		params.WriteAttributes = expandStringList(v.(*schema.Set).List())
+	}
+
+	log.Printf("[DEBUG] Creating Cognito User Pool App Client: %s", params)
+
+	resp, err := conn.CreateUserPoolClient(params)
+	if err != nil {
+		return errwrap.Wrapf("Error creating Cognito User Pool App Client: {{err}}", err)
+	}
+
+	d.SetId(*resp.UserPoolClient.ClientId)
+
+	return resourceAwsCognitoUserPoolAppClientRead(d, meta)
+}
+
+func resourceAwsCognitoUserPoolAppClientRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cognitoidpconn
+
+	params := &cognitoidentityprovider.DescribeUserPoolClientInput{
+		ClientId:   aws.String(d.Id()),
+		UserPoolId: aws.String(d.Get("user_pool_id").(string)),
+	}
+
+	log.Printf("[DEBUG] Reading Cognito User Pool: %s", params)
+
+	resp, err := conn.DescribeUserPoolClient(params)
+	if err != nil {
+		return errwrap.Wrapf("Error reading Cognito User Pool App Client: {{err}}", err)
+	}
+
+	if resp.UserPoolClient.ClientSecret != nil {
+		d.Set("client_secret", *resp.UserPoolClient.ClientName)
+	}
+	if resp.UserPoolClient.RefreshTokenValidity != nil {
+		d.Set("refresh_token_validity", *resp.UserPoolClient.RefreshTokenValidity)
+	}
+	if resp.UserPoolClient.ReadAttributes != nil {
+		d.Set("read_attributes", flattenStringList(resp.UserPoolClient.ReadAttributes))
+	}
+	if resp.UserPoolClient.WriteAttributes != nil {
+		d.Set("write_attributes", flattenStringList(resp.UserPoolClient.WriteAttributes))
+	}
+
+	d.Set("name", *resp.UserPoolClient.ClientName)
+
+	return nil
+}
+
+func resourceAwsCognitoUserPoolAppClientUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cognitoidpconn
+
+	params := &cognitoidentityprovider.UpdateUserPoolClientInput{
+		ClientId:   aws.String(d.Id()),
+		UserPoolId: aws.String(d.Get("user_pool_id").(string)),
+	}
+
+	if d.HasChange("name") {
+		params.ClientName = aws.String(d.Get("name").(string))
+	}
+
+	if d.HasChange("refresh_token_validity") {
+		params.RefreshTokenValidity = aws.Int64(int64(d.Get("refresh_token_validity").(int)))
+	}
+
+	if d.HasChange("read_attributes") {
+		params.ReadAttributes = expandStringList(d.Get("read_attributes").(*schema.Set).List())
+	}
+
+	if d.HasChange("write_attributes") {
+		params.WriteAttributes = expandStringList(d.Get("write_attributes").(*schema.Set).List())
+	}
+
+	log.Printf("[DEBUG] Updating Cognito User Pool: %s", params)
+
+	_, err := conn.UpdateUserPoolClient(params)
+	if err != nil {
+		return errwrap.Wrapf("Error updating Cognito User Pool App Client: {{err}}", err)
+	}
+
+	return resourceAwsCognitoUserPoolAppClientRead(d, meta)
+}
+
+func resourceAwsCognitoUserPoolAppClientDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cognitoidpconn
+
+	params := &cognitoidentityprovider.DeleteUserPoolClientInput{
+		ClientId:   aws.String(d.Id()),
+		UserPoolId: aws.String(d.Get("user_pool_id").(string)),
+	}
+
+	log.Printf("[DEBUG] Deleting Cognito User Pool App Client: %s", params)
+
+	_, err := conn.DeleteUserPoolClient(params)
+
+	if err != nil {
+		return errwrap.Wrapf("Error deleting user pool App Client: {{err}}", err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_cognito_user_pool_app_client.go
+++ b/aws/resource_aws_cognito_user_pool_app_client.go
@@ -24,7 +24,6 @@ func resourceAwsCognitoUserPoolAppClient() *schema.Resource {
 			"generate_secret": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				// Check this
 				ForceNew: true,
 			},
 			"name": {

--- a/aws/resource_aws_cognito_user_pool_app_client.go
+++ b/aws/resource_aws_cognito_user_pool_app_client.go
@@ -112,17 +112,12 @@ func resourceAwsCognitoUserPoolAppClientRead(d *schema.ResourceData, meta interf
 	if resp.UserPoolClient.ClientSecret != nil {
 		d.Set("client_secret", *resp.UserPoolClient.ClientName)
 	}
-	if resp.UserPoolClient.RefreshTokenValidity != nil {
-		d.Set("refresh_token_validity", *resp.UserPoolClient.RefreshTokenValidity)
-	}
-	if resp.UserPoolClient.ReadAttributes != nil {
-		d.Set("read_attributes", flattenStringList(resp.UserPoolClient.ReadAttributes))
-	}
-	if resp.UserPoolClient.WriteAttributes != nil {
-		d.Set("write_attributes", flattenStringList(resp.UserPoolClient.WriteAttributes))
-	}
 
 	d.Set("name", *resp.UserPoolClient.ClientName)
+	d.Set("refresh_token_validity", *resp.UserPoolClient.RefreshTokenValidity)
+
+	d.Set("read_attributes", flattenStringList(resp.UserPoolClient.ReadAttributes))
+	d.Set("write_attributes", flattenStringList(resp.UserPoolClient.WriteAttributes))
 
 	return nil
 }
@@ -143,12 +138,12 @@ func resourceAwsCognitoUserPoolAppClientUpdate(d *schema.ResourceData, meta inte
 		params.RefreshTokenValidity = aws.Int64(int64(d.Get("refresh_token_validity").(int)))
 	}
 
-	if d.HasChange("read_attributes") {
-		params.ReadAttributes = expandStringList(d.Get("read_attributes").(*schema.Set).List())
+	if v, ok := d.GetOk("read_attributes"); ok {
+		params.ReadAttributes = expandStringList(v.(*schema.Set).List())
 	}
 
-	if d.HasChange("write_attributes") {
-		params.WriteAttributes = expandStringList(d.Get("write_attributes").(*schema.Set).List())
+	if v, ok := d.GetOk("write_attributes"); ok {
+		params.WriteAttributes = expandStringList(v.(*schema.Set).List())
 	}
 
 	log.Printf("[DEBUG] Updating Cognito User Pool: %s", params)

--- a/aws/resource_aws_cognito_user_pool_app_client_test.go
+++ b/aws/resource_aws_cognito_user_pool_app_client_test.go
@@ -1,0 +1,281 @@
+package aws
+
+import (
+	"errors"
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"testing"
+)
+
+func TestAccAWSCognitoUserPoolAppClient_basic(t *testing.T) {
+	name := acctest.RandString(5)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCognitoUserPoolAppClientDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCognitoUserPoolAppClientConfig_basic(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoUserPoolAppClientExists("aws_cognito_user_pool_app_client.basic"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_app_client.basic", "name", "terraform-test-pool-app-client-"+name),
+					resource.TestCheckNoResourceAttr("aws_cognito_user_pool_app_client.basic", "client_secret"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCognitoUserPoolAppClient_generate_secret(t *testing.T) {
+	name := acctest.RandString(5)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCognitoUserPoolAppClientDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCognitoUserPoolAppClientConfig_generate_secret(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoUserPoolAppClientExists("aws_cognito_user_pool_app_client.secret"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_app_client.secret", "name", "terraform-test-pool-app-client-"+name),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_app_client.secret", "generate_secret", "true"),
+					resource.TestCheckResourceAttrSet("aws_cognito_user_pool_app_client.secret", "client_secret"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCognitoUserPoolAppClient_complex(t *testing.T) {
+	name := acctest.RandString(5)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCognitoUserPoolAppClientDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCognitoUserPoolAppClientConfig_complex(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoUserPoolAppClientExists("aws_cognito_user_pool_app_client.complex"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_app_client.complex", "name", "terraform-test-pool-app-client-"+name),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_app_client.complex", "generate_secret", "false"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_app_client.complex", "refresh_token_validity", "7"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_app_client.complex", "read_attributes.881205744", "email"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_app_client.complex", "read_attributes.140932285", "email_verified"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_app_client.complex", "read_attributes.2318696674", "name"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_app_client.complex", "read_attributes.2135446866", "custom:foo"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_app_client.complex", "read_attributes.98075411", "custom:bar"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_app_client.complex", "write_attributes.881205744", "email"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_app_client.complex", "write_attributes.2318696674", "name"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_app_client.complex", "write_attributes.98075411", "custom:bar"),
+					resource.TestCheckNoResourceAttr("aws_cognito_user_pool_app_client.complex", "client_secret"),
+				),
+			},
+			{
+				Config: testAccAWSCognitoUserPoolAppClientConfig_complex_updated(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoUserPoolAppClientExists("aws_cognito_user_pool_app_client.complex"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_app_client.complex", "name", "terraform-test-pool-app-client-"+name),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_app_client.complex", "generate_secret", "false"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_app_client.complex", "refresh_token_validity", "15"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_app_client.complex", "read_attributes.881205744", "email"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_app_client.complex", "read_attributes.140932285", "email_verified"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_app_client.complex", "read_attributes.2318696674", "name"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_app_client.complex", "read_attributes.2090881135", "custom:foobar"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_app_client.complex", "write_attributes.881205744", "email"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_app_client.complex", "write_attributes.2318696674", "name"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_app_client.complex", "write_attributes.2090881135", "custom:foobar"),
+					resource.TestCheckNoResourceAttr("aws_cognito_user_pool_app_client.complex", "read_attributes.2135446866"),
+					resource.TestCheckNoResourceAttr("aws_cognito_user_pool_app_client.complex", "read_attributes.98075411"),
+					resource.TestCheckNoResourceAttr("aws_cognito_user_pool_app_client.complex", "write_attributes.98075411"),
+					resource.TestCheckNoResourceAttr("aws_cognito_user_pool_app_client.complex", "client_secret"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSCognitoUserPoolAppClientDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).cognitoidpconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_cognito_user_pool_app_client" {
+			continue
+		}
+
+		params := &cognitoidentityprovider.DescribeUserPoolClientInput{
+			ClientId:   aws.String(rs.Primary.ID),
+			UserPoolId: aws.String(rs.Primary.Attributes["user_pool_id"]),
+		}
+
+		_, err := conn.DescribeUserPoolClient(params)
+
+		if err != nil {
+			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "ResourceNotFoundException" {
+				return nil
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAWSCognitoUserPoolAppClientExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("No Cognito User Pool App Client ID set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).cognitoidpconn
+
+		params := &cognitoidentityprovider.DescribeUserPoolClientInput{
+			ClientId:   aws.String(rs.Primary.ID),
+			UserPoolId: aws.String(rs.Primary.Attributes["user_pool_id"]),
+		}
+
+		_, err := conn.DescribeUserPoolClient(params)
+
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+func testAccAWSCognitoUserPoolAppClientConfig_basic(name string) string {
+	return fmt.Sprintf(`
+resource "aws_cognito_user_pool" "pool" {
+  name = "terraform-test-pool-%s"
+}
+
+resource "aws_cognito_user_pool_app_client" "basic" {
+  name         = "terraform-test-pool-app-client-%s"
+  user_pool_id = "${aws_cognito_user_pool.pool.id}"
+}`, name, name)
+}
+
+func testAccAWSCognitoUserPoolAppClientConfig_generate_secret(name string) string {
+	return fmt.Sprintf(`
+resource "aws_cognito_user_pool" "pool" {
+  name = "terraform-test-pool-%s"
+}
+
+resource "aws_cognito_user_pool_app_client" "secret" {
+  name         = "terraform-test-pool-app-client-%s"
+  user_pool_id = "${aws_cognito_user_pool.pool.id}"
+
+  generate_secret = true
+}`, name, name)
+}
+
+func testAccAWSCognitoUserPoolAppClientConfig_complex(name string) string {
+	return fmt.Sprintf(`
+resource "aws_cognito_user_pool" "pool" {
+  name = "terraform-test-pool-%s"
+
+  schema {
+    attribute_data_type      = "String"
+    developer_only_attribute = false
+    mutable                  = false
+    name                     = "foo"
+    required                 = false
+  }
+
+  schema {
+    attribute_data_type      = "String"
+    developer_only_attribute = false
+    mutable                  = false
+    name                     = "bar"
+    required                 = false
+  }
+}
+
+resource "aws_cognito_user_pool_app_client" "complex" {
+  name         = "terraform-test-pool-app-client-%s"
+  user_pool_id = "${aws_cognito_user_pool.pool.id}"
+
+  generate_secret        = false
+  refresh_token_validity = 7
+
+  read_attributes = [
+    "email",
+    "email_verified",
+    "name",
+    "custom:foo",
+    "custom:bar",
+  ]
+
+  write_attributes = [
+    "email",
+    "name",
+    "custom:bar",
+  ]
+}`, name, name)
+}
+
+func testAccAWSCognitoUserPoolAppClientConfig_complex_updated(name string) string {
+	return fmt.Sprintf(`
+resource "aws_cognito_user_pool" "pool" {
+  name = "terraform-test-pool-%s"
+
+  schema {
+    attribute_data_type      = "String"
+    developer_only_attribute = false
+    mutable                  = false
+    name                     = "foo"
+    required                 = false
+  }
+
+  schema {
+    attribute_data_type      = "String"
+    developer_only_attribute = false
+    mutable                  = false
+    name                     = "bar"
+    required                 = false
+  }
+
+  schema {
+    attribute_data_type      = "String"
+    developer_only_attribute = false
+    mutable                  = false
+    name                     = "foobar"
+    required                 = false
+  }
+}
+
+resource "aws_cognito_user_pool_app_client" "complex" {
+  name         = "terraform-test-pool-app-client-%s"
+  user_pool_id = "${aws_cognito_user_pool.pool.id}"
+
+  generate_secret        = false
+  refresh_token_validity = 15
+
+  read_attributes = [
+    "email",
+    "email_verified",
+    "name",
+    "custom:foobar",
+  ]
+
+  write_attributes = [
+    "email",
+    "name",
+    "custom:foobar",
+  ]
+}`, name, name)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -487,6 +487,9 @@
                         <li<%= sidebar_current("docs-aws-resource-cognito-user-pool") %>>
                             <a href="/docs/providers/aws/r/cognito_user_pool.html">aws_cognito_user_pool</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-resource-cognito-user-pool-app-client") %>>
+                            <a href="/docs/providers/aws/r/cognito_user_pool.html">aws_cognito_user_pool_app_client</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-resource-cognito-user-pool-domain") %>>
                             <a href="/docs/providers/aws/r/cognito_user_pool_domain.html">aws_cognito_user_pool_domain</a>
                         </li>

--- a/website/docs/r/cognito_user_pool_app_client.markdown
+++ b/website/docs/r/cognito_user_pool_app_client.markdown
@@ -1,0 +1,104 @@
+---
+layout: "aws"
+page_title: "AWS: aws_cognito_user_pool_app-client"
+side_bar_current: "docs-aws-resource-cognito-user-pool-app-client"
+description: |-
+  Provides a Cognito User Pool App Client resource.
+---
+
+# aws_cognito_user_pool_app_client
+
+Provides a Cognito User Pool App Client resource.
+
+## Example Usage
+
+### Basic configuration
+
+```hcl
+data "aws_region" "current" {
+  current = true
+}
+
+resource "aws_cognito_user_pool" "user_pool" {
+  name = "my-user-pool"
+}
+
+resource "aws_cognito_user_pool_app_client" "app_client" {
+  name         = "my-user-pool-client"
+  user_pool_id = "${aws_cognito_user_pool.user_pool.id}"
+}
+
+resource "aws_cognito_identity_pool" "identity_pool" {
+  identity_pool_name               = "identitypool"
+  allow_unauthenticated_identities = true
+
+  cognito_identity_providers {
+    client_id               = "${aws_cognito_user_pool_app_client.app_client.id}"
+    provider_name           = "cognito-idp.${data.aws_region.current.name}.amazonaws.com/${aws_cognito_user_pool.user_pool.id}"
+    server_side_token_check = false
+  }
+}
+```
+
+### Setting attributes to be read and written by users
+
+```hcl
+resource "aws_cognito_user_pool" "user_pool" {
+  name = "my-user-pool"
+
+  schema {
+    attribute_data_type      = "String"
+    developer_only_attribute = false
+    mutable                  = false
+    name                     = "foo"
+    required                 = false
+  }
+
+  schema {
+    attribute_data_type      = "String"
+    developer_only_attribute = false
+    mutable                  = false
+    name                     = "bar"
+    required                 = false
+  }
+}
+
+resource "aws_cognito_user_pool_app_client" "app_client" {
+  name         = "my-user-pool-client"
+  user_pool_id = "${aws_cognito_user_pool.user_pool.id}"
+
+  generate_secret        = false
+  refresh_token_validity = 7
+
+  read_attributes = [
+    "email",
+    "email_verified",
+    "name",
+    "custom:foo",
+    "custom:bar",
+  ]
+
+  write_attributes = [
+    "email",
+    "name",
+    "custom:bar",
+  ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `generate_secret` - (Optional) Whether to generate a secret for the user pool app client.
+* `name` - (Required) The name of the user pool app client.
+* `refresh_token_validity` - (Optional) The time limit, in days, after which the refresh token is no longer valid and cannot be used.
+* `read_attributes` - (Optional) A list of attributes that users may read. Custom attributes defined in the user pool must be prefixed with `custom:`.
+* `write_attributes` - (Optional) A list of attributes that users may write. Custom attributes defined in the user pool must be prefixed with `custom:`.
+
+## Attribute Reference
+
+The following additional attributes are exported:
+
+* `id` - The id of the user pool app client.
+* `client_secret` - The user pool app client's secret. This is only exported if `generate_secret` is set to true.


### PR DESCRIPTION
Minimal Cognito User Pool App/Client resource.
Only implements generate_secret, refresh_token_validity and read/write_attributes so far.
All the Oauth stuff has been left for work at a later date.
  