### PR TITLE
r/aws_eip: Do not disassociate on tags-only update

### DIFF
--- a/aws/resource_aws_eip.go
+++ b/aws/resource_aws_eip.go
@@ -225,17 +225,13 @@ func resourceAwsEipUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	domain := resourceAwsEipDomain(d)
 
-	// Associate to instance or interface if specified
-	v_instance, ok_instance := d.GetOk("instance")
-	v_interface, ok_interface := d.GetOk("network_interface")
-
 	// If we are updating an EIP that is not newly created, and we are attached to
 	// an instance or interface, detach first.
 	disassociate := false
 	if !d.IsNewResource() {
-		if (d.Get("instance").(string) != "") && d.HasChange("instance") {
+		if d.HasChange("instance") && d.Get("instance").(string) != "" {
 			disassociate = true
-		} else if (d.Get("association_id").(string) != "") && (d.HasChange("network_interface") || d.HasChange("associate_with_private_ip")) {
+		} else if (d.HasChange("network_interface") || d.HasChange("associate_with_private_ip")) && d.Get("association_id").(string) != "" {
 			disassociate = true
 		}
 	}
@@ -245,10 +241,14 @@ func resourceAwsEipUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
+	// Associate to instance or interface if specified
 	associate := false
-	if ok_instance && d.HasChange("instance") {
+	v_instance, ok_instance := d.GetOk("instance")
+	v_interface, ok_interface := d.GetOk("network_interface")
+
+	if d.HasChange("instance") && ok_instance {
 		associate = true
-	} else if ok_interface && (d.HasChange("network_interface") || d.HasChange("associate_with_private_ip")) {
+	} else if (d.HasChange("network_interface") || d.HasChange("associate_with_private_ip")) && ok_interface {
 		associate = true
 	}
 	if associate {


### PR DESCRIPTION
Fixes #2968 

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSEIP'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSEIP -timeout 120m
=== RUN   TestAccAWSEIPAssociation_basic
--- PASS: TestAccAWSEIPAssociation_basic (129.19s)
=== RUN   TestAccAWSEIPAssociation_ec2Classic
--- SKIP: TestAccAWSEIPAssociation_ec2Classic (1.24s)
	provider_test.go:69: This test can only run in EC2 Classic, platforms available in us-east-1: ["VPC"]
=== RUN   TestAccAWSEIPAssociation_disappears
--- PASS: TestAccAWSEIPAssociation_disappears (119.98s)
=== RUN   TestAccAWSEIP_importEc2Classic
--- SKIP: TestAccAWSEIP_importEc2Classic (1.02s)
	provider_test.go:69: This test can only run in EC2 Classic, platforms available in us-east-1: ["VPC"]
=== RUN   TestAccAWSEIP_importVpc
--- PASS: TestAccAWSEIP_importVpc (42.70s)
=== RUN   TestAccAWSEIP_basic
--- PASS: TestAccAWSEIP_basic (11.04s)
=== RUN   TestAccAWSEIP_instance
--- PASS: TestAccAWSEIP_instance (283.45s)
=== RUN   TestAccAWSEIP_network_interface
--- PASS: TestAccAWSEIP_network_interface (43.12s)
=== RUN   TestAccAWSEIP_twoEIPsOneNetworkInterface
--- PASS: TestAccAWSEIP_twoEIPsOneNetworkInterface (44.22s)
=== RUN   TestAccAWSEIP_associated_user_private_ip
--- PASS: TestAccAWSEIP_associated_user_private_ip (148.83s)
=== RUN   TestAccAWSEIP_classic_disassociate
--- SKIP: TestAccAWSEIP_classic_disassociate (1.35s)
	provider_test.go:69: This test can only run in EC2 Classic, platforms available in us-west-2: ["VPC"]
=== RUN   TestAccAWSEIP_disappears
--- PASS: TestAccAWSEIP_disappears (8.40s)
=== RUN   TestAccAWSEIPAssociate_not_associated
--- PASS: TestAccAWSEIPAssociate_not_associated (144.82s)
=== RUN   TestAccAWSEIP_tags
--- PASS: TestAccAWSEIP_tags (19.69s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	999.115s
```