### PR TITLE
New Resource: aws_dynamodb_table_item

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -332,6 +332,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_dx_connection":                            resourceAwsDxConnection(),
 			"aws_dx_connection_association":                resourceAwsDxConnectionAssociation(),
 			"aws_dynamodb_table":                           resourceAwsDynamoDbTable(),
+			"aws_dynamodb_table_item":                      resourceAwsDynamoDbTableItem(),
 			"aws_dynamodb_global_table":                    resourceAwsDynamoDbGlobalTable(),
 			"aws_ebs_snapshot":                             resourceAwsEbsSnapshot(),
 			"aws_ebs_volume":                               resourceAwsEbsVolume(),

--- a/aws/resource_aws_dynamodb_table_item.go
+++ b/aws/resource_aws_dynamodb_table_item.go
@@ -1,0 +1,464 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	strings "strings"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/schema"
+
+	"bytes"
+	"encoding/json"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	reflect "reflect"
+)
+
+// A number of these are marked as computed because if you don't
+// provide a value, DynamoDB will provide you with defaults (which are the
+// default values specified below)
+func resourceAwsDynamoDbTableItem() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsDynamoDbTableItemCreate,
+		Read:   resourceAwsDynamoDbTableItemRead,
+		Update: resourceAwsDynamoDbTableItemUpdate,
+		Delete: resourceAwsDynamoDbTableItemDelete,
+		Schema: map[string]*schema.Schema{
+			"table_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"hash_key": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"item": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"range_key": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"query_key": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"range_value": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"hash_value": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"consumed_capacity": &schema.Schema{
+				Type:     schema.TypeFloat,
+				Computed: true,
+			},
+			"last_modified": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsDynamoDbTableItemCreate(d *schema.ResourceData, meta interface{}) error {
+	dynamodbconn := meta.(*AWSClient).dynamodbconn
+
+	tableName := d.Get("table_name").(string)
+	hashKey := d.Get("hash_key").(string)
+	rangeKey := d.Get("range_key").(string)
+
+	log.Printf("[DEBUG] DynamoDB item create: %s", tableName)
+
+	item := d.Get("item").(string)
+
+	var av map[string]*dynamodb.AttributeValue
+
+	avDec := json.NewDecoder(strings.NewReader(item))
+
+	if err := avDec.Decode(&av); err != nil {
+		return fmt.Errorf("Error deserializing DynamoDB item JSON: %s", err)
+	}
+
+	exists := false
+	req := &dynamodb.PutItemInput{
+		Item: av,
+		Expected: map[string]*dynamodb.ExpectedAttributeValue{
+			hashKey: {
+				// Explode if item exists. We didn't create it.
+				Exists: &exists,
+			},
+		},
+		TableName: &tableName,
+	}
+
+	id := getId(tableName, hashKey, rangeKey, av)
+	err := retryLoop(func() error {
+		_, err := dynamodbconn.PutItem(req)
+
+		return err
+	}, fmt.Sprintf("creating DynamoDB table item '%s'", id))
+
+	if err != nil {
+		return err
+	}
+
+	setQueryKey(d, av, item, hashKey, rangeKey)
+
+	d.SetId(id)
+
+	return resourceAwsDynamoDbTableItemRead(d, meta)
+}
+
+func getId(tableName string, hashKey string, rangeKey string, av map[string]*dynamodb.AttributeValue) string {
+	hashVal := av[hashKey]
+
+	id := []string{
+		tableName,
+		hashKey,
+		base64Encode(hashVal.B),
+	}
+
+	if hashVal.S != nil {
+		id = append(id, *hashVal.S)
+	} else {
+		id = append(id, "")
+	}
+	if hashVal.N != nil {
+		id = append(id, *hashVal.N)
+	} else {
+		id = append(id, "")
+	}
+	if rangeKey != "" {
+		rangeVal := av[rangeKey]
+
+		id = append(id,
+			rangeKey,
+			base64Encode(rangeVal.B),
+		)
+
+		if rangeVal.S != nil {
+			id = append(id, *rangeVal.S)
+		} else {
+			id = append(id, "")
+		}
+
+		if rangeVal.N != nil {
+			id = append(id, *rangeVal.N)
+		} else {
+			id = append(id, "")
+		}
+
+	}
+
+	return strings.Join(id, "|")
+}
+
+func resourceAwsDynamoDbTableItemUpdate(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] Updating DynamoDB table %s", d.Id())
+	dynamodbconn := meta.(*AWSClient).dynamodbconn
+
+	if d.HasChange("item") {
+		o, n := d.GetChange("item")
+
+		tableName := d.Get("table_name").(string)
+		hashKey := d.Get("hash_key").(string)
+		rangeKey := d.Get("range_key").(string)
+
+		newJson := n.(string)
+
+		var newItem map[string]*dynamodb.AttributeValue
+
+		newDec := json.NewDecoder(strings.NewReader(newJson))
+		if err := newDec.Decode(&newItem); err != nil {
+			return fmt.Errorf("Error deserializing DynamoDB item JSON: %s", err)
+		}
+
+		newQueryKey := getQueryKey(newItem, hashKey, rangeKey)
+
+		updates := map[string]*dynamodb.AttributeValueUpdate{}
+
+		for k, v := range newItem {
+			// We shouldn't update the key values
+			skip := false
+			for qk := range newQueryKey {
+				if skip = (qk == k); skip {
+					break
+				}
+			}
+			if skip {
+				continue
+			}
+
+			action := "PUT"
+			updates[k] = &dynamodb.AttributeValueUpdate{
+				Action: &action,
+				Value:  v,
+			}
+		}
+
+		req := dynamodb.UpdateItemInput{
+			AttributeUpdates: updates,
+			TableName:        &tableName,
+			Key:              newQueryKey,
+		}
+
+		err := retryLoop(func() error {
+			_, err := dynamodbconn.UpdateItem(&req)
+
+			return err
+		}, "updating DynamoDB table item '%s'")
+
+		if err != nil {
+			return err
+		}
+
+		// If we finished successfully, delete the old record if the query key is different
+		oldJson := o.(string)
+
+		var oldItem map[string]*dynamodb.AttributeValue
+
+		oldDec := json.NewDecoder(strings.NewReader(oldJson))
+		if err := oldDec.Decode(&oldItem); err != nil {
+			return fmt.Errorf("Error deserializing DynamoDB item JSON: %s", err)
+		}
+
+		oldQueryKey := getQueryKey(oldItem, hashKey, rangeKey)
+
+		id := getId(tableName, hashKey, rangeKey, newItem)
+
+		if !reflect.DeepEqual(oldQueryKey, newQueryKey) {
+			req := dynamodb.DeleteItemInput{
+				Key:       oldQueryKey,
+				TableName: &tableName,
+			}
+
+			err := retryLoop(func() error {
+				_, err := dynamodbconn.DeleteItem(&req)
+				return err
+			}, fmt.Sprintf("deleting old DynamoDB item '%s'", id))
+
+			if err != nil {
+				return err
+			}
+		}
+
+		setQueryKey(d, newItem, newJson, hashKey, rangeKey)
+
+		d.SetId(id)
+	}
+
+	return resourceAwsDynamoDbTableItemRead(d, meta)
+}
+
+func getQueryKey(av map[string]*dynamodb.AttributeValue, hashKey string, rangeKey string) map[string]*dynamodb.AttributeValue {
+	qk := map[string]*dynamodb.AttributeValue{}
+
+	flen := 1
+	if rangeKey != "" {
+		flen = 2
+	}
+
+	for k, v := range av {
+		if k == hashKey || k == rangeKey {
+			qk[k] = v
+		}
+		if len(qk) == flen {
+			break
+		}
+	}
+
+	return qk
+}
+
+func setQueryKey(d *schema.ResourceData, av map[string]*dynamodb.AttributeValue, item string, hashKey string, rangeKey string) {
+	var itemRaw map[string]json.RawMessage
+
+	hashDec := json.NewDecoder(strings.NewReader(item))
+	hashDec.Decode(&itemRaw)
+
+	keyRaw := map[string]json.RawMessage{}
+
+	hashRaw := itemRaw[hashKey]
+
+	keyRaw[hashKey] = hashRaw
+
+	hashBytes, _ := hashRaw.MarshalJSON()
+	d.Set("hash_value", string(hashBytes))
+
+	if rangeKey != "" {
+		rangeRaw := itemRaw[rangeKey]
+
+		keyRaw[rangeKey] = rangeRaw
+
+		rangeBytes, _ := rangeRaw.MarshalJSON()
+		d.Set("range_value", string(rangeBytes))
+	}
+
+	queryKeyBuf := bytes.NewBufferString("")
+	queryKeyEnc := json.NewEncoder(queryKeyBuf)
+	queryKeyEnc.Encode(keyRaw)
+
+	d.Set("query_key", queryKeyBuf.String())
+}
+
+func retryLoop(action func() error, actionDetails string) error {
+	attemptCount := 1
+	for attemptCount <= DYNAMODB_MAX_THROTTLE_RETRIES {
+		err := action()
+
+		if err != nil {
+			if awsErr, ok := err.(awserr.Error); ok {
+				switch code := awsErr.Code(); code {
+				case "ThrottlingException":
+					log.Printf("[DEBUG] Attempt %d/%d: Sleeping for a bit to throttle back %s", attemptCount, DYNAMODB_MAX_THROTTLE_RETRIES, actionDetails)
+					time.Sleep(DYNAMODB_THROTTLE_SLEEP)
+					attemptCount += 1
+				case "LimitExceededException":
+					// If we're at resource capacity, error out without retry
+					if strings.Contains(awsErr.Message(), "Subscriber limit exceeded:") {
+						return fmt.Errorf("AWS Error %s: %s", actionDetails, err)
+					}
+					log.Printf("[DEBUG] Limit on concurrency of %s, sleeping for a bit", actionDetails)
+					time.Sleep(DYNAMODB_LIMIT_EXCEEDED_SLEEP)
+					attemptCount += 1
+				default:
+					// Some other non-retryable exception occurred
+					return fmt.Errorf("AWS Error %s: %s", actionDetails, err)
+				}
+			} else {
+				// Non-AWS exception occurred, give up
+				return fmt.Errorf("Error %s: %s", actionDetails, err)
+			}
+		} else {
+			return nil
+		}
+	}
+
+	// Too many throttling events occurred, give up
+	return fmt.Errorf("Failed %s after %d attempts", actionDetails, attemptCount)
+}
+
+func resourceAwsDynamoDbTableItemRead(d *schema.ResourceData, meta interface{}) error {
+	dynamodbconn := meta.(*AWSClient).dynamodbconn
+	log.Printf("[DEBUG] Loading data for DynamoDB table item '%s'", d.Id())
+
+	tableName := d.Get("table_name").(string)
+
+	// The record exists, now test if it differs from what is desired
+	item := d.Get("item").(string)
+	hashKey := d.Get("hash_key").(string)
+	rangeKey := d.Get("range_key").(string)
+
+	var av map[string]*dynamodb.AttributeValue
+	itemDec := json.NewDecoder(strings.NewReader(item))
+	itemDec.Decode(&av)
+
+	itemAttributes := []string{}
+	for k := range av {
+		itemAttributes = append(itemAttributes, k)
+	}
+
+	queryKey := getQueryKey(av, hashKey, rangeKey)
+
+	expressionAttributeNames := map[string]*string{}
+	projection := "#a_" + strings.Join(itemAttributes, ", #a_")
+
+	for _, v := range itemAttributes {
+		w := v
+		expressionAttributeNames["#a_"+v] = &w
+	}
+
+	req := dynamodb.GetItemInput{
+		TableName:                &tableName,
+		Key:                      queryKey,
+		ProjectionExpression:     &projection,
+		ExpressionAttributeNames: expressionAttributeNames,
+	}
+
+	result, err := dynamodbconn.GetItem(&req)
+
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "ResourceNotFoundException" {
+			log.Printf("[WARN] Dynamodb Table Item (%s) not found, error code (404)", d.Id())
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error retrieving DynamoDB table item: %s %s", err, req)
+	}
+
+	// The record exists, now test if it differs from what is desired
+	if result.Item != nil && !reflect.DeepEqual(result.Item, av) {
+		buf := bytes.NewBufferString("")
+		enc := json.NewEncoder(buf)
+		enc.Encode(result.Item)
+
+		var itemRaw map[string]map[string]interface{}
+
+		// Reserialize so we get rid of the nulls
+		dec := json.NewDecoder(strings.NewReader(buf.String()))
+		dec.Decode(&itemRaw)
+
+		for _, val := range itemRaw {
+			for typeName, typeVal := range val {
+				if typeVal == nil {
+					delete(val, typeName)
+				}
+			}
+		}
+
+		rawBuf := bytes.NewBufferString("")
+		rawEnc := json.NewEncoder(rawBuf)
+		rawEnc.Encode(itemRaw)
+
+		d.Set("item", rawBuf.String())
+
+		id := getId(tableName, hashKey, rangeKey, result.Item)
+		d.SetId(id)
+	} else if result.Item == nil {
+		d.SetId("")
+	}
+
+	d.Set("consumed_capacity", result.ConsumedCapacity)
+
+	return nil
+}
+
+func resourceAwsDynamoDbTableItemDelete(d *schema.ResourceData, meta interface{}) error {
+	dynamodbconn := meta.(*AWSClient).dynamodbconn
+
+	tableName := d.Get("table_name").(string)
+
+	item := d.Get("item").(string)
+	hashKey := d.Get("hash_key").(string)
+	rangeKey := d.Get("range_key").(string)
+
+	var av map[string]*dynamodb.AttributeValue
+	itemDec := json.NewDecoder(strings.NewReader(item))
+	itemDec.Decode(&av)
+
+	queryKey := getQueryKey(av, hashKey, rangeKey)
+
+	req := dynamodb.DeleteItemInput{
+		Key:       queryKey,
+		TableName: &tableName,
+	}
+
+	err := retryLoop(func() error {
+		_, err := dynamodbconn.DeleteItem(&req)
+
+		return err
+	}, fmt.Sprintf("deleting DynamoDB table item '%s'", d.Id()))
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/aws/resource_aws_dynamodb_table_item.go
+++ b/aws/resource_aws_dynamodb_table_item.go
@@ -3,119 +3,244 @@ package aws
 import (
 	"fmt"
 	"log"
-	strings "strings"
-	"time"
+	"reflect"
+	"strings"
 
-	"github.com/hashicorp/terraform/helper/schema"
-
-	"bytes"
-	"encoding/json"
-	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
-	reflect "reflect"
+	"github.com/hashicorp/terraform/helper/schema"
 )
 
-// A number of these are marked as computed because if you don't
-// provide a value, DynamoDB will provide you with defaults (which are the
-// default values specified below)
 func resourceAwsDynamoDbTableItem() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsDynamoDbTableItemCreate,
 		Read:   resourceAwsDynamoDbTableItemRead,
 		Update: resourceAwsDynamoDbTableItemUpdate,
 		Delete: resourceAwsDynamoDbTableItemDelete,
+
 		Schema: map[string]*schema.Schema{
-			"table_name": &schema.Schema{
+			"table_name": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
-			"hash_key": &schema.Schema{
+			"hash_key": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
-			"item": &schema.Schema{
+			"range_key": {
 				Type:     schema.TypeString,
-				Required: true,
-			},
-			"range_key": &schema.Schema{
-				Type:     schema.TypeString,
+				ForceNew: true,
 				Optional: true,
 			},
-			"query_key": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"range_value": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"hash_value": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"consumed_capacity": &schema.Schema{
-				Type:     schema.TypeFloat,
-				Computed: true,
-			},
-			"last_modified": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
+			"item": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateDynamoDbTableItem,
 			},
 		},
 	}
 }
 
+func validateDynamoDbTableItem(v interface{}, k string) (ws []string, errors []error) {
+	_, err := expandDynamoDbTableItemAttributes(v.(string))
+	if err != nil {
+		errors = append(errors, fmt.Errorf("Invalid format of %q: %s", k, err))
+	}
+	return
+}
+
 func resourceAwsDynamoDbTableItemCreate(d *schema.ResourceData, meta interface{}) error {
-	dynamodbconn := meta.(*AWSClient).dynamodbconn
+	conn := meta.(*AWSClient).dynamodbconn
 
 	tableName := d.Get("table_name").(string)
 	hashKey := d.Get("hash_key").(string)
-	rangeKey := d.Get("range_key").(string)
-
-	log.Printf("[DEBUG] DynamoDB item create: %s", tableName)
-
 	item := d.Get("item").(string)
-
-	var av map[string]*dynamodb.AttributeValue
-
-	avDec := json.NewDecoder(strings.NewReader(item))
-
-	if err := avDec.Decode(&av); err != nil {
-		return fmt.Errorf("Error deserializing DynamoDB item JSON: %s", err)
-	}
-
-	exists := false
-	req := &dynamodb.PutItemInput{
-		Item: av,
-		Expected: map[string]*dynamodb.ExpectedAttributeValue{
-			hashKey: {
-				// Explode if item exists. We didn't create it.
-				Exists: &exists,
-			},
-		},
-		TableName: &tableName,
-	}
-
-	id := getId(tableName, hashKey, rangeKey, av)
-	err := retryLoop(func() error {
-		_, err := dynamodbconn.PutItem(req)
-
-		return err
-	}, fmt.Sprintf("creating DynamoDB table item '%s'", id))
-
+	attributes, err := expandDynamoDbTableItemAttributes(item)
 	if err != nil {
 		return err
 	}
 
-	setQueryKey(d, av, item, hashKey, rangeKey)
+	log.Printf("[DEBUG] DynamoDB item create: %s", tableName)
+
+	_, err = conn.PutItem(&dynamodb.PutItemInput{
+		Item: attributes,
+		// Explode if item exists. We didn't create it.
+		Expected: map[string]*dynamodb.ExpectedAttributeValue{
+			hashKey: {
+				Exists: aws.Bool(false),
+			},
+		},
+		TableName: aws.String(tableName),
+	})
+	if err != nil {
+		return err
+	}
+
+	rangeKey := d.Get("range_key").(string)
+	id := buildDynamoDbTableItemId(tableName, hashKey, rangeKey, attributes)
 
 	d.SetId(id)
 
 	return resourceAwsDynamoDbTableItemRead(d, meta)
 }
 
-func getId(tableName string, hashKey string, rangeKey string, av map[string]*dynamodb.AttributeValue) string {
-	hashVal := av[hashKey]
+func resourceAwsDynamoDbTableItemUpdate(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] Updating DynamoDB table %s", d.Id())
+	conn := meta.(*AWSClient).dynamodbconn
+
+	if d.HasChange("item") {
+		tableName := d.Get("table_name").(string)
+		hashKey := d.Get("hash_key").(string)
+		rangeKey := d.Get("range_key").(string)
+
+		oldItem, newItem := d.GetChange("item")
+
+		attributes, err := expandDynamoDbTableItemAttributes(newItem.(string))
+		if err != nil {
+			return err
+		}
+		newQueryKey := buildDynamoDbTableItemQueryKey(attributes, hashKey, rangeKey)
+
+		updates := map[string]*dynamodb.AttributeValueUpdate{}
+		for key, value := range attributes {
+			// Hash keys are not updatable, so we'll basically create
+			// a new record and delete the old one below
+			if key == hashKey {
+				continue
+			}
+			updates[key] = &dynamodb.AttributeValueUpdate{
+				Action: aws.String(dynamodb.AttributeActionPut),
+				Value:  value,
+			}
+		}
+
+		_, err = conn.UpdateItem(&dynamodb.UpdateItemInput{
+			AttributeUpdates: updates,
+			TableName:        aws.String(tableName),
+			Key:              newQueryKey,
+		})
+		if err != nil {
+			return err
+		}
+
+		oItem := oldItem.(string)
+		oldAttributes, err := expandDynamoDbTableItemAttributes(oItem)
+		if err != nil {
+			return err
+		}
+
+		// New record is created via UpdateItem in case we're changing hash key
+		// so we need to get rid of the old one
+		oldQueryKey := buildDynamoDbTableItemQueryKey(oldAttributes, hashKey, rangeKey)
+		if !reflect.DeepEqual(oldQueryKey, newQueryKey) {
+			log.Printf("[DEBUG] Deleting old record: %#v", oldQueryKey)
+			_, err := conn.DeleteItem(&dynamodb.DeleteItemInput{
+				Key:       oldQueryKey,
+				TableName: aws.String(tableName),
+			})
+			if err != nil {
+				return err
+			}
+		}
+
+		id := buildDynamoDbTableItemId(tableName, hashKey, rangeKey, attributes)
+		d.SetId(id)
+	}
+
+	return resourceAwsDynamoDbTableItemRead(d, meta)
+}
+
+func resourceAwsDynamoDbTableItemRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).dynamodbconn
+
+	log.Printf("[DEBUG] Loading data for DynamoDB table item '%s'", d.Id())
+
+	tableName := d.Get("table_name").(string)
+	hashKey := d.Get("hash_key").(string)
+	rangeKey := d.Get("range_key").(string)
+	attributes, err := expandDynamoDbTableItemAttributes(d.Get("item").(string))
+	if err != nil {
+		return err
+	}
+
+	result, err := conn.GetItem(&dynamodb.GetItemInput{
+		TableName:                aws.String(tableName),
+		ConsistentRead:           aws.Bool(true),
+		Key:                      buildDynamoDbTableItemQueryKey(attributes, hashKey, rangeKey),
+		ProjectionExpression:     buildDynamoDbProjectionExpression(attributes),
+		ExpressionAttributeNames: buildDynamoDbExpressionAttributeNames(attributes),
+	})
+	if err != nil {
+		if isAWSErr(err, dynamodb.ErrCodeResourceNotFoundException, "") {
+			log.Printf("[WARN] Dynamodb Table Item (%s) not found, error code (404)", d.Id())
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error retrieving DynamoDB table item: %s", err)
+	}
+
+	if result.Item == nil {
+		log.Printf("[WARN] Dynamodb Table Item (%s) not found", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	// The record exists, now test if it differs from what is desired
+	if !reflect.DeepEqual(result.Item, attributes) {
+		itemAttrs, err := flattenDynamoDbTableItemAttributes(result.Item)
+		if err != nil {
+			return err
+		}
+		d.Set("item", itemAttrs)
+		id := buildDynamoDbTableItemId(tableName, hashKey, rangeKey, result.Item)
+		d.SetId(id)
+	}
+
+	return nil
+}
+
+func resourceAwsDynamoDbTableItemDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).dynamodbconn
+
+	attributes, err := expandDynamoDbTableItemAttributes(d.Get("item").(string))
+	if err != nil {
+		return err
+	}
+	hashKey := d.Get("hash_key").(string)
+	rangeKey := d.Get("range_key").(string)
+	queryKey := buildDynamoDbTableItemQueryKey(attributes, hashKey, rangeKey)
+
+	_, err = conn.DeleteItem(&dynamodb.DeleteItemInput{
+		Key:       queryKey,
+		TableName: aws.String(d.Get("table_name").(string)),
+	})
+	return err
+}
+
+// Helpers
+
+func buildDynamoDbExpressionAttributeNames(attrs map[string]*dynamodb.AttributeValue) map[string]*string {
+	names := map[string]*string{}
+	for key, _ := range attrs {
+		names["#a_"+key] = aws.String(key)
+	}
+
+	return names
+}
+
+func buildDynamoDbProjectionExpression(attrs map[string]*dynamodb.AttributeValue) *string {
+	keys := []string{}
+	for key, _ := range attrs {
+		keys = append(keys, key)
+	}
+	return aws.String("#a_" + strings.Join(keys, ", #a_"))
+}
+
+func buildDynamoDbTableItemId(tableName string, hashKey string, rangeKey string, attrs map[string]*dynamodb.AttributeValue) string {
+	hashVal := attrs[hashKey]
 
 	id := []string{
 		tableName,
@@ -134,7 +259,7 @@ func getId(tableName string, hashKey string, rangeKey string, av map[string]*dyn
 		id = append(id, "")
 	}
 	if rangeKey != "" {
-		rangeVal := av[rangeKey]
+		rangeVal := attrs[rangeKey]
 
 		id = append(id,
 			rangeKey,
@@ -158,307 +283,13 @@ func getId(tableName string, hashKey string, rangeKey string, av map[string]*dyn
 	return strings.Join(id, "|")
 }
 
-func resourceAwsDynamoDbTableItemUpdate(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] Updating DynamoDB table %s", d.Id())
-	dynamodbconn := meta.(*AWSClient).dynamodbconn
-
-	if d.HasChange("item") {
-		o, n := d.GetChange("item")
-
-		tableName := d.Get("table_name").(string)
-		hashKey := d.Get("hash_key").(string)
-		rangeKey := d.Get("range_key").(string)
-
-		newJson := n.(string)
-
-		var newItem map[string]*dynamodb.AttributeValue
-
-		newDec := json.NewDecoder(strings.NewReader(newJson))
-		if err := newDec.Decode(&newItem); err != nil {
-			return fmt.Errorf("Error deserializing DynamoDB item JSON: %s", err)
-		}
-
-		newQueryKey := getQueryKey(newItem, hashKey, rangeKey)
-
-		updates := map[string]*dynamodb.AttributeValueUpdate{}
-
-		for k, v := range newItem {
-			// We shouldn't update the key values
-			skip := false
-			for qk := range newQueryKey {
-				if skip = (qk == k); skip {
-					break
-				}
-			}
-			if skip {
-				continue
-			}
-
-			action := "PUT"
-			updates[k] = &dynamodb.AttributeValueUpdate{
-				Action: &action,
-				Value:  v,
-			}
-		}
-
-		req := dynamodb.UpdateItemInput{
-			AttributeUpdates: updates,
-			TableName:        &tableName,
-			Key:              newQueryKey,
-		}
-
-		err := retryLoop(func() error {
-			_, err := dynamodbconn.UpdateItem(&req)
-
-			return err
-		}, "updating DynamoDB table item '%s'")
-
-		if err != nil {
-			return err
-		}
-
-		// If we finished successfully, delete the old record if the query key is different
-		oldJson := o.(string)
-
-		var oldItem map[string]*dynamodb.AttributeValue
-
-		oldDec := json.NewDecoder(strings.NewReader(oldJson))
-		if err := oldDec.Decode(&oldItem); err != nil {
-			return fmt.Errorf("Error deserializing DynamoDB item JSON: %s", err)
-		}
-
-		oldQueryKey := getQueryKey(oldItem, hashKey, rangeKey)
-
-		id := getId(tableName, hashKey, rangeKey, newItem)
-
-		if !reflect.DeepEqual(oldQueryKey, newQueryKey) {
-			req := dynamodb.DeleteItemInput{
-				Key:       oldQueryKey,
-				TableName: &tableName,
-			}
-
-			err := retryLoop(func() error {
-				_, err := dynamodbconn.DeleteItem(&req)
-				return err
-			}, fmt.Sprintf("deleting old DynamoDB item '%s'", id))
-
-			if err != nil {
-				return err
-			}
-		}
-
-		setQueryKey(d, newItem, newJson, hashKey, rangeKey)
-
-		d.SetId(id)
+func buildDynamoDbTableItemQueryKey(attrs map[string]*dynamodb.AttributeValue, hashKey string, rangeKey string) map[string]*dynamodb.AttributeValue {
+	queryKey := map[string]*dynamodb.AttributeValue{
+		hashKey: attrs[hashKey],
 	}
-
-	return resourceAwsDynamoDbTableItemRead(d, meta)
-}
-
-func getQueryKey(av map[string]*dynamodb.AttributeValue, hashKey string, rangeKey string) map[string]*dynamodb.AttributeValue {
-	qk := map[string]*dynamodb.AttributeValue{}
-
-	flen := 1
 	if rangeKey != "" {
-		flen = 2
+		queryKey[rangeKey] = attrs[rangeKey]
 	}
 
-	for k, v := range av {
-		if k == hashKey || k == rangeKey {
-			qk[k] = v
-		}
-		if len(qk) == flen {
-			break
-		}
-	}
-
-	return qk
-}
-
-func setQueryKey(d *schema.ResourceData, av map[string]*dynamodb.AttributeValue, item string, hashKey string, rangeKey string) {
-	var itemRaw map[string]json.RawMessage
-
-	hashDec := json.NewDecoder(strings.NewReader(item))
-	hashDec.Decode(&itemRaw)
-
-	keyRaw := map[string]json.RawMessage{}
-
-	hashRaw := itemRaw[hashKey]
-
-	keyRaw[hashKey] = hashRaw
-
-	hashBytes, _ := hashRaw.MarshalJSON()
-	d.Set("hash_value", string(hashBytes))
-
-	if rangeKey != "" {
-		rangeRaw := itemRaw[rangeKey]
-
-		keyRaw[rangeKey] = rangeRaw
-
-		rangeBytes, _ := rangeRaw.MarshalJSON()
-		d.Set("range_value", string(rangeBytes))
-	}
-
-	queryKeyBuf := bytes.NewBufferString("")
-	queryKeyEnc := json.NewEncoder(queryKeyBuf)
-	queryKeyEnc.Encode(keyRaw)
-
-	d.Set("query_key", queryKeyBuf.String())
-}
-
-func retryLoop(action func() error, actionDetails string) error {
-	attemptCount := 1
-	for attemptCount <= DYNAMODB_MAX_THROTTLE_RETRIES {
-		err := action()
-
-		if err != nil {
-			if awsErr, ok := err.(awserr.Error); ok {
-				switch code := awsErr.Code(); code {
-				case "ThrottlingException":
-					log.Printf("[DEBUG] Attempt %d/%d: Sleeping for a bit to throttle back %s", attemptCount, DYNAMODB_MAX_THROTTLE_RETRIES, actionDetails)
-					time.Sleep(DYNAMODB_THROTTLE_SLEEP)
-					attemptCount += 1
-				case "LimitExceededException":
-					// If we're at resource capacity, error out without retry
-					if strings.Contains(awsErr.Message(), "Subscriber limit exceeded:") {
-						return fmt.Errorf("AWS Error %s: %s", actionDetails, err)
-					}
-					log.Printf("[DEBUG] Limit on concurrency of %s, sleeping for a bit", actionDetails)
-					time.Sleep(DYNAMODB_LIMIT_EXCEEDED_SLEEP)
-					attemptCount += 1
-				default:
-					// Some other non-retryable exception occurred
-					return fmt.Errorf("AWS Error %s: %s", actionDetails, err)
-				}
-			} else {
-				// Non-AWS exception occurred, give up
-				return fmt.Errorf("Error %s: %s", actionDetails, err)
-			}
-		} else {
-			return nil
-		}
-	}
-
-	// Too many throttling events occurred, give up
-	return fmt.Errorf("Failed %s after %d attempts", actionDetails, attemptCount)
-}
-
-func resourceAwsDynamoDbTableItemRead(d *schema.ResourceData, meta interface{}) error {
-	dynamodbconn := meta.(*AWSClient).dynamodbconn
-	log.Printf("[DEBUG] Loading data for DynamoDB table item '%s'", d.Id())
-
-	tableName := d.Get("table_name").(string)
-
-	// The record exists, now test if it differs from what is desired
-	item := d.Get("item").(string)
-	hashKey := d.Get("hash_key").(string)
-	rangeKey := d.Get("range_key").(string)
-
-	var av map[string]*dynamodb.AttributeValue
-	itemDec := json.NewDecoder(strings.NewReader(item))
-	itemDec.Decode(&av)
-
-	itemAttributes := []string{}
-	for k := range av {
-		itemAttributes = append(itemAttributes, k)
-	}
-
-	queryKey := getQueryKey(av, hashKey, rangeKey)
-
-	expressionAttributeNames := map[string]*string{}
-	projection := "#a_" + strings.Join(itemAttributes, ", #a_")
-
-	for _, v := range itemAttributes {
-		w := v
-		expressionAttributeNames["#a_"+v] = &w
-	}
-
-	req := dynamodb.GetItemInput{
-		TableName:                &tableName,
-		Key:                      queryKey,
-		ProjectionExpression:     &projection,
-		ExpressionAttributeNames: expressionAttributeNames,
-	}
-
-	result, err := dynamodbconn.GetItem(&req)
-
-	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "ResourceNotFoundException" {
-			log.Printf("[WARN] Dynamodb Table Item (%s) not found, error code (404)", d.Id())
-			d.SetId("")
-			return nil
-		}
-
-		return fmt.Errorf("Error retrieving DynamoDB table item: %s %s", err, req)
-	}
-
-	// The record exists, now test if it differs from what is desired
-	if result.Item != nil && !reflect.DeepEqual(result.Item, av) {
-		buf := bytes.NewBufferString("")
-		enc := json.NewEncoder(buf)
-		enc.Encode(result.Item)
-
-		var itemRaw map[string]map[string]interface{}
-
-		// Reserialize so we get rid of the nulls
-		dec := json.NewDecoder(strings.NewReader(buf.String()))
-		dec.Decode(&itemRaw)
-
-		for _, val := range itemRaw {
-			for typeName, typeVal := range val {
-				if typeVal == nil {
-					delete(val, typeName)
-				}
-			}
-		}
-
-		rawBuf := bytes.NewBufferString("")
-		rawEnc := json.NewEncoder(rawBuf)
-		rawEnc.Encode(itemRaw)
-
-		d.Set("item", rawBuf.String())
-
-		id := getId(tableName, hashKey, rangeKey, result.Item)
-		d.SetId(id)
-	} else if result.Item == nil {
-		d.SetId("")
-	}
-
-	d.Set("consumed_capacity", result.ConsumedCapacity)
-
-	return nil
-}
-
-func resourceAwsDynamoDbTableItemDelete(d *schema.ResourceData, meta interface{}) error {
-	dynamodbconn := meta.(*AWSClient).dynamodbconn
-
-	tableName := d.Get("table_name").(string)
-
-	item := d.Get("item").(string)
-	hashKey := d.Get("hash_key").(string)
-	rangeKey := d.Get("range_key").(string)
-
-	var av map[string]*dynamodb.AttributeValue
-	itemDec := json.NewDecoder(strings.NewReader(item))
-	itemDec.Decode(&av)
-
-	queryKey := getQueryKey(av, hashKey, rangeKey)
-
-	req := dynamodb.DeleteItemInput{
-		Key:       queryKey,
-		TableName: &tableName,
-	}
-
-	err := retryLoop(func() error {
-		_, err := dynamodbconn.DeleteItem(&req)
-
-		return err
-	}, fmt.Sprintf("deleting DynamoDB table item '%s'", d.Id()))
-
-	if err != nil {
-		return err
-	}
-
-	d.SetId("")
-	return nil
+	return queryKey
 }

--- a/aws/resource_aws_dynamodb_table_item_test.go
+++ b/aws/resource_aws_dynamodb_table_item_test.go
@@ -1,0 +1,363 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSDynamoDbTableItem_basic(t *testing.T) {
+	var conf dynamodb.GetItemOutput
+
+	tableName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(8))
+	hashKey := "hashKey"
+	itemContent := `{
+	"hashKey": {"S": "something"},
+	"one": {"N": "11111"},
+	"two": {"N": "22222"},
+	"three": {"N": "33333"},
+	"four": {"N": "44444"}
+}`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDynamoDbItemDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDynamoDbItemConfigBasic(tableName, hashKey, itemContent),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDynamoDbTableItemExists("aws_dynamodb_table_item.test", &conf),
+					testAccCheckAWSDynamoDbTableItemCount(tableName, 1),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_item.test", "hash_key", hashKey),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_item.test", "table_name", tableName),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_item.test", "item", itemContent+"\n"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDynamoDbTableItem_rangeKey(t *testing.T) {
+	var conf dynamodb.GetItemOutput
+
+	tableName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(8))
+	hashKey := "hashKey"
+	rangeKey := "rangeKey"
+	itemContent := `{
+	"hashKey": {"S": "something"},
+	"rangeKey": {"S": "something-else"},
+	"one": {"N": "11111"},
+	"two": {"N": "22222"},
+	"three": {"N": "33333"},
+	"four": {"N": "44444"}
+}`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDynamoDbItemDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDynamoDbItemConfigWithRangeKey(tableName, hashKey, rangeKey, itemContent),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDynamoDbTableItemExists("aws_dynamodb_table_item.test", &conf),
+					testAccCheckAWSDynamoDbTableItemCount(tableName, 1),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_item.test", "hash_key", hashKey),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_item.test", "range_key", rangeKey),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_item.test", "table_name", tableName),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_item.test", "item", itemContent+"\n"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDynamoDbTableItem_withMultipleItems(t *testing.T) {
+	var conf1 dynamodb.GetItemOutput
+	var conf2 dynamodb.GetItemOutput
+
+	tableName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(8))
+	hashKey := "hashKey"
+	rangeKey := "rangeKey"
+	firstItem := `{
+	"hashKey": {"S": "something"},
+	"rangeKey": {"S": "first"},
+	"one": {"N": "11111"},
+	"two": {"N": "22222"},
+	"three": {"N": "33333"}
+}`
+	secondItem := `{
+	"hashKey": {"S": "something"},
+	"rangeKey": {"S": "second"},
+	"one": {"S": "one"},
+	"two": {"S": "two"},
+	"three": {"S": "three"},
+	"four": {"S": "four"}
+}`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDynamoDbItemDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDynamoDbItemConfigWithMultipleItems(tableName, hashKey, rangeKey, firstItem, secondItem),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDynamoDbTableItemExists("aws_dynamodb_table_item.test1", &conf1),
+					testAccCheckAWSDynamoDbTableItemExists("aws_dynamodb_table_item.test2", &conf2),
+					testAccCheckAWSDynamoDbTableItemCount(tableName, 2),
+
+					resource.TestCheckResourceAttr("aws_dynamodb_table_item.test1", "hash_key", hashKey),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_item.test1", "range_key", rangeKey),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_item.test1", "table_name", tableName),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_item.test1", "item", firstItem+"\n"),
+
+					resource.TestCheckResourceAttr("aws_dynamodb_table_item.test2", "hash_key", hashKey),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_item.test2", "range_key", rangeKey),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_item.test2", "table_name", tableName),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_item.test2", "item", secondItem+"\n"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDynamoDbTableItem_update(t *testing.T) {
+	var conf dynamodb.GetItemOutput
+
+	tableName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(8))
+	hashKey := "hashKey"
+
+	itemBefore := `{
+	"hashKey": {"S": "before"},
+	"one": {"N": "11111"},
+	"two": {"N": "22222"},
+	"three": {"N": "33333"},
+	"four": {"N": "44444"}
+}`
+	itemAfter := `{
+	"hashKey": {"S": "before"},
+	"one": {"N": "11111"},
+	"two": {"N": "22222"},
+	"new": {"S": "shiny new one"}
+}`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDynamoDbItemDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDynamoDbItemConfigBasic(tableName, hashKey, itemBefore),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDynamoDbTableItemExists("aws_dynamodb_table_item.test", &conf),
+					testAccCheckAWSDynamoDbTableItemCount(tableName, 1),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_item.test", "hash_key", hashKey),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_item.test", "table_name", tableName),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_item.test", "item", itemBefore+"\n"),
+				),
+			},
+			{
+				Config: testAccAWSDynamoDbItemConfigBasic(tableName, hashKey, itemAfter),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDynamoDbTableItemExists("aws_dynamodb_table_item.test", &conf),
+					testAccCheckAWSDynamoDbTableItemCount(tableName, 1),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_item.test", "hash_key", hashKey),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_item.test", "table_name", tableName),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_item.test", "item", itemAfter+"\n"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSDynamoDbItemDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).dynamodbconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_dynamodb_table_item" {
+			continue
+		}
+
+		attrs := rs.Primary.Attributes
+		attributes, err := expandDynamoDbTableItemAttributes(attrs["item"])
+		if err != nil {
+			return err
+		}
+
+		result, err := conn.GetItem(&dynamodb.GetItemInput{
+			TableName:                aws.String(attrs["table_name"]),
+			ConsistentRead:           aws.Bool(true),
+			Key:                      buildDynamoDbTableItemQueryKey(attributes, attrs["hash_key"], attrs["range_key"]),
+			ProjectionExpression:     buildDynamoDbProjectionExpression(attributes),
+			ExpressionAttributeNames: buildDynamoDbExpressionAttributeNames(attributes),
+		})
+		if err != nil {
+			if isAWSErr(err, dynamodb.ErrCodeResourceNotFoundException, "") {
+				return nil
+			}
+			return fmt.Errorf("Error retrieving DynamoDB table item: %s", err)
+		}
+		if result.Item == nil {
+			return nil
+		}
+
+		return fmt.Errorf("DynamoDB table item %s still exists.", rs.Primary.ID)
+	}
+
+	return nil
+}
+
+func testAccCheckAWSDynamoDbTableItemExists(n string, item *dynamodb.GetItemOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No DynamoDB table item ID specified!")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).dynamodbconn
+
+		attrs := rs.Primary.Attributes
+		attributes, err := expandDynamoDbTableItemAttributes(attrs["item"])
+		if err != nil {
+			return err
+		}
+
+		result, err := conn.GetItem(&dynamodb.GetItemInput{
+			TableName:                aws.String(attrs["table_name"]),
+			ConsistentRead:           aws.Bool(true),
+			Key:                      buildDynamoDbTableItemQueryKey(attributes, attrs["hash_key"], attrs["range_key"]),
+			ProjectionExpression:     buildDynamoDbProjectionExpression(attributes),
+			ExpressionAttributeNames: buildDynamoDbExpressionAttributeNames(attributes),
+		})
+		if err != nil {
+			return fmt.Errorf("[ERROR] Problem getting table item '%s': %s", rs.Primary.ID, err)
+		}
+
+		*item = *result
+
+		return nil
+	}
+}
+
+func testAccCheckAWSDynamoDbTableItemCount(tableName string, count int64) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).dynamodbconn
+		out, err := conn.Scan(&dynamodb.ScanInput{
+			ConsistentRead: aws.Bool(true),
+			TableName:      aws.String(tableName),
+			Select:         aws.String(dynamodb.SelectCount),
+		})
+		if err != nil {
+			return err
+		}
+		expectedCount := count
+		if *out.Count != expectedCount {
+			return fmt.Errorf("Expected %d items, got %d", expectedCount, *out.Count)
+		}
+		return nil
+	}
+}
+
+func testAccAWSDynamoDbItemConfigBasic(tableName, hashKey, item string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  name = "%s"
+  read_capacity = 10
+  write_capacity = 10
+  hash_key = "%s"
+
+  attribute {
+    name = "%s"
+    type = "S"
+  }
+}
+
+resource "aws_dynamodb_table_item" "test" {
+  table_name = "${aws_dynamodb_table.test.name}"
+  hash_key = "${aws_dynamodb_table.test.hash_key}"
+  item = <<ITEM
+%s
+ITEM
+}
+`, tableName, hashKey, hashKey, item)
+}
+
+func testAccAWSDynamoDbItemConfigWithRangeKey(tableName, hashKey, rangeKey, item string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  name = "%s"
+  read_capacity = 10
+  write_capacity = 10
+  hash_key = "%s"
+  range_key = "%s"
+
+  attribute {
+    name = "%s"
+    type = "S"
+  }
+  attribute {
+    name = "%s"
+    type = "S"
+  }
+}
+
+resource "aws_dynamodb_table_item" "test" {
+  table_name = "${aws_dynamodb_table.test.name}"
+  hash_key = "${aws_dynamodb_table.test.hash_key}"
+  range_key = "${aws_dynamodb_table.test.range_key}"
+  item = <<ITEM
+%s
+ITEM
+}
+`, tableName, hashKey, rangeKey, hashKey, rangeKey, item)
+}
+
+func testAccAWSDynamoDbItemConfigWithMultipleItems(tableName, hashKey, rangeKey, firstItem, secondItem string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  name = "%s"
+  read_capacity = 10
+  write_capacity = 10
+  hash_key = "%s"
+  range_key = "%s"
+
+  attribute {
+    name = "%s"
+    type = "S"
+  }
+  attribute {
+    name = "%s"
+    type = "S"
+  }
+}
+
+resource "aws_dynamodb_table_item" "test1" {
+  table_name = "${aws_dynamodb_table.test.name}"
+  hash_key = "${aws_dynamodb_table.test.hash_key}"
+  range_key = "${aws_dynamodb_table.test.range_key}"
+  item = <<ITEM
+%s
+ITEM
+}
+
+resource "aws_dynamodb_table_item" "test2" {
+  table_name = "${aws_dynamodb_table.test.name}"
+  hash_key = "${aws_dynamodb_table.test.hash_key}"
+  range_key = "${aws_dynamodb_table.test.range_key}"
+  item = <<ITEM
+%s
+ITEM
+}
+`, tableName, hashKey, rangeKey, hashKey, rangeKey, firstItem, secondItem)
+}

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -3618,4 +3619,51 @@ func flattenVpcEndpointServiceAllowedPrincipals(allowedPrincipals []*ec2.Allowed
 		}
 	}
 	return result
+}
+
+func expandDynamoDbTableItemAttributes(input string) (map[string]*dynamodb.AttributeValue, error) {
+	var attributes map[string]*dynamodb.AttributeValue
+
+	dec := json.NewDecoder(strings.NewReader(input))
+	err := dec.Decode(&attributes)
+	if err != nil {
+		return nil, fmt.Errorf("Decoding failed: %s", err)
+	}
+
+	return attributes, nil
+}
+
+func flattenDynamoDbTableItemAttributes(attrs map[string]*dynamodb.AttributeValue) (string, error) {
+	buf := bytes.NewBufferString("")
+	encoder := json.NewEncoder(buf)
+	err := encoder.Encode(attrs)
+	if err != nil {
+		return "", fmt.Errorf("Encoding failed: %s", err)
+	}
+
+	var rawData map[string]map[string]interface{}
+
+	// Reserialize so we get rid of the nulls
+	decoder := json.NewDecoder(strings.NewReader(buf.String()))
+	err = decoder.Decode(&rawData)
+	if err != nil {
+		return "", fmt.Errorf("Decoding failed: %s", err)
+	}
+
+	for _, value := range rawData {
+		for typeName, typeVal := range value {
+			if typeVal == nil {
+				delete(value, typeName)
+			}
+		}
+	}
+
+	rawBuffer := bytes.NewBufferString("")
+	rawEncoder := json.NewEncoder(rawBuffer)
+	err = rawEncoder.Encode(rawData)
+	if err != nil {
+		return "", fmt.Errorf("Re-encoding failed: %s", err)
+	}
+
+	return rawBuffer.String(), nil
 }

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -633,6 +633,10 @@
                             <a href="/docs/providers/aws/r/dynamodb_table.html">aws_dynamodb_table</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-dynamodb-table-item") %>>
+                            <a href="/docs/providers/aws/r/dynamodb_table_item.html">aws_dynamodb_table_item</a>
+                        </li>
+
                     </ul>
                 </li>
 

--- a/website/docs/r/dynamodb_table_item.html.markdown
+++ b/website/docs/r/dynamodb_table_item.html.markdown
@@ -1,0 +1,62 @@
+---
+layout: "aws"
+page_title: "AWS: dynamodb_table_item"
+sidebar_current: "docs-aws-resource-dynamodb-table-item"
+description: |-
+  Provides a DynamoDB table item resource
+---
+
+# aws_dynamodb_table_item
+
+Provides a DynamoDB table item resource
+
+-> **Note:** This resource is not meant to be used for managing large amounts of data in your table, it is not designed to scale.
+  You should perform **regular backups** of all data in the table, see [AWS docs for more](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/BackupRestore.html).
+
+## Example Usage
+
+```hcl
+resource "aws_dynamodb_table_item" "example" {
+  table_name = "${aws_dynamodb_table.example.name}"
+  hash_key = "${aws_dynamodb_table.example.hash_key}"
+  item = <<ITEM
+{
+  "exampleHashKey": {"S": "something"},
+  "one": {"N": "11111"},
+  "two": {"N": "22222"},
+  "three": {"N": "33333"},
+  "four": {"N": "44444"}
+}
+ITEM
+}
+
+resource "aws_dynamodb_table" "example" {
+  name = "example-name"
+  read_capacity = 10
+  write_capacity = 10
+  hash_key = "exampleHashKey"
+
+  attribute {
+    name = "exampleHashKey"
+    type = "S"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `table_name` - (Required) The name of the table to contain the item.
+* `hash_key` - (Required) Hash key to use for lookups and identification of the item
+* `range_key` - (Optional) Range key to use for lookups and identification of the item. Required if there is range key defined in the table.
+* `item` - (Required) JSON representation of a map of attribute name/value pairs, one for each attribute.
+  Only the primary key attributes are required; you can optionally provide other attribute name-value pairs for the item.
+
+## Attributes Reference
+
+All of the arguments above are exported as attributes.
+
+## Import
+
+DynamoDB table items cannot be imported.


### PR DESCRIPTION
Replacement for https://github.com/terraform-providers/terraform-provider-aws/pull/1378

Closes #517

-----

This is a rough summary of my changes I added on top of @galadriel2143's PR:

 - Use standard retry helpers
 - Simplify code by extracting code into reusable functions
 - Remove fields which seemed unnecessary - if there's any interest we can add them later, but I think they'd unnecessarily increase the complexity of otherwise simple resource
 - Add validation
 - Add missing acceptance tests
 - Add missing docs

The original commit was retained, so @galadriel2143 can still receive the credit they deserve. 😉 

## Test results

```
=== RUN   TestAccAWSDynamoDbTableItem_basic
--- PASS: TestAccAWSDynamoDbTableItem_basic (41.73s)
=== RUN   TestAccAWSDynamoDbTableItem_rangeKey
--- PASS: TestAccAWSDynamoDbTableItem_rangeKey (48.55s)
=== RUN   TestAccAWSDynamoDbTableItem_withMultipleItems
--- PASS: TestAccAWSDynamoDbTableItem_withMultipleItems (56.37s)
=== RUN   TestAccAWSDynamoDbTableItem_update
--- PASS: TestAccAWSDynamoDbTableItem_update (79.85s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	226.544s
```
