### PR TITLE
test/aws_iam_*: Randomize names

### DIFF
--- a/aws/import_aws_iam_group_test.go
+++ b/aws/import_aws_iam_group_test.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -8,8 +9,10 @@ import (
 )
 
 func TestAccAWSIAMGroup_importBasic(t *testing.T) {
-	rInt := acctest.RandInt()
 	resourceName := "aws_iam_group.group"
+
+	rString := acctest.RandString(8)
+	groupName := fmt.Sprintf("tf-acc-group-import-%s", rString)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -17,7 +20,7 @@ func TestAccAWSIAMGroup_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSGroupConfig(rInt),
+				Config: testAccAWSGroupConfig(groupName),
 			},
 
 			{

--- a/aws/resource_aws_iam_group_test.go
+++ b/aws/resource_aws_iam_group_test.go
@@ -52,7 +52,10 @@ func TestValidateIamGroupName(t *testing.T) {
 
 func TestAccAWSIAMGroup_basic(t *testing.T) {
 	var conf iam.GetGroupOutput
-	rInt := acctest.RandInt()
+
+	rString := acctest.RandString(8)
+	groupName := fmt.Sprintf("tf-acc-group-basic-%s", rString)
+	groupName2 := fmt.Sprintf("tf-acc-group-basic-2-%s", rString)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -60,17 +63,17 @@ func TestAccAWSIAMGroup_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSGroupConfig(rInt),
+				Config: testAccAWSGroupConfig(groupName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSGroupExists("aws_iam_group.group", &conf),
-					testAccCheckAWSGroupAttributes(&conf, fmt.Sprintf("test-group-%d", rInt), "/"),
+					testAccCheckAWSGroupAttributes(&conf, groupName, "/"),
 				),
 			},
 			{
-				Config: testAccAWSGroupConfig2(rInt),
+				Config: testAccAWSGroupConfig2(groupName2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSGroupExists("aws_iam_group.group2", &conf),
-					testAccCheckAWSGroupAttributes(&conf, fmt.Sprintf("test-group-%d-2", rInt), "/funnypath/"),
+					testAccCheckAWSGroupAttributes(&conf, groupName2, "/funnypath/"),
 				),
 			},
 		},
@@ -146,18 +149,18 @@ func testAccCheckAWSGroupAttributes(group *iam.GetGroupOutput, name string, path
 	}
 }
 
-func testAccAWSGroupConfig(rInt int) string {
+func testAccAWSGroupConfig(groupName string) string {
 	return fmt.Sprintf(`
-	resource "aws_iam_group" "group" {
-		name = "test-group-%d"
-		path = "/"
-	}`, rInt)
+resource "aws_iam_group" "group" {
+	name = "%s"
+	path = "/"
+}`, groupName)
 }
 
-func testAccAWSGroupConfig2(rInt int) string {
+func testAccAWSGroupConfig2(groupName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_group" "group2" {
-	name = "test-group-%d-2"
+	name = "%s"
 	path = "/funnypath/"
-}`, rInt)
+}`, groupName)
 }


### PR DESCRIPTION
This was originally to address the following test failure:

```
=== RUN   TestAccAWSPolicyAttachment_basic
--- FAIL: TestAccAWSPolicyAttachment_basic (6.31s)
    testing.go:513: Step 0 error: Error applying: 2 error(s) occurred:
        
        * aws_iam_group.group: 1 error(s) occurred:
        
        * aws_iam_group.group: Error creating IAM Group test-group: EntityAlreadyExists: Group with name test-group already exists.
            status code: 409, request id: e917b459-fce3-11e7-a753-691a83f812d3
        * aws_iam_policy.policy: 1 error(s) occurred:
        
        * aws_iam_policy.policy: Error creating IAM policy test-policy: EntityAlreadyExists: A policy called test-policy already exists. Duplicate names are not allowed.
            status code: 409, request id: e908e75c-fce3-11e7-8cb6-099baf526cdd
```
but eventually turns out to be slightly bigger refactoring of tests 🤷‍♂️ Sorry! #notsorry

## Test Results

```
=== RUN   TestAccAWSIAMInstanceProfile_missingRoleThrowsError
--- PASS: TestAccAWSIAMInstanceProfile_missingRoleThrowsError (3.65s)
=== RUN   TestAccAWSIAMAccountPasswordPolicy_importBasic
--- PASS: TestAccAWSIAMAccountPasswordPolicy_importBasic (9.49s)
=== RUN   TestAccAWSIAMGroupPolicy_generatedName
--- PASS: TestAccAWSIAMGroupPolicy_generatedName (11.11s)
=== RUN   TestAccAWSIAMSamlProvider_importBasic
--- PASS: TestAccAWSIAMSamlProvider_importBasic (11.23s)
=== RUN   TestAccAWSIAMPolicy_importBasic
--- PASS: TestAccAWSIAMPolicy_importBasic (11.53s)
=== RUN   TestAccAWSIAMGroupPolicy_namePrefix
--- PASS: TestAccAWSIAMGroupPolicy_namePrefix (12.11s)
=== RUN   TestAccAWSIAMInstanceProfile_namePrefix
--- PASS: TestAccAWSIAMInstanceProfile_namePrefix (13.40s)
=== RUN   TestAccAWSIAMInstanceProfile_importBasic
--- PASS: TestAccAWSIAMInstanceProfile_importBasic (14.37s)
=== RUN   TestAccAWSIAMRolePolicy_invalidJSON
--- PASS: TestAccAWSIAMRolePolicy_invalidJSON (1.36s)
=== RUN   TestAccAWSIAMRolePolicy_importBasic
--- PASS: TestAccAWSIAMRolePolicy_importBasic (17.11s)
=== RUN   TestAccAWSIAMRole_importBasic
--- PASS: TestAccAWSIAMRole_importBasic (17.68s)
=== RUN   TestAccAWSIAMRole_basic
--- PASS: TestAccAWSIAMRole_basic (10.24s)
=== RUN   TestAccAWSIAMOpenIDConnectProvider_importBasic
--- PASS: TestAccAWSIAMOpenIDConnectProvider_importBasic (22.47s)
=== RUN   TestAccAWSIAMRole_badJSON
--- PASS: TestAccAWSIAMRole_badJSON (1.03s)
=== RUN   TestAccAWSIAMRole_namePrefix
--- PASS: TestAccAWSIAMRole_namePrefix (10.27s)
=== RUN   TestAccAWSIAMGroupPolicy_basic
--- PASS: TestAccAWSIAMGroupPolicy_basic (28.65s)
=== RUN   TestAccAWSIAMOpenIDConnectProvider_disappears
--- PASS: TestAccAWSIAMOpenIDConnectProvider_disappears (19.70s)
=== RUN   TestAccAWSIAMOpenIDConnectProvider_basic
--- PASS: TestAccAWSIAMOpenIDConnectProvider_basic (29.44s)
=== RUN   TestAccAWSIAMRolePolicy_generatedName
--- PASS: TestAccAWSIAMRolePolicy_generatedName (16.06s)
=== RUN   TestAccAWSIAMRolePolicy_namePrefix
--- PASS: TestAccAWSIAMRolePolicy_namePrefix (18.22s)
=== RUN   TestAccAWSIAMServerCertificate_importBasic
--- PASS: TestAccAWSIAMServerCertificate_importBasic (36.72s)
=== RUN   TestAccAWSIAMServerCertificate_basic
--- PASS: TestAccAWSIAMServerCertificate_basic (8.19s)
=== RUN   TestAccAWSIAMGroup_basic
--- PASS: TestAccAWSIAMGroup_basic (36.97s)
=== RUN   TestAccAWSIAMRolePolicy_basic
--- PASS: TestAccAWSIAMRolePolicy_basic (27.39s)
=== RUN   TestAccAWSIAMAccountAlias
=== RUN   TestAccAWSIAMAccountAlias/Basic
=== RUN   TestAccAWSIAMAccountAlias/Basic/basic
=== RUN   TestAccAWSIAMAccountAlias/Import
=== RUN   TestAccAWSIAMAccountAlias/Import/import
--- PASS: TestAccAWSIAMAccountAlias (38.97s)
    --- PASS: TestAccAWSIAMAccountAlias/Basic (30.57s)
        --- PASS: TestAccAWSIAMAccountAlias/Basic/basic (30.57s)
    --- PASS: TestAccAWSIAMAccountAlias/Import (8.41s)
        --- PASS: TestAccAWSIAMAccountAlias/Import/import (8.41s)
=== RUN   TestAccAWSIAMServerCertificate_name_prefix
--- PASS: TestAccAWSIAMServerCertificate_name_prefix (11.14s)
=== RUN   TestAccAWSIAMInstanceProfile_withRoleNotRoles
--- PASS: TestAccAWSIAMInstanceProfile_withRoleNotRoles (40.60s)
=== RUN   TestAccAWSIAMGroupPolicyAttachment_basic
--- PASS: TestAccAWSIAMGroupPolicyAttachment_basic (40.95s)
=== RUN   TestAccAWSIAMRole_force_detach_policies
--- PASS: TestAccAWSIAMRole_force_detach_policies (15.90s)
=== RUN   TestAccAWSIAMServerCertificate_disappears
--- PASS: TestAccAWSIAMServerCertificate_disappears (16.96s)
=== RUN   TestAccAWSIAMInstanceProfile_basic
--- PASS: TestAccAWSIAMInstanceProfile_basic (46.69s)
=== RUN   TestAccAWSIAMSamlProvider_basic
--- PASS: TestAccAWSIAMSamlProvider_basic (20.05s)
=== RUN   TestAccAWSIAMRole_testNameChange
--- PASS: TestAccAWSIAMRole_testNameChange (24.82s)
=== RUN   TestAccAWSIAMServerCertificate_file
--- PASS: TestAccAWSIAMServerCertificate_file (24.56s)
=== RUN   TestAccAWSIAMUserPolicy_basic
--- PASS: TestAccAWSIAMUserPolicy_basic (24.01s)
=== RUN   TestAccAWSIAMRole_basicWithDescription
--- PASS: TestAccAWSIAMRole_basicWithDescription (39.82s)
=== RUN   TestAccAWSIAMUserPolicy_generatedName
--- PASS: TestAccAWSIAMUserPolicy_generatedName (23.72s)
=== RUN   TestAccAWSIAMUserPolicy_namePrefix
--- PASS: TestAccAWSIAMUserPolicy_namePrefix (30.48s)
=== RUN   TestAccAWSIAMUserPolicy_multiplePolicies
--- PASS: TestAccAWSIAMUserPolicy_multiplePolicies (36.17s)
=== RUN   TestAccAWSIAMPolicyAttachment_basic
--- PASS: TestAccAWSIAMPolicyAttachment_basic (74.56s)
=== RUN   TestAccAWSIAMAccountPasswordPolicy_basic
--- PASS: TestAccAWSIAMAccountPasswordPolicy_basic (118.36s)
=== RUN   TestAccAWSIAMPolicyAttachment_paginatedEntities
--- PASS: TestAccAWSIAMPolicyAttachment_paginatedEntities (134.43s)
=== RUN   TestAccAWSIAMGroup_importBasic
--- PASS: TestAccAWSIAMGroup_importBasic (171.26s)
```