### PR TITLE
provider: Automatically validate new regions from AWS SDK

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -255,11 +255,10 @@ into Terraform.
 
 #### New Region
 
-Implementing a new region gives Terraform the ability to connect and interact
-with endpoints in a new geographic area. While baseline region support is fairly
-trivial to add, new regions are generally limited in which services they support.
+While region validation is automatically added with SDK updates, new regions
+are generally limited in which services they support. Below are some
+manually sourced values from documentation.
 
- - [ ] Add region to `aws/config.go`
  - [ ] Check [Regions and Endpoints ELB regions](https://docs.aws.amazon.com/general/latest/gr/rande.html#elb_region) and add Route53 Hosted Zone ID if available to `aws/data_source_aws_elb_hosted_zone_id.go`
  - [ ] Check [Regions and Endpoints S3 website endpoints](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) and add Route53 Hosted Zone ID if available to `aws/hosted_zones.go`
  - [ ] Check [CloudTrail Supported Regions docs](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-supported-regions.html) and add AWS Account ID if available to `aws/data_source_aws_cloudtrail_service_account.go`

--- a/aws/config.go
+++ b/aws/config.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/acm"
@@ -216,20 +217,13 @@ func (c *AWSClient) DynamoDB() *dynamodb.DynamoDB {
 }
 
 func (c *AWSClient) IsGovCloud() bool {
-	if c.region == "us-gov-west-1" {
-		return true
-	}
-	return false
+	_, isGovCloud := endpoints.PartitionForRegion([]endpoints.Partition{endpoints.AwsUsGovPartition()}, c.region)
+	return isGovCloud
 }
 
 func (c *AWSClient) IsChinaCloud() bool {
-	if c.region == "cn-north-1" {
-		return true
-	}
-	if c.region == "cn-northwest-1" {
-		return true
-	}
-	return false
+	_, isChinaCloud := endpoints.PartitionForRegion([]endpoints.Partition{endpoints.AwsCnPartition()}, c.region)
+	return isChinaCloud
 }
 
 // Client configures and returns a fully initialized AWSClient
@@ -501,32 +495,14 @@ func hasEc2Classic(platforms []string) bool {
 // ValidateRegion returns an error if the configured region is not a
 // valid aws region and nil otherwise.
 func (c *Config) ValidateRegion() error {
-	var regions = []string{
-		"ap-northeast-1",
-		"ap-northeast-2",
-		"ap-south-1",
-		"ap-southeast-1",
-		"ap-southeast-2",
-		"ca-central-1",
-		"cn-north-1",
-		"cn-northwest-1",
-		"eu-central-1",
-		"eu-west-1",
-		"eu-west-2",
-		"eu-west-3",
-		"sa-east-1",
-		"us-east-1",
-		"us-east-2",
-		"us-gov-west-1",
-		"us-west-1",
-		"us-west-2",
-	}
-
-	for _, valid := range regions {
-		if c.Region == valid {
-			return nil
+	for _, partition := range endpoints.DefaultPartitions() {
+		for _, region := range partition.Regions() {
+			if c.Region == region.ID() {
+				return nil
+			}
 		}
 	}
+
 	return fmt.Errorf("Not a valid region: %s", c.Region)
 }
 


### PR DESCRIPTION
Reference: https://docs.aws.amazon.com/sdk-for-go/api/aws/endpoints/

This version keeps the stricter `==` matching for `ValidateRegion()`, but we could loosen it to the below, which would also turn on regexp matching.

```
if _, isValidRegion := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), c.Region); isValidRegion {
  return nil
}
```