### PR TITLE
resource/aws_codepipeline: Prevent crash on empty artifacts

### DIFF
--- a/aws/resource_aws_codepipeline.go
+++ b/aws/resource_aws_codepipeline.go
@@ -416,6 +416,9 @@ func flattenAwsCodePipelineStageActionConfiguration(config map[string]*string) m
 func expandAwsCodePipelineActionsOutputArtifacts(s []interface{}) []*codepipeline.OutputArtifact {
 	outputArtifacts := []*codepipeline.OutputArtifact{}
 	for _, artifact := range s {
+		if artifact == nil {
+			continue
+		}
 		outputArtifacts = append(outputArtifacts, &codepipeline.OutputArtifact{
 			Name: aws.String(artifact.(string)),
 		})
@@ -434,6 +437,9 @@ func flattenAwsCodePipelineActionsOutputArtifacts(artifacts []*codepipeline.Outp
 func expandAwsCodePipelineActionsInputArtifacts(s []interface{}) []*codepipeline.InputArtifact {
 	outputArtifacts := []*codepipeline.InputArtifact{}
 	for _, artifact := range s {
+		if artifact == nil {
+			continue
+		}
 		outputArtifacts = append(outputArtifacts, &codepipeline.InputArtifact{
 			Name: aws.String(artifact.(string)),
 		})

--- a/aws/resource_aws_codepipeline_test.go
+++ b/aws/resource_aws_codepipeline_test.go
@@ -49,6 +49,40 @@ func TestAccAWSCodePipeline_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSCodePipeline_emptyArtifacts(t *testing.T) {
+	if os.Getenv("GITHUB_TOKEN") == "" {
+		t.Skip("Environment variable GITHUB_TOKEN is not set")
+	}
+
+	name := acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodePipelineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodePipelineConfig_emptyArtifacts(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodePipelineExists("aws_codepipeline.bar"),
+					resource.TestMatchResourceAttr("aws_codepipeline.bar", "arn",
+						regexp.MustCompile(fmt.Sprintf("^arn:aws:codepipeline:[^:]+:[0-9]{12}:test-pipeline-%s", name))),
+					resource.TestCheckResourceAttr("aws_codepipeline.bar", "artifact_store.0.type", "S3"),
+					resource.TestCheckResourceAttr("aws_codepipeline.bar", "stage.1.name", "Build"),
+					resource.TestCheckResourceAttr("aws_codepipeline.bar", "stage.1.action.#", "1"),
+					resource.TestCheckResourceAttr("aws_codepipeline.bar", "stage.1.action.0.name", "Build"),
+					resource.TestCheckResourceAttr("aws_codepipeline.bar", "stage.1.action.0.category", "Build"),
+					resource.TestCheckResourceAttr("aws_codepipeline.bar", "stage.1.action.0.owner", "AWS"),
+					resource.TestCheckResourceAttr("aws_codepipeline.bar", "stage.1.action.0.provider", "CodeBuild"),
+					resource.TestCheckResourceAttr("aws_codepipeline.bar", "stage.1.action.0.input_artifacts.#", "1"),
+					resource.TestCheckResourceAttr("aws_codepipeline.bar", "stage.1.action.0.output_artifacts.#", "0"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSCodePipeline_deployWithServiceRole(t *testing.T) {
 	if os.Getenv("GITHUB_TOKEN") == "" {
 		t.Skip("Environment variable GITHUB_TOKEN is not set")
@@ -338,6 +372,114 @@ resource "aws_codepipeline" "bar" {
 
       configuration {
         ProjectName = "foo"
+      }
+    }
+  }
+}
+`, rName, rName, rName)
+}
+
+func testAccAWSCodePipelineConfig_emptyArtifacts(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "foo" {
+  bucket = "tf-test-pipeline-%s"
+  acl    = "private"
+}
+
+resource "aws_iam_role" "codepipeline_role" {
+  name = "codepipeline-role-%s"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "codepipeline.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "codepipeline_policy" {
+  name = "codepipeline_policy"
+  role = "${aws_iam_role.codepipeline_role.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect":"Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:GetObjectVersion",
+        "s3:GetBucketVersioning"
+      ],
+      "Resource": [
+        "${aws_s3_bucket.foo.arn}",
+        "${aws_s3_bucket.foo.arn}/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "codebuild:BatchGetBuilds",
+        "codebuild:StartBuild"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_codepipeline" "bar" {
+  name     = "test-pipeline-%s"
+  role_arn = "${aws_iam_role.codepipeline_role.arn}"
+
+  artifact_store {
+    location = "${aws_s3_bucket.foo.bucket}"
+    type     = "S3"
+  }
+
+  stage {
+    name = "Source"
+
+    action {
+      name             = "Source"
+      category         = "Source"
+      owner            = "ThirdParty"
+      provider         = "GitHub"
+      version          = "1"
+      output_artifacts = ["test"]
+
+      configuration {
+        Owner  = "lifesum-terraform"
+        Repo   = "test"
+        Branch = "master"
+      }
+    }
+  }
+
+  stage {
+    name = "Build"
+
+    action {
+      name             = "Build"
+      category         = "Build"
+      owner            = "AWS"
+      provider         = "CodeBuild"
+      input_artifacts  = ["test", ""]
+      output_artifacts = [""]
+      version          = "1"
+
+      configuration {
+        ProjectName = "test"
       }
     }
   }


### PR DESCRIPTION
Fixes #2396

## Test results

```
=== RUN   TestAccAWSCodePipeline_emptyArtifacts
--- PASS: TestAccAWSCodePipeline_emptyArtifacts (85.80s)
```