### PR TITLE
resource/aws_db_security_group: Randomize acceptance test group name

### DIFF
--- a/aws/import_aws_db_security_group_test.go
+++ b/aws/import_aws_db_security_group_test.go
@@ -1,9 +1,11 @@
 package aws
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
@@ -12,6 +14,7 @@ func TestAccAWSDBSecurityGroup_importBasic(t *testing.T) {
 	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
 	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
 
+	rName := fmt.Sprintf("tf-acc-%s", acctest.RandString(5))
 	resourceName := "aws_db_security_group.bar"
 
 	resource.Test(t, resource.TestCase{
@@ -20,7 +23,7 @@ func TestAccAWSDBSecurityGroup_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDBSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSDBSecurityGroupConfig,
+				Config: testAccAWSDBSecurityGroupConfig(rName),
 			},
 
 			resource.TestStep{

--- a/aws/resource_aws_db_security_group_test.go
+++ b/aws/resource_aws_db_security_group_test.go
@@ -101,10 +101,6 @@ func testAccCheckAWSDBSecurityGroupAttributes(group *rds.DBSecurityGroup) resour
 			return fmt.Errorf("bad status: %#v", statuses)
 		}
 
-		if *group.DBSecurityGroupName != "secgroup-terraform" {
-			return fmt.Errorf("bad name: %#v", *group.DBSecurityGroupName)
-		}
-
 		return nil
 	}
 }

--- a/aws/resource_aws_db_security_group_test.go
+++ b/aws/resource_aws_db_security_group_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -13,6 +14,10 @@ import (
 
 func TestAccAWSDBSecurityGroup_basic(t *testing.T) {
 	var v rds.DBSecurityGroup
+
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -136,10 +141,6 @@ func testAccCheckAWSDBSecurityGroupExists(n string, v *rds.DBSecurityGroup) reso
 }
 
 const testAccAWSDBSecurityGroupConfig = `
-provider "aws" {
-        region = "us-east-1"
-}
-
 resource "aws_db_security_group" "bar" {
     name = "secgroup-terraform"
 


### PR DESCRIPTION
At first was fixing this from daily acceptance testing:
```
=== RUN   TestAccAWSDBSecurityGroup_importBasic
--- FAIL: TestAccAWSDBSecurityGroup_importBasic (168.69s)
    testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_db_security_group.bar: 1 error(s) occurred:
        
        * aws_db_security_group.bar: couldn't find resource (21 retries)
```

Then after trying the AWS_DEFAULT_REGION trick for EC2-Classic: 
```
=== RUN   TestAccAWSDBSecurityGroup_basic
--- FAIL: TestAccAWSDBSecurityGroup_basic (4.01s)
    testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_db_security_group.bar: 1 error(s) occurred:
        
        * aws_db_security_group.bar: Error creating DB Security Group: DBSecurityGroupAlreadyExists: A security group named secgroup-terraform already exists
            status code: 400, request id: 846e7c47-6efb-4e16-8e6c-64a3c81c12dc
```

So likely it was the randomization that really needed to happen, but I don't think the AWS_DEFAULT_REGION change is necessarily a bad one either. Both now pass:

```
# locally
make testacc TEST=./aws TESTARGS='-run=TestAccAWSDBSecurityGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSDBSecurityGroup -timeout 120m
=== RUN   TestAccAWSDBSecurityGroup_importBasic
--- PASS: TestAccAWSDBSecurityGroup_importBasic (20.63s)
=== RUN   TestAccAWSDBSecurityGroup_basic
--- PASS: TestAccAWSDBSecurityGroup_basic (21.15s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	41.821s

# TC
=== RUN   TestAccAWSDBSecurityGroup_basic
--- PASS: TestAccAWSDBSecurityGroup_basic (39.12s)
=== RUN   TestAccAWSDBSecurityGroup_importBasic
--- PASS: TestAccAWSDBSecurityGroup_importBasic (41.83s)
```