### PR TITLE
data-source/aws_region: Remove EC2 API call, default to current if no endpoint or name specified

### DIFF
--- a/aws/data_source_aws_region.go
+++ b/aws/data_source_aws_region.go
@@ -2,10 +2,9 @@ package aws
 
 import (
 	"fmt"
-	"log"
+	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -36,48 +35,74 @@ func dataSourceAwsRegion() *schema.Resource {
 }
 
 func dataSourceAwsRegionRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*AWSClient).ec2conn
 	currentRegion := meta.(*AWSClient).region
 
-	req := &ec2.DescribeRegionsInput{}
+	var matchingRegion *endpoints.Region
 
-	req.RegionNames = make([]*string, 0, 2)
-	if name := d.Get("name").(string); name != "" {
-		req.RegionNames = append(req.RegionNames, aws.String(name))
+	if v, ok := d.GetOk("endpoint"); ok {
+		endpoint := v.(string)
+		for _, partition := range endpoints.DefaultPartitions() {
+			for _, region := range partition.Regions() {
+				regionEndpointEc2, err := region.ResolveEndpoint(endpoints.Ec2ServiceID)
+				if err != nil {
+					return err
+				}
+				if strings.TrimPrefix(regionEndpointEc2.URL, "https://") == endpoint {
+					matchingRegion = &region
+					break
+				}
+			}
+		}
+		if matchingRegion == nil {
+			return fmt.Errorf("region not found for endpoint: %s", endpoint)
+		}
 	}
 
-	if d.Get("current").(bool) {
-		req.RegionNames = append(req.RegionNames, aws.String(currentRegion))
+	if v, ok := d.GetOk("name"); ok {
+		name := v.(string)
+		for _, partition := range endpoints.DefaultPartitions() {
+			for _, region := range partition.Regions() {
+				if region.ID() == name {
+					if matchingRegion != nil && (*matchingRegion).ID() != name {
+						return fmt.Errorf("multiple regions matched; use additional constraints to reduce matches to a single region")
+					}
+					matchingRegion = &region
+					break
+				}
+			}
+		}
+		if matchingRegion == nil {
+			return fmt.Errorf("region not found for name: %s", name)
+		}
 	}
 
-	req.Filters = buildEC2AttributeFilterList(
-		map[string]string{
-			"endpoint": d.Get("endpoint").(string),
-		},
-	)
-	if len(req.Filters) == 0 {
-		// Don't send an empty filters list; the EC2 API won't accept it.
-		req.Filters = nil
+	current := d.Get("current").(bool)
+	for _, partition := range endpoints.DefaultPartitions() {
+		for _, region := range partition.Regions() {
+			if region.ID() == currentRegion {
+				if matchingRegion == nil {
+					matchingRegion = &region
+					break
+				}
+				if current && (*matchingRegion).ID() != currentRegion {
+					return fmt.Errorf("multiple regions matched; use additional constraints to reduce matches to a single region")
+				}
+			}
+		}
 	}
 
-	log.Printf("[DEBUG] Reading Region: %s", req)
-	resp, err := conn.DescribeRegions(req)
+	region := *matchingRegion
+
+	d.SetId(region.ID())
+	d.Set("current", region.ID() == currentRegion)
+
+	regionEndpointEc2, err := region.ResolveEndpoint(endpoints.Ec2ServiceID)
 	if err != nil {
 		return err
 	}
-	if resp == nil || len(resp.Regions) == 0 {
-		return fmt.Errorf("no matching regions found")
-	}
-	if len(resp.Regions) > 1 {
-		return fmt.Errorf("multiple regions matched; use additional constraints to reduce matches to a single region")
-	}
+	d.Set("endpoint", strings.TrimPrefix(regionEndpointEc2.URL, "https://"))
 
-	region := resp.Regions[0]
-
-	d.SetId(*region.RegionName)
-	d.Set("name", region.RegionName)
-	d.Set("endpoint", region.Endpoint)
-	d.Set("current", *region.RegionName == currentRegion)
+	d.Set("name", region.ID())
 
 	return nil
 }

--- a/aws/data_source_aws_region.go
+++ b/aws/data_source_aws_region.go
@@ -20,9 +20,10 @@ func dataSourceAwsRegion() *schema.Resource {
 			},
 
 			"current": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Computed: true,
+				Type:       schema.TypeBool,
+				Optional:   true,
+				Computed:   true,
+				Deprecated: "Defaults to current provider region if no other filtering is enabled",
 			},
 
 			"endpoint": {
@@ -35,66 +36,42 @@ func dataSourceAwsRegion() *schema.Resource {
 }
 
 func dataSourceAwsRegionRead(d *schema.ResourceData, meta interface{}) error {
-	currentRegion := meta.(*AWSClient).region
+	providerRegion := meta.(*AWSClient).region
 
-	var matchingRegion *endpoints.Region
+	var region *endpoints.Region
 
 	if v, ok := d.GetOk("endpoint"); ok {
 		endpoint := v.(string)
-		for _, partition := range endpoints.DefaultPartitions() {
-			for _, region := range partition.Regions() {
-				regionEndpointEc2, err := region.ResolveEndpoint(endpoints.Ec2ServiceID)
-				if err != nil {
-					return err
-				}
-				if strings.TrimPrefix(regionEndpointEc2.URL, "https://") == endpoint {
-					matchingRegion = &region
-					break
-				}
-			}
+		matchingRegion, err := findRegionByEc2Endpoint(endpoint)
+		if err != nil {
+			return err
 		}
-		if matchingRegion == nil {
-			return fmt.Errorf("region not found for endpoint: %s", endpoint)
-		}
+		region = matchingRegion
 	}
 
 	if v, ok := d.GetOk("name"); ok {
 		name := v.(string)
-		for _, partition := range endpoints.DefaultPartitions() {
-			for _, region := range partition.Regions() {
-				if region.ID() == name {
-					if matchingRegion != nil && (*matchingRegion).ID() != name {
-						return fmt.Errorf("multiple regions matched; use additional constraints to reduce matches to a single region")
-					}
-					matchingRegion = &region
-					break
-				}
-			}
+		matchingRegion, err := findRegionByName(name)
+		if err != nil {
+			return err
 		}
-		if matchingRegion == nil {
-			return fmt.Errorf("region not found for name: %s", name)
+		if region != nil && region.ID() != matchingRegion.ID() {
+			return fmt.Errorf("multiple regions matched; use additional constraints to reduce matches to a single region")
 		}
+		region = matchingRegion
 	}
 
-	current := d.Get("current").(bool)
-	for _, partition := range endpoints.DefaultPartitions() {
-		for _, region := range partition.Regions() {
-			if region.ID() == currentRegion {
-				if matchingRegion == nil {
-					matchingRegion = &region
-					break
-				}
-				if current && (*matchingRegion).ID() != currentRegion {
-					return fmt.Errorf("multiple regions matched; use additional constraints to reduce matches to a single region")
-				}
-			}
+	// Default to provider current region if no other filters matched
+	if region == nil {
+		matchingRegion, err := findRegionByName(providerRegion)
+		if err != nil {
+			return err
 		}
+		region = matchingRegion
 	}
-
-	region := *matchingRegion
 
 	d.SetId(region.ID())
-	d.Set("current", region.ID() == currentRegion)
+	d.Set("current", region.ID() == providerRegion)
 
 	regionEndpointEc2, err := region.ResolveEndpoint(endpoints.Ec2ServiceID)
 	if err != nil {
@@ -105,4 +82,30 @@ func dataSourceAwsRegionRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("name", region.ID())
 
 	return nil
+}
+
+func findRegionByEc2Endpoint(endpoint string) (*endpoints.Region, error) {
+	for _, partition := range endpoints.DefaultPartitions() {
+		for _, region := range partition.Regions() {
+			regionEndpointEc2, err := region.ResolveEndpoint(endpoints.Ec2ServiceID)
+			if err != nil {
+				return nil, err
+			}
+			if strings.TrimPrefix(regionEndpointEc2.URL, "https://") == endpoint {
+				return &region, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("region not found for endpoint: %s", endpoint)
+}
+
+func findRegionByName(name string) (*endpoints.Region, error) {
+	for _, partition := range endpoints.DefaultPartitions() {
+		for _, region := range partition.Regions() {
+			if region.ID() == name {
+				return &region, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("region not found for name: %s", name)
 }

--- a/aws/data_source_aws_region_test.go
+++ b/aws/data_source_aws_region_test.go
@@ -2,63 +2,194 @@ package aws
 
 import (
 	"fmt"
+	"os"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccDataSourceAwsRegion(t *testing.T) {
+func TestAccDataSourceAwsRegion_basic(t *testing.T) {
+	// Ensure we always get a consistent result
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
+	resourceName := "data.aws_region.test"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccDataSourceAwsRegionConfig,
+				Config: testAccDataSourceAwsRegionConfig_empty,
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceAwsRegionCheck("data.aws_region.by_name_current", "us-west-2", "true"),
-					testAccDataSourceAwsRegionCheck("data.aws_region.by_name_other", "us-west-1", "false"),
-					testAccDataSourceAwsRegionCheck("data.aws_region.by_current", "us-west-2", "true"),
+					testAccDataSourceAwsRegionCheck(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "current", "true"),
+					resource.TestCheckResourceAttr(resourceName, "endpoint", "ec2.us-east-1.amazonaws.com"),
+					resource.TestCheckResourceAttr(resourceName, "name", "us-east-1"),
 				),
 			},
 		},
 	})
 }
 
-func testAccDataSourceAwsRegionCheck(name, region, current string) resource.TestCheckFunc {
+func TestAccDataSourceAwsRegion_endpoint(t *testing.T) {
+	// Ensure we always get a consistent result
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
+	endpoint1 := "ec2.us-east-1.amazonaws.com"
+	endpoint2 := "ec2.us-east-2.amazonaws.com"
+	name1 := "us-east-1"
+	name2 := "us-east-2"
+	resourceName := "data.aws_region.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDataSourceAwsRegionConfig_endpoint(endpoint1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsRegionCheck(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "current", "true"),
+					resource.TestCheckResourceAttr(resourceName, "endpoint", endpoint1),
+					resource.TestCheckResourceAttr(resourceName, "name", name1),
+				),
+			},
+			resource.TestStep{
+				Config: testAccDataSourceAwsRegionConfig_endpoint(endpoint2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsRegionCheck(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "current", "false"),
+					resource.TestCheckResourceAttr(resourceName, "endpoint", endpoint2),
+					resource.TestCheckResourceAttr(resourceName, "name", name2),
+				),
+			},
+			resource.TestStep{
+				Config: testAccDataSourceAwsRegionConfig_currentAndEndpoint(endpoint1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsRegionCheck(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "current", "true"),
+					resource.TestCheckResourceAttr(resourceName, "endpoint", endpoint1),
+					resource.TestCheckResourceAttr(resourceName, "name", name1),
+				),
+			},
+			resource.TestStep{
+				Config:      testAccDataSourceAwsRegionConfig_endpoint("does-not-exist"),
+				ExpectError: regexp.MustCompile(`region not found for endpoint: does-not-exist`),
+			},
+			resource.TestStep{
+				Config:      testAccDataSourceAwsRegionConfig_currentAndEndpoint(endpoint2),
+				ExpectError: regexp.MustCompile(`multiple regions matched`),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsRegion_name(t *testing.T) {
+	// Ensure we always get a consistent result
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
+	endpoint1 := "ec2.us-east-1.amazonaws.com"
+	endpoint2 := "ec2.us-east-2.amazonaws.com"
+	name1 := "us-east-1"
+	name2 := "us-east-2"
+	resourceName := "data.aws_region.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDataSourceAwsRegionConfig_name(name1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsRegionCheck(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "current", "true"),
+					resource.TestCheckResourceAttr(resourceName, "endpoint", endpoint1),
+					resource.TestCheckResourceAttr(resourceName, "name", name1),
+				),
+			},
+			resource.TestStep{
+				Config: testAccDataSourceAwsRegionConfig_name(name2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsRegionCheck(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "current", "false"),
+					resource.TestCheckResourceAttr(resourceName, "endpoint", endpoint2),
+					resource.TestCheckResourceAttr(resourceName, "name", name2),
+				),
+			},
+			resource.TestStep{
+				Config: testAccDataSourceAwsRegionConfig_currentAndName(name1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsRegionCheck(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "current", "true"),
+					resource.TestCheckResourceAttr(resourceName, "endpoint", endpoint1),
+					resource.TestCheckResourceAttr(resourceName, "name", name1),
+				),
+			},
+			resource.TestStep{
+				Config:      testAccDataSourceAwsRegionConfig_name("does-not-exist"),
+				ExpectError: regexp.MustCompile(`region not found for name: does-not-exist`),
+			},
+			resource.TestStep{
+				Config:      testAccDataSourceAwsRegionConfig_currentAndName(name2),
+				ExpectError: regexp.MustCompile(`multiple regions matched`),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsRegionCheck(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		_, ok := s.RootModule().Resources[name]
 		if !ok {
 			return fmt.Errorf("root module has no resource called %s", name)
-		}
-
-		attr := rs.Primary.Attributes
-
-		if attr["name"] != region {
-			return fmt.Errorf("bad name %s", attr["name"])
-		}
-		if attr["current"] != current {
-			return fmt.Errorf("bad current %s; want %s", attr["current"], current)
 		}
 
 		return nil
 	}
 }
 
-const testAccDataSourceAwsRegionConfig = `
-provider "aws" {
-  region = "us-west-2"
-}
-
-data "aws_region" "by_name_current" {
-  name = "us-west-2"
-}
-
-data "aws_region" "by_name_other" {
-  name = "us-west-1"
-}
-
-data "aws_region" "by_current" {
-  current = true
-}
+const testAccDataSourceAwsRegionConfig_empty = `
+data "aws_region" "test" {}
 `
+
+func testAccDataSourceAwsRegionConfig_currentAndEndpoint(endpoint string) string {
+	return fmt.Sprintf(`
+data "aws_region" "test" {
+  current  = true
+  endpoint = "%s"
+}
+`, endpoint)
+}
+
+func testAccDataSourceAwsRegionConfig_currentAndName(name string) string {
+	return fmt.Sprintf(`
+data "aws_region" "test" {
+  current = true
+  name    = "%s"
+}
+`, name)
+}
+
+func testAccDataSourceAwsRegionConfig_endpoint(endpoint string) string {
+	return fmt.Sprintf(`
+data "aws_region" "test" {
+  endpoint = "%s"
+}
+`, endpoint)
+}
+
+func testAccDataSourceAwsRegionConfig_name(name string) string {
+	return fmt.Sprintf(`
+data "aws_region" "test" {
+  name = "%s"
+}
+`, name)
+}

--- a/website/docs/d/region.html.markdown
+++ b/website/docs/d/region.html.markdown
@@ -32,9 +32,6 @@ exported as attributes.
 
 * `name` - (Optional) The full name of the region to select.
 
-* `current` - (Optional) Set to `true` to match only the region configured
-  in the provider. Defaults to `true` if `endpoint` or `name` is not given.
-
 * `endpoint` - (Optional) The EC2 endpoint of the region to select.
 
 ## Attributes Reference

--- a/website/docs/d/region.html.markdown
+++ b/website/docs/d/region.html.markdown
@@ -10,10 +10,10 @@ description: |-
 
 `aws_region` provides details about a specific AWS region.
 
-As well as validating a given region name (and optionally obtaining its
-endpoint) this resource can be used to discover the name of the region
-configured within the provider. The latter can be useful in a child module
-which is inheriting an AWS provider configuration from its parent module.
+As well as validating a given region name this resource can be used to
+discover the name of the region configured within the provider. The latter
+can be useful in a child module which is inheriting an AWS provider
+configuration from its parent module.
 
 ## Example Usage
 
@@ -21,9 +21,7 @@ The following example shows how the resource might be used to obtain
 the name of the AWS region configured on the provider.
 
 ```hcl
-data "aws_region" "current" {
-  current = true
-}
+data "aws_region" "current" {}
 ```
 
 ## Argument Reference
@@ -35,12 +33,9 @@ exported as attributes.
 * `name` - (Optional) The full name of the region to select.
 
 * `current` - (Optional) Set to `true` to match only the region configured
-  in the provider. (It is not meaningful to set this to `false`.)
+  in the provider. Defaults to `true` if `endpoint` or `name` is not given.
 
-* `endpoint` - (Optional) The endpoint of the region to select.
-
-At least one of the above attributes should be provided to ensure that only
-one region is matched.
+* `endpoint` - (Optional) The EC2 endpoint of the region to select.
 
 ## Attributes Reference
 
@@ -51,4 +46,4 @@ The following attributes are exported:
 * `current` - `true` if the selected region is the one configured on the
   provider, or `false` otherwise.
 
-* `endpoint` - The endpoint for the selected region.
+* `endpoint` - The EC2 endpoint for the selected region.


### PR DESCRIPTION
This PR accomplishes a few things here:
* Removes `ec2.DescribeRegions` API call. The SDK provides all regions and EC2 endpoint information already and this resource will automatically update when we update the SDK. The provider will not work in a new region without an updated release anyways.
* Fixes `current` to match the documentation that listed it as optional, so `current = true` is no longer necessary if `endpoint` and `name` are omitted.

```
make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsRegion'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccDataSourceAwsRegion -timeout 120m
=== RUN   TestAccDataSourceAwsRegion_basic
--- PASS: TestAccDataSourceAwsRegion_basic (6.91s)
=== RUN   TestAccDataSourceAwsRegion_endpoint
--- PASS: TestAccDataSourceAwsRegion_endpoint (8.90s)
=== RUN   TestAccDataSourceAwsRegion_name
--- PASS: TestAccDataSourceAwsRegion_name (10.58s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	26.443s
```
