### PR TITLE
resource/aws_lb_target_group: Allow a blank health check path, for TCP healtchecks

### DIFF
--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -395,7 +395,7 @@ func validateAwsLbTargetGroupHealthCheckPath(v interface{}, k string) (ws []stri
 		errors = append(errors, fmt.Errorf(
 			"%q cannot be longer than 1024 characters: %q", k, value))
 	}
-	if !strings.HasPrefix(value, "/") {
+	if len(value) > 0 && !strings.HasPrefix(value, "/") {
 		errors = append(errors, fmt.Errorf(
 			"%q must begin with a '/' character: %q", k, value))
 	}


### PR DESCRIPTION
Fixes #2978 "Validation forces invalid path for TCP health check" 

Currently the validation forces the health check path to begin with a slash("/"), even when the protocol is TCP, in which case the health check path must be blank. The validation is preventing valid use cases. 

Since this validation can only check the one field on its own, the check is amended to only validate the path begins with a "/" if the path is not blank. Note that when the path is blank, it is not passed to AWS at all (see lines 226-228), so I think this change does not weaken validation.