### PR TITLE
Add support for Aurora MySQL 5.7

### DIFF
--- a/aws/resource_aws_rds_cluster_instance_test.go
+++ b/aws/resource_aws_rds_cluster_instance_test.go
@@ -141,8 +141,8 @@ func TestAccAWSRDSClusterInstance_disappears(t *testing.T) {
 func testAccCheckAWSDBClusterInstanceAttributes(v *rds.DBInstance) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		if *v.Engine != "aurora" && *v.Engine != "aurora-postgresql" {
-			return fmt.Errorf("bad engine, expected \"aurora\" or \"aurora-postgresql\": %#v", *v.Engine)
+		if *v.Engine != "aurora" && *v.Engine != "aurora-postgresql" && *v.Engine != "aurora-mysql" {
+			return fmt.Errorf("bad engine, expected \"aurora\", \"aurora-mysql\" or \"aurora-postgresql\": %#v", *v.Engine)
 		}
 
 		if !strings.HasPrefix(*v.DBClusterIdentifier, "tf-aurora-cluster") {

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -73,6 +73,7 @@ func validateRdsEngine(v interface{}, k string) (ws []string, errors []error) {
 
 	validTypes := map[string]bool{
 		"aurora":            true,
+		"aurora-mysql":      true,
 		"aurora-postgresql": true,
 	}
 

--- a/website/docs/r/rds_cluster.html.markdown
+++ b/website/docs/r/rds_cluster.html.markdown
@@ -31,7 +31,22 @@ for more information.
 
 ## Example Usage
 
-### Aurora with Default engine (MySQL)
+### Aurora MySQL 2.x (MySQL 5.7)
+
+```hcl
+resource "aws_rds_cluster" "default" {
+  cluster_identifier      = "aurora-cluster-demo"
+  engine                  = "aurora-mysql"
+  availability_zones      = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  database_name           = "mydb"
+  master_username         = "foo"
+  master_password         = "bar"
+  backup_retention_period = 5
+  preferred_backup_window = "07:00-09:00"
+}
+```
+
+### Aurora MySQL 1.x (MySQL 5.6)
 
 ```hcl
 resource "aws_rds_cluster" "default" {


### PR DESCRIPTION
AWS launched support for Aurora based on MySQL 5.7, aka Aurora MySQL 2.

This uses the engine name `aurora-mysql` instead of just `aurora`.

https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AuroraMySQL.Updates.20180206.html