### PR TITLE
test/aws_eip: Add missing depend_on for Internet Gateway in testAccAWSEIPNetworkInterfaceConfig

### DIFF
--- a/aws/resource_aws_eip_test.go
+++ b/aws/resource_aws_eip_test.go
@@ -657,6 +657,7 @@ resource "aws_network_interface" "bar" {
 resource "aws_eip" "bar" {
 	vpc = "true"
 	network_interface = "${aws_network_interface.bar.id}"
+	depends_on = ["aws_internet_gateway.bar"]
 }
 `
 


### PR DESCRIPTION
To address intermittent test failure:
```
=== RUN   TestAccAWSEIP_importVpc
--- FAIL: TestAccAWSEIP_importVpc (44.10s)
    testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_eip.bar: 1 error(s) occurred:
        
        * aws_eip.bar: Failure associating EIP: Gateway.NotAttached: Network vpc-aaf95bd3 is not attached to any internet gateway
            status code: 400, request id: 57da8fa2-6645-464e-b5cd-8c2803b89a3f
```

Passes locally for me:
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSEIP_importVpc'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSEIP_importVpc -timeout 120m
=== RUN   TestAccAWSEIP_importVpc
--- PASS: TestAccAWSEIP_importVpc (41.82s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	41.863s
```