### PR TITLE
Trim trailing dot when importing route53 records.

### DIFF
--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -922,5 +922,6 @@ func parseRecordId(id string) [4]string {
 			}
 		}
 	}
+	recName = strings.TrimSuffix(recName, ".")
 	return [4]string{recZone, recName, recType, recSet}
 }

--- a/aws/resource_aws_route53_record_test.go
+++ b/aws/resource_aws_route53_record_test.go
@@ -77,6 +77,7 @@ func TestParseRecordId(t *testing.T) {
 		Input, Zone, Name, Type, Set string
 	}{
 		{"ABCDEF_test.notexample.com_A", "ABCDEF", "test.notexample.com", "A", ""},
+		{"ABCDEF_test.notexample.com._A", "ABCDEF", "test.notexample.com", "A", ""},
 		{"ABCDEF_test.notexample.com_A_set1", "ABCDEF", "test.notexample.com", "A", "set1"},
 		{"ABCDEF__underscore.notexample.com_A", "ABCDEF", "_underscore.notexample.com", "A", ""},
 		{"ABCDEF__underscore.notexample.com_A_set1", "ABCDEF", "_underscore.notexample.com", "A", "set1"},


### PR DESCRIPTION
We already trim trailing dots from names in https://github.com/terraform-providers/terraform-provider-aws/blob/master/aws/resource_aws_route53_record.go#L42-L45, so we should also trim trailing dots on import, so that we can import a resource, plan, and expect no changes.

[Resolves #241]

cc @wjwoodson