### PR TITLE
documentation: remove reference to cloudwatch_log_subscription_filter arn attribute

### DIFF
--- a/website/docs/r/cloudwatch_log_subscription_filter.html.markdown
+++ b/website/docs/r/cloudwatch_log_subscription_filter.html.markdown
@@ -34,6 +34,4 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-The following attributes are exported:
-
-* `arn` - The Amazon Resource Name (ARN) specifying the log subscription filter.
+No extra attributes are exported.


### PR DESCRIPTION
While trying to adopt Terraform v0.11 I found an output variable in my code that was attempting to use the arn attribute of cloudwatch_log_subscription_filter, but Terraform complained that the attribute did not exist.  I double checked [the code](https://github.com/terraform-providers/terraform-provider-aws/blob/master/aws/resource_aws_cloudwatch_log_subscription_filter.go) and it seems like the documentation was wrong.