### PR TITLE
resource/aws_appautoscaling_policy: Match correct policy when multiple policies with same name

### DIFF
--- a/aws/resource_aws_appautoscaling_policy.go
+++ b/aws/resource_aws_appautoscaling_policy.go
@@ -567,8 +567,10 @@ func getAwsAppautoscalingPolicy(d *schema.ResourceData, meta interface{}) (*appl
 	conn := meta.(*AWSClient).appautoscalingconn
 
 	params := applicationautoscaling.DescribeScalingPoliciesInput{
-		PolicyNames:      []*string{aws.String(d.Get("name").(string))},
-		ServiceNamespace: aws.String(d.Get("service_namespace").(string)),
+		PolicyNames:       []*string{aws.String(d.Get("name").(string))},
+		ResourceId:        aws.String(d.Get("resource_id").(string)),
+		ScalableDimension: aws.String(d.Get("scalable_dimension").(string)),
+		ServiceNamespace:  aws.String(d.Get("service_namespace").(string)),
 	}
 
 	log.Printf("[DEBUG] Application AutoScaling Policy Describe Params: %#v", params)
@@ -576,17 +578,11 @@ func getAwsAppautoscalingPolicy(d *schema.ResourceData, meta interface{}) (*appl
 	if err != nil {
 		return nil, fmt.Errorf("Error retrieving scaling policies: %s", err)
 	}
-
-	// find scaling policy
-	name := d.Get("name").(string)
-	dimension := d.Get("scalable_dimension").(string)
-	for idx, sp := range resp.ScalingPolicies {
-		if *sp.PolicyName == name && *sp.ScalableDimension == dimension {
-			return resp.ScalingPolicies[idx], nil
-		}
+	if len(resp.ScalingPolicies) == 0 {
+		return nil, fmt.Errorf("Application AutoScaling Policy not found: %s", params)
 	}
 
-	return nil, nil
+	return resp.ScalingPolicies[0], nil
 }
 
 func expandStepScalingPolicyConfiguration(cfg []interface{}) *applicationautoscaling.StepScalingPolicyConfiguration {

--- a/aws/resource_aws_appautoscaling_policy.go
+++ b/aws/resource_aws_appautoscaling_policy.go
@@ -579,7 +579,7 @@ func getAwsAppautoscalingPolicy(d *schema.ResourceData, meta interface{}) (*appl
 		return nil, fmt.Errorf("Error retrieving scaling policies: %s", err)
 	}
 	if len(resp.ScalingPolicies) == 0 {
-		return nil, fmt.Errorf("Application AutoScaling Policy not found: %s", params)
+		return nil, nil
 	}
 
 	return resp.ScalingPolicies[0], nil

--- a/aws/resource_aws_appautoscaling_policy_test.go
+++ b/aws/resource_aws_appautoscaling_policy_test.go
@@ -122,7 +122,40 @@ func TestAccAWSAppautoScalingPolicy_dynamoDb(t *testing.T) {
 	})
 }
 
-func TestAccAWSAppautoScalingPolicy_multiplePolicies(t *testing.T) {
+func TestAccAWSAppautoScalingPolicy_multiplePoliciesSameName(t *testing.T) {
+	var readPolicy1 applicationautoscaling.ScalingPolicy
+	var readPolicy2 applicationautoscaling.ScalingPolicy
+
+	tableName1 := fmt.Sprintf("tf-autoscaled-table-%s", acctest.RandString(5))
+	tableName2 := fmt.Sprintf("tf-autoscaled-table-%s", acctest.RandString(5))
+	namePrefix := fmt.Sprintf("tf-appautoscaling-policy-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAppautoscalingPolicyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSAppautoscalingPolicy_multiplePoliciesSameName(tableName1, tableName2, namePrefix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAppautoscalingPolicyExists("aws_appautoscaling_policy.read1", &readPolicy1),
+					resource.TestCheckResourceAttr("aws_appautoscaling_policy.read1", "name", namePrefix+"-read"),
+					resource.TestCheckResourceAttr("aws_appautoscaling_policy.read1", "resource_id", "table/"+tableName1),
+					resource.TestCheckResourceAttr("aws_appautoscaling_policy.read1", "service_namespace", "dynamodb"),
+					resource.TestCheckResourceAttr("aws_appautoscaling_policy.read1", "scalable_dimension", "dynamodb:table:ReadCapacityUnits"),
+
+					testAccCheckAWSAppautoscalingPolicyExists("aws_appautoscaling_policy.read2", &readPolicy2),
+					resource.TestCheckResourceAttr("aws_appautoscaling_policy.read2", "name", namePrefix+"-read"),
+					resource.TestCheckResourceAttr("aws_appautoscaling_policy.read2", "resource_id", "table/"+tableName2),
+					resource.TestCheckResourceAttr("aws_appautoscaling_policy.read2", "service_namespace", "dynamodb"),
+					resource.TestCheckResourceAttr("aws_appautoscaling_policy.read2", "scalable_dimension", "dynamodb:table:ReadCapacityUnits"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAppautoScalingPolicy_multiplePoliciesSameResource(t *testing.T) {
 	var readPolicy applicationautoscaling.ScalingPolicy
 	var writePolicy applicationautoscaling.ScalingPolicy
 
@@ -135,15 +168,17 @@ func TestAccAWSAppautoScalingPolicy_multiplePolicies(t *testing.T) {
 		CheckDestroy: testAccCheckAWSAppautoscalingPolicyDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSAppautoscalingPolicy_multiplePolicies(tableName, namePrefix),
+				Config: testAccAWSAppautoscalingPolicy_multiplePoliciesSameResource(tableName, namePrefix),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAppautoscalingPolicyExists("aws_appautoscaling_policy.read", &readPolicy),
 					resource.TestCheckResourceAttr("aws_appautoscaling_policy.read", "name", namePrefix+"-read"),
+					resource.TestCheckResourceAttr("aws_appautoscaling_policy.read", "resource_id", "table/"+tableName),
 					resource.TestCheckResourceAttr("aws_appautoscaling_policy.read", "service_namespace", "dynamodb"),
 					resource.TestCheckResourceAttr("aws_appautoscaling_policy.read", "scalable_dimension", "dynamodb:table:ReadCapacityUnits"),
 
 					testAccCheckAWSAppautoscalingPolicyExists("aws_appautoscaling_policy.write", &writePolicy),
 					resource.TestCheckResourceAttr("aws_appautoscaling_policy.write", "name", namePrefix+"-write"),
+					resource.TestCheckResourceAttr("aws_appautoscaling_policy.write", "resource_id", "table/"+tableName),
 					resource.TestCheckResourceAttr("aws_appautoscaling_policy.write", "service_namespace", "dynamodb"),
 					resource.TestCheckResourceAttr("aws_appautoscaling_policy.write", "scalable_dimension", "dynamodb:table:WriteCapacityUnits"),
 				),
@@ -427,7 +462,83 @@ resource "aws_appautoscaling_policy" "dynamo_test" {
 `, randPolicyName, randPolicyName)
 }
 
-func testAccAWSAppautoscalingPolicy_multiplePolicies(tableName, namePrefix string) string {
+func testAccAWSAppautoscalingPolicy_multiplePoliciesSameName(tableName1, tableName2, namePrefix string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "dynamodb_table_test1" {
+  name           = "%[1]s"
+  read_capacity  = 1
+  write_capacity = 1
+  hash_key       = "FooKey"
+  attribute {
+    name = "FooKey"
+    type = "S"
+  }
+}
+
+resource "aws_dynamodb_table" "dynamodb_table_test2" {
+  name           = "%[2]s"
+  read_capacity  = 1
+  write_capacity = 1
+  hash_key       = "FooKey"
+  attribute {
+    name = "FooKey"
+    type = "S"
+  }
+}
+
+resource "aws_appautoscaling_target" "read1" {
+  service_namespace = "dynamodb"
+  resource_id = "table/${aws_dynamodb_table.dynamodb_table_test1.name}"
+  scalable_dimension = "dynamodb:table:ReadCapacityUnits"
+  min_capacity = 1
+  max_capacity = 10
+}
+
+resource "aws_appautoscaling_policy" "read1" {
+  name = "%[3]s-read"
+  policy_type = "TargetTrackingScaling"
+  service_namespace = "dynamodb"
+  resource_id = "${aws_appautoscaling_target.read1.resource_id}"
+  scalable_dimension = "${aws_appautoscaling_target.read1.scalable_dimension}"
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "DynamoDBReadCapacityUtilization"
+    }
+    scale_in_cooldown = 10
+    scale_out_cooldown = 10
+    target_value = 70
+  }
+}
+
+resource "aws_appautoscaling_target" "read2" {
+  service_namespace = "dynamodb"
+  resource_id = "table/${aws_dynamodb_table.dynamodb_table_test2.name}"
+  scalable_dimension = "dynamodb:table:ReadCapacityUnits"
+  min_capacity = 1
+  max_capacity = 10
+}
+
+resource "aws_appautoscaling_policy" "read2" {
+  name = "%[3]s-read"
+  policy_type = "TargetTrackingScaling"
+  service_namespace = "dynamodb"
+  resource_id = "table/${aws_dynamodb_table.dynamodb_table_test2.name}"
+  scalable_dimension = "${aws_appautoscaling_target.read2.scalable_dimension}"
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "DynamoDBReadCapacityUtilization"
+    }
+    scale_in_cooldown = 10
+    scale_out_cooldown = 10
+    target_value = 70
+  }
+}
+`, tableName1, tableName2, namePrefix)
+}
+
+func testAccAWSAppautoscalingPolicy_multiplePoliciesSameResource(tableName, namePrefix string) string {
 	return fmt.Sprintf(`
 resource "aws_dynamodb_table" "dynamodb_table_test" {
   name           = "%s"


### PR DESCRIPTION
`DescribeScalingPolicies` allows using `ResourceId` and `ScalableDimension` for additional filtering.

Closes #751 

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSAppautoScalingPolicy'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSAppautoScalingPolicy -timeout 120m
=== RUN   TestAccAWSAppautoScalingPolicy_basic
--- PASS: TestAccAWSAppautoScalingPolicy_basic (39.47s)
=== RUN   TestAccAWSAppautoScalingPolicy_nestedSchema
--- PASS: TestAccAWSAppautoScalingPolicy_nestedSchema (29.96s)
=== RUN   TestAccAWSAppautoScalingPolicy_spotFleetRequest
--- PASS: TestAccAWSAppautoScalingPolicy_spotFleetRequest (70.29s)
=== RUN   TestAccAWSAppautoScalingPolicy_dynamoDb
--- PASS: TestAccAWSAppautoScalingPolicy_dynamoDb (33.25s)
=== RUN   TestAccAWSAppautoScalingPolicy_multiplePolicies
--- PASS: TestAccAWSAppautoScalingPolicy_multiplePolicies (35.19s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	208.225s
```