### PR TITLE
provider: Fallback to session-derived credentials

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -265,16 +265,21 @@ func (c *Config) Client() (interface{}, error) {
 	cp, err := creds.Get()
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NoCredentialProviders" {
-			// If a profile wasn't specified then error out
-			if c.Profile == "" {
+			// The session may still be able to resolve credentials from shared config.
+			sess, err := session.NewSession()
+			if err != nil {
 				return nil, errors.New(`No valid credential sources found for AWS Provider.
   Please see https://terraform.io/docs/providers/aws/index.html for more information on
   providing credentials for the AWS Provider`)
 			}
-			// add the profile and enable share config file usage
-			log.Printf("[INFO] AWS Auth using Profile: %q", c.Profile)
-			opt.Profile = c.Profile
-			opt.SharedConfigState = session.SharedConfigEnable
+			_, err = sess.Config.Credentials.Get()
+			if err != nil {
+				return nil, errors.New(`No valid credential sources found for AWS Provider.
+  Please see https://terraform.io/docs/providers/aws/index.html for more information on
+  providing credentials for the AWS Provider`)
+			}
+			log.Printf("[INFO] Using session-derived AWS Auth")
+			opt.Config.Credentials = sess.Config.Credentials
 		} else {
 			return nil, fmt.Errorf("Error loading credentials for AWS Provider: %s", err)
 		}

--- a/aws/config.go
+++ b/aws/config.go
@@ -265,21 +265,27 @@ func (c *Config) Client() (interface{}, error) {
 	cp, err := creds.Get()
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NoCredentialProviders" {
-			// The session may still be able to resolve credentials from shared config.
-			sess, err := session.NewSession()
-			if err != nil {
-				return nil, errors.New(`No valid credential sources found for AWS Provider.
-  Please see https://terraform.io/docs/providers/aws/index.html for more information on
-  providing credentials for the AWS Provider`)
+			// If a profile wasn't specified, the session may still be able to resolve credentials from shared config.
+			if c.Profile == "" {
+				sess, err := session.NewSession()
+				if err != nil {
+					return nil, errors.New(`No valid credential sources found for AWS Provider.
+	Please see https://terraform.io/docs/providers/aws/index.html for more information on
+	providing credentials for the AWS Provider`)
+				}
+				_, err = sess.Config.Credentials.Get()
+				if err != nil {
+					return nil, errors.New(`No valid credential sources found for AWS Provider.
+	Please see https://terraform.io/docs/providers/aws/index.html for more information on
+	providing credentials for the AWS Provider`)
+				}
+				log.Printf("[INFO] Using session-derived AWS Auth")
+				opt.Config.Credentials = sess.Config.Credentials
+			} else {
+				log.Printf("[INFO] AWS Auth using Profile: %q", c.Profile)
+				opt.Profile = c.Profile
+				opt.SharedConfigState = session.SharedConfigEnable
 			}
-			_, err = sess.Config.Credentials.Get()
-			if err != nil {
-				return nil, errors.New(`No valid credential sources found for AWS Provider.
-  Please see https://terraform.io/docs/providers/aws/index.html for more information on
-  providing credentials for the AWS Provider`)
-			}
-			log.Printf("[INFO] Using session-derived AWS Auth")
-			opt.Config.Credentials = sess.Config.Credentials
 		} else {
 			return nil, fmt.Errorf("Error loading credentials for AWS Provider: %s", err)
 		}


### PR DESCRIPTION
#1608 allows for the session to figure out credentials by setting `opt.SharedConfigState = session.SharedConfigEnable` whenever the Profile is not empty.

This appropriately allows shared config (`~/.aws/config`) to work correctly (including using assumed roles) _iff_ the `profile` is set within the Terraform provider configuration.

This does **not** work correctly in the case of an assumed role when relying on environment variables `AWS_PROFILE` and `AWS_SDK_LOAD_CONFIG`.

This patch alters the behavior to the following:

- We still use the existing method of manually creating a credential chain and attempting to load credentials via a mix of explicit configuration and environment variables found in auth_helpers.go `GetCredentials`
- If this fails, we create a default session object and attempt to extract credentials from AWS credential code found in the session.  If this is successful, we use that credential.
- Otherwise, we bomb out with an error message.

I am a little worried that assumed role (or any form of temporary credential) does not seem to have the capability to auto-renew.  I'm not sure how much of a problem this is, as terraform plans are (generally) not long-lived processes.

This should effectively resolve #1184.
  
NOTE: we'll need to bump terraform proper (as in hashicorp/terraform#16661) again, if this PR is accepted/merged.