### PR TITLE
data-source/aws_iam_policy_document: Support layering via source_json and override_json attributes

### DIFF
--- a/aws/data_source_aws_iam_policy_document_test.go
+++ b/aws/data_source_aws_iam_policy_document_test.go
@@ -28,6 +28,34 @@ func TestAccAWSDataSourceIAMPolicyDocument_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSDataSourceIAMPolicyDocument_source(t *testing.T) {
+	// This really ought to be able to be a unit test rather than an
+	// acceptance test, but just instantiating the AWS provider requires
+	// some AWS API calls, and so this needs valid AWS credentials to work.
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSIAMPolicyDocumentSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckStateValue("data.aws_iam_policy_document.test_source", "json",
+						testAccAWSIAMPolicyDocumentSourceExpectedJSON,
+					),
+				),
+			},
+			{
+				Config: testAccAWSIAMPolicyDocumentSourceBlankConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckStateValue("data.aws_iam_policy_document.test_source_blank", "json",
+						testAccAWSIAMPolicyDocumentSourceBlankExpectedJSON,
+					),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckStateValue(id, name, value string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[id]
@@ -184,6 +212,186 @@ var testAccAWSIAMPolicyDocumentExpectedJSON = `{
       "Effect": "Allow",
       "Action": "firehose:*",
       "Principal": "*"
+    }
+  ]
+}`
+
+var testAccAWSIAMPolicyDocumentSourceConfig = `
+data "aws_iam_policy_document" "test" {
+    policy_id = "policy_id"
+    statement {
+        sid = "1"
+        actions = [
+            "s3:ListAllMyBuckets",
+            "s3:GetBucketLocation",
+        ]
+        resources = [
+            "arn:aws:s3:::*",
+        ]
+    }
+
+    statement {
+        actions = [
+            "s3:ListBucket",
+        ]
+        resources = [
+            "arn:aws:s3:::foo",
+        ]
+        condition {
+            test = "StringLike"
+            variable = "s3:prefix"
+            values = [
+                "home/",
+                "home/&{aws:username}/",
+            ]
+        }
+
+        not_principals {
+            type = "AWS"
+            identifiers = ["arn:blahblah:example"]
+        }
+    }
+
+    statement {
+        actions = [
+            "s3:*",
+        ]
+        resources = [
+            "arn:aws:s3:::foo/home/&{aws:username}",
+            "arn:aws:s3:::foo/home/&{aws:username}/*",
+        ]
+        principals {
+            type = "AWS"
+            identifiers = ["arn:blahblah:example"]
+        }
+    }
+
+    statement {
+        effect = "Deny"
+        not_actions = ["s3:*"]
+        not_resources = ["arn:aws:s3:::*"]
+    }
+
+    # Normalization of wildcard principals
+    statement {
+        effect = "Allow"
+        actions = ["kinesis:*"]
+        principals {
+            type = "AWS"
+            identifiers = ["*"]
+        }
+    }
+    statement {
+        effect = "Allow"
+        actions = ["firehose:*"]
+        principals {
+            type = "*"
+            identifiers = ["*"]
+        }
+    }
+
+}
+
+data "aws_iam_policy_document" "test_source" {
+    source_json = "${data.aws_iam_policy_document.test.json}"
+
+    statement {
+        sid       = "SourceJSONTest1"
+        actions   = ["*"]
+        resources = ["*"]
+    }
+}
+`
+
+var testAccAWSIAMPolicyDocumentSourceExpectedJSON = `{
+  "Version": "2012-10-17",
+  "Id": "policy_id",
+  "Statement": [
+    {
+      "Sid": "1",
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListAllMyBuckets",
+        "s3:GetBucketLocation"
+      ],
+      "Resource": "arn:aws:s3:::*"
+    },
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::foo",
+      "NotPrincipal": {
+        "AWS": "arn:blahblah:example"
+      },
+      "Condition": {
+        "StringLike": {
+          "s3:prefix": [
+            "home/${aws:username}/",
+            "home/"
+          ]
+        }
+      }
+    },
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": "s3:*",
+      "Resource": [
+        "arn:aws:s3:::foo/home/${aws:username}/*",
+        "arn:aws:s3:::foo/home/${aws:username}"
+      ],
+      "Principal": {
+        "AWS": "arn:blahblah:example"
+      }
+    },
+    {
+      "Sid": "",
+      "Effect": "Deny",
+      "NotAction": "s3:*",
+      "NotResource": "arn:aws:s3:::*"
+    },
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": "kinesis:*",
+      "Principal": "*"
+    },
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": "firehose:*",
+      "Principal": "*"
+    },
+    {
+      "Sid": "SourceJSONTest1",
+      "Effect": "Allow",
+      "Action": "*",
+      "Resource": "*"
+    }
+  ]
+}`
+
+var testAccAWSIAMPolicyDocumentSourceBlankConfig = `
+data "aws_iam_policy_document" "test_source_blank" {
+    source_json = ""
+
+    statement {
+        sid       = "SourceJSONTest2"
+        actions   = ["*"]
+        resources = ["*"]
+    }
+}
+`
+
+var testAccAWSIAMPolicyDocumentSourceBlankExpectedJSON = `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "SourceJSONTest2",
+      "Effect": "Allow",
+      "Action": "*",
+      "Resource": "*"
     }
   ]
 }`

--- a/aws/iam_policy_model.go
+++ b/aws/iam_policy_model.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"encoding/json"
+	"fmt"
 	"sort"
 )
 
@@ -75,6 +76,29 @@ func (ps IAMPolicyStatementPrincipalSet) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&raw)
 }
 
+func (ps *IAMPolicyStatementPrincipalSet) UnmarshalJSON(b []byte) error {
+	var out IAMPolicyStatementPrincipalSet
+
+	var data interface{}
+	if err := json.Unmarshal(b, &data); err != nil {
+		return err
+	}
+
+	switch t := data.(type) {
+	case string:
+		out = append(out, IAMPolicyStatementPrincipal{Type: "*", Identifiers: []string{"*"}})
+	case map[string]interface{}:
+		for key, value := range data.(map[string]interface{}) {
+			out = append(out, IAMPolicyStatementPrincipal{Type: key, Identifiers: value})
+		}
+	default:
+		return fmt.Errorf("Unsupported data type %s for IAMPolicyStatementPrincipalSet", t)
+	}
+
+	*ps = out
+	return nil
+}
+
 func (cs IAMPolicyStatementConditionSet) MarshalJSON() ([]byte, error) {
 	raw := map[string]map[string]interface{}{}
 
@@ -97,6 +121,33 @@ func (cs IAMPolicyStatementConditionSet) MarshalJSON() ([]byte, error) {
 	}
 
 	return json.Marshal(&raw)
+}
+
+func (cs *IAMPolicyStatementConditionSet) UnmarshalJSON(b []byte) error {
+	var out IAMPolicyStatementConditionSet
+
+	var data map[string]map[string]interface{}
+	if err := json.Unmarshal(b, &data); err != nil {
+		return err
+	}
+
+	for test_key, test_value := range data {
+		for var_key, var_values := range test_value {
+			switch var_values.(type) {
+			case string:
+				out = append(out, IAMPolicyStatementCondition{Test: test_key, Variable: var_key, Values: []string{var_values.(string)}})
+			case []interface{}:
+				values := []string{}
+				for _, v := range var_values.([]interface{}) {
+					values = append(values, v.(string))
+				}
+				out = append(out, IAMPolicyStatementCondition{Test: test_key, Variable: var_key, Values: values})
+			}
+		}
+	}
+
+	*cs = out
+	return nil
 }
 
 func iamPolicyDecodeConfigStringList(lI []interface{}) interface{} {

--- a/aws/iam_policy_model.go
+++ b/aws/iam_policy_model.go
@@ -38,6 +38,22 @@ type IAMPolicyStatementCondition struct {
 type IAMPolicyStatementPrincipalSet []IAMPolicyStatementPrincipal
 type IAMPolicyStatementConditionSet []IAMPolicyStatementCondition
 
+func (self *IAMPolicyDoc) DeDupSids() {
+	// de-dupe the statements by traversing backwards and removing duplicate Sids
+	sidsSeen := map[string]bool{}
+	l := len(self.Statements) - 1
+	for i := range self.Statements {
+		if sid := self.Statements[l-i].Sid; len(sid) > 0 {
+			if sidsSeen[sid] {
+				// we've seen this sid already so remove the duplicate
+				self.Statements = append(self.Statements[:l-i], self.Statements[l-i+1:]...)
+			}
+			// mark this sid seen
+			sidsSeen[sid] = true
+		}
+	}
+}
+
 func (ps IAMPolicyStatementPrincipalSet) MarshalJSON() ([]byte, error) {
 	raw := map[string]interface{}{}
 

--- a/website/docs/d/iam_policy_document.html.markdown
+++ b/website/docs/d/iam_policy_document.html.markdown
@@ -78,6 +78,9 @@ valid to use literal JSON strings within your configuration, or to use the
 The following arguments are supported:
 
 * `policy_id` (Optional) - An ID for the policy document.
+* `source_json` (Optional) - An IAM policy document to import and add the
+  statements from.  Use this to, for example, customize resource policies in
+  modules.
 * `statement` (Required) - A nested configuration block (described below)
   configuring one *statement* to be included in the policy document.
 

--- a/website/docs/d/iam_policy_document.html.markdown
+++ b/website/docs/d/iam_policy_document.html.markdown
@@ -78,9 +78,14 @@ valid to use literal JSON strings within your configuration, or to use the
 The following arguments are supported:
 
 * `policy_id` (Optional) - An ID for the policy document.
-* `source_json` (Optional) - An IAM policy document to import and add the
-  statements from.  Use this to, for example, customize resource policies in
-  modules.
+* `source_json` (Optional) - An IAM policy document to import as a base for the
+  current policy document.  Statements with non-blank `sid`s in the current
+  policy document will overwrite statements with the same `sid` in the source
+  json.  Statements without an `sid` cannot be overwritten.
+* `override_json` (Optional) - An IAM policy document to import and override the
+  current policy document.  Statements with non-blank `sid`s in the override
+  document will overwrite statements with the same `sid` in the current document.
+  Statements without an `sid` cannot be overwritten.
 * `statement` (Required) - A nested configuration block (described below)
   configuring one *statement* to be included in the policy document.
 
@@ -169,3 +174,116 @@ data "aws_iam_policy_document" "event_stream_bucket_role_assume_role_policy" {
   }
 }
 ```
+
+## Example with Source and Override
+
+Showing how you can use `source_json` and `override_json`
+
+```hcl
+data "aws_iam_policy_document" "source" {
+  statement {
+    actions   = ["ec2:*"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "SidToOverwrite"
+
+    actions   = ["s3:*"]
+    resources = ["*"]
+  }
+}
+
+data "aws_iam_policy_document" "source_json_example" {
+  source_json = "${data.aws_iam_policy_document.source.json}"
+
+  statement {
+    sid = "SidToOverwrite"
+
+    actions = ["s3:*"]
+
+    resources = [
+      "arn:aws:s3:::somebucket",
+      "arn:aws:s3:::somebucket/*",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "override" {
+  statement {
+    sid = "SidToOverwrite"
+
+    actions   = ["s3:*"]
+    resources = ["*"]
+  }
+}
+
+data "aws_iam_policy_document" "override_json_example" {
+  override_json = "${data.aws_iam_policy_document.override.json}"
+
+  statement {
+    actions   = ["ec2:*"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "SidToOverwrite"
+
+    actions = ["s3:*"]
+
+    resources = [
+      "arn:aws:s3:::somebucket",
+      "arn:aws:s3:::somebucket/*",
+    ]
+  }
+}
+```
+
+`data.aws_iam_policy_document.source_json_example.json` will evaluate to:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": "ec2:*",
+      "Resource": "*"
+    },
+    {
+      "Sid": "SidToOverwrite",
+      "Effect": "Allow",
+      "Action": "s3:*",
+      "Resource": [
+        "arn:aws:s3:::somebucket/*",
+        "arn:aws:s3:::somebucket"
+      ]
+    }
+  ]
+}
+```
+
+`data.aws_iam_policy_document.override_json_example.json` will evaluate to:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": "ec2:*",
+      "Resource": "*"
+    },
+    {
+      "Sid": "SidToOverwrite",
+      "Effect": "Allow",
+      "Action": "s3:*",
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+You can also combine `source_json` and `override_json` in the same document.


### PR DESCRIPTION
Adds a source_json property to aws_iam_policy_document to allow for merging of IAM policy statements.  Useful for abstracting resource policies in modules where it's only possible to attach one and reducing repetition when policies are nearly identical.