### PR TITLE
Force vpc endpoint type to gateway in govcloud partition.

### DIFF
--- a/aws/data_source_aws_vpc_endpoint.go
+++ b/aws/data_source_aws_vpc_endpoint.go
@@ -135,5 +135,5 @@ func dataSourceAwsVpcEndpointRead(d *schema.ResourceData, meta interface{}) erro
 	vpce := resp.VpcEndpoints[0]
 	d.SetId(aws.StringValue(vpce.VpcEndpointId))
 
-	return vpcEndpointAttributes(d, vpce, conn)
+	return vpcEndpointAttributes(d, vpce, conn, meta.(*AWSClient).IsGovCloud())
 }

--- a/aws/data_source_aws_vpc_endpoint.go
+++ b/aws/data_source_aws_vpc_endpoint.go
@@ -135,5 +135,5 @@ func dataSourceAwsVpcEndpointRead(d *schema.ResourceData, meta interface{}) erro
 	vpce := resp.VpcEndpoints[0]
 	d.SetId(aws.StringValue(vpce.VpcEndpointId))
 
-	return vpcEndpointAttributes(d, vpce, conn, meta.(*AWSClient).IsGovCloud())
+	return vpcEndpointAttributes(d, vpce, meta)
 }

--- a/aws/data_source_aws_vpc_endpoint.go
+++ b/aws/data_source_aws_vpc_endpoint.go
@@ -135,5 +135,5 @@ func dataSourceAwsVpcEndpointRead(d *schema.ResourceData, meta interface{}) erro
 	vpce := resp.VpcEndpoints[0]
 	d.SetId(aws.StringValue(vpce.VpcEndpointId))
 
-	return vpcEndpointAttributes(d, vpce, meta)
+	return vpcEndpointAttributes(d, vpce, conn)
 }

--- a/aws/resource_aws_vpc_endpoint.go
+++ b/aws/resource_aws_vpc_endpoint.go
@@ -347,7 +347,7 @@ func vpcEndpointAttributes(d *schema.ResourceData, vpce *ec2.VpcEndpoint, meta i
 
 	serviceName := aws.StringValue(vpce.ServiceName)
 	d.Set("service_name", serviceName)
-	if meta.(*AWSClient).IsGovCloud() {
+	if meta.(*AWSClient).IsGovCloud() && aws.StringValue(vpce.VpcEndpointType) == "" {
 		d.Set("vpc_endpoint_type", ec2.VpcEndpointTypeGateway)
 	} else {
 		d.Set("vpc_endpoint_type", vpce.VpcEndpointType)


### PR DESCRIPTION
The aws govcloud partition only supports gateway type vpc endpoints
and doesn't return a type when listing connections. To fix, temporarily
force vpc endpoint types to gateway if partition is govcloud.

After vpc endpoint types were added in 1.9, govcloud vpc endpoints
want to destroy and recreate on every apply, since the aws api doesn't
return an endpoint type.

cc @wjwoodson