### PR TITLE
Makefile: Fixed test outputs

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,5 @@
 SWEEP?=us-east-1,us-west-2
+TEST?=./...
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 
 default: build
@@ -8,13 +9,13 @@ build: fmtcheck
 
 sweep:
 	@echo "WARNING: This will destroy infrastructure. Use only in development accounts."
-	go test ./... -v -sweep=$(SWEEP) $(SWEEPARGS)
+	go test $(TEST) -v -sweep=$(SWEEP) $(SWEEPARGS)
 
 test: fmtcheck
-	go test ./... -timeout=30s -parallel=4
+	go test $(TEST) -timeout=30s -parallel=4
 
 testacc: fmtcheck
-	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m
 
 vet:
 	@echo "go vet ."


### PR DESCRIPTION
## Description
Since https://github.com/terraform-providers/terraform-provider-aws/commit/0cb3568983d0f224f32c28623f6db0bce0c9deef, acceptance tests show 2 inconveniences:
* `?   	github.com/terraform-providers/terraform-provider-aws	[no test files]` even though the `TEST` dir was specified
* Output was buffered until the last of the tests was displayed, failing or passing (see the `Before` section with wildcard dir)

I discovered it is the combination of `./...` and `-v` that causes this issue, but didn't investigate much further.

Note: `-v` provides the output as it has it

#### Before
**Using the `TEST=./...` dir**
![wildcard_test](https://user-images.githubusercontent.com/855022/34831347-02ffb1de-f6e7-11e7-9e84-e9676cfccb9f.gif)

**Using the `TEST=./aws` dir**
![aws_test](https://user-images.githubusercontent.com/855022/34831344-00951ba0-f6e7-11e7-97aa-ce6044a3dee2.gif)

#### After
![after](https://user-images.githubusercontent.com/855022/34831343-007ff2e8-f6e7-11e7-882a-305b3127b3dc.gif)

