### PR TITLE
test/aws_ecs_service: Randomize names

### DIFF
--- a/aws/resource_aws_ecs_service_test.go
+++ b/aws/resource_aws_ecs_service_test.go
@@ -84,39 +84,27 @@ func TestParseTaskDefinition(t *testing.T) {
 	}
 }
 
-func TestAccAWSEcsServiceWithARN(t *testing.T) {
-	rInt := acctest.RandInt()
+func TestAccAWSEcsService_withARN(t *testing.T) {
+	rString := acctest.RandString(8)
+
+	clusterName := fmt.Sprintf("tf-acc-cluster-svc-w-arn-%s", rString)
+	tdName := fmt.Sprintf("tf-acc-td-svc-w-arn-%s", rString)
+	svcName := fmt.Sprintf("tf-acc-svc-w-arn-%s", rString)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEcsService(rInt),
+				Config: testAccAWSEcsService(clusterName, tdName, svcName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsServiceExists("aws_ecs_service.mongo"),
 				),
 			},
 
 			{
-				Config: testAccAWSEcsServiceModified(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEcsServiceExists("aws_ecs_service.mongo"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSEcsServiceWithUnnormalizedPlacementStrategy(t *testing.T) {
-	rInt := acctest.RandInt()
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSEcsServiceWithInterchangeablePlacementStrategy(rInt),
+				Config: testAccAWSEcsServiceModified(clusterName, tdName, svcName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsServiceExists("aws_ecs_service.mongo"),
 				),
@@ -125,22 +113,49 @@ func TestAccAWSEcsServiceWithUnnormalizedPlacementStrategy(t *testing.T) {
 	})
 }
 
-func TestAccAWSEcsServiceWithFamilyAndRevision(t *testing.T) {
-	rName := acctest.RandomWithPrefix("tf-test")
+func TestAccAWSEcsService_withUnnormalizedPlacementStrategy(t *testing.T) {
+	rString := acctest.RandString(8)
+
+	clusterName := fmt.Sprintf("tf-acc-cluster-svc-w-ups-%s", rString)
+	tdName := fmt.Sprintf("tf-acc-td-svc-w-ups-%s", rString)
+	svcName := fmt.Sprintf("tf-acc-svc-w-ups-%s", rString)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEcsServiceWithFamilyAndRevision(rName),
+				Config: testAccAWSEcsServiceWithInterchangeablePlacementStrategy(clusterName, tdName, svcName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcsServiceExists("aws_ecs_service.mongo"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEcsService_withFamilyAndRevision(t *testing.T) {
+	rString := acctest.RandString(8)
+
+	clusterName := fmt.Sprintf("tf-acc-cluster-svc-w-far-%s", rString)
+	tdName := fmt.Sprintf("tf-acc-td-svc-w-far-%s", rString)
+	svcName := fmt.Sprintf("tf-acc-svc-w-far-%s", rString)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEcsServiceWithFamilyAndRevision(clusterName, tdName, svcName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsServiceExists("aws_ecs_service.jenkins"),
 				),
 			},
 
 			{
-				Config: testAccAWSEcsServiceWithFamilyAndRevisionModified(rName),
+				Config: testAccAWSEcsServiceWithFamilyAndRevisionModified(clusterName, tdName, svcName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsServiceExists("aws_ecs_service.jenkins"),
 				),
@@ -150,11 +165,18 @@ func TestAccAWSEcsServiceWithFamilyAndRevision(t *testing.T) {
 }
 
 // Regression for https://github.com/hashicorp/terraform/issues/2427
-func TestAccAWSEcsServiceWithRenamedCluster(t *testing.T) {
+func TestAccAWSEcsService_withRenamedCluster(t *testing.T) {
+	rString := acctest.RandString(8)
+
+	clusterName := fmt.Sprintf("tf-acc-cluster-svc-w-rc-%s", rString)
+	uClusterName := fmt.Sprintf("tf-acc-cluster-svc-w-rc-updated-%s", rString)
+	tdName := fmt.Sprintf("tf-acc-td-svc-w-rc-%s", rString)
+	svcName := fmt.Sprintf("tf-acc-svc-w-rc-%s", rString)
+
 	originalRegexp := regexp.MustCompile(
-		"^arn:aws:ecs:[^:]+:[0-9]+:cluster/terraformecstest3$")
+		"^arn:aws:ecs:[^:]+:[0-9]+:cluster/" + clusterName + "$")
 	modifiedRegexp := regexp.MustCompile(
-		"^arn:aws:ecs:[^:]+:[0-9]+:cluster/terraformecstest3modified$")
+		"^arn:aws:ecs:[^:]+:[0-9]+:cluster/" + uClusterName + "$")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -162,7 +184,7 @@ func TestAccAWSEcsServiceWithRenamedCluster(t *testing.T) {
 		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEcsServiceWithRenamedCluster,
+				Config: testAccAWSEcsServiceWithRenamedCluster(clusterName, tdName, svcName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsServiceExists("aws_ecs_service.ghost"),
 					resource.TestMatchResourceAttr(
@@ -171,7 +193,7 @@ func TestAccAWSEcsServiceWithRenamedCluster(t *testing.T) {
 			},
 
 			{
-				Config: testAccAWSEcsServiceWithRenamedClusterModified,
+				Config: testAccAWSEcsServiceWithRenamedCluster(uClusterName, tdName, svcName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsServiceExists("aws_ecs_service.ghost"),
 					resource.TestMatchResourceAttr(
@@ -183,7 +205,17 @@ func TestAccAWSEcsServiceWithRenamedCluster(t *testing.T) {
 }
 
 func TestAccAWSEcsService_healthCheckGracePeriodSeconds(t *testing.T) {
-	rName := acctest.RandomWithPrefix("tf-acc")
+	rString := acctest.RandString(8)
+
+	vpcNameTag := fmt.Sprintf("tf-acc-vpc-svc-w-hcgps-%s", rString)
+	clusterName := fmt.Sprintf("tf-acc-cluster-svc-w-hcgps-%s", rString)
+	tdName := fmt.Sprintf("tf-acc-td-svc-w-hcgps-%s", rString)
+	roleName := fmt.Sprintf("tf-acc-role-svc-w-hcgps-%s", rString)
+	policyName := fmt.Sprintf("tf-acc-policy-svc-w-hcgps-%s", rString)
+	tgName := fmt.Sprintf("tf-acc-tg-svc-w-hcgps-%s", rString)
+	lbName := fmt.Sprintf("tf-acc-lb-svc-w-hcgps-%s", rString)
+	svcName := fmt.Sprintf("tf-acc-svc-w-hcgps-%s", rString)
+
 	resourceName := "aws_ecs_service.with_alb"
 
 	resource.Test(t, resource.TestCase{
@@ -192,22 +224,26 @@ func TestAccAWSEcsService_healthCheckGracePeriodSeconds(t *testing.T) {
 		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccAWSEcsService_healthCheckGracePeriodSeconds(rName, t.Name(), -1),
+				Config: testAccAWSEcsService_healthCheckGracePeriodSeconds(vpcNameTag, clusterName, tdName,
+					roleName, policyName, tgName, lbName, svcName, -1),
 				ExpectError: regexp.MustCompile(`must be between 0 and 1800`),
 			},
 			{
-				Config:      testAccAWSEcsService_healthCheckGracePeriodSeconds(rName, t.Name(), 1801),
+				Config: testAccAWSEcsService_healthCheckGracePeriodSeconds(vpcNameTag, clusterName, tdName,
+					roleName, policyName, tgName, lbName, svcName, 1801),
 				ExpectError: regexp.MustCompile(`must be between 0 and 1800`),
 			},
 			{
-				Config: testAccAWSEcsService_healthCheckGracePeriodSeconds(rName, t.Name(), 300),
+				Config: testAccAWSEcsService_healthCheckGracePeriodSeconds(vpcNameTag, clusterName, tdName,
+					roleName, policyName, tgName, lbName, svcName, 300),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsServiceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "health_check_grace_period_seconds", "300"),
 				),
 			},
 			{
-				Config: testAccAWSEcsService_healthCheckGracePeriodSeconds(rName, t.Name(), 600),
+				Config: testAccAWSEcsService_healthCheckGracePeriodSeconds(vpcNameTag, clusterName, tdName,
+					roleName, policyName, tgName, lbName, svcName, 600),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsServiceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "health_check_grace_period_seconds", "600"),
@@ -218,13 +254,21 @@ func TestAccAWSEcsService_healthCheckGracePeriodSeconds(t *testing.T) {
 }
 
 func TestAccAWSEcsService_withIamRole(t *testing.T) {
+	rString := acctest.RandString(8)
+
+	clusterName := fmt.Sprintf("tf-acc-cluster-svc-w-iam-role-%s", rString)
+	tdName := fmt.Sprintf("tf-acc-td-svc-w-iam-role-%s", rString)
+	roleName := fmt.Sprintf("tf-acc-role-svc-w-iam-role-%s", rString)
+	policyName := fmt.Sprintf("tf-acc-policy-svc-w-iam-role-%s", rString)
+	svcName := fmt.Sprintf("tf-acc-svc-w-iam-role-%s", rString)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEcsService_withIamRole,
+				Config: testAccAWSEcsService_withIamRole(clusterName, tdName, roleName, policyName, svcName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsServiceExists("aws_ecs_service.ghost"),
 				),
@@ -234,14 +278,19 @@ func TestAccAWSEcsService_withIamRole(t *testing.T) {
 }
 
 func TestAccAWSEcsService_withDeploymentValues(t *testing.T) {
-	rInt := acctest.RandInt()
+	rString := acctest.RandString(8)
+
+	clusterName := fmt.Sprintf("tf-acc-cluster-svc-w-dv-%s", rString)
+	tdName := fmt.Sprintf("tf-acc-td-svc-w-dv-%s", rString)
+	svcName := fmt.Sprintf("tf-acc-svc-w-dv-%s", rString)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEcsServiceWithDeploymentValues(rInt),
+				Config: testAccAWSEcsServiceWithDeploymentValues(clusterName, tdName, svcName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsServiceExists("aws_ecs_service.mongo"),
 					resource.TestCheckResourceAttr(
@@ -256,19 +305,27 @@ func TestAccAWSEcsService_withDeploymentValues(t *testing.T) {
 
 // Regression for https://github.com/hashicorp/terraform/issues/3444
 func TestAccAWSEcsService_withLbChanges(t *testing.T) {
+	rString := acctest.RandString(8)
+
+	clusterName := fmt.Sprintf("tf-acc-cluster-svc-w-lbc-%s", rString)
+	tdName := fmt.Sprintf("tf-acc-td-svc-w-lbc-%s", rString)
+	roleName := fmt.Sprintf("tf-acc-role-svc-w-lbc-%s", rString)
+	policyName := fmt.Sprintf("tf-acc-policy-svc-w-lbc-%s", rString)
+	svcName := fmt.Sprintf("tf-acc-svc-w-lbc-%s", rString)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEcsService_withLbChanges,
+				Config: testAccAWSEcsService_withLbChanges(clusterName, tdName, roleName, policyName, svcName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsServiceExists("aws_ecs_service.with_lb_changes"),
 				),
 			},
 			{
-				Config: testAccAWSEcsService_withLbChanges_modified,
+				Config: testAccAWSEcsService_withLbChanges_modified(clusterName, tdName, roleName, policyName, svcName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsServiceExists("aws_ecs_service.with_lb_changes"),
 				),
@@ -279,17 +336,22 @@ func TestAccAWSEcsService_withLbChanges(t *testing.T) {
 
 // Regression for https://github.com/hashicorp/terraform/issues/3361
 func TestAccAWSEcsService_withEcsClusterName(t *testing.T) {
-	clusterName := regexp.MustCompile("^terraformecstestcluster$")
+	rString := acctest.RandString(8)
+
+	clusterName := fmt.Sprintf("tf-acc-cluster-svc-w-cluster-name-%s", rString)
+	tdName := fmt.Sprintf("tf-acc-td-svc-w-cluster-name-%s", rString)
+	svcName := fmt.Sprintf("tf-acc-svc-w-cluster-name-%s", rString)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEcsServiceWithEcsClusterName,
+				Config: testAccAWSEcsServiceWithEcsClusterName(clusterName, tdName, svcName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsServiceExists("aws_ecs_service.jenkins"),
-					resource.TestMatchResourceAttr(
+					resource.TestCheckResourceAttr(
 						"aws_ecs_service.jenkins", "cluster", clusterName),
 				),
 			},
@@ -298,7 +360,15 @@ func TestAccAWSEcsService_withEcsClusterName(t *testing.T) {
 }
 
 func TestAccAWSEcsService_withAlb(t *testing.T) {
-	rName := acctest.RandomWithPrefix("tf-acc")
+	rString := acctest.RandString(8)
+
+	clusterName := fmt.Sprintf("tf-acc-cluster-svc-w-alb-%s", rString)
+	tdName := fmt.Sprintf("tf-acc-td-svc-w-alb-%s", rString)
+	roleName := fmt.Sprintf("tf-acc-role-svc-w-alb-%s", rString)
+	policyName := fmt.Sprintf("tf-acc-policy-svc-w-alb-%s", rString)
+	tgName := fmt.Sprintf("tf-acc-tg-svc-w-alb-%s", rString)
+	lbName := fmt.Sprintf("tf-acc-lb-svc-w-alb-%s", rString)
+	svcName := fmt.Sprintf("tf-acc-svc-w-alb-%s", rString)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -306,7 +376,7 @@ func TestAccAWSEcsService_withAlb(t *testing.T) {
 		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEcsServiceWithAlb(rName),
+				Config: testAccAWSEcsServiceWithAlb(clusterName, tdName, roleName, policyName, tgName, lbName, svcName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsServiceExists("aws_ecs_service.with_alb"),
 				),
@@ -315,22 +385,27 @@ func TestAccAWSEcsService_withAlb(t *testing.T) {
 	})
 }
 
-func TestAccAWSEcsServiceWithPlacementStrategy(t *testing.T) {
-	rInt := acctest.RandInt()
+func TestAccAWSEcsService_withPlacementStrategy(t *testing.T) {
+	rString := acctest.RandString(8)
+
+	clusterName := fmt.Sprintf("tf-acc-cluster-svc-w-ps-%s", rString)
+	tdName := fmt.Sprintf("tf-acc-td-svc-w-ps-%s", rString)
+	svcName := fmt.Sprintf("tf-acc-svc-w-ps-%s", rString)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEcsService(rInt),
+				Config: testAccAWSEcsService(clusterName, tdName, svcName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsServiceExists("aws_ecs_service.mongo"),
 					resource.TestCheckResourceAttr("aws_ecs_service.mongo", "placement_strategy.#", "0"),
 				),
 			},
 			{
-				Config: testAccAWSEcsServiceWithPlacementStrategy(rInt),
+				Config: testAccAWSEcsServiceWithPlacementStrategy(clusterName, tdName, svcName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsServiceExists("aws_ecs_service.mongo"),
 					resource.TestCheckResourceAttr("aws_ecs_service.mongo", "placement_strategy.#", "1"),
@@ -340,15 +415,20 @@ func TestAccAWSEcsServiceWithPlacementStrategy(t *testing.T) {
 	})
 }
 
-func TestAccAWSEcsServiceWithPlacementConstraints(t *testing.T) {
-	rInt := acctest.RandInt()
+func TestAccAWSEcsService_withPlacementConstraints(t *testing.T) {
+	rString := acctest.RandString(8)
+
+	clusterName := fmt.Sprintf("tf-acc-cluster-svc-w-pc-%s", rString)
+	tdName := fmt.Sprintf("tf-acc-td-svc-w-pc-%s", rString)
+	svcName := fmt.Sprintf("tf-acc-svc-w-pc-%s", rString)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEcsServiceWithPlacementConstraint(rInt),
+				Config: testAccAWSEcsServiceWithPlacementConstraint(clusterName, tdName, svcName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsServiceExists("aws_ecs_service.mongo"),
 					resource.TestCheckResourceAttr("aws_ecs_service.mongo", "placement_constraints.#", "1"),
@@ -358,15 +438,20 @@ func TestAccAWSEcsServiceWithPlacementConstraints(t *testing.T) {
 	})
 }
 
-func TestAccAWSEcsServiceWithPlacementConstraints_emptyExpression(t *testing.T) {
-	rInt := acctest.RandInt()
+func TestAccAWSEcsService_withPlacementConstraints_emptyExpression(t *testing.T) {
+	rString := acctest.RandString(8)
+
+	clusterName := fmt.Sprintf("tf-acc-cluster-svc-w-pc-ee-%s", rString)
+	tdName := fmt.Sprintf("tf-acc-td-svc-w-pc-ee-%s", rString)
+	svcName := fmt.Sprintf("tf-acc-svc-w-pc-ee-%s", rString)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEcsServiceWithPlacementConstraintEmptyExpression(rInt),
+				Config: testAccAWSEcsServiceWithPlacementConstraintEmptyExpression(clusterName, tdName, svcName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsServiceExists("aws_ecs_service.mongo"),
 					resource.TestCheckResourceAttr("aws_ecs_service.mongo", "placement_constraints.#", "1"),
@@ -376,15 +461,22 @@ func TestAccAWSEcsServiceWithPlacementConstraints_emptyExpression(t *testing.T) 
 	})
 }
 
-func TestAccAWSEcsServiceWithLaunchTypeFargate(t *testing.T) {
-	rInt := acctest.RandInt()
+func TestAccAWSEcsService_withLaunchTypeFargate(t *testing.T) {
+	rString := acctest.RandString(8)
+
+	sg1Name := fmt.Sprintf("tf-acc-sg-1-svc-w-ltf-%s", rString)
+	sg2Name := fmt.Sprintf("tf-acc-sg-2-svc-w-ltf-%s", rString)
+	clusterName := fmt.Sprintf("tf-acc-cluster-svc-w-ltf-%s", rString)
+	tdName := fmt.Sprintf("tf-acc-td-svc-w-ltf-%s", rString)
+	svcName := fmt.Sprintf("tf-acc-svc-w-ltf-%s", rString)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEcsServiceWithLaunchTypeFargate(rInt),
+				Config: testAccAWSEcsServiceWithLaunchTypeFargate(sg1Name, sg2Name, clusterName, tdName, svcName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsServiceExists("aws_ecs_service.main"),
 					resource.TestCheckResourceAttr("aws_ecs_service.main", "launch_type", "FARGATE"),
@@ -394,14 +486,22 @@ func TestAccAWSEcsServiceWithLaunchTypeFargate(t *testing.T) {
 	})
 }
 
-func TestAccAWSEcsServiceWithNetworkConfiguration(t *testing.T) {
+func TestAccAWSEcsService_withNetworkConfiguration(t *testing.T) {
+	rString := acctest.RandString(8)
+
+	sg1Name := fmt.Sprintf("tf-acc-sg-1-svc-w-nc-%s", rString)
+	sg2Name := fmt.Sprintf("tf-acc-sg-2-svc-w-nc-%s", rString)
+	clusterName := fmt.Sprintf("tf-acc-cluster-svc-w-nc-%s", rString)
+	tdName := fmt.Sprintf("tf-acc-td-svc-w-nc-%s", rString)
+	svcName := fmt.Sprintf("tf-acc-svc-w-nc-%s", rString)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEcsServiceWithNetworkConfigration(acctest.RandString(5)),
+				Config: testAccAWSEcsServiceWithNetworkConfigration(sg1Name, sg2Name, clusterName, tdName, svcName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsServiceExists("aws_ecs_service.main"),
 				),
@@ -457,14 +557,14 @@ func testAccCheckAWSEcsServiceExists(name string) resource.TestCheckFunc {
 	}
 }
 
-func testAccAWSEcsService(rInt int) string {
+func testAccAWSEcsService(clusterName, tdName, svcName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "default" {
-	name = "terraformecstest%d"
+	name = "%s"
 }
 
 resource "aws_ecs_task_definition" "mongo" {
-  family = "mongodb"
+  family = "%s"
   container_definitions = <<DEFINITION
 [
   {
@@ -479,22 +579,22 @@ DEFINITION
 }
 
 resource "aws_ecs_service" "mongo" {
-  name = "mongodb-%d"
+  name = "%s"
   cluster = "${aws_ecs_cluster.default.id}"
   task_definition = "${aws_ecs_task_definition.mongo.arn}"
   desired_count = 1
 }
-`, rInt, rInt)
+`, clusterName, tdName, svcName)
 }
 
-func testAccAWSEcsServiceModified(rInt int) string {
+func testAccAWSEcsServiceModified(clusterName, tdName, svcName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "default" {
-	name = "terraformecstest%d"
+	name = "%s"
 }
 
 resource "aws_ecs_task_definition" "mongo" {
-  family = "mongodb"
+  family = "%s"
   container_definitions = <<DEFINITION
 [
   {
@@ -509,22 +609,22 @@ DEFINITION
 }
 
 resource "aws_ecs_service" "mongo" {
-  name = "mongodb-%d"
+  name = "%s"
   cluster = "${aws_ecs_cluster.default.id}"
   task_definition = "${aws_ecs_task_definition.mongo.arn}"
   desired_count = 2
 }
-`, rInt, rInt)
+`, clusterName, tdName, svcName)
 }
 
-func testAccAWSEcsServiceWithInterchangeablePlacementStrategy(rInt int) string {
+func testAccAWSEcsServiceWithInterchangeablePlacementStrategy(clusterName, tdName, svcName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "default" {
-	name = "terraformecstest%d"
+	name = "%s"
 }
 
 resource "aws_ecs_task_definition" "mongo" {
-  family = "mongodb"
+  family = "%s"
   container_definitions = <<DEFINITION
 [
   {
@@ -539,7 +639,7 @@ DEFINITION
 }
 
 resource "aws_ecs_service" "mongo" {
-  name = "mongodb-%d"
+  name = "%s"
   cluster = "${aws_ecs_cluster.default.id}"
   task_definition = "${aws_ecs_task_definition.mongo.arn}"
   desired_count = 1
@@ -548,17 +648,17 @@ resource "aws_ecs_service" "mongo" {
 	  type = "spread"
   }
 }
-`, rInt, rInt)
+`, clusterName, tdName, svcName)
 }
 
-func testAccAWSEcsServiceWithPlacementStrategy(rInt int) string {
+func testAccAWSEcsServiceWithPlacementStrategy(clusterName, tdName, svcName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "default" {
-	name = "terraformecstest%d"
+	name = "%s"
 }
 
 resource "aws_ecs_task_definition" "mongo" {
-  family = "mongodb"
+  family = "%s"
   container_definitions = <<DEFINITION
 [
   {
@@ -573,7 +673,7 @@ DEFINITION
 }
 
 resource "aws_ecs_service" "mongo" {
-  name = "mongodb-%d"
+  name = "%s"
   cluster = "${aws_ecs_cluster.default.id}"
   task_definition = "${aws_ecs_task_definition.mongo.arn}"
   desired_count = 1
@@ -582,17 +682,17 @@ resource "aws_ecs_service" "mongo" {
 	field = "memory"
   }
 }
-`, rInt, rInt)
+`, clusterName, tdName, svcName)
 }
 
-func testAccAWSEcsServiceWithPlacementConstraint(rInt int) string {
+func testAccAWSEcsServiceWithPlacementConstraint(clusterName, tdName, svcName string) string {
 	return fmt.Sprintf(`
 	resource "aws_ecs_cluster" "default" {
-		name = "terraformecstest%d"
+		name = "%s"
 	}
 
 	resource "aws_ecs_task_definition" "mongo" {
-	  family = "mongodb"
+	  family = "%s"
 	  container_definitions = <<DEFINITION
 	[
 	  {
@@ -607,7 +707,7 @@ func testAccAWSEcsServiceWithPlacementConstraint(rInt int) string {
 	}
 
 	resource "aws_ecs_service" "mongo" {
-	  name = "mongodb-%d"
+	  name = "%s"
 	  cluster = "${aws_ecs_cluster.default.id}"
 	  task_definition = "${aws_ecs_task_definition.mongo.arn}"
 	  desired_count = 1
@@ -616,16 +716,16 @@ func testAccAWSEcsServiceWithPlacementConstraint(rInt int) string {
 		expression = "attribute:ecs.availability-zone in [us-west-2a, us-west-2b]"
 	  }
 	}
-	`, rInt, rInt)
+	`, clusterName, tdName, svcName)
 }
 
-func testAccAWSEcsServiceWithPlacementConstraintEmptyExpression(rInt int) string {
+func testAccAWSEcsServiceWithPlacementConstraintEmptyExpression(clusterName, tdName, svcName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "default" {
-	name = "terraformecstest%d"
+	name = "%s"
 }
 resource "aws_ecs_task_definition" "mongo" {
-  family = "mongodb"
+  family = "%s"
   container_definitions = <<DEFINITION
 [
   {
@@ -639,7 +739,7 @@ resource "aws_ecs_task_definition" "mongo" {
 DEFINITION
 }
 resource "aws_ecs_service" "mongo" {
-  name = "mongodb-%d"
+  name = "%s"
   cluster = "${aws_ecs_cluster.default.id}"
   task_definition = "${aws_ecs_task_definition.mongo.arn}"
   desired_count = 1
@@ -647,10 +747,10 @@ resource "aws_ecs_service" "mongo" {
 	  type = "distinctInstance"
   }
 }
-`, rInt, rInt)
+`, clusterName, tdName, svcName)
 }
 
-func testAccAWSEcsServiceWithLaunchTypeFargate(rInt int) string {
+func testAccAWSEcsServiceWithLaunchTypeFargate(sg1Name, sg2Name, clusterName, tdName, svcName string) string {
 	return fmt.Sprintf(`
 provider "aws" {
   region = "us-east-1"
@@ -669,7 +769,7 @@ resource "aws_subnet" "main" {
 }
 
 resource "aws_security_group" "allow_all_a" {
-  name        = "allow_all_a_%d"
+  name        = "%s"
   description = "Allow all inbound traffic"
   vpc_id      = "${aws_vpc.main.id}"
 
@@ -682,7 +782,7 @@ resource "aws_security_group" "allow_all_a" {
 }
 
 resource "aws_security_group" "allow_all_b" {
-  name        = "allow_all_b_%d"
+  name        = "%s"
   description = "Allow all inbound traffic"
   vpc_id      = "${aws_vpc.main.id}"
 
@@ -695,11 +795,11 @@ resource "aws_security_group" "allow_all_b" {
 }
 
 resource "aws_ecs_cluster" "main" {
-  name = "tf-ecs-cluster-%d"
+  name = "%s"
 }
 
 resource "aws_ecs_task_definition" "mongo" {
-  family = "mongodb"
+  family = "%s"
   network_mode = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu = "256"
@@ -720,7 +820,7 @@ DEFINITION
 }
 
 resource "aws_ecs_service" "main" {
-  name = "tf-ecs-service-%d"
+  name = "%s"
   cluster = "${aws_ecs_cluster.main.id}"
   task_definition = "${aws_ecs_task_definition.mongo.arn}"
   desired_count = 1
@@ -730,17 +830,18 @@ resource "aws_ecs_service" "main" {
     subnets = ["${aws_subnet.main.*.id}"]
   }
 }
-`, rInt, rInt, rInt, rInt)
+`, sg1Name, sg2Name, clusterName, tdName, svcName)
 }
 
-func testAccAWSEcsService_healthCheckGracePeriodSeconds(rName string, testName string, healthCheckGracePeriodSeconds int) string {
+func testAccAWSEcsService_healthCheckGracePeriodSeconds(vpcNameTag, clusterName, tdName, roleName, policyName,
+	tgName, lbName, svcName string, healthCheckGracePeriodSeconds int) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {}
 
 resource "aws_vpc" "main" {
   cidr_block = "10.10.0.0/16"
   tags {
-    Name = "%[2]s"
+    Name = "%s"
   }
 }
 
@@ -752,11 +853,11 @@ resource "aws_subnet" "main" {
 }
 
 resource "aws_ecs_cluster" "main" {
-  name = "%[1]s"
+  name = "%s"
 }
 
 resource "aws_ecs_task_definition" "with_lb_changes" {
-  family = "%[1]s"
+  family = "%s"
   container_definitions = <<DEFINITION
 [
   {
@@ -777,7 +878,7 @@ DEFINITION
 }
 
 resource "aws_iam_role" "ecs_service" {
-  name = "%[1]s"
+  name = "%s"
   assume_role_policy = <<EOF
 {
   "Version": "2008-10-17",
@@ -796,7 +897,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "ecs_service" {
-  name = "%[1]s"
+  name = "%s"
   role = "${aws_iam_role.ecs_service.name}"
   policy = <<EOF
 {
@@ -820,14 +921,14 @@ EOF
 }
 
 resource "aws_lb_target_group" "test" {
-  name = "%[1]s"
+  name = "%s"
   port = 80
   protocol = "HTTP"
   vpc_id = "${aws_vpc.main.id}"
 }
 
 resource "aws_lb" "main" {
-  name            = "%[1]s"
+  name            = "%s"
   internal        = true
   subnets         = ["${aws_subnet.main.*.id}"]
 }
@@ -844,11 +945,11 @@ resource "aws_lb_listener" "front_end" {
 }
 
 resource "aws_ecs_service" "with_alb" {
-  name = "%[1]s"
+  name = "%s"
   cluster = "${aws_ecs_cluster.main.id}"
   task_definition = "${aws_ecs_task_definition.with_lb_changes.arn}"
   desired_count = 1
-  health_check_grace_period_seconds = %[3]d
+  health_check_grace_period_seconds = %d
   iam_role = "${aws_iam_role.ecs_service.name}"
 
   load_balancer {
@@ -862,16 +963,18 @@ resource "aws_ecs_service" "with_alb" {
     "aws_lb_listener.front_end"
   ]
 }
-`, rName, testName, healthCheckGracePeriodSeconds)
+`, vpcNameTag, clusterName, tdName, roleName, policyName,
+		tgName, lbName, svcName, healthCheckGracePeriodSeconds)
 }
 
-var testAccAWSEcsService_withIamRole = `
+func testAccAWSEcsService_withIamRole(clusterName, tdName, roleName, policyName, svcName string) string {
+	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "main" {
-	name = "terraformecstest11"
+	name = "%s"
 }
 
 resource "aws_ecs_task_definition" "ghost" {
-  family = "ghost_service"
+  family = "%s"
   container_definitions = <<DEFINITION
 [
   {
@@ -892,7 +995,7 @@ DEFINITION
 }
 
 resource "aws_iam_role" "ecs_service" {
-    name = "EcsService"
+    name = "%s"
     assume_role_policy = <<EOF
 {
     "Version": "2012-10-17",
@@ -909,7 +1012,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "ecs_service" {
-    name = "EcsService"
+    name = "%s"
     role = "${aws_iam_role.ecs_service.name}"
     policy = <<EOF
 {
@@ -943,7 +1046,7 @@ resource "aws_elb" "main" {
 }
 
 resource "aws_ecs_service" "ghost" {
-  name = "ghost"
+  name = "%s"
   cluster = "${aws_ecs_cluster.main.id}"
   task_definition = "${aws_ecs_task_definition.ghost.arn}"
   desired_count = 1
@@ -957,16 +1060,17 @@ resource "aws_ecs_service" "ghost" {
 
   depends_on = ["aws_iam_role_policy.ecs_service"]
 }
-`
+`, clusterName, tdName, roleName, policyName, svcName)
+}
 
-func testAccAWSEcsServiceWithDeploymentValues(rInt int) string {
+func testAccAWSEcsServiceWithDeploymentValues(clusterName, tdName, svcName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "default" {
-	name = "terraformecstest-%d"
+	name = "%s"
 }
 
 resource "aws_ecs_task_definition" "mongo" {
-  family = "mongodb"
+  family = "%s"
   container_definitions = <<DEFINITION
 [
   {
@@ -981,33 +1085,36 @@ DEFINITION
 }
 
 resource "aws_ecs_service" "mongo" {
-  name = "mongodb-%d"
+  name = "%s"
   cluster = "${aws_ecs_cluster.default.id}"
   task_definition = "${aws_ecs_task_definition.mongo.arn}"
   desired_count = 1
 }
-`, rInt, rInt)
+`, clusterName, tdName, svcName)
 }
 
-var tpl_testAccAWSEcsService_withLbChanges = `
+func tpl_testAccAWSEcsService_withLbChanges(clusterName, tdName, image,
+	containerName string, containerPort, hostPort int, roleName, policyName string,
+	instancePort int, svcName string) string {
+	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "main" {
-	name = "terraformecstest12"
+	name = "%[1]s"
 }
 
 resource "aws_ecs_task_definition" "with_lb_changes" {
-  family = "ghost_lbd"
+  family = "%[2]s"
   container_definitions = <<DEFINITION
 [
   {
     "cpu": 128,
     "essential": true,
-    "image": "%s",
+    "image": "%[3]s",
     "memory": 128,
-    "name": "%s",
+    "name": "%[4]s",
     "portMappings": [
       {
-        "containerPort": %d,
-        "hostPort": %d
+        "containerPort": %[5]d,
+        "hostPort": %[6]d
       }
     ]
   }
@@ -1016,7 +1123,7 @@ DEFINITION
 }
 
 resource "aws_iam_role" "ecs_service" {
-    name = "EcsServiceLbd"
+    name = "%[7]s"
     assume_role_policy = <<EOF
 {
     "Version": "2012-10-17",
@@ -1033,7 +1140,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "ecs_service" {
-    name = "EcsServiceLbd"
+    name = "%[8]s"
     role = "${aws_iam_role.ecs_service.name}"
     policy = <<EOF
 {
@@ -1059,7 +1166,7 @@ resource "aws_elb" "main" {
   availability_zones = ["us-west-2a"]
 
   listener {
-    instance_port = %d
+    instance_port = %[6]d
     instance_protocol = "http"
     lb_port = 80
     lb_protocol = "http"
@@ -1067,7 +1174,7 @@ resource "aws_elb" "main" {
 }
 
 resource "aws_ecs_service" "with_lb_changes" {
-  name = "ghost"
+  name = "%[10]s"
   cluster = "${aws_ecs_cluster.main.id}"
   task_definition = "${aws_ecs_task_definition.with_lb_changes.arn}"
   desired_count = 1
@@ -1075,22 +1182,26 @@ resource "aws_ecs_service" "with_lb_changes" {
 
   load_balancer {
     elb_name = "${aws_elb.main.id}"
-    container_name = "%s"
-    container_port = "%d"
+    container_name = "%[4]s"
+    container_port = "%[5]d"
   }
 
   depends_on = ["aws_iam_role_policy.ecs_service"]
 }
-`
+`, clusterName, tdName, image, containerName, containerPort, hostPort, roleName, policyName, instancePort, svcName)
+}
 
-var testAccAWSEcsService_withLbChanges = fmt.Sprintf(
-	tpl_testAccAWSEcsService_withLbChanges,
-	"ghost:latest", "ghost", 2368, 8080, 8080, "ghost", 2368)
-var testAccAWSEcsService_withLbChanges_modified = fmt.Sprintf(
-	tpl_testAccAWSEcsService_withLbChanges,
-	"nginx:latest", "nginx", 80, 8080, 8080, "nginx", 80)
+func testAccAWSEcsService_withLbChanges(clusterName, tdName, roleName, policyName, svcName string) string {
+	return tpl_testAccAWSEcsService_withLbChanges(
+		clusterName, tdName, "ghost:latest", "ghost", 2368, 8080, roleName, policyName, 2368, svcName)
+}
 
-func testAccAWSEcsServiceWithFamilyAndRevision(rName string) string {
+func testAccAWSEcsService_withLbChanges_modified(clusterName, tdName, roleName, policyName, svcName string) string {
+	return tpl_testAccAWSEcsService_withLbChanges(
+		clusterName, tdName, "nginx:latest", "nginx", 80, 8080, roleName, policyName, 80, svcName)
+}
+
+func testAccAWSEcsServiceWithFamilyAndRevision(clusterName, tdName, svcName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "default" {
 	name = "%s"
@@ -1116,10 +1227,10 @@ resource "aws_ecs_service" "jenkins" {
   cluster = "${aws_ecs_cluster.default.id}"
   task_definition = "${aws_ecs_task_definition.jenkins.family}:${aws_ecs_task_definition.jenkins.revision}"
   desired_count = 1
-}`, rName, rName, rName)
+}`, clusterName, tdName, svcName)
 }
 
-func testAccAWSEcsServiceWithFamilyAndRevisionModified(rName string) string {
+func testAccAWSEcsServiceWithFamilyAndRevisionModified(clusterName, tdName, svcName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "default" {
 	name = "%s"
@@ -1145,15 +1256,16 @@ resource "aws_ecs_service" "jenkins" {
   cluster = "${aws_ecs_cluster.default.id}"
   task_definition = "${aws_ecs_task_definition.jenkins.family}:${aws_ecs_task_definition.jenkins.revision}"
   desired_count = 1
-}`, rName, rName, rName)
+}`, clusterName, tdName, svcName)
 }
 
-var testAccAWSEcsServiceWithRenamedCluster = `
+func testAccAWSEcsServiceWithRenamedCluster(clusterName, tdName, svcName string) string {
+	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "default" {
-	name = "terraformecstest3"
+	name = "%s"
 }
 resource "aws_ecs_task_definition" "ghost" {
-  family = "ghost"
+  family = "%s"
   container_definitions = <<DEFINITION
 [
   {
@@ -1167,46 +1279,22 @@ resource "aws_ecs_task_definition" "ghost" {
 DEFINITION
 }
 resource "aws_ecs_service" "ghost" {
-  name = "ghost"
+  name = "%s"
   cluster = "${aws_ecs_cluster.default.id}"
   task_definition = "${aws_ecs_task_definition.ghost.family}:${aws_ecs_task_definition.ghost.revision}"
   desired_count = 1
 }
-`
+`, clusterName, tdName, svcName)
+}
 
-var testAccAWSEcsServiceWithRenamedClusterModified = `
+func testAccAWSEcsServiceWithEcsClusterName(clusterName, tdName, svcName string) string {
+	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "default" {
-	name = "terraformecstest3modified"
-}
-resource "aws_ecs_task_definition" "ghost" {
-  family = "ghost"
-  container_definitions = <<DEFINITION
-[
-  {
-    "cpu": 128,
-    "essential": true,
-    "image": "ghost:latest",
-    "memory": 128,
-    "name": "ghost"
-  }
-]
-DEFINITION
-}
-resource "aws_ecs_service" "ghost" {
-  name = "ghost"
-  cluster = "${aws_ecs_cluster.default.id}"
-  task_definition = "${aws_ecs_task_definition.ghost.family}:${aws_ecs_task_definition.ghost.revision}"
-  desired_count = 1
-}
-`
-
-var testAccAWSEcsServiceWithEcsClusterName = `
-resource "aws_ecs_cluster" "default" {
-	name = "terraformecstestcluster"
+	name = "%s"
 }
 
 resource "aws_ecs_task_definition" "jenkins" {
-  family = "jenkins"
+  family = "%s"
   container_definitions = <<DEFINITION
 [
   {
@@ -1221,14 +1309,15 @@ DEFINITION
 }
 
 resource "aws_ecs_service" "jenkins" {
-  name = "jenkins"
+  name = "%s"
   cluster = "${aws_ecs_cluster.default.name}"
   task_definition = "${aws_ecs_task_definition.jenkins.arn}"
   desired_count = 1
 }
-`
+`, clusterName, tdName, svcName)
+}
 
-func testAccAWSEcsServiceWithAlb(rName string) string {
+func testAccAWSEcsServiceWithAlb(clusterName, tdName, roleName, policyName, tgName, lbName, svcName string) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {}
 
@@ -1356,10 +1445,10 @@ resource "aws_ecs_service" "with_alb" {
     "aws_lb_listener.front_end"
   ]
 }
-`, rName, rName, rName, rName, rName, rName, rName)
+`, clusterName, tdName, roleName, policyName, tgName, lbName, svcName)
 }
 
-func testAccAWSEcsServiceWithNetworkConfigration(rName string) string {
+func testAccAWSEcsServiceWithNetworkConfigration(sg1Name, sg2Name, clusterName, tdName, svcName string) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {}
 
@@ -1375,7 +1464,7 @@ resource "aws_subnet" "main" {
 }
 
 resource "aws_security_group" "allow_all_a" {
-  name        = "allow_all_a"
+  name        = "%s"
   description = "Allow all inbound traffic"
   vpc_id      = "${aws_vpc.main.id}"
 
@@ -1388,7 +1477,7 @@ resource "aws_security_group" "allow_all_a" {
 }
 
 resource "aws_security_group" "allow_all_b" {
-  name        = "allow_all_b"
+  name        = "%s"
   description = "Allow all inbound traffic"
   vpc_id      = "${aws_vpc.main.id}"
 
@@ -1401,11 +1490,11 @@ resource "aws_security_group" "allow_all_b" {
 }
 
 resource "aws_ecs_cluster" "main" {
-	name = "tf-ecs-cluster-%s"
+	name = "%s"
 }
 
 resource "aws_ecs_task_definition" "mongo" {
-  family = "mongodb"
+  family = "%s"
 	network_mode = "awsvpc"
   container_definitions = <<DEFINITION
 [
@@ -1421,7 +1510,7 @@ DEFINITION
 }
 
 resource "aws_ecs_service" "main" {
-  name = "tf-ecs-service-%s"
+  name = "%s"
   cluster = "${aws_ecs_cluster.main.id}"
   task_definition = "${aws_ecs_task_definition.mongo.arn}"
   desired_count = 1
@@ -1430,5 +1519,5 @@ resource "aws_ecs_service" "main" {
 		subnets = ["${aws_subnet.main.*.id}"]
 	}
 }
-`, rName, rName)
+`, sg1Name, sg2Name, clusterName, tdName, svcName)
 }


### PR DESCRIPTION
This is to (hopefully) avoid the following test failures:

```
=== RUN   TestAccAWSEcsServiceWithRenamedCluster
--- FAIL: TestAccAWSEcsServiceWithRenamedCluster (769.19s)
    testing.go:503: Step 1 error: Error applying: 1 error(s) occurred:
        
        * aws_ecs_service.ghost: 1 error(s) occurred:
        
        * aws_ecs_service.ghost: InvalidParameterException: Creation of service was not idempotent.
            status code: 400, request id: 42ed3185-f5c6-11e7-9e80-a7e1d73a562a "ghost"
    testing.go:563: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Error applying: 1 error(s) occurred:
        
        * aws_ecs_cluster.default (destroy): 1 error(s) occurred:
        
        * aws_ecs_cluster.default: ClusterContainsServicesException: The Cluster cannot be deleted while Services are active.
            status code: 400, request id: a6be3623-f5c7-11e7-85e2-19f0de267d6c
        
        State: aws_ecs_cluster.default:
          ID = arn:aws:ecs:us-west-2:*******:cluster/terraformecstest3modified
          arn = arn:aws:ecs:us-west-2:*******:cluster/terraformecstest3modified
          name = terraformecstest3modified
=== RUN   TestAccAWSEcsService_withEcsClusterName
--- FAIL: TestAccAWSEcsService_withEcsClusterName (723.87s)
    testing.go:503: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_ecs_service.jenkins: 1 error(s) occurred:
        
        * aws_ecs_service.jenkins: InvalidParameterException: Creation of service was not idempotent.
            status code: 400, request id: 41e55ec8-f5c6-11e7-bb22-9d94b865de72 "jenkins"
    testing.go:563: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Error applying: 1 error(s) occurred:
        
        * aws_ecs_cluster.default (destroy): 1 error(s) occurred:
        
        * aws_ecs_cluster.default: ClusterContainsServicesException: The Cluster cannot be deleted while Services are active.
            status code: 400, request id: a4f16585-f5c7-11e7-a29e-0b4a711b8499
        
        State: aws_ecs_cluster.default:
          ID = arn:aws:ecs:us-west-2:*******:cluster/terraformecstestcluster
          arn = arn:aws:ecs:us-west-2:*******:cluster/terraformecstestcluster
          name = terraformecstestcluster
=== RUN   TestAccAWSEcsService_withIamRole
--- FAIL: TestAccAWSEcsService_withIamRole (728.75s)
    testing.go:503: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_ecs_service.ghost: 1 error(s) occurred:
        
        * aws_ecs_service.ghost: InvalidParameterException: Creation of service was not idempotent.
            status code: 400, request id: 2f510d3b-f5c6-11e7-8a2c-5fcfb1f4a900 "ghost"
    testing.go:563: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Error applying: 1 error(s) occurred:
        
        * aws_ecs_cluster.main (destroy): 1 error(s) occurred:
        
        * aws_ecs_cluster.main: ClusterContainsServicesException: The Cluster cannot be deleted while Services are active.
            status code: 400, request id: 928ed287-f5c7-11e7-aed6-b59cec5a653d
        
        State: aws_ecs_cluster.main:
          ID = arn:aws:ecs:us-west-2:*******:cluster/terraformecstest11
          arn = arn:aws:ecs:us-west-2:*******:cluster/terraformecstest11
          name = terraformecstest11
=== RUN   TestAccAWSEcsService_withLbChanges
--- FAIL: TestAccAWSEcsService_withLbChanges (726.09s)
    testing.go:503: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_ecs_service.with_lb_changes: 1 error(s) occurred:
        
        * aws_ecs_service.with_lb_changes: InvalidParameterException: Creation of service was not idempotent.
            status code: 400, request id: 3cfc8021-f5c6-11e7-a0aa-d3b9fc2cbf56 "ghost"
    testing.go:563: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Error applying: 1 error(s) occurred:
        
        * aws_ecs_cluster.main (destroy): 1 error(s) occurred:
        
        * aws_ecs_cluster.main: ClusterContainsServicesException: The Cluster cannot be deleted while Services are active.
            status code: 400, request id: a104e8fb-f5c7-11e7-9e80-a7e1d73a562a
        
        State: aws_ecs_cluster.main:
          ID = arn:aws:ecs:us-west-2:*******:cluster/terraformecstest12
          arn = arn:aws:ecs:us-west-2:*******:cluster/terraformecstest12
          name = terraformecstest12
```

At the very least we'll eliminate one possible reason for the failure.

## Test results

```
=== RUN   TestAccAWSEcsService_withPlacementConstraints
--- PASS: TestAccAWSEcsService_withPlacementConstraints (9.20s)
=== RUN   TestAccAWSEcsService_withDeploymentValues
--- PASS: TestAccAWSEcsService_withDeploymentValues (13.66s)
=== RUN   TestAccAWSEcsService_withPlacementStrategy
--- PASS: TestAccAWSEcsService_withPlacementStrategy (23.09s)
=== RUN   TestAccAWSEcsService_withUnnormalizedPlacementStrategy
--- PASS: TestAccAWSEcsService_withUnnormalizedPlacementStrategy (25.63s)
=== RUN   TestAccAWSEcsService_withEcsClusterName
--- PASS: TestAccAWSEcsService_withEcsClusterName (36.67s)
=== RUN   TestAccAWSEcsService_withARN
--- PASS: TestAccAWSEcsService_withARN (36.83s)
=== RUN   TestAccAWSEcsService_withNetworkConfiguration
--- PASS: TestAccAWSEcsService_withNetworkConfiguration (40.11s)
=== RUN   TestAccAWSEcsService_withPlacementConstraints_emptyExpression
--- PASS: TestAccAWSEcsService_withPlacementConstraints_emptyExpression (40.06s)
=== RUN   TestAccAWSEcsService_withFamilyAndRevision
--- PASS: TestAccAWSEcsService_withFamilyAndRevision (43.42s)
=== RUN   TestAccAWSEcsService_withRenamedCluster
--- PASS: TestAccAWSEcsService_withRenamedCluster (47.60s)
=== RUN   TestAccAWSEcsService_withLaunchTypeFargate
--- PASS: TestAccAWSEcsService_withLaunchTypeFargate (80.79s)
=== RUN   TestAccAWSEcsService_withIamRole
--- PASS: TestAccAWSEcsService_withIamRole (169.41s)
=== RUN   TestAccAWSEcsService_healthCheckGracePeriodSeconds
--- PASS: TestAccAWSEcsService_healthCheckGracePeriodSeconds (209.05s)
=== RUN   TestAccAWSEcsService_withAlb
--- PASS: TestAccAWSEcsService_withAlb (253.74s)
=== RUN   TestAccAWSEcsService_withLbChanges
--- PASS: TestAccAWSEcsService_withLbChanges (259.41s)
```