### PR TITLE
Docs example for preserving desired count on an autoscaled ECS Service

### DIFF
--- a/website/docs/r/appautoscaling_policy.html.markdown
+++ b/website/docs/r/appautoscaling_policy.html.markdown
@@ -74,7 +74,7 @@ resource "aws_appautoscaling_policy" "ecs_policy" {
 }
 ```
 
-### Preserve desired count on an autoscaled ECS Service
+### Preserve desired count when updating an autoscaled ECS Service
 
 ```hcl
 resource "aws_ecs_service" "ecs_service" {

--- a/website/docs/r/appautoscaling_policy.html.markdown
+++ b/website/docs/r/appautoscaling_policy.html.markdown
@@ -74,6 +74,21 @@ resource "aws_appautoscaling_policy" "ecs_policy" {
 }
 ```
 
+### Preserve desired count on an autoscaled ECS Service
+
+```hcl
+resource "aws_ecs_service" "ecs_service" {
+  name = "serviceName"
+  cluster = "clusterName"
+  task_definition = "taskDefinitionFamily:1"
+  desired_count = 2
+
+  lifecycle {
+    ignore_changes = ["desired_count"]
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:


### PR DESCRIPTION
This is a problem that many people seem to encounter when they are terraforming an autoscaled ECS service. 

The only place to find the solution is by scrolling through open and closed issues.

Until you encounter examples it is hard to understand when terraform lifecycle rules are relevant.