### PR TITLE
resource/aws_cognito_identity_pool_roles_attachment: Validate role existence

### DIFF
--- a/aws/resource_aws_cognito_identity_pool_roles_attachment.go
+++ b/aws/resource_aws_cognito_identity_pool_roles_attachment.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"bytes"
@@ -10,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/cognitoidentity"
+	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -106,11 +108,20 @@ func resourceAwsCognitoIdentityPoolRolesAttachment() *schema.Resource {
 
 func resourceAwsCognitoIdentityPoolRolesAttachmentCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).cognitoconn
+	iamconn := meta.(*AWSClient).iamconn
 
 	// Validates role keys to be either authenticated or unauthenticated,
 	// since ValidateFunc validates only the value not the key.
-	if errors := validateCognitoRoles(d.Get("roles").(map[string]interface{}), "roles"); len(errors) > 0 {
-		return fmt.Errorf("Error validating Roles: %v", errors)
+	roles, errors := validateCognitoRoles(d.Get("roles").(map[string]interface{}), "roles")
+
+	if len(errors) > 0 {
+		return fmt.Errorf("Error validating roles argument: %v", errors)
+	}
+
+	errors = validateRoleExistance(iamconn, roles)
+
+	if len(errors) != 0 {
+		return fmt.Errorf("Error validating role existance: %v", errors)
 	}
 
 	params := &cognitoidentity.SetIdentityPoolRolesInput{
@@ -168,11 +179,20 @@ func resourceAwsCognitoIdentityPoolRolesAttachmentRead(d *schema.ResourceData, m
 
 func resourceAwsCognitoIdentityPoolRolesAttachmentUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).cognitoconn
+	iamconn := meta.(*AWSClient).iamconn
 
 	// Validates role keys to be either authenticated or unauthenticated,
 	// since ValidateFunc validates only the value not the key.
-	if errors := validateCognitoRoles(d.Get("roles").(map[string]interface{}), "roles"); len(errors) > 0 {
-		return fmt.Errorf("Error validating Roles: %v", errors)
+	roles, errors := validateCognitoRoles(d.Get("roles").(map[string]interface{}), "roles")
+
+	if len(errors) > 0 {
+		return fmt.Errorf("Error validating roles argument: %v", errors)
+	}
+
+	errors = validateRoleExistance(iamconn, roles)
+
+	if len(errors) != 0 {
+		return fmt.Errorf("Error validating role existance: %v", errors)
 	}
 
 	params := &cognitoidentity.SetIdentityPoolRolesInput{
@@ -282,4 +302,18 @@ func cognitoRoleMappingRulesConfigurationHash(v interface{}) int {
 	}
 
 	return hashcode.String(buf.String())
+}
+
+func validateRoleExistance(conn *iam.IAM, roles []string) (errors []error) {
+	for _, role := range roles {
+		if role != "" {
+			log.Printf("[DEBUG] validating role: %s", role)
+			roleName := strings.Split(role, "/")[1]
+			_, err := conn.GetRole(&iam.GetRoleInput{RoleName: aws.String(roleName)})
+			if err != nil {
+				errors = append(errors, err)
+			}
+		}
+	}
+	return
 }

--- a/aws/resource_aws_cognito_identity_pool_roles_attachment_test.go
+++ b/aws/resource_aws_cognito_identity_pool_roles_attachment_test.go
@@ -43,6 +43,22 @@ func TestAccAWSCognitoIdentityPoolRolesAttachment_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSCognitoIdentityPoolRolesAttachment_invalidRole(t *testing.T) {
+	name := fmt.Sprintf("%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCognitoIdentityPoolRolesAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSCognitoIdentityPoolRolesAttachmentConfig_invalidRole(name),
+				ExpectError: regexp.MustCompile(`Error validating role existance`),
+			},
+		},
+	})
+}
+
 func TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappings(t *testing.T) {
 	name := fmt.Sprintf("%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
@@ -310,6 +326,18 @@ resource "aws_cognito_identity_pool_roles_attachment" "main" {
 
   roles {
     "authenticated" = "${aws_iam_role.authenticated.arn}"
+  }
+}
+`)
+}
+
+func testAccAWSCognitoIdentityPoolRolesAttachmentConfig_invalidRole(name string) string {
+	return fmt.Sprintf(baseAWSCognitoIdentityPoolRolesAttachmentConfig(name) + `
+resource "aws_cognito_identity_pool_roles_attachment" "main" {
+  identity_pool_id = "${aws_cognito_identity_pool.main.id}"
+
+  roles {
+    "authenticated" = "${aws_iam_role.authenticated.arn}_invalid"
   }
 }
 `)

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -2008,9 +2008,10 @@ func validateCognitoRoleMappingsType(v interface{}, k string) (ws []string, erro
 }
 
 // Validates that either authenticated or unauthenticated is defined
-func validateCognitoRoles(v map[string]interface{}, k string) (errors []error) {
-	_, hasAuthenticated := v["authenticated"].(string)
-	_, hasUnauthenticated := v["unauthenticated"].(string)
+func validateCognitoRoles(v map[string]interface{}, k string) (roles []string, errors []error) {
+	authRole, hasAuthenticated := v["authenticated"].(string)
+	unauthRole, hasUnauthenticated := v["unauthenticated"].(string)
+	roles = append(roles, authRole, unauthRole)
 
 	if !hasAuthenticated && !hasUnauthenticated {
 		errors = append(errors, fmt.Errorf("%q: Either \"authenticated\" or \"unauthenticated\" must be defined", k))

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -2752,7 +2752,7 @@ func TestValidateCognitoRoles(t *testing.T) {
 	}
 
 	for _, s := range validValues {
-		errors := validateCognitoRoles(s, "roles")
+		_, errors := validateCognitoRoles(s, "roles")
 		if len(errors) > 0 {
 			t.Fatalf("%q should be a valid Cognito Roles: %v", s, errors)
 		}
@@ -2764,7 +2764,7 @@ func TestValidateCognitoRoles(t *testing.T) {
 	}
 
 	for _, s := range invalidValues {
-		errors := validateCognitoRoles(s, "roles")
+		_, errors := validateCognitoRoles(s, "roles")
 		if len(errors) == 0 {
 			t.Fatalf("%q should not be a valid Cognito Roles: %v", s, errors)
 		}


### PR DESCRIPTION
Fixes #3008 

AWS `SetIdentityPoolRoles` silently passes if provided role doesn't exist at all. As a user, I'd prefer to raising en error instead of resetting roles to none.