### PR TITLE
resource/aws_route53_record: Suppress uppercase alias name diff

### DIFF
--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -102,10 +102,7 @@ func resourceAwsRoute53Record() *schema.Resource {
 							Required:  true,
 							StateFunc: normalizeAwsAliasName,
 							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-								if strings.ToLower(old) == strings.ToLower(new) {
-									return true
-								}
-								return false
+								return strings.ToLower(old) == strings.ToLower(new)
 							},
 						},
 

--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -101,6 +101,12 @@ func resourceAwsRoute53Record() *schema.Resource {
 							Type:      schema.TypeString,
 							Required:  true,
 							StateFunc: normalizeAwsAliasName,
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								if strings.ToLower(old) == strings.ToLower(new) {
+									return true
+								}
+								return false
+							},
 						},
 
 						"evaluate_target_health": {
@@ -898,11 +904,11 @@ func nilString(s string) *string {
 
 func normalizeAwsAliasName(alias interface{}) string {
 	input := alias.(string)
-	if strings.HasPrefix(input, "dualstack.") {
-		return strings.Replace(input, "dualstack.", "", -1)
+	output := strings.ToLower(input)
+	if strings.HasPrefix(output, "dualstack.") {
+		output = strings.TrimLeft(output, "dualstack.")
 	}
-
-	return strings.TrimRight(input, ".")
+	return strings.TrimRight(output, ".")
 }
 
 func parseRecordId(id string) [4]string {


### PR DESCRIPTION
Closes #361
Closes #439 
Closes #1005 

Uppercase ALB/ELB names generate an uppercase `dns_name` attribute from AWS which is subsequently saved into Terraform. When these are used for alias Route53 records, Route53 normalizes these to lowercase and only returns the lowercase value.  Most folks have used the workaround (myself included) of using `name = "${lower(aws_elb.X.dns_name)}"`.

I do not believe a state migration should be necessary for this change since uppercase name would have always generated the perpetual diff with the hash and name attribute itself.

Previously:
```
=== RUN   TestAccAWSRoute53Record_aliasUppercase
--- FAIL: TestAccAWSRoute53Record_aliasUppercase (234.96s)
	testing.go:513: Step 0 error: After applying this step, the plan was not empty:

		DIFF:

		UPDATE: aws_route53_record.alias
		  alias.1754141646.evaluate_target_health: "true" => "false"
		  alias.1754141646.name:                   "foobar-terraform-elb-1n1r4g62w0-123456789012.us-west-2.elb.amazonaws.com" => ""
		  alias.1754141646.zone_id:                "ZONEID" => ""
		  alias.561810618.evaluate_target_health:  "" => "true"
		  alias.561810618.name:                    "" => "FOOBAR-TERRAFORM-ELB-1n1r4g62w0-123456789012.us-west-2.elb.amazonaws.com"
		  alias.561810618.zone_id:                 "" => "ZONEID"
```

Passes local testing for me:
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSRoute53Record'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSRoute53Record -timeout 120m
=== RUN   TestAccAWSRoute53Record_basic
--- PASS: TestAccAWSRoute53Record_basic (146.94s)
=== RUN   TestAccAWSRoute53Record_basic_fqdn
--- PASS: TestAccAWSRoute53Record_basic_fqdn (142.64s)
=== RUN   TestAccAWSRoute53Record_txtSupport
--- PASS: TestAccAWSRoute53Record_txtSupport (146.45s)
=== RUN   TestAccAWSRoute53Record_spfSupport
--- PASS: TestAccAWSRoute53Record_spfSupport (131.89s)
=== RUN   TestAccAWSRoute53Record_caaSupport
--- PASS: TestAccAWSRoute53Record_caaSupport (157.52s)
=== RUN   TestAccAWSRoute53Record_generatesSuffix
--- PASS: TestAccAWSRoute53Record_generatesSuffix (148.82s)
=== RUN   TestAccAWSRoute53Record_wildcard
--- PASS: TestAccAWSRoute53Record_wildcard (192.87s)
=== RUN   TestAccAWSRoute53Record_failover
--- PASS: TestAccAWSRoute53Record_failover (137.64s)
=== RUN   TestAccAWSRoute53Record_weighted_basic
--- PASS: TestAccAWSRoute53Record_weighted_basic (138.17s)
=== RUN   TestAccAWSRoute53Record_alias
--- PASS: TestAccAWSRoute53Record_alias (170.03s)
=== RUN   TestAccAWSRoute53Record_aliasUppercase
--- PASS: TestAccAWSRoute53Record_aliasUppercase (210.80s)
=== RUN   TestAccAWSRoute53Record_s3_alias
--- PASS: TestAccAWSRoute53Record_s3_alias (159.76s)
=== RUN   TestAccAWSRoute53Record_weighted_alias
--- PASS: TestAccAWSRoute53Record_weighted_alias (296.04s)
=== RUN   TestAccAWSRoute53Record_geolocation_basic
--- PASS: TestAccAWSRoute53Record_geolocation_basic (153.61s)
=== RUN   TestAccAWSRoute53Record_latency_basic
--- PASS: TestAccAWSRoute53Record_latency_basic (150.90s)
=== RUN   TestAccAWSRoute53Record_TypeChange
--- PASS: TestAccAWSRoute53Record_TypeChange (168.72s)
=== RUN   TestAccAWSRoute53Record_SetIdentiferChange
--- PASS: TestAccAWSRoute53Record_SetIdentiferChange (250.73s)
=== RUN   TestAccAWSRoute53Record_AliasChange
--- PASS: TestAccAWSRoute53Record_AliasChange (263.28s)
=== RUN   TestAccAWSRoute53Record_empty
--- PASS: TestAccAWSRoute53Record_empty (177.55s)
=== RUN   TestAccAWSRoute53Record_longTXTrecord
--- PASS: TestAccAWSRoute53Record_longTXTrecord (197.82s)
=== RUN   TestAccAWSRoute53Record_multivalue_answer_basic
--- PASS: TestAccAWSRoute53Record_multivalue_answer_basic (209.47s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	3751.723s
```