### PR TITLE
resource/aws_iam_user_policy: Fix updates with generated policy names and validate JSON

### DIFF
--- a/aws/resource_aws_iam_user_policy.go
+++ b/aws/resource_aws_iam_user_policy.go
@@ -24,8 +24,10 @@ func resourceAwsIamUserPolicy() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"policy": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateFunc:     validateIAMPolicyJson,
+				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
 			},
 			"name": &schema.Schema{
 				Type:          schema.TypeString,
@@ -57,7 +59,9 @@ func resourceAwsIamUserPolicyPut(d *schema.ResourceData, meta interface{}) error
 	}
 
 	var policyName string
-	if v, ok := d.GetOk("name"); ok {
+	if d.Id() != "" {
+		_, policyName = resourceAwsIamUserPolicyParseId(d.Id())
+	} else if v, ok := d.GetOk("name"); ok {
 		policyName = v.(string)
 	} else if v, ok := d.GetOk("name_prefix"); ok {
 		policyName = resource.PrefixedUniqueId(v.(string))

--- a/aws/resource_aws_iam_user_policy.go
+++ b/aws/resource_aws_iam_user_policy.go
@@ -59,7 +59,7 @@ func resourceAwsIamUserPolicyPut(d *schema.ResourceData, meta interface{}) error
 	}
 
 	var policyName string
-	if d.Id() != "" {
+	if !d.IsNewResource() {
 		_, policyName = resourceAwsIamUserPolicyParseId(d.Id())
 	} else if v, ok := d.GetOk("name"); ok {
 		policyName = v.(string)


### PR DESCRIPTION
Replaces bugfix portions of #2450 
Closes #781

This also refactors the acceptance testing to check attributes, test policy updates for name/name_prefix/generated names, and starts to reuse test configurations where possible (e.g `testAccAWSUserConfig` from `aws_iam_user` tests).

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSIAMUserPolicy'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSIAMUserPolicy -timeout 120m
=== RUN   TestAccAWSIAMUserPolicy_basic
--- PASS: TestAccAWSIAMUserPolicy_basic (14.98s)
=== RUN   TestAccAWSIAMUserPolicy_namePrefix
--- PASS: TestAccAWSIAMUserPolicy_namePrefix (15.72s)
=== RUN   TestAccAWSIAMUserPolicy_generatedName
--- PASS: TestAccAWSIAMUserPolicy_generatedName (13.47s)
=== RUN   TestAccAWSIAMUserPolicy_multiplePolicies
--- PASS: TestAccAWSIAMUserPolicy_multiplePolicies (25.55s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	69.761s
```