### PR TITLE
test/aws_api_gateway_*: Fix invalid domain

### DIFF
--- a/aws/resource_aws_api_gateway_base_path_mapping_test.go
+++ b/aws/resource_aws_api_gateway_base_path_mapping_test.go
@@ -20,7 +20,7 @@ func TestAccAWSAPIGatewayBasePath_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
+		Providers:    testAccProvidersWithTLS,
 		CheckDestroy: testAccCheckAWSAPIGatewayBasePathDestroy(name),
 		Steps: []resource.TestStep{
 			{
@@ -42,7 +42,7 @@ func TestAccAWSAPIGatewayEmptyBasePath_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
+		Providers:    testAccProvidersWithTLS,
 		CheckDestroy: testAccCheckAWSAPIGatewayBasePathDestroy(name),
 		Steps: []resource.TestStep{
 			{
@@ -143,12 +143,13 @@ func testAccCheckAWSAPIGatewayBasePathDestroy(name string) resource.TestCheckFun
 	}
 }
 
-func testAccAWSAPIGatewayBasePathConfig(name string) string {
+func testAccAWSAPIGatewayBasePathConfig(domainName string) string {
 	return fmt.Sprintf(`
 resource "aws_api_gateway_rest_api" "test" {
   name = "tf-acc-apigateway-base-path-mapping"
   description = "Terraform Acceptance Tests"
 }
+
 # API gateway won't let us deploy an empty API
 resource "aws_api_gateway_resource" "test" {
   rest_api_id = "${aws_api_gateway_rest_api.test.id}"
@@ -181,17 +182,15 @@ resource "aws_api_gateway_base_path_mapping" "test" {
 resource "aws_api_gateway_domain_name" "test" {
   domain_name = "%s"
   certificate_name = "tf-apigateway-base-path-mapping-test"
-  certificate_body = <<EOF
-%vEOF
-  certificate_chain = <<EOF
-%vEOF
-  certificate_private_key = <<EOF
-%vEOF
+  certificate_body = "${tls_locally_signed_cert.leaf.cert_pem}"
+  certificate_chain = "${tls_self_signed_cert.ca.cert_pem}"
+  certificate_private_key = "${tls_private_key.test.private_key_pem}"
 }
-`, name, testAccAWSAPIGatewayCertBody, testAccAWSAPIGatewayCertChain, testAccAWSAPIGatewayCertPrivateKey)
+%s
+`, domainName, testAccAWSAPIGatewayCerts(domainName))
 }
 
-func testAccAWSAPIGatewayEmptyBasePathConfig(name string) string {
+func testAccAWSAPIGatewayEmptyBasePathConfig(domainName string) string {
 	return fmt.Sprintf(`
 resource "aws_api_gateway_rest_api" "test" {
   name = "tf-acc-apigateway-base-path-mapping"
@@ -223,12 +222,10 @@ resource "aws_api_gateway_base_path_mapping" "test" {
 resource "aws_api_gateway_domain_name" "test" {
   domain_name = "%s"
   certificate_name = "tf-apigateway-base-path-mapping-test"
-  certificate_body = <<EOF
-%vEOF
-  certificate_chain = <<EOF
-%vEOF
-  certificate_private_key = <<EOF
-%vEOF
+  certificate_body = "${tls_locally_signed_cert.leaf.cert_pem}"
+  certificate_chain = "${tls_self_signed_cert.ca.cert_pem}"
+  certificate_private_key = "${tls_private_key.test.private_key_pem}"
 }
-`, name, testAccAWSAPIGatewayCertBody, testAccAWSAPIGatewayCertChain, testAccAWSAPIGatewayCertPrivateKey)
+%s
+`, domainName, testAccAWSAPIGatewayCerts(domainName))
 }

--- a/aws/resource_aws_api_gateway_base_path_mapping_test.go
+++ b/aws/resource_aws_api_gateway_base_path_mapping_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/apigateway"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -15,7 +16,7 @@ func TestAccAWSAPIGatewayBasePath_basic(t *testing.T) {
 	var conf apigateway.BasePathMapping
 
 	// Our test cert is for a wildcard on this domain
-	name := fmt.Sprintf("%s.tf-acc.invalid", resource.UniqueId())
+	name := fmt.Sprintf("tf-acc-%s.terraformtest.com", acctest.RandString(8))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -37,7 +38,7 @@ func TestAccAWSAPIGatewayEmptyBasePath_basic(t *testing.T) {
 	var conf apigateway.BasePathMapping
 
 	// Our test cert is for a wildcard on this domain
-	name := fmt.Sprintf("%s.tf-acc.invalid", resource.UniqueId())
+	name := fmt.Sprintf("tf-acc-%s.terraformtest.com", acctest.RandString(8))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/aws/resource_aws_api_gateway_domain_name_test.go
+++ b/aws/resource_aws_api_gateway_domain_name_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/apigateway"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -15,9 +16,9 @@ func TestAccAWSAPIGatewayDomainName_basic(t *testing.T) {
 	var conf apigateway.DomainName
 
 	// Our test cert is for a wildcard on this domain
-	uniqueId := resource.UniqueId()
-	name := fmt.Sprintf("%s.tf-acc.invalid", uniqueId)
-	nameModified := fmt.Sprintf("test-acc.%s.tf-acc.invalid", uniqueId)
+	rString := acctest.RandString(8)
+	name := fmt.Sprintf("tf-acc-%s.terraformtest.com", rString)
+	nameModified := fmt.Sprintf("tf-acc-%s-modified.terraformtest.com", rString)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/aws/resource_aws_api_gateway_domain_name_test.go
+++ b/aws/resource_aws_api_gateway_domain_name_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -15,36 +16,38 @@ import (
 func TestAccAWSAPIGatewayDomainName_basic(t *testing.T) {
 	var conf apigateway.DomainName
 
-	// Our test cert is for a wildcard on this domain
 	rString := acctest.RandString(8)
 	name := fmt.Sprintf("tf-acc-%s.terraformtest.com", rString)
 	nameModified := fmt.Sprintf("tf-acc-%s-modified.terraformtest.com", rString)
+	commonName := "*.terraformtest.com"
+	certRe := regexp.MustCompile("^-----BEGIN CERTIFICATE-----\n")
+	keyRe := regexp.MustCompile("^-----BEGIN RSA PRIVATE KEY-----\n")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
+		Providers:    testAccProvidersWithTLS,
 		CheckDestroy: testAccCheckAWSAPIGatewayDomainNameDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSAPIGatewayDomainNameConfigCreate(name),
+				Config: testAccAWSAPIGatewayDomainNameConfig(name, commonName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayDomainNameExists("aws_api_gateway_domain_name.test", &conf),
-					resource.TestCheckResourceAttr("aws_api_gateway_domain_name.test", "certificate_body", testAccAWSAPIGatewayCertBody),
-					resource.TestCheckResourceAttr("aws_api_gateway_domain_name.test", "certificate_chain", testAccAWSAPIGatewayCertChain),
+					resource.TestMatchResourceAttr("aws_api_gateway_domain_name.test", "certificate_body", certRe),
+					resource.TestMatchResourceAttr("aws_api_gateway_domain_name.test", "certificate_chain", certRe),
 					resource.TestCheckResourceAttr("aws_api_gateway_domain_name.test", "certificate_name", "tf-acc-apigateway-domain-name"),
-					resource.TestCheckResourceAttr("aws_api_gateway_domain_name.test", "certificate_private_key", testAccAWSAPIGatewayCertPrivateKey),
+					resource.TestMatchResourceAttr("aws_api_gateway_domain_name.test", "certificate_private_key", keyRe),
 					resource.TestCheckResourceAttr("aws_api_gateway_domain_name.test", "domain_name", name),
 					resource.TestCheckResourceAttrSet("aws_api_gateway_domain_name.test", "certificate_upload_date"),
 				),
 			},
 			{
-				Config: testAccAWSAPIGatewayDomainNameConfigUpdate(name),
+				Config: testAccAWSAPIGatewayDomainNameConfig(nameModified, commonName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayDomainNameExists("aws_api_gateway_domain_name.test", &conf),
-					resource.TestCheckResourceAttr("aws_api_gateway_domain_name.test", "certificate_body", testAccAWSAPIGatewayCertBody),
-					resource.TestCheckResourceAttr("aws_api_gateway_domain_name.test", "certificate_chain", testAccAWSAPIGatewayCertChain),
+					resource.TestMatchResourceAttr("aws_api_gateway_domain_name.test", "certificate_body", certRe),
+					resource.TestMatchResourceAttr("aws_api_gateway_domain_name.test", "certificate_chain", certRe),
 					resource.TestCheckResourceAttr("aws_api_gateway_domain_name.test", "certificate_name", "tf-acc-apigateway-domain-name"),
-					resource.TestCheckResourceAttr("aws_api_gateway_domain_name.test", "certificate_private_key", testAccAWSAPIGatewayCertPrivateKey),
+					resource.TestMatchResourceAttr("aws_api_gateway_domain_name.test", "certificate_private_key", keyRe),
 					resource.TestCheckResourceAttr("aws_api_gateway_domain_name.test", "domain_name", nameModified),
 					resource.TestCheckResourceAttrSet("aws_api_gateway_domain_name.test", "certificate_upload_date"),
 				),
@@ -115,121 +118,65 @@ func testAccCheckAWSAPIGatewayDomainNameDestroy(s *terraform.State) error {
 	return nil
 }
 
-// Expires on August 20, 2026
-const testAccAWSAPIGatewayCertBody = `-----BEGIN CERTIFICATE-----
-MIIEfjCCA2agAwIBAgIRAPHiUbRWC/Ff/reiyzqh3wAwDQYJKoZIhvcNAQELBQAw
-gcsxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJDQTEWMBQGA1UEBxMNUGlyYXRlIEhh
-cmJvcjEZMBcGA1UECRMQNTg3OSBDb3R0b24gTGluazETMBEGA1UEERMKOTU1NTkt
-MTIyNzEVMBMGA1UEChMMRXhhbXBsZSwgSW5jMSgwJgYDVQQLEx9EZXBhcnRtZW50
-IG9mIFRlcnJhZm9ybSBUZXN0aW5nMRowGAYDVQQDExF0Zi1hY2MtY2EuaW52YWxp
-ZDEKMAgGA1UEBRMBMjAeFw0xNjA4MjIxNjQ1NTZaFw0yNjA4MjAxNjQ1NTZaMIHK
-MQswCQYDVQQGEwJVUzELMAkGA1UECBMCQ0ExFjAUBgNVBAcTDVBpcmF0ZSBIYXJi
-b3IxGTAXBgNVBAkTEDU4NzkgQ290dG9uIExpbmsxEzARBgNVBBETCjk1NTU5LTEy
-MjcxFTATBgNVBAoTDEV4YW1wbGUsIEluYzEoMCYGA1UECxMfRGVwYXJ0bWVudCBv
-ZiBUZXJyYWZvcm0gVGVzdGluZzEZMBcGA1UEAxMQKi50Zi1hY2MuaW52YWxpZDEK
-MAgGA1UEBRMBMjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL/xTPoz
-3tnvkLjthqsMKwWVtE1yi210UnseBYkc2w6iQUXMCsXkw2PZXW6QIW7o1GNjnrE5
-9jkeEJ2ABEYyor+ooaNZmjJ0dvY1tFerMhsOkQudDBz+eaR13UQvMFc42nFWrS5/
-XCInm4HjWblEfw2b/wbGwTPzIN3+zWdt2XTsSzIRUYgjXy/93aLIVhWaYDsP45RM
-C48qhJKSsYOVH/PSkgw4AfohDXzn2iltTUBFdGZqBufMW4sPp8G8DIOvt01NsXB2
-QLLVgcMJVegx9xxg50+cf6ILck5Ap/SzkCN7XYk8zWC36/QIkiQ6bMMy0nJtgE0B
-jwmwnFF+zF/A4oMCAwEAAaNcMFowDgYDVR0PAQH/BAQDAgWgMBkGA1UdJQQSMBAG
-CCsGAQUFBwMBBgRVHSUAMAwGA1UdEwEB/wQCMAAwHwYDVR0jBBgwFoAU/hWQ+UUh
-7EiLd0fCsgy1jvSgxkswDQYJKoZIhvcNAQELBQADggEBABnTdSEOqj2+7FTeiSR9
-iPGQ3swhrmk59j8XUszrlm6MvZX9AeV9gLcE9J0PfFaAcZM0pR+XZBmyZLoBxUgU
-8Y17yWwAxZo13EwgzTOmebDxm4W+Og4vBxsKS3x/L8D8BKdzBcmVJvggJqTs5Qau
-ePetAQcD/Tfbq7vY9fNQJ4XQTlF5sN625miijTQcNg/s/H2Fj3FENR3UaFiQDtLQ
-eatV0KGF/ik8XFHPbFm7XUZfUcDxvoaljglJfXyVttU956j892ZakvAHzhylFRyy
-/wJnKV7K3zQVCEV0n/dJpXhf7w9PuWHrCp+HZJLMPMtm1IPblVxPNwHhGBG40I+Z
-FSg=
------END CERTIFICATE-----
-`
+func testAccAWSAPIGatewayCerts(commonName string) string {
+	return fmt.Sprintf(`
+resource "tls_private_key" "test" {
+  algorithm = "RSA"
+}
 
-// Expires on August 20, 2026
-const testAccAWSAPIGatewayCertChain = `-----BEGIN CERTIFICATE-----
-MIIEoDCCA4igAwIBAgIQRR1EBw7bN+mMYtXrrvzLdzANBgkqhkiG9w0BAQsFADCB
-yzELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1QaXJhdGUgSGFy
-Ym9yMRkwFwYDVQQJExA1ODc5IENvdHRvbiBMaW5rMRMwEQYDVQQREwo5NTU1OS0x
-MjI3MRUwEwYDVQQKEwxFeGFtcGxlLCBJbmMxKDAmBgNVBAsTH0RlcGFydG1lbnQg
-b2YgVGVycmFmb3JtIFRlc3RpbmcxGjAYBgNVBAMTEXRmLWFjYy1jYS5pbnZhbGlk
-MQowCAYDVQQFEwEyMB4XDTE2MDgyMjE2NDU1NloXDTI2MDgyMDE2NDU1Nlowgcsx
-CzAJBgNVBAYTAlVTMQswCQYDVQQIEwJDQTEWMBQGA1UEBxMNUGlyYXRlIEhhcmJv
-cjEZMBcGA1UECRMQNTg3OSBDb3R0b24gTGluazETMBEGA1UEERMKOTU1NTktMTIy
-NzEVMBMGA1UEChMMRXhhbXBsZSwgSW5jMSgwJgYDVQQLEx9EZXBhcnRtZW50IG9m
-IFRlcnJhZm9ybSBUZXN0aW5nMRowGAYDVQQDExF0Zi1hY2MtY2EuaW52YWxpZDEK
-MAgGA1UEBRMBMjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAK7k1xdX
-HdA0HTajtSPvCwIeNE4HO3IsYn9jnUBvhQ52EJ72GPzlg91AhdVufIncJRjk51iP
-n86TO/bg/dx4d+G45aUFw7WmZGTTZjurhnVWCDPeeetItV3PmsWHkwTiBj4GJYW4
-1mJk0ACjmmGEyz24T46Cn87Tljk+ivdCQL/oYTjpC7jc2i5b7ziiwsToWMEljWV1
-cf/4qQNFmFnETbaQW2qcFdjUoO8N1gRNkC9yvOjo6Fc+lETRHn3e926jDSaqfbwJ
-hKKBoXciYnddNXgA83GBTdnsRiRoD4zFEhNThmgvy5MmkEEdwKl5QIz6ajo4Xxtd
-54XZpt0y/ZVy6BECAwEAAaN+MHwwDgYDVR0PAQH/BAQDAgIEMBkGA1UdJQQSMBAG
-CCsGAQUFBwMBBgRVHSUAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFP4VkPlF
-IexIi3dHwrIMtY70oMZLMB8GA1UdIwQYMBaAFP4VkPlFIexIi3dHwrIMtY70oMZL
-MA0GCSqGSIb3DQEBCwUAA4IBAQBlXSOkvE/c8pcI6vijInnAWY+eX2W7njCzEfmP
-gkDeW/2A1/6eSM6C/ym+9zEgZ9YLxPfiQKzN8Ej+EziFiZW3ZBHnWcW9rZt36wFA
-swF2nIqWa5nkVnAX2aPVfULN1u1BQiv3XZqNNlBk6m9AsgxiZ9jtOY8oQQU3uDYe
-bs9ttLMKJApbe08sKmPawVlXHqj6qb85Pg4bzzknA+euRee9KIi87eTlWc/Ht+WN
-Huh16WqokePii7e/PAaiTAe7ubsPav29lzmHq2NooXrs+FljXveQJpBqu6wKKTXe
-6/5BBsp2474RiZgTbuO2Mbr2nwcoJ9V6iu1M9siCGbbt1nQr
------END CERTIFICATE-----
-`
+resource "tls_self_signed_cert" "ca" {
+  key_algorithm         = "RSA"
+  private_key_pem       = "${tls_private_key.test.private_key_pem}"
+  is_ca_certificate     = true
+  validity_period_hours = 12
 
-const testAccAWSAPIGatewayCertPrivateKey = `-----BEGIN RSA PRIVATE KEY-----
-MIIEpAIBAAKCAQEAv/FM+jPe2e+QuO2GqwwrBZW0TXKLbXRSex4FiRzbDqJBRcwK
-xeTDY9ldbpAhbujUY2OesTn2OR4QnYAERjKiv6iho1maMnR29jW0V6syGw6RC50M
-HP55pHXdRC8wVzjacVatLn9cIiebgeNZuUR/DZv/BsbBM/Mg3f7NZ23ZdOxLMhFR
-iCNfL/3doshWFZpgOw/jlEwLjyqEkpKxg5Uf89KSDDgB+iENfOfaKW1NQEV0ZmoG
-58xbiw+nwbwMg6+3TU2xcHZAstWBwwlV6DH3HGDnT5x/ogtyTkCn9LOQI3tdiTzN
-YLfr9AiSJDpswzLScm2ATQGPCbCcUX7MX8DigwIDAQABAoIBAFSRcXQPpJFrDt2b
-sajtTItCYVV6MVpBVRHvsUqvDwkMjiu9ccWtPDVjENpk4IYoSWOdAc9eFVEnIPTz
-8W4oYzKEjusU0G6Ih92E3fd+cy4epeNzB2JC8L94OswO6oKThxNGuDjzXlmiD88T
-p3WMa1pIr/2BVqCX75Q/7qoyaQwtR/anvOes154gRGY70ucsUpEzo3fyfXdCKO/o
-y1quQ4mmCS50lPCJ3i8JZH2YmGY+xThnXzk7Q9ipjGrHTjinpX8f9tQB2RRwqlA/
-uQ+/q6cOKUAehLtriXyr2QAoCzdz1Lfm8L5KQ3EdrxUUe9dhs/a7bKw4N5eHjw/x
-eBUagsECgYEAyoaIqZ0ur5NQEHuY9Givs6a+ObWLjM18EdfQ7zX7NJRPL3q0jdkm
-KW+pn2OzoRxhwgaD6WuJJmj3rd3ledkwxoO6Efwo8x2z1u/T43FsknW/X3wJLLga
-fPU2T9lSHRufBQUAhPYkf4dSqUklHJ4YSMafbCkvSXKGZqGVLQfu1iECgYEA8p9s
-/5+d0Pcnykau7Hp8a9z9ehHEIF+ce/wb6/6p3fgCP04FLvKqs74p9SrEnyl9uiFx
-ZC9P2XhmEwNFGA+qKPaRBo4RoGeAYgCKD0BfdaGfmp6WLhO0pSnl4c06bXnvwqbD
-DhhT6UvMs6m/uSufwtfCGO48yYiY1z6DqBjuHCMCgYBWJyrltHbSu8D4cgucFRiB
-PPJ5DDCkIhmgYYWA7R7CvEB/OxyppvFj+RtYMYqNg8xWRH1DA7rhOw/5x4ZB8lGc
-cRbrZbBp033YdkdV3r9IAoz5aoNgoaSq+Yk0KIeU2FYqRXl2FltqYL+aQgJmjR5Z
-fxz8Xvy9qtlfuWcDM/e24QKBgQDGtH8mk+lCfUkfRuh4UJCaHnGSif5grS2R9ZZA
-n18rpbThd9qS6reXYgUm/5Hs8KRBzqX5cS4qY4rlw2XRIPMxfU6lWbFh96KToPFx
-MD1+L5JxpbRFpGnsYvYdCmHxy03r03wojRAcH7JU6o9U7j936hDTLjqmq7LRhid5
-goFwlQKBgQCGxTWqQu9FJjtmjdM/ARi7CcwWT40NI8ybyebjDtElekILFMUwO+/w
-M78Me3d5g/oyeS6qCfyK1f7vBb/WhxLBBegaqMGUWbRoKYD0LH5U3zkqZ9ehnDFB
-vhcEnoxPD9HmdFkRduJscyzVNJ50lMuQ3uk7zwiYuS/Z7shH81xzMQ==
------END RSA PRIVATE KEY-----
-`
+  subject {
+    common_name  = "ACME Root CA"
+    organization = "ACME Example Holdings"
+  }
 
-func testAccAWSAPIGatewayDomainNameConfigCreate(name string) string {
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+  ]
+}
+
+resource "tls_cert_request" "test" {
+  key_algorithm   = "RSA"
+  private_key_pem = "${tls_private_key.test.private_key_pem}"
+
+  subject {
+    common_name  = "%s"
+    organization = "ACME Example Holdings, Inc"
+  }
+}
+
+resource "tls_locally_signed_cert" "leaf" {
+  cert_request_pem      = "${tls_cert_request.test.cert_request_pem}"
+  ca_key_algorithm      = "RSA"
+  ca_private_key_pem    = "${tls_private_key.test.private_key_pem}"
+  ca_cert_pem           = "${tls_self_signed_cert.ca.cert_pem}"
+  validity_period_hours = 12
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+  ]
+}
+`, commonName)
+}
+
+func testAccAWSAPIGatewayDomainNameConfig(domainName, commonName string) string {
 	return fmt.Sprintf(`
 resource "aws_api_gateway_domain_name" "test" {
   domain_name = "%s"
-  certificate_body = <<EOF
-%vEOF
-  certificate_chain = <<EOF
-%vEOF
+  certificate_body = "${tls_locally_signed_cert.leaf.cert_pem}"
+  certificate_chain = "${tls_self_signed_cert.ca.cert_pem}"
   certificate_name = "tf-acc-apigateway-domain-name"
-  certificate_private_key = <<EOF
-%vEOF
+  certificate_private_key = "${tls_private_key.test.private_key_pem}"
 }
-`, name, testAccAWSAPIGatewayCertBody, testAccAWSAPIGatewayCertChain, testAccAWSAPIGatewayCertPrivateKey)
-}
-
-func testAccAWSAPIGatewayDomainNameConfigUpdate(name string) string {
-	return fmt.Sprintf(`
-resource "aws_api_gateway_domain_name" "test" {
-  domain_name = "test-acc.%s"
-  certificate_body = <<EOF
-%vEOF
-  certificate_chain = <<EOF
-%vEOF
-  certificate_name = "tf-acc-apigateway-domain-name"
-  certificate_private_key = <<EOF
-%vEOF
-}
-`, name, testAccAWSAPIGatewayCertBody, testAccAWSAPIGatewayCertChain, testAccAWSAPIGatewayCertPrivateKey)
+%s
+`, domainName, testAccAWSAPIGatewayCerts(commonName))
 }


### PR DESCRIPTION
This is to address a few failing tests.

```
=== RUN   TestAccAWSAPIGatewayBasePath_basic
--- FAIL: TestAccAWSAPIGatewayBasePath_basic (854.78s)
    testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_api_gateway_domain_name.test: 1 error(s) occurred:
        
        * aws_api_gateway_domain_name.test: Error creating API Gateway Domain Name: BadRequestException: Unable to create CloudFront distribution for new domain name. 
        Ensure that the domain name is long enough to be valid and try again. If the problem persists, 
        please contact support and reference request ID b77717c0-fb45-11e7-9757-e150e17fb129
            status code: 400, request id: b77717c0-fb45-11e7-9757-e150e17fb129
=== RUN   TestAccAWSAPIGatewayDomainName_basic
--- FAIL: TestAccAWSAPIGatewayDomainName_basic (8.70s)
    testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_api_gateway_domain_name.test: 1 error(s) occurred:
        
        * aws_api_gateway_domain_name.test: Error creating API Gateway Domain Name: BadRequestException: Unable to create CloudFront distribution for new domain name. 
        Ensure that the domain name is long enough to be valid and try again. If the problem persists, 
        please contact support and reference request ID c66c22b5-fb45-11e7-9f73-3b19123f51ae
            status code: 400, request id: c66c22b5-fb45-11e7-9f73-3b19123f51ae
=== RUN   TestAccAWSAPIGatewayEmptyBasePath_basic
--- FAIL: TestAccAWSAPIGatewayEmptyBasePath_basic (58.46s)
    testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_api_gateway_domain_name.test: 1 error(s) occurred:
        
        * aws_api_gateway_domain_name.test: Error creating API Gateway Domain Name: BadRequestException: Unable to create CloudFront distribution for new domain name. 
        Ensure that the domain name is long enough to be valid and try again. If the problem persists, 
        please contact support and reference request ID a0e90375-fb45-11e7-b53f-dd17562d11fb
            status code: 400, request id: a0e90375-fb45-11e7-b53f-dd17562d11fb
```

## Test results

```
=== RUN   TestAccAWSAPIGatewayAccount_importBasic
--- PASS: TestAccAWSAPIGatewayAccount_importBasic (9.36s)
=== RUN   TestAccAWSAPIGatewayClientCertificate_importBasic
--- PASS: TestAccAWSAPIGatewayClientCertificate_importBasic (9.80s)
=== RUN   TestAccAWSAPIGatewayApiKey_basic
--- PASS: TestAccAWSAPIGatewayApiKey_basic (12.85s)
=== RUN   TestAccAWSAPIGatewayClientCertificate_basic
--- PASS: TestAccAWSAPIGatewayClientCertificate_basic (16.58s)
=== RUN   TestAccAWSAPIGatewayMethodResponse_basic
--- PASS: TestAccAWSAPIGatewayMethodResponse_basic (35.04s)
=== RUN   TestAccAWSAPIGatewayMethod_basic
--- PASS: TestAccAWSAPIGatewayMethod_basic (63.03s)
=== RUN   TestAccAWSAPIGatewayUsagePlan_importBasic
--- PASS: TestAccAWSAPIGatewayUsagePlan_importBasic (103.32s)
=== RUN   TestAccAWSAPIGatewayAccount_basic
--- PASS: TestAccAWSAPIGatewayAccount_basic (110.66s)
=== RUN   TestAccAWSAPIGatewayDomainName_basic
--- PASS: TestAccAWSAPIGatewayDomainName_basic (120.44s)
=== RUN   TestAccAWSAPIGatewayResource_update
--- PASS: TestAccAWSAPIGatewayResource_update (13.70s)
=== RUN   TestAccAWSAPIGatewayRestApi_basic
--- PASS: TestAccAWSAPIGatewayRestApi_basic (30.94s)
=== RUN   TestAccAWSAPIGatewayRequestValidator_basic
--- PASS: TestAccAWSAPIGatewayRequestValidator_basic (92.66s)
=== RUN   TestAccAWSAPIGatewayRestApi_openapi
--- PASS: TestAccAWSAPIGatewayRestApi_openapi (61.20s)
=== RUN   TestAccAWSAPIGatewayIntegration_cache_key_parameters
--- PASS: TestAccAWSAPIGatewayIntegration_cache_key_parameters (293.59s)
=== RUN   TestAccAWSAPIGatewayUsagePlan_basic
--- PASS: TestAccAWSAPIGatewayUsagePlan_basic (49.98s)
=== RUN   TestAccAWSAPIGatewayIntegration_basic
--- PASS: TestAccAWSAPIGatewayIntegration_basic (406.65s)
=== RUN   TestAccAWSAPIGatewayDeployment_basic
--- PASS: TestAccAWSAPIGatewayDeployment_basic (413.57s)
=== RUN   TestAccAWSAPIGatewayUsagePlanKey_basic
--- PASS: TestAccAWSAPIGatewayUsagePlanKey_basic (238.75s)
=== RUN   TestAccAWSAPIGatewayUsagePlan_throttlingInitialRateLimit
--- PASS: TestAccAWSAPIGatewayUsagePlan_throttlingInitialRateLimit (72.88s)
=== RUN   TestAccAWSAPIGatewayUsagePlan_productCode
--- PASS: TestAccAWSAPIGatewayUsagePlan_productCode (152.80s)
=== RUN   TestAccAWSAPIGatewayUsagePlan_throttling
--- PASS: TestAccAWSAPIGatewayUsagePlan_throttling (177.31s)
=== RUN   TestAccAWSAPIGatewayMethodSettings_basic
--- PASS: TestAccAWSAPIGatewayMethodSettings_basic (616.63s)
=== RUN   TestAccAWSAPIGatewayDocumentationPart_importBasic
--- PASS: TestAccAWSAPIGatewayDocumentationPart_importBasic (657.89s)
=== RUN   TestAccAWSAPIGatewayUsagePlan_apiStages
--- PASS: TestAccAWSAPIGatewayUsagePlan_apiStages (123.29s)
=== RUN   TestAccAWSAPIGatewayEmptyBasePath_basic
--- PASS: TestAccAWSAPIGatewayEmptyBasePath_basic (713.74s)
=== RUN   TestAccAWSAPIGatewayDocumentationPart_method
--- PASS: TestAccAWSAPIGatewayDocumentationPart_method (735.00s)
=== RUN   TestAccAWSAPIGatewayAuthorizer_basic
--- PASS: TestAccAWSAPIGatewayAuthorizer_basic (795.83s)
=== RUN   TestAccAWSAPIGatewayApiKey_importBasic
--- PASS: TestAccAWSAPIGatewayApiKey_importBasic (826.12s)
=== RUN   TestAccAWSAPIGatewayModel_basic
--- PASS: TestAccAWSAPIGatewayModel_basic (830.32s)
=== RUN   TestAccAWSAPIGatewayUsagePlan_quota
--- PASS: TestAccAWSAPIGatewayUsagePlan_quota (415.52s)
=== RUN   TestAccAWSAPIGatewayBasePath_basic
--- PASS: TestAccAWSAPIGatewayBasePath_basic (975.13s)
=== RUN   TestAccAWSAPIGatewayDocumentationPart_basic
--- PASS: TestAccAWSAPIGatewayDocumentationPart_basic (999.71s)
=== RUN   TestAccAWSAPIGatewayUsagePlan_description
--- PASS: TestAccAWSAPIGatewayUsagePlan_description (680.16s)
=== RUN   TestAccAWSAPIGatewayIntegrationResponse_basic
--- PASS: TestAccAWSAPIGatewayIntegrationResponse_basic (1093.89s)
=== RUN   TestAccAWSAPIGatewayStage_basic
--- PASS: TestAccAWSAPIGatewayStage_basic (971.43s)
=== RUN   TestAccAWSAPIGatewayResource_basic
--- PASS: TestAccAWSAPIGatewayResource_basic (1061.84s)
=== RUN   TestAccAWSAPIGatewayGatewayResponse_basic
--- PASS: TestAccAWSAPIGatewayGatewayResponse_basic (1188.80s)
=== RUN   TestAccAWSAPIGatewayMethod_customrequestvalidator
--- PASS: TestAccAWSAPIGatewayMethod_customrequestvalidator (1213.91s)
=== RUN   TestAccAWSAPIGatewayMethod_customauthorizer
--- PASS: TestAccAWSAPIGatewayMethod_customauthorizer (1276.44s)
=== RUN   TestAccAWSAPIGatewayDocumentationPart_responseHeader
--- PASS: TestAccAWSAPIGatewayDocumentationPart_responseHeader (1354.96s)
```