### PR TITLE
tests: Normalize aws_vpc Name tag (E-M)

### DIFF
--- a/aws/resource_aws_ecs_service_test.go
+++ b/aws/resource_aws_ecs_service_test.go
@@ -235,7 +235,7 @@ func TestAccAWSEcsService_withRenamedCluster(t *testing.T) {
 func TestAccAWSEcsService_healthCheckGracePeriodSeconds(t *testing.T) {
 	rString := acctest.RandString(8)
 
-	vpcNameTag := fmt.Sprintf("tf-acc-vpc-svc-w-hcgps-%s", rString)
+	vpcNameTag := "terraform-testacc-ecs-service-health-check-grace-period"
 	clusterName := fmt.Sprintf("tf-acc-cluster-svc-w-hcgps-%s", rString)
 	tdName := fmt.Sprintf("tf-acc-td-svc-w-hcgps-%s", rString)
 	roleName := fmt.Sprintf("tf-acc-role-svc-w-hcgps-%s", rString)
@@ -830,6 +830,9 @@ data "aws_availability_zones" "available" {}
 
 resource "aws_vpc" "main" {
   cidr_block = "10.10.0.0/16"
+  tags {
+  	Name = "terraform-testacc-ecs-service-with-launch-type-fargate"
+  }
 }
 
 resource "aws_subnet" "main" {
@@ -1396,7 +1399,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "main" {
   cidr_block = "10.10.0.0/16"
 	tags {
-		Name = "TestAccAWSEcsService_withAlb"
+		Name = "terraform-testacc-ecs-service-with-alb"
 	}
 }
 
@@ -1539,6 +1542,9 @@ data "aws_availability_zones" "available" {}
 
 resource "aws_vpc" "main" {
   cidr_block = "10.10.0.0/16"
+  tags {
+  	Name = "terraform-testacc-ecs-service-with-network-config"
+  }
 }
 
 resource "aws_subnet" "main" {

--- a/aws/resource_aws_efs_mount_target_test.go
+++ b/aws/resource_aws_efs_mount_target_test.go
@@ -235,7 +235,7 @@ resource "aws_efs_mount_target" "alpha" {
 resource "aws_vpc" "foo" {
 	cidr_block = "10.0.0.0/16"
 	tags {
-		Name = "testAccAWSEFSMountTargetConfig"
+		Name = "terraform-testacc-efs-mount-target"
 	}
 }
 
@@ -266,7 +266,7 @@ resource "aws_efs_mount_target" "beta" {
 resource "aws_vpc" "foo" {
 	cidr_block = "10.0.0.0/16"
 	tags {
-		Name = "testAccAWSEFSMountTargetConfigModified"
+		Name = "terraform-testacc-efs-mount-target-modified"
 	}
 }
 

--- a/aws/resource_aws_egress_only_internet_gateway_test.go
+++ b/aws/resource_aws_egress_only_internet_gateway_test.go
@@ -85,7 +85,7 @@ resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	assign_generated_ipv6_cidr_block = true
 	tags {
-		Name = "testAccAWSEgressOnlyInternetGatewayConfig_basic"
+		Name = "terraform-testacc-egress-only-igw-basic"
 	}
 }
 

--- a/aws/resource_aws_eip_association_test.go
+++ b/aws/resource_aws_eip_association_test.go
@@ -213,7 +213,7 @@ const testAccAWSEIPAssociationConfig = `
 resource "aws_vpc" "main" {
 	cidr_block = "192.168.0.0/24"
 	tags {
-		Name = "testAccAWSEIPAssociationConfig"
+		Name = "terraform-testacc-eip-association"
 	}
 }
 resource "aws_subnet" "sub" {
@@ -265,7 +265,7 @@ const testAccAWSEIPAssociationConfigDisappears = `
 resource "aws_vpc" "main" {
 	cidr_block = "192.168.0.0/24"
 	tags {
-		Name = "testAccAWSEIPAssociationConfigDisappears"
+		Name = "terraform-testacc-eip-association-disappears"
 	}
 }
 resource "aws_subnet" "sub" {

--- a/aws/resource_aws_eip_test.go
+++ b/aws/resource_aws_eip_test.go
@@ -497,7 +497,7 @@ resource "aws_vpc" "default" {
   enable_dns_hostnames = true
 
   tags {
-    Name = "default"
+    Name = "terraform-testacc-eip-instance-associated"
   }
 }
 
@@ -562,7 +562,7 @@ resource "aws_vpc" "default" {
   enable_dns_hostnames = true
 
   tags {
-    Name = "default"
+    Name = "terraform-testacc-eip-instance-associated"
   }
 }
 
@@ -638,7 +638,7 @@ const testAccAWSEIPNetworkInterfaceConfig = `
 resource "aws_vpc" "bar" {
 	cidr_block = "10.0.0.0/24"
 	tags {
-		Name = "testAccAWSEIPNetworkInterfaceConfig"
+		Name = "terraform-testacc-eip-network-interface"
 	}
 }
 resource "aws_internet_gateway" "bar" {
@@ -665,7 +665,7 @@ const testAccAWSEIPMultiNetworkInterfaceConfig = `
 resource "aws_vpc" "bar" {
   cidr_block = "10.0.0.0/24"
 	tags {
-		Name = "testAccAWSEIPMultiNetworkInterfaceConfig"
+		Name = "terraform-testacc-eip-multi-network-interface"
 	}
 }
 
@@ -737,7 +737,7 @@ resource "aws_instance" "example" {
 resource "aws_vpc" "example" {
   cidr_block = "10.0.0.0/16"
 	tags {
-		Name = "TestAccAWSEIP_classic_disassociate"
+		Name = "terraform-testacc-eip-classic-disassociate"
 	}
 }
 

--- a/aws/resource_aws_elastic_beanstalk_configuration_template_test.go
+++ b/aws/resource_aws_elastic_beanstalk_configuration_template_test.go
@@ -162,7 +162,7 @@ resource "aws_vpc" "tf_b_test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "beanstalk_crash"
+    Name = "terraform-testacc-elastic-beanstalk-cfg-tpl-vpc"
   }
 }
 

--- a/aws/resource_aws_elastic_beanstalk_environment_test.go
+++ b/aws/resource_aws_elastic_beanstalk_environment_test.go
@@ -917,7 +917,7 @@ func testAccBeanstalkEnv_VPC(name string, rInt int) string {
 resource "aws_vpc" "tf_b_test" {
   cidr_block = "10.0.0.0/16"
 	tags {
-		Name = "testAccBeanstalkEnv_VPC"
+		Name = "terraform-testacc-elastic-beanstalk-env-vpc"
 	}
 }
 

--- a/aws/resource_aws_elasticache_cluster_test.go
+++ b/aws/resource_aws_elasticache_cluster_test.go
@@ -410,7 +410,7 @@ var testAccAWSElasticacheClusterInVPCConfig = fmt.Sprintf(`
 resource "aws_vpc" "foo" {
     cidr_block = "192.168.0.0/16"
     tags {
-            Name = "tf-test"
+        Name = "terraform-testacc-elasticache-cluster-in-vpc"
     }
 }
 
@@ -467,7 +467,7 @@ var testAccAWSElasticacheClusterMultiAZInVPCConfig = fmt.Sprintf(`
 resource "aws_vpc" "foo" {
     cidr_block = "192.168.0.0/16"
     tags {
-            Name = "tf-test"
+        Name = "terraform-testacc-elasticache-cluster-multi-az-in-vpc"
     }
 }
 

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -738,7 +738,7 @@ var testAccAWSElasticacheReplicationGroupInVPCConfig = fmt.Sprintf(`
 resource "aws_vpc" "foo" {
     cidr_block = "192.168.0.0/16"
     tags {
-            Name = "tf-test"
+        Name = "terraform-testacc-elasticache-replication-group-in-vpc"
     }
 }
 
@@ -788,7 +788,7 @@ var testAccAWSElasticacheReplicationGroupMultiAZInVPCConfig = fmt.Sprintf(`
 resource "aws_vpc" "foo" {
     cidr_block = "192.168.0.0/16"
     tags {
-            Name = "tf-test"
+        Name = "terraform-testacc-elasticache-replication-group-multi-az-in-vpc"
     }
 }
 
@@ -851,7 +851,7 @@ var testAccAWSElasticacheReplicationGroupRedisClusterInVPCConfig = fmt.Sprintf(`
 resource "aws_vpc" "foo" {
     cidr_block = "192.168.0.0/16"
     tags {
-            Name = "tf-test"
+        Name = "terraform-testacc-elasticache-replication-group-redis-cluster-in-vpc"
     }
 }
 
@@ -917,7 +917,7 @@ func testAccAWSElasticacheReplicationGroupNativeRedisClusterErrorConfig(rInt int
 resource "aws_vpc" "foo" {
     cidr_block = "192.168.0.0/16"
     tags {
-        Name = "tf-test"
+        Name = "terraform-testacc-elasticache-replication-group-native-redis-cluster-err"
     }
 }
 
@@ -982,7 +982,7 @@ func testAccAWSElasticacheReplicationGroupNativeRedisClusterConfig(rInt int, rNa
 resource "aws_vpc" "foo" {
     cidr_block = "192.168.0.0/16"
     tags {
-        Name = "tf-test"
+        Name = "terraform-testacc-elasticache-replication-group-native-redis-cluster"
     }
 }
 
@@ -1046,7 +1046,7 @@ func testAccAWSElasticacheReplicationGroup_EnableAtRestEncryptionConfig(rInt int
 resource "aws_vpc" "foo" {
   cidr_block = "192.168.0.0/16"
   tags {
-    Name = "tf-test"
+    Name = "terraform-testacc-elasticache-replication-group-at-rest-encryption"
   }
 }
 
@@ -1100,7 +1100,7 @@ func testAccAWSElasticacheReplicationGroup_EnableAuthTokenTransitEncryptionConfi
 resource "aws_vpc" "foo" {
   cidr_block = "192.168.0.0/16"
   tags {
-    Name = "tf-test"
+    Name = "terraform-testacc-elasticache-replication-group-auth-token-transit-encryption"
   }
 }
 

--- a/aws/resource_aws_elasticache_subnet_group_test.go
+++ b/aws/resource_aws_elasticache_subnet_group_test.go
@@ -144,7 +144,7 @@ var testAccAWSElasticacheSubnetGroupConfig = `
 resource "aws_vpc" "foo" {
     cidr_block = "192.168.0.0/16"
     tags {
-            Name = "tf-test"
+        Name = "terraform-testacc-elasticache-subnet-group"
     }
 }
 
@@ -153,7 +153,7 @@ resource "aws_subnet" "foo" {
     cidr_block = "192.168.0.0/20"
     availability_zone = "us-west-2a"
     tags {
-            Name = "tf-test"
+        Name = "tf-test"
     }
 }
 
@@ -169,7 +169,7 @@ var testAccAWSElasticacheSubnetGroupUpdateConfigPre = `
 resource "aws_vpc" "foo" {
     cidr_block = "10.0.0.0/16"
     tags {
-            Name = "tf-elc-sub-test"
+        Name = "terraform-testacc-elasticache-subnet-group-update"
     }
 }
 
@@ -178,7 +178,7 @@ resource "aws_subnet" "foo" {
     cidr_block = "10.0.1.0/24"
     availability_zone = "us-west-2a"
     tags {
-            Name = "tf-test"
+        Name = "tf-test"
     }
 }
 
@@ -193,7 +193,7 @@ var testAccAWSElasticacheSubnetGroupUpdateConfigPost = `
 resource "aws_vpc" "foo" {
     cidr_block = "10.0.0.0/16"
     tags {
-            Name = "tf-elc-sub-test"
+        Name = "terraform-testacc-elasticache-subnet-group-update"
     }
 }
 
@@ -202,7 +202,7 @@ resource "aws_subnet" "foo" {
     cidr_block = "10.0.1.0/24"
     availability_zone = "us-west-2a"
     tags {
-            Name = "tf-test"
+        Name = "tf-test"
     }
 }
 
@@ -211,7 +211,7 @@ resource "aws_subnet" "bar" {
     cidr_block = "10.0.2.0/24"
     availability_zone = "us-west-2a"
     tags {
-            Name = "tf-test-foo-update"
+        Name = "tf-test-foo-update"
     }
 }
 

--- a/aws/resource_aws_elasticsearch_domain_test.go
+++ b/aws/resource_aws_elasticsearch_domain_test.go
@@ -660,6 +660,9 @@ data "aws_availability_zones" "available" {
 
 resource "aws_vpc" "elasticsearch_in_vpc" {
   cidr_block = "192.168.0.0/22"
+  tags {
+    Name = "terraform-testacc-elasticsearch-domain-in-vpc"
+  }
 }
 
 resource "aws_subnet" "first" {
@@ -720,6 +723,9 @@ data "aws_availability_zones" "available" {
 
 resource "aws_vpc" "elasticsearch_in_vpc" {
   cidr_block = "192.168.0.0/22"
+  tags {
+    Name = "terraform-testacc-elasticsearch-domain-in-vpc-update"
+  }
 }
 
 resource "aws_subnet" "az1_first" {
@@ -783,6 +789,9 @@ data "aws_availability_zones" "available" {
 
 resource "aws_vpc" "elasticsearch_in_vpc" {
   cidr_block = "192.168.0.0/22"
+  tags {
+    Name = "terraform-testacc-elasticsearch-domain-internet-to-vpc-endpoint"
+  }
 }
 
 resource "aws_subnet" "first" {

--- a/aws/resource_aws_elb_test.go
+++ b/aws/resource_aws_elb_test.go
@@ -1507,7 +1507,7 @@ resource "aws_vpc" "azelb" {
   enable_dns_hostnames = true
 
   tags {
-    Name = "subnet-vpc"
+    Name = "terraform-testacc-elb-subnets"
   }
 }
 
@@ -1569,7 +1569,7 @@ resource "aws_vpc" "azelb" {
   enable_dns_hostnames = true
 
   tags {
-    Name = "subnet-vpc"
+    Name = "terraform-testacc-elb-subnet-swap"
   }
 }
 

--- a/aws/resource_aws_emr_cluster_test.go
+++ b/aws/resource_aws_emr_cluster_test.go
@@ -591,7 +591,7 @@ resource "aws_vpc" "main" {
   enable_dns_hostnames = true
 
   tags {
-    Name = "emr_test_cts"
+    Name = "terraform-testacc-emr-cluster-bootstrap"
   }
 }
 
@@ -681,12 +681,8 @@ POLICY
 
 func testAccAWSEmrClusterConfig(r int) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_emr_cluster" "tf-test-cluster" {
-  name          = "emr-test-%d"
+  name          = "emr-test-%[1]d"
   release_label = "emr-4.6.0"
   applications  = ["Spark"]
 
@@ -727,7 +723,7 @@ resource "aws_emr_cluster" "tf-test-cluster" {
 }
 
 resource "aws_security_group" "allow_all" {
-  name        = "allow_all_%d"
+  name        = "allow_all_%[1]d"
   description = "Allow all inbound traffic"
   vpc_id      = "${aws_vpc.main.id}"
 
@@ -761,7 +757,7 @@ resource "aws_vpc" "main" {
   enable_dns_hostnames = true
 
   tags {
-    Name = "emr_test_%d"
+    Name = "terraform-testacc-emr-cluster"
   }
 }
 
@@ -770,7 +766,7 @@ resource "aws_subnet" "main" {
   cidr_block = "168.31.0.0/20"
 
   tags {
-    Name = "emr_test_%d"
+    Name = "emr_test_%[1]d"
   }
 }
 
@@ -800,7 +796,7 @@ resource "aws_main_route_table_association" "a" {
 
 # IAM role for EMR Service
 resource "aws_iam_role" "iam_emr_default_role" {
-  name = "iam_emr_default_role_%d"
+  name = "iam_emr_default_role_%[1]d"
 
   assume_role_policy = <<EOT
 {
@@ -825,7 +821,7 @@ resource "aws_iam_role_policy_attachment" "service-attach" {
 }
 
 resource "aws_iam_policy" "iam_emr_default_policy" {
-  name = "iam_emr_default_policy_%d"
+  name = "iam_emr_default_policy_%[1]d"
 
   policy = <<EOT
 {
@@ -895,7 +891,7 @@ EOT
 
 # IAM Role for EC2 Instance Profile
 resource "aws_iam_role" "iam_emr_profile_role" {
-  name = "iam_emr_profile_role_%d"
+  name = "iam_emr_profile_role_%[1]d"
 
   assume_role_policy = <<EOT
 {
@@ -915,7 +911,7 @@ EOT
 }
 
 resource "aws_iam_instance_profile" "emr_profile" {
-  name  = "emr_profile_%d"
+  name  = "emr_profile_%[1]d"
   role = "${aws_iam_role.iam_emr_profile_role.name}"
 }
 
@@ -925,7 +921,7 @@ resource "aws_iam_role_policy_attachment" "profile-attach" {
 }
 
 resource "aws_iam_policy" "iam_emr_profile_policy" {
-  name = "iam_emr_profile_policy_%d"
+  name = "iam_emr_profile_policy_%[1]d"
 
   policy = <<EOT
 {
@@ -964,7 +960,7 @@ EOT
 
 # IAM Role for autoscaling
 resource "aws_iam_role" "emr-autoscaling-role" {
-  name               = "EMR_AutoScaling_DefaultRole_%d"
+  name               = "EMR_AutoScaling_DefaultRole_%[1]d"
   assume_role_policy = "${data.aws_iam_policy_document.emr-autoscaling-role-policy.json}"
 }
 
@@ -983,7 +979,7 @@ resource "aws_iam_role_policy_attachment" "emr-autoscaling-role" {
   role       = "${aws_iam_role.emr-autoscaling-role.name}"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceforAutoScalingRole"
 }
-`, r, r, r, r, r, r, r, r, r, r)
+`, r)
 }
 
 func testAccAWSEmrClusterConfig_SecurityConfiguration(r int) string {
@@ -1069,7 +1065,7 @@ resource "aws_vpc" "main" {
   enable_dns_hostnames = true
 
   tags {
-    Name = "emr_test_%d"
+    Name = "terraform-testacc-emr-cluster-security-configuration"
   }
 }
 
@@ -1333,17 +1329,13 @@ resource "aws_kms_key" "foo" {
 }
 POLICY
 }
-`, r, r, r, r, r, r, r, r, r, r, r)
+`, r, r, r, r, r, r, r, r, r, r)
 }
 
 func testAccAWSEmrClusterConfigInstanceGroups(r int) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_emr_cluster" "tf-test-cluster" {
-  name          = "emr-test-%d"
+  name          = "emr-test-%[1]d"
   release_label = "emr-4.6.0"
   applications  = ["Spark"]
 
@@ -1398,7 +1390,7 @@ resource "aws_emr_cluster" "tf-test-cluster" {
 }
 
 resource "aws_security_group" "allow_all" {
-  name        = "allow_all_%d"
+  name        = "allow_all_%[1]d"
   description = "Allow all inbound traffic"
   vpc_id      = "${aws_vpc.main.id}"
 
@@ -1432,7 +1424,7 @@ resource "aws_vpc" "main" {
   enable_dns_hostnames = true
 
   tags {
-    Name = "emr_test_%d"
+    Name = "terraform-testacc-emr-cluster-instance-groups"
   }
 }
 
@@ -1441,7 +1433,7 @@ resource "aws_subnet" "main" {
   cidr_block = "168.31.0.0/20"
 
   tags {
-    Name = "emr_test_%d"
+    Name = "emr_test_%[1]d"
   }
 }
 
@@ -1471,7 +1463,7 @@ resource "aws_main_route_table_association" "a" {
 
 # IAM role for EMR Service
 resource "aws_iam_role" "iam_emr_default_role" {
-  name = "iam_emr_default_role_%d"
+  name = "iam_emr_default_role_%[1]d"
 
   assume_role_policy = <<EOT
 {
@@ -1496,7 +1488,7 @@ resource "aws_iam_role_policy_attachment" "service-attach" {
 }
 
 resource "aws_iam_policy" "iam_emr_default_policy" {
-  name = "iam_emr_default_policy_%d"
+  name = "iam_emr_default_policy_%[1]d"
 
   policy = <<EOT
 {
@@ -1566,7 +1558,7 @@ EOT
 
 # IAM Role for EC2 Instance Profile
 resource "aws_iam_role" "iam_emr_profile_role" {
-  name = "iam_emr_profile_role_%d"
+  name = "iam_emr_profile_role_%[1]d"
 
   assume_role_policy = <<EOT
 {
@@ -1586,7 +1578,7 @@ EOT
 }
 
 resource "aws_iam_instance_profile" "emr_profile" {
-  name  = "emr_profile_%d"
+  name  = "emr_profile_%[1]d"
   role = "${aws_iam_role.iam_emr_profile_role.name}"
 }
 
@@ -1596,7 +1588,7 @@ resource "aws_iam_role_policy_attachment" "profile-attach" {
 }
 
 resource "aws_iam_policy" "iam_emr_profile_policy" {
-  name = "iam_emr_profile_policy_%d"
+  name = "iam_emr_profile_policy_%[1]d"
 
   policy = <<EOT
 {
@@ -1635,7 +1627,7 @@ EOT
 
 # IAM Role for autoscaling
 resource "aws_iam_role" "emr-autoscaling-role" {
-  name               = "EMR_AutoScaling_DefaultRole_%d"
+  name               = "EMR_AutoScaling_DefaultRole_%[1]d"
   assume_role_policy = "${data.aws_iam_policy_document.emr-autoscaling-role-policy.json}"
 }
 
@@ -1654,18 +1646,13 @@ resource "aws_iam_role_policy_attachment" "emr-autoscaling-role" {
   role       = "${aws_iam_role.emr-autoscaling-role.name}"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceforAutoScalingRole"
 }
-
-`, r, r, r, r, r, r, r, r, r, r)
+`, r)
 }
 
 func testAccAWSEmrClusterConfigTerminationPolicy(r int, term string) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_emr_cluster" "tf-test-cluster" {
-  name          = "emr-test-%d"
+  name          = "emr-test-%[1]d"
   release_label = "emr-4.6.0"
   applications  = ["Spark"]
 
@@ -1688,7 +1675,7 @@ resource "aws_emr_cluster" "tf-test-cluster" {
   }
 
   keep_job_flow_alive_when_no_steps = true
-  termination_protection = %s
+  termination_protection = %[2]s
 
   bootstrap_action {
     path = "s3://elasticmapreduce/bootstrap-actions/run-if"
@@ -1705,7 +1692,7 @@ resource "aws_emr_cluster" "tf-test-cluster" {
 }
 
 resource "aws_security_group" "allow_all" {
-  name        = "allow_all_%d"
+  name        = "allow_all_%[1]d"
   description = "Allow all inbound traffic"
   vpc_id      = "${aws_vpc.main.id}"
 
@@ -1739,7 +1726,7 @@ resource "aws_vpc" "main" {
   enable_dns_hostnames = true
 
   tags {
-    Name = "emr_test_%d"
+    Name = "terraform-testacc-emr-cluster-termination-policy"
   }
 }
 
@@ -1748,7 +1735,7 @@ resource "aws_subnet" "main" {
   cidr_block = "168.31.0.0/20"
 
   tags {
-    Name = "emr_test_%d"
+    Name = "emr_test_%[1]d"
   }
 }
 
@@ -1778,7 +1765,7 @@ resource "aws_main_route_table_association" "a" {
 
 # IAM role for EMR Service
 resource "aws_iam_role" "iam_emr_default_role" {
-  name = "iam_emr_default_role_%d"
+  name = "iam_emr_default_role_%[1]d"
 
   assume_role_policy = <<EOT
 {
@@ -1803,7 +1790,7 @@ resource "aws_iam_role_policy_attachment" "service-attach" {
 }
 
 resource "aws_iam_policy" "iam_emr_default_policy" {
-  name = "iam_emr_default_policy_%d"
+  name = "iam_emr_default_policy_%[1]d"
 
   policy = <<EOT
 {
@@ -1873,7 +1860,7 @@ EOT
 
 # IAM Role for EC2 Instance Profile
 resource "aws_iam_role" "iam_emr_profile_role" {
-  name = "iam_emr_profile_role_%d"
+  name = "iam_emr_profile_role_%[1]d"
 
   assume_role_policy = <<EOT
 {
@@ -1893,7 +1880,7 @@ EOT
 }
 
 resource "aws_iam_instance_profile" "emr_profile" {
-  name  = "emr_profile_%d"
+  name  = "emr_profile_%[1]d"
   role = "${aws_iam_role.iam_emr_profile_role.name}"
 }
 
@@ -1903,7 +1890,7 @@ resource "aws_iam_role_policy_attachment" "profile-attach" {
 }
 
 resource "aws_iam_policy" "iam_emr_profile_policy" {
-  name = "iam_emr_profile_policy_%d"
+  name = "iam_emr_profile_policy_%[1]d"
 
   policy = <<EOT
 {
@@ -1942,7 +1929,7 @@ EOT
 
 # IAM Role for autoscaling
 resource "aws_iam_role" "emr-autoscaling-role" {
-  name               = "EMR_AutoScaling_DefaultRole_%d"
+  name               = "EMR_AutoScaling_DefaultRole_%[1]d"
   assume_role_policy = "${data.aws_iam_policy_document.emr-autoscaling-role-policy.json}"
 }
 
@@ -1962,7 +1949,7 @@ resource "aws_iam_role_policy_attachment" "emr-autoscaling-role" {
   role       = "${aws_iam_role.emr-autoscaling-role.name}"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceforAutoScalingRole"
 }
-`, r, term, r, r, r, r, r, r, r, r, r)
+`, r, term)
 }
 
 func testAccAWSEmrClusterConfigVisibleToAllUsersUpdated(r int) string {
@@ -2046,7 +2033,7 @@ resource "aws_vpc" "main" {
   enable_dns_hostnames = true
 
   tags {
-    Name = "emr_test_%d"
+    Name = "terraform-testacc-emr-cluster-visible-to-all-users"
   }
 }
 
@@ -2269,17 +2256,13 @@ resource "aws_iam_role_policy_attachment" "emr-autoscaling-role" {
   role       = "${aws_iam_role.emr-autoscaling-role.name}"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceforAutoScalingRole"
 }
-`, r, r, r, r, r, r, r, r, r, r)
+`, r, r, r, r, r, r, r, r, r)
 }
 
 func testAccAWSEmrClusterConfigUpdatedTags(r int) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_emr_cluster" "tf-test-cluster" {
-  name          = "emr-test-%d"
+  name          = "emr-test-%[1]d"
   release_label = "emr-4.6.0"
   applications  = ["Spark"]
 
@@ -2318,7 +2301,7 @@ resource "aws_emr_cluster" "tf-test-cluster" {
 }
 
 resource "aws_security_group" "allow_all" {
-  name        = "allow_all_%d"
+  name        = "allow_all_%[1]d"
   description = "Allow all inbound traffic"
   vpc_id      = "${aws_vpc.main.id}"
 
@@ -2352,7 +2335,7 @@ resource "aws_vpc" "main" {
   enable_dns_hostnames = true
 
   tags {
-    Name = "emr_test_%d"
+    Name = "terraform-testacc-emr-cluster-updated-tags"
   }
 }
 
@@ -2361,7 +2344,7 @@ resource "aws_subnet" "main" {
   cidr_block = "168.31.0.0/20"
 
   tags {
-    Name = "emr_test_%d"
+    Name = "emr_test_%[1]d"
   }
 }
 
@@ -2391,7 +2374,7 @@ resource "aws_main_route_table_association" "a" {
 
 # IAM role for EMR Service
 resource "aws_iam_role" "iam_emr_default_role" {
-  name = "iam_emr_default_role_%d"
+  name = "iam_emr_default_role_%[1]d"
 
   assume_role_policy = <<EOT
 {
@@ -2416,7 +2399,7 @@ resource "aws_iam_role_policy_attachment" "service-attach" {
 }
 
 resource "aws_iam_policy" "iam_emr_default_policy" {
-  name = "iam_emr_default_policy_%d"
+  name = "iam_emr_default_policy_%[1]d"
 
   policy = <<EOT
 {
@@ -2486,7 +2469,7 @@ EOT
 
 # IAM Role for EC2 Instance Profile
 resource "aws_iam_role" "iam_emr_profile_role" {
-  name = "iam_emr_profile_role_%d"
+  name = "iam_emr_profile_role_%[1]d"
 
   assume_role_policy = <<EOT
 {
@@ -2506,7 +2489,7 @@ EOT
 }
 
 resource "aws_iam_instance_profile" "emr_profile" {
-  name  = "emr_profile_%d"
+  name  = "emr_profile_%[1]d"
   role = "${aws_iam_role.iam_emr_profile_role.name}"
 }
 
@@ -2516,7 +2499,7 @@ resource "aws_iam_role_policy_attachment" "profile-attach" {
 }
 
 resource "aws_iam_policy" "iam_emr_profile_policy" {
-  name = "iam_emr_profile_policy_%d"
+  name = "iam_emr_profile_policy_%[1]d"
 
   policy = <<EOT
 {
@@ -2555,7 +2538,7 @@ EOT
 
 # IAM Role for autoscaling
 resource "aws_iam_role" "emr-autoscaling-role" {
-  name               = "EMR_AutoScaling_DefaultRole_%d"
+  name               = "EMR_AutoScaling_DefaultRole_%[1]d"
   assume_role_policy = "${data.aws_iam_policy_document.emr-autoscaling-role-policy.json}"
 }
 
@@ -2575,7 +2558,7 @@ resource "aws_iam_role_policy_attachment" "emr-autoscaling-role" {
   role       = "${aws_iam_role.emr-autoscaling-role.name}"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceforAutoScalingRole"
 }
-`, r, r, r, r, r, r, r, r, r, r)
+`, r)
 }
 
 func testAccAWSEmrClusterConfigUpdatedRootVolumeSize(r int) string {
@@ -2660,7 +2643,7 @@ resource "aws_vpc" "main" {
   enable_dns_hostnames = true
 
   tags {
-    Name = "emr_test_%d"
+    Name = "terraform-testacc-emr-cluster-updated-root-volume-size"
   }
 }
 
@@ -2882,7 +2865,7 @@ resource "aws_iam_role_policy_attachment" "emr-autoscaling-role" {
   role       = "${aws_iam_role.emr-autoscaling-role.name}"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceforAutoScalingRole"
 }
-`, r, r, r, r, r, r, r, r, r, r)
+`, r, r, r, r, r, r, r, r, r)
 }
 
 func testAccAWSEmrClusterConfigS3Logging(rInt int) string {
@@ -2894,6 +2877,9 @@ resource "aws_s3_bucket" "test" {
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/24"
+  tags {
+    Name = "terraform-testacc-emr-cluster-s3-logging"
+  }
 }
 
 resource "aws_subnet" "test" {

--- a/aws/resource_aws_emr_instance_group_test.go
+++ b/aws/resource_aws_emr_instance_group_test.go
@@ -200,7 +200,7 @@ resource "aws_vpc" "main" {
   enable_dns_hostnames = true
 
 	tags {
-		Name = "tf_acc_emr_tests"
+		Name = "terraform-testacc-emr-instance-group"
 	}
 }
 

--- a/aws/resource_aws_flow_log_test.go
+++ b/aws/resource_aws_flow_log_test.go
@@ -111,19 +111,19 @@ func testAccCheckFlowLogDestroy(s *terraform.State) error {
 func testAccFlowLogConfig_basic(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "default" {
-        cidr_block = "10.0.0.0/16"
-        tags {
-                Name = "tf-flow-log-test"
-        }
+    cidr_block = "10.0.0.0/16"
+    tags {
+        Name = "terraform-testacc-flow-log-basic"
+    }
 }
 
 resource "aws_subnet" "test_subnet" {
-        vpc_id = "${aws_vpc.default.id}"
-        cidr_block = "10.0.1.0/24"
+    vpc_id = "${aws_vpc.default.id}"
+    cidr_block = "10.0.1.0/24"
 
-        tags {
-                Name = "tf-flow-test"
-        }
+    tags {
+        Name = "tf-flow-test"
+    }
 }
 
 resource "aws_iam_role" "test_role" {
@@ -152,17 +152,17 @@ resource "aws_cloudwatch_log_group" "foobar" {
     name = "tf-test-fl-%d"
 }
 resource "aws_flow_log" "test_flow_log" {
-        log_group_name = "${aws_cloudwatch_log_group.foobar.name}"
-        iam_role_arn = "${aws_iam_role.test_role.arn}"
-        vpc_id = "${aws_vpc.default.id}"
-        traffic_type = "ALL"
+    log_group_name = "${aws_cloudwatch_log_group.foobar.name}"
+    iam_role_arn = "${aws_iam_role.test_role.arn}"
+    vpc_id = "${aws_vpc.default.id}"
+    traffic_type = "ALL"
 }
 
 resource "aws_flow_log" "test_flow_log_subnet" {
-        log_group_name = "${aws_cloudwatch_log_group.foobar.name}"
-        iam_role_arn = "${aws_iam_role.test_role.arn}"
-        subnet_id = "${aws_subnet.test_subnet.id}"
-        traffic_type = "ALL"
+    log_group_name = "${aws_cloudwatch_log_group.foobar.name}"
+    iam_role_arn = "${aws_iam_role.test_role.arn}"
+    subnet_id = "${aws_subnet.test_subnet.id}"
+    traffic_type = "ALL"
 }
 `, rInt, rInt)
 }
@@ -170,19 +170,19 @@ resource "aws_flow_log" "test_flow_log_subnet" {
 func testAccFlowLogConfig_subnet(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "default" {
-        cidr_block = "10.0.0.0/16"
-        tags {
-                Name = "tf-flow-log-test"
-        }
+    cidr_block = "10.0.0.0/16"
+    tags {
+        Name = "terraform-testacc-flow-log-subnet"
+    }
 }
 
 resource "aws_subnet" "test_subnet" {
-        vpc_id = "${aws_vpc.default.id}"
-        cidr_block = "10.0.1.0/24"
+    vpc_id = "${aws_vpc.default.id}"
+    cidr_block = "10.0.1.0/24"
 
-        tags {
-                Name = "tf-flow-test"
-        }
+    tags {
+        Name = "tf-flow-test"
+    }
 }
 
 resource "aws_iam_role" "test_role" {
@@ -211,10 +211,10 @@ resource "aws_cloudwatch_log_group" "foobar" {
 }
 
 resource "aws_flow_log" "test_flow_log_subnet" {
-        log_group_name = "${aws_cloudwatch_log_group.foobar.name}"
-        iam_role_arn = "${aws_iam_role.test_role.arn}"
-        subnet_id = "${aws_subnet.test_subnet.id}"
-        traffic_type = "ALL"
+    log_group_name = "${aws_cloudwatch_log_group.foobar.name}"
+    iam_role_arn = "${aws_iam_role.test_role.arn}"
+    subnet_id = "${aws_subnet.test_subnet.id}"
+    traffic_type = "ALL"
 }
 `, rInt, rInt)
 }

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -1614,7 +1614,7 @@ const testAccInstanceConfigSourceDestEnable = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "testAccInstanceConfigSourceDestEnable"
+		Name = "terraform-testacc-instance-source-dest-enable"
 	}
 }
 
@@ -1635,7 +1635,7 @@ const testAccInstanceConfigSourceDestDisable = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "testAccInstanceConfigSourceDestDisable"
+		Name = "terraform-testacc-instance-source-dest-disable"
 	}
 }
 
@@ -1658,7 +1658,7 @@ func testAccInstanceConfigDisableAPITermination(val bool) string {
 	resource "aws_vpc" "foo" {
 		cidr_block = "10.1.0.0/16"
 		tags {
-			Name = "testAccInstanceConfigDisableAPITermination"
+			Name = "terraform-testacc-instance-disable-api-termination"
 		}
 	}
 
@@ -1681,7 +1681,7 @@ const testAccInstanceConfigVPC = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "testAccInstanceConfigVPC"
+		Name = "terraform-testacc-instance-vpc"
 	}
 }
 
@@ -1707,7 +1707,7 @@ func testAccInstanceConfigPlacementGroup(rStr string) string {
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
   tags {
-    Name = "testAccInstanceConfigPlacementGroup_%s"
+    Name = "terraform-testacc-instance-placement-group"
   }
 }
 
@@ -1732,7 +1732,7 @@ resource "aws_instance" "foo" {
   # pre-encoded base64 data
   user_data = "3dc39dda39be1205215e776bad998da361a5955d"
 }
-`, rStr, rStr)
+`, rStr)
 }
 
 const testAccInstanceConfigIpv6ErrorConfig = `
@@ -1740,7 +1740,7 @@ resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	assign_generated_ipv6_cidr_block = true
 	tags {
-		Name = "tf-ipv6-instance-acc-test"
+		Name = "terraform-testacc-instance-ipv6-err"
 	}
 }
 
@@ -1771,7 +1771,7 @@ resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	assign_generated_ipv6_cidr_block = true
 	tags {
-		Name = "tf-ipv6-instance-acc-test"
+		Name = "terraform-testacc-instance-ipv6-support"
 	}
 }
 
@@ -1802,7 +1802,7 @@ resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	assign_generated_ipv6_cidr_block = true
 	tags {
-		Name = "tf-ipv6-instance-acc-test"
+		Name = "terraform-testacc-instance-ipv6-support-with-ipv4"
 	}
 }
 
@@ -2091,7 +2091,7 @@ const testAccInstanceConfigPrivateIP = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "testAccInstanceConfigPrivateIP"
+		Name = "terraform-testacc-instance-private-ip"
 	}
 }
 
@@ -2112,7 +2112,7 @@ const testAccInstanceConfigAssociatePublicIPAndPrivateIP = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "testAccInstanceConfigAssociatePublicIPAndPrivateIP"
+		Name = "terraform-testacc-instance-public-ip-and-private-ip"
 	}
 }
 
@@ -2139,7 +2139,7 @@ resource "aws_internet_gateway" "gw" {
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "tf-network-test"
+		Name = "terraform-testacc-instance-network-security-groups"
 	}
 }
 
@@ -2187,7 +2187,7 @@ resource "aws_internet_gateway" "gw" {
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "tf-network-test"
+		Name = "terraform-testacc-instance-network-vpc-sg-ids"
 	}
 }
 
@@ -2251,7 +2251,7 @@ const testAccInstanceConfigRootBlockDeviceMismatch = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "testAccInstanceConfigRootBlockDeviceMismatch"
+		Name = "terraform-testacc-instance-root-block-device-mismatch"
 	}
 }
 
@@ -2275,7 +2275,7 @@ const testAccInstanceConfigForceNewAndTagsDrift = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "testAccInstanceConfigForceNewAndTagsDrift"
+		Name = "terraform-testacc-instance-force-new-and-tags-drift"
 	}
 }
 
@@ -2295,7 +2295,7 @@ const testAccInstanceConfigForceNewAndTagsDrift_Update = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "testAccInstanceConfigForceNewAndTagsDrift_Update"
+		Name = "terraform-testacc-instance-force-new-and-tags-drift"
 	}
 }
 
@@ -2315,7 +2315,7 @@ const testAccInstanceConfigPrimaryNetworkInterface = `
 resource "aws_vpc" "foo" {
   cidr_block = "172.16.0.0/16"
   tags {
-    Name = "tf-instance-test"
+    Name = "terraform-testacc-instance-primary-network-iface"
   }
 }
 
@@ -2350,7 +2350,7 @@ const testAccInstanceConfigPrimaryNetworkInterfaceSourceDestCheck = `
 resource "aws_vpc" "foo" {
   cidr_block = "172.16.0.0/16"
   tags {
-    Name = "tf-instance-test"
+    Name = "terraform-testacc-instance-primary-network-iface-source-dest-check"
   }
 }
 
@@ -2386,7 +2386,7 @@ const testAccInstanceConfigAddSecondaryNetworkInterfaceBefore = `
 resource "aws_vpc" "foo" {
   cidr_block = "172.16.0.0/16"
   tags {
-    Name = "tf-instance-test"
+    Name = "terraform-testacc-instance-add-secondary-network-iface"
   }
 }
 
@@ -2429,7 +2429,7 @@ const testAccInstanceConfigAddSecondaryNetworkInterfaceAfter = `
 resource "aws_vpc" "foo" {
   cidr_block = "172.16.0.0/16"
   tags {
-    Name = "tf-instance-test"
+    Name = "terraform-testacc-instance-add-secondary-network-iface"
   }
 }
 
@@ -2476,9 +2476,9 @@ resource "aws_instance" "foo" {
 const testAccInstanceConfigAddSecurityGroupBefore = `
 resource "aws_vpc" "foo" {
     cidr_block = "172.16.0.0/16"
-        tags {
-            Name = "tf-eni-test"
-        }
+    tags {
+        Name = "terraform-testacc-instance-add-security-group"
+    }
 }
 
 resource "aws_subnet" "foo" {
@@ -2541,9 +2541,9 @@ resource "aws_network_interface" "bar" {
 const testAccInstanceConfigAddSecurityGroupAfter = `
 resource "aws_vpc" "foo" {
     cidr_block = "172.16.0.0/16"
-        tags {
-            Name = "tf-eni-test"
-        }
+    tags {
+        Name = "terraform-testacc-instance-add-security-group"
+    }
 }
 
 resource "aws_subnet" "foo" {
@@ -2609,7 +2609,7 @@ func testAccInstanceConfig_associatePublic_defaultPrivate(rInt int) string {
 resource "aws_vpc" "my_vpc" {
   cidr_block = "172.16.0.0/16"
   tags {
-    Name = "tf-acctest-%d"
+    Name = "terraform-testacc-instance-associate-public-default-private"
   }
 }
 
@@ -2627,7 +2627,7 @@ resource "aws_instance" "foo" {
   tags {
     Name = "tf-acctest-%d"
   }
-}`, rInt, rInt)
+}`, rInt)
 }
 
 func testAccInstanceConfig_associatePublic_defaultPublic(rInt int) string {
@@ -2635,7 +2635,7 @@ func testAccInstanceConfig_associatePublic_defaultPublic(rInt int) string {
 resource "aws_vpc" "my_vpc" {
   cidr_block = "172.16.0.0/16"
   tags {
-    Name = "tf-acctest-%d"
+    Name = "terraform-testacc-instance-associate-public-default-public"
   }
 }
 
@@ -2653,7 +2653,7 @@ resource "aws_instance" "foo" {
   tags {
     Name = "tf-acctest-%d"
   }
-}`, rInt, rInt)
+}`, rInt)
 }
 
 func testAccInstanceConfig_associatePublic_explicitPublic(rInt int) string {
@@ -2661,7 +2661,7 @@ func testAccInstanceConfig_associatePublic_explicitPublic(rInt int) string {
 resource "aws_vpc" "my_vpc" {
   cidr_block = "172.16.0.0/16"
   tags {
-    Name = "tf-acctest-%d"
+    Name = "terraform-testacc-instance-associate-public-explicit-public"
   }
 }
 
@@ -2680,7 +2680,7 @@ resource "aws_instance" "foo" {
   tags {
     Name = "tf-acctest-%d"
   }
-}`, rInt, rInt)
+}`, rInt)
 }
 
 func testAccInstanceConfig_associatePublic_explicitPrivate(rInt int) string {
@@ -2688,7 +2688,7 @@ func testAccInstanceConfig_associatePublic_explicitPrivate(rInt int) string {
 resource "aws_vpc" "my_vpc" {
   cidr_block = "172.16.0.0/16"
   tags {
-    Name = "tf-acctest-%d"
+    Name = "terraform-testacc-instance-associate-public-explicit-private"
   }
 }
 
@@ -2707,7 +2707,7 @@ resource "aws_instance" "foo" {
   tags {
     Name = "tf-acctest-%d"
   }
-}`, rInt, rInt)
+}`, rInt)
 }
 
 func testAccInstanceConfig_associatePublic_overridePublic(rInt int) string {
@@ -2715,7 +2715,7 @@ func testAccInstanceConfig_associatePublic_overridePublic(rInt int) string {
 resource "aws_vpc" "my_vpc" {
   cidr_block = "172.16.0.0/16"
   tags {
-    Name = "tf-acctest-%d"
+    Name = "terraform-testacc-instance-associate-public-override-public"
   }
 }
 
@@ -2734,7 +2734,7 @@ resource "aws_instance" "foo" {
   tags {
     Name = "tf-acctest-%d"
   }
-}`, rInt, rInt)
+}`, rInt)
 }
 
 func testAccInstanceConfig_associatePublic_overridePrivate(rInt int) string {
@@ -2742,7 +2742,7 @@ func testAccInstanceConfig_associatePublic_overridePrivate(rInt int) string {
 resource "aws_vpc" "my_vpc" {
   cidr_block = "172.16.0.0/16"
   tags {
-    Name = "tf-acctest-%d"
+    Name = "terraform-testacc-instance-associate-public-override-private"
   }
 }
 
@@ -2761,5 +2761,5 @@ resource "aws_instance" "foo" {
   tags {
     Name = "tf-acctest-%d"
   }
-}`, rInt, rInt)
+}`, rInt)
 }

--- a/aws/resource_aws_internet_gateway_test.go
+++ b/aws/resource_aws_internet_gateway_test.go
@@ -183,7 +183,7 @@ const testAccNoInternetGatewayConfig = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "testAccNoInternetGatewayConfig"
+		Name = "terraform-testacc-no-internet-gateway"
 	}
 }
 `
@@ -192,7 +192,7 @@ const testAccInternetGatewayConfig = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "testAccInternetGatewayConfig"
+		Name = "terraform-testacc-internet-gateway"
 	}
 }
 
@@ -205,14 +205,14 @@ const testAccInternetGatewayConfigChangeVPC = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "testAccInternetGatewayConfigChangeVPC"
+		Name = "terraform-testacc-internet-gateway-change-vpc"
 	}
 }
 
 resource "aws_vpc" "bar" {
 	cidr_block = "10.2.0.0/16"
 	tags {
-		Name = "testAccInternetGatewayConfigChangeVPC_other"
+		Name = "terraform-testacc-internet-gateway-change-vpc-other"
 	}
 }
 
@@ -225,7 +225,7 @@ const testAccCheckInternetGatewayConfigTags = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "testAccCheckInternetGatewayConfigTags"
+		Name = "terraform-testacc-internet-gateway-tags"
 	}
 }
 
@@ -241,7 +241,7 @@ const testAccCheckInternetGatewayConfigTagsUpdate = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "testAccCheckInternetGatewayConfigTagsUpdate"
+		Name = "terraform-testacc-internet-gateway-tags"
 	}
 }
 

--- a/aws/resource_aws_lambda_function_test.go
+++ b/aws/resource_aws_lambda_function_test.go
@@ -1167,9 +1167,9 @@ EOF
 
 resource "aws_vpc" "vpc_for_lambda" {
     cidr_block = "10.0.0.0/16"
-		tags {
-			Name = "baseAccAWSLambdaConfig"
-		}
+	tags {
+		Name = "terraform-testacc-lambda-function"
+	}
 }
 
 resource "aws_subnet" "subnet_for_lambda" {

--- a/aws/resource_aws_launch_configuration_test.go
+++ b/aws/resource_aws_launch_configuration_test.go
@@ -548,11 +548,11 @@ resource "aws_launch_configuration" "baz" {
 
 const testAccAWSLaunchConfigurationConfig_withVpcClassicLink = `
 resource "aws_vpc" "foo" {
-   cidr_block = "10.0.0.0/16"
-   enable_classiclink = true
-	tags {
-		Name = "testAccAWSLaunchConfigurationConfig_withVpcClassicLink"
-	}
+    cidr_block = "10.0.0.0/16"
+    enable_classiclink = true
+    tags {
+        Name = "terraform-testacc-launch-configuration-with-vpc-classic-link"
+    }
 }
 
 resource "aws_security_group" "foo" {

--- a/aws/resource_aws_lb_listener_rule_test.go
+++ b/aws/resource_aws_lb_listener_rule_test.go
@@ -332,7 +332,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "terraform-testacc-lb-listener-rule-multiple-conditions"
   }
 }
 
@@ -443,7 +443,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "terraform-testacc-lb-listener-rule-basic"
   }
 }
 
@@ -554,7 +554,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "terraform-testacc-lb-listener-rule-bc"
   }
 }
 
@@ -666,7 +666,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "terraform-testacc-lb-listener-rule-update-rule-priority"
   }
 }
 
@@ -789,7 +789,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "terraform-testacc-lb-listener-rule-change-rule-arn"
   }
 }
 

--- a/aws/resource_aws_lb_listener_test.go
+++ b/aws/resource_aws_lb_listener_test.go
@@ -217,7 +217,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "terraform-testacc-lb-listener-basic"
   }
 }
 
@@ -313,7 +313,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "terraform-testacc-lb-listener-bc"
   }
 }
 
@@ -411,7 +411,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "terraform-testacc-lb-listener-https"
   }
 }
 

--- a/aws/resource_aws_lb_target_group_attachment_test.go
+++ b/aws/resource_aws_lb_target_group_attachment_test.go
@@ -177,11 +177,13 @@ resource "aws_lb_target_group_attachment" "test" {
   target_group_arn = "${aws_lb_target_group.test.arn}"
   target_id = "${aws_instance.test.id}"
 }
+
 resource "aws_instance" "test" {
   ami = "ami-f701cb97"
   instance_type = "t2.micro"
   subnet_id = "${aws_subnet.subnet.id}"
 }
+
 resource "aws_lb_target_group" "test" {
   name = "%s"
   port = 443
@@ -203,14 +205,16 @@ resource "aws_lb_target_group" "test" {
     matcher = "200-299"
   }
 }
+
 resource "aws_subnet" "subnet" {
   cidr_block = "10.0.1.0/24"
   vpc_id = "${aws_vpc.test.id}"
 }
+
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 	tags {
-		Name = "testAccAWSLBTargetGroupAttachmentConfigWithoutPort"
+		Name = "terraform-testacc-lb-target-group-attachment-without-port"
 	}
 }`, targetGroupName)
 }
@@ -222,11 +226,13 @@ resource "aws_lb_target_group_attachment" "test" {
   target_id = "${aws_instance.test.id}"
   port = 80
 }
+
 resource "aws_instance" "test" {
   ami = "ami-f701cb97"
   instance_type = "t2.micro"
   subnet_id = "${aws_subnet.subnet.id}"
 }
+
 resource "aws_lb_target_group" "test" {
   name = "%s"
   port = 443
@@ -248,14 +254,16 @@ resource "aws_lb_target_group" "test" {
     matcher = "200-299"
   }
 }
+
 resource "aws_subnet" "subnet" {
   cidr_block = "10.0.1.0/24"
   vpc_id = "${aws_vpc.test.id}"
 }
+
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 	tags {
-		Name = "testAccAWSLBTargetGroupAttachmentConfig_basic"
+		Name = "terraform-testacc-lb-target-group-attachment-basic"
 	}
 }`, targetGroupName)
 }
@@ -267,11 +275,13 @@ resource "aws_alb_target_group_attachment" "test" {
   target_id = "${aws_instance.test.id}"
   port = 80
 }
+
 resource "aws_instance" "test" {
   ami = "ami-f701cb97"
   instance_type = "t2.micro"
   subnet_id = "${aws_subnet.subnet.id}"
 }
+
 resource "aws_alb_target_group" "test" {
   name = "%s"
   port = 443
@@ -293,14 +303,16 @@ resource "aws_alb_target_group" "test" {
     matcher = "200-299"
   }
 }
+
 resource "aws_subnet" "subnet" {
   cidr_block = "10.0.1.0/24"
   vpc_id = "${aws_vpc.test.id}"
 }
+
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 	tags {
-		Name = "testAccAWSLBTargetGroupAttachmentConfig_basic"
+		Name = "terraform-testacc-lb-target-group-attachment-bc"
 	}
 }`, targetGroupName)
 }
@@ -346,7 +358,7 @@ resource "aws_subnet" "subnet" {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 	tags {
-		Name = "testAccAWSALBTargetGroupAttachmentConfigWithoutPort"
+		Name = "terraform-testacc-lb-target-group-attachment-with-ip-address"
 	}
 }`, targetGroupName)
 }

--- a/aws/resource_aws_lb_target_group_test.go
+++ b/aws/resource_aws_lb_target_group_test.go
@@ -852,7 +852,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "TestAccAWSLBTargetGroup_application_LB_defaults"
+    Name = "terraform-testacc-lb-target-group-alb-defaults"
   }
 }`, name)
 }
@@ -880,7 +880,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "TestAccAWSLBTargetGroup_application_LB_defaults"
+    Name = "terraform-testacc-lb-target-group-nlb-defaults"
   }
 }`, name, healthCheckBlock)
 }
@@ -919,7 +919,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    TestName = "TestAccAWSLBTargetGroup_basic"
+    TestName = "terraform-testacc-lb-target-group-basic"
   }
 }`, targetGroupName)
 }
@@ -958,7 +958,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    TestName = "TestAccAWSLBTargetGroup_basic"
+    TestName = "terraform-testacc-lb-target-group-bc"
   }
 }`, targetGroupName)
 }
@@ -997,7 +997,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    TestName = "TestAccAWSLBTargetGroup_basic"
+    TestName = "terraform-testacc-lb-target-group-basic"
   }
 }`, targetGroupName)
 }
@@ -1036,7 +1036,7 @@ resource "aws_vpc" "test2" {
   cidr_block = "10.10.0.0/16"
 
   tags {
-    TestName = "TestAccAWSLBTargetGroup_basic"
+    TestName = "terraform-testacc-lb-target-group-basic-2"
   }
 }
 
@@ -1044,7 +1044,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    TestName = "TestAccAWSLBTargetGroup_basic"
+    TestName = "terraform-testacc-lb-target-group-basic"
   }
 }`, targetGroupName)
 }
@@ -1083,7 +1083,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    TestName = "TestAccAWSLBTargetGroup_basic"
+    TestName = "terraform-testacc-lb-target-group-updated-vpc"
   }
 }`, targetGroupName)
 }
@@ -1123,7 +1123,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    TestName = "TestAccAWSLBTargetGroup_basic"
+    TestName = "terraform-testacc-lb-target-group-update-tags"
   }
 }`, targetGroupName)
 }
@@ -1158,7 +1158,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    TestName = "TestAccAWSLBTargetGroup_basic"
+    TestName = "terraform-testacc-lb-target-group-update-health-check"
   }
 }`, targetGroupName)
 }
@@ -1189,7 +1189,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "TestAcc_networkLB_TargetGroup"
+    Name = "terraform-testacc-lb-target-group-type-tcp"
   }
 }`, targetGroupName)
 }
@@ -1220,7 +1220,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "TestAcc_networkLB_TargetGroup"
+    Name = "terraform-testacc-lb-target-group-type-tcp-threshold-updated"
   }
 }`, targetGroupName)
 }
@@ -1251,7 +1251,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "TestAcc_networkLB_TargetGroup"
+    Name = "terraform-testacc-lb-target-group-type-tcp-interval-updated"
   }
 }`, targetGroupName)
 }
@@ -1282,7 +1282,7 @@ func testAccAWSLBTargetGroupConfig_typeTCP_HTTPHealthCheck(targetGroupName, path
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
   tags {
-    Name = "TestAcc_networkLB_HTTPHealthCheck"
+    Name = "terraform-testacc-lb-target-group-type-tcp-http-health-check"
   }
 }`, targetGroupName, threshold, path)
 }
@@ -1324,7 +1324,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    TestName = "TestAccAWSALBTargetGroup_stickiness"
+    TestName = "terraform-testacc-lb-target-group-stickiness"
   }
 }`, targetGroupName, stickinessBlock)
 }
@@ -1340,7 +1340,7 @@ resource "aws_lb_target_group" "test" {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 	tags {
-		Name = "testAccAWSLBTargetGroupConfig_namePrefix"
+		Name = "terraform-testacc-lb-target-group-name-prefix"
 	}
 }
 `
@@ -1355,7 +1355,7 @@ resource "aws_lb_target_group" "test" {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 	tags {
-		Name = "testAccAWSLBTargetGroupConfig_generatedName"
+		Name = "terraform-testacc-lb-target-group-generated-name"
 	}
 }
 `

--- a/aws/resource_aws_lb_test.go
+++ b/aws/resource_aws_lb_test.go
@@ -615,7 +615,7 @@ resource "aws_vpc" "alb_test" {
   assign_generated_ipv6_cidr_block = true
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "terraform-testacc-lb-with-ip-address-type-updated"
   }
 }
 
@@ -726,7 +726,7 @@ resource "aws_vpc" "alb_test" {
   assign_generated_ipv6_cidr_block = true
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "terraform-testacc-lb-with-ip-address-type"
   }
 }
 
@@ -802,7 +802,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "terraform-testacc-lb-basic"
   }
 }
 
@@ -848,7 +848,7 @@ func testAccAWSLBConfig_networkLoadbalancer_subnets(lbName string) string {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "testAccAWSLBConfig_networkLoadbalancer_subnets"
+    Name = "terraform-testacc-lb-network-load-balancer-subnets"
   }
 }
 
@@ -923,7 +923,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.10.0.0/16"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "terraform-testacc-network-load-balancer"
   }
 }
 
@@ -947,6 +947,9 @@ data "aws_availability_zones" "available" {}
 
 resource "aws_vpc" "main" {
   cidr_block = "10.10.0.0/16"
+  tags {
+  	Name = "terraform-testacc-lb-network-load-balancer-eip"
+  }
 }
 
 resource "aws_subnet" "public" {
@@ -1019,7 +1022,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "terraform-testacc-lb-bc"
   }
 }
 
@@ -1086,7 +1089,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "terraform-testacc-lb-update-subnets"
   }
 }
 
@@ -1153,7 +1156,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "terraform-testacc-lb-generated-name"
   }
 }
 
@@ -1234,7 +1237,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "terraform-testacc-lb-zero-value-name"
   }
 }
 
@@ -1310,7 +1313,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "terraform-testacc-lb-name-prefix"
   }
 }
 
@@ -1377,7 +1380,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "terraform-testacc-lb-updated-tags"
   }
 }
 
@@ -1488,7 +1491,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "terraform-testacc-lb-access-logs"
   }
 }
 
@@ -1554,7 +1557,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "terraform-testacc-lb-no-sg"
   }
 }
 
@@ -1597,7 +1600,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "terraform-testacc-lb-update-security-groups"
   }
 }
 

--- a/aws/resource_aws_main_route_table_association_test.go
+++ b/aws/resource_aws_main_route_table_association_test.go
@@ -105,7 +105,7 @@ const testAccMainRouteTableAssociationConfig = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "testAccMainRouteTableAssociationConfig"
+		Name = "terraform-testacc-main-route-table-association"
 	}
 }
 
@@ -136,7 +136,7 @@ const testAccMainRouteTableAssociationConfigUpdate = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "testAccMainRouteTableAssociationConfigUpdate"
+		Name = "terraform-testacc-main-route-table-association-update"
 	}
 }
 

--- a/aws/resource_aws_mq_broker_test.go
+++ b/aws/resource_aws_mq_broker_test.go
@@ -655,7 +655,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "main" {
   cidr_block = "10.11.0.0/16"
   tags {
-    Name = "TfAccTest-MqBroker"
+    Name = "terraform-testacc-mq-broker-all-fields-custom-vpc"
   }
 }
 


### PR DESCRIPTION
## Test results

```
=== RUN   TestAccAWSEcsService_withPlacementConstraints
--- PASS: TestAccAWSEcsService_withPlacementConstraints (35.69s)
=== RUN   TestAccAWSEgressOnlyInternetGateway_basic
--- PASS: TestAccAWSEgressOnlyInternetGateway_basic (36.61s)
=== RUN   TestAccAWSEcsService_withIamRole
--- PASS: TestAccAWSEcsService_withIamRole (42.22s)
=== RUN   TestAccAWSEcsService_basicImport
--- PASS: TestAccAWSEcsService_basicImport (48.96s)
=== RUN   TestAccAWSEcsService_withDeploymentValues
--- PASS: TestAccAWSEcsService_withDeploymentValues (49.75s)
=== RUN   TestAccAWSEcsService_withARN
--- PASS: TestAccAWSEcsService_withARN (59.04s)
=== RUN   TestAccAWSEIP_basic
--- PASS: TestAccAWSEIP_basic (10.53s)
=== RUN   TestAccAWSEcsService_withFamilyAndRevision
--- PASS: TestAccAWSEcsService_withFamilyAndRevision (78.15s)
=== RUN   TestAccAWSEcsService_withPlacementStrategy
--- PASS: TestAccAWSEcsService_withPlacementStrategy (81.64s)
=== RUN   TestAccAWSEcsService_withRenamedCluster
--- PASS: TestAccAWSEcsService_withRenamedCluster (115.47s)
=== RUN   TestAccAWSEIP_twoEIPsOneNetworkInterface
--- PASS: TestAccAWSEIP_twoEIPsOneNetworkInterface (34.96s)
=== RUN   TestAccAWSEIP_disappears
--- PASS: TestAccAWSEIP_disappears (14.63s)
=== RUN   TestAccAWSEIPAssociation_ec2Classic
--- PASS: TestAccAWSEIPAssociation_ec2Classic (99.31s)
=== RUN   TestAccAWSEcsService_withPlacementConstraints_emptyExpression
--- PASS: TestAccAWSEcsService_withPlacementConstraints_emptyExpression (141.22s)
=== RUN   TestAccAWSEIPAssociation_basic
--- PASS: TestAccAWSEIPAssociation_basic (143.62s)
=== RUN   TestAccAWSEIPAssociation_disappears
--- PASS: TestAccAWSEIPAssociation_disappears (104.54s)
=== RUN   TestAccAWSBeanstalkConfigurationTemplate_Setting
--- PASS: TestAccAWSBeanstalkConfigurationTemplate_Setting (17.53s)
=== RUN   TestAccAWSEIP_tags
--- PASS: TestAccAWSEIP_tags (32.92s)
=== RUN   TestAccAWSBeanstalkEnv_tier
--- FAIL: TestAccAWSBeanstalkEnv_tier (8.53s)
	testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
		
		* aws_iam_role.tftest: 1 error(s) occurred:
		
		* aws_iam_role.tftest: Error creating IAM Role tftest_role: EntityAlreadyExists: Role with name tftest_role already exists.
			status code: 409, request id: f7188640-119c-11e8-8b57-4189d45ea4ef
FAIL
=== RUN   TestAccAWSEIP_network_interface
--- PASS: TestAccAWSEIP_network_interface (104.70s)
=== RUN   TestAccAWSBeanstalkConfigurationTemplate_VPC
--- PASS: TestAccAWSBeanstalkConfigurationTemplate_VPC (40.21s)
=== RUN   TestAccAWSEIP_importVpc
--- PASS: TestAccAWSEIP_importVpc (141.61s)
=== RUN   TestAccAWSEIPAssociation_spotInstance
--- PASS: TestAccAWSEIPAssociation_spotInstance (192.71s)
=== RUN   TestAccAWSEcsService_withLaunchTypeFargate
--- PASS: TestAccAWSEcsService_withLaunchTypeFargate (251.57s)
=== RUN   TestAccAWSBeanstalkConfigurationTemplate_basic
--- PASS: TestAccAWSBeanstalkConfigurationTemplate_basic (118.65s)
=== RUN   TestAccAWSEIP_importEc2Classic
--- PASS: TestAccAWSEIP_importEc2Classic (216.51s)
=== RUN   TestAccAWSEIP_instance
--- PASS: TestAccAWSEIP_instance (238.62s)
=== RUN   TestAccAWSEFSMountTarget_disappears
--- PASS: TestAccAWSEFSMountTarget_disappears (314.16s)
=== RUN   TestAccAWSEIPAssociate_not_associated
--- PASS: TestAccAWSEIPAssociate_not_associated (191.09s)
=== RUN   TestAccAWSEcsService_healthCheckGracePeriodSeconds
--- PASS: TestAccAWSEcsService_healthCheckGracePeriodSeconds (328.71s)
=== RUN   TestAccAWSEIP_associated_user_private_ip
--- PASS: TestAccAWSEIP_associated_user_private_ip (266.39s)
=== RUN   TestAccAWSEFSMountTarget_basic
--- PASS: TestAccAWSEFSMountTarget_basic (430.02s)
=== RUN   TestAccAWSBeanstalkEnv_basic
--- PASS: TestAccAWSBeanstalkEnv_basic (422.83s)
=== RUN   TestAccAWSBeanstalkEnv_outputs
--- PASS: TestAccAWSBeanstalkEnv_outputs (418.46s)
=== RUN   TestAccAWSEcsService_withEcsClusterName
--- FAIL: TestAccAWSEcsService_withEcsClusterName (605.78s)
	testing.go:513: Step 0 error: Check failed: Check 1/2 error: Not found: aws_ecs_service.jenkins
	testing.go:573: Error destroying resource! WARNING: Dangling resources
		may exist. The full state and error is shown below.
		
		Error: Error applying: 1 error(s) occurred:
		
		* aws_ecs_cluster.default (destroy): 1 error(s) occurred:
		
		* aws_ecs_cluster.default: ClusterContainsServicesException: The Cluster cannot be deleted while Services are active.
			status code: 400, request id: f46a12e8-119d-11e8-b05a-a30ab9e2235e
		
...
=== RUN   TestAccAWSBeanstalkEnv_resource
--- PASS: TestAccAWSBeanstalkEnv_resource (420.16s)
=== RUN   TestAccAWSBeanstalkEnv_cname_prefix
--- PASS: TestAccAWSBeanstalkEnv_cname_prefix (438.99s)
=== RUN   TestAccAWSEcsService_withLbChanges
--- FAIL: TestAccAWSEcsService_withLbChanges (663.32s)
	testing.go:513: Step 0 error: Check failed: Check 1/1 error: Not found: aws_ecs_service.with_lb_changes
	testing.go:573: Error destroying resource! WARNING: Dangling resources
		may exist. The full state and error is shown below.
		
		Error: Error applying: 1 error(s) occurred:
		
		* aws_ecs_cluster.main (destroy): 1 error(s) occurred:
		
		* aws_ecs_cluster.main: ClusterContainsServicesException: The Cluster cannot be deleted while Services are active.
			status code: 400, request id: 1602896a-119e-11e8-88db-536c5e1d59b3
		
...
=== RUN   TestAccAWSEcsService_withUnnormalizedPlacementStrategy
--- FAIL: TestAccAWSEcsService_withUnnormalizedPlacementStrategy (700.89s)
	testing.go:513: Step 0 error: Check failed: Check 1/1 error: Not found: aws_ecs_service.mongo
	testing.go:573: Error destroying resource! WARNING: Dangling resources
		may exist. The full state and error is shown below.
		
		Error: Error applying: 1 error(s) occurred:
		
		* aws_ecs_cluster.default (destroy): 1 error(s) occurred:
		
		* aws_ecs_cluster.default: ClusterContainsServicesException: The Cluster cannot be deleted while Services are active.
			status code: 400, request id: 2cabee28-119e-11e8-b452-f387f80e146b
		
...
=== RUN   TestAccAWSBeanstalkEnv_vpc
--- PASS: TestAccAWSBeanstalkEnv_vpc (518.83s)
=== RUN   TestAccAWSBeanstalkEnv_config
--- PASS: TestAccAWSBeanstalkEnv_config (592.52s)
=== RUN   TestAccAWSEcsService_withAlb
--- FAIL: TestAccAWSEcsService_withAlb (800.34s)
	testing.go:513: Step 0 error: Check failed: Check 1/1 error: Not found: aws_ecs_service.with_alb
	testing.go:573: Error destroying resource! WARNING: Dangling resources
		may exist. The full state and error is shown below.
		
		Error: Error applying: 1 error(s) occurred:
		
		* aws_ecs_cluster.main (destroy): 1 error(s) occurred:
		
		* aws_ecs_cluster.main: ClusterContainsServicesException: The Cluster cannot be deleted while Services are active.
			status code: 400, request id: 6807b2a2-119e-11e8-ac2e-1f1c069f23c4
		
...
=== RUN   TestAccAWSElasticacheCluster_basic
--- PASS: TestAccAWSElasticacheCluster_basic (508.30s)
=== RUN   TestAccAWSElasticacheReplicationGroup_clusteringAndCacheNodesCausesError
--- PASS: TestAccAWSElasticacheReplicationGroup_clusteringAndCacheNodesCausesError (6.15s)
=== RUN   TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration
--- FAIL: TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration (856.82s)
	testing.go:513: Step 0 error: Check failed: Check 1/4 error: Not found: aws_ecs_service.main
	testing.go:573: Error destroying resource! WARNING: Dangling resources
		may exist. The full state and error is shown below.
		
		Error: Error applying: 1 error(s) occurred:
		
		* aws_ecs_cluster.main (destroy): 1 error(s) occurred:
		
		* aws_ecs_cluster.main: ClusterContainsServicesException: The Cluster cannot be deleted while Services are active.
			status code: 400, request id: 89df7c7e-119e-11e8-b1ba-274d5102bdeb
		
...
=== RUN   TestAccAWSBeanstalkEnv_basic_settings_update
--- PASS: TestAccAWSBeanstalkEnv_basic_settings_update (687.01s)
=== RUN   TestAccAWSBeanstalkEnv_template_change
--- PASS: TestAccAWSBeanstalkEnv_template_change (793.60s)
=== RUN   TestAccAWSElasticacheSubnetGroup_basic
--- PASS: TestAccAWSElasticacheSubnetGroup_basic (8.52s)
=== RUN   TestAccAWSElasticacheSubnetGroup_update
--- PASS: TestAccAWSElasticacheSubnetGroup_update (14.85s)
=== RUN   TestAccAWSBeanstalkEnv_version_label
--- PASS: TestAccAWSBeanstalkEnv_version_label (823.70s)
=== RUN   TestAccAWSElasticacheCluster_multiAZInVpc
--- PASS: TestAccAWSElasticacheCluster_multiAZInVpc (676.62s)
=== RUN   TestAccAWSElasticacheReplicationGroup_Uppercase
--- PASS: TestAccAWSElasticacheReplicationGroup_Uppercase (582.32s)
=== RUN   TestAccAWSElasticacheCluster_vpc
--- PASS: TestAccAWSElasticacheCluster_vpc (798.59s)
=== RUN   TestAccAWSBeanstalkEnv_settingWithJsonValue
--- PASS: TestAccAWSBeanstalkEnv_settingWithJsonValue (929.01s)
=== RUN   TestAccAWSElasticacheReplicationGroup_vpc
--- PASS: TestAccAWSElasticacheReplicationGroup_vpc (767.96s)
=== RUN   TestAccAWSElasticacheCluster_decreasingCacheNodes
--- PASS: TestAccAWSElasticacheCluster_decreasingCacheNodes (1156.17s)
=== RUN   TestAccAWSElasticacheCluster_snapshotsWithUpdates
--- PASS: TestAccAWSElasticacheCluster_snapshotsWithUpdates (1177.44s)
=== RUN   TestAccAWSElasticacheReplicationGroup_basic
--- PASS: TestAccAWSElasticacheReplicationGroup_basic (967.86s)
=== RUN   TestAccAWSElasticacheReplicationGroup_enableAuthTokenTransitEncryption
--- PASS: TestAccAWSElasticacheReplicationGroup_enableAuthTokenTransitEncryption (707.36s)
=== RUN   TestAccAWSElasticacheReplicationGroup_enableAtRestEncryption
--- PASS: TestAccAWSElasticacheReplicationGroup_enableAtRestEncryption (637.24s)
=== RUN   TestAccAWSElasticacheReplicationGroup_updateDescription
--- PASS: TestAccAWSElasticacheReplicationGroup_updateDescription (1010.09s)
=== RUN   TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow
--- PASS: TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow (1009.08s)
=== RUN   TestAccAWSElasticacheReplicationGroup_enableSnapshotting
--- PASS: TestAccAWSElasticacheReplicationGroup_enableSnapshotting (917.52s)
=== RUN   TestAccAWSELB_basic
--- PASS: TestAccAWSELB_basic (8.80s)
=== RUN   TestAccAWSELB_fullCharacterRange
--- PASS: TestAccAWSELB_fullCharacterRange (7.26s)
=== RUN   TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2
--- PASS: TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2 (1000.71s)
=== RUN   TestAccAWSELB_AccessLogs_enabled
--- PASS: TestAccAWSELB_AccessLogs_enabled (22.34s)
=== RUN   TestAccAWSELB_namePrefix
--- PASS: TestAccAWSELB_namePrefix (7.93s)
=== RUN   TestAccAWSELB_AccessLogs_disabled
--- PASS: TestAccAWSELB_AccessLogs_disabled (22.01s)
=== RUN   TestAccAWSELB_generatedName
--- PASS: TestAccAWSELB_generatedName (7.42s)
=== RUN   TestAccAWSELB_generatesNameForZeroValue
--- PASS: TestAccAWSELB_generatesNameForZeroValue (8.24s)
=== RUN   TestAccAWSELB_availabilityZones
--- PASS: TestAccAWSELB_availabilityZones (12.70s)
=== RUN   TestAccAWSELB_tags
--- PASS: TestAccAWSELB_tags (11.91s)
=== RUN   TestAccAWSELB_swap_subnets
--- PASS: TestAccAWSELB_swap_subnets (26.25s)
=== RUN   TestAccAWSELB_iam_server_cert
--- PASS: TestAccAWSELB_iam_server_cert (47.37s)
=== RUN   TestAccAWSELBUpdate_Listener
--- PASS: TestAccAWSELBUpdate_Listener (12.10s)
=== RUN   TestAccAWSELB_HealthCheck
--- PASS: TestAccAWSELB_HealthCheck (8.87s)
=== RUN   TestAccAWSELBUpdate_HealthCheck
--- PASS: TestAccAWSELBUpdate_HealthCheck (13.29s)
=== RUN   TestAccAWSELB_Timeout
--- PASS: TestAccAWSELB_Timeout (8.10s)
=== RUN   TestAccAWSELBUpdate_Timeout
--- PASS: TestAccAWSELBUpdate_Timeout (13.16s)
=== RUN   TestAccAWSELB_ConnectionDraining
--- PASS: TestAccAWSELB_ConnectionDraining (8.40s)
=== RUN   TestAccAWSElasticacheReplicationGroup_updateParameterGroup
--- PASS: TestAccAWSElasticacheReplicationGroup_updateParameterGroup (1272.27s)
=== RUN   TestAccAWSELBUpdate_ConnectionDraining
--- PASS: TestAccAWSELBUpdate_ConnectionDraining (16.81s)
=== RUN   TestAccAWSElasticacheReplicationGroup_nativeRedisCluster
--- PASS: TestAccAWSElasticacheReplicationGroup_nativeRedisCluster (1143.43s)
=== RUN   TestAccAWSELB_SecurityGroups
--- PASS: TestAccAWSELB_SecurityGroups (17.62s)
=== RUN   TestAccAWSElasticacheReplicationGroup_multiAzInVpc
--- PASS: TestAccAWSElasticacheReplicationGroup_multiAzInVpc (1221.90s)
=== RUN   TestAccAWSELB_InstanceAttaching
--- PASS: TestAccAWSELB_InstanceAttaching (183.19s)
=== RUN   TestAccAWSElasticacheReplicationGroup_updateNodeSize
--- PASS: TestAccAWSElasticacheReplicationGroup_updateNodeSize (1722.98s)
=== RUN   TestAccAWSEMRCluster_security_config
--- PASS: TestAccAWSEMRCluster_security_config (415.95s)
=== RUN   TestAccAWSEMRCluster_basic
--- PASS: TestAccAWSEMRCluster_basic (429.52s)
=== RUN   TestAccAWSElasticSearchDomain_importBasic
--- PASS: TestAccAWSElasticSearchDomain_importBasic (1304.50s)
=== RUN   TestAccAWSEMRCluster_bootstrap_ordering
--- PASS: TestAccAWSEMRCluster_bootstrap_ordering (443.91s)
=== RUN   TestAccAWSEMRCluster_terminationProtected
--- PASS: TestAccAWSEMRCluster_terminationProtected (423.67s)
=== RUN   TestAccAWSEMRCluster_instance_group
--- PASS: TestAccAWSEMRCluster_instance_group (539.67s)
=== RUN   TestAccAWSElasticSearchDomain_basic
--- PASS: TestAccAWSElasticSearchDomain_basic (1483.28s)
=== RUN   TestAccAWSElasticSearchDomain_duplicate
--- PASS: TestAccAWSElasticSearchDomain_duplicate (1586.35s)
=== RUN   TestAccAWSFlowLog_basic
--- PASS: TestAccAWSFlowLog_basic (9.14s)
=== RUN   TestAccAWSFlowLog_subnet
--- PASS: TestAccAWSFlowLog_subnet (9.21s)
=== RUN   TestAccAWSElasticSearchDomain_complex
--- PASS: TestAccAWSElasticSearchDomain_complex (1596.73s)
=== RUN   TestAccAWSElasticSearchDomain_tags
--- PASS: TestAccAWSElasticSearchDomain_tags (1189.22s)
=== RUN   TestAccAWSElasticSearchDomain_LogPublishingOptions
--- PASS: TestAccAWSElasticSearchDomain_LogPublishingOptions (1326.76s)
=== RUN   TestAccAWSElasticSearchDomain_internetToVpcEndpoint
--- FAIL: TestAccAWSElasticSearchDomain_internetToVpcEndpoint (1362.97s)
	testing.go:513: Step 1 error: Error applying: 1 error(s) occurred:
		
		* aws_elasticsearch_domain.example: 1 error(s) occurred:
		
		* aws_elasticsearch_domain.example: ValidationException: Domain is still being deleted
			status code: 400, request id: 2f7ef226-11a3-11e8-953a-531ed69890e6
=== RUN   TestAccAWSInstance_GP2IopsDevice
--- PASS: TestAccAWSInstance_GP2IopsDevice (56.22s)
=== RUN   TestAccAWSInstance_GP2WithIopsValue
--- PASS: TestAccAWSInstance_GP2WithIopsValue (54.60s)
=== RUN   TestAccAWSInstance_basic
--- PASS: TestAccAWSInstance_basic (222.80s)
=== RUN   TestAccAWSElasticSearchDomain_encrypt_at_rest_specify_key
--- PASS: TestAccAWSElasticSearchDomain_encrypt_at_rest_specify_key (1339.11s)
=== RUN   TestAccAWSInstance_rootInstanceStore
--- PASS: TestAccAWSInstance_rootInstanceStore (65.93s)
=== RUN   TestAccAWSEMRCluster_s3Logging
--- PASS: TestAccAWSEMRCluster_s3Logging (580.56s)
=== RUN   TestAccAWSInstance_userDataBase64
--- PASS: TestAccAWSInstance_userDataBase64 (189.55s)
=== RUN   TestAccAWSEMRCluster_custom_ami_id
--- PASS: TestAccAWSEMRCluster_custom_ami_id (556.58s)
=== RUN   TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError
--- PASS: TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError (10.79s)
=== RUN   TestAccAWSInstance_blockDevices
--- PASS: TestAccAWSInstance_blockDevices (200.57s)
=== RUN   TestAccAWSInstance_noAMIEphemeralDevices
--- PASS: TestAccAWSInstance_noAMIEphemeralDevices (166.46s)
=== RUN   TestAccAWSInstance_placementGroup
--- PASS: TestAccAWSInstance_placementGroup (111.67s)
=== RUN   TestAccAWSEMRInstanceGroup_basic
--- PASS: TestAccAWSEMRInstanceGroup_basic (648.49s)
=== RUN   TestAccAWSInstance_vpc
--- PASS: TestAccAWSInstance_vpc (184.53s)
=== RUN   TestAccAWSInstance_sourceDestCheck
--- PASS: TestAccAWSInstance_sourceDestCheck (221.14s)
=== RUN   TestAccAWSEMRCluster_visibleToAllUsers
--- PASS: TestAccAWSEMRCluster_visibleToAllUsers (809.51s)
=== RUN   TestAccAWSInstance_disableApiTermination
--- PASS: TestAccAWSInstance_disableApiTermination (247.67s)
=== RUN   TestAccAWSEMRCluster_tags
--- PASS: TestAccAWSEMRCluster_tags (804.70s)
=== RUN   TestAccAWSInstance_multipleRegions
--- PASS: TestAccAWSInstance_multipleRegions (138.39s)
=== RUN   TestAccAWSEMRInstanceGroup_zero_count
--- PASS: TestAccAWSEMRInstanceGroup_zero_count (704.58s)
=== RUN   TestAccAWSInstance_ipv6_supportAddressCount
--- PASS: TestAccAWSInstance_ipv6_supportAddressCount (229.72s)
=== RUN   TestAccAWSEMRInstanceGroup_ebsBasic
--- PASS: TestAccAWSEMRInstanceGroup_ebsBasic (668.75s)
=== RUN   TestAccAWSInstance_NetworkInstanceSecurityGroups
--- PASS: TestAccAWSInstance_NetworkInstanceSecurityGroups (175.33s)
=== RUN   TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs
--- PASS: TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs (173.47s)
=== RUN   TestAccAWSInstance_ipv6_supportAddressCountWithIpv4
--- PASS: TestAccAWSInstance_ipv6_supportAddressCountWithIpv4 (258.42s)
=== RUN   TestAccAWSInstance_volumeTagsComputed
--- PASS: TestAccAWSInstance_volumeTagsComputed (119.34s)
=== RUN   TestAccAWSElasticSearchDomain_encrypt_at_rest_default_key
--- PASS: TestAccAWSElasticSearchDomain_encrypt_at_rest_default_key (1693.79s)
=== RUN   TestAccAWSInstance_keyPairCheck
--- PASS: TestAccAWSInstance_keyPairCheck (82.99s)
=== RUN   TestAccAWSInstance_tags
--- PASS: TestAccAWSInstance_tags (242.69s)
=== RUN   TestAccAWSInstance_withIamInstanceProfile
--- PASS: TestAccAWSInstance_withIamInstanceProfile (203.11s)
=== RUN   TestAccAWSInstance_volumeTags
--- PASS: TestAccAWSInstance_volumeTags (275.46s)
=== RUN   TestAccAWSInstance_privateIP
--- PASS: TestAccAWSInstance_privateIP (228.43s)
=== RUN   TestAccAWSInstance_instanceProfileChange
--- PASS: TestAccAWSInstance_instanceProfileChange (252.21s)
=== RUN   TestAccAWSElasticSearchDomain_v23
--- PASS: TestAccAWSElasticSearchDomain_v23 (2258.01s)
=== RUN   TestAccAWSElasticSearchDomain_vpc
--- PASS: TestAccAWSElasticSearchDomain_vpc (2220.93s)
=== RUN   TestAccAWSInstance_rootBlockDeviceMismatch
--- PASS: TestAccAWSInstance_rootBlockDeviceMismatch (265.28s)
=== RUN   TestAccAWSInstance_associatePublicIPAndPrivateIP
--- PASS: TestAccAWSInstance_associatePublicIPAndPrivateIP (310.79s)
=== RUN   TestAccAWSInstance_associatePublic_defaultPublic
--- PASS: TestAccAWSInstance_associatePublic_defaultPublic (182.09s)
=== RUN   TestAccAWSInstance_changeInstanceType
--- PASS: TestAccAWSInstance_changeInstanceType (342.09s)
=== RUN   TestAccAWSLambdaFunction_concurrency
--- PASS: TestAccAWSLambdaFunction_concurrency (64.92s)
=== RUN   TestAccAWSInstance_associatePublic_overridePrivate
--- PASS: TestAccAWSInstance_associatePublic_overridePrivate (189.32s)
=== RUN   TestAccAWSInternetGateway_tags
--- PASS: TestAccAWSInternetGateway_tags (150.15s)
=== RUN   TestAccAWSElasticSearchDomain_policy
--- PASS: TestAccAWSElasticSearchDomain_policy (2076.06s)
=== RUN   TestAccAWSLambdaFunction_updateRuntime
--- PASS: TestAccAWSLambdaFunction_updateRuntime (56.04s)
=== RUN   TestAccAWSInstance_primaryNetworkInterface
--- PASS: TestAccAWSInstance_primaryNetworkInterface (414.90s)
=== RUN   TestAccAWSInternetGateway_delete
--- PASS: TestAccAWSInternetGateway_delete (212.01s)
=== RUN   TestAccAWSInstance_forceNewAndTagsDrift
--- PASS: TestAccAWSInstance_forceNewAndTagsDrift (479.36s)
=== RUN   TestAccAWSLambdaFunction_versioned
--- PASS: TestAccAWSLambdaFunction_versioned (87.48s)
=== RUN   TestAccAWSLambdaFunction_DeadLetterConfig
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfig (87.62s)
=== RUN   TestAccAWSLambdaFunction_nilDeadLetterConfig
--- PASS: TestAccAWSLambdaFunction_nilDeadLetterConfig (42.83s)
=== RUN   TestAccAWSLambdaFunction_DeadLetterConfigUpdated
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfigUpdated (102.21s)
=== RUN   TestAccAWSInstance_associatePublic_defaultPrivate
--- PASS: TestAccAWSInstance_associatePublic_defaultPrivate (553.03s)
=== RUN   TestAccAWSInstance_associatePublic_explicitPrivate
--- PASS: TestAccAWSInstance_associatePublic_explicitPrivate (467.14s)
=== RUN   TestAccAWSLambdaFunction_s3
--- PASS: TestAccAWSLambdaFunction_s3 (37.95s)
=== RUN   TestAccAWSLambdaFunction_basic
--- PASS: TestAccAWSLambdaFunction_basic (379.80s)
=== RUN   TestAccAWSLambdaFunction_encryptedEnvVariables
--- PASS: TestAccAWSLambdaFunction_encryptedEnvVariables (249.91s)
=== RUN   TestAccAWSLambdaFunction_tracingConfig
--- PASS: TestAccAWSLambdaFunction_tracingConfig (147.05s)
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_noRuntime
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_noRuntime (0.86s)
=== RUN   TestAccAWSLambdaFunction_VPC
--- PASS: TestAccAWSLambdaFunction_VPC (152.56s)
=== RUN   TestAccAWSLambdaFunction_localUpdate
--- PASS: TestAccAWSLambdaFunction_localUpdate (36.78s)
=== RUN   TestAccAWSInstance_addSecurityGroupNetworkInterface
--- PASS: TestAccAWSInstance_addSecurityGroupNetworkInterface (633.95s)
=== RUN   TestAccAWSLambdaFunction_localUpdate_nameOnly
--- PASS: TestAccAWSLambdaFunction_localUpdate_nameOnly (30.50s)
=== RUN   TestAccAWSLambdaFunction_VPC_withInvocation
--- PASS: TestAccAWSLambdaFunction_VPC_withInvocation (138.30s)
=== RUN   TestAccAWSLambdaFunction_s3Update_unversioned
--- PASS: TestAccAWSLambdaFunction_s3Update_unversioned (43.71s)
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_nodeJs43
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_nodeJs43 (56.52s)
=== RUN   TestAccAWSLaunchConfiguration_basic
--- PASS: TestAccAWSLaunchConfiguration_basic (41.51s)
=== RUN   TestAccAWSEMRCluster_root_volume_size
--- PASS: TestAccAWSEMRCluster_root_volume_size (1556.93s)
=== RUN   TestAccAWSInstance_associatePublic_explicitPublic
--- PASS: TestAccAWSInstance_associatePublic_explicitPublic (598.64s)
=== RUN   TestAccAWSLambdaFunction_concurrencyCycle
--- PASS: TestAccAWSLambdaFunction_concurrencyCycle (409.56s)
=== RUN   TestAccAWSLaunchConfiguration_withSpotPrice
--- PASS: TestAccAWSLaunchConfiguration_withSpotPrice (25.32s)
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_python27
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python27 (90.41s)
=== RUN   TestAccAWSLaunchConfiguration_updateRootBlockDevice
--- PASS: TestAccAWSLaunchConfiguration_updateRootBlockDevice (72.59s)
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_python36
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python36 (136.96s)
=== RUN   TestAccAWSLaunchConfiguration_withEncryption
--- PASS: TestAccAWSLaunchConfiguration_withEncryption (67.77s)
=== RUN   TestAccAWSInternetGateway_basic
--- PASS: TestAccAWSInternetGateway_basic (610.03s)
=== RUN   TestAccAWSLBListenerRule_multipleConditionThrowsError
--- PASS: TestAccAWSLBListenerRule_multipleConditionThrowsError (0.87s)
=== RUN   TestAccAWSLaunchConfiguration_withIAMProfile
--- PASS: TestAccAWSLaunchConfiguration_withIAMProfile (77.73s)
=== RUN   TestAccAWSLaunchConfiguration_withVpcClassicLink
--- PASS: TestAccAWSLaunchConfiguration_withVpcClassicLink (88.38s)
=== RUN   TestAccAWSLaunchConfiguration_updateEbsBlockDevices
--- PASS: TestAccAWSLaunchConfiguration_updateEbsBlockDevices (86.02s)
=== RUN   TestAccAWSLambdaFunction_tags
--- PASS: TestAccAWSLambdaFunction_tags (175.62s)
=== RUN   TestAccAWSLaunchConfiguration_withBlockDevices
--- PASS: TestAccAWSLaunchConfiguration_withBlockDevices (143.10s)
=== RUN   TestAccAWSInstance_addSecondaryInterface
--- FAIL: TestAccAWSInstance_addSecondaryInterface (812.31s)
	testing.go:573: Error destroying resource! WARNING: Dangling resources
		may exist. The full state and error is shown below.
		
		Error: Error applying: 1 error(s) occurred:
		
		* aws_network_interface.secondary (destroy): 1 error(s) occurred:
		
		* aws_network_interface.secondary: Error waiting for ENI (eni-dceec3e8) to become dettached: timeout while waiting for state to become 'false' (timeout: 10m0s)
		
...
=== RUN   TestAccAWSInstance_associatePublic_overridePublic
--- PASS: TestAccAWSInstance_associatePublic_overridePublic (714.78s)
=== RUN   TestAccAWSLambdaFunction_VPCUpdate
--- PASS: TestAccAWSLambdaFunction_VPCUpdate (389.14s)
=== RUN   TestAccAWSLBTargetGroup_basic
--- PASS: TestAccAWSLBTargetGroup_basic (20.72s)
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_java8
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_java8 (251.33s)
=== RUN   TestAccAWSLBTargetGroupBackwardsCompatibility
--- PASS: TestAccAWSLBTargetGroupBackwardsCompatibility (31.16s)
=== RUN   TestAccAWSLBTargetGroupAttachmentBackwardsCompatibility
--- PASS: TestAccAWSLBTargetGroupAttachmentBackwardsCompatibility (118.23s)
=== RUN   TestAccAWSLBTargetGroupAttachment_basic
--- PASS: TestAccAWSLBTargetGroupAttachment_basic (130.44s)
=== RUN   TestAccAWSLBTargetGroupAttachment_withoutPort
--- PASS: TestAccAWSLBTargetGroupAttachment_withoutPort (136.63s)
=== RUN   TestAccAWSLBTargetGroup_generatedName
--- PASS: TestAccAWSLBTargetGroup_generatedName (24.69s)
=== RUN   TestAccAWSLBListenerRule_basic
--- PASS: TestAccAWSLBListenerRule_basic (256.07s)
=== RUN   TestAccAWSALBTargetGroupAttachment_ipAddress
--- PASS: TestAccAWSALBTargetGroupAttachment_ipAddress (201.51s)
=== RUN   TestAccAWSLBListenerBackwardsCompatibility
--- PASS: TestAccAWSLBListenerBackwardsCompatibility (233.05s)
=== RUN   TestAccAWSLBTargetGroup_changeNameForceNew
--- PASS: TestAccAWSLBTargetGroup_changeNameForceNew (106.81s)
=== RUN   TestAccAWSLBTargetGroup_namePrefix
--- PASS: TestAccAWSLBTargetGroup_namePrefix (127.95s)
=== RUN   TestAccAWSLBTargetGroup_changeVpcForceNew
--- PASS: TestAccAWSLBTargetGroup_changeVpcForceNew (81.18s)
=== RUN   TestAccAWSLBListener_basic
--- PASS: TestAccAWSLBListener_basic (274.14s)
=== RUN   TestAccAWSLBTargetGroup_changePortForceNew
--- PASS: TestAccAWSLBTargetGroup_changePortForceNew (115.20s)
=== RUN   TestAccAWSLambdaFunction_envVariables
--- FAIL: TestAccAWSLambdaFunction_envVariables (718.77s)
	testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
		
		* aws_vpc.vpc_for_lambda: 1 error(s) occurred:
		
		* aws_vpc.vpc_for_lambda: Error waiting for VPC (vpc-c16ee3b8) to become available: timeout while waiting for state to become 'available' (timeout: 10m0s)
=== RUN   TestAccAWSLambdaFunction_expectFilenameAndS3Attributes
--- PASS: TestAccAWSLambdaFunction_expectFilenameAndS3Attributes (744.96s)
=== RUN   TestAccAWSLBTargetGroup_defaults_application
--- PASS: TestAccAWSLBTargetGroup_defaults_application (61.20s)
=== RUN   TestAccAWSLBListenerRule_updateRulePriority
--- PASS: TestAccAWSLBListenerRule_updateRulePriority (336.72s)
=== RUN   TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck
--- PASS: TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck (240.20s)
=== RUN   TestAccAWSLBTargetGroup_defaults_network
--- PASS: TestAccAWSLBTargetGroup_defaults_network (64.69s)
=== RUN   TestAccAWSLambdaFunction_s3Update_basic
--- PASS: TestAccAWSLambdaFunction_s3Update_basic (527.80s)
=== RUN   TestAccAWSLBListenerRuleBackwardsCompatibility
--- PASS: TestAccAWSLBListenerRuleBackwardsCompatibility (440.36s)
=== RUN   TestAccAWSLBTargetGroup_updateHealthCheck
--- PASS: TestAccAWSLBTargetGroup_updateHealthCheck (175.93s)
=== RUN   TestAccAWSLBTargetGroup_changeProtocolForceNew
--- PASS: TestAccAWSLBTargetGroup_changeProtocolForceNew (262.54s)
=== RUN   TestAccAWSLBTargetGroup_updateSticknessEnabled
--- PASS: TestAccAWSLBTargetGroup_updateSticknessEnabled (172.28s)
=== RUN   TestAccAWSElasticSearchDomain_vpc_update
--- FAIL: TestAccAWSElasticSearchDomain_vpc_update (3021.68s)
	testing.go:573: Error destroying resource! WARNING: Dangling resources
		may exist. The full state and error is shown below.
		
		Error: Error applying: 1 error(s) occurred:
		
		* aws_subnet.az2_first (destroy): 1 error(s) occurred:
		
		* aws_subnet.az2_first: Error deleting subnet: timeout while waiting for state to become 'destroyed' (last state: 'pending', timeout: 10m0s)
		
...
=== RUN   TestAccAWSLBTargetGroup_tags
--- PASS: TestAccAWSLBTargetGroup_tags (248.31s)
=== RUN   TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew
--- PASS: TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew (515.90s)
=== RUN   TestAccAWSLBBackwardsCompatibility
--- PASS: TestAccAWSLBBackwardsCompatibility (220.14s)
=== RUN   TestAccAWSLB_generatedName
--- PASS: TestAccAWSLB_generatedName (221.51s)
=== RUN   TestAccAWSLB_networkLoadbalancer
--- PASS: TestAccAWSLB_networkLoadbalancer (261.59s)
=== RUN   TestAccAWSMainRouteTableAssociation_basic
--- PASS: TestAccAWSMainRouteTableAssociation_basic (86.25s)
=== RUN   TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck
--- PASS: TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck (1368.44s)
=== RUN   TestAccAWSLB_networkLoadbalancerEIP
--- PASS: TestAccAWSLB_networkLoadbalancerEIP (282.42s)
=== RUN   TestAccAWSLBTargetGroup_networkLB_TargetGroup
--- PASS: TestAccAWSLBTargetGroup_networkLB_TargetGroup (549.10s)
=== RUN   TestAccAWSLB_noSecurityGroup
--- PASS: TestAccAWSLB_noSecurityGroup (233.69s)
=== RUN   TestAccAWSLB_generatesNameForZeroValue
--- PASS: TestAccAWSLB_generatesNameForZeroValue (350.72s)
=== RUN   TestAccAWSLB_basic
--- PASS: TestAccAWSLB_basic (427.51s)
=== RUN   TestAccAWSLB_networkLoadbalancer_subnet_change
--- PASS: TestAccAWSLB_networkLoadbalancer_subnet_change (259.38s)
=== RUN   TestAccAWSLB_namePrefix
--- PASS: TestAccAWSLB_namePrefix (388.09s)
=== RUN   TestAccAWSLB_updatedSecurityGroups
--- PASS: TestAccAWSLB_updatedSecurityGroups (368.33s)
=== RUN   TestAccAWSLB_updatedIpAddressType
--- PASS: TestAccAWSLB_updatedIpAddressType (314.25s)
=== RUN   TestAccAWSLB_updatedSubnets
--- PASS: TestAccAWSLB_updatedSubnets (356.15s)
=== RUN   TestAccAWSLBListener_https
--- PASS: TestAccAWSLBListener_https (764.54s)
=== RUN   TestAccAWSLB_accesslogs
--- PASS: TestAccAWSLB_accesslogs (353.01s)
=== RUN   TestAccAWSLB_tags
--- PASS: TestAccAWSLB_tags (470.05s)
=== RUN   TestAccAWSElasticSearchDomain_update
--- PASS: TestAccAWSElasticSearchDomain_update (3470.22s)
=== RUN   TestAccAwsMqBroker_basic
--- PASS: TestAccAwsMqBroker_basic (1033.12s)
=== RUN   TestAccAwsMqBroker_updateUsers
--- PASS: TestAccAwsMqBroker_updateUsers (1443.71s)
=== RUN   TestAccAwsMqBroker_allFieldsDefaultVpc
--- PASS: TestAccAwsMqBroker_allFieldsDefaultVpc (2096.07s)
=== RUN   TestAccAwsMqBroker_allFieldsCustomVpc
--- PASS: TestAccAwsMqBroker_allFieldsCustomVpc (2179.57s)
```

All failures should be unrelated.