### PR TITLE
resource/aws_vpc_endpoint: Treat pending as expected state during deletion

### DIFF
--- a/aws/resource_aws_vpc_endpoint.go
+++ b/aws/resource_aws_vpc_endpoint.go
@@ -257,7 +257,7 @@ func resourceAwsVpcEndpointDelete(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"available", "deleting"},
+		Pending:    []string{"available", "pending", "deleting"},
 		Target:     []string{"deleted"},
 		Refresh:    vpcEndpointStateRefresh(conn, d.Id()),
 		Timeout:    10 * time.Minute,

--- a/aws/resource_aws_vpc_endpoint_test.go
+++ b/aws/resource_aws_vpc_endpoint_test.go
@@ -76,7 +76,6 @@ func TestAccAwsVpcEndpoint_gatewayWithRouteTableAndPolicy(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_vpc_endpoint.s3", "security_group_ids.#", "0"),
 					resource.TestCheckResourceAttr("aws_vpc_endpoint.s3", "private_dns_enabled", "false"),
 				),
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})


### PR DESCRIPTION
This is to address the following test failures:

```
=== RUN   TestAccAwsVpcEndpointSubnetAssociation_basic
--- FAIL: TestAccAwsVpcEndpointSubnetAssociation_basic (109.96s)
    testing.go:573: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Error applying: 1 error(s) occurred:
        
        * aws_vpc_endpoint.ec2 (destroy): 1 error(s) occurred:
        
        * aws_vpc_endpoint.ec2: Error waiting for VPC Endpoint vpce-0de87e4d69ceff0c0 to delete: unexpected state 'pending', wanted target 'deleted'. last error: %!s(<nil>)

=== RUN   TestAccAwsVpcEndpoint_gatewayWithRouteTableAndPolicy
--- FAIL: TestAccAwsVpcEndpoint_gatewayWithRouteTableAndPolicy (736.16s)
    testing.go:513: Step 1 error: Expected a non-empty plan, but got an empty plan!
FAIL
```

The second test was failing since the test step was introduced in https://github.com/terraform-providers/terraform-provider-aws/commit/6876bf71bb6a3a04e0721e954b2e891c7d87a2b5#diff-1b6af3d3ebf63b2a6cae2399a0681cadR79. I assume it was just overlooked in such a large-scope PR.

## Test results
```
=== RUN   TestAccAwsVpcEndpointConnectionNotification_importBasic
--- PASS: TestAccAwsVpcEndpointConnectionNotification_importBasic (290.04s)
=== RUN   TestAccAwsVpcEndpointService_importBasic
--- PASS: TestAccAwsVpcEndpointService_importBasic (298.93s)
=== RUN   TestAccAwsVpcEndpoint_importBasic
--- PASS: TestAccAwsVpcEndpoint_importBasic (85.44s)
=== RUN   TestAccAwsVpcEndpointConnectionNotification_basic
--- PASS: TestAccAwsVpcEndpointConnectionNotification_basic (334.46s)
=== RUN   TestAccAwsVpcEndpointRouteTableAssociation_basic
--- PASS: TestAccAwsVpcEndpointRouteTableAssociation_basic (79.16s)
=== RUN   TestAccAwsVpcEndpointServiceAllowedPrincipal_basic
--- PASS: TestAccAwsVpcEndpointServiceAllowedPrincipal_basic (285.35s)
=== RUN   TestAccAwsVpcEndpointService_basic
--- PASS: TestAccAwsVpcEndpointService_basic (518.51s)
=== RUN   TestAccAwsVpcEndpointService_removed
--- PASS: TestAccAwsVpcEndpointService_removed (276.15s)
=== RUN   TestAccAwsVpcEndpointSubnetAssociation_basic
--- PASS: TestAccAwsVpcEndpointSubnetAssociation_basic (108.20s)
=== RUN   TestAccAwsVpcEndpoint_gatewayBasic
--- PASS: TestAccAwsVpcEndpoint_gatewayBasic (76.45s)
=== RUN   TestAccAwsVpcEndpoint_gatewayWithRouteTableAndPolicy
--- PASS: TestAccAwsVpcEndpoint_gatewayWithRouteTableAndPolicy (138.08s)
=== RUN   TestAccAwsVpcEndpoint_interfaceBasic
--- PASS: TestAccAwsVpcEndpoint_interfaceBasic (80.84s)
=== RUN   TestAccAwsVpcEndpoint_interfaceWithSubnetAndSecurityGroup
--- PASS: TestAccAwsVpcEndpoint_interfaceWithSubnetAndSecurityGroup (320.24s)
=== RUN   TestAccAwsVpcEndpoint_interfaceNonAWSService
--- PASS: TestAccAwsVpcEndpoint_interfaceNonAWSService (320.66s)
=== RUN   TestAccAwsVpcEndpoint_removed
--- PASS: TestAccAwsVpcEndpoint_removed (62.88s)
```

cc @ewbankkit @jen20 