### PR TITLE
resource/aws_api_gateway_integration: Allow update of content_handling attributes

### DIFF
--- a/aws/resource_aws_api_gateway_integration.go
+++ b/aws/resource_aws_api_gateway_integration.go
@@ -89,7 +89,6 @@ func resourceAwsApiGatewayIntegration() *schema.Resource {
 			"content_handling": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ForceNew:     true,
 				ValidateFunc: validateApiGatewayIntegrationContentHandling,
 			},
 
@@ -377,6 +376,14 @@ func resourceAwsApiGatewayIntegrationUpdate(d *schema.ResourceData, meta interfa
 			Op:    aws.String("replace"),
 			Path:  aws.String("/uri"),
 			Value: aws.String(d.Get("uri").(string)),
+		})
+	}
+
+	if d.HasChange("content_handling") {
+		operations = append(operations, &apigateway.PatchOperation{
+			Op:    aws.String("replace"),
+			Path:  aws.String("/contentHandling"),
+			Value: aws.String(d.Get("content_handling").(string)),
 		})
 	}
 

--- a/aws/resource_aws_api_gateway_integration_test.go
+++ b/aws/resource_aws_api_gateway_integration_test.go
@@ -112,6 +112,74 @@ func TestAccAWSAPIGatewayIntegration_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSAPIGatewayIntegration_contentHandling(t *testing.T) {
+	var conf apigateway.Integration
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayIntegrationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayIntegrationConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayIntegrationExists("aws_api_gateway_integration.test", &conf),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "type", "HTTP"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "integration_http_method", "GET"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "uri", "https://www.google.de"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "passthrough_behavior", "WHEN_NO_MATCH"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "content_handling", "CONVERT_TO_TEXT"),
+					resource.TestCheckNoResourceAttr("aws_api_gateway_integration.test", "credentials"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.%", "2"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.integration.request.header.X-Authorization", "'static'"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.integration.request.header.X-Foo", "'Bar'"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.%", "2"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.application/json", ""),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.application/xml", "#set($inputRoot = $input.path('$'))\n{ }"),
+				),
+			},
+
+			{
+				Config: testAccAWSAPIGatewayIntegrationConfigUpdateContentHandling,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayIntegrationExists("aws_api_gateway_integration.test", &conf),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "type", "HTTP"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "integration_http_method", "GET"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "uri", "https://www.google.de"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "passthrough_behavior", "WHEN_NO_MATCH"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "content_handling", "CONVERT_TO_BINARY"),
+					resource.TestCheckNoResourceAttr("aws_api_gateway_integration.test", "credentials"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.%", "2"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.integration.request.header.X-Authorization", "'static'"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.integration.request.header.X-Foo", "'Bar'"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.%", "2"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.application/json", ""),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.application/xml", "#set($inputRoot = $input.path('$'))\n{ }"),
+				),
+			},
+
+			{
+				Config: testAccAWSAPIGatewayIntegrationConfigRemoveContentHandling,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayIntegrationExists("aws_api_gateway_integration.test", &conf),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "type", "HTTP"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "integration_http_method", "GET"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "uri", "https://www.google.de"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "passthrough_behavior", "WHEN_NO_MATCH"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "content_handling", ""),
+					resource.TestCheckNoResourceAttr("aws_api_gateway_integration.test", "credentials"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.%", "2"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.integration.request.header.X-Authorization", "'static'"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.integration.request.header.X-Foo", "'Bar'"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.%", "2"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.application/json", ""),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.application/xml", "#set($inputRoot = $input.path('$'))\n{ }"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSAPIGatewayIntegration_cache_key_parameters(t *testing.T) {
 	var conf apigateway.Integration
 
@@ -340,6 +408,95 @@ resource "aws_api_gateway_integration" "test" {
   integration_http_method = "GET"
   passthrough_behavior = "WHEN_NO_MATCH"
   content_handling = "CONVERT_TO_TEXT"
+}
+`
+
+const testAccAWSAPIGatewayIntegrationConfigUpdateContentHandling = `
+resource "aws_api_gateway_rest_api" "test" {
+  name = "test"
+}
+
+resource "aws_api_gateway_resource" "test" {
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  parent_id = "${aws_api_gateway_rest_api.test.root_resource_id}"
+  path_part = "test"
+}
+
+resource "aws_api_gateway_method" "test" {
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  resource_id = "${aws_api_gateway_resource.test.id}"
+  http_method = "GET"
+  authorization = "NONE"
+
+  request_models = {
+    "application/json" = "Error"
+  }
+}
+
+resource "aws_api_gateway_integration" "test" {
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  resource_id = "${aws_api_gateway_resource.test.id}"
+  http_method = "${aws_api_gateway_method.test.http_method}"
+
+  request_templates = {
+    "application/json" = ""
+    "application/xml" = "#set($inputRoot = $input.path('$'))\n{ }"
+  }
+
+  request_parameters = {
+    "integration.request.header.X-Authorization" = "'static'"
+    "integration.request.header.X-Foo" = "'Bar'"
+  }
+
+  type = "HTTP"
+  uri = "https://www.google.de"
+  integration_http_method = "GET"
+  passthrough_behavior = "WHEN_NO_MATCH"
+  content_handling = "CONVERT_TO_BINARY"
+}
+`
+
+const testAccAWSAPIGatewayIntegrationConfigRemoveContentHandling = `
+resource "aws_api_gateway_rest_api" "test" {
+  name = "test"
+}
+
+resource "aws_api_gateway_resource" "test" {
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  parent_id = "${aws_api_gateway_rest_api.test.root_resource_id}"
+  path_part = "test"
+}
+
+resource "aws_api_gateway_method" "test" {
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  resource_id = "${aws_api_gateway_resource.test.id}"
+  http_method = "GET"
+  authorization = "NONE"
+
+  request_models = {
+    "application/json" = "Error"
+  }
+}
+
+resource "aws_api_gateway_integration" "test" {
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  resource_id = "${aws_api_gateway_resource.test.id}"
+  http_method = "${aws_api_gateway_method.test.http_method}"
+
+  request_templates = {
+    "application/json" = ""
+    "application/xml" = "#set($inputRoot = $input.path('$'))\n{ }"
+  }
+
+  request_parameters = {
+    "integration.request.header.X-Authorization" = "'static'"
+    "integration.request.header.X-Foo" = "'Bar'"
+  }
+
+  type = "HTTP"
+  uri = "https://www.google.de"
+  integration_http_method = "GET"
+  passthrough_behavior = "WHEN_NO_MATCH"
 }
 `
 


### PR DESCRIPTION
Instead of always forcing a new resource creation for content_handling changes, the integration:update action allows for in place updates.