### PR TITLE
data-source/aws_ssm_parameter: Fix wrong arn attribute for full path parameter names

### DIFF
--- a/aws/data_source_aws_ssm_parameter.go
+++ b/aws/data_source_aws_ssm_parameter.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
@@ -72,7 +73,7 @@ func dataAwsSsmParameterRead(d *schema.ResourceData, meta interface{}) error {
 		Region:    meta.(*AWSClient).region,
 		Service:   "ssm",
 		AccountID: meta.(*AWSClient).accountid,
-		Resource:  fmt.Sprintf("parameter/%s", d.Id()),
+		Resource:  fmt.Sprintf("parameter/%s", strings.TrimPrefix(d.Id(), "/")),
 	}
 	d.Set("arn", arn.String())
 


### PR DESCRIPTION
This should fix the issue described in https://github.com/terraform-providers/terraform-provider-aws/issues/2593

As I'm not experienced with programming in Go, I couldn't implement a respective testcase for this.