### PR TITLE
Fix aws_iam_user_ssh_key update method, set key status after creation

### DIFF
--- a/aws/resource_aws_iam_user_ssh_key.go
+++ b/aws/resource_aws_iam_user_ssh_key.go
@@ -69,9 +69,10 @@ func resourceAwsIamUserSshKeyCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	d.Set("ssh_public_key_id", createResp.SSHPublicKey.SSHPublicKeyId)
+	d.Set("fingerprint", createResp.SSHPublicKey.Fingerprint)
 	d.SetId(*createResp.SSHPublicKey.SSHPublicKeyId)
 
-	return resourceAwsIamUserSshKeyRead(d, meta)
+	return resourceAwsIamUserSshKeyUpdate(d, meta)
 }
 
 func resourceAwsIamUserSshKeyRead(d *schema.ResourceData, meta interface{}) error {
@@ -119,7 +120,7 @@ func resourceAwsIamUserSshKeyUpdate(d *schema.ResourceData, meta interface{}) er
 			}
 			return fmt.Errorf("Error updating IAM User SSH Key %s: %s", d.Id(), err)
 		}
-		return resourceAwsIamUserRead(d, meta)
+		return resourceAwsIamUserSshKeyRead(d, meta)
 	}
 	return nil
 }

--- a/aws/resource_aws_iam_user_ssh_key.go
+++ b/aws/resource_aws_iam_user_ssh_key.go
@@ -94,7 +94,7 @@ func resourceAwsIamUserSshKeyRead(d *schema.ResourceData, meta interface{}) erro
 
 	d.Set("fingerprint", getResp.SSHPublicKey.Fingerprint)
 	d.Set("status", getResp.SSHPublicKey.Status)
-	d.Set("ssh_public_key_id", createResp.SSHPublicKey.SSHPublicKeyId)
+	d.Set("ssh_public_key_id", getResp.SSHPublicKey.SSHPublicKeyId)
 	return nil
 }
 

--- a/aws/resource_aws_iam_user_ssh_key.go
+++ b/aws/resource_aws_iam_user_ssh_key.go
@@ -68,8 +68,6 @@ func resourceAwsIamUserSshKeyCreate(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Error creating IAM User SSH Key %s: %s", username, err)
 	}
 
-	d.Set("ssh_public_key_id", createResp.SSHPublicKey.SSHPublicKeyId)
-	d.Set("fingerprint", createResp.SSHPublicKey.Fingerprint)
 	d.SetId(*createResp.SSHPublicKey.SSHPublicKeyId)
 
 	return resourceAwsIamUserSshKeyUpdate(d, meta)
@@ -96,7 +94,7 @@ func resourceAwsIamUserSshKeyRead(d *schema.ResourceData, meta interface{}) erro
 
 	d.Set("fingerprint", getResp.SSHPublicKey.Fingerprint)
 	d.Set("status", getResp.SSHPublicKey.Status)
-
+	d.Set("ssh_public_key_id", createResp.SSHPublicKey.SSHPublicKeyId)
 	return nil
 }
 
@@ -120,9 +118,8 @@ func resourceAwsIamUserSshKeyUpdate(d *schema.ResourceData, meta interface{}) er
 			}
 			return fmt.Errorf("Error updating IAM User SSH Key %s: %s", d.Id(), err)
 		}
-		return resourceAwsIamUserSshKeyRead(d, meta)
 	}
-	return nil
+	return resourceAwsIamUserSshKeyRead(d, meta)
 }
 
 func resourceAwsIamUserSshKeyDelete(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_iam_user_ssh_key_test.go
+++ b/aws/resource_aws_iam_user_ssh_key_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -112,6 +113,17 @@ func testAccCheckAWSUserSSHKeyExists(n string, res *iam.GetSSHPublicKeyOutput) r
 
 		*res = *resp
 
+		keyStruct := resp.SSHPublicKey
+		keyFields := strings.Fields(rs.Primary.Attributes["public_key"])
+		sshkey := fmt.Sprintf("%s %s", keyFields[0], keyFields[1])
+
+		if *keyStruct.Status != "Inactive" {
+			return fmt.Errorf("Key status has wrong status should be Inactive is %s", *keyStruct.Status)
+		}
+
+		if *keyStruct.SSHPublicKeyBody != sshkey {
+			return fmt.Errorf("Public key mismatch. \nIAM: %s\nResource: %s\n", *keyStruct.SSHPublicKeyBody, sshkey)
+		}
 		return nil
 	}
 }
@@ -126,6 +138,7 @@ resource "aws_iam_user_ssh_key" "user" {
 	username = "${aws_iam_user.user.name}"
 	encoding = "SSH"
 	public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
+	status = "Inactive"
 }
 `
 


### PR DESCRIPTION
This PR solves #3363.

## Test reasults
```
--- PASS: TestAccAWSUserSSHKey_basic (26.10s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	26.139s
```