### PR TITLE
resource/aws_emr_cluster: Retry creation on ValidationException (IAM)

### DIFF
--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -376,17 +376,26 @@ func resourceAwsEMRClusterCreate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	log.Printf("[DEBUG] EMR Cluster create options: %s", params)
-	resp, err := conn.RunJobFlow(params)
 
+	var resp *emr.RunJobFlowOutput
+	err := resource.Retry(30*time.Second, func() *resource.RetryError {
+		var err error
+		resp, err = conn.RunJobFlow(params)
+		if err != nil {
+			if isAWSErr(err, "ValidationException", "Invalid InstanceProfile:") {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
 	if err != nil {
-		log.Printf("[ERROR] %s", err)
 		return err
 	}
 
 	d.SetId(*resp.JobFlowId)
 
-	log.Println(
-		"[INFO] Waiting for EMR Cluster to be available")
+	log.Println("[INFO] Waiting for EMR Cluster to be available")
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"STARTING", "BOOTSTRAPPING"},


### PR DESCRIPTION
This is to address the following test failures caused by eventual consistency:

```
=== RUN   TestAccAWSEMRCluster_terminationProtected
--- FAIL: TestAccAWSEMRCluster_terminationProtected (31.22s)
    testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_emr_cluster.tf-test-cluster: 1 error(s) occurred:
        
        * aws_emr_cluster.tf-test-cluster: ValidationException: Invalid InstanceProfile: arn:aws:iam::*******:instance-profile/emr_profile_1856153968257931906.
            status code: 400, request id: 254aeef3-fb51-11e7-9e9d-cd5480f30d78
=== RUN   TestAccAWSEMRCluster_visibleToAllUsers
--- FAIL: TestAccAWSEMRCluster_visibleToAllUsers (53.67s)
    testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_emr_cluster.tf-test-cluster: 1 error(s) occurred:
        
        * aws_emr_cluster.tf-test-cluster: ValidationException: Invalid InstanceProfile: arn:aws:iam::*******:instance-profile/emr_profile_4968740420325977163.
            status code: 400, request id: 2f9d9aeb-fb51-11e7-82e3-f1fe4c15039a
=== RUN   TestAccAWSEMRCluster_basic
--- FAIL: TestAccAWSEMRCluster_basic (24.83s)
    testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_emr_cluster.tf-test-cluster: 1 error(s) occurred:
        
        * aws_emr_cluster.tf-test-cluster: ValidationException: Invalid InstanceProfile: arn:aws:iam::*******:instance-profile/emr_profile_500783995907791605.
            status code: 400, request id: 13c3efb4-fb51-11e7-8cb1-11ab57cf4bec
=== RUN   TestAccAWSEMRCluster_instance_group
--- FAIL: TestAccAWSEMRCluster_instance_group (39.47s)
    testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_emr_cluster.tf-test-cluster: 1 error(s) occurred:
        
        * aws_emr_cluster.tf-test-cluster: ValidationException: Invalid InstanceProfile: arn:aws:iam::*******:instance-profile/emr_profile_9031346896681791865.
            status code: 400, request id: 13db4851-fb51-11e7-9e9d-cd5480f30d78
=== RUN   TestAccAWSEMRCluster_root_volume_size
--- FAIL: TestAccAWSEMRCluster_root_volume_size (28.04s)
    testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_emr_cluster.tf-test-cluster: 1 error(s) occurred:
        
        * aws_emr_cluster.tf-test-cluster: ValidationException: Invalid InstanceProfile: arn:aws:iam::*******:instance-profile/emr_profile_6892146858256526138.
            status code: 400, request id: 39f0464d-fb51-11e7-acbd-b750accd83ef
=== RUN   TestAccAWSEMRInstanceGroup_basic
--- FAIL: TestAccAWSEMRInstanceGroup_basic (18.32s)
    testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_emr_cluster.tf-test-cluster: 1 error(s) occurred:
        
        * aws_emr_cluster.tf-test-cluster: ValidationException: Invalid InstanceProfile: arn:aws:iam::*******:instance-profile/emr_profile_3527589066725277676.
            status code: 400, request id: 454ee353-fb51-11e7-b1e7-09a314c1a2f6
=== RUN   TestAccAWSEMRInstanceGroup_ebsBasic
--- FAIL: TestAccAWSEMRInstanceGroup_ebsBasic (21.88s)
    testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_emr_cluster.tf-test-cluster: 1 error(s) occurred:
        
        * aws_emr_cluster.tf-test-cluster: ValidationException: Invalid InstanceProfile: arn:aws:iam::*******:instance-profile/emr_profile_2986140183728315022.
            status code: 400, request id: 5256006c-fb51-11e7-9e9d-cd5480f30d78
=== RUN   TestAccAWSEMRInstanceGroup_zero_count
--- FAIL: TestAccAWSEMRInstanceGroup_zero_count (21.22s)
    testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_emr_cluster.tf-test-cluster: 1 error(s) occurred:
        
        * aws_emr_cluster.tf-test-cluster: ValidationException: Invalid InstanceProfile: arn:aws:iam::*******:instance-profile/emr_profile_7691005927260896194.
            status code: 400, request id: 4aa4da72-fb51-11e7-af15-cd893ebf8cc9
```

## Test results

```
=== RUN   TestAccAWSEMRCluster_security_config
--- PASS: TestAccAWSEMRCluster_security_config (516.97s)
=== RUN   TestAccAWSEMRCluster_basic
--- PASS: TestAccAWSEMRCluster_basic (537.61s)
=== RUN   TestAccAWSEMRCluster_terminationProtected
--- PASS: TestAccAWSEMRCluster_terminationProtected (635.60s)
=== RUN   TestAccAWSEMRCluster_s3Logging
--- PASS: TestAccAWSEMRCluster_s3Logging (639.43s)
=== RUN   TestAccAWSEMRCluster_bootstrap_ordering
--- PASS: TestAccAWSEMRCluster_bootstrap_ordering (639.95s)
=== RUN   TestAccAWSEMRCluster_instance_group
--- PASS: TestAccAWSEMRCluster_instance_group (679.98s)
=== RUN   TestAccAWSEMRInstanceGroup_ebsBasic
--- PASS: TestAccAWSEMRInstanceGroup_ebsBasic (744.62s)
=== RUN   TestAccAWSEMRInstanceGroup_basic
--- PASS: TestAccAWSEMRInstanceGroup_basic (745.12s)
=== RUN   TestAccAWSEMRInstanceGroup_zero_count
--- PASS: TestAccAWSEMRInstanceGroup_zero_count (770.33s)
=== RUN   TestAccAWSEMRCluster_root_volume_size
--- PASS: TestAccAWSEMRCluster_root_volume_size (949.05s)
=== RUN   TestAccAWSEMRCluster_tags
--- PASS: TestAccAWSEMRCluster_tags (976.47s)
=== RUN   TestAccAWSEMRCluster_visibleToAllUsers
--- PASS: TestAccAWSEMRCluster_visibleToAllUsers (1009.24s)
```