### PR TITLE
resource/aws_acm_certificate_validation: Prevent crash on validation_record_fqdns

### DIFF
--- a/aws/resource_aws_acm_certificate_validation.go
+++ b/aws/resource_aws_acm_certificate_validation.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"reflect"
@@ -92,13 +91,13 @@ func resourceAwsAcmCertificateCheckValidationRecords(validation_record_fqdns []i
 			CertificateArn: cert.CertificateArn,
 		}
 		err := resource.Retry(1*time.Minute, func() *resource.RetryError {
-			log.Printf("[DEBUG] Certificate domain validation options empty, retrying")
+			log.Printf("[DEBUG] Certificate domain validation options empty for %q, retrying", cert.CertificateArn)
 			output, err := conn.DescribeCertificate(input)
 			if err != nil {
 				return resource.NonRetryableError(err)
 			}
 			if len(output.Certificate.DomainValidationOptions) == 0 {
-				return resource.RetryableError(errors.New("Certificate domain validation options empty"))
+				return resource.RetryableError(fmt.Errorf("Certificate domain validation options empty for %s", *cert.CertificateArn))
 			}
 			cert = output.Certificate
 			return nil

--- a/website/docs/r/acm_certificate_validation.html.markdown
+++ b/website/docs/r/acm_certificate_validation.html.markdown
@@ -12,13 +12,15 @@ This resource represents a successful validation of an ACM certificate in concer
 with other resources.
 
 Most commonly, this resource is used to together with [`aws_route53_record`](route53_record.html) and
-[`aws_acm_certificate_validation`](acm_certificate_validation.html) to request a DNS validated certificate,
+[`aws_acm_certificate`](acm_certificate.html) to request a DNS validated certificate,
 deploy the required validation records and wait for validation to complete.
 
 ~> **WARNING:** This resource implements a part of the validation workflow. It does not represent a real-world entity in AWS, therefore changing or deleting this resource on its own has no immediate effect.
 
 
 ## Example Usage
+
+### DNS Validation with Route 53
 
 ```hcl
 resource "aws_acm_certificate" "cert" {
@@ -50,12 +52,27 @@ resource "aws_lb_listener" "front_end" {
 }
 ```
 
+### Email Validation
+
+In this situation, the resource is simply a waiter for manual email approval of ACM certificates.
+
+```hcl
+resource "aws_acm_certificate" "cert" {
+  domain_name       = "example.com"
+  validation_method = "EMAIL"
+}
+
+resource "aws_acm_certificate_validation" "cert" {
+  certificate_arn = "${aws_acm_certificate.cert.arn}"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
 * `certificate_arn` - (Required) The ARN of the certificate that is being validated.
-* `validation_record_fqdns` - (Optional) List of FQDNs that implement the validation. If this is set, the resource can implement additional sanity checks and has an explicit dependency on the resource that is implementing the validation
+* `validation_record_fqdns` - (Optional) List of FQDNs that implement the validation. Only valid for DNS validation method ACM certificates. If this is set, the resource can implement additional sanity checks and has an explicit dependency on the resource that is implementing the validation
 
 ## Timeouts
 


### PR DESCRIPTION
Fixes #3330 

Other changes:
* Will retry until domain validation options are actually available when using validation_record_fqdns
* Will now return an error if validation_record_fqdns is used on EMAIL validation method ACM certificates (with associated acceptance test)
* Add docs example for email validation
* Fix docs link to aws_acm_certificate resource instead of self-referencing

```
make testacc TEST=./aws TESTARGS='-run=TestAccAwsAcmCertificateValidation_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAwsAcmCertificateValidation_basic -timeout 120m
=== RUN   TestAccAwsAcmCertificateValidation_basic
--- PASS: TestAccAwsAcmCertificateValidation_basic (225.96s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	226.000s
```