### PR TITLE
resource/aws_kms_alias: Exposed target_key_id in the documentation

### DIFF
--- a/website/docs/r/kms_alias.html.markdown
+++ b/website/docs/r/kms_alias.html.markdown
@@ -35,7 +35,7 @@ The name must start with the word "alias" followed by a forward slash (alias/). 
 
 ## Attributes Reference
 
-The following additional attributes are exported:
+In addition to the arguments, the following attributes are exported:
 
 * `arn` - The Amazon Resource Name (ARN) of the key alias.
 * `target_key_arn` - The Amazon Resource Name (ARN) of the target key identifier.


### PR DESCRIPTION
This resolves comment https://github.com/terraform-providers/terraform-provider-aws/issues/3019#issuecomment-359657403

Even though the kms_alias resource code actually write the [`target_key_id` to the state](https://github.com/terraform-providers/terraform-provider-aws/blob/master/aws/resource_aws_kms_alias.go#L119), the documentation isn't reflecting that.
The related data source is indeed OK for this particular point ([source](https://github.com/terraform-providers/terraform-provider-aws/blob/master/aws/data_source_aws_kms_alias.go#L80)).