### PR TITLE
data.aws_kms_alias: Use kms:DescribeKey to get target key Id & ARN

### DIFF
--- a/aws/data_source_aws_kms_alias.go
+++ b/aws/data_source_aws_kms_alias.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -64,25 +64,27 @@ func dataSourceAwsKmsAliasRead(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(time.Now().UTC().String())
 	d.Set("arn", alias.AliasArn)
 
-	// Some aliases do not return TargetKeyId (e.g. aliases for AWS services or
-	// aliases not associated with a Customer Managed Key (CMK))
+	// ListAliases can return an alias for an AWS service key (e.g.
+	// alias/aws/rds) without a TargetKeyId if the alias has not yet been
+	// used for the first time. In that situation, calling DescribeKey will
+	// associate an actual key with the alias, and the next call to
+	// ListAliases will have a TargetKeyId for the alias.
+	//
+	// For a simpler codepath, we always call DescribeKey with the alias
+	// name to get the target key's ARN and Id direct from AWS.
+	//
 	// https://docs.aws.amazon.com/kms/latest/APIReference/API_ListAliases.html
-	if alias.TargetKeyId != nil {
-		aliasARN, err := arn.Parse(*alias.AliasArn)
-		if err != nil {
-			return err
-		}
-		targetKeyARN := arn.ARN{
-			Partition: aliasARN.Partition,
-			Service:   aliasARN.Service,
-			Region:    aliasARN.Region,
-			AccountID: aliasARN.AccountID,
-			Resource:  fmt.Sprintf("key/%s", *alias.TargetKeyId),
-		}
-		d.Set("target_key_arn", targetKeyARN.String())
 
-		d.Set("target_key_id", alias.TargetKeyId)
+	req := &kms.DescribeKeyInput{
+		KeyId: aws.String(target.(string)),
 	}
+	resp, err := conn.DescribeKey(req)
+	if err != nil {
+		return errwrap.Wrapf("Error calling KMS DescribeKey: {{err}}", err)
+	}
+
+	d.Set("target_key_arn", resp.KeyMetadata.Arn)
+	d.Set("target_key_id", resp.KeyMetadata.KeyId)
 
 	return nil
 }

--- a/aws/data_source_aws_kms_alias_test.go
+++ b/aws/data_source_aws_kms_alias_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAccDataSourceAwsKmsAlias_AwsService(t *testing.T) {
-	name := "alias/aws/redshift"
+	name := "alias/aws/s3"
 	resourceName := "data.aws_kms_alias.test"
 
 	resource.Test(t, resource.TestCase{
@@ -25,8 +25,8 @@ func TestAccDataSourceAwsKmsAlias_AwsService(t *testing.T) {
 					testAccDataSourceAwsKmsAliasCheckExists(resourceName),
 					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:kms:[^:]+:[^:]+:%s$", name))),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckNoResourceAttr(resourceName, "target_key_arn"),
-					resource.TestCheckNoResourceAttr(resourceName, "target_key_id"),
+					resource.TestMatchResourceAttr(resourceName, "target_key_arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:kms:[^:]+:[^:]+:key/[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}$"))),
+					resource.TestMatchResourceAttr(resourceName, "target_key_id", regexp.MustCompile(fmt.Sprintf("^[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}$"))),
 				),
 			},
 		},


### PR DESCRIPTION
Context/fixes: https://github.com/terraform-providers/terraform-provider-aws/issues/2009#issuecomment-363072588

`make testacc TESTARGS='-run=TestAccDataSourceAwsKmsAlias'` passes.

cc @bflad @trung 