### PR TITLE
resource/aws_iam_user: Fix issues with update

### DIFF
--- a/aws/resource_aws_iam_user.go
+++ b/aws/resource_aws_iam_user.go
@@ -48,7 +48,6 @@ func resourceAwsIamUser() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "/",
-				ForceNew: true,
 			},
 			"force_destroy": &schema.Schema{
 				Type:        schema.TypeBool,
@@ -136,6 +135,8 @@ func resourceAwsIamUserUpdate(d *schema.ResourceData, meta interface{}) error {
 			}
 			return fmt.Errorf("Error updating IAM User %s: %s", d.Id(), err)
 		}
+
+		d.SetId(*request.NewUserName)
 		return resourceAwsIamUserRead(d, meta)
 	}
 	return nil


### PR DESCRIPTION
1. Path can be updated without creating a new user
2. When updating a user's name, the Read query fetched the user with the old name, resulting in a 404.