### PR TITLE
resource/aws_service_discovery_public_dns_namespace: Support import

### DIFF
--- a/aws/resource_aws_service_discovery_public_dns_namespace.go
+++ b/aws/resource_aws_service_discovery_public_dns_namespace.go
@@ -16,6 +16,10 @@ func resourceAwsServiceDiscoveryPublicDnsNamespace() *schema.Resource {
 		Read:   resourceAwsServiceDiscoveryPublicDnsNamespaceRead,
 		Delete: resourceAwsServiceDiscoveryPublicDnsNamespaceDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -89,6 +93,7 @@ func resourceAwsServiceDiscoveryPublicDnsNamespaceRead(d *schema.ResourceData, m
 		return err
 	}
 
+	d.Set("name", resp.Namespace.Name)
 	d.Set("description", resp.Namespace.Description)
 	d.Set("arn", resp.Namespace.Arn)
 	if resp.Namespace.Properties != nil {

--- a/aws/resource_aws_service_discovery_public_dns_namespace_test.go
+++ b/aws/resource_aws_service_discovery_public_dns_namespace_test.go
@@ -29,6 +29,27 @@ func TestAccAwsServiceDiscoveryPublicDnsNamespace_basic(t *testing.T) {
 	})
 }
 
+func TestAccAwsServiceDiscoveryPublicDnsNamespace_import(t *testing.T) {
+	resourceName := "aws_service_discovery_public_dns_namespace.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsServiceDiscoveryPublicDnsNamespaceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccServiceDiscoveryPublicDnsNamespaceConfig(acctest.RandString(5)),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAwsServiceDiscoveryPublicDnsNamespaceDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).sdconn
 
@@ -54,9 +75,20 @@ func testAccCheckAwsServiceDiscoveryPublicDnsNamespaceDestroy(s *terraform.State
 
 func testAccCheckAwsServiceDiscoveryPublicDnsNamespaceExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		_, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[name]
 		if !ok {
 			return fmt.Errorf("Not found: %s", name)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).sdconn
+
+		input := &servicediscovery.GetNamespaceInput{
+			Id: aws.String(rs.Primary.ID),
+		}
+
+		_, err := conn.GetNamespace(input)
+		if err != nil {
+			return err
 		}
 
 		return nil

--- a/website/docs/r/service_discovery_public_dns_namespace.html.markdown
+++ b/website/docs/r/service_discovery_public_dns_namespace.html.markdown
@@ -33,3 +33,11 @@ The following attributes are exported:
 * `id` - The ID of a namespace.
 * `arn` - The ARN that Amazon Route 53 assigns to the namespace when you create it.
 * `hosted_zone` - The ID for the hosted zone that Amazon Route 53 creates when you create a namespace.
+
+## Import
+
+Service Discovery Public DNS Namespace can be imported using the namespace ID, e.g.
+
+```
+$ terraform import aws_service_discovery_public_dns_namespace.example 0123456789
+```


### PR DESCRIPTION
```
TF_ACC=1 go test ./aws -v -run=TestAccAwsServiceDiscoveryPublicDnsNamespace_import -timeout 120m
=== RUN   TestAccAwsServiceDiscoveryPublicDnsNamespace_import
--- PASS: TestAccAwsServiceDiscoveryPublicDnsNamespace_import (42.56s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	42.599s
```