### PR TITLE
[WIP] resource/aws_cloudwatch_log_metric_filter: Unable to keep default value unset

### DIFF
--- a/aws/resource_aws_cloudwatch_log_metric_filter_test.go
+++ b/aws/resource_aws_cloudwatch_log_metric_filter_test.go
@@ -56,6 +56,7 @@ func TestAccAWSCloudWatchLogMetricFilter_basic(t *testing.T) {
 						MetricName:      aws.String("AccessDeniedCount"),
 						MetricNamespace: aws.String("MyNamespace"),
 						MetricValue:     aws.String("2"),
+						DefaultValue:    aws.Float64(1),
 					}),
 				),
 			},
@@ -107,6 +108,14 @@ func testAccCheckCloudWatchLogMetricFilterTransformation(mf *cloudwatchlogs.Metr
 		if *given.MetricValue != *expected.MetricValue {
 			return fmt.Errorf("Expected metric value: %q, received: %q",
 				*expected.MetricValue, *given.MetricValue)
+		}
+
+		if (given.DefaultValue != nil) != (expected.DefaultValue != nil) {
+			return fmt.Errorf("Expected default value to be present: %t, received: %t",
+				expected.DefaultValue != nil, given.DefaultValue != nil)
+		} else if (given.DefaultValue != nil) && *given.DefaultValue != *expected.DefaultValue {
+			return fmt.Errorf("Expected metric value: %g, received: %g",
+				*expected.DefaultValue, *given.DefaultValue)
 		}
 
 		return nil

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -1541,7 +1541,7 @@ func expandCloudWachLogMetricTransformations(m map[string]interface{}) ([]*cloud
 		MetricValue:     aws.String(m["value"].(string)),
 	}
 
-	if m["default_value"] != "" {
+	if m["default_value"] != nil {
 		transformation.DefaultValue = aws.Float64(m["default_value"].(float64))
 	}
 


### PR DESCRIPTION
Hello,

there is a bug in r/cloudwatch_log_metric_filter where `metric_transformation/default_value` gets set to 0 via API even if it is missing in the tf code like:

```hcl
resource "aws_cloudwatch_log_metric_filter" "foobar" {
  name = "MyAppAccessCount-%d"
  pattern = ""
  log_group_name = "${aws_cloudwatch_log_group.dada.name}"

  metric_transformation {
  	name = "EventCount"
  	namespace = "YourNamespace"
  	value = "1"
  }
}
```

`$ aws logs describe-metric-filters --region us-west-2`
```
{
    "metricFilters": [
        {
            "filterName": "MyAppAccessCount-11111111",
            "metricTransformations": [
                {
                    "metricName": "EventCount",
                    "metricNamespace": "YourNamespace",
                    "metricValue": "1",
                    "defaultValue": 0.0
                }
            ],
            "creationTime": 1515482147102,
            "logGroupName": "MyApp/access-11111.log"
        }
    ]
}
```

In this WIP PR so far I have improved acc tests to fail this case:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCloudWatchLogMetricFilter_' 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCloudWatchLogMetricFilter_ -timeout 120m
=== RUN   TestAccAWSCloudWatchLogMetricFilter_basic
--- FAIL: TestAccAWSCloudWatchLogMetricFilter_basic (27.05s)
        testing.go:503: Step 0 error: Check failed: Check 10/10 error: Expected default value to be present: false, received: true
FAIL
exit status 1
FAIL    github.com/terraform-providers/terraform-provider-aws/aws       27.079s
GNUmakefile:20: recipe for target 'testacc' failed
make: *** [testacc] Error 1
```

However, I have failed to resolve this bug since it appears there is some complicated magic involved here which always sets golangs Zero value on `TypeFloat` parameter which is `Optional` and non-present, e.g. here: 

https://github.com/hashicorp/terraform/blame/master/helper/schema/field_reader.go#L242

There is similar magic which converts `nil` or entirely missing parameter in data map to `0` during either during [d.Set()](https://github.com/terraform-providers/terraform-provider-aws/blob/master/aws/resource_aws_cloudwatch_log_metric_filter.go#L132) or during serialization to tfstate, just not sure.

Anyway, I'm lost and I seeking your advice here how to do solve this properly. To be honest, this implicit zero value trend is one of the most annoying "features" of golang in my opinion since it can be so unpredictable sometimes like this case  :/