### PR TITLE
resource/aws_kinesis_firehose_delivery_stream: Prevent crash on empty CW logging opts

### DIFF
--- a/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -186,21 +186,22 @@ func flattenCloudwatchLoggingOptions(clo firehose.CloudWatchLoggingOptions) *sch
 	return schema.NewSet(cloudwatchLoggingOptionsHash, []interface{}{cloudwatchLoggingOptions})
 }
 
-func flattenFirehoseS3Configuration(s3 firehose.S3DestinationDescription) []map[string]interface{} {
-	s3Configuration := make([]map[string]interface{}, 1)
-	s3Configuration[0] = map[string]interface{}{
-		"role_arn":                   *s3.RoleARN,
-		"bucket_arn":                 *s3.BucketARN,
-		"prefix":                     *s3.Prefix,
-		"buffer_size":                *s3.BufferingHints.SizeInMBs,
-		"buffer_interval":            *s3.BufferingHints.IntervalInSeconds,
-		"compression_format":         *s3.CompressionFormat,
-		"cloudwatch_logging_options": flattenCloudwatchLoggingOptions(*s3.CloudWatchLoggingOptions),
+func flattenFirehoseS3Configuration(s3 firehose.S3DestinationDescription) []interface{} {
+	s3Configuration := map[string]interface{}{
+		"role_arn":           *s3.RoleARN,
+		"bucket_arn":         *s3.BucketARN,
+		"prefix":             *s3.Prefix,
+		"buffer_size":        *s3.BufferingHints.SizeInMBs,
+		"buffer_interval":    *s3.BufferingHints.IntervalInSeconds,
+		"compression_format": *s3.CompressionFormat,
+	}
+	if s3.CloudWatchLoggingOptions != nil {
+		s3Configuration["cloudwatch_logging_options"] = flattenCloudwatchLoggingOptions(*s3.CloudWatchLoggingOptions)
 	}
 	if s3.EncryptionConfiguration.KMSEncryptionConfig != nil {
-		s3Configuration[0]["kms_key_arn"] = *s3.EncryptionConfiguration.KMSEncryptionConfig
+		s3Configuration["kms_key_arn"] = *s3.EncryptionConfiguration.KMSEncryptionConfig
 	}
-	return s3Configuration
+	return []interface{}{s3Configuration}
 }
 
 func flattenProcessingConfiguration(pc firehose.ProcessingConfiguration, roleArn string) []map[string]interface{} {


### PR DESCRIPTION
Fixes #3005

## Test results

```
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidProcessorType
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidProcessorType (1.65s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidParameterName
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidParameterName (1.67s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_s3WithCloudwatchLogging
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3WithCloudwatchLogging (116.94s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_s3KinesisStreamSource
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3KinesisStreamSource (121.48s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_s3ConfigUpdates
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3ConfigUpdates (206.30s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_missingProcessingConfiguration
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_missingProcessingConfiguration (247.98s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3basic
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3basic (248.14s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_s3basic
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basic (249.02s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3Updates
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3Updates (254.06s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_importBasic
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_importBasic (256.83s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigUpdates
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigUpdates (1001.21s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_RedshiftConfigUpdates
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_RedshiftConfigUpdates (1053.73s)
```