### PR TITLE
resource/api_gateway_authorizer: support authorizer type as COGNITO_USER_POOLS

### DIFF
--- a/aws/resource_aws_api_gateway_authorizer.go
+++ b/aws/resource_aws_api_gateway_authorizer.go
@@ -19,44 +19,44 @@ func resourceAwsApiGatewayAuthorizer() *schema.Resource {
 		Delete: resourceAwsApiGatewayAuthorizerDelete,
 
 		Schema: map[string]*schema.Schema{
-			"authorizer_uri": &schema.Schema{
+			"authorizer_uri": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"identity_source": &schema.Schema{
+			"identity_source": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "method.request.header.Authorization",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"rest_api_id": &schema.Schema{
+			"rest_api_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"type": &schema.Schema{
+			"type": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "TOKEN",
 				ForceNew: true,
 			},
-			"authorizer_credentials": &schema.Schema{
+			"authorizer_credentials": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"authorizer_result_ttl_in_seconds": &schema.Schema{
+			"authorizer_result_ttl_in_seconds": {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				ValidateFunc: validateIntegerInRange(0, 3600),
 			},
-			"identity_validation_expression": &schema.Schema{
+			"identity_validation_expression": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"provider_arns": &schema.Schema{
+			"provider_arns": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},

--- a/aws/resource_aws_api_gateway_authorizer.go
+++ b/aws/resource_aws_api_gateway_authorizer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/apigateway"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsApiGatewayAuthorizer() *schema.Resource {
@@ -42,7 +43,11 @@ func resourceAwsApiGatewayAuthorizer() *schema.Resource {
 				Optional: true,
 				Default:  "TOKEN",
 				ForceNew: true,
-			},
+				ValidateFunc: validation.StringInSlice([]string{
+					apigateway.AuthorizerTypeCognitoUserPools,
+					apigateway.AuthorizerTypeRequest,
+					apigateway.AuthorizerTypeToken,
+				}, false)},
 			"authorizer_credentials": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/aws/resource_aws_api_gateway_authorizer_test.go
+++ b/aws/resource_aws_api_gateway_authorizer_test.go
@@ -8,16 +8,21 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/apigateway"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccAWSAPIGatewayAuthorizer_basic(t *testing.T) {
 	var conf apigateway.Authorizer
+	rString := acctest.RandString(7)
+	apiGatewayName := "tf-acctest-apigw-" + rString
+	authorizerName := "tf-acctest-igw-authorizer-" + rString
+	lambdaName := "tf-acctest-igw-auth-lambda-" + rString
 
 	expectedAuthUri := regexp.MustCompile("arn:aws:apigateway:[a-z0-9-]+:lambda:path/2015-03-31/functions/" +
-		"arn:aws:lambda:[a-z0-9-]+:[0-9]{12}:function:tf_acc_api_gateway_authorizer/invocations")
-	expectedCreds := regexp.MustCompile("arn:aws:iam::[0-9]{12}:role/tf_acc_api_gateway_auth_invocation_role")
+		"arn:aws:lambda:[a-z0-9-]+:[0-9]{12}:function:" + lambdaName + "/invocations")
+	expectedCreds := regexp.MustCompile("arn:aws:iam::[0-9]{12}:role/" + apiGatewayName + "_auth_invocation_role")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -25,43 +30,118 @@ func TestAccAWSAPIGatewayAuthorizer_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSAPIGatewayAuthorizerDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSAPIGatewayAuthorizerConfig,
+				Config: testAccAWSAPIGatewayAuthorizerConfig_lambda(apiGatewayName, authorizerName, lambdaName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayAuthorizerExists("aws_api_gateway_authorizer.test", &conf),
+					testAccCheckAWSAPIGatewayAuthorizerExists("aws_api_gateway_authorizer.acctest", &conf),
 					testAccCheckAWSAPIGatewayAuthorizerAuthorizerUri(&conf, expectedAuthUri),
-					resource.TestMatchResourceAttr("aws_api_gateway_authorizer.test", "authorizer_uri", expectedAuthUri),
+					resource.TestMatchResourceAttr("aws_api_gateway_authorizer.acctest", "authorizer_uri", expectedAuthUri),
 					testAccCheckAWSAPIGatewayAuthorizerIdentitySource(&conf, "method.request.header.Authorization"),
-					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.test", "identity_source", "method.request.header.Authorization"),
-					testAccCheckAWSAPIGatewayAuthorizerName(&conf, "tf-acc-test-authorizer"),
-					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.test", "name", "tf-acc-test-authorizer"),
+					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "identity_source", "method.request.header.Authorization"),
+					testAccCheckAWSAPIGatewayAuthorizerName(&conf, authorizerName),
+					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "name", authorizerName),
 					testAccCheckAWSAPIGatewayAuthorizerType(&conf, "TOKEN"),
-					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.test", "type", "TOKEN"),
+					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "type", "TOKEN"),
 					testAccCheckAWSAPIGatewayAuthorizerAuthorizerCredentials(&conf, expectedCreds),
-					resource.TestMatchResourceAttr("aws_api_gateway_authorizer.test", "authorizer_credentials", expectedCreds),
+					resource.TestMatchResourceAttr("aws_api_gateway_authorizer.acctest", "authorizer_credentials", expectedCreds),
 					testAccCheckAWSAPIGatewayAuthorizerAuthorizerResultTtlInSeconds(&conf, nil),
-					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.test", "authorizer_result_ttl_in_seconds", "0"),
+					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "authorizer_result_ttl_in_seconds", "0"),
 					testAccCheckAWSAPIGatewayAuthorizerIdentityValidationExpression(&conf, nil),
-					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.test", "identity_validation_expression", ""),
+					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "identity_validation_expression", ""),
 				),
 			},
 			resource.TestStep{
-				Config: testAccAWSAPIGatewayAuthorizerUpdatedConfig,
+				Config: testAccAWSAPIGatewayAuthorizerConfig_lambdaUpdate(apiGatewayName, authorizerName, lambdaName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayAuthorizerExists("aws_api_gateway_authorizer.test", &conf),
+					testAccCheckAWSAPIGatewayAuthorizerExists("aws_api_gateway_authorizer.acctest", &conf),
 					testAccCheckAWSAPIGatewayAuthorizerAuthorizerUri(&conf, expectedAuthUri),
-					resource.TestMatchResourceAttr("aws_api_gateway_authorizer.test", "authorizer_uri", expectedAuthUri),
+					resource.TestMatchResourceAttr("aws_api_gateway_authorizer.acctest", "authorizer_uri", expectedAuthUri),
 					testAccCheckAWSAPIGatewayAuthorizerIdentitySource(&conf, "method.request.header.Authorization"),
-					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.test", "identity_source", "method.request.header.Authorization"),
-					testAccCheckAWSAPIGatewayAuthorizerName(&conf, "tf-acc-test-authorizer_modified"),
-					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.test", "name", "tf-acc-test-authorizer_modified"),
+					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "identity_source", "method.request.header.Authorization"),
+					testAccCheckAWSAPIGatewayAuthorizerName(&conf, authorizerName+"_modified"),
+					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "name", authorizerName+"_modified"),
 					testAccCheckAWSAPIGatewayAuthorizerType(&conf, "TOKEN"),
-					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.test", "type", "TOKEN"),
+					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "type", "TOKEN"),
 					testAccCheckAWSAPIGatewayAuthorizerAuthorizerCredentials(&conf, expectedCreds),
-					resource.TestMatchResourceAttr("aws_api_gateway_authorizer.test", "authorizer_credentials", expectedCreds),
+					resource.TestMatchResourceAttr("aws_api_gateway_authorizer.acctest", "authorizer_credentials", expectedCreds),
 					testAccCheckAWSAPIGatewayAuthorizerAuthorizerResultTtlInSeconds(&conf, aws.Int64(360)),
-					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.test", "authorizer_result_ttl_in_seconds", "360"),
+					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "authorizer_result_ttl_in_seconds", "360"),
 					testAccCheckAWSAPIGatewayAuthorizerIdentityValidationExpression(&conf, aws.String(".*")),
-					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.test", "identity_validation_expression", ".*"),
+					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "identity_validation_expression", ".*"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayAuthorizer_cognito(t *testing.T) {
+	rString := acctest.RandString(7)
+	apiGatewayName := "tf-acctest-apigw-" + rString
+	authorizerName := "tf-acctest-igw-authorizer-" + rString
+	cognitoName := "tf-acctest-cognito-user-pool-" + rString
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayAuthorizerDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSAPIGatewayAuthorizerConfig_cognito(apiGatewayName, authorizerName, cognitoName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "name", authorizerName+"-cognito"),
+					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "provider_arns.#", "2"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSAPIGatewayAuthorizerConfig_cognitoUpdate(apiGatewayName, authorizerName, cognitoName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "name", authorizerName+"-cognito-update"),
+					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "provider_arns.#", "3"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayAuthorizer_switchAuthType(t *testing.T) {
+	rString := acctest.RandString(7)
+	apiGatewayName := "tf-acctest-apigw-" + rString
+	authorizerName := "tf-acctest-igw-authorizer-" + rString
+	cognitoName := "tf-acctest-cognito-user-pool-" + rString
+	lambdaName := "tf-acctest-igw-auth-lambda-" + rString
+
+	expectedAuthUri := regexp.MustCompile("arn:aws:apigateway:[a-z0-9-]+:lambda:path/2015-03-31/functions/" +
+		"arn:aws:lambda:[a-z0-9-]+:[0-9]{12}:function:" + lambdaName + "/invocations")
+	expectedCreds := regexp.MustCompile("arn:aws:iam::[0-9]{12}:role/" + apiGatewayName + "_auth_invocation_role")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayAuthorizerDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSAPIGatewayAuthorizerConfig_lambda(apiGatewayName, authorizerName, lambdaName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "name", authorizerName),
+					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "type", "TOKEN"),
+					resource.TestMatchResourceAttr("aws_api_gateway_authorizer.acctest", "authorizer_uri", expectedAuthUri),
+					resource.TestMatchResourceAttr("aws_api_gateway_authorizer.acctest", "authorizer_credentials", expectedCreds),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSAPIGatewayAuthorizerConfig_cognito(apiGatewayName, authorizerName, cognitoName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "name", authorizerName+"-cognito"),
+					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "type", "COGNITO_USER_POOLS"),
+					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "provider_arns.#", "2"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSAPIGatewayAuthorizerConfig_lambdaUpdate(apiGatewayName, authorizerName, lambdaName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "name", authorizerName+"_modified"),
+					resource.TestCheckResourceAttr("aws_api_gateway_authorizer.acctest", "type", "TOKEN"),
+					resource.TestMatchResourceAttr("aws_api_gateway_authorizer.acctest", "authorizer_uri", expectedAuthUri),
+					resource.TestMatchResourceAttr("aws_api_gateway_authorizer.acctest", "authorizer_credentials", expectedCreds),
 				),
 			},
 		},
@@ -228,13 +308,14 @@ func testAccCheckAWSAPIGatewayAuthorizerDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccAWSAPIGatewayAuthorizerConfig_base = `
-resource "aws_api_gateway_rest_api" "test" {
-  name = "tf-auth-test"
+func testAccAWSAPIGatewayAuthorizerConfig_baseLambda(apiGatewayName, lambdaName string) string {
+	return fmt.Sprintf(`
+resource "aws_api_gateway_rest_api" "acctest" {
+  name = "%s"
 }
 
 resource "aws_iam_role" "invocation_role" {
-  name = "tf_acc_api_gateway_auth_invocation_role"
+  name = "%s_auth_invocation_role"
   path = "/"
   assume_role_policy = <<EOF
 {
@@ -271,7 +352,7 @@ EOF
 }
 
 resource "aws_iam_role" "iam_for_lambda" {
-  name = "tf_acc_iam_for_lambda_api_gateway_authorizer"
+  name = "%s_authorizer_lambda"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -292,29 +373,73 @@ EOF
 resource "aws_lambda_function" "authorizer" {
   filename = "test-fixtures/lambdatest.zip"
   source_code_hash = "${base64sha256(file("test-fixtures/lambdatest.zip"))}"
-  function_name = "tf_acc_api_gateway_authorizer"
+  function_name = "%s"
   role = "${aws_iam_role.iam_for_lambda.arn}"
   handler = "exports.example"
-	runtime = "nodejs4.3"
+  runtime = "nodejs4.3"
 }
-`
+`, apiGatewayName, apiGatewayName, apiGatewayName, lambdaName)
+}
 
-const testAccAWSAPIGatewayAuthorizerConfig = testAccAWSAPIGatewayAuthorizerConfig_base + `
-resource "aws_api_gateway_authorizer" "test" {
-  name = "tf-acc-test-authorizer"
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+func testAccAWSAPIGatewayAuthorizerConfig_lambda(apiGatewayName, authorizerName, lambdaName string) string {
+	return testAccAWSAPIGatewayAuthorizerConfig_baseLambda(apiGatewayName, lambdaName) + fmt.Sprintf(`
+resource "aws_api_gateway_authorizer" "acctest" {
+  name = "%s"
+  rest_api_id = "${aws_api_gateway_rest_api.acctest.id}"
   authorizer_uri = "${aws_lambda_function.authorizer.invoke_arn}"
   authorizer_credentials = "${aws_iam_role.invocation_role.arn}"
 }
-`
+`, authorizerName)
+}
 
-const testAccAWSAPIGatewayAuthorizerUpdatedConfig = testAccAWSAPIGatewayAuthorizerConfig_base + `
-resource "aws_api_gateway_authorizer" "test" {
-  name = "tf-acc-test-authorizer_modified"
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+func testAccAWSAPIGatewayAuthorizerConfig_lambdaUpdate(apiGatewayName, authorizerName, lambdaName string) string {
+	return testAccAWSAPIGatewayAuthorizerConfig_baseLambda(apiGatewayName, lambdaName) + fmt.Sprintf(`
+resource "aws_api_gateway_authorizer" "acctest" {
+  name = "%s_modified"
+  rest_api_id = "${aws_api_gateway_rest_api.acctest.id}"
   authorizer_uri = "${aws_lambda_function.authorizer.invoke_arn}"
   authorizer_credentials = "${aws_iam_role.invocation_role.arn}"
   authorizer_result_ttl_in_seconds = 360
   identity_validation_expression = ".*"
+}`, authorizerName)
 }
-`
+
+func testAccAWSAPIGatewayAuthorizerConfig_cognito(apiGatewayName, authorizerName, cognitoName string) string {
+	return fmt.Sprintf(`
+resource "aws_api_gateway_rest_api" "acctest" {
+  name = "%s"
+}
+
+resource "aws_cognito_user_pool" "acctest" {
+  count = 2
+  name = "%s-${count.index}"
+}
+
+resource "aws_api_gateway_authorizer" "acctest" {
+  name = "%s-cognito"
+  rest_api_id = "${aws_api_gateway_rest_api.acctest.id}"
+  type = "COGNITO_USER_POOLS"
+  provider_arns = ["${aws_cognito_user_pool.acctest.*.arn}"]
+}
+`, apiGatewayName, cognitoName, authorizerName)
+}
+
+func testAccAWSAPIGatewayAuthorizerConfig_cognitoUpdate(apiGatewayName, authorizerName, cognitoName string) string {
+	return fmt.Sprintf(`
+resource "aws_api_gateway_rest_api" "acctest" {
+  name = "%s"
+}
+
+resource "aws_cognito_user_pool" "acctest_update" {
+  count = 3
+  name = "%s-${count.index}-update"
+}
+
+resource "aws_api_gateway_authorizer" "acctest" {
+  name = "%s-cognito-update"
+  rest_api_id = "${aws_api_gateway_rest_api.acctest.id}"
+  type = "COGNITO_USER_POOLS"
+  provider_arns = ["${aws_cognito_user_pool.acctest_update.*.arn}"]
+}
+`, apiGatewayName, cognitoName, authorizerName)
+}

--- a/website/docs/r/api_gateway_authorizer.html.markdown
+++ b/website/docs/r/api_gateway_authorizer.html.markdown
@@ -96,14 +96,14 @@ resource "aws_lambda_function" "authorizer" {
 
 The following arguments are supported:
 
-* `authorizer_uri` - (Required) The authorizer's Uniform Resource Identifier (URI).
+* `authorizer_uri` - (Optional) The authorizer's Uniform Resource Identifier (URI).
 	For `TOKEN` type, this must be a well-formed Lambda function URI in the form of
 	`arn:aws:apigateway:{region}:lambda:path/{service_api}`. e.g. `arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:012345678912:function:my-function/invocations`
 * `name` - (Required) The name of the authorizer
 * `rest_api_id` - (Required) The ID of the associated REST API
 * `identity_source` - (Optional) The source of the identity in an incoming request.
 	Defaults to `method.request.header.Authorization`. For `REQUEST` type, this may be a comma-separated list of values, including headers, query string parameters and stage variables - e.g. `"method.request.header.SomeHeaderName,method.request.querystring.SomeQueryStringName,stageVariables.SomeStageVariableName"`
-* `type` - (Optional) The type of the authorizer. Possible values are `TOKEN` and `REQUEST`.
+* `type` - (Optional) The type of the authorizer. Possible values are `TOKEN` for a Lambda function using a single authorization token submitted in a custom header, `REQUEST` for a Lambda function using incoming request parameters, or `COGNITO_USER_POOLS` for using an Amazon Cognito user pool.
 	Defaults to `TOKEN`.
 * `authorizer_credentials` - (Optional) The credentials required for the authorizer.
 	To specify an IAM Role for API Gateway to assume, use the IAM Role ARN.
@@ -113,3 +113,4 @@ The following arguments are supported:
 	For `TOKEN` type, this value should be a regular expression. The incoming token from the client is matched
 	against this expression, and will proceed if the token matches. If the token doesn't match,
 	the client receives a 401 Unauthorized response.
+* `provider_arns` - (Optional, required for type `COGNITO_USER_POOLS`) A list of the Amazon Cognito user pool ARNs. Each element is of this format: `arn:aws:cognito-idp:{region}:{account_id}:userpool/{user_pool_id}`.

--- a/website/docs/r/api_gateway_authorizer.html.markdown
+++ b/website/docs/r/api_gateway_authorizer.html.markdown
@@ -96,9 +96,9 @@ resource "aws_lambda_function" "authorizer" {
 
 The following arguments are supported:
 
-* `authorizer_uri` - (Optional) The authorizer's Uniform Resource Identifier (URI).
-	For `TOKEN` type, this must be a well-formed Lambda function URI in the form of
-	`arn:aws:apigateway:{region}:lambda:path/{service_api}`. e.g. `arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:012345678912:function:my-function/invocations`
+* `authorizer_uri` - (Optional, required for type `TOKEN`/`REQUEST`) The authorizer's Uniform Resource Identifier (URI).
+	This must be a well-formed Lambda function URI in the form of `arn:aws:apigateway:{region}:lambda:path/{service_api}`,
+	e.g. `arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:012345678912:function:my-function/invocations`
 * `name` - (Required) The name of the authorizer
 * `rest_api_id` - (Required) The ID of the associated REST API
 * `identity_source` - (Optional) The source of the identity in an incoming request.
@@ -113,4 +113,5 @@ The following arguments are supported:
 	For `TOKEN` type, this value should be a regular expression. The incoming token from the client is matched
 	against this expression, and will proceed if the token matches. If the token doesn't match,
 	the client receives a 401 Unauthorized response.
-* `provider_arns` - (Optional, required for type `COGNITO_USER_POOLS`) A list of the Amazon Cognito user pool ARNs. Each element is of this format: `arn:aws:cognito-idp:{region}:{account_id}:userpool/{user_pool_id}`.
+* `provider_arns` - (Optional, required for type `COGNITO_USER_POOLS`) A list of the Amazon Cognito user pool ARNs.
+	Each element is of this format: `arn:aws:cognito-idp:{region}:{account_id}:userpool/{user_pool_id}`.


### PR DESCRIPTION
Fixes #1106
Duplicate of #2189 

I missed existing issue and pr when I started. Anyway I continued with this new pr.

**QUSTION**: `type` changed to `ForceNew`

Because `COGNITO_USER_POOLS` is different with `TOKEN`/`REQUEST`. But when changing between `TOKEN` and `REQUEST`, it doesn't required new resource. To conditionally `ForceNew`, the only way I can think of is to have some logic in `update` function that will detect `type` change and call `create` function. I was wondering if terraform has already supported conditional `ForceNew` someway or we just go with always `ForceNew`.