### PR TITLE
tests: Normalize aws_vpc Name tag

### DIFF
--- a/aws/core_acceptance_test.go
+++ b/aws/core_acceptance_test.go
@@ -32,7 +32,7 @@ const testMatchedDiffs = `resource "aws_vpc" "test" {
     cidr_block = "10.0.0.0/16"
 
     tags {
-        Name = "Repro GH-4965"
+        Name = "terraform-testacc-repro-GH-4965"
     }
 
     lifecycle {

--- a/aws/data_source_aws_efs_mount_target_test.go
+++ b/aws/data_source_aws_efs_mount_target_test.go
@@ -42,7 +42,7 @@ resource "aws_efs_mount_target" "alpha" {
 resource "aws_vpc" "foo" {
 	cidr_block = "10.0.0.0/16"
 	tags {
-		Name = "testAccAWSEFSMountTargetConfig"
+		Name = "terraform-testacc-efs-mount-target"
 	}
 }
 

--- a/aws/data_source_aws_elb_test.go
+++ b/aws/data_source_aws_elb_test.go
@@ -68,7 +68,7 @@ resource "aws_vpc" "elb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    TestName = "%[2]s"
+    Name = "terraform-testacc-elb-data-source"
   }
 }
 

--- a/aws/data_source_aws_instance_test.go
+++ b/aws/data_source_aws_instance_test.go
@@ -364,7 +364,7 @@ const testAccInstanceDataSourceConfig_privateIP = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
   tags {
-    Name = "testAccInstanceDataSourceConfig_privateIP"
+    Name = "terraform-testacc-instance-ds-private-ip"
   }
 }
 
@@ -421,7 +421,7 @@ const testAccInstanceDataSourceConfig_VPC = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
   tags {
-    Name = "testAccInstanceDataSourceConfig_VPC"
+    Name = "terraform-testacc-instance-data-source-vpc"
   }
 }
 
@@ -451,7 +451,7 @@ func testAccInstanceDataSourceConfig_PlacementGroup(rStr string) string {
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
   tags {
-    Name = "testAccInstanceDataSourceConfig_PlacementGroup_%s"
+    Name = "terraform-testacc-instance-data-source-placement-group"
   }
 }
 
@@ -480,7 +480,7 @@ resource "aws_instance" "foo" {
 data "aws_instance" "foo" {
   instance_id = "${aws_instance.foo.id}"
 }
-`, rStr, rStr)
+`, rStr)
 }
 
 func testAccInstanceDataSourceConfig_SecurityGroups(rInt int) string {
@@ -522,7 +522,7 @@ resource "aws_internet_gateway" "gw" {
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
   tags {
-    Name = "tf-network-test"
+    Name = "terraform-testacc-instance-data-source-vpc-sgs"
   }
 }
 

--- a/aws/data_source_aws_internet_gateway_test.go
+++ b/aws/data_source_aws_internet_gateway_test.go
@@ -73,7 +73,7 @@ resource "aws_vpc" "test" {
   cidr_block = "172.16.0.0/16"
 
   tags {
-    Name = "terraform-testacc-data-source-igw-vpc"
+    Name = "terraform-testacc-igw-data-source"
   }
 }
 

--- a/aws/data_source_aws_lb_listener_test.go
+++ b/aws/data_source_aws_lb_listener_test.go
@@ -163,7 +163,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    TestName = "TestAccAWSALB_basic"
+    Name = "terraform-testacc-lb-listener-data-source-basic"
   }
 }
 
@@ -270,7 +270,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    TestName = "TestAccAWSALB_basic"
+    Name = "terraform-testacc-lb-listener-data-source-bc"
   }
 }
 
@@ -378,7 +378,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    TestName = "TestAccAWSALB_basic"
+    Name = "terraform-testacc-lb-listener-data-source-https"
   }
 }
 

--- a/aws/data_source_aws_lb_target_group_test.go
+++ b/aws/data_source_aws_lb_target_group_test.go
@@ -177,7 +177,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    TestName = "TestAccDataSourceAWSALBTargetGroup_basic"
+    Name = "terraform-testacc-lb-data-source-target-group-basic"
   }
 }
 
@@ -285,7 +285,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    TestName = "TestAccDataSourceAWSALBTargetGroup_basic"
+    Name = "terraform-testacc-lb-data-source-target-group-bc"
   }
 }
 

--- a/aws/data_source_aws_lb_test.go
+++ b/aws/data_source_aws_lb_test.go
@@ -114,7 +114,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    TestName = "TestAccAWSALB_basic"
+    Name = "terraform-testacc-lb-data-source-basic"
   }
 }
 
@@ -189,7 +189,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    TestName = "TestAccAWSALB_basic"
+    Name = "terraform-testacc-lb-data-source-bc"
   }
 }
 

--- a/aws/data_source_aws_nat_gateway_test.go
+++ b/aws/data_source_aws_nat_gateway_test.go
@@ -46,7 +46,7 @@ provider "aws" {
 resource "aws_vpc" "test" {
   cidr_block = "172.%d.0.0/16"
   tags {
-    Name = "terraform-testacc-nat-gateway-data-source-%d"
+    Name = "terraform-testacc-nat-gw-data-source"
   }
 }
 
@@ -89,5 +89,5 @@ data "aws_nat_gateway" "test_by_subnet_id" {
   subnet_id = "${aws_nat_gateway.test.subnet_id}"
 }
 
-`, rInt, rInt, rInt, rInt, rInt)
+`, rInt, rInt, rInt, rInt)
 }

--- a/aws/data_source_aws_network_interface_test.go
+++ b/aws/data_source_aws_network_interface_test.go
@@ -31,6 +31,9 @@ data "aws_availability_zones" "available" {}
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
+  tags {
+    Name = "terraform-testacc-eni-data-source-basic"
+  }
 }
 
 resource "aws_subnet" "test" {
@@ -53,7 +56,7 @@ resource "aws_network_interface" "test" {
 data "aws_network_interface" "test" {
   id = "${aws_network_interface.test.id}"
 }
-    `, rName)
+`, rName)
 }
 
 func TestAccDataSourceAwsNetworkInterface_filters(t *testing.T) {
@@ -79,6 +82,9 @@ data "aws_availability_zones" "available" {}
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
+  tags {
+    Name = "terraform-testacc-eni-data-source-filters"
+  }
 }
 
 resource "aws_subnet" "test" {
@@ -104,5 +110,5 @@ data "aws_network_interface" "test" {
     values = ["${aws_network_interface.test.id}"]
   }
 }
-    `, rName)
+`, rName)
 }

--- a/aws/data_source_aws_rds_cluster_test.go
+++ b/aws/data_source_aws_rds_cluster_test.go
@@ -47,7 +47,7 @@ func testAccDataSourceAwsRdsClusterConfigBasic(clusterName string) string {
 resource "aws_vpc" "test" {
 	cidr_block = "10.0.0.0/16"
 	tags {
-	  Name = "testAccDataSourceAwsRdsClusterConfigBasic"
+	  Name = "terraform-testacc-rds-cluster-data-source-basic"
 	}
 }
   

--- a/aws/data_source_aws_route53_zone_test.go
+++ b/aws/data_source_aws_route53_zone_test.go
@@ -78,7 +78,7 @@ func testAccDataSourceAwsRoute53ZoneConfig(rInt int) string {
 	resource "aws_vpc" "test" {
 		cidr_block = "172.16.0.0/16"
 		tags {
-			Name = "testAccDataSourceAwsRoute53ZoneConfig"
+			Name = "terraform-testacc-r53-zone-data-source"
 		}
 	}
 

--- a/aws/data_source_aws_route_table_test.go
+++ b/aws/data_source_aws_route_table_test.go
@@ -137,7 +137,7 @@ resource "aws_vpc" "test" {
   cidr_block = "172.16.0.0/16"
 
   tags {
-    Name = "terraform-testacc-data-source"
+    Name = "terraform-testacc-route-table-data-source"
   }
 }
 
@@ -197,7 +197,7 @@ resource "aws_vpc" "test" {
   cidr_block = "172.16.0.0/16"
 
   tags {
-    Name = "terraform-testacc-data-source"
+    Name = "terraform-testacc-route-table-data-source-main-route"
   }
 }
 

--- a/aws/data_source_aws_subnet_test.go
+++ b/aws/data_source_aws_subnet_test.go
@@ -204,7 +204,7 @@ resource "aws_vpc" "test" {
   assign_generated_ipv6_cidr_block = true
 
   tags {
-    Name = "terraform-testacc-subnet-data-source-ipv6"
+    Name = "terraform-testacc-subnet-data-source-ipv6-with-ds-filter"
   }
 }
 
@@ -235,7 +235,7 @@ resource "aws_vpc" "test" {
   assign_generated_ipv6_cidr_block = true
 
   tags {
-    Name = "terraform-testacc-subnet-data-source-ipv6"
+    Name = "terraform-testacc-subnet-data-source-ipv6-cidr-block"
   }
 }
 

--- a/aws/data_source_aws_vpc_endpoint_service_test.go
+++ b/aws/data_source_aws_vpc_endpoint_service_test.go
@@ -152,7 +152,7 @@ resource "aws_vpc" "nlb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "testAccVpcEndpointServiceBasicConfig_vpc"
+    Name = "terraform-testacc-vpc-endpoint-service-custom"
   }
 }
 

--- a/aws/data_source_aws_vpc_endpoint_test.go
+++ b/aws/data_source_aws_vpc_endpoint_test.go
@@ -123,7 +123,7 @@ resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
   tags {
-    Name = "terraform-testacc-vpc-endpoint-data-source-foo"
+    Name = "terraform-testacc-vpc-endpoint-data-source-gw-basic"
   }
 }
 
@@ -148,7 +148,7 @@ resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
   tags {
-    Name = "terraform-testacc-vpc-endpoint-data-source-foo"
+    Name = "terraform-testacc-vpc-endpoint-data-source-by-id"
   }
 }
 
@@ -171,7 +171,7 @@ resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
   tags {
-    Name = "terraform-testacc-vpc-endpoint-data-source-foo"
+    Name = "terraform-testacc-vpc-endpoint-data-source-with-route-table"
   }
 }
 
@@ -201,7 +201,7 @@ resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
   tags {
-    Name = "terraform-testacc-vpc-endpoint-data-source-foo"
+    Name = "terraform-testacc-vpc-endpoint-data-source-interface"
   }
 }
 

--- a/aws/data_source_aws_vpc_test.go
+++ b/aws/data_source_aws_vpc_test.go
@@ -14,7 +14,7 @@ func TestAccDataSourceAwsVpc_basic(t *testing.T) {
 	rand.Seed(time.Now().UTC().UnixNano())
 	rInt := rand.Intn(16)
 	cidr := fmt.Sprintf("172.%d.0.0/16", rInt)
-	tag := fmt.Sprintf("terraform-testacc-vpc-data-source-%d", rInt)
+	tag := fmt.Sprintf("terraform-testacc-vpc-data-source-basic-%d", rInt)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -40,7 +40,7 @@ func TestAccDataSourceAwsVpc_ipv6Associated(t *testing.T) {
 	rand.Seed(time.Now().UTC().UnixNano())
 	rInt := rand.Intn(16)
 	cidr := fmt.Sprintf("172.%d.0.0/16", rInt)
-	tag := fmt.Sprintf("terraform-testacc-vpc-data-source-%d", rInt)
+	tag := fmt.Sprintf("terraform-testacc-vpc-data-source-ipv6-associated-%d", rInt)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,

--- a/aws/data_source_aws_vpn_gateway_test.go
+++ b/aws/data_source_aws_vpn_gateway_test.go
@@ -93,7 +93,7 @@ resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
   tags {
-    Name = "terraform-testacc-vpn-gateway-data-source-foo-%d"
+    Name = "terraform-testacc-vpn-gateway-data-source-attached-%d"
   }
 }
 

--- a/aws/import_aws_route_table_test.go
+++ b/aws/import_aws_route_table_test.go
@@ -70,7 +70,7 @@ resource "aws_vpc" "default" {
   enable_dns_hostnames = true
 
   tags {
-    Name = "tf-rt-import-test"
+    Name = "terraform-testacc-route-table-import-complex-default"
   }
 }
 
@@ -142,7 +142,7 @@ resource "aws_vpc" "bar" {
   cidr_block = "10.1.0.0/16"
 
   tags {
-    Name = "tf-rt-import-test"
+    Name = "terraform-testacc-route-table-import-complex-bar"
   }
 }
 


### PR DESCRIPTION
## Test results

```
=== RUN   TestAccDataSourceAwsInternetGateway_typical
--- PASS: TestAccDataSourceAwsInternetGateway_typical (54.81s)
=== RUN   TestAccAWSVPC_coreMismatchedDiffs
--- PASS: TestAccAWSVPC_coreMismatchedDiffs (58.70s)
=== RUN   TestAccAWSInstanceDataSource_SecurityGroups
--- PASS: TestAccAWSInstanceDataSource_SecurityGroups (123.05s)
=== RUN   TestAccDataSourceAWSELB_basic
--- PASS: TestAccDataSourceAWSELB_basic (138.61s)
=== RUN   TestAccAWSInstanceDataSource_gp2IopsDevice
--- PASS: TestAccAWSInstanceDataSource_gp2IopsDevice (168.09s)
=== RUN   TestAccAWSInstanceDataSource_tags
--- PASS: TestAccAWSInstanceDataSource_tags (196.74s)
=== RUN   TestAccAWSInstanceDataSource_keyPair
--- PASS: TestAccAWSInstanceDataSource_keyPair (201.91s)
=== RUN   TestAccAWSInstanceDataSource_basic
--- PASS: TestAccAWSInstanceDataSource_basic (220.84s)
=== RUN   TestAccAWSInstanceDataSource_VPCSecurityGroups
--- PASS: TestAccAWSInstanceDataSource_VPCSecurityGroups (225.50s)
=== RUN   TestAccAWSInstanceDataSource_rootInstanceStore
--- PASS: TestAccAWSInstanceDataSource_rootInstanceStore (231.02s)
=== RUN   TestAccAWSInstanceDataSource_PlacementGroup
--- PASS: TestAccAWSInstanceDataSource_PlacementGroup (243.32s)
=== RUN   TestAccAWSInstanceDataSource_privateIP
--- PASS: TestAccAWSInstanceDataSource_privateIP (248.59s)
=== RUN   TestAccDataSourceAWSLBTargetGroupBackwardsCompatibility
--- PASS: TestAccDataSourceAWSLBTargetGroupBackwardsCompatibility (203.59s)
=== RUN   TestAccDataSourceAWSLBListener_basic
--- PASS: TestAccDataSourceAWSLBListener_basic (266.31s)
=== RUN   TestAccAWSInstanceDataSource_blockDevices
--- PASS: TestAccAWSInstanceDataSource_blockDevices (268.42s)
=== RUN   TestAccDataSourceAwsRouteTable_basic
--- PASS: TestAccDataSourceAwsRouteTable_basic (47.07s)
=== RUN   TestAccDataSourceAWSLB_basic
--- FAIL: TestAccDataSourceAWSLB_basic (215.49s)
	testing.go:513: Step 0 error: After applying this step, the plan was not empty:
		
		DIFF:
		
		UPDATE: aws_subnet.alb_test.0
		  map_public_ip_on_launch: "false" => "true"
		
		STATE:
...
FAIL
=== RUN   TestAccDataSourceAwsRouteTable_main
--- PASS: TestAccDataSourceAwsRouteTable_main (45.09s)
=== RUN   TestAccDataSourceAWSALBTargetGroup_basic
--- PASS: TestAccDataSourceAWSALBTargetGroup_basic (285.55s)
=== RUN   TestAccDataSourceAwsVpcEndpointService_gateway
--- PASS: TestAccDataSourceAwsVpcEndpointService_gateway (20.27s)
=== RUN   TestAccDataSourceAwsVpcEndpointService_interface
--- PASS: TestAccDataSourceAwsVpcEndpointService_interface (22.44s)
=== RUN   TestAccDataSourceAwsNetworkInterface_filters
--- PASS: TestAccDataSourceAwsNetworkInterface_filters (97.94s)
=== RUN   TestAccDataSourceAwsRoute53Zone
--- PASS: TestAccDataSourceAwsRoute53Zone (75.39s)
=== RUN   TestAccDataSourceAwsVpc_ipv6Associated
--- PASS: TestAccDataSourceAwsVpc_ipv6Associated (52.06s)
=== RUN   TestAccDataSourceAwsSubnet_ipv6ByIpv6Filter
--- PASS: TestAccDataSourceAwsSubnet_ipv6ByIpv6Filter (113.82s)
=== RUN   TestAccDataSourceAwsEfsMountTargetByMountTargetId
--- PASS: TestAccDataSourceAwsEfsMountTargetByMountTargetId (392.31s)
=== RUN   TestAccDataSourceAwsVpnGateway_unattached
--- PASS: TestAccDataSourceAwsVpnGateway_unattached (100.72s)
=== RUN   TestAccDataSourceAWSLBListenerBackwardsCompatibility
--- PASS: TestAccDataSourceAWSLBListenerBackwardsCompatibility (438.09s)
=== RUN   TestAccDataSourceAwsVpc_basic
--- PASS: TestAccDataSourceAwsVpc_basic (152.38s)
=== RUN   TestAccAWSRouteTable_importBasic
--- PASS: TestAccAWSRouteTable_importBasic (87.60s)
=== RUN   TestAccDataSourceAwsVpcEndpoint_interface
--- PASS: TestAccDataSourceAwsVpcEndpoint_interface (176.54s)
=== RUN   TestAccDataSourceAwsNatGateway
--- PASS: TestAccDataSourceAwsNatGateway (327.45s)
=== RUN   TestAccDataSourceAwsSubnet_basic
--- PASS: TestAccDataSourceAwsSubnet_basic (222.68s)
=== RUN   TestAccDataSourceAwsVpnGateway_attached
--- PASS: TestAccDataSourceAwsVpnGateway_attached (122.34s)
=== RUN   TestAccDataSourceAwsVpcEndpoint_gatewayBasic
--- PASS: TestAccDataSourceAwsVpcEndpoint_gatewayBasic (194.91s)
=== RUN   TestAccAWSInstanceDataSource_VPC
--- PASS: TestAccAWSInstanceDataSource_VPC (480.31s)
=== RUN   TestAccDataSourceAWSLBBackwardsCompatibility
--- PASS: TestAccDataSourceAWSLBBackwardsCompatibility (366.28s)
=== RUN   TestAccAWSInstanceDataSource_AzUserData
--- PASS: TestAccAWSInstanceDataSource_AzUserData (525.06s)
=== RUN   TestAccDataSourceAwsSubnet_ipv6ByIpv6CidrBlock
--- PASS: TestAccDataSourceAwsSubnet_ipv6ByIpv6CidrBlock (275.73s)
=== RUN   TestAccDataSourceAWSLBListener_https
--- PASS: TestAccDataSourceAWSLBListener_https (537.66s)
=== RUN   TestAccDataSourceAwsVpcEndpointService_custom
--- PASS: TestAccDataSourceAwsVpcEndpointService_custom (297.93s)
=== RUN   TestAccDataSourceAwsVpcEndpoint_gatewayWithRouteTable
--- PASS: TestAccDataSourceAwsVpcEndpoint_gatewayWithRouteTable (290.04s)
=== RUN   TestAccAWSRouteTable_complex
--- PASS: TestAccAWSRouteTable_complex (185.75s)
=== RUN   TestAccDataSourceAwsRdsCluster_basic
--- PASS: TestAccDataSourceAwsRdsCluster_basic (376.27s)
=== RUN   TestAccDataSourceAwsNetworkInterface_basic
--- PASS: TestAccDataSourceAwsNetworkInterface_basic (421.10s)
=== RUN   TestAccDataSourceAwsVpcEndpoint_byId
--- PASS: TestAccDataSourceAwsVpcEndpoint_byId (440.57s)
```

How did I choose which tests to run?

```
git diff-tree --no-commit-id --name-only -r HEAD | xargs -I{} grep 'func TestAcc' {}
```

This is just first PR focusing on data sources only, separate one(s) will be submitted for resources.