### PR TITLE
resource/aws_autoscaling_policy: Support ec2 autoscaling TargetTrackingScaling policy

### DIFF
--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1099,6 +1099,45 @@ func validateDmsReplicationTaskId(v interface{}, k string) (ws []string, es []er
 	return
 }
 
+func validateAutoscalingPredefinedMetricSpecificationPredefinedMetricType(v interface{}, k string) (ws []string, errors []error) {
+	validMetricType := []string{
+		"ASGAverageCPUUtilization",
+		"ASGAverageNetworkIn",
+		"ASGAverageNetworkOut",
+		"ALBRequestCountPerTarget",
+	}
+	metricType := v.(string)
+	for _, o := range validMetricType {
+		if metricType == o {
+			return
+		}
+	}
+	errors = append(errors, fmt.Errorf(
+		"%q contains an invalid type %q. Valid type are %q.",
+		k, metricType, validMetricType))
+	return
+}
+
+func validateAutoscalingCustomizedMetricSpecificationStatistic(v interface{}, k string) (ws []string, errors []error) {
+	validStatistic := []string{
+		"Average",
+		"Minimum",
+		"Maximum",
+		"SampleCount",
+		"Sum",
+	}
+	statistic := v.(string)
+	for _, o := range validStatistic {
+		if statistic == o {
+			return
+		}
+	}
+	errors = append(errors, fmt.Errorf(
+		"%q contains an invalid statistic %q. Valid statistic are %q.",
+		k, statistic, validStatistic))
+	return
+}
+
 func validateAppautoscalingScalableDimension(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	dimensions := map[string]bool{

--- a/website/docs/r/autoscaling_policy.html.markdown
+++ b/website/docs/r/autoscaling_policy.html.markdown
@@ -18,6 +18,8 @@ or [dynamic](https://docs.aws.amazon.com/AutoScaling/latest/DeveloperGuide/as-sc
 
 ## Example Usage
 
+### Simple Scaling
+
 ```hcl
 resource "aws_autoscaling_policy" "bat" {
   name                   = "foobar3-terraform-test"
@@ -39,22 +41,57 @@ resource "aws_autoscaling_group" "bar" {
 }
 ```
 
+### Step Scaling
+
+```hcl
+resource "aws_autoscaling_policy" "foobar_step" {
+  name = "foobar_step"
+  adjustment_type = "ChangeInCapacity"
+  policy_type = "StepScaling"
+  estimated_instance_warmup = 200
+  metric_aggregation_type = "Minimum"
+  step_adjustment {
+    scaling_adjustment = 1
+    metric_interval_lower_bound = 2.0
+  }
+  autoscaling_group_name = "${aws_autoscaling_group.bar.name}"
+}
+```
+
+### Target Tracking Scaling
+
+```hcl
+resource "aws_autoscaling_policy" "foobar_targettracking" {
+  name = "foobar_targettracking"
+  policy_type = "TargetTrackingScaling"
+  estimated_instance_warmup = 200
+  target_tracking_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ASGAverageCPUUtilization"
+    }
+    target_value = 20
+  }
+  autoscaling_group_name = "${aws_autoscaling_group.bar.name}"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
 * `name` - (Required) The name of the policy.
 * `autoscaling_group_name` - (Required) The name of the autoscaling group.
+* `policy_type` - (Optional) The policy type, either "SimpleScaling", "StepScaling" or "TargetTrackingScaling". If this value isn't provided, AWS will default to "SimpleScaling."
+
+The following arguments are available to "SimpleScaling" type policies:
+
 * `adjustment_type` - (Required) Specifies whether the adjustment is an absolute number or a percentage of the current capacity. Valid values are `ChangeInCapacity`, `ExactCapacity`, and `PercentChangeInCapacity`.
-* `policy_type` - (Optional) The policy type, either "SimpleScaling" or "StepScaling". If this value isn't provided, AWS will default to "SimpleScaling."
-
-The following arguments are only available to "SimpleScaling" type policies:
-
 * `cooldown` - (Optional) The amount of time, in seconds, after a scaling activity completes and before the next scaling activity can start.
 * `scaling_adjustment` - (Optional) The number of instances by which to scale. `adjustment_type` determines the interpretation of this number (e.g., as an absolute number or as a percentage of the existing Auto Scaling group size). A positive increment adds to the current capacity and a negative value removes from the current capacity.
 
-The following arguments are only available to "StepScaling" type policies:
+The following arguments are available to "StepScaling" type policies:
 
+* `adjustment_type` - (Required) Specifies whether the adjustment is an absolute number or a percentage of the current capacity. Valid values are `ChangeInCapacity`, `ExactCapacity`, and `PercentChangeInCapacity`.
 * `metric_aggregation_type` - (Optional) The aggregation type for the policy's metrics. Valid values are "Minimum", "Maximum", and "Average". Without a value, AWS will treat the aggregation type as "Average".
 * `estimated_instance_warmup` - (Optional) The estimated time, in seconds, until a newly launched instance will contribute CloudWatch metrics. Without a value, AWS will default to the group's specified cooldown period.
 * `step_adjustments` - (Optional) A set of adjustments that manage
@@ -89,6 +126,30 @@ must be greater than the lower bound.
 The following arguments are supported for backwards compatibility but should not be used:
 
 * `min_adjustment_step` - (Optional) Use `min_adjustment_magnitude` instead.
+
+The following arguments are available to "TargetTrackingScaling" type policies:
+
+* `target_tracking_configuration` - (Required) A target tracking policy, requires `policy_type = "TargetTrackingScaling"`.
+
+`target_tracking_configuration` supported fields below.
+
+* `target_value` - (Optional) The target value for the metric.
+* `disable_scale_in` - (Optional) Indicates whether scale in by the target tracking policy is disabled. If the value is true, scale in is disabled and the target tracking policy won't remove capacity from the scalable resource. Otherwise, scale in is enabled and the target tracking policy can remove capacity from the scalable resource. The default value is `false`.
+* `customized_metric_specification` - (Optional) Reserved for future use. See supported fields below.
+* `predefined_metric_specification` - (Optional) A predefined metric. See supported fields below.
+
+`customized_metric_specification` supported fields below.
+
+* `dimensions` - (Optional) The dimensions of the metric.
+* `metric_name` - (Optional) The name of the metric.
+* `namespace` - (Optional) The namespace of the metric.
+* `statistic` - (Optional) The statistic of the metric. May be one of `"Average"`, `"Minimum"`, `"Maximum"`, `"SampleCount"` or `"Sum"`.
+* `unit` - (Optional) The unit of the metric.
+
+`predefined_metric_specification` supported fields below.
+
+* `predefined_metric_type` - (Required) The metric type. May be one of `"ASGAverageCPUUtilization"`, `"ASGAverageNetworkIn"`, `"ASGAverageNetworkOut"` or `"ALBRequestCountPerTarget"`.
+* `resource_label` - (Optional) Reserved for future use.
 
 ## Attribute Reference
 * `arn` - The ARN assigned by AWS to the scaling policy.


### PR DESCRIPTION
close #1156

- related api spec
  - https://docs.aws.amazon.com/ja_jp/autoscaling/ec2/APIReference/API_PutScalingPolicy.html
  - https://docs.aws.amazon.com/cli/latest/reference/autoscaling/put-scaling-policy.html

```sh
> TF_ACC=1 go test ./aws -v -run=TestAccAWSAutoscalingPolicy -timeout 120m
=== RUN   TestAccAWSAutoscalingPolicy_basic
--- PASS: TestAccAWSAutoscalingPolicy_basic (205.29s)
=== RUN   TestAccAWSAutoscalingPolicy_disappears
--- PASS: TestAccAWSAutoscalingPolicy_disappears (211.57s)
=== RUN   TestAccAWSAutoscalingPolicy_upgrade
--- PASS: TestAccAWSAutoscalingPolicy_upgrade (243.48s)
=== RUN   TestAccAWSAutoscalingPolicy_SimpleScalingStepAdjustment
--- PASS: TestAccAWSAutoscalingPolicy_SimpleScalingStepAdjustment (89.07s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       749.468s
```

- [x] Acceptance test coverage of new behavior
- [x] Documentation updates
- [x] Well-formed Code
- [x] ~~Vendor additions~~
