### PR TITLE
tests/aws_appautoscaling_*: Remove role_arn

### DIFF
--- a/aws/resource_aws_appautoscaling_policy_test.go
+++ b/aws/resource_aws_appautoscaling_policy_test.go
@@ -202,35 +202,6 @@ func testAccAWSAppautoscalingPolicyConfig(
 	randClusterName string,
 	randPolicyName string) string {
 	return fmt.Sprintf(`
-resource "aws_iam_role" "autoscale_role" {
-	name = "%s"
-	path = "/"
-
-	assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Action\":[\"sts:AssumeRole\"]}]}"
-}
-
-resource "aws_iam_role_policy" "autoscale_role_policy" {
-	name = "%s"
-	role = "${aws_iam_role.autoscale_role.id}"
-
-	policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ecs:DescribeServices",
-                "ecs:UpdateService",
-				"cloudwatch:DescribeAlarms"
-            ],
-            "Resource": ["*"]
-        }
-    ]
-}
-EOF
-}
-
 resource "aws_ecs_cluster" "foo" {
 	name = "%s"
 }
@@ -263,7 +234,6 @@ resource "aws_appautoscaling_target" "tgt" {
 	service_namespace = "ecs"
 	resource_id = "service/${aws_ecs_cluster.foo.name}/${aws_ecs_service.service.name}"
 	scalable_dimension = "ecs:service:DesiredCount"
-	role_arn = "${aws_iam_role.autoscale_role.arn}"
 	min_capacity = 1
 	max_capacity = 4
 }
@@ -282,7 +252,7 @@ resource "aws_appautoscaling_policy" "foobar_simple" {
 	}
 	depends_on = ["aws_appautoscaling_target.tgt"]
 }
-`, randClusterName, randClusterName, randClusterName, randPolicyName)
+`, randClusterName, randPolicyName)
 }
 
 func testAccAWSAppautoscalingPolicySpotFleetRequestConfig(
@@ -326,38 +296,10 @@ resource "aws_spot_fleet_request" "test" {
   }
 }
 
-resource "aws_iam_role" "autoscale_role" {
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "application-autoscaling.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_role_policy_attachment" "autoscale_role_policy_a" {
-  role = "${aws_iam_role.autoscale_role.name}"
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole"
-}
-
-resource "aws_iam_role_policy_attachment" "autoscale_role_policy_b" {
-  role = "${aws_iam_role.autoscale_role.name}"
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetAutoscaleRole"
-}
-
 resource "aws_appautoscaling_target" "test" {
   service_namespace = "ec2"
   resource_id = "spot-fleet-request/${aws_spot_fleet_request.test.id}"
   scalable_dimension = "ec2:spot-fleet-request:TargetCapacity"
-  role_arn = "${aws_iam_role.autoscale_role.arn}"
   min_capacity = 1
   max_capacity = 3
 }
@@ -385,35 +327,6 @@ func testAccAWSAppautoscalingPolicyNestedSchemaConfig(
 	randClusterName string,
 	randPolicyName string) string {
 	return fmt.Sprintf(`
-resource "aws_iam_role" "autoscale_role" {
-	name = "%s"
-	path = "/"
-
-	assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Action\":[\"sts:AssumeRole\"]}]}"
-}
-
-resource "aws_iam_role_policy" "autoscale_role_policy" {
-	name = "%s"
-	role = "${aws_iam_role.autoscale_role.id}"
-
-	policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ecs:DescribeServices",
-                "ecs:UpdateService",
-				"cloudwatch:DescribeAlarms"
-            ],
-            "Resource": ["*"]
-        }
-    ]
-}
-EOF
-}
-
 resource "aws_ecs_cluster" "foo" {
 	name = "%s"
 }
@@ -446,7 +359,6 @@ resource "aws_appautoscaling_target" "tgt" {
 	service_namespace = "ecs"
 	resource_id = "service/${aws_ecs_cluster.foo.name}/${aws_ecs_service.service.name}"
 	scalable_dimension = "ecs:service:DesiredCount"
-	role_arn = "${aws_iam_role.autoscale_role.arn}"
 	min_capacity = 1
 	max_capacity = 4
 }
@@ -468,7 +380,7 @@ resource "aws_appautoscaling_policy" "foobar_simple" {
 	}
 	depends_on = ["aws_appautoscaling_target.tgt"]
 }
-`, randClusterName, randClusterName, randClusterName, randPolicyName)
+`, randClusterName, randPolicyName)
 }
 
 func testAccAWSAppautoscalingPolicyDynamoDB(
@@ -485,53 +397,12 @@ resource "aws_dynamodb_table" "dynamodb_table_test" {
   }
 }
 
-resource "aws_iam_role" "autoscale_role" {
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "application-autoscaling.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_role_policy" "p" {
-  role = "${aws_iam_role.autoscale_role.name}"
-  policy = <<POLICY
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "dynamodb:DescribeTable",
-                "dynamodb:UpdateTable",
-                "cloudwatch:PutMetricAlarm",
-                "cloudwatch:DescribeAlarms",
-                "cloudwatch:DeleteAlarms"
-            ],
-            "Resource": "*"
-        }
-    ]
-}
-POLICY
-}
-
 resource "aws_appautoscaling_target" "dynamo_test" {
   service_namespace = "dynamodb"
   resource_id = "table/${aws_dynamodb_table.dynamodb_table_test.name}"
   scalable_dimension = "dynamodb:table:WriteCapacityUnits"
-  role_arn = "${aws_iam_role.autoscale_role.arn}"
   min_capacity = 1
   max_capacity = 10
-  depends_on = ["aws_iam_role_policy.p"]
 }
 
 resource "aws_appautoscaling_policy" "dynamo_test" {
@@ -569,53 +440,12 @@ resource "aws_dynamodb_table" "dynamodb_table_test" {
   }
 }
 
-resource "aws_iam_role" "autoscale_role" {
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "application-autoscaling.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_role_policy" "p" {
-  role = "${aws_iam_role.autoscale_role.name}"
-  policy = <<POLICY
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "dynamodb:DescribeTable",
-                "dynamodb:UpdateTable",
-                "cloudwatch:PutMetricAlarm",
-                "cloudwatch:DescribeAlarms",
-                "cloudwatch:DeleteAlarms"
-            ],
-            "Resource": "*"
-        }
-    ]
-}
-POLICY
-}
-
 resource "aws_appautoscaling_target" "write" {
   service_namespace = "dynamodb"
   resource_id = "table/${aws_dynamodb_table.dynamodb_table_test.name}"
   scalable_dimension = "dynamodb:table:WriteCapacityUnits"
-  role_arn = "${aws_iam_role.autoscale_role.arn}"
   min_capacity = 1
   max_capacity = 10
-  depends_on = ["aws_iam_role_policy.p"]
 }
 
 resource "aws_appautoscaling_policy" "write" {
@@ -640,10 +470,8 @@ resource "aws_appautoscaling_target" "read" {
   service_namespace = "dynamodb"
   resource_id = "table/${aws_dynamodb_table.dynamodb_table_test.name}"
   scalable_dimension = "dynamodb:table:ReadCapacityUnits"
-  role_arn = "${aws_iam_role.autoscale_role.arn}"
   min_capacity = 1
   max_capacity = 10
-  depends_on = ["aws_iam_role_policy.p"]
 }
 
 resource "aws_appautoscaling_policy" "read" {


### PR DESCRIPTION
Related to https://github.com/terraform-providers/terraform-provider-aws/pull/2889

## Before

(broken by introduced API changes)

```
=== RUN   TestAccAWSAppautoScalingPolicy_basic
--- FAIL: TestAccAWSAppautoScalingPolicy_basic (23.00s)
    testing.go:503: Step 0 error: After applying this step, the plan was not empty:
        
        DIFF:
        
        DESTROY/CREATE: aws_appautoscaling_target.tgt
          max_capacity:       "4" => "4"
          min_capacity:       "1" => "1"
          resource_id:        "service/clusterjpehs2et3o/foobar" => "service/clusterjpehs2et3o/foobar"
          role_arn:           "arn:aws:iam::*******:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService" => "arn:aws:iam::*******:role/clusterjpehs2et3o" (forces new resource)
          scalable_dimension: "ecs:service:DesiredCount" => "ecs:service:DesiredCount"
          service_namespace:  "ecs" => "ecs"

        ...

=== RUN   TestAccAWSAppautoScalingPolicy_dynamoDb
--- FAIL: TestAccAWSAppautoScalingPolicy_dynamoDb (18.46s)
    testing.go:503: Step 0 error: After applying this step, the plan was not empty:
        
        DIFF:
        
        DESTROY/CREATE: aws_appautoscaling_target.dynamo_test
          max_capacity:       "10" => "10"
          min_capacity:       "1" => "1"
          resource_id:        "table/test-appautoscaling-policy-v3f3w" => "table/test-appautoscaling-policy-v3f3w"
          role_arn:           "arn:aws:iam::*******:role/aws-service-role/dynamodb.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_DynamoDBTable" => "arn:aws:iam::*******:role/terraform-20180109045056575800000001" (forces new resource)
          scalable_dimension: "dynamodb:table:WriteCapacityUnits" => "dynamodb:table:WriteCapacityUnits"
          service_namespace:  "dynamodb" => "dynamodb"

        ...

=== RUN   TestAccAWSAppautoScalingPolicy_multiplePolicies
--- FAIL: TestAccAWSAppautoScalingPolicy_multiplePolicies (16.12s)
    testing.go:503: Step 0 error: After applying this step, the plan was not empty:
        
        DIFF:
        
        DESTROY/CREATE: aws_appautoscaling_target.read
          max_capacity:       "10" => "10"
          min_capacity:       "1" => "1"
          resource_id:        "table/tf-autoscaled-table-942zg" => "table/tf-autoscaled-table-942zg"
          role_arn:           "arn:aws:iam::*******:role/aws-service-role/dynamodb.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_DynamoDBTable" => "arn:aws:iam::*******:role/terraform-20180109045113595800000001" (forces new resource)
          scalable_dimension: "dynamodb:table:ReadCapacityUnits" => "dynamodb:table:ReadCapacityUnits"
          service_namespace:  "dynamodb" => "dynamodb"
        DESTROY/CREATE: aws_appautoscaling_target.write
          max_capacity:       "10" => "10"
          min_capacity:       "1" => "1"
          resource_id:        "table/tf-autoscaled-table-942zg" => "table/tf-autoscaled-table-942zg"
          role_arn:           "arn:aws:iam::*******:role/aws-service-role/dynamodb.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_DynamoDBTable" => "arn:aws:iam::*******:role/terraform-20180109045113595800000001" (forces new resource)
          scalable_dimension: "dynamodb:table:WriteCapacityUnits" => "dynamodb:table:WriteCapacityUnits"
          service_namespace:  "dynamodb" => "dynamodb"

        ...

=== RUN   TestAccAWSAppautoScalingPolicy_nestedSchema
--- FAIL: TestAccAWSAppautoScalingPolicy_nestedSchema (14.62s)
    testing.go:503: Step 0 error: After applying this step, the plan was not empty:
        
        DIFF:
        
        DESTROY/CREATE: aws_appautoscaling_target.tgt
          max_capacity:       "4" => "4"
          min_capacity:       "1" => "1"
          resource_id:        "service/clusterj8acd3pmd0/foobar" => "service/clusterj8acd3pmd0/foobar"
          role_arn:           "arn:aws:iam::*******:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService" => "arn:aws:iam::*******:role/clusterj8acd3pmd0" (forces new resource)
          scalable_dimension: "ecs:service:DesiredCount" => "ecs:service:DesiredCount"
          service_namespace:  "ecs" => "ecs"
        
        ...

=== RUN   TestAccAWSAppautoScalingPolicy_spotFleetRequest
--- FAIL: TestAccAWSAppautoScalingPolicy_spotFleetRequest (56.05s)
    testing.go:503: Step 0 error: After applying this step, the plan was not empty:
        
        DIFF:
        
        DESTROY/CREATE: aws_appautoscaling_target.test
          max_capacity:       "3" => "3"
          min_capacity:       "1" => "1"
          resource_id:        "spot-fleet-request/sfr-533cca3a-8bf2-4566-9e96-4a016522442a" => "spot-fleet-request/sfr-533cca3a-8bf2-4566-9e96-4a016522442a"
          role_arn:           "arn:aws:iam::*******:role/aws-service-role/ec2.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_EC2SpotFleetRequest" => "arn:aws:iam::*******:role/terraform-20180109045052291400000001" (forces new resource)
          scalable_dimension: "ec2:spot-fleet-request:TargetCapacity" => "ec2:spot-fleet-request:TargetCapacity"
          service_namespace:  "ec2" => "ec2"
        
        ...

=== RUN   TestAccAwsAppautoscalingScheduledAction_ECS
--- FAIL: TestAccAwsAppautoscalingScheduledAction_ECS (32.46s)
    testing.go:503: Step 0 error: After applying this step, the plan was not empty:
        
        DIFF:
        
        DESTROY/CREATE: aws_appautoscaling_target.hoge
          max_capacity:       "3" => "3"
          min_capacity:       "1" => "1"
          resource_id:        "service/tf-ecs-cluster-epwa7/tf-ecs-service-epwa7" => "service/tf-ecs-cluster-epwa7/tf-ecs-service-epwa7"
          role_arn:           "arn:aws:iam::*******:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService" => "arn:aws:iam::*******:role/terraform-20180109045129718300000001" (forces new resource)
          scalable_dimension: "ecs:service:DesiredCount" => "ecs:service:DesiredCount"
          service_namespace:  "ecs" => "ecs"
        
        ...

=== RUN   TestAccAwsAppautoscalingScheduledAction_SpotFleet
--- FAIL: TestAccAwsAppautoscalingScheduledAction_SpotFleet (56.02s)
    testing.go:503: Step 0 error: After applying this step, the plan was not empty:
        
        DIFF:
        
        DESTROY/CREATE: aws_appautoscaling_target.hoge
          max_capacity:       "3" => "3"
          min_capacity:       "1" => "1"
          resource_id:        "spot-fleet-request/sfr-c3184700-7fdc-4ba2-8cb9-a6becf2015eb" => "spot-fleet-request/sfr-c3184700-7fdc-4ba2-8cb9-a6becf2015eb"
          role_arn:           "arn:aws:iam::*******:role/aws-service-role/ec2.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_EC2SpotFleetRequest" => "arn:aws:iam::*******:role/terraform-20180109045143503700000002" (forces new resource)
          scalable_dimension: "ec2:spot-fleet-request:TargetCapacity" => "ec2:spot-fleet-request:TargetCapacity"
          service_namespace:  "ec2" => "ec2"
        
        ...

=== RUN   TestAccAwsAppautoscalingScheduledAction_dynamo
--- FAIL: TestAccAwsAppautoscalingScheduledAction_dynamo (17.22s)
    testing.go:503: Step 0 error: After applying this step, the plan was not empty:
        
        DIFF:
        
        DESTROY/CREATE: aws_appautoscaling_target.read
          max_capacity:       "10" => "10"
          min_capacity:       "1" => "1"
          resource_id:        "table/tf-ddb-fdchl" => "table/tf-ddb-fdchl"
          role_arn:           "arn:aws:iam::*******:role/aws-service-role/dynamodb.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_DynamoDBTable" => "arn:aws:iam::*******:role/terraform-20180109045115033300000001" (forces new resource)
          scalable_dimension: "dynamodb:table:ReadCapacityUnits" => "dynamodb:table:ReadCapacityUnits"
          service_namespace:  "dynamodb" => "dynamodb"
        
        ...
```

## After

```
=== RUN   TestAccAWSAppautoScalingPolicy_basic
--- PASS: TestAccAWSAppautoScalingPolicy_basic (11.87s)
=== RUN   TestAccAWSAppautoScalingPolicy_nestedSchema
--- PASS: TestAccAWSAppautoScalingPolicy_nestedSchema (15.31s)
=== RUN   TestAccAWSAppautoScalingPolicy_multiplePolicies
--- PASS: TestAccAWSAppautoScalingPolicy_multiplePolicies (19.18s)
=== RUN   TestAccAWSAppautoScalingPolicy_dynamoDb
--- PASS: TestAccAWSAppautoScalingPolicy_dynamoDb (19.27s)
=== RUN   TestAccAWSAppautoScalingPolicy_spotFleetRequest
--- PASS: TestAccAWSAppautoScalingPolicy_spotFleetRequest (50.07s)
=== RUN   TestAccAwsAppautoscalingScheduledAction_dynamo
--- PASS: TestAccAwsAppautoscalingScheduledAction_dynamo (19.13s)
=== RUN   TestAccAwsAppautoscalingScheduledAction_ECS
--- PASS: TestAccAwsAppautoscalingScheduledAction_ECS (33.14s)
=== RUN   TestAccAwsAppautoscalingScheduledAction_SpotFleet
--- PASS: TestAccAwsAppautoscalingScheduledAction_SpotFleet (50.03s)
=== RUN   TestAccAwsAppautoscalingScheduledAction_EMR
--- PASS: TestAccAwsAppautoscalingScheduledAction_EMR (404.23s)
```