### PR TITLE
resource/aws_instance: Retry IAM instance profile (re)association for eventual consistency on update

### DIFF
--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -822,7 +822,7 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 		if _, ok := d.GetOk("iam_instance_profile"); ok {
 			// Does not have an Iam Instance Profile associated with it, need to associate
 			if len(resp.IamInstanceProfileAssociations) == 0 {
-				err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+				err := resource.Retry(1*time.Minute, func() *resource.RetryError {
 					_, err := conn.AssociateIamInstanceProfile(&ec2.AssociateIamInstanceProfileInput{
 						InstanceId: aws.String(d.Id()),
 						IamInstanceProfile: &ec2.IamInstanceProfileSpecification{
@@ -845,7 +845,7 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 				// Has an Iam Instance Profile associated with it, need to replace the association
 				associationId := resp.IamInstanceProfileAssociations[0].AssociationId
 
-				err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+				err := resource.Retry(1*time.Minute, func() *resource.RetryError {
 					_, err := conn.ReplaceIamInstanceProfileAssociation(&ec2.ReplaceIamInstanceProfileAssociationInput{
 						AssociationId: associationId,
 						IamInstanceProfile: &ec2.IamInstanceProfileSpecification{

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -822,11 +822,20 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 		if _, ok := d.GetOk("iam_instance_profile"); ok {
 			// Does not have an Iam Instance Profile associated with it, need to associate
 			if len(resp.IamInstanceProfileAssociations) == 0 {
-				_, err := conn.AssociateIamInstanceProfile(&ec2.AssociateIamInstanceProfileInput{
-					InstanceId: aws.String(d.Id()),
-					IamInstanceProfile: &ec2.IamInstanceProfileSpecification{
-						Name: aws.String(d.Get("iam_instance_profile").(string)),
-					},
+				err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+					_, err := conn.AssociateIamInstanceProfile(&ec2.AssociateIamInstanceProfileInput{
+						InstanceId: aws.String(d.Id()),
+						IamInstanceProfile: &ec2.IamInstanceProfileSpecification{
+							Name: aws.String(d.Get("iam_instance_profile").(string)),
+						},
+					})
+					if err != nil {
+						if isAWSErr(err, "InvalidParameterValue", "Invalid IAM Instance Profile") {
+							return resource.RetryableError(err)
+						}
+						return resource.NonRetryableError(err)
+					}
+					return nil
 				})
 				if err != nil {
 					return err
@@ -836,11 +845,20 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 				// Has an Iam Instance Profile associated with it, need to replace the association
 				associationId := resp.IamInstanceProfileAssociations[0].AssociationId
 
-				_, err := conn.ReplaceIamInstanceProfileAssociation(&ec2.ReplaceIamInstanceProfileAssociationInput{
-					AssociationId: associationId,
-					IamInstanceProfile: &ec2.IamInstanceProfileSpecification{
-						Name: aws.String(d.Get("iam_instance_profile").(string)),
-					},
+				err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+					_, err := conn.ReplaceIamInstanceProfileAssociation(&ec2.ReplaceIamInstanceProfileAssociationInput{
+						AssociationId: associationId,
+						IamInstanceProfile: &ec2.IamInstanceProfileSpecification{
+							Name: aws.String(d.Get("iam_instance_profile").(string)),
+						},
+					})
+					if err != nil {
+						if isAWSErr(err, "InvalidParameterValue", "Invalid IAM Instance Profile") {
+							return resource.RetryableError(err)
+						}
+						return resource.NonRetryableError(err)
+					}
+					return nil
 				})
 				if err != nil {
 					return err

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -2072,18 +2072,13 @@ resource "aws_iam_role" "test" {
 	assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"ec2.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
 }
 
-resource "aws_iam_instance_profile" "test" {
-	name = "test-%s"
-	roles = ["${aws_iam_role.test.name}"]
-}
-
 resource "aws_instance" "foo" {
 	ami = "ami-4fccb37f"
 	instance_type = "m1.small"
 	tags {
 		bar = "baz"
 	}
-}`, rName, rName)
+}`, rName)
 }
 
 func testAccInstanceConfigWithInstanceProfile(rName string) string {


### PR DESCRIPTION
Closes #838 

Adjusting the existing test for adding `aws_instance.iam_instance_profile` after instance creation by simultaneously creating the `aws_iam_instance_profile` instead generates the error reported:

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSInstance_instanceProfileChange'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSInstance_instanceProfileChange -timeout 120m
=== RUN   TestAccAWSInstance_instanceProfileChange
--- FAIL: TestAccAWSInstance_instanceProfileChange (128.36s)
	testing.go:513: Step 1 error: Error applying: 1 error(s) occurred:

		* aws_instance.foo: 1 error(s) occurred:

		* aws_instance.foo: InvalidParameterValue: Value (test-kg7zd) for parameter iamInstanceProfile.name is invalid. Invalid IAM Instance Profile name
			status code: 400, request id: a753eb1d-bc9e-4e3e-9ad6-c6bac7968f6d
FAIL
exit status 1
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	128.410s
make: *** [testacc] Error 1
```

After code update (I'll replace with full results shortly):
```
# locally
make testacc TEST=./aws TESTARGS='-run=TestAccAWSInstance_instanceProfileChange'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSInstance_instanceProfileChange -timeout 120m
=== RUN   TestAccAWSInstance_instanceProfileChange
--- PASS: TestAccAWSInstance_instanceProfileChange (144.92s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	144.971s
# TC (failure unrelated)
=== RUN   TestAccAWSInstance_importInEc2Classic
--- SKIP: TestAccAWSInstance_importInEc2Classic (1.77s)
=== RUN   TestAccAWSInstanceDataSource_keyPair
--- PASS: TestAccAWSInstanceDataSource_keyPair (101.02s)
=== RUN   TestAccAWSInstanceDataSource_gp2IopsDevice
--- PASS: TestAccAWSInstanceDataSource_gp2IopsDevice (147.80s)
=== RUN   TestAccAWSInstanceDataSource_AzUserData
--- PASS: TestAccAWSInstanceDataSource_AzUserData (159.59s)
=== RUN   TestAccAWSInstance_GP2WithIopsValue
--- PASS: TestAccAWSInstance_GP2WithIopsValue (186.40s)
=== RUN   TestAccAWSInstanceDataSource_SecurityGroups
--- FAIL: TestAccAWSInstanceDataSource_SecurityGroups (198.42s)
	testing.go:513: Step 0 error: Check failed: Check 3/5 error: data.aws_instance.foo: Attribute 'vpc_security_group_ids.#' expected "0", got "1"
=== RUN   TestAccAWSInstanceDataSource_VPC
--- PASS: TestAccAWSInstanceDataSource_VPC (203.38s)
=== RUN   TestAccAWSInstance_blockDevices
--- PASS: TestAccAWSInstance_blockDevices (112.79s)
=== RUN   TestAccAWSInstanceDataSource_rootInstanceStore
--- PASS: TestAccAWSInstanceDataSource_rootInstanceStore (216.17s)
=== RUN   TestAccAWSInstance_GP2IopsDevice
--- PASS: TestAccAWSInstance_GP2IopsDevice (229.55s)
=== RUN   TestAccAWSInstanceDataSource_tags
--- PASS: TestAccAWSInstanceDataSource_tags (240.79s)
=== RUN   TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError
--- PASS: TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError (11.26s)
=== RUN   TestAccAWSInstance_importInDefaultVpc
--- PASS: TestAccAWSInstance_importInDefaultVpc (243.61s)
=== RUN   TestAccAWSInstanceDataSource_blockDevices
--- PASS: TestAccAWSInstanceDataSource_blockDevices (244.99s)
=== RUN   TestAccAWSInstance_userDataBase64
--- PASS: TestAccAWSInstance_userDataBase64 (294.39s)
=== RUN   TestAccAWSInstanceDataSource_VPCSecurityGroups
--- PASS: TestAccAWSInstanceDataSource_VPCSecurityGroups (322.24s)
=== RUN   TestAccAWSInstancesDataSource_basic
--- PASS: TestAccAWSInstancesDataSource_basic (373.74s)
=== RUN   TestAccAWSInstanceDataSource_basic
--- PASS: TestAccAWSInstanceDataSource_basic (375.88s)
=== RUN   TestAccAWSInstance_basic
--- PASS: TestAccAWSInstance_basic (401.58s)
=== RUN   TestAccAWSInstanceDataSource_PlacementGroup
--- PASS: TestAccAWSInstanceDataSource_PlacementGroup (410.32s)
=== RUN   TestAccAWSInstance_rootInstanceStore
--- PASS: TestAccAWSInstance_rootInstanceStore (262.81s)
=== RUN   TestAccAWSInstance_noAMIEphemeralDevices
--- PASS: TestAccAWSInstance_noAMIEphemeralDevices (275.77s)
=== RUN   TestAccAWSInstance_placementGroup
--- PASS: TestAccAWSInstance_placementGroup (249.71s)
=== RUN   TestAccAWSInstance_NetworkInstanceSecurityGroups
--- PASS: TestAccAWSInstance_NetworkInstanceSecurityGroups (225.38s)
=== RUN   TestAccAWSInstancesDataSource_tags
--- PASS: TestAccAWSInstancesDataSource_tags (481.43s)
=== RUN   TestAccAWSInstance_vpc
--- PASS: TestAccAWSInstance_vpc (310.98s)
=== RUN   TestAccAWSInstance_ipv6_supportAddressCount
--- PASS: TestAccAWSInstance_ipv6_supportAddressCount (306.08s)
=== RUN   TestAccAWSInstance_keyPairCheck
--- PASS: TestAccAWSInstance_keyPairCheck (94.62s)
=== RUN   TestAccAWSInstance_withIamInstanceProfile
--- PASS: TestAccAWSInstance_withIamInstanceProfile (159.68s)
=== RUN   TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs
--- PASS: TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs (320.27s)
=== RUN   TestAccAWSInstance_sourceDestCheck
--- PASS: TestAccAWSInstance_sourceDestCheck (411.29s)
=== RUN   TestAccAWSInstance_rootBlockDeviceMismatch
--- PASS: TestAccAWSInstance_rootBlockDeviceMismatch (136.56s)
=== RUN   TestAccAWSInstance_privateIP
--- PASS: TestAccAWSInstance_privateIP (220.23s)
=== RUN   TestAccAWSInstance_tags
--- PASS: TestAccAWSInstance_tags (364.20s)
=== RUN   TestAccAWSInstance_instanceProfileChange
--- PASS: TestAccAWSInstance_instanceProfileChange (285.09s)
=== RUN   TestAccAWSInstance_associatePublicIPAndPrivateIP
--- PASS: TestAccAWSInstance_associatePublicIPAndPrivateIP (300.37s)
=== RUN   TestAccAWSInstance_multipleRegions
--- PASS: TestAccAWSInstance_multipleRegions (503.82s)
=== RUN   TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck
--- PASS: TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck (222.50s)
=== RUN   TestAccAWSInstance_associatePublic_defaultPrivate
--- PASS: TestAccAWSInstance_associatePublic_defaultPrivate (193.05s)
=== RUN   TestAccAWSInstance_associatePublic_explicitPublic
--- PASS: TestAccAWSInstance_associatePublic_explicitPublic (158.24s)
=== RUN   TestAccAWSInstanceDataSource_privateIP
--- PASS: TestAccAWSInstanceDataSource_privateIP (789.92s)
=== RUN   TestAccAWSInstance_primaryNetworkInterface
--- PASS: TestAccAWSInstance_primaryNetworkInterface (276.56s)
=== RUN   TestAccAWSInstance_forceNewAndTagsDrift
--- PASS: TestAccAWSInstance_forceNewAndTagsDrift (325.26s)
=== RUN   TestAccAWSInstance_disableApiTermination
--- PASS: TestAccAWSInstance_disableApiTermination (611.15s)
=== RUN   TestAccAWSInstance_associatePublic_overridePublic
--- PASS: TestAccAWSInstance_associatePublic_overridePublic (157.23s)
=== RUN   TestAccAWSInstance_associatePublic_defaultPublic
--- PASS: TestAccAWSInstance_associatePublic_defaultPublic (216.99s)
=== RUN   TestAccAWSInstance_associatePublic_explicitPrivate
--- PASS: TestAccAWSInstance_associatePublic_explicitPrivate (189.76s)
=== RUN   TestAccAWSInstance_changeInstanceType
--- PASS: TestAccAWSInstance_changeInstanceType (340.71s)
=== RUN   TestAccAWSInstance_volumeTags
--- PASS: TestAccAWSInstance_volumeTags (511.13s)
=== RUN   TestAccAWSInstance_ipv6_supportAddressCountWithIpv4
--- PASS: TestAccAWSInstance_ipv6_supportAddressCountWithIpv4 (602.57s)
=== RUN   TestAccAWSInstance_importBasic
--- PASS: TestAccAWSInstance_importBasic (892.13s)
=== RUN   TestAccAWSInstance_addSecondaryInterface
--- PASS: TestAccAWSInstance_addSecondaryInterface (404.71s)
=== RUN   TestAccAWSInstance_volumeTagsComputed
--- PASS: TestAccAWSInstance_volumeTagsComputed (572.92s)
=== RUN   TestAccAWSInstance_associatePublic_overridePrivate
--- PASS: TestAccAWSInstance_associatePublic_overridePrivate (307.70s)
=== RUN   TestAccAWSInstance_addSecurityGroupNetworkInterface
--- PASS: TestAccAWSInstance_addSecurityGroupNetworkInterface (709.20s)
```