### PR TITLE
test/aws_db_option_group: Replace option name with a valid one

### DIFF
--- a/aws/resource_aws_db_option_group_test.go
+++ b/aws/resource_aws_db_option_group_test.go
@@ -487,7 +487,7 @@ resource "aws_db_option_group" "bar" {
   major_engine_version     = "11.00"
 
   option {
-    option_name = "Mirroring"
+    option_name = "TDE"
   }
 }
 `, r)


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSDBOptionGroup_sqlServerOptionsUpdate
--- FAIL: TestAccAWSDBOptionGroup_sqlServerOptionsUpdate (11.24s)
    testing.go:503: Step 1 error: Error applying: 1 error(s) occurred:
        
        * aws_db_option_group.bar: 1 error(s) occurred:
        
        * aws_db_option_group.bar: Error modifying DB Option Group: InvalidParameterValue: Unknown option: Mirroring
            status code: 400, request id: f0891661-3239-40aa-a00e-5550502dc724
FAIL
```

## Test results

```
=== RUN   TestAccAWSDBOptionGroup_sqlServerOptionsUpdate
--- PASS: TestAccAWSDBOptionGroup_sqlServerOptionsUpdate (49.31s)
```