### PR TITLE
test/aws_spot_fleet_request: Bump low bid price

### DIFF
--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -902,7 +902,7 @@ resource "aws_subnet" "bar" {
 
 resource "aws_spot_fleet_request" "foo" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
-    spot_price = "0.0265"
+    spot_price = "0.03"
     target_capacity = 4
     valid_until = "2019-11-04T20:44:20Z"
     terminate_instances_with_expiration = true


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList
--- FAIL: TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList (269.18s)
    testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_spot_fleet_request.foo: 1 error(s) occurred:
        
        * aws_spot_fleet_request.foo: Last events: [{
          EventInformation: {
            EventDescription: "m3.large, ami-d0f506b0, Linux/UNIX, us-west-2b, Spot bid price is less than Spot market price $0.0287",
            EventSubType: "launchSpecUnusable"
          },
          EventType: "information",
          Timestamp: 2018-01-23 09:26:44.668 +0000 UTC
        } {
          EventInformation: {
            EventDescription: "m3.large, ami-d0f506b0, Linux/UNIX, us-west-2a, Spot bid price is less than Spot market price $0.0287",
            EventSubType: "launchSpecUnusable"
          },
          EventType: "information",
          Timestamp: 2018-01-23 09:26:44.682 +0000 UTC
        } {
          EventInformation: {
            EventDescription: "All launch specifications are unusable. Please refer to individual information events for more detail.",
            EventSubType: "fleetProgressHalted"
          },
          EventType: "information",
          Timestamp: 2018-01-23 09:26:44.691 +0000 UTC
        }]
```

## Test results

```
=== RUN   TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList (292.57s)
```