### PR TITLE
docs/resource/aws_appautoscaling_target: Fix links to AWS documentation and add DynamoDB Index Autoscaling example

### DIFF
--- a/website/docs/r/appautoscaling_target.html.markdown
+++ b/website/docs/r/appautoscaling_target.html.markdown
@@ -25,6 +25,19 @@ resource "aws_appautoscaling_target" "dynamodb_table_read_target" {
 }
 ```
 
+### DynamoDB Index Autoscaling
+
+```hcl
+resource "aws_appautoscaling_target" "dynamodb_index_read_target" {
+  max_capacity       = 100
+  min_capacity       = 5
+  resource_id        = "table/tableName/index/indexName"
+  role_arn           = "${data.aws_iam_role.DynamoDBAutoscaleRole.arn}"
+  scalable_dimension = "dynamodb:index:ReadCapacityUnits"
+  service_namespace  = "dynamodb"
+}
+```
+
 ### ECS Service Autoscaling
 
 ```hcl
@@ -44,8 +57,8 @@ The following arguments are supported:
 
 * `max_capacity` - (Required) The max capacity of the scalable target.
 * `min_capacity` - (Required) The min capacity of the scalable target.
-* `resource_id` - (Required) The resource type and unique identifier string for the resource associated with the scaling policy. Documentation can be found in the `ResourceId` parameter at: [AWS Application Auto Scaling API Reference](http://docs.aws.amazon.com/ApplicationAutoScaling/latest/APIReference/API_RegisterScalableTarget.html#API_RegisterScalableTarget_RequestParameters)
+* `resource_id` - (Required) The resource type and unique identifier string for the resource associated with the scaling policy. Documentation can be found in the `ResourceId` parameter at: [AWS Application Auto Scaling API Reference](https://docs.aws.amazon.com/autoscaling/application/APIReference/API_RegisterScalableTarget.html#API_RegisterScalableTarget_RequestParameters)
 * `role_arn` - (Optional) The ARN of the IAM role that allows Application
 AutoScaling to modify your scalable target on your behalf.
-* `scalable_dimension` - (Required) The scalable dimension of the scalable target. Documentation can be found in the `ScalableDimension` parameter at: [AWS Application Auto Scaling API Reference](http://docs.aws.amazon.com/ApplicationAutoScaling/latest/APIReference/API_RegisterScalableTarget.html#API_RegisterScalableTarget_RequestParameters)
-* `service_namespace` - (Required) The AWS service namespace of the scalable target. Documentation can be found in the `ServiceNamespace` parameter at: [AWS Application Auto Scaling API Reference](http://docs.aws.amazon.com/ApplicationAutoScaling/latest/APIReference/API_RegisterScalableTarget.html#API_RegisterScalableTarget_RequestParameters)
+* `scalable_dimension` - (Required) The scalable dimension of the scalable target. Documentation can be found in the `ScalableDimension` parameter at: [AWS Application Auto Scaling API Reference](https://docs.aws.amazon.com/autoscaling/application/APIReference/API_RegisterScalableTarget.html#API_RegisterScalableTarget_RequestParameters)
+* `service_namespace` - (Required) The AWS service namespace of the scalable target. Documentation can be found in the `ServiceNamespace` parameter at: [AWS Application Auto Scaling API Reference](https://docs.aws.amazon.com/autoscaling/application/APIReference/API_RegisterScalableTarget.html#API_RegisterScalableTarget_RequestParameters)


### PR DESCRIPTION
Noticed while answering: https://github.com/hashicorp/terraform/issues/15470#issuecomment-358816698