### PR TITLE
Bump aws-sdk-go to v1.12.59

### DIFF
--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.12.57"
+const SDKVersion = "1.12.59"

--- a/vendor/github.com/aws/aws-sdk-go/service/directoryservice/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/directoryservice/api.go
@@ -4805,6 +4805,10 @@ type CreateMicrosoftADInput struct {
 	// console Directory Details page after the directory is created.
 	Description *string `type:"string"`
 
+	// AWS Microsoft AD is available in two editions: Standard and Enterprise. Enterprise
+	// is the default.
+	Edition *string `type:"string" enum:"DirectoryEdition"`
+
 	// The fully qualified domain name for the directory, such as corp.example.com.
 	// This name will resolve inside your VPC only. It does not need to be publicly
 	// resolvable.
@@ -4865,6 +4869,12 @@ func (s *CreateMicrosoftADInput) Validate() error {
 // SetDescription sets the Description field's value.
 func (s *CreateMicrosoftADInput) SetDescription(v string) *CreateMicrosoftADInput {
 	s.Description = &v
+	return s
+}
+
+// SetEdition sets the Edition field's value.
+func (s *CreateMicrosoftADInput) SetEdition(v string) *CreateMicrosoftADInput {
+	s.Edition = &v
 	return s
 }
 
@@ -6208,6 +6218,9 @@ type DirectoryDescription struct {
 	// which the AD Connector is connected.
 	DnsIpAddrs []*string `type:"list"`
 
+	// The edition associated with this directory.
+	Edition *string `type:"string" enum:"DirectoryEdition"`
+
 	// Specifies when the directory was created.
 	LaunchTime *time.Time `type:"timestamp" timestampFormat:"unix"`
 
@@ -6298,6 +6311,12 @@ func (s *DirectoryDescription) SetDirectoryId(v string) *DirectoryDescription {
 // SetDnsIpAddrs sets the DnsIpAddrs field's value.
 func (s *DirectoryDescription) SetDnsIpAddrs(v []*string) *DirectoryDescription {
 	s.DnsIpAddrs = v
+	return s
+}
+
+// SetEdition sets the Edition field's value.
+func (s *DirectoryDescription) SetEdition(v string) *DirectoryDescription {
+	s.Edition = &v
 	return s
 }
 
@@ -6534,10 +6553,7 @@ type DirectoryVpcSettingsDescription struct {
 	// The list of Availability Zones that the directory is in.
 	AvailabilityZones []*string `type:"list"`
 
-	// The security group identifier for the directory. If the directory was created
-	// before 8/1/2014, this is the identifier of the directory members security
-	// group that was created when the directory was created. If the directory was
-	// created after this date, this value is null.
+	// The domain controller security group identifier for the directory.
 	SecurityGroupId *string `type:"string"`
 
 	// The identifiers of the subnets for the directory servers.
@@ -8707,6 +8723,14 @@ func (s *VerifyTrustOutput) SetTrustId(v string) *VerifyTrustOutput {
 	s.TrustId = &v
 	return s
 }
+
+const (
+	// DirectoryEditionEnterprise is a DirectoryEdition enum value
+	DirectoryEditionEnterprise = "Enterprise"
+
+	// DirectoryEditionStandard is a DirectoryEdition enum value
+	DirectoryEditionStandard = "Standard"
+)
 
 const (
 	// DirectorySizeSmall is a DirectorySize enum value

--- a/vendor/github.com/aws/aws-sdk-go/service/kms/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/kms/api.go
@@ -4596,8 +4596,8 @@ type CreateKeyInput struct {
 
 	// A flag to indicate whether to bypass the key policy lockout safety check.
 	//
-	// Setting this value to true increases the likelihood that the CMK becomes
-	// unmanageable. Do not set this value to true indiscriminately.
+	// Setting this value to true increases the risk that the CMK becomes unmanageable.
+	// Do not set this value to true indiscriminately.
 	//
 	// For more information, refer to the scenario in the Default Key Policy (http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam)
 	// section in the AWS Key Management Service Developer Guide.
@@ -4634,28 +4634,29 @@ type CreateKeyInput struct {
 
 	// The key policy to attach to the CMK.
 	//
-	// If you specify a policy and do not set BypassPolicyLockoutSafetyCheck to
-	// true, the policy must meet the following criteria:
+	// If you provide a key policy, it must meet the following criteria:
 	//
-	//    * It must allow the principal that is making the CreateKey request to
-	//    make a subsequent PutKeyPolicy request on the CMK. This reduces the likelihood
-	//    that the CMK becomes unmanageable. For more information, refer to the
-	//    scenario in the Default Key Policy (http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam)
-	//    section in the AWS Key Management Service Developer Guide.
+	//    * If you don't set BypassPolicyLockoutSafetyCheck to true, the key policy
+	//    must allow the principal that is making the CreateKey request to make
+	//    a subsequent PutKeyPolicy request on the CMK. This reduces the risk that
+	//    the CMK becomes unmanageable. For more information, refer to the scenario
+	//    in the Default Key Policy (http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam)
+	//    section of the AWS Key Management Service Developer Guide.
 	//
-	//    * The principals that are specified in the key policy must exist and be
-	//    visible to AWS KMS. When you create a new AWS principal (for example,
-	//    an IAM user or role), you might need to enforce a delay before specifying
-	//    the new principal in a key policy because the new principal might not
-	//    immediately be visible to AWS KMS. For more information, see Changes that
-	//    I make are not always immediately visible (http://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_eventual-consistency)
-	//    in the IAM User Guide.
+	//    * Each statement in the key policy must contain one or more principals.
+	//    The principals in the key policy must exist and be visible to AWS KMS.
+	//    When you create a new AWS principal (for example, an IAM user or role),
+	//    you might need to enforce a delay before including the new principal in
+	//    a key policy because the new principal might not be immediately visible
+	//    to AWS KMS. For more information, see Changes that I make are not always
+	//    immediately visible (http://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_eventual-consistency)
+	//    in the AWS Identity and Access Management User Guide.
 	//
-	// If you do not specify a policy, AWS KMS attaches a default key policy to
-	// the CMK. For more information, see Default Key Policy (http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default)
+	// If you do not provide a key policy, AWS KMS attaches a default key policy
+	// to the CMK. For more information, see Default Key Policy (http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default)
 	// in the AWS Key Management Service Developer Guide.
 	//
-	// The policy size limit is 32 kilobytes (32768 bytes).
+	// The key policy size limit is 32 kilobytes (32768 bytes).
 	Policy *string `min:"1" type:"string"`
 
 	// One or more tags. Each tag consists of a tag key and a tag value. Tag keys
@@ -5878,8 +5879,8 @@ type GetKeyPolicyInput struct {
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
 
-	// Specifies the name of the policy. The only valid name is default. To get
-	// the names of key policies, use ListKeyPolicies.
+	// Specifies the name of the key policy. The only valid name is default. To
+	// get the names of key policies, use ListKeyPolicies.
 	//
 	// PolicyName is a required field
 	PolicyName *string `min:"1" type:"string" required:"true"`
@@ -5933,7 +5934,7 @@ func (s *GetKeyPolicyInput) SetPolicyName(v string) *GetKeyPolicyInput {
 type GetKeyPolicyOutput struct {
 	_ struct{} `type:"structure"`
 
-	// A policy document in JSON format.
+	// A key policy document in JSON format.
 	Policy *string `min:"1" type:"string"`
 }
 
@@ -6976,8 +6977,8 @@ type ListKeyPoliciesOutput struct {
 	// use for the Marker parameter in a subsequent request.
 	NextMarker *string `min:"1" type:"string"`
 
-	// A list of policy names. Currently, there is only one policy and it is named
-	// "Default".
+	// A list of key policy names. Currently, there is only one key policy per CMK
+	// and it is always named default.
 	PolicyNames []*string `type:"list"`
 
 	// A flag that indicates whether there are more items in the list. When this
@@ -7337,8 +7338,8 @@ type PutKeyPolicyInput struct {
 
 	// A flag to indicate whether to bypass the key policy lockout safety check.
 	//
-	// Setting this value to true increases the likelihood that the CMK becomes
-	// unmanageable. Do not set this value to true indiscriminately.
+	// Setting this value to true increases the risk that the CMK becomes unmanageable.
+	// Do not set this value to true indiscriminately.
 	//
 	// For more information, refer to the scenario in the Default Key Policy (http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam)
 	// section in the AWS Key Management Service Developer Guide.
@@ -7366,24 +7367,25 @@ type PutKeyPolicyInput struct {
 
 	// The key policy to attach to the CMK.
 	//
-	// If you do not set BypassPolicyLockoutSafetyCheck to true, the policy must
-	// meet the following criteria:
+	// The key policy must meet the following criteria:
 	//
-	//    * It must allow the principal that is making the PutKeyPolicy request
-	//    to make a subsequent PutKeyPolicy request on the CMK. This reduces the
-	//    likelihood that the CMK becomes unmanageable. For more information, refer
-	//    to the scenario in the Default Key Policy (http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam)
-	//    section in the AWS Key Management Service Developer Guide.
+	//    * If you don't set BypassPolicyLockoutSafetyCheck to true, the key policy
+	//    must allow the principal that is making the PutKeyPolicy request to make
+	//    a subsequent PutKeyPolicy request on the CMK. This reduces the risk that
+	//    the CMK becomes unmanageable. For more information, refer to the scenario
+	//    in the Default Key Policy (http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam)
+	//    section of the AWS Key Management Service Developer Guide.
 	//
-	//    * The principals that are specified in the key policy must exist and be
-	//    visible to AWS KMS. When you create a new AWS principal (for example,
-	//    an IAM user or role), you might need to enforce a delay before specifying
-	//    the new principal in a key policy because the new principal might not
-	//    immediately be visible to AWS KMS. For more information, see Changes that
-	//    I make are not always immediately visible (http://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_eventual-consistency)
-	//    in the IAM User Guide.
+	//    * Each statement in the key policy must contain one or more principals.
+	//    The principals in the key policy must exist and be visible to AWS KMS.
+	//    When you create a new AWS principal (for example, an IAM user or role),
+	//    you might need to enforce a delay before including the new principal in
+	//    a key policy because the new principal might not be immediately visible
+	//    to AWS KMS. For more information, see Changes that I make are not always
+	//    immediately visible (http://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_eventual-consistency)
+	//    in the AWS Identity and Access Management User Guide.
 	//
-	// The policy size limit is 32 kilobytes (32768 bytes).
+	// The key policy size limit is 32 kilobytes (32768 bytes).
 	//
 	// Policy is a required field
 	Policy *string `min:"1" type:"string" required:"true"`

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -141,844 +141,844 @@
 			"revisionTime": "2017-07-27T15:54:43Z"
 		},
 		{
-			"checksumSHA1": "h8863Fok+80x0JWRr78XXcGywxM=",
+			"checksumSHA1": "s4OiIOYhXiesEXjwmg1scSc0//o=",
 			"path": "github.com/aws/aws-sdk-go/aws",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "DtuTqKH29YnLjrIJkRYX0HQtXY0=",
 			"path": "github.com/aws/aws-sdk-go/aws/arn",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "Y9W+4GimK4Fuxq+vyIskVYFRnX4=",
 			"path": "github.com/aws/aws-sdk-go/aws/awserr",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "yyYr41HZ1Aq0hWc3J5ijXwYEcac=",
 			"path": "github.com/aws/aws-sdk-go/aws/awsutil",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "9nE/FjZ4pYrT883KtV2/aI+Gayo=",
 			"path": "github.com/aws/aws-sdk-go/aws/client",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "ieAJ+Cvp/PKv1LpUEnUXpc3OI6E=",
 			"path": "github.com/aws/aws-sdk-go/aws/client/metadata",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "7/8j/q0TWtOgXyvEcv4B2Dhl00o=",
 			"path": "github.com/aws/aws-sdk-go/aws/corehandlers",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "Y+cPwQL0dZMyqp3wI+KJWmA9KQ8=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "u3GOAJLmdvbuNUeUEcZSEAOeL/0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "NUJUTWlc1sV8b7WjfiYc4JZbXl0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/endpointcreds",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "JEYqmF83O5n5bHkupAzA6STm0no=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "OnU/n7R33oYXiB4SAGd5pK7I0Bs=",
 			"path": "github.com/aws/aws-sdk-go/aws/defaults",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "/EXbk/z2TWjWc1Hvb4QYs3Wmhb8=",
 			"path": "github.com/aws/aws-sdk-go/aws/ec2metadata",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "BT2+PhuOjbAuMcLpdop0FKQY5EY=",
 			"path": "github.com/aws/aws-sdk-go/aws/endpoints",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "9GvAyILJ7g+VUg8Ef5DsT5GuYsg=",
 			"path": "github.com/aws/aws-sdk-go/aws/request",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "HcGL4e6Uep4/80eCUI5xkcWjpQ0=",
 			"path": "github.com/aws/aws-sdk-go/aws/session",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "iU00ZjhAml/13g+1YXT21IqoXqg=",
 			"path": "github.com/aws/aws-sdk-go/aws/signer/v4",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "04ypv4x12l4q0TksA1zEVsmgpvw=",
 			"path": "github.com/aws/aws-sdk-go/internal/shareddefaults",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "NStHCXEvYqG72GknZyv1jaKaeH0=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "1QmQ3FqV37w0Zi44qv8pA1GeR0A=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/ec2query",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "yHfT5DTbeCLs4NE2Rgnqrhe15ls=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/json/jsonutil",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "R00RL5jJXRYq1iiK1+PGvMfvXyM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/jsonrpc",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "ZqY5RWavBLWTo6j9xqdyBEaNFRk=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "9V1PvtFQ9MObZTc3sa86WcuOtOU=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "pkeoOfZpHRvFG/AOZeTf0lwtsFg=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/rest",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "Rpu8KBtHZgvhkwHxUfaky+qW+G4=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restjson",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "ODo+ko8D6unAxZuN1jGzMcN4QCc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restxml",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "0qYPUga28aQVkxZgBR3Z86AbGUQ=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "F6mth+G7dXN1GI+nktaGo8Lx8aE=",
 			"path": "github.com/aws/aws-sdk-go/private/signer/v2",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "vnYDXA1NxJ7Hu+DMfXNk1UnmkWg=",
 			"path": "github.com/aws/aws-sdk-go/service/acm",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "DPl/OkvEUjrd+XKqX73l6nUNw3U=",
 			"path": "github.com/aws/aws-sdk-go/service/apigateway",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "X8tOI6i+RJwXIgg1qBjDNclyG/0=",
 			"path": "github.com/aws/aws-sdk-go/service/applicationautoscaling",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "aDAaH6YiA50IrJ5Smfg0fovrniA=",
 			"path": "github.com/aws/aws-sdk-go/service/appsync",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "oBXDw1zQTfxcKsK3ZjtKcS7gBLI=",
 			"path": "github.com/aws/aws-sdk-go/service/athena",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "ITAwWyJp4t9AGfUXm9M3pFWTHVA=",
 			"path": "github.com/aws/aws-sdk-go/service/autoscaling",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "Zz8qI6RloveM1zrXAglLxJZT1ZA=",
 			"path": "github.com/aws/aws-sdk-go/service/batch",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "/nO06EpnD22+Ex80gHi4UYrAvKc=",
 			"path": "github.com/aws/aws-sdk-go/service/budgets",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "6gM3CZZgiB0JvS7EK1c31Q8L09U=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudformation",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "T80IDetBz1hqJpq5Wqmx3MwCh8w=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudfront",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "bYrI9mxspB0xDFZEy3OIfWuez5g=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudtrail",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "oB+M+kOmYG28V0PuI75IF6E+/w8=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatch",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "Nc3vXlV7s309PprScYpRDPQWeDQ=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchevents",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "bPh7NF3mLpGMV0rIakolMPHqMyw=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "P6qyaFX9X6Nnvm3avLigjmjfYds=",
 			"path": "github.com/aws/aws-sdk-go/service/codebuild",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "7nW1Ho2X3RcUU8FaFBhJIUeuDNw=",
 			"path": "github.com/aws/aws-sdk-go/service/codecommit",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "+petAU2sPfykSoVBAitmGxvGOlw=",
 			"path": "github.com/aws/aws-sdk-go/service/codedeploy",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "LKw7fnNwq17Eqy0clzS/LK89vS4=",
 			"path": "github.com/aws/aws-sdk-go/service/codepipeline",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "aXh1KIbNX+g+tH+lh3pk++9lm3k=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentity",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "IWi9xZz+OncotjM/vJ87Iffg2Qk=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentityprovider",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "56F6Stg8hQ1kxiAEzqB0TDctW9k=",
 			"path": "github.com/aws/aws-sdk-go/service/configservice",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "hYCwLQdIjHj8rMHLGVyUVhecI4s=",
 			"path": "github.com/aws/aws-sdk-go/service/databasemigrationservice",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "siWpqsOY3u69XkgPF8+F8V1K0Pc=",
 			"path": "github.com/aws/aws-sdk-go/service/dax",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "26CWoHQP/dyL2VzE5ZNd8zNzhko=",
 			"path": "github.com/aws/aws-sdk-go/service/devicefarm",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "6g94rUHAgjcqMMTtMqKUbLU37wY=",
 			"path": "github.com/aws/aws-sdk-go/service/directconnect",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
-			"checksumSHA1": "oFnS6I0u7KqnxK0/r1uoz8rTkxI=",
+			"checksumSHA1": "edM36y+5lmI7Hne0/38qapLzGO4=",
 			"path": "github.com/aws/aws-sdk-go/service/directoryservice",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "0TXXUPjrbOCHpX555B6suH36Nnk=",
 			"path": "github.com/aws/aws-sdk-go/service/dynamodb",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "INaeHZ2L5x6RlrcQBm4q1hFqNRM=",
 			"path": "github.com/aws/aws-sdk-go/service/ec2",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "uEv9kkBsVIjg7K4+Y8TVlU0Cc8o=",
 			"path": "github.com/aws/aws-sdk-go/service/ecr",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "3B3RtWG7IY9qhFhWGEwroeMxnPI=",
 			"path": "github.com/aws/aws-sdk-go/service/ecs",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "eoM9nF5iVMbuGOmkY33d19aHt8Y=",
 			"path": "github.com/aws/aws-sdk-go/service/efs",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "dU5MPXUUOYD/E9sNncpFZ/U86Cw=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticache",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "pj8mBWT3HE0Iid6HSmhw7lmyZDU=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticbeanstalk",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "VYGtTaSiajfKOVTbi9/SNmbiIac=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticsearchservice",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "SZ7yLDZ6RvMhpWe0Goyem64kgyA=",
 			"path": "github.com/aws/aws-sdk-go/service/elastictranscoder",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "WYqHhdRNsiGGBLWlBLbOItZf+zA=",
 			"path": "github.com/aws/aws-sdk-go/service/elb",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "ae7VWg/xuXpnSD6wGumN44qEd+Q=",
 			"path": "github.com/aws/aws-sdk-go/service/elbv2",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "NbkH6F+792jQ7BW4lGCb+vJVw58=",
 			"path": "github.com/aws/aws-sdk-go/service/emr",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "5btWHj2fZrPc/zfYdJLPaOcivxI=",
 			"path": "github.com/aws/aws-sdk-go/service/firehose",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "Rodm1XwZ9Ncah1NLHep0behQpXg=",
 			"path": "github.com/aws/aws-sdk-go/service/gamelift",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "oDoGvSfmO2Z099ixV2HXn+SDeHE=",
 			"path": "github.com/aws/aws-sdk-go/service/glacier",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "HRmbBf3dUEBAfdC2xKaoWAGeM7Y=",
 			"path": "github.com/aws/aws-sdk-go/service/glue",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "6JlxJoy1JCArNK2qBkaJ5IV6qBc=",
 			"path": "github.com/aws/aws-sdk-go/service/guardduty",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "oZaxMqnwl2rA+V/W0tJ3uownORI=",
 			"path": "github.com/aws/aws-sdk-go/service/iam",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "nMdRXIfhgvEKBHnLX61Ze3EUJWU=",
 			"path": "github.com/aws/aws-sdk-go/service/inspector",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "pZwCI4DpP5hcMa/ItKhiwo/ukd0=",
 			"path": "github.com/aws/aws-sdk-go/service/iot",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "IoSyRZhlL0petrB28nXk5jKM9YA=",
 			"path": "github.com/aws/aws-sdk-go/service/kinesis",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
-			"checksumSHA1": "oAFLgD0uJiVOZkFkL5dd/wUgBz4=",
+			"checksumSHA1": "JOfgA6YehzwZ/4Mgh+3lY/+Gz3E=",
 			"path": "github.com/aws/aws-sdk-go/service/kms",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "XDVse9fKF0RkAywzzgsO31AV4oc=",
 			"path": "github.com/aws/aws-sdk-go/service/lambda",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "HluEcyZNywrbKnj/aR3tXbu29d8=",
 			"path": "github.com/aws/aws-sdk-go/service/lexmodelbuildingservice",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "wjs9YBsHx0YQH0zKBA7Ibd1UV5Y=",
 			"path": "github.com/aws/aws-sdk-go/service/lightsail",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "4VfB5vMLNYs0y6K159YCBgo9T3c=",
 			"path": "github.com/aws/aws-sdk-go/service/mediaconvert",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "Ox3VWHYSQq0YKmlr0paUPdr5W/0=",
 			"path": "github.com/aws/aws-sdk-go/service/medialive",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "Rs7QtkcLl3XNPnKb8ss/AhF2X50=",
 			"path": "github.com/aws/aws-sdk-go/service/mediapackage",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "QjiIL8LrlhwrQw8FboF+wMNvUF0=",
 			"path": "github.com/aws/aws-sdk-go/service/mediastore",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "ZY1SJNE03I6NL2OBJD9hlwVsqO0=",
 			"path": "github.com/aws/aws-sdk-go/service/mediastoredata",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "ynB7Flcudp0VOqBVKZJ+23DtLHU=",
 			"path": "github.com/aws/aws-sdk-go/service/mq",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "fpsBu+F79ktlLRwal1GugVMUDo0=",
 			"path": "github.com/aws/aws-sdk-go/service/opsworks",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "IddJCt5BrI6zRuUpFJqqnS9qrIM=",
 			"path": "github.com/aws/aws-sdk-go/service/rds",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "vP1FcccUZbuUlin7ME89w1GVJtA=",
 			"path": "github.com/aws/aws-sdk-go/service/redshift",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "fgSXmayOZRgur/41Gp1tFvH0GGg=",
 			"path": "github.com/aws/aws-sdk-go/service/route53",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "sCaHoPWsJXRHFbilUKwN71qFTOI=",
 			"path": "github.com/aws/aws-sdk-go/service/s3",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "QZU8vR9cOIenYiH+Ywl4Gzfnlp0=",
 			"path": "github.com/aws/aws-sdk-go/service/servicecatalog",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "dk6ebvA0EYgdPyc5HPKLBPEtsm4=",
 			"path": "github.com/aws/aws-sdk-go/service/servicediscovery",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "Ex1Ma0SFGpqeNuPbeXZtsliZ3zo=",
 			"path": "github.com/aws/aws-sdk-go/service/ses",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "maVXeR3WDAkONlzf04e4mDgCYxo=",
 			"path": "github.com/aws/aws-sdk-go/service/sfn",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "ADoR4mlCW5usH8iOa6mPNSy49LM=",
 			"path": "github.com/aws/aws-sdk-go/service/shield",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "B3CgAFSREebpsFoFOo4vrQ6u04w=",
 			"path": "github.com/aws/aws-sdk-go/service/simpledb",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "FfY8w4DM8XIULdRnFhd3Um8Mj8c=",
 			"path": "github.com/aws/aws-sdk-go/service/sns",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "Wx189wAbIhWChx4kVbvsyqKMF4U=",
 			"path": "github.com/aws/aws-sdk-go/service/sqs",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "Al7CCaQRNd22FwUZXigUEWN820M=",
 			"path": "github.com/aws/aws-sdk-go/service/ssm",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "W1oFtpaT4TWIIJrAvFcn/XdcT7g=",
 			"path": "github.com/aws/aws-sdk-go/service/sts",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "Uw4pOUxSMbx4xBHUcOUkNhtnywE=",
 			"path": "github.com/aws/aws-sdk-go/service/swf",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "on6d7Hydx2bM9jkFOf1JZcZZgeY=",
 			"path": "github.com/aws/aws-sdk-go/service/waf",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "rHqjsOndIR82gX5mSKybaRWf3UY=",
 			"path": "github.com/aws/aws-sdk-go/service/wafregional",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "y0XODBzpJjZvR1e9F6ULItV5nG4=",
 			"path": "github.com/aws/aws-sdk-go/service/workspaces",
-			"revision": "5177d71d80f123f6d82aaf762387e39b88c5ba23",
-			"revisionTime": "2018-01-09T00:04:15Z",
-			"version": "v1.12.57",
-			"versionExact": "v1.12.57"
+			"revision": "3c754f1d340244540350f0a00b940781bae9c905",
+			"revisionTime": "2018-01-09T22:08:02Z",
+			"version": "v1.12.59",
+			"versionExact": "v1.12.59"
 		},
 		{
 			"checksumSHA1": "usT4LCSQItkFvFOQT7cBlkCuGaE=",


### PR DESCRIPTION
`govendor fetch github.com/aws/aws-sdk-go/...@v1.12.59`

Happy New year! 🎆 🍾 🎈 