### PR TITLE
Default is 10 minutes not 5

### DIFF
--- a/website/docs/r/autoscaling_group.html.markdown
+++ b/website/docs/r/autoscaling_group.html.markdown
@@ -228,7 +228,7 @@ care to not duplicate these hooks in `aws_autoscaling_lifecycle_hook`.
 `autoscaling_group` provides the following
 [Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
 
-- `delete` - (Default `5 minutes`) Used for destroying ASG.
+- `delete` - (Default `10 minutes`) Used for destroying ASG.
 
 
 ## Waiting for Capacity


### PR DESCRIPTION
As per this line of code: https://github.com/terraform-providers/terraform-provider-aws/blob/a3126b43fb9dca62efc97efe8e3b1f4b11031f8b/aws/resource_aws_autoscaling_group.go#L30-L32