### PR TITLE
resource/aws_sqs_queue: Retry creation on QueueDeletedRecently for additional 10 seconds

### DIFF
--- a/aws/resource_aws_sqs_queue.go
+++ b/aws/resource_aws_sqs_queue.go
@@ -189,7 +189,7 @@ func resourceAwsSqsQueueCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	var output *sqs.CreateQueueOutput
-	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+	err := resource.Retry(70*time.Second, func() *resource.RetryError {
 		var err error
 		output, err = sqsconn.CreateQueue(req)
 		if err != nil {


### PR DESCRIPTION
Followup to #3113 

The retry handler needs another ten seconds to pass:
```
2018/01/26 07:57:29 [DEBUG] [aws-sdk-go] ... QueueDeletedRecently
...
2018/01/26 07:58:05 [DEBUG] [aws-sdk-go] ... QueueDeletedRecently
2018/01/26 07:58:15 [DEBUG] [aws-sdk-go] ... QueueDeletedRecently
2018/01/26 07:58:25 [DEBUG] [aws-sdk-go] ... QueueDeletedRecently
2018/01/26 07:58:29 [WARN] WaitForState timeout after 1m0s
```

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSSQSQueue_queueDeletedRecently'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSSQSQueue_queueDeletedRecently -timeout 120m
=== RUN   TestAccAWSSQSQueue_queueDeletedRecently
--- PASS: TestAccAWSSQSQueue_queueDeletedRecently (84.99s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	85.038s
```