### PR TITLE
Ensure Elem is always either a *Schema or *Resource

### DIFF
--- a/aws/data_source_aws_ecs_container_definition.go
+++ b/aws/data_source_aws_ecs_container_definition.go
@@ -53,12 +53,12 @@ func dataSourceAwsEcsContainerDefinition() *schema.Resource {
 			"docker_labels": {
 				Type:     schema.TypeMap,
 				Computed: true,
-				Elem:     schema.TypeString,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"environment": {
 				Type:     schema.TypeMap,
 				Computed: true,
-				Elem:     schema.TypeString,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}

--- a/aws/data_source_aws_vpc_peering_connection.go
+++ b/aws/data_source_aws_vpc_peering_connection.go
@@ -67,12 +67,12 @@ func dataSourceAwsVpcPeeringConnection() *schema.Resource {
 			"accepter": {
 				Type:     schema.TypeMap,
 				Computed: true,
-				Elem:     schema.TypeBool,
+				Elem:     &schema.Schema{Type: schema.TypeBool},
 			},
 			"requester": {
 				Type:     schema.TypeMap,
 				Computed: true,
-				Elem:     schema.TypeBool,
+				Elem:     &schema.Schema{Type: schema.TypeBool},
 			},
 			"filter": ec2CustomFiltersSchema(),
 			"tags":   tagsSchemaComputed(),

--- a/aws/resource_aws_api_gateway_deployment.go
+++ b/aws/resource_aws_api_gateway_deployment.go
@@ -47,7 +47,7 @@ func resourceAwsApiGatewayDeployment() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
-				Elem:     schema.TypeString,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
 			"created_date": {

--- a/aws/resource_aws_api_gateway_gateway_response.go
+++ b/aws/resource_aws_api_gateway_gateway_response.go
@@ -39,13 +39,13 @@ func resourceAwsApiGatewayGatewayResponse() *schema.Resource {
 
 			"response_templates": {
 				Type:     schema.TypeMap,
-				Elem:     schema.TypeString,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 				Optional: true,
 			},
 
 			"response_parameters": {
 				Type:     schema.TypeMap,
-				Elem:     schema.TypeString,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 				Optional: true,
 			},
 		},

--- a/aws/resource_aws_api_gateway_integration.go
+++ b/aws/resource_aws_api_gateway_integration.go
@@ -70,12 +70,12 @@ func resourceAwsApiGatewayIntegration() *schema.Resource {
 			"request_templates": {
 				Type:     schema.TypeMap,
 				Optional: true,
-				Elem:     schema.TypeString,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
 			"request_parameters": {
 				Type:          schema.TypeMap,
-				Elem:          schema.TypeString,
+				Elem:          &schema.Schema{Type: schema.TypeString},
 				Optional:      true,
 				ConflictsWith: []string{"request_parameters_in_json"},
 			},

--- a/aws/resource_aws_api_gateway_integration_response.go
+++ b/aws/resource_aws_api_gateway_integration_response.go
@@ -53,12 +53,12 @@ func resourceAwsApiGatewayIntegrationResponse() *schema.Resource {
 			"response_templates": {
 				Type:     schema.TypeMap,
 				Optional: true,
-				Elem:     schema.TypeString,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
 			"response_parameters": {
 				Type:          schema.TypeMap,
-				Elem:          schema.TypeString,
+				Elem:          &schema.Schema{Type: schema.TypeString},
 				Optional:      true,
 				ConflictsWith: []string{"response_parameters_in_json"},
 			},

--- a/aws/resource_aws_api_gateway_method.go
+++ b/aws/resource_aws_api_gateway_method.go
@@ -60,12 +60,12 @@ func resourceAwsApiGatewayMethod() *schema.Resource {
 			"request_models": &schema.Schema{
 				Type:     schema.TypeMap,
 				Optional: true,
-				Elem:     schema.TypeString,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
 			"request_parameters": &schema.Schema{
 				Type:          schema.TypeMap,
-				Elem:          schema.TypeBool,
+				Elem:          &schema.Schema{Type: schema.TypeBool},
 				Optional:      true,
 				ConflictsWith: []string{"request_parameters_in_json"},
 			},

--- a/aws/resource_aws_api_gateway_method_response.go
+++ b/aws/resource_aws_api_gateway_method_response.go
@@ -52,12 +52,12 @@ func resourceAwsApiGatewayMethodResponse() *schema.Resource {
 			"response_models": &schema.Schema{
 				Type:     schema.TypeMap,
 				Optional: true,
-				Elem:     schema.TypeString,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
 			"response_parameters": &schema.Schema{
 				Type:          schema.TypeMap,
-				Elem:          schema.TypeBool,
+				Elem:          &schema.Schema{Type: schema.TypeBool},
 				Optional:      true,
 				ConflictsWith: []string{"response_parameters_in_json"},
 			},

--- a/aws/resource_aws_batch_job_definition.go
+++ b/aws/resource_aws_batch_job_definition.go
@@ -39,7 +39,7 @@ func resourceAwsBatchJobDefinition() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
-				Elem:     schema.TypeString,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"retry_strategy": {
 				Type:     schema.TypeList,

--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -170,7 +170,7 @@ func resourceAwsLambdaFunction() *schema.Resource {
 						"variables": {
 							Type:     schema.TypeMap,
 							Optional: true,
-							Elem:     schema.TypeString,
+							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 					},
 				},


### PR DESCRIPTION
This PR prepares this provider for hashicorp/terraform#17037, which will cause Provider.InternalValidate to reject schemas which assign invalid types (anything other than a *Schema or a *Resource) to the Elem field of a Schema.

This mostly addresses issues where the expected type for a Map is provided directly rather than wrapped in schema.Schema{}. Today this is a non-issue, but will cause problems in the future if we enforce type checking on Map types.