### PR TITLE
Include size of user_data in validation error message

### DIFF
--- a/aws/validators.go
+++ b/aws/validators.go
@@ -17,9 +17,10 @@ import (
 
 func validateInstanceUserDataSize(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
+	length := len(value)
 
-	if len(value) > 16384 {
-		errors = append(errors, fmt.Errorf("%q cannot be longer than 16384 bytes", k))
+	if length > 16384 {
+		errors = append(errors, fmt.Errorf("%q is %d bytes, cannot be longer than 16384 bytes", k, length))
 	}
 	return
 }

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -28,11 +28,15 @@ func TestValidateInstanceUserDataSize(t *testing.T) {
 
 	for _, s := range invalidValues {
 		_, errors := validateInstanceUserDataSize(s, "user_data")
-		if len(errors) == 0 {
+		if len(errors) != 1 {
 			t.Fatalf("%q should not be valid user data with limited size: %v", s, errors)
+		}
+		if !strings.Contains(errors[0].Error(), "16385") {
+			t.Fatalf("%q should trigger error message with actual size: %v", s, errors)
 		}
 	}
 }
+
 func TestValidateEcrRepositoryName(t *testing.T) {
 	validNames := []string{
 		"nginx-web-app",


### PR DESCRIPTION
Related to #2765 , puts the actual size of the user_data in the error message so you can see how close (or not) you are
