### PR TITLE
Update s3 etag schema

### DIFF
--- a/aws/resource_aws_s3_bucket_object.go
+++ b/aws/resource_aws_s3_bucket_object.go
@@ -111,6 +111,7 @@ func resourceAwsS3BucketObject() *schema.Resource {
 				// See http://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html
 				Optional:      true,
 				Computed:      true,
+				ForceNew:      true,
 				ConflictsWith: []string{"kms_key_id", "server_side_encryption"},
 			},
 


### PR DESCRIPTION
Fix for bug where `etag` change doesn't trigger a new upload of the resource and instead just changed the etag.

Added `ForceNew` to the `resource_s3_bucket_object` `etag` schema to make sure it trigger a new resource every time.


Fixes #2411