### PR TITLE
If an access_logs block is specified in an aws_lb resource, default to enabled

### DIFF
--- a/aws/resource_aws_lb.go
+++ b/aws/resource_aws_lb.go
@@ -140,6 +140,7 @@ func resourceAwsLb() *schema.Resource {
 							Type:     schema.TypeBool,
 							Optional: true,
 							Computed: true,
+							Default:  true,
 						},
 					},
 				},


### PR DESCRIPTION
`aws_lb` defaults to `false` if an `access_logs` block exists, and the documentation doesn't make any mention of this. In fact, documentation *omits* this parameter in examples, leading you to believe the default is `true`- but `aws_elb` has the opposite behaviour when an `access_logs` block is specified!

https://github.com/terraform-providers/terraform-provider-aws/blob/dcf901296bc5ad485a176b4892484009e2bbeb3e/aws/resource_aws_lb.go#L139-L143
https://github.com/terraform-providers/terraform-provider-aws/blob/dcf901296bc5ad485a176b4892484009e2bbeb3e/aws/resource_aws_elb.go#L151

Generally I try to stay positive when it comes to contributing to OSS, but uh, folks? This is bad and you should feel bad. I mean that the nicest way possible.