### PR TITLE
data-source/aws_instance: Add missing volume_id fields

### DIFF
--- a/aws/data_source_aws_instance.go
+++ b/aws/data_source_aws_instance.go
@@ -173,6 +173,11 @@ func dataSourceAwsInstance() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+
+						"volume_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},
@@ -197,6 +202,11 @@ func dataSourceAwsInstance() *schema.Resource {
 						},
 
 						"volume_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"volume_id": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},


### PR DESCRIPTION
This is to address the following test failures related to #1489

```
=== RUN   TestAccAWSInstanceDataSource_PlacementGroup
--- FAIL: TestAccAWSInstanceDataSource_PlacementGroup (231.35s)
    testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
        
        * data.aws_instance.foo: data.aws_instance.foo: Invalid address to set: []string{"root_block_device", "0", "volume_id"}
    testing.go:573: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Error refreshing: 1 error(s) occurred:
        
        * data.aws_instance.foo: 1 error(s) occurred:
        
        * data.aws_instance.foo: data.aws_instance.foo: Invalid address to set: []string{"root_block_device", "0", "volume_id"}
        
        State: <nil>
=== RUN   TestAccAWSInstanceDataSource_VPCSecurityGroups
--- FAIL: TestAccAWSInstanceDataSource_VPCSecurityGroups (145.01s)
    testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
        
        * data.aws_instance.foo: data.aws_instance.foo: Invalid address to set: []string{"root_block_device", "0", "volume_id"}
    testing.go:573: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Error refreshing: 1 error(s) occurred:
        
        * data.aws_instance.foo: 1 error(s) occurred:
        
        * data.aws_instance.foo: data.aws_instance.foo: Invalid address to set: []string{"root_block_device", "0", "volume_id"}
        
        State: <nil>
=== RUN   TestAccAWSInstanceDataSource_blockDevices
--- FAIL: TestAccAWSInstanceDataSource_blockDevices (30.65s)
    testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
        
        * data.aws_instance.foo: data.aws_instance.foo: Invalid address to set: []string{"ebs_block_device", "0", "volume_id"}
    testing.go:573: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Error refreshing: 1 error(s) occurred:
        
        * data.aws_instance.foo: 1 error(s) occurred:
        
        * data.aws_instance.foo: data.aws_instance.foo: Invalid address to set: []string{"ebs_block_device", "0", "volume_id"}
        
        State: <nil>
=== RUN   TestAccAWSInstanceDataSource_gp2IopsDevice
--- FAIL: TestAccAWSInstanceDataSource_gp2IopsDevice (32.75s)
    testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
        
        * data.aws_instance.foo: data.aws_instance.foo: Invalid address to set: []string{"root_block_device", "0", "volume_id"}
    testing.go:573: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Error refreshing: 1 error(s) occurred:
        
        * data.aws_instance.foo: 1 error(s) occurred:
        
        * data.aws_instance.foo: data.aws_instance.foo: Invalid address to set: []string{"root_block_device", "0", "volume_id"}
        
        State: <nil>
=== RUN   TestAccAWSInstanceDataSource_keyPair
--- FAIL: TestAccAWSInstanceDataSource_keyPair (45.90s)
    testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
        
        * data.aws_instance.foo: data.aws_instance.foo: Invalid address to set: []string{"root_block_device", "0", "volume_id"}
    testing.go:573: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Error refreshing: 1 error(s) occurred:
        
        * data.aws_instance.foo: 1 error(s) occurred:
        
        * data.aws_instance.foo: data.aws_instance.foo: Invalid address to set: []string{"root_block_device", "0", "volume_id"}
        
        State: <nil>
=== RUN   TestAccAWSInstanceDataSource_privateIP
--- FAIL: TestAccAWSInstanceDataSource_privateIP (88.66s)
    testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
        
        * data.aws_instance.foo: data.aws_instance.foo: Invalid address to set: []string{"root_block_device", "0", "volume_id"}
    testing.go:573: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Error refreshing: 1 error(s) occurred:
        
        * data.aws_instance.foo: 1 error(s) occurred:
        
        * data.aws_instance.foo: data.aws_instance.foo: Invalid address to set: []string{"root_block_device", "0", "volume_id"}
        
        State: <nil>
=== RUN   TestAccAWSInstanceDataSource_SecurityGroups
--- FAIL: TestAccAWSInstanceDataSource_SecurityGroups (78.04s)
    testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
        
        * data.aws_instance.foo: data.aws_instance.foo: Invalid address to set: []string{"root_block_device", "0", "volume_id"}
    testing.go:573: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Error refreshing: 1 error(s) occurred:
        
        * data.aws_instance.foo: 1 error(s) occurred:
        
        * data.aws_instance.foo: data.aws_instance.foo: Invalid address to set: []string{"root_block_device", "0", "volume_id"}
        
        State: <nil>
```

## Test results

```
=== RUN   TestAccAWSInstanceDataSource_basic
--- PASS: TestAccAWSInstanceDataSource_basic (653.96s)
=== RUN   TestAccAWSInstanceDataSource_tags
--- PASS: TestAccAWSInstanceDataSource_tags (247.97s)
=== RUN   TestAccAWSInstanceDataSource_AzUserData
--- PASS: TestAccAWSInstanceDataSource_AzUserData (507.52s)
=== RUN   TestAccAWSInstanceDataSource_gp2IopsDevice
--- PASS: TestAccAWSInstanceDataSource_gp2IopsDevice (258.03s)
=== RUN   TestAccAWSInstanceDataSource_blockDevices
--- PASS: TestAccAWSInstanceDataSource_blockDevices (247.48s)
=== RUN   TestAccAWSInstanceDataSource_rootInstanceStore
--- PASS: TestAccAWSInstanceDataSource_rootInstanceStore (156.10s)
=== RUN   TestAccAWSInstanceDataSource_privateIP
--- PASS: TestAccAWSInstanceDataSource_privateIP (359.39s)
=== RUN   TestAccAWSInstanceDataSource_keyPair
--- PASS: TestAccAWSInstanceDataSource_keyPair (132.83s)
=== RUN   TestAccAWSInstanceDataSource_VPC
--- PASS: TestAccAWSInstanceDataSource_VPC (194.66s)
=== RUN   TestAccAWSInstanceDataSource_PlacementGroup
--- PASS: TestAccAWSInstanceDataSource_PlacementGroup (181.95s)
=== RUN   TestAccAWSInstanceDataSource_SecurityGroups
--- FAIL: TestAccAWSInstanceDataSource_SecurityGroups (154.28s)
	testing.go:503: Step 0 error: Check failed: Check 3/5 error: data.aws_instance.foo: Attribute 'vpc_security_group_ids.#' expected "0", got "1"
=== RUN   TestAccAWSInstanceDataSource_VPCSecurityGroups
--- PASS: TestAccAWSInstanceDataSource_VPCSecurityGroups (221.65s)
```

That last failure is unrelated and will need to be addressed in a separate PR.