### PR TITLE
resource/aws_dx_lag: Deprecate number_of_connections

### DIFF
--- a/aws/resource_aws_dx_connection_association_test.go
+++ b/aws/resource_aws_dx_connection_association_test.go
@@ -92,7 +92,6 @@ resource "aws_dx_lag" "test" {
   name = "tf-dx-%s"
   connections_bandwidth = "1Gbps"
   location = "EqSe2"
-  number_of_connections = 1
   force_destroy = true
 }
 
@@ -121,7 +120,6 @@ resource "aws_dx_lag" "test" {
   name = "tf-dx-%s"
   connections_bandwidth = "1Gbps"
   location = "EqSe2"
-  number_of_connections = 1
   force_destroy = true
 }
 

--- a/aws/resource_aws_dx_lag.go
+++ b/aws/resource_aws_dx_lag.go
@@ -41,8 +41,11 @@ func resourceAwsDxLag() *schema.Resource {
 			},
 			"number_of_connections": {
 				Type:     schema.TypeInt,
-				Required: true,
+				Optional: true,
+				Computed: true,
 				ForceNew: true,
+				Deprecated: "Use aws_dx_connection and aws_dx_connection_association resources instead. " +
+					"Default connections will be removed as part of LAG creation automatically in future versions.",
 			},
 			"force_destroy": {
 				Type:     schema.TypeBool,
@@ -57,11 +60,18 @@ func resourceAwsDxLag() *schema.Resource {
 func resourceAwsDxLagCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).dxconn
 
+	var noOfConnections int
+	if v, ok := d.GetOk("number_of_connections"); ok {
+		noOfConnections = v.(int)
+	} else {
+		noOfConnections = 1
+	}
+
 	req := &directconnect.CreateLagInput{
 		ConnectionsBandwidth: aws.String(d.Get("connections_bandwidth").(string)),
 		LagName:              aws.String(d.Get("name").(string)),
 		Location:             aws.String(d.Get("location").(string)),
-		NumberOfConnections:  aws.Int64(int64(d.Get("number_of_connections").(int))),
+		NumberOfConnections:  aws.Int64(int64(noOfConnections)),
 	}
 
 	log.Printf("[DEBUG] Creating Direct Connect LAG: %#v", req)
@@ -69,6 +79,9 @@ func resourceAwsDxLagCreate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
+
+	// TODO: Remove default connection(s) automatically provisioned by AWS
+	// per NumberOfConnections
 
 	d.SetId(aws.StringValue(resp.LagId))
 	return resourceAwsDxLagUpdate(d, meta)
@@ -119,7 +132,6 @@ func resourceAwsDxLagRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("name", lag.LagName)
 	d.Set("connections_bandwidth", lag.ConnectionsBandwidth)
 	d.Set("location", lag.Location)
-	d.Set("number_of_connections", lag.NumberOfConnections)
 
 	if err := getTagsDX(conn, d, arn); err != nil {
 		return err

--- a/aws/resource_aws_dx_lag_test.go
+++ b/aws/resource_aws_dx_lag_test.go
@@ -27,7 +27,6 @@ func TestAccAwsDxLag_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_dx_lag.hoge", "name", lagName1),
 					resource.TestCheckResourceAttr("aws_dx_lag.hoge", "connections_bandwidth", "1Gbps"),
 					resource.TestCheckResourceAttr("aws_dx_lag.hoge", "location", "EqSe2"),
-					resource.TestCheckResourceAttr("aws_dx_lag.hoge", "number_of_connections", "2"),
 					resource.TestCheckResourceAttr("aws_dx_lag.hoge", "tags.%", "0"),
 				),
 			},
@@ -38,7 +37,6 @@ func TestAccAwsDxLag_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_dx_lag.hoge", "name", lagName2),
 					resource.TestCheckResourceAttr("aws_dx_lag.hoge", "connections_bandwidth", "1Gbps"),
 					resource.TestCheckResourceAttr("aws_dx_lag.hoge", "location", "EqSe2"),
-					resource.TestCheckResourceAttr("aws_dx_lag.hoge", "number_of_connections", "2"),
 					resource.TestCheckResourceAttr("aws_dx_lag.hoge", "tags.%", "0"),
 				),
 			},
@@ -127,7 +125,6 @@ resource "aws_dx_lag" "hoge" {
   name = "%s"
   connections_bandwidth = "1Gbps"
   location = "EqSe2"
-  number_of_connections = 2
   force_destroy = true
 }
 `, n)
@@ -139,7 +136,6 @@ resource "aws_dx_lag" "hoge" {
   name = "%s"
   connections_bandwidth = "1Gbps"
   location = "EqSe2"
-  number_of_connections = 2
   force_destroy = true
 
   tags {
@@ -156,7 +152,6 @@ resource "aws_dx_lag" "hoge" {
   name = "%s"
   connections_bandwidth = "1Gbps"
   location = "EqSe2"
-  number_of_connections = 2
   force_destroy = true
 
   tags {

--- a/website/docs/r/dx_lag.html.markdown
+++ b/website/docs/r/dx_lag.html.markdown
@@ -29,7 +29,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the LAG.
 * `connections_bandwidth` - (Required) The bandwidth of the individual physical connections bundled by the LAG. Available values: 1Gbps, 10Gbps. Case sensitive.
 * `location` - (Required) The AWS Direct Connect location in which the LAG should be allocated. See [DescribeLocations](https://docs.aws.amazon.com/directconnect/latest/APIReference/API_DescribeLocations.html) for the list of AWS Direct Connect locations. Use `locationCode`.
-* `number_of_connections` - (Required) The number of physical connections initially provisioned and bundled by the LAG.
+* `number_of_connections` - (**Deprecated**) The number of physical connections initially provisioned and bundled by the LAG. Use `aws_dx_connection` and `aws_dx_connection_association` resources instead. Default connections will be removed as part of LAG creation automatically in future versions.
 * `force_destroy` - (Optional, Default:false) A boolean that indicates all connections associated with the LAG should be deleted so that the LAG can be destroyed without error. These objects are *not* recoverable.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
This is to address the following test failures:

```
=== RUN   TestAccAwsDxConnectionAssociation_basic
--- FAIL: TestAccAwsDxConnectionAssociation_basic (17.22s)
    testing.go:513: Step 0 error: After applying this step and refreshing, the plan was not empty:
        
        DIFF:
        
        DESTROY/CREATE: aws_dx_connection_association.test
          connection_id: "dxcon-fft4eqt7" => "dxcon-fft4eqt7"
          lag_id:        "dxlag-fgktz5h3" => "<computed>" (forces new resource)
        DESTROY/CREATE: aws_dx_lag.test
          arn:                   "arn:aws:directconnect:us-west-2:*******:dxlag/dxlag-fgktz5h3" => "<computed>"
          connections_bandwidth: "1Gbps" => "1Gbps"
          force_destroy:         "true" => "true"
          location:              "EqSe2" => "EqSe2"
          name:                  "tf-dx-t90nd" => "tf-dx-t90nd"
          number_of_connections: "2" => "1" (forces new resource)

=== RUN   TestAccAwsDxConnectionAssociation_multiConns
--- FAIL: TestAccAwsDxConnectionAssociation_multiConns (17.12s)
    testing.go:513: Step 0 error: After applying this step and refreshing, the plan was not empty:
        
        DIFF:
        
        DESTROY/CREATE: aws_dx_connection_association.test1
          connection_id: "dxcon-ffzd1kty" => "dxcon-ffzd1kty"
          lag_id:        "dxlag-fh87u1zp" => "<computed>" (forces new resource)
        DESTROY/CREATE: aws_dx_connection_association.test2
          connection_id: "dxcon-fgeqoh9q" => "dxcon-fgeqoh9q"
          lag_id:        "dxlag-fh87u1zp" => "<computed>" (forces new resource)
        DESTROY/CREATE: aws_dx_lag.test
          arn:                   "arn:aws:directconnect:us-west-2:*******:dxlag/dxlag-fh87u1zp" => "<computed>"
          connections_bandwidth: "1Gbps" => "1Gbps"
          force_destroy:         "true" => "true"
          location:              "EqSe2" => "EqSe2"
          name:                  "tf-dx-3a2u0" => "tf-dx-3a2u0"
          number_of_connections: "3" => "1" (forces new resource)
```

The story is that AWS provisions connections & associations automatically per `number_of_connections` (as it's passed to the API). This makes further management of connections tricky because any new non-default connection created via `aws_dx_connection_association` will cause Amazon to bump `number_of_connections` and cause drift as the number of connections no longer matches the initial number.

Unfortunately there's no way to avoid automated provisioning as `NumberOfConnections` is a required field in the API and has to be `> 0`. For that reason I decided to apply similar approach we already apply in some other resources (e.g. route table) and that is to plan removal of these default connections & associations.

I didn't implement that as part of this PR though, because that would be a breaking change. The goal is to inform the user about how we're going to tackle it going forward and avoid the drift for now.

## Test results

```
=== RUN   TestAccAwsDxConnectionAssociation_basic
--- PASS: TestAccAwsDxConnectionAssociation_basic (47.35s)
=== RUN   TestAccAwsDxConnectionAssociation_multiConns
--- PASS: TestAccAwsDxConnectionAssociation_multiConns (46.58s)
=== RUN   TestAccAwsDxConnection_basic
--- PASS: TestAccAwsDxConnection_basic (39.48s)
=== RUN   TestAccAwsDxConnection_tags
--- PASS: TestAccAwsDxConnection_tags (61.83s)
=== RUN   TestAccAwsDxLag_basic
--- PASS: TestAccAwsDxLag_basic (92.54s)
=== RUN   TestAccAwsDxLag_tags
--- PASS: TestAccAwsDxLag_tags (118.86s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	406.689s
```