### PR TITLE
resource/aws_iam_user_policy: Add support to import state

### DIFF
--- a/aws/import_aws_iam_user_policy_test.go
+++ b/aws/import_aws_iam_user_policy_test.go
@@ -1,0 +1,54 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func testAccAwsIamUserPolicyConfig(suffix string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_user" "user_%[1]s" {
+	name = "tf_test_user_test_%[1]s"
+	path = "/"
+}
+
+resource "aws_iam_user_policy" "foo_%[1]s" {
+	name = "tf_test_policy_test_%[1]s"
+	user = "${aws_iam_user.user_%[1]s.name}"
+	policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Action": "*",
+    "Resource": "*"
+  }
+}
+EOF
+}
+`, suffix)
+}
+
+func TestAccAWSIAMUserPolicy_importBasic(t *testing.T) {
+	suffix := randomString(10)
+	resourceName := fmt.Sprintf("aws_iam_user_policy.foo_%s", suffix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIAMUserPolicyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAwsIamUserPolicyConfig(suffix),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/aws/resource_aws_iam_user_policy.go
+++ b/aws/resource_aws_iam_user_policy.go
@@ -19,6 +19,10 @@ func resourceAwsIamUserPolicy() *schema.Resource {
 		Create: resourceAwsIamUserPolicyPut,
 		Update: resourceAwsIamUserPolicyPut,
 
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
 		Read:   resourceAwsIamUserPolicyRead,
 		Delete: resourceAwsIamUserPolicyDelete,
 
@@ -59,8 +63,12 @@ func resourceAwsIamUserPolicyPut(d *schema.ResourceData, meta interface{}) error
 	}
 
 	var policyName string
+	var err error
 	if !d.IsNewResource() {
-		_, policyName = resourceAwsIamUserPolicyParseId(d.Id())
+		_, policyName, err = resourceAwsIamUserPolicyParseId(d.Id())
+		if err != nil {
+			return err
+		}
 	} else if v, ok := d.GetOk("name"); ok {
 		policyName = v.(string)
 	} else if v, ok := d.GetOk("name_prefix"); ok {
@@ -81,14 +89,16 @@ func resourceAwsIamUserPolicyPut(d *schema.ResourceData, meta interface{}) error
 func resourceAwsIamUserPolicyRead(d *schema.ResourceData, meta interface{}) error {
 	iamconn := meta.(*AWSClient).iamconn
 
-	user, name := resourceAwsIamUserPolicyParseId(d.Id())
+	user, name, err := resourceAwsIamUserPolicyParseId(d.Id())
+	if err != nil {
+		return err
+	}
 
 	request := &iam.GetUserPolicyInput{
 		PolicyName: aws.String(name),
 		UserName:   aws.String(user),
 	}
 
-	var err error
 	getResp, err := iamconn.GetUserPolicy(request)
 	if err != nil {
 		if iamerr, ok := err.(awserr.Error); ok && iamerr.Code() == "NoSuchEntity" { // XXX test me
@@ -106,13 +116,22 @@ func resourceAwsIamUserPolicyRead(d *schema.ResourceData, meta interface{}) erro
 	if err != nil {
 		return err
 	}
-	return d.Set("policy", policy)
+	if err := d.Set("policy", policy); err != nil {
+		return err
+	}
+	if err := d.Set("name", name); err != nil {
+		return err
+	}
+	return d.Set("user", user)
 }
 
 func resourceAwsIamUserPolicyDelete(d *schema.ResourceData, meta interface{}) error {
 	iamconn := meta.(*AWSClient).iamconn
 
-	user, name := resourceAwsIamUserPolicyParseId(d.Id())
+	user, name, err := resourceAwsIamUserPolicyParseId(d.Id())
+	if err != nil {
+		return err
+	}
 
 	request := &iam.DeleteUserPolicyInput{
 		PolicyName: aws.String(name),
@@ -125,8 +144,13 @@ func resourceAwsIamUserPolicyDelete(d *schema.ResourceData, meta interface{}) er
 	return nil
 }
 
-func resourceAwsIamUserPolicyParseId(id string) (userName, policyName string) {
+func resourceAwsIamUserPolicyParseId(id string) (userName, policyName string, err error) {
 	parts := strings.SplitN(id, ":", 2)
+	if len(parts) != 2 {
+		err = fmt.Errorf("user_policy id must be of the form <user name>:<policy name>")
+		return
+	}
+
 	userName = parts[0]
 	policyName = parts[1]
 	return

--- a/aws/resource_aws_iam_user_policy_test.go
+++ b/aws/resource_aws_iam_user_policy_test.go
@@ -190,14 +190,16 @@ func testAccCheckIAMUserPolicyDestroy(s *terraform.State) error {
 			continue
 		}
 
-		user, name := resourceAwsIamUserPolicyParseId(rs.Primary.ID)
+		user, name, err := resourceAwsIamUserPolicyParseId(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
 
 		request := &iam.GetUserPolicyInput{
 			PolicyName: aws.String(name),
 			UserName:   aws.String(user),
 		}
 
-		var err error
 		getResp, err := iamconn.GetUserPolicy(request)
 		if err != nil {
 			if iamerr, ok := err.(awserr.Error); ok && iamerr.Code() == "NoSuchEntity" {
@@ -234,8 +236,12 @@ func testAccCheckIAMUserPolicy(
 		}
 
 		iamconn := testAccProvider.Meta().(*AWSClient).iamconn
-		username, name := resourceAwsIamUserPolicyParseId(policy.Primary.ID)
-		_, err := iamconn.GetUserPolicy(&iam.GetUserPolicyInput{
+		username, name, err := resourceAwsIamUserPolicyParseId(policy.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		_, err = iamconn.GetUserPolicy(&iam.GetUserPolicyInput{
 			UserName:   aws.String(username),
 			PolicyName: aws.String(name),
 		})


### PR DESCRIPTION
# Description
Add support to import state for inline IAM user policies using `terraform import <USER>:<POLICY_NAME>`.

# Context
Replaces https://github.com/terraform-providers/terraform-provider-aws/pull/2931 which attempted to solve this **and** adding support to import `aws_iam_user_policy` via `aws_iam_user` dynamically.

The previous PR also had conflicts after #3031.

# Acceptance Tests
`r/aws_iam_user_policy` acceptance tests:
```
make testacc TESTARGS="-run 'TestAccAWSIAMUserPolicy_import*'"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run 'TestAccAWSIAMUserPolicy_import*' -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSIAMUserPolicy_importBasic
--- PASS: TestAccAWSIAMUserPolicy_importBasic (30.10s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       30.619s
```