### PR TITLE
resource/aws_lambda_function: Retry updates for IAM eventual consistency

### DIFF
--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -649,6 +649,10 @@ func resourceAwsLambdaFunctionUpdate(d *schema.ResourceData, meta interface{}) e
 			if err != nil {
 				log.Printf("[DEBUG] Received error modifying Lambda Function Configuration %s: %s", d.Id(), err)
 
+				if isAWSErr(err, "InvalidParameterValueException", "The provided execution role does not have permissions") {
+					log.Printf("[DEBUG] Received %s, retrying UpdateFunctionConfiguration", err)
+					return resource.RetryableError(err)
+				}
 				if isAWSErr(err, "InvalidParameterValueException", "Your request has been throttled by EC2, please make sure you have enough API rate limit.") {
 					log.Printf("[DEBUG] Received %s, retrying UpdateFunctionConfiguration", err)
 					return resource.RetryableError(err)


### PR DESCRIPTION
Closes #1507. This is duplicate retry logic from the create function.

Testing passes (failure is unrelated eventual consistency issue with `aws_security_group` egress):
```
=== RUN   TestAccAWSLambdaFunction_s3
--- PASS: TestAccAWSLambdaFunction_s3 (29.23s)
=== RUN   TestAccAWSLambdaFunction_importS3
--- PASS: TestAccAWSLambdaFunction_importS3 (29.92s)
=== RUN   TestAccAWSLambdaFunction_concurrency
--- FAIL: TestAccAWSLambdaFunction_concurrency (78.74s)
=== RUN   TestAccAWSLambdaFunction_importLocalFile
--- PASS: TestAccAWSLambdaFunction_importLocalFile (83.98s)
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_noRuntime
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_noRuntime (0.81s)
=== RUN   TestAccAWSLambdaFunction_versioned
--- PASS: TestAccAWSLambdaFunction_versioned (98.87s)
=== RUN   TestAccAWSLambdaFunction_VPC_withInvocation
--- PASS: TestAccAWSLambdaFunction_VPC_withInvocation (114.66s)
=== RUN   TestAccAWSLambdaFunction_localUpdate_nameOnly
--- PASS: TestAccAWSLambdaFunction_localUpdate_nameOnly (90.72s)
=== RUN   TestAccAWSLambdaFunction_localUpdate
--- PASS: TestAccAWSLambdaFunction_localUpdate (125.61s)
=== RUN   TestAccAWSLambdaFunction_nilDeadLetterConfig
--- PASS: TestAccAWSLambdaFunction_nilDeadLetterConfig (128.31s)
=== RUN   TestAccAWSLambdaFunction_DeadLetterConfig
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfig (160.98s)
=== RUN   TestAccAWSLambdaFunction_importLocalFile_VPC
--- PASS: TestAccAWSLambdaFunction_importLocalFile_VPC (166.84s)
=== RUN   TestAccAWSLambdaFunction_expectFilenameAndS3Attributes
--- PASS: TestAccAWSLambdaFunction_expectFilenameAndS3Attributes (166.89s)
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_nodeJs43
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_nodeJs43 (89.96s)
=== RUN   TestAccAWSLambdaFunction_tracingConfig
--- PASS: TestAccAWSLambdaFunction_tracingConfig (195.55s)
=== RUN   TestAccAWSLambdaFunction_s3Update_unversioned
--- PASS: TestAccAWSLambdaFunction_s3Update_unversioned (120.19s)
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_python36
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python36 (102.81s)
=== RUN   TestAccAWSLambdaFunction_updateRuntime
--- PASS: TestAccAWSLambdaFunction_updateRuntime (234.82s)
=== RUN   TestAccAWSLambdaFunction_DeadLetterConfigUpdated
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfigUpdated (244.78s)
=== RUN   TestAccAWSLambdaFunction_concurrencyCycle
--- PASS: TestAccAWSLambdaFunction_concurrencyCycle (252.41s)
=== RUN   TestAccAWSLambdaFunction_s3Update_basic
--- PASS: TestAccAWSLambdaFunction_s3Update_basic (224.64s)
=== RUN   TestAccAWSLambdaFunction_tags
--- PASS: TestAccAWSLambdaFunction_tags (142.69s)
=== RUN   TestAccAWSLambdaFunction_envVariables
--- PASS: TestAccAWSLambdaFunction_envVariables (266.13s)
=== RUN   TestAccAWSLambdaFunction_encryptedEnvVariables
--- PASS: TestAccAWSLambdaFunction_encryptedEnvVariables (271.68s)
=== RUN   TestAccAWSLambdaFunction_VPC
--- PASS: TestAccAWSLambdaFunction_VPC (343.13s)
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_python27
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python27 (252.02s)
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_java8
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_java8 (245.90s)
=== RUN   TestAccAWSLambdaFunction_basic
--- PASS: TestAccAWSLambdaFunction_basic (385.52s)
=== RUN   TestAccAWSLambdaFunction_VPCUpdate
--- PASS: TestAccAWSLambdaFunction_VPCUpdate (434.56s)
```