### PR TITLE
resource/aws_kinesis_firehose_delivery_stream: Prevent panic on missing S3 configuration prefix

### DIFF
--- a/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -190,7 +190,6 @@ func flattenFirehoseS3Configuration(s3 firehose.S3DestinationDescription) []inte
 	s3Configuration := map[string]interface{}{
 		"role_arn":           *s3.RoleARN,
 		"bucket_arn":         *s3.BucketARN,
-		"prefix":             *s3.Prefix,
 		"buffer_size":        *s3.BufferingHints.SizeInMBs,
 		"buffer_interval":    *s3.BufferingHints.IntervalInSeconds,
 		"compression_format": *s3.CompressionFormat,
@@ -200,6 +199,9 @@ func flattenFirehoseS3Configuration(s3 firehose.S3DestinationDescription) []inte
 	}
 	if s3.EncryptionConfiguration.KMSEncryptionConfig != nil {
 		s3Configuration["kms_key_arn"] = *s3.EncryptionConfiguration.KMSEncryptionConfig
+	}
+	if s3.Prefix != nil {
+		s3Configuration["prefix"] = *s3.Prefix
 	}
 	return []interface{}{s3Configuration}
 }


### PR DESCRIPTION
We are trying to deference an optional attribute (Prefix) from the Firehose API: https://docs.aws.amazon.com/firehose/latest/APIReference/API_S3DestinationDescription.html

Closes #3071 

```
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidProcessorType
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidProcessorType (1.62s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidParameterName
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidParameterName (1.78s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_missingProcessingConfiguration
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_missingProcessingConfiguration (116.79s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_s3WithCloudwatchLogging
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3WithCloudwatchLogging (117.58s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_s3basic
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basic (118.65s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_s3KinesisStreamSource
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3KinesisStreamSource (125.15s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_s3ConfigUpdates
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3ConfigUpdates (213.76s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3Updates
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3Updates (305.24s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3basic
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3basic (317.18s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_importBasic
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_importBasic (326.89s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_RedshiftConfigUpdates
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_RedshiftConfigUpdates (965.11s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigUpdates
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigUpdates (1058.67s)
```