### PR TITLE
test/resource/aws_sns_platform_application: Support APNS private key and certificate file contents

### DIFF
--- a/aws/resource_aws_sns_platform_application_test.go
+++ b/aws/resource_aws_sns_platform_application_test.go
@@ -67,9 +67,9 @@ func testAccAwsSnsPlatformApplicationPlatformFromEnv(t *testing.T) []*testAccAws
 
 		platform := &testAccAwsSnsPlatformApplicationPlatform{
 			Name:           "APNS_SANDBOX",
-			Credential:     fmt.Sprintf("${file(pathexpand(%q))}", os.Getenv("APNS_SANDBOX_CREDENTIAL_PATH")),
+			Credential:     strconv.Quote(fmt.Sprintf("${file(pathexpand(%q))}", os.Getenv("APNS_SANDBOX_CREDENTIAL_PATH"))),
 			CredentialHash: credentialHash,
-			Principal:      fmt.Sprintf("${file(pathexpand(%q))}", os.Getenv("APNS_SANDBOX_PRINCIPAL_PATH")),
+			Principal:      strconv.Quote(fmt.Sprintf("${file(pathexpand(%q))}", os.Getenv("APNS_SANDBOX_PRINCIPAL_PATH"))),
 			PrincipalHash:  principalHash,
 		}
 		platforms = append(platforms, platform)


### PR DESCRIPTION
Locally:
```
export APNS_SANDBOX_CREDENTIAL=$(cat /path/to/valid-private-key.pem)
export APNS_SANDBOX_PRINCIPAL=$(cat /path/to/valid-certificate.pem)

make testacc TEST=./aws TESTARGS='-run=TestAccAwsSnsPlatformApplication'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAwsSnsPlatformApplication -timeout 120m
=== RUN   TestAccAwsSnsPlatformApplication_basic
=== RUN   TestAccAwsSnsPlatformApplication_basic/APNS_SANDBOX
--- PASS: TestAccAwsSnsPlatformApplication_basic (21.84s)
    --- PASS: TestAccAwsSnsPlatformApplication_basic/APNS_SANDBOX (21.84s)
=== RUN   TestAccAwsSnsPlatformApplication_basicAttributes
=== RUN   TestAccAwsSnsPlatformApplication_basicAttributes/APNS_SANDBOX
=== RUN   TestAccAwsSnsPlatformApplication_basicAttributes/APNS_SANDBOX/success_feedback_sample_rate
--- PASS: TestAccAwsSnsPlatformApplication_basicAttributes (19.94s)
    --- PASS: TestAccAwsSnsPlatformApplication_basicAttributes/APNS_SANDBOX/success_feedback_sample_rate (19.94s)
    --- PASS: TestAccAwsSnsPlatformApplication_basicAttributes/APNS_SANDBOX (19.94s)
=== RUN   TestAccAwsSnsPlatformApplication_iamRoleAttributes
=== RUN   TestAccAwsSnsPlatformApplication_iamRoleAttributes/APNS_SANDBOX
=== RUN   TestAccAwsSnsPlatformApplication_iamRoleAttributes/APNS_SANDBOX/failure_feedback_role_arn
=== RUN   TestAccAwsSnsPlatformApplication_iamRoleAttributes/APNS_SANDBOX/success_feedback_role_arn
--- PASS: TestAccAwsSnsPlatformApplication_iamRoleAttributes (85.66s)
    --- PASS: TestAccAwsSnsPlatformApplication_iamRoleAttributes/APNS_SANDBOX/failure_feedback_role_arn (43.10s)
    --- PASS: TestAccAwsSnsPlatformApplication_iamRoleAttributes/APNS_SANDBOX/success_feedback_role_arn (42.56s)
    --- PASS: TestAccAwsSnsPlatformApplication_iamRoleAttributes/APNS_SANDBOX (85.66s)
=== RUN   TestAccAwsSnsPlatformApplication_snsTopicAttributes
=== RUN   TestAccAwsSnsPlatformApplication_snsTopicAttributes/APNS_SANDBOX
=== RUN   TestAccAwsSnsPlatformApplication_snsTopicAttributes/APNS_SANDBOX/event_delivery_failure_topic_arn
=== RUN   TestAccAwsSnsPlatformApplication_snsTopicAttributes/APNS_SANDBOX/event_endpoint_created_topic_arn
=== RUN   TestAccAwsSnsPlatformApplication_snsTopicAttributes/APNS_SANDBOX/event_endpoint_deleted_topic_arn
=== RUN   TestAccAwsSnsPlatformApplication_snsTopicAttributes/APNS_SANDBOX/event_endpoint_updated_topic_arn
--- PASS: TestAccAwsSnsPlatformApplication_snsTopicAttributes (95.64s)
    --- PASS: TestAccAwsSnsPlatformApplication_snsTopicAttributes/APNS_SANDBOX/event_delivery_failure_topic_arn (23.38s)
    --- PASS: TestAccAwsSnsPlatformApplication_snsTopicAttributes/APNS_SANDBOX/event_endpoint_created_topic_arn (23.47s)
    --- PASS: TestAccAwsSnsPlatformApplication_snsTopicAttributes/APNS_SANDBOX/event_endpoint_deleted_topic_arn (24.46s)
    --- PASS: TestAccAwsSnsPlatformApplication_snsTopicAttributes/APNS_SANDBOX/event_endpoint_updated_topic_arn (24.33s)
    --- PASS: TestAccAwsSnsPlatformApplication_snsTopicAttributes/APNS_SANDBOX (95.64s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	223.127s
```