### PR TITLE
New Data Source: aws_security_groups

### DIFF
--- a/aws/data_source_aws_security_groups.go
+++ b/aws/data_source_aws_security_groups.go
@@ -1,0 +1,98 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"log"
+)
+
+func dataSourceAwsSecurityGroups() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsSecurityGroupsRead,
+
+		Schema: map[string]*schema.Schema{
+			"filter": dataSourceFiltersSchema(),
+			"tags":   tagsSchemaComputed(),
+
+			"ids": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"vpc_ids": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceAwsSecurityGroupsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+	req := &ec2.DescribeSecurityGroupsInput{}
+
+	filters, filtersOk := d.GetOk("filter")
+	tags, tagsOk := d.GetOk("tags")
+
+	if !filtersOk && !tagsOk {
+		return fmt.Errorf("One of filters or tags must be assigned")
+	}
+
+	if filtersOk {
+		req.Filters = append(req.Filters,
+			buildAwsDataSourceFilters(filters.(*schema.Set))...)
+	}
+	if tagsOk {
+		req.Filters = append(req.Filters, buildEC2TagFilterList(
+			tagsFromMap(tags.(map[string]interface{})),
+		)...)
+	}
+
+	log.Printf("[DEBUG] Reading Security Groups with request: %s", req)
+
+	var ids, vpc_ids []string
+	nextToken := ""
+	for {
+		if nextToken != "" {
+			req.NextToken = aws.String(nextToken)
+		}
+
+		resp, err := conn.DescribeSecurityGroups(req)
+		if err != nil {
+			return err
+		}
+
+		for _, sg := range resp.SecurityGroups {
+			ids = append(ids, *sg.GroupId)
+			vpc_ids = append(vpc_ids, *sg.VpcId)
+		}
+
+		if resp.NextToken == nil {
+			break
+		}
+		nextToken = *resp.NextToken
+	}
+
+	if len(ids) < 1 {
+		return fmt.Errorf("Your query returned no results. Please change your search criteria and try again.")
+	}
+
+	log.Printf("[DEBUG] Found %d securuity groups via given filter: %s", len(ids), req)
+
+	d.SetId(resource.UniqueId())
+	err := d.Set("ids", ids)
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("vpc_ids", vpc_ids)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/aws/data_source_aws_security_groups_test.go
+++ b/aws/data_source_aws_security_groups_test.go
@@ -1,0 +1,99 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"testing"
+)
+
+func TestAccDataSourceAwsSecurityGroups_tag(t *testing.T) {
+	rInt := acctest.RandInt()
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsSecurityGroupsConfig_tag(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_security_groups.by_tag", "ids.#", "3"),
+					resource.TestCheckResourceAttr("data.aws_security_groups.by_tag", "vpc_ids.#", "3"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsSecurityGroups_filter(t *testing.T) {
+	rInt := acctest.RandInt()
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsSecurityGroupsConfig_filter(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_security_groups.by_filter", "ids.#", "3"),
+					resource.TestCheckResourceAttr("data.aws_security_groups.by_filter", "vpc_ids.#", "3"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsSecurityGroupsConfig_tag(rInt int) string {
+	return fmt.Sprintf(`
+	resource "aws_vpc" "test_tag" {
+		cidr_block = "172.16.0.0/16"
+		tags {
+			Name = "terraform-testacc-security-group-data-source"
+		}
+	}
+
+	resource "aws_security_group" "test" {
+		count = 3
+		vpc_id = "${aws_vpc.test_tag.id}"
+		name = "tf-%[1]d-${count.index}"
+		tags {
+			Seed = "%[1]d"
+		}
+	}
+
+	data "aws_security_groups" "by_tag" {
+		tags {
+			Seed = "${aws_security_group.test.0.tags["Seed"]}"
+		}
+	}
+`, rInt)
+}
+
+func testAccDataSourceAwsSecurityGroupsConfig_filter(rInt int) string {
+	return fmt.Sprintf(`
+	resource "aws_vpc" "test_filter" {
+		cidr_block = "172.16.0.0/16"
+		tags {
+			Name = "terraform-testacc-security-group-data-source"
+		}
+	}
+
+	resource "aws_security_group" "test" {
+		count = 3
+		vpc_id = "${aws_vpc.test_filter.id}"
+		name = "tf-%[1]d-${count.index}"
+		tags {
+			Seed = "%[1]d"
+		}
+	}
+
+	data "aws_security_groups" "by_filter" {
+		filter {
+			name = "vpc-id"
+			values = ["${aws_vpc.test_filter.id}"]
+		}
+		filter {
+			name = "group-name"
+			values = ["tf-${aws_security_group.test.0.tags["Seed"]}-*"]
+		}
+	}
+`, rInt)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -221,6 +221,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_subnet":                           dataSourceAwsSubnet(),
 			"aws_subnet_ids":                       dataSourceAwsSubnetIDs(),
 			"aws_security_group":                   dataSourceAwsSecurityGroup(),
+			"aws_security_groups":                  dataSourceAwsSecurityGroups(),
 			"aws_vpc":                              dataSourceAwsVpc(),
 			"aws_vpc_endpoint":                     dataSourceAwsVpcEndpoint(),
 			"aws_vpc_endpoint_service":             dataSourceAwsVpcEndpointService(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -203,6 +203,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-security-group") %>>
                          <a href="/docs/providers/aws/d/security_group.html">aws_security_group</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-security-groups") %>>
+                         <a href="/docs/providers/aws/d/security_groups.html">aws_security_group</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-sns-topic") %>>
                          <a href="/docs/providers/aws/d/sns_topic.html">aws_sns_topic</a>
                         </li>

--- a/website/docs/d/security_groups.html.markdown
+++ b/website/docs/d/security_groups.html.markdown
@@ -1,0 +1,52 @@
+---
+layout: "aws"
+page_title: "AWS: aws_security_groups"
+sidebar_current: "docs-aws-datasource-security-groups"
+description: |-
+  Get information about a set of Security Groups.
+---
+
+# Data Source: aws_security_groups
+
+Use this data source to get IDs and VPC membership of Security Groups that are created
+outside of Terraform.
+
+## Example Usage
+```hcl
+data "aws_security_groups" "test" {
+  tags {
+    Application = "k8s",
+    Environment = "dev"
+  }
+}
+```
+
+```hcl
+data "aws_security_groups" "test" {
+  filter {
+    name   = "group-name"
+    values = ["*nodes*"]
+  }
+  filter {
+    name   = "vpc-id"
+    values = ["${var.vpc_id}"]
+  }
+}
+```
+
+## Argument Reference
+
+* `tags` - (Optional) A mapping of tags, each pair of which must exactly match for
+desired security groups.
+
+* `filter` - (Optional) One or more name/value pairs to use as filters. There are
+several valid keys, for a full reference, check out
+[describe-security-groups in the AWS CLI reference][1].
+
+## Attributes Reference
+
+* `ids` - IDs of the matches security groups.
+* `vpc_ids` - The VPC IDs of the matched security groups. The data source's tag or filter *will span VPCs*
+unless the `vpc-id` filter is also used.
+
+[1]: https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-security-groups.html


### PR DESCRIPTION
Resolves #2740.

Using the data sources `aws_instance`/`aws_instances` naming convention, this creates an `aws_security_groups` data source for multiple security groups to complement the `aws_security_group` data source that fetches single security groups.

The example code in the documentation could use an example of creating a resource actually using the data source but I couldn't think of a concise AWS resource that uses a list of security groups that would make much sense in context.

Tests:
```
make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsSecurityGroups_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccDataSourceAwsSecurityGroups_ -timeout 120m
=== RUN   TestAccDataSourceAwsSecurityGroups_tag
--- PASS: TestAccDataSourceAwsSecurityGroups_tag (24.85s)
=== RUN   TestAccDataSourceAwsSecurityGroups_filter
--- PASS: TestAccDataSourceAwsSecurityGroups_filter (25.24s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	50.130s
```