### PR TITLE
test/aws_cloudformation_stack: Randomize names

### DIFF
--- a/aws/data_source_aws_cloudformation_stack_test.go
+++ b/aws/data_source_aws_cloudformation_stack_test.go
@@ -1,19 +1,24 @@
 package aws
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccAWSCloudFormationStack_dataSource_basic(t *testing.T) {
+	rString := acctest.RandString(8)
+	stackName := fmt.Sprintf("tf-acc-ds-basic-%s", rString)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckAwsCloudFormationStackDataSourceConfig_basic,
+				Config: testAccCheckAwsCloudFormationStackDataSourceConfig_basic(stackName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.aws_cloudformation_stack.network", "outputs.%", "1"),
 					resource.TestMatchResourceAttr("data.aws_cloudformation_stack.network", "outputs.VPCId",
@@ -33,9 +38,10 @@ func TestAccAWSCloudFormationStack_dataSource_basic(t *testing.T) {
 	})
 }
 
-const testAccCheckAwsCloudFormationStackDataSourceConfig_basic = `
+func testAccCheckAwsCloudFormationStackDataSourceConfig_basic(stackName string) string {
+	return fmt.Sprintf(`
 resource "aws_cloudformation_stack" "cfs" {
-  name = "tf-acc-ds-networking-stack"
+  name = "%s"
   parameters {
     CIDR = "10.10.10.0/24"
   }
@@ -75,15 +81,19 @@ STACK
 data "aws_cloudformation_stack" "network" {
   name = "${aws_cloudformation_stack.cfs.name}"
 }
-`
+`, stackName)
+}
 
 func TestAccAWSCloudFormationStack_dataSource_yaml(t *testing.T) {
+	rString := acctest.RandString(8)
+	stackName := fmt.Sprintf("tf-acc-ds-yaml-%s", rString)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckAwsCloudFormationStackDataSourceConfig_yaml,
+				Config: testAccCheckAwsCloudFormationStackDataSourceConfig_yaml(stackName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.aws_cloudformation_stack.yaml", "outputs.%", "1"),
 					resource.TestMatchResourceAttr("data.aws_cloudformation_stack.yaml", "outputs.VPCId",
@@ -103,9 +113,10 @@ func TestAccAWSCloudFormationStack_dataSource_yaml(t *testing.T) {
 	})
 }
 
-const testAccCheckAwsCloudFormationStackDataSourceConfig_yaml = `
+func testAccCheckAwsCloudFormationStackDataSourceConfig_yaml(stackName string) string {
+	return fmt.Sprintf(`
 resource "aws_cloudformation_stack" "yaml" {
-  name = "tf-acc-ds-yaml-stack"
+  name = "%s"
   parameters {
     CIDR = "10.10.10.0/24"
   }
@@ -139,4 +150,5 @@ STACK
 data "aws_cloudformation_stack" "yaml" {
   name = "${aws_cloudformation_stack.yaml.name}"
 }
-`
+`, stackName)
+}


### PR DESCRIPTION
This is to address the following test failures:

```
=== RUN   TestAccAWSCloudFormationStack_dataSource_basic
--- FAIL: TestAccAWSCloudFormationStack_dataSource_basic (6.59s)
    testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_cloudformation_stack.cfs: 1 error(s) occurred:
        
        * aws_cloudformation_stack.cfs: Creating CloudFormation stack failed: AlreadyExistsException: Stack [tf-acc-ds-networking-stack] already exists
            status code: 400, request id: dfcbad2e-fc06-11e7-95b7-89100c24f612
=== RUN   TestAccAWSCloudFormationStack_dataSource_yaml
--- FAIL: TestAccAWSCloudFormationStack_dataSource_yaml (12.16s)
    testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_cloudformation_stack.yaml: 1 error(s) occurred:
        
        * aws_cloudformation_stack.yaml: Creating CloudFormation stack failed: AlreadyExistsException: Stack [tf-acc-ds-yaml-stack] already exists
            status code: 400, request id: e4da8953-fc06-11e7-a552-4135c550139d
```

## Test results

```
=== RUN   TestAccAWSCloudFormationStack_dataSource_basic
--- PASS: TestAccAWSCloudFormationStack_dataSource_basic (103.35s)
=== RUN   TestAccAWSCloudFormationStack_dataSource_yaml
--- PASS: TestAccAWSCloudFormationStack_dataSource_yaml (110.49s)
```