### PR TITLE
resource/aws_codebuild_project: Prevent crash when using source auth configuration

### DIFF
--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -532,7 +532,7 @@ func flattenAwsCodebuildProjectSource(source *codebuild.ProjectSource) []interfa
 	m["type"] = *source.Type
 
 	if source.Auth != nil {
-		m["auth"] = []interface{}{sourceAuthToMap(source.Auth)}
+		m["auth"] = schema.NewSet(resourceAwsCodeBuildProjectSourceAuthHash, []interface{}{sourceAuthToMap(source.Auth)})
 	}
 
 	if source.Buildspec != nil {

--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -532,7 +532,7 @@ func flattenAwsCodebuildProjectSource(source *codebuild.ProjectSource) []interfa
 	m["type"] = *source.Type
 
 	if source.Auth != nil {
-		m["auth"] = sourceAuthToMap(source.Auth)
+		m["auth"] = []interface{}{sourceAuthToMap(source.Auth)}
 	}
 
 	if source.Buildspec != nil {

--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -43,8 +43,7 @@ func TestAccAWSCodeBuildProject_basic(t *testing.T) {
 }
 
 func TestAccAWSCodeBuildProject_sourceAuth(t *testing.T) {
-	authResource1 := "FAKERESOURCE1"
-	authResource2 := "FAKERESOURCE2"
+	authResource := "FAKERESOURCE1"
 	authType := "OAUTH"
 	name := acctest.RandString(10)
 	resourceName := "aws_codebuild_project.foo"
@@ -55,23 +54,15 @@ func TestAccAWSCodeBuildProject_sourceAuth(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCodeBuildProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccAWSCodeBuildProjectConfig_sourceAuth(name, authResource1, "INVALID"),
+				Config:      testAccAWSCodeBuildProjectConfig_sourceAuth(name, authResource, "INVALID"),
 				ExpectError: regexp.MustCompile(`Source Auth Type can only be`),
 			},
 			{
-				Config: testAccAWSCodeBuildProjectConfig_sourceAuth(name, authResource1, authType),
+				Config: testAccAWSCodeBuildProjectConfig_sourceAuth(name, authResource, authType),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeBuildProjectExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "source.1060593600.auth.0.resource", authResource1),
-					resource.TestCheckResourceAttr(resourceName, "source.1060593600.auth.0.type", authType),
-				),
-			},
-			{
-				Config: testAccAWSCodeBuildProjectConfig_sourceAuth(name, authResource2, authType),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeBuildProjectExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "source.1060593600.auth.0.resource", authResource2),
-					resource.TestCheckResourceAttr(resourceName, "source.1060593600.auth.0.type", authType),
+					resource.TestCheckResourceAttr(resourceName, "source.1060593600.auth.2706882902.resource", authResource),
+					resource.TestCheckResourceAttr(resourceName, "source.1060593600.auth.2706882902.type", authType),
 				),
 			},
 		},

--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 	"unicode"
@@ -35,6 +36,42 @@ func TestAccAWSCodeBuildProject_basic(t *testing.T) {
 					testAccCheckAWSCodeBuildProjectExists("aws_codebuild_project.foo"),
 					resource.TestCheckResourceAttr(
 						"aws_codebuild_project.foo", "build_timeout", "50"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeBuildProject_sourceAuth(t *testing.T) {
+	authResource1 := "FAKERESOURCE1"
+	authResource2 := "FAKERESOURCE2"
+	authType := "OAUTH"
+	name := acctest.RandString(10)
+	resourceName := "aws_codebuild_project.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeBuildProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSCodeBuildProjectConfig_sourceAuth(name, authResource1, "INVALID"),
+				ExpectError: regexp.MustCompile(`Source Auth Type can only be`),
+			},
+			{
+				Config: testAccAWSCodeBuildProjectConfig_sourceAuth(name, authResource1, authType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeBuildProjectExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "source.1060593600.auth.0.resource", authResource1),
+					resource.TestCheckResourceAttr(resourceName, "source.1060593600.auth.0.type", authType),
+				),
+			},
+			{
+				Config: testAccAWSCodeBuildProjectConfig_sourceAuth(name, authResource2, authType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeBuildProjectExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "source.1060593600.auth.0.resource", authResource2),
+					resource.TestCheckResourceAttr(resourceName, "source.1060593600.auth.0.type", authType),
 				),
 			},
 		},
@@ -569,4 +606,92 @@ resource "aws_codebuild_project" "foo" {
   }
 }
 `, rName, rName, rName, rName)
+}
+
+func testAccAWSCodeBuildProjectConfig_sourceAuth(rName, authResource, authType string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "codebuild_role" {
+  name = "codebuild-role-%[1]s"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "codebuild.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "codebuild_policy" {
+    name        = "codebuild-policy-%[1]s"
+    path        = "/service-role/"
+    description = "Policy used in trust relationship with CodeBuild"
+    policy      = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ],
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ]
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_policy_attachment" "codebuild_policy_attachment" {
+  name       = "codebuild-policy-attachment-%[1]s"
+  policy_arn = "${aws_iam_policy.codebuild_policy.arn}"
+  roles      = ["${aws_iam_role.codebuild_role.id}"]
+}
+
+resource "aws_codebuild_project" "foo" {
+  name         = "test-project-%[1]s"
+  description  = "test_codebuild_project"
+  build_timeout      = "5"
+  service_role = "${aws_iam_role.codebuild_role.arn}"
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type = "BUILD_GENERAL1_SMALL"
+    image        = "2"
+    type         = "LINUX_CONTAINER"
+
+    environment_variable = {
+      "name"  = "SOME_KEY"
+      "value" = "SOME_VALUE"
+    }
+  }
+
+  source {
+    type     = "GITHUB"
+    location = "https://github.com/hashicorp/packer.git"
+
+    auth {
+      resource = "%[2]s"
+      type     = "%[3]s"
+    }
+  }
+
+  tags {
+    "Environment" = "Test"
+  }
+}
+`, rName, authResource, authType)
 }


### PR DESCRIPTION
Previously:
```
 make testacc TEST=./aws TESTARGS='-run=TestAccAWSCodeBuildProject_sourceAuth'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCodeBuildProject_sourceAuth -timeout 120m
=== RUN   TestAccAWSCodeBuildProject_sourceAuth
panic: interface conversion: interface {} is map[string]interface {}, not *schema.Set

goroutine 606 [running]:
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema.(*MapFieldWriter).setSet(0xc4204a7840, 0xc42081bad0, 0x3, 0x3, 0x3440d20, 0xc42081b9e0, 0xc4203b52c0, 0xffffffffffffffff, 0x0)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema/field_writer_map.go:343 +0xb95
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema.(*MapFieldWriter).set(0xc4204a7840, 0xc42081bad0, 0x3, 0x3, 0x3440d20, 0xc42081b9e0, 0x0, 0x0)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema/field_writer_map.go:107 +0x2ac
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema.(*MapFieldWriter).setObject(0xc4204a7840, 0xc4204a78a0, 0x2, 0x2, 0x3440d20, 0xc42081b9b0, 0xc420928960, 0x0, 0x1836aa4)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema/field_writer_map.go:225 +0x241
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema.(*MapFieldWriter).set(0xc4204a7840, 0xc4204a78a0, 0x2, 0x2, 0x3440d20, 0xc42081b9b0, 0x1, 0x1)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema/field_writer_map.go:109 +0x22b
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema.(*MapFieldWriter).setList.func1(0x3a97667, 0x1, 0x3440d20, 0xc42081b9b0, 0x0, 0x0)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema/field_writer_map.go:123 +0x139
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema.(*MapFieldWriter).setList(0xc4204a7840, 0xc420719460, 0x1, 0x1, 0x316aca0, 0xc4204a7800, 0xc4209283c0, 0x6, 0xc42039d9d0)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema/field_writer_map.go:143 +0x242
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema.(*MapFieldWriter).set(0xc4204a7840, 0xc420719460, 0x1, 0x1, 0x316aca0, 0xc4204a7800, 0x1, 0x600000000d0)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema/field_writer_map.go:103 +0x10b
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema.(*MapFieldWriter).WriteField(0xc4204a7840, 0xc420719460, 0x1, 0x1, 0x316aca0, 0xc4204a7800, 0x0, 0x0)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema/field_writer_map.go:89 +0x49e
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema.(*MapFieldWriter).setSet(0xc420632e80, 0xc420719460, 0x1, 0x1, 0x316aca0, 0xc4204a7800, 0xc4203b5d10, 0x6, 0xc42039d9d0)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema/field_writer_map.go:306 +0x681
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema.(*MapFieldWriter).set(0xc420632e80, 0xc420719460, 0x1, 0x1, 0x316aca0, 0xc4204a7800, 0x1, 0x1)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema/field_writer_map.go:107 +0x2ac
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema.(*MapFieldWriter).WriteField(0xc420632e80, 0xc420719460, 0x1, 0x1, 0x316aca0, 0xc4204a7800, 0x0, 0x0)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema/field_writer_map.go:89 +0x49e
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema.(*ResourceData).Set(0xc4201adb90, 0x39c422d, 0x6, 0x316aca0, 0xc4204a7800, 0x0, 0x0)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema/resource_data.go:189 +0x12b
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsCodeBuildProjectRead(0xc4201adb90, 0x35bfbe0, 0xc4200a7b80, 0x0, 0x0)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_codebuild_project.go:391 +0x344
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsCodeBuildProjectUpdate(0xc4201adb90, 0x35bfbe0, 0xc4200a7b80, 0x0, 0xc420a59470)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_codebuild_project.go:458 +0x48c
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsCodeBuildProjectCreate(0xc4201adb90, 0x35bfbe0, 0xc4200a7b80, 0xc4201adb90, 0x0)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_codebuild_project.go:246 +0x539
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema.(*Resource).Apply(0xc42039da40, 0xc4201bed20, 0xc42061bb60, 0x35bfbe0, 0xc4200a7b80, 0xc42063e801, 0x39, 0x0)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema/resource.go:227 +0x364
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema.(*Provider).Apply(0xc4200fae70, 0xc4205dd7c0, 0xc4201bed20, 0xc42061bb60, 0x1, 0x54, 0x13)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema/provider.go:283 +0xa4
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/terraform.(*EvalApply).Eval(0xc4202c6d00, 0x586b3c0, 0xc4207f4680, 0x2, 0x2, 0x39c1bf5, 0x4)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/terraform/eval_apply.go:57 +0x239
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/terraform.EvalRaw(0x585afa0, 0xc4202c6d00, 0x586b3c0, 0xc4207f4680, 0x0, 0x0, 0x0, 0x0)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/terraform/eval.go:53 +0x173
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/terraform.(*EvalSequence).Eval(0xc4205839c0, 0x586b3c0, 0xc4207f4680, 0x2, 0x2, 0x39c1bf5, 0x4)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/terraform/eval_sequence.go:14 +0x7e
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/terraform.EvalRaw(0x585ba60, 0xc4205839c0, 0x586b3c0, 0xc4207f4680, 0x33fe6e0, 0x586c402, 0x31ad300, 0xc4205c9900)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/terraform/eval.go:53 +0x173
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/terraform.Eval(0x585ba60, 0xc4205839c0, 0x586b3c0, 0xc4207f4680, 0xc4205839c0, 0x585ba60, 0xc4205839c0, 0x108c8d4)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/terraform/eval.go:34 +0x4d
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/terraform.(*Graph).walk.func1(0x3927140, 0xc42000e330, 0x0, 0x0)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/terraform/graph.go:126 +0xd0d
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/dag.(*Walker).walkVertex(0xc4205432d0, 0x3927140, 0xc42000e330, 0xc420a70700)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/dag/walk.go:387 +0x3c1
created by github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/dag.(*Walker).Update
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/dag/walk.go:310 +0x1364
exit status 2
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	22.678s
make: *** [testacc] Error 1
```

Tests pass with new code:
```
=== RUN   TestAccAWSCodeBuildProject_sourceAuth
--- PASS: TestAccAWSCodeBuildProject_sourceAuth (26.59s)
=== RUN   TestAccAWSCodeBuildProject_default_build_timeout
--- PASS: TestAccAWSCodeBuildProject_default_build_timeout (33.90s)
=== RUN   TestAccAWSCodeBuildProject_basic
--- PASS: TestAccAWSCodeBuildProject_basic (34.03s)
```