### PR TITLE
resource/aws_rds_cluster_instance: PerformanceInsightsKMSKeyId is not necessarily an ARN

### DIFF
--- a/aws/resource_aws_rds_cluster_instance.go
+++ b/aws/resource_aws_rds_cluster_instance.go
@@ -189,7 +189,6 @@ func resourceAwsRDSClusterInstance() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validateArn,
 			},
 
 			"tags": tagsSchema(),

--- a/aws/resource_aws_rds_cluster_instance.go
+++ b/aws/resource_aws_rds_cluster_instance.go
@@ -186,9 +186,9 @@ func resourceAwsRDSClusterInstance() *schema.Resource {
 			},
 
 			"performance_insights_kms_key_id": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 			},
 
 			"tags": tagsSchema(),

--- a/aws/resource_aws_rds_cluster_instance_test.go
+++ b/aws/resource_aws_rds_cluster_instance_test.go
@@ -245,7 +245,7 @@ func TestAccAWSRDSClusterInstance_withInstancePerformanceInsights(t *testing.T) 
 					testAccCheckAWSClusterInstanceExists("aws_rds_cluster_instance.cluster_instances", &v),
 					testAccCheckAWSDBClusterInstanceAttributes(&v),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_instance.cluster_instances", "performance_insights_enabled", "true")
+						"aws_rds_cluster_instance.cluster_instances", "performance_insights_enabled", "true"),
 				),
 			},
 		},

--- a/aws/resource_aws_rds_cluster_instance_test.go
+++ b/aws/resource_aws_rds_cluster_instance_test.go
@@ -233,7 +233,6 @@ func TestAccAWSRDSClusterInstance_withInstanceEnhancedMonitor(t *testing.T) {
 
 func TestAccAWSRDSClusterInstance_withInstancePerformanceInsights(t *testing.T) {
 	var v rds.DBInstance
-	keyRegex := regexp.MustCompile("^arn:aws:kms:")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -246,9 +245,7 @@ func TestAccAWSRDSClusterInstance_withInstancePerformanceInsights(t *testing.T) 
 					testAccCheckAWSClusterInstanceExists("aws_rds_cluster_instance.cluster_instances", &v),
 					testAccCheckAWSDBClusterInstanceAttributes(&v),
 					resource.TestCheckResourceAttr(
-						"aws_rds_cluster_instance.cluster_instances", "performance_insights_enabled", "true"),
-					resource.TestMatchResourceAttr(
-						"aws_rds_cluster_instance.cluster_instances", "performance_insights_kms_key_id", keyRegex),
+						"aws_rds_cluster_instance.cluster_instances", "performance_insights_enabled", "true")
 				),
 			},
 		},

--- a/website/docs/r/rds_cluster_instance.html.markdown
+++ b/website/docs/r/rds_cluster_instance.html.markdown
@@ -80,7 +80,7 @@ what IAM permissions are needed to allow Enhanced Monitoring for RDS Instances.
   Syntax: "ddd:hh24:mi-ddd:hh24:mi". Eg: "Mon:00:00-Mon:03:00".
 * `auto_minor_version_upgrade` - (Optional) Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window. Default `true`.
 * `performance_insights_enabled` - (Optional) Specifies whether Performance Insights is enabled or not.
-* `performance_insights_kms_key_id` - (Optional) The ARN for the KMS key to encrypt Performance Insights data. When specifying `performance_insights_kms_key_id`, `performance_insights_enabled` needs to be set to true.
+* `performance_insights_kms_key_id` - (Optional) The identifier for the KMS key to encrypt Performance Insights data. The identifier is the Amazon Resource Name (ARN), KMS key identifier, or the KMS key alias for the KMS encryption key. When specifying `performance_insights_kms_key_id`, `performance_insights_enabled` needs to be set to true.
 * `tags` - (Optional) A mapping of tags to assign to the instance.
 
 ## Attributes Reference


### PR DESCRIPTION
Fixing https://github.com/terraform-providers/terraform-provider-aws/issues/3014

cc @ColinHebert