### PR TITLE
resource/aws_elasticsearch_domain: Retry creation on ValidationException

### DIFF
--- a/aws/resource_aws_elasticsearch_domain.go
+++ b/aws/resource_aws_elasticsearch_domain.go
@@ -405,6 +405,9 @@ func resourceAwsElasticSearchDomainCreate(d *schema.ResourceData, meta interface
 			if isAWSErr(err, "ValidationException", "enable a service-linked role to give Amazon ES permissions") {
 				return resource.RetryableError(err)
 			}
+			if isAWSErr(err, "ValidationException", "Domain is still being deleted") {
+				return resource.RetryableError(err)
+			}
 
 			return resource.NonRetryableError(err)
 		}


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSElasticSearchDomain_internetToVpcEndpoint
--- FAIL: TestAccAWSElasticSearchDomain_internetToVpcEndpoint (2455.98s)
    testing.go:513: Step 1 error: Error applying: 1 error(s) occurred:
        
        * aws_elasticsearch_domain.example: 1 error(s) occurred:
        
        * aws_elasticsearch_domain.example: ValidationException: Domain is still being deleted
            status code: 400, request id: dac12a3b-1153-11e8-92d1-cb0c50ee7128
```

## Test results

```
=== RUN   TestAccAWSElasticSearchDomain_duplicate
--- PASS: TestAccAWSElasticSearchDomain_duplicate (946.40s)
=== RUN   TestAccAWSElasticSearchDomain_encrypt_at_rest_default_key
--- PASS: TestAccAWSElasticSearchDomain_encrypt_at_rest_default_key (1349.60s)
=== RUN   TestAccAWSElasticSearchDomain_basic
--- PASS: TestAccAWSElasticSearchDomain_basic (1375.41s)
=== RUN   TestAccAWSElasticSearchDomain_v23
--- PASS: TestAccAWSElasticSearchDomain_v23 (1401.15s)
=== RUN   TestAccAWSElasticSearchDomain_complex
--- PASS: TestAccAWSElasticSearchDomain_complex (1633.79s)
=== RUN   TestAccAWSElasticSearchDomain_encrypt_at_rest_specify_key
--- PASS: TestAccAWSElasticSearchDomain_encrypt_at_rest_specify_key (1659.92s)
=== RUN   TestAccAWSElasticSearchDomain_policy
--- PASS: TestAccAWSElasticSearchDomain_policy (1795.72s)
=== RUN   TestAccAWSElasticSearchDomain_tags
--- PASS: TestAccAWSElasticSearchDomain_tags (1817.82s)
=== RUN   TestAccAWSElasticSearchDomain_vpc
--- PASS: TestAccAWSElasticSearchDomain_vpc (1882.77s)
=== RUN   TestAccAWSElasticSearchDomain_importBasic
--- PASS: TestAccAWSElasticSearchDomain_importBasic (2111.04s)
=== RUN   TestAccAWSElasticSearchDomain_LogPublishingOptions
--- PASS: TestAccAWSElasticSearchDomain_LogPublishingOptions (2420.60s)
=== RUN   TestAccAWSElasticSearchDomain_update
--- PASS: TestAccAWSElasticSearchDomain_update (2614.35s)
=== RUN   TestAccAWSElasticSearchDomain_internetToVpcEndpoint
--- PASS: TestAccAWSElasticSearchDomain_internetToVpcEndpoint (3433.46s)
=== RUN   TestAccAWSElasticSearchDomain_vpc_update
--- PASS: TestAccAWSElasticSearchDomain_vpc_update (3779.43s)
```