### PR TITLE
resource/aws_iam_user: Name change requires id to be reset

### DIFF
--- a/aws/resource_aws_iam_user.go
+++ b/aws/resource_aws_iam_user.go
@@ -136,6 +136,7 @@ func resourceAwsIamUserUpdate(d *schema.ResourceData, meta interface{}) error {
 			}
 			return fmt.Errorf("Error updating IAM User %s: %s", d.Id(), err)
 		}
+		d.SetId(nn.(string))
 		return resourceAwsIamUserRead(d, meta)
 	}
 	return nil

--- a/aws/resource_aws_iam_user_test.go
+++ b/aws/resource_aws_iam_user_test.go
@@ -80,6 +80,34 @@ func TestAccAWSUser_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSUser_nameChange(t *testing.T) {
+	var conf iam.GetUserOutput
+
+	name1 := fmt.Sprintf("test-user-%d", acctest.RandInt())
+	name2 := fmt.Sprintf("test-user-%d", acctest.RandInt())
+	path := "/"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSUserConfig(name1, path),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSUserExists("aws_iam_user.user", &conf),
+				),
+			},
+			{
+				Config: testAccAWSUserConfig(name2, path),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSUserExists("aws_iam_user.user", &conf),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSUserDestroy(s *terraform.State) error {
 	iamconn := testAccProvider.Meta().(*AWSClient).iamconn
 


### PR DESCRIPTION
addresses #2949

Ran into this the other day. Changing name on a user does not result in new entry in state after update. The Id is required to be reset after update.

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSUser_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSUser_ -timeout 120m
=== RUN   TestAccAWSUser_importBasic
--- PASS: TestAccAWSUser_importBasic (22.50s)
=== RUN   TestAccAWSUser_basic
--- PASS: TestAccAWSUser_basic (32.59s)
=== RUN   TestAccAWSUser_nameChange
--- PASS: TestAccAWSUser_nameChange (29.65s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	84.776s
```