### PR TITLE
r/guardduty: fix typo in guardduty import test

### DIFF
--- a/aws/resource_aws_guardduty_detector_test.go
+++ b/aws/resource_aws_guardduty_detector_test.go
@@ -50,7 +50,7 @@ func testAccAwsGuardDutyDetector_import(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSesTemplateDestroy,
+		CheckDestroy: testAccCheckAwsGuardDutyDetectorDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccGuardDutyDetectorConfig_basic1,

--- a/aws/resource_aws_guardduty_member_test.go
+++ b/aws/resource_aws_guardduty_member_test.go
@@ -39,7 +39,7 @@ func testAccAwsGuardDutyMember_import(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSesTemplateDestroy,
+		CheckDestroy: testAccCheckAwsGuardDutyMemberDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccGuardDutyMemberConfig_basic("111111111111", "required@example.com"),


### PR DESCRIPTION
```
TF_ACC=1 go test ./aws -v -run=TestAccAWSGuardDuty -timeout 120m
=== RUN   TestAccAWSGuardDuty
=== RUN   TestAccAWSGuardDuty/Detector
=== RUN   TestAccAWSGuardDuty/Detector/basic
=== RUN   TestAccAWSGuardDuty/Detector/import
=== RUN   TestAccAWSGuardDuty/Member
=== RUN   TestAccAWSGuardDuty/Member/import
=== RUN   TestAccAWSGuardDuty/Member/basic
--- PASS: TestAccAWSGuardDuty (396.98s)
    --- PASS: TestAccAWSGuardDuty/Detector (254.44s)
        --- PASS: TestAccAWSGuardDuty/Detector/basic (185.02s)
        --- PASS: TestAccAWSGuardDuty/Detector/import (69.42s)
    --- PASS: TestAccAWSGuardDuty/Member (142.54s)
        --- PASS: TestAccAWSGuardDuty/Member/import (49.35s)
        --- PASS: TestAccAWSGuardDuty/Member/basic (93.18s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	397.018s
```