### PR TITLE
Bump AWS SDK to v1.12.73

### DIFF
--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.12.72"
+const SDKVersion = "1.12.73"

--- a/vendor/github.com/aws/aws-sdk-go/service/budgets/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/budgets/api.go
@@ -53,7 +53,7 @@ func (c *Budgets) CreateBudgetRequest(input *CreateBudgetInput) (req *request.Re
 
 // CreateBudget API operation for AWS Budgets.
 //
-// Create a new budget
+// Creates a budget and, if included, notifications and subscribers.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -64,19 +64,18 @@ func (c *Budgets) CreateBudgetRequest(input *CreateBudgetInput) (req *request.Re
 //
 // Returned Error Codes:
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
-//   This exception is thrown if any request is given an invalid parameter. E.g.,
-//   if a required Date field is null.
+//   An error on the client occurred. Typically, the cause is an invalid input
+//   value.
 //
 //   * ErrCodeInternalErrorException "InternalErrorException"
-//   This exception is thrown on an unknown internal failure.
+//   An error on the server occurred during the processing of your request. Try
+//   again later.
 //
 //   * ErrCodeCreationLimitExceededException "CreationLimitExceededException"
-//   The exception is thrown when customer tries to create a record (e.g. budget),
-//   but the number this record already exceeds the limitation.
+//   You've exceeded the notification or subscriber limit.
 //
 //   * ErrCodeDuplicateRecordException "DuplicateRecordException"
-//   The exception is thrown when customer tries to create a record (e.g. budget)
-//   that already exists.
+//   The budget name already exists. Budget names must be unique within an account.
 //
 func (c *Budgets) CreateBudget(input *CreateBudgetInput) (*CreateBudgetOutput, error) {
 	req, out := c.CreateBudgetRequest(input)
@@ -141,7 +140,8 @@ func (c *Budgets) CreateNotificationRequest(input *CreateNotificationInput) (req
 
 // CreateNotification API operation for AWS Budgets.
 //
-// Create a new Notification with subscribers for a budget
+// Creates a notification. You must create the budget before you create the
+// associated notification.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -152,23 +152,21 @@ func (c *Budgets) CreateNotificationRequest(input *CreateNotificationInput) (req
 //
 // Returned Error Codes:
 //   * ErrCodeInternalErrorException "InternalErrorException"
-//   This exception is thrown on an unknown internal failure.
+//   An error on the server occurred during the processing of your request. Try
+//   again later.
 //
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
-//   This exception is thrown if any request is given an invalid parameter. E.g.,
-//   if a required Date field is null.
+//   An error on the client occurred. Typically, the cause is an invalid input
+//   value.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
-//   This exception is thrown if a requested entity is not found. E.g., if a budget
-//   id doesn't exist for an account ID.
+//   We can’t locate the resource that you specified.
 //
 //   * ErrCodeCreationLimitExceededException "CreationLimitExceededException"
-//   The exception is thrown when customer tries to create a record (e.g. budget),
-//   but the number this record already exceeds the limitation.
+//   You've exceeded the notification or subscriber limit.
 //
 //   * ErrCodeDuplicateRecordException "DuplicateRecordException"
-//   The exception is thrown when customer tries to create a record (e.g. budget)
-//   that already exists.
+//   The budget name already exists. Budget names must be unique within an account.
 //
 func (c *Budgets) CreateNotification(input *CreateNotificationInput) (*CreateNotificationOutput, error) {
 	req, out := c.CreateNotificationRequest(input)
@@ -233,7 +231,8 @@ func (c *Budgets) CreateSubscriberRequest(input *CreateSubscriberInput) (req *re
 
 // CreateSubscriber API operation for AWS Budgets.
 //
-// Create a new Subscriber for a notification
+// Creates a subscriber. You must create the associated budget and notification
+// before you create the subscriber.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -244,23 +243,21 @@ func (c *Budgets) CreateSubscriberRequest(input *CreateSubscriberInput) (req *re
 //
 // Returned Error Codes:
 //   * ErrCodeInternalErrorException "InternalErrorException"
-//   This exception is thrown on an unknown internal failure.
+//   An error on the server occurred during the processing of your request. Try
+//   again later.
 //
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
-//   This exception is thrown if any request is given an invalid parameter. E.g.,
-//   if a required Date field is null.
+//   An error on the client occurred. Typically, the cause is an invalid input
+//   value.
 //
 //   * ErrCodeCreationLimitExceededException "CreationLimitExceededException"
-//   The exception is thrown when customer tries to create a record (e.g. budget),
-//   but the number this record already exceeds the limitation.
+//   You've exceeded the notification or subscriber limit.
 //
 //   * ErrCodeDuplicateRecordException "DuplicateRecordException"
-//   The exception is thrown when customer tries to create a record (e.g. budget)
-//   that already exists.
+//   The budget name already exists. Budget names must be unique within an account.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
-//   This exception is thrown if a requested entity is not found. E.g., if a budget
-//   id doesn't exist for an account ID.
+//   We can’t locate the resource that you specified.
 //
 func (c *Budgets) CreateSubscriber(input *CreateSubscriberInput) (*CreateSubscriberOutput, error) {
 	req, out := c.CreateSubscriberRequest(input)
@@ -325,7 +322,10 @@ func (c *Budgets) DeleteBudgetRequest(input *DeleteBudgetInput) (req *request.Re
 
 // DeleteBudget API operation for AWS Budgets.
 //
-// Delete a budget and related notifications
+// Deletes a budget. You can delete your budget at any time.
+//
+// Deleting a budget also deletes the notifications and subscribers associated
+// with that budget.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -336,15 +336,15 @@ func (c *Budgets) DeleteBudgetRequest(input *DeleteBudgetInput) (req *request.Re
 //
 // Returned Error Codes:
 //   * ErrCodeInternalErrorException "InternalErrorException"
-//   This exception is thrown on an unknown internal failure.
+//   An error on the server occurred during the processing of your request. Try
+//   again later.
 //
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
-//   This exception is thrown if any request is given an invalid parameter. E.g.,
-//   if a required Date field is null.
+//   An error on the client occurred. Typically, the cause is an invalid input
+//   value.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
-//   This exception is thrown if a requested entity is not found. E.g., if a budget
-//   id doesn't exist for an account ID.
+//   We can’t locate the resource that you specified.
 //
 func (c *Budgets) DeleteBudget(input *DeleteBudgetInput) (*DeleteBudgetOutput, error) {
 	req, out := c.DeleteBudgetRequest(input)
@@ -409,7 +409,10 @@ func (c *Budgets) DeleteNotificationRequest(input *DeleteNotificationInput) (req
 
 // DeleteNotification API operation for AWS Budgets.
 //
-// Delete a notification and related subscribers
+// Deletes a notification.
+//
+// Deleting a notification also deletes the subscribers associated with the
+// notification.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -420,15 +423,15 @@ func (c *Budgets) DeleteNotificationRequest(input *DeleteNotificationInput) (req
 //
 // Returned Error Codes:
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
-//   This exception is thrown if any request is given an invalid parameter. E.g.,
-//   if a required Date field is null.
+//   An error on the client occurred. Typically, the cause is an invalid input
+//   value.
 //
 //   * ErrCodeInternalErrorException "InternalErrorException"
-//   This exception is thrown on an unknown internal failure.
+//   An error on the server occurred during the processing of your request. Try
+//   again later.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
-//   This exception is thrown if a requested entity is not found. E.g., if a budget
-//   id doesn't exist for an account ID.
+//   We can’t locate the resource that you specified.
 //
 func (c *Budgets) DeleteNotification(input *DeleteNotificationInput) (*DeleteNotificationOutput, error) {
 	req, out := c.DeleteNotificationRequest(input)
@@ -493,7 +496,9 @@ func (c *Budgets) DeleteSubscriberRequest(input *DeleteSubscriberInput) (req *re
 
 // DeleteSubscriber API operation for AWS Budgets.
 //
-// Delete a Subscriber for a notification
+// Deletes a subscriber.
+//
+// Deleting the last subscriber to a notification also deletes the notification.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -504,15 +509,15 @@ func (c *Budgets) DeleteSubscriberRequest(input *DeleteSubscriberInput) (req *re
 //
 // Returned Error Codes:
 //   * ErrCodeInternalErrorException "InternalErrorException"
-//   This exception is thrown on an unknown internal failure.
+//   An error on the server occurred during the processing of your request. Try
+//   again later.
 //
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
-//   This exception is thrown if any request is given an invalid parameter. E.g.,
-//   if a required Date field is null.
+//   An error on the client occurred. Typically, the cause is an invalid input
+//   value.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
-//   This exception is thrown if a requested entity is not found. E.g., if a budget
-//   id doesn't exist for an account ID.
+//   We can’t locate the resource that you specified.
 //
 func (c *Budgets) DeleteSubscriber(input *DeleteSubscriberInput) (*DeleteSubscriberOutput, error) {
 	req, out := c.DeleteSubscriberRequest(input)
@@ -577,7 +582,7 @@ func (c *Budgets) DescribeBudgetRequest(input *DescribeBudgetInput) (req *reques
 
 // DescribeBudget API operation for AWS Budgets.
 //
-// Get a single budget
+// Describes a budget.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -588,15 +593,15 @@ func (c *Budgets) DescribeBudgetRequest(input *DescribeBudgetInput) (req *reques
 //
 // Returned Error Codes:
 //   * ErrCodeInternalErrorException "InternalErrorException"
-//   This exception is thrown on an unknown internal failure.
+//   An error on the server occurred during the processing of your request. Try
+//   again later.
 //
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
-//   This exception is thrown if any request is given an invalid parameter. E.g.,
-//   if a required Date field is null.
+//   An error on the client occurred. Typically, the cause is an invalid input
+//   value.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
-//   This exception is thrown if a requested entity is not found. E.g., if a budget
-//   id doesn't exist for an account ID.
+//   We can’t locate the resource that you specified.
 //
 func (c *Budgets) DescribeBudget(input *DescribeBudgetInput) (*DescribeBudgetOutput, error) {
 	req, out := c.DescribeBudgetRequest(input)
@@ -661,7 +666,7 @@ func (c *Budgets) DescribeBudgetsRequest(input *DescribeBudgetsInput) (req *requ
 
 // DescribeBudgets API operation for AWS Budgets.
 //
-// Get all budgets for an account
+// Lists the budgets associated with an account.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -672,22 +677,21 @@ func (c *Budgets) DescribeBudgetsRequest(input *DescribeBudgetsInput) (req *requ
 //
 // Returned Error Codes:
 //   * ErrCodeInternalErrorException "InternalErrorException"
-//   This exception is thrown on an unknown internal failure.
+//   An error on the server occurred during the processing of your request. Try
+//   again later.
 //
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
-//   This exception is thrown if any request is given an invalid parameter. E.g.,
-//   if a required Date field is null.
+//   An error on the client occurred. Typically, the cause is an invalid input
+//   value.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
-//   This exception is thrown if a requested entity is not found. E.g., if a budget
-//   id doesn't exist for an account ID.
+//   We can’t locate the resource that you specified.
 //
 //   * ErrCodeInvalidNextTokenException "InvalidNextTokenException"
-//   This exception is thrown if paging token signature didn't match the token,
-//   or the paging token isn't for this request
+//   The pagination token is invalid.
 //
 //   * ErrCodeExpiredNextTokenException "ExpiredNextTokenException"
-//   This exception is thrown if the paging token is expired - past its TTL
+//   The pagination token expired.
 //
 func (c *Budgets) DescribeBudgets(input *DescribeBudgetsInput) (*DescribeBudgetsOutput, error) {
 	req, out := c.DescribeBudgetsRequest(input)
@@ -752,7 +756,7 @@ func (c *Budgets) DescribeNotificationsForBudgetRequest(input *DescribeNotificat
 
 // DescribeNotificationsForBudget API operation for AWS Budgets.
 //
-// Get notifications of a budget
+// Lists the notifications associated with a budget.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -763,22 +767,21 @@ func (c *Budgets) DescribeNotificationsForBudgetRequest(input *DescribeNotificat
 //
 // Returned Error Codes:
 //   * ErrCodeInternalErrorException "InternalErrorException"
-//   This exception is thrown on an unknown internal failure.
+//   An error on the server occurred during the processing of your request. Try
+//   again later.
 //
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
-//   This exception is thrown if any request is given an invalid parameter. E.g.,
-//   if a required Date field is null.
+//   An error on the client occurred. Typically, the cause is an invalid input
+//   value.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
-//   This exception is thrown if a requested entity is not found. E.g., if a budget
-//   id doesn't exist for an account ID.
+//   We can’t locate the resource that you specified.
 //
 //   * ErrCodeInvalidNextTokenException "InvalidNextTokenException"
-//   This exception is thrown if paging token signature didn't match the token,
-//   or the paging token isn't for this request
+//   The pagination token is invalid.
 //
 //   * ErrCodeExpiredNextTokenException "ExpiredNextTokenException"
-//   This exception is thrown if the paging token is expired - past its TTL
+//   The pagination token expired.
 //
 func (c *Budgets) DescribeNotificationsForBudget(input *DescribeNotificationsForBudgetInput) (*DescribeNotificationsForBudgetOutput, error) {
 	req, out := c.DescribeNotificationsForBudgetRequest(input)
@@ -843,7 +846,7 @@ func (c *Budgets) DescribeSubscribersForNotificationRequest(input *DescribeSubsc
 
 // DescribeSubscribersForNotification API operation for AWS Budgets.
 //
-// Get subscribers of a notification
+// Lists the subscribers associated with a notification.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -854,22 +857,21 @@ func (c *Budgets) DescribeSubscribersForNotificationRequest(input *DescribeSubsc
 //
 // Returned Error Codes:
 //   * ErrCodeInternalErrorException "InternalErrorException"
-//   This exception is thrown on an unknown internal failure.
+//   An error on the server occurred during the processing of your request. Try
+//   again later.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
-//   This exception is thrown if a requested entity is not found. E.g., if a budget
-//   id doesn't exist for an account ID.
+//   We can’t locate the resource that you specified.
 //
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
-//   This exception is thrown if any request is given an invalid parameter. E.g.,
-//   if a required Date field is null.
+//   An error on the client occurred. Typically, the cause is an invalid input
+//   value.
 //
 //   * ErrCodeInvalidNextTokenException "InvalidNextTokenException"
-//   This exception is thrown if paging token signature didn't match the token,
-//   or the paging token isn't for this request
+//   The pagination token is invalid.
 //
 //   * ErrCodeExpiredNextTokenException "ExpiredNextTokenException"
-//   This exception is thrown if the paging token is expired - past its TTL
+//   The pagination token expired.
 //
 func (c *Budgets) DescribeSubscribersForNotification(input *DescribeSubscribersForNotificationInput) (*DescribeSubscribersForNotificationOutput, error) {
 	req, out := c.DescribeSubscribersForNotificationRequest(input)
@@ -934,7 +936,9 @@ func (c *Budgets) UpdateBudgetRequest(input *UpdateBudgetInput) (req *request.Re
 
 // UpdateBudget API operation for AWS Budgets.
 //
-// Update the information of a budget already created
+// Updates a budget. You can change every part of a budget except for the budgetName
+// and the calculatedSpend. When a budget is modified, the calculatedSpend drops
+// to zero until AWS has new usage data to use for forecasting.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -945,15 +949,15 @@ func (c *Budgets) UpdateBudgetRequest(input *UpdateBudgetInput) (req *request.Re
 //
 // Returned Error Codes:
 //   * ErrCodeInternalErrorException "InternalErrorException"
-//   This exception is thrown on an unknown internal failure.
+//   An error on the server occurred during the processing of your request. Try
+//   again later.
 //
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
-//   This exception is thrown if any request is given an invalid parameter. E.g.,
-//   if a required Date field is null.
+//   An error on the client occurred. Typically, the cause is an invalid input
+//   value.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
-//   This exception is thrown if a requested entity is not found. E.g., if a budget
-//   id doesn't exist for an account ID.
+//   We can’t locate the resource that you specified.
 //
 func (c *Budgets) UpdateBudget(input *UpdateBudgetInput) (*UpdateBudgetOutput, error) {
 	req, out := c.UpdateBudgetRequest(input)
@@ -1018,7 +1022,7 @@ func (c *Budgets) UpdateNotificationRequest(input *UpdateNotificationInput) (req
 
 // UpdateNotification API operation for AWS Budgets.
 //
-// Update the information about a notification already created
+// Updates a notification.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1029,19 +1033,18 @@ func (c *Budgets) UpdateNotificationRequest(input *UpdateNotificationInput) (req
 //
 // Returned Error Codes:
 //   * ErrCodeInternalErrorException "InternalErrorException"
-//   This exception is thrown on an unknown internal failure.
+//   An error on the server occurred during the processing of your request. Try
+//   again later.
 //
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
-//   This exception is thrown if any request is given an invalid parameter. E.g.,
-//   if a required Date field is null.
+//   An error on the client occurred. Typically, the cause is an invalid input
+//   value.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
-//   This exception is thrown if a requested entity is not found. E.g., if a budget
-//   id doesn't exist for an account ID.
+//   We can’t locate the resource that you specified.
 //
 //   * ErrCodeDuplicateRecordException "DuplicateRecordException"
-//   The exception is thrown when customer tries to create a record (e.g. budget)
-//   that already exists.
+//   The budget name already exists. Budget names must be unique within an account.
 //
 func (c *Budgets) UpdateNotification(input *UpdateNotificationInput) (*UpdateNotificationOutput, error) {
 	req, out := c.UpdateNotificationRequest(input)
@@ -1106,7 +1109,7 @@ func (c *Budgets) UpdateSubscriberRequest(input *UpdateSubscriberInput) (req *re
 
 // UpdateSubscriber API operation for AWS Budgets.
 //
-// Update a subscriber
+// Updates a subscriber.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1117,19 +1120,18 @@ func (c *Budgets) UpdateSubscriberRequest(input *UpdateSubscriberInput) (req *re
 //
 // Returned Error Codes:
 //   * ErrCodeInternalErrorException "InternalErrorException"
-//   This exception is thrown on an unknown internal failure.
+//   An error on the server occurred during the processing of your request. Try
+//   again later.
 //
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
-//   This exception is thrown if any request is given an invalid parameter. E.g.,
-//   if a required Date field is null.
+//   An error on the client occurred. Typically, the cause is an invalid input
+//   value.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
-//   This exception is thrown if a requested entity is not found. E.g., if a budget
-//   id doesn't exist for an account ID.
+//   We can’t locate the resource that you specified.
 //
 //   * ErrCodeDuplicateRecordException "DuplicateRecordException"
-//   The exception is thrown when customer tries to create a record (e.g. budget)
-//   that already exists.
+//   The budget name already exists. Budget names must be unique within an account.
 //
 func (c *Budgets) UpdateSubscriber(input *UpdateSubscriberInput) (*UpdateSubscriberOutput, error) {
 	req, out := c.UpdateSubscriberRequest(input)
@@ -1152,41 +1154,62 @@ func (c *Budgets) UpdateSubscriberWithContext(ctx aws.Context, input *UpdateSubs
 	return out, req.Send()
 }
 
-// AWS Budget model
+// Represents the output of the CreateBudget operation. The content consists
+// of the detailed metadata and data file information, and the current status
+// of the budget.
+//
+// The ARN pattern for a budget is: arn:aws:budgetservice::AccountId:budget/budgetName
 type Budget struct {
 	_ struct{} `type:"structure"`
 
-	// A structure that represents either a cost spend or usage spend. Contains
-	// an amount and a unit.
+	// The total amount of cost, usage, or RI utilization that you want to track
+	// with your budget.
 	//
-	// BudgetLimit is a required field
-	BudgetLimit *Spend `type:"structure" required:"true"`
+	// BudgetLimit is required for cost or usage budgets, but optional for RI utilization
+	// budgets. RI utilization budgets default to the only valid value for RI utilization
+	// budgets, which is 100.
+	BudgetLimit *Spend `type:"structure"`
 
-	// A string represents the budget name. No ":" and "\" character is allowed.
+	// The name of a budget. Unique within accounts. : and \ characters are not
+	// allowed in the BudgetName.
 	//
 	// BudgetName is a required field
 	BudgetName *string `type:"string" required:"true"`
 
-	// The type of a budget. It should be COST, USAGE, or RI_UTILIZATION.
+	// Whether this budget tracks monetary costs, usage, or RI utilization.
 	//
 	// BudgetType is a required field
 	BudgetType *string `type:"string" required:"true" enum:"BudgetType"`
 
-	// A structure that holds the actual and forecasted spend for a budget.
+	// The actual and forecasted cost or usage being tracked by a budget.
 	CalculatedSpend *CalculatedSpend `type:"structure"`
 
-	// A map that represents the cost filters applied to the budget.
+	// The cost filters applied to a budget, such as service or region.
 	CostFilters map[string][]*string `type:"map"`
 
-	// This includes the options for getting the cost of a budget.
+	// The types of costs included in this budget.
 	CostTypes *CostTypes `type:"structure"`
 
-	// A time period indicating the start date and end date of a budget.
+	// The period of time covered by a budget. Has a start date and an end date.
+	// The start date must come before the end date. There are no restrictions on
+	// the end date.
 	//
-	// TimePeriod is a required field
-	TimePeriod *TimePeriod `type:"structure" required:"true"`
+	// If you created your budget and didn't specify a start date, AWS defaults
+	// to the start of your chosen time period (i.e. DAILY, MONTHLY, QUARTERLY,
+	// ANNUALLY). For example, if you created your budget on January 24th 2018,
+	// chose DAILY, and didn't set a start date, AWS set your start date to 01/24/18
+	// 00:00 UTC. If you chose MONTHLY, AWS set your start date to 01/01/18 00:00
+	// UTC. If you didn't specify an end date, AWS set your end date to 06/15/87
+	// 00:00 UTC. The defaults are the same for the AWS Billing and Cost Management
+	// console and the API.
+	//
+	// You can change either date with the UpdateBudget operation.
+	//
+	// After the end date, AWS deletes the budget and all associated notifications
+	// and subscribers.
+	TimePeriod *TimePeriod `type:"structure"`
 
-	// The time unit of the budget. e.g. MONTHLY, QUARTERLY, etc.
+	// The length of time until a budget resets the actual and forecasted spend.
 	//
 	// TimeUnit is a required field
 	TimeUnit *string `type:"string" required:"true" enum:"TimeUnit"`
@@ -1205,17 +1228,11 @@ func (s Budget) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *Budget) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "Budget"}
-	if s.BudgetLimit == nil {
-		invalidParams.Add(request.NewErrParamRequired("BudgetLimit"))
-	}
 	if s.BudgetName == nil {
 		invalidParams.Add(request.NewErrParamRequired("BudgetName"))
 	}
 	if s.BudgetType == nil {
 		invalidParams.Add(request.NewErrParamRequired("BudgetType"))
-	}
-	if s.TimePeriod == nil {
-		invalidParams.Add(request.NewErrParamRequired("TimePeriod"))
 	}
 	if s.TimeUnit == nil {
 		invalidParams.Add(request.NewErrParamRequired("TimeUnit"))
@@ -1228,11 +1245,6 @@ func (s *Budget) Validate() error {
 	if s.CalculatedSpend != nil {
 		if err := s.CalculatedSpend.Validate(); err != nil {
 			invalidParams.AddNested("CalculatedSpend", err.(request.ErrInvalidParams))
-		}
-	}
-	if s.TimePeriod != nil {
-		if err := s.TimePeriod.Validate(); err != nil {
-			invalidParams.AddNested("TimePeriod", err.(request.ErrInvalidParams))
 		}
 	}
 
@@ -1290,18 +1302,22 @@ func (s *Budget) SetTimeUnit(v string) *Budget {
 	return s
 }
 
-// A structure that holds the actual and forecasted spend for a budget.
+// The spend objects associated with this budget. The actualSpend tracks how
+// much you've used, cost, usage, or RI units, and the forecastedSpend tracks
+// how much you are predicted to spend if your current usage remains steady.
+//
+// For example, if it is the 20th of the month and you have spent 50 dollars
+// on Amazon EC2, your actualSpend is 50 USD, and your forecastedSpend is 75
+// USD.
 type CalculatedSpend struct {
 	_ struct{} `type:"structure"`
 
-	// A structure that represents either a cost spend or usage spend. Contains
-	// an amount and a unit.
+	// The amount of cost, usage, or RI units that you have used.
 	//
 	// ActualSpend is a required field
 	ActualSpend *Spend `type:"structure" required:"true"`
 
-	// A structure that represents either a cost spend or usage spend. Contains
-	// an amount and a unit.
+	// The amount of cost, usage, or RI units that you are forecasted to use.
 	ForecastedSpend *Spend `type:"structure"`
 }
 
@@ -1350,41 +1366,63 @@ func (s *CalculatedSpend) SetForecastedSpend(v *Spend) *CalculatedSpend {
 	return s
 }
 
-// This includes the options for getting the cost of a budget.
+// The types of cost included in a budget, such as tax and subscriptions.
 type CostTypes struct {
 	_ struct{} `type:"structure"`
 
-	// A boolean value whether to include credits in the cost budget.
+	// Specifies whether a budget includes credits.
+	//
+	// The default value is true.
 	IncludeCredit *bool `type:"boolean"`
 
-	// A boolean value whether to include discounts in the cost budget.
+	// Specifies whether a budget includes discounts.
+	//
+	// The default value is true.
 	IncludeDiscount *bool `type:"boolean"`
 
-	// A boolean value whether to include other subscription costs in the cost budget.
+	// Specifies whether a budget includes non-RI subscription costs.
+	//
+	// The default value is true.
 	IncludeOtherSubscription *bool `type:"boolean"`
 
-	// A boolean value whether to include recurring costs in the cost budget.
+	// Specifies whether a budget includes recurring fees such as monthly RI fees.
+	//
+	// The default value is true.
 	IncludeRecurring *bool `type:"boolean"`
 
-	// A boolean value whether to include refunds in the cost budget.
+	// Specifies whether a budget includes refunds.
+	//
+	// The default value is true.
 	IncludeRefund *bool `type:"boolean"`
 
-	// A boolean value whether to include subscriptions in the cost budget.
+	// Specifies whether a budget includes subscriptions.
+	//
+	// The default value is true.
 	IncludeSubscription *bool `type:"boolean"`
 
-	// A boolean value whether to include support costs in the cost budget.
+	// Specifies whether a budget includes support subscription fees.
+	//
+	// The default value is true.
 	IncludeSupport *bool `type:"boolean"`
 
-	// A boolean value whether to include tax in the cost budget.
+	// Specifies whether a budget includes taxes.
+	//
+	// The default value is true.
 	IncludeTax *bool `type:"boolean"`
 
-	// A boolean value whether to include upfront costs in the cost budget.
+	// Specifies whether a budget includes upfront RI costs.
+	//
+	// The default value is true.
 	IncludeUpfront *bool `type:"boolean"`
 
-	// A boolean value whether to include amortized costs in the cost budget.
+	// Specifies whether a budget uses the amortized rate.
+	//
+	// The default value is false.
 	UseAmortized *bool `type:"boolean"`
 
-	// A boolean value whether to use blended costs in the cost budget.
+	// Specifies whether a budget uses blended rate.
+	//
+	// The default value is false.
 	UseBlended *bool `type:"boolean"`
 }
 
@@ -1468,17 +1506,21 @@ func (s *CostTypes) SetUseBlended(v bool) *CostTypes {
 type CreateBudgetInput struct {
 	_ struct{} `type:"structure"`
 
-	// Account Id of the customer. It should be a 12 digit number.
+	// The accountId that is associated with the budget.
 	//
 	// AccountId is a required field
 	AccountId *string `min:"12" type:"string" required:"true"`
 
-	// AWS Budget model
+	// The budget object that you want to create.
 	//
 	// Budget is a required field
 	Budget *Budget `type:"structure" required:"true"`
 
-	// A list of Notifications, each with a list of subscribers.
+	// A notification that you want to associate with a budget. A budget can have
+	// up to five notifications, and each notification can have one SNS subscriber
+	// and up to ten email subscribers. If you include notifications and subscribers
+	// in your CreateBudget call, AWS creates the notifications and subscribers
+	// for you.
 	NotificationsWithSubscribers []*NotificationWithSubscribers `type:"list"`
 }
 
@@ -1563,23 +1605,25 @@ func (s CreateBudgetOutput) GoString() string {
 type CreateNotificationInput struct {
 	_ struct{} `type:"structure"`
 
-	// Account Id of the customer. It should be a 12 digit number.
+	// The accountId that is associated with the budget that you want to create
+	// a notification for.
 	//
 	// AccountId is a required field
 	AccountId *string `min:"12" type:"string" required:"true"`
 
-	// A string represents the budget name. No ":" and "\" character is allowed.
+	// The name of the budget that you want AWS to notified you about. Budget names
+	// must be unique within an account.
 	//
 	// BudgetName is a required field
 	BudgetName *string `type:"string" required:"true"`
 
-	// Notification model. Each budget may contain multiple notifications with different
-	// settings.
+	// The notification that you want to create.
 	//
 	// Notification is a required field
 	Notification *Notification `type:"structure" required:"true"`
 
-	// A list of subscribers.
+	// A list of subscribers that you want to associate with the notification. Each
+	// notification can have one SNS subscriber and up to ten email subscribers.
 	//
 	// Subscribers is a required field
 	Subscribers []*Subscriber `min:"1" type:"list" required:"true"`
@@ -1681,24 +1725,24 @@ func (s CreateNotificationOutput) GoString() string {
 type CreateSubscriberInput struct {
 	_ struct{} `type:"structure"`
 
-	// Account Id of the customer. It should be a 12 digit number.
+	// The accountId associated with the budget that you want to create a subscriber
+	// for.
 	//
 	// AccountId is a required field
 	AccountId *string `min:"12" type:"string" required:"true"`
 
-	// A string represents the budget name. No ":" and "\" character is allowed.
+	// The name of the budget that you want to subscribe to. Budget names must be
+	// unique within an account.
 	//
 	// BudgetName is a required field
 	BudgetName *string `type:"string" required:"true"`
 
-	// Notification model. Each budget may contain multiple notifications with different
-	// settings.
+	// The notification that you want to create a subscriber for.
 	//
 	// Notification is a required field
 	Notification *Notification `type:"structure" required:"true"`
 
-	// Subscriber model. Each notification may contain multiple subscribers with
-	// different addresses.
+	// The subscriber that you want to associate with a budget notification.
 	//
 	// Subscriber is a required field
 	Subscriber *Subscriber `type:"structure" required:"true"`
@@ -1792,12 +1836,12 @@ func (s CreateSubscriberOutput) GoString() string {
 type DeleteBudgetInput struct {
 	_ struct{} `type:"structure"`
 
-	// Account Id of the customer. It should be a 12 digit number.
+	// The accountId that is associated with the budget that you want to delete.
 	//
 	// AccountId is a required field
 	AccountId *string `min:"12" type:"string" required:"true"`
 
-	// A string represents the budget name. No ":" and "\" character is allowed.
+	// The name of the budget that you want to delete.
 	//
 	// BudgetName is a required field
 	BudgetName *string `type:"string" required:"true"`
@@ -1863,18 +1907,18 @@ func (s DeleteBudgetOutput) GoString() string {
 type DeleteNotificationInput struct {
 	_ struct{} `type:"structure"`
 
-	// Account Id of the customer. It should be a 12 digit number.
+	// The accountId that is associated with the budget whose notification you want
+	// to delete.
 	//
 	// AccountId is a required field
 	AccountId *string `min:"12" type:"string" required:"true"`
 
-	// A string represents the budget name. No ":" and "\" character is allowed.
+	// The name of the budget whose notification you want to delete.
 	//
 	// BudgetName is a required field
 	BudgetName *string `type:"string" required:"true"`
 
-	// Notification model. Each budget may contain multiple notifications with different
-	// settings.
+	// The notification that you want to delete.
 	//
 	// Notification is a required field
 	Notification *Notification `type:"structure" required:"true"`
@@ -1954,24 +1998,23 @@ func (s DeleteNotificationOutput) GoString() string {
 type DeleteSubscriberInput struct {
 	_ struct{} `type:"structure"`
 
-	// Account Id of the customer. It should be a 12 digit number.
+	// The accountId that is associated with the budget whose subscriber you want
+	// to delete.
 	//
 	// AccountId is a required field
 	AccountId *string `min:"12" type:"string" required:"true"`
 
-	// A string represents the budget name. No ":" and "\" character is allowed.
+	// The name of the budget whose subscriber you want to delete.
 	//
 	// BudgetName is a required field
 	BudgetName *string `type:"string" required:"true"`
 
-	// Notification model. Each budget may contain multiple notifications with different
-	// settings.
+	// The notification whose subscriber you want to delete.
 	//
 	// Notification is a required field
 	Notification *Notification `type:"structure" required:"true"`
 
-	// Subscriber model. Each notification may contain multiple subscribers with
-	// different addresses.
+	// The subscriber that you want to delete.
 	//
 	// Subscriber is a required field
 	Subscriber *Subscriber `type:"structure" required:"true"`
@@ -2065,12 +2108,13 @@ func (s DeleteSubscriberOutput) GoString() string {
 type DescribeBudgetInput struct {
 	_ struct{} `type:"structure"`
 
-	// Account Id of the customer. It should be a 12 digit number.
+	// The accountId that is associated with the budget that you want a description
+	// of.
 	//
 	// AccountId is a required field
 	AccountId *string `min:"12" type:"string" required:"true"`
 
-	// A string represents the budget name. No ":" and "\" character is allowed.
+	// The name of the budget that you want a description of.
 	//
 	// BudgetName is a required field
 	BudgetName *string `type:"string" required:"true"`
@@ -2121,7 +2165,7 @@ func (s *DescribeBudgetInput) SetBudgetName(v string) *DescribeBudgetInput {
 type DescribeBudgetOutput struct {
 	_ struct{} `type:"structure"`
 
-	// AWS Budget model
+	// The description of the budget.
 	Budget *Budget `type:"structure"`
 }
 
@@ -2145,16 +2189,16 @@ func (s *DescribeBudgetOutput) SetBudget(v *Budget) *DescribeBudgetOutput {
 type DescribeBudgetsInput struct {
 	_ struct{} `type:"structure"`
 
-	// Account Id of the customer. It should be a 12 digit number.
+	// The accountId that is associated with the budgets that you want descriptions
+	// of.
 	//
 	// AccountId is a required field
 	AccountId *string `min:"12" type:"string" required:"true"`
 
-	// An integer to represent how many entries a paginated response contains. Maximum
-	// is set to 100.
+	// Optional integer. Specifies the maximum number of results to return in response.
 	MaxResults *int64 `min:"1" type:"integer"`
 
-	// A generic String.
+	// The pagination token that indicates the next set of results to retrieve.
 	NextToken *string `type:"string"`
 }
 
@@ -2209,10 +2253,11 @@ func (s *DescribeBudgetsInput) SetNextToken(v string) *DescribeBudgetsInput {
 type DescribeBudgetsOutput struct {
 	_ struct{} `type:"structure"`
 
-	// A list of budgets
+	// A list of budgets.
 	Budgets []*Budget `type:"list"`
 
-	// A generic String.
+	// The pagination token that indicates the next set of results that you can
+	// retrieve.
 	NextToken *string `type:"string"`
 }
 
@@ -2242,21 +2287,21 @@ func (s *DescribeBudgetsOutput) SetNextToken(v string) *DescribeBudgetsOutput {
 type DescribeNotificationsForBudgetInput struct {
 	_ struct{} `type:"structure"`
 
-	// Account Id of the customer. It should be a 12 digit number.
+	// The accountId that is associated with the budget whose notifications you
+	// want descriptions of.
 	//
 	// AccountId is a required field
 	AccountId *string `min:"12" type:"string" required:"true"`
 
-	// A string represents the budget name. No ":" and "\" character is allowed.
+	// The name of the budget whose notifications you want descriptions of.
 	//
 	// BudgetName is a required field
 	BudgetName *string `type:"string" required:"true"`
 
-	// An integer to represent how many entries a paginated response contains. Maximum
-	// is set to 100.
+	// Optional integer. Specifies the maximum number of results to return in response.
 	MaxResults *int64 `min:"1" type:"integer"`
 
-	// A generic String.
+	// The pagination token that indicates the next set of results to retrieve.
 	NextToken *string `type:"string"`
 }
 
@@ -2320,10 +2365,11 @@ func (s *DescribeNotificationsForBudgetInput) SetNextToken(v string) *DescribeNo
 type DescribeNotificationsForBudgetOutput struct {
 	_ struct{} `type:"structure"`
 
-	// A generic String.
+	// The pagination token that indicates the next set of results that you can
+	// retrieve.
 	NextToken *string `type:"string"`
 
-	// A list of notifications.
+	// A list of notifications associated with a budget.
 	Notifications []*Notification `type:"list"`
 }
 
@@ -2353,25 +2399,24 @@ func (s *DescribeNotificationsForBudgetOutput) SetNotifications(v []*Notificatio
 type DescribeSubscribersForNotificationInput struct {
 	_ struct{} `type:"structure"`
 
-	// Account Id of the customer. It should be a 12 digit number.
+	// The accountId that is associated with the budget whose subscribers you want
+	// descriptions of.
 	//
 	// AccountId is a required field
 	AccountId *string `min:"12" type:"string" required:"true"`
 
-	// A string represents the budget name. No ":" and "\" character is allowed.
+	// The name of the budget whose subscribers you want descriptions of.
 	//
 	// BudgetName is a required field
 	BudgetName *string `type:"string" required:"true"`
 
-	// An integer to represent how many entries a paginated response contains. Maximum
-	// is set to 100.
+	// Optional integer. Specifies the maximum number of results to return in response.
 	MaxResults *int64 `min:"1" type:"integer"`
 
-	// A generic String.
+	// The pagination token that indicates the next set of results to retrieve.
 	NextToken *string `type:"string"`
 
-	// Notification model. Each budget may contain multiple notifications with different
-	// settings.
+	// The notification whose subscribers you want to list.
 	//
 	// Notification is a required field
 	Notification *Notification `type:"structure" required:"true"`
@@ -2451,10 +2496,11 @@ func (s *DescribeSubscribersForNotificationInput) SetNotification(v *Notificatio
 type DescribeSubscribersForNotificationOutput struct {
 	_ struct{} `type:"structure"`
 
-	// A generic String.
+	// The pagination token that indicates the next set of results that you can
+	// retrieve.
 	NextToken *string `type:"string"`
 
-	// A list of subscribers.
+	// A list of subscribers associated with a notification.
 	Subscribers []*Subscriber `min:"1" type:"list"`
 }
 
@@ -2480,28 +2526,41 @@ func (s *DescribeSubscribersForNotificationOutput) SetSubscribers(v []*Subscribe
 	return s
 }
 
-// Notification model. Each budget may contain multiple notifications with different
-// settings.
+// A notification associated with a budget. A budget can have up to five notifications.
+//
+// Each notification must have at least one subscriber. A notification can have
+// one SNS subscriber and up to ten email subscribers, for a total of 11 subscribers.
+//
+// For example, if you have a budget for 200 dollars and you want to be notified
+// when you go over 160 dollars, create a notification with the following parameters:
+//
+//    * A notificationType of ACTUAL
+//
+//    * A comparisonOperator of GREATER_THAN
+//
+//    * A notification threshold of 80
 type Notification struct {
 	_ struct{} `type:"structure"`
 
-	// The comparison operator of a notification. Currently we support less than,
-	// equal to and greater than.
+	// The comparison used for this notification.
 	//
 	// ComparisonOperator is a required field
 	ComparisonOperator *string `type:"string" required:"true" enum:"ComparisonOperator"`
 
-	// The type of a notification. It should be ACTUAL or FORECASTED.
+	// Whether the notification is for how much you have spent (ACTUAL) or for how
+	// much you are forecasted to spend (FORECASTED).
 	//
 	// NotificationType is a required field
 	NotificationType *string `type:"string" required:"true" enum:"NotificationType"`
 
-	// The threshold of a notification. It should be a number between 0 and 1,000,000,000.
+	// The threshold associated with a notification. Thresholds are always a percentage.
 	//
 	// Threshold is a required field
 	Threshold *float64 `min:"0.1" type:"double" required:"true"`
 
-	// The type of threshold for a notification. It can be PERCENTAGE or ABSOLUTE_VALUE.
+	// The type of threshold for a notification. For ACTUAL thresholds, AWS notifies
+	// you when you go over the threshold, and for FORECASTED thresholds AWS notifies
+	// you when you are forecasted to go over the threshold.
 	ThresholdType *string `type:"string" enum:"ThresholdType"`
 }
 
@@ -2561,18 +2620,17 @@ func (s *Notification) SetThresholdType(v string) *Notification {
 	return s
 }
 
-// A structure to relate notification and a list of subscribers who belong to
-// the notification.
+// A notification with subscribers. A notification can have one SNS subscriber
+// and up to ten email subscribers, for a total of 11 subscribers.
 type NotificationWithSubscribers struct {
 	_ struct{} `type:"structure"`
 
-	// Notification model. Each budget may contain multiple notifications with different
-	// settings.
+	// The notification associated with a budget.
 	//
 	// Notification is a required field
 	Notification *Notification `type:"structure" required:"true"`
 
-	// A list of subscribers.
+	// A list of subscribers who are subscribed to this notification.
 	//
 	// Subscribers is a required field
 	Subscribers []*Subscriber `min:"1" type:"list" required:"true"`
@@ -2634,17 +2692,24 @@ func (s *NotificationWithSubscribers) SetSubscribers(v []*Subscriber) *Notificat
 	return s
 }
 
-// A structure that represents either a cost spend or usage spend. Contains
-// an amount and a unit.
+// The amount of cost or usage being measured for a budget.
+//
+// For example, a Spend for 3 GB of S3 usage would have the following parameters:
+//
+//    * An Amount of 3
+//
+//    * A unit of GB
 type Spend struct {
 	_ struct{} `type:"structure"`
 
-	// A string to represent NumericValue.
+	// The cost or usage amount associated with a budget forecast, actual spend,
+	// or budget threshold.
 	//
 	// Amount is a required field
 	Amount *string `type:"string" required:"true"`
 
-	// A string to represent budget spend unit. It should be not null and not empty.
+	// The unit of measurement used for the budget forecast, actual spend, or budget
+	// threshold, such as dollars or GB.
 	//
 	// Unit is a required field
 	Unit *string `min:"1" type:"string" required:"true"`
@@ -2691,17 +2756,24 @@ func (s *Spend) SetUnit(v string) *Spend {
 	return s
 }
 
-// Subscriber model. Each notification may contain multiple subscribers with
-// different addresses.
+// The subscriber to a budget notification. The subscriber consists of a subscription
+// type and either an Amazon Simple Notification Service topic or an email address.
+//
+// For example, an email subscriber would have the following parameters:
+//
+//    * A subscriptionType of EMAIL
+//
+//    * An address of example@example.com
 type Subscriber struct {
 	_ struct{} `type:"structure"`
 
-	// String containing email or sns topic for the subscriber address.
+	// The address that AWS sends budget notifications to, either an SNS topic or
+	// an email.
 	//
 	// Address is a required field
 	Address *string `min:"1" type:"string" required:"true"`
 
-	// The subscription type of the subscriber. It can be SMS or EMAIL.
+	// The type of notification that AWS sends to a subscriber.
 	//
 	// SubscriptionType is a required field
 	SubscriptionType *string `type:"string" required:"true" enum:"SubscriptionType"`
@@ -2748,19 +2820,30 @@ func (s *Subscriber) SetSubscriptionType(v string) *Subscriber {
 	return s
 }
 
-// A time period indicating the start date and end date of a budget.
+// The period of time covered by a budget. Has a start date and an end date.
+// The start date must come before the end date. There are no restrictions on
+// the end date.
 type TimePeriod struct {
 	_ struct{} `type:"structure"`
 
-	// A generic timestamp. In Java it is transformed to a Date object.
+	// The end date for a budget. If you didn't specify an end date, AWS set your
+	// end date to 06/15/87 00:00 UTC. The defaults are the same for the AWS Billing
+	// and Cost Management console and the API.
 	//
-	// End is a required field
-	End *time.Time `type:"timestamp" timestampFormat:"unix" required:"true"`
+	// After the end date, AWS deletes the budget and all associated notifications
+	// and subscribers. You can change your end date with the UpdateBudget operation.
+	End *time.Time `type:"timestamp" timestampFormat:"unix"`
 
-	// A generic timestamp. In Java it is transformed to a Date object.
+	// The start date for a budget. If you created your budget and didn't specify
+	// a start date, AWS defaults to the start of your chosen time period (i.e.
+	// DAILY, MONTHLY, QUARTERLY, ANNUALLY). For example, if you created your budget
+	// on January 24th 2018, chose DAILY, and didn't set a start date, AWS set your
+	// start date to 01/24/18 00:00 UTC. If you chose MONTHLY, AWS set your start
+	// date to 01/01/18 00:00 UTC. The defaults are the same for the AWS Billing
+	// and Cost Management console and the API.
 	//
-	// Start is a required field
-	Start *time.Time `type:"timestamp" timestampFormat:"unix" required:"true"`
+	// You can change your start date with the UpdateBudget operation.
+	Start *time.Time `type:"timestamp" timestampFormat:"unix"`
 }
 
 // String returns the string representation
@@ -2771,22 +2854,6 @@ func (s TimePeriod) String() string {
 // GoString returns the string representation
 func (s TimePeriod) GoString() string {
 	return s.String()
-}
-
-// Validate inspects the fields of the type to determine if they are valid.
-func (s *TimePeriod) Validate() error {
-	invalidParams := request.ErrInvalidParams{Context: "TimePeriod"}
-	if s.End == nil {
-		invalidParams.Add(request.NewErrParamRequired("End"))
-	}
-	if s.Start == nil {
-		invalidParams.Add(request.NewErrParamRequired("Start"))
-	}
-
-	if invalidParams.Len() > 0 {
-		return invalidParams
-	}
-	return nil
 }
 
 // SetEnd sets the End field's value.
@@ -2805,12 +2872,12 @@ func (s *TimePeriod) SetStart(v time.Time) *TimePeriod {
 type UpdateBudgetInput struct {
 	_ struct{} `type:"structure"`
 
-	// Account Id of the customer. It should be a 12 digit number.
+	// The accountId that is associated with the budget that you want to update.
 	//
 	// AccountId is a required field
 	AccountId *string `min:"12" type:"string" required:"true"`
 
-	// AWS Budget model
+	// The budget that you want to update your budget to.
 	//
 	// NewBudget is a required field
 	NewBudget *Budget `type:"structure" required:"true"`
@@ -2881,24 +2948,23 @@ func (s UpdateBudgetOutput) GoString() string {
 type UpdateNotificationInput struct {
 	_ struct{} `type:"structure"`
 
-	// Account Id of the customer. It should be a 12 digit number.
+	// The accountId that is associated with the budget whose notification you want
+	// to update.
 	//
 	// AccountId is a required field
 	AccountId *string `min:"12" type:"string" required:"true"`
 
-	// A string represents the budget name. No ":" and "\" character is allowed.
+	// The name of the budget whose notification you want to update.
 	//
 	// BudgetName is a required field
 	BudgetName *string `type:"string" required:"true"`
 
-	// Notification model. Each budget may contain multiple notifications with different
-	// settings.
+	// The updated notification to be associated with a budget.
 	//
 	// NewNotification is a required field
 	NewNotification *Notification `type:"structure" required:"true"`
 
-	// Notification model. Each budget may contain multiple notifications with different
-	// settings.
+	// The previous notification associated with a budget.
 	//
 	// OldNotification is a required field
 	OldNotification *Notification `type:"structure" required:"true"`
@@ -2992,30 +3058,28 @@ func (s UpdateNotificationOutput) GoString() string {
 type UpdateSubscriberInput struct {
 	_ struct{} `type:"structure"`
 
-	// Account Id of the customer. It should be a 12 digit number.
+	// The accountId that is associated with the budget whose subscriber you want
+	// to update.
 	//
 	// AccountId is a required field
 	AccountId *string `min:"12" type:"string" required:"true"`
 
-	// A string represents the budget name. No ":" and "\" character is allowed.
+	// The name of the budget whose subscriber you want to update.
 	//
 	// BudgetName is a required field
 	BudgetName *string `type:"string" required:"true"`
 
-	// Subscriber model. Each notification may contain multiple subscribers with
-	// different addresses.
+	// The updated subscriber associated with a budget notification.
 	//
 	// NewSubscriber is a required field
 	NewSubscriber *Subscriber `type:"structure" required:"true"`
 
-	// Notification model. Each budget may contain multiple notifications with different
-	// settings.
+	// The notification whose subscriber you want to update.
 	//
 	// Notification is a required field
 	Notification *Notification `type:"structure" required:"true"`
 
-	// Subscriber model. Each notification may contain multiple subscribers with
-	// different addresses.
+	// The previous subscriber associated with a budget notification.
 	//
 	// OldSubscriber is a required field
 	OldSubscriber *Subscriber `type:"structure" required:"true"`

--- a/vendor/github.com/aws/aws-sdk-go/service/budgets/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/budgets/doc.go
@@ -3,7 +3,39 @@
 // Package budgets provides the client and types for making API
 // requests to AWS Budgets.
 //
-// All public APIs for AWS Budgets
+// Budgets enable you to plan your service usage, service costs, and your RI
+// utilization. You can also track how close your plan is to your budgeted amount
+// or to the free tier limits. Budgets provide you with a quick way to see your
+// usage-to-date and current estimated charges from AWS and to see how much
+// your predicted usage accrues in charges by the end of the month. Budgets
+// also compare current estimates and charges to the amount that you indicated
+// you want to use or spend and lets you see how much of your budget has been
+// used. AWS updates your budget status several times a day. Budgets track your
+// unblended costs, subscriptions, and refunds. You can create the following
+// types of budgets:
+//
+//    * Cost budgets allow you to say how much you want to spend on a service.
+//
+//    * Usage budgets allow you to say how many hours you want to use for one
+//    or more services.
+//
+//    * RI utilization budgets allow you to define a utilization threshold and
+//    receive alerts when RIs are tracking below that threshold.
+//
+// You can create up to 20,000 budgets per AWS master account. Your first two
+// budgets are free of charge. Each additional budget costs $0.02 per day. You
+// can set up optional notifications that warn you if you exceed, or are forecasted
+// to exceed, your budgeted amount. You can have notifications sent to an Amazon
+// SNS topic, to an email address, or to both. For more information, see Creating
+// an Amazon SNS Topic for Budget Notifications (https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/budgets-sns-policy.html).
+// AWS Free Tier usage alerts via AWS Budgets are provided for you, and do not
+// count toward your budget limits.
+//
+// Service Endpoint
+//
+// The AWS Budgets API provides the following endpoint:
+//
+//    * https://budgets.us-east-1.amazonaws.com
 //
 // See budgets package documentation for more information.
 // https://docs.aws.amazon.com/sdk-for-go/api/service/budgets/

--- a/vendor/github.com/aws/aws-sdk-go/service/budgets/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/budgets/errors.go
@@ -7,47 +7,44 @@ const (
 	// ErrCodeCreationLimitExceededException for service response error code
 	// "CreationLimitExceededException".
 	//
-	// The exception is thrown when customer tries to create a record (e.g. budget),
-	// but the number this record already exceeds the limitation.
+	// You've exceeded the notification or subscriber limit.
 	ErrCodeCreationLimitExceededException = "CreationLimitExceededException"
 
 	// ErrCodeDuplicateRecordException for service response error code
 	// "DuplicateRecordException".
 	//
-	// The exception is thrown when customer tries to create a record (e.g. budget)
-	// that already exists.
+	// The budget name already exists. Budget names must be unique within an account.
 	ErrCodeDuplicateRecordException = "DuplicateRecordException"
 
 	// ErrCodeExpiredNextTokenException for service response error code
 	// "ExpiredNextTokenException".
 	//
-	// This exception is thrown if the paging token is expired - past its TTL
+	// The pagination token expired.
 	ErrCodeExpiredNextTokenException = "ExpiredNextTokenException"
 
 	// ErrCodeInternalErrorException for service response error code
 	// "InternalErrorException".
 	//
-	// This exception is thrown on an unknown internal failure.
+	// An error on the server occurred during the processing of your request. Try
+	// again later.
 	ErrCodeInternalErrorException = "InternalErrorException"
 
 	// ErrCodeInvalidNextTokenException for service response error code
 	// "InvalidNextTokenException".
 	//
-	// This exception is thrown if paging token signature didn't match the token,
-	// or the paging token isn't for this request
+	// The pagination token is invalid.
 	ErrCodeInvalidNextTokenException = "InvalidNextTokenException"
 
 	// ErrCodeInvalidParameterException for service response error code
 	// "InvalidParameterException".
 	//
-	// This exception is thrown if any request is given an invalid parameter. E.g.,
-	// if a required Date field is null.
+	// An error on the client occurred. Typically, the cause is an invalid input
+	// value.
 	ErrCodeInvalidParameterException = "InvalidParameterException"
 
 	// ErrCodeNotFoundException for service response error code
 	// "NotFoundException".
 	//
-	// This exception is thrown if a requested entity is not found. E.g., if a budget
-	// id doesn't exist for an account ID.
+	// We can’t locate the resource that you specified.
 	ErrCodeNotFoundException = "NotFoundException"
 )

--- a/vendor/github.com/aws/aws-sdk-go/service/databasemigrationservice/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/databasemigrationservice/api.go
@@ -2275,6 +2275,145 @@ func (c *DatabaseMigrationService) DescribeRefreshSchemasStatusWithContext(ctx a
 	return out, req.Send()
 }
 
+const opDescribeReplicationInstanceTaskLogs = "DescribeReplicationInstanceTaskLogs"
+
+// DescribeReplicationInstanceTaskLogsRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeReplicationInstanceTaskLogs operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeReplicationInstanceTaskLogs for more information on using the DescribeReplicationInstanceTaskLogs
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeReplicationInstanceTaskLogsRequest method.
+//    req, resp := client.DescribeReplicationInstanceTaskLogsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/DescribeReplicationInstanceTaskLogs
+func (c *DatabaseMigrationService) DescribeReplicationInstanceTaskLogsRequest(input *DescribeReplicationInstanceTaskLogsInput) (req *request.Request, output *DescribeReplicationInstanceTaskLogsOutput) {
+	op := &request.Operation{
+		Name:       opDescribeReplicationInstanceTaskLogs,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"Marker"},
+			OutputTokens:    []string{"Marker"},
+			LimitToken:      "MaxRecords",
+			TruncationToken: "",
+		},
+	}
+
+	if input == nil {
+		input = &DescribeReplicationInstanceTaskLogsInput{}
+	}
+
+	output = &DescribeReplicationInstanceTaskLogsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeReplicationInstanceTaskLogs API operation for AWS Database Migration Service.
+//
+// Returns information about the task logs for the specified task.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Database Migration Service's
+// API operation DescribeReplicationInstanceTaskLogs for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceNotFoundFault "ResourceNotFoundFault"
+//   The resource could not be found.
+//
+//   * ErrCodeInvalidResourceStateFault "InvalidResourceStateFault"
+//   The resource is in a state that prevents it from being used for database
+//   migration.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/DescribeReplicationInstanceTaskLogs
+func (c *DatabaseMigrationService) DescribeReplicationInstanceTaskLogs(input *DescribeReplicationInstanceTaskLogsInput) (*DescribeReplicationInstanceTaskLogsOutput, error) {
+	req, out := c.DescribeReplicationInstanceTaskLogsRequest(input)
+	return out, req.Send()
+}
+
+// DescribeReplicationInstanceTaskLogsWithContext is the same as DescribeReplicationInstanceTaskLogs with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeReplicationInstanceTaskLogs for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *DatabaseMigrationService) DescribeReplicationInstanceTaskLogsWithContext(ctx aws.Context, input *DescribeReplicationInstanceTaskLogsInput, opts ...request.Option) (*DescribeReplicationInstanceTaskLogsOutput, error) {
+	req, out := c.DescribeReplicationInstanceTaskLogsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+// DescribeReplicationInstanceTaskLogsPages iterates over the pages of a DescribeReplicationInstanceTaskLogs operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See DescribeReplicationInstanceTaskLogs method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a DescribeReplicationInstanceTaskLogs operation.
+//    pageNum := 0
+//    err := client.DescribeReplicationInstanceTaskLogsPages(params,
+//        func(page *DescribeReplicationInstanceTaskLogsOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *DatabaseMigrationService) DescribeReplicationInstanceTaskLogsPages(input *DescribeReplicationInstanceTaskLogsInput, fn func(*DescribeReplicationInstanceTaskLogsOutput, bool) bool) error {
+	return c.DescribeReplicationInstanceTaskLogsPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// DescribeReplicationInstanceTaskLogsPagesWithContext same as DescribeReplicationInstanceTaskLogsPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *DatabaseMigrationService) DescribeReplicationInstanceTaskLogsPagesWithContext(ctx aws.Context, input *DescribeReplicationInstanceTaskLogsInput, fn func(*DescribeReplicationInstanceTaskLogsOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *DescribeReplicationInstanceTaskLogsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeReplicationInstanceTaskLogsRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	cont := true
+	for p.Next() && cont {
+		cont = fn(p.Page().(*DescribeReplicationInstanceTaskLogsOutput), !p.HasNextPage())
+	}
+	return p.Err()
+}
+
 const opDescribeReplicationInstances = "DescribeReplicationInstances"
 
 // DescribeReplicationInstancesRequest generates a "aws/request.Request" representing the
@@ -3161,6 +3300,9 @@ func (c *DatabaseMigrationService) ImportCertificateRequest(input *ImportCertifi
 //   * ErrCodeInvalidCertificateFault "InvalidCertificateFault"
 //   The certificate was not valid.
 //
+//   * ErrCodeResourceQuotaExceededFault "ResourceQuotaExceededFault"
+//   The quota for this resource quota has been exceeded.
+//
 // See also, https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/ImportCertificate
 func (c *DatabaseMigrationService) ImportCertificate(input *ImportCertificateInput) (*ImportCertificateOutput, error) {
 	req, out := c.ImportCertificateRequest(input)
@@ -3726,6 +3868,90 @@ func (c *DatabaseMigrationService) ModifyReplicationTask(input *ModifyReplicatio
 // for more information on using Contexts.
 func (c *DatabaseMigrationService) ModifyReplicationTaskWithContext(ctx aws.Context, input *ModifyReplicationTaskInput, opts ...request.Option) (*ModifyReplicationTaskOutput, error) {
 	req, out := c.ModifyReplicationTaskRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opRebootReplicationInstance = "RebootReplicationInstance"
+
+// RebootReplicationInstanceRequest generates a "aws/request.Request" representing the
+// client's request for the RebootReplicationInstance operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See RebootReplicationInstance for more information on using the RebootReplicationInstance
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the RebootReplicationInstanceRequest method.
+//    req, resp := client.RebootReplicationInstanceRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/RebootReplicationInstance
+func (c *DatabaseMigrationService) RebootReplicationInstanceRequest(input *RebootReplicationInstanceInput) (req *request.Request, output *RebootReplicationInstanceOutput) {
+	op := &request.Operation{
+		Name:       opRebootReplicationInstance,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &RebootReplicationInstanceInput{}
+	}
+
+	output = &RebootReplicationInstanceOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// RebootReplicationInstance API operation for AWS Database Migration Service.
+//
+// Reboots a replication instance. Rebooting results in a momentary outage,
+// until the replication instance becomes available again.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Database Migration Service's
+// API operation RebootReplicationInstance for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceNotFoundFault "ResourceNotFoundFault"
+//   The resource could not be found.
+//
+//   * ErrCodeInvalidResourceStateFault "InvalidResourceStateFault"
+//   The resource is in a state that prevents it from being used for database
+//   migration.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/dms-2016-01-01/RebootReplicationInstance
+func (c *DatabaseMigrationService) RebootReplicationInstance(input *RebootReplicationInstanceInput) (*RebootReplicationInstanceOutput, error) {
+	req, out := c.RebootReplicationInstanceRequest(input)
+	return out, req.Send()
+}
+
+// RebootReplicationInstanceWithContext is the same as RebootReplicationInstance with the addition of
+// the ability to pass a context and additional request options.
+//
+// See RebootReplicationInstance for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *DatabaseMigrationService) RebootReplicationInstanceWithContext(ctx aws.Context, input *RebootReplicationInstanceInput, opts ...request.Option) (*RebootReplicationInstanceOutput, error) {
+	req, out := c.RebootReplicationInstanceRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -4668,8 +4894,8 @@ type CreateEndpointInput struct {
 	EndpointType *string `type:"string" required:"true" enum:"ReplicationEndpointTypeValue"`
 
 	// The type of engine for the endpoint. Valid values, depending on the EndPointType,
-	// include MYSQL, ORACLE, POSTGRES, MARIADB, AURORA, REDSHIFT, S3, SYBASE, DYNAMODB,
-	// MONGODB, and SQLSERVER.
+	// include mysql, oracle, postgres, mariadb, aurora, redshift, S3, sybase, dynamodb,
+	// mongodb, and sqlserver.
 	//
 	// EngineName is a required field
 	EngineName *string `type:"string" required:"true"`
@@ -6794,6 +7020,114 @@ func (s *DescribeRefreshSchemasStatusOutput) SetRefreshSchemasStatus(v *RefreshS
 	return s
 }
 
+type DescribeReplicationInstanceTaskLogsInput struct {
+	_ struct{} `type:"structure"`
+
+	// An optional pagination token provided by a previous request. If this parameter
+	// is specified, the response includes only records beyond the marker, up to
+	// the value specified by MaxRecords.
+	Marker *string `type:"string"`
+
+	// The maximum number of records to include in the response. If more records
+	// exist than the specified MaxRecords value, a pagination token called a marker
+	// is included in the response so that the remaining results can be retrieved.
+	//
+	// Default: 100
+	//
+	// Constraints: Minimum 20, maximum 100.
+	MaxRecords *int64 `type:"integer"`
+
+	// The Amazon Resource Name (ARN) of the replication instance.
+	//
+	// ReplicationInstanceArn is a required field
+	ReplicationInstanceArn *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DescribeReplicationInstanceTaskLogsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeReplicationInstanceTaskLogsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeReplicationInstanceTaskLogsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeReplicationInstanceTaskLogsInput"}
+	if s.ReplicationInstanceArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReplicationInstanceArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeReplicationInstanceTaskLogsInput) SetMarker(v string) *DescribeReplicationInstanceTaskLogsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetMaxRecords sets the MaxRecords field's value.
+func (s *DescribeReplicationInstanceTaskLogsInput) SetMaxRecords(v int64) *DescribeReplicationInstanceTaskLogsInput {
+	s.MaxRecords = &v
+	return s
+}
+
+// SetReplicationInstanceArn sets the ReplicationInstanceArn field's value.
+func (s *DescribeReplicationInstanceTaskLogsInput) SetReplicationInstanceArn(v string) *DescribeReplicationInstanceTaskLogsInput {
+	s.ReplicationInstanceArn = &v
+	return s
+}
+
+type DescribeReplicationInstanceTaskLogsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// An optional pagination token provided by a previous request. If this parameter
+	// is specified, the response includes only records beyond the marker, up to
+	// the value specified by MaxRecords.
+	Marker *string `type:"string"`
+
+	// The Amazon Resource Name (ARN) of the replication instance.
+	ReplicationInstanceArn *string `type:"string"`
+
+	// An array of replication task log metadata. Each member of the array contains
+	// the replication task name, ARN, and task log size (in bytes).
+	ReplicationInstanceTaskLogs []*ReplicationInstanceTaskLog `type:"list"`
+}
+
+// String returns the string representation
+func (s DescribeReplicationInstanceTaskLogsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeReplicationInstanceTaskLogsOutput) GoString() string {
+	return s.String()
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeReplicationInstanceTaskLogsOutput) SetMarker(v string) *DescribeReplicationInstanceTaskLogsOutput {
+	s.Marker = &v
+	return s
+}
+
+// SetReplicationInstanceArn sets the ReplicationInstanceArn field's value.
+func (s *DescribeReplicationInstanceTaskLogsOutput) SetReplicationInstanceArn(v string) *DescribeReplicationInstanceTaskLogsOutput {
+	s.ReplicationInstanceArn = &v
+	return s
+}
+
+// SetReplicationInstanceTaskLogs sets the ReplicationInstanceTaskLogs field's value.
+func (s *DescribeReplicationInstanceTaskLogsOutput) SetReplicationInstanceTaskLogs(v []*ReplicationInstanceTaskLog) *DescribeReplicationInstanceTaskLogsOutput {
+	s.ReplicationInstanceTaskLogs = v
+	return s
+}
+
 type DescribeReplicationInstancesInput struct {
 	_ struct{} `type:"structure"`
 
@@ -7495,8 +7829,8 @@ type Endpoint struct {
 	EndpointType *string `type:"string" enum:"ReplicationEndpointTypeValue"`
 
 	// The database engine name. Valid values, depending on the EndPointType, include
-	// MYSQL, ORACLE, POSTGRES, MARIADB, AURORA, REDSHIFT, S3, SYBASE, DYNAMODB,
-	// MONGODB, and SQLSERVER.
+	// mysql, oracle, postgres, mariadb, aurora, redshift, S3, sybase, dynamodb,
+	// mongodb, and sqlserver.
 	EngineName *string `type:"string"`
 
 	// Value returned by a call to CreateEndpoint that can be used for cross-account
@@ -8095,8 +8429,8 @@ type ModifyEndpointInput struct {
 	EndpointType *string `type:"string" enum:"ReplicationEndpointTypeValue"`
 
 	// The type of engine for the endpoint. Valid values, depending on the EndPointType,
-	// include MYSQL, ORACLE, POSTGRES, MARIADB, AURORA, REDSHIFT, S3, DYNAMODB,
-	// MONGODB, SYBASE, and SQLSERVER.
+	// include mysql, oracle, postgres, mariadb, aurora, redshift, S3, sybase, dynamodb,
+	// mongodb, and sqlserver.
 	EngineName *string `type:"string"`
 
 	// Additional attributes associated with the connection. To reset this parameter,
@@ -8987,6 +9321,77 @@ func (s *OrderableReplicationInstance) SetStorageType(v string) *OrderableReplic
 	return s
 }
 
+type RebootReplicationInstanceInput struct {
+	_ struct{} `type:"structure"`
+
+	// If this parameter is true, the reboot is conducted through a Multi-AZ failover.
+	// (If the instance isn't configured for Multi-AZ, then you can't specify true.)
+	ForceFailover *bool `type:"boolean"`
+
+	// The Amazon Resource Name (ARN) of the replication instance.
+	//
+	// ReplicationInstanceArn is a required field
+	ReplicationInstanceArn *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s RebootReplicationInstanceInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s RebootReplicationInstanceInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RebootReplicationInstanceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RebootReplicationInstanceInput"}
+	if s.ReplicationInstanceArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReplicationInstanceArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetForceFailover sets the ForceFailover field's value.
+func (s *RebootReplicationInstanceInput) SetForceFailover(v bool) *RebootReplicationInstanceInput {
+	s.ForceFailover = &v
+	return s
+}
+
+// SetReplicationInstanceArn sets the ReplicationInstanceArn field's value.
+func (s *RebootReplicationInstanceInput) SetReplicationInstanceArn(v string) *RebootReplicationInstanceInput {
+	s.ReplicationInstanceArn = &v
+	return s
+}
+
+type RebootReplicationInstanceOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The replication instance that is being rebooted.
+	ReplicationInstance *ReplicationInstance `type:"structure"`
+}
+
+// String returns the string representation
+func (s RebootReplicationInstanceOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s RebootReplicationInstanceOutput) GoString() string {
+	return s.String()
+}
+
+// SetReplicationInstance sets the ReplicationInstance field's value.
+func (s *RebootReplicationInstanceOutput) SetReplicationInstance(v *ReplicationInstance) *RebootReplicationInstanceOutput {
+	s.ReplicationInstance = v
+	return s
+}
+
 type RefreshSchemasInput struct {
 	_ struct{} `type:"structure"`
 
@@ -9486,6 +9891,48 @@ func (s *ReplicationInstance) SetSecondaryAvailabilityZone(v string) *Replicatio
 // SetVpcSecurityGroups sets the VpcSecurityGroups field's value.
 func (s *ReplicationInstance) SetVpcSecurityGroups(v []*VpcSecurityGroupMembership) *ReplicationInstance {
 	s.VpcSecurityGroups = v
+	return s
+}
+
+// Contains metadata for a replication instance task log.
+type ReplicationInstanceTaskLog struct {
+	_ struct{} `type:"structure"`
+
+	// The size, in bytes, of the replication task log.
+	ReplicationInstanceTaskLogSize *int64 `type:"long"`
+
+	// The Amazon Resource Name (ARN) of the replication task.
+	ReplicationTaskArn *string `type:"string"`
+
+	// The name of the replication task.
+	ReplicationTaskName *string `type:"string"`
+}
+
+// String returns the string representation
+func (s ReplicationInstanceTaskLog) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ReplicationInstanceTaskLog) GoString() string {
+	return s.String()
+}
+
+// SetReplicationInstanceTaskLogSize sets the ReplicationInstanceTaskLogSize field's value.
+func (s *ReplicationInstanceTaskLog) SetReplicationInstanceTaskLogSize(v int64) *ReplicationInstanceTaskLog {
+	s.ReplicationInstanceTaskLogSize = &v
+	return s
+}
+
+// SetReplicationTaskArn sets the ReplicationTaskArn field's value.
+func (s *ReplicationInstanceTaskLog) SetReplicationTaskArn(v string) *ReplicationInstanceTaskLog {
+	s.ReplicationTaskArn = &v
+	return s
+}
+
+// SetReplicationTaskName sets the ReplicationTaskName field's value.
+func (s *ReplicationInstanceTaskLog) SetReplicationTaskName(v string) *ReplicationInstanceTaskLog {
+	s.ReplicationTaskName = &v
 	return s
 }
 
@@ -10235,8 +10682,8 @@ type SupportedEndpointType struct {
 	EndpointType *string `type:"string" enum:"ReplicationEndpointTypeValue"`
 
 	// The database engine name. Valid values, depending on the EndPointType, include
-	// MYSQL, ORACLE, POSTGRES, MARIADB, AURORA, REDSHIFT, S3, SYBASE, DYNAMODB,
-	// MONGODB, and SQLSERVER.
+	// mysql, oracle, postgres, mariadb, aurora, redshift, S3, sybase, dynamodb,
+	// mongodb, and sqlserver.
 	EngineName *string `type:"string"`
 
 	// Indicates if Change Data Capture (CDC) is supported.

--- a/vendor/github.com/aws/aws-sdk-go/service/dynamodb/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/dynamodb/api.go
@@ -420,23 +420,21 @@ func (c *DynamoDB) CreateBackupRequest(input *CreateBackupInput) (req *request.R
 // Each time you create an On-Demand Backup, the entire table data is backed
 // up. There is no limit to the number of on-demand backups that can be taken.
 //
+// When you create an On-Demand Backup, a time marker of the request is cataloged,
+// and the backup is created asynchronously, by applying all changes until the
+// time of the request to the last full table snapshot. Backup requests are
+// processed instantaneously and become available for restore within minutes.
+//
 // You can call CreateBackup at a maximum rate of 50 times per second.
 //
 // All backups in DynamoDB work without consuming any provisioned throughput
-// on the table. This results in a fast, low-cost, and scalable backup process.
-// In general, the larger the table, the more time it takes to back up. The
-// backup is stored in an S3 data store that is maintained and managed by DynamoDB.
+// on the table.
 //
-// Backups incorporate all writes (delete, put, update) that were completed
-// within the last minute before the backup request was initiated. Backups might
-// include some writes (delete, put, update) that were completed before the
-// backup request was finished.
-//
-// For example, if you submit the backup request on 2018-12-14 at 14:25:00,
-// the backup is guaranteed to contain all data committed to the table up to
-// 14:24:00, and data committed after 14:26:00 will not be. The backup may or
-// may not contain data modifications made between 14:24:00 and 14:26:00. On-Demand
-// Backup does not support causal consistency.
+// If you submit a backup request on 2018-12-14 at 14:25:00, the backup is guaranteed
+// to contain all data committed to the table up to 14:24:00, and data committed
+// after 14:26:00 will not be. The backup may or may not contain data modifications
+// made between 14:24:00 and 14:26:00. On-Demand Backup does not support causal
+// consistency.
 //
 // Along with data, the following are also included on the backups:
 //
@@ -471,12 +469,21 @@ func (c *DynamoDB) CreateBackupRequest(input *CreateBackupInput) (req *request.R
 //   table. The backups is either being created, deleted or restored to a table.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   The number of concurrent table requests (cumulative number of tables in the
-//   CREATING, DELETING or UPDATING state) exceeds the maximum allowed of 10.
+//   Up to 50 CreateBackup operations are allowed per second, per account. There
+//   is no limit to the number of daily on-demand backups that can be taken.
 //
-//   Also, for tables with secondary indexes, only one of those tables can be
-//   in the CREATING state at any point in time. Do not attempt to create more
-//   than one such table simultaneously.
+//   Up to 10 simultaneous table operations are allowed per account. These operations
+//   include CreateTable, UpdateTable, DeleteTable,UpdateTimeToLive, and RestoreTableFromBackup.
+//
+//   For tables with secondary indexes, only one of those tables can be in the
+//   CREATING state at any point in time. Do not attempt to create more than one
+//   such table simultaneously.
+//
+//   The total limit of tables in the ACTIVE state is 250.
+//
+//   For tables with secondary indexes, only one of those tables can be in the
+//   CREATING state at any point in time. Do not attempt to create more than one
+//   such table simultaneously.
 //
 //   The total limit of tables in the ACTIVE state is 250.
 //
@@ -573,12 +580,21 @@ func (c *DynamoDB) CreateGlobalTableRequest(input *CreateGlobalTableInput) (req 
 //
 // Returned Error Codes:
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   The number of concurrent table requests (cumulative number of tables in the
-//   CREATING, DELETING or UPDATING state) exceeds the maximum allowed of 10.
+//   Up to 50 CreateBackup operations are allowed per second, per account. There
+//   is no limit to the number of daily on-demand backups that can be taken.
 //
-//   Also, for tables with secondary indexes, only one of those tables can be
-//   in the CREATING state at any point in time. Do not attempt to create more
-//   than one such table simultaneously.
+//   Up to 10 simultaneous table operations are allowed per account. These operations
+//   include CreateTable, UpdateTable, DeleteTable,UpdateTimeToLive, and RestoreTableFromBackup.
+//
+//   For tables with secondary indexes, only one of those tables can be in the
+//   CREATING state at any point in time. Do not attempt to create more than one
+//   such table simultaneously.
+//
+//   The total limit of tables in the ACTIVE state is 250.
+//
+//   For tables with secondary indexes, only one of those tables can be in the
+//   CREATING state at any point in time. Do not attempt to create more than one
+//   such table simultaneously.
 //
 //   The total limit of tables in the ACTIVE state is 250.
 //
@@ -688,12 +704,21 @@ func (c *DynamoDB) CreateTableRequest(input *CreateTableInput) (req *request.Req
 //   in the CREATING state.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   The number of concurrent table requests (cumulative number of tables in the
-//   CREATING, DELETING or UPDATING state) exceeds the maximum allowed of 10.
+//   Up to 50 CreateBackup operations are allowed per second, per account. There
+//   is no limit to the number of daily on-demand backups that can be taken.
 //
-//   Also, for tables with secondary indexes, only one of those tables can be
-//   in the CREATING state at any point in time. Do not attempt to create more
-//   than one such table simultaneously.
+//   Up to 10 simultaneous table operations are allowed per account. These operations
+//   include CreateTable, UpdateTable, DeleteTable,UpdateTimeToLive, and RestoreTableFromBackup.
+//
+//   For tables with secondary indexes, only one of those tables can be in the
+//   CREATING state at any point in time. Do not attempt to create more than one
+//   such table simultaneously.
+//
+//   The total limit of tables in the ACTIVE state is 250.
+//
+//   For tables with secondary indexes, only one of those tables can be in the
+//   CREATING state at any point in time. Do not attempt to create more than one
+//   such table simultaneously.
 //
 //   The total limit of tables in the ACTIVE state is 250.
 //
@@ -786,12 +811,21 @@ func (c *DynamoDB) DeleteBackupRequest(input *DeleteBackupInput) (req *request.R
 //   table. The backups is either being created, deleted or restored to a table.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   The number of concurrent table requests (cumulative number of tables in the
-//   CREATING, DELETING or UPDATING state) exceeds the maximum allowed of 10.
+//   Up to 50 CreateBackup operations are allowed per second, per account. There
+//   is no limit to the number of daily on-demand backups that can be taken.
 //
-//   Also, for tables with secondary indexes, only one of those tables can be
-//   in the CREATING state at any point in time. Do not attempt to create more
-//   than one such table simultaneously.
+//   Up to 10 simultaneous table operations are allowed per account. These operations
+//   include CreateTable, UpdateTable, DeleteTable,UpdateTimeToLive, and RestoreTableFromBackup.
+//
+//   For tables with secondary indexes, only one of those tables can be in the
+//   CREATING state at any point in time. Do not attempt to create more than one
+//   such table simultaneously.
+//
+//   The total limit of tables in the ACTIVE state is 250.
+//
+//   For tables with secondary indexes, only one of those tables can be in the
+//   CREATING state at any point in time. Do not attempt to create more than one
+//   such table simultaneously.
 //
 //   The total limit of tables in the ACTIVE state is 250.
 //
@@ -1012,12 +1046,21 @@ func (c *DynamoDB) DeleteTableRequest(input *DeleteTableInput) (req *request.Req
 //   might not be specified correctly, or its status might not be ACTIVE.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   The number of concurrent table requests (cumulative number of tables in the
-//   CREATING, DELETING or UPDATING state) exceeds the maximum allowed of 10.
+//   Up to 50 CreateBackup operations are allowed per second, per account. There
+//   is no limit to the number of daily on-demand backups that can be taken.
 //
-//   Also, for tables with secondary indexes, only one of those tables can be
-//   in the CREATING state at any point in time. Do not attempt to create more
-//   than one such table simultaneously.
+//   Up to 10 simultaneous table operations are allowed per account. These operations
+//   include CreateTable, UpdateTable, DeleteTable,UpdateTimeToLive, and RestoreTableFromBackup.
+//
+//   For tables with secondary indexes, only one of those tables can be in the
+//   CREATING state at any point in time. Do not attempt to create more than one
+//   such table simultaneously.
+//
+//   The total limit of tables in the ACTIVE state is 250.
+//
+//   For tables with secondary indexes, only one of those tables can be in the
+//   CREATING state at any point in time. Do not attempt to create more than one
+//   such table simultaneously.
 //
 //   The total limit of tables in the ACTIVE state is 250.
 //
@@ -1261,7 +1304,7 @@ func (c *DynamoDB) DescribeGlobalTableRequest(input *DescribeGlobalTableInput) (
 
 // DescribeGlobalTable API operation for Amazon DynamoDB.
 //
-// Returns information about the global table.
+// Returns information about the specified global table.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1837,8 +1880,7 @@ func (c *DynamoDB) ListGlobalTablesRequest(input *ListGlobalTablesInput) (req *r
 
 // ListGlobalTables API operation for Amazon DynamoDB.
 //
-// Lists all the global tables. Only those global tables that have replicas
-// in the region specified as input are returned.
+// Lists all global tables that have a replica in the specified region.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2491,6 +2533,8 @@ func (c *DynamoDB) RestoreTableFromBackupRequest(input *RestoreTableFromBackupIn
 //
 //    * Tags
 //
+//    * Stream settings
+//
 //    * Time to Live (TTL) settings
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -2515,12 +2559,21 @@ func (c *DynamoDB) RestoreTableFromBackupRequest(input *RestoreTableFromBackupIn
 //   table. The backups is either being created, deleted or restored to a table.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   The number of concurrent table requests (cumulative number of tables in the
-//   CREATING, DELETING or UPDATING state) exceeds the maximum allowed of 10.
+//   Up to 50 CreateBackup operations are allowed per second, per account. There
+//   is no limit to the number of daily on-demand backups that can be taken.
 //
-//   Also, for tables with secondary indexes, only one of those tables can be
-//   in the CREATING state at any point in time. Do not attempt to create more
-//   than one such table simultaneously.
+//   Up to 10 simultaneous table operations are allowed per account. These operations
+//   include CreateTable, UpdateTable, DeleteTable,UpdateTimeToLive, and RestoreTableFromBackup.
+//
+//   For tables with secondary indexes, only one of those tables can be in the
+//   CREATING state at any point in time. Do not attempt to create more than one
+//   such table simultaneously.
+//
+//   The total limit of tables in the ACTIVE state is 250.
+//
+//   For tables with secondary indexes, only one of those tables can be in the
+//   CREATING state at any point in time. Do not attempt to create more than one
+//   such table simultaneously.
 //
 //   The total limit of tables in the ACTIVE state is 250.
 //
@@ -2786,12 +2839,21 @@ func (c *DynamoDB) TagResourceRequest(input *TagResourceInput) (req *request.Req
 //
 // Returned Error Codes:
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   The number of concurrent table requests (cumulative number of tables in the
-//   CREATING, DELETING or UPDATING state) exceeds the maximum allowed of 10.
+//   Up to 50 CreateBackup operations are allowed per second, per account. There
+//   is no limit to the number of daily on-demand backups that can be taken.
 //
-//   Also, for tables with secondary indexes, only one of those tables can be
-//   in the CREATING state at any point in time. Do not attempt to create more
-//   than one such table simultaneously.
+//   Up to 10 simultaneous table operations are allowed per account. These operations
+//   include CreateTable, UpdateTable, DeleteTable,UpdateTimeToLive, and RestoreTableFromBackup.
+//
+//   For tables with secondary indexes, only one of those tables can be in the
+//   CREATING state at any point in time. Do not attempt to create more than one
+//   such table simultaneously.
+//
+//   The total limit of tables in the ACTIVE state is 250.
+//
+//   For tables with secondary indexes, only one of those tables can be in the
+//   CREATING state at any point in time. Do not attempt to create more than one
+//   such table simultaneously.
 //
 //   The total limit of tables in the ACTIVE state is 250.
 //
@@ -2890,12 +2952,21 @@ func (c *DynamoDB) UntagResourceRequest(input *UntagResourceInput) (req *request
 //
 // Returned Error Codes:
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   The number of concurrent table requests (cumulative number of tables in the
-//   CREATING, DELETING or UPDATING state) exceeds the maximum allowed of 10.
+//   Up to 50 CreateBackup operations are allowed per second, per account. There
+//   is no limit to the number of daily on-demand backups that can be taken.
 //
-//   Also, for tables with secondary indexes, only one of those tables can be
-//   in the CREATING state at any point in time. Do not attempt to create more
-//   than one such table simultaneously.
+//   Up to 10 simultaneous table operations are allowed per account. These operations
+//   include CreateTable, UpdateTable, DeleteTable,UpdateTimeToLive, and RestoreTableFromBackup.
+//
+//   For tables with secondary indexes, only one of those tables can be in the
+//   CREATING state at any point in time. Do not attempt to create more than one
+//   such table simultaneously.
+//
+//   The total limit of tables in the ACTIVE state is 250.
+//
+//   For tables with secondary indexes, only one of those tables can be in the
+//   CREATING state at any point in time. Do not attempt to create more than one
+//   such table simultaneously.
 //
 //   The total limit of tables in the ACTIVE state is 250.
 //
@@ -2977,9 +3048,15 @@ func (c *DynamoDB) UpdateGlobalTableRequest(input *UpdateGlobalTableInput) (req 
 
 // UpdateGlobalTable API operation for Amazon DynamoDB.
 //
-// Adds or removes replicas to the specified global table. The global table
-// should already exist to be able to use this operation. Currently, the replica
-// to be added should be empty.
+// Adds or removes replicas in the specified global table. The global table
+// must already exist to be able to use this operation. Any replica to be added
+// must be empty, must have the same name as the global table, must have the
+// same key schema, must have DynamoDB Streams enabled, and cannot have any
+// local secondary indexes (LSIs).
+//
+// Although you can use UpdateGlobalTable to add replicas and remove replicas
+// in a single request, for simplicity we recommend that you issue separate
+// requests for adding or removing replicas.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3213,12 +3290,21 @@ func (c *DynamoDB) UpdateTableRequest(input *UpdateTableInput) (req *request.Req
 //   might not be specified correctly, or its status might not be ACTIVE.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   The number of concurrent table requests (cumulative number of tables in the
-//   CREATING, DELETING or UPDATING state) exceeds the maximum allowed of 10.
+//   Up to 50 CreateBackup operations are allowed per second, per account. There
+//   is no limit to the number of daily on-demand backups that can be taken.
 //
-//   Also, for tables with secondary indexes, only one of those tables can be
-//   in the CREATING state at any point in time. Do not attempt to create more
-//   than one such table simultaneously.
+//   Up to 10 simultaneous table operations are allowed per account. These operations
+//   include CreateTable, UpdateTable, DeleteTable,UpdateTimeToLive, and RestoreTableFromBackup.
+//
+//   For tables with secondary indexes, only one of those tables can be in the
+//   CREATING state at any point in time. Do not attempt to create more than one
+//   such table simultaneously.
+//
+//   The total limit of tables in the ACTIVE state is 250.
+//
+//   For tables with secondary indexes, only one of those tables can be in the
+//   CREATING state at any point in time. Do not attempt to create more than one
+//   such table simultaneously.
 //
 //   The total limit of tables in the ACTIVE state is 250.
 //
@@ -3338,12 +3424,21 @@ func (c *DynamoDB) UpdateTimeToLiveRequest(input *UpdateTimeToLiveInput) (req *r
 //   might not be specified correctly, or its status might not be ACTIVE.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   The number of concurrent table requests (cumulative number of tables in the
-//   CREATING, DELETING or UPDATING state) exceeds the maximum allowed of 10.
+//   Up to 50 CreateBackup operations are allowed per second, per account. There
+//   is no limit to the number of daily on-demand backups that can be taken.
 //
-//   Also, for tables with secondary indexes, only one of those tables can be
-//   in the CREATING state at any point in time. Do not attempt to create more
-//   than one such table simultaneously.
+//   Up to 10 simultaneous table operations are allowed per account. These operations
+//   include CreateTable, UpdateTable, DeleteTable,UpdateTimeToLive, and RestoreTableFromBackup.
+//
+//   For tables with secondary indexes, only one of those tables can be in the
+//   CREATING state at any point in time. Do not attempt to create more than one
+//   such table simultaneously.
+//
+//   The total limit of tables in the ACTIVE state is 250.
+//
+//   For tables with secondary indexes, only one of those tables can be in the
+//   CREATING state at any point in time. Do not attempt to create more than one
+//   such table simultaneously.
 //
 //   The total limit of tables in the ACTIVE state is 250.
 //
@@ -3658,7 +3753,7 @@ type AttributeValueUpdate struct {
 	// Each attribute value is described as a name-value pair. The name is the data
 	// type, and the value is the data itself.
 	//
-	// For more information, see Data TYpes (http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes)
+	// For more information, see Data Types (http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes)
 	// in the Amazon DynamoDB Developer Guide.
 	Value *AttributeValue `type:"structure"`
 }
@@ -4950,6 +5045,9 @@ type CreateTableInput struct {
 	// ProvisionedThroughput is a required field
 	ProvisionedThroughput *ProvisionedThroughput `type:"structure" required:"true"`
 
+	// Represents the settings used to enable server-side encryption.
+	SSESpecification *SSESpecification `type:"structure"`
+
 	// The settings for DynamoDB Streams on the table. These settings consist of:
 	//
 	//    * StreamEnabled - Indicates whether Streams is to be enabled (true) or
@@ -5054,6 +5152,11 @@ func (s *CreateTableInput) Validate() error {
 			invalidParams.AddNested("ProvisionedThroughput", err.(request.ErrInvalidParams))
 		}
 	}
+	if s.SSESpecification != nil {
+		if err := s.SSESpecification.Validate(); err != nil {
+			invalidParams.AddNested("SSESpecification", err.(request.ErrInvalidParams))
+		}
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -5088,6 +5191,12 @@ func (s *CreateTableInput) SetLocalSecondaryIndexes(v []*LocalSecondaryIndex) *C
 // SetProvisionedThroughput sets the ProvisionedThroughput field's value.
 func (s *CreateTableInput) SetProvisionedThroughput(v *ProvisionedThroughput) *CreateTableInput {
 	s.ProvisionedThroughput = v
+	return s
+}
+
+// SetSSESpecification sets the SSESpecification field's value.
+func (s *CreateTableInput) SetSSESpecification(v *SSESpecification) *CreateTableInput {
+	s.SSESpecification = v
 	return s
 }
 
@@ -8486,10 +8595,11 @@ type QueryInput struct {
 	// the Query action.
 	//
 	// The condition must perform an equality test on a single partition key value.
-	// The condition can also perform one of several comparison tests on a single
-	// sort key value. Query can use KeyConditionExpression to retrieve one item
-	// with a given partition key value and sort key value, or several items that
-	// have the same partition key value but different sort key values.
+	//
+	// The condition can optionally perform one of several comparison tests on a
+	// single sort key value. This allows Query to retrieve one item with a given
+	// partition key value and sort key value, or several items that have the same
+	// partition key value but different sort key values.
 	//
 	// The partition key equality test is required, and must be specified in the
 	// following format:
@@ -9157,6 +9267,78 @@ func (s *RestoreTableFromBackupOutput) SetTableDescription(v *TableDescription) 
 	return s
 }
 
+// The description of the server-side encryption status on the specified table.
+type SSEDescription struct {
+	_ struct{} `type:"structure"`
+
+	// The current state of server-side encryption:
+	//
+	//    * ENABLING - Server-side encryption is being enabled.
+	//
+	//    * ENABLED - Server-side encryption is enabled.
+	//
+	//    * DISABLING - Server-side encryption is being disabled.
+	//
+	//    * DISABLED - Server-side encryption is disabled.
+	Status *string `type:"string" enum:"SSEStatus"`
+}
+
+// String returns the string representation
+func (s SSEDescription) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SSEDescription) GoString() string {
+	return s.String()
+}
+
+// SetStatus sets the Status field's value.
+func (s *SSEDescription) SetStatus(v string) *SSEDescription {
+	s.Status = &v
+	return s
+}
+
+// Represents the settings used to enable server-side encryption.
+type SSESpecification struct {
+	_ struct{} `type:"structure"`
+
+	// Indicates whether server-side encryption is enabled (true) or disabled (false)
+	// on the table.
+	//
+	// Enabled is a required field
+	Enabled *bool `type:"boolean" required:"true"`
+}
+
+// String returns the string representation
+func (s SSESpecification) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SSESpecification) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SSESpecification) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SSESpecification"}
+	if s.Enabled == nil {
+		invalidParams.Add(request.NewErrParamRequired("Enabled"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetEnabled sets the Enabled field's value.
+func (s *SSESpecification) SetEnabled(v bool) *SSESpecification {
+	s.Enabled = &v
+	return s
+}
+
 // Represents the input of a Scan operation.
 type ScanInput struct {
 	_ struct{} `type:"structure"`
@@ -9746,6 +9928,10 @@ type SourceTableFeatureDetails struct {
 	// at the time of backup.
 	LocalSecondaryIndexes []*LocalSecondaryIndexInfo `type:"list"`
 
+	// The description of the server-side encryption status on the table when the
+	// backup was created.
+	SSEDescription *SSEDescription `type:"structure"`
+
 	// Stream settings on the table when the backup was created.
 	StreamDescription *StreamSpecification `type:"structure"`
 
@@ -9772,6 +9958,12 @@ func (s *SourceTableFeatureDetails) SetGlobalSecondaryIndexes(v []*GlobalSeconda
 // SetLocalSecondaryIndexes sets the LocalSecondaryIndexes field's value.
 func (s *SourceTableFeatureDetails) SetLocalSecondaryIndexes(v []*LocalSecondaryIndexInfo) *SourceTableFeatureDetails {
 	s.LocalSecondaryIndexes = v
+	return s
+}
+
+// SetSSEDescription sets the SSEDescription field's value.
+func (s *SourceTableFeatureDetails) SetSSEDescription(v *SSEDescription) *SourceTableFeatureDetails {
+	s.SSEDescription = v
 	return s
 }
 
@@ -10010,6 +10202,9 @@ type TableDescription struct {
 	// Contains details for the restore.
 	RestoreSummary *RestoreSummary `type:"structure"`
 
+	// The description of the server-side encryption status on the specified table.
+	SSEDescription *SSEDescription `type:"structure"`
+
 	// The current DynamoDB Streams configuration for the table.
 	StreamSpecification *StreamSpecification `type:"structure"`
 
@@ -10106,6 +10301,12 @@ func (s *TableDescription) SetProvisionedThroughput(v *ProvisionedThroughputDesc
 // SetRestoreSummary sets the RestoreSummary field's value.
 func (s *TableDescription) SetRestoreSummary(v *RestoreSummary) *TableDescription {
 	s.RestoreSummary = v
+	return s
+}
+
+// SetSSEDescription sets the SSEDescription field's value.
+func (s *TableDescription) SetSSEDescription(v *SSEDescription) *TableDescription {
+	s.SSEDescription = v
 	return s
 }
 
@@ -11456,6 +11657,20 @@ const (
 
 	// ReturnValueUpdatedNew is a ReturnValue enum value
 	ReturnValueUpdatedNew = "UPDATED_NEW"
+)
+
+const (
+	// SSEStatusEnabling is a SSEStatus enum value
+	SSEStatusEnabling = "ENABLING"
+
+	// SSEStatusEnabled is a SSEStatus enum value
+	SSEStatusEnabled = "ENABLED"
+
+	// SSEStatusDisabling is a SSEStatus enum value
+	SSEStatusDisabling = "DISABLING"
+
+	// SSEStatusDisabled is a SSEStatus enum value
+	SSEStatusDisabled = "DISABLED"
 )
 
 const (

--- a/vendor/github.com/aws/aws-sdk-go/service/dynamodb/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/dynamodb/errors.go
@@ -57,12 +57,21 @@ const (
 	// ErrCodeLimitExceededException for service response error code
 	// "LimitExceededException".
 	//
-	// The number of concurrent table requests (cumulative number of tables in the
-	// CREATING, DELETING or UPDATING state) exceeds the maximum allowed of 10.
+	// Up to 50 CreateBackup operations are allowed per second, per account. There
+	// is no limit to the number of daily on-demand backups that can be taken.
 	//
-	// Also, for tables with secondary indexes, only one of those tables can be
-	// in the CREATING state at any point in time. Do not attempt to create more
-	// than one such table simultaneously.
+	// Up to 10 simultaneous table operations are allowed per account. These operations
+	// include CreateTable, UpdateTable, DeleteTable,UpdateTimeToLive, and RestoreTableFromBackup.
+	//
+	// For tables with secondary indexes, only one of those tables can be in the
+	// CREATING state at any point in time. Do not attempt to create more than one
+	// such table simultaneously.
+	//
+	// The total limit of tables in the ACTIVE state is 250.
+	//
+	// For tables with secondary indexes, only one of those tables can be in the
+	// CREATING state at any point in time. Do not attempt to create more than one
+	// such table simultaneously.
 	//
 	// The total limit of tables in the ACTIVE state is 250.
 	ErrCodeLimitExceededException = "LimitExceededException"

--- a/vendor/github.com/aws/aws-sdk-go/service/gamelift/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/gamelift/api.go
@@ -309,24 +309,43 @@ func (c *GameLift) CreateBuildRequest(input *CreateBuildInput) (req *request.Req
 
 // CreateBuild API operation for Amazon GameLift.
 //
-// Creates a new Amazon GameLift build from a set of game server binary files
-// stored in an Amazon Simple Storage Service (Amazon S3) location. To use this
-// API call, create a .zip file containing all of the files for the build and
-// store it in an Amazon S3 bucket under your AWS account. For help on packaging
-// your build files and creating a build, see Uploading Your Game to Amazon
-// GameLift (http://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-build-intro.html).
+// Creates a new Amazon GameLift build record for your game server binary files
+// and points to the location of your game server build files in an Amazon Simple
+// Storage Service (Amazon S3) location.
 //
-// Use this API action ONLY if you are storing your game build files in an Amazon
-// S3 bucket. To create a build using files stored locally, use the CLI command
-// upload-build (http://docs.aws.amazon.com/cli/latest/reference/gamelift/upload-build.html),
-// which uploads the build files from a file location you specify.
+// Game server binaries must be combined into a .zip file for use with Amazon
+// GameLift. See Uploading Your Game (http://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-build-intro.html)
+// for more information.
 //
-// To create a new build using CreateBuild, identify the storage location and
-// operating system of your game build. You also have the option of specifying
-// a build name and version. If successful, this action creates a new build
-// record with an unique build ID and in INITIALIZED status. Use the API call
-// DescribeBuild to check the status of your build. A build must be in READY
-// status before it can be used to create fleets to host your game.
+// To create new builds quickly and easily, use the AWS CLI command upload-build
+// (http://docs.aws.amazon.com/cli/latest/reference/gamelift/upload-build.html).
+// This helper command uploads your build and creates a new build record in
+// one step, and automatically handles the necessary permissions. See  Upload
+// Build Files to Amazon GameLift (http://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-build-cli-uploading.html)
+// for more help.
+//
+// The CreateBuild operation should be used only when you need to manually upload
+// your build files, as in the following scenarios:
+//
+//    * Store a build file in an Amazon S3 bucket under your own AWS account.
+//    To use this option, you must first give Amazon GameLift access to that
+//    Amazon S3 bucket. See  Create a Build with Files in Amazon S3 (http://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-build-cli-uploading.html#gamelift-build-cli-uploading-create-build)
+//    for detailed help. To create a new build record using files in your Amazon
+//    S3 bucket, call CreateBuild and specify a build name, operating system,
+//    and the storage location of your game build.
+//
+//    * Upload a build file directly to Amazon GameLift's Amazon S3 account.
+//    To use this option, you first call CreateBuild with a build name and operating
+//    system. This action creates a new build record and returns an Amazon S3
+//    storage location (bucket and key only) and temporary access credentials.
+//    Use the credentials to manually upload your build file to the storage
+//    location (see the Amazon S3 topic Uploading Objects (http://docs.aws.amazon.com/AmazonS3/latest/dev/UploadingObjects.html)).
+//    You can upload files to a location only once.
+//
+// If successful, this operation creates a new build record with a unique build
+// ID and places it in INITIALIZED status. You can use DescribeBuild to check
+// the status of your build. A build must be in READY status before it can be
+// used to create fleets.
 //
 // Build-related operations include:
 //
@@ -2773,7 +2792,7 @@ func (c *GameLift) DescribeBuildRequest(input *DescribeBuildInput) (req *request
 
 // DescribeBuild API operation for Amazon GameLift.
 //
-// Retrieves properties for a build. To get a build record, specify a build
+// Retrieves properties for a build. To request a build record, specify a build
 // ID. If successful, an object containing the build properties is returned.
 //
 // Build-related operations include:
@@ -4320,19 +4339,18 @@ func (c *GameLift) DescribeMatchmakingRequest(input *DescribeMatchmakingInput) (
 
 // DescribeMatchmaking API operation for Amazon GameLift.
 //
-// Retrieves a set of one or more matchmaking tickets. Use this operation to
-// retrieve ticket information, including status and--once a successful match
-// is made--acquire connection information for the resulting new game session.
+// Retrieves one or more matchmaking tickets. Use this operation to retrieve
+// ticket information, including status and--once a successful match is made--acquire
+// connection information for the resulting new game session.
 //
 // You can use this operation to track the progress of matchmaking requests
 // (through polling) as an alternative to using event notifications. See more
 // details on tracking matchmaking requests through polling or notifications
 // in StartMatchmaking.
 //
-// You can request data for a one or a list of ticket IDs. If the request is
-// successful, a ticket object is returned for each requested ID. When specifying
-// a list of ticket IDs, objects are returned only for tickets that currently
-// exist.
+// To request matchmaking tickets, provide a list of up to 10 ticket IDs. If
+// the request is successful, a ticket object is returned for each requested
+// ID that currently exists.
 //
 // Matchmaking-related operations include:
 //
@@ -6005,9 +6023,13 @@ func (c *GameLift) RequestUploadCredentialsRequest(input *RequestUploadCredentia
 
 // RequestUploadCredentials API operation for Amazon GameLift.
 //
-// This API call is not currently in use.  Retrieves a fresh set of upload credentials
-// and the assigned Amazon S3 storage location for a specific build. Valid credentials
-// are required to upload your game build files to Amazon S3.
+// Retrieves a fresh set of credentials for use when uploading a new set of
+// game build files to Amazon GameLift's Amazon S3. This is done as part of
+// the build creation process; see CreateBuild.
+//
+// To request new credentials, specify the build ID as returned with an initial
+// CreateBuild request. If successful, a new set of credentials are returned,
+// along with the S3 storage location associated with the build ID.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -6212,14 +6234,9 @@ func (c *GameLift) SearchGameSessionsRequest(input *SearchGameSessionsInput) (re
 
 // SearchGameSessions API operation for Amazon GameLift.
 //
-// Retrieves a set of game sessions that match a set of search criteria and
-// sorts them in a specified order. A game session search is limited to a single
-// fleet. Search results include only game sessions that are in ACTIVE status.
-// If you need to retrieve game sessions with a status other than active, use
-// DescribeGameSessions. If you need to retrieve the protection policy for each
-// game session, use DescribeGameSessionDetails.
-//
-// You can search or sort by the following game session attributes:
+// Retrieves all active game sessions that match a set of search criteria and
+// sorts them in a specified order. You can search or sort by the following
+// game session attributes:
 //
 //    * gameSessionId -- Unique identifier for the game session. You can use
 //    either a GameSessionId or GameSessionArn value.
@@ -6229,6 +6246,17 @@ func (c *GameLift) SearchGameSessionsRequest(input *SearchGameSessionsInput) (re
 //    with UpdateGameSession. Game session names do not need to be unique to
 //    a game session.
 //
+//    * gameSessionProperties -- Custom data defined in a game session's GameProperty
+//    parameter. GameProperty values are stored as key:value pairs; the filter
+//    expression must indicate the key and a string to search the data values
+//    for. For example, to search for game sessions with custom data containing
+//    the key:value pair "gameMode:brawl", specify the following: gameSessionProperties.gameMode
+//    = "brawl". All custom data values are searched as strings.
+//
+//    * maximumSessions -- Maximum number of player sessions allowed for a game
+//    session. This value is set when requesting a new game session with CreateGameSession
+//    or updating with UpdateGameSession.
+//
 //    * creationTimeMillis -- Value indicating when a game session was created.
 //    It is expressed in Unix time as milliseconds.
 //
@@ -6236,25 +6264,25 @@ func (c *GameLift) SearchGameSessionsRequest(input *SearchGameSessionsInput) (re
 //    session. This value changes rapidly as players join the session or drop
 //    out.
 //
-//    * maximumSessions -- Maximum number of player sessions allowed for a game
-//    session. This value is set when requesting a new game session with CreateGameSession
-//    or updating with UpdateGameSession.
-//
 //    * hasAvailablePlayerSessions -- Boolean value indicating whether a game
-//    session has reached its maximum number of players. When searching with
-//    this attribute, the search value must be true or false. It is highly recommended
+//    session has reached its maximum number of players. It is highly recommended
 //    that all search requests include this filter attribute to optimize search
 //    performance and return only sessions that players can join.
-//
-// To search or sort, specify either a fleet ID or an alias ID, and provide
-// a search filter expression, a sort expression, or both. Use the pagination
-// parameters to retrieve results as a set of sequential pages. If successful,
-// a collection of GameSession objects matching the request is returned.
 //
 // Returned values for playerSessionCount and hasAvailablePlayerSessions change
 // quickly as players join sessions and others drop out. Results should be considered
 // a snapshot in time. Be sure to refresh search results often, and handle sessions
 // that fill up before a player can join.
+//
+// To search or sort, specify either a fleet ID or an alias ID, and provide
+// a search filter expression, a sort expression, or both. If successful, a
+// collection of GameSession objects matching the request is returned. Use the
+// pagination parameters to retrieve results as a set of sequential pages.
+//
+// You can search for game sessions one fleet at a time only. To find game sessions
+// across multiple fleets, you must search each fleet separately and combine
+// the results. This search feature finds only game sessions that are in ACTIVE
+// status. To locate games in statuses other than active, use DescribeGameSessionDetails.
 //
 // Game-session-related operations include:
 //
@@ -6480,6 +6508,132 @@ func (c *GameLift) StartGameSessionPlacement(input *StartGameSessionPlacementInp
 // for more information on using Contexts.
 func (c *GameLift) StartGameSessionPlacementWithContext(ctx aws.Context, input *StartGameSessionPlacementInput, opts ...request.Option) (*StartGameSessionPlacementOutput, error) {
 	req, out := c.StartGameSessionPlacementRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opStartMatchBackfill = "StartMatchBackfill"
+
+// StartMatchBackfillRequest generates a "aws/request.Request" representing the
+// client's request for the StartMatchBackfill operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See StartMatchBackfill for more information on using the StartMatchBackfill
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the StartMatchBackfillRequest method.
+//    req, resp := client.StartMatchBackfillRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/gamelift-2015-10-01/StartMatchBackfill
+func (c *GameLift) StartMatchBackfillRequest(input *StartMatchBackfillInput) (req *request.Request, output *StartMatchBackfillOutput) {
+	op := &request.Operation{
+		Name:       opStartMatchBackfill,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &StartMatchBackfillInput{}
+	}
+
+	output = &StartMatchBackfillOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// StartMatchBackfill API operation for Amazon GameLift.
+//
+// Finds new players to fill open slots in an existing game session. This operation
+// can be used to add players to matched games that start with fewer than the
+// maximum number of players or to replace players when they drop out. By backfilling
+// with the same matchmaker used to create the original match, you ensure that
+// new players meet the match criteria and maintain a consistent experience
+// throughout the game session. You can backfill a match anytime after a game
+// session has been created.
+//
+// To request a match backfill, specify a unique ticket ID, the existing game
+// session's ARN, a matchmaking configuration, and a set of data that describes
+// all current players in the game session. If successful, a match backfill
+// ticket is created and returned with status set to QUEUED. The ticket is placed
+// in the matchmaker's ticket pool and processed. Track the status of the ticket
+// to respond as needed. For more detail how to set up backfilling, see  Set
+// up Match Backfilling (http://docs.aws.amazon.com/gamelift/latest/developerguide/match-backfill.html).
+//
+// The process of finding backfill matches is essentially identical to the initial
+// matchmaking process. The matchmaker searches the pool and groups tickets
+// together to form potential matches, allowing only one backfill ticket per
+// potential match. Once the a match is formed, the matchmaker creates player
+// sessions for the new players. All tickets in the match are updated with the
+// game session's connection information, and the GameSession object is updated
+// to include matchmaker data on the new players. For more detail on how match
+// backfill requests are processed, see  How Amazon GameLift FlexMatch Works
+// (http://docs.aws.amazon.com/gamelift/latest/developerguide/match-intro.html).
+//
+// Matchmaking-related operations include:
+//
+//    * StartMatchmaking
+//
+//    * DescribeMatchmaking
+//
+//    * StopMatchmaking
+//
+//    * AcceptMatch
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon GameLift's
+// API operation StartMatchBackfill for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   One or more parameter values in the request are invalid. Correct the invalid
+//   parameter values before retrying.
+//
+//   * ErrCodeNotFoundException "NotFoundException"
+//   A service resource associated with the request could not be found. Clients
+//   should not retry such requests.
+//
+//   * ErrCodeInternalServiceException "InternalServiceException"
+//   The service encountered an unrecoverable internal failure while processing
+//   the request. Clients can retry such requests immediately or after a waiting
+//   period.
+//
+//   * ErrCodeUnsupportedRegionException "UnsupportedRegionException"
+//   The requested operation is not supported in the region specified.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/gamelift-2015-10-01/StartMatchBackfill
+func (c *GameLift) StartMatchBackfill(input *StartMatchBackfillInput) (*StartMatchBackfillOutput, error) {
+	req, out := c.StartMatchBackfillRequest(input)
+	return out, req.Send()
+}
+
+// StartMatchBackfillWithContext is the same as StartMatchBackfill with the addition of
+// the ability to pass a context and additional request options.
+//
+// See StartMatchBackfill for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *GameLift) StartMatchBackfillWithContext(ctx aws.Context, input *StartMatchBackfillInput, opts ...request.Option) (*StartMatchBackfillOutput, error) {
+	req, out := c.StartMatchBackfillRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -8341,7 +8495,7 @@ func (s *Alias) SetRoutingStrategy(v *RoutingStrategy) *Alias {
 	return s
 }
 
-// Values for use in Player attribute type:value pairs. This object lets you
+// Values for use in Player attribute key:value pairs. This object lets you
 // specify an attribute value using any of the valid data types: string, number,
 // string array or data map. Each AttributeValue object can use only one of
 // the available properties.
@@ -8354,8 +8508,8 @@ type AttributeValue struct {
 	// For single string values. Maximum string length is 100 characters.
 	S *string `min:"1" type:"string"`
 
-	// For a map of up to 10 type:value pairs. Maximum length for each string value
-	// is 100 characters.
+	// For a map of up to 10 data type:value pairs. Maximum length for each string
+	// value is 100 characters.
 	SDM map[string]*float64 `type:"map"`
 
 	// For a list of up to 10 strings. Maximum length for each string is 100 characters.
@@ -8668,15 +8822,17 @@ type CreateBuildInput struct {
 	// Operating system that the game server binaries are built to run on. This
 	// value determines the type of fleet resources that you can use for this build.
 	// If your game build contains multiple executables, they all must run on the
-	// same operating system.
+	// same operating system. If an operating system is not specified when creating
+	// a build, Amazon GameLift uses the default value (WINDOWS_2012). This value
+	// cannot be changed later.
 	OperatingSystem *string `type:"string" enum:"OperatingSystem"`
 
-	// Amazon S3 location of the game build files to be uploaded. The S3 bucket
-	// must be owned by the same AWS account that you're using to manage Amazon
-	// GameLift. It also must in the same region that you want to create a new build
-	// in. Before calling CreateBuild with this location, you must allow Amazon
-	// GameLift to access your Amazon S3 bucket (see Create a Build with Files in
-	// Amazon S3 (http://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-build-cli-uploading.html#gamelift-build-cli-uploading-create-build)).
+	// Information indicating where your game build files are stored. Use this parameter
+	// only when creating a build with files stored in an Amazon S3 bucket that
+	// you own. The storage location must specify an Amazon S3 bucket name and key,
+	// as well as a role ARN that you set up to allow Amazon GameLift to access
+	// your Amazon S3 bucket. The S3 bucket must be in the same region that you
+	// want to create a new build in.
 	StorageLocation *S3Location `type:"structure"`
 
 	// Version that is associated with this build. Version strings do not need to
@@ -8746,10 +8902,13 @@ type CreateBuildOutput struct {
 	// The newly created build record, including a unique build ID and status.
 	Build *Build `type:"structure"`
 
-	// Amazon S3 location specified in the request.
+	// Amazon S3 location for your game build file, including bucket name and key.
 	StorageLocation *S3Location `type:"structure"`
 
-	// This element is not currently in use.
+	// This element is returned only when the operation is called without a storage
+	// location. It contains credentials to use when you are uploading a build file
+	// to an Amazon S3 bucket that is owned by Amazon GameLift. Credentials have
+	// a limited life span. To refresh these credentials, call RequestUploadCredentials.
 	UploadCredentials *AwsCredentials `type:"structure"`
 }
 
@@ -8817,9 +8976,10 @@ type CreateFleetInput struct {
 	// See more information in the Server API Reference (http://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-sdk-server-api-ref.html#gamelift-sdk-server-api-ref-dataypes-process).
 	LogPaths []*string `type:"list"`
 
-	// Names of metric groups to add this fleet to. Use an existing metric group
-	// name to add this fleet to the group. Or use a new name to create a new metric
-	// group. A fleet can only be included in one metric group at a time.
+	// Name of a metric group to add this fleet to. A metric group tracks metrics
+	// across all fleets in the group. Use an existing metric group name to add
+	// this fleet to the group, or use a new name to create a new metric group.
+	// A fleet can only be included in one metric group at a time.
 	MetricGroups []*string `type:"list"`
 
 	// Descriptive label that is associated with a fleet. Fleet names do not need
@@ -9070,16 +9230,14 @@ type CreateGameSessionInput struct {
 	// reference either a fleet ID or alias ID, but not both.
 	FleetId *string `type:"string"`
 
-	// Set of developer-defined properties for a game session, formatted as a set
-	// of type:value pairs. These properties are included in the GameSession object,
-	// which is passed to the game server with a request to start a new game session
-	// (see Start a Game Session (http://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-sdk-server-api.html#gamelift-sdk-server-startsession)).
+	// Set of custom properties for a game session, formatted as key:value pairs.
+	// These properties are passed to a game server process in the GameSession object
+	// with a request to start a new game session (see Start a Game Session (http://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-sdk-server-api.html#gamelift-sdk-server-startsession)).
 	GameProperties []*GameProperty `type:"list"`
 
-	// Set of developer-defined game session properties, formatted as a single string
-	// value. This data is included in the GameSession object, which is passed to
-	// the game server with a request to start a new game session (see Start a Game
-	// Session (http://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-sdk-server-api.html#gamelift-sdk-server-startsession)).
+	// Set of custom game session properties, formatted as a single string value.
+	// This data is passed to a game server process in the GameSession object with
+	// a request to start a new game session (see Start a Game Session (http://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-sdk-server-api.html#gamelift-sdk-server-startsession)).
 	GameSessionData *string `min:"1" type:"string"`
 
 	// This parameter is no longer preferred. Please use IdempotencyToken instead.
@@ -9380,18 +9538,16 @@ type CreateMatchmakingConfigurationInput struct {
 	// Meaningful description of the matchmaking configuration.
 	Description *string `min:"1" type:"string"`
 
-	// Set of developer-defined properties for a game session, formatted as a set
-	// of type:value pairs. These properties are included in the GameSession object,
-	// which is passed to the game server with a request to start a new game session
-	// (see Start a Game Session (http://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-sdk-server-api.html#gamelift-sdk-server-startsession)).
+	// Set of custom properties for a game session, formatted as key:value pairs.
+	// These properties are passed to a game server process in the GameSession object
+	// with a request to start a new game session (see Start a Game Session (http://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-sdk-server-api.html#gamelift-sdk-server-startsession)).
 	// This information is added to the new GameSession object that is created for
 	// a successful match.
 	GameProperties []*GameProperty `type:"list"`
 
-	// Set of developer-defined game session properties, formatted as a single string
-	// value. This data is included in the GameSession object, which is passed to
-	// the game server with a request to start a new game session (see Start a Game
-	// Session (http://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-sdk-server-api.html#gamelift-sdk-server-startsession)).
+	// Set of custom game session properties, formatted as a single string value.
+	// This data is passed to a game server process in the GameSession object with
+	// a request to start a new game session (see Start a Game Session (http://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-sdk-server-api.html#gamelift-sdk-server-startsession)).
 	// This information is added to the new GameSession object that is created for
 	// a successful match.
 	GameSessionData *string `min:"1" type:"string"`
@@ -11872,8 +12028,7 @@ func (s *DescribeMatchmakingConfigurationsOutput) SetNextToken(v string) *Descri
 type DescribeMatchmakingInput struct {
 	_ struct{} `type:"structure"`
 
-	// Unique identifier for a matchmaking ticket. To request all existing tickets,
-	// leave this parameter empty.
+	// Unique identifier for a matchmaking ticket. You can include up to 10 ID values.
 	//
 	// TicketIds is a required field
 	TicketIds []*string `type:"list" required:"true"`
@@ -13398,16 +13553,15 @@ type GameSession struct {
 	// Unique identifier for a fleet that the game session is running on.
 	FleetId *string `type:"string"`
 
-	// Set of developer-defined properties for a game session, formatted as a set
-	// of type:value pairs. These properties are included in the GameSession object,
-	// which is passed to the game server with a request to start a new game session
-	// (see Start a Game Session (http://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-sdk-server-api.html#gamelift-sdk-server-startsession)).
+	// Set of custom properties for a game session, formatted as key:value pairs.
+	// These properties are passed to a game server process in the GameSession object
+	// with a request to start a new game session (see Start a Game Session (http://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-sdk-server-api.html#gamelift-sdk-server-startsession)).
+	// You can search for active game sessions based on this custom data with SearchGameSessions.
 	GameProperties []*GameProperty `type:"list"`
 
-	// Set of developer-defined game session properties, formatted as a single string
-	// value. This data is included in the GameSession object, which is passed to
-	// the game server with a request to start a new game session (see Start a Game
-	// Session (http://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-sdk-server-api.html#gamelift-sdk-server-startsession)).
+	// Set of custom game session properties, formatted as a single string value.
+	// This data is passed to a game server process in the GameSession object with
+	// a request to start a new game session (see Start a Game Session (http://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-sdk-server-api.html#gamelift-sdk-server-startsession)).
 	GameSessionData *string `min:"1" type:"string"`
 
 	// Unique identifier for the game session. A game session ARN has the following
@@ -13418,6 +13572,15 @@ type GameSession struct {
 	// IP address of the game session. To connect to a Amazon GameLift game server,
 	// an app needs both the IP address and port number.
 	IpAddress *string `type:"string"`
+
+	// Information about the matchmaking process that was used to create the game
+	// session. It is in JSON syntax, formated as a string. In addition the matchmaking
+	// configuration used, it contains data on all players assigned to the match,
+	// including player attributes and team assignments. For more details on matchmaker
+	// data, see Match Data (http://docs.aws.amazon.com/gamelift/latest/developerguide/match-server.html#match-server-data).
+	// Matchmaker data is useful when requesting match backfills, and is updated
+	// whenever new players are added during a successful backfill (see StartMatchBackfill).
+	MatchmakerData *string `min:"1" type:"string"`
 
 	// Maximum number of players that can be connected simultaneously to the game
 	// session.
@@ -13498,6 +13661,12 @@ func (s *GameSession) SetGameSessionId(v string) *GameSession {
 // SetIpAddress sets the IpAddress field's value.
 func (s *GameSession) SetIpAddress(v string) *GameSession {
 	s.IpAddress = &v
+	return s
+}
+
+// SetMatchmakerData sets the MatchmakerData field's value.
+func (s *GameSession) SetMatchmakerData(v string) *GameSession {
+	s.MatchmakerData = &v
 	return s
 }
 
@@ -13654,10 +13823,9 @@ type GameSessionPlacement struct {
 	// out.
 	EndTime *time.Time `type:"timestamp" timestampFormat:"unix"`
 
-	// Set of developer-defined properties for a game session, formatted as a set
-	// of type:value pairs. These properties are included in the GameSession object,
-	// which is passed to the game server with a request to start a new game session
-	// (see Start a Game Session (http://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-sdk-server-api.html#gamelift-sdk-server-startsession)).
+	// Set of custom properties for a game session, formatted as key:value pairs.
+	// These properties are passed to a game server process in the GameSession object
+	// with a request to start a new game session (see Start a Game Session (http://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-sdk-server-api.html#gamelift-sdk-server-startsession)).
 	GameProperties []*GameProperty `type:"list"`
 
 	// Identifier for the game session created by this placement request. This value
@@ -13666,10 +13834,9 @@ type GameSessionPlacement struct {
 	// GameSessionId value as needed.
 	GameSessionArn *string `min:"1" type:"string"`
 
-	// Set of developer-defined game session properties, formatted as a single string
-	// value. This data is included in the GameSession object, which is passed to
-	// the game server with a request to start a new game session (see Start a Game
-	// Session (http://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-sdk-server-api.html#gamelift-sdk-server-startsession)).
+	// Set of custom game session properties, formatted as a single string value.
+	// This data is passed to a game server process in the GameSession object with
+	// a request to start a new game session (see Start a Game Session (http://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-sdk-server-api.html#gamelift-sdk-server-startsession)).
 	GameSessionData *string `min:"1" type:"string"`
 
 	// Unique identifier for the game session. This value is set once the new game
@@ -13693,6 +13860,14 @@ type GameSessionPlacement struct {
 	// an app needs both the IP address and port number. This value is set once
 	// the new game session is placed (placement status is FULFILLED).
 	IpAddress *string `type:"string"`
+
+	// Information on the matchmaking process for this game. Data is in JSON syntax,
+	// formated as a string. It identifies the matchmaking configuration used to
+	// create the match, and contains data on all players assigned to the match,
+	// including player attributes and team assignments. For more details on matchmaker
+	// data, see http://docs.aws.amazon.com/gamelift/latest/developerguide/match-server.html#match-server-data
+	// (http://docs.aws.amazon.com/gamelift/latest/developerguide/match-server.html#match-server-data).
+	MatchmakerData *string `min:"1" type:"string"`
 
 	// Maximum number of players that can be connected simultaneously to the game
 	// session.
@@ -13799,6 +13974,12 @@ func (s *GameSessionPlacement) SetGameSessionRegion(v string) *GameSessionPlacem
 // SetIpAddress sets the IpAddress field's value.
 func (s *GameSessionPlacement) SetIpAddress(v string) *GameSessionPlacement {
 	s.IpAddress = &v
+	return s
+}
+
+// SetMatchmakerData sets the MatchmakerData field's value.
+func (s *GameSessionPlacement) SetMatchmakerData(v string) *GameSessionPlacement {
+	s.MatchmakerData = &v
 	return s
 }
 
@@ -14824,18 +15005,16 @@ type MatchmakingConfiguration struct {
 	// Descriptive label that is associated with matchmaking configuration.
 	Description *string `min:"1" type:"string"`
 
-	// Set of developer-defined properties for a game session, formatted as a set
-	// of type:value pairs. These properties are included in the GameSession object,
-	// which is passed to the game server with a request to start a new game session
-	// (see Start a Game Session (http://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-sdk-server-api.html#gamelift-sdk-server-startsession)).
+	// Set of custom properties for a game session, formatted as key:value pairs.
+	// These properties are passed to a game server process in the GameSession object
+	// with a request to start a new game session (see Start a Game Session (http://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-sdk-server-api.html#gamelift-sdk-server-startsession)).
 	// This information is added to the new GameSession object that is created for
 	// a successful match.
 	GameProperties []*GameProperty `type:"list"`
 
-	// Set of developer-defined game session properties, formatted as a single string
-	// value. This data is included in the GameSession object, which is passed to
-	// the game server with a request to start a new game session (see Start a Game
-	// Session (http://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-sdk-server-api.html#gamelift-sdk-server-startsession)).
+	// Set of custom game session properties, formatted as a single string value.
+	// This data is passed to a game server process in the GameSession object with
+	// a request to start a new game session (see Start a Game Session (http://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-sdk-server-api.html#gamelift-sdk-server-startsession)).
 	// This information is added to the new GameSession object that is created for
 	// a successful match.
 	GameSessionData *string `min:"1" type:"string"`
@@ -14958,8 +15137,8 @@ func (s *MatchmakingConfiguration) SetRuleSetName(v string) *MatchmakingConfigur
 // sets are used in MatchmakingConfiguration objects.
 //
 // A rule set may define the following elements for a match. For detailed information
-// and examples showing how to construct a rule set, see Create Matchmaking
-// Rules for Your Game (http://docs.aws.amazon.com/gamelift/latest/developerguide/match-rules.html).
+// and examples showing how to construct a rule set, see Build a FlexMatch Rule
+// Set (http://docs.aws.amazon.com/gamelift/latest/developerguide/match-rulesets.html).
 //
 //    * Teams -- Required. A rule set must define one or multiple teams for
 //    the match and set minimum and maximum team sizes. For example, a rule
@@ -14974,12 +15153,15 @@ func (s *MatchmakingConfiguration) SetRuleSetName(v string) *MatchmakingConfigur
 //
 //    * Rules -- Optional. Rules define how to evaluate potential players for
 //    a match based on player attributes. A rule might specify minimum requirements
-//    for individual players--such as each player must meet a certain skill
-//    level, or may describe an entire group--such as all teams must be evenly
-//    matched or have at least one player in a certain role.
+//    for individual players, teams, or entire matches. For example, a rule
+//    might require each player to meet a certain skill level, each team to
+//    have at least one player in a certain role, or the match to have a minimum
+//    average skill level. or may describe an entire group--such as all teams
+//    must be evenly matched or have at least one player in a certain role.
+//
 //
 //    * Expansions -- Optional. Expansions allow you to relax the rules after
-//    a period of time if no acceptable matches are found. This feature lets
+//    a period of time when no acceptable matches are found. This feature lets
 //    you balance getting players into games in a reasonable amount of time
 //    instead of making them wait indefinitely for the best possible match.
 //    For example, you might use an expansion to increase the maximum skill
@@ -15084,14 +15266,16 @@ type MatchmakingTicket struct {
 	//    information for players.
 	//
 	//    * FAILED -- The matchmaking request was not completed. Tickets with players
-	//    who fail to accept a proposed match are placed in FAILED status; new matchmaking
-	//    requests can be submitted for these players.
+	//    who fail to accept a proposed match are placed in FAILED status.
 	//
 	//    * CANCELLED -- The matchmaking request was canceled with a call to StopMatchmaking.
 	//
-	//    * TIMED_OUT -- The matchmaking request was not completed within the duration
-	//    specified in the matchmaking configuration. Matchmaking requests that
-	//    time out can be resubmitted.
+	//    * TIMED_OUT -- The matchmaking request was not successful within the duration
+	//    specified in the matchmaking configuration.
+	//
+	// Matchmaking requests that fail to successfully complete (statuses FAILED,
+	// CANCELLED, TIMED_OUT) can be resubmitted as new requests with new ticket
+	// IDs.
 	Status *string `type:"string" enum:"MatchmakingConfigurationStatus"`
 
 	// Additional information about the current status.
@@ -15245,9 +15429,9 @@ type Player struct {
 	// is not matchable.
 	LatencyInMs map[string]*int64 `type:"map"`
 
-	// Collection of name:value pairs containing player information for use in matchmaking.
-	// Player attribute names need to match playerAttributes names in the rule set
-	// being used. Example: "PlayerAttributes": {"skill": {"N": "23"}, "gameMode":
+	// Collection of key:value pairs containing player information for use in matchmaking.
+	// Player attribute keys must match the playerAttributes used in a matchmaking
+	// rule set. Example: "PlayerAttributes": {"skill": {"N": "23"}, "gameMode":
 	// {"S": "deathmatch"}}.
 	PlayerAttributes map[string]*AttributeValue `type:"map"`
 
@@ -16474,17 +16658,17 @@ type SearchGameSessionsInput struct {
 	// consists of the following:
 	//
 	//    * Operand -- Name of a game session attribute. Valid values are gameSessionName,
-	//    gameSessionId, creationTimeMillis, playerSessionCount, maximumSessions,
-	//    hasAvailablePlayerSessions.
+	//    gameSessionId, gameSessionProperties, maximumSessions, creationTimeMillis,
+	//    playerSessionCount, hasAvailablePlayerSessions.
 	//
 	//    * Comparator -- Valid comparators are: =, <>, <, >, <=, >=.
 	//
-	//    * Value -- Value to be searched for. Values can be numbers, boolean values
-	//    (true/false) or strings. String values are case sensitive, enclosed in
-	//    single quotes. Special characters must be escaped. Boolean and string
-	//    values can only be used with the comparators = and <>. For example, the
-	//    following filter expression searches on gameSessionName: "FilterExpression":
-	//    "gameSessionName = 'Matt\\'s Awesome Game 1'".
+	//    * Value -- Value to be searched for. Values may be numbers, boolean values
+	//    (true/false) or strings depending on the operand. String values are case
+	//    sensitive and must be enclosed in single quotes. Special characters must
+	//    be escaped. Boolean and string values can only be used with the comparators
+	//    = and <>. For example, the following filter expression searches on gameSessionName:
+	//    "FilterExpression": "gameSessionName = 'Matt\\'s Awesome Game 1'".
 	//
 	// To chain multiple conditions in a single expression, use the logical keywords
 	// AND, OR, and NOT and parentheses as needed. For example: x AND y AND NOT
@@ -16526,8 +16710,8 @@ type SearchGameSessionsInput struct {
 	// consists of the following elements:
 	//
 	//    * Operand -- Name of a game session attribute. Valid values are gameSessionName,
-	//    gameSessionId, creationTimeMillis, playerSessionCount, maximumSessions,
-	//    hasAvailablePlayerSessions.
+	//    gameSessionId, gameSessionProperties, maximumSessions, creationTimeMillis,
+	//    playerSessionCount, hasAvailablePlayerSessions.
 	//
 	//    * Order -- Valid sort orders are ASC (ascending) and DESC (descending).
 	//
@@ -16729,16 +16913,14 @@ type StartGameSessionPlacementInput struct {
 	// Set of information on each player to create a player session for.
 	DesiredPlayerSessions []*DesiredPlayerSession `type:"list"`
 
-	// Set of developer-defined properties for a game session, formatted as a set
-	// of type:value pairs. These properties are included in the GameSession object,
-	// which is passed to the game server with a request to start a new game session
-	// (see Start a Game Session (http://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-sdk-server-api.html#gamelift-sdk-server-startsession)).
+	// Set of custom properties for a game session, formatted as key:value pairs.
+	// These properties are passed to a game server process in the GameSession object
+	// with a request to start a new game session (see Start a Game Session (http://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-sdk-server-api.html#gamelift-sdk-server-startsession)).
 	GameProperties []*GameProperty `type:"list"`
 
-	// Set of developer-defined game session properties, formatted as a single string
-	// value. This data is included in the GameSession object, which is passed to
-	// the game server with a request to start a new game session (see Start a Game
-	// Session (http://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-sdk-server-api.html#gamelift-sdk-server-startsession)).
+	// Set of custom game session properties, formatted as a single string value.
+	// This data is passed to a game server process in the GameSession object with
+	// a request to start a new game session (see Start a Game Session (http://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-sdk-server-api.html#gamelift-sdk-server-startsession)).
 	GameSessionData *string `min:"1" type:"string"`
 
 	// Descriptive label that is associated with a game session. Session names do
@@ -16916,6 +17098,147 @@ func (s *StartGameSessionPlacementOutput) SetGameSessionPlacement(v *GameSession
 }
 
 // Represents the input for a request action.
+type StartMatchBackfillInput struct {
+	_ struct{} `type:"structure"`
+
+	// Name of the matchmaker to use for this request. The name of the matchmaker
+	// that was used with the original game session is listed in the GameSession
+	// object, MatchmakerData property. This property contains a matchmaking configuration
+	// ARN value, which includes the matchmaker name. (In the ARN value "arn:aws:gamelift:us-west-2:111122223333:matchmakingconfiguration/MM-4v4",
+	// the matchmaking configuration name is "MM-4v4".) Use only the name for this
+	// parameter.
+	//
+	// ConfigurationName is a required field
+	ConfigurationName *string `min:"1" type:"string" required:"true"`
+
+	// Amazon Resource Name (ARN (http://docs.aws.amazon.com/AmazonS3/latest/dev/s3-arn-format.html))
+	// that is assigned to a game session and uniquely identifies it.
+	//
+	// GameSessionArn is a required field
+	GameSessionArn *string `min:"1" type:"string" required:"true"`
+
+	// Match information on all players that are currently assigned to the game
+	// session. This information is used by the matchmaker to find new players and
+	// add them to the existing game.
+	//
+	//    * PlayerID, PlayerAttributes, Team -- This information is maintained in
+	//    the GameSession object, MatchmakerData property, for all players who are
+	//    currently assigned to the game session. The matchmaker data is in JSON
+	//    syntax, formatted as a string. For more details, see  Match Data (http://docs.aws.amazon.com/gamelift/latest/developerguide/match-server.html#match-server-data).
+	//
+	//
+	//    * LatencyInMs -- If the matchmaker uses player latency, include a latency
+	//    value, in milliseconds, for the region that the game session is currently
+	//    in. Do not include latency values for any other region.
+	//
+	// Players is a required field
+	Players []*Player `type:"list" required:"true"`
+
+	// Unique identifier for a matchmaking ticket. If no ticket ID is specified
+	// here, Amazon GameLift will generate one in the form of a UUID. Use this identifier
+	// to track the match backfill ticket status and retrieve match results.
+	TicketId *string `min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s StartMatchBackfillInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s StartMatchBackfillInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StartMatchBackfillInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StartMatchBackfillInput"}
+	if s.ConfigurationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ConfigurationName"))
+	}
+	if s.ConfigurationName != nil && len(*s.ConfigurationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ConfigurationName", 1))
+	}
+	if s.GameSessionArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("GameSessionArn"))
+	}
+	if s.GameSessionArn != nil && len(*s.GameSessionArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GameSessionArn", 1))
+	}
+	if s.Players == nil {
+		invalidParams.Add(request.NewErrParamRequired("Players"))
+	}
+	if s.TicketId != nil && len(*s.TicketId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TicketId", 1))
+	}
+	if s.Players != nil {
+		for i, v := range s.Players {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Players", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetConfigurationName sets the ConfigurationName field's value.
+func (s *StartMatchBackfillInput) SetConfigurationName(v string) *StartMatchBackfillInput {
+	s.ConfigurationName = &v
+	return s
+}
+
+// SetGameSessionArn sets the GameSessionArn field's value.
+func (s *StartMatchBackfillInput) SetGameSessionArn(v string) *StartMatchBackfillInput {
+	s.GameSessionArn = &v
+	return s
+}
+
+// SetPlayers sets the Players field's value.
+func (s *StartMatchBackfillInput) SetPlayers(v []*Player) *StartMatchBackfillInput {
+	s.Players = v
+	return s
+}
+
+// SetTicketId sets the TicketId field's value.
+func (s *StartMatchBackfillInput) SetTicketId(v string) *StartMatchBackfillInput {
+	s.TicketId = &v
+	return s
+}
+
+// Represents the returned data in response to a request action.
+type StartMatchBackfillOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Ticket representing the backfill matchmaking request. This object includes
+	// the information in the request, ticket status, and match results as generated
+	// during the matchmaking process.
+	MatchmakingTicket *MatchmakingTicket `type:"structure"`
+}
+
+// String returns the string representation
+func (s StartMatchBackfillOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s StartMatchBackfillOutput) GoString() string {
+	return s.String()
+}
+
+// SetMatchmakingTicket sets the MatchmakingTicket field's value.
+func (s *StartMatchBackfillOutput) SetMatchmakingTicket(v *MatchmakingTicket) *StartMatchBackfillOutput {
+	s.MatchmakingTicket = v
+	return s
+}
+
+// Represents the input for a request action.
 type StartMatchmakingInput struct {
 	_ struct{} `type:"structure"`
 
@@ -16933,8 +17256,9 @@ type StartMatchmakingInput struct {
 	// Players is a required field
 	Players []*Player `type:"list" required:"true"`
 
-	// Unique identifier for a matchmaking ticket. Use this identifier to track
-	// the matchmaking ticket status and retrieve match results.
+	// Unique identifier for a matchmaking ticket. If no ticket ID is specified
+	// here, Amazon GameLift will generate one in the form of a UUID. Use this identifier
+	// to track the matchmaking ticket status and retrieve match results.
 	TicketId *string `min:"1" type:"string"`
 }
 
@@ -17909,18 +18233,16 @@ type UpdateMatchmakingConfigurationInput struct {
 	// Descriptive label that is associated with matchmaking configuration.
 	Description *string `min:"1" type:"string"`
 
-	// Set of developer-defined properties for a game session, formatted as a set
-	// of type:value pairs. These properties are included in the GameSession object,
-	// which is passed to the game server with a request to start a new game session
-	// (see Start a Game Session (http://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-sdk-server-api.html#gamelift-sdk-server-startsession)).
+	// Set of custom properties for a game session, formatted as key:value pairs.
+	// These properties are passed to a game server process in the GameSession object
+	// with a request to start a new game session (see Start a Game Session (http://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-sdk-server-api.html#gamelift-sdk-server-startsession)).
 	// This information is added to the new GameSession object that is created for
 	// a successful match.
 	GameProperties []*GameProperty `type:"list"`
 
-	// Set of developer-defined game session properties, formatted as a single string
-	// value. This data is included in the GameSession object, which is passed to
-	// the game server with a request to start a new game session (see Start a Game
-	// Session (http://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-sdk-server-api.html#gamelift-sdk-server-startsession)).
+	// Set of custom game session properties, formatted as a single string value.
+	// This data is passed to a game server process in the GameSession object with
+	// a request to start a new game session (see Start a Game Session (http://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-sdk-server-api.html#gamelift-sdk-server-startsession)).
 	// This information is added to the new GameSession object that is created for
 	// a successful match.
 	GameSessionData *string `min:"1" type:"string"`
@@ -18434,7 +18756,7 @@ func (s *VpcPeeringConnection) SetVpcPeeringConnectionId(v string) *VpcPeeringCo
 
 // Represents status information for a VPC peering connection. Status is associated
 // with a VpcPeeringConnection object. Status codes and messages are provided
-// from EC2 (). (http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_VpcPeeringConnectionStateReason.html)
+// from EC2 (see VpcPeeringConnectionStateReason (http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_VpcPeeringConnectionStateReason.html)).
 // Connection status information is also communicated as a fleet Event.
 type VpcPeeringConnectionStatus struct {
 	_ struct{} `type:"structure"`

--- a/vendor/github.com/aws/aws-sdk-go/service/gamelift/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/gamelift/doc.go
@@ -4,11 +4,11 @@
 // requests to Amazon GameLift.
 //
 // Amazon GameLift is a managed service for developers who need a scalable,
-// dedicated server solution for their multiplayer games. Amazon GameLift provides
-// tools for the following tasks: (1) acquire computing resources and deploy
-// game servers, (2) scale game server capacity to meet player demand, (3) host
-// game sessions and manage player access, and (4) track in-depth metrics on
-// player usage and server performance.
+// dedicated server solution for their multiplayer games. Use Amazon GameLift
+// for these tasks: (1) set up computing resources and deploy your game servers,
+// (2) run game sessions and get players into games, (3) automatically scale
+// your resources to meet player demand and manage costs, and (4) track in-depth
+// metrics on game server performance and player usage.
 //
 // The Amazon GameLift service API includes two important function sets:
 //
@@ -43,13 +43,13 @@
 //    a subset of key API actions, which can be called from either the AWS CLI
 //    or programmatically. See Testing an Integration (http://docs.aws.amazon.com/gamelift/latest/developerguide/integration-testing-local.html).
 //
-// MORE RESOURCES
+// Learn more
 //
-//    * Amazon GameLift Developer Guide (http://docs.aws.amazon.com/gamelift/latest/developerguide/)
-//    -- Learn more about Amazon GameLift features and how to use them.
+//    *  Developer Guide (http://docs.aws.amazon.com/gamelift/latest/developerguide/)
+//    -- Read about Amazon GameLift features and how to use them.
 //
-//    * Lumberyard and Amazon GameLift Tutorials (https://gamedev.amazon.com/forums/tutorials)
-//    -- Get started fast with walkthroughs and sample projects.
+//    * Tutorials (https://gamedev.amazon.com/forums/tutorials) -- Get started
+//    fast with walkthroughs and sample projects.
 //
 //    * GameDev Blog (http://aws.amazon.com/blogs/gamedev/) -- Stay up to date
 //    with new features and techniques.
@@ -57,9 +57,10 @@
 //    * GameDev Forums (https://gamedev.amazon.com/forums/spaces/123/gamelift-discussion.html)
 //    -- Connect with the GameDev community.
 //
-//    * Amazon GameLift Document History (http://docs.aws.amazon.com/gamelift/latest/developerguide/doc-history.html)
-//    -- See changes to the Amazon GameLift service, SDKs, and documentation,
-//    as well as links to release notes.
+//    * Release notes (http://aws.amazon.com/releasenotes/Amazon-GameLift/)
+//    and document history (http://docs.aws.amazon.com/gamelift/latest/developerguide/doc-history.html)
+//    -- Stay current with updates to the Amazon GameLift service, SDKs, and
+//    documentation.
 //
 // API SUMMARY
 //
@@ -103,6 +104,9 @@
 // AcceptMatch -- Register that a player accepts a proposed match, for matches
 //    that require player acceptance.
 //
+// StartMatchBackfill - Request additional player matches to fill empty slots
+//    in an existing game session.
+//
 // StopMatchmaking -- Cancel a matchmaking request.
 //
 //    * Manage game session data
@@ -141,8 +145,8 @@
 //    * Manage game builds
 //
 // CreateBuild -- Create a new build using files stored in an Amazon S3 bucket.
-//    (Update uploading permissions with RequestUploadCredentials.) To create
-//    a build and upload files from a local path, use the AWS CLI command upload-build.
+//    To create a build and upload files from a local path, use the AWS CLI
+//    command upload-build.
 //
 // ListBuilds -- Get a list of all builds uploaded to a Amazon GameLift region.
 //

--- a/vendor/github.com/aws/aws-sdk-go/service/medialive/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/medialive/api.go
@@ -1436,6 +1436,96 @@ func (c *MediaLive) StopChannelWithContext(ctx aws.Context, input *StopChannelIn
 	return out, req.Send()
 }
 
+const opUpdateChannel = "UpdateChannel"
+
+// UpdateChannelRequest generates a "aws/request.Request" representing the
+// client's request for the UpdateChannel operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See UpdateChannel for more information on using the UpdateChannel
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the UpdateChannelRequest method.
+//    req, resp := client.UpdateChannelRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/UpdateChannel
+func (c *MediaLive) UpdateChannelRequest(input *UpdateChannelInput) (req *request.Request, output *UpdateChannelOutput) {
+	op := &request.Operation{
+		Name:       opUpdateChannel,
+		HTTPMethod: "PUT",
+		HTTPPath:   "/prod/channels/{channelId}",
+	}
+
+	if input == nil {
+		input = &UpdateChannelInput{}
+	}
+
+	output = &UpdateChannelOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// UpdateChannel API operation for AWS Elemental MediaLive.
+//
+// Updates a channel.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Elemental MediaLive's
+// API operation UpdateChannel for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeUnprocessableEntityException "UnprocessableEntityException"
+//
+//   * ErrCodeBadRequestException "BadRequestException"
+//
+//   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//
+//   * ErrCodeForbiddenException "ForbiddenException"
+//
+//   * ErrCodeBadGatewayException "BadGatewayException"
+//
+//   * ErrCodeGatewayTimeoutException "GatewayTimeoutException"
+//
+//   * ErrCodeConflictException "ConflictException"
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/UpdateChannel
+func (c *MediaLive) UpdateChannel(input *UpdateChannelInput) (*UpdateChannelOutput, error) {
+	req, out := c.UpdateChannelRequest(input)
+	return out, req.Send()
+}
+
+// UpdateChannelWithContext is the same as UpdateChannel with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UpdateChannel for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *MediaLive) UpdateChannelWithContext(ctx aws.Context, input *UpdateChannelInput, opts ...request.Option) (*UpdateChannelOutput, error) {
+	req, out := c.UpdateChannelRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 type AacSettings struct {
 	_ struct{} `type:"structure"`
 
@@ -2720,8 +2810,8 @@ func (s *CaptionDestinationSettings) SetWebvttDestinationSettings(v *WebvttDesti
 type CaptionLanguageMapping struct {
 	_ struct{} `type:"structure"`
 
-	// Channel to insert closed captions. Each channel mapping must have a unique
-	// channel number (maximum of 4)
+	// The closed caption channel being described by this CaptionLanguageMapping.
+	// Each channel mapping must have a unique channel number (maximum of 4)
 	CaptionChannel *int64 `locationName:"captionChannel" type:"integer"`
 
 	// Three character ISO 639-2 language code (see http://www.loc.gov/standards/iso639-2)
@@ -3121,7 +3211,7 @@ type CreateChannelInput struct {
 
 	RequestId *string `locationName:"requestId" type:"string" idempotencyToken:"true"`
 
-	Reserved *string `locationName:"reserved" type:"string"`
+	Reserved *string `locationName:"reserved" deprecated:"true" type:"string"`
 
 	RoleArn *string `locationName:"roleArn" type:"string"`
 }
@@ -8954,6 +9044,104 @@ func (s *UdpOutputSettings) SetDestination(v *OutputLocationRef) *UdpOutputSetti
 // SetFecOutputSettings sets the FecOutputSettings field's value.
 func (s *UdpOutputSettings) SetFecOutputSettings(v *FecOutputSettings) *UdpOutputSettings {
 	s.FecOutputSettings = v
+	return s
+}
+
+type UpdateChannelInput struct {
+	_ struct{} `type:"structure"`
+
+	// ChannelId is a required field
+	ChannelId *string `location:"uri" locationName:"channelId" type:"string" required:"true"`
+
+	Destinations []*OutputDestination `locationName:"destinations" type:"list"`
+
+	EncoderSettings *EncoderSettings `locationName:"encoderSettings" type:"structure"`
+
+	InputSpecification *InputSpecification `locationName:"inputSpecification" type:"structure"`
+
+	Name *string `locationName:"name" type:"string"`
+
+	RoleArn *string `locationName:"roleArn" type:"string"`
+}
+
+// String returns the string representation
+func (s UpdateChannelInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateChannelInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateChannelInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateChannelInput"}
+	if s.ChannelId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ChannelId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetChannelId sets the ChannelId field's value.
+func (s *UpdateChannelInput) SetChannelId(v string) *UpdateChannelInput {
+	s.ChannelId = &v
+	return s
+}
+
+// SetDestinations sets the Destinations field's value.
+func (s *UpdateChannelInput) SetDestinations(v []*OutputDestination) *UpdateChannelInput {
+	s.Destinations = v
+	return s
+}
+
+// SetEncoderSettings sets the EncoderSettings field's value.
+func (s *UpdateChannelInput) SetEncoderSettings(v *EncoderSettings) *UpdateChannelInput {
+	s.EncoderSettings = v
+	return s
+}
+
+// SetInputSpecification sets the InputSpecification field's value.
+func (s *UpdateChannelInput) SetInputSpecification(v *InputSpecification) *UpdateChannelInput {
+	s.InputSpecification = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *UpdateChannelInput) SetName(v string) *UpdateChannelInput {
+	s.Name = &v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *UpdateChannelInput) SetRoleArn(v string) *UpdateChannelInput {
+	s.RoleArn = &v
+	return s
+}
+
+type UpdateChannelOutput struct {
+	_ struct{} `type:"structure"`
+
+	Channel *Channel `locationName:"channel" type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateChannelOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateChannelOutput) GoString() string {
+	return s.String()
+}
+
+// SetChannel sets the Channel field's value.
+func (s *UpdateChannelOutput) SetChannel(v *Channel) *UpdateChannelOutput {
+	s.Channel = v
 	return s
 }
 

--- a/vendor/github.com/aws/aws-sdk-go/service/mediastore/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/mediastore/api.go
@@ -271,6 +271,99 @@ func (c *MediaStore) DeleteContainerPolicyWithContext(ctx aws.Context, input *De
 	return out, req.Send()
 }
 
+const opDeleteCorsPolicy = "DeleteCorsPolicy"
+
+// DeleteCorsPolicyRequest generates a "aws/request.Request" representing the
+// client's request for the DeleteCorsPolicy operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DeleteCorsPolicy for more information on using the DeleteCorsPolicy
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DeleteCorsPolicyRequest method.
+//    req, resp := client.DeleteCorsPolicyRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/mediastore-2017-09-01/DeleteCorsPolicy
+func (c *MediaStore) DeleteCorsPolicyRequest(input *DeleteCorsPolicyInput) (req *request.Request, output *DeleteCorsPolicyOutput) {
+	op := &request.Operation{
+		Name:       opDeleteCorsPolicy,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DeleteCorsPolicyInput{}
+	}
+
+	output = &DeleteCorsPolicyOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DeleteCorsPolicy API operation for AWS Elemental MediaStore.
+//
+// Deletes the cross-origin resource sharing (CORS) configuration information
+// that is set for the container.
+//
+// To use this operation, you must have permission to perform the MediaStore:DeleteCorsPolicy
+// action. The container owner has this permission by default and can grant
+// this permission to others.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Elemental MediaStore's
+// API operation DeleteCorsPolicy for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeContainerInUseException "ContainerInUseException"
+//   Resource already exists or is being updated.
+//
+//   * ErrCodeContainerNotFoundException "ContainerNotFoundException"
+//   Could not perform an operation on a container that does not exist.
+//
+//   * ErrCodeCorsPolicyNotFoundException "CorsPolicyNotFoundException"
+//   Could not perform an operation on a policy that does not exist.
+//
+//   * ErrCodeInternalServerError "InternalServerError"
+//   The service is temporarily unavailable.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/mediastore-2017-09-01/DeleteCorsPolicy
+func (c *MediaStore) DeleteCorsPolicy(input *DeleteCorsPolicyInput) (*DeleteCorsPolicyOutput, error) {
+	req, out := c.DeleteCorsPolicyRequest(input)
+	return out, req.Send()
+}
+
+// DeleteCorsPolicyWithContext is the same as DeleteCorsPolicy with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeleteCorsPolicy for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *MediaStore) DeleteCorsPolicyWithContext(ctx aws.Context, input *DeleteCorsPolicyInput, opts ...request.Option) (*DeleteCorsPolicyOutput, error) {
+	req, out := c.DeleteCorsPolicyRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opDescribeContainer = "DescribeContainer"
 
 // DescribeContainerRequest generates a "aws/request.Request" representing the
@@ -315,9 +408,12 @@ func (c *MediaStore) DescribeContainerRequest(input *DescribeContainerInput) (re
 
 // DescribeContainer API operation for AWS Elemental MediaStore.
 //
-// Retrieves the properties of the requested container. This returns a single
-// Container object based on ContainerName. To return all Container objects
-// that are associated with a specified AWS account, use ListContainers.
+// Retrieves the properties of the requested container. This request is commonly
+// used to retrieve the endpoint of a container. An endpoint is a value assigned
+// by the service when a new container is created. A container's endpoint does
+// not change after it has been assigned. The DescribeContainer request returns
+// a single Container object based on ContainerName. To return all Container
+// objects that are associated with a specified AWS account, use ListContainers.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -440,6 +536,99 @@ func (c *MediaStore) GetContainerPolicy(input *GetContainerPolicyInput) (*GetCon
 // for more information on using Contexts.
 func (c *MediaStore) GetContainerPolicyWithContext(ctx aws.Context, input *GetContainerPolicyInput, opts ...request.Option) (*GetContainerPolicyOutput, error) {
 	req, out := c.GetContainerPolicyRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opGetCorsPolicy = "GetCorsPolicy"
+
+// GetCorsPolicyRequest generates a "aws/request.Request" representing the
+// client's request for the GetCorsPolicy operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See GetCorsPolicy for more information on using the GetCorsPolicy
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the GetCorsPolicyRequest method.
+//    req, resp := client.GetCorsPolicyRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/mediastore-2017-09-01/GetCorsPolicy
+func (c *MediaStore) GetCorsPolicyRequest(input *GetCorsPolicyInput) (req *request.Request, output *GetCorsPolicyOutput) {
+	op := &request.Operation{
+		Name:       opGetCorsPolicy,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &GetCorsPolicyInput{}
+	}
+
+	output = &GetCorsPolicyOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// GetCorsPolicy API operation for AWS Elemental MediaStore.
+//
+// Returns the cross-origin resource sharing (CORS) configuration information
+// that is set for the container.
+//
+// To use this operation, you must have permission to perform the MediaStore:GetCorsPolicy
+// action. By default, the container owner has this permission and can grant
+// it to others.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Elemental MediaStore's
+// API operation GetCorsPolicy for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeContainerInUseException "ContainerInUseException"
+//   Resource already exists or is being updated.
+//
+//   * ErrCodeContainerNotFoundException "ContainerNotFoundException"
+//   Could not perform an operation on a container that does not exist.
+//
+//   * ErrCodeCorsPolicyNotFoundException "CorsPolicyNotFoundException"
+//   Could not perform an operation on a policy that does not exist.
+//
+//   * ErrCodeInternalServerError "InternalServerError"
+//   The service is temporarily unavailable.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/mediastore-2017-09-01/GetCorsPolicy
+func (c *MediaStore) GetCorsPolicy(input *GetCorsPolicyInput) (*GetCorsPolicyOutput, error) {
+	req, out := c.GetCorsPolicyRequest(input)
+	return out, req.Send()
+}
+
+// GetCorsPolicyWithContext is the same as GetCorsPolicy with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetCorsPolicy for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *MediaStore) GetCorsPolicyWithContext(ctx aws.Context, input *GetCorsPolicyInput, opts ...request.Option) (*GetCorsPolicyOutput, error) {
+	req, out := c.GetCorsPolicyRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -625,6 +814,101 @@ func (c *MediaStore) PutContainerPolicyWithContext(ctx aws.Context, input *PutCo
 	return out, req.Send()
 }
 
+const opPutCorsPolicy = "PutCorsPolicy"
+
+// PutCorsPolicyRequest generates a "aws/request.Request" representing the
+// client's request for the PutCorsPolicy operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See PutCorsPolicy for more information on using the PutCorsPolicy
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the PutCorsPolicyRequest method.
+//    req, resp := client.PutCorsPolicyRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/mediastore-2017-09-01/PutCorsPolicy
+func (c *MediaStore) PutCorsPolicyRequest(input *PutCorsPolicyInput) (req *request.Request, output *PutCorsPolicyOutput) {
+	op := &request.Operation{
+		Name:       opPutCorsPolicy,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &PutCorsPolicyInput{}
+	}
+
+	output = &PutCorsPolicyOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// PutCorsPolicy API operation for AWS Elemental MediaStore.
+//
+// Sets the cross-origin resource sharing (CORS) configuration on a container
+// so that the container can service cross-origin requests. For example, you
+// might want to enable a request whose origin is http://www.example.com to
+// access your AWS Elemental MediaStore container at my.example.container.com
+// by using the browser's XMLHttpRequest capability.
+//
+// To enable CORS on a container, you attach a CORS policy to the container.
+// In the CORS policy, you configure rules that identify origins and the HTTP
+// methods that can be executed on your container. The policy can contain up
+// to 398,000 characters. You can add up to 100 rules to a CORS policy. If more
+// than one rule applies, the service uses the first applicable rule listed.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Elemental MediaStore's
+// API operation PutCorsPolicy for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeContainerNotFoundException "ContainerNotFoundException"
+//   Could not perform an operation on a container that does not exist.
+//
+//   * ErrCodeContainerInUseException "ContainerInUseException"
+//   Resource already exists or is being updated.
+//
+//   * ErrCodeInternalServerError "InternalServerError"
+//   The service is temporarily unavailable.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/mediastore-2017-09-01/PutCorsPolicy
+func (c *MediaStore) PutCorsPolicy(input *PutCorsPolicyInput) (*PutCorsPolicyOutput, error) {
+	req, out := c.PutCorsPolicyRequest(input)
+	return out, req.Send()
+}
+
+// PutCorsPolicyWithContext is the same as PutCorsPolicy with the addition of
+// the ability to pass a context and additional request options.
+//
+// See PutCorsPolicy for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *MediaStore) PutCorsPolicyWithContext(ctx aws.Context, input *PutCorsPolicyInput, opts ...request.Option) (*PutCorsPolicyOutput, error) {
+	req, out := c.PutCorsPolicyRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 // This section describes operations that you can perform on an AWS Elemental
 // MediaStore container.
 type Container struct {
@@ -641,8 +925,10 @@ type Container struct {
 	// Unix timestamp.
 	CreationTime *time.Time `type:"timestamp" timestampFormat:"unix"`
 
-	// The DNS endpoint of the container. Use from 1 to 255 characters. Use this
-	// endpoint to identify this container when sending requests to the data plane.
+	// The DNS endpoint of the container. Use the endpoint to identify the specific
+	// container when sending requests to the data plane. The service assigns this
+	// value when the container is created. Once the value has been assigned, it
+	// does not change.
 	Endpoint *string `min:"1" type:"string"`
 
 	// The name of the container.
@@ -692,6 +978,88 @@ func (s *Container) SetName(v string) *Container {
 // SetStatus sets the Status field's value.
 func (s *Container) SetStatus(v string) *Container {
 	s.Status = &v
+	return s
+}
+
+// A rule for a CORS policy. You can add up to 100 rules to a CORS policy. If
+// more than one rule applies, the service uses the first applicable rule listed.
+type CorsRule struct {
+	_ struct{} `type:"structure"`
+
+	// Specifies which headers are allowed in a preflight OPTIONS request through
+	// the Access-Control-Request-Headers header. Each header name that is specified
+	// in Access-Control-Request-Headers must have a corresponding entry in the
+	// rule. Only the headers that were requested are sent back.
+	//
+	// This element can contain only one wildcard character (*).
+	AllowedHeaders []*string `type:"list"`
+
+	// Identifies an HTTP method that the origin that is specified in the rule is
+	// allowed to execute.
+	//
+	// Each CORS rule must contain at least one AllowedMethod and one AllowedOrigin
+	// element.
+	AllowedMethods []*string `type:"list"`
+
+	// One or more response headers that you want users to be able to access from
+	// their applications (for example, from a JavaScript XMLHttpRequest object).
+	//
+	// Each CORS rule must have at least one AllowedOrigin element. The string value
+	// can include only one wildcard character (*), for example, http://*.example.com.
+	// Additionally, you can specify only one wildcard character to allow cross-origin
+	// access for all origins.
+	AllowedOrigins []*string `type:"list"`
+
+	// One or more headers in the response that you want users to be able to access
+	// from their applications (for example, from a JavaScript XMLHttpRequest object).
+	//
+	// This element is optional for each rule.
+	ExposeHeaders []*string `type:"list"`
+
+	// The time in seconds that your browser caches the preflight response for the
+	// specified resource.
+	//
+	// A CORS rule can have only one MaxAgeSeconds element.
+	MaxAgeSeconds *int64 `type:"integer"`
+}
+
+// String returns the string representation
+func (s CorsRule) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CorsRule) GoString() string {
+	return s.String()
+}
+
+// SetAllowedHeaders sets the AllowedHeaders field's value.
+func (s *CorsRule) SetAllowedHeaders(v []*string) *CorsRule {
+	s.AllowedHeaders = v
+	return s
+}
+
+// SetAllowedMethods sets the AllowedMethods field's value.
+func (s *CorsRule) SetAllowedMethods(v []*string) *CorsRule {
+	s.AllowedMethods = v
+	return s
+}
+
+// SetAllowedOrigins sets the AllowedOrigins field's value.
+func (s *CorsRule) SetAllowedOrigins(v []*string) *CorsRule {
+	s.AllowedOrigins = v
+	return s
+}
+
+// SetExposeHeaders sets the ExposeHeaders field's value.
+func (s *CorsRule) SetExposeHeaders(v []*string) *CorsRule {
+	s.ExposeHeaders = v
+	return s
+}
+
+// SetMaxAgeSeconds sets the MaxAgeSeconds field's value.
+func (s *CorsRule) SetMaxAgeSeconds(v int64) *CorsRule {
+	s.MaxAgeSeconds = &v
 	return s
 }
 
@@ -748,7 +1116,7 @@ type CreateContainerOutput struct {
 	//
 	// ContainerName: The container name as specified in the request.
 	//
-	// CreationTime: Unix timestamp.
+	// CreationTime: Unix time stamp.
 	//
 	// Status: The status of container creation or deletion. The status is one of
 	// the following: CREATING, ACTIVE, or DELETING. While the service is creating
@@ -888,6 +1256,61 @@ func (s DeleteContainerPolicyOutput) GoString() string {
 	return s.String()
 }
 
+type DeleteCorsPolicyInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the container to remove the policy from.
+	//
+	// ContainerName is a required field
+	ContainerName *string `min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DeleteCorsPolicyInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteCorsPolicyInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteCorsPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteCorsPolicyInput"}
+	if s.ContainerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ContainerName"))
+	}
+	if s.ContainerName != nil && len(*s.ContainerName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ContainerName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetContainerName sets the ContainerName field's value.
+func (s *DeleteCorsPolicyInput) SetContainerName(v string) *DeleteCorsPolicyInput {
+	s.ContainerName = &v
+	return s
+}
+
+type DeleteCorsPolicyOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteCorsPolicyOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteCorsPolicyOutput) GoString() string {
+	return s.String()
+}
+
 type DescribeContainerInput struct {
 	_ struct{} `type:"structure"`
 
@@ -1010,6 +1433,72 @@ func (s GetContainerPolicyOutput) GoString() string {
 // SetPolicy sets the Policy field's value.
 func (s *GetContainerPolicyOutput) SetPolicy(v string) *GetContainerPolicyOutput {
 	s.Policy = &v
+	return s
+}
+
+type GetCorsPolicyInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the container that the policy is assigned to.
+	//
+	// ContainerName is a required field
+	ContainerName *string `min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s GetCorsPolicyInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetCorsPolicyInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetCorsPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetCorsPolicyInput"}
+	if s.ContainerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ContainerName"))
+	}
+	if s.ContainerName != nil && len(*s.ContainerName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ContainerName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetContainerName sets the ContainerName field's value.
+func (s *GetCorsPolicyInput) SetContainerName(v string) *GetCorsPolicyInput {
+	s.ContainerName = &v
+	return s
+}
+
+type GetCorsPolicyOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The CORS policy of the container.
+	//
+	// CorsPolicy is a required field
+	CorsPolicy []*CorsRule `min:"1" type:"list" required:"true"`
+}
+
+// String returns the string representation
+func (s GetCorsPolicyOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetCorsPolicyOutput) GoString() string {
+	return s.String()
+}
+
+// SetCorsPolicy sets the CorsPolicy field's value.
+func (s *GetCorsPolicyOutput) SetCorsPolicy(v []*CorsRule) *GetCorsPolicyOutput {
+	s.CorsPolicy = v
 	return s
 }
 
@@ -1177,6 +1666,78 @@ func (s PutContainerPolicyOutput) GoString() string {
 	return s.String()
 }
 
+type PutCorsPolicyInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the container that you want to assign the CORS policy to.
+	//
+	// ContainerName is a required field
+	ContainerName *string `min:"1" type:"string" required:"true"`
+
+	// The CORS policy to apply to the container.
+	//
+	// CorsPolicy is a required field
+	CorsPolicy []*CorsRule `min:"1" type:"list" required:"true"`
+}
+
+// String returns the string representation
+func (s PutCorsPolicyInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PutCorsPolicyInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutCorsPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutCorsPolicyInput"}
+	if s.ContainerName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ContainerName"))
+	}
+	if s.ContainerName != nil && len(*s.ContainerName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ContainerName", 1))
+	}
+	if s.CorsPolicy == nil {
+		invalidParams.Add(request.NewErrParamRequired("CorsPolicy"))
+	}
+	if s.CorsPolicy != nil && len(s.CorsPolicy) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CorsPolicy", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetContainerName sets the ContainerName field's value.
+func (s *PutCorsPolicyInput) SetContainerName(v string) *PutCorsPolicyInput {
+	s.ContainerName = &v
+	return s
+}
+
+// SetCorsPolicy sets the CorsPolicy field's value.
+func (s *PutCorsPolicyInput) SetCorsPolicy(v []*CorsRule) *PutCorsPolicyInput {
+	s.CorsPolicy = v
+	return s
+}
+
+type PutCorsPolicyOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutCorsPolicyOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PutCorsPolicyOutput) GoString() string {
+	return s.String()
+}
+
 const (
 	// ContainerStatusActive is a ContainerStatus enum value
 	ContainerStatusActive = "ACTIVE"
@@ -1186,4 +1747,18 @@ const (
 
 	// ContainerStatusDeleting is a ContainerStatus enum value
 	ContainerStatusDeleting = "DELETING"
+)
+
+const (
+	// MethodNamePut is a MethodName enum value
+	MethodNamePut = "PUT"
+
+	// MethodNameGet is a MethodName enum value
+	MethodNameGet = "GET"
+
+	// MethodNameDelete is a MethodName enum value
+	MethodNameDelete = "DELETE"
+
+	// MethodNameHead is a MethodName enum value
+	MethodNameHead = "HEAD"
 )

--- a/vendor/github.com/aws/aws-sdk-go/service/mediastore/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/mediastore/errors.go
@@ -16,6 +16,12 @@ const (
 	// Could not perform an operation on a container that does not exist.
 	ErrCodeContainerNotFoundException = "ContainerNotFoundException"
 
+	// ErrCodeCorsPolicyNotFoundException for service response error code
+	// "CorsPolicyNotFoundException".
+	//
+	// Could not perform an operation on a policy that does not exist.
+	ErrCodeCorsPolicyNotFoundException = "CorsPolicyNotFoundException"
+
 	// ErrCodeInternalServerError for service response error code
 	// "InternalServerError".
 	//

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -39,868 +39,868 @@
 			"revisionTime": "2017-07-27T15:54:43Z"
 		},
 		{
-			"checksumSHA1": "mFHEkH8cgZqBuQ5qVqNP1SLN4QA=",
+			"checksumSHA1": "3U3U5SzawV/N/rjwlntapRlgtWQ=",
 			"path": "github.com/aws/aws-sdk-go/aws",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "DtuTqKH29YnLjrIJkRYX0HQtXY0=",
 			"path": "github.com/aws/aws-sdk-go/aws/arn",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "Y9W+4GimK4Fuxq+vyIskVYFRnX4=",
 			"path": "github.com/aws/aws-sdk-go/aws/awserr",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "yyYr41HZ1Aq0hWc3J5ijXwYEcac=",
 			"path": "github.com/aws/aws-sdk-go/aws/awsutil",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "9nE/FjZ4pYrT883KtV2/aI+Gayo=",
 			"path": "github.com/aws/aws-sdk-go/aws/client",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "ieAJ+Cvp/PKv1LpUEnUXpc3OI6E=",
 			"path": "github.com/aws/aws-sdk-go/aws/client/metadata",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "7/8j/q0TWtOgXyvEcv4B2Dhl00o=",
 			"path": "github.com/aws/aws-sdk-go/aws/corehandlers",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "Y+cPwQL0dZMyqp3wI+KJWmA9KQ8=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "u3GOAJLmdvbuNUeUEcZSEAOeL/0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "NUJUTWlc1sV8b7WjfiYc4JZbXl0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/endpointcreds",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "JEYqmF83O5n5bHkupAzA6STm0no=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "OnU/n7R33oYXiB4SAGd5pK7I0Bs=",
 			"path": "github.com/aws/aws-sdk-go/aws/defaults",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "/EXbk/z2TWjWc1Hvb4QYs3Wmhb8=",
 			"path": "github.com/aws/aws-sdk-go/aws/ec2metadata",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "CJNEM69cgdO9tZi6c5Lj07jI+dk=",
 			"path": "github.com/aws/aws-sdk-go/aws/endpoints",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "657ICMok3uC5dm5e9bKcVF2HaxE=",
 			"path": "github.com/aws/aws-sdk-go/aws/request",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "DIn7B+oP++/nw603OB95fmupzu8=",
 			"path": "github.com/aws/aws-sdk-go/aws/session",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "iU00ZjhAml/13g+1YXT21IqoXqg=",
 			"path": "github.com/aws/aws-sdk-go/aws/signer/v4",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "04ypv4x12l4q0TksA1zEVsmgpvw=",
 			"path": "github.com/aws/aws-sdk-go/internal/shareddefaults",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "NStHCXEvYqG72GknZyv1jaKaeH0=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "1QmQ3FqV37w0Zi44qv8pA1GeR0A=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/ec2query",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "yHfT5DTbeCLs4NE2Rgnqrhe15ls=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/json/jsonutil",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "R00RL5jJXRYq1iiK1+PGvMfvXyM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/jsonrpc",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "ZqY5RWavBLWTo6j9xqdyBEaNFRk=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "9V1PvtFQ9MObZTc3sa86WcuOtOU=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "pkeoOfZpHRvFG/AOZeTf0lwtsFg=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/rest",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "Rpu8KBtHZgvhkwHxUfaky+qW+G4=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restjson",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "ODo+ko8D6unAxZuN1jGzMcN4QCc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restxml",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "0qYPUga28aQVkxZgBR3Z86AbGUQ=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "F6mth+G7dXN1GI+nktaGo8Lx8aE=",
 			"path": "github.com/aws/aws-sdk-go/private/signer/v2",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "Ih4il2OyFyaSuoMv6hhvPUN8Gn4=",
 			"path": "github.com/aws/aws-sdk-go/service/acm",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "DPl/OkvEUjrd+XKqX73l6nUNw3U=",
 			"path": "github.com/aws/aws-sdk-go/service/apigateway",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "edPLU/Lb9QzcB2tFBgkKvF/WdY8=",
 			"path": "github.com/aws/aws-sdk-go/service/applicationautoscaling",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "zXFZtpt4wA834ihX1gEAEwSGwio=",
 			"path": "github.com/aws/aws-sdk-go/service/appsync",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "wrOVdI/6ZTZ/H0Kxjh3bBEZtVzk=",
 			"path": "github.com/aws/aws-sdk-go/service/athena",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "q4j8cW2zBulU/xx16A8/NxexXKE=",
 			"path": "github.com/aws/aws-sdk-go/service/autoscaling",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "P5gDOoqIdVjMU77e5Nhy48QLpS4=",
 			"path": "github.com/aws/aws-sdk-go/service/batch",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
-			"checksumSHA1": "wAlaD9A7nwt34AL920T9RbY8O9Q=",
+			"checksumSHA1": "BrC9UCeefniH5UN7x0PFr8A9l6Y=",
 			"path": "github.com/aws/aws-sdk-go/service/budgets",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "EoaTzMilW+OIi5eETJUpd+giyTc=",
 			"path": "github.com/aws/aws-sdk-go/service/cloud9",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "yuFNzmUIWppfji/Xx6Aao0EE4cY=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudformation",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "0nPnGWlegQG7bn/iIIfjJFoljyU=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudfront",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "XJAlmauOOHsHEUW7n0XO/eEpcWI=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudsearch",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "VTc9UOMqIwuhWJ6oGQDsMkTW09I=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudtrail",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "ItXljM1vG/0goVleodRgbfYgyxQ=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatch",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "5lmoDceAWT0vrUTf3wKAaZRXwbg=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchevents",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "HHct8eQygkIJ+vrQpKhB0IEDymQ=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "22txzj8ItH1+lzyyLlFz/vtRV2I=",
 			"path": "github.com/aws/aws-sdk-go/service/codebuild",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "RRQCgy4s3k6CJQae3ueLepkK4PI=",
 			"path": "github.com/aws/aws-sdk-go/service/codecommit",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "wvXGTyWPjtgC4OjXb80IxYdpqmE=",
 			"path": "github.com/aws/aws-sdk-go/service/codedeploy",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "V1Y05qfjN4xOCy+GnPWSCqIeZb4=",
 			"path": "github.com/aws/aws-sdk-go/service/codepipeline",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "Ju8efcqcIgggB7N8io/as9ERVdc=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentity",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "Q4nvxp3mwkpNITKAPWGk5uFjLl8=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentityprovider",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "kt8wGmAKAo+iC1dR/g9iJn46nDo=",
 			"path": "github.com/aws/aws-sdk-go/service/configservice",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
-			"checksumSHA1": "DOWkxT0mAO8D+RUzDrVB/+jxV68=",
+			"checksumSHA1": "45sgs1urdRiXDb35iuAhQPzl0e4=",
 			"path": "github.com/aws/aws-sdk-go/service/databasemigrationservice",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "bu1R1eKCK2fc5+hMcXmagr3iIik=",
 			"path": "github.com/aws/aws-sdk-go/service/dax",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "EaEfUc3nt1sS/cdfSYGq+JtSVKs=",
 			"path": "github.com/aws/aws-sdk-go/service/devicefarm",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "LRdh5oXUe2yURIk5FDH6ceEZGMo=",
 			"path": "github.com/aws/aws-sdk-go/service/directconnect",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "a7itHIwtyXtOGQ0KsiefmsHgu4s=",
 			"path": "github.com/aws/aws-sdk-go/service/directoryservice",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
-			"checksumSHA1": "R5cCbmbRXM5EAtq5CXDMJf587oc=",
+			"checksumSHA1": "8JiVrxMjFSdBOfVWCy1QU+JzB08=",
 			"path": "github.com/aws/aws-sdk-go/service/dynamodb",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "Sj6NTKuc/6+amv4RsMqrZkvkvpc=",
 			"path": "github.com/aws/aws-sdk-go/service/ec2",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "kEgV0dSAj3M3M1waEkC27JS7VnU=",
 			"path": "github.com/aws/aws-sdk-go/service/ecr",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "WeevJuELH3BFpUQJC4cqZODz4c0=",
 			"path": "github.com/aws/aws-sdk-go/service/ecs",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "4XmkiujbDA68x39KGgURR1+uPiQ=",
 			"path": "github.com/aws/aws-sdk-go/service/efs",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "o73xT1zFo3C+giQwKcRj02OAZhM=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticache",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "1U0w3+W7kvH901jSftehitrRHCg=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticbeanstalk",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "VYGtTaSiajfKOVTbi9/SNmbiIac=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticsearchservice",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "SZ7yLDZ6RvMhpWe0Goyem64kgyA=",
 			"path": "github.com/aws/aws-sdk-go/service/elastictranscoder",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "iRI32eUYQfumh0LybzZ+5iWV3jE=",
 			"path": "github.com/aws/aws-sdk-go/service/elb",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "SvXeFtI3yR9UmamKEYKY/diBWDY=",
 			"path": "github.com/aws/aws-sdk-go/service/elbv2",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "5x77vwxya74Qu5YEq75/lhyYkqY=",
 			"path": "github.com/aws/aws-sdk-go/service/emr",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "t7BmfpJqmQ7Y0EYcj/CR9Aup9go=",
 			"path": "github.com/aws/aws-sdk-go/service/firehose",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
-			"checksumSHA1": "CHKNgqZj/f5z5d68w3rHRwYtII4=",
+			"checksumSHA1": "iHyMxl+rkonWCTlysoO4ISkumCA=",
 			"path": "github.com/aws/aws-sdk-go/service/gamelift",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "oDoGvSfmO2Z099ixV2HXn+SDeHE=",
 			"path": "github.com/aws/aws-sdk-go/service/glacier",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "M01rYrldc6zwbpAeaLX5UJ6b25g=",
 			"path": "github.com/aws/aws-sdk-go/service/glue",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "L+3qjFRMMQHkpY+Wg4PAtaN/lrg=",
 			"path": "github.com/aws/aws-sdk-go/service/guardduty",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "I8CWKTI9BLrIF9ZKf6SpWhG+LXM=",
 			"path": "github.com/aws/aws-sdk-go/service/iam",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "45gdBZuM7PWLQzWuBasytvZZpK0=",
 			"path": "github.com/aws/aws-sdk-go/service/inspector",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "pZwCI4DpP5hcMa/ItKhiwo/ukd0=",
 			"path": "github.com/aws/aws-sdk-go/service/iot",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "DfzNze8B3ME2tV3TtXP7eQXUjD0=",
 			"path": "github.com/aws/aws-sdk-go/service/kinesis",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "P132J6pP1Z5ddG/8UqeuQFmeei4=",
 			"path": "github.com/aws/aws-sdk-go/service/kms",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "lAgaKbwpyflY7+t4V3EeH18RwgA=",
 			"path": "github.com/aws/aws-sdk-go/service/lambda",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "XokRL2pJ+MpMnJnc8f64nNF7Df8=",
 			"path": "github.com/aws/aws-sdk-go/service/lexmodelbuildingservice",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "4yGrGQatXcr8eGRWUoBg3KqAHK8=",
 			"path": "github.com/aws/aws-sdk-go/service/lightsail",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "ucK45ZI1VbasqgeAo9/D96XXsUA=",
 			"path": "github.com/aws/aws-sdk-go/service/mediaconvert",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
-			"checksumSHA1": "qTJKoiNiFUAH3wgAlbcXSq/Myhw=",
+			"checksumSHA1": "eqgtjNmN9OC4YhZ6TXv5PG9+L0Y=",
 			"path": "github.com/aws/aws-sdk-go/service/medialive",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "Uc40skINWoBmH5LglPNfoKxET0g=",
 			"path": "github.com/aws/aws-sdk-go/service/mediapackage",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
-			"checksumSHA1": "eaK0X1VvbUIo/noVaH54yCAhzC0=",
+			"checksumSHA1": "kEZmPI9Y9+05SWuRCdtt+QkqwLI=",
 			"path": "github.com/aws/aws-sdk-go/service/mediastore",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "1hKLl5dLV28iH5rMfOPlWmD+oXk=",
 			"path": "github.com/aws/aws-sdk-go/service/mediastoredata",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "3QV+ZVkQ8g8JkNkftwHaOCevyqM=",
 			"path": "github.com/aws/aws-sdk-go/service/mq",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "QuOSKqV8nFvvzN4wcsToltMFI1Y=",
 			"path": "github.com/aws/aws-sdk-go/service/opsworks",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "FebVAmRZZjhzA4+wq71PTS+avf0=",
 			"path": "github.com/aws/aws-sdk-go/service/organizations",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "9AwJ02ip5HmAz2PtMTOGHX0U984=",
 			"path": "github.com/aws/aws-sdk-go/service/rds",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "Pj9IgrR635tqA0YamoSC1GaHeao=",
 			"path": "github.com/aws/aws-sdk-go/service/redshift",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "EaDeOWEVUQ21y3cFDyDuZPaK470=",
 			"path": "github.com/aws/aws-sdk-go/service/route53",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "fXQn3V0ZRBZpTXUEHl4/yOjR4mQ=",
 			"path": "github.com/aws/aws-sdk-go/service/s3",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "OvcZyDFahfuNIdFU/A/f/9G18ic=",
 			"path": "github.com/aws/aws-sdk-go/service/sagemaker",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "rtKbVK1uZVIdkTR7yJIhAte97XQ=",
 			"path": "github.com/aws/aws-sdk-go/service/servicecatalog",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "erg+1BSdtfOk1KFXmnJ2bFHJpBY=",
 			"path": "github.com/aws/aws-sdk-go/service/servicediscovery",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "8LeTeLzNs+0vNxTeOjMCtSrSwqo=",
 			"path": "github.com/aws/aws-sdk-go/service/ses",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "u3AMeFxtHGtiJCxDeIm4dAwzBIc=",
 			"path": "github.com/aws/aws-sdk-go/service/sfn",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "B3CgAFSREebpsFoFOo4vrQ6u04w=",
 			"path": "github.com/aws/aws-sdk-go/service/simpledb",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "9Qj8yLl67q9uxBUCc0PT20YiP1M=",
 			"path": "github.com/aws/aws-sdk-go/service/sns",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "XmEJe50M8MddNEkwbZoC+YvRjgg=",
 			"path": "github.com/aws/aws-sdk-go/service/sqs",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "jl3IYnqe0OFL2bemYhF5tLOwvvs=",
 			"path": "github.com/aws/aws-sdk-go/service/ssm",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "x7HCNPJnQi+4P6FKpBTY1hm3m6o=",
 			"path": "github.com/aws/aws-sdk-go/service/sts",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "Uw4pOUxSMbx4xBHUcOUkNhtnywE=",
 			"path": "github.com/aws/aws-sdk-go/service/swf",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "ZKwkpd+UVwEKTOMhsbNpfXGUIvI=",
 			"path": "github.com/aws/aws-sdk-go/service/waf",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "Uk2A+lTH7aAlQlkj7WIm2RFZV8A=",
 			"path": "github.com/aws/aws-sdk-go/service/wafregional",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "FVK4fHBkjOIaCRIY4DleqSKtZKs=",
 			"path": "github.com/aws/aws-sdk-go/service/workspaces",
-			"revision": "586c9ba6027a527800564282bb843d7e6e7985c9",
-			"revisionTime": "2018-02-07T00:16:19Z",
-			"version": "v1.12.72",
-			"versionExact": "v1.12.72"
+			"revision": "de28909e9837364f0368d94ddcba085c57af3c12",
+			"revisionTime": "2018-02-08T20:25:49Z",
+			"version": "v1.12.73",
+			"versionExact": "v1.12.73"
 		},
 		{
 			"checksumSHA1": "usT4LCSQItkFvFOQT7cBlkCuGaE=",


### PR DESCRIPTION
Required for
* https://github.com/terraform-providers/terraform-provider-aws/issues/3298

```
govendor fetch github.com/aws/aws-sdk-go/aws/...@v1.12.73
govendor fetch github.com/aws/aws-sdk-go/internal/...@v1.12.73
govendor fetch github.com/aws/aws-sdk-go/models/...@v1.12.73
govendor fetch github.com/aws/aws-sdk-go/private/...@v1.12.73
govendor fetch github.com/aws/aws-sdk-go/service/...@v1.12.73
```