### PR TITLE
resource/aws_cloudwatch_log_subscription_filter: Add support for distribution

### DIFF
--- a/aws/resource_aws_cloudwatch_log_subscription_filter.go
+++ b/aws/resource_aws_cloudwatch_log_subscription_filter.go
@@ -48,6 +48,10 @@ func resourceAwsCloudwatchLogSubscriptionFilter() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"distribution": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -119,6 +123,10 @@ func getAwsCloudWatchLogsSubscriptionFilterInput(d *schema.ResourceData) cloudwa
 
 	if _, ok := d.GetOk("role_arn"); ok {
 		params.RoleArn = aws.String(d.Get("role_arn").(string))
+	}
+
+	if _, ok := d.GetOk("distribution"); ok {
+		params.Distribution = aws.String(d.Get("distribution").(string))
 	}
 
 	return params

--- a/aws/resource_aws_cloudwatch_log_subscription_filter_test.go
+++ b/aws/resource_aws_cloudwatch_log_subscription_filter_test.go
@@ -154,7 +154,7 @@ resource "aws_cloudwatch_log_subscription_filter" "test_lambdafunction_logfilter
   log_group_name  = "${aws_cloudwatch_log_group.logs.name}"
   filter_pattern  = "logtype test"
   destination_arn = "${aws_lambda_function.test_lambdafunction.arn}"
-	distribution    = "Random"
+  distribution    = "Random"
 }
 
 resource "aws_lambda_function" "test_lambdafunction" {

--- a/aws/resource_aws_cloudwatch_log_subscription_filter_test.go
+++ b/aws/resource_aws_cloudwatch_log_subscription_filter_test.go
@@ -31,6 +31,8 @@ func TestAccAWSCloudwatchLogSubscriptionFilter_basic(t *testing.T) {
 						"aws_cloudwatch_log_subscription_filter.test_lambdafunction_logfilter", "name", fmt.Sprintf("test_lambdafunction_logfilter_%s", rstring)),
 					resource.TestCheckResourceAttr(
 						"aws_cloudwatch_log_subscription_filter.test_lambdafunction_logfilter", "log_group_name", fmt.Sprintf("example_lambda_name_%s", rstring)),
+					resource.TestCheckResourceAttr(
+						"aws_cloudwatch_log_subscription_filter.test_lambdafunction_logfilter", "distribution", "Random"),
 				),
 			},
 		},
@@ -152,6 +154,7 @@ resource "aws_cloudwatch_log_subscription_filter" "test_lambdafunction_logfilter
   log_group_name  = "${aws_cloudwatch_log_group.logs.name}"
   filter_pattern  = "logtype test"
   destination_arn = "${aws_lambda_function.test_lambdafunction.arn}"
+	distribution    = "Random"
 }
 
 resource "aws_lambda_function" "test_lambdafunction" {

--- a/website/docs/r/cloudwatch_log_subscription_filter.html.markdown
+++ b/website/docs/r/cloudwatch_log_subscription_filter.html.markdown
@@ -19,6 +19,7 @@ resource "aws_cloudwatch_log_subscription_filter" "test_lambdafunction_logfilter
   log_group_name  = "/aws/lambda/example_lambda_name"
   filter_pattern  = "logtype test"
   destination_arn = "${aws_kinesis_stream.test_logstream.arn}"
+  distribution    = "Random"
 }
 ```
 
@@ -31,6 +32,7 @@ The following arguments are supported:
 * `filter_pattern` - (Required) A valid CloudWatch Logs filter pattern for subscribing to a filtered stream of log events.
 * `log_group_name` - (Required) The name of the log group to associate the subscription filter with
 * `role_arn` - (Optional) The ARN of an IAM role that grants Amazon CloudWatch Logs permissions to deliver ingested log events to the destination. If you use Lambda as a destination, you should skip this argument and use `aws_lambda_permission` resource for granting access from CloudWatch logs to the destination Lambda function. 
+* `distribution` - (Optional) The method used to distribute log data to the destination. By default log data is grouped by log stream, but the grouping can be set to random for a more even distribution. This property is only applicable when the destination is an Amazon Kinesis stream. Valid values are "Random" and "ByLogStream".
 
 ## Attributes Reference
 


### PR DESCRIPTION
resolves: #2853

### Changes
* Adding support for the optional `distribution` attribute to the `aws_cloudwatch_log_subscription_filter` resource.
* Updating acceptance tests for the new attribute.
* Updating docs for the website for the `aws_cloudwatch_log_subscription_filter` resource to include the `distribution` attribute.

### Testing
* Built the provider locally and created the resource `aws_cloudwatch_log_subscription_filter`:

**_main.tf_**:
```hcl
resource "aws_cloudwatch_log_group" "rd_logs" {
  name              = "rd_logs"
  retention_in_days = 1
}

resource "aws_cloudwatch_log_subscription_filter" "test_log_filter" {
  name            = "test_log_filter"
  log_group_name  = "${aws_cloudwatch_log_group.rd_logs.name}"
  filter_pattern  = "[version, account]"
  destination_arn = "<omitted>"
  distribution    = "Random"
}
```
**_output of `terraform plan`_**:
```
Terraform will perform the following actions:

  + aws_cloudwatch_log_group.rd_logs
      id:                <computed>
      arn:               <computed>
      name:              "rd_logs"
      retention_in_days: "1"

  + aws_cloudwatch_log_subscription_filter.test_log_filter
      id:                <computed>
      destination_arn:   "<omitted>"
      distribution:      "Random"
      filter_pattern:    "[version, account]"
      log_group_name:    "rd_logs"
      name:              "test_log_filter"
      role_arn:          <computed>

Plan: 2 to add, 0 to change, 0 to destroy.
```

**_verification with awscli after apply_**:
```bash
$ aws logs describe-subscription-filters --log-group-name rd_logs
{
    "subscriptionFilters": [
        {
            "filterPattern": "[version, account]", 
            "filterName": "test_log_filter", 
            "creationTime": 1516255168390, 
            "logGroupName": "rd_logs", 
            "destinationArn": "<omitted>", 
            "distribution": "Random"
        }
    ]
}
```
* Also tested with a handful of invalid values, etc.
* Re-applying with the `distribution` attribute omitted will cause the resource to default to the `"ByLogStream" value.

