### PR TITLE
Support encryption at rest for DynamoDB tables

### DIFF
--- a/aws/data_source_aws_dynamodb_table.go
+++ b/aws/data_source_aws_dynamodb_table.go
@@ -167,6 +167,20 @@ func dataSourceAwsDynamoDbTable() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+			"encrypt_at_rest": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }

--- a/aws/data_source_aws_dynamodb_table.go
+++ b/aws/data_source_aws_dynamodb_table.go
@@ -167,7 +167,7 @@ func dataSourceAwsDynamoDbTable() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
-			"encrypt_at_rest": {
+			"server_side_encryption": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,

--- a/aws/data_source_aws_dynamodb_table_test.go
+++ b/aws/data_source_aws_dynamodb_table_test.go
@@ -28,6 +28,7 @@ func TestAccDataSourceAwsDynamoDbTable_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.aws_dynamodb_table.dynamodb_table_test", "tags.%", "2"),
 					resource.TestCheckResourceAttr("data.aws_dynamodb_table.dynamodb_table_test", "tags.Name", "dynamodb-table-1"),
 					resource.TestCheckResourceAttr("data.aws_dynamodb_table.dynamodb_table_test", "tags.Environment", "test"),
+					resource.TestCheckResourceAttr("data.aws_dynamodb_table.dynamodb_table_test", "encrypt_at_rest.#", "0"),
 				),
 			},
 		},
@@ -41,22 +42,22 @@ func testAccDataSourceAwsDynamoDbTableConfigBasic(tableName string) string {
   write_capacity = 20
   hash_key       = "UserId"
   range_key      = "GameTitle"
-	
+
   attribute {
     name = "UserId"
     type = "S"
   }
-	
+
   attribute {
     name = "GameTitle"
     type = "S"
   }
-	
+
   attribute {
     name = "TopScore"
     type = "N"
   }
-	
+
   global_secondary_index {
     name               = "GameTitleIndex"
     hash_key           = "GameTitle"
@@ -66,7 +67,7 @@ func testAccDataSourceAwsDynamoDbTableConfigBasic(tableName string) string {
     projection_type    = "INCLUDE"
     non_key_attributes = ["UserId"]
   }
-	
+
   tags {
     Name        = "dynamodb-table-1"
     Environment = "test"

--- a/aws/data_source_aws_dynamodb_table_test.go
+++ b/aws/data_source_aws_dynamodb_table_test.go
@@ -28,7 +28,7 @@ func TestAccDataSourceAwsDynamoDbTable_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.aws_dynamodb_table.dynamodb_table_test", "tags.%", "2"),
 					resource.TestCheckResourceAttr("data.aws_dynamodb_table.dynamodb_table_test", "tags.Name", "dynamodb-table-1"),
 					resource.TestCheckResourceAttr("data.aws_dynamodb_table.dynamodb_table_test", "tags.Environment", "test"),
-					resource.TestCheckResourceAttr("data.aws_dynamodb_table.dynamodb_table_test", "encrypt_at_rest.#", "0"),
+					resource.TestCheckResourceAttr("data.aws_dynamodb_table.dynamodb_table_test", "server_side_encryption.#", "0"),
 				),
 			},
 		},

--- a/aws/resource_aws_dynamodb_table.go
+++ b/aws/resource_aws_dynamodb_table.go
@@ -196,7 +196,7 @@ func resourceAwsDynamoDbTable() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"encrypt_at_rest": {
+			"server_side_encryption": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
@@ -265,10 +265,10 @@ func resourceAwsDynamoDbTableCreate(d *schema.ResourceData, meta interface{}) er
 		}
 	}
 
-	if v, ok := d.GetOk("encrypt_at_rest"); ok {
+	if v, ok := d.GetOk("server_side_encryption"); ok {
 		options := v.([]interface{})
 		if len(options) == 0 || options[0] == nil {
-			return fmt.Errorf("At least one field is expected inside encrypt_at_rest")
+			return fmt.Errorf("At least one field is expected inside server_side_encryption")
 		}
 
 		s := options[0].(map[string]interface{})

--- a/aws/resource_aws_dynamodb_table.go
+++ b/aws/resource_aws_dynamodb_table.go
@@ -267,7 +267,7 @@ func resourceAwsDynamoDbTableCreate(d *schema.ResourceData, meta interface{}) er
 
 	if v, ok := d.GetOk("server_side_encryption"); ok {
 		options := v.([]interface{})
-		if len(options) == 0 || options[0] == nil {
+		if options[0] == nil {
 			return fmt.Errorf("At least one field is expected inside server_side_encryption")
 		}
 

--- a/aws/resource_aws_dynamodb_table.go
+++ b/aws/resource_aws_dynamodb_table.go
@@ -267,7 +267,7 @@ func resourceAwsDynamoDbTableCreate(d *schema.ResourceData, meta interface{}) er
 
 	if v, ok := d.GetOk("encrypt_at_rest"); ok {
 		options := v.([]interface{})
-		if options[0] == nil {
+		if len(options) == 0 || options[0] == nil {
 			return fmt.Errorf("At least one field is expected inside encrypt_at_rest")
 		}
 

--- a/aws/resource_aws_dynamodb_table_test.go
+++ b/aws/resource_aws_dynamodb_table_test.go
@@ -639,8 +639,8 @@ func TestAccAWSDynamoDbTable_encryption(t *testing.T) {
 				Config: testAccAWSDynamoDbConfigInitialStateWithEncryption(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInitialAWSDynamoDbTableExists("aws_dynamodb_table.basic-dynamodb-table", &conf),
-					resource.TestCheckResourceAttr("aws_dynamodb_table.basic-dynamodb-table", "encrypt_at_rest.#", "1"),
-					resource.TestCheckResourceAttr("aws_dynamodb_table.basic-dynamodb-table", "encrypt_at_rest.0.enabled", "true"),
+					resource.TestCheckResourceAttr("aws_dynamodb_table.basic-dynamodb-table", "server_side_encryption.#", "1"),
+					resource.TestCheckResourceAttr("aws_dynamodb_table.basic-dynamodb-table", "server_side_encryption.0.enabled", "true"),
 				),
 			},
 		},
@@ -966,7 +966,7 @@ resource "aws_dynamodb_table" "basic-dynamodb-table" {
     type = "S"
   }
 
-  encrypt_at_rest {
+  server_side_encryption {
     enabled = true
   }
 }

--- a/aws/resource_aws_dynamodb_table_test.go
+++ b/aws/resource_aws_dynamodb_table_test.go
@@ -295,7 +295,7 @@ func TestAccAWSDynamoDbTable_basic(t *testing.T) {
 				Config: testAccAWSDynamoDbConfigInitialState(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInitialAWSDynamoDbTableExists("aws_dynamodb_table.basic-dynamodb-table", &conf),
-					testAccCheckInitialAWSDynamoDbTableConf("aws_dynamodb_table.basic-dynamodb-table", false),
+					testAccCheckInitialAWSDynamoDbTableConf("aws_dynamodb_table.basic-dynamodb-table"),
 				),
 			},
 			{
@@ -368,7 +368,7 @@ func TestAccAWSDynamoDbTable_tags(t *testing.T) {
 				Config: testAccAWSDynamoDbConfigTags(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInitialAWSDynamoDbTableExists("aws_dynamodb_table.basic-dynamodb-table", &conf),
-					testAccCheckInitialAWSDynamoDbTableConf("aws_dynamodb_table.basic-dynamodb-table", false),
+					testAccCheckInitialAWSDynamoDbTableConf("aws_dynamodb_table.basic-dynamodb-table"),
 					resource.TestCheckResourceAttr(
 						"aws_dynamodb_table.basic-dynamodb-table", "tags.%", "3"),
 				),
@@ -639,7 +639,8 @@ func TestAccAWSDynamoDbTable_encryption(t *testing.T) {
 				Config: testAccAWSDynamoDbConfigInitialStateWithEncryption(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInitialAWSDynamoDbTableExists("aws_dynamodb_table.basic-dynamodb-table", &conf),
-					testAccCheckInitialAWSDynamoDbTableConf("aws_dynamodb_table.basic-dynamodb-table", true),
+					resource.TestCheckResourceAttr("aws_dynamodb_table.basic-dynamodb-table", "encrypt_at_rest.#", "1"),
+					resource.TestCheckResourceAttr("aws_dynamodb_table.basic-dynamodb-table", "encrypt_at_rest.0.enabled", "true"),
 				),
 			},
 		},
@@ -746,7 +747,7 @@ func testAccCheckInitialAWSDynamoDbTableExists(n string, table *dynamodb.Describ
 	}
 }
 
-func testAccCheckInitialAWSDynamoDbTableConf(n string, sse bool) resource.TestCheckFunc {
+func testAccCheckInitialAWSDynamoDbTableConf(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		log.Printf("[DEBUG] Trying to create initial table state!")
 		rs, ok := s.RootModule().Resources[n]
@@ -782,14 +783,8 @@ func testAccCheckInitialAWSDynamoDbTableConf(n string, sse bool) resource.TestCh
 			return fmt.Errorf("Provisioned read capacity was %d, not 10!", table.ProvisionedThroughput.ReadCapacityUnits)
 		}
 
-		if sse {
-			if table.SSEDescription == nil || *table.SSEDescription.Status != dynamodb.SSEStatusEnabled {
-				return fmt.Errorf("SSE status was not %s", dynamodb.SSEStatusEnabled)
-			}
-		} else {
-			if table.SSEDescription != nil && *table.SSEDescription.Status != dynamodb.SSEStatusDisabled {
-				return fmt.Errorf("SSE status was %s, not %s", *table.SSEDescription.Status, dynamodb.SSEStatusDisabled)
-			}
+		if table.SSEDescription != nil && *table.SSEDescription.Status != dynamodb.SSEStatusDisabled {
+			return fmt.Errorf("SSE status was %s, not %s", *table.SSEDescription.Status, dynamodb.SSEStatusDisabled)
 		}
 
 		attrCount := len(table.AttributeDefinitions)
@@ -962,49 +957,18 @@ func testAccAWSDynamoDbConfigInitialStateWithEncryption(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_dynamodb_table" "basic-dynamodb-table" {
   name = "%s"
-  read_capacity = 10
-  write_capacity = 20
+  read_capacity = 1
+  write_capacity = 1
   hash_key = "TestTableHashKey"
-  range_key = "TestTableRangeKey"
 
   attribute {
     name = "TestTableHashKey"
     type = "S"
   }
 
-  attribute {
-    name = "TestTableRangeKey"
-    type = "S"
+  encrypt_at_rest {
+    enabled = true
   }
-
-  attribute {
-    name = "TestLSIRangeKey"
-    type = "N"
-  }
-
-  attribute {
-    name = "TestGSIRangeKey"
-    type = "S"
-  }
-
-  local_secondary_index {
-    name = "TestTableLSI"
-    range_key = "TestLSIRangeKey"
-    projection_type = "ALL"
-  }
-
-  global_secondary_index {
-    name = "InitialTestTableGSI"
-    hash_key = "TestTableHashKey"
-    range_key = "TestGSIRangeKey"
-    write_capacity = 10
-    read_capacity = 10
-    projection_type = "KEYS_ONLY"
-	}
-
-	encrypt_at_rest {
-		enabled = true
-	}
 }
 `, rName)
 }

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -3528,7 +3528,7 @@ func flattenAwsDynamoDbTableResource(d *schema.ResourceData, table *dynamodb.Tab
 		m["enabled"] = aws.StringValue(table.SSEDescription.Status) == dynamodb.SSEStatusEnabled
 		sseOptions = []map[string]interface{}{m}
 	}
-	err = d.Set("encrypt_at_rest", sseOptions)
+	err = d.Set("server_side_encryption", sseOptions)
 	if err != nil {
 		return err
 	}

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -3522,6 +3522,17 @@ func flattenAwsDynamoDbTableResource(d *schema.ResourceData, table *dynamodb.Tab
 		return err
 	}
 
+	sseOptions := []map[string]interface{}{}
+	if table.SSEDescription != nil {
+		m := map[string]interface{}{}
+		m["enabled"] = aws.StringValue(table.SSEDescription.Status) == dynamodb.SSEStatusEnabled
+		sseOptions = []map[string]interface{}{m}
+	}
+	err = d.Set("encrypt_at_rest", sseOptions)
+	if err != nil {
+		return err
+	}
+
 	d.Set("arn", table.TableArn)
 
 	return nil
@@ -3608,6 +3619,16 @@ func expandDynamoDbKeySchema(data map[string]interface{}) []*dynamodb.KeySchemaE
 	}
 
 	return keySchema
+}
+
+func expandDynamoDbEncryptAtRestOptions(m map[string]interface{}) *dynamodb.SSESpecification {
+	options := dynamodb.SSESpecification{}
+
+	if v, ok := m["enabled"]; ok {
+		options.Enabled = aws.Bool(v.(bool))
+	}
+
+	return &options
 }
 
 func flattenVpcEndpointServiceAllowedPrincipals(allowedPrincipals []*ec2.AllowedPrincipal) []string {

--- a/website/docs/r/dynamodb_table.html.markdown
+++ b/website/docs/r/dynamodb_table.html.markdown
@@ -88,6 +88,7 @@ definition after you have created the resource.
 attributes, etc.
 * `stream_enabled` - (Optional) Indicates whether Streams are to be enabled (true) or disabled (false).
 * `stream_view_type` - (Optional) When an item in the table is modified, StreamViewType determines what information is written to the table's stream. Valid values are `KEYS_ONLY`, `NEW_IMAGE`, `OLD_IMAGE`, `NEW_AND_OLD_IMAGES`.
+* `encrypt_at_rest` - (Optional) Encrypt at rest options.
 * `tags` - (Optional) A map of tags to populate on the created table.
 
 ### Timeouts
@@ -129,6 +130,10 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 * `non_key_attributes` - (Optional) Only required with `INCLUDE` as a
   projection type; a list of attributes to project into the index. These
   do not need to be defined as attributes on the table.
+
+#### `encrypt_at_rest`
+
+* `enabled` - (Required) Whether to enable encryption at rest. If the `encrypt_at_rest` block is not provided then this defaults to `false`.
 
 ### A note about attributes
 

--- a/website/docs/r/dynamodb_table.html.markdown
+++ b/website/docs/r/dynamodb_table.html.markdown
@@ -88,7 +88,7 @@ definition after you have created the resource.
 attributes, etc.
 * `stream_enabled` - (Optional) Indicates whether Streams are to be enabled (true) or disabled (false).
 * `stream_view_type` - (Optional) When an item in the table is modified, StreamViewType determines what information is written to the table's stream. Valid values are `KEYS_ONLY`, `NEW_IMAGE`, `OLD_IMAGE`, `NEW_AND_OLD_IMAGES`.
-* `encrypt_at_rest` - (Optional) Encrypt at rest options.
+* `server_side_encryption` - (Optional) Encrypt at rest options.
 * `tags` - (Optional) A map of tags to populate on the created table.
 
 ### Timeouts
@@ -131,9 +131,9 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
   projection type; a list of attributes to project into the index. These
   do not need to be defined as attributes on the table.
 
-#### `encrypt_at_rest`
+#### `server_side_encryption`
 
-* `enabled` - (Required) Whether to enable encryption at rest. If the `encrypt_at_rest` block is not provided then this defaults to `false`.
+* `enabled` - (Required) Whether to enable encryption at rest. If the `server_side_encryption` block is not provided then this defaults to `false`.
 
 ### A note about attributes
 


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/3298.
Added an `encrypt_at_rest` block to `aws_dynamodb_table` resource and data source, similar to `aws_elasticsearch_domain`.

Acceptance tests:
```
make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSDynamoDbTable_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAWSDynamoDbTable_basic -timeout 120m
=== RUN   TestAccAWSDynamoDbTable_basic
--- PASS: TestAccAWSDynamoDbTable_basic (199.52s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	199.527s

make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSDynamoDbTable_encryption'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAWSDynamoDbTable_encryption -timeout 120m
=== RUN   TestAccAWSDynamoDbTable_encryption
--- PASS: TestAccAWSDynamoDbTable_encryption (55.71s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	55.729s

make testacc TEST=./aws/ TESTARGS='-run=TestAccDataSourceAwsDynamoDbTable_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccDataSourceAwsDynamoDbTable_basic -timeout 120m
=== RUN   TestAccDataSourceAwsDynamoDbTable_basic
--- PASS: TestAccDataSourceAwsDynamoDbTable_basic (49.30s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	49.304s

make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSDynamoDbTable_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAWSDynamoDbTable_basic -timeout 120m
=== RUN   TestAccAWSDynamoDbTable_basic
--- PASS: TestAccAWSDynamoDbTable_basic (199.52s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	199.527s
```