### PR TITLE
resource/aws_elastic_beanstalk_application: Retry DescribeApplication after creation

### DIFF
--- a/aws/resource_aws_elastic_beanstalk_application.go
+++ b/aws/resource_aws_elastic_beanstalk_application.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/elasticbeanstalk"
 	"github.com/hashicorp/terraform/helper/resource"
 )
@@ -89,27 +88,37 @@ func resourceAwsElasticBeanstalkApplicationDescriptionUpdate(beanstalkConn *elas
 }
 
 func resourceAwsElasticBeanstalkApplicationRead(d *schema.ResourceData, meta interface{}) error {
-	a, err := getBeanstalkApplication(d, meta)
+	conn := meta.(*AWSClient).elasticbeanstalkconn
+
+	var app *elasticbeanstalk.ApplicationDescription
+	err := resource.Retry(30*time.Second, func() *resource.RetryError {
+		var err error
+		app, err = getBeanstalkApplication(d.Id(), conn)
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		if app == nil {
+			if d.IsNewResource() {
+				return resource.RetryableError(fmt.Errorf("Elastic Beanstalk Application %q not found.", d.Id()))
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
 	if err != nil {
 		return err
 	}
-	if a == nil {
-		return err
-	}
 
-	d.Set("name", a.ApplicationName)
-	d.Set("description", a.Description)
+	d.Set("name", app.ApplicationName)
+	d.Set("description", app.Description)
 	return nil
 }
 
 func resourceAwsElasticBeanstalkApplicationDelete(d *schema.ResourceData, meta interface{}) error {
 	beanstalkConn := meta.(*AWSClient).elasticbeanstalkconn
 
-	a, err := getBeanstalkApplication(d, meta)
-	if err != nil {
-		return err
-	}
-	_, err = beanstalkConn.DeleteApplication(&elasticbeanstalk.DeleteApplicationInput{
+	_, err := beanstalkConn.DeleteApplication(&elasticbeanstalk.DeleteApplicationInput{
 		ApplicationName: aws.String(d.Id()),
 	})
 	if err != nil {
@@ -117,7 +126,12 @@ func resourceAwsElasticBeanstalkApplicationDelete(d *schema.ResourceData, meta i
 	}
 
 	return resource.Retry(10*time.Second, func() *resource.RetryError {
-		if a, err = getBeanstalkApplication(d, meta); a != nil {
+		app, err := getBeanstalkApplication(d.Id(), meta.(*AWSClient).elasticbeanstalkconn)
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		if app != nil {
 			return resource.RetryableError(
 				fmt.Errorf("Beanstalk Application (%s) still exists: %s", d.Id(), err))
 		}
@@ -125,31 +139,24 @@ func resourceAwsElasticBeanstalkApplicationDelete(d *schema.ResourceData, meta i
 	})
 }
 
-func getBeanstalkApplication(
-	d *schema.ResourceData,
-	meta interface{}) (*elasticbeanstalk.ApplicationDescription, error) {
-	conn := meta.(*AWSClient).elasticbeanstalkconn
-
+func getBeanstalkApplication(id string, conn *elasticbeanstalk.ElasticBeanstalk) (*elasticbeanstalk.ApplicationDescription, error) {
 	resp, err := conn.DescribeApplications(&elasticbeanstalk.DescribeApplicationsInput{
-		ApplicationNames: []*string{aws.String(d.Id())},
+		ApplicationNames: []*string{aws.String(id)},
 	})
-
 	if err != nil {
-		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() != "InvalidBeanstalkAppID.NotFound" {
-			log.Printf("[Err] Error reading Elastic Beanstalk Application (%s): Application not found", d.Id())
-			d.SetId("")
+		if isAWSErr(err, "InvalidBeanstalkAppID.NotFound", "") {
 			return nil, nil
 		}
 		return nil, err
 	}
 
-	switch {
-	case len(resp.Applications) > 1:
+	if len(resp.Applications) > 1 {
 		return nil, fmt.Errorf("Error %d Applications matched, expected 1", len(resp.Applications))
-	case len(resp.Applications) == 0:
-		d.SetId("")
-		return nil, nil
-	default:
-		return resp.Applications[0], nil
 	}
+
+	if len(resp.Applications) == 0 {
+		return nil, nil
+	}
+
+	return resp.Applications[0], nil
 }


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSBeanstalkConfigurationTemplate_Setting
--- FAIL: TestAccAWSBeanstalkConfigurationTemplate_Setting (3.30s)
    testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_elastic_beanstalk_configuration_template.tf_template: Resource 'aws_elastic_beanstalk_application.tftest' does not have attribute 'name' for variable 'aws_elastic_beanstalk_application.tftest.name'
```

Snippet from related debug log:

```
2018/01/19 06:01:38 [DEBUG] [aws-sdk-go] DEBUG: Response elasticbeanstalk/CreateApplication Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 200 OK
Connection: close
Content-Length: 1074
Content-Type: text/xml
Date: Fri, 19 Jan 2018 06:01:38 GMT
X-Amzn-Requestid: c6550632-5f63-4361-afd6-31fda2e949f9


<CreateApplicationResponse xmlns="http://elasticbeanstalk.amazonaws.com/docs/2010-12-01/">
  <CreateApplicationResult>
    <Application>
      <ConfigurationTemplates/>
      <DateCreated>2018-01-19T06:01:38.652Z</DateCreated>
      <ResourceLifecycleConfig>
        <VersionLifecycleConfig>
          <MaxAgeRule>
            <MaxAgeInDays>180</MaxAgeInDays>
            <DeleteSourceFromS3>false</DeleteSourceFromS3>
            <Enabled>false</Enabled>
          </MaxAgeRule>
          <MaxCountRule>
            <DeleteSourceFromS3>false</DeleteSourceFromS3>
            <MaxCount>200</MaxCount>
            <Enabled>false</Enabled>
          </MaxCountRule>
        </VersionLifecycleConfig>
      </ResourceLifecycleConfig>
      <Description>tf-test-desc</Description>
      <ApplicationName>tf-test-qvufh</ApplicationName>
      <DateUpdated>2018-01-19T06:01:38.652Z</DateUpdated>
    </Application>
  </CreateApplicationResult>
  <ResponseMetadata>
    <RequestId>c6550632-5f63-4361-afd6-31fda2e949f9</RequestId>
  </ResponseMetadata>
</CreateApplicationResponse>
-----------------------------------------------------
2018/01/19 06:01:38 [DEBUG] [aws-sdk-go] DEBUG: Request elasticbeanstalk/DescribeApplications Details:
---[ REQUEST POST-SIGN ]-----------------------------
POST / HTTP/1.1
Host: elasticbeanstalk.us-west-2.amazonaws.com
User-Agent: aws-sdk-go/1.12.62 (go1.9.2; linux; amd64) APN/1.0 HashiCorp/1.0 Terraform/0.11.2
Content-Length: 86
Authorization: AWS4-HMAC-SHA256 Credential=*REDACTED*/20180119/us-west-2/elasticbeanstalk/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-date, Signature=*REDACTED*
Content-Type: application/x-www-form-urlencoded; charset=utf-8
X-Amz-Date: 20180119T060138Z
Accept-Encoding: gzip

Action=DescribeApplications&ApplicationNames.member.1=tf-test-qvufh&Version=2010-12-01
-----------------------------------------------------
2018/01/19 06:01:38 [DEBUG] [aws-sdk-go] DEBUG: Response elasticbeanstalk/DescribeApplications Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 200 OK
Connection: close
Content-Length: 316
Content-Type: text/xml
Date: Fri, 19 Jan 2018 06:01:38 GMT
X-Amzn-Requestid: d81365e0-3fc5-42b7-b6f5-39ea236658b4

<DescribeApplicationsResponse xmlns="http://elasticbeanstalk.amazonaws.com/docs/2010-12-01/">
  <DescribeApplicationsResult>
    <Applications/>
  </DescribeApplicationsResult>
  <ResponseMetadata>
    <RequestId>d81365e0-3fc5-42b7-b6f5-39ea236658b4</RequestId>
  </ResponseMetadata>
</DescribeApplicationsResponse>
-----------------------------------------------------
```

## Test results

```
=== RUN   TestAccAWSBeanstalkAppVersion_basic
--- PASS: TestAccAWSBeanstalkAppVersion_basic (24.43s)
=== RUN   TestAccAWSBeanstalkApp_basic
--- PASS: TestAccAWSBeanstalkApp_basic (26.20s)
=== RUN   TestAccAWSBeanstalkAppVersion_duplicateLabels
--- PASS: TestAccAWSBeanstalkAppVersion_duplicateLabels (26.21s)
=== RUN   TestAccAWSBeanstalkConfigurationTemplate_Setting
--- PASS: TestAccAWSBeanstalkConfigurationTemplate_Setting (33.73s)
=== RUN   TestAccAWSBeanstalkConfigurationTemplate_basic
--- PASS: TestAccAWSBeanstalkConfigurationTemplate_basic (44.31s)
=== RUN   TestAccAWSBeanstalkConfigurationTemplate_VPC
--- PASS: TestAccAWSBeanstalkConfigurationTemplate_VPC (60.89s)
=== RUN   TestAccAWSBeanstalkEnv_cname_prefix
--- PASS: TestAccAWSBeanstalkEnv_cname_prefix (378.22s)
=== RUN   TestAccAWSBeanstalkEnv_resource
--- PASS: TestAccAWSBeanstalkEnv_resource (461.59s)
=== RUN   TestAccAWSBeanstalkEnv_basic
--- PASS: TestAccAWSBeanstalkEnv_basic (481.40s)
=== RUN   TestAccAWSBeanstalkEnv_template_change
--- PASS: TestAccAWSBeanstalkEnv_template_change (520.16s)
=== RUN   TestAccAWSBeanstalkEnv_outputs
--- PASS: TestAccAWSBeanstalkEnv_outputs (525.34s)
=== RUN   TestAccAWSBeanstalkEnv_vpc
--- PASS: TestAccAWSBeanstalkEnv_vpc (559.63s)
=== RUN   TestAccAWSBeanstalkEnv_config
--- PASS: TestAccAWSBeanstalkEnv_config (639.16s)
=== RUN   TestAccAWSBeanstalkEnv_tier
--- PASS: TestAccAWSBeanstalkEnv_tier (686.40s)
=== RUN   TestAccAWSBeanstalkEnv_basic_settings_update
--- PASS: TestAccAWSBeanstalkEnv_basic_settings_update (796.62s)
=== RUN   TestAccAWSBeanstalkEnv_version_label
--- PASS: TestAccAWSBeanstalkEnv_version_label (901.47s)
=== RUN   TestAccAWSBeanstalkEnv_settingWithJsonValue
--- PASS: TestAccAWSBeanstalkEnv_settingWithJsonValue (977.73s)
```