### PR TITLE
resource/aws_redshift_cluster: Send correct values when resizing

### DIFF
--- a/aws/resource_aws_redshift_cluster.go
+++ b/aws/resource_aws_redshift_cluster.go
@@ -642,25 +642,17 @@ func resourceAwsRedshiftClusterUpdate(d *schema.ResourceData, meta interface{}) 
 		ClusterIdentifier: aws.String(d.Id()),
 	}
 
-	if d.HasChange("cluster_type") {
+	// If the cluster type, node type, or number of nodes changed, then the AWS API expects all three
+	// items to be sent over
+	if d.HasChange("cluster_type") || d.HasChange("node_type") || d.HasChange("number_of_nodes") {
 		req.ClusterType = aws.String(d.Get("cluster_type").(string))
-		requestUpdate = true
-	}
-
-	if d.HasChange("node_type") {
 		req.NodeType = aws.String(d.Get("node_type").(string))
-		requestUpdate = true
-	}
-
-	if d.HasChange("number_of_nodes") {
 		if v := d.Get("number_of_nodes").(int); v > 1 {
 			req.ClusterType = aws.String("multi-node")
 			req.NumberOfNodes = aws.Int64(int64(d.Get("number_of_nodes").(int)))
 		} else {
 			req.ClusterType = aws.String("single-node")
 		}
-
-		req.NodeType = aws.String(d.Get("node_type").(string))
 		requestUpdate = true
 	}
 

--- a/aws/resource_aws_redshift_cluster_test.go
+++ b/aws/resource_aws_redshift_cluster_test.go
@@ -383,9 +383,9 @@ func TestAccAWSRedshiftCluster_updateNodeCount(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_redshift_cluster.default", "number_of_nodes", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_redshift_cluster.default", "cluster-type", "multi-node"),
+						"aws_redshift_cluster.default", "cluster_type", "multi-node"),
 					resource.TestCheckResourceAttr(
-						"aws_redshift_cluster.default", "node-type", "dc1.large"),
+						"aws_redshift_cluster.default", "node_type", "dc1.large"),
 				),
 			},
 		},
@@ -409,7 +409,7 @@ func TestAccAWSRedshiftCluster_updateNodeType(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRedshiftClusterExists("aws_redshift_cluster.default", &v),
 					resource.TestCheckResourceAttr(
-						"aws_redshift_cluster.default", "node-type", "dc1.large"),
+						"aws_redshift_cluster.default", "node_type", "dc1.large"),
 				),
 			},
 
@@ -420,9 +420,9 @@ func TestAccAWSRedshiftCluster_updateNodeType(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_redshift_cluster.default", "number_of_nodes", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_redshift_cluster.default", "cluster-type", "single-node"),
+						"aws_redshift_cluster.default", "cluster_type", "single-node"),
 					resource.TestCheckResourceAttr(
-						"aws_redshift_cluster.default", "node-type", "dc1.8xlarge"),
+						"aws_redshift_cluster.default", "node_type", "dc1.8xlarge"),
 				),
 			},
 		},

--- a/aws/resource_aws_redshift_cluster_test.go
+++ b/aws/resource_aws_redshift_cluster_test.go
@@ -422,7 +422,7 @@ func TestAccAWSRedshiftCluster_updateNodeType(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_redshift_cluster.default", "cluster_type", "single-node"),
 					resource.TestCheckResourceAttr(
-						"aws_redshift_cluster.default", "node_type", "dc1.8xlarge"),
+						"aws_redshift_cluster.default", "node_type", "dc2.large"),
 				),
 			},
 		},
@@ -787,7 +787,7 @@ resource "aws_redshift_cluster" "default" {
   database_name = "mydb"
   master_username = "foo_test"
   master_password = "Mustbe8characters"
-  node_type = "dc1.8xlarge"
+  node_type = "dc2.large"
   automated_snapshot_retention_period = 0
   allow_version_upgrade = false
   number_of_nodes = 1

--- a/aws/resource_aws_redshift_cluster_test.go
+++ b/aws/resource_aws_redshift_cluster_test.go
@@ -382,6 +382,47 @@ func TestAccAWSRedshiftCluster_updateNodeCount(t *testing.T) {
 					testAccCheckAWSRedshiftClusterExists("aws_redshift_cluster.default", &v),
 					resource.TestCheckResourceAttr(
 						"aws_redshift_cluster.default", "number_of_nodes", "2"),
+					resource.TestCheckResourceAttr(
+						"aws_redshift_cluster.default", "cluster-type", "multi-node"),
+					resource.TestCheckResourceAttr(
+						"aws_redshift_cluster.default", "node-type", "dc1.large"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSRedshiftCluster_updateNodeType(t *testing.T) {
+	var v redshift.Cluster
+
+	ri := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	preConfig := testAccAWSRedshiftClusterConfig_basic(ri)
+	postConfig := testAccAWSRedshiftClusterConfig_updateNodeType(ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRedshiftClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: preConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRedshiftClusterExists("aws_redshift_cluster.default", &v),
+					resource.TestCheckResourceAttr(
+						"aws_redshift_cluster.default", "node-type", "dc1.large"),
+				),
+			},
+
+			{
+				Config: postConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRedshiftClusterExists("aws_redshift_cluster.default", &v),
+					resource.TestCheckResourceAttr(
+						"aws_redshift_cluster.default", "number_of_nodes", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_redshift_cluster.default", "cluster-type", "single-node"),
+					resource.TestCheckResourceAttr(
+						"aws_redshift_cluster.default", "node-type", "dc1.8xlarge"),
 				),
 			},
 		},
@@ -733,6 +774,23 @@ resource "aws_redshift_cluster" "default" {
   automated_snapshot_retention_period = 0
   allow_version_upgrade = false
   number_of_nodes = 2
+  skip_final_snapshot = true
+}
+`, rInt)
+}
+
+func testAccAWSRedshiftClusterConfig_updateNodeType(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_redshift_cluster" "default" {
+  cluster_identifier = "tf-redshift-cluster-%d"
+  availability_zone = "us-west-2a"
+  database_name = "mydb"
+  master_username = "foo_test"
+  master_password = "Mustbe8characters"
+  node_type = "dc1.8xlarge"
+  automated_snapshot_retention_period = 0
+  allow_version_upgrade = false
+  number_of_nodes = 1
   skip_final_snapshot = true
 }
 `, rInt)


### PR DESCRIPTION
When resizing a Redshift cluster, the AWS API is expecting the Cluster
Type, Node Type, and Number of Nodes regardless of which value changed.
If not passed it will error out with
`[WARN] Error modifying Redshift Cluster (navistone-public-cluster):
InvalidParameterCombination: Number of nodes for cluster type multi-node
must be greater than or equal to 2`

Now we send all values if any one of them change.  Closes #484

Signed-off-by: Ken Herner <kherner@navistone.com>