### PR TITLE
resource/aws_lb_target_group: Attempt to resolve catch-22 around NLB's stickiness

### DIFF
--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -330,7 +330,11 @@ func resourceAwsLbTargetGroupUpdate(d *schema.ResourceData, meta interface{}) er
 		})
 	}
 
-	if d.HasChange("stickiness") {
+	// In CustomizeDiff we allow LB stickiness to be declared for TCP target
+	// groups, so long as it's not enabled. This allows for better support for
+	// modules, but also means we need to completely skip sending the data to the
+	// API if it's defined on a TCP target group.
+	if d.HasChange("stickiness") && d.Get("protocol") != "TCP" {
 		stickinessBlocks := d.Get("stickiness").([]interface{})
 		if len(stickinessBlocks) == 1 {
 			stickiness := stickinessBlocks[0].(map[string]interface{})
@@ -541,8 +545,40 @@ func flattenAwsLbTargetGroupResource(d *schema.ResourceData, meta interface{}, t
 		return errwrap.Wrapf("Error retrieving Target Group Attributes: {{err}}", err)
 	}
 
+	// We only read in the stickiness attributes if the target group is not
+	// TCP-based. This ensures we don't end up causing a spurious diff if someone
+	// has defined the stickiness block on a TCP target group (albeit with
+	// false), for which this update would clobber the state coming from config
+	// for.
+	//
+	// This is a workaround to support module design where the module needs to
+	// support HTTP and TCP target groups.
+	if *targetGroup.Protocol != "TCP" {
+		if err = flattenAwsLbTargetGroupStickiness(d, attrResp.Attributes); err != nil {
+			return err
+		}
+	}
+
+	tagsResp, err := elbconn.DescribeTags(&elbv2.DescribeTagsInput{
+		ResourceArns: []*string{aws.String(d.Id())},
+	})
+	if err != nil {
+		return errwrap.Wrapf("Error retrieving Target Group Tags: {{err}}", err)
+	}
+	for _, t := range tagsResp.TagDescriptions {
+		if *t.ResourceArn == d.Id() {
+			if err := d.Set("tags", tagsToMapELBv2(t.Tags)); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func flattenAwsLbTargetGroupStickiness(d *schema.ResourceData, attributes []*elbv2.TargetGroupAttribute) error {
 	stickinessMap := map[string]interface{}{}
-	for _, attr := range attrResp.Attributes {
+	for _, attr := range attributes {
 		switch *attr.Key {
 		case "stickiness.enabled":
 			enabled, err := strconv.ParseBool(*attr.Value)
@@ -574,21 +610,6 @@ func flattenAwsLbTargetGroupResource(d *schema.ResourceData, meta interface{}, t
 	if err := d.Set("stickiness", setStickyMap); err != nil {
 		return err
 	}
-
-	tagsResp, err := elbconn.DescribeTags(&elbv2.DescribeTagsInput{
-		ResourceArns: []*string{aws.String(d.Id())},
-	})
-	if err != nil {
-		return errwrap.Wrapf("Error retrieving Target Group Tags: {{err}}", err)
-	}
-	for _, t := range tagsResp.TagDescriptions {
-		if *t.ResourceArn == d.Id() {
-			if err := d.Set("tags", tagsToMapELBv2(t.Tags)); err != nil {
-				return err
-			}
-		}
-	}
-
 	return nil
 }
 

--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -553,8 +553,13 @@ func flattenAwsLbTargetGroupResource(d *schema.ResourceData, meta interface{}, t
 	//
 	// This is a workaround to support module design where the module needs to
 	// support HTTP and TCP target groups.
-	if *targetGroup.Protocol != "TCP" {
+	switch {
+	case *targetGroup.Protocol != "TCP":
 		if err = flattenAwsLbTargetGroupStickiness(d, attrResp.Attributes); err != nil {
+			return err
+		}
+	case *targetGroup.Protocol == "TCP" && len(d.Get("stickiness").([]interface{})) < 1:
+		if err = d.Set("stickiness", []interface{}{}); err != nil {
 			return err
 		}
 	}

--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -596,9 +596,11 @@ func resourceAwsLbTargetGroupCustomizeDiff(diff *schema.ResourceDiff, v interfac
 	protocol := diff.Get("protocol").(string)
 	if protocol == "TCP" {
 		// TCP load balancers do not support stickiness
-		stickinessBlocks := diff.Get("stickiness").([]interface{})
-		if len(stickinessBlocks) != 0 {
-			return fmt.Errorf("Network Load Balancers do not support Stickiness")
+		if stickinessBlocks := diff.Get("stickiness").([]interface{}); len(stickinessBlocks) == 1 {
+			stickiness := stickinessBlocks[0].(map[string]interface{})
+			if val := stickiness["enabled"].(bool); val {
+				return fmt.Errorf("Network Load Balancers do not support Stickiness")
+			}
 		}
 	}
 

--- a/website/docs/r/lb_target_group.html.markdown
+++ b/website/docs/r/lb_target_group.html.markdown
@@ -53,6 +53,8 @@ Stickiness Blocks (`stickiness`) support the following:
 * `cookie_duration` - (Optional) The time period, in seconds, during which requests from a client should be routed to the same target. After this time period expires, the load balancer-generated cookie is considered stale. The range is 1 second to 1 week (604800 seconds). The default value is 1 day (86400 seconds).
 * `enabled` - (Optional) Boolean to enable / disable `stickiness`. Default is `true`
 
+~> **NOTE:** To help facilitate the authoring of modules that support target groups of any protocol, you can define `stickiness` regardless of the protocol chosen. However, for `TCP` target groups, `enabled` must be `false`.
+
 Health Check Blocks (`health_check`):
 
 ~> **Note:** The Health Check parameters you can set vary by the `protocol` of


### PR DESCRIPTION
See https://github.com/terraform-providers/terraform-provider-aws/issues/2746

The catch-22 is that stickiness is not allowed for NLBs, stickiness is enabled by default for all LBs, and the check to make sure an NLB has not enabled stickiness only looks for the existence of a stickiness block -- leaving you damned if you define it damned if you don't.

There might be more principled approaches which break current defaults, but it seems natural enough to go to define the stickiness block (to disable stickiness) after being told your LB doesn't support it.