### PR TITLE
resource/lb_listener_rule: update maximum priority value to 50000

### DIFF
--- a/aws/resource_aws_lb_listener_rule.go
+++ b/aws/resource_aws_lb_listener_rule.go
@@ -38,7 +38,7 @@ func resourceAwsLbbListenerRule() *schema.Resource {
 				Type:         schema.TypeInt,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validateAwsLbListenerRulePriority,
+				ValidateFunc: validateIntegerInRange(1, 50000),
 			},
 			"action": {
 				Type:     schema.TypeList,
@@ -274,14 +274,6 @@ func resourceAwsLbListenerRuleDelete(d *schema.ResourceData, meta interface{}) e
 		return errwrap.Wrapf("Error deleting LB Listener Rule: {{err}}", err)
 	}
 	return nil
-}
-
-func validateAwsLbListenerRulePriority(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(int)
-	if value < 1 || value > 50000 {
-		errors = append(errors, fmt.Errorf("%q must be in the range 1-50000", k))
-	}
-	return
 }
 
 func validateAwsListenerRuleField(v interface{}, k string) (ws []string, errors []error) {

--- a/aws/resource_aws_lb_listener_rule.go
+++ b/aws/resource_aws_lb_listener_rule.go
@@ -154,7 +154,7 @@ func resourceAwsLbListenerRuleRead(d *schema.ResourceData, meta interface{}) err
 
 	// Rules are evaluated in priority order, from the lowest value to the highest value. The default rule has the lowest priority.
 	if *rule.Priority == "default" {
-		d.Set("priority", 99999)
+		d.Set("priority", 50000)
 	} else {
 		if priority, err := strconv.Atoi(*rule.Priority); err != nil {
 			return errwrap.Wrapf("Cannot convert rule priority %q to int: {{err}}", err)
@@ -278,8 +278,8 @@ func resourceAwsLbListenerRuleDelete(d *schema.ResourceData, meta interface{}) e
 
 func validateAwsLbListenerRulePriority(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(int)
-	if value < 1 || value > 99999 {
-		errors = append(errors, fmt.Errorf("%q must be in the range 1-99999", k))
+	if value < 1 || value > 50000 {
+		errors = append(errors, fmt.Errorf("%q must be in the range 1-50000", k))
 	}
 	return
 }

--- a/website/docs/r/lb_listener_rule.html.markdown
+++ b/website/docs/r/lb_listener_rule.html.markdown
@@ -61,7 +61,7 @@ resource "aws_lb_listener_rule" "host_based_routing" {
 The following arguments are supported:
 
 * `listener_arn` - (Required, Forces New Resource) The ARN of the listener to which to attach the rule.
-* `priority` - (Required) The priority for the rule. A listener can't have multiple rules with the same priority.
+* `priority` - (Required) The priority for the rule between `1` and `50000`. A listener can't have multiple rules with the same priority.
 * `action` - (Required) An Action block. Action blocks are documented below.
 * `condition` - (Required) A Condition block. Condition blocks are documented below.
 


### PR DESCRIPTION
update according to the latest document:
https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateRule.html
```
Valid Range: Minimum value of 1. Maximum value of 50000.
```