### PR TITLE
resource/aws_acm_certificate_validation: Fix root and wildcard validation_record_fqdns handling

### DIFF
--- a/aws/resource_aws_acm_certificate_test.go
+++ b/aws/resource_aws_acm_certificate_test.go
@@ -19,7 +19,14 @@ var certificateArnRegex = regexp.MustCompile(`^arn:aws:acm:[^:]+:[^:]+:certifica
 
 func testAccAwsAcmCertificateDomainFromEnv(t *testing.T) string {
 	if os.Getenv("ACM_CERTIFICATE_ROOT_DOMAIN") == "" {
-		t.Skip("Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set")
+		t.Skip(
+			"Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. " +
+				"For DNS validation requests, this domain must be publicly " +
+				"accessible and configurable via Route53 during the testing. " +
+				"For email validation requests, you must have access to one of " +
+				"the five standard email addresses used (admin|administrator|" +
+				"hostmaster|postmaster|webmaster)@domain or one of the WHOIS " +
+				"contact addresses.")
 	}
 	return os.Getenv("ACM_CERTIFICATE_ROOT_DOMAIN")
 }
@@ -125,7 +132,7 @@ func TestAccAwsAcmCertificate_root(t *testing.T) {
 	})
 }
 
-func TestAccAwsAcmCertificate_rootAndWildcardSubjectAlternativeName(t *testing.T) {
+func TestAccAwsAcmCertificate_rootAndWildcardSan(t *testing.T) {
 	rootDomain := testAccAwsAcmCertificateDomainFromEnv(t)
 	wildcardDomain := fmt.Sprintf("*.%s", rootDomain)
 
@@ -163,7 +170,7 @@ func TestAccAwsAcmCertificate_rootAndWildcardSubjectAlternativeName(t *testing.T
 	})
 }
 
-func TestAccAwsAcmCertificate_subjectAlternativeName(t *testing.T) {
+func TestAccAwsAcmCertificate_san_single(t *testing.T) {
 	rootDomain := testAccAwsAcmCertificateDomainFromEnv(t)
 
 	rInt1 := acctest.RandInt()
@@ -205,7 +212,7 @@ func TestAccAwsAcmCertificate_subjectAlternativeName(t *testing.T) {
 	})
 }
 
-func TestAccAwsAcmCertificate_subjectAlternativeNames(t *testing.T) {
+func TestAccAwsAcmCertificate_san_multiple(t *testing.T) {
 	rootDomain := testAccAwsAcmCertificateDomainFromEnv(t)
 
 	rInt1 := acctest.RandInt()
@@ -286,7 +293,7 @@ func TestAccAwsAcmCertificate_wildcard(t *testing.T) {
 	})
 }
 
-func TestAccAwsAcmCertificate_wildcardAndRootSubjectAlternativeName(t *testing.T) {
+func TestAccAwsAcmCertificate_wildcardAndRootSan(t *testing.T) {
 	rootDomain := testAccAwsAcmCertificateDomainFromEnv(t)
 	wildcardDomain := fmt.Sprintf("*.%s", rootDomain)
 

--- a/aws/resource_aws_acm_certificate_test.go
+++ b/aws/resource_aws_acm_certificate_test.go
@@ -17,16 +17,19 @@ import (
 
 var certificateArnRegex = regexp.MustCompile(`^arn:aws:acm:[^:]+:[^:]+:certificate/.+$`)
 
-func TestAccAwsAcmCertificate_emailValidation(t *testing.T) {
+func testAccAwsAcmCertificateDomainFromEnv(t *testing.T) string {
 	if os.Getenv("ACM_CERTIFICATE_ROOT_DOMAIN") == "" {
 		t.Skip("Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set")
 	}
+	return os.Getenv("ACM_CERTIFICATE_ROOT_DOMAIN")
+}
 
-	root_zone_domain := os.Getenv("ACM_CERTIFICATE_ROOT_DOMAIN")
+func TestAccAwsAcmCertificate_emailValidation(t *testing.T) {
+	rootDomain := testAccAwsAcmCertificateDomainFromEnv(t)
 
 	rInt1 := acctest.RandInt()
 
-	domain := fmt.Sprintf("tf-acc-%d.%s", rInt1, root_zone_domain)
+	domain := fmt.Sprintf("tf-acc-%d.%s", rInt1, rootDomain)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -38,6 +41,7 @@ func TestAccAwsAcmCertificate_emailValidation(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("aws_acm_certificate.cert", "arn", certificateArnRegex),
 					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_name", domain),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_validation_options.#", "0"),
 					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "subject_alternative_names.#", "0"),
 					resource.TestMatchResourceAttr("aws_acm_certificate.cert", "validation_emails.0", regexp.MustCompile(`^[^@]+@.+$`)),
 					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "validation_method", acm.ValidationMethodEmail),
@@ -54,15 +58,11 @@ func TestAccAwsAcmCertificate_emailValidation(t *testing.T) {
 }
 
 func TestAccAwsAcmCertificate_dnsValidation(t *testing.T) {
-	if os.Getenv("ACM_CERTIFICATE_ROOT_DOMAIN") == "" {
-		t.Skip("Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set")
-	}
-
-	root_zone_domain := os.Getenv("ACM_CERTIFICATE_ROOT_DOMAIN")
+	rootDomain := testAccAwsAcmCertificateDomainFromEnv(t)
 
 	rInt1 := acctest.RandInt()
 
-	domain := fmt.Sprintf("tf-acc-%d.%s", rInt1, root_zone_domain)
+	domain := fmt.Sprintf("tf-acc-%d.%s", rInt1, rootDomain)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -74,7 +74,125 @@ func TestAccAwsAcmCertificate_dnsValidation(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("aws_acm_certificate.cert", "arn", certificateArnRegex),
 					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_name", domain),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_validation_options.#", "1"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_validation_options.0.domain_name", domain),
+					resource.TestCheckResourceAttrSet("aws_acm_certificate.cert", "domain_validation_options.0.resource_record_name"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_validation_options.0.resource_record_type", "CNAME"),
+					resource.TestCheckResourceAttrSet("aws_acm_certificate.cert", "domain_validation_options.0.resource_record_value"),
 					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "subject_alternative_names.#", "0"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "validation_emails.#", "0"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "validation_method", acm.ValidationMethodDns),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "aws_acm_certificate.cert",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsAcmCertificate_root(t *testing.T) {
+	rootDomain := testAccAwsAcmCertificateDomainFromEnv(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAcmCertificateDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAcmCertificateConfig(rootDomain, acm.ValidationMethodDns),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("aws_acm_certificate.cert", "arn", certificateArnRegex),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_name", rootDomain),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_validation_options.#", "1"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_validation_options.0.domain_name", rootDomain),
+					resource.TestCheckResourceAttrSet("aws_acm_certificate.cert", "domain_validation_options.0.resource_record_name"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_validation_options.0.resource_record_type", "CNAME"),
+					resource.TestCheckResourceAttrSet("aws_acm_certificate.cert", "domain_validation_options.0.resource_record_value"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "subject_alternative_names.#", "0"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "validation_emails.#", "0"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "validation_method", acm.ValidationMethodDns),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "aws_acm_certificate.cert",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsAcmCertificate_rootAndWildcardSubjectAlternativeName(t *testing.T) {
+	rootDomain := testAccAwsAcmCertificateDomainFromEnv(t)
+	wildcardDomain := fmt.Sprintf("*.%s", rootDomain)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAcmCertificateDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAcmCertificateConfig_subjectAlternativeNames(rootDomain, strconv.Quote(wildcardDomain), acm.ValidationMethodDns),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("aws_acm_certificate.cert", "arn", certificateArnRegex),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_name", rootDomain),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_validation_options.#", "2"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_validation_options.0.domain_name", rootDomain),
+					resource.TestCheckResourceAttrSet("aws_acm_certificate.cert", "domain_validation_options.0.resource_record_name"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_validation_options.0.resource_record_type", "CNAME"),
+					resource.TestCheckResourceAttrSet("aws_acm_certificate.cert", "domain_validation_options.0.resource_record_value"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_validation_options.1.domain_name", wildcardDomain),
+					resource.TestCheckResourceAttrSet("aws_acm_certificate.cert", "domain_validation_options.1.resource_record_name"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_validation_options.1.resource_record_type", "CNAME"),
+					resource.TestCheckResourceAttrSet("aws_acm_certificate.cert", "domain_validation_options.1.resource_record_value"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "subject_alternative_names.#", "1"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "subject_alternative_names.0", wildcardDomain),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "validation_emails.#", "0"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "validation_method", acm.ValidationMethodDns),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "aws_acm_certificate.cert",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsAcmCertificate_subjectAlternativeName(t *testing.T) {
+	rootDomain := testAccAwsAcmCertificateDomainFromEnv(t)
+
+	rInt1 := acctest.RandInt()
+
+	domain := fmt.Sprintf("tf-acc-%d.%s", rInt1, rootDomain)
+	sanDomain := fmt.Sprintf("tf-acc-%d-san.%s", rInt1, rootDomain)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAcmCertificateDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAcmCertificateConfig_subjectAlternativeNames(domain, strconv.Quote(sanDomain), acm.ValidationMethodDns),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("aws_acm_certificate.cert", "arn", certificateArnRegex),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_name", domain),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_validation_options.#", "2"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_validation_options.0.domain_name", domain),
+					resource.TestCheckResourceAttrSet("aws_acm_certificate.cert", "domain_validation_options.0.resource_record_name"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_validation_options.0.resource_record_type", "CNAME"),
+					resource.TestCheckResourceAttrSet("aws_acm_certificate.cert", "domain_validation_options.0.resource_record_value"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_validation_options.1.domain_name", sanDomain),
+					resource.TestCheckResourceAttrSet("aws_acm_certificate.cert", "domain_validation_options.1.resource_record_name"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_validation_options.1.resource_record_type", "CNAME"),
+					resource.TestCheckResourceAttrSet("aws_acm_certificate.cert", "domain_validation_options.1.resource_record_value"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "subject_alternative_names.#", "1"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "subject_alternative_names.0", sanDomain),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "validation_emails.#", "0"),
 					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "validation_method", acm.ValidationMethodDns),
 				),
 			},
@@ -88,16 +206,13 @@ func TestAccAwsAcmCertificate_dnsValidation(t *testing.T) {
 }
 
 func TestAccAwsAcmCertificate_subjectAlternativeNames(t *testing.T) {
-	if os.Getenv("ACM_CERTIFICATE_ROOT_DOMAIN") == "" {
-		t.Skip("Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set")
-	}
-
-	root_zone_domain := os.Getenv("ACM_CERTIFICATE_ROOT_DOMAIN")
+	rootDomain := testAccAwsAcmCertificateDomainFromEnv(t)
 
 	rInt1 := acctest.RandInt()
 
-	domain := fmt.Sprintf("tf-acc-%d.%s", rInt1, root_zone_domain)
-	sanDomain := fmt.Sprintf("tf-acc-%d-san.%s", rInt1, root_zone_domain)
+	domain := fmt.Sprintf("tf-acc-%d.%s", rInt1, rootDomain)
+	sanDomain1 := fmt.Sprintf("tf-acc-%d-san1.%s", rInt1, rootDomain)
+	sanDomain2 := fmt.Sprintf("tf-acc-%d-san2.%s", rInt1, rootDomain)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -105,12 +220,98 @@ func TestAccAwsAcmCertificate_subjectAlternativeNames(t *testing.T) {
 		CheckDestroy: testAccCheckAcmCertificateDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAcmCertificateConfig_subjectAlternativeNames(domain, strconv.Quote(sanDomain), acm.ValidationMethodDns),
+				Config: testAccAcmCertificateConfig_subjectAlternativeNames(domain, fmt.Sprintf("%q, %q", sanDomain1, sanDomain2), acm.ValidationMethodDns),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("aws_acm_certificate.cert", "arn", certificateArnRegex),
 					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_name", domain),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_validation_options.#", "3"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_validation_options.0.domain_name", domain),
+					resource.TestCheckResourceAttrSet("aws_acm_certificate.cert", "domain_validation_options.0.resource_record_name"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_validation_options.0.resource_record_type", "CNAME"),
+					resource.TestCheckResourceAttrSet("aws_acm_certificate.cert", "domain_validation_options.0.resource_record_value"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_validation_options.1.domain_name", sanDomain1),
+					resource.TestCheckResourceAttrSet("aws_acm_certificate.cert", "domain_validation_options.1.resource_record_name"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_validation_options.1.resource_record_type", "CNAME"),
+					resource.TestCheckResourceAttrSet("aws_acm_certificate.cert", "domain_validation_options.1.resource_record_value"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_validation_options.2.domain_name", sanDomain2),
+					resource.TestCheckResourceAttrSet("aws_acm_certificate.cert", "domain_validation_options.2.resource_record_name"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_validation_options.2.resource_record_type", "CNAME"),
+					resource.TestCheckResourceAttrSet("aws_acm_certificate.cert", "domain_validation_options.2.resource_record_value"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "subject_alternative_names.#", "2"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "subject_alternative_names.0", sanDomain1),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "subject_alternative_names.1", sanDomain2),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "validation_emails.#", "0"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "validation_method", acm.ValidationMethodDns),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "aws_acm_certificate.cert",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsAcmCertificate_wildcard(t *testing.T) {
+	rootDomain := testAccAwsAcmCertificateDomainFromEnv(t)
+	wildcardDomain := fmt.Sprintf("*.%s", rootDomain)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAcmCertificateDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAcmCertificateConfig(wildcardDomain, acm.ValidationMethodDns),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("aws_acm_certificate.cert", "arn", certificateArnRegex),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_name", wildcardDomain),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_validation_options.#", "1"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_validation_options.0.domain_name", wildcardDomain),
+					resource.TestCheckResourceAttrSet("aws_acm_certificate.cert", "domain_validation_options.0.resource_record_name"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_validation_options.0.resource_record_type", "CNAME"),
+					resource.TestCheckResourceAttrSet("aws_acm_certificate.cert", "domain_validation_options.0.resource_record_value"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "subject_alternative_names.#", "0"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "validation_emails.#", "0"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "validation_method", acm.ValidationMethodDns),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "aws_acm_certificate.cert",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsAcmCertificate_wildcardAndRootSubjectAlternativeName(t *testing.T) {
+	rootDomain := testAccAwsAcmCertificateDomainFromEnv(t)
+	wildcardDomain := fmt.Sprintf("*.%s", rootDomain)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAcmCertificateDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAcmCertificateConfig_subjectAlternativeNames(wildcardDomain, strconv.Quote(rootDomain), acm.ValidationMethodDns),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("aws_acm_certificate.cert", "arn", certificateArnRegex),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_name", wildcardDomain),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_validation_options.#", "2"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_validation_options.0.domain_name", wildcardDomain),
+					resource.TestCheckResourceAttrSet("aws_acm_certificate.cert", "domain_validation_options.0.resource_record_name"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_validation_options.0.resource_record_type", "CNAME"),
+					resource.TestCheckResourceAttrSet("aws_acm_certificate.cert", "domain_validation_options.0.resource_record_value"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_validation_options.1.domain_name", rootDomain),
+					resource.TestCheckResourceAttrSet("aws_acm_certificate.cert", "domain_validation_options.1.resource_record_name"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_validation_options.1.resource_record_type", "CNAME"),
+					resource.TestCheckResourceAttrSet("aws_acm_certificate.cert", "domain_validation_options.1.resource_record_value"),
 					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "subject_alternative_names.#", "1"),
-					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "subject_alternative_names.0", sanDomain),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "subject_alternative_names.0", rootDomain),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "validation_emails.#", "0"),
 					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "validation_method", acm.ValidationMethodDns),
 				),
 			},
@@ -124,15 +325,11 @@ func TestAccAwsAcmCertificate_subjectAlternativeNames(t *testing.T) {
 }
 
 func TestAccAwsAcmCertificate_tags(t *testing.T) {
-	if os.Getenv("ACM_CERTIFICATE_ROOT_DOMAIN") == "" {
-		t.Skip("Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set")
-	}
-
-	root_zone_domain := os.Getenv("ACM_CERTIFICATE_ROOT_DOMAIN")
+	rootDomain := testAccAwsAcmCertificateDomainFromEnv(t)
 
 	rInt1 := acctest.RandInt()
 
-	domain := fmt.Sprintf("tf-acc-%d.%s", rInt1, root_zone_domain)
+	domain := fmt.Sprintf("tf-acc-%d.%s", rInt1, rootDomain)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/aws/resource_aws_acm_certificate_validation_test.go
+++ b/aws/resource_aws_acm_certificate_validation_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"strconv"
 	"testing"
@@ -13,16 +12,11 @@ import (
 )
 
 func TestAccAwsAcmCertificateValidation_basic(t *testing.T) {
-	if os.Getenv("ACM_CERTIFICATE_ROOT_DOMAIN") == "" {
-		t.Skip("Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set")
-	}
-
-	root_zone_domain := os.Getenv("ACM_CERTIFICATE_ROOT_DOMAIN")
+	rootDomain := testAccAwsAcmCertificateDomainFromEnv(t)
 
 	rInt1 := acctest.RandInt()
 
-	domain := fmt.Sprintf("tf-acc-%d.%s", rInt1, root_zone_domain)
-	sanDomain := fmt.Sprintf("tf-acc-%d-san.%s", rInt1, root_zone_domain)
+	domain := fmt.Sprintf("tf-acc-%d.%s", rInt1, rootDomain)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -31,64 +25,225 @@ func TestAccAwsAcmCertificateValidation_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Test that validation times out if certificate can't be validated
 			resource.TestStep{
-				Config:      testAccAcmCertificateValidation_basic(domain),
+				Config:      testAccAcmCertificateValidation_timeout(domain),
 				ExpectError: regexp.MustCompile("Expected certificate to be issued but was in state PENDING_VALIDATION"),
 			},
-			// Test that validation fails if given validation_fqdns don't match
+			// Test that validation succeeds
 			resource.TestStep{
-				Config:      testAccAcmCertificateValidation_validationRecordFqdns(domain, acm.ValidationMethodDns, `"some-wrong-fqdn.example.com"`),
-				ExpectError: regexp.MustCompile("Certificate needs .* to be set but only .* was passed to validation_record_fqdns"),
-			},
-			// Test that validation fails if not DNS validation
-			resource.TestStep{
-				Config:      testAccAcmCertificateValidation_validationRecordFqdns(domain, acm.ValidationMethodEmail, `"some-wrong-fqdn.example.com"`),
-				ExpectError: regexp.MustCompile("validation_record_fqdns is only valid for DNS validation"),
-			},
-			// Test that validation succeeds once we provide the right DNS validation records
-			resource.TestStep{
-				Config: testAccAcmCertificateValidation_withRoute53Records(root_zone_domain, domain, strconv.Quote(sanDomain)),
+				Config: testAccAcmCertificateValidation_basic(rootDomain, domain),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("aws_acm_certificate_validation.cert", "certificate_arn", certificateArnRegex),
 				),
-			},
-			// Test that we can import a validated certificate
-			resource.TestStep{
-				ResourceName:      "aws_acm_certificate.cert",
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
-func testAccAcmCertificateValidation_basic(domainName string) string {
+func TestAccAwsAcmCertificateValidation_validationRecordFqdns(t *testing.T) {
+	rootDomain := testAccAwsAcmCertificateDomainFromEnv(t)
+
+	rInt1 := acctest.RandInt()
+
+	domain := fmt.Sprintf("tf-acc-%d.%s", rInt1, rootDomain)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAcmCertificateDestroy,
+		Steps: []resource.TestStep{
+			// Test that validation fails if given validation_fqdns don't match
+			resource.TestStep{
+				Config:      testAccAcmCertificateValidation_validationRecordFqdnsWrongFqdn(domain),
+				ExpectError: regexp.MustCompile("missing .+ DNS validation record: .+"),
+			},
+			// Test that validation fails if not DNS validation
+			resource.TestStep{
+				Config:      testAccAcmCertificateValidation_validationRecordFqdnsEmailValidation(domain),
+				ExpectError: regexp.MustCompile("validation_record_fqdns is only valid for DNS validation"),
+			},
+			// Test that validation succeeds with validation
+			resource.TestStep{
+				Config: testAccAcmCertificateValidation_validationRecordFqdnsOneRoute53Record(rootDomain, domain),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("aws_acm_certificate_validation.cert", "certificate_arn", certificateArnRegex),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAwsAcmCertificateValidation_validationRecordFqdnsRoot(t *testing.T) {
+	rootDomain := testAccAwsAcmCertificateDomainFromEnv(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAcmCertificateDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAcmCertificateValidation_validationRecordFqdnsOneRoute53Record(rootDomain, rootDomain),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("aws_acm_certificate_validation.cert", "certificate_arn", certificateArnRegex),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAwsAcmCertificateValidation_validationRecordFqdnsRootAndWildcard(t *testing.T) {
+	rootDomain := testAccAwsAcmCertificateDomainFromEnv(t)
+	wildcardDomain := fmt.Sprintf("*.%s", rootDomain)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAcmCertificateDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAcmCertificateValidation_validationRecordFqdnsTwoRoute53Records(rootDomain, rootDomain, strconv.Quote(wildcardDomain)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("aws_acm_certificate_validation.cert", "certificate_arn", certificateArnRegex),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAwsAcmCertificateValidation_validationRecordFqdnsSan(t *testing.T) {
+	rootDomain := testAccAwsAcmCertificateDomainFromEnv(t)
+
+	rInt1 := acctest.RandInt()
+
+	domain := fmt.Sprintf("tf-acc-%d.%s", rInt1, rootDomain)
+	sanDomain := fmt.Sprintf("tf-acc-%d-san.%s", rInt1, rootDomain)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAcmCertificateDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAcmCertificateValidation_validationRecordFqdnsTwoRoute53Records(rootDomain, domain, strconv.Quote(sanDomain)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("aws_acm_certificate_validation.cert", "certificate_arn", certificateArnRegex),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAwsAcmCertificateValidation_validationRecordFqdnsWildcard(t *testing.T) {
+	rootDomain := testAccAwsAcmCertificateDomainFromEnv(t)
+	wildcardDomain := fmt.Sprintf("*.%s", rootDomain)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAcmCertificateDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAcmCertificateValidation_validationRecordFqdnsOneRoute53Record(rootDomain, wildcardDomain),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("aws_acm_certificate_validation.cert", "certificate_arn", certificateArnRegex),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAwsAcmCertificateValidation_validationRecordFqdnsWildcardAndRoot(t *testing.T) {
+	rootDomain := testAccAwsAcmCertificateDomainFromEnv(t)
+	wildcardDomain := fmt.Sprintf("*.%s", rootDomain)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAcmCertificateDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAcmCertificateValidation_validationRecordFqdnsTwoRoute53Records(rootDomain, wildcardDomain, strconv.Quote(rootDomain)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("aws_acm_certificate_validation.cert", "certificate_arn", certificateArnRegex),
+				),
+			},
+		},
+	})
+}
+
+func testAccAcmCertificateValidation_basic(rootZoneDomain, domainName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "aws_route53_zone" "zone" {
+  name = "%s."
+  private_zone = false
+}
+
+resource "aws_route53_record" "cert_validation" {
+  name = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_name}"
+  type = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_type}"
+  zone_id = "${data.aws_route53_zone.zone.id}"
+  records = ["${aws_acm_certificate.cert.domain_validation_options.0.resource_record_value}"]
+  ttl = 60
+}
+
+resource "aws_acm_certificate_validation" "cert" {
+  depends_on = ["aws_route53_record.cert_validation"]
+
+  certificate_arn = "${aws_acm_certificate.cert.arn}"
+}
+`, testAccAcmCertificateConfig(domainName, acm.ValidationMethodDns), rootZoneDomain)
+}
+
+func testAccAcmCertificateValidation_timeout(domainName string) string {
 	return fmt.Sprintf(`
 %s
 
 resource "aws_acm_certificate_validation" "cert" {
   certificate_arn = "${aws_acm_certificate.cert.arn}"
   timeouts {
-    create = "20s"
+    create = "5s"
   }
 }
 `, testAccAcmCertificateConfig(domainName, acm.ValidationMethodDns))
 }
 
-func testAccAcmCertificateValidation_validationRecordFqdns(domainName, validationMethod, validationRecordFqdns string) string {
+func testAccAcmCertificateValidation_validationRecordFqdnsEmailValidation(domainName string) string {
 	return fmt.Sprintf(`
 %s
 
 resource "aws_acm_certificate_validation" "cert" {
   certificate_arn = "${aws_acm_certificate.cert.arn}"
-  validation_record_fqdns = [%s]
-  timeouts {
-    create = "20s"
-  }
+  validation_record_fqdns = ["wrong-validation-fqdn.example.com"]
 }
-`, testAccAcmCertificateConfig(domainName, validationMethod), validationRecordFqdns)
+`, testAccAcmCertificateConfig(domainName, acm.ValidationMethodEmail))
 }
 
-func testAccAcmCertificateValidation_withRoute53Records(rootZoneDomain, domainName, subjectAlternativeNames string) string {
+func testAccAcmCertificateValidation_validationRecordFqdnsOneRoute53Record(rootZoneDomain, domainName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "aws_route53_zone" "zone" {
+  name = "%s."
+  private_zone = false
+}
+
+resource "aws_route53_record" "cert_validation" {
+  name = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_name}"
+  type = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_type}"
+  zone_id = "${data.aws_route53_zone.zone.id}"
+  records = ["${aws_acm_certificate.cert.domain_validation_options.0.resource_record_value}"]
+  ttl = 60
+}
+
+resource "aws_acm_certificate_validation" "cert" {
+  certificate_arn = "${aws_acm_certificate.cert.arn}"
+  validation_record_fqdns = ["${aws_route53_record.cert_validation.fqdn}"]
+}
+`, testAccAcmCertificateConfig(domainName, acm.ValidationMethodDns), rootZoneDomain)
+}
+
+func testAccAcmCertificateValidation_validationRecordFqdnsTwoRoute53Records(rootZoneDomain, domainName, subjectAlternativeNames string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -116,9 +271,20 @@ resource "aws_route53_record" "cert_validation_san" {
 resource "aws_acm_certificate_validation" "cert" {
   certificate_arn = "${aws_acm_certificate.cert.arn}"
   validation_record_fqdns = [
-	"${aws_route53_record.cert_validation.fqdn}",
-	"${aws_route53_record.cert_validation_san.fqdn}"
+    "${aws_route53_record.cert_validation.fqdn}",
+    "${aws_route53_record.cert_validation_san.fqdn}"
   ]
 }
 `, testAccAcmCertificateConfig_subjectAlternativeNames(domainName, subjectAlternativeNames, acm.ValidationMethodDns), rootZoneDomain)
+}
+
+func testAccAcmCertificateValidation_validationRecordFqdnsWrongFqdn(domainName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "aws_acm_certificate_validation" "cert" {
+  certificate_arn = "${aws_acm_certificate.cert.arn}"
+  validation_record_fqdns = ["wrong-validation-fqdn.example.com"]
+}
+`, testAccAcmCertificateConfig(domainName, acm.ValidationMethodDns))
 }

--- a/aws/resource_aws_acm_certificate_validation_test.go
+++ b/aws/resource_aws_acm_certificate_validation_test.go
@@ -23,17 +23,32 @@ func TestAccAwsAcmCertificateValidation_basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAcmCertificateDestroy,
 		Steps: []resource.TestStep{
-			// Test that validation times out if certificate can't be validated
-			resource.TestStep{
-				Config:      testAccAcmCertificateValidation_timeout(domain),
-				ExpectError: regexp.MustCompile("Expected certificate to be issued but was in state PENDING_VALIDATION"),
-			},
 			// Test that validation succeeds
 			resource.TestStep{
 				Config: testAccAcmCertificateValidation_basic(rootDomain, domain),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("aws_acm_certificate_validation.cert", "certificate_arn", certificateArnRegex),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAwsAcmCertificateValidation_timeout(t *testing.T) {
+	rootDomain := testAccAwsAcmCertificateDomainFromEnv(t)
+
+	rInt1 := acctest.RandInt()
+
+	domain := fmt.Sprintf("tf-acc-%d.%s", rInt1, rootDomain)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAcmCertificateDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config:      testAccAcmCertificateValidation_timeout(domain),
+				ExpectError: regexp.MustCompile("Expected certificate to be issued but was in state PENDING_VALIDATION"),
 			},
 		},
 	})


### PR DESCRIPTION
Fixes #3329 (and heavily augments the ACM testing)

ACM will return the same validation record name across two domain validation objects when creating a certificate for the root domain and wildcard for the same domain. Previously `validation_record_fqdns` (always a set of 1 in this case) was trying to deeply equal the domain validation record names (a list of 2), which is impossible to workaround. This PR makes the domain validation record names a set for the validation. This also updates the error handling.

Previously the error handling returned (this is the bug that was fixed):
```
--- FAIL: TestAccAwsAcmCertificateValidation_validationRecordFqdnsRootAndWildcard (128.89s)
	testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:

		* aws_acm_certificate_validation.cert: 1 error(s) occurred:

		* aws_acm_certificate_validation.cert: Certificate needs [_219c781bc2b7b0e36289413e77c82bbc.example.com _219c781bc2b7b0e36289413e77c82bbc.example.com] to be set but only [_219c781bc2b7b0e36289413e77c82bbc.example.com] was passed to validation_record_fqdns
```


Now returns missing records via multierror along with the associated domain name, which should be very helpful for those with high SAN count:
```
		* aws_acm_certificate_validation.cert: 2 error(s) occurred:

		* missing tf-acc-8703199145279883318.example.com DNS validation record: _b700c37a7e02189fd014362b37e2ba68.tf-acc-8703199145279883318.example.com
		* missing tf-acc-san-8703199145279883318.example.com DNS validation record: _ee97edac7b32d661f2e43e4cbc99eae6.tf-acc-san-8703199145279883318.example.com
```

Passes testing locally:
```
make testacc TEST=./aws TESTARGS='-run=TestAccAwsAcmCertificate_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAwsAcmCertificate_ -timeout 120m
=== RUN   TestAccAwsAcmCertificate_emailValidation
--- PASS: TestAccAwsAcmCertificate_emailValidation (17.08s)
=== RUN   TestAccAwsAcmCertificate_dnsValidation
--- PASS: TestAccAwsAcmCertificate_dnsValidation (16.44s)
=== RUN   TestAccAwsAcmCertificate_root
--- PASS: TestAccAwsAcmCertificate_root (15.04s)
=== RUN   TestAccAwsAcmCertificate_rootAndWildcardSubjectAlternativeName
--- PASS: TestAccAwsAcmCertificate_rootAndWildcardSubjectAlternativeName (19.28s)
=== RUN   TestAccAwsAcmCertificate_subjectAlternativeName
--- PASS: TestAccAwsAcmCertificate_subjectAlternativeName (21.36s)
=== RUN   TestAccAwsAcmCertificate_subjectAlternativeNames
--- PASS: TestAccAwsAcmCertificate_subjectAlternativeNames (18.03s)
=== RUN   TestAccAwsAcmCertificate_wildcard
--- PASS: TestAccAwsAcmCertificate_wildcard (14.93s)
=== RUN   TestAccAwsAcmCertificate_wildcardAndRootSubjectAlternativeName
--- PASS: TestAccAwsAcmCertificate_wildcardAndRootSubjectAlternativeName (19.80s)
=== RUN   TestAccAwsAcmCertificate_tags
--- PASS: TestAccAwsAcmCertificate_tags (40.03s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	182.029s

make testacc TEST=./aws TESTARGS='-run=TestAccAwsAcmCertificateValidation_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAwsAcmCertificateValidation_ -timeout 120m
=== RUN   TestAccAwsAcmCertificateValidation_basic
--- PASS: TestAccAwsAcmCertificateValidation_basic (227.62s)
=== RUN   TestAccAwsAcmCertificateValidation_validationRecordFqdns
--- PASS: TestAccAwsAcmCertificateValidation_validationRecordFqdns (140.92s)
=== RUN   TestAccAwsAcmCertificateValidation_validationRecordFqdnsRoot
--- PASS: TestAccAwsAcmCertificateValidation_validationRecordFqdnsRoot (196.60s)
=== RUN   TestAccAwsAcmCertificateValidation_validationRecordFqdnsRootAndWildcard
--- PASS: TestAccAwsAcmCertificateValidation_validationRecordFqdnsRootAndWildcard (146.92s)
=== RUN   TestAccAwsAcmCertificateValidation_validationRecordFqdnsSan
--- PASS: TestAccAwsAcmCertificateValidation_validationRecordFqdnsSan (212.38s)
=== RUN   TestAccAwsAcmCertificateValidation_validationRecordFqdnsWildcard
--- PASS: TestAccAwsAcmCertificateValidation_validationRecordFqdnsWildcard (171.43s)
=== RUN   TestAccAwsAcmCertificateValidation_validationRecordFqdnsWildcardAndRoot
--- PASS: TestAccAwsAcmCertificateValidation_validationRecordFqdnsWildcardAndRoot (147.40s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1243.333s
```