### PR TITLE
r/lb_target_group: Fix validation rules for LB's healthcheck

### DIFF
--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -600,10 +600,15 @@ func resourceAwsLbTargetGroupCustomizeDiff(diff *schema.ResourceDiff, v interfac
 		if len(stickinessBlocks) != 0 {
 			return fmt.Errorf("Network Load Balancers do not support Stickiness")
 		}
-		// Network Load Balancers have many special qwirks to them.
-		// See http://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateTargetGroup.html
-		if healthChecks := diff.Get("health_check").([]interface{}); len(healthChecks) == 1 {
-			healthCheck := healthChecks[0].(map[string]interface{})
+	}
+
+	// Network Load Balancers have many special qwirks to them.
+	// See http://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateTargetGroup.html
+	if healthChecks := diff.Get("health_check").([]interface{}); len(healthChecks) == 1 {
+		healthCheck := healthChecks[0].(map[string]interface{})
+		protocol := healthCheck["protocol"].(string)
+
+		if protocol == "TCP" {
 			// Cannot set custom matcher on TCP health checks
 			if m := healthCheck["matcher"].(string); m != "" {
 				return fmt.Errorf("%s: custom matcher is not supported for target_groups with TCP protocol", diff.Id())
@@ -639,6 +644,12 @@ func resourceAwsLbTargetGroupCustomizeDiff(diff *schema.ResourceDiff, v interfac
 		if diff.HasChange("health_check.0.interval") {
 			old, new := diff.GetChange("health_check.0.interval")
 			return fmt.Errorf("Health check interval cannot be updated from %d to %d for TCP based Target Group %s,"+
+				" use 'terraform taint' to recreate the resource if you wish",
+				old, new, diff.Id())
+		}
+		if diff.HasChange("health_check.0.timeout") {
+			old, new := diff.GetChange("health_check.0.timeout")
+			return fmt.Errorf("Health check timeout cannot be updated from %d to %d for TCP based Target Group %s,"+
 				" use 'terraform taint' to recreate the resource if you wish",
 				old, new, diff.Id())
 		}

--- a/aws/resource_aws_lb_target_group_test.go
+++ b/aws/resource_aws_lb_target_group_test.go
@@ -137,7 +137,7 @@ func TestAccAWSLBTargetGroup_networkLB_TargetGroup(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.port", "traffic-port"),
 					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.protocol", "TCP"),
 					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.timeout", "10"),
-					testAccCheckAWSLBTargetGroupHealthCheckTimeout(&confBefore, 10),
+					testAccCheckAWSLBTargetGroupHealthCheckTimeout(&confAfter, 10),
 					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.healthy_threshold", "5"),
 					testAccCheckAWSLBTargetGroupHealthyThreshold(&confAfter, 5),
 					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.unhealthy_threshold", "5"),
@@ -151,6 +151,73 @@ func TestAccAWSLBTargetGroup_networkLB_TargetGroup(t *testing.T) {
 
 				ExpectNonEmptyPlan: true,
 				ExpectError:        regexp.MustCompile("Health check interval cannot be updated"),
+			},
+		},
+	})
+}
+
+func TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck(t *testing.T) {
+	var confBefore, confAfter elbv2.TargetGroup
+	rString := acctest.RandString(8)
+	targetGroupName := fmt.Sprintf("test-tg-tcp-http-hc-%s", rString)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_lb_target_group.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLBTargetGroupConfig_typeTCP_HTTPHealthCheck(targetGroupName, "/healthz", 2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLBTargetGroupExists("aws_lb_target_group.test", &confBefore),
+					resource.TestCheckResourceAttrSet("aws_lb_target_group.test", "arn"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "name", targetGroupName),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "port", "8082"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "protocol", "TCP"),
+					resource.TestCheckResourceAttrSet("aws_lb_target_group.test", "vpc_id"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "deregistration_delay", "300"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.#", "1"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.interval", "30"),
+					testAccCheckAWSLBTargetGroupHealthCheckInterval(&confBefore, 30),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.path", "/healthz"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.port", "443"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.protocol", "HTTPS"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.timeout", "10"),
+					testAccCheckAWSLBTargetGroupHealthCheckTimeout(&confBefore, 10),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.healthy_threshold", "2"),
+					testAccCheckAWSLBTargetGroupHealthyThreshold(&confBefore, 2),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.unhealthy_threshold", "2"),
+					testAccCheckAWSLBTargetGroupUnhealthyThreshold(&confBefore, 2),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "tags.%", "1"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "tags.Name", "TestAcc_networkLB_HTTPHealthCheck"),
+				),
+			},
+			{
+				Config: testAccAWSLBTargetGroupConfig_typeTCP_HTTPHealthCheck(targetGroupName, "/healthz2", 4),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLBTargetGroupExists("aws_lb_target_group.test", &confAfter),
+					resource.TestCheckResourceAttrSet("aws_lb_target_group.test", "arn"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "name", targetGroupName),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "port", "8082"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "protocol", "TCP"),
+					resource.TestCheckResourceAttrSet("aws_lb_target_group.test", "vpc_id"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "deregistration_delay", "300"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.#", "1"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.interval", "30"),
+					testAccCheckAWSLBTargetGroupHealthCheckInterval(&confAfter, 30),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.path", "/healthz2"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.port", "443"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.protocol", "HTTPS"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.timeout", "10"),
+					testAccCheckAWSLBTargetGroupHealthCheckTimeout(&confAfter, 10),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.healthy_threshold", "4"),
+					testAccCheckAWSLBTargetGroupHealthyThreshold(&confAfter, 4),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.unhealthy_threshold", "4"),
+					testAccCheckAWSLBTargetGroupUnhealthyThreshold(&confAfter, 4),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "tags.%", "1"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "tags.Name", "TestAcc_networkLB_HTTPHealthCheck"),
+				),
 			},
 		},
 	})
@@ -574,24 +641,24 @@ func TestAccAWSLBTargetGroup_defaults_network(t *testing.T) {
     interval = 10
     port     = 8081
     protocol = "TCP"
-        `
+    `
 	healthCheckInvalid2 := `
     interval = 10
     port     = 8081
     protocol = "TCP"
-                matcher = "200"
-        `
+    matcher = "200"
+    `
 	healthCheckInvalid3 := `
     interval = 10
     port     = 8081
     protocol = "TCP"
-                timeout = 4
-        `
+    timeout = 4
+    `
 	healthCheckValid := `
     interval = 10
     port     = 8081
     protocol = "TCP"
-        `
+    `
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -1187,6 +1254,37 @@ resource "aws_vpc" "test" {
     Name = "TestAcc_networkLB_TargetGroup"
   }
 }`, targetGroupName)
+}
+
+func testAccAWSLBTargetGroupConfig_typeTCP_HTTPHealthCheck(targetGroupName, path string, threshold int) string {
+	return fmt.Sprintf(`resource "aws_lb_target_group" "test" {
+  name     = "%[1]s"
+  port     = 8082
+  protocol = "TCP"
+  vpc_id   = "${aws_vpc.test.id}"
+
+  health_check {
+    healthy_threshold   = %[2]d
+    unhealthy_threshold = %[2]d
+    timeout             = "10"
+    port                = "443"
+    path                = "%[3]s"
+    protocol            = "HTTPS"
+    interval            = 30
+    matcher             = "200-399"
+  }
+
+  tags {
+    Name = "TestAcc_networkLB_HTTPHealthCheck"
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+  tags {
+    Name = "TestAcc_networkLB_HTTPHealthCheck"
+  }
+}`, targetGroupName, threshold, path)
 }
 
 func testAccAWSLBTargetGroupConfig_stickiness(targetGroupName string, addStickinessBlock bool, enabled bool) string {


### PR DESCRIPTION
Network load balancer can still have a HTTP-based health check and all of matcher, path and timeout can be set for such health check so here I am fixing the validation which assumed NLB is always going to have TCP health checks.

Attached is a test which demonstrates this.

Fixes #2708

## Test results

Test failures are intermittent and unrelated to this PR.

```
=== RUN   TestAccAWSLBListenerRule_multipleConditionThrowsError
--- PASS: TestAccAWSLBListenerRule_multipleConditionThrowsError (2.49s)
=== RUN   TestAccAWSLBSSLNegotiationPolicy_basic
--- PASS: TestAccAWSLBSSLNegotiationPolicy_basic (52.91s)
=== RUN   TestAccAWSLBTargetGroup_generatedName
--- PASS: TestAccAWSLBTargetGroup_generatedName (61.63s)
=== RUN   TestAccAWSLBCookieStickinessPolicy_missingLB
--- PASS: TestAccAWSLBCookieStickinessPolicy_missingLB (75.90s)
=== RUN   TestAccAWSLBTargetGroup_basic
--- PASS: TestAccAWSLBTargetGroup_basic (108.03s)
=== RUN   TestAccAWSLBSSLNegotiationPolicy_missingLB
--- PASS: TestAccAWSLBSSLNegotiationPolicy_missingLB (108.33s)
=== RUN   TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck
--- PASS: TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck (136.35s)
=== RUN   TestAccAWSLBTargetGroup_changeNameForceNew
--- PASS: TestAccAWSLBTargetGroup_changeNameForceNew (85.12s)
=== RUN   TestAccAWSLBTargetGroup_tags
--- PASS: TestAccAWSLBTargetGroup_tags (74.37s)
=== RUN   TestAccAWSLBTargetGroup_changeVpcForceNew
--- PASS: TestAccAWSLBTargetGroup_changeVpcForceNew (79.20s)
=== RUN   TestAccAWSLBTargetGroupAttachment_withoutPort
--- PASS: TestAccAWSLBTargetGroupAttachment_withoutPort (216.48s)
=== RUN   TestAccAWSLBTargetGroup_networkLB_TargetGroup
--- PASS: TestAccAWSLBTargetGroup_networkLB_TargetGroup (228.47s)
=== RUN   TestAccAWSLBListener_basic
--- PASS: TestAccAWSLBListener_basic (242.39s)
=== RUN   TestAccAWSLBTargetGroup_defaults_application
--- PASS: TestAccAWSLBTargetGroup_defaults_application (72.54s)
=== RUN   TestAccAWSLBTargetGroup_changeProtocolForceNew
--- PASS: TestAccAWSLBTargetGroup_changeProtocolForceNew (194.01s)
=== RUN   TestAccAWSLBTargetGroup_defaults_network
--- PASS: TestAccAWSLBTargetGroup_defaults_network (89.38s)
=== RUN   TestAccAWSLBCookieStickinessPolicy_basic
--- PASS: TestAccAWSLBCookieStickinessPolicy_basic (283.47s)
=== RUN   TestAccAWSLBListenerBackwardsCompatibility
--- PASS: TestAccAWSLBListenerBackwardsCompatibility (309.23s)
=== RUN   TestAccAWSLBListenerRule_updateRulePriority
--- PASS: TestAccAWSLBListenerRule_updateRulePriority (330.00s)
=== RUN   TestAccAWSLBTargetGroup_namePrefix
--- PASS: TestAccAWSLBTargetGroup_namePrefix (370.10s)
=== RUN   TestAccAWSLBTargetGroup_changePortForceNew
--- PASS: TestAccAWSLBTargetGroup_changePortForceNew (304.06s)
=== RUN   TestAccAWSLBTargetGroup_updateSticknessEnabled
--- PASS: TestAccAWSLBTargetGroup_updateSticknessEnabled (245.85s)
=== RUN   TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew
--- PASS: TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew (388.32s)
=== RUN   TestAccAWSLBTargetGroup_updateHealthCheck
--- PASS: TestAccAWSLBTargetGroup_updateHealthCheck (261.16s)
=== RUN   TestAccAWSLB_networkLoadbalancer
--- PASS: TestAccAWSLB_networkLoadbalancer (211.08s)
=== RUN   TestAccAWSLBBackwardsCompatibility
--- PASS: TestAccAWSLBBackwardsCompatibility (196.24s)
=== RUN   TestAccAWSLB_networkLoadbalancerEIP
--- FAIL: TestAccAWSLB_networkLoadbalancerEIP (210.26s)
	testing.go:503: Step 0 error: After applying this step, the plan was not empty:
		
		DIFF:
		
		UPDATE: aws_route_table.public
		  route.#:                                   "0" => "1"
		  route.302326152.cidr_block:                "" => "0.0.0.0/0"
		  route.302326152.egress_only_gateway_id:    "" => ""
		  route.302326152.gateway_id:                "" => "igw-dd71bdbb"
		  route.302326152.instance_id:               "" => ""
		  route.302326152.ipv6_cidr_block:           "" => ""
		  route.302326152.nat_gateway_id:            "" => ""
		  route.302326152.network_interface_id:      "" => ""
		  route.302326152.vpc_peering_connection_id: "" => ""
		
		STATE:
		...
FAIL
=== RUN   TestAccAWSLB_basic
--- PASS: TestAccAWSLB_basic (239.23s)
=== RUN   TestAccAWSLBTargetGroupBackwardsCompatibility
--- PASS: TestAccAWSLBTargetGroupBackwardsCompatibility (457.27s)
=== RUN   TestAccAWSLB_generatedName
--- PASS: TestAccAWSLB_generatedName (234.37s)
=== RUN   TestAccAWSLB_generatesNameForZeroValue
--- PASS: TestAccAWSLB_generatesNameForZeroValue (217.28s)
=== RUN   TestAccAWSLB_namePrefix
--- PASS: TestAccAWSLB_namePrefix (237.42s)
=== RUN   TestAccAWSLBTargetGroupAttachmentBackwardsCompatibility
--- PASS: TestAccAWSLBTargetGroupAttachmentBackwardsCompatibility (559.68s)
=== RUN   TestAccAWSLBListenerRule_basic
--- PASS: TestAccAWSLBListenerRule_basic (566.04s)
=== RUN   TestAccAWSLBTargetGroupAttachment_basic
--- PASS: TestAccAWSLBTargetGroupAttachment_basic (566.29s)
=== RUN   TestAccAWSLB_noSecurityGroup
--- PASS: TestAccAWSLB_noSecurityGroup (194.98s)
=== RUN   TestAccAWSLB_networkLoadbalancer_subnet_change
--- PASS: TestAccAWSLB_networkLoadbalancer_subnet_change (233.12s)
=== RUN   TestAccAWSLB_updatedIpAddressType
--- PASS: TestAccAWSLB_updatedIpAddressType (252.19s)
=== RUN   TestAccAWSLBListener_https
--- FAIL: TestAccAWSLBListener_https (642.87s)
	testing.go:503: Step 0 error: Error applying: 1 error(s) occurred:
		
		* aws_lb_listener.front_end: 1 error(s) occurred:
		
		* aws_lb_listener.front_end: Error creating LB Listener: CertificateNotFound: Certificate 'arn:aws:iam::*******:server-certificate/terraform-test-cert-2789446306923563187' not found
			status code: 400, request id: 64feff3a-f53e-11e7-902b-d15f0db787be
=== RUN   TestAccAWSLB_updatedSecurityGroups
--- PASS: TestAccAWSLB_updatedSecurityGroups (318.89s)
=== RUN   TestAccAWSLB_updatedSubnets
--- PASS: TestAccAWSLB_updatedSubnets (288.13s)
=== RUN   TestAccAWSLBListenerRuleBackwardsCompatibility
--- PASS: TestAccAWSLBListenerRuleBackwardsCompatibility (684.28s)
=== RUN   TestAccAWSLB_accesslogs
--- PASS: TestAccAWSLB_accesslogs (308.73s)
=== RUN   TestAccAWSLB_tags
--- PASS: TestAccAWSLB_tags (389.22s)
```