### PR TITLE
New Data Source: aws_lb_ssl_policy

### DIFF
--- a/aws/data_source_aws_lb_ssl_policy.go
+++ b/aws/data_source_aws_lb_ssl_policy.go
@@ -1,0 +1,46 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsLbSSLPolicy() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsLbSSLPolicyRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsLbSSLPolicyRead(d *schema.ResourceData, meta interface{}) error {
+	elbconn := meta.(*AWSClient).elbv2conn
+
+	input := &elbv2.DescribeSSLPoliciesInput{}
+
+	if v, ok := d.GetOk("name"); ok {
+		input.Names = []*string{aws.String(v.(string))}
+	}
+
+	resp, err := elbconn.DescribeSSLPolicies(input)
+	if err != nil {
+		return nil
+	}
+
+	if len(resp.SslPolicies) == 0 {
+		return fmt.Errorf("SSL Policies not found")
+	}
+
+	policy := resp.SslPolicies[0]
+	d.Set("name", policy.Name)
+	d.SetId(*policy.Name)
+	return nil
+}

--- a/aws/data_source_aws_lb_ssl_policy_test.go
+++ b/aws/data_source_aws_lb_ssl_policy_test.go
@@ -1,0 +1,41 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceAwsLbSSLPolicy_basic(t *testing.T) {
+	policyName := "ELBSecurityPolicy-TLS-1-2-2017-01"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsLbSSLPolicyConfig_basic,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.aws_lb_ssl_policy.basic", "name"),
+				),
+			},
+			{
+				Config: testAccDataSourceAwsLbSSLPolicyConfig_name(policyName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_lb_ssl_policy.tls", "name", policyName),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceAwsLbSSLPolicyConfig_basic = `data "aws_lb_ssl_policy" "basic" {}`
+
+func testAccDataSourceAwsLbSSLPolicyConfig_name(pname string) string {
+	return fmt.Sprintf(`
+data "aws_lb_ssl_policy" "tls" {
+  name = "%s"
+}
+`, pname)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -206,6 +206,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_kms_alias":                        dataSourceAwsKmsAlias(),
 			"aws_kms_ciphertext":                   dataSourceAwsKmsCiphertext(),
 			"aws_kms_secret":                       dataSourceAwsKmsSecret(),
+			"aws_lb_ssl_policy":                    dataSourceAwsLbSSLPolicy(),
 			"aws_nat_gateway":                      dataSourceAwsNatGateway(),
 			"aws_network_interface":                dataSourceAwsNetworkInterface(),
 			"aws_partition":                        dataSourceAwsPartition(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -173,6 +173,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-lb-listener") %>>
                             <a href="/docs/providers/aws/d/lb_listener.html">aws_lb_listener</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-lb-ssl-policy") %>>
+                            <a href="/docs/providers/aws/d/lb_ssl_policy.html">aws_lb_ssl_policy</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-lb-target-group") %>>
                             <a href="/docs/providers/aws/d/lb_target_group.html">aws_lb_target_group</a>
                         </li>

--- a/website/docs/d/lb_ssl_policy.html.markdown
+++ b/website/docs/d/lb_ssl_policy.html.markdown
@@ -1,0 +1,36 @@
+---
+layout: "aws"
+page_title: "AWS: aws_lb_ssl_policy"
+sidebar_current: "docs-aws-datasource-lb-ssl-policy"
+description: |-
+  Provides a Load Balancer SSL Policy data source.
+---
+
+# Data Source: aws_lb_ssl_policy
+
+Provides information about a Load Balancer SSL Policy.
+
+~> **Note:** When you don't specify `name`, the default policy will be set as `name`.
+
+## Example Usage
+
+```hcl
+data "aws_lb_ssl_policy" "default" {}
+
+data "aws_lb_ssl_policy" "tls" {
+  name = "ELBSecurityPolicy-TLS-1-2-2017-01"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Optional) The name of the policy.
+
+## Attributes Reference
+
+The following attributes are supported:
+
+* `id` - The name of the policy.
+* `name` - The name of the policy.


### PR DESCRIPTION
```
TF_ACC=1 go test ./aws -v -run=TestAccDataSourceAwsLbSSLPolicy_basic -timeout 120m
=== RUN   TestAccDataSourceAwsLbSSLPolicy_basic
--- PASS: TestAccDataSourceAwsLbSSLPolicy_basic (49.11s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	49.148s
```

The motivation is to follow the default policy which AWS defines.
For example,
```
data "aws_lb_ssl_policy" "default" {}

resource "aws_lb_listener" "example" {
  load_balancer_arn = "hogehoge"
  port              = "443"
  protocol          = "HTTPS"
  ssl_policy        = "${data.aws_lb_ssl_policy.default.name}"
  certificate_arn   = "fugafuga"
}
```

The first element of `SslPolicies` seems to be the default policy.