### PR TITLE
Store all config-specified DB params in state.

### DIFF
--- a/aws/resource_aws_db_parameter_group.go
+++ b/aws/resource_aws_db_parameter_group.go
@@ -221,7 +221,10 @@ func resourceAwsDbParameterGroupRead(d *schema.ResourceData, meta interface{}) e
 		}
 	}
 
-	d.Set("parameter", flattenParameters(userParams))
+	err = d.Set("parameter", flattenParameters(userParams))
+	if err != nil {
+		return fmt.Errorf("error setting 'parameter' in state: %#v", err)
+	}
 
 	paramGroup := describeResp.DBParameterGroups[0]
 	arn, err := buildRDSPGARN(d.Id(), meta.(*AWSClient).partition, meta.(*AWSClient).accountid, meta.(*AWSClient).region)

--- a/aws/resource_aws_db_parameter_group.go
+++ b/aws/resource_aws_db_parameter_group.go
@@ -151,18 +151,77 @@ func resourceAwsDbParameterGroupRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("family", describeResp.DBParameterGroups[0].DBParameterGroupFamily)
 	d.Set("description", describeResp.DBParameterGroups[0].Description)
 
-	// Only include user customized parameters as there's hundreds of system/default ones
+	configParams := d.Get("parameter").(*schema.Set)
 	describeParametersOpts := rds.DescribeDBParametersInput{
 		DBParameterGroupName: aws.String(d.Id()),
-		Source:               aws.String("user"),
+	}
+	if configParams.Len() < 1 {
+		// if we don't have any params in the ResourceData already, two possibilities
+		// first, we don't have a config available to us. Second, we do, but it has
+		// no parameters. We're going to assume the first, to be safe. In this case,
+		// we're only going to ask for the user-modified values, because any defaults
+		// the user may have _also_ set are indistinguishable from the hundreds of
+		// defaults AWS sets. If the user hasn't set any parameters, this will return
+		// an empty list anyways, so we just make some unnecessary requests. But in
+		// the more common case (I assume) of an import, this will make fewer requests
+		// and "do the right thing".
+		describeParametersOpts.Source = aws.String("user")
 	}
 
-	describeParametersResp, err := rdsconn.DescribeDBParameters(&describeParametersOpts)
+	var parameters []*rds.Parameter
+	err = rdsconn.DescribeDBParametersPages(&describeParametersOpts,
+		func(describeParametersResp *rds.DescribeDBParametersOutput, lastPage bool) bool {
+			parameters = append(parameters, describeParametersResp.Parameters...)
+			return !lastPage
+		})
 	if err != nil {
 		return err
 	}
 
-	d.Set("parameter", flattenParameters(describeParametersResp.Parameters))
+	var userParams []*rds.Parameter
+	if configParams.Len() < 1 {
+		// if we have no config/no parameters in config, we've already asked for only
+		// user-modified values, so we can just use the entire response.
+		userParams = parameters
+	} else {
+		// if we have a config available to us, we have two possible classes of value
+		// in the config. On the one hand, the user could have specified a parameter
+		// that _actually_ changed things, in which case its Source would be set to
+		// user. On the other, they may have specified a parameter that coincides with
+		// the default value. In that case, the Source will be set to "system" or
+		// "engine-default". We need to set the union of all "user" Source parameters
+		// _and_ the "system"/"engine-default" Source parameters _that appear in the
+		// config_ in the state, or the user gets a perpetual diff. See
+		// terraform-providers/terraform-provider-aws#593 for more context and details.
+		confParams, err := expandParameters(configParams.List())
+		if err != nil {
+			return err
+		}
+		for _, param := range parameters {
+			if param.Source == nil || param.ParameterName == nil {
+				continue
+			}
+			if *param.Source == "user" {
+				userParams = append(userParams, param)
+				continue
+			}
+			var paramFound bool
+			for _, cp := range confParams {
+				if cp.ParameterName == nil {
+					continue
+				}
+				if *cp.ParameterName == *param.ParameterName {
+					userParams = append(userParams, param)
+					break
+				}
+			}
+			if !paramFound {
+				log.Printf("[DEBUG] Not persisting %s to state, as its source is %q and it isn't in the config", *param.ParameterName, *param.Source)
+			}
+		}
+	}
+
+	d.Set("parameter", flattenParameters(userParams))
 
 	paramGroup := describeResp.DBParameterGroups[0]
 	arn, err := buildRDSPGARN(d.Id(), meta.(*AWSClient).partition, meta.(*AWSClient).accountid, meta.(*AWSClient).region)


### PR DESCRIPTION
Prior to this commit, only database parameters that AWS recognised as
being user-altered were stored in state. This would be fine, except if
users specified the same value for a parameter as AWS' default for that
value, they would get a perpetual diff, because AWS would report it as a
non-user-changed parameter. Meaning it wouldn't be set in state, no
matter how many times the user applied.

This fixes the problem by retrieving all parameters, regardless of how
AWS reports them being set. We then select out from those parameters
only the ones that report that they're user-modified _or_ those that are
found in a config, if a config is available.

This commit also adds a test which exhibits this behaviour, which failed
before this fix was applied, and passes now that it has been applied.

Test output:

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSDBParameterGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSDBParameterGroup -timeout 120m
=== RUN   TestAccAWSDBParameterGroup_importBasic
2018/01/29 06:36:10 [WARN] Invalid log level: "1". Defaulting to level: TRACE. Valid levels are: [TRACE DEBUG INFO WARN ERROR]
--- PASS: TestAccAWSDBParameterGroup_importBasic (23.90s)
=== RUN   TestAccAWSDBParameterGroup_limit
--- PASS: TestAccAWSDBParameterGroup_limit (38.34s)
=== RUN   TestAccAWSDBParameterGroup_basic
--- PASS: TestAccAWSDBParameterGroup_basic (37.90s)
=== RUN   TestAccAWSDBParameterGroup_Disappears
--- PASS: TestAccAWSDBParameterGroup_Disappears (14.18s)
=== RUN   TestAccAWSDBParameterGroup_namePrefix
--- PASS: TestAccAWSDBParameterGroup_namePrefix (20.24s)
=== RUN   TestAccAWSDBParameterGroup_generatedName
--- PASS: TestAccAWSDBParameterGroup_generatedName (20.38s)
=== RUN   TestAccAWSDBParameterGroup_withApplyMethod
--- PASS: TestAccAWSDBParameterGroup_withApplyMethod (20.29s)
=== RUN   TestAccAWSDBParameterGroup_Only
--- PASS: TestAccAWSDBParameterGroup_Only (18.85s)
=== RUN   TestAccAWSDBParameterGroup_MatchDefault
--- PASS: TestAccAWSDBParameterGroup_MatchDefault (19.41s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       213.508s
```

Fixes #593.