### PR TITLE
r/aws_dynamodb_table - add validation for attribute types

### DIFF
--- a/aws/resource_aws_dynamodb_table.go
+++ b/aws/resource_aws_dynamodb_table.go
@@ -70,8 +70,9 @@ func resourceAwsDynamoDbTable() *schema.Resource {
 							Required: true,
 						},
 						"type": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateDynamoAttributeType,
 						},
 					},
 				},

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/applicationautoscaling"
 	"github.com/aws/aws-sdk-go/service/cognitoidentity"
 	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/gamelift"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -195,7 +196,11 @@ func validateStreamViewType(v interface{}, k string) (ws []string, errors []erro
 
 func validateDynamoAttributeType(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-	validTypes := []string{"B", "N", "S"}
+	validTypes := []string{
+		dynamodb.ScalarAttributeTypeB,
+		dynamodb.ScalarAttributeTypeN,
+		dynamodb.ScalarAttributeTypeS,
+	}
 
 	for _, t := range validTypes {
 		if t == value {

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -193,6 +193,21 @@ func validateStreamViewType(v interface{}, k string) (ws []string, errors []erro
 	return
 }
 
+func validateDynamoAttributeType(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	validTypes := []string{"B", "N", "S"}
+
+	for _, t := range validTypes {
+		if t == value {
+			return
+		}
+	}
+
+	errors = append(errors, fmt.Errorf("%q must be a valid DynamoDB attribute type", k))
+
+	return
+}
+
 func validateElbName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if len(value) == 0 {

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -1959,6 +1959,25 @@ func TestValidateApiGatewayUsagePlanQuotaSettings(t *testing.T) {
 	}
 }
 
+func TestValidateDynamoAttributeType(t *testing.T) {
+	validTypes := []string{"B", "N", "S"}
+
+	for _, s := range validTypes {
+		_, errors := validateDynamoAttributeType(s, "attribute")
+		if len(errors) > 0 {
+			t.Fatalf("%q should be a valid DynamoDB Attribute Type: %v", s, errors)
+		}
+	}
+
+	invalidTypes := []string{"A", "0", "DERP", "SO"}
+	for _, s := range invalidTypes {
+		_, errors := validateDynamoAttributeType(s, "attribute")
+		if len(errors) == 0 {
+			t.Fatalf("%q should not be a valid DynamoDB Attribute Type", s)
+		}
+	}
+}
+
 func TestValidateElbName(t *testing.T) {
 	validNames := []string{
 		"tf-test-elb",


### PR DESCRIPTION
Adds validation for DynamoDB table attribute types
```
$ TF_ACC=1 aws-vault exec development -- go test -v -timeout 60m -run AWSDynamoDb ./...
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSDynamoDbTable_importBasic
--- PASS: TestAccAWSDynamoDbTable_importBasic (98.88s)
=== RUN   TestAccAWSDynamoDbTable_importTags
--- PASS: TestAccAWSDynamoDbTable_importTags (96.56s)
=== RUN   TestAccAWSDynamoDbTable_importTimeToLive
--- PASS: TestAccAWSDynamoDbTable_importTimeToLive (75.67s)
=== RUN   TestAccAWSDynamoDbTable_basic
--- PASS: TestAccAWSDynamoDbTable_basic (348.35s)
=== RUN   TestAccAWSDynamoDbTable_streamSpecification
--- PASS: TestAccAWSDynamoDbTable_streamSpecification (79.78s)
=== RUN   TestAccAWSDynamoDbTable_tags
--- PASS: TestAccAWSDynamoDbTable_tags (83.97s)
=== RUN   TestAccAWSDynamoDbTable_gsiUpdateCapacity
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateCapacity (184.32s)
=== RUN   TestAccAWSDynamoDbTable_gsiUpdateOtherAttributes
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateOtherAttributes (565.24s)
=== RUN   TestAccAWSDynamoDbTable_gsiUpdateNonKeyAttributes
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateNonKeyAttributes (309.46s)
=== RUN   TestAccAWSDynamoDbTable_ttl
--- PASS: TestAccAWSDynamoDbTable_ttl (98.10s)
=== RUN   TestResourceAWSDynamoDbTableStreamViewType_validation
--- PASS: TestResourceAWSDynamoDbTableStreamViewType_validation (0.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1940.383s
```