### PR TITLE
test/aws_mq_broker: Add dependency on IGW

### DIFF
--- a/aws/resource_aws_mq_broker_test.go
+++ b/aws/resource_aws_mq_broker_test.go
@@ -689,6 +689,8 @@ resource "aws_mq_broker" "test" {
     console_access = true
     groups = ["first", "second", "third"]
   }
+
+  depends_on = ["aws_internet_gateway.test"]
 }`, sgName, sgName, cfgName, cfgBody, brokerName)
 }
 


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAwsMqBroker_allFieldsCustomVpc
--- FAIL: TestAccAwsMqBroker_allFieldsCustomVpc (177.28s)
    testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_mq_broker.test: 1 error(s) occurred:
        
        * aws_mq_broker.test: BadRequestException: The VPC associated with the provided subnets must have an available internet gateway attachment.
            status code: 400, request id: e53c0111-0018-11e8-ad33-07f096e8eb22
```

## Test results

```
=== RUN   TestAccAwsMqBroker_allFieldsCustomVpc
--- PASS: TestAccAwsMqBroker_allFieldsCustomVpc (2339.20s)
```