### PR TITLE
Don't mangle DNS aliases: Trim{Prefix,Suffix} not Trim{Left,Right}.

### DIFF
--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -900,12 +900,9 @@ func nilString(s string) *string {
 }
 
 func normalizeAwsAliasName(alias interface{}) string {
-	input := alias.(string)
-	output := strings.ToLower(input)
-	if strings.HasPrefix(output, "dualstack.") {
-		output = strings.TrimLeft(output, "dualstack.")
-	}
-	return strings.TrimRight(output, ".")
+	input := strings.ToLower(alias.(string))
+	output := strings.TrimPrefix(input, "dualstack.")
+	return strings.TrimSuffix(output, ".")
 }
 
 func parseRecordId(id string) [4]string {

--- a/aws/resource_aws_route53_record_test.go
+++ b/aws/resource_aws_route53_record_test.go
@@ -59,6 +59,8 @@ func TestNormalizeAwsAliasName(t *testing.T) {
 		{"www.nonexample.com", "www.nonexample.com"},
 		{"www.nonexample.com.", "www.nonexample.com"},
 		{"dualstack.name-123456789.region.elb.amazonaws.com", "name-123456789.region.elb.amazonaws.com"},
+		{"dualstack.test-987654321.region.elb.amazonaws.com", "test-987654321.region.elb.amazonaws.com"},
+		{"dualstacktest.com", "dualstacktest.com"},
 		{"NAME-123456789.region.elb.amazonaws.com", "name-123456789.region.elb.amazonaws.com"},
 	}
 


### PR DESCRIPTION
## Description

A bug in Route 53 alias processing (where the leading string "dualstack." is removed, if present) will strip off all leading characters from a DNS alias name that are in the set of "dualstack." (or "acdklstu.", when sorted and de-duplicated), until it reaches a character that is not in that set. So, "dualstack.listenapi" becomes "istenapi" (instead of "listenapi") because "l" is in the set to trim, but "i" is not.

[source](https://github.com/terraform-providers/terraform-provider-aws/issues/3185#issuecomment-361410720)

Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/3185