### PR TITLE
Added provider configuration for data sources

### DIFF
--- a/aws/data_source_aws_autoscaling_groups_test.go
+++ b/aws/data_source_aws_autoscaling_groups_test.go
@@ -81,6 +81,10 @@ func testAccCheckAwsAutoscalingGroupsAvailable(attrs map[string]string) ([]strin
 
 func testAccCheckAwsAutoscalingGroupsConfig(rInt1, rInt2, rInt3 int) string {
 	return fmt.Sprintf(`
+provider "aws" {
+  region = "us-west-2"
+}
+
 resource "aws_launch_configuration" "foobar" {
   image_id = "ami-21f78e11"
   instance_type = "t1.micro"
@@ -143,6 +147,10 @@ resource "aws_autoscaling_group" "barbaz" {
 
 func testAccCheckAwsAutoscalingGroupsConfigWithDataSource(rInt1, rInt2, rInt3 int) string {
 	return fmt.Sprintf(`
+provider "aws" {
+  region = "us-west-2"
+}
+
 resource "aws_launch_configuration" "foobar" {
   image_id = "ami-21f78e11"
   instance_type = "t1.micro"

--- a/aws/data_source_aws_ebs_snapshot_ids_test.go
+++ b/aws/data_source_aws_ebs_snapshot_ids_test.go
@@ -71,6 +71,10 @@ func TestAccDataSourceAwsEbsSnapshotIds_empty(t *testing.T) {
 }
 
 const testAccDataSourceAwsEbsSnapshotIdsConfig_basic = `
+provider "aws" {
+  region = "us-west-2"
+}
+
 resource "aws_ebs_volume" "test" {
     availability_zone = "us-west-2a"
     size              = 1
@@ -87,11 +91,14 @@ data "aws_ebs_snapshot_ids" "test" {
 
 func testAccDataSourceAwsEbsSnapshotIdsConfig_sorted1(uuid string) string {
 	return fmt.Sprintf(`
+provider "aws" {
+  region = "us-west-2"
+}
+
 resource "aws_ebs_volume" "test" {
     availability_zone = "us-west-2a"
     size              = 1
-
-    count = 2
+    count             = 2
 }
 
 resource "aws_ebs_snapshot" "a" {

--- a/aws/data_source_aws_ebs_snapshot_test.go
+++ b/aws/data_source_aws_ebs_snapshot_test.go
@@ -58,6 +58,10 @@ func testAccCheckAwsEbsSnapshotDataSourceID(n string) resource.TestCheckFunc {
 }
 
 const testAccCheckAwsEbsSnapshotDataSourceConfig = `
+provider "aws" {
+  region = "us-west-2"
+}
+
 resource "aws_ebs_volume" "example" {
   availability_zone = "us-west-2a"
   type = "gp2"
@@ -78,6 +82,10 @@ data "aws_ebs_snapshot" "snapshot" {
 `
 
 const testAccCheckAwsEbsSnapshotDataSourceConfigWithMultipleFilters = `
+provider "aws" {
+  region = "us-west-2"
+}
+
 resource "aws_ebs_volume" "external1" {
   availability_zone = "us-west-2a"
   type = "gp2"

--- a/aws/data_source_aws_ebs_volume_test.go
+++ b/aws/data_source_aws_ebs_volume_test.go
@@ -61,6 +61,10 @@ func testAccCheckAwsEbsVolumeDataSourceID(n string) resource.TestCheckFunc {
 }
 
 const testAccCheckAwsEbsVolumeDataSourceConfig = `
+provider "aws" {
+  region = "us-west-2"
+}
+
 resource "aws_ebs_volume" "example" {
   availability_zone = "us-west-2a"
   type = "gp2"
@@ -84,6 +88,10 @@ data "aws_ebs_volume" "ebs_volume" {
 `
 
 const testAccCheckAwsEbsVolumeDataSourceConfigWithMultipleFilters = `
+provider "aws" {
+  region = "us-west-2"
+}
+
 resource "aws_ebs_volume" "external1" {
   availability_zone = "us-west-2a"
   type = "gp2"

--- a/aws/data_source_aws_efs_mount_target_test.go
+++ b/aws/data_source_aws_efs_mount_target_test.go
@@ -30,6 +30,10 @@ func TestAccDataSourceAwsEfsMountTargetByMountTargetId(t *testing.T) {
 
 func testAccAwsEfsMountTargetConfigByMountTargetId(ct string) string {
 	return fmt.Sprintf(`
+provider "aws" {
+  region = "us-west-2"
+}
+
 resource "aws_efs_file_system" "foo" {
 	creation_token = "%s"
 }

--- a/aws/data_source_aws_instance_test.go
+++ b/aws/data_source_aws_instance_test.go
@@ -235,9 +235,12 @@ func TestAccAWSInstanceDataSource_VPCSecurityGroups(t *testing.T) {
 
 // Lookup based on InstanceID
 const testAccInstanceDataSourceConfig = `
+provider "aws" {
+  region = "us-west-2"
+}
+
 resource "aws_instance" "web" {
-  # us-west-2
-  ami = "ami-4fccb37f"
+  ami = "ami-4fccb37f" # us-west-2
   instance_type = "m1.small"
   tags {
     Name = "HelloWorld"
@@ -255,9 +258,12 @@ data "aws_instance" "web-instance" {
 // Use the tags attribute to filter
 func testAccInstanceDataSourceConfig_Tags(rInt int) string {
 	return fmt.Sprintf(`
+provider "aws" {
+  region = "us-west-2"
+}
+
 resource "aws_instance" "web" {
-  # us-west-2
-  ami = "ami-4fccb37f"
+  ami = "ami-4fccb37f" # us-west-2
   instance_type = "m1.small"
   tags {
     Name = "HelloWorld"
@@ -276,6 +282,10 @@ data "aws_instance" "web-instance" {
 
 // filter on tag, populate more attributes
 const testAccInstanceDataSourceConfig_AzUserData = `
+provider "aws" {
+  region = "us-west-2"
+}
+
 resource "aws_instance" "foo" {
   # us-west-2
   ami = "ami-4fccb37f"
@@ -295,6 +305,10 @@ data "aws_instance" "foo" {
 
 // GP2IopsDevice
 const testAccInstanceDataSourceConfig_gp2IopsDevice = `
+provider "aws" {
+  region = "us-west-2"
+}
+
 resource "aws_instance" "foo" {
   # us-west-2
   ami = "ami-55a7ea65"
@@ -312,6 +326,10 @@ data "aws_instance" "foo" {
 
 // Block Device
 const testAccInstanceDataSourceConfig_blockDevices = `
+provider "aws" {
+  region = "us-west-2"
+}
+
 resource "aws_instance" "foo" {
   # us-west-2
   ami = "ami-55a7ea65"
@@ -351,6 +369,10 @@ data "aws_instance" "foo" {
 `
 
 const testAccInstanceDataSourceConfig_rootInstanceStore = `
+provider "aws" {
+  region = "us-west-2"
+}
+
 resource "aws_instance" "foo" {
   ami = "ami-44c36524"
   instance_type = "m3.medium"
@@ -361,6 +383,10 @@ data "aws_instance" "foo" {
 `
 
 const testAccInstanceDataSourceConfig_privateIP = `
+provider "aws" {
+  region = "us-west-2"
+}
+
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
   tags {
@@ -418,6 +444,10 @@ data "aws_instance" "foo" {
 }
 
 const testAccInstanceDataSourceConfig_VPC = `
+provider "aws" {
+  region = "us-west-2"
+}
+
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
   tags {
@@ -448,6 +478,10 @@ data "aws_instance" "foo" {
 
 func testAccInstanceDataSourceConfig_PlacementGroup(rStr string) string {
 	return fmt.Sprintf(`
+provider "aws" {
+  region = "us-west-2"
+}
+
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
   tags {
@@ -515,6 +549,10 @@ data "aws_instance" "foo" {
 }
 
 const testAccInstanceDataSourceConfig_VPCSecurityGroups = `
+provider "aws" {
+  region = "us-west-2"
+}
+
 resource "aws_internet_gateway" "gw" {
   vpc_id = "${aws_vpc.foo.id}"
 }

--- a/aws/data_source_aws_rds_cluster_test.go
+++ b/aws/data_source_aws_rds_cluster_test.go
@@ -32,7 +32,12 @@ func TestAccDataSourceAwsRdsCluster_basic(t *testing.T) {
 }
 
 func testAccDataSourceAwsRdsClusterConfigBasic(clusterName string) string {
-	return fmt.Sprintf(`resource "aws_rds_cluster" "rds_cluster_test" {
+	return fmt.Sprintf(`
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_rds_cluster" "rds_cluster_test" {
 	cluster_identifier = "%s"
 	database_name = "mydb"
 	db_cluster_parameter_group_name = "default.aurora5.6"
@@ -70,5 +75,6 @@ resource "aws_db_subnet_group" "test" {
 
 data "aws_rds_cluster" "rds_cluster_test" {
 	cluster_identifier = "${aws_rds_cluster.rds_cluster_test.cluster_identifier}"
-}`, clusterName, clusterName)
+}
+`, clusterName, clusterName)
 }

--- a/aws/data_source_aws_subnet_ids_test.go
+++ b/aws/data_source_aws_subnet_ids_test.go
@@ -30,8 +30,11 @@ func TestAccDataSourceAwsSubnetIDs(t *testing.T) {
 }
 
 func testAccDataSourceAwsSubnetIDsConfigWithDataSource(rInt int) string {
-	return fmt.Sprintf(
-		`
+	return fmt.Sprintf(`
+	provider "aws" {
+		region = "us-west-2"
+	}
+
 	resource "aws_vpc" "test" {
 	  cidr_block = "172.%d.0.0/16"
 

--- a/aws/data_source_aws_subnet_test.go
+++ b/aws/data_source_aws_subnet_test.go
@@ -175,6 +175,10 @@ func testAccDataSourceAwsSubnetConfig(rInt int) string {
 
 func testAccDataSourceAwsSubnetConfigIpv6(rInt int) string {
 	return fmt.Sprintf(`
+provider "aws" {
+  region = "us-west-2"
+}
+
 resource "aws_vpc" "test" {
   cidr_block = "172.%d.0.0/16"
   assign_generated_ipv6_cidr_block = true
@@ -199,6 +203,10 @@ resource "aws_subnet" "test" {
 
 func testAccDataSourceAwsSubnetConfigIpv6WithDataSourceFilter(rInt int) string {
 	return fmt.Sprintf(`
+provider "aws" {
+  region = "us-west-2"
+}
+
 resource "aws_vpc" "test" {
   cidr_block = "172.%d.0.0/16"
   assign_generated_ipv6_cidr_block = true
@@ -230,6 +238,10 @@ data "aws_subnet" "by_ipv6_cidr" {
 
 func testAccDataSourceAwsSubnetConfigIpv6WithDataSourceIpv6CidrBlock(rInt int) string {
 	return fmt.Sprintf(`
+provider "aws" {
+  region = "us-west-2"
+}
+
 resource "aws_vpc" "test" {
   cidr_block = "172.%d.0.0/16"
   assign_generated_ipv6_cidr_block = true

--- a/aws/data_source_aws_vpc_endpoint_test.go
+++ b/aws/data_source_aws_vpc_endpoint_test.go
@@ -87,6 +87,10 @@ func testAccDataSourceAwsVpcEndpointCheckExists(name string) resource.TestCheckF
 }
 
 const testAccDataSourceAwsVpcEndpointConfig = `
+provider "aws" {
+  region = "us-west-2"
+}
+
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
@@ -110,6 +114,10 @@ data "aws_vpc_endpoint" "s3" {
 `
 
 const testAccDataSourceAwsVpcEndpointConfigById = `
+provider "aws" {
+  region = "us-west-2"
+}
+
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
@@ -129,6 +137,10 @@ data "aws_vpc_endpoint" "by_id" {
 `
 
 const testAccDataSourceAwsVpcEndpointWithRouteTableConfig = `
+provider "aws" {
+  region = "us-west-2"
+}
+
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 


### PR DESCRIPTION
## Description
Living in France, I'm always trying to use `eu-west-1` / `eu-central-1` / `eu-west-3` regions for acceptance testing.
Thus, I've been struggling with tests only passing in eu-west-2. This work is the first of many ones, adding provider configuration into acceptance tests.

## Tests

```
$ make testacc TEST=./aws TESTARGS='-run=\(TestAccAWSAutoscalingGroups_\|TestAccDataSourceAwsEbsSnapshotIds_\|TestAccAWSEbsVolumeDataSource_\|data_source_aws_ebs_snapshot_test\|TestAccDataSourceAwsEfsMountTargetByMountTargetId\|TestAccAWSInstanceDataSource_\|TestAccDataSourceAwsVpcEndpoint_\|data_source_aws_subnet_test\|data_source_aws_subnet_ids_test\|data_source_aws_rds_cluster_test\)' 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=\(TestAccAWSAutoscalingGroups_\|TestAccDataSourceAwsEbsSnapshotIds_\|TestAccAWSEbsVolumeDataSource_\|data_source_aws_ebs_snapshot_test\|TestAccDataSourceAwsEfsMountTargetByMountTargetId\|TestAccAWSInstanceDataSource_\|TestAccDataSourceAwsVpcEndpoint_\|data_source_aws_subnet_test\|data_source_aws_subnet_ids_test\|data_source_aws_rds_cluster_test\) -timeout 120m
=== RUN   TestAccAWSAutoscalingGroups_basic
--- PASS: TestAccAWSAutoscalingGroups_basic (91.54s)
=== RUN   TestAccDataSourceAwsEbsSnapshotIds_basic
--- PASS: TestAccDataSourceAwsEbsSnapshotIds_basic (74.68s)
=== RUN   TestAccDataSourceAwsEbsSnapshotIds_sorted
--- PASS: TestAccDataSourceAwsEbsSnapshotIds_sorted (107.64s)
=== RUN   TestAccDataSourceAwsEbsSnapshotIds_empty
--- PASS: TestAccDataSourceAwsEbsSnapshotIds_empty (16.29s)
=== RUN   TestAccAWSEbsVolumeDataSource_basic
--- PASS: TestAccAWSEbsVolumeDataSource_basic (41.32s)
=== RUN   TestAccAWSEbsVolumeDataSource_multipleFilters
--- PASS: TestAccAWSEbsVolumeDataSource_multipleFilters (38.72s)
=== RUN   TestAccDataSourceAwsEfsMountTargetByMountTargetId
--- PASS: TestAccDataSourceAwsEfsMountTargetByMountTargetId (246.43s)
=== RUN   TestAccAWSInstanceDataSource_basic
--- PASS: TestAccAWSInstanceDataSource_basic (145.02s)
=== RUN   TestAccAWSInstanceDataSource_tags
--- PASS: TestAccAWSInstanceDataSource_tags (155.89s)
=== RUN   TestAccAWSInstanceDataSource_AzUserData
--- PASS: TestAccAWSInstanceDataSource_AzUserData (144.87s)
=== RUN   TestAccAWSInstanceDataSource_gp2IopsDevice
--- PASS: TestAccAWSInstanceDataSource_gp2IopsDevice (110.22s)
=== RUN   TestAccAWSInstanceDataSource_blockDevices
--- PASS: TestAccAWSInstanceDataSource_blockDevices (130.66s)
=== RUN   TestAccAWSInstanceDataSource_rootInstanceStore
--- PASS: TestAccAWSInstanceDataSource_rootInstanceStore (112.03s)
=== RUN   TestAccAWSInstanceDataSource_privateIP
--- PASS: TestAccAWSInstanceDataSource_privateIP (141.86s)
=== RUN   TestAccAWSInstanceDataSource_keyPair
--- PASS: TestAccAWSInstanceDataSource_keyPair (100.83s)
=== RUN   TestAccAWSInstanceDataSource_VPC
--- PASS: TestAccAWSInstanceDataSource_VPC (134.00s)
=== RUN   TestAccAWSInstanceDataSource_PlacementGroup
--- PASS: TestAccAWSInstanceDataSource_PlacementGroup (127.25s)
=== RUN   TestAccAWSInstanceDataSource_SecurityGroups
--- PASS: TestAccAWSInstanceDataSource_SecurityGroups (130.77s)
=== RUN   TestAccAWSInstanceDataSource_VPCSecurityGroups
--- PASS: TestAccAWSInstanceDataSource_VPCSecurityGroups (161.46s)
=== RUN   TestAccDataSourceAwsVpcEndpoint_basic
--- PASS: TestAccDataSourceAwsVpcEndpoint_basic (53.55s)
=== RUN   TestAccDataSourceAwsVpcEndpoint_byId
--- PASS: TestAccDataSourceAwsVpcEndpoint_byId (56.00s)
=== RUN   TestAccDataSourceAwsVpcEndpoint_withRouteTable
--- PASS: TestAccDataSourceAwsVpcEndpoint_withRouteTable (59.72s)
```