### PR TITLE
resource/aws_dynamodb_table: Retry on deletion ResourceInUseException and refactor

### DIFF
--- a/aws/resource_aws_dynamodb_table_test.go
+++ b/aws/resource_aws_dynamodb_table_test.go
@@ -6,7 +6,6 @@ import (
 	"regexp"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -46,20 +45,7 @@ func testSweepDynamoDbTables(region string) error {
 			}
 			log.Printf("[INFO] Deleting DynamoDB Table: %s", *tableName)
 
-			input := &dynamodb.DeleteTableInput{
-				TableName: tableName,
-			}
-			err := resource.Retry(1*time.Minute, func() *resource.RetryError {
-				_, err := conn.DeleteTable(input)
-				if err != nil {
-					// Subscriber limit exceeded: Only 10 tables can be created, updated, or deleted simultaneously
-					if isAWSErr(err, dynamodb.ErrCodeLimitExceededException, "simultaneously") {
-						return resource.RetryableError(err)
-					}
-					return resource.NonRetryableError(err)
-				}
-				return nil
-			})
+			err := deleteAwsDynamoDbTable(*tableName, conn)
 			if err != nil {
 				log.Printf("[ERROR] Failed to delete DynamoDB Table %s: %s", *tableName, err)
 				continue


### PR DESCRIPTION
This prevents the consistent acceptance test failure, which was originally fixed as part of #2517, but missed in refactor review of #3136:

```
--- FAIL: TestAccAwsDynamoDbGlobalTable_multipleRegions (89.23s)
    testing.go:573: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Error applying: 1 error(s) occurred:
        
        * aws_dynamodb_table.us-east-1 (destroy): 1 error(s) occurred:
        
        * aws_dynamodb_table.us-east-1: ResourceInUseException: Attempt to change a resource which is still in use: Table is being deleted: tf-acc-test-mryz6
            status code: 400, request id: M916D78UO89CO2GHJ2RQT8T0HJVV4KQNSO5AEMVJF66Q9ASUAAJG
```

```
=== RUN   TestAccAwsDynamoDbGlobalTable_basic
--- PASS: TestAccAwsDynamoDbGlobalTable_basic (49.66s)
=== RUN   TestAccAwsDynamoDbGlobalTable_multipleRegions
--- PASS: TestAccAwsDynamoDbGlobalTable_multipleRegions (108.21s)
=== RUN   TestAccAwsDynamoDbGlobalTable_import
--- PASS: TestAccAwsDynamoDbGlobalTable_import (72.88s)
=== RUN   TestAccAWSDynamoDbTable_streamSpecificationValidation
--- PASS: TestAccAWSDynamoDbTable_streamSpecificationValidation (2.75s)
=== RUN   TestAccAWSDynamoDbTableItem_basic
--- PASS: TestAccAWSDynamoDbTableItem_basic (16.92s)
=== RUN   TestAccAWSDynamoDbTableItem_withMultipleItems
--- PASS: TestAccAWSDynamoDbTableItem_withMultipleItems (16.99s)
=== RUN   TestAccAWSDynamoDbTableItem_rangeKey
--- PASS: TestAccAWSDynamoDbTableItem_rangeKey (22.00s)
=== RUN   TestAccAWSDynamoDbTable_streamSpecification
--- PASS: TestAccAWSDynamoDbTable_streamSpecification (34.66s)
=== RUN   TestAccAWSDynamoDbTable_importTags
--- PASS: TestAccAWSDynamoDbTable_importTags (42.38s)
=== RUN   TestAccAWSDynamoDbTable_importTimeToLive
--- PASS: TestAccAWSDynamoDbTable_importTimeToLive (44.29s)
=== RUN   TestAccAWSDynamoDbTableItem_update
--- PASS: TestAccAWSDynamoDbTableItem_update (55.78s)
=== RUN   TestAccAWSDynamoDbTable_importBasic
--- PASS: TestAccAWSDynamoDbTable_importBasic (78.20s)
=== RUN   TestAccAWSDynamoDbTable_ttl
--- PASS: TestAccAWSDynamoDbTable_ttl (103.80s)
=== RUN   TestAccAWSDynamoDbTable_tags
--- PASS: TestAccAWSDynamoDbTable_tags (127.60s)
=== RUN   TestAccAWSDynamoDbTable_gsiUpdateCapacity
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateCapacity (129.13s)
=== RUN   TestAccAWSDynamoDbTable_gsiUpdateNonKeyAttributes
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateNonKeyAttributes (358.22s)
=== RUN   TestAccAWSDynamoDbTable_basic
--- PASS: TestAccAWSDynamoDbTable_basic (360.78s)
=== RUN   TestAccAWSDynamoDbTable_gsiUpdateOtherAttributes
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateOtherAttributes (662.76s)
```