### PR TITLE
resource/aws_lb+aws_elb: Fix regression with undefined 'name'

### DIFF
--- a/aws/resource_aws_elb.go
+++ b/aws/resource_aws_elb.go
@@ -37,16 +37,6 @@ func resourceAwsElb() *schema.Resource {
 				ForceNew:      true,
 				ConflictsWith: []string{"name_prefix"},
 				ValidateFunc:  validateElbName,
-				// This is to work around an unexpected schema behaviour returning diff
-				// for an empty field when it has a pre-computed value from previous run
-				// (e.g. from name_prefix)
-				// TODO: Revisit after we find the real root cause
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					if new == "" {
-						return true
-					}
-					return false
-				},
 			},
 			"name_prefix": &schema.Schema{
 				Type:         schema.TypeString,

--- a/aws/resource_aws_elb_test.go
+++ b/aws/resource_aws_elb_test.go
@@ -1231,6 +1231,11 @@ resource "aws_elb" "foo" {
     lb_protocol = "http"
   }
 }
+
+# See https://github.com/terraform-providers/terraform-provider-aws/issues/2498
+output "lb_name" {
+  value = "${aws_elb.foo.name}"
+}
 `
 
 const testAccAWSELBConfig_AvailabilityZonesUpdate = `

--- a/aws/resource_aws_lb.go
+++ b/aws/resource_aws_lb.go
@@ -54,16 +54,6 @@ func resourceAwsLb() *schema.Resource {
 				ForceNew:      true,
 				ConflictsWith: []string{"name_prefix"},
 				ValidateFunc:  validateElbName,
-				// This is to work around an unexpected schema behaviour returning diff
-				// for an empty field when it has a pre-computed value from previous run
-				// (e.g. from name_prefix)
-				// TODO: Revisit after we find the real root cause
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					if new == "" {
-						return true
-					}
-					return false
-				},
 			},
 
 			"name_prefix": {

--- a/aws/resource_aws_lb_test.go
+++ b/aws/resource_aws_lb_test.go
@@ -1218,6 +1218,11 @@ resource "aws_lb" "lb_test" {
   }
 }
 
+# See https://github.com/terraform-providers/terraform-provider-aws/issues/2498
+output "lb_name" {
+  value = "${aws_lb.lb_test.name}"
+}
+
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
   type    = "list"


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/2498

This also addresses the following test failure:

```
=== RUN   TestAccAWSAutoScalingGroup_WithLoadBalancer
--- FAIL: TestAccAWSAutoScalingGroup_WithLoadBalancer (2.67s)
    testing.go:513: Step 0 error: Error planning: 1 error(s) occurred:
        
        * aws_autoscaling_group.bar: 1 error(s) occurred:
        
        * aws_autoscaling_group.bar: Resource 'aws_elb.bar' does not have attribute 'name' for variable 'aws_elb.bar.name'
FAIL
```

and basically reverts https://github.com/terraform-providers/terraform-provider-aws/pull/2314 which was (wrongly) based on the assumption that the new schema behaviour is desired. The upstream regression was already fixed and merged in #2348

## Test results

```
=== RUN   TestAccAWSAutoScalingGroup_WithLoadBalancer
--- PASS: TestAccAWSAutoScalingGroup_WithLoadBalancer (526.14s)
=== RUN   TestAccAWSELB_generatesNameForZeroValue
--- PASS: TestAccAWSELB_generatesNameForZeroValue (52.35s)
=== RUN   TestAccAWSLB_generatesNameForZeroValue
--- PASS: TestAccAWSLB_generatesNameForZeroValue (307.74s)
```