### PR TITLE
data-source/aws_kms_alias: Prevent crash on aliases without target key

### DIFF
--- a/aws/data_source_aws_kms_alias.go
+++ b/aws/data_source_aws_kms_alias.go
@@ -64,20 +64,24 @@ func dataSourceAwsKmsAliasRead(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(time.Now().UTC().String())
 	d.Set("arn", alias.AliasArn)
 
-	aliasARN, err := arn.Parse(*alias.AliasArn)
-	if err != nil {
-		return err
-	}
-	targetKeyARN := arn.ARN{
-		Partition: aliasARN.Partition,
-		Service:   aliasARN.Service,
-		Region:    aliasARN.Region,
-		AccountID: aliasARN.AccountID,
-		Resource:  fmt.Sprintf("key/%s", *alias.TargetKeyId),
-	}
-	d.Set("target_key_arn", targetKeyARN.String())
+	// AWS service aliases do not return TargetKeyId:
+	// https://docs.aws.amazon.com/kms/latest/APIReference/API_ListAliases.html
+	if alias.TargetKeyId != nil {
+		aliasARN, err := arn.Parse(*alias.AliasArn)
+		if err != nil {
+			return err
+		}
+		targetKeyARN := arn.ARN{
+			Partition: aliasARN.Partition,
+			Service:   aliasARN.Service,
+			Region:    aliasARN.Region,
+			AccountID: aliasARN.AccountID,
+			Resource:  fmt.Sprintf("key/%s", *alias.TargetKeyId),
+		}
+		d.Set("target_key_arn", targetKeyARN.String())
 
-	d.Set("target_key_id", alias.TargetKeyId)
+		d.Set("target_key_id", alias.TargetKeyId)
+	}
 
 	return nil
 }

--- a/aws/data_source_aws_kms_alias.go
+++ b/aws/data_source_aws_kms_alias.go
@@ -64,7 +64,8 @@ func dataSourceAwsKmsAliasRead(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(time.Now().UTC().String())
 	d.Set("arn", alias.AliasArn)
 
-	// AWS service aliases do not return TargetKeyId:
+	// Some aliases do not return TargetKeyId (e.g. aliases for AWS services or
+	// aliases not associated with a Customer Managed Key (CMK))
 	// https://docs.aws.amazon.com/kms/latest/APIReference/API_ListAliases.html
 	if alias.TargetKeyId != nil {
 		aliasARN, err := arn.Parse(*alias.AliasArn)

--- a/aws/data_source_aws_kms_alias_test.go
+++ b/aws/data_source_aws_kms_alias_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -10,32 +11,69 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccDataSourceAwsKmsAlias(t *testing.T) {
-	rInt := acctest.RandInt()
+func TestAccDataSourceAwsKmsAlias_AwsService(t *testing.T) {
+	name := "alias/aws/redshift"
+	resourceName := "data.aws_kms_alias.test"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccDataSourceAwsKmsAlias(rInt),
+				Config: testAccDataSourceAwsKmsAlias_name(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceAwsKmsAliasCheck("data.aws_kms_alias.by_name"),
+					testAccDataSourceAwsKmsAliasCheckExists(resourceName),
+					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:kms:[^:]+:[^:]+:%s$", name))),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckNoResourceAttr(resourceName, "target_key_arn"),
+					resource.TestCheckNoResourceAttr(resourceName, "target_key_id"),
 				),
 			},
 		},
 	})
 }
 
-func testAccDataSourceAwsKmsAliasCheck(name string) resource.TestCheckFunc {
+func TestAccDataSourceAwsKmsAlias_CMK(t *testing.T) {
+	rInt := acctest.RandInt()
+	aliasResourceName := "aws_kms_alias.test"
+	datasourceAliasResourceName := "data.aws_kms_alias.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDataSourceAwsKmsAlias_CMK(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsKmsAliasCheckExists(datasourceAliasResourceName),
+					testAccDataSourceAwsKmsAliasCheckCMKAttributes(aliasResourceName, datasourceAliasResourceName),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsKmsAliasCheckExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		_, ok := s.RootModule().Resources[name]
 		if !ok {
 			return fmt.Errorf("root module has no resource called %s", name)
 		}
 
-		kmsKeyRs, ok := s.RootModule().Resources["aws_kms_alias.single"]
+		return nil
+	}
+}
+
+func testAccDataSourceAwsKmsAliasCheckCMKAttributes(aliasResourceName, datasourceAliasResourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[datasourceAliasResourceName]
 		if !ok {
-			return fmt.Errorf("can't find aws_kms_alias.single in state")
+			return fmt.Errorf("root module has no resource called %s", datasourceAliasResourceName)
+		}
+
+		kmsKeyRs, ok := s.RootModule().Resources[aliasResourceName]
+		if !ok {
+			return fmt.Errorf("can't find %s in state", aliasResourceName)
 		}
 
 		attr := rs.Primary.Attributes
@@ -69,19 +107,25 @@ func testAccDataSourceAwsKmsAliasCheck(name string) resource.TestCheckFunc {
 	}
 }
 
-func testAccDataSourceAwsKmsAlias(rInt int) string {
+func testAccDataSourceAwsKmsAlias_name(name string) string {
 	return fmt.Sprintf(`
-resource "aws_kms_key" "one" {
+data "aws_kms_alias" "test" {
+  name = "%s"
+}`, name)
+}
+
+func testAccDataSourceAwsKmsAlias_CMK(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "test" {
     description = "Terraform acc test"
     deletion_window_in_days = 7
 }
 
-resource "aws_kms_alias" "single" {
+resource "aws_kms_alias" "test" {
     name = "alias/tf-acc-key-alias-%d"
-    target_key_id = "${aws_kms_key.one.key_id}"
+    target_key_id = "${aws_kms_key.test.key_id}"
 }
 
-data "aws_kms_alias" "by_name" {
-  name = "${aws_kms_alias.single.name}"
-}`, rInt)
+%s
+`, rInt, testAccDataSourceAwsKmsAlias_name("${aws_kms_alias.test.name}"))
 }


### PR DESCRIPTION
According to the [KMS API documentation](https://docs.aws.amazon.com/kms/latest/APIReference/API_ListAliases.html), AWS service KMS aliases (e.g. `alias/aws/redshift`) do not return TargetKeyId. This PR adds testing against those aliases and ensures the data source does not return `target_key_arn` or `target_key_id` in that scenario.

New acceptance test without data source changes:
```
make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsKmsAlias'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccDataSourceAwsKmsAlias -timeout 120m
=== RUN   TestAccDataSourceAwsKmsAlias_AwsService
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x25b13d3]

goroutine 143 [running]:
github.com/terraform-providers/terraform-provider-aws/aws.dataSourceAwsKmsAliasRead(0xc420209110, 0x3584220, 0xc420280780, 0xc420209110, 0x0)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/aws/data_source_aws_kms_alias.go:76 +0x3b3
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema.(*Resource).ReadDataApply(0xc42034c000, 0xc4205bde60, 0x3584220, 0xc420280780, 0xc420264988, 0xc4205b2601, 0xc4205a7680)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema/resource.go:292 +0x8b
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema.(*Provider).ReadDataApply(0xc4200f8fc0, 0xc420793e50, 0xc4205bde60, 0x0, 0x400, 0x44)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema/provider.go:426 +0x9a
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/terraform.(*EvalReadDataApply).Eval(0xc4205bdc00, 0x580b380, 0xc4203141a0, 0x2, 0x2, 0x3985d99, 0x4)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/terraform/eval_read_data.go:122 +0x100
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/terraform.EvalRaw(0x57fb860, 0xc4205bdc00, 0x580b380, 0xc4203141a0, 0x0, 0x0, 0x0, 0x0)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/terraform/eval.go:53 +0x173
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/terraform.(*EvalSequence).Eval(0xc4205bdc20, 0x580b380, 0xc4203141a0, 0x2, 0x2, 0x3985d99, 0x4)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/terraform/eval_sequence.go:14 +0x7e
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/terraform.EvalRaw(0x57fba60, 0xc4205bdc20, 0x580b380, 0xc4203141a0, 0x33c2ec0, 0x580c3c5, 0x3171b80, 0xc4204fc1d0)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/terraform/eval.go:53 +0x173
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/terraform.Eval(0x57fba60, 0xc4205bdc20, 0x580b380, 0xc4203141a0, 0xc4205bdc20, 0x57fba60, 0xc4205bdc20, 0x108c434)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/terraform/eval.go:34 +0x4d
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/terraform.(*Graph).walk.func1(0x38c5680, 0xc42059cb30, 0x0, 0x0)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/terraform/graph.go:126 +0xd0d
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/dag.(*Walker).walkVertex(0xc4202087e0, 0x38c5680, 0xc42059cb30, 0xc42053f340)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/dag/walk.go:387 +0x3c1
created by github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/dag.(*Walker).Update
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/dag/walk.go:310 +0x1364
exit status 2
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	3.447s
make: *** [testacc] Error 1
```

After:
```
 make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsKmsAlias'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccDataSourceAwsKmsAlias -timeout 120m
=== RUN   TestAccDataSourceAwsKmsAlias_AwsService
--- PASS: TestAccDataSourceAwsKmsAlias_AwsService (9.54s)
=== RUN   TestAccDataSourceAwsKmsAlias_CMK
--- PASS: TestAccDataSourceAwsKmsAlias_CMK (41.27s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	50.859s
```
