### PR TITLE
New Resource: aws_kms_grant

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -393,6 +393,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_kinesis_firehose_delivery_stream":         resourceAwsKinesisFirehoseDeliveryStream(),
 			"aws_kinesis_stream":                           resourceAwsKinesisStream(),
 			"aws_kms_alias":                                resourceAwsKmsAlias(),
+			"aws_kms_grant":                                resourceAwsKmsGrant(),
 			"aws_kms_key":                                  resourceAwsKmsKey(),
 			"aws_lambda_function":                          resourceAwsLambdaFunction(),
 			"aws_lambda_event_source_mapping":              resourceAwsLambdaEventSourceMapping(),

--- a/aws/resource_aws_kms_grant.go
+++ b/aws/resource_aws_kms_grant.go
@@ -1,0 +1,418 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsKmsGrant() *schema.Resource {
+	return &schema.Resource{
+		// There is no API for updating/modifying grants, hence no Update
+		// Instead changes to most fields will force a new resource
+		Create: resourceAwsKmsGrantCreate,
+		Read:   resourceAwsKmsGrantRead,
+		Delete: resourceAwsKmsGrantDelete,
+		Exists: resourceAwsKmsGrantExists,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateAwsKmsGrantName,
+			},
+			"key_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"grantee_principal": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArn,
+			},
+			"operations": {
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validateAwsKmsGrantOperation,
+				},
+				Required: true,
+				ForceNew: true,
+			},
+			"constraints": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"encryption_context_equals": {
+							Type:          schema.TypeMap,
+							Optional:      true,
+							Elem:          schema.TypeString,
+							ConflictsWith: []string{"constraints.0.encryption_context_subset"},
+						},
+						"encryption_context_subset": {
+							Type:          schema.TypeMap,
+							Optional:      true,
+							Elem:          schema.TypeString,
+							ConflictsWith: []string{"constraints.0.encryption_context_equals"},
+						},
+					},
+				},
+			},
+			"retiring_principal": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArn,
+			},
+			"grant_creation_tokens": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
+				ForceNew: true,
+			},
+			"grant_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"grant_token": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsKmsGrantCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).kmsconn
+
+	input := kms.CreateGrantInput{
+		GranteePrincipal: aws.String(d.Get("grantee_principal").(string)),
+		KeyId:            aws.String(d.Get("key_id").(string)),
+		Operations:       expandStringList(d.Get("operations").([]interface{})),
+	}
+
+	if v, ok := d.GetOk("name"); ok {
+		input.Name = aws.String(v.(string))
+	}
+	if v, ok := d.GetOk("constraints"); ok {
+		input.Constraints = expandKmsGrantConstraints(v.([]interface{}))
+	}
+	if v, ok := d.GetOk("retiring_principal"); ok {
+		input.RetiringPrincipal = aws.String(v.(string))
+	}
+	if v, ok := d.GetOk("grant_creation_tokens"); ok {
+		input.GrantTokens = expandStringList(v.([]interface{}))
+	}
+
+	log.Printf("[DEBUG]: Adding new KMS Grant: %s", input)
+
+	var out *kms.CreateGrantOutput
+
+	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+		var err error
+
+		out, err = conn.CreateGrant(&input)
+
+		if err != nil {
+			if awsErr, ok := err.(awserr.Error); ok {
+				// Error Codes: https://docs.aws.amazon.com/sdk-for-go/api/service/kms/#KMS.CreateGrant
+				// Under some circumstances a newly created IAM Role doesn't show up and causes
+				// an InvalidArnException to be thrown. TODO: Possibly change the aws_iam_role code?
+				if awsErr.Code() == "DependencyTimeoutException" ||
+					awsErr.Code() == "InternalException" ||
+					awsErr.Code() == "InvalidArnException" {
+					return resource.RetryableError(
+						fmt.Errorf("[WARN] Error adding new KMS Grant for key: %s, retrying %s",
+							*input.KeyId, err))
+				}
+			}
+			log.Printf("[ERROR] An error occured creating new AWS KMS Grant: %s", err)
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] Created new KMS Grant: %s", *out.GrantId)
+	d.SetId(*out.GrantId)
+	d.Set("grant_id", out.GrantId)
+	d.Set("grant_token", out.GrantToken)
+
+	return resourceAwsKmsGrantRead(d, meta)
+}
+
+func resourceAwsKmsGrantRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).kmsconn
+
+	grantId := d.Id()
+	keyId := d.Get("key_id").(string)
+
+	log.Printf("[DEBUG] Looking for grant id: %s", grantId)
+	grant, err := findKmsGrantByIdWithRetry(conn, keyId, grantId)
+
+	if err != nil {
+		return err
+	}
+	if grant != nil {
+		// The grant sometimes contains principals that identified by their unique id: "AROAJYCVIVUZIMTXXXXX"
+		// instead of "arn:aws:...", in this case don't update the state file
+		if strings.HasPrefix(*grant.GranteePrincipal, "arn:aws") {
+			d.Set("grantee_principal", grant.GranteePrincipal)
+		} else {
+			log.Printf(
+				"[WARN] Unable to update grantee principal state %s for grant id %s for key id %s.",
+				*grant.GranteePrincipal, grantId, keyId)
+		}
+
+		if grant.RetiringPrincipal != nil {
+			if strings.HasPrefix(*grant.RetiringPrincipal, "arn:aws") {
+				d.Set("retiring_principal", grant.RetiringPrincipal)
+			} else {
+				log.Printf(
+					"[WARN] Unable to update retiring principal state %s for grant id %s for key id %s",
+					*grant.RetiringPrincipal, grantId, keyId)
+			}
+		}
+
+		d.Set("operations", grant.Operations)
+		if *grant.Name != "" {
+			d.Set("name", grant.Name)
+		}
+		if grant.Constraints != nil {
+			d.Set("constraints", flattenKmsGrantConstraints(grant.Constraints))
+		}
+	} else {
+		log.Printf("[WARN] %s KMS grant id not found for key id %s, removing from state file", grantId, keyId)
+		d.SetId("")
+	}
+
+	return nil
+}
+
+// Retiring grants requires special permissions (i.e. the
+// caller to be root, retiree principal, or grantee principal with retire grant
+// privileges). So just revoke grants.
+func resourceAwsKmsGrantDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).kmsconn
+
+	grantId := d.Get("grant_id").(string)
+	keyId := d.Get("key_id").(string)
+	input := kms.RevokeGrantInput{
+		GrantId: aws.String(grantId),
+		KeyId:   aws.String(keyId),
+	}
+
+	log.Printf("[DEBUG] Revoking KMS grant: %s", grantId)
+	_, err := conn.RevokeGrant(&input)
+
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] Checking if grant is revoked: %s", grantId)
+	err = waitForKmsGrantToBeRevoked(conn, keyId, grantId)
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourceAwsKmsGrantExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	conn := meta.(*AWSClient).kmsconn
+
+	grantId := d.Id()
+	keyId := d.Get("key_id").(string)
+
+	log.Printf("[DEBUG] Looking for Grant: %s", grantId)
+	grant, err := findKmsGrantByIdWithRetry(conn, keyId, grantId)
+
+	if err != nil {
+		if grant != nil {
+			return true, err
+		}
+		return false, err
+	}
+	if grant != nil {
+		return true, err
+	}
+
+	return false, err
+}
+
+func getKmsGrantById(grants []*kms.GrantListEntry, grantIdentifier string) *kms.GrantListEntry {
+	for idx := range grants {
+		if *grants[idx].GrantId == grantIdentifier {
+			return grants[idx]
+		}
+	}
+
+	return nil
+}
+
+/*
+In the functions below it is not possible to use retryOnAwsCodes function, as there
+is no describe grants call, so an error has to be created if the grant is or isn't returned
+by the list grants call when expected.
+*/
+
+// NB: This function only retries the grant not being returned and some edge cases, while AWS Errors
+// are handled by the findKmsGrantById function
+func findKmsGrantByIdWithRetry(conn *kms.KMS, keyId string, grantId string) (*kms.GrantListEntry, error) {
+	var grant *kms.GrantListEntry
+	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+		var err error
+		grant, err = findKmsGrantById(conn, keyId, grantId, nil)
+
+		if err != nil {
+			if serr, ok := err.(KmsGrantMissingError); ok {
+				// Force a retry if the grant should exist
+				return resource.RetryableError(serr)
+			}
+
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	return grant, err
+}
+
+// Used by the tests as well
+func waitForKmsGrantToBeRevoked(conn *kms.KMS, keyId string, grantId string) error {
+	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+		grant, err := findKmsGrantById(conn, keyId, grantId, nil)
+		if err != nil {
+			if _, ok := err.(KmsGrantMissingError); ok {
+				if grant == nil {
+					return nil
+				}
+			}
+		}
+
+		if grant != nil {
+			// Force a retry if the grant still exists
+			return resource.RetryableError(
+				fmt.Errorf("[DEBUG] Grant still exists while expected to be revoked, retyring revocation check: %s", *grant.GrantId))
+		}
+
+		return resource.NonRetryableError(err)
+	})
+
+	return err
+}
+
+// The ListGrants API defaults to listing only 50 grants
+// Use a marker to iterate over all grants in "pages"
+// NB: This function only retries on AWS Errors
+func findKmsGrantById(conn *kms.KMS, keyId string, grantId string, marker *string) (*kms.GrantListEntry, error) {
+
+	input := kms.ListGrantsInput{
+		KeyId:  aws.String(keyId),
+		Limit:  aws.Int64(int64(100)),
+		Marker: marker,
+	}
+
+	var out *kms.ListGrantsResponse
+	var err error
+	var grant *kms.GrantListEntry
+
+	err = resource.Retry(2*time.Minute, func() *resource.RetryError {
+		out, err = conn.ListGrants(&input)
+
+		if err != nil {
+			if awsErr, ok := err.(awserr.Error); ok {
+				if awsErr.Code() == "NotFoundException" ||
+					awsErr.Code() == "DependencyTimeoutException" ||
+					awsErr.Code() == "InternalException" {
+					return resource.RetryableError(err)
+				}
+			}
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	grant = getKmsGrantById(out.Grants, grantId)
+	if grant != nil {
+		return grant, nil
+	}
+	if *out.Truncated {
+		log.Printf("[DEBUG] KMS Grant list truncated, getting next page via marker: %s", *out.NextMarker)
+		return findKmsGrantById(conn, keyId, grantId, out.NextMarker)
+	}
+
+	return nil, NewKmsGrantMissingError(fmt.Sprintf("[DEBUG] Grant %s not found for key id: %s", grantId, keyId))
+}
+
+func expandKmsGrantConstraints(configured []interface{}) *kms.GrantConstraints {
+	if len(configured) < 1 {
+		return nil
+	}
+
+	var constraint kms.GrantConstraints
+
+	for _, raw := range configured {
+		data := raw.(map[string]interface{})
+		if contextEq, ok := data["encryption_context_equals"]; ok {
+			constraint.EncryptionContextEquals = stringMapToPointers(contextEq.(map[string]interface{}))
+		}
+		if contextSub, ok := data["encryption_context_subset"]; ok {
+			constraint.SetEncryptionContextSubset(stringMapToPointers(contextSub.(map[string]interface{})))
+		}
+	}
+
+	return &constraint
+}
+
+func flattenKmsGrantConstraints(constraint *kms.GrantConstraints) []interface{} {
+	if constraint == nil {
+		return []interface{}{}
+	}
+
+	m := make(map[string]interface{}, 0)
+
+	if constraint.EncryptionContextEquals != nil {
+		m["encryption_context_equals"] = pointersMapToStringList(constraint.EncryptionContextEquals)
+	}
+	if constraint.EncryptionContextSubset != nil {
+		m["encryption_context_subset"] = pointersMapToStringList(constraint.EncryptionContextSubset)
+	}
+
+	return []interface{}{m}
+}
+
+// Custom error, so we don't have to rely on
+// the content of an error message
+type KmsGrantMissingError struct {
+	msg string
+}
+
+func (e KmsGrantMissingError) Error() string {
+	return e.msg
+}
+
+func NewKmsGrantMissingError(msg string) KmsGrantMissingError {
+	return KmsGrantMissingError{
+		msg: msg,
+	}
+}

--- a/aws/resource_aws_kms_grant.go
+++ b/aws/resource_aws_kms_grant.go
@@ -205,14 +205,14 @@ func resourceAwsKmsGrantRead(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if err := d.Set("operations", aws.StringValueSlice(grant.Operations)); err != nil {
-			log.Print("[DEBUG] Error setting operations for grant %s with error %s", grantId, err)
+			log.Printf("[DEBUG] Error setting operations for grant %s with error %s", grantId, err)
 		}
 		if *grant.Name != "" {
 			d.Set("name", grant.Name)
 		}
 		if grant.Constraints != nil {
 			if err := d.Set("constraints", flattenKmsGrantConstraints(grant.Constraints)); err != nil {
-				log.Print("[DEBUG] Error setting constraints for grant %s with error %s", grantId, err)
+				log.Printf("[DEBUG] Error setting constraints for grant %s with error %s", grantId, err)
 			}
 		}
 	}

--- a/aws/resource_aws_kms_grant_test.go
+++ b/aws/resource_aws_kms_grant_test.go
@@ -1,0 +1,238 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAWSKmsGrant_Basic(t *testing.T) {
+	timestamp := time.Now().Format(time.RFC1123)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSKmsGrantDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSKmsGrant_Basic("basic", timestamp, "\"Encrypt\", \"Decrypt\""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSKmsGrantExists("aws_kms_grant.basic"),
+					resource.TestCheckResourceAttr("aws_kms_grant.basic", "name", "basic"),
+					resource.TestCheckResourceAttr("aws_kms_grant.basic", "operations.#", "2"),
+					resource.TestCheckResourceAttr("aws_kms_grant.basic", "operations.0", "Encrypt"),
+					resource.TestCheckResourceAttr("aws_kms_grant.basic", "operations.1", "Decrypt"),
+					resource.TestCheckResourceAttrSet("aws_kms_grant.basic", "grantee_principal"),
+					resource.TestCheckResourceAttrSet("aws_kms_grant.basic", "key_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAWSKmsGrant_withConstraints(t *testing.T) {
+	timestamp := time.Now().Format(time.RFC1123)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSKmsGrantDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSKmsGrant_withConstraints("withConstraints", timestamp, "foo = \"bar\""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSKmsGrantExists("aws_kms_grant.withConstraints"),
+					resource.TestCheckResourceAttr("aws_kms_grant.withConstraints", "name", "withConstraints"),
+					resource.TestCheckResourceAttr("aws_kms_grant.withConstraints", "constraints.0.encryption_context_equals.foo", "bar"),
+				),
+			},
+		},
+	})
+}
+
+func TestAWSKmsGrant_withRetiringPrincipal(t *testing.T) {
+	timestamp := time.Now().Format(time.RFC1123)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSKmsGrantDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSKmsGrant_withRetiringPrincipal("withRetiringPrincipal", timestamp),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSKmsGrantExists("aws_kms_grant.withRetiringPrincipal"),
+					resource.TestCheckResourceAttrSet("aws_kms_grant.withRetiringPrincipal", "retiring_principal"),
+				),
+			},
+		},
+	})
+}
+
+func TestAWSKmsGrant_bare(t *testing.T) {
+	timestamp := time.Now().Format(time.RFC1123)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSKmsGrantDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSKmsGrant_bare("bare", timestamp),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSKmsGrantExists("aws_kms_grant.bare"),
+					resource.TestCheckNoResourceAttr("aws_kms_grant.bare", "name"),
+					resource.TestCheckNoResourceAttr("aws_kms_grant.bare", "constraints.#"),
+					resource.TestCheckNoResourceAttr("aws_kms_grant.bare", "retiring_principal"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSKmsGrantDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).kmsconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_kms_grant" {
+			continue
+		}
+
+		err := waitForKmsGrantToBeRevoked(conn, rs.Primary.Attributes["key_id"], rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	return nil
+}
+
+func testAccCheckAWSKmsGrantExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("not found: %s", name)
+		}
+
+		return nil
+	}
+}
+
+func testAccAWSKmsGrant_Basic(rName string, timestamp string, operations string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "tf-acc-test-key" {
+    description = "Terraform acc test key %s"
+    deletion_window_in_days = 7
+}
+
+%s
+
+resource "aws_iam_role" "tf-acc-test-role" {
+  name               = "tf-acc-test-kms-grant-role-%s"
+  path               = "/service-role/"
+  assume_role_policy = "${data.aws_iam_policy_document.assumerole-policy-template.json}"
+}
+
+resource "aws_kms_grant" "%s" {
+	name = "%s"
+	key_id = "${aws_kms_key.tf-acc-test-key.key_id}"
+	grantee_principal = "${aws_iam_role.tf-acc-test-role.arn}"
+	operations = [ %s ]
+}
+`, timestamp, staticAssumeRolePolicyString, rName, rName, rName, operations)
+}
+
+func testAccAWSKmsGrant_withConstraints(rName string, timestamp string, encryptionContextEq string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "tf-acc-test-key" {
+    description = "Terraform acc test key %s"
+    deletion_window_in_days = 7
+}
+
+%s
+
+resource "aws_iam_role" "tf-acc-test-role" {
+  name               = "tf-acc-test-kms-grant-role-%s"
+  path               = "/service-role/"
+  assume_role_policy = "${data.aws_iam_policy_document.assumerole-policy-template.json}"
+}
+
+resource "aws_kms_grant" "%s" {
+	name = "%s"
+	key_id = "${aws_kms_key.tf-acc-test-key.key_id}"
+	grantee_principal = "${aws_iam_role.tf-acc-test-role.arn}"
+	operations = [ "RetireGrant", "DescribeKey" ]
+	constraints {
+		encryption_context_equals {
+			%s
+		}
+	}
+}
+`, timestamp, staticAssumeRolePolicyString, rName, rName, rName, encryptionContextEq)
+}
+
+func testAccAWSKmsGrant_withRetiringPrincipal(rName string, timestamp string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "tf-acc-test-key" {
+    description = "Terraform acc test key %s"
+    deletion_window_in_days = 7
+}
+
+%s
+
+resource "aws_iam_role" "tf-acc-test-role" {
+  name               = "tf-acc-test-kms-grant-role-%s"
+  path               = "/service-role/"
+  assume_role_policy = "${data.aws_iam_policy_document.assumerole-policy-template.json}"
+}
+
+resource "aws_kms_grant" "%s" {
+	name = "%s"
+	key_id = "${aws_kms_key.tf-acc-test-key.key_id}"
+	grantee_principal = "${aws_iam_role.tf-acc-test-role.arn}"
+	operations = [ "ReEncryptTo", "CreateGrant" ]
+	retiring_principal = "${aws_iam_role.tf-acc-test-role.arn}"
+}
+`, timestamp, staticAssumeRolePolicyString, rName, rName, rName)
+}
+
+func testAccAWSKmsGrant_bare(rName string, timestamp string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "tf-acc-test-key" {
+    description = "Terraform acc test key %s"
+    deletion_window_in_days = 7
+}
+
+%s
+
+resource "aws_iam_role" "tf-acc-test-role" {
+  name               = "tf-acc-test-kms-grant-role-%s"
+  path               = "/service-role/"
+  assume_role_policy = "${data.aws_iam_policy_document.assumerole-policy-template.json}"
+}
+
+resource "aws_kms_grant" "%s" {
+	key_id = "${aws_kms_key.tf-acc-test-key.key_id}"
+	grantee_principal = "${aws_iam_role.tf-acc-test-role.arn}"
+	operations = [ "ReEncryptTo", "CreateGrant" ]
+}
+`, timestamp, staticAssumeRolePolicyString, rName, rName)
+}
+
+var staticAssumeRolePolicyString = `
+data "aws_iam_policy_document" "assumerole-policy-template" {
+  statement {
+    effect  = "Allow"
+    actions = [ "sts:AssumeRole" ]
+    principals {
+      type        = "Service"
+      identifiers = [ "ec2.amazonaws.com" ]
+    }
+  }
+}
+`

--- a/aws/resource_aws_kms_grant_test.go
+++ b/aws/resource_aws_kms_grant_test.go
@@ -23,8 +23,6 @@ func TestAWSKmsGrant_Basic(t *testing.T) {
 					testAccCheckAWSKmsGrantExists("aws_kms_grant.basic"),
 					resource.TestCheckResourceAttr("aws_kms_grant.basic", "name", "basic"),
 					resource.TestCheckResourceAttr("aws_kms_grant.basic", "operations.#", "2"),
-					resource.TestCheckResourceAttr("aws_kms_grant.basic", "operations.0", "Encrypt"),
-					resource.TestCheckResourceAttr("aws_kms_grant.basic", "operations.1", "Decrypt"),
 					resource.TestCheckResourceAttrSet("aws_kms_grant.basic", "grantee_principal"),
 					resource.TestCheckResourceAttrSet("aws_kms_grant.basic", "key_id"),
 				),

--- a/aws/resource_aws_kms_grant_test.go
+++ b/aws/resource_aws_kms_grant_test.go
@@ -44,7 +44,7 @@ func TestAWSKmsGrant_withConstraints(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSKmsGrantExists("aws_kms_grant.withConstraints"),
 					resource.TestCheckResourceAttr("aws_kms_grant.withConstraints", "name", "withConstraints"),
-					resource.TestCheckResourceAttr("aws_kms_grant.withConstraints", "constraints.0.encryption_context_equals.foo", "bar"),
+					resource.TestCheckResourceAttr("aws_kms_grant.withConstraints", "constraints.#", "1"),
 				),
 			},
 		},

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1398,21 +1398,26 @@ func validateAwsKmsName(v interface{}, k string) (ws []string, es []error) {
 func validateAwsKmsGrantOperation(v interface{}, k string) (ws []string, es []error) {
 	value := v.(string)
 
-	validTypes := map[string]bool{
-		"Decrypt":                         true,
-		"Encrypt":                         true,
-		"GenerateDataKey":                 true,
-		"GenerateDataKeyWithoutPlaintext": true,
-		"ReEncryptFrom":                   true,
-		"ReEncryptTo":                     true,
-		"CreateGrant":                     true,
-		"RetireGrant":                     true,
-		"DescribeKey":                     true,
+	validTypes := map[string]struct{}{
+		"Decrypt":                         {},
+		"Encrypt":                         {},
+		"GenerateDataKey":                 {},
+		"GenerateDataKeyWithoutPlaintext": {},
+		"ReEncryptFrom":                   {},
+		"ReEncryptTo":                     {},
+		"CreateGrant":                     {},
+		"RetireGrant":                     {},
+		"DescribeKey":                     {},
+	}
+
+	validOperations := make([]string, len(validTypes))
+	for operation := range validTypes {
+		validOperations = append(validOperations, operation)
 	}
 
 	if _, ok := validTypes[value]; !ok {
 		es = append(es, fmt.Errorf(
-			"%s must be one of the following: [ Decrypt, Encrypt, GenerateDataKey, GenerateDataKeyWithoutPlaintext, ReEncryptFrom, ReEncryptTo, CreateGrant, RetireGrant, DescribeKey ]", k))
+			"%s must be one of the following: %v", k, validOperations))
 
 	}
 	return

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1395,34 +1395,6 @@ func validateAwsKmsName(v interface{}, k string) (ws []string, es []error) {
 	return
 }
 
-func validateAwsKmsGrantOperation(v interface{}, k string) (ws []string, es []error) {
-	value := v.(string)
-
-	validTypes := map[string]struct{}{
-		"Decrypt":                         {},
-		"Encrypt":                         {},
-		"GenerateDataKey":                 {},
-		"GenerateDataKeyWithoutPlaintext": {},
-		"ReEncryptFrom":                   {},
-		"ReEncryptTo":                     {},
-		"CreateGrant":                     {},
-		"RetireGrant":                     {},
-		"DescribeKey":                     {},
-	}
-
-	validOperations := make([]string, len(validTypes))
-	for operation := range validTypes {
-		validOperations = append(validOperations, operation)
-	}
-
-	if _, ok := validTypes[value]; !ok {
-		es = append(es, fmt.Errorf(
-			"%s must be one of the following: %v", k, validOperations))
-
-	}
-	return
-}
-
 func validateAwsKmsGrantName(v interface{}, k string) (ws []string, es []error) {
 	value := v.(string)
 

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1395,6 +1395,43 @@ func validateAwsKmsName(v interface{}, k string) (ws []string, es []error) {
 	return
 }
 
+func validateAwsKmsGrantOperation(v interface{}, k string) (ws []string, es []error) {
+	value := v.(string)
+
+	validTypes := map[string]bool{
+		"Decrypt":                         true,
+		"Encrypt":                         true,
+		"GenerateDataKey":                 true,
+		"GenerateDataKeyWithoutPlaintext": true,
+		"ReEncryptFrom":                   true,
+		"ReEncryptTo":                     true,
+		"CreateGrant":                     true,
+		"RetireGrant":                     true,
+		"DescribeKey":                     true,
+	}
+
+	if _, ok := validTypes[value]; !ok {
+		es = append(es, fmt.Errorf(
+			"%s must be one of the following: [ Decrypt, Encrypt, GenerateDataKey, GenerateDataKeyWithoutPlaintext, ReEncryptFrom, ReEncryptTo, CreateGrant, RetireGrant, DescribeKey ]", k))
+
+	}
+	return
+}
+
+func validateAwsKmsGrantName(v interface{}, k string) (ws []string, es []error) {
+	value := v.(string)
+
+	if len(value) > 256 {
+		es = append(es, fmt.Errorf("%s can not be greater than 256 characters", k))
+	}
+
+	if !regexp.MustCompile(`^[a-zA-Z0-9:/_-]+$`).MatchString(value) {
+		es = append(es, fmt.Errorf("%s must only contain [a-zA-Z0-9:/_-]", k))
+	}
+
+	return
+}
+
 func validateCognitoIdentityPoolName(v interface{}, k string) (ws []string, errors []error) {
 	val := v.(string)
 	if !regexp.MustCompile("^[\\w _]+$").MatchString(val) {

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -2179,6 +2179,69 @@ func TestValidateAwsKmsName(t *testing.T) {
 	}
 }
 
+func TestValidateAwsKmsGrantName(t *testing.T) {
+	validValues := []string{
+		"123",
+		"Abc",
+		"grant_1",
+		"grant:/-",
+	}
+
+	for _, s := range validValues {
+		_, errors := validateAwsKmsGrantName(s, "name")
+		if len(errors) > 0 {
+			t.Fatalf("%q AWS KMS Grant Name should have been valid: %v", s, errors)
+		}
+	}
+
+	invalidValues := []string{
+		strings.Repeat("w", 257),
+		"grant.invalid",
+		";",
+		"white space",
+	}
+
+	for _, s := range invalidValues {
+		_, errors := validateAwsKmsGrantName(s, "name")
+		if len(errors) == 0 {
+			t.Fatalf("%q should not be a valid AWS KMS Grant Name", s)
+		}
+	}
+}
+
+func TestValidateAwsKmsGrantOperation(t *testing.T) {
+	validValues := []string{
+		"Decrypt",
+		"Encrypt",
+		"GenerateDataKey",
+		"GenerateDataKeyWithoutPlaintext",
+		"ReEncryptFrom",
+		"ReEncryptTo",
+		"CreateGrant",
+		"RetireGrant",
+		"DescribeKey",
+	}
+
+	for _, s := range validValues {
+		_, errors := validateAwsKmsGrantOperation(s, "operation")
+		if len(errors) > 0 {
+			t.Fatalf("%q should be a valid AWS KMS Grant Operation: %v", s, errors)
+		}
+	}
+
+	invalidValues := []string{
+		"foo",
+		"bar",
+	}
+
+	for _, s := range invalidValues {
+		_, errors := validateAwsKmsGrantOperation(s, "operation")
+		if len(errors) == 0 {
+			t.Fatalf("%q should not be a valid AWS KMS Grant Operation", s)
+		}
+	}
+}
+
 func TestValidateCognitoIdentityPoolName(t *testing.T) {
 	validValues := []string{
 		"123",

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -2209,39 +2209,6 @@ func TestValidateAwsKmsGrantName(t *testing.T) {
 	}
 }
 
-func TestValidateAwsKmsGrantOperation(t *testing.T) {
-	validValues := []string{
-		"Decrypt",
-		"Encrypt",
-		"GenerateDataKey",
-		"GenerateDataKeyWithoutPlaintext",
-		"ReEncryptFrom",
-		"ReEncryptTo",
-		"CreateGrant",
-		"RetireGrant",
-		"DescribeKey",
-	}
-
-	for _, s := range validValues {
-		_, errors := validateAwsKmsGrantOperation(s, "operation")
-		if len(errors) > 0 {
-			t.Fatalf("%q should be a valid AWS KMS Grant Operation: %v", s, errors)
-		}
-	}
-
-	invalidValues := []string{
-		"foo",
-		"bar",
-	}
-
-	for _, s := range invalidValues {
-		_, errors := validateAwsKmsGrantOperation(s, "operation")
-		if len(errors) == 0 {
-			t.Fatalf("%q should not be a valid AWS KMS Grant Operation", s)
-		}
-	}
-}
-
 func TestValidateCognitoIdentityPoolName(t *testing.T) {
 	validValues := []string{
 		"123",

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1107,6 +1107,10 @@
                     <a href="/docs/providers/aws/r/kms_alias.html">aws_kms_alias</a>
                   </li>
 
+                  <li<%= sidebar_current("docs-aws-resource-kms-grant") %>>
+                    <a href="/docs/providers/aws/r/kms_grant.html">aws_kms_grant</a>
+                  </li>
+
                   <li<%= sidebar_current("docs-aws-resource-kms-key") %>>
                     <a href="/docs/providers/aws/r/kms_key.html">aws_kms_key</a>
                   </li>

--- a/website/docs/r/kms_grant.html.markdown
+++ b/website/docs/r/kms_grant.html.markdown
@@ -1,0 +1,73 @@
+---
+layout: "aws"
+page_title: "AWS: aws_kms_grant"
+sidebar_current: "docs-aws-resource-kms-grant"
+description: |-
+  Provides a resource-based access control mechanism for KMS Customer Master Keys.
+---
+
+# aws_kms_grant
+
+Provides a resource-based access control mechanism for a KMS customer master key.
+
+## Example Usage
+
+```hcl
+resource "aws_kms_key" "a" {}
+
+resource "aws_iam_role" "a" {
+name = "iam-role-for-grant"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_kms_grant" "a" {
+  name              = "my-grant"
+  key_id            = "${aws_kms_key.a.key_id}"
+  grantee_principal = "${aws_iam_role.a.arn}"
+  operations        = [ "Encrypt", "Decrypt", "GenerateDataKey" ]
+  constraints {
+    encryption_context_equals {
+      Department = "Finance"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Optional, Forces new resources) A friendly name for identifying the grant.
+* `key_id` - (Required, Forces new resources) The unique identifier for the customer master key (CMK) that the grant applies to.
+* `grantee_principal` - (Required, Forces new resources) The principal that is given permission to perform the operations that the grant permits.
+* `operations` - (Required, Forces new resources) A list of operations that the grant permits. The permitted values are: `Decrypt, Encrypt, GenerateDataKey, GenerateDataKeyWithoutPlaintext, ReEncryptFrom, ReEncryptTo, CreateGrant, RetireGrant, DescribeKey`
+* `retiree_principal` - (Optional, Forces new resources) The principal that is given permission to retire the grant by using RetireGrant operation.
+* `constraints` - (Optional, Forces new resources) A structure that you can use to allow certain operations in the grant only when the desired encryption context is present. For more information about encryption context, see [Encryption Context](http://docs.aws.amazon.com/kms/latest/developerguide/encryption-context.html).
+* `grant_creation_tokens` - (Optional, Forces new resources) A list of grant tokens to be used when creating the grant. See [Grant Tokens](http://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token) for more information about grant tokens.
+
+The `constraints` block supports the following arguments:
+
+* `encryption_context_equals` - (Optional) A list of key-value pairs that must be present in the encryption context of certain subsequent operations that the grant allows. Conflicts with `encryption_context_subset`.
+* `encryption_context_subset` - (Optional) A list of key-value pairs, all of which must be present in the encryption context of certain subsequent operations that the grant allows. Conflicts with `encryption_context_equals`.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `grant_id` - The unique identifier for the grant.
+* `grant_token` - The grant token for the created grant. For more information, see [Grant Tokens](http://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token).

--- a/website/docs/r/kms_grant.html.markdown
+++ b/website/docs/r/kms_grant.html.markdown
@@ -59,6 +59,8 @@ The following arguments are supported:
 * `retiree_principal` - (Optional, Forces new resources) The principal that is given permission to retire the grant by using RetireGrant operation.
 * `constraints` - (Optional, Forces new resources) A structure that you can use to allow certain operations in the grant only when the desired encryption context is present. For more information about encryption context, see [Encryption Context](http://docs.aws.amazon.com/kms/latest/developerguide/encryption-context.html).
 * `grant_creation_tokens` - (Optional, Forces new resources) A list of grant tokens to be used when creating the grant. See [Grant Tokens](http://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token) for more information about grant tokens.
+* `retire_on_delete` -(Defaults to false, Forces new resources) If set to false (the default) the grants will be revoked upon deletion, and if set to true the grants will try to be retired upon deletion. Note that retiring grants requires special permissions, hence why we default to revoking grants.
+  See [RetireGrant](https://docs.aws.amazon.com/kms/latest/APIReference/API_RetireGrant.html) for more information.
 
 The `constraints` block supports the following arguments:
 

--- a/website/docs/r/kms_grant.html.markdown
+++ b/website/docs/r/kms_grant.html.markdown
@@ -54,9 +54,9 @@ The following arguments are supported:
 
 * `name` - (Optional, Forces new resources) A friendly name for identifying the grant.
 * `key_id` - (Required, Forces new resources) The unique identifier for the customer master key (CMK) that the grant applies to.
-* `grantee_principal` - (Required, Forces new resources) The principal that is given permission to perform the operations that the grant permits.
+* `grantee_principal` - (Required, Forces new resources) The principal that is given permission to perform the operations that the grant permits in ARN format. Note that due to eventual consistency issues around IAM principals, terraform's state may not always be refreshed to reflect what is true in AWS.
 * `operations` - (Required, Forces new resources) A list of operations that the grant permits. The permitted values are: `Decrypt, Encrypt, GenerateDataKey, GenerateDataKeyWithoutPlaintext, ReEncryptFrom, ReEncryptTo, CreateGrant, RetireGrant, DescribeKey`
-* `retiree_principal` - (Optional, Forces new resources) The principal that is given permission to retire the grant by using RetireGrant operation.
+* `retiree_principal` - (Optional, Forces new resources) The principal that is given permission to retire the grant by using RetireGrant operation in ARN format. Note that due to eventual consistency issues around IAM principals, terraform's state may not always be refreshed to reflect what is true in AWS.
 * `constraints` - (Optional, Forces new resources) A structure that you can use to allow certain operations in the grant only when the desired encryption context is present. For more information about encryption context, see [Encryption Context](http://docs.aws.amazon.com/kms/latest/developerguide/encryption-context.html).
 * `grant_creation_tokens` - (Optional, Forces new resources) A list of grant tokens to be used when creating the grant. See [Grant Tokens](http://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token) for more information about grant tokens.
 * `retire_on_delete` -(Defaults to false, Forces new resources) If set to false (the default) the grants will be revoked upon deletion, and if set to true the grants will try to be retired upon deletion. Note that retiring grants requires special permissions, hence why we default to revoking grants.


### PR DESCRIPTION
Hey,

Basically I think this is close to being ready to merge, but I see two flaws with it:

* Dealing with the `InvalidArnException` upon creation of a grant that depends on a newly created role. I have a retry in my code, but it will just retry in the case that the arn is actually invalid. I don't see a way to distinguish between eventual consistency and a truly invalid arn.
  - I think this maybe okay behavior.
* In a similar vein, if you refresh the state quickly after creating a role and grant (as is the case with the acceptance tests currently). The read function will sometimes get an internal identifier (AROAXXXXX instad of arn:aws:XXX) to the grantee principal instead of an ARN, which would if you naively take the value be written to the state file and cause a new resource to be created since grants have no way of being updated. 
  - What I did, which I saw done in another resource file, is if the read doesn't return valid grant or retiree principals then don't update the state file for those attributes and log a warning. This will only happen in two cases ~1 minute after iam principal creation (aws acknoleged eventual consistency problem) and if one of the principals has been deleted (in cases where it is managed outside of terraform).

If merged this resolves #641

I have run the acceptance tests in their current form, and they pass:

```
$ make testacc TESTARGS='-run=TestAWSKmsGrant'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAWSKmsGrant -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAWSKmsGrant_Basic
--- PASS: TestAWSKmsGrant_Basic (39.08s)
=== RUN   TestAWSKmsGrant_withConstraints
--- PASS: TestAWSKmsGrant_withConstraints (30.75s)
=== RUN   TestAWSKmsGrant_withRetiringPrincipal
--- PASS: TestAWSKmsGrant_withRetiringPrincipal (39.39s)
=== RUN   TestAWSKmsGrant_bare
--- PASS: TestAWSKmsGrant_bare (38.95s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	148.205s
```

I have also run the unit tests and they pass:

```
$ make test
==> Checking that code complies with gofmt requirements...
go test ./... -timeout=30s -parallel=4
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1.765s
```