### PR TITLE
New Resource: aws_api_gateway_documentation_part

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -247,6 +247,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_api_gateway_base_path_mapping":            resourceAwsApiGatewayBasePathMapping(),
 			"aws_api_gateway_client_certificate":           resourceAwsApiGatewayClientCertificate(),
 			"aws_api_gateway_deployment":                   resourceAwsApiGatewayDeployment(),
+			"aws_api_gateway_documentation_part":           resourceAwsApiGatewayDocumentationPart(),
 			"aws_api_gateway_domain_name":                  resourceAwsApiGatewayDomainName(),
 			"aws_api_gateway_gateway_response":             resourceAwsApiGatewayGatewayResponse(),
 			"aws_api_gateway_integration":                  resourceAwsApiGatewayIntegration(),

--- a/aws/resource_aws_api_gateway_documentation_part.go
+++ b/aws/resource_aws_api_gateway_documentation_part.go
@@ -1,0 +1,202 @@
+package aws
+
+import (
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/apigateway"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsApiGatewayDocumentationPart() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsApiGatewayDocumentationPartCreate,
+		Read:   resourceAwsApiGatewayDocumentationPartRead,
+		Update: resourceAwsApiGatewayDocumentationPartUpdate,
+		Delete: resourceAwsApiGatewayDocumentationPartDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"location": {
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"method": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"path": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"status_code": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
+			"properties": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"rest_api_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAwsApiGatewayDocumentationPartCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).apigateway
+
+	out, err := conn.CreateDocumentationPart(&apigateway.CreateDocumentationPartInput{
+		Location:   expandApiGatewayDocumentationPartLocation(d.Get("location").([]interface{})),
+		Properties: aws.String(d.Get("properties").(string)),
+		RestApiId:  aws.String(d.Get("rest_api_id").(string)),
+	})
+	if err != nil {
+		return err
+	}
+	d.SetId(*out.Id)
+
+	return nil
+}
+
+func resourceAwsApiGatewayDocumentationPartRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).apigateway
+
+	log.Printf("[INFO] Reading API Gateway Documentation Part %s", d.Id())
+	docPart, err := conn.GetDocumentationPart(&apigateway.GetDocumentationPartInput{
+		DocumentationPartId: aws.String(d.Id()),
+		RestApiId:           aws.String(d.Get("rest_api_id").(string)),
+	})
+	if err != nil {
+		if isAWSErr(err, "NotFoundException", "") {
+			log.Printf("[WARN] API Gateway Documentation Part (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	log.Printf("[DEBUG] Received API Gateway Documentation Part: %s", docPart)
+
+	d.Set("location", flattenApiGatewayDocumentationPartLocation(docPart.Location))
+	d.Set("properties", docPart.Properties)
+
+	return nil
+}
+
+func resourceAwsApiGatewayDocumentationPartUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).apigateway
+
+	input := apigateway.UpdateDocumentationPartInput{
+		DocumentationPartId: aws.String(d.Id()),
+		RestApiId:           aws.String(d.Get("rest_api_id").(string)),
+	}
+	operations := make([]*apigateway.PatchOperation, 0)
+
+	if d.HasChange("properties") {
+		properties := d.Get("properties").(string)
+		operations = append(operations, &apigateway.PatchOperation{
+			Op:    aws.String("replace"),
+			Path:  aws.String("/properties"),
+			Value: aws.String(properties),
+		})
+	}
+
+	input.PatchOperations = operations
+
+	log.Printf("[INFO] Updating API Gateway Documentation Part: %s", input)
+
+	out, err := conn.UpdateDocumentationPart(&input)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] API Gateway Documentation Part updated: %s", out)
+
+	return resourceAwsApiGatewayDocumentationPartRead(d, meta)
+}
+
+func resourceAwsApiGatewayDocumentationPartDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).apigateway
+
+	_, err := conn.DeleteDocumentationPart(&apigateway.DeleteDocumentationPartInput{
+		DocumentationPartId: aws.String(d.Id()),
+		RestApiId:           aws.String(d.Get("rest_api_id").(string)),
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func expandApiGatewayDocumentationPartLocation(l []interface{}) *apigateway.DocumentationPartLocation {
+	if len(l) == 0 {
+		return nil
+	}
+	loc := l[0].(map[string]interface{})
+	out := &apigateway.DocumentationPartLocation{
+		Type: aws.String(loc["type"].(string)),
+	}
+	if v, ok := loc["method"]; ok {
+		out.Method = aws.String(v.(string))
+	}
+	if v, ok := loc["name"]; ok {
+		out.Name = aws.String(v.(string))
+	}
+	if v, ok := loc["path"]; ok {
+		out.Path = aws.String(v.(string))
+	}
+	if v, ok := loc["status_code"]; ok {
+		out.StatusCode = aws.String(v.(string))
+	}
+	return out
+}
+
+func flattenApiGatewayDocumentationPartLocation(l *apigateway.DocumentationPartLocation) []interface{} {
+	if l == nil {
+		return []interface{}{}
+	}
+
+	m := make(map[string]interface{}, 0)
+	m["type"] = *l.Type
+	if l.Method != nil {
+		m["method"] = *l.Method
+	}
+	if l.Name != nil {
+		m["name"] = *l.Name
+	}
+	if l.Path != nil {
+		m["path"] = *l.Path
+	}
+	if l.StatusCode != nil {
+		m["status_code"] = *l.StatusCode
+	}
+
+	return []interface{}{m}
+}

--- a/aws/resource_aws_api_gateway_documentation_part_test.go
+++ b/aws/resource_aws_api_gateway_documentation_part_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -15,9 +16,11 @@ func TestAccAWSAPIGatewayDocumentationPart_basic(t *testing.T) {
 	var conf apigateway.DocumentationPart
 
 	rString := acctest.RandString(8)
-	apiName := fmt.Sprintf("tf_acc_api_%s", rString)
-	properties := `{\"description\":\"Terraform Acceptance Test\"}`
-	uProperties := `{\"description\":\"Terraform Acceptance Test Updated\"}`
+	apiName := fmt.Sprintf("tf_acc_api_doc_part_basic_%s", rString)
+	properties := `{"description":"Terraform Acceptance Test"}`
+	uProperties := `{"description":"Terraform Acceptance Test Updated"}`
+
+	resourceName := "aws_api_gateway_documentation_part.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -25,23 +28,23 @@ func TestAccAWSAPIGatewayDocumentationPart_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSAPIGatewayDocumentationPartDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSAPIGatewayDocumentationPartConfig(apiName, properties),
+				Config: testAccAWSAPIGatewayDocumentationPartConfig(apiName, strconv.Quote(properties)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayDocumentationPartExists("aws_api_gateway_documentation_part.test", &conf),
-					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.#", "1"),
-					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.0.type", "API"),
-					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "properties", `{"description":"Terraform Acceptance Test"}`),
-					resource.TestCheckResourceAttrSet("aws_api_gateway_documentation_part.test", "rest_api_id"),
+					testAccCheckAWSAPIGatewayDocumentationPartExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "location.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "location.0.type", "API"),
+					resource.TestCheckResourceAttr(resourceName, "properties", properties),
+					resource.TestCheckResourceAttrSet(resourceName, "rest_api_id"),
 				),
 			},
 			resource.TestStep{
-				Config: testAccAWSAPIGatewayDocumentationPartConfig(apiName, uProperties),
+				Config: testAccAWSAPIGatewayDocumentationPartConfig(apiName, strconv.Quote(uProperties)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayDocumentationPartExists("aws_api_gateway_documentation_part.test", &conf),
-					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.#", "1"),
-					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.0.type", "API"),
-					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "properties", `{"description":"Terraform Acceptance Test Updated"}`),
-					resource.TestCheckResourceAttrSet("aws_api_gateway_documentation_part.test", "rest_api_id"),
+					testAccCheckAWSAPIGatewayDocumentationPartExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "location.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "location.0.type", "API"),
+					resource.TestCheckResourceAttr(resourceName, "properties", uProperties),
+					resource.TestCheckResourceAttrSet(resourceName, "rest_api_id"),
 				),
 			},
 		},
@@ -52,9 +55,11 @@ func TestAccAWSAPIGatewayDocumentationPart_method(t *testing.T) {
 	var conf apigateway.DocumentationPart
 
 	rString := acctest.RandString(8)
-	apiName := fmt.Sprintf("tf_acc_api_%s", rString)
-	properties := `{\"description\":\"Terraform Acceptance Test\"}`
-	uProperties := `{\"description\":\"Terraform Acceptance Test Updated\"}`
+	apiName := fmt.Sprintf("tf_acc_api_doc_part_method_%s", rString)
+	properties := `{"description":"Terraform Acceptance Test"}`
+	uProperties := `{"description":"Terraform Acceptance Test Updated"}`
+
+	resourceName := "aws_api_gateway_documentation_part.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -62,27 +67,27 @@ func TestAccAWSAPIGatewayDocumentationPart_method(t *testing.T) {
 		CheckDestroy: testAccCheckAWSAPIGatewayDocumentationPartDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSAPIGatewayDocumentationPartMethodConfig(apiName, properties),
+				Config: testAccAWSAPIGatewayDocumentationPartMethodConfig(apiName, strconv.Quote(properties)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayDocumentationPartExists("aws_api_gateway_documentation_part.test", &conf),
-					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.#", "1"),
-					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.0.type", "METHOD"),
-					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.0.method", "GET"),
-					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.0.path", "/terraform-acc-test"),
-					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "properties", `{"description":"Terraform Acceptance Test"}`),
-					resource.TestCheckResourceAttrSet("aws_api_gateway_documentation_part.test", "rest_api_id"),
+					testAccCheckAWSAPIGatewayDocumentationPartExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "location.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "location.0.type", "METHOD"),
+					resource.TestCheckResourceAttr(resourceName, "location.0.method", "GET"),
+					resource.TestCheckResourceAttr(resourceName, "location.0.path", "/terraform-acc-test"),
+					resource.TestCheckResourceAttr(resourceName, "properties", properties),
+					resource.TestCheckResourceAttrSet(resourceName, "rest_api_id"),
 				),
 			},
 			resource.TestStep{
-				Config: testAccAWSAPIGatewayDocumentationPartMethodConfig(apiName, uProperties),
+				Config: testAccAWSAPIGatewayDocumentationPartMethodConfig(apiName, strconv.Quote(uProperties)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayDocumentationPartExists("aws_api_gateway_documentation_part.test", &conf),
-					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.#", "1"),
-					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.0.type", "METHOD"),
-					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.0.method", "GET"),
-					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.0.path", "/terraform-acc-test"),
-					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "properties", `{"description":"Terraform Acceptance Test Updated"}`),
-					resource.TestCheckResourceAttrSet("aws_api_gateway_documentation_part.test", "rest_api_id"),
+					testAccCheckAWSAPIGatewayDocumentationPartExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "location.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "location.0.type", "METHOD"),
+					resource.TestCheckResourceAttr(resourceName, "location.0.method", "GET"),
+					resource.TestCheckResourceAttr(resourceName, "location.0.path", "/terraform-acc-test"),
+					resource.TestCheckResourceAttr(resourceName, "properties", uProperties),
+					resource.TestCheckResourceAttrSet(resourceName, "rest_api_id"),
 				),
 			},
 		},
@@ -93,9 +98,11 @@ func TestAccAWSAPIGatewayDocumentationPart_responseHeader(t *testing.T) {
 	var conf apigateway.DocumentationPart
 
 	rString := acctest.RandString(8)
-	apiName := fmt.Sprintf("tf_acc_api_%s", rString)
-	properties := `{\"description\":\"Terraform Acceptance Test\"}`
-	uProperties := `{\"description\":\"Terraform Acceptance Test Updated\"}`
+	apiName := fmt.Sprintf("tf_acc_api_doc_part_resp_header_%s", rString)
+	properties := `{"description":"Terraform Acceptance Test"}`
+	uProperties := `{"description":"Terraform Acceptance Test Updated"}`
+
+	resourceName := "aws_api_gateway_documentation_part.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -103,32 +110,65 @@ func TestAccAWSAPIGatewayDocumentationPart_responseHeader(t *testing.T) {
 		CheckDestroy: testAccCheckAWSAPIGatewayDocumentationPartDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSAPIGatewayDocumentationPartResponseHeaderConfig(apiName, properties),
+				Config: testAccAWSAPIGatewayDocumentationPartResponseHeaderConfig(apiName, strconv.Quote(properties)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayDocumentationPartExists("aws_api_gateway_documentation_part.test", &conf),
-					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.#", "1"),
-					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.0.type", "RESPONSE_HEADER"),
-					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.0.method", "GET"),
-					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.0.name", "tfacc"),
-					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.0.path", "/terraform-acc-test"),
-					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.0.status_code", "200"),
-					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "properties", `{"description":"Terraform Acceptance Test"}`),
-					resource.TestCheckResourceAttrSet("aws_api_gateway_documentation_part.test", "rest_api_id"),
+					testAccCheckAWSAPIGatewayDocumentationPartExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "location.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "location.0.type", "RESPONSE_HEADER"),
+					resource.TestCheckResourceAttr(resourceName, "location.0.method", "GET"),
+					resource.TestCheckResourceAttr(resourceName, "location.0.name", "tfacc"),
+					resource.TestCheckResourceAttr(resourceName, "location.0.path", "/terraform-acc-test"),
+					resource.TestCheckResourceAttr(resourceName, "location.0.status_code", "200"),
+					resource.TestCheckResourceAttr(resourceName, "properties", properties),
+					resource.TestCheckResourceAttrSet(resourceName, "rest_api_id"),
 				),
 			},
 			resource.TestStep{
-				Config: testAccAWSAPIGatewayDocumentationPartResponseHeaderConfig(apiName, uProperties),
+				Config: testAccAWSAPIGatewayDocumentationPartResponseHeaderConfig(apiName, strconv.Quote(uProperties)),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayDocumentationPartExists("aws_api_gateway_documentation_part.test", &conf),
-					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.#", "1"),
-					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.0.type", "RESPONSE_HEADER"),
-					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.0.method", "GET"),
-					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.0.name", "tfacc"),
-					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.0.path", "/terraform-acc-test"),
-					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.0.status_code", "200"),
-					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "properties", `{"description":"Terraform Acceptance Test Updated"}`),
-					resource.TestCheckResourceAttrSet("aws_api_gateway_documentation_part.test", "rest_api_id"),
+					testAccCheckAWSAPIGatewayDocumentationPartExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "location.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "location.0.type", "RESPONSE_HEADER"),
+					resource.TestCheckResourceAttr(resourceName, "location.0.method", "GET"),
+					resource.TestCheckResourceAttr(resourceName, "location.0.name", "tfacc"),
+					resource.TestCheckResourceAttr(resourceName, "location.0.path", "/terraform-acc-test"),
+					resource.TestCheckResourceAttr(resourceName, "location.0.status_code", "200"),
+					resource.TestCheckResourceAttr(resourceName, "properties", uProperties),
+					resource.TestCheckResourceAttrSet(resourceName, "rest_api_id"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayDocumentationPart_importBasic(t *testing.T) {
+	var conf apigateway.DocumentationPart
+
+	rString := acctest.RandString(8)
+	apiName := fmt.Sprintf("tf_acc_api_doc_part_import_%s", rString)
+	properties := `{"description":"Terraform Acceptance Test"}`
+
+	resourceName := "aws_api_gateway_documentation_part.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayDocumentationPartDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSAPIGatewayDocumentationPartConfig(apiName, strconv.Quote(properties)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayDocumentationPartExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "location.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "location.0.type", "API"),
+					resource.TestCheckResourceAttr(resourceName, "properties", properties),
+					resource.TestCheckResourceAttrSet(resourceName, "rest_api_id"),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -147,9 +187,14 @@ func testAccCheckAWSAPIGatewayDocumentationPartExists(n string, res *apigateway.
 
 		conn := testAccProvider.Meta().(*AWSClient).apigateway
 
+		apiId, id, err := decodeApiGatewayDocumentationPartId(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		req := &apigateway.GetDocumentationPartInput{
-			DocumentationPartId: aws.String(rs.Primary.ID),
-			RestApiId:           aws.String(rs.Primary.Attributes["rest_api_id"]),
+			DocumentationPartId: aws.String(id),
+			RestApiId:           aws.String(apiId),
 		}
 		docPart, err := conn.GetDocumentationPart(req)
 		if err != nil {
@@ -170,20 +215,24 @@ func testAccCheckAWSAPIGatewayDocumentationPartDestroy(s *terraform.State) error
 			continue
 		}
 
-		req := &apigateway.GetDocumentationPartInput{
-			DocumentationPartId: aws.String(rs.Primary.ID),
-			RestApiId:           aws.String(rs.Primary.Attributes["rest_api_id"]),
-		}
-		_, err := conn.GetDocumentationPart(req)
+		apiId, id, err := decodeApiGatewayDocumentationPartId(rs.Primary.ID)
 		if err != nil {
-			if isAWSErr(err, "NotFoundException", "") {
+			return err
+		}
+
+		req := &apigateway.GetDocumentationPartInput{
+			DocumentationPartId: aws.String(id),
+			RestApiId:           aws.String(apiId),
+		}
+		_, err = conn.GetDocumentationPart(req)
+		if err != nil {
+			if isAWSErr(err, apigateway.ErrCodeNotFoundException, "") {
 				return nil
 			}
 			return err
 		}
 
-		return fmt.Errorf("API Gateway Documentation Part %s/%s still exists.",
-			rs.Primary.ID, rs.Primary.Attributes["rest_api_id"])
+		return fmt.Errorf("API Gateway Documentation Part %q still exists.", rs.Primary.ID)
 	}
 	return nil
 }
@@ -194,7 +243,7 @@ resource "aws_api_gateway_documentation_part" "test" {
   location {
     type = "API"
   }
-  properties = "%s"
+  properties = %v
   rest_api_id = "${aws_api_gateway_rest_api.test.id}"
 }
 
@@ -212,7 +261,7 @@ resource "aws_api_gateway_documentation_part" "test" {
     method = "GET"
     path = "/terraform-acc-test"
   }
-  properties = "%s"
+  properties = %v
   rest_api_id = "${aws_api_gateway_rest_api.test.id}"
 }
 
@@ -232,7 +281,7 @@ resource "aws_api_gateway_documentation_part" "test" {
     path = "/terraform-acc-test"
     status_code = "200"
   }
-  properties = "%s"
+  properties = %v
   rest_api_id = "${aws_api_gateway_rest_api.test.id}"
 }
 

--- a/aws/resource_aws_api_gateway_documentation_part_test.go
+++ b/aws/resource_aws_api_gateway_documentation_part_test.go
@@ -1,0 +1,243 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/apigateway"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSAPIGatewayDocumentationPart_basic(t *testing.T) {
+	var conf apigateway.DocumentationPart
+
+	rString := acctest.RandString(8)
+	apiName := fmt.Sprintf("tf_acc_api_%s", rString)
+	properties := `{\"description\":\"Terraform Acceptance Test\"}`
+	uProperties := `{\"description\":\"Terraform Acceptance Test Updated\"}`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayDocumentationPartDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSAPIGatewayDocumentationPartConfig(apiName, properties),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayDocumentationPartExists("aws_api_gateway_documentation_part.test", &conf),
+					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.#", "1"),
+					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.0.type", "API"),
+					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "properties", `{"description":"Terraform Acceptance Test"}`),
+					resource.TestCheckResourceAttrSet("aws_api_gateway_documentation_part.test", "rest_api_id"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSAPIGatewayDocumentationPartConfig(apiName, uProperties),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayDocumentationPartExists("aws_api_gateway_documentation_part.test", &conf),
+					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.#", "1"),
+					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.0.type", "API"),
+					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "properties", `{"description":"Terraform Acceptance Test Updated"}`),
+					resource.TestCheckResourceAttrSet("aws_api_gateway_documentation_part.test", "rest_api_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayDocumentationPart_method(t *testing.T) {
+	var conf apigateway.DocumentationPart
+
+	rString := acctest.RandString(8)
+	apiName := fmt.Sprintf("tf_acc_api_%s", rString)
+	properties := `{\"description\":\"Terraform Acceptance Test\"}`
+	uProperties := `{\"description\":\"Terraform Acceptance Test Updated\"}`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayDocumentationPartDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSAPIGatewayDocumentationPartMethodConfig(apiName, properties),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayDocumentationPartExists("aws_api_gateway_documentation_part.test", &conf),
+					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.#", "1"),
+					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.0.type", "METHOD"),
+					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.0.method", "GET"),
+					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.0.path", "/terraform-acc-test"),
+					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "properties", `{"description":"Terraform Acceptance Test"}`),
+					resource.TestCheckResourceAttrSet("aws_api_gateway_documentation_part.test", "rest_api_id"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSAPIGatewayDocumentationPartMethodConfig(apiName, uProperties),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayDocumentationPartExists("aws_api_gateway_documentation_part.test", &conf),
+					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.#", "1"),
+					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.0.type", "METHOD"),
+					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.0.method", "GET"),
+					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.0.path", "/terraform-acc-test"),
+					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "properties", `{"description":"Terraform Acceptance Test Updated"}`),
+					resource.TestCheckResourceAttrSet("aws_api_gateway_documentation_part.test", "rest_api_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayDocumentationPart_responseHeader(t *testing.T) {
+	var conf apigateway.DocumentationPart
+
+	rString := acctest.RandString(8)
+	apiName := fmt.Sprintf("tf_acc_api_%s", rString)
+	properties := `{\"description\":\"Terraform Acceptance Test\"}`
+	uProperties := `{\"description\":\"Terraform Acceptance Test Updated\"}`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayDocumentationPartDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSAPIGatewayDocumentationPartResponseHeaderConfig(apiName, properties),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayDocumentationPartExists("aws_api_gateway_documentation_part.test", &conf),
+					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.#", "1"),
+					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.0.type", "RESPONSE_HEADER"),
+					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.0.method", "GET"),
+					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.0.name", "tfacc"),
+					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.0.path", "/terraform-acc-test"),
+					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.0.status_code", "200"),
+					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "properties", `{"description":"Terraform Acceptance Test"}`),
+					resource.TestCheckResourceAttrSet("aws_api_gateway_documentation_part.test", "rest_api_id"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSAPIGatewayDocumentationPartResponseHeaderConfig(apiName, uProperties),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayDocumentationPartExists("aws_api_gateway_documentation_part.test", &conf),
+					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.#", "1"),
+					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.0.type", "RESPONSE_HEADER"),
+					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.0.method", "GET"),
+					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.0.name", "tfacc"),
+					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.0.path", "/terraform-acc-test"),
+					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "location.0.status_code", "200"),
+					resource.TestCheckResourceAttr("aws_api_gateway_documentation_part.test", "properties", `{"description":"Terraform Acceptance Test Updated"}`),
+					resource.TestCheckResourceAttrSet("aws_api_gateway_documentation_part.test", "rest_api_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSAPIGatewayDocumentationPartExists(n string, res *apigateway.DocumentationPart) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No API Gateway Documentation Part ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).apigateway
+
+		req := &apigateway.GetDocumentationPartInput{
+			DocumentationPartId: aws.String(rs.Primary.ID),
+			RestApiId:           aws.String(rs.Primary.Attributes["rest_api_id"]),
+		}
+		docPart, err := conn.GetDocumentationPart(req)
+		if err != nil {
+			return err
+		}
+
+		*res = *docPart
+
+		return nil
+	}
+}
+
+func testAccCheckAWSAPIGatewayDocumentationPartDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).apigateway
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_api_gateway_documentation_part" {
+			continue
+		}
+
+		req := &apigateway.GetDocumentationPartInput{
+			DocumentationPartId: aws.String(rs.Primary.ID),
+			RestApiId:           aws.String(rs.Primary.Attributes["rest_api_id"]),
+		}
+		_, err := conn.GetDocumentationPart(req)
+		if err != nil {
+			if isAWSErr(err, "NotFoundException", "") {
+				return nil
+			}
+			return err
+		}
+
+		return fmt.Errorf("API Gateway Documentation Part %s/%s still exists.",
+			rs.Primary.ID, rs.Primary.Attributes["rest_api_id"])
+	}
+	return nil
+}
+
+func testAccAWSAPIGatewayDocumentationPartConfig(apiName, properties string) string {
+	return fmt.Sprintf(`
+resource "aws_api_gateway_documentation_part" "test" {
+  location {
+    type = "API"
+  }
+  properties = "%s"
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+}
+
+resource "aws_api_gateway_rest_api" "test" {
+  name = "%s"
+}
+`, properties, apiName)
+}
+
+func testAccAWSAPIGatewayDocumentationPartMethodConfig(apiName, properties string) string {
+	return fmt.Sprintf(`
+resource "aws_api_gateway_documentation_part" "test" {
+  location {
+    type = "METHOD"
+    method = "GET"
+    path = "/terraform-acc-test"
+  }
+  properties = "%s"
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+}
+
+resource "aws_api_gateway_rest_api" "test" {
+  name = "%s"
+}
+`, properties, apiName)
+}
+
+func testAccAWSAPIGatewayDocumentationPartResponseHeaderConfig(apiName, properties string) string {
+	return fmt.Sprintf(`
+resource "aws_api_gateway_documentation_part" "test" {
+  location {
+    type = "RESPONSE_HEADER"
+    method = "GET"
+    name = "tfacc"
+    path = "/terraform-acc-test"
+    status_code = "200"
+  }
+  properties = "%s"
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+}
+
+resource "aws_api_gateway_rest_api" "test" {
+  name = "%s"
+}
+`, properties, apiName)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -254,6 +254,9 @@
                         <li<%= sidebar_current("docs-aws-resource-api-gateway-deployment") %>>
                             <a href="/docs/providers/aws/r/api_gateway_deployment.html">aws_api_gateway_deployment</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-resource-api-gateway-documentation-part") %>>
+                            <a href="/docs/providers/aws/r/api_gateway_documentation_part.html">aws_api_gateway_documentation_part</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-resource-api-gateway-domain-name") %>>
                             <a href="/docs/providers/aws/r/api_gateway_domain_name.html">aws_api_gateway_domain_name</a>
                         </li>

--- a/website/docs/r/api_gateway_documentation_part.html.markdown
+++ b/website/docs/r/api_gateway_documentation_part.html.markdown
@@ -1,0 +1,61 @@
+---
+layout: "aws"
+page_title: "AWS: aws_api_gateway_documentation_part"
+sidebar_current: "docs-aws-resource-api-gateway-documentation-part"
+description: |-
+  Provides a settings of an API Gateway Documentation Part.
+---
+
+# aws_api_gateway_documentation_part
+
+Provides a settings of an API Gateway Documentation Part.
+
+## Example Usage
+
+```hcl
+resource "aws_api_gateway_documentation_part" "example" {
+  location {
+    type = "METHOD"
+    method = "GET"
+    path = "/example"
+  }
+  properties = "{\"description\":\"Example description\"}"
+  rest_api_id = "${aws_api_gateway_rest_api.example.id}"
+}
+
+resource "aws_api_gateway_rest_api" "example" {
+  name = "example_api"
+}
+```
+
+## Argument Reference
+
+The following argument is supported:
+
+* `location` - (Required) The location of the targeted API entity of the to-be-created documentation part. See below.
+* `properties` - (Required) A content map of API-specific key-value pairs describing the targeted API entity. The map must be encoded as a JSON string, e.g., "{ \"description\": \"The API does ...\" }". Only Swagger-compliant key-value pairs can be exported and, hence, published.
+* `rest_api_id` - (Required) The ID of the associated Rest API
+
+### Nested fields
+
+#### `location`
+
+* `method` - (Optional) The HTTP verb of a method. It is a valid field for the API entity types of `METHOD`, `PATH_PARAMETER`, `QUERY_PARAMETER`, `REQUEST_HEADER`, `REQUEST_BODY`, `RESPONSE`, `RESPONSE_HEADER`, and `RESPONSE_BODY`. The default value is `*` for any method.
+* `name` - (Optional) The name of the targeted API entity. It is a valid and required field for the API entity types of `AUTHORIZER`, `MODEL`, `PATH_PARAMETER`, `QUERY_PARAMETER`, `REQUEST_HEADER`, `REQUEST_BODY` and `RESPONSE_HEADER`.
+* `path` - (Optional) The URL path of the target. It is a valid field for the API entity types of `RESOURCE`, `METHOD`, `PATH_PARAMETER`, `QUERY_PARAMETER`, `REQUEST_HEADER`, `REQUEST_BODY`, `RESPONSE`, `RESPONSE_HEADER`, and `RESPONSE_BODY`. The default value is `/` for the root resource.
+* `status_code` - (Optional) The HTTP status code of a response. It is a valid field for the API entity types of `RESPONSE`, `RESPONSE_HEADER`, and `RESPONSE_BODY`. The default value is `*` for any status code.
+* `type` - (Required) The type of API entity to which the documentation content applies. e.g. `API`, `METHOD` or `REQUEST_BODY`
+
+## Attribute Reference
+
+The following attribute is exported in addition to the arguments listed above:
+
+* `id` - The unique ID of the Documentation Part
+
+## Import
+
+API Gateway documentation_parts can be imported using the word `api-gateway-documentation_part`, e.g.
+
+```
+$ terraform import aws_api_gateway_documentation_part.example 3oyy3t
+```

--- a/website/docs/r/api_gateway_documentation_part.html.markdown
+++ b/website/docs/r/api_gateway_documentation_part.html.markdown
@@ -40,10 +40,12 @@ The following argument is supported:
 
 #### `location`
 
-* `method` - (Optional) The HTTP verb of a method. It is a valid field for the API entity types of `METHOD`, `PATH_PARAMETER`, `QUERY_PARAMETER`, `REQUEST_HEADER`, `REQUEST_BODY`, `RESPONSE`, `RESPONSE_HEADER`, and `RESPONSE_BODY`. The default value is `*` for any method.
-* `name` - (Optional) The name of the targeted API entity. It is a valid and required field for the API entity types of `AUTHORIZER`, `MODEL`, `PATH_PARAMETER`, `QUERY_PARAMETER`, `REQUEST_HEADER`, `REQUEST_BODY` and `RESPONSE_HEADER`.
-* `path` - (Optional) The URL path of the target. It is a valid field for the API entity types of `RESOURCE`, `METHOD`, `PATH_PARAMETER`, `QUERY_PARAMETER`, `REQUEST_HEADER`, `REQUEST_BODY`, `RESPONSE`, `RESPONSE_HEADER`, and `RESPONSE_BODY`. The default value is `/` for the root resource.
-* `status_code` - (Optional) The HTTP status code of a response. It is a valid field for the API entity types of `RESPONSE`, `RESPONSE_HEADER`, and `RESPONSE_BODY`. The default value is `*` for any status code.
+See supported entity types for each field in the [official docs](https://docs.aws.amazon.com/apigateway/api-reference/resource/documentation-part/).
+
+* `method` - (Optional) The HTTP verb of a method. The default value is `*` for any method.
+* `name` - (Optional) The name of the targeted API entity.
+* `path` - (Optional) The URL path of the target. The default value is `/` for the root resource.
+* `status_code` - (Optional) The HTTP status code of a response. The default value is `*` for any status code.
 * `type` - (Required) The type of API entity to which the documentation content applies. e.g. `API`, `METHOD` or `REQUEST_BODY`
 
 ## Attribute Reference
@@ -54,8 +56,8 @@ The following attribute is exported in addition to the arguments listed above:
 
 ## Import
 
-API Gateway documentation_parts can be imported using the word `api-gateway-documentation_part`, e.g.
+API Gateway documentation_parts can be imported using `REST-API-ID/DOC-PART-ID`, e.g.
 
 ```
-$ terraform import aws_api_gateway_documentation_part.example 3oyy3t
+$ terraform import aws_api_gateway_documentation_part.example 5i4e1ko720/3oyy3t
 ```


### PR DESCRIPTION
## Test results

```
$ make testacc TESTARGS='-run=TestAccAWSAPIGatewayDocumentationPart_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccAWSAPIGatewayDocumentationPart_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSAPIGatewayDocumentationPart_basic
--- PASS: TestAccAWSAPIGatewayDocumentationPart_basic (107.73s)
=== RUN   TestAccAWSAPIGatewayDocumentationPart_method
--- PASS: TestAccAWSAPIGatewayDocumentationPart_method (60.31s)
=== RUN   TestAccAWSAPIGatewayDocumentationPart_responseHeader
--- PASS: TestAccAWSAPIGatewayDocumentationPart_responseHeader (61.64s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	229.724s
```