### PR TITLE
New Data Source: aws_lambda_function

### DIFF
--- a/aws/data_source_aws_lambda_function.go
+++ b/aws/data_source_aws_lambda_function.go
@@ -1,0 +1,154 @@
+package aws
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsLambdaFunction() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsLambdaFunctionRead,
+
+		Schema: map[string]*schema.Schema{
+			"function_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"qualifier": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "$LATEST",
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"dead_letter_config": {
+				Type:     schema.TypeList,
+				Computed: true,
+				MinItems: 0,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"target_arn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"handler": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"memory_size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"reserved_concurrent_executions": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"role": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"runtime": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"timeout": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vpc_config": {
+				Type:     schema.TypeList,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"subnet_ids": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
+						},
+						"security_group_ids": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
+						},
+						"vpc_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"qualified_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"invoke_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"last_modified": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"source_code_hash": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"source_code_size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"environment": {
+				Type:     schema.TypeList,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"variables": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     schema.TypeString,
+						},
+					},
+				},
+			},
+			"tracing_config": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"mode": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"kms_key_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsLambdaFunctionRead(d *schema.ResourceData, meta interface{}) error {
+	d.SetId(d.Get("function_name").(string))
+	return resourceAwsLambdaFunctionRead(d, meta)
+}

--- a/aws/data_source_aws_lambda_function_test.go
+++ b/aws/data_source_aws_lambda_function_test.go
@@ -1,0 +1,338 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceAWSLambdaFunction_basic(t *testing.T) {
+	rString := acctest.RandString(7)
+	roleName := fmt.Sprintf("tf-acctest-d-lambda-function-basic-role-%s", rString)
+	policyName := fmt.Sprintf("tf-acctest-d-lambda-function-basic-policy-%s", rString)
+	sgName := fmt.Sprintf("tf-acctest-d-lambda-function-basic-sg-%s", rString)
+	funcName := fmt.Sprintf("tf-acctest-d-lambda-function-basic-func-%s", rString)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAWSLambdaFunctionConfigBasic(roleName, policyName, sgName, funcName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.aws_lambda_function.acctest", "arn"),
+					resource.TestCheckResourceAttrSet("data.aws_lambda_function.acctest", "role"),
+					resource.TestCheckResourceAttrSet("data.aws_lambda_function.acctest", "source_code_hash"),
+					resource.TestCheckResourceAttrSet("data.aws_lambda_function.acctest", "source_code_size"),
+					resource.TestCheckResourceAttrSet("data.aws_lambda_function.acctest", "last_modified"),
+					resource.TestCheckResourceAttrSet("data.aws_lambda_function.acctest", "qualified_arn"),
+					resource.TestCheckResourceAttrSet("data.aws_lambda_function.acctest", "invoke_arn"),
+					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "function_name", funcName),
+					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "description", funcName),
+					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "qualifier", "$LATEST"),
+					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "handler", "exports.example"),
+					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "memory_size", "128"),
+					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "runtime", "nodejs4.3"),
+					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "timeout", "3"),
+					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "version", "$LATEST"),
+					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "reserved_concurrent_executions", "0"),
+					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "dead_letter_config.#", "0"),
+					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "tracing_config.#", "1"),
+					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "tracing_config.0.mode", "PassThrough"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAWSLambdaFunction_version(t *testing.T) {
+	rString := acctest.RandString(7)
+	roleName := fmt.Sprintf("tf-acctest-d-lambda-function-version-role-%s", rString)
+	policyName := fmt.Sprintf("tf-acctest-d-lambda-function-version-policy-%s", rString)
+	sgName := fmt.Sprintf("tf-acctest-d-lambda-function-version-sg-%s", rString)
+	funcName := fmt.Sprintf("tf-acctest-d-lambda-function-version-func-%s", rString)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAWSLambdaFunctionConfigVersion(roleName, policyName, sgName, funcName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.aws_lambda_function.acctest", "arn"),
+					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "function_name", funcName),
+					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "qualifier", "1"),
+					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "version", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAWSLambdaFunction_alias(t *testing.T) {
+	rString := acctest.RandString(7)
+	roleName := fmt.Sprintf("tf-acctest-d-lambda-function-alias-role-%s", rString)
+	policyName := fmt.Sprintf("tf-acctest-d-lambda-function-alias-policy-%s", rString)
+	sgName := fmt.Sprintf("tf-acctest-d-lambda-function-alias-sg-%s", rString)
+	funcName := fmt.Sprintf("tf-acctest-d-lambda-function-alias-func-%s", rString)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAWSLambdaFunctionConfigAlias(roleName, policyName, sgName, funcName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.aws_lambda_function.acctest", "arn"),
+					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "function_name", funcName),
+					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "qualifier", "alias-name"),
+					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "version", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAWSLambdaFunction_vpc(t *testing.T) {
+	rString := acctest.RandString(7)
+	roleName := fmt.Sprintf("tf-acctest-d-lambda-function-vpc-role-%s", rString)
+	policyName := fmt.Sprintf("tf-acctest-d-lambda-function-vpc-policy-%s", rString)
+	sgName := fmt.Sprintf("tf-acctest-d-lambda-function-vpc-sg-%s", rString)
+	funcName := fmt.Sprintf("tf-acctest-d-lambda-function-vpc-func-%s", rString)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAWSLambdaFunctionConfigVPC(roleName, policyName, sgName, funcName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.aws_lambda_function.acctest", "arn"),
+					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "vpc_config.#", "1"),
+					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "vpc_config.0.security_group_ids.#", "1"),
+					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "vpc_config.0.subnet_ids.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAWSLambdaFunction_environment(t *testing.T) {
+	rString := acctest.RandString(7)
+	roleName := fmt.Sprintf("tf-acctest-d-lambda-function-environment-role-%s", rString)
+	policyName := fmt.Sprintf("tf-acctest-d-lambda-function-environment-policy-%s", rString)
+	sgName := fmt.Sprintf("tf-acctest-d-lambda-function-environment-sg-%s", rString)
+	funcName := fmt.Sprintf("tf-acctest-d-lambda-function-environment-func-%s", rString)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAWSLambdaFunctionConfigEnvironment(roleName, policyName, sgName, funcName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.aws_lambda_function.acctest", "arn"),
+					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "environment.#", "1"),
+					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "environment.0.variables.%", "2"),
+					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "environment.0.variables.key1", "value1"),
+					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "environment.0.variables.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAWSLambdaFunctionConfigBase(roleName, policyName, sgName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "lambda" {
+  name = "%s"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "lambda" {
+  name = "%s"
+  role = "${aws_iam_role.lambda.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents"
+            ],
+            "Resource": "arn:aws:logs:*:*:*"
+        },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateNetworkInterface",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DeleteNetworkInterface"
+      ],
+      "Resource": [
+        "*"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_vpc" "lambda" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "lambda" {
+  vpc_id     = "${aws_vpc.lambda.id}"
+  cidr_block = "10.0.1.0/24"
+}
+
+resource "aws_security_group" "lambda" {
+  name        = "%s"
+  description = "Allow all inbound traffic for lambda test"
+  vpc_id      = "${aws_vpc.lambda.id}"
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+`, roleName, policyName, sgName)
+}
+
+func testAccDataSourceAWSLambdaFunctionConfigBasic(roleName, policyName, sgName, funcName string) string {
+	return fmt.Sprintf(testAccDataSourceAWSLambdaFunctionConfigBase(roleName, policyName, sgName)+`
+resource "aws_lambda_function" "acctest_create" {
+  function_name = "%s"
+  description = "%s"
+  filename = "test-fixtures/lambdatest.zip"
+  role = "${aws_iam_role.lambda.arn}"
+  handler = "exports.example"
+  runtime = "nodejs4.3"
+}
+
+data "aws_lambda_function" "acctest" {
+  function_name = "${aws_lambda_function.acctest_create.function_name}"
+}
+`, funcName, funcName)
+}
+
+func testAccDataSourceAWSLambdaFunctionConfigVersion(roleName, policyName, sgName, funcName string) string {
+	return fmt.Sprintf(testAccDataSourceAWSLambdaFunctionConfigBase(roleName, policyName, sgName)+`
+resource "aws_lambda_function" "acctest_create" {
+  function_name = "%s"
+  description = "%s"
+  filename = "test-fixtures/lambdatest.zip"
+  role = "${aws_iam_role.lambda.arn}"
+  handler = "exports.example"
+  runtime = "nodejs4.3"
+  publish = true
+}
+
+data "aws_lambda_function" "acctest" {
+  function_name = "${aws_lambda_function.acctest_create.function_name}"
+  qualifier     = 1
+}
+`, funcName, funcName)
+}
+
+func testAccDataSourceAWSLambdaFunctionConfigAlias(roleName, policyName, sgName, funcName string) string {
+	return fmt.Sprintf(testAccDataSourceAWSLambdaFunctionConfigBase(roleName, policyName, sgName)+`
+resource "aws_lambda_function" "acctest_create" {
+  function_name = "%s"
+  description = "%s"
+  filename = "test-fixtures/lambdatest.zip"
+  role = "${aws_iam_role.lambda.arn}"
+  handler = "exports.example"
+  runtime = "nodejs4.3"
+  publish = true
+}
+
+resource "aws_lambda_alias" "alias" {
+  name             = "alias-name"
+  function_name    = "${aws_lambda_function.acctest_create.arn}"
+  function_version = "1"
+}
+
+data "aws_lambda_function" "acctest" {
+  function_name = "${aws_lambda_function.acctest_create.function_name}"
+  qualifier     = "${aws_lambda_alias.alias.name}"
+}
+`, funcName, funcName)
+}
+
+func testAccDataSourceAWSLambdaFunctionConfigVPC(roleName, policyName, sgName, funcName string) string {
+	return fmt.Sprintf(testAccDataSourceAWSLambdaFunctionConfigBase(roleName, policyName, sgName)+`
+resource "aws_lambda_function" "acctest_create" {
+  function_name = "%s"
+  description = "%s"
+  filename = "test-fixtures/lambdatest.zip"
+  role = "${aws_iam_role.lambda.arn}"
+  handler = "exports.example"
+  runtime = "nodejs4.3"
+
+  vpc_config = {
+    subnet_ids = ["${aws_subnet.lambda.id}"]
+    security_group_ids = ["${aws_security_group.lambda.id}"]
+  }
+}
+
+data "aws_lambda_function" "acctest" {
+  function_name = "${aws_lambda_function.acctest_create.function_name}"
+}
+`, funcName, funcName)
+}
+
+func testAccDataSourceAWSLambdaFunctionConfigEnvironment(roleName, policyName, sgName, funcName string) string {
+	return fmt.Sprintf(testAccDataSourceAWSLambdaFunctionConfigBase(roleName, policyName, sgName)+`
+resource "aws_lambda_function" "acctest_create" {
+  function_name = "%s"
+  description = "%s"
+  filename = "test-fixtures/lambdatest.zip"
+  role = "${aws_iam_role.lambda.arn}"
+  handler = "exports.example"
+  runtime = "nodejs4.3"
+
+  environment {
+    variables = {
+      key1 = "value1"
+      key2 = "value2"
+    }
+  }
+}
+
+data "aws_lambda_function" "acctest" {
+  function_name = "${aws_lambda_function.acctest_create.function_name}"
+}
+`, funcName, funcName)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -213,6 +213,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_kms_ciphertext":                   dataSourceAwsKmsCiphertext(),
 			"aws_kms_key":                          dataSourceAwsKmsKey(),
 			"aws_kms_secret":                       dataSourceAwsKmsSecret(),
+			"aws_lambda_function":                  dataSourceAwsLambdaFunction(),
 			"aws_nat_gateway":                      dataSourceAwsNatGateway(),
 			"aws_network_interface":                dataSourceAwsNetworkInterface(),
 			"aws_partition":                        dataSourceAwsPartition(),

--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -176,7 +176,6 @@ func resourceAwsLambdaFunction() *schema.Resource {
 			},
 			"source_code_size": {
 				Type:     schema.TypeInt,
-				Optional: true,
 				Computed: true,
 			},
 			"environment": {
@@ -498,20 +497,16 @@ func resourceAwsLambdaFunctionRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("source_code_hash", function.CodeSha256)
 	d.Set("source_code_size", function.CodeSize)
 
-	vpcConfig := flattenLambdaVpcConfigResponse(function.VpcConfig)
-	if vpcConfig != nil {
-		log.Printf("[INFO] Setting Lambda %s VPC config %#v from API", d.Id(), vpcConfig)
-		if err := d.Set("vpc_config", vpcConfig); err != nil {
-			return fmt.Errorf("Failed setting vpc_config: %s", err)
-		}
+	config := flattenLambdaVpcConfigResponse(function.VpcConfig)
+	log.Printf("[INFO] Setting Lambda %s VPC config %#v from API", d.Id(), config)
+	if err := d.Set("vpc_config", config); err != nil {
+		return fmt.Errorf("[ERR] Error setting vpc_config for Lambda Function (%s): %s", d.Id(), err)
 	}
 
 	environment := flattenLambdaEnvironment(function.Environment)
-	if environment != nil {
-		log.Printf("[INFO] Setting Lambda %s environment %#v from API", d.Id(), environment)
-		if err := d.Set("environment", environment); err != nil {
-			log.Printf("[ERR] Error setting environment for Lambda Function (%s): %s", d.Id(), err)
-		}
+	log.Printf("[INFO] Setting Lambda %s environment %#v from API", d.Id(), environment)
+	if err := d.Set("environment", environment); err != nil {
+		log.Printf("[ERR] Error setting environment for Lambda Function (%s): %s", d.Id(), err)
 	}
 
 	if function.DeadLetterConfig != nil && function.DeadLetterConfig.TargetArn != nil {

--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -174,6 +174,11 @@ func resourceAwsLambdaFunction() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"source_code_size": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
 			"environment": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -188,7 +193,6 @@ func resourceAwsLambdaFunction() *schema.Resource {
 					},
 				},
 			},
-
 			"tracing_config": {
 				Type:     schema.TypeList,
 				MaxItems: 1,
@@ -204,13 +208,11 @@ func resourceAwsLambdaFunction() *schema.Resource {
 					},
 				},
 			},
-
 			"kms_key_arn": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validateArn,
 			},
-
 			"tags": tagsSchema(),
 		},
 
@@ -443,10 +445,17 @@ func resourceAwsLambdaFunctionCreate(d *schema.ResourceData, meta interface{}) e
 func resourceAwsLambdaFunctionRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).lambdaconn
 
-	log.Printf("[DEBUG] Fetching Lambda Function: %s", d.Id())
-
 	params := &lambda.GetFunctionInput{
 		FunctionName: aws.String(d.Get("function_name").(string)),
+	}
+
+	// qualifier for lambda function data source
+	qualifier, qualifierExistance := d.GetOk("qualifier")
+	if qualifierExistance {
+		params.Qualifier = aws.String(qualifier.(string))
+		log.Printf("[DEBUG] Fetching Lambda Function: %s:%s", d.Id(), qualifier.(string))
+	} else {
+		log.Printf("[DEBUG] Fetching Lambda Function: %s", d.Id())
 	}
 
 	getFunctionOutput, err := conn.GetFunction(params)
@@ -456,6 +465,18 @@ func resourceAwsLambdaFunctionRead(d *schema.ResourceData, meta interface{}) err
 			return nil
 		}
 		return err
+	}
+
+	if getFunctionOutput.Concurrency != nil {
+		d.Set("reserved_concurrent_executions", getFunctionOutput.Concurrency.ReservedConcurrentExecutions)
+	} else {
+		d.Set("reserved_concurrent_executions", nil)
+	}
+
+	// Tagging operations are permitted on Lambda functions only.
+	// Tags on aliases and versions are not supported.
+	if !qualifierExistance {
+		d.Set("tags", tagsToMapGeneric(getFunctionOutput.Tags))
 	}
 
 	// getFunctionOutput.Code.Location is a pre-signed URL pointing at the zip
@@ -474,19 +495,23 @@ func resourceAwsLambdaFunctionRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("runtime", function.Runtime)
 	d.Set("timeout", function.Timeout)
 	d.Set("kms_key_arn", function.KMSKeyArn)
-	d.Set("tags", tagsToMapGeneric(getFunctionOutput.Tags))
+	d.Set("source_code_hash", function.CodeSha256)
+	d.Set("source_code_size", function.CodeSize)
 
-	config := flattenLambdaVpcConfigResponse(function.VpcConfig)
-	log.Printf("[INFO] Setting Lambda %s VPC config %#v from API", d.Id(), config)
-	vpcSetErr := d.Set("vpc_config", config)
-	if vpcSetErr != nil {
-		return fmt.Errorf("Failed setting vpc_config: %s", vpcSetErr)
+	vpcConfig := flattenLambdaVpcConfigResponse(function.VpcConfig)
+	if vpcConfig != nil {
+		log.Printf("[INFO] Setting Lambda %s VPC config %#v from API", d.Id(), vpcConfig)
+		if err := d.Set("vpc_config", vpcConfig); err != nil {
+			return fmt.Errorf("Failed setting vpc_config: %s", err)
+		}
 	}
 
-	d.Set("source_code_hash", function.CodeSha256)
-
-	if err := d.Set("environment", flattenLambdaEnvironment(function.Environment)); err != nil {
-		log.Printf("[ERR] Error setting environment for Lambda Function (%s): %s", d.Id(), err)
+	environment := flattenLambdaEnvironment(function.Environment)
+	if environment != nil {
+		log.Printf("[INFO] Setting Lambda %s environment %#v from API", d.Id(), environment)
+		if err := d.Set("environment", environment); err != nil {
+			log.Printf("[ERR] Error setting environment for Lambda Function (%s): %s", d.Id(), err)
+		}
 	}
 
 	if function.DeadLetterConfig != nil && function.DeadLetterConfig.TargetArn != nil {
@@ -537,12 +562,6 @@ func resourceAwsLambdaFunctionRead(d *schema.ResourceData, meta interface{}) err
 		Resource:  fmt.Sprintf("path/2015-03-31/functions/%s/invocations", *function.FunctionArn),
 	}.String()
 	d.Set("invoke_arn", invokeArn)
-
-	if getFunctionOutput.Concurrency != nil {
-		d.Set("reserved_concurrent_executions", getFunctionOutput.Concurrency.ReservedConcurrentExecutions)
-	} else {
-		d.Set("reserved_concurrent_executions", nil)
-	}
 
 	return nil
 }

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -199,6 +199,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-network-interface") %>>
                             <a href="/docs/providers/aws/d/network_interface.html">aws_network_interface</a>
                          </li>
+                         <li<%= sidebar_current("docs-aws-datasource-lambda-function") %>>
+                             <a href="/docs/providers/aws/d/lambda-function.html">aws_lambda_function</a>
+                         </li>
                         <li<%= sidebar_current("docs-aws-datasource-lb-x") %>>
                             <a href="/docs/providers/aws/d/lb.html">aws_lb</a>
                         </li>

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -198,10 +198,10 @@
                         </li>
                         <li<%= sidebar_current("docs-aws-datasource-network-interface") %>>
                             <a href="/docs/providers/aws/d/network_interface.html">aws_network_interface</a>
-                         </li>
-                         <li<%= sidebar_current("docs-aws-datasource-lambda-function") %>>
-                             <a href="/docs/providers/aws/d/lambda-function.html">aws_lambda_function</a>
-                         </li>
+                        </li>
+                        <li<%= sidebar_current("docs-aws-datasource-lambda-function") %>>
+                            <a href="/docs/providers/aws/d/lambda_function.html">aws_lambda_function</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-lb-x") %>>
                             <a href="/docs/providers/aws/d/lb.html">aws_lb</a>
                         </li>

--- a/website/docs/d/lambda_function.html.markdown
+++ b/website/docs/d/lambda_function.html.markdown
@@ -1,0 +1,54 @@
+---
+layout: "aws"
+page_title: "AWS: aws_lambda_function"
+sidebar_current: "docs-aws-datasource-lambda-function"
+description: |-
+  Provides a Lambda Function data source.
+---
+
+# aws_lambda_function
+
+Provides information about a Lambda Function.
+
+## Example Usage
+
+```hcl
+variable "function_name" {
+  type = "string"
+}
+
+data "aws_lambda_function" "existing" {
+  function_name = "${var.function_name}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `function_name` - (Required) Name of the lambda function.
+* `qualifier` - (Optional) Qualifier of the lambda function. Defaults to `$LATEST`.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `arn` - The Amazon Resource Name (ARN) identifying your Lambda Function.
+* `dead_letter_config` - Configure the function's *dead letter queue*.
+* `description` - Description of what your Lambda Function does.
+* `environment` - The Lambda environment's configuration settings.
+* `handler` - The function entrypoint in your code.
+* `invoke_arn` - The ARN to be used for invoking Lambda Function from API Gateway.
+* `kms_key_arn` - The ARN for the KMS encryption key.
+* `last_modified` - The date this resource was last modified.
+* `memory_size` - Amount of memory in MB your Lambda Function can use at runtime.
+* `qualified_arn` - The Amazon Resource Name (ARN) identifying your Lambda Function Version
+* `reserved_concurrent_executions` - The amount of reserved concurrent executions for this lambda function.
+* `role` - IAM role attached to the Lambda Function.
+* `runtime` - The runtime environment for the Lambda function..
+* `source_code_hash` - Base64-encoded representation of raw SHA-256 sum of the zip file.
+* `source_code_size` - The size in bytes of the function .zip file.
+* `timeout` - The function execution time at which Lambda should terminate the function.
+* `tracing_config` - Tracing settings of the function.
+* `version` - The version of the Lambda function.
+* `vpc_config` - VPC configuration associated with your Lambda function.

--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -121,8 +121,8 @@ For **environment** the following attributes are supported:
 * `version` - Latest published version of your Lambda Function.
 * `last_modified` - The date this resource was last modified.
 * `kms_key_arn` - (Optional) The ARN for the KMS encryption key.
-* `source_code_hash` - Base64-encoded representation of raw SHA-256 sum of the zip file
-  provided either via `filename` or `s3_*` parameters.
+* `source_code_hash` - Base64-encoded representation of raw SHA-256 sum of the zip file, provided either via `filename` or `s3_*` parameters.
+* `source_code_size` - The size in bytes of the function .zip file.
 
 [1]: https://docs.aws.amazon.com/lambda/latest/dg/welcome.html
 [2]: https://docs.aws.amazon.com/lambda/latest/dg/walkthrough-s3-events-adminuser-create-test-function-create-function.html


### PR DESCRIPTION
To get information of lambda function.

Attributes are returned from read function of `aws_lambda_function` resource. Most of the attributes for resource are available for data source. `tags` is one exception though because it doesn't exist if `qualifier` is specified.