### PR TITLE
resource/aws_emr_cluster: Add scale_down_behavior

### DIFF
--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -496,7 +496,11 @@ func resourceAwsEMRClusterRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("name", cluster.Name)
-	d.Set("scale_down_behavior", cluster.ScaleDownBehavior)
+
+	if d.Get("scale_down_behavior").(string) != "" {
+		d.Set("scale_down_behavior", cluster.ScaleDownBehavior)
+	}
+
 	d.Set("service_role", cluster.ServiceRole)
 	d.Set("security_configuration", cluster.SecurityConfiguration)
 	d.Set("autoscaling_role", cluster.AutoScalingRole)

--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -236,6 +236,11 @@ func resourceAwsEMRCluster() *schema.Resource {
 				ForceNew: true,
 				Required: true,
 			},
+			"scale_down_behavior": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+			},
 			"security_configuration": {
 				Type:     schema.TypeString,
 				ForceNew: true,
@@ -363,8 +368,13 @@ func resourceAwsEMRClusterCreate(d *schema.ResourceData, meta interface{}) error
 	if v, ok := d.GetOk("log_uri"); ok {
 		params.LogUri = aws.String(v.(string))
 	}
+
 	if v, ok := d.GetOk("autoscaling_role"); ok {
 		params.AutoScalingRole = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("scale_down_behavior"); ok {
+		params.ScaleDownBehavior = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("security_configuration"); ok {
@@ -486,6 +496,7 @@ func resourceAwsEMRClusterRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("name", cluster.Name)
+	d.Set("scale_down_behavior", cluster.ScaleDownBehavior)
 	d.Set("service_role", cluster.ServiceRole)
 	d.Set("security_configuration", cluster.SecurityConfiguration)
 	d.Set("autoscaling_role", cluster.AutoScalingRole)

--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/structure"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsEMRCluster() *schema.Resource {
@@ -240,6 +241,11 @@ func resourceAwsEMRCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				ForceNew: true,
 				Optional: true,
+				Computed: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					emr.ScaleDownBehaviorTerminateAtInstanceHour,
+					emr.ScaleDownBehaviorTerminateAtTaskCompletion,
+				}, false),
 			},
 			"security_configuration": {
 				Type:     schema.TypeString,
@@ -496,10 +502,6 @@ func resourceAwsEMRClusterRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("name", cluster.Name)
-
-	if d.Get("scale_down_behavior").(string) != "" {
-		d.Set("scale_down_behavior", cluster.ScaleDownBehavior)
-	}
 
 	d.Set("service_role", cluster.ServiceRole)
 	d.Set("security_configuration", cluster.SecurityConfiguration)

--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -512,6 +512,7 @@ func resourceAwsEMRClusterRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("visible_to_all_users", cluster.VisibleToAllUsers)
 	d.Set("tags", tagsToMapEMR(cluster.Tags))
 	d.Set("ebs_root_volume_size", cluster.EbsRootVolumeSize)
+	d.Set("scale_down_behavior", cluster.ScaleDownBehavior)
 
 	if cluster.CustomAmiId != nil {
 		d.Set("custom_ami_id", cluster.CustomAmiId)

--- a/aws/resource_aws_emr_cluster_test.go
+++ b/aws/resource_aws_emr_cluster_test.go
@@ -1004,6 +1004,8 @@ resource "aws_emr_cluster" "tf-test-cluster" {
   core_instance_type   = "c4.large"
   core_instance_count  = 1
 
+  scale_down_behavior = "TERMINATE_AT_INSTANCE_HOUR"
+
   security_configuration = "${aws_emr_security_configuration.foo.name}"
 
   tags {

--- a/aws/resource_aws_emr_cluster_test.go
+++ b/aws/resource_aws_emr_cluster_test.go
@@ -24,7 +24,10 @@ func TestAccAWSEMRCluster_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSEmrClusterConfig(r),
-				Check:  testAccCheckAWSEmrClusterExists("aws_emr_cluster.tf-test-cluster", &cluster),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEmrClusterExists("aws_emr_cluster.tf-test-cluster", &cluster),
+					resource.TestCheckResourceAttrSet("aws_emr_cluster.tf-test-cluster", "scale_down_behavior"),
+				),
 			},
 		},
 	})
@@ -707,6 +710,8 @@ resource "aws_emr_cluster" "tf-test-cluster" {
   keep_job_flow_alive_when_no_steps = true
   termination_protection = false
 
+  scale_down_behavior = "TERMINATE_AT_TASK_COMPLETION"
+
   bootstrap_action {
     path = "s3://elasticmapreduce/bootstrap-actions/run-if"
     name = "runif"
@@ -1003,8 +1008,6 @@ resource "aws_emr_cluster" "tf-test-cluster" {
   master_instance_type = "c4.large"
   core_instance_type   = "c4.large"
   core_instance_count  = 1
-
-  scale_down_behavior = "TERMINATE_AT_INSTANCE_HOUR"
 
   security_configuration = "${aws_emr_security_configuration.foo.name}"
 

--- a/aws/resource_aws_emr_cluster_test.go
+++ b/aws/resource_aws_emr_cluster_test.go
@@ -26,7 +26,7 @@ func TestAccAWSEMRCluster_basic(t *testing.T) {
 				Config: testAccAWSEmrClusterConfig(r),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEmrClusterExists("aws_emr_cluster.tf-test-cluster", &cluster),
-					resource.TestCheckResourceAttrSet("aws_emr_cluster.tf-test-cluster", "scale_down_behavior"),
+					resource.TestCheckResourceAttr("aws_emr_cluster.tf-test-cluster", "scale_down_behavior", "TERMINATE_AT_TASK_COMPLETION"),
 				),
 			},
 		},

--- a/website/docs/r/emr_cluster.html.markdown
+++ b/website/docs/r/emr_cluster.html.markdown
@@ -112,6 +112,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the job flow
 * `release_label` - (Required) The release label for the Amazon EMR release
 * `master_instance_type` - (Optional) The EC2 instance type of the master node. Exactly one of `master_instance_type` and `instance_group` must be specified.
+* `scale_down_behavior` - (Optional) The way that individual Amazon EC2 instances terminate when an automatic scale-in activity occurs or an `instance group` is resized. 
 * `service_role` - (Required) IAM role that will be assumed by the Amazon EMR service to access AWS resources
 * `security_configuration` - (Optional) The security configuration name to attach to the EMR cluster. Only valid for EMR clusters with `release_label` 4.8.0 or greater
 * `core_instance_type` - (Optional) The EC2 instance type of the slave nodes. Cannot be specified if `instance_groups` is set


### PR DESCRIPTION
This provides the ability to configure the scale down behavior of a cluster. From the docs:


> ScaleDownBehavior
> The way that individual Amazon EC2 instances terminate when an automatic scale-in activity occurs or an instance group is resized. TERMINATE_AT_INSTANCE_HOUR indicates that Amazon EMR terminates nodes at the instance-hour boundary, regardless of when the request to terminate the instance was submitted. This option is only available with Amazon EMR 5.1.0 and later and is the default for clusters created using that version. TERMINATE_AT_TASK_COMPLETION indicates that Amazon EMR blacklists and drains tasks from nodes before terminating the Amazon EC2 instances, regardless of the instance-hour boundary. With either behavior, Amazon EMR removes the least active nodes first and blocks instance termination if it could lead to HDFS corruption. TERMINATE_AT_TASK_COMPLETION available only in Amazon EMR version 4.1.0 and later, and is the default for versions of Amazon EMR earlier than 5.1.0.
> 
> Type: String
> 
> Valid Values: TERMINATE_AT_INSTANCE_HOUR | TERMINATE_AT_TASK_COMPLETION
> 
> Required: No



Source: https://docs.aws.amazon.com/emr/latest/APIReference/API_JobFlowDetail.html

I've added a test which attempts to set the value to TERMINATE_AT_INSTANCE_HOUR for a cluster version of 5.5.0. This is the default for this version, but I didn't want to interfere with the tests as it may prevent the cluster from shutting down should any tasks be running. 

I've not yet been able to run this against AWS to test. 