### PR TITLE
resource/aws_appautoscaling_policy: Support additional predefined metric types in validation

### DIFF
--- a/aws/validators.go
+++ b/aws/validators.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/apigateway"
+	"github.com/aws/aws-sdk-go/service/applicationautoscaling"
 	"github.com/aws/aws-sdk-go/service/cognitoidentity"
 	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -1125,8 +1126,16 @@ func validateAppautoscalingCustomizedMetricSpecificationStatistic(v interface{},
 
 func validateAppautoscalingPredefinedMetricSpecification(v interface{}, k string) (ws []string, errors []error) {
 	validMetrics := []string{
-		"DynamoDBReadCapacityUtilization",
-		"DynamoDBWriteCapacityUtilization",
+		applicationautoscaling.MetricTypeAlbrequestCountPerTarget,
+		applicationautoscaling.MetricTypeDynamoDbreadCapacityUtilization,
+		applicationautoscaling.MetricTypeDynamoDbwriteCapacityUtilization,
+		applicationautoscaling.MetricTypeEc2spotFleetRequestAverageCpuutilization,
+		applicationautoscaling.MetricTypeEc2spotFleetRequestAverageNetworkIn,
+		applicationautoscaling.MetricTypeEc2spotFleetRequestAverageNetworkOut,
+		applicationautoscaling.MetricTypeEcsserviceAverageCpuutilization,
+		applicationautoscaling.MetricTypeEcsserviceAverageMemoryUtilization,
+		applicationautoscaling.MetricTypeRdsreaderAverageCpuutilization,
+		applicationautoscaling.MetricTypeRdsreaderAverageDatabaseConnections,
 	}
 	metric := v.(string)
 	for _, o := range validMetrics {

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -2864,6 +2864,65 @@ func TestResourceAWSElastiCacheReplicationGroupAuthTokenValidation(t *testing.T)
 	}
 }
 
+func TestValidateAppautoscalingPredefinedMetricSpecification(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "ALBRequestCountPerTarget",
+			ErrCount: 0,
+		},
+		{
+			Value:    "DynamoDBReadCapacityUtilization",
+			ErrCount: 0,
+		},
+		{
+			Value:    "DynamoDBWriteCapacityUtilization",
+			ErrCount: 0,
+		},
+		{
+			Value:    "EC2SpotFleetRequestAverageCPUUtilization",
+			ErrCount: 0,
+		},
+		{
+			Value:    "EC2SpotFleetRequestAverageNetworkIn",
+			ErrCount: 0,
+		},
+		{
+			Value:    "EC2SpotFleetRequestAverageNetworkOut",
+			ErrCount: 0,
+		},
+		{
+			Value:    "ECSServiceAverageCPUUtilization",
+			ErrCount: 0,
+		},
+		{
+			Value:    "ECSServiceAverageMemoryUtilization",
+			ErrCount: 0,
+		},
+		{
+			Value:    "RDSReaderAverageCPUUtilization",
+			ErrCount: 0,
+		},
+		{
+			Value:    "RDSReaderAverageDatabaseConnections",
+			ErrCount: 0,
+		},
+		{
+			Value:    "NotValid",
+			ErrCount: 1,
+		},
+	}
+	for _, tc := range cases {
+		_, errors := validateAppautoscalingPredefinedMetricSpecification(tc.Value, "predefined_metric_type")
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected %d errors, got %d: %s", tc.ErrCount, len(errors), errors)
+		}
+	}
+}
+
 func TestValidateCognitoUserPoolDomain(t *testing.T) {
 	validTypes := []string{
 		"valid-domain",


### PR DESCRIPTION
Closes #3112 

Validation of the attributes for `aws_appautoscaling_policy` has been a mixed bag of requests for the validation at plan time and issues like this where the validation is not up to date. Ideally, we would perform some type of compile time reflection of these `applicationautoscaling.MetricType*` constants instead, but this at least brings us up to all the currently supported predefined metrics types and adds unit testing.

```
make test TEST=./aws TESTARGS='-run=TestValidateAppautoscalingPredefinedMetricSpecification'
==> Checking that code complies with gofmt requirements...
go test ./aws -timeout=30s -parallel=4
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1.800s
```