### PR TITLE
Fixed name on resource_aws_ebs_snapshot kms_key_id

### DIFF
--- a/aws/resource_aws_ebs_snapshot.go
+++ b/aws/resource_aws_ebs_snapshot.go
@@ -113,7 +113,7 @@ func resourceAwsEbsSnapshotRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("owner_alias", snapshot.OwnerAlias)
 	d.Set("volume_id", snapshot.VolumeId)
 	d.Set("data_encryption_key_id", snapshot.DataEncryptionKeyId)
-	d.Set("kms_keey_id", snapshot.KmsKeyId)
+	d.Set("kms_key_id", snapshot.KmsKeyId)
 	d.Set("volume_size", snapshot.VolumeSize)
 
 	if err := d.Set("tags", tagsToMap(snapshot.Tags)); err != nil {

--- a/aws/resource_aws_ebs_snapshot_test.go
+++ b/aws/resource_aws_ebs_snapshot_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -38,6 +39,24 @@ func TestAccAWSEBSSnapshot_withDescription(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotExists("aws_ebs_snapshot.test", &v),
 					resource.TestCheckResourceAttr("aws_ebs_snapshot.test", "description", "EBS Snapshot Acceptance Test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEBSSnapshot_withKms(t *testing.T) {
+	var v ec2.Snapshot
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsEbsSnapshotConfigWithKms,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSnapshotExists("aws_ebs_snapshot.test", &v),
+					resource.TestMatchResourceAttr("aws_ebs_snapshot.test", "kms_key_id",
+						regexp.MustCompile("^arn:aws:kms:[a-z]{2}-[a-z]+-\\d{1}:[0-9]{12}:key/[a-z0-9-]{36}$")),
 				),
 			},
 		},
@@ -96,5 +115,34 @@ resource "aws_ebs_volume" "description_test" {
 resource "aws_ebs_snapshot" "test" {
 	volume_id = "${aws_ebs_volume.description_test.id}"
 	description = "EBS Snapshot Acceptance Test"
+}
+`
+
+const testAccAwsEbsSnapshotConfigWithKms = `
+resource "aws_kms_key" "test" {
+  deletion_window_in_days = 7
+
+  tags {
+    Name = "testAccAwsEbsSnapshotConfigWithKms"
+  }
+}
+
+resource "aws_ebs_volume" "test" {
+  availability_zone = "us-west-2a"
+  size              = 1
+  encrypted         = true
+  kms_key_id        = "${aws_kms_key.test.arn}"
+
+  tags {
+    Name = "testAccAwsEbsSnapshotConfigWithKms"
+  }
+}
+
+resource "aws_ebs_snapshot" "test" {
+  volume_id = "${aws_ebs_volume.test.id}"
+
+  tags {
+    Name = "testAccAwsEbsSnapshotConfigWithKms"
+  }
 }
 `


### PR DESCRIPTION
Looks like there is an naming error when setting the `kms_key_id` on `aws_ebs_snapshot`.

Please let me know if there is anything else needed here.