### PR TITLE
#2296 aws_s3_bucket-replication-config-update-fix

### DIFF
--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -337,6 +337,7 @@ func resourceAwsS3Bucket() *schema.Resource {
 			"replication_configuration": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -978,11 +979,9 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] S3 Bucket: %s, read replication configuration: %v", d.Id(), replication)
-	if r := replication.ReplicationConfiguration; r != nil {
-		if err := d.Set("replication_configuration", flattenAwsS3BucketReplicationConfiguration(replication.ReplicationConfiguration)); err != nil {
-			log.Printf("[DEBUG] Error setting replication configuration: %s", err)
-			return err
-		}
+	if err := d.Set("replication_configuration", flattenAwsS3BucketReplicationConfiguration(replication.ReplicationConfiguration)); err != nil {
+		log.Printf("[DEBUG] Error setting replication configuration: %s", err)
+		return err
 	}
 
 	// Read the bucket server side encryption configuration
@@ -1893,6 +1892,11 @@ func flattenAwsS3ServerSideEncryptionConfiguration(c *s3.ServerSideEncryptionCon
 
 func flattenAwsS3BucketReplicationConfiguration(r *s3.ReplicationConfiguration) []map[string]interface{} {
 	replication_configuration := make([]map[string]interface{}, 0, 1)
+
+	if r == nil {
+		return replication_configuration
+	}
+
 	m := make(map[string]interface{})
 
 	if r.Role != nil && *r.Role != "" {

--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -337,7 +337,6 @@ func resourceAwsS3Bucket() *schema.Resource {
 			"replication_configuration": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -766,6 +766,7 @@ func TestAccAWSS3Bucket_Replication(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketExistsWithProviders("aws_s3_bucket.bucket", "us-west-2", &providers),
 					testAccCheckAWSS3BucketExistsWithProviders("aws_s3_bucket.destination", "eu-west-1", &providers),
+					resource.TestCheckResourceAttr("aws_s3_bucket.bucket", "replication_configuration.#", "0"),
 				),
 			},
 			{


### PR DESCRIPTION
Always update replication_configuration fields.
Fix for #2296 