### PR TITLE
resource/aws_security_group_rule: Fix regex escaping in TestAccAWSSecurityGroupRule_ExpectInvalidTypeError

### DIFF
--- a/aws/resource_aws_security_group_rule_test.go
+++ b/aws/resource_aws_security_group_rule_test.go
@@ -348,7 +348,7 @@ func TestAccAWSSecurityGroupRule_ExpectInvalidTypeError(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAWSSecurityGroupRuleExpectInvalidType(rInt),
-				ExpectError: regexp.MustCompile(`\\"type\\" contains an invalid Security Group Rule type \\"foobar\\"`),
+				ExpectError: regexp.MustCompile(`\"type\" contains an invalid Security Group Rule type \"foobar\"`),
 			},
 		},
 	})


### PR DESCRIPTION
From daily acceptance testing, old and busted:
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSSecurityGroupRule_ExpectInvalidTypeError'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSSecurityGroupRule_ExpectInvalidTypeError -timeout 120m
=== RUN   TestAccAWSSecurityGroupRule_ExpectInvalidTypeError
--- FAIL: TestAccAWSSecurityGroupRule_ExpectInvalidTypeError (1.63s)
	testing.go:506: Step 0, expected error:

		config is invalid: aws_security_group_rule.allow_self: "type" contains an invalid Security Group Rule type "foobar". Valid types are either "ingress" or "egress".

		To match:

		\\"type\\" contains an invalid Security Group Rule type \\"foobar\\"


FAIL
exit status 1
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	1.673s
make: *** [testacc] Error 1
```

New hotness:
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSSecurityGroupRule_ExpectInvalidTypeError'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSSecurityGroupRule_ExpectInvalidTypeError -timeout 120m
=== RUN   TestAccAWSSecurityGroupRule_ExpectInvalidTypeError
--- PASS: TestAccAWSSecurityGroupRule_ExpectInvalidTypeError (1.25s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1.291s
```