### PR TITLE
resource/aws_config_delivery_channel: Retry deletion

### DIFF
--- a/aws/resource_aws_config_delivery_channel.go
+++ b/aws/resource_aws_config_delivery_channel.go
@@ -162,7 +162,18 @@ func resourceAwsConfigDeliveryChannelDelete(d *schema.ResourceData, meta interfa
 	input := configservice.DeleteDeliveryChannelInput{
 		DeliveryChannelName: aws.String(d.Id()),
 	}
-	_, err := conn.DeleteDeliveryChannel(&input)
+
+	err := resource.Retry(30*time.Second, func() *resource.RetryError {
+		_, err := conn.DeleteDeliveryChannel(&input)
+		if err != nil {
+			if isAWSErr(err, configservice.ErrCodeLastDeliveryChannelDeleteFailedException, "there is a running configuration recorder") {
+				return resource.RetryableError(err)
+			}
+
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
 	if err != nil {
 		return fmt.Errorf("Unable to delete delivery channel: %s", err)
 	}


### PR DESCRIPTION
This is to address the following test failure:
```
        --- FAIL: TestAccAWSConfig/ConfigurationRecorderStatus/importBasic (47.21s)
            testing.go:563: Error destroying resource! WARNING: Dangling resources
                may exist. The full state and error is shown below.
                
                Error: Error applying: 1 error(s) occurred:
                
                * aws_config_delivery_channel.foo (destroy): 1 error(s) occurred:
                
                * aws_config_delivery_channel.foo: Unable to delete delivery channel: LastDeliveryChannelDeleteFailedException: Failed to delete last specified delivery channel with name 'tf-acc-test-awsconfig-6670192826583674632', because there is a running configuration recorder.
                    status code: 400, request id: 40ddcaf5-df0f-11e7-aa42-c989f54ca168
                ...
```

I also double checked the debug log to verify that it's actually eventual consistency, not a missing/wrong dependency:

```
2017/12/12 07:37:05 [DEBUG] [aws-sdk-go] DEBUG: Request config/StopConfigurationRecorder Details:
---[ REQUEST POST-SIGN ]-----------------------------
POST / HTTP/1.1
Host: config.us-west-2.amazonaws.com
User-Agent: aws-sdk-go/1.12.44 (go1.9; linux; amd64) APN/1.0 HashiCorp/1.0 Terraform/0.11.0-beta1
Content-Length: 63
Authorization: AWS4-HMAC-SHA256 Credential=*REDACTED*/20171212/us-west-2/config/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-date;x-amz-target, Signature=*REDACTED*
Content-Type: application/x-amz-json-1.1
X-Amz-Date: 20171212T073705Z
X-Amz-Target: StarlingDoveService.StopConfigurationRecorder
Accept-Encoding: gzip

{"ConfigurationRecorderName":"tf-acc-test-6670192826583674632"}
-----------------------------------------------------
2017/12/12 07:37:05 [DEBUG] [aws-sdk-go] DEBUG: Response config/StopConfigurationRecorder Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 200 OK
Connection: close
Content-Length: 0
Content-Type: application/x-amz-json-1.1
Date: Tue, 12 Dec 2017 07:37:06 GMT
X-Amzn-Requestid: 40c53951-df0f-11e7-b9d0-ed903b6f8a82


-----------------------------------------------------

...

2017/12/12 07:37:05 [DEBUG] [aws-sdk-go] DEBUG: Request config/DeleteDeliveryChannel Details:
---[ REQUEST POST-SIGN ]-----------------------------
POST / HTTP/1.1
Host: config.us-west-2.amazonaws.com
User-Agent: aws-sdk-go/1.12.44 (go1.9; linux; amd64) APN/1.0 HashiCorp/1.0 Terraform/0.11.0-beta1
Content-Length: 67
Authorization: AWS4-HMAC-SHA256 Credential=*REDACTED*/20171212/us-west-2/config/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-date;x-amz-target, Signature=*REDACTED*
Content-Type: application/x-amz-json-1.1
X-Amz-Date: 20171212T073705Z
X-Amz-Target: StarlingDoveService.DeleteDeliveryChannel
Accept-Encoding: gzip

{"DeliveryChannelName":"tf-acc-test-awsconfig-6670192826583674632"}
-----------------------------------------------------
2017/12/12 07:37:05 [DEBUG] [aws-sdk-go] DEBUG: Request config/DeleteConfigurationRecorder Details:
---[ REQUEST POST-SIGN ]-----------------------------
POST / HTTP/1.1
Host: config.us-west-2.amazonaws.com
User-Agent: aws-sdk-go/1.12.44 (go1.9; linux; amd64) APN/1.0 HashiCorp/1.0 Terraform/0.11.0-beta1
Content-Length: 63
Authorization: AWS4-HMAC-SHA256 Credential=*REDACTED*/20171212/us-west-2/config/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-date;x-amz-target, Signature=*REDACTED*
Content-Type: application/x-amz-json-1.1
X-Amz-Date: 20171212T073705Z
X-Amz-Target: StarlingDoveService.DeleteConfigurationRecorder
Accept-Encoding: gzip

{"ConfigurationRecorderName":"tf-acc-test-6670192826583674632"}
-----------------------------------------------------
2017/12/12 07:37:05 [DEBUG] [aws-sdk-go] DEBUG: Response config/DeleteDeliveryChannel Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 400 Bad Request
Connection: close
Content-Length: 220
Content-Type: application/x-amz-json-1.1
Date: Tue, 12 Dec 2017 07:37:06 GMT
X-Amzn-Requestid: 40ddcaf5-df0f-11e7-aa42-c989f54ca168


{"__type":"LastDeliveryChannelDeleteFailedException","message":"Failed to delete last specified delivery channel with name 'tf-acc-test-awsconfig-6670192826583674632', because there is a running configuration recorder."}
-----------------------------------------------------
```

## Test results

```
=== RUN   TestAccAWSConfig
=== RUN   TestAccAWSConfig/Config
=== RUN   TestAccAWSConfig/Config/importAws
=== RUN   TestAccAWSConfig/Config/importLambda
=== RUN   TestAccAWSConfig/Config/basic
=== RUN   TestAccAWSConfig/Config/ownerAws
=== RUN   TestAccAWSConfig/Config/customlambda
=== RUN   TestAccAWSConfig/ConfigurationRecorderStatus
=== RUN   TestAccAWSConfig/ConfigurationRecorderStatus/importBasic
=== RUN   TestAccAWSConfig/ConfigurationRecorderStatus/basic
=== RUN   TestAccAWSConfig/ConfigurationRecorderStatus/startEnabled
=== RUN   TestAccAWSConfig/ConfigurationRecorder
=== RUN   TestAccAWSConfig/ConfigurationRecorder/basic
=== RUN   TestAccAWSConfig/ConfigurationRecorder/allParams
=== RUN   TestAccAWSConfig/ConfigurationRecorder/importBasic
=== RUN   TestAccAWSConfig/DeliveryChannel
=== RUN   TestAccAWSConfig/DeliveryChannel/basic
=== RUN   TestAccAWSConfig/DeliveryChannel/allParams
=== RUN   TestAccAWSConfig/DeliveryChannel/importBasic
--- PASS: TestAccAWSConfig (738.46s)
    --- PASS: TestAccAWSConfig/Config (472.55s)
        --- PASS: TestAccAWSConfig/Config/importAws (89.94s)
        --- PASS: TestAccAWSConfig/Config/importLambda (103.66s)
        --- PASS: TestAccAWSConfig/Config/basic (88.20s)
        --- PASS: TestAccAWSConfig/Config/ownerAws (88.32s)
        --- PASS: TestAccAWSConfig/Config/customlambda (102.44s)
    --- PASS: TestAccAWSConfig/ConfigurationRecorderStatus (98.34s)
        --- PASS: TestAccAWSConfig/ConfigurationRecorderStatus/importBasic (28.20s)
        --- PASS: TestAccAWSConfig/ConfigurationRecorderStatus/basic (29.65s)
        --- PASS: TestAccAWSConfig/ConfigurationRecorderStatus/startEnabled (40.50s)
    --- PASS: TestAccAWSConfig/ConfigurationRecorder (82.45s)
        --- PASS: TestAccAWSConfig/ConfigurationRecorder/basic (26.80s)
        --- PASS: TestAccAWSConfig/ConfigurationRecorder/allParams (28.06s)
        --- PASS: TestAccAWSConfig/ConfigurationRecorder/importBasic (27.60s)
    --- PASS: TestAccAWSConfig/DeliveryChannel (85.12s)
        --- PASS: TestAccAWSConfig/DeliveryChannel/basic (28.35s)
        --- PASS: TestAccAWSConfig/DeliveryChannel/allParams (27.95s)
        --- PASS: TestAccAWSConfig/DeliveryChannel/importBasic (28.82s)
PASS
```