### PR TITLE
test/aws_s3_bucket_notification: Randomize names

### DIFF
--- a/aws/import_aws_s3_bucket_notification_test.go
+++ b/aws/import_aws_s3_bucket_notification_test.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -8,6 +9,14 @@ import (
 )
 
 func TestAccAWSS3BucketNotification_importBasic(t *testing.T) {
+	rString := acctest.RandString(8)
+
+	topicName := fmt.Sprintf("tf-acc-topic-s3-b-n-import-%s", rString)
+	bucketName := fmt.Sprintf("tf-acc-bucket-n-import-%s", rString)
+	queueName := fmt.Sprintf("tf-acc-queue-s3-b-n-import-%s", rString)
+	roleName := fmt.Sprintf("tf-acc-role-s3-b-n-import-%s", rString)
+	lambdaFuncName := fmt.Sprintf("tf-acc-lambda-func-s3-b-n-import-%s", rString)
+
 	resourceName := "aws_s3_bucket_notification.notification"
 
 	resource.Test(t, resource.TestCase{
@@ -16,7 +25,7 @@ func TestAccAWSS3BucketNotification_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSS3BucketNotificationDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSS3BucketConfigWithTopicNotification(acctest.RandInt()),
+				Config: testAccAWSS3BucketConfigWithTopicNotification(topicName, bucketName),
 			},
 
 			resource.TestStep{
@@ -33,7 +42,7 @@ func TestAccAWSS3BucketNotification_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSS3BucketNotificationDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSS3BucketConfigWithQueueNotification(acctest.RandInt()),
+				Config: testAccAWSS3BucketConfigWithQueueNotification(queueName, bucketName),
 			},
 
 			resource.TestStep{
@@ -50,7 +59,7 @@ func TestAccAWSS3BucketNotification_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSS3BucketNotificationDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSS3BucketConfigWithLambdaNotification(acctest.RandInt()),
+				Config: testAccAWSS3BucketConfigWithLambdaNotification(roleName, lambdaFuncName, bucketName),
 			},
 
 			resource.TestStep{


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSS3Bucket_Notification
--- FAIL: TestAccAWSS3Bucket_Notification (107.39s)
    testing.go:503: Step 2 error: Error applying: 1 error(s) occurred:
        
        * aws_iam_role.iam_for_lambda: 1 error(s) occurred:
        
        * aws_iam_role.iam_for_lambda: Error creating IAM Role iam_for_lambda: EntityAlreadyExists: Role with name iam_for_lambda already exists.
            status code: 409, request id: 94f43c81-f5d6-11e7-83b4-b5b7f64802dd
FAIL
```

## Test results
```
=== RUN   TestAccAWSS3BucketNotification_withoutFilter
--- PASS: TestAccAWSS3BucketNotification_withoutFilter (11.83s)
=== RUN   TestAccAWSS3BucketNotification_basic
--- PASS: TestAccAWSS3BucketNotification_basic (42.54s)
=== RUN   TestAccAWSS3BucketNotification_importBasic
--- PASS: TestAccAWSS3BucketNotification_importBasic (51.38s)
```