### PR TITLE
resource/aws_codebuild_project: Prevent crash on empty source buildspec and location

### DIFF
--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -388,7 +388,10 @@ func resourceAwsCodeBuildProjectRead(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	d.Set("source", flattenAwsCodebuildProjectSource(project.Source))
+	if err := d.Set("source", flattenAwsCodebuildProjectSource(project.Source)); err != nil {
+		return err
+	}
+
 	d.Set("description", project.Description)
 	d.Set("encryption_key", project.EncryptionKey)
 	d.Set("name", project.Name)

--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -147,6 +147,7 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 								},
 							},
 							Optional: true,
+							Set:      resourceAwsCodeBuildProjectSourceAuthHash,
 						},
 						"buildspec": {
 							Type:     schema.TypeString,
@@ -165,6 +166,7 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 				},
 				Required: true,
 				MaxItems: 1,
+				Set:      resourceAwsCodeBuildProjectSourceHash,
 			},
 			"timeout": {
 				Type:         schema.TypeInt,
@@ -386,10 +388,7 @@ func resourceAwsCodeBuildProjectRead(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	if err := d.Set("source", flattenAwsCodebuildProjectSource(project.Source)); err != nil {
-		return err
-	}
-
+	d.Set("source", flattenAwsCodebuildProjectSource(project.Source))
 	d.Set("description", project.Description)
 	d.Set("encryption_key", project.EncryptionKey)
 	d.Set("name", project.Name)
@@ -523,37 +522,27 @@ func flattenAwsCodebuildProjectEnvironment(environment *codebuild.ProjectEnviron
 
 }
 
-func flattenAwsCodebuildProjectSource(source *codebuild.ProjectSource) *schema.Set {
+func flattenAwsCodebuildProjectSource(source *codebuild.ProjectSource) []interface{} {
+	l := make([]interface{}, 1)
+	m := map[string]interface{}{}
 
-	sourceSet := schema.Set{
-		F: resourceAwsCodeBuildProjectSourceHash,
-	}
-
-	authSet := schema.Set{
-		F: resourceAwsCodeBuildProjectSourceAuthHash,
-	}
-
-	sourceConfig := map[string]interface{}{}
-
-	sourceConfig["type"] = *source.Type
+	m["type"] = *source.Type
 
 	if source.Auth != nil {
-		authSet.Add(sourceAuthToMap(source.Auth))
-		sourceConfig["auth"] = &authSet
+		m["auth"] = sourceAuthToMap(source.Auth)
 	}
 
 	if source.Buildspec != nil {
-		sourceConfig["buildspec"] = *source.Buildspec
+		m["buildspec"] = *source.Buildspec
 	}
 
 	if source.Location != nil {
-		sourceConfig["location"] = *source.Location
+		m["location"] = *source.Location
 	}
 
-	sourceSet.Add(sourceConfig)
+	l[0] = m
 
-	return &sourceSet
-
+	return l
 }
 
 func resourceAwsCodeBuildProjectArtifactsHash(v interface{}) int {
@@ -594,13 +583,13 @@ func resourceAwsCodeBuildProjectSourceHash(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
 
-	sourceType := m["type"].(string)
-	buildspec := m["buildspec"].(string)
-	location := m["location"].(string)
-
-	buf.WriteString(fmt.Sprintf("%s-", sourceType))
-	buf.WriteString(fmt.Sprintf("%s-", buildspec))
-	buf.WriteString(fmt.Sprintf("%s-", location))
+	buf.WriteString(fmt.Sprintf("%s-", m["type"].(string)))
+	if v, ok := m["buildspec"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+	}
+	if v, ok := m["location"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+	}
 
 	return hashcode.String(buf.String())
 }


### PR DESCRIPTION
Also simplifies flattenAwsCodebuildProjectSource and moves Set Hash declarations to schema.

Closes #2673 

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSCodeBuildProject_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCodeBuildProject_ -timeout 120m
=== RUN   TestAccAWSCodeBuildProject_basic
--- PASS: TestAccAWSCodeBuildProject_basic (39.20s)
=== RUN   TestAccAWSCodeBuildProject_default_build_timeout
--- PASS: TestAccAWSCodeBuildProject_default_build_timeout (36.96s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	76.212s
```