### PR TITLE
test/aws_route53_zone: Randomize zone names

### DIFF
--- a/aws/import_aws_route53_zone_test.go
+++ b/aws/import_aws_route53_zone_test.go
@@ -1,13 +1,18 @@
 package aws
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccAWSRoute53Zone_importBasic(t *testing.T) {
 	resourceName := "aws_route53_zone.main"
+
+	rString := acctest.RandString(8)
+	zoneName := fmt.Sprintf("%s.terraformtest.com", rString)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -15,7 +20,7 @@ func TestAccAWSRoute53Zone_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccRoute53ZoneConfig,
+				Config: testAccRoute53ZoneConfig(zoneName),
 			},
 
 			resource.TestStep{

--- a/aws/resource_aws_route53_delegation_set_test.go
+++ b/aws/resource_aws_route53_delegation_set_test.go
@@ -15,7 +15,8 @@ import (
 )
 
 func TestAccAWSRoute53DelegationSet_basic(t *testing.T) {
-	refName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
+	rString := acctest.RandString(8)
+	refName := fmt.Sprintf("tf_acc_%s", rString)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
@@ -36,7 +37,11 @@ func TestAccAWSRoute53DelegationSet_basic(t *testing.T) {
 
 func TestAccAWSRoute53DelegationSet_withZones(t *testing.T) {
 	var zone route53.GetHostedZoneOutput
-	refName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
+
+	rString := acctest.RandString(8)
+	refName := fmt.Sprintf("tf_acc_%s", rString)
+	zoneName1 := fmt.Sprintf("%s-primary.terraformtest.com", rString)
+	zoneName2 := fmt.Sprintf("%s-secondary.terraformtest.com", rString)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
@@ -46,7 +51,7 @@ func TestAccAWSRoute53DelegationSet_withZones(t *testing.T) {
 		CheckDestroy:    testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccRoute53DelegationSetWithZonesConfig(refName),
+				Config: testAccRoute53DelegationSetWithZonesConfig(refName, zoneName1, zoneName2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53DelegationSetExists("aws_route53_delegation_set.main"),
 					testAccCheckRoute53ZoneExists("aws_route53_zone.primary", &zone),
@@ -146,20 +151,20 @@ resource "aws_route53_delegation_set" "test" {
 `, refName)
 }
 
-func testAccRoute53DelegationSetWithZonesConfig(refName string) string {
+func testAccRoute53DelegationSetWithZonesConfig(refName, zoneName1, zoneName2 string) string {
 	return fmt.Sprintf(`
 resource "aws_route53_delegation_set" "main" {
     reference_name = "%s"
 }
 
 resource "aws_route53_zone" "primary" {
-    name = "hashicorp.com"
+    name = "%s"
     delegation_set_id = "${aws_route53_delegation_set.main.id}"
 }
 
 resource "aws_route53_zone" "secondary" {
-    name = "terraform.io"
+    name = "%s"
     delegation_set_id = "${aws_route53_delegation_set.main.id}"
 }
-`, refName)
+`, refName, zoneName1, zoneName2)
 }


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSRoute53DelegationSet_withZones
--- FAIL: TestAccAWSRoute53DelegationSet_withZones (54.53s)
    testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_route53_zone.secondary: 1 error(s) occurred:
        
        * aws_route53_zone.secondary: ConflictingDomainExists: Cannot create hosted zone with DelegationSetId DelegationSetId:N3LYKNBXFL7NRH as the DNSName terraform.io. conflicts with existing ones sharing the delegation set
            status code: 400, request id: fd6ecaab-fceb-11e7-b5f1-3761d69c0cd3
```

## Test results

```
=== RUN   TestAccAWSRoute53HealthCheck_IpConfig
--- PASS: TestAccAWSRoute53HealthCheck_IpConfig (13.86s)
=== RUN   TestAccAWSRoute53HealthCheck_importBasic
--- PASS: TestAccAWSRoute53HealthCheck_importBasic (16.50s)
=== RUN   TestAccAWSRoute53HealthCheck_withHealthCheckRegions
--- PASS: TestAccAWSRoute53HealthCheck_withHealthCheckRegions (16.54s)
=== RUN   TestAccAWSRoute53DelegationSet_importBasic
--- PASS: TestAccAWSRoute53DelegationSet_importBasic (16.90s)
=== RUN   TestAccAWSRoute53HealthCheck_CloudWatchAlarmCheck
--- PASS: TestAccAWSRoute53HealthCheck_CloudWatchAlarmCheck (21.31s)
=== RUN   TestAccAWSRoute53DelegationSet_basic
--- PASS: TestAccAWSRoute53DelegationSet_basic (21.57s)
=== RUN   TestAccAWSRoute53HealthCheck_basic
--- PASS: TestAccAWSRoute53HealthCheck_basic (29.03s)
=== RUN   TestAccAWSRoute53HealthCheck_withChildHealthChecks
--- PASS: TestAccAWSRoute53HealthCheck_withChildHealthChecks (29.65s)
=== RUN   TestAccAWSRoute53HealthCheck_withSNI
--- PASS: TestAccAWSRoute53HealthCheck_withSNI (30.75s)
=== RUN   TestAccAWSRoute53HealthCheck_withSearchString
--- PASS: TestAccAWSRoute53HealthCheck_withSearchString (31.81s)
=== RUN   TestAccAWSRoute53Zone_importBasic
--- PASS: TestAccAWSRoute53Zone_importBasic (50.26s)
=== RUN   TestAccAWSRoute53DelegationSet_withZones
--- PASS: TestAccAWSRoute53DelegationSet_withZones (78.17s)
=== RUN   TestAccAWSRoute53QueryLog_Import
--- PASS: TestAccAWSRoute53QueryLog_Import (80.44s)
=== RUN   TestAccAWSRoute53QueryLog_Basic
--- PASS: TestAccAWSRoute53QueryLog_Basic (82.69s)
=== RUN   TestAccAWSRoute53Record_basic
--- PASS: TestAccAWSRoute53Record_basic (161.20s)
=== RUN   TestAccAWSRoute53Record_basic_fqdn
--- PASS: TestAccAWSRoute53Record_basic_fqdn (166.30s)
=== RUN   TestAccAWSRoute53Record_s3_alias
--- PASS: TestAccAWSRoute53Record_s3_alias (146.54s)
=== RUN   TestAccAWSRoute53Record_spfSupport
--- PASS: TestAccAWSRoute53Record_spfSupport (176.72s)
=== RUN   TestAccAWSRoute53Record_caaSupport
--- PASS: TestAccAWSRoute53Record_caaSupport (181.68s)
=== RUN   TestAccAWSRoute53Record_txtSupport
--- PASS: TestAccAWSRoute53Record_txtSupport (188.37s)
=== RUN   TestAccAWSRoute53Record_generatesSuffix
--- PASS: TestAccAWSRoute53Record_generatesSuffix (221.81s)
=== RUN   TestAccAWSRoute53Record_weighted_basic
--- PASS: TestAccAWSRoute53Record_weighted_basic (206.98s)
=== RUN   TestAccAWSRoute53Zone_basic
--- PASS: TestAccAWSRoute53Zone_basic (59.70s)
=== RUN   TestAccAWSRoute53Record_alias
--- PASS: TestAccAWSRoute53Record_alias (216.21s)
=== RUN   TestAccAWSRoute53Record_geolocation_basic
--- PASS: TestAccAWSRoute53Record_geolocation_basic (208.81s)
=== RUN   TestAccAWSRoute53Zone_private_basic
--- PASS: TestAccAWSRoute53Zone_private_basic (50.18s)
=== RUN   TestAccAWSRoute53Record_failover
--- PASS: TestAccAWSRoute53Record_failover (225.17s)
=== RUN   TestAccAWSRoute53Record_empty
--- PASS: TestAccAWSRoute53Record_empty (163.91s)
=== RUN   TestAccAWSRoute53Record_latency_basic
--- PASS: TestAccAWSRoute53Record_latency_basic (216.57s)
=== RUN   TestAccAWSRoute53Record_SetIdentiferChange
--- PASS: TestAccAWSRoute53Record_SetIdentiferChange (220.49s)
=== RUN   TestAccAWSRoute53Zone_updateComment
--- PASS: TestAccAWSRoute53Zone_updateComment (72.43s)
=== RUN   TestAccAWSRoute53Record_longTXTrecord
--- PASS: TestAccAWSRoute53Record_longTXTrecord (176.72s)
=== RUN   TestAccAWSRoute53Record_multivalue_answer_basic
--- PASS: TestAccAWSRoute53Record_multivalue_answer_basic (176.70s)
=== RUN   TestAccAWSRoute53ZoneAssociation_basic
--- PASS: TestAccAWSRoute53ZoneAssociation_basic (102.99s)
=== RUN   TestAccAWSRoute53ZoneAssociation_region
--- PASS: TestAccAWSRoute53ZoneAssociation_region (107.01s)
=== RUN   TestAccAWSRoute53Record_wildcard
--- PASS: TestAccAWSRoute53Record_wildcard (270.52s)
=== RUN   TestAccAWSRoute53Record_AliasChange
--- PASS: TestAccAWSRoute53Record_AliasChange (236.96s)
=== RUN   TestAccAWSRoute53Zone_private_region
--- PASS: TestAccAWSRoute53Zone_private_region (67.46s)
=== RUN   TestAccAWSRoute53Record_TypeChange
--- PASS: TestAccAWSRoute53Record_TypeChange (276.52s)
=== RUN   TestAccAWSRoute53Record_weighted_alias
--- PASS: TestAccAWSRoute53Record_weighted_alias (346.01s)
=== RUN   TestAccAWSRoute53Zone_forceDestroy
--- PASS: TestAccAWSRoute53Zone_forceDestroy (562.78s)
```