### PR TITLE
resource/aws_ses_template: Send only specified attributes for update

### DIFF
--- a/aws/resource_aws_ses_template.go
+++ b/aws/resource_aws_ses_template.go
@@ -110,10 +110,19 @@ func resourceAwsSesTemplateUpdate(d *schema.ResourceData, meta interface{}) erro
 	templateName := d.Id()
 
 	template := ses.Template{
-		HtmlPart:     aws.String(d.Get("html").(string)),
 		TemplateName: aws.String(templateName),
-		SubjectPart:  aws.String(d.Get("subject").(string)),
-		TextPart:     aws.String(d.Get("text").(string)),
+	}
+
+	if v, ok := d.GetOk("html"); ok {
+		template.HtmlPart = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("subject"); ok {
+		template.SubjectPart = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("text"); ok {
+		template.TextPart = aws.String(v.(string))
 	}
 
 	input := ses.UpdateTemplateInput{


### PR DESCRIPTION
Addresses an issue where all text-only emails suddenly turned into emails after an update. Currently the `UpdateTemplate` call will set the `HtmlPart` to an empty string if it's not specified for the resource, which results in an email with an empty body in most mail clients.