### PR TITLE
test/aws_opsworks_custom_layer: Fix test

### DIFF
--- a/aws/import_aws_opsworks_custom_layer_test.go
+++ b/aws/import_aws_opsworks_custom_layer_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccAWSOpsworksCustomLayerImportBasic(t *testing.T) {
+func TestAccAWSOpsworksCustomLayer_importBasic(t *testing.T) {
 	name := acctest.RandString(10)
 
 	resourceName := "aws_opsworks_custom_layer.tf-acc"

--- a/aws/resource_aws_opsworks_custom_layer_test.go
+++ b/aws/resource_aws_opsworks_custom_layer_test.go
@@ -16,7 +16,7 @@ import (
 // These tests assume the existence of predefined Opsworks IAM roles named `aws-opsworks-ec2-role`
 // and `aws-opsworks-service-role`.
 
-func TestAccAWSOpsworksCustomLayer(t *testing.T) {
+func TestAccAWSOpsworksCustomLayer_basic(t *testing.T) {
 	stackName := fmt.Sprintf("tf-%d", acctest.RandInt())
 	var opslayer opsworks.Layer
 	resource.Test(t, resource.TestCase{
@@ -220,11 +220,12 @@ func testAccCheckAWSOpsworksCreateLayerAttributes(
 
 		expectedEbsVolumes := []*opsworks.VolumeConfiguration{
 			{
-				VolumeType:    aws.String("gp2"),
-				NumberOfDisks: aws.Int64(2),
+				Encrypted:     aws.Bool(false),
 				MountPoint:    aws.String("/home"),
-				Size:          aws.Int64(100),
+				NumberOfDisks: aws.Int64(2),
 				RaidLevel:     aws.Int64(0),
+				Size:          aws.Int64(100),
+				VolumeType:    aws.String("gp2"),
 			},
 		}
 


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSOpsworksCustomLayer
--- FAIL: TestAccAWSOpsworksCustomLayer (24.99s)
    testing.go:513: Step 0 error: Check failed: Check 2/16 error: Unnexpected VolumeConfiguration: [{
          Encrypted: false,
          MountPoint: "/home",
          NumberOfDisks: 2,
          RaidLevel: 0,
          Size: 100,
          VolumeType: "gp2"
        }]
FAIL
```

## Test results

```
=== RUN   TestAccAWSOpsworksCustomLayer_importBasic
--- PASS: TestAccAWSOpsworksCustomLayer_importBasic (101.80s)
=== RUN   TestAccAWSOpsworksCustomLayer_basic
--- PASS: TestAccAWSOpsworksCustomLayer_basic (74.91s)
```