### PR TITLE
d/lb_listener: get listener from load balancer and listener port

### DIFF
--- a/aws/data_source_aws_lb_listener.go
+++ b/aws/data_source_aws_lb_listener.go
@@ -1,6 +1,13 @@
 package aws
 
-import "github.com/hashicorp/terraform/helper/schema"
+import (
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/hashicorp/terraform/helper/schema"
+)
 
 func dataSourceAwsLbListener() *schema.Resource {
 	return &schema.Resource{
@@ -8,17 +15,20 @@ func dataSourceAwsLbListener() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"arn": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"load_balancer_arn", "port"},
 			},
 
 			"load_balancer_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"arn"},
 			},
 			"port": {
-				Type:     schema.TypeInt,
-				Computed: true,
+				Type:          schema.TypeInt,
+				Optional:      true,
+				ConflictsWith: []string{"arn"},
 			},
 
 			"protocol": {
@@ -57,6 +67,34 @@ func dataSourceAwsLbListener() *schema.Resource {
 }
 
 func dataSourceAwsLbListenerRead(d *schema.ResourceData, meta interface{}) error {
-	d.SetId(d.Get("arn").(string))
-	return resourceAwsLbListenerRead(d, meta)
+	if _, ok := d.GetOk("arn"); ok {
+		d.SetId(d.Get("arn").(string))
+		//log.Printf("[DEBUG] read listener %s", d.Get("arn").(string))
+		return resourceAwsLbListenerRead(d, meta)
+	}
+
+	conn := meta.(*AWSClient).elbv2conn
+	lbArn, lbOk := d.GetOk("load_balancer_arn")
+	port, portOk := d.GetOk("port")
+	if !lbOk || !portOk {
+		return errors.New("both load_balancer_arn and port must be set")
+	}
+	resp, err := conn.DescribeListeners(&elbv2.DescribeListenersInput{
+		LoadBalancerArn: aws.String(lbArn.(string)),
+	})
+	if err != nil {
+		return err
+	}
+	if len(resp.Listeners) == 0 {
+		return fmt.Errorf("[DEBUG] no listener exists for load balancer: %s", lbArn)
+	}
+	for _, listener := range resp.Listeners {
+		if *listener.Port == int64(port.(int)) {
+			//log.Printf("[DEBUG] get listener arn for %s:%s: %s", lbArn, port, *listener.Port)
+			d.SetId(*listener.ListenerArn)
+			return resourceAwsLbListenerRead(d, meta)
+		}
+	}
+
+	return errors.New("failed to get listener arn with given arguments")
 }

--- a/aws/data_source_aws_lb_listener_test.go
+++ b/aws/data_source_aws_lb_listener_test.go
@@ -23,11 +23,18 @@ func TestAccDataSourceAWSLBListener_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.aws_lb_listener.front_end", "load_balancer_arn"),
 					resource.TestCheckResourceAttrSet("data.aws_lb_listener.front_end", "arn"),
+					resource.TestCheckResourceAttrSet("data.aws_lb_listener.front_end", "default_action.0.target_group_arn"),
 					resource.TestCheckResourceAttr("data.aws_lb_listener.front_end", "protocol", "HTTP"),
 					resource.TestCheckResourceAttr("data.aws_lb_listener.front_end", "port", "80"),
 					resource.TestCheckResourceAttr("data.aws_lb_listener.front_end", "default_action.#", "1"),
 					resource.TestCheckResourceAttr("data.aws_lb_listener.front_end", "default_action.0.type", "forward"),
-					resource.TestCheckResourceAttrSet("data.aws_lb_listener.front_end", "default_action.0.target_group_arn"),
+					resource.TestCheckResourceAttrSet("data.aws_lb_listener.from_lb_and_port", "load_balancer_arn"),
+					resource.TestCheckResourceAttrSet("data.aws_lb_listener.from_lb_and_port", "arn"),
+					resource.TestCheckResourceAttrSet("data.aws_lb_listener.from_lb_and_port", "default_action.0.target_group_arn"),
+					resource.TestCheckResourceAttr("data.aws_lb_listener.from_lb_and_port", "protocol", "HTTP"),
+					resource.TestCheckResourceAttr("data.aws_lb_listener.from_lb_and_port", "port", "80"),
+					resource.TestCheckResourceAttr("data.aws_lb_listener.from_lb_and_port", "default_action.#", "1"),
+					resource.TestCheckResourceAttr("data.aws_lb_listener.from_lb_and_port", "default_action.0.type", "forward"),
 				),
 			},
 		},
@@ -47,11 +54,18 @@ func TestAccDataSourceAWSLBListenerBackwardsCompatibility(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.aws_alb_listener.front_end", "load_balancer_arn"),
 					resource.TestCheckResourceAttrSet("data.aws_alb_listener.front_end", "arn"),
+					resource.TestCheckResourceAttrSet("data.aws_alb_listener.front_end", "default_action.0.target_group_arn"),
 					resource.TestCheckResourceAttr("data.aws_alb_listener.front_end", "protocol", "HTTP"),
 					resource.TestCheckResourceAttr("data.aws_alb_listener.front_end", "port", "80"),
 					resource.TestCheckResourceAttr("data.aws_alb_listener.front_end", "default_action.#", "1"),
 					resource.TestCheckResourceAttr("data.aws_alb_listener.front_end", "default_action.0.type", "forward"),
-					resource.TestCheckResourceAttrSet("data.aws_alb_listener.front_end", "default_action.0.target_group_arn"),
+					resource.TestCheckResourceAttrSet("data.aws_alb_listener.from_lb_and_port", "load_balancer_arn"),
+					resource.TestCheckResourceAttrSet("data.aws_alb_listener.from_lb_and_port", "arn"),
+					resource.TestCheckResourceAttrSet("data.aws_alb_listener.from_lb_and_port", "default_action.0.target_group_arn"),
+					resource.TestCheckResourceAttr("data.aws_alb_listener.from_lb_and_port", "protocol", "HTTP"),
+					resource.TestCheckResourceAttr("data.aws_alb_listener.from_lb_and_port", "port", "80"),
+					resource.TestCheckResourceAttr("data.aws_alb_listener.from_lb_and_port", "default_action.#", "1"),
+					resource.TestCheckResourceAttr("data.aws_alb_listener.from_lb_and_port", "default_action.0.type", "forward"),
 				),
 			},
 		},
@@ -71,13 +85,22 @@ func TestAccDataSourceAWSLBListener_https(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.aws_lb_listener.front_end", "load_balancer_arn"),
 					resource.TestCheckResourceAttrSet("data.aws_lb_listener.front_end", "arn"),
+					resource.TestCheckResourceAttrSet("data.aws_lb_listener.front_end", "default_action.0.target_group_arn"),
+					resource.TestCheckResourceAttrSet("data.aws_lb_listener.front_end", "certificate_arn"),
 					resource.TestCheckResourceAttr("data.aws_lb_listener.front_end", "protocol", "HTTPS"),
 					resource.TestCheckResourceAttr("data.aws_lb_listener.front_end", "port", "443"),
 					resource.TestCheckResourceAttr("data.aws_lb_listener.front_end", "default_action.#", "1"),
 					resource.TestCheckResourceAttr("data.aws_lb_listener.front_end", "default_action.0.type", "forward"),
-					resource.TestCheckResourceAttrSet("data.aws_lb_listener.front_end", "default_action.0.target_group_arn"),
-					resource.TestCheckResourceAttrSet("data.aws_lb_listener.front_end", "certificate_arn"),
 					resource.TestCheckResourceAttr("data.aws_lb_listener.front_end", "ssl_policy", "ELBSecurityPolicy-2015-05"),
+					resource.TestCheckResourceAttrSet("data.aws_lb_listener.from_lb_and_port", "load_balancer_arn"),
+					resource.TestCheckResourceAttrSet("data.aws_lb_listener.from_lb_and_port", "arn"),
+					resource.TestCheckResourceAttrSet("data.aws_lb_listener.from_lb_and_port", "default_action.0.target_group_arn"),
+					resource.TestCheckResourceAttrSet("data.aws_lb_listener.from_lb_and_port", "certificate_arn"),
+					resource.TestCheckResourceAttr("data.aws_lb_listener.from_lb_and_port", "protocol", "HTTPS"),
+					resource.TestCheckResourceAttr("data.aws_lb_listener.from_lb_and_port", "port", "443"),
+					resource.TestCheckResourceAttr("data.aws_lb_listener.from_lb_and_port", "default_action.#", "1"),
+					resource.TestCheckResourceAttr("data.aws_lb_listener.from_lb_and_port", "default_action.0.type", "forward"),
+					resource.TestCheckResourceAttr("data.aws_lb_listener.from_lb_and_port", "ssl_policy", "ELBSecurityPolicy-2015-05"),
 				),
 			},
 		},
@@ -85,15 +108,16 @@ func TestAccDataSourceAWSLBListener_https(t *testing.T) {
 }
 
 func testAccDataSourceAWSLBListenerConfigBasic(lbName, targetGroupName string) string {
-	return fmt.Sprintf(`resource "aws_lb_listener" "front_end" {
-   load_balancer_arn = "${aws_lb.alb_test.id}"
-   protocol = "HTTP"
-   port = "80"
+	return fmt.Sprintf(`
+resource "aws_lb_listener" "front_end" {
+  load_balancer_arn = "${aws_lb.alb_test.id}"
+  protocol          = "HTTP"
+  port              = "80"
 
-   default_action {
-     target_group_arn = "${aws_lb_target_group.test.id}"
-     type = "forward"
-   }
+  default_action {
+    target_group_arn = "${aws_lb_target_group.test.id}"
+    type             = "forward"
+  }
 }
 
 resource "aws_lb" "alb_test" {
@@ -102,7 +126,7 @@ resource "aws_lb" "alb_test" {
   security_groups = ["${aws_security_group.alb_test.id}"]
   subnets         = ["${aws_subnet.alb_test.*.id}"]
 
-  idle_timeout = 30
+  idle_timeout               = 30
   enable_deletion_protection = false
 
   tags {
@@ -111,20 +135,20 @@ resource "aws_lb" "alb_test" {
 }
 
 resource "aws_lb_target_group" "test" {
-  name = "%s"
-  port = 8080
+  name     = "%s"
+  port     = 8080
   protocol = "HTTP"
-  vpc_id = "${aws_vpc.alb_test.id}"
+  vpc_id   = "${aws_vpc.alb_test.id}"
 
   health_check {
-    path = "/health"
-    interval = 60
-    port = 8081
-    protocol = "HTTP"
-    timeout = 3
-    healthy_threshold = 3
+    path                = "/health"
+    interval            = 60
+    port                = 8081
+    protocol            = "HTTP"
+    timeout             = 3
+    healthy_threshold   = 3
     unhealthy_threshold = 3
-    matcher = "200-299"
+    matcher             = "200-299"
   }
 }
 
@@ -180,20 +204,27 @@ resource "aws_security_group" "alb_test" {
 }
 
 data "aws_lb_listener" "front_end" {
-	arn = "${aws_lb_listener.front_end.arn}"
-}`, lbName, targetGroupName)
+  arn = "${aws_lb_listener.front_end.arn}"
+}
+
+data "aws_lb_listener" "from_lb_and_port" {
+  load_balancer_arn = "${aws_lb.alb_test.arn}"
+  port              = "${aws_lb_listener.front_end.port}"
+}
+`, lbName, targetGroupName)
 }
 
 func testAccDataSourceAWSLBListenerConfigBackwardsCompatibility(lbName, targetGroupName string) string {
-	return fmt.Sprintf(`resource "aws_alb_listener" "front_end" {
-   load_balancer_arn = "${aws_alb.alb_test.id}"
-   protocol = "HTTP"
-   port = "80"
+	return fmt.Sprintf(`
+resource "aws_alb_listener" "front_end" {
+  load_balancer_arn = "${aws_alb.alb_test.id}"
+  protocol          = "HTTP"
+  port              = "80"
 
-   default_action {
-     target_group_arn = "${aws_alb_target_group.test.id}"
-     type = "forward"
-   }
+  default_action {
+    target_group_arn = "${aws_alb_target_group.test.id}"
+    type             = "forward"
+  }
 }
 
 resource "aws_alb" "alb_test" {
@@ -202,7 +233,7 @@ resource "aws_alb" "alb_test" {
   security_groups = ["${aws_security_group.alb_test.id}"]
   subnets         = ["${aws_subnet.alb_test.*.id}"]
 
-  idle_timeout = 30
+  idle_timeout               = 30
   enable_deletion_protection = false
 
   tags {
@@ -211,20 +242,20 @@ resource "aws_alb" "alb_test" {
 }
 
 resource "aws_alb_target_group" "test" {
-  name = "%s"
-  port = 8080
+  name     = "%s"
+  port     = 8080
   protocol = "HTTP"
-  vpc_id = "${aws_vpc.alb_test.id}"
+  vpc_id   = "${aws_vpc.alb_test.id}"
 
   health_check {
-    path = "/health"
-    interval = 60
-    port = 8081
-    protocol = "HTTP"
-    timeout = 3
-    healthy_threshold = 3
+    path                = "/health"
+    interval            = 60
+    port                = 8081
+    protocol            = "HTTP"
+    timeout             = 3
+    healthy_threshold   = 3
     unhealthy_threshold = 3
-    matcher = "200-299"
+    matcher             = "200-299"
   }
 }
 
@@ -280,22 +311,28 @@ resource "aws_security_group" "alb_test" {
 }
 
 data "aws_alb_listener" "front_end" {
-	arn = "${aws_alb_listener.front_end.arn}"
+  arn = "${aws_alb_listener.front_end.arn}"
+}
+
+data "aws_alb_listener" "from_lb_and_port" {
+  load_balancer_arn = "${aws_alb.alb_test.arn}"
+  port              = "${aws_alb_listener.front_end.port}"
 }`, lbName, targetGroupName)
 }
 
 func testAccDataSourceAWSLBListenerConfigHTTPS(lbName, targetGroupName string) string {
-	return fmt.Sprintf(`resource "aws_lb_listener" "front_end" {
-   load_balancer_arn = "${aws_lb.alb_test.id}"
-   protocol = "HTTPS"
-   port = "443"
-   ssl_policy = "ELBSecurityPolicy-2015-05"
-   certificate_arn = "${aws_iam_server_certificate.test_cert.arn}"
+	return fmt.Sprintf(`
+resource "aws_lb_listener" "front_end" {
+  load_balancer_arn = "${aws_lb.alb_test.id}"
+  protocol          = "HTTPS"
+  port              = "443"
+  ssl_policy        = "ELBSecurityPolicy-2015-05"
+  certificate_arn   = "${aws_iam_server_certificate.test_cert.arn}"
 
-   default_action {
-     target_group_arn = "${aws_lb_target_group.test.id}"
-     type = "forward"
-   }
+  default_action {
+    target_group_arn = "${aws_lb_target_group.test.id}"
+    type             = "forward"
+  }
 }
 
 resource "aws_lb" "alb_test" {
@@ -304,7 +341,7 @@ resource "aws_lb" "alb_test" {
   security_groups = ["${aws_security_group.alb_test.id}"]
   subnets         = ["${aws_subnet.alb_test.*.id}"]
 
-  idle_timeout = 30
+  idle_timeout               = 30
   enable_deletion_protection = false
 
   tags {
@@ -313,20 +350,20 @@ resource "aws_lb" "alb_test" {
 }
 
 resource "aws_lb_target_group" "test" {
-  name = "%s"
-  port = 8080
+  name     = "%s"
+  port     = 8080
   protocol = "HTTP"
-  vpc_id = "${aws_vpc.alb_test.id}"
+  vpc_id   = "${aws_vpc.alb_test.id}"
 
   health_check {
-    path = "/health"
-    interval = 60
-    port = 8081
-    protocol = "HTTP"
-    timeout = 3
-    healthy_threshold = 3
+    path                = "/health"
+    interval            = 60
+    port                = 8081
+    protocol            = "HTTP"
+    timeout             = 3
+    healthy_threshold   = 3
     unhealthy_threshold = 3
-    matcher = "200-299"
+    matcher             = "200-299"
   }
 }
 
@@ -346,11 +383,11 @@ resource "aws_vpc" "alb_test" {
 }
 
 resource "aws_internet_gateway" "gw" {
-    vpc_id = "${aws_vpc.alb_test.id}"
+  vpc_id = "${aws_vpc.alb_test.id}"
 
-    tags {
-        TestName = "TestAccAWSALB_basic"
-    }
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
 }
 
 resource "aws_subnet" "alb_test" {
@@ -390,7 +427,7 @@ resource "aws_security_group" "alb_test" {
 }
 
 resource "aws_iam_server_certificate" "test_cert" {
-  name = "terraform-test-cert-%d"
+  name             = "terraform-test-cert-%d"
   certificate_body = "${tls_self_signed_cert.example.cert_pem}"
   private_key      = "${tls_private_key.example.private_key_pem}"
 }
@@ -418,6 +455,11 @@ resource "tls_self_signed_cert" "example" {
 }
 
 data "aws_lb_listener" "front_end" {
-	arn = "${aws_lb_listener.front_end.arn}"
+  arn = "${aws_lb_listener.front_end.arn}"
+}
+
+data "aws_lb_listener" "from_lb_and_port" {
+  load_balancer_arn = "${aws_lb.alb_test.arn}"
+  port              = "${aws_lb_listener.front_end.port}"
 }`, lbName, targetGroupName, rand.New(rand.NewSource(time.Now().UnixNano())).Int())
 }

--- a/website/docs/d/lb_listener.html.markdown
+++ b/website/docs/d/lb_listener.html.markdown
@@ -19,6 +19,8 @@ information specific to the listener in question.
 ## Example Usage
 
 ```hcl
+# get listener from listener arn
+
 variable "listener_arn" {
   type = "string"
 }
@@ -26,13 +28,26 @@ variable "listener_arn" {
 data "aws_lb_listener" "listener" {
   arn = "${var.listener_arn}"
 }
+
+# get listener from load_balancer_arn and port
+
+data "aws_lb" "selected" {
+  name = "default-public"
+}
+
+data "aws_lb_listener" "selected443" {
+  load_balancer_arn = "${data.aws_lb.selected.arn}"
+  port = 443
+}
 ```
 
 ## Argument Reference
 
 The following arguments are supported:
 
-* `arn` - (Required) The ARN of the listener.
+* `arn` - (Optional) The arn of the listener. Required if `load_balancer_arn` and `port` is not set.
+* `load_balancer_arn` - (Optional) The arn of the load balander. Required if `arn` is not set.
+* `port` - (Optional) The port of the listener. Required if `arn` is not set.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Attempt to fix #2885 

The code itself works as I wanted but help is needed with acceptance test.

I added a few tests and data sources with arguments of `load_balancer_arn` and `port` but got complains. It seems like the new data source was not created. I'm not sure if I missed anything.

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccDataSourceAWSLBListener_basic -timeout 120m
=== RUN   TestAccDataSourceAWSLBListener_basic
--- FAIL: TestAccDataSourceAWSLBListener_basic (298.25s)
	testing.go:503: Step 0 error: After applying this step and refreshing, the plan was not empty:

		DIFF:

		CREATE: data.aws_lb_listener.from_lb_and_port
		  certificate_arn:   "" => "<computed>"
		  default_action.#:  "" => "<computed>"
		  load_balancer_arn: "" => "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/testlistener-basic-caq0p2ni9w7t6/7ff6e128ac7481fb"
		  port:              "" => "80"
		  protocol:          "" => "<computed>"
		  ssl_policy:        "" => "<computed>"

		STATE:

		aws_lb.alb_test:
		  ID = arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/testlistener-basic-caq0p2ni9w7t6/7ff6e128ac7481fb
		  access_logs.# = 0
		  arn = arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/testlistener-basic-caq0p2ni9w7t6/7ff6e128ac7481fb
		  arn_suffix = app/testlistener-basic-caq0p2ni9w7t6/7ff6e128ac7481fb
		  dns_name = internal-testlistener-basic-caq0p2ni9w7t6-158504234.us-west-2.elb.amazonaws.com
		  enable_deletion_protection = false
		  idle_timeout = 30
		  internal = true
		  ip_address_type = ipv4
		  load_balancer_type = application
		  name = testlistener-basic-caq0p2ni9w7t6
		  security_groups.# = 1
		  security_groups.3305298391 = sg-971a3feb
		  subnets.# = 2
		  subnets.13837635 = subnet-d3022a9b
		  subnets.2632197195 = subnet-dda3aabb
		  tags.% = 1
		  tags.TestName = TestAccAWSALB_basic
		  vpc_id = vpc-cca76fb5
		  zone_id = Z1H1FL5HABSF5

		  Dependencies:
		    aws_security_group.alb_test
		    aws_subnet.alb_test.*
		aws_lb_listener.front_end:
		  ID = arn:aws:elasticloadbalancing:us-west-2:123456789012:listener/app/testlistener-basic-caq0p2ni9w7t6/7ff6e128ac7481fb/9fc3720c0e60225b
		  arn = arn:aws:elasticloadbalancing:us-west-2:123456789012:listener/app/testlistener-basic-caq0p2ni9w7t6/7ff6e128ac7481fb/9fc3720c0e60225b
		  default_action.# = 1
		  default_action.0.target_group_arn = arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/testtargetgroup-b2pysi8cr0/15b98e136e37e60f
		  default_action.0.type = forward
		  load_balancer_arn = arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/testlistener-basic-caq0p2ni9w7t6/7ff6e128ac7481fb
		  port = 80
		  protocol = HTTP
		  ssl_policy =

		  Dependencies:
		    aws_lb.alb_test
		    aws_lb_target_group.test
		aws_lb_target_group.test:
		  ID = arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/testtargetgroup-b2pysi8cr0/15b98e136e37e60f
		  arn = arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/testtargetgroup-b2pysi8cr0/15b98e136e37e60f
		  arn_suffix = targetgroup/testtargetgroup-b2pysi8cr0/15b98e136e37e60f
		  deregistration_delay = 300
		  health_check.# = 1
		  health_check.0.healthy_threshold = 3
		  health_check.0.interval = 60
		  health_check.0.matcher = 200-299
		  health_check.0.path = /health
		  health_check.0.port = 8081
		  health_check.0.protocol = HTTP
		  health_check.0.timeout = 3
		  health_check.0.unhealthy_threshold = 3
		  name = testtargetgroup-b2pysi8cr0
		  port = 8080
		  protocol = HTTP
		  stickiness.# = 1
		  stickiness.0.cookie_duration = 86400
		  stickiness.0.enabled = false
		  stickiness.0.type = lb_cookie
		  tags.% = 0
		  target_type = instance
		  vpc_id = vpc-cca76fb5

		  Dependencies:
		    aws_vpc.alb_test
		aws_security_group.alb_test:
		  ID = sg-971a3feb
		  description = Used for ALB Testing
		  egress.# = 1
		  egress.482069346.cidr_blocks.# = 1
		  egress.482069346.cidr_blocks.0 = 0.0.0.0/0
		  egress.482069346.description =
		  egress.482069346.from_port = 0
		  egress.482069346.ipv6_cidr_blocks.# = 0
		  egress.482069346.prefix_list_ids.# = 0
		  egress.482069346.protocol = -1
		  egress.482069346.security_groups.# = 0
		  egress.482069346.self = false
		  egress.482069346.to_port = 0
		  ingress.# = 1
		  ingress.482069346.cidr_blocks.# = 1
		  ingress.482069346.cidr_blocks.0 = 0.0.0.0/0
		  ingress.482069346.description =
		  ingress.482069346.from_port = 0
		  ingress.482069346.ipv6_cidr_blocks.# = 0
		  ingress.482069346.protocol = -1
		  ingress.482069346.security_groups.# = 0
		  ingress.482069346.self = false
		  ingress.482069346.to_port = 0
		  name = allow_all_alb_test
		  owner_id = 123456789012
		  revoke_rules_on_delete = false
		  tags.% = 1
		  tags.TestName = TestAccAWSALB_basic
		  vpc_id = vpc-cca76fb5

		  Dependencies:
		    aws_vpc.alb_test
		aws_subnet.alb_test.0:
		  ID = subnet-d3022a9b
		  assign_ipv6_address_on_creation = false
		  availability_zone = us-west-2a
		  cidr_block = 10.0.1.0/24
		  map_public_ip_on_launch = true
		  tags.% = 1
		  tags.TestName = TestAccAWSALB_basic
		  vpc_id = vpc-cca76fb5

		  Dependencies:
		    aws_vpc.alb_test
		    data.aws_availability_zones.available
		aws_subnet.alb_test.1:
		  ID = subnet-dda3aabb
		  assign_ipv6_address_on_creation = false
		  availability_zone = us-west-2b
		  cidr_block = 10.0.2.0/24
		  map_public_ip_on_launch = true
		  tags.% = 1
		  tags.TestName = TestAccAWSALB_basic
		  vpc_id = vpc-cca76fb5

		  Dependencies:
		    aws_vpc.alb_test
		    data.aws_availability_zones.available
		aws_vpc.alb_test:
		  ID = vpc-cca76fb5
		  assign_generated_ipv6_cidr_block = false
		  cidr_block = 10.0.0.0/16
		  default_network_acl_id = acl-1215516b
		  default_route_table_id = rtb-0cc02474
		  default_security_group_id = sg-44e5c038
		  dhcp_options_id = dopt-30a2c254
		  enable_classiclink = false
		  enable_classiclink_dns_support = false
		  enable_dns_hostnames = false
		  enable_dns_support = true
		  instance_tenancy = default
		  main_route_table_id = rtb-0cc02474
		  tags.% = 1
		  tags.TestName = TestAccAWSALB_basic
		data.aws_availability_zones.available:
		  ID = 2018-01-06 19:07:56.409056 +0000 UTC
		  names.# = 3
		  names.0 = us-west-2a
		  names.1 = us-west-2b
		  names.2 = us-west-2c
		data.aws_lb_listener.front_end:
		  ID = arn:aws:elasticloadbalancing:us-west-2:123456789012:listener/app/testlistener-basic-caq0p2ni9w7t6/7ff6e128ac7481fb/9fc3720c0e60225b
		  arn = arn:aws:elasticloadbalancing:us-west-2:123456789012:listener/app/testlistener-basic-caq0p2ni9w7t6/7ff6e128ac7481fb/9fc3720c0e60225b
		  default_action.# = 1
		  default_action.0.target_group_arn = arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/testtargetgroup-b2pysi8cr0/15b98e136e37e60f
		  default_action.0.type = forward
		  load_balancer_arn = arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/testlistener-basic-caq0p2ni9w7t6/7ff6e128ac7481fb
		  port = 80
		  protocol = HTTP
		  ssl_policy =

		  Dependencies:
		    aws_lb_listener.front_end
FAIL
exit status 1
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	298.309s
make: *** [testacc] Error 1
```
  