### PR TITLE
resource/aws_dynamodb_table: Allow disabling stream w/ empty view type

### DIFF
--- a/aws/resource_aws_dynamodb_table.go
+++ b/aws/resource_aws_dynamodb_table.go
@@ -30,6 +30,10 @@ func resourceAwsDynamoDbTable() *schema.Resource {
 			Update: schema.DefaultTimeout(10 * time.Minute),
 		},
 
+		CustomizeDiff: func(diff *schema.ResourceDiff, v interface{}) error {
+			return validateDynamoDbStreamSpec(diff)
+		},
+
 		SchemaVersion: 1,
 		MigrateState:  resourceAwsDynamoDbTableMigrateState,
 
@@ -173,7 +177,6 @@ func resourceAwsDynamoDbTable() *schema.Resource {
 			"stream_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Computed: true,
 			},
 			"stream_view_type": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
Fixes #1134

Despite `stream_view_type` being optional the validation is still being triggered which makes it impossible to parametrise the stream spec as described in #1134

## Test results

```
=== RUN   TestAccAWSDynamoDbTable_streamSpecification
--- PASS: TestAccAWSDynamoDbTable_streamSpecification (92.66s)
```