### PR TITLE
New Resource: aws_api_gateway_documentation_version

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -250,6 +250,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_api_gateway_client_certificate":           resourceAwsApiGatewayClientCertificate(),
 			"aws_api_gateway_deployment":                   resourceAwsApiGatewayDeployment(),
 			"aws_api_gateway_documentation_part":           resourceAwsApiGatewayDocumentationPart(),
+			"aws_api_gateway_documentation_version":        resourceAwsApiGatewayDocumentationVersion(),
 			"aws_api_gateway_domain_name":                  resourceAwsApiGatewayDomainName(),
 			"aws_api_gateway_gateway_response":             resourceAwsApiGatewayGatewayResponse(),
 			"aws_api_gateway_integration":                  resourceAwsApiGatewayIntegration(),

--- a/aws/resource_aws_api_gateway_documentation_version.go
+++ b/aws/resource_aws_api_gateway_documentation_version.go
@@ -1,0 +1,137 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/apigateway"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsApiGatewayDocumentationVersion() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsApiGatewayDocumentationVersionCreate,
+		Read:   resourceAwsApiGatewayDocumentationVersionRead,
+		Update: resourceAwsApiGatewayDocumentationVersionUpdate,
+		Delete: resourceAwsApiGatewayDocumentationVersionDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"version": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"rest_api_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceAwsApiGatewayDocumentationVersionCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).apigateway
+
+	restApiId := d.Get("rest_api_id").(string)
+
+	params := &apigateway.CreateDocumentationVersionInput{
+		DocumentationVersion: aws.String(d.Get("version").(string)),
+		RestApiId:            aws.String(restApiId),
+	}
+	if v, ok := d.GetOk("description"); ok {
+		params.Description = aws.String(v.(string))
+	}
+
+	log.Printf("[DEBUG] Creating API Gateway Documentation Version: %s", params)
+
+	version, err := conn.CreateDocumentationVersion(params)
+	if err != nil {
+		return fmt.Errorf("Error creating API Gateway Documentation Version: %s", err)
+	}
+
+	d.SetId(restApiId + "/" + *version.Version)
+
+	return resourceAwsApiGatewayDocumentationVersionRead(d, meta)
+}
+
+func resourceAwsApiGatewayDocumentationVersionRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).apigateway
+	log.Printf("[DEBUG] Reading API Gateway Documentation Version %s", d.Id())
+
+	apiId, docVersion, err := decodeApiGatewayDocumentationVersionId(d.Id())
+	if err != nil {
+		return err
+	}
+
+	version, err := conn.GetDocumentationVersion(&apigateway.GetDocumentationVersionInput{
+		DocumentationVersion: aws.String(docVersion),
+		RestApiId:            aws.String(apiId),
+	})
+	if err != nil {
+		if isAWSErr(err, apigateway.ErrCodeNotFoundException, "") {
+			log.Printf("[WARN] API Gateway Documentation Version (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	d.Set("rest_api_id", apiId)
+	d.Set("description", version.Description)
+	d.Set("version", version.Version)
+
+	return nil
+}
+
+func resourceAwsApiGatewayDocumentationVersionUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).apigateway
+	log.Printf("[DEBUG] Updating API Gateway Documentation Version %s", d.Id())
+
+	_, err := conn.UpdateDocumentationVersion(&apigateway.UpdateDocumentationVersionInput{
+		DocumentationVersion: aws.String(d.Get("version").(string)),
+		RestApiId:            aws.String(d.Get("rest_api_id").(string)),
+		PatchOperations: []*apigateway.PatchOperation{
+			{
+				Op:    aws.String(apigateway.OpReplace),
+				Path:  aws.String("/description"),
+				Value: aws.String(d.Get("description").(string)),
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+	log.Printf("[DEBUG] Updated API Gateway Documentation Version %s", d.Id())
+
+	return resourceAwsApiGatewayDocumentationVersionRead(d, meta)
+}
+
+func resourceAwsApiGatewayDocumentationVersionDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).apigateway
+	log.Printf("[DEBUG] Deleting API Gateway Documentation Version: %s", d.Id())
+
+	_, err := conn.DeleteDocumentationVersion(&apigateway.DeleteDocumentationVersionInput{
+		DocumentationVersion: aws.String(d.Get("version").(string)),
+		RestApiId:            aws.String(d.Get("rest_api_id").(string)),
+	})
+	return err
+}
+
+func decodeApiGatewayDocumentationVersionId(id string) (string, string, error) {
+	parts := strings.Split(id, "/")
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("Expected ID in the form of REST-API-ID/VERSION, given: %q", id)
+	}
+	return parts[0], parts[1], nil
+}

--- a/aws/resource_aws_api_gateway_documentation_version_test.go
+++ b/aws/resource_aws_api_gateway_documentation_version_test.go
@@ -1,0 +1,285 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/apigateway"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSAPIGatewayDocumentationVersion_basic(t *testing.T) {
+	var conf apigateway.DocumentationVersion
+
+	rString := acctest.RandString(8)
+	version := fmt.Sprintf("tf_acc_version_%s", rString)
+	apiName := fmt.Sprintf("tf_acc_api_doc_version_basic_%s", rString)
+
+	resourceName := "aws_api_gateway_documentation_version.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayDocumentationVersionDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSAPIGatewayDocumentationVersionBasicConfig(version, apiName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayDocumentationVersionExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "version", version),
+					resource.TestCheckResourceAttrSet(resourceName, "rest_api_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayDocumentationVersion_allFields(t *testing.T) {
+	var conf apigateway.DocumentationVersion
+
+	rString := acctest.RandString(8)
+	version := fmt.Sprintf("tf_acc_version_%s", rString)
+	apiName := fmt.Sprintf("tf_acc_api_doc_version_method_%s", rString)
+	stageName := fmt.Sprintf("tf_acc_stage_%s", rString)
+	description := fmt.Sprintf("Tf Acc Test description %s", rString)
+	uDescription := fmt.Sprintf("Tf Acc Test description updated %s", rString)
+
+	resourceName := "aws_api_gateway_documentation_version.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayDocumentationVersionDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSAPIGatewayDocumentationVersionAllFieldsConfig(version, apiName, stageName, description),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayDocumentationVersionExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "version", version),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+					resource.TestCheckResourceAttrSet(resourceName, "rest_api_id"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSAPIGatewayDocumentationVersionAllFieldsConfig(version, apiName, stageName, uDescription),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayDocumentationVersionExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "version", version),
+					resource.TestCheckResourceAttr(resourceName, "description", uDescription),
+					resource.TestCheckResourceAttrSet(resourceName, "rest_api_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayDocumentationVersion_importBasic(t *testing.T) {
+	rString := acctest.RandString(8)
+	version := fmt.Sprintf("tf_acc_version_import_%s", rString)
+	apiName := fmt.Sprintf("tf_acc_api_doc_version_import_%s", rString)
+
+	resourceName := "aws_api_gateway_documentation_version.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayDocumentationVersionDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSAPIGatewayDocumentationVersionBasicConfig(version, apiName),
+			},
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayDocumentationVersion_importAllFields(t *testing.T) {
+	rString := acctest.RandString(8)
+	version := fmt.Sprintf("tf_acc_version_import_af_%s", rString)
+	apiName := fmt.Sprintf("tf_acc_api_doc_version_import_af_%s", rString)
+	stageName := fmt.Sprintf("tf_acc_stage_%s", rString)
+	description := fmt.Sprintf("Tf Acc Test description %s", rString)
+
+	resourceName := "aws_api_gateway_documentation_version.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayDocumentationVersionDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSAPIGatewayDocumentationVersionAllFieldsConfig(version, apiName, stageName, description),
+			},
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSAPIGatewayDocumentationVersionExists(n string, res *apigateway.DocumentationVersion) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No API Gateway Documentation Version ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).apigateway
+
+		apiId, version, err := decodeApiGatewayDocumentationVersionId(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		req := &apigateway.GetDocumentationVersionInput{
+			DocumentationVersion: aws.String(version),
+			RestApiId:            aws.String(apiId),
+		}
+		docVersion, err := conn.GetDocumentationVersion(req)
+		if err != nil {
+			return err
+		}
+
+		*res = *docVersion
+
+		return nil
+	}
+}
+
+func testAccCheckAWSAPIGatewayDocumentationVersionDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).apigateway
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_api_gateway_documentation_version" {
+			continue
+		}
+
+		version, apiId, err := decodeApiGatewayDocumentationVersionId(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		req := &apigateway.GetDocumentationVersionInput{
+			DocumentationVersion: aws.String(version),
+			RestApiId:            aws.String(apiId),
+		}
+		_, err = conn.GetDocumentationVersion(req)
+		if err != nil {
+			if isAWSErr(err, apigateway.ErrCodeNotFoundException, "") {
+				return nil
+			}
+			return err
+		}
+
+		return fmt.Errorf("API Gateway Documentation Version %q still exists.", rs.Primary.ID)
+	}
+	return nil
+}
+
+func testAccAWSAPIGatewayDocumentationVersionBasicConfig(version, apiName string) string {
+	return fmt.Sprintf(`
+resource "aws_api_gateway_documentation_version" "test" {
+  version = "%s"
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  depends_on = ["aws_api_gateway_documentation_part.test"]
+}
+
+resource "aws_api_gateway_documentation_part" "test" {
+  location {
+    type = "API"
+  }
+  properties = "{\"description\":\"Terraform Acceptance Test\"}"
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+}
+
+resource "aws_api_gateway_rest_api" "test" {
+  name = "%s"
+}
+`, version, apiName)
+}
+
+func testAccAWSAPIGatewayDocumentationVersionAllFieldsConfig(version, apiName, stageName, description string) string {
+	return fmt.Sprintf(`
+resource "aws_api_gateway_documentation_version" "test" {
+  version = "%s"
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  description = "%s"
+  depends_on = ["aws_api_gateway_documentation_part.test"]
+}
+
+resource "aws_api_gateway_documentation_part" "test" {
+  location {
+    type = "API"
+  }
+  properties = "{\"description\":\"Terraform Acceptance Test\"}"
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+}
+
+resource "aws_api_gateway_resource" "test" {
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  parent_id = "${aws_api_gateway_rest_api.test.root_resource_id}"
+  path_part = "test"
+}
+
+resource "aws_api_gateway_method" "test" {
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  resource_id = "${aws_api_gateway_resource.test.id}"
+  http_method = "GET"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_method_response" "error" {
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  resource_id = "${aws_api_gateway_resource.test.id}"
+  http_method = "${aws_api_gateway_method.test.http_method}"
+  status_code = "400"
+}
+
+resource "aws_api_gateway_integration" "test" {
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  resource_id = "${aws_api_gateway_resource.test.id}"
+  http_method = "${aws_api_gateway_method.test.http_method}"
+
+  type = "HTTP"
+  uri = "https://www.google.co.uk"
+  integration_http_method = "GET"
+}
+
+resource "aws_api_gateway_integration_response" "test" {
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  resource_id = "${aws_api_gateway_resource.test.id}"
+  http_method = "${aws_api_gateway_integration.test.http_method}"
+  status_code = "${aws_api_gateway_method_response.error.status_code}"
+}
+
+resource "aws_api_gateway_deployment" "test" {
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  stage_name  = "first"
+  depends_on = ["aws_api_gateway_integration_response.test"]
+}
+
+resource "aws_api_gateway_stage" "test" {
+  stage_name = "%s"
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  deployment_id = "${aws_api_gateway_deployment.test.id}"
+  documentation_version = "${aws_api_gateway_documentation_version.test.version}"
+}
+
+resource "aws_api_gateway_rest_api" "test" {
+  name = "%s"
+}
+`, version, description, stageName, apiName)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -263,6 +263,9 @@
                         <li<%= sidebar_current("docs-aws-resource-api-gateway-documentation-part") %>>
                             <a href="/docs/providers/aws/r/api_gateway_documentation_part.html">aws_api_gateway_documentation_part</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-resource-api-gateway-documentation-version") %>>
+                            <a href="/docs/providers/aws/r/api_gateway_documentation_version.html">aws_api_gateway_documentation_version</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-resource-api-gateway-domain-name") %>>
                             <a href="/docs/providers/aws/r/api_gateway_domain_name.html">aws_api_gateway_domain_name</a>
                         </li>

--- a/website/docs/r/api_gateway_documentation_version.html.markdown
+++ b/website/docs/r/api_gateway_documentation_version.html.markdown
@@ -1,0 +1,54 @@
+---
+layout: "aws"
+page_title: "AWS: aws_api_gateway_documentation_version"
+sidebar_current: "docs-aws-resource-api-gateway-documentation-version"
+description: |-
+  Provides a resource to manage an API Gateway Documentation Version.
+---
+
+# aws_api_gateway_documentation_version
+
+Provides a resource to manage an API Gateway Documentation Version.
+
+## Example Usage
+
+```hcl
+resource "aws_api_gateway_documentation_version" "example" {
+  version = "example_version"
+  rest_api_id = "${aws_api_gateway_rest_api.example.id}"
+  description = "Example description"
+  depends_on = ["aws_api_gateway_documentation_part.example"]
+}
+
+resource "aws_api_gateway_rest_api" "example" {
+  name = "example_api"
+}
+
+resource "aws_api_gateway_documentation_part" "example" {
+  location {
+    type = "API"
+  }
+  properties = "{\"description\":\"Example\"}"
+  rest_api_id = "${aws_api_gateway_rest_api.example.id}"
+}
+```
+
+## Argument Reference
+
+The following argument is supported:
+
+* `version` - (Required) The version identifier of the API documentation snapshot.
+* `rest_api_id` - (Required) The ID of the associated Rest API
+* `description` - (Optional) The description of the API documentation version.
+
+## Attribute Reference
+
+The arguments listed above are all exported as attributes.
+
+## Import
+
+API Gateway documentation versions can be imported using `REST-API-ID/VERSION`, e.g.
+
+```
+$ terraform import aws_api_gateway_documentation_version.example 5i4e1ko720/example-version
+```


### PR DESCRIPTION
## Test results

```
=== RUN   TestAccAWSAPIGatewayDocumentationVersion_basic
--- PASS: TestAccAWSAPIGatewayDocumentationVersion_basic (45.77s)
=== RUN   TestAccAWSAPIGatewayDocumentationVersion_allFields
--- PASS: TestAccAWSAPIGatewayDocumentationVersion_allFields (108.51s)
=== RUN   TestAccAWSAPIGatewayDocumentationVersion_importBasic
--- PASS: TestAccAWSAPIGatewayDocumentationVersion_importBasic (50.27s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	204.595s
```