### PR TITLE
terraform import aws_dx_lag and aws_dx_connection

### DIFF
--- a/aws/import_aws_dx_connection_test.go
+++ b/aws/import_aws_dx_connection_test.go
@@ -1,0 +1,29 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAwsDxConnection_importBasic(t *testing.T) {
+	resourceName := "aws_dx_connection.hoge"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsDxConnectionDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDxConnectionConfig(acctest.RandString(5)),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/aws/import_aws_dx_lag_test.go
+++ b/aws/import_aws_dx_lag_test.go
@@ -1,0 +1,30 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAwsDxLag_importBasic(t *testing.T) {
+	resourceName := "aws_dx_lag.hoge"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsDxLagDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDxLagConfig(acctest.RandString(5)),
+			},
+
+			resource.TestStep{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+		},
+	})
+}

--- a/aws/resource_aws_dx_connection.go
+++ b/aws/resource_aws_dx_connection.go
@@ -18,6 +18,9 @@ func resourceAwsDxConnection() *schema.Resource {
 		Read:   resourceAwsDxConnectionRead,
 		Update: resourceAwsDxConnectionUpdate,
 		Delete: resourceAwsDxConnectionDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"arn": {

--- a/aws/resource_aws_dx_lag.go
+++ b/aws/resource_aws_dx_lag.go
@@ -18,6 +18,9 @@ func resourceAwsDxLag() *schema.Resource {
 		Read:   resourceAwsDxLagRead,
 		Update: resourceAwsDxLagUpdate,
 		Delete: resourceAwsDxLagDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"arn": {

--- a/website/docs/r/dx_connection.html.markdown
+++ b/website/docs/r/dx_connection.html.markdown
@@ -35,3 +35,11 @@ The following attributes are exported:
 
 * `id` - The ID of the connection.
 * `arn` - The ARN of the connection.
+
+## Import
+
+Direct Connect connections can be imported using the `connection id`, e.g.
+
+```
+$ terraform import aws_dx_connection.test_connection dxcon-ffre0ec3
+```

--- a/website/docs/r/dx_lag.html.markdown
+++ b/website/docs/r/dx_lag.html.markdown
@@ -39,3 +39,11 @@ The following attributes are exported:
 
 * `id` - The ID of the LAG.
 * `arn` - The ARN of the LAG.
+
+## Import
+
+Direct Connect LAGs can be imported using the `lag id`, e.g.
+
+```
+$ terraform import aws_dx_lag.test_lag dxlag-fgnsp5rq
+```


### PR DESCRIPTION
Fixes #2991

Acceptance tests at present:
```
make testacc TEST=./aws/ TESTARGS='-run=TestAccAwsDxLag_import'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAwsDxLag_import -timeout 120m
=== RUN   TestAccAwsDxLag_importBasic
--- FAIL: TestAccAwsDxLag_importBasic (27.22s)
	testing.go:513: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.
		
		(map[string]string) {
		}
		
		
		(map[string]string) (len=5) {
		 (string) (len=21) "connections_bandwidth": (string) (len=5) "1Gbps",
		 (string) (len=13) "force_destroy": (string) (len=4) "true",
		 (string) (len=8) "location": (string) (len=5) "EqSe2",
		 (string) (len=4) "name": (string) (len=15) "tf-dx-lag-9ke1v",
		 (string) (len=21) "number_of_connections": (string) (len=1) "2"
		}
		
FAIL
exit status 1
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	27.228s
GNUmakefile:18: recipe for target 'testacc' failed
make: *** [testacc] Error 1
```
```
make testacc TEST=./aws/ TESTARGS='-run=TestAccAwsDxConnection_import'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAwsDxConnection_import -timeout 120m
=== RUN   TestAccAwsDxConnection_importBasic
--- FAIL: TestAccAwsDxConnection_importBasic (26.03s)
	testing.go:513: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.
		
		(map[string]string) {
		}
		
		
		(map[string]string) (len=3) {
		 (string) (len=9) "bandwidth": (string) (len=5) "1Gbps",
		 (string) (len=8) "location": (string) (len=5) "EqSe2",
		 (string) (len=4) "name": (string) (len=11) "tf-dx-en2vq"
		}
		
FAIL
exit status 1
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	26.037s
GNUmakefile:18: recipe for target 'testacc' failed
make: *** [testacc] Error 1
```

I do NOT expect these to pass until https://github.com/terraform-providers/terraform-provider-aws/issues/2989 is merged.