### PR TITLE
data-source/aws_db_snaphost: Prevent crash on unfinished snapshots

### DIFF
--- a/aws/data_source_aws_db_snapshot.go
+++ b/aws/data_source_aws_db_snapshot.go
@@ -183,6 +183,14 @@ type rdsSnapshotSort []*rds.DBSnapshot
 func (a rdsSnapshotSort) Len() int      { return len(a) }
 func (a rdsSnapshotSort) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 func (a rdsSnapshotSort) Less(i, j int) bool {
+	// Snapshot creation can be in progress
+	if a[i].SnapshotCreateTime == nil {
+		return true
+	}
+	if a[j].SnapshotCreateTime == nil {
+		return false
+	}
+
 	return (*a[i].SnapshotCreateTime).Before(*a[j].SnapshotCreateTime)
 }
 


### PR DESCRIPTION
Fixes #2112

## Test results

```
=== RUN   TestAccAWSDbSnapshotDataSource_basic
--- PASS: TestAccAWSDbSnapshotDataSource_basic (910.24s)
```