### PR TITLE
resource/aws_lambda_function: Recompute Lambda function version and qualified_arn on publish

### DIFF
--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -206,11 +206,13 @@ func resourceAwsLambdaFunction() *schema.Resource {
 }
 
 func updateComputedAttributesOnPublish(d *schema.ResourceDiff, meta interface{}) error {
-	publish := d.Get("publish").(bool)
-	if publish && needsFunctionCodeUpdate(d) {
-		d.SetNewComputed("version")
-		d.SetNewComputed("qualified_arn")
+	if needsFunctionCodeUpdate(d) {
 		d.SetNewComputed("last_modified")
+		publish := d.Get("publish").(bool)
+		if publish {
+			d.SetNewComputed("version")
+			d.SetNewComputed("qualified_arn")
+		}
 	}
 	return nil
 }

--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -201,14 +201,16 @@ func resourceAwsLambdaFunction() *schema.Resource {
 			"tags": tagsSchema(),
 		},
 
-		CustomizeDiff: updateVerionIfPublish,
+		CustomizeDiff: updateComputedAttributesOnPublish,
 	}
 }
 
-func updateVerionIfPublish(d *schema.ResourceDiff, meta interface{}) error {
+func updateComputedAttributesOnPublish(d *schema.ResourceDiff, meta interface{}) error {
 	publish := d.Get("publish").(bool)
 	if publish && needsFunctionCodeUpdate(d) {
 		d.SetNewComputed("version")
+		d.SetNewComputed("qualified_arn")
+		d.SetNewComputed("last_modified")
 	}
 	return nil
 }


### PR DESCRIPTION
This change will cause the lambda function publishes to correctly trigger version updates that will affect downstream resources.

Fixes #626, #2915, #1124 and #3192