### PR TITLE
resource/aws_sqs_queue: Skip SQS ListQueueTags in aws-us-gov partition

### DIFF
--- a/aws/resource_aws_sqs_queue.go
+++ b/aws/resource_aws_sqs_queue.go
@@ -311,13 +311,17 @@ func resourceAwsSqsQueueRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("fifo_queue", d.Get("fifo_queue").(bool))
 	d.Set("content_based_deduplication", d.Get("content_based_deduplication").(bool))
 
-	listTagsOutput, err := sqsconn.ListQueueTags(&sqs.ListQueueTagsInput{
-		QueueUrl: aws.String(d.Id()),
-	})
-	if err != nil {
-		return err
+	tags := make(map[string]string)
+	if !meta.(*AWSClient).IsGovCloud() {
+		listTagsOutput, err := sqsconn.ListQueueTags(&sqs.ListQueueTagsInput{
+			QueueUrl: aws.String(d.Id()),
+		})
+		if err != nil {
+			return err
+		}
+		tags = tagsToMapGeneric(listTagsOutput.Tags)
 	}
-	d.Set("tags", tagsToMapGeneric(listTagsOutput.Tags))
+	d.Set("tags", tags)
 
 	return nil
 }


### PR DESCRIPTION
Closes #2534 It seems there are other eventual consistency issues in us-gov-west-1 (we are correctly calling SetQueueAttributes), but this at least allows the resource to be usable for folks.

Previously:
```
 make testacc TEST=./aws TESTARGS='-run=TestAccAWSSQSQueue_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSSQSQueue_basic -timeout 120m
=== RUN   TestAccAWSSQSQueue_basic
--- FAIL: TestAccAWSSQSQueue_basic (9.42s)
	testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:

		* aws_sqs_queue.queue: 1 error(s) occurred:

		* aws_sqs_queue.queue: InvalidAction: The action ListQueueTags is not valid for this endpoint.
			status code: 400, request id: dd0b3da4-12e0-51c8-82d6-6f5a40467820
```

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSSQSQueue_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSSQSQueue_basic -timeout 120m
=== RUN   TestAccAWSSQSQueue_basic
--- FAIL: TestAccAWSSQSQueue_basic (29.12s)
	testing.go:513: Step 1 error: After applying this step, the plan was not empty:

		DIFF:

		UPDATE: aws_sqs_queue.queue
		  delay_seconds:              "0" => "90"
		  max_message_size:           "262144" => "2048"
		  message_retention_seconds:  "345600" => "86400"
		  receive_wait_time_seconds:  "0" => "10"
		  visibility_timeout_seconds: "30" => "60"
```