### PR TITLE
resource/aws_sqs_queue: Retry queue creation on QueueDeletedRecently error

### DIFF
--- a/aws/resource_aws_sqs_queue.go
+++ b/aws/resource_aws_sqs_queue.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/url"
 	"strconv"
+	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"
 
@@ -165,9 +166,9 @@ func resourceAwsSqsQueueCreate(d *schema.ResourceData, meta interface{}) error {
 
 	attributes := make(map[string]*string)
 
-	resource := *resourceAwsSqsQueue()
+	queueResource := *resourceAwsSqsQueue()
 
-	for k, s := range resource.Schema {
+	for k, s := range queueResource.Schema {
 		if attrKey, ok := sqsQueueAttributeMap[k]; ok {
 			if value, ok := d.GetOk(k); ok {
 				switch s.Type {
@@ -187,7 +188,18 @@ func resourceAwsSqsQueueCreate(d *schema.ResourceData, meta interface{}) error {
 		req.Attributes = attributes
 	}
 
-	output, err := sqsconn.CreateQueue(req)
+	var output *sqs.CreateQueueOutput
+	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+		var err error
+		output, err = sqsconn.CreateQueue(req)
+		if err != nil {
+			if isAWSErr(err, sqs.ErrCodeQueueDeletedRecently, "You must wait 60 seconds after deleting a queue before you can create another with the same name.") {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
 	if err != nil {
 		return fmt.Errorf("Error creating SQS queue: %s", err)
 	}

--- a/aws/resource_aws_sqs_queue_test.go
+++ b/aws/resource_aws_sqs_queue_test.go
@@ -120,6 +120,33 @@ func TestAccAWSSQSQueue_policy(t *testing.T) {
 	})
 }
 
+func TestAccAWSSQSQueue_queueDeletedRecently(t *testing.T) {
+	queueName := fmt.Sprintf("sqs-queue-%s", acctest.RandString(10))
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSQSConfigWithDefaults(queueName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSQSExistsWithDefaults("aws_sqs_queue.queue"),
+				),
+			},
+			{
+				Config: "# delete queue to quickly recreate",
+				Check:  testAccCheckAWSSQSQueueDestroy,
+			},
+			{
+				Config: testAccAWSSQSConfigWithDefaults(queueName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSQSExistsWithDefaults("aws_sqs_queue.queue"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSSQSQueue_redrivePolicy(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },


### PR DESCRIPTION
Closes #831 

Failing test before implementation:
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSSQSQueue_queueDeletedRecently'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSSQSQueue_queueDeletedRecently -timeout 120m
=== RUN   TestAccAWSSQSQueue_queueDeletedRecently
--- FAIL: TestAccAWSSQSQueue_queueDeletedRecently (14.98s)
	testing.go:513: Step 2 error: Error applying: 1 error(s) occurred:

		* aws_sqs_queue.queue: 1 error(s) occurred:

		* aws_sqs_queue.queue: Error creating SQS queue: AWS.SimpleQueueService.QueueDeletedRecently: You must wait 60 seconds after deleting a queue before you can create another with the same name.
			status code: 400, request id: 8f81b2fe-c49a-5819-abb2-e01f98ce0b03
FAIL
exit status 1
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	15.024s
make: *** [testacc] Error 1
```

Passing test after implementation:
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSSQSQueue_queueDeletedRecently'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSSQSQueue_queueDeletedRecently -timeout 120m
=== RUN   TestAccAWSSQSQueue_queueDeletedRecently
--- PASS: TestAccAWSSQSQueue_queueDeletedRecently (83.52s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	83.572s
```