### PR TITLE
test/aws_service_discovery_service: Fix failing test

### DIFF
--- a/aws/resource_aws_service_discovery_service_test.go
+++ b/aws/resource_aws_service_discovery_service_test.go
@@ -52,22 +52,22 @@ func TestAccAwsServiceDiscoveryService_public(t *testing.T) {
 		CheckDestroy: testAccCheckAwsServiceDiscoveryServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceDiscoveryServiceConfig_public(rName, 5, "path"),
+				Config: testAccServiceDiscoveryServiceConfig_public(rName, 5, "/path"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsServiceDiscoveryServiceExists("aws_service_discovery_service.test"),
 					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "health_check_config.0.type", "HTTP"),
 					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "health_check_config.0.failure_threshold", "5"),
-					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "health_check_config.0.resource_path", "path"),
+					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "health_check_config.0.resource_path", "/path"),
 					resource.TestCheckResourceAttrSet("aws_service_discovery_service.test", "arn"),
 				),
 			},
 			{
-				Config: testAccServiceDiscoveryServiceConfig_public(rName, 3, "update"),
+				Config: testAccServiceDiscoveryServiceConfig_public(rName, 3, "/updated-path"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsServiceDiscoveryServiceExists("aws_service_discovery_service.test"),
 					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "health_check_config.0.type", "HTTP"),
 					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "health_check_config.0.failure_threshold", "3"),
-					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "health_check_config.0.resource_path", "update"),
+					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "health_check_config.0.resource_path", "/updated-path"),
 					resource.TestCheckResourceAttrSet("aws_service_discovery_service.test", "arn"),
 				),
 			},


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAwsServiceDiscoveryService_public
--- FAIL: TestAccAwsServiceDiscoveryService_public (112.60s)
    testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_service_discovery_service.test: 1 error(s) occurred:
        
        * aws_service_discovery_service.test: InvalidInput: Health check resource path must start with /
            status code: 400, request id: 06caf986-f6ad-11e7-9e4d-29f16293ef3d
FAIL
```

## Test results

```
=== RUN   TestAccAwsServiceDiscoveryService_public
--- PASS: TestAccAwsServiceDiscoveryService_public (83.64s)
```

cc @atsushi-ishibashi 