### PR TITLE
resource/aws_instance: Expose reason of 'shutting-down' during creation

### DIFF
--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -552,7 +552,7 @@ func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"pending"},
 		Target:     []string{"running"},
-		Refresh:    InstanceStateRefreshFunc(conn, *instance.InstanceId, "terminated"),
+		Refresh:    InstanceStateRefreshFunc(conn, *instance.InstanceId, []string{"terminated", "shutting-down"}),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
 		Delay:      10 * time.Second,
 		MinTimeout: 3 * time.Second,
@@ -965,7 +965,7 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 		stateConf := &resource.StateChangeConf{
 			Pending:    []string{"pending", "running", "shutting-down", "stopped", "stopping"},
 			Target:     []string{"stopped"},
-			Refresh:    InstanceStateRefreshFunc(conn, d.Id(), ""),
+			Refresh:    InstanceStateRefreshFunc(conn, d.Id(), []string{}),
 			Timeout:    d.Timeout(schema.TimeoutUpdate),
 			Delay:      10 * time.Second,
 			MinTimeout: 3 * time.Second,
@@ -996,7 +996,7 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 		stateConf = &resource.StateChangeConf{
 			Pending:    []string{"pending", "stopped"},
 			Target:     []string{"running"},
-			Refresh:    InstanceStateRefreshFunc(conn, d.Id(), "terminated"),
+			Refresh:    InstanceStateRefreshFunc(conn, d.Id(), []string{"terminated"}),
 			Timeout:    d.Timeout(schema.TimeoutUpdate),
 			Delay:      10 * time.Second,
 			MinTimeout: 3 * time.Second,
@@ -1074,7 +1074,7 @@ func resourceAwsInstanceDelete(d *schema.ResourceData, meta interface{}) error {
 
 // InstanceStateRefreshFunc returns a resource.StateRefreshFunc that is used to watch
 // an EC2 instance.
-func InstanceStateRefreshFunc(conn *ec2.EC2, instanceID, failState string) resource.StateRefreshFunc {
+func InstanceStateRefreshFunc(conn *ec2.EC2, instanceID string, failStates []string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		resp, err := conn.DescribeInstances(&ec2.DescribeInstancesInput{
 			InstanceIds: []*string{aws.String(instanceID)},
@@ -1098,10 +1098,11 @@ func InstanceStateRefreshFunc(conn *ec2.EC2, instanceID, failState string) resou
 		i := resp.Reservations[0].Instances[0]
 		state := *i.State.Name
 
-		if state == failState {
-			return i, state, fmt.Errorf("Failed to reach target state. Reason: %s",
-				stringifyStateReason(i.StateReason))
-
+		for _, failState := range failStates {
+			if state == failState {
+				return i, state, fmt.Errorf("Failed to reach target state. Reason: %s",
+					stringifyStateReason(i.StateReason))
+			}
 		}
 
 		return i, state, nil
@@ -1716,7 +1717,7 @@ func awsTerminateInstance(conn *ec2.EC2, id string, d *schema.ResourceData) erro
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"pending", "running", "shutting-down", "stopped", "stopping"},
 		Target:     []string{"terminated"},
-		Refresh:    InstanceStateRefreshFunc(conn, id, ""),
+		Refresh:    InstanceStateRefreshFunc(conn, id, []string{}),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
 		Delay:      10 * time.Second,
 		MinTimeout: 3 * time.Second,

--- a/aws/resource_aws_volume_attachment.go
+++ b/aws/resource_aws_volume_attachment.go
@@ -82,7 +82,7 @@ func resourceAwsVolumeAttachmentCreate(d *schema.ResourceData, meta interface{})
 		stateConf := &resource.StateChangeConf{
 			Pending:    []string{"pending", "stopping"},
 			Target:     []string{"running", "stopped"},
-			Refresh:    InstanceStateRefreshFunc(conn, iID, "terminated"),
+			Refresh:    InstanceStateRefreshFunc(conn, iID, []string{"terminated"}),
 			Timeout:    10 * time.Minute,
 			Delay:      10 * time.Second,
 			MinTimeout: 3 * time.Second,

--- a/aws/resource_aws_volume_attachment_test.go
+++ b/aws/resource_aws_volume_attachment_test.go
@@ -78,7 +78,7 @@ func TestAccAWSVolumeAttachment_attachStopped(t *testing.T) {
 		stateConf := &resource.StateChangeConf{
 			Pending:    []string{"pending", "running", "stopping"},
 			Target:     []string{"stopped"},
-			Refresh:    InstanceStateRefreshFunc(conn, *i.InstanceId, ""),
+			Refresh:    InstanceStateRefreshFunc(conn, *i.InstanceId, []string{}),
 			Timeout:    10 * time.Minute,
 			Delay:      10 * time.Second,
 			MinTimeout: 3 * time.Second,


### PR DESCRIPTION
This is to improve the following message:

```
=== RUN   TestAccAWSSSMAssociation_basic
--- FAIL: TestAccAWSSSMAssociation_basic (71.48s)
    testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_instance.foo: 1 error(s) occurred:
        
        * aws_instance.foo: Error waiting for instance (i-0d22a4b3d279c4f44) to become ready: unexpected state 'shutting-down', wanted target 'running'. last error: %!s(<nil>)
    testing.go:573: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Check failed: Default error in SSM Association Test
        
        State: <no state>
```

It probably won't be much more helpful for the user in all cases, in our case above it was specifically `Server.InternalError: Internal error on launch` 🤷‍♂️ Either way all we can/should do is to expose whatever the API exposes.