### PR TITLE
New Resource: aws_waf_geo_match_set

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -553,6 +553,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_waf_web_acl":                              resourceAwsWafWebAcl(),
 			"aws_waf_xss_match_set":                        resourceAwsWafXssMatchSet(),
 			"aws_waf_sql_injection_match_set":              resourceAwsWafSqlInjectionMatchSet(),
+			"aws_waf_geo_match_set":                        resourceAwsWafGeoMatchSet(),
 			"aws_wafregional_byte_match_set":               resourceAwsWafRegionalByteMatchSet(),
 			"aws_wafregional_ipset":                        resourceAwsWafRegionalIPSet(),
 			"aws_wafregional_xss_match_set":                resourceAwsWafRegionalXssMatchSet(),

--- a/aws/resource_aws_waf_geo_match_set.go
+++ b/aws/resource_aws_waf_geo_match_set.go
@@ -1,0 +1,200 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/waf"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsWafGeoMatchSet() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsWafGeoMatchSetCreate,
+		Read:   resourceAwsWafGeoMatchSetRead,
+		Update: resourceAwsWafGeoMatchSetUpdate,
+		Delete: resourceAwsWafGeoMatchSetDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"geo_match_constraint": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsWafGeoMatchSetCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafconn
+
+	log.Printf("[INFO] Creating GeoMatchSet: %s", d.Get("name").(string))
+
+	wr := newWafRetryer(conn, "global")
+	out, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
+		params := &waf.CreateGeoMatchSetInput{
+			ChangeToken: token,
+			Name:        aws.String(d.Get("name").(string)),
+		}
+
+		return conn.CreateGeoMatchSet(params)
+	})
+	if err != nil {
+		return errwrap.Wrapf("[ERROR] Error creating GeoMatchSet: {{err}}", err)
+	}
+	resp := out.(*waf.CreateGeoMatchSetOutput)
+
+	d.SetId(*resp.GeoMatchSet.GeoMatchSetId)
+
+	return resourceAwsWafGeoMatchSetUpdate(d, meta)
+}
+
+func resourceAwsWafGeoMatchSetRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafconn
+	log.Printf("[INFO] Reading GeoMatchSet: %s", d.Get("name").(string))
+	params := &waf.GetGeoMatchSetInput{
+		GeoMatchSetId: aws.String(d.Id()),
+	}
+
+	resp, err := conn.GetGeoMatchSet(params)
+	if err != nil {
+		if isAWSErr(err, "WAFNonexistentItemException", "") {
+			log.Printf("[WARN] WAF GeoMatchSet (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+
+		return err
+	}
+
+	d.Set("name", resp.GeoMatchSet.Name)
+	d.Set("geo_match_constraint", flattenWafGeoMatchConstraint(resp.GeoMatchSet.GeoMatchConstraints))
+
+	return nil
+}
+
+func resourceAwsWafGeoMatchSetUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafconn
+
+	if d.HasChange("geo_match_constraint") {
+		o, n := d.GetChange("geo_match_constraint")
+		oldT, newT := o.(*schema.Set).List(), n.(*schema.Set).List()
+
+		err := updateGeoMatchSetResource(d.Id(), oldT, newT, conn)
+		if err != nil {
+			return errwrap.Wrapf("[ERROR] Error updating GeoMatchSet: {{err}}", err)
+		}
+	}
+
+	return resourceAwsWafGeoMatchSetRead(d, meta)
+}
+
+func resourceAwsWafGeoMatchSetDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafconn
+
+	oldConstraints := d.Get("geo_match_constraint").(*schema.Set).List()
+	if len(oldConstraints) > 0 {
+		noConstraints := []interface{}{}
+		err := updateGeoMatchSetResource(d.Id(), oldConstraints, noConstraints, conn)
+		if err != nil {
+			return fmt.Errorf("Error updating GeoMatchConstraint: %s", err)
+		}
+	}
+
+	wr := newWafRetryer(conn, "global")
+	_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
+		req := &waf.DeleteGeoMatchSetInput{
+			ChangeToken:   token,
+			GeoMatchSetId: aws.String(d.Id()),
+		}
+
+		return conn.DeleteGeoMatchSet(req)
+	})
+	if err != nil {
+		return errwrap.Wrapf("[ERROR] Error deleting GeoMatchSet: {{err}}", err)
+	}
+
+	return nil
+}
+
+func updateGeoMatchSetResource(id string, oldT, newT []interface{}, conn *waf.WAF) error {
+	wr := newWafRetryer(conn, "global")
+	_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
+		req := &waf.UpdateGeoMatchSetInput{
+			ChangeToken:   token,
+			GeoMatchSetId: aws.String(id),
+			Updates:       diffWafGeoMatchSetConstraints(oldT, newT),
+		}
+
+		log.Printf("[INFO] Updating GeoMatchSet constraints: %s", req)
+		return conn.UpdateGeoMatchSet(req)
+	})
+	if err != nil {
+		return errwrap.Wrapf("[ERROR] Error updating GeoMatchSet: {{err}}", err)
+	}
+
+	return nil
+}
+
+func flattenWafGeoMatchConstraint(ts []*waf.GeoMatchConstraint) []interface{} {
+	out := make([]interface{}, len(ts), len(ts))
+	for i, t := range ts {
+		m := make(map[string]interface{})
+		m["type"] = *t.Type
+		m["value"] = *t.Value
+		out[i] = m
+	}
+	return out
+}
+
+func diffWafGeoMatchSetConstraints(oldT, newT []interface{}) []*waf.GeoMatchSetUpdate {
+	updates := make([]*waf.GeoMatchSetUpdate, 0)
+
+	for _, od := range oldT {
+		constraint := od.(map[string]interface{})
+
+		if idx, contains := sliceContainsMap(newT, constraint); contains {
+			newT = append(newT[:idx], newT[idx+1:]...)
+			continue
+		}
+
+		updates = append(updates, &waf.GeoMatchSetUpdate{
+			Action: aws.String(waf.ChangeActionDelete),
+			GeoMatchConstraint: &waf.GeoMatchConstraint{
+				Type:  aws.String(constraint["type"].(string)),
+				Value: aws.String(constraint["value"].(string)),
+			},
+		})
+	}
+
+	for _, nd := range newT {
+		constraint := nd.(map[string]interface{})
+
+		updates = append(updates, &waf.GeoMatchSetUpdate{
+			Action: aws.String(waf.ChangeActionInsert),
+			GeoMatchConstraint: &waf.GeoMatchConstraint{
+				Type:  aws.String(constraint["type"].(string)),
+				Value: aws.String(constraint["value"].(string)),
+			},
+		})
+	}
+	return updates
+}

--- a/aws/resource_aws_waf_geo_match_set_test.go
+++ b/aws/resource_aws_waf_geo_match_set_test.go
@@ -1,0 +1,326 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/waf"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/acctest"
+)
+
+func TestAccAWSWafGeoMatchSet_basic(t *testing.T) {
+	var v waf.GeoMatchSet
+	geoMatchSet := fmt.Sprintf("geoMatchSet-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafGeoMatchSetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSWafGeoMatchSetConfig(geoMatchSet),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSWafGeoMatchSetExists("aws_waf_geo_match_set.geo_match_set", &v),
+					resource.TestCheckResourceAttr(
+						"aws_waf_geo_match_set.geo_match_set", "name", geoMatchSet),
+					resource.TestCheckResourceAttr(
+						"aws_waf_geo_match_set.geo_match_set", "geo_match_constraint.#", "2"),
+					resource.TestCheckResourceAttr(
+						"aws_waf_geo_match_set.geo_match_set", "geo_match_constraint.384465307.type", "Country"),
+					resource.TestCheckResourceAttr(
+						"aws_waf_geo_match_set.geo_match_set", "geo_match_constraint.384465307.value", "US"),
+					resource.TestCheckResourceAttr(
+						"aws_waf_geo_match_set.geo_match_set", "geo_match_constraint.1991628426.type", "Country"),
+					resource.TestCheckResourceAttr(
+						"aws_waf_geo_match_set.geo_match_set", "geo_match_constraint.1991628426.value", "CA"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSWafGeoMatchSet_changeNameForceNew(t *testing.T) {
+	var before, after waf.GeoMatchSet
+	geoMatchSet := fmt.Sprintf("geoMatchSet-%s", acctest.RandString(5))
+	geoMatchSetNewName := fmt.Sprintf("geoMatchSetNewName-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafGeoMatchSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSWafGeoMatchSetConfig(geoMatchSet),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSWafGeoMatchSetExists("aws_waf_geo_match_set.geo_match_set", &before),
+					resource.TestCheckResourceAttr(
+						"aws_waf_geo_match_set.geo_match_set", "name", geoMatchSet),
+					resource.TestCheckResourceAttr(
+						"aws_waf_geo_match_set.geo_match_set", "geo_match_constraint.#", "2"),
+				),
+			},
+			{
+				Config: testAccAWSWafGeoMatchSetConfigChangeName(geoMatchSetNewName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSWafGeoMatchSetExists("aws_waf_geo_match_set.geo_match_set", &after),
+					resource.TestCheckResourceAttr(
+						"aws_waf_geo_match_set.geo_match_set", "name", geoMatchSetNewName),
+					resource.TestCheckResourceAttr(
+						"aws_waf_geo_match_set.geo_match_set", "geo_match_constraint.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSWafGeoMatchSet_disappears(t *testing.T) {
+	var v waf.GeoMatchSet
+	geoMatchSet := fmt.Sprintf("geoMatchSet-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafGeoMatchSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSWafGeoMatchSetConfig(geoMatchSet),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSWafGeoMatchSetExists("aws_waf_geo_match_set.geo_match_set", &v),
+					testAccCheckAWSWafGeoMatchSetDisappears(&v),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSWafGeoMatchSet_changeConstraints(t *testing.T) {
+	var before, after waf.GeoMatchSet
+	setName := fmt.Sprintf("geoMatchSet-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafGeoMatchSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSWafGeoMatchSetConfig(setName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSWafGeoMatchSetExists("aws_waf_geo_match_set.geo_match_set", &before),
+					resource.TestCheckResourceAttr(
+						"aws_waf_geo_match_set.geo_match_set", "name", setName),
+					resource.TestCheckResourceAttr(
+						"aws_waf_geo_match_set.geo_match_set", "geo_match_constraint.#", "2"),
+					resource.TestCheckResourceAttr(
+						"aws_waf_geo_match_set.geo_match_set", "geo_match_constraint.384465307.type", "Country"),
+					resource.TestCheckResourceAttr(
+						"aws_waf_geo_match_set.geo_match_set", "geo_match_constraint.384465307.value", "US"),
+					resource.TestCheckResourceAttr(
+						"aws_waf_geo_match_set.geo_match_set", "geo_match_constraint.1991628426.type", "Country"),
+					resource.TestCheckResourceAttr(
+						"aws_waf_geo_match_set.geo_match_set", "geo_match_constraint.1991628426.value", "CA"),
+				),
+			},
+			{
+				Config: testAccAWSWafGeoMatchSetConfig_changeConstraints(setName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSWafGeoMatchSetExists("aws_waf_geo_match_set.geo_match_set", &after),
+					resource.TestCheckResourceAttr(
+						"aws_waf_geo_match_set.geo_match_set", "name", setName),
+					resource.TestCheckResourceAttr(
+						"aws_waf_geo_match_set.geo_match_set", "geo_match_constraint.#", "2"),
+					resource.TestCheckResourceAttr(
+						"aws_waf_geo_match_set.geo_match_set", "geo_match_constraint.1174390936.type", "Country"),
+					resource.TestCheckResourceAttr(
+						"aws_waf_geo_match_set.geo_match_set", "geo_match_constraint.1174390936.value", "RU"),
+					resource.TestCheckResourceAttr(
+						"aws_waf_geo_match_set.geo_match_set", "geo_match_constraint.4046309957.type", "Country"),
+					resource.TestCheckResourceAttr(
+						"aws_waf_geo_match_set.geo_match_set", "geo_match_constraint.4046309957.value", "CN"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSWafGeoMatchSet_noConstraints(t *testing.T) {
+	var ipset waf.GeoMatchSet
+	setName := fmt.Sprintf("geoMatchSet-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafGeoMatchSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSWafGeoMatchSetConfig_noConstraints(setName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSWafGeoMatchSetExists("aws_waf_geo_match_set.geo_match_set", &ipset),
+					resource.TestCheckResourceAttr(
+						"aws_waf_geo_match_set.geo_match_set", "name", setName),
+					resource.TestCheckResourceAttr(
+						"aws_waf_geo_match_set.geo_match_set", "geo_match_constraint.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSWafGeoMatchSetDisappears(v *waf.GeoMatchSet) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).wafconn
+
+		wr := newWafRetryer(conn, "global")
+		_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
+			req := &waf.UpdateGeoMatchSetInput{
+				ChangeToken:   token,
+				GeoMatchSetId: v.GeoMatchSetId,
+			}
+
+			for _, geoMatchConstraint := range v.GeoMatchConstraints {
+				geoMatchConstraintUpdate := &waf.GeoMatchSetUpdate{
+					Action: aws.String("DELETE"),
+					GeoMatchConstraint: &waf.GeoMatchConstraint{
+						Type:  geoMatchConstraint.Type,
+						Value: geoMatchConstraint.Value,
+					},
+				}
+				req.Updates = append(req.Updates, geoMatchConstraintUpdate)
+			}
+			return conn.UpdateGeoMatchSet(req)
+		})
+		if err != nil {
+			return errwrap.Wrapf("[ERROR] Error updating GeoMatchSet: {{err}}", err)
+		}
+
+		_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {
+			opts := &waf.DeleteGeoMatchSetInput{
+				ChangeToken:   token,
+				GeoMatchSetId: v.GeoMatchSetId,
+			}
+			return conn.DeleteGeoMatchSet(opts)
+		})
+		if err != nil {
+			return errwrap.Wrapf("[ERROR] Error deleting GeoMatchSet: {{err}}", err)
+		}
+		return nil
+	}
+}
+
+func testAccCheckAWSWafGeoMatchSetExists(n string, v *waf.GeoMatchSet) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No WAF GeoMatchSet ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).wafconn
+		resp, err := conn.GetGeoMatchSet(&waf.GetGeoMatchSetInput{
+			GeoMatchSetId: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if *resp.GeoMatchSet.GeoMatchSetId == rs.Primary.ID {
+			*v = *resp.GeoMatchSet
+			return nil
+		}
+
+		return fmt.Errorf("WAF GeoMatchSet (%s) not found", rs.Primary.ID)
+	}
+}
+
+func testAccCheckAWSWafGeoMatchSetDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_waf_geo_match_set" {
+			continue
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).wafconn
+		resp, err := conn.GetGeoMatchSet(
+			&waf.GetGeoMatchSetInput{
+				GeoMatchSetId: aws.String(rs.Primary.ID),
+			})
+
+		if err == nil {
+			if *resp.GeoMatchSet.GeoMatchSetId == rs.Primary.ID {
+				return fmt.Errorf("WAF GeoMatchSet %s still exists", rs.Primary.ID)
+			}
+		}
+
+		// Return nil if the GeoMatchSet is already destroyed
+		if isAWSErr(err, "WAFNonexistentItemException", "") {
+			return nil
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func testAccAWSWafGeoMatchSetConfig(name string) string {
+	return fmt.Sprintf(`
+resource "aws_waf_geo_match_set" "geo_match_set" {
+  name = "%s"
+  geo_match_constraint {
+    type = "Country"
+    value = "US"
+  }
+
+  geo_match_constraint {
+    type = "Country"
+    value = "CA"
+  }
+}`, name)
+}
+
+func testAccAWSWafGeoMatchSetConfigChangeName(name string) string {
+	return fmt.Sprintf(`
+resource "aws_waf_geo_match_set" "geo_match_set" {
+  name = "%s"
+  geo_match_constraint {
+    type = "Country"
+    value = "US"
+  }
+
+  geo_match_constraint {
+    type = "Country"
+    value = "CA"
+  }
+}`, name)
+}
+
+func testAccAWSWafGeoMatchSetConfig_changeConstraints(name string) string {
+	return fmt.Sprintf(`
+resource "aws_waf_geo_match_set" "geo_match_set" {
+  name = "%s"
+  geo_match_constraint {
+    type = "Country"
+    value = "RU"
+  }
+
+  geo_match_constraint {
+    type = "Country"
+    value = "CN"
+  }
+}`, name)
+}
+
+func testAccAWSWafGeoMatchSetConfig_noConstraints(name string) string {
+	return fmt.Sprintf(`
+resource "aws_waf_geo_match_set" "geo_match_set" {
+  name = "%s"
+}`, name)
+}

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1452,6 +1452,7 @@ func validateWafPredicatesType() schema.SchemaValidateFunc {
 		waf.PredicateTypeSqlInjectionMatch,
 		waf.PredicateTypeSizeConstraint,
 		waf.PredicateTypeXssMatch,
+		waf.PredicateTypeGeoMatch,
 	}, false)
 }
 

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1468,6 +1468,10 @@
                     <a href="/docs/providers/aws/r/waf_byte_match_set.html">aws_waf_byte_match_set</a>
                   </li>
 
+                  <li<%= sidebar_current("docs-aws-resource-waf-geo-match-set") %>>
+                    <a href="/docs/providers/aws/r/waf_geo_match_set.html">aws_waf_geo_match_set</a>
+                  </li>
+
                   <li<%= sidebar_current("docs-aws-resource-waf-ipset") %>>
                     <a href="/docs/providers/aws/r/waf_ipset.html">aws_waf_ipset</a>
                   </li>

--- a/website/docs/r/waf_geo_match_set.html.markdown
+++ b/website/docs/r/waf_geo_match_set.html.markdown
@@ -1,0 +1,55 @@
+---
+layout: "aws"
+page_title: "AWS: waf_geo_match_set"
+sidebar_current: "docs-aws-resource-waf-geo-match-set"
+description: |-
+  Provides a AWS WAF GeoMatchSet resource.
+---
+
+# aws_waf_geo_match_set
+
+Provides a WAF Geo Match Set Resource
+
+## Example Usage
+
+```hcl
+resource "aws_waf_geo_match_set" "geo_match_set" {
+  name = "geo_match_set"
+
+  geo_match_constraint {
+    type  = "Country"
+    value = "US"
+  }
+
+  geo_match_constraint {
+    type  = "Country"
+    value = "CA"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name or description of the GeoMatchSet.
+* `geo_match_constraint` - (Optional) The GeoMatchConstraint objects which contain the country that you want AWS WAF to search for.
+
+## Nested Blocks
+
+### `geo_match_constraint`
+
+#### Arguments
+
+* `type` - (Required) The type of geographical area you want AWS WAF to search for. Currently Country is the only valid value.
+* `value` - (Required) The country that you want AWS WAF to search for.
+  This is the two-letter country code, e.g. `US`, `CA`, `RU`, `CN`, etc.
+  See [docs](https://docs.aws.amazon.com/waf/latest/APIReference/API_GeoMatchConstraint.html) for all supported values.
+
+## Remarks
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the WAF GeoMatchSet.

--- a/website/docs/r/waf_rule.html.markdown
+++ b/website/docs/r/waf_rule.html.markdown
@@ -54,7 +54,8 @@ The following arguments are supported:
   For example, if an IPSet includes the IP address `192.0.2.44`, AWS WAF will allow or block requests based on that IP address.
   If set to `true`, AWS WAF will allow, block, or count requests based on all IP addresses _except_ `192.0.2.44`.
 * `data_id` - (Required) A unique identifier for a predicate in the rule, such as Byte Match Set ID or IPSet ID.
-* `type` - (Required) The type of predicate in a rule. Valid value is one of `ByteMatch`, `IPMatch`, `SizeConstraint`, `SqlInjectionMatch` or `XssMatch`.
+* `type` - (Required) The type of predicate in a rule. Valid value is one of `ByteMatch`, `IPMatch`, `SizeConstraint`, `SqlInjectionMatch`, or `XssMatch`.
+  See [docs](https://docs.aws.amazon.com/waf/latest/APIReference/API_Predicate.html) for all supported values.
 
 ## Remarks
 


### PR DESCRIPTION
I added a `aws_waf_geo_match_set` resource which supports the AWS WAF [GeoMatchSet](https://docs.aws.amazon.com/waf/latest/APIReference/API_GeoMatchSet.html) feature added back in October 2017.

Per the [contributing guidelines](https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md), I followed the conventions used by the existing WAF resources/ match sets, included and passed acceptance tests, updated the documentation, and kept the LOC to a minimum.

I also added an acceptance test to the existing `aws_waf_rule` resource to verify that it works with the new `aws_waf_geo_match_set` resource.

This was relatively straightforward to implement, as the behavior of the new resource is identical to the existing WAF match set resources, with its main difference being a simpler schema (i.e. compared to `aws_waf_xss_match_set`).

Please let me know if you have any questions, concerns, or would like me to make any changes, thanks!

### Related
- Resolves #2529
- Fixes #2655