### PR TITLE
tests: Normalize aws_vpc Name tag (A-D)

### DIFF
--- a/aws/resource_aws_alb_target_group_test.go
+++ b/aws/resource_aws_alb_target_group_test.go
@@ -510,7 +510,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    TestName = "TestAccAWSALBTargetGroup_basic"
+    Name = "terraform-testacc-alb-target-group-basic"
   }
 }`, targetGroupName)
 }
@@ -549,7 +549,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    TestName = "TestAccAWSALBTargetGroup_basic"
+    Name = "terraform-testacc-alb-target-group-basic"
   }
 }`, targetGroupName)
 }
@@ -588,7 +588,7 @@ resource "aws_vpc" "test2" {
   cidr_block = "10.10.0.0/16"
 
   tags {
-    TestName = "TestAccAWSALBTargetGroup_basic"
+    Name = "terraform-testacc-alb-target-group-basic-2"
   }
 }
 
@@ -596,7 +596,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    TestName = "TestAccAWSALBTargetGroup_basic"
+    Name = "terraform-testacc-alb-target-group-basic"
   }
 }`, targetGroupName)
 }
@@ -635,7 +635,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    TestName = "TestAccAWSALBTargetGroup_basic"
+    Name = "terraform-testacc-alb-target-group-basic"
   }
 }`, targetGroupName)
 }
@@ -675,7 +675,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    TestName = "TestAccAWSALBTargetGroup_basic"
+    Name = "terraform-testacc-alb-target-group-basic"
   }
 }`, targetGroupName)
 }
@@ -710,7 +710,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    TestName = "TestAccAWSALBTargetGroup_basic"
+    Name = "terraform-testacc-alb-target-group-basic"
   }
 }`, targetGroupName)
 }
@@ -752,7 +752,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    TestName = "TestAccAWSALBTargetGroup_stickiness"
+    Name = "terraform-testacc-alb-target-group-stickiness"
   }
 }`, targetGroupName, stickinessBlock)
 }
@@ -768,7 +768,7 @@ resource "aws_alb_target_group" "test" {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 	tags {
-		Name = "testAccAWSALBTargetGroupConfig_namePrefix"
+		Name = "terraform-testacc-alb-target-group-name-prefix"
 	}
 }
 `
@@ -783,7 +783,7 @@ resource "aws_alb_target_group" "test" {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 	tags {
-		Name = "testAccAWSALBTargetGroupConfig_generatedName"
+		Name = "terraform-testacc-alb-target-group-generated-name"
 	}
 }
 `

--- a/aws/resource_aws_ami_copy_test.go
+++ b/aws/resource_aws_ami_copy_test.go
@@ -163,7 +163,7 @@ provider "aws" {
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "testAccAWSAMICopyConfig"
+		Name = "terraform-testacc-ami-copy"
 	}
 }
 

--- a/aws/resource_aws_appautoscaling_scheduled_action_test.go
+++ b/aws/resource_aws_appautoscaling_scheduled_action_test.go
@@ -280,6 +280,9 @@ resource "aws_security_group" "hoge" {
 resource "aws_vpc" "hoge" {
   cidr_block           = "168.31.0.0/16"
   enable_dns_hostnames = true
+  tags {
+    Name = "terraform-testacc-appautoscaling-scheduled-action-emr"
+  }
 }
 
 resource "aws_subnet" "hoge" {

--- a/aws/resource_aws_appautoscaling_target_test.go
+++ b/aws/resource_aws_appautoscaling_target_test.go
@@ -371,7 +371,7 @@ resource "aws_security_group" "allow_all" {
   }
 
   tags {
-    name = "emr_test"
+    Name = "emr_test"
   }
 }
 
@@ -380,7 +380,7 @@ resource "aws_vpc" "main" {
   enable_dns_hostnames = true
 
   tags {
-    name = "emr_test_%d"
+    Name = "terraform-testacc-appautoscaling-target-emr-cluster"
   }
 }
 
@@ -389,7 +389,7 @@ resource "aws_subnet" "main" {
   cidr_block = "168.31.0.0/20"
 
   tags {
-    name = "emr_test_%d"
+    Name = "emr_test_%d"
   }
 }
 
@@ -606,7 +606,7 @@ resource "aws_appautoscaling_target" "bar" {
 	max_capacity = 8
 }
 
-`, rInt, rInt, rInt, rInt, rInt, rInt, rInt, rInt, rInt, rInt)
+`, rInt, rInt, rInt, rInt, rInt, rInt, rInt, rInt, rInt)
 }
 
 var testAccAWSAppautoscalingTargetSpotFleetRequestConfig = fmt.Sprintf(`

--- a/aws/resource_aws_autoscaling_attachment_test.go
+++ b/aws/resource_aws_autoscaling_attachment_test.go
@@ -234,7 +234,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    TestName = "TestAccAWSLBTargetGroup_basic"
+    Name = "terraform-testacc-autoscaling-attachment-alb"
   }
 }
 `, rInt, rInt, rInt, rInt)

--- a/aws/resource_aws_autoscaling_group_test.go
+++ b/aws/resource_aws_autoscaling_group_test.go
@@ -1211,7 +1211,9 @@ resource "aws_autoscaling_group" "bar" {
 const testAccAWSAutoScalingGroupConfigWithLoadBalancer = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-	tags { Name = "tf-asg-test" }
+  tags {
+    Name = "terraform-testacc-autoscaling-group-with-lb"
+  }
 }
 
 resource "aws_internet_gateway" "gw" {
@@ -1290,7 +1292,7 @@ const testAccAWSAutoScalingGroupConfigWithAZ = `
 resource "aws_vpc" "default" {
   cidr_block = "10.0.0.0/16"
   tags {
-     Name = "terraform-test"
+    Name = "terraform-testacc-autoscaling-group-with-az"
   }
 }
 
@@ -1337,7 +1339,7 @@ const testAccAWSAutoScalingGroupConfigWithVPCIdent = `
 resource "aws_vpc" "default" {
   cidr_block = "10.0.0.0/16"
   tags {
-     Name = "terraform-test"
+    Name = "terraform-testacc-autoscaling-group-with-vpc-id"
   }
 }
 
@@ -1516,7 +1518,7 @@ resource "aws_vpc" "default" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "testAccAWSAutoScalingGroupConfig_ALB_TargetGroup"
+    Name = "terraform-testacc-autoscaling-group-alb-target-group"
   }
 }
 
@@ -1607,7 +1609,7 @@ resource "aws_vpc" "default" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "testAccAWSAutoScalingGroupConfig_ALB_TargetGroup"
+    Name = "terraform-testacc-autoscaling-group-alb-target-group"
   }
 }
 
@@ -1704,7 +1706,7 @@ resource "aws_vpc" "default" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "testAccAWSAutoScalingGroupConfig_ALB_TargetGroup"
+    Name = "terraform-testacc-autoscaling-group-alb-target-group"
   }
 }
 
@@ -1857,7 +1859,7 @@ resource "aws_vpc" "default" {
   enable_dns_support   = "true"
 
   tags {
-    Name = "testAccAWSAutoScalingGroupConfig_ALB_TargetGroup_ELBCapacity"
+    Name = "terraform-testacc-autoscaling-group-alb-target-group-elb-capacity"
   }
 }
 
@@ -2121,6 +2123,9 @@ resource "aws_launch_configuration" "test" {
 const testAccAWSAutoScalingGroupConfig_emptyAvailabilityZones = `
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
+  tags {
+    Name = "terraform-testacc-autoscaling-group-empty-azs"
+  }
 }
 
 resource "aws_subnet" "test" {

--- a/aws/resource_aws_batch_compute_environment_test.go
+++ b/aws/resource_aws_batch_compute_environment_test.go
@@ -365,6 +365,9 @@ resource "aws_security_group" "test_acc" {
 
 resource "aws_vpc" "test_acc" {
   cidr_block = "10.1.0.0/16"
+  tags {
+    Name = "terraform-testacc-batch-compute-environment"
+  }
 }
 
 resource "aws_subnet" "test_acc" {

--- a/aws/resource_aws_batch_job_queue_test.go
+++ b/aws/resource_aws_batch_job_queue_test.go
@@ -198,6 +198,9 @@ resource "aws_security_group" "test_acc" {
 
 resource "aws_vpc" "test_acc" {
   cidr_block = "10.1.0.0/16"
+  tags {
+    Name = "terraform-testacc-batch-job-queue"
+  }
 }
 
 resource "aws_subnet" "test_acc" {

--- a/aws/resource_aws_cloud9_environment_ec2_test.go
+++ b/aws/resource_aws_cloud9_environment_ec2_test.go
@@ -203,6 +203,9 @@ resource "aws_cloud9_environment_ec2" "test" {
 
 resource "aws_vpc" "test" {
   cidr_block = "10.10.0.0/16"
+  tags {
+    Name = "terraform-testacc-cloud9-environment-ec2-all-fields"
+  }
 }
 
 resource "aws_subnet" "test" {

--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -1132,7 +1132,7 @@ func testAccAWSDBInstanceConfigWithSubnetGroup(rName string) string {
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name="testAccAWSDBInstanceConfigWithSubnetGroup"
+		Name = "terraform-testacc-db-instance-with-subnet-group"
 	}
 }
 
@@ -1186,14 +1186,14 @@ func testAccAWSDBInstanceConfigWithSubnetGroupUpdated(rName string) string {
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name="testAccAWSDBInstanceConfigWithSubnetGroupUpdated"
+		Name = "terraform-testacc-db-instance-with-subnet-group-updated-foo"
 	}
 }
 
 resource "aws_vpc" "bar" {
 	cidr_block = "10.10.0.0/16"
 	tags {
-		Name="testAccAWSDBInstanceConfigWithSubnetGroupUpdated_other"
+		Name = "terraform-testacc-db-instance-with-subnet-group-updated-bar"
 	}
 }
 
@@ -1274,9 +1274,9 @@ func testAccAWSDBMSSQL_timezone(rInt int) string {
 resource "aws_vpc" "foo" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
-	tags {
-		Name = "tf-rds-mssql-timezone-test"
-	}
+  tags {
+    Name = "terraform-testacc-db-instance-mssql-timezone"
+  }
 }
 
 resource "aws_db_subnet_group" "rds_one" {
@@ -1340,9 +1340,9 @@ func testAccAWSDBMSSQL_timezone_AKST(rInt int) string {
 resource "aws_vpc" "foo" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
-	tags {
-		Name = "tf-rds-mssql-timezone-test"
-	}
+  tags {
+    Name = "terraform-testacc-db-instance-mssql-timezone-akst"
+  }
 }
 
 resource "aws_db_subnet_group" "rds_one" {

--- a/aws/resource_aws_db_subnet_group_test.go
+++ b/aws/resource_aws_db_subnet_group_test.go
@@ -210,7 +210,7 @@ func testAccDBSubnetGroupConfig(rName string) string {
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "testAccDBSubnetGroupConfig"
+		Name = "terraform-testacc-db-subnet-group"
 	}
 }
 
@@ -246,7 +246,7 @@ func testAccDBSubnetGroupConfig_updatedDescription(rName string) string {
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "testAccDBSubnetGroupConfig_updatedDescription"
+		Name = "terraform-testacc-db-subnet-group-updated-description"
 	}
 }
 
@@ -282,7 +282,7 @@ const testAccDBSubnetGroupConfig_namePrefix = `
 resource "aws_vpc" "test" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "testAccDBSubnetGroupConfig_namePrefix"
+		Name = "terraform-testacc-db-subnet-group-name-prefix"
 	}
 }
 
@@ -307,7 +307,7 @@ const testAccDBSubnetGroupConfig_generatedName = `
 resource "aws_vpc" "test" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "testAccDBSubnetGroupConfig_generatedName"
+		Name = "terraform-testacc-db-subnet-group-generated-name"
 	}
 }
 
@@ -331,7 +331,7 @@ const testAccDBSubnetGroupConfig_withUnderscoresAndPeriodsAndSpaces = `
 resource "aws_vpc" "main" {
     cidr_block = "192.168.0.0/16"
 		tags {
-			Name = "testAccDBSubnetGroupConfig_withUnderscoresAndPeriodsAndSpaces"
+			Name = "terraform-testacc-db-subnet-group-w-underscores-etc"
 		}
 }
 

--- a/aws/resource_aws_default_network_acl_test.go
+++ b/aws/resource_aws_default_network_acl_test.go
@@ -233,7 +233,7 @@ resource "aws_vpc" "tftestvpc" {
   cidr_block = "10.1.0.0/16"
 
   tags {
-    Name = "TestAccAWSDefaultNetworkAcl_basic"
+    Name = "terraform-testacc-default-network-acl-basic"
   }
 }
 
@@ -251,7 +251,7 @@ resource "aws_vpc" "tftestvpc" {
   cidr_block = "10.1.0.0/16"
 
   tags {
-    Name = "TestAccAWSDefaultNetworkAcl_basic"
+    Name = "terraform-testacc-default-network-acl-including-ipv6-rule"
   }
 }
 
@@ -278,7 +278,7 @@ resource "aws_vpc" "tftestvpc" {
   cidr_block = "10.1.0.0/16"
 
   tags {
-    Name = "TestAccAWSDefaultNetworkAcl_basic"
+    Name = "terraform-testacc-default-network-acl-deny-ingress"
   }
 }
 
@@ -305,7 +305,7 @@ resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
   tags {
-    Name = "TestAccAWSDefaultNetworkAcl_SubnetRemoval"
+    Name = "terraform-testacc-default-network-acl-subnets"
   }
 }
 
@@ -351,7 +351,7 @@ resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
   tags {
-    Name = "TestAccAWSDefaultNetworkAcl_SubnetRemoval"
+    Name = "terraform-testacc-default-network-acl-subnets-remove"
   }
 }
 
@@ -395,7 +395,7 @@ resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
   tags {
-    Name = "TestAccAWSDefaultNetworkAcl_SubnetRemoval"
+    Name = "terraform-testacc-default-network-acl-subnets-move"
   }
 }
 
@@ -448,7 +448,7 @@ resource "aws_vpc" "tftestvpc" {
 	assign_generated_ipv6_cidr_block = true
 
 	tags {
-		Name = "TestAccAWSDefaultNetworkAcl_basicIpv6Vpc"
+		Name = "terraform-testacc-default-network-acl-basic-ipv6-vpc"
 	}
 }
 

--- a/aws/resource_aws_default_route_table_test.go
+++ b/aws/resource_aws_default_route_table_test.go
@@ -129,7 +129,7 @@ resource "aws_vpc" "foo" {
   enable_dns_hostnames = true
 
   tags {
-    Name = "tf-default-route-table-test"
+    Name = "terraform-testacc-default-route-table"
   }
 }
 
@@ -164,7 +164,7 @@ resource "aws_vpc" "foo" {
   enable_dns_hostnames = true
 
   tags {
-    Name = "tf-default-route-table"
+    Name = "terraform-testacc-default-route-table-change"
   }
 }
 
@@ -214,7 +214,7 @@ resource "aws_vpc" "foo" {
   enable_dns_hostnames = true
 
   tags {
-    Name = "tf-default-route-table"
+    Name = "terraform-testacc-default-route-table-change"
   }
 }
 
@@ -268,7 +268,7 @@ resource "aws_vpc" "test" {
     cidr_block = "10.0.0.0/16"
 
     tags {
-        Name = "test"
+        Name = "terraform-testacc-default-route-table-vpc-endpoint"
     }
 }
 

--- a/aws/resource_aws_default_security_group_test.go
+++ b/aws/resource_aws_default_security_group_test.go
@@ -142,7 +142,7 @@ const testAccAWSDefaultSecurityGroupConfig = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "testAccAWSDefaultSecurityGroupConfig"
+		Name = "terraform-testacc-default-security-group"
 	}
 }
 

--- a/aws/resource_aws_directory_service_directory_test.go
+++ b/aws/resource_aws_directory_service_directory_test.go
@@ -327,7 +327,7 @@ resource "aws_directory_service_directory" "bar" {
 resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
 	tags {
-		Name = "testAccDirectoryServiceDirectoryConfig"
+		Name = "terraform-testacc-directory-service-directory"
 	}
 }
 
@@ -363,7 +363,7 @@ resource "aws_directory_service_directory" "bar" {
 resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
 	tags {
-		Name = "testAccDirectoryServiceDirectoryConfig"
+		Name = "terraform-testacc-directory-service-directory-tags"
 	}
 }
 
@@ -408,7 +408,7 @@ resource "aws_directory_service_directory" "connector" {
 resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
 	tags {
-		Name = "testAccDirectoryServiceDirectoryConfig_connector"
+		Name = "terraform-testacc-directory-service-directory-connector"
 	}
 }
 
@@ -439,7 +439,7 @@ resource "aws_directory_service_directory" "bar" {
 resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
 	tags {
-		Name = "testAccDirectoryServiceDirectoryConfig_microsoft"
+		Name = "terraform-testacc-directory-service-directory-microsoft"
 	}
 }
 
@@ -472,7 +472,7 @@ resource "aws_directory_service_directory" "bar_a" {
 resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
 	tags {
-		Name = "testAccDirectoryServiceDirectoryConfig_withAlias"
+		Name = "terraform-testacc-directory-service-directory-with-alias"
 	}
 }
 
@@ -505,7 +505,7 @@ resource "aws_directory_service_directory" "bar_a" {
 resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
 	tags {
-		Name = "testAccDirectoryServiceDirectoryConfig_withSso"
+		Name = "terraform-testacc-directory-service-directory-with-sso"
 	}
 }
 
@@ -538,7 +538,7 @@ resource "aws_directory_service_directory" "bar_a" {
 resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
 	tags {
-		Name = "testAccDirectoryServiceDirectoryConfig_withSso_modified"
+		Name = "terraform-testacc-directory-service-directory-with-sso-modified"
 	}
 }
 

--- a/aws/resource_aws_dms_replication_instance_test.go
+++ b/aws/resource_aws_dms_replication_instance_test.go
@@ -96,7 +96,7 @@ func dmsReplicationInstanceConfig(randId string) string {
 resource "aws_vpc" "dms_vpc" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "tf-test-dms-vpc-%[1]s"
+		Name = "terraform-testacc-dms-replication-instance"
 	}
 }
 
@@ -152,7 +152,7 @@ func dmsReplicationInstanceConfigUpdate(randId string) string {
 resource "aws_vpc" "dms_vpc" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "tf-test-dms-vpc-%[1]s"
+		Name = "terraform-testacc-dms-replication-instance"
 	}
 }
 

--- a/aws/resource_aws_dms_replication_subnet_group_test.go
+++ b/aws/resource_aws_dms_replication_subnet_group_test.go
@@ -104,7 +104,7 @@ func dmsReplicationSubnetGroupConfig(randId string) string {
 resource "aws_vpc" "dms_vpc" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "tf-test-dms-vpc-%[1]s"
+		Name = "terraform-testacc-dms-replication-subnet-group"
 	}
 }
 
@@ -156,7 +156,7 @@ func dmsReplicationSubnetGroupConfigUpdate(randId string) string {
 resource "aws_vpc" "dms_vpc" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "tf-test-dms-vpc-%[1]s"
+		Name = "terraform-testacc-dms-replication-subnet-group"
 	}
 }
 

--- a/aws/resource_aws_dms_replication_task_test.go
+++ b/aws/resource_aws_dms_replication_task_test.go
@@ -107,7 +107,7 @@ func dmsReplicationTaskConfig(randId string) string {
 resource "aws_vpc" "dms_vpc" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "tf-test-dms-vpc-%[1]s"
+		Name = "terraform-testacc-dms-replication-task"
 	}
 }
 
@@ -191,7 +191,7 @@ func dmsReplicationTaskConfigUpdate(randId string) string {
 resource "aws_vpc" "dms_vpc" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "tf-test-dms-vpc-%[1]s"
+		Name = "terraform-testacc-dms-replication-task"
 	}
 }
 


### PR DESCRIPTION
## Test results

```
=== RUN   TestAccAWSVPC_coreMismatchedDiffs
--- PASS: TestAccAWSVPC_coreMismatchedDiffs (39.37s)
=== RUN   TestAccDataSourceAwsInternetGateway_typical
--- PASS: TestAccDataSourceAwsInternetGateway_typical (54.33s)
=== RUN   TestAccAWSInstanceDataSource_keyPair
--- PASS: TestAccAWSInstanceDataSource_keyPair (88.58s)
=== RUN   TestAccAWSInstanceDataSource_SecurityGroups
--- PASS: TestAccAWSInstanceDataSource_SecurityGroups (114.45s)
=== RUN   TestAccAWSInstanceDataSource_gp2IopsDevice
--- PASS: TestAccAWSInstanceDataSource_gp2IopsDevice (153.56s)
=== RUN   TestAccDataSourceAwsNetworkInterface_basic
--- PASS: TestAccDataSourceAwsNetworkInterface_basic (26.66s)
=== RUN   TestAccAWSInstanceDataSource_tags
--- PASS: TestAccAWSInstanceDataSource_tags (187.65s)
=== RUN   TestAccAWSInstanceDataSource_basic
--- PASS: TestAccAWSInstanceDataSource_basic (188.30s)
=== RUN   TestAccAWSInstanceDataSource_blockDevices
--- PASS: TestAccAWSInstanceDataSource_blockDevices (189.90s)
=== RUN   TestAccAWSInstanceDataSource_rootInstanceStore
--- PASS: TestAccAWSInstanceDataSource_rootInstanceStore (194.42s)
=== RUN   TestAccDataSourceAWSELB_basic
--- PASS: TestAccDataSourceAWSELB_basic (203.06s)
=== RUN   TestAccDataSourceAwsRouteTable_main
--- PASS: TestAccDataSourceAwsRouteTable_main (21.22s)
=== RUN   TestAccDataSourceAwsRouteTable_basic
--- PASS: TestAccDataSourceAwsRouteTable_basic (45.49s)
=== RUN   TestAccAWSInstanceDataSource_VPC
--- PASS: TestAccAWSInstanceDataSource_VPC (236.64s)
=== RUN   TestAccDataSourceAwsNetworkInterface_filters
--- PASS: TestAccDataSourceAwsNetworkInterface_filters (74.05s)
=== RUN   TestAccDataSourceAWSLBListener_https
--- PASS: TestAccDataSourceAWSLBListener_https (263.27s)
=== RUN   TestAccDataSourceAwsRoute53Zone
--- PASS: TestAccDataSourceAwsRoute53Zone (75.59s)
=== RUN   TestAccDataSourceAwsVpcEndpointService_gateway
--- PASS: TestAccDataSourceAwsVpcEndpointService_gateway (27.61s)
=== RUN   TestAccDataSourceAwsVpcEndpointService_interface
--- PASS: TestAccDataSourceAwsVpcEndpointService_interface (23.11s)
=== RUN   TestAccDataSourceAWSALBTargetGroup_basic
--- PASS: TestAccDataSourceAWSALBTargetGroup_basic (306.26s)
=== RUN   TestAccDataSourceAWSLBTargetGroupBackwardsCompatibility
--- PASS: TestAccDataSourceAWSLBTargetGroupBackwardsCompatibility (269.03s)
=== RUN   TestAccDataSourceAwsRdsCluster_basic
--- PASS: TestAccDataSourceAwsRdsCluster_basic (148.98s)
=== RUN   TestAccDataSourceAwsSubnet_basic
--- PASS: TestAccDataSourceAwsSubnet_basic (145.30s)
=== RUN   TestAccDataSourceAWSLBBackwardsCompatibility
--- PASS: TestAccDataSourceAWSLBBackwardsCompatibility (276.64s)
=== RUN   TestAccDataSourceAwsVpnGateway_unattached
--- PASS: TestAccDataSourceAwsVpnGateway_unattached (24.75s)
=== RUN   TestAccAWSInstanceDataSource_AzUserData
--- PASS: TestAccAWSInstanceDataSource_AzUserData (375.73s)
=== RUN   TestAccDataSourceAwsVpcEndpoint_byId
--- PASS: TestAccDataSourceAwsVpcEndpoint_byId (129.80s)
=== RUN   TestAccDataSourceAwsVpc_basic
--- PASS: TestAccDataSourceAwsVpc_basic (88.04s)
=== RUN   TestAccDataSourceAwsVpcEndpoint_gatewayBasic
--- PASS: TestAccDataSourceAwsVpcEndpoint_gatewayBasic (144.37s)
=== RUN   TestAccDataSourceAwsVpc_ipv6Associated
--- PASS: TestAccDataSourceAwsVpc_ipv6Associated (75.08s)
=== RUN   TestAccAWSInstanceDataSource_privateIP
--- PASS: TestAccAWSInstanceDataSource_privateIP (417.39s)
=== RUN   TestAccDataSourceAwsNatGateway
--- PASS: TestAccDataSourceAwsNatGateway (307.38s)
=== RUN   TestAccAWSRouteTable_importBasic
--- PASS: TestAccAWSRouteTable_importBasic (65.78s)
=== RUN   TestAccDataSourceAwsEfsMountTargetByMountTargetId
--- PASS: TestAccDataSourceAwsEfsMountTargetByMountTargetId (442.31s)
=== RUN   TestAccDataSourceAwsSubnet_ipv6ByIpv6CidrBlock
--- PASS: TestAccDataSourceAwsSubnet_ipv6ByIpv6CidrBlock (219.79s)
=== RUN   TestAccDataSourceAwsSubnet_ipv6ByIpv6Filter
--- PASS: TestAccDataSourceAwsSubnet_ipv6ByIpv6Filter (261.90s)
=== RUN   TestAccDataSourceAwsVpnGateway_attached
--- PASS: TestAccDataSourceAwsVpnGateway_attached (123.79s)
=== RUN   TestAccDataSourceAwsVpcEndpoint_gatewayWithRouteTable
--- PASS: TestAccDataSourceAwsVpcEndpoint_gatewayWithRouteTable (212.10s)
=== RUN   TestAccAWSInstanceDataSource_PlacementGroup
--- PASS: TestAccAWSInstanceDataSource_PlacementGroup (514.66s)
=== RUN   TestAccDataSourceAwsVpcEndpointService_custom
--- PASS: TestAccDataSourceAwsVpcEndpointService_custom (272.64s)
=== RUN   TestAccDataSourceAWSLB_basic
--- PASS: TestAccDataSourceAWSLB_basic (497.77s)
=== RUN   TestAccDataSourceAwsVpcEndpoint_interface
--- PASS: TestAccDataSourceAwsVpcEndpoint_interface (252.13s)
=== RUN   TestAccDataSourceAWSLBListener_basic
--- PASS: TestAccDataSourceAWSLBListener_basic (597.86s)
=== RUN   TestAccAWSRouteTable_complex
--- PASS: TestAccAWSRouteTable_complex (229.06s)
=== RUN   TestAccDataSourceAWSLBListenerBackwardsCompatibility
--- PASS: TestAccDataSourceAWSLBListenerBackwardsCompatibility (608.49s)
=== RUN   TestAccAWSInstanceDataSource_VPCSecurityGroups
--- FAIL: TestAccAWSInstanceDataSource_VPCSecurityGroups (648.90s)
	testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
		
		* aws_security_group.tf_test_foo: 1 error(s) occurred:
		
		* aws_security_group.tf_test_foo: Error waiting for Security Group (sg-3836b147) to become available: timeout while waiting for state to become 'exists' (timeout: 10m0s)
FAIL
```