### PR TITLE
resource/aws_dynamodb_table: (actually) fix disabling stream

### DIFF
--- a/aws/resource_aws_dynamodb_table.go
+++ b/aws/resource_aws_dynamodb_table.go
@@ -305,12 +305,16 @@ func resourceAwsDynamoDbTableUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if (d.HasChange("stream_enabled") || d.HasChange("stream_view_type")) && !d.IsNewResource() {
+		toEnable := d.Get("stream_enabled").(bool)
+		streamSpec := dynamodb.StreamSpecification{
+			StreamEnabled: aws.Bool(toEnable),
+		}
+		if toEnable {
+			streamSpec.StreamViewType = aws.String(d.Get("stream_view_type").(string))
+		}
 		input := &dynamodb.UpdateTableInput{
-			TableName: aws.String(d.Id()),
-			StreamSpecification: &dynamodb.StreamSpecification{
-				StreamEnabled:  aws.Bool(d.Get("stream_enabled").(bool)),
-				StreamViewType: aws.String(d.Get("stream_view_type").(string)),
-			},
+			TableName:           aws.String(d.Id()),
+			StreamSpecification: &streamSpec,
 		}
 		_, err := conn.UpdateTable(input)
 		if err != nil {

--- a/aws/resource_aws_dynamodb_table_test.go
+++ b/aws/resource_aws_dynamodb_table_test.go
@@ -311,13 +311,15 @@ func TestAccAWSDynamoDbTable_basic(t *testing.T) {
 func TestAccAWSDynamoDbTable_streamSpecification(t *testing.T) {
 	var conf dynamodb.DescribeTableOutput
 
+	tableName := fmt.Sprintf("TerraformTestStreamTable-%s", acctest.RandString(8))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSDynamoDbTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDynamoDbConfigStreamSpecification(true, "KEYS_ONLY"),
+				Config: testAccAWSDynamoDbConfigStreamSpecification(tableName, true, "KEYS_ONLY"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInitialAWSDynamoDbTableExists("aws_dynamodb_table.basic-dynamodb-table", &conf),
 					resource.TestCheckResourceAttr("aws_dynamodb_table.basic-dynamodb-table", "stream_enabled", "true"),
@@ -327,13 +329,13 @@ func TestAccAWSDynamoDbTable_streamSpecification(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSDynamoDbConfigStreamSpecification(false, ""),
+				Config: testAccAWSDynamoDbConfigStreamSpecification(tableName, false, ""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInitialAWSDynamoDbTableExists("aws_dynamodb_table.basic-dynamodb-table", &conf),
 					resource.TestCheckResourceAttr("aws_dynamodb_table.basic-dynamodb-table", "stream_enabled", "false"),
-					resource.TestCheckNoResourceAttr("aws_dynamodb_table.basic-dynamodb-table", "stream_view_type"),
-					resource.TestCheckNoResourceAttr("aws_dynamodb_table.basic-dynamodb-table", "stream_arn"),
-					resource.TestCheckNoResourceAttr("aws_dynamodb_table.basic-dynamodb-table", "stream_label"),
+					resource.TestCheckResourceAttr("aws_dynamodb_table.basic-dynamodb-table", "stream_view_type", ""),
+					resource.TestCheckResourceAttrSet("aws_dynamodb_table.basic-dynamodb-table", "stream_arn"),
+					resource.TestCheckResourceAttrSet("aws_dynamodb_table.basic-dynamodb-table", "stream_label"),
 				),
 			},
 		},
@@ -347,7 +349,7 @@ func TestAccAWSDynamoDbTable_streamSpecificationValidation(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDynamoDbTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccAWSDynamoDbConfigStreamSpecification(true, ""),
+				Config:      testAccAWSDynamoDbConfigStreamSpecification("anything", true, ""),
 				ExpectError: regexp.MustCompile(`stream_view_type is required when stream_enabled = true$`),
 			},
 		},
@@ -972,10 +974,10 @@ resource "aws_dynamodb_table" "basic-dynamodb-table" {
 }`, rName)
 }
 
-func testAccAWSDynamoDbConfigStreamSpecification(enabled bool, viewType string) string {
+func testAccAWSDynamoDbConfigStreamSpecification(tableName string, enabled bool, viewType string) string {
 	return fmt.Sprintf(`
 resource "aws_dynamodb_table" "basic-dynamodb-table" {
-  name = "TerraformTestStreamTable-%d"
+  name = "%s"
   read_capacity = 10
   write_capacity = 20
   hash_key = "TestTableHashKey"
@@ -988,7 +990,7 @@ resource "aws_dynamodb_table" "basic-dynamodb-table" {
   stream_enabled = %t
   stream_view_type = "%s"
 }
-`, acctest.RandInt(), enabled, viewType)
+`, tableName, enabled, viewType)
 }
 
 func testAccAWSDynamoDbConfigTags() string {

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -3287,9 +3287,13 @@ func flattenAwsDynamoDbTableResource(d *schema.ResourceData, table *dynamodb.Tab
 	if table.StreamSpecification != nil {
 		d.Set("stream_view_type", table.StreamSpecification.StreamViewType)
 		d.Set("stream_enabled", table.StreamSpecification.StreamEnabled)
-		d.Set("stream_arn", table.LatestStreamArn)
-		d.Set("stream_label", table.LatestStreamLabel)
+	} else {
+		d.Set("stream_view_type", "")
+		d.Set("stream_enabled", false)
 	}
+
+	d.Set("stream_arn", table.LatestStreamArn)
+	d.Set("stream_label", table.LatestStreamLabel)
 
 	err = d.Set("global_secondary_index", gsiList)
 	if err != nil {


### PR DESCRIPTION
https://github.com/terraform-providers/terraform-provider-aws/pull/3197 didn't actually address the issue because I overlooked a test which was generating new table name between steps and causing it to be recreated - hence never _updating_ the table. 🙈 

## Test results

```
=== RUN   TestAccAWSDynamoDbTable_streamSpecificationValidation
--- PASS: TestAccAWSDynamoDbTable_streamSpecificationValidation (2.64s)
=== RUN   TestAccAWSDynamoDbTable_streamSpecification
--- PASS: TestAccAWSDynamoDbTable_streamSpecification (40.34s)
=== RUN   TestAccAWSDynamoDbTable_importTags
--- PASS: TestAccAWSDynamoDbTable_importTags (51.92s)
=== RUN   TestAccAWSDynamoDbTable_importTimeToLive
--- PASS: TestAccAWSDynamoDbTable_importTimeToLive (52.31s)
=== RUN   TestAccAWSDynamoDbTable_tags
--- PASS: TestAccAWSDynamoDbTable_tags (107.27s)
=== RUN   TestAccAWSDynamoDbTable_ttl
--- PASS: TestAccAWSDynamoDbTable_ttl (143.47s)
=== RUN   TestAccAWSDynamoDbTable_gsiUpdateCapacity
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateCapacity (182.99s)
=== RUN   TestAccAWSDynamoDbTable_importBasic
--- PASS: TestAccAWSDynamoDbTable_importBasic (199.82s)
=== RUN   TestAccAWSDynamoDbTable_basic
--- PASS: TestAccAWSDynamoDbTable_basic (414.13s)
=== RUN   TestAccAWSDynamoDbTable_gsiUpdateNonKeyAttributes
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateNonKeyAttributes (417.06s)
=== RUN   TestAccAWSDynamoDbTable_gsiUpdateOtherAttributes
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateOtherAttributes (713.90s)
```