### PR TITLE
Update documentation to reflect external regional peering.

### DIFF
--- a/website/docs/r/vpc_peering.html.markdown
+++ b/website/docs/r/vpc_peering.html.markdown
@@ -138,8 +138,6 @@ The following attributes are exported:
 
 ## Notes
 
-AWS only supports VPC peering within the same AWS region.
-
 If both VPCs are not in the same AWS account do not enable the `auto_accept` attribute.
 The accepter can manage its side of the connection using the `aws_vpc_peering_connection_accepter` resource
 or accept the connection manually using the AWS Management Console, AWS CLI, through SDKs, etc.


### PR DESCRIPTION
The previous phrase "AWS only supports VPC peering within the same AWS region." existed in the documentation, it's no longer accurate since terraform-providers/terraform-provider-aws#2508 opened up multi-regional peering capabilities and was merged and released in provider version 1.7.