### PR TITLE
test/resource/aws_s3_bucket: Prevent BucketRegionError for multi-region tests

### DIFF
--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -79,3 +79,32 @@ func testAccEC2ClassicPreCheck(t *testing.T) {
 			region, platforms)
 	}
 }
+
+func testAccAwsRegionProvider(region string, providers *[]*schema.Provider) *schema.Provider {
+	if region == "" || providers == nil {
+		return nil
+	}
+	log.Printf("[DEBUG] Checking providers for AWS region: %s", region)
+	for _, provider := range *providers {
+		// Ignore if Meta is empty, this can happen for validation providers
+		if provider == nil || provider.Meta() == nil {
+			log.Printf("[DEBUG] Skipping empty provider")
+			continue
+		}
+
+		// Ignore if Meta is not AWSClient, this will happen for other providers
+		client, ok := provider.Meta().(*AWSClient)
+		if !ok {
+			log.Printf("[DEBUG] Skipping non-AWS provider")
+			continue
+		}
+
+		clientRegion := client.region
+		log.Printf("[DEBUG] Checking AWS provider region %q against %q", clientRegion, region)
+		if clientRegion == region {
+			log.Printf("[DEBUG] Found AWS provider with region: %s", region)
+			return provider
+		}
+	}
+	return nil
+}

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -963,12 +963,16 @@ func testAccCheckAWSS3BucketExistsWithProviders(n string, providers *[]*schema.P
 			})
 
 			if err != nil {
+				// Different than NoSuchBucket -- the S3 bucket is in another provider
+				if isAWSErr(err, "BucketRegionError", "incorrect region") {
+					continue
+				}
 				return fmt.Errorf("S3Bucket error: %v", err)
 			}
 			return nil
 		}
 
-		return fmt.Errorf("Instance not found")
+		return fmt.Errorf("S3 bucket not found")
 	}
 }
 


### PR DESCRIPTION
The testing logic loops through each test provider calling HeadBucket to ensure the bucket actually exists after the resource made it. When testing multiple providers in different regions, the first provider and its associated region could be incorrect with where the bucket actually lives, which S3 will send a 301 BucketRegionError to point you to the correct region. This tells the testing to skip this provider and keep trying others.

Previously flakey test:
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSS3Bucket_Replication\$$'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSS3Bucket_Replication\$ -timeout 120m
=== RUN   TestAccAWSS3Bucket_Replication
--- FAIL: TestAccAWSS3Bucket_Replication (38.04s)
	testing.go:513: Step 0 error: Check failed: Check 1/1 error: S3Bucket error: BucketRegionError: incorrect region, the bucket is not in 'eu-west-1' region
			status code: 301, request id: , host id:
FAIL
exit status 1
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	38.088s
make: *** [testacc] Error 1
```

Should pass more consistently now:
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSS3Bucket_Replication'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSS3Bucket_Replication -timeout 120m
=== RUN   TestAccAWSS3Bucket_Replication
--- PASS: TestAccAWSS3Bucket_Replication (82.65s)
=== RUN   TestAccAWSS3Bucket_ReplicationWithoutStorageClass
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutStorageClass (53.22s)
=== RUN   TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError
--- PASS: TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError (37.07s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	172.991s
```

Full testing run:
```
=== RUN   TestAccAWSS3BucketObject_tags
--- PASS: TestAccAWSS3BucketObject_tags (10.09s)
=== RUN   TestAccAWSS3Bucket_namePrefix
--- PASS: TestAccAWSS3Bucket_namePrefix (10.22s)
=== RUN   TestAccAWSS3BucketObject_content
--- PASS: TestAccAWSS3BucketObject_content (10.49s)
=== RUN   TestAccAWSS3BucketObject_sse
--- PASS: TestAccAWSS3BucketObject_sse (10.57s)
=== RUN   TestAccAWSS3BucketObject_source
--- PASS: TestAccAWSS3BucketObject_source (10.82s)
=== RUN   TestAccAWSS3Bucket_basic
--- PASS: TestAccAWSS3Bucket_basic (10.82s)
=== RUN   TestAccAWSS3BucketObject_withContentCharacteristics
--- PASS: TestAccAWSS3BucketObject_withContentCharacteristics (11.79s)
=== RUN   TestAccAWSS3Bucket_importWithPolicy
--- PASS: TestAccAWSS3Bucket_importWithPolicy (12.38s)
=== RUN   TestAccAWSS3BucketPolicy_basic
--- PASS: TestAccAWSS3BucketPolicy_basic (13.43s)
=== RUN   TestAccAWSS3Bucket_generatedName
--- PASS: TestAccAWSS3Bucket_generatedName (14.31s)
=== RUN   TestAccAWSS3Bucket_importBasic
--- PASS: TestAccAWSS3Bucket_importBasic (18.10s)
=== RUN   TestAccAWSS3BucketPolicy_policyUpdate
--- PASS: TestAccAWSS3BucketPolicy_policyUpdate (27.12s)
=== RUN   TestAccAWSS3BucketObject_updates
--- PASS: TestAccAWSS3BucketObject_updates (29.34s)
=== RUN   TestAccAWSS3BucketObject_kms
--- PASS: TestAccAWSS3BucketObject_kms (29.86s)
=== RUN   TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed
--- PASS: TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed (25.69s)
=== RUN   TestAccAWSS3Bucket_shouldFailNotFound
--- PASS: TestAccAWSS3Bucket_shouldFailNotFound (17.62s)
=== RUN   TestAccAWSS3BucketObject_storageClass
--- PASS: TestAccAWSS3BucketObject_storageClass (46.46s)
=== RUN   TestAccAWSS3BucketObject_updatesWithVersioning
--- PASS: TestAccAWSS3BucketObject_updatesWithVersioning (46.53s)
=== RUN   TestAccAWSS3Bucket_region
--- PASS: TestAccAWSS3Bucket_region (37.15s)
=== RUN   TestAccAWSS3Bucket_Policy
--- PASS: TestAccAWSS3Bucket_Policy (42.63s)
=== RUN   TestAccAWSS3BucketNotification_withoutFilter
--- PASS: TestAccAWSS3BucketNotification_withoutFilter (55.99s)
=== RUN   TestAccAWSS3Bucket_WebsiteRoutingRules
--- PASS: TestAccAWSS3Bucket_WebsiteRoutingRules (44.49s)
=== RUN   TestAccAWSS3BucketObject_acl
--- PASS: TestAccAWSS3BucketObject_acl (59.78s)
=== RUN   TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical
--- PASS: TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical (50.56s)
=== RUN   TestAccAWSS3Bucket_Logging
--- PASS: TestAccAWSS3Bucket_Logging (24.51s)
=== RUN   TestAccAWSS3Bucket_RequestPayer
--- PASS: TestAccAWSS3Bucket_RequestPayer (54.70s)
=== RUN   TestAccAWSS3Bucket_UpdateAcl
--- PASS: TestAccAWSS3Bucket_UpdateAcl (61.54s)
=== RUN   TestAccAWSS3Bucket_Versioning
--- PASS: TestAccAWSS3Bucket_Versioning (53.00s)
=== RUN   TestAccAWSS3Bucket_Cors
--- PASS: TestAccAWSS3Bucket_Cors (59.63s)
=== RUN   TestAccAWSS3Bucket_acceleration
--- PASS: TestAccAWSS3Bucket_acceleration (79.85s)
=== RUN   TestAccAWSS3Bucket_Lifecycle
--- PASS: TestAccAWSS3Bucket_Lifecycle (49.86s)
=== RUN   TestAccAWSS3BucketNotification_importBasic
--- PASS: TestAccAWSS3BucketNotification_importBasic (108.54s)
=== RUN   TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled
--- PASS: TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled (103.99s)
=== RUN   TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError
--- PASS: TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError (75.61s)
=== RUN   TestAccAWSS3Bucket_Website_Simple
--- PASS: TestAccAWSS3Bucket_Website_Simple (112.38s)
=== RUN   TestAccAWSS3Bucket_WebsiteRedirect
--- PASS: TestAccAWSS3Bucket_WebsiteRedirect (115.14s)
=== RUN   TestAccAWSS3Bucket_Replication
--- PASS: TestAccAWSS3Bucket_Replication (83.02s)
=== RUN   TestAccAWSS3Bucket_ReplicationWithoutStorageClass
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutStorageClass (93.84s)
=== RUN   TestAccAWSS3BucketNotification_basic
--- PASS: TestAccAWSS3BucketNotification_basic (150.31s)
```