### PR TITLE
Fix Cognito RoleMapping validation for Token types

### DIFF
--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1891,7 +1891,7 @@ func validateCognitoRoleMappingsRulesConfiguration(v map[string]interface{}) (er
 		errors = append(errors, fmt.Errorf("mapping_rule is required for Rules"))
 	}
 
-	if (ok || valLength > 0) && t == cognitoidentity.RoleMappingTypeToken {
+	if (!ok || valLength > 0) && t == cognitoidentity.RoleMappingTypeToken {
 		errors = append(errors, fmt.Errorf("mapping_rule must not be set for Token based role mapping"))
 	}
 

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1884,14 +1884,16 @@ func validateCognitoRoleMappingsAmbiguousRoleResolutionAgainstType(v map[string]
 
 func validateCognitoRoleMappingsRulesConfiguration(v map[string]interface{}) (errors []error) {
 	t := v["type"].(string)
-	value, ok := v["mapping_rule"]
-	valLength := len(value.([]interface{}))
+	valLength := 0
+	if value, ok := v["mapping_rule"]; ok {
+		valLength = len(value.([]interface{}))
+	}
 
-	if (!ok || valLength == 0) && t == cognitoidentity.RoleMappingTypeRules {
+	if (valLength == 0) && t == cognitoidentity.RoleMappingTypeRules {
 		errors = append(errors, fmt.Errorf("mapping_rule is required for Rules"))
 	}
 
-	if (!ok || valLength > 0) && t == cognitoidentity.RoleMappingTypeToken {
+	if (valLength > 0) && t == cognitoidentity.RoleMappingTypeToken {
 		errors = append(errors, fmt.Errorf("mapping_rule must not be set for Token based role mapping"))
 	}
 

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -2632,6 +2632,63 @@ func TestValidateCognitoRoleMappingsAmbiguousRoleResolutionAgainstType(t *testin
 	}
 }
 
+func TestValidateCognitoRoleMappingsRulesConfiguration(t *testing.T) {
+	cases := []struct {
+		MappingRule []interface{}
+		Type        string
+		ErrCount    int
+	}{
+		{
+			MappingRule: nil,
+			Type:        cognitoidentity.RoleMappingTypeRules,
+			ErrCount:    1,
+		},
+		{
+			MappingRule: []interface{}{
+				map[string]interface{}{
+					"Claim":     "isAdmin",
+					"MatchType": "Equals",
+					"RoleARN":   "arn:foo",
+					"Value":     "paid",
+				},
+			},
+			Type:     cognitoidentity.RoleMappingTypeRules,
+			ErrCount: 0,
+		},
+		{
+			MappingRule: []interface{}{
+				map[string]interface{}{
+					"Claim":     "isAdmin",
+					"MatchType": "Equals",
+					"RoleARN":   "arn:foo",
+					"Value":     "paid",
+				},
+			},
+			Type:     cognitoidentity.RoleMappingTypeToken,
+			ErrCount: 1,
+		},
+		{
+			MappingRule: nil,
+			Type:        cognitoidentity.RoleMappingTypeToken,
+			ErrCount:    0,
+		},
+	}
+
+	for _, tc := range cases {
+		m := make(map[string]interface{})
+		// Reproducing the undefined mapping_rule
+		if tc.MappingRule != nil {
+			m["mapping_rule"] = tc.MappingRule
+		}
+		m["type"] = tc.Type
+
+		errors := validateCognitoRoleMappingsRulesConfiguration(m)
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Cognito Role Mappings validation failed: %v, expected err count %d, got %d, for config %#v", errors, tc.ErrCount, len(errors), m)
+		}
+	}
+}
+
 func TestValidateCognitoRoleMappingsAmbiguousRoleResolution(t *testing.T) {
 	validValues := []string{
 		cognitoidentity.AmbiguousRoleResolutionTypeAuthenticatedRole,


### PR DESCRIPTION
If the mapping_rule isn't set then this should be the equivalent of it not having any mapping rules defined.
Looks like the negation was missed on this.

Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/2232