### PR TITLE
New Resource: aws_cloudwatch_event_permission

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -276,6 +276,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_cloudfront_distribution":                  resourceAwsCloudFrontDistribution(),
 			"aws_cloudfront_origin_access_identity":        resourceAwsCloudFrontOriginAccessIdentity(),
 			"aws_cloudtrail":                               resourceAwsCloudTrail(),
+			"aws_cloudwatch_event_permission":              resourceAwsCloudWatchEventPermission(),
 			"aws_cloudwatch_event_rule":                    resourceAwsCloudWatchEventRule(),
 			"aws_cloudwatch_event_target":                  resourceAwsCloudWatchEventTarget(),
 			"aws_cloudwatch_log_destination":               resourceAwsCloudWatchLogDestination(),

--- a/aws/resource_aws_cloudwatch_event_permission.go
+++ b/aws/resource_aws_cloudwatch_event_permission.go
@@ -1,0 +1,218 @@
+package aws
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"regexp"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	events "github.com/aws/aws-sdk-go/service/cloudwatchevents"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsCloudWatchEventPermission() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsCloudWatchEventPermissionCreate,
+		Read:   resourceAwsCloudWatchEventPermissionRead,
+		Update: resourceAwsCloudWatchEventPermissionUpdate,
+		Delete: resourceAwsCloudWatchEventPermissionDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"action": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "events:PutEvents",
+				ValidateFunc: validateCloudWatchEventPermissionAction,
+			},
+			"principal": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateCloudWatchEventPermissionPrincipal,
+			},
+			"statement_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateCloudWatchEventPermissionStatementID,
+			},
+		},
+	}
+}
+
+func resourceAwsCloudWatchEventPermissionCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudwatcheventsconn
+
+	statementID := d.Get("statement_id").(string)
+
+	input := events.PutPermissionInput{
+		Action:      aws.String(d.Get("action").(string)),
+		Principal:   aws.String(d.Get("principal").(string)),
+		StatementId: aws.String(statementID),
+	}
+
+	log.Printf("[DEBUG] Creating CloudWatch Events permission: %s", input)
+	_, err := conn.PutPermission(&input)
+	if err != nil {
+		return fmt.Errorf("Creating CloudWatch Events permission failed: %s", err.Error())
+	}
+
+	d.SetId(statementID)
+
+	return resourceAwsCloudWatchEventPermissionRead(d, meta)
+}
+
+// See also: https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_DescribeEventBus.html
+func resourceAwsCloudWatchEventPermissionRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudwatcheventsconn
+	input := events.DescribeEventBusInput{}
+	var policyDoc CloudWatchEventPermissionPolicyDoc
+	var policyStatement *CloudWatchEventPermissionPolicyStatement
+
+	// Especially with concurrent PutPermission calls there can be a slight delay
+	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+		log.Printf("[DEBUG] Reading CloudWatch Events bus: %s", input)
+		debo, err := conn.DescribeEventBus(&input)
+		if err != nil {
+			return resource.NonRetryableError(fmt.Errorf("Reading CloudWatch Events permission '%s' failed: %s", d.Id(), err.Error()))
+		}
+
+		if debo.Policy == nil {
+			return resource.RetryableError(fmt.Errorf("CloudWatch Events permission %q not found", d.Id()))
+		}
+
+		err = json.Unmarshal([]byte(*debo.Policy), &policyDoc)
+		if err != nil {
+			return resource.NonRetryableError(fmt.Errorf("Reading CloudWatch Events permission '%s' failed: %s", d.Id(), err.Error()))
+		}
+
+		for _, statement := range policyDoc.Statements {
+			if statement.Sid == d.Id() {
+				policyStatement = &statement
+				return nil
+			}
+		}
+		if policyStatement == nil {
+			return resource.RetryableError(fmt.Errorf("CloudWatch Events permission %q not found", d.Id()))
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if policyStatement == nil {
+		log.Printf("[WARN] CloudWatch Events permission %q not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("action", policyStatement.Action)
+
+	principalString, ok := policyStatement.Principal.(string)
+	if ok && (principalString == "*") {
+		d.Set("principal", "*")
+	} else {
+		principalMap := policyStatement.Principal.(map[string]interface{})
+		policyARN, err := arn.Parse(principalMap["AWS"].(string))
+		if err != nil {
+			return fmt.Errorf("Reading CloudWatch Events permission '%s' failed: %s", d.Id(), err.Error())
+		}
+		d.Set("principal", policyARN.AccountID)
+	}
+	d.Set("statement_id", policyStatement.Sid)
+
+	return nil
+}
+
+func resourceAwsCloudWatchEventPermissionUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudwatcheventsconn
+
+	input := events.PutPermissionInput{
+		Action:      aws.String(d.Get("action").(string)),
+		Principal:   aws.String(d.Get("principal").(string)),
+		StatementId: aws.String(d.Get("statement_id").(string)),
+	}
+
+	log.Printf("[DEBUG] Update CloudWatch Events permission: %s", input)
+	_, err := conn.PutPermission(&input)
+	if err != nil {
+		return fmt.Errorf("Updating CloudWatch Events permission '%s' failed: %s", d.Id(), err.Error())
+	}
+
+	return resourceAwsCloudWatchEventPermissionRead(d, meta)
+}
+
+func resourceAwsCloudWatchEventPermissionDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudwatcheventsconn
+	input := events.RemovePermissionInput{
+		StatementId: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Delete CloudWatch Events permission: %s", input)
+	_, err := conn.RemovePermission(&input)
+	if err != nil {
+		return fmt.Errorf("Deleting CloudWatch Events permission '%s' failed: %s", d.Id(), err.Error())
+	}
+	return nil
+}
+
+// https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_PutPermission.html#API_PutPermission_RequestParameters
+func validateCloudWatchEventPermissionAction(v interface{}, k string) (ws []string, es []error) {
+	value := v.(string)
+	if (len(value) < 1) || (len(value) > 64) {
+		es = append(es, fmt.Errorf("%q must be between 1 and 64 characters", k))
+	}
+
+	if !regexp.MustCompile(`^events:[a-zA-Z]+$`).MatchString(value) {
+		es = append(es, fmt.Errorf("%q must be: events: followed by one or more alphabetic characters", k))
+	}
+	return
+}
+
+// https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_PutPermission.html#API_PutPermission_RequestParameters
+func validateCloudWatchEventPermissionPrincipal(v interface{}, k string) (ws []string, es []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^(\d{12}|\*)$`).MatchString(value) {
+		es = append(es, fmt.Errorf("%q must be * or a 12 digit AWS account ID", k))
+	}
+	return
+}
+
+// https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_PutPermission.html#API_PutPermission_RequestParameters
+func validateCloudWatchEventPermissionStatementID(v interface{}, k string) (ws []string, es []error) {
+	value := v.(string)
+	if (len(value) < 1) || (len(value) > 64) {
+		es = append(es, fmt.Errorf("%q must be between 1 and 64 characters", k))
+	}
+
+	if !regexp.MustCompile(`^[a-zA-Z0-9-_]+$`).MatchString(value) {
+		es = append(es, fmt.Errorf("%q must be one or more alphanumeric, hyphen, or underscore characters", k))
+	}
+	return
+}
+
+// CloudWatchEventPermissionPolicyDoc represents the Policy attribute of DescribeEventBus
+// See also: https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_DescribeEventBus.html
+type CloudWatchEventPermissionPolicyDoc struct {
+	Version    string
+	ID         string                                     `json:"Id,omitempty"`
+	Statements []CloudWatchEventPermissionPolicyStatement `json:"Statement"`
+}
+
+// CloudWatchEventPermissionPolicyStatement represents the Statement attribute of CloudWatchEventPermissionPolicyDoc
+// See also: https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_DescribeEventBus.html
+type CloudWatchEventPermissionPolicyStatement struct {
+	Sid       string
+	Effect    string
+	Action    string
+	Principal interface{} // "*" or {"AWS": "arn:aws:iam::111111111111:root"}
+	Resource  string
+}

--- a/aws/resource_aws_cloudwatch_event_permission_test.go
+++ b/aws/resource_aws_cloudwatch_event_permission_test.go
@@ -1,0 +1,295 @@
+package aws
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"testing"
+	"time"
+
+	events "github.com/aws/aws-sdk-go/service/cloudwatchevents"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSCloudWatchEventPermission_Basic(t *testing.T) {
+	principal1 := "111111111111"
+	principal2 := "*"
+	statementID := acctest.RandomWithPrefix(t.Name())
+	resourceName := "aws_cloudwatch_event_permission.test1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckAwsCloudWatchEventPermissionResourceConfigBasic("", statementID),
+				ExpectError: regexp.MustCompile(`must be \* or a 12 digit AWS account ID`),
+			},
+			{
+				Config:      testAccCheckAwsCloudWatchEventPermissionResourceConfigBasic(".", statementID),
+				ExpectError: regexp.MustCompile(`must be \* or a 12 digit AWS account ID`),
+			},
+			{
+				Config:      testAccCheckAwsCloudWatchEventPermissionResourceConfigBasic("12345678901", statementID),
+				ExpectError: regexp.MustCompile(`must be \* or a 12 digit AWS account ID`),
+			},
+			{
+				Config:      testAccCheckAwsCloudWatchEventPermissionResourceConfigBasic("abcdefghijkl", statementID),
+				ExpectError: regexp.MustCompile(`must be \* or a 12 digit AWS account ID`),
+			},
+			{
+				Config:      testAccCheckAwsCloudWatchEventPermissionResourceConfigBasic(principal1, ""),
+				ExpectError: regexp.MustCompile(`must be between 1 and 64 characters`),
+			},
+			{
+				Config:      testAccCheckAwsCloudWatchEventPermissionResourceConfigBasic(principal1, acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`must be between 1 and 64 characters`),
+			},
+			{
+				Config:      testAccCheckAwsCloudWatchEventPermissionResourceConfigBasic(principal1, " "),
+				ExpectError: regexp.MustCompile(`must be one or more alphanumeric, hyphen, or underscore characters`),
+			},
+			{
+				Config: testAccCheckAwsCloudWatchEventPermissionResourceConfigBasic(principal1, statementID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchEventPermissionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "action", "events:PutEvents"),
+					resource.TestCheckResourceAttr(resourceName, "principal", principal1),
+					resource.TestCheckResourceAttr(resourceName, "statement_id", statementID),
+				),
+			},
+			{
+				Config: testAccCheckAwsCloudWatchEventPermissionResourceConfigBasic(principal2, statementID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchEventPermissionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "principal", principal2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudWatchEventPermission_Action(t *testing.T) {
+	principal := "111111111111"
+	statementID := acctest.RandomWithPrefix(t.Name())
+	resourceName := "aws_cloudwatch_event_permission.test1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckAwsCloudWatchEventPermissionResourceConfigAction("", principal, statementID),
+				ExpectError: regexp.MustCompile(`must be between 1 and 64 characters`),
+			},
+			{
+				Config:      testAccCheckAwsCloudWatchEventPermissionResourceConfigAction(acctest.RandString(65), principal, statementID),
+				ExpectError: regexp.MustCompile(`must be between 1 and 64 characters`),
+			},
+			{
+				Config:      testAccCheckAwsCloudWatchEventPermissionResourceConfigAction("events:", principal, statementID),
+				ExpectError: regexp.MustCompile(`must be: events: followed by one or more alphabetic characters`),
+			},
+			{
+				Config:      testAccCheckAwsCloudWatchEventPermissionResourceConfigAction("events:1", principal, statementID),
+				ExpectError: regexp.MustCompile(`must be: events: followed by one or more alphabetic characters`),
+			},
+			{
+				Config: testAccCheckAwsCloudWatchEventPermissionResourceConfigAction("events:PutEvents", principal, statementID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchEventPermissionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "action", "events:PutEvents"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudWatchEventPermission_Import(t *testing.T) {
+	principal := "123456789012"
+	statementID := acctest.RandomWithPrefix(t.Name())
+	resourceName := "aws_cloudwatch_event_permission.test1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudWatchEventPermissionDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckAwsCloudWatchEventPermissionResourceConfigBasic(principal, statementID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchEventPermissionExists(resourceName),
+				),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudWatchEventPermission_Multiple(t *testing.T) {
+	principal1 := "111111111111"
+	principal2 := "222222222222"
+	statementID1 := acctest.RandomWithPrefix(t.Name())
+	statementID2 := acctest.RandomWithPrefix(t.Name())
+	resourceName1 := "aws_cloudwatch_event_permission.test1"
+	resourceName2 := "aws_cloudwatch_event_permission.test2"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAwsCloudWatchEventPermissionResourceConfigBasic(principal1, statementID1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchEventPermissionExists(resourceName1),
+					resource.TestCheckResourceAttr(resourceName1, "principal", principal1),
+					resource.TestCheckResourceAttr(resourceName1, "statement_id", statementID1),
+				),
+			},
+			{
+				Config: testAccCheckAwsCloudWatchEventPermissionResourceConfigMultiple(principal1, statementID1, principal2, statementID2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchEventPermissionExists(resourceName1),
+					testAccCheckCloudWatchEventPermissionExists(resourceName2),
+					resource.TestCheckResourceAttr(resourceName1, "principal", principal1),
+					resource.TestCheckResourceAttr(resourceName1, "statement_id", statementID1),
+					resource.TestCheckResourceAttr(resourceName2, "principal", principal2),
+					resource.TestCheckResourceAttr(resourceName2, "statement_id", statementID2),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCloudWatchEventPermissionExists(pr string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).cloudwatcheventsconn
+		rs, ok := s.RootModule().Resources[pr]
+		if !ok {
+			return fmt.Errorf("Not found: %s", pr)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		debo, err := conn.DescribeEventBus(&events.DescribeEventBusInput{})
+		if err != nil {
+			return fmt.Errorf("Reading CloudWatch Events bus policy for '%s' failed: %s", pr, err.Error())
+		}
+
+		if debo.Policy == nil {
+			return fmt.Errorf("Not found: %s", pr)
+		}
+
+		var policyDoc CloudWatchEventPermissionPolicyDoc
+		err = json.Unmarshal([]byte(*debo.Policy), &policyDoc)
+		if err != nil {
+			return fmt.Errorf("Reading CloudWatch Events bus policy for '%s' failed: %s", pr, err.Error())
+		}
+
+		var policyStatement *CloudWatchEventPermissionPolicyStatement
+		for _, statement := range policyDoc.Statements {
+			if statement.Sid == rs.Primary.ID {
+				policyStatement = &statement
+				break
+			}
+		}
+		if policyStatement == nil {
+			return fmt.Errorf("Not found: %s", pr)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckCloudWatchEventPermissionDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).cloudwatcheventsconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_cloudwatch_event_permission" {
+			continue
+		}
+
+		err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+			input := events.DescribeEventBusInput{}
+
+			debo, err := conn.DescribeEventBus(&input)
+			if err != nil {
+				return resource.NonRetryableError(err)
+			}
+			if debo.Policy == nil {
+				return nil
+			}
+
+			var policyDoc CloudWatchEventPermissionPolicyDoc
+			err = json.Unmarshal([]byte(*debo.Policy), &policyDoc)
+			if err != nil {
+				return resource.NonRetryableError(fmt.Errorf("Reading CloudWatch Events permission '%s' failed: %s", rs.Primary.ID, err.Error()))
+			}
+
+			var policyStatement *CloudWatchEventPermissionPolicyStatement
+			for _, statement := range policyDoc.Statements {
+				if statement.Sid == rs.Primary.ID {
+					policyStatement = &statement
+					break
+				}
+			}
+			if policyStatement == nil {
+				return resource.RetryableError(fmt.Errorf("CloudWatch Events permission exists: %s", rs.Primary.ID))
+			}
+
+			return nil
+		})
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAwsCloudWatchEventPermissionResourceConfigBasic(principal, statementID string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_event_permission" "test1" {
+  principal    = "%[1]s"
+  statement_id = "%[2]s"
+}
+`, principal, statementID)
+}
+
+func testAccCheckAwsCloudWatchEventPermissionResourceConfigAction(action, principal, statementID string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_event_permission" "test1" {
+  action       = "%[1]s"
+  principal    = "%[2]s"
+  statement_id = "%[3]s"
+}
+`, action, principal, statementID)
+}
+
+func testAccCheckAwsCloudWatchEventPermissionResourceConfigMultiple(principal1, statementID1, principal2, statementID2 string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_event_permission" "test1" {
+  principal    = "%[1]s"
+  statement_id = "%[2]s"
+}
+
+resource "aws_cloudwatch_event_permission" "test2" {
+  principal    = "%[3]s"
+  statement_id = "%[4]s"
+}
+`, principal1, statementID1, principal2, statementID2)
+}

--- a/aws/resource_aws_cloudwatch_event_permission_test.go
+++ b/aws/resource_aws_cloudwatch_event_permission_test.go
@@ -199,15 +199,9 @@ func testAccCheckCloudWatchEventPermissionExists(pr string) resource.TestCheckFu
 			return fmt.Errorf("Reading CloudWatch Events bus policy for '%s' failed: %s", pr, err.Error())
 		}
 
-		var policyStatement *CloudWatchEventPermissionPolicyStatement
-		for _, statement := range policyDoc.Statements {
-			if statement.Sid == rs.Primary.ID {
-				policyStatement = &statement
-				break
-			}
-		}
-		if policyStatement == nil {
-			return fmt.Errorf("Not found: %s", pr)
+		_, err = findCloudWatchEventPermissionPolicyStatementByID(&policyDoc, rs.Primary.ID)
+		if err != nil {
+			return err
 		}
 
 		return nil
@@ -239,14 +233,8 @@ func testAccCheckCloudWatchEventPermissionDestroy(s *terraform.State) error {
 				return resource.NonRetryableError(fmt.Errorf("Reading CloudWatch Events permission '%s' failed: %s", rs.Primary.ID, err.Error()))
 			}
 
-			var policyStatement *CloudWatchEventPermissionPolicyStatement
-			for _, statement := range policyDoc.Statements {
-				if statement.Sid == rs.Primary.ID {
-					policyStatement = &statement
-					break
-				}
-			}
-			if policyStatement == nil {
+			_, err = findCloudWatchEventPermissionPolicyStatementByID(&policyDoc, rs.Primary.ID)
+			if err == nil {
 				return resource.RetryableError(fmt.Errorf("CloudWatch Events permission exists: %s", rs.Primary.ID))
 			}
 

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -375,6 +375,10 @@
                             <a href="/docs/providers/aws/r/cloudwatch_dashboard.html">aws_cloudwatch_dashboard</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-cloudwatch-event-permission") %>>
+                            <a href="/docs/providers/aws/r/cloudwatch_event_permission.html">aws_cloudwatch_event_permission</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-aws-resource-cloudwatch-event-rule") %>>
                             <a href="/docs/providers/aws/r/cloudwatch_event_rule.html">aws_cloudwatch_event_rule</a>
                         </li>

--- a/website/docs/r/cloudwatch_event_permission.html.markdown
+++ b/website/docs/r/cloudwatch_event_permission.html.markdown
@@ -1,0 +1,42 @@
+---
+layout: "aws"
+page_title: "AWS: aws_cloudwatch_event_permission"
+sidebar_current: "docs-aws-resource-cloudwatch-event-permission"
+description: |-
+  Provides a resource to create a CloudWatch Events permission to support cross-account events in the current account default event bus.
+---
+
+# aws_cloudwatch_event_permission
+
+Provides a resource to create a CloudWatch Events permission to support cross-account events in the current account default event bus.
+
+## Example Usage
+
+```hcl
+resource "aws_cloudwatch_event_permission" "DevAccountAccess" {
+  principal    = "123456789012"
+  statement_id = "DevAccountAccess"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `principal` - (Required) The 12-digit AWS account ID that you are permitting to put events to your default event bus. Specify `*` to permit any account to put events to your default event bus.
+* `statement_id` - (Required) An identifier string for the external account that you are granting permissions to.
+* `action` - (Optional) The action that you are enabling the other account to perform. Defaults to `events:PutEvents`.
+
+## Attributes Reference
+
+The following additional attributes are exported:
+
+* `id` - The statement ID of the CloudWatch Events permission.
+
+## Import
+
+CloudWatch Events permissions can be imported using the statement ID, e.g.
+
+```shell
+$ terraform import aws_cloudwatch_event_permission.DevAccountAccess DevAccountAccess
+```


### PR DESCRIPTION
Closes #1042 

Please note the implementation is a little awkward because there are `PutPermission`/`RemovePermission` API actions but reading is done via the backend created IAM policy on the event bus, available via the `Policy` attribute on `DescribeEventBus`. There's also a peculiarity with the `PutPermission` API concurrency where two "parallel" operations will only write the last received entry, but it always returns 200 OKs for both requests. If there's a good solution for a resource-wide mutex, this would be a good place for one.

References:
* https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/CloudWatchEvents-CrossAccountEventDelivery.html
* https://docs.aws.amazon.com/sdk-for-go/api/service/cloudwatchevents/
* https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_PutPermission.html

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSCloudWatchEventPermission'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCloudWatchEventPermission -timeout 120m
=== RUN   TestAccAWSCloudWatchEventPermission_Basic
--- PASS: TestAccAWSCloudWatchEventPermission_Basic (21.94s)
=== RUN   TestAccAWSCloudWatchEventPermission_Action
--- PASS: TestAccAWSCloudWatchEventPermission_Action (12.60s)
=== RUN   TestAccAWSCloudWatchEventPermission_Import
--- PASS: TestAccAWSCloudWatchEventPermission_Import (12.90s)
=== RUN   TestAccAWSCloudWatchEventPermission_Multiple
--- PASS: TestAccAWSCloudWatchEventPermission_Multiple (21.84s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	69.327s
```