### PR TITLE
resource/aws_elastic_beanstalk_application: Prevent crash on reading missing application

### DIFF
--- a/aws/resource_aws_elastic_beanstalk_application.go
+++ b/aws/resource_aws_elastic_beanstalk_application.go
@@ -99,14 +99,20 @@ func resourceAwsElasticBeanstalkApplicationRead(d *schema.ResourceData, meta int
 		}
 
 		if app == nil {
+			err = fmt.Errorf("Elastic Beanstalk Application %q not found", d.Id())
 			if d.IsNewResource() {
-				return resource.RetryableError(fmt.Errorf("Elastic Beanstalk Application %q not found.", d.Id()))
+				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)
 		}
 		return nil
 	})
 	if err != nil {
+		if app == nil {
+			log.Printf("[WARN] %s, removing from state", err)
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
Closes #3083 

Testing passes:
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSBeanstalkApp_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSBeanstalkApp_basic -timeout 120m
=== RUN   TestAccAWSBeanstalkApp_basic
--- PASS: TestAccAWSBeanstalkApp_basic (12.08s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	12.125s

make testacc TEST=./aws TESTARGS='-run=TestAWSElasticBeanstalkApplication'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAWSElasticBeanstalkApplication -timeout 120m
=== RUN   TestAWSElasticBeanstalkApplication_importBasic
--- PASS: TestAWSElasticBeanstalkApplication_importBasic (14.10s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	14.146s
```