### PR TITLE
test/aws_lambda_function: Fix failing tests related to 'runtime'

### DIFF
--- a/aws/resource_aws_lambda_function_test.go
+++ b/aws/resource_aws_lambda_function_test.go
@@ -781,28 +781,7 @@ func TestAccAWSLambdaFunction_runtimeValidation_noRuntime(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAWSLambdaConfigNoRuntime(funcName, policyName, roleName, sgName),
-				ExpectError: regexp.MustCompile(`\\"runtime\\": required field is not set`),
-			},
-		},
-	})
-}
-
-func TestAccAWSLambdaFunction_runtimeValidation_nodeJs(t *testing.T) {
-	rString := acctest.RandString(8)
-
-	funcName := fmt.Sprintf("tf_acc_lambda_func_runtime_valid_nodejs_%s", rString)
-	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_runtime_valid_nodejs_%s", rString)
-	roleName := fmt.Sprintf("tf_acc_role_lambda_func_runtime_valid_nodejs_%s", rString)
-	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_runtime_valid_nodejs_%s", rString)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLambdaFunctionDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccAWSLambdaConfigNodeJsRuntime(funcName, policyName, roleName, sgName),
-				ExpectError: regexp.MustCompile(fmt.Sprintf("%s has reached end of life since October 2016 and has been deprecated in favor of %s", lambda.RuntimeNodejs, lambda.RuntimeNodejs43)),
+				ExpectError: regexp.MustCompile(`"runtime": required field is not set`),
 			},
 		},
 	})
@@ -1610,19 +1589,6 @@ resource "aws_lambda_function" "lambda_function_test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs4.3"
-}
-`, funcName)
-}
-
-func testAccAWSLambdaConfigNodeJsRuntime(funcName, policyName, roleName, sgName string) string {
-	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
-resource "aws_lambda_function" "lambda_function_test" {
-    filename = "test-fixtures/lambdatest.zip"
-    function_name = "%s"
-    role = "${aws_iam_role.iam_for_lambda.arn}"
-    handler = "exports.example"
-    runtime = "nodejs4.3"
 }
 `, funcName)
 }


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_noRuntime
--- FAIL: TestAccAWSLambdaFunction_runtimeValidation_noRuntime (64.36s)
    testing.go:494: Step 0, no error received, but expected a match to:
        
        \\"runtime\\": required field is not set
```

and remove the following test (as `nodejs` runtime was deprecated for a while and more importantly we're really testing the API here, not the code):

```
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_nodeJs
--- FAIL: TestAccAWSLambdaFunction_runtimeValidation_nodeJs (54.41s)
    testing.go:494: Step 0, no error received, but expected a match to:
        
        nodejs has reached end of life since October 2016 and has been deprecated in favor of nodejs4.3
        
```

They both most likely emerged after merging #2348