### PR TITLE
resource/aws_kms_alias: Add target_key_arn attribute

### DIFF
--- a/aws/resource_aws_kms_alias_test.go
+++ b/aws/resource_aws_kms_alias_test.go
@@ -22,6 +22,7 @@ func TestAccAWSKmsAlias_basic(t *testing.T) {
 				Config: testAccAWSKmsSingleAlias(rInt, kmsAliasTimestamp),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSKmsAliasExists("aws_kms_alias.single"),
+					resource.TestCheckResourceAttrSet("aws_kms_alias.single", "target_key_arn"),
 				),
 			},
 			{
@@ -46,6 +47,7 @@ func TestAccAWSKmsAlias_name_prefix(t *testing.T) {
 				Config: testAccAWSKmsSingleAlias(rInt, kmsAliasTimestamp),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSKmsAliasExists("aws_kms_alias.name_prefix"),
+					resource.TestCheckResourceAttrSet("aws_kms_alias.name_prefix", "target_key_arn"),
 				),
 			},
 		},
@@ -64,6 +66,7 @@ func TestAccAWSKmsAlias_no_name(t *testing.T) {
 				Config: testAccAWSKmsSingleAlias(rInt, kmsAliasTimestamp),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSKmsAliasExists("aws_kms_alias.nothing"),
+					resource.TestCheckResourceAttrSet("aws_kms_alias.nothing", "target_key_arn"),
 				),
 			},
 		},
@@ -82,7 +85,9 @@ func TestAccAWSKmsAlias_multiple(t *testing.T) {
 				Config: testAccAWSKmsMultipleAliases(rInt, kmsAliasTimestamp),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSKmsAliasExists("aws_kms_alias.one"),
+					resource.TestCheckResourceAttrSet("aws_kms_alias.one", "target_key_arn"),
 					testAccCheckAWSKmsAliasExists("aws_kms_alias.two"),
+					resource.TestCheckResourceAttrSet("aws_kms_alias.two", "target_key_arn"),
 				),
 			},
 		},

--- a/website/docs/r/kms_alias.html.markdown
+++ b/website/docs/r/kms_alias.html.markdown
@@ -35,9 +35,10 @@ The name must start with the word "alias" followed by a forward slash (alias/). 
 
 ## Attributes Reference
 
-The following attributes are exported:
+The following additional attributes are exported:
 
 * `arn` - The Amazon Resource Name (ARN) of the key alias.
+* `target_key_arn` - The Amazon Resource Name (ARN) of the target key identifier.
 
 ## Import
 


### PR DESCRIPTION
Simple followup to #2551 to add `target_key_arn` attribute to the `aws_kms_alias` resource as well. We would need to augment `testAccCheckAWSKmsAliasExists` in the acceptance testing to pass back a `kms.ListAliasEntry` or similar in order to properly check the new attribute value from the existing key ID value (I don't mind implementing this though).

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSKmsAlias'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSKmsAlias -timeout 120m
=== RUN   TestAccAWSKmsAlias_importBasic
--- PASS: TestAccAWSKmsAlias_importBasic (43.47s)
=== RUN   TestAccAWSKmsAlias_basic
--- PASS: TestAccAWSKmsAlias_basic (50.60s)
=== RUN   TestAccAWSKmsAlias_name_prefix
--- PASS: TestAccAWSKmsAlias_name_prefix (39.43s)
=== RUN   TestAccAWSKmsAlias_no_name
--- PASS: TestAccAWSKmsAlias_no_name (39.46s)
=== RUN   TestAccAWSKmsAlias_multiple
--- PASS: TestAccAWSKmsAlias_multiple (38.73s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	211.737s
```