### PR TITLE
tests: Normalize aws_vpc Name tag (N-Z)

### DIFF
--- a/aws/resource_aws_nat_gateway_test.go
+++ b/aws/resource_aws_nat_gateway_test.go
@@ -129,7 +129,7 @@ const testAccNatGatewayConfig = `
 resource "aws_vpc" "vpc" {
   cidr_block = "10.0.0.0/16"
   tags {
-    Name = "testAccNatGatewayConfig"
+    Name = "terraform-testacc-nat-gw-basic"
   }
 }
 
@@ -194,7 +194,7 @@ const testAccNatGatewayConfigTags = `
 resource "aws_vpc" "vpc" {
   cidr_block = "10.0.0.0/16"
   tags {
-    Name = "testAccNatGatewayConfig"
+    Name = "terraform-testacc-nat-gw-tags"
   }
 }
 
@@ -263,7 +263,7 @@ const testAccNatGatewayConfigTagsUpdate = `
 resource "aws_vpc" "vpc" {
   cidr_block = "10.0.0.0/16"
   tags {
-    Name = "testAccNatGatewayConfig"
+    Name = "terraform-testacc-nat-gw-tags"
   }
 }
 

--- a/aws/resource_aws_network_acl_rule_test.go
+++ b/aws/resource_aws_network_acl_rule_test.go
@@ -267,15 +267,18 @@ const testAccAWSNetworkAclRuleBasicConfig = `
 provider "aws" {
   region = "us-east-1"
 }
+
 resource "aws_vpc" "foo" {
 	cidr_block = "10.3.0.0/16"
 	tags {
-		Name = "testAccAWSNetworkAclRuleBasicConfig"
+		Name = "terraform-testacc-network-acl-rule-basic"
 	}
 }
+
 resource "aws_network_acl" "bar" {
 	vpc_id = "${aws_vpc.foo.id}"
 }
+
 resource "aws_network_acl_rule" "baz" {
 	network_acl_id = "${aws_network_acl.bar.id}"
 	rule_number = 200
@@ -286,6 +289,7 @@ resource "aws_network_acl_rule" "baz" {
 	from_port = 22
 	to_port = 22
 }
+
 resource "aws_network_acl_rule" "qux" {
 	network_acl_id = "${aws_network_acl.bar.id}"
 	rule_number = 300
@@ -295,6 +299,7 @@ resource "aws_network_acl_rule" "qux" {
 	icmp_type = 0
 	icmp_code = -1
 }
+
 resource "aws_network_acl_rule" "wibble" {
 	network_acl_id = "${aws_network_acl.bar.id}"
 	rule_number = 400
@@ -310,15 +315,18 @@ const testAccAWSNetworkAclRuleMissingParam = `
 provider "aws" {
   region = "us-east-1"
 }
+
 resource "aws_vpc" "foo" {
 	cidr_block = "10.3.0.0/16"
 	tags {
-		Name = "testAccAWSNetworkAclRuleMissingParam"
+		Name = "terraform-testacc-network-acl-rule-missing-param"
 	}
 }
+
 resource "aws_network_acl" "bar" {
 	vpc_id = "${aws_vpc.foo.id}"
 }
+
 resource "aws_network_acl_rule" "baz" {
 	network_acl_id = "${aws_network_acl.bar.id}"
 	rule_number = 200
@@ -334,12 +342,14 @@ const testAccAWSNetworkAclRuleAllProtocolConfigNoRealUpdate = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.3.0.0/16"
 	tags {
-		Name = "testAccAWSNetworkAclRuleAllProtocolConfigNoRealUpdate"
+		Name = "terraform-testacc-network-acl-rule-all-proto-no-real-upd"
 	}
 }
+
 resource "aws_network_acl" "bar" {
 	vpc_id = "${aws_vpc.foo.id}"
 }
+
 resource "aws_network_acl_rule" "baz" {
 	network_acl_id = "${aws_network_acl.bar.id}"
 	rule_number = 150
@@ -356,12 +366,14 @@ const testAccAWSNetworkAclRuleAllProtocolConfig = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.3.0.0/16"
 	tags {
-		Name = "testAccAWSNetworkAclRuleAllProtocolConfig"
+		Name = "terraform-testacc-network-acl-rule-proto"
 	}
 }
+
 resource "aws_network_acl" "bar" {
 	vpc_id = "${aws_vpc.foo.id}"
 }
+
 resource "aws_network_acl_rule" "baz" {
 	network_acl_id = "${aws_network_acl.bar.id}"
 	rule_number = 150
@@ -378,12 +390,14 @@ const testAccAWSNetworkAclRuleIpv6Config = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.3.0.0/16"
 	tags {
-		Name = "testAccAWSNetworkAclRuleIpv6Config"
+		Name = "terraform-testacc-network-acl-rule-ipv6"
 	}
 }
+
 resource "aws_network_acl" "bar" {
 	vpc_id = "${aws_vpc.foo.id}"
 }
+
 resource "aws_network_acl_rule" "baz" {
 	network_acl_id = "${aws_network_acl.bar.id}"
 	rule_number = 150
@@ -394,5 +408,4 @@ resource "aws_network_acl_rule" "baz" {
 	from_port = 22
 	to_port = 22
 }
-
 `

--- a/aws/resource_aws_network_acl_test.go
+++ b/aws/resource_aws_network_acl_test.go
@@ -457,9 +457,10 @@ const testAccAWSNetworkAclIpv6Config = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "TestAccAWSNetworkAcl_ipv6Rules"
+		Name = "terraform-testacc-network-acl-ipv6"
 	}
 }
+
 resource "aws_subnet" "blob" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
@@ -490,7 +491,7 @@ resource "aws_vpc" "foo" {
 	assign_generated_ipv6_cidr_block = true
 
 	tags {
-		Name = "TestAccAWSNetworkAcl_ipv6VpcRules"
+		Name = "terraform-testacc-network-acl-ipv6-vpc-rules"
 	}
 }
 
@@ -511,14 +512,16 @@ const testAccAWSNetworkAclIngressConfig = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "TestAccAWSNetworkAcl_OnlyIngressRules"
+		Name = "terraform-testacc-network-acl-ingress"
 	}
 }
+
 resource "aws_subnet" "blob" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
 	map_public_ip_on_launch = true
 }
+
 resource "aws_network_acl" "foos" {
 	vpc_id = "${aws_vpc.foo.id}"
 	ingress = {
@@ -546,14 +549,16 @@ const testAccAWSNetworkAclCaseSensitiveConfig = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "TestAccAWSNetworkAcl_OnlyIngressRules"
+		Name = "terraform-testacc-network-acl-ingress"
 	}
 }
+
 resource "aws_subnet" "blob" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
 	map_public_ip_on_launch = true
 }
+
 resource "aws_network_acl" "foos" {
 	vpc_id = "${aws_vpc.foo.id}"
 	ingress = {
@@ -572,14 +577,16 @@ const testAccAWSNetworkAclIngressConfigChange = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "TestAccAWSNetworkAcl_OnlyIngressRules"
+		Name = "terraform-testacc-network-acl-ingress"
 	}
 }
+
 resource "aws_subnet" "blob" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
 	map_public_ip_on_launch = true
 }
+
 resource "aws_network_acl" "foos" {
 	vpc_id = "${aws_vpc.foo.id}"
 	ingress = {
@@ -598,14 +605,16 @@ const testAccAWSNetworkAclEgressConfig = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.2.0.0/16"
 	tags {
-		Name = "TestAccAWSNetworkAcl_OnlyEgressRules"
+		Name = "terraform-testacc-network-acl-egress"
 	}
 }
+
 resource "aws_subnet" "blob" {
 	cidr_block = "10.2.0.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
 	map_public_ip_on_launch = true
 }
+
 resource "aws_network_acl" "bond" {
 	vpc_id = "${aws_vpc.foo.id}"
 	egress = {
@@ -654,14 +663,16 @@ const testAccAWSNetworkAclEgressNIngressConfig = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.3.0.0/16"
 	tags {
-		Name = "TestAccAWSNetworkAcl_EgressAndIngressRules"
+		Name = "terraform-testacc-network-acl-egress-and-ingress"
 	}
 }
+
 resource "aws_subnet" "blob" {
 	cidr_block = "10.3.0.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
 	map_public_ip_on_launch = true
 }
+
 resource "aws_network_acl" "bar" {
 	vpc_id = "${aws_vpc.foo.id}"
 	egress = {
@@ -687,23 +698,27 @@ const testAccAWSNetworkAclSubnetConfig = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "TestAccAWSNetworkAcl_SubnetChange"
+		Name = "terraform-testacc-network-acl-subnet-change"
 	}
 }
+
 resource "aws_subnet" "old" {
 	cidr_block = "10.1.111.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
 	map_public_ip_on_launch = true
 }
+
 resource "aws_subnet" "new" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
 	map_public_ip_on_launch = true
 }
+
 resource "aws_network_acl" "roll" {
 	vpc_id = "${aws_vpc.foo.id}"
 	subnet_ids = ["${aws_subnet.new.id}"]
 }
+
 resource "aws_network_acl" "bar" {
 	vpc_id = "${aws_vpc.foo.id}"
 	subnet_ids = ["${aws_subnet.old.id}"]
@@ -714,19 +729,22 @@ const testAccAWSNetworkAclSubnetConfigChange = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "TestAccAWSNetworkAcl_SubnetChange"
+		Name = "terraform-testacc-network-acl-subnet-change"
 	}
 }
+
 resource "aws_subnet" "old" {
 	cidr_block = "10.1.111.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
 	map_public_ip_on_launch = true
 }
+
 resource "aws_subnet" "new" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
 	map_public_ip_on_launch = true
 }
+
 resource "aws_network_acl" "bar" {
 	vpc_id = "${aws_vpc.foo.id}"
 	subnet_ids = ["${aws_subnet.new.id}"]
@@ -737,9 +755,10 @@ const testAccAWSNetworkAclSubnet_SubnetIds = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "TestAccAWSNetworkAcl_Subnets"
+		Name = "terraform-testacc-network-acl-subnet-ids"
 	}
 }
+
 resource "aws_subnet" "one" {
 	cidr_block = "10.1.111.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
@@ -747,6 +766,7 @@ resource "aws_subnet" "one" {
 		Name = "acl-subnets-test"
 	}
 }
+
 resource "aws_subnet" "two" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
@@ -754,6 +774,7 @@ resource "aws_subnet" "two" {
 		Name = "acl-subnets-test"
 	}
 }
+
 resource "aws_network_acl" "bar" {
 	vpc_id = "${aws_vpc.foo.id}"
 	subnet_ids = ["${aws_subnet.one.id}", "${aws_subnet.two.id}"]
@@ -767,9 +788,10 @@ const testAccAWSNetworkAclSubnet_SubnetIdsUpdate = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "TestAccAWSNetworkAcl_Subnets"
+		Name = "terraform-testacc-network-acl-subnet-ids"
 	}
 }
+
 resource "aws_subnet" "one" {
 	cidr_block = "10.1.111.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
@@ -777,6 +799,7 @@ resource "aws_subnet" "one" {
 		Name = "acl-subnets-test"
 	}
 }
+
 resource "aws_subnet" "two" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
@@ -792,6 +815,7 @@ resource "aws_subnet" "three" {
 		Name = "acl-subnets-test"
 	}
 }
+
 resource "aws_subnet" "four" {
 	cidr_block = "10.1.4.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
@@ -799,6 +823,7 @@ resource "aws_subnet" "four" {
 		Name = "acl-subnets-test"
 	}
 }
+
 resource "aws_network_acl" "bar" {
 	vpc_id = "${aws_vpc.foo.id}"
 	subnet_ids = [
@@ -816,7 +841,7 @@ const testAccAWSNetworkAclEsp = `
 resource "aws_vpc" "testespvpc" {
   cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "testAccAWSNetworkAclEsp"
+		Name = "terraform-testacc-network-acl-esp"
 	}
 }
 

--- a/aws/resource_aws_network_interface_attacment_test.go
+++ b/aws/resource_aws_network_interface_attacment_test.go
@@ -43,9 +43,9 @@ func testAccAWSNetworkInterfaceAttachmentConfig_basic(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "foo" {
     cidr_block = "172.16.0.0/16"
-		tags {
-			Name = "testAccAWSNetworkInterfaceAttachmentConfig_basic"
-		}
+	tags {
+		Name = "terraform-testacc-network-iface-attachment-basic"
+	}
 }
 
 resource "aws_subnet" "foo" {

--- a/aws/resource_aws_network_interface_test.go
+++ b/aws/resource_aws_network_interface_test.go
@@ -302,9 +302,9 @@ const testAccAWSENIConfig = `
 resource "aws_vpc" "foo" {
 	cidr_block = "172.16.0.0/16"
 	enable_dns_hostnames = true
-		tags {
-			Name = "testAccAWSENIConfig"
-		}
+	tags {
+		Name = "terraform-testacc-network-interface"
+	}
 }
 
 resource "aws_subnet" "foo" {
@@ -341,9 +341,9 @@ const testAccAWSENIConfigUpdatedDescription = `
 resource "aws_vpc" "foo" {
 	cidr_block = "172.16.0.0/16"
 	enable_dns_hostnames = true
-		tags {
-			Name = "testAccAWSENIConfigUpdatedDescription"
-		}
+	tags {
+		Name = "terraform-testacc-network-interface-update-desc"
+	}
 }
 
 resource "aws_subnet" "foo" {
@@ -380,9 +380,9 @@ const testAccAWSENIConfigWithSourceDestCheck = `
 resource "aws_vpc" "foo" {
 	cidr_block = "172.16.0.0/16"
 	enable_dns_hostnames = true
-		tags {
-			Name = "testAccAWSENIConfigWithSourceDestCheck"
-		}
+	tags {
+		Name = "terraform-testacc-network-interface-w-source-dest-check"
+	}
 }
 
 resource "aws_subnet" "foo" {
@@ -402,9 +402,9 @@ const testAccAWSENIConfigWithNoPrivateIPs = `
 resource "aws_vpc" "foo" {
 	cidr_block = "172.16.0.0/16"
 	enable_dns_hostnames = true
-		tags {
-			Name = "testAccAWSENIConfigWithNoPrivateIPs"
-		}
+	tags {
+		Name = "terraform-testacc-network-interface-w-no-private-ips"
+	}
 }
 
 resource "aws_subnet" "foo" {
@@ -423,9 +423,9 @@ const testAccAWSENIConfigWithAttachment = `
 resource "aws_vpc" "foo" {
 	cidr_block = "172.16.0.0/16"
 	enable_dns_hostnames = true
-        tags {
-            Name = "tf-eni-test"
-        }
+    tags {
+        Name = "terraform-testacc-network-interface-w-attachment"
+    }
 }
 
 resource "aws_subnet" "foo" {
@@ -481,27 +481,27 @@ const testAccAWSENIConfigExternalAttachment = `
 resource "aws_vpc" "foo" {
 	cidr_block = "172.16.0.0/16"
 	enable_dns_hostnames = true
-        tags {
-            Name = "tf-eni-test"
-        }
+    tags {
+        Name = "terraform-testacc-network-interface-external-attachment"
+    }
 }
 
 resource "aws_subnet" "foo" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "172.16.10.0/24"
     availability_zone = "us-west-2a"
-        tags {
-            Name = "tf-eni-test"
-        }
+    tags {
+        Name = "tf-eni-test"
+    }
 }
 
 resource "aws_subnet" "bar" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "172.16.11.0/24"
     availability_zone = "us-west-2a"
-        tags {
-            Name = "tf-eni-test"
-        }
+    tags {
+        Name = "tf-eni-test"
+    }
 }
 
 resource "aws_security_group" "foo" {

--- a/aws/resource_aws_opsworks_stack_test.go
+++ b/aws/resource_aws_opsworks_stack_test.go
@@ -1005,7 +1005,7 @@ func testAccAwsOpsworksStackConfigVpcCreate(name string) string {
 resource "aws_vpc" "tf-acc" {
   cidr_block = "10.3.5.0/24"
   tags {
-    Name = "testAccAwsOpsworksStackConfigVpcCreate"
+    Name = "terraform-testacc-opsworks-stack-vpc-create"
   }
 }
 resource "aws_subnet" "tf-acc" {
@@ -1099,7 +1099,7 @@ func testAccAWSOpsworksStackConfigVpcUpdate(name string) string {
 resource "aws_vpc" "tf-acc" {
   cidr_block = "10.3.5.0/24"
   tags {
-    Name = "testAccAWSOpsworksStackConfigVpcUpdate"
+    Name = "terraform-testacc-opsworks-stack-vpc-update"
   }
 }
 resource "aws_subnet" "tf-acc" {

--- a/aws/resource_aws_rds_cluster_instance_test.go
+++ b/aws/resource_aws_rds_cluster_instance_test.go
@@ -348,7 +348,7 @@ resource "aws_rds_cluster" "test" {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 	tags {
-		Name = "testAccAWSClusterInstanceConfig_namePrefix"
+		Name = "terraform-testacc-rds-cluster-instance-name-prefix"
 	}
 }
 
@@ -389,7 +389,7 @@ resource "aws_rds_cluster" "test" {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 	tags {
-		Name = "testAccAWSClusterInstanceConfig_generatedName"
+		Name = "terraform-testacc-rds-cluster-instance-generated-name"
 	}
 }
 

--- a/aws/resource_aws_rds_cluster_test.go
+++ b/aws/resource_aws_rds_cluster_test.go
@@ -438,7 +438,7 @@ resource "aws_rds_cluster" "test" {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 	tags {
-		Name = "testAccAWSClusterConfig_namePrefix"
+		Name = "terraform-testacc-rds-cluster-name-prefix"
 	}
 }
 
@@ -479,7 +479,7 @@ resource "aws_rds_cluster" "test" {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 	tags {
-		Name = "testAccAWSClusterConfig_generatedName"
+		Name = "terraform-testacc-rds-cluster-generated-name"
 	}
 }
 

--- a/aws/resource_aws_redshift_cluster_test.go
+++ b/aws/resource_aws_redshift_cluster_test.go
@@ -1054,7 +1054,7 @@ func testAccAWSRedshiftClusterConfig_notPubliclyAccessible(rInt int) string {
 	resource "aws_vpc" "foo" {
 		cidr_block = "10.1.0.0/16"
 		tags {
-			Name = "testAccAWSRedshiftClusterConfig_notPubliclyAccessible"
+			Name = "terraform-testacc-redshift-cluster-no-publicly-accessible"
 		}
 	}
 	resource "aws_internet_gateway" "foo" {
@@ -1114,7 +1114,7 @@ func testAccAWSRedshiftClusterConfig_updatePubliclyAccessible(rInt int) string {
 	resource "aws_vpc" "foo" {
 		cidr_block = "10.1.0.0/16"
 		tags {
-			Name = "testAccAWSRedshiftClusterConfig_updatePubliclyAccessible"
+			Name = "terraform-testacc-redshift-cluster-upd-publicly-accessible"
 		}
 	}
 	resource "aws_internet_gateway" "foo" {

--- a/aws/resource_aws_redshift_subnet_group_test.go
+++ b/aws/resource_aws_redshift_subnet_group_test.go
@@ -231,7 +231,7 @@ func testAccRedshiftSubnetGroupConfig(rInt int) string {
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "testAccRedshiftSubnetGroupConfig"
+		Name = "terraform-testacc-redshift-subnet-group"
 	}
 }
 
@@ -266,7 +266,7 @@ func testAccRedshiftSubnetGroup_updateDescription(rInt int) string {
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "testAccRedshiftSubnetGroup_updateDescription"
+		Name = "terraform-testacc-redshift-subnet-group-upd-description"
 	}
 }
 
@@ -301,7 +301,7 @@ func testAccRedshiftSubnetGroupConfigWithTags(rInt int) string {
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "testAccRedshiftSubnetGroupConfigWithTags"
+		Name = "terraform-testacc-redshift-subnet-group-with-tags"
 	}
 }
 
@@ -338,7 +338,7 @@ func testAccRedshiftSubnetGroupConfigWithTagsUpdated(rInt int) string {
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "testAccRedshiftSubnetGroupConfigWithTags"
+		Name = "terraform-testacc-redshift-subnet-group-with-tags"
 	}
 }
 
@@ -377,7 +377,7 @@ func testAccRedshiftSubnetGroupConfig_updateSubnetIds(rInt int) string {
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "testAccRedshiftSubnetGroupConfig_updateSubnetIds"
+		Name = "terraform-testacc-redshift-subnet-group-upd-subnet-ids"
 	}
 }
 

--- a/aws/resource_aws_route53_zone_association_test.go
+++ b/aws/resource_aws_route53_zone_association_test.go
@@ -159,12 +159,18 @@ resource "aws_vpc" "foo" {
 	cidr_block = "10.6.0.0/16"
 	enable_dns_hostnames = true
 	enable_dns_support = true
+	tags {
+		Name = "terraform-testacc-route53-zone-association-foo"
+	}
 }
 
 resource "aws_vpc" "bar" {
 	cidr_block = "10.7.0.0/16"
 	enable_dns_hostnames = true
 	enable_dns_support = true
+	tags {
+		Name = "terraform-testacc-route53-zone-association-bar"
+	}
 }
 
 resource "aws_route53_zone" "foo" {
@@ -194,6 +200,9 @@ resource "aws_vpc" "foo" {
 	cidr_block = "10.6.0.0/16"
 	enable_dns_hostnames = true
 	enable_dns_support = true
+	tags {
+		Name = "terraform-testacc-route53-zone-association-region-foo"
+	}
 }
 
 resource "aws_vpc" "bar" {
@@ -201,6 +210,9 @@ resource "aws_vpc" "bar" {
 	cidr_block = "10.7.0.0/16"
 	enable_dns_hostnames = true
 	enable_dns_support = true
+	tags {
+		Name = "terraform-testacc-route53-zone-association-region-bar"
+	}
 }
 
 resource "aws_route53_zone" "foo" {

--- a/aws/resource_aws_route53_zone_test.go
+++ b/aws/resource_aws_route53_zone_test.go
@@ -469,6 +469,9 @@ resource "aws_vpc" "main" {
 	instance_tenancy = "default"
 	enable_dns_support = true
 	enable_dns_hostnames = true
+	tags {
+		Name = "terraform-testacc-route53-zone-private"
+	}
 }
 
 resource "aws_route53_zone" "main" {
@@ -496,6 +499,9 @@ resource "aws_vpc" "main" {
 	instance_tenancy = "default"
 	enable_dns_support = true
 	enable_dns_hostnames = true
+	tags {
+		Name = "terraform-testacc-route53-zone-private-region"
+	}
 }
 
 resource "aws_route53_zone" "main" {

--- a/aws/resource_aws_route_table_association_test.go
+++ b/aws/resource_aws_route_table_association_test.go
@@ -108,6 +108,9 @@ func testAccCheckRouteTableAssociationExists(n string, v *ec2.RouteTable) resour
 const testAccRouteTableAssociationConfig = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
+	tags {
+		Name = "terraform-testacc-route-table-association"
+	}
 }
 
 resource "aws_subnet" "foo" {
@@ -136,6 +139,9 @@ resource "aws_route_table_association" "foo" {
 const testAccRouteTableAssociationConfigChange = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
+	tags {
+		Name = "terraform-testacc-route-table-association"
+	}
 }
 
 resource "aws_subnet" "foo" {

--- a/aws/resource_aws_route_table_test.go
+++ b/aws/resource_aws_route_table_test.go
@@ -348,6 +348,9 @@ func TestAccAWSRouteTable_vgwRoutePropagation(t *testing.T) {
 const testAccRouteTableConfig = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
+	tags {
+		Name = "terraform-testacc-route-table"
+	}
 }
 
 resource "aws_internet_gateway" "foo" {
@@ -367,6 +370,9 @@ resource "aws_route_table" "foo" {
 const testAccRouteTableConfigChange = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
+	tags {
+		Name = "terraform-testacc-route-table"
+	}
 }
 
 resource "aws_internet_gateway" "foo" {
@@ -392,6 +398,9 @@ const testAccRouteTableConfigIpv6 = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
   assign_generated_ipv6_cidr_block = true
+  tags {
+    Name = "terraform-testacc-route-table-ipv6"
+  }
 }
 
 resource "aws_egress_only_internet_gateway" "foo" {
@@ -411,6 +420,9 @@ resource "aws_route_table" "foo" {
 const testAccRouteTableConfigInstance = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
+	tags {
+		Name = "terraform-testacc-route-table-instance"
+	}
 }
 
 resource "aws_subnet" "foo" {
@@ -438,6 +450,9 @@ resource "aws_route_table" "foo" {
 const testAccRouteTableConfigTags = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
+	tags {
+		Name = "terraform-testacc-route-table-tags"
+	}
 }
 
 resource "aws_route_table" "foo" {
@@ -452,6 +467,9 @@ resource "aws_route_table" "foo" {
 const testAccRouteTableConfigTagsUpdate = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
+	tags {
+		Name = "terraform-testacc-route-table-tags"
+	}
 }
 
 resource "aws_route_table" "foo" {
@@ -467,6 +485,9 @@ resource "aws_route_table" "foo" {
 const testAccRouteTableVpcPeeringConfig = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
+	tags {
+		Name = "terraform-testacc-route-table-vpc-peering-foo"
+	}
 }
 
 resource "aws_internet_gateway" "foo" {
@@ -475,6 +496,9 @@ resource "aws_internet_gateway" "foo" {
 
 resource "aws_vpc" "bar" {
 	cidr_block = "10.3.0.0/16"
+	tags {
+		Name = "terraform-testacc-route-table-vpc-peering-bar"
+	}
 }
 
 resource "aws_internet_gateway" "bar" {
@@ -502,6 +526,9 @@ resource "aws_route_table" "foo" {
 const testAccRouteTableVgwRoutePropagationConfig = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
+	tags {
+		Name = "terraform-testacc-route-table-vgw-route-propagation"
+	}
 }
 
 resource "aws_vpn_gateway" "foo" {
@@ -519,6 +546,9 @@ resource "aws_route_table" "foo" {
 const testAccRouteTableConfigPanicEmptyRoute = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.2.0.0/16"
+	tags {
+		Name = "terraform-testacc-route-table-panic-empty-route"
+	}
 }
 
 resource "aws_route_table" "foo" {

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -351,6 +351,9 @@ func testAccCheckAWSRouteDestroy(s *terraform.State) error {
 var testAccAWSRouteBasicConfig = fmt.Sprint(`
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
+	tags {
+		Name = "terraform-testacc-route-basic"
+	}
 }
 
 resource "aws_internet_gateway" "foo" {
@@ -372,6 +375,9 @@ var testAccAWSRouteConfigIpv6InternetGateway = fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
   assign_generated_ipv6_cidr_block = true
+  tags {
+    Name = "terraform-testacc-route-ipv6-igw"
+  }
 }
 
 resource "aws_egress_only_internet_gateway" "foo" {
@@ -399,6 +405,9 @@ resource "aws_vpc" "examplevpc" {
   cidr_block = "10.100.0.0/16"
   enable_dns_hostnames = true
   assign_generated_ipv6_cidr_block = true
+  tags {
+    Name = "terraform-testacc-route-ipv6-network-interface"
+  }
 }
 
 data "aws_availability_zones" "available" {}
@@ -495,6 +504,9 @@ resource "aws_vpc" "examplevpc" {
   cidr_block = "10.100.0.0/16"
   enable_dns_hostnames = true
   assign_generated_ipv6_cidr_block = true
+  tags {
+    Name = "terraform-testacc-route-ipv6-instance"
+  }
 }
 
 data "aws_availability_zones" "available" {}
@@ -579,6 +591,9 @@ var testAccAWSRouteConfigIpv6PeeringConnection = fmt.Sprintf(`
 resource "aws_vpc" "foo" {
 	cidr_block = "10.0.0.0/16"
 	assign_generated_ipv6_cidr_block = true
+	tags {
+		Name = "terraform-testacc-route-ipv6-peering-connection"
+	}
 }
 
 resource "aws_vpc" "bar" {
@@ -608,6 +623,9 @@ var testAccAWSRouteConfigIpv6 = fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
   assign_generated_ipv6_cidr_block = true
+  tags {
+    Name = "terraform-testacc-route-ipv6"
+  }
 }
 
 resource "aws_egress_only_internet_gateway" "foo" {
@@ -630,6 +648,9 @@ resource "aws_route" "bar" {
 var testAccAWSRouteBasicConfigChangeCidr = fmt.Sprint(`
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
+	tags {
+		Name = "terraform-testacc-route-change-cidr"
+	}
 }
 
 resource "aws_internet_gateway" "foo" {
@@ -651,6 +672,9 @@ resource "aws_route" "bar" {
 var testAccAWSRouteMixConfig = fmt.Sprint(`
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
+	tags {
+		Name = "terraform-testacc-route-route-mix"
+	}
 }
 
 resource "aws_internet_gateway" "foo" {
@@ -676,6 +700,9 @@ resource "aws_route" "bar" {
 var testAccAWSRouteNoopChange = fmt.Sprint(`
 resource "aws_vpc" "test" {
   cidr_block = "10.10.0.0/16"
+  tags {
+    Name = "terraform-testacc-route-route-noop-change"
+  }
 }
 
 resource "aws_route_table" "test" {
@@ -703,6 +730,9 @@ resource "aws_instance" "nat" {
 var testAccAWSRouteWithVPCEndpoint = fmt.Sprint(`
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
+  tags {
+    Name = "terraform-testacc-route-with-vpc-endpoint"
+  }
 }
 
 resource "aws_internet_gateway" "foo" {

--- a/aws/resource_aws_security_group_rule_test.go
+++ b/aws/resource_aws_security_group_rule_test.go
@@ -1008,7 +1008,7 @@ resource "aws_vpc" "tftest" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "tf-testing"
+    Name = "terraform-testacc-security-group-rule-ingress-ipv6"
   }
 }
 
@@ -1036,7 +1036,7 @@ resource "aws_vpc" "tftest" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "tf-testing"
+    Name = "terraform-testacc-security-group-rule-ingress-protocol"
   }
 }
 
@@ -1166,7 +1166,9 @@ func testAccAWSSecurityGroupRuleMultiDescription(rInt int, rType string) string 
 	b.WriteString(fmt.Sprintf(`
 	resource "aws_vpc" "tf_sgrule_description_test" {
 		cidr_block = "10.0.0.0/16"
-		tags { Name = "tf-sg-rule-description" }
+		tags {
+			Name = "terraform-testacc-security-group-rule-multi-desc"
+		}
 	}
 
 	resource "aws_vpc_endpoint" "s3-us-west-2" {
@@ -1245,7 +1247,7 @@ provider "aws" {
 resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
   tags {
-    Name = "sg-self-test"
+    Name = "terraform-testacc-security-group-rule-self-ref"
   }
 }
 
@@ -1272,7 +1274,7 @@ func testAccAWSSecurityGroupRulePartialMatchingConfig(rInt int) string {
 	resource "aws_vpc" "default" {
 		cidr_block = "10.0.0.0/16"
 		tags {
-			Name = "tf-sg-rule-bug"
+			Name = "terraform-testacc-security-group-rule-partial-match"
 		}
 	}
 
@@ -1329,7 +1331,7 @@ func testAccAWSSecurityGroupRulePartialMatching_SourceConfig(rInt int) string {
 	resource "aws_vpc" "default" {
 		cidr_block = "10.0.0.0/16"
 		tags {
-			Name = "tf-sg-rule-bug"
+			Name = "terraform-testacc-security-group-rule-partial-match"
 		}
 	}
 
@@ -1375,7 +1377,7 @@ const testAccAWSSecurityGroupRulePrefixListEgressConfig = `
 resource "aws_vpc" "tf_sg_prefix_list_egress_test" {
     cidr_block = "10.0.0.0/16"
     tags {
-            Name = "tf_sg_prefix_list_egress_test"
+        Name = "terraform-testacc-security-group-rule-prefix-list-egress"
     }
 }
 
@@ -1517,7 +1519,9 @@ var testAccAWSSecurityGroupRuleRace = func() string {
 	b.WriteString(fmt.Sprintf(`
 		resource "aws_vpc" "default" {
 			cidr_block = "10.0.0.0/16"
-			tags { Name = "tf-sg-rule-race" }
+			tags {
+				Name = "terraform-testacc-security-group-rule-race"
+			}
 		}
 
 		resource "aws_security_group" "race" {
@@ -1555,7 +1559,7 @@ func testAccAWSSecurityGroupRuleSelfInSource(rInt int) string {
 		cidr_block = "10.1.0.0/16"
 
 		tags {
-			Name = "tf_sg_rule_self_group"
+			Name = "terraform-testacc-security-group-rule-self-ingress"
 		}
 	}
 
@@ -1581,7 +1585,7 @@ func testAccAWSSecurityGroupRuleExpectInvalidType(rInt int) string {
 		cidr_block = "10.1.0.0/16"
 
 		tags {
-			Name = "tf_sg_rule_self_group"
+			Name = "terraform-testacc-security-group-rule-invalid-type"
 		}
 	}
 

--- a/aws/resource_aws_security_group_test.go
+++ b/aws/resource_aws_security_group_test.go
@@ -1611,6 +1611,9 @@ func TestAccAWSSecurityGroup_failWithDiffMismatch(t *testing.T) {
 const testAccAWSSecurityGroupConfigForTagsOrdering = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
+  tags {
+    Name = "terraform-testacc-security-group-tags-ordering"
+  }
 }
 
 resource "aws_security_group" "web" {
@@ -1640,6 +1643,9 @@ resource "aws_security_group" "web" {
 const testAccAWSSecurityGroupConfigIpv6 = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
+  tags {
+    Name = "terraform-testacc-security-group-ipv6"
+  }
 }
 
 resource "aws_security_group" "web" {
@@ -1671,7 +1677,7 @@ const testAccAWSSecurityGroupConfig = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "tf-acc-revoke-test"
+		Name = "terraform-testacc-security-group"
 	}
 }
 
@@ -1697,7 +1703,7 @@ const testAccAWSSecurityGroupConfig_revoke_base_removed = `
 resource "aws_vpc" "sg-race-revoke" {
   cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "tf-acc-revoke-test"
+		Name = "terraform-testacc-security-group-revoke"
 	}
 }
 `
@@ -1705,7 +1711,7 @@ const testAccAWSSecurityGroupConfig_revoke_base = `
 resource "aws_vpc" "sg-race-revoke" {
   cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "tf-acc-revoke-test"
+		Name = "terraform-testacc-security-group-revoke"
 	}
 }
 
@@ -1734,7 +1740,7 @@ const testAccAWSSecurityGroupConfig_revoke_false = `
 resource "aws_vpc" "sg-race-revoke" {
   cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "tf-acc-revoke-test"
+		Name = "terraform-testacc-security-group-revoke"
 	}
 }
 
@@ -1767,7 +1773,7 @@ const testAccAWSSecurityGroupConfig_revoke_true = `
 resource "aws_vpc" "sg-race-revoke" {
   cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "tf-acc-revoke-test"
+		Name = "terraform-testacc-security-group-revoke"
 	}
 }
 
@@ -1799,6 +1805,9 @@ resource "aws_security_group" "secondary" {
 const testAccAWSSecurityGroupConfigChange = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
+  tags {
+    Name = "terraform-testacc-security-group-change"
+  }
 }
 
 resource "aws_security_group" "web" {
@@ -1832,6 +1841,9 @@ resource "aws_security_group" "web" {
 const testAccAWSSecurityGroupConfigRuleDescription = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
+  tags {
+    Name = "terraform-testacc-security-group-description"
+  }
 }
 
 resource "aws_security_group" "web" {
@@ -1843,16 +1855,16 @@ resource "aws_security_group" "web" {
     protocol = "6"
     from_port = 80
     to_port = 8000
-		cidr_blocks = ["10.0.0.0/8"]
-		description = "Ingress description"
+    cidr_blocks = ["10.0.0.0/8"]
+    description = "Ingress description"
   }
 
   egress {
     protocol = "tcp"
     from_port = 80
     to_port = 8000
-		cidr_blocks = ["10.0.0.0/8"]
-		description = "Egress description"
+    cidr_blocks = ["10.0.0.0/8"]
+    description = "Egress description"
   }
 
 	tags {
@@ -1864,6 +1876,9 @@ resource "aws_security_group" "web" {
 const testAccAWSSecurityGroupConfigChangeRuleDescription = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
+  tags {
+    Name = "terraform-testacc-security-group-change-rule-desc"
+  }
 }
 
 resource "aws_security_group" "web" {
@@ -1887,15 +1902,18 @@ resource "aws_security_group" "web" {
 		description = "New egress description"
   }
 
-	tags {
-		Name = "tf-acc-test"
-	}
+  tags {
+    Name = "tf-acc-test"
+  }
 }
 `
 
 const testAccAWSSecurityGroupConfigSelf = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
+  tags {
+    Name = "terraform-testacc-security-group-self"
+  }
 }
 
 resource "aws_security_group" "web" {
@@ -1922,6 +1940,9 @@ resource "aws_security_group" "web" {
 const testAccAWSSecurityGroupConfigVpc = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
+  tags {
+    Name = "terraform-testacc-security-group-vpc"
+  }
 }
 
 resource "aws_security_group" "web" {
@@ -1948,6 +1969,9 @@ resource "aws_security_group" "web" {
 const testAccAWSSecurityGroupConfigVpcNegOneIngress = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
+	tags {
+		Name = "terraform-testacc-security-group-vpc-neg-one-ingress"
+	}
 }
 
 resource "aws_security_group" "web" {
@@ -1967,6 +1991,9 @@ resource "aws_security_group" "web" {
 const testAccAWSSecurityGroupConfigVpcProtoNumIngress = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
+	tags {
+		Name = "terraform-testacc-security-group-vpc-proto-num-ingress"
+	}
 }
 
 resource "aws_security_group" "web" {
@@ -1986,6 +2013,9 @@ resource "aws_security_group" "web" {
 const testAccAWSSecurityGroupConfigMultiIngress = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
+	tags {
+		Name = "terraform-testacc-security-group-multi-ingress"
+	}
 }
 
 resource "aws_security_group" "worker" {
@@ -2046,6 +2076,9 @@ resource "aws_security_group" "web" {
 const testAccAWSSecurityGroupConfigTags = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
+	tags {
+		Name = "terraform-testacc-security-group-tags"
+	}
 }
 
 resource "aws_security_group" "foo" {
@@ -2076,6 +2109,9 @@ resource "aws_security_group" "foo" {
 const testAccAWSSecurityGroupConfigTagsUpdate = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
+	tags {
+		Name = "terraform-testacc-security-group-tags"
+	}
 }
 
 resource "aws_security_group" "foo" {
@@ -2107,6 +2143,9 @@ resource "aws_security_group" "foo" {
 const testAccAWSSecurityGroupConfig_generatedName = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
+	tags {
+		Name = "terraform-testacc-security-group-generated-name"
+	}
 }
 
 resource "aws_security_group" "web" {
@@ -2134,10 +2173,10 @@ resource "aws_security_group" "web" {
 
 const testAccAWSSecurityGroupConfigDefaultEgress = `
 resource "aws_vpc" "tf_sg_egress_test" {
-        cidr_block = "10.0.0.0/16"
-        tags {
-                Name = "tf_sg_egress_test"
-        }
+    cidr_block = "10.0.0.0/16"
+    tags {
+        Name = "terraform-testacc-security-group-default-egress"
+    }
 }
 
 resource "aws_security_group" "worker" {
@@ -2207,6 +2246,9 @@ func testAccAWSSecurityGroupConfig_drift_complex() string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
+	tags {
+		Name = "terraform-testacc-security-group-drift-complex"
+	}
 }
 
 resource "aws_security_group" "otherweb" {
@@ -2319,6 +2361,9 @@ resource "aws_security_group" "foo" {
 const testAccAWSSecurityGroupCombindCIDRandGroups = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
+	tags {
+		Name = "terraform-testacc-security-group-combine-rand-groups"
+	}
 }
 
 resource "aws_security_group" "two" {
@@ -2371,6 +2416,9 @@ resource "aws_security_group" "mixed" {
 const testAccAWSSecurityGroupConfig_ingressWithCidrAndSGs = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
+	tags {
+		Name = "terraform-testacc-security-group-ingress-w-cidr-and-sg"
+	}
 }
 
 resource "aws_security_group" "other_web" {
@@ -2468,7 +2516,7 @@ resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "tf-test"
+    Name = "terraform-testacc-security-group-fail-w-diff-mismatch"
   }
 }
 
@@ -2512,7 +2560,7 @@ resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
   tags {
-    Name = "tf_sg_import_test"
+    Name = "terraform-testacc-security-group-import-self"
   }
 }
 
@@ -2548,7 +2596,7 @@ resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
   tags {
-    Name = "tf_sg_import_test"
+    Name = "terraform-testacc-security-group-import-source-sg"
   }
 }
 
@@ -2593,7 +2641,7 @@ resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
   tags {
-    Name = "tf_sg_import_test"
+    Name = "terraform-testacc-security-group-import-ip-range-and-sg"
   }
 }
 
@@ -2643,7 +2691,7 @@ resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
   tags {
-    Name = "tf_sg_import_test"
+    Name = "terraform-testacc-security-group-import-ip-ranges"
   }
 }
 
@@ -2678,7 +2726,7 @@ resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
   assign_generated_ipv6_cidr_block = true
   tags {
-      Name = "tf_sg_ipv4_and_ipv6_acc_test"
+      Name = "terraform-testacc-security-group-ipv4-and-ipv6-egress"
   }
 }
 
@@ -2711,7 +2759,7 @@ const testAccAWSSecurityGroupConfigPrefixListEgress = `
 resource "aws_vpc" "tf_sg_prefix_list_egress_test" {
     cidr_block = "10.0.0.0/16"
     tags {
-            Name = "tf_sg_prefix_list_egress_test"
+        Name = "terraform-testacc-security-group-prefix-list-egress"
     }
 }
 

--- a/aws/resource_aws_service_discovery_private_dns_namespace_test.go
+++ b/aws/resource_aws_service_discovery_private_dns_namespace_test.go
@@ -67,6 +67,9 @@ func testAccServiceDiscoveryPrivateDnsNamespaceConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
+  tags {
+    Name = "terraform-testacc-service-discovery-private-dns-ns"
+  }
 }
 
 resource "aws_service_discovery_private_dns_namespace" "test" {

--- a/aws/resource_aws_service_discovery_service_test.go
+++ b/aws/resource_aws_service_discovery_service_test.go
@@ -147,6 +147,9 @@ func testAccServiceDiscoveryServiceConfig_private(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
+  tags {
+    Name = "terraform-testacc-service-discovery-service-private"
+  }
 }
 
 resource "aws_service_discovery_private_dns_namespace" "test" {
@@ -172,6 +175,9 @@ func testAccServiceDiscoveryServiceConfig_private_update(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
+  tags {
+    Name = "terraform-testacc-service-discovery-service-private"
+  }
 }
 
 resource "aws_service_discovery_private_dns_namespace" "test" {

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -886,6 +886,9 @@ EOF
 
 resource "aws_vpc" "foo" {
     cidr_block = "10.1.0.0/16"
+    tags {
+        Name = "terraform-testacc-spot-fleet-request-w-subnet"
+    }
 }
 
 resource "aws_subnet" "foo" {
@@ -1066,6 +1069,9 @@ EOF
 
 resource "aws_vpc" "foo" {
     cidr_block = "10.1.0.0/16"
+    tags {
+        Name = "terraform-testacc-spot-fleet-request-multi-instance-types"
+    }
 }
 
 resource "aws_subnet" "foo" {
@@ -1080,7 +1086,7 @@ resource "aws_spot_fleet_request" "foo" {
     target_capacity = 4
     valid_until = "2019-11-04T20:44:20Z"
     terminate_instances_with_expiration = true
-	wait_for_fulfillment = true
+    wait_for_fulfillment = true
     launch_specification {
         instance_type = "m3.large"
         ami = "ami-d0f506b0"

--- a/aws/resource_aws_spot_instance_request_test.go
+++ b/aws/resource_aws_spot_instance_request_test.go
@@ -454,6 +454,9 @@ func testAccAWSSpotInstanceRequestConfigVPC(rInt int) string {
 	return fmt.Sprintf(`
 	resource "aws_vpc" "foo_VPC" {
 		cidr_block = "10.1.0.0/16"
+		tags {
+			Name = "terraform-testacc-spot-instance-request-vpc"
+		}
 	}
 
 	resource "aws_subnet" "foo_VPC" {
@@ -505,7 +508,7 @@ func testAccAWSSpotInstanceRequestConfig_SubnetAndSGAndPublicIpAddress(rInt int)
 		enable_dns_hostnames = true
 
 		tags {
-			Name = "tf_test_vpc"
+			Name = "terraform-testacc-spot-instance-request-subnet-and-sg-public-ip"
 		}
 	}
 

--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -259,6 +259,9 @@ func testAccCheckSubnetExists(n string, v *ec2.Subnet) resource.TestCheckFunc {
 const testAccSubnetConfig = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
+	tags {
+		Name = "terraform-testacc-subnet"
+	}
 }
 
 resource "aws_subnet" "foo" {
@@ -275,6 +278,9 @@ const testAccSubnetConfigPreIpv6 = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.10.0.0/16"
 	assign_generated_ipv6_cidr_block = true
+	tags {
+		Name = "terraform-testacc-subnet-ipv6"
+	}
 }
 
 resource "aws_subnet" "foo" {
@@ -291,6 +297,9 @@ const testAccSubnetConfigIpv6 = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.10.0.0/16"
 	assign_generated_ipv6_cidr_block = true
+	tags {
+		Name = "terraform-testacc-subnet-ipv6"
+	}
 }
 
 resource "aws_subnet" "foo" {
@@ -309,6 +318,9 @@ const testAccSubnetConfigIpv6UpdateAssignIpv6OnCreation = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.10.0.0/16"
 	assign_generated_ipv6_cidr_block = true
+	tags {
+		Name = "terraform-testacc-subnet-assign-ipv6-on-creation"
+	}
 }
 
 resource "aws_subnet" "foo" {
@@ -327,6 +339,9 @@ const testAccSubnetConfigIpv6UpdateIpv6Cidr = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.10.0.0/16"
 	assign_generated_ipv6_cidr_block = true
+	tags {
+		Name = "terraform-testacc-ipv6-update-cidr"
+	}
 }
 
 resource "aws_subnet" "foo" {

--- a/aws/resource_aws_vpc_dhcp_options_association_test.go
+++ b/aws/resource_aws_vpc_dhcp_options_association_test.go
@@ -78,6 +78,9 @@ func testAccCheckDHCPOptionsAssociationExist(n string, vpc *ec2.Vpc) resource.Te
 const testAccDHCPOptionsAssociationConfig = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
+	tags {
+		Name = "terraform-testacc-vpc-dhcp-options-association"
+	}
 }
 
 resource "aws_vpc_dhcp_options" "foo" {

--- a/aws/resource_aws_vpc_endpoint_connection_notification_test.go
+++ b/aws/resource_aws_vpc_endpoint_connection_notification_test.go
@@ -106,7 +106,7 @@ resource "aws_vpc" "nlb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "testAccVpcEndpointConnectionNotificationBasicConfig_vpc"
+    Name = "terraform-testacc-vpc-endpoint-connection-notification"
   }
 }
 
@@ -195,7 +195,7 @@ func testAccVpcEndpointConnectionNotificationModifiedConfig(lbName string) strin
 			cidr_block = "10.0.0.0/16"
 
 			tags {
-				Name = "testAccVpcEndpointConnectionNotificationBasicConfig_vpc"
+				Name = "terraform-testacc-vpc-endpoint-connection-notification"
 			}
 		}
 

--- a/aws/resource_aws_vpc_endpoint_route_table_association_test.go
+++ b/aws/resource_aws_vpc_endpoint_route_table_association_test.go
@@ -109,6 +109,9 @@ provider "aws" {
 
 resource "aws_vpc" "foo" {
     cidr_block = "10.0.0.0/16"
+    tags {
+        Name = "terraform-testacc-vpc-endpoint-route-table-association"
+    }
 }
 
 resource "aws_vpc_endpoint" "s3" {

--- a/aws/resource_aws_vpc_endpoint_service_allowed_principal_test.go
+++ b/aws/resource_aws_vpc_endpoint_service_allowed_principal_test.go
@@ -101,7 +101,7 @@ resource "aws_vpc" "nlb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "testAccVpcEndpointServiceBasicConfig_vpc"
+    Name = "terraform-testacc-vpc-endpoint-service-allowed-principal"
   }
 }
 

--- a/aws/resource_aws_vpc_endpoint_service_test.go
+++ b/aws/resource_aws_vpc_endpoint_service_test.go
@@ -143,7 +143,7 @@ resource "aws_vpc" "nlb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "testAccVpcEndpointServiceBasicConfig_vpc"
+    Name = "terraform-testacc-vpc-endpoint-service"
   }
 }
 
@@ -208,7 +208,7 @@ resource "aws_vpc" "nlb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "testAccVpcEndpointServiceBasicConfig_vpc"
+    Name = "terraform-testacc-vpc-endpoint-service"
   }
 }
 

--- a/aws/resource_aws_vpc_endpoint_subnet_association_test.go
+++ b/aws/resource_aws_vpc_endpoint_subnet_association_test.go
@@ -109,6 +109,9 @@ provider "aws" {
 
 resource "aws_vpc" "foo" {
   cidr_block = "10.0.0.0/16"
+  tags {
+    Name = "terraform-testacc-vpc-endpoint-subnet-association"
+  }
 }
 
 data "aws_security_group" "default" {

--- a/aws/resource_aws_vpc_endpoint_test.go
+++ b/aws/resource_aws_vpc_endpoint_test.go
@@ -294,12 +294,11 @@ func testAccCheckVpcEndpointPrefixListAvailable(n string) resource.TestCheckFunc
 }
 
 const testAccVpcEndpointConfig_gatewayWithRouteTableAndPolicy = `
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_vpc" "foo" {
   cidr_block = "10.0.0.0/16"
+  tags {
+    Name = "terraform-testacc-vpc-endpoint-gw-w-route-table-and-policy"
+  }
 }
 
 resource "aws_subnet" "foo" {
@@ -336,12 +335,11 @@ resource "aws_route_table_association" "main" {
 `
 
 const testAccVpcEndpointConfig_gatewayWithRouteTableAndPolicyModified = `
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_vpc" "foo" {
   cidr_block = "10.0.0.0/16"
+  tags {
+    Name = "terraform-testacc-vpc-endpoint-gw-w-route-table-and-policy"
+  }
 }
 
 resource "aws_subnet" "foo" {
@@ -376,12 +374,11 @@ resource "aws_route_table_association" "main" {
 `
 
 const testAccVpcEndpointConfig_gatewayWithoutRouteTableOrPolicy = `
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_vpc" "foo" {
   cidr_block = "10.0.0.0/16"
+  tags {
+    Name = "terraform-testacc-vpc-endpoint-gw-wout-route-table-or-policy"
+  }
 }
 
 resource "aws_vpc_endpoint" "s3" {
@@ -391,12 +388,11 @@ resource "aws_vpc_endpoint" "s3" {
 `
 
 const testAccVpcEndpointConfig_interfaceWithoutSubnet = `
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_vpc" "foo" {
   cidr_block = "10.0.0.0/16"
+  tags {
+    Name = "terraform-testacc-vpc-endpoint-iface-wout-subnet"
+  }
 }
 
 data "aws_security_group" "default" {
@@ -413,14 +409,13 @@ resource "aws_vpc_endpoint" "ec2" {
 `
 
 const testAccVpcEndpointConfig_interfaceWithSubnet = `
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_vpc" "foo" {
 	cidr_block = "10.0.0.0/16"
 	enable_dns_support = true
 	enable_dns_hostnames = true
+	tags {
+		Name = "terraform-testacc-vpc-endpoint-iface-w-subnet"
+	}
 }
 
 resource "aws_subnet" "sn1" {
@@ -454,14 +449,13 @@ resource "aws_vpc_endpoint" "ec2" {
 `
 
 const testAccVpcEndpointConfig_interfaceWithSubnetModified = `
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_vpc" "foo" {
 	cidr_block = "10.0.0.0/16"
 	enable_dns_support = true
 	enable_dns_hostnames = true
+	tags {
+		Name = "terraform-testacc-vpc-endpoint-iface-w-subnet"
+	}
 }
 
 resource "aws_subnet" "sn1" {
@@ -495,13 +489,12 @@ resource "aws_vpc_endpoint" "ec2" {
 `
 
 func testAccVpcEndpointConfig_interfaceNonAWSService(lbName string) string {
-	return fmt.Sprintf(
-		`
+	return fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "testAccVpcEndpointServiceBasicConfig_vpc"
+    Name = "terraform-testacc-vpc-endpoint-iface-non-aws-svc"
   }
 }
 

--- a/aws/resource_aws_vpc_peering_connection_accepter_test.go
+++ b/aws/resource_aws_vpc_peering_connection_accepter_test.go
@@ -73,14 +73,14 @@ const testAccAwsVPCPeeringConnectionAccepterSameRegion = `
 resource "aws_vpc" "main" {
 	cidr_block = "10.0.0.0/16"
 	tags {
-		Name = "tf-acc-revoke-vpc-peering-connection-accepter-same-region"
+		Name = "terraform-testacc-vpc-peering-conn-accepter-same-region-main"
 	}
 }
 
 resource "aws_vpc" "peer" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "tf-acc-revoke-vpc-peering-connection-accepter-same-region"
+		Name = "terraform-testacc-vpc-peering-conn-accepter-same-region-peer"
 	}
 }
 
@@ -113,7 +113,7 @@ resource "aws_vpc" "main" {
 	provider = "aws.main"
 	cidr_block = "10.0.0.0/16"
 	tags {
-		Name = "tf-acc-revoke-vpc-peering-connection-accepter-different-region"
+		Name = "terraform-testacc-vpc-peering-conn-accepter-diff-region-main"
 	}
 }
 
@@ -121,7 +121,7 @@ resource "aws_vpc" "peer" {
 	provider = "aws.peer"
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "tf-acc-revoke-vpc-peering-connection-accepter-different-region"
+		Name = "terraform-testacc-vpc-peering-conn-accepter-diff-region-peer"
 	}
 }
 

--- a/aws/resource_aws_vpc_peering_connection_test.go
+++ b/aws/resource_aws_vpc_peering_connection_test.go
@@ -367,14 +367,14 @@ const testAccVpcPeeringConfig = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.0.0.0/16"
 	tags {
-		Name = "tf-acc-revoke-vpc-peering-connection-basic"
+		Name = "terraform-testacc-vpc-peering-conn-foo"
 	}
 }
 
 resource "aws_vpc" "bar" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "tf-acc-revoke-vpc-peering-connection-basic"
+		Name = "terraform-testacc-vpc-peering-conn-bar"
 	}
 }
 
@@ -389,14 +389,14 @@ const testAccVpcPeeringConfigTags = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.0.0.0/16"
 	tags {
-		Name = "tf-acc-revoke-vpc-peering-connection-tags"
+		Name = "terraform-testacc-vpc-peering-conn-tags-foo"
 	}
 }
 
 resource "aws_vpc" "bar" {
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "tf-acc-revoke-vpc-peering-connection-tags"
+		Name = "terraform-testacc-vpc-peering-conn-tags-bar"
 	}
 }
 
@@ -414,7 +414,7 @@ const testAccVpcPeeringConfigOptions = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.0.0.0/16"
 	tags {
-		Name = "tf-acc-revoke-vpc-peering-connection-options"
+		Name = "terraform-testacc-vpc-peering-conn-options-foo"
 	}
 }
 
@@ -422,7 +422,7 @@ resource "aws_vpc" "bar" {
 	cidr_block = "10.1.0.0/16"
 	enable_dns_hostnames = true
 	tags {
-		Name = "tf-acc-revoke-vpc-peering-connection-options"
+		Name = "terraform-testacc-vpc-peering-conn-options-bar"
 	}
 }
 
@@ -446,14 +446,14 @@ const testAccVpcPeeringConfigFailedState = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.0.0.0/16"
 	tags {
-		Name = "tf-acc-revoke-vpc-peering-connection-failedState"
+		Name = "terraform-testacc-vpc-peering-conn-failed-state-foo"
 	}
 }
 
 resource "aws_vpc" "bar" {
 	cidr_block = "10.0.0.0/16"
 	tags {
-		Name = "tf-acc-revoke-vpc-peering-connection-failedState"
+		Name = "terraform-testacc-vpc-peering-conn-failed-state-bar"
 	}
 }
 
@@ -478,7 +478,7 @@ resource "aws_vpc" "foo" {
 	provider = "aws.main"
 	cidr_block = "10.0.0.0/16"
 	tags {
-		Name = "tf-acc-revoke-vpc-peering-connection-region"
+		Name = "terraform-testacc-vpc-peering-conn-region-auto-accept-foo"
 	}
 }
 
@@ -486,7 +486,7 @@ resource "aws_vpc" "bar" {
 	provider = "aws.peer"
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "tf-acc-revoke-vpc-peering-connection-region"
+		Name = "terraform-testacc-vpc-peering-conn-region-auto-accept-bar"
 	}
 }
 
@@ -514,7 +514,7 @@ resource "aws_vpc" "foo" {
 	provider = "aws.main"
 	cidr_block = "10.0.0.0/16"
 	tags {
-		Name = "tf-acc-revoke-vpc-peering-connection-region"
+		Name = "terraform-testacc-vpc-peering-conn-region-foo"
 	}
 }
 
@@ -522,7 +522,7 @@ resource "aws_vpc" "bar" {
 	provider = "aws.peer"
 	cidr_block = "10.1.0.0/16"
 	tags {
-		Name = "tf-acc-revoke-vpc-peering-connection-region"
+		Name = "terraform-testacc-vpc-peering-conn-region-bar"
 	}
 }
 

--- a/aws/resource_aws_vpc_test.go
+++ b/aws/resource_aws_vpc_test.go
@@ -37,10 +37,7 @@ func testSweepVPCs(region string) error {
 			{
 				Name: aws.String("tag-value"),
 				Values: []*string{
-					aws.String("tf-acc-revoke*"),
-					aws.String("terraform-testacc-vpc-data-source-*"),
-					aws.String("terraform-testacc-subnet-data-source*"),
-					aws.String("terraform-testacc-vpn-gateway*"),
+					aws.String("terraform-testacc-*"),
 				},
 			},
 		},
@@ -377,6 +374,9 @@ func TestAccAWSVpc_classiclinkDnsSupportOptionSet(t *testing.T) {
 const testAccVpcConfig = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
+	tags {
+		Name = "terraform-testacc-vpc"
+	}
 }
 `
 
@@ -384,12 +384,18 @@ const testAccVpcConfigIpv6Enabled = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	assign_generated_ipv6_cidr_block = true
+	tags {
+		Name = "terraform-testacc-vpc-ipv6"
+	}
 }
 `
 
 const testAccVpcConfigIpv6Disabled = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
+	tags {
+		Name = "terraform-testacc-vpc-ipv6"
+	}
 }
 `
 
@@ -397,6 +403,9 @@ const testAccVpcConfigUpdate = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	enable_dns_hostnames = true
+	tags {
+		Name = "terraform-testacc-vpc"
+	}
 }
 `
 
@@ -406,6 +415,7 @@ resource "aws_vpc" "foo" {
 
 	tags {
 		foo = "bar"
+		Name = "terraform-testacc-vpc-tags"
 	}
 }
 `
@@ -416,14 +426,17 @@ resource "aws_vpc" "foo" {
 
 	tags {
 		bar = "baz"
+		Name = "terraform-testacc-vpc-tags"
 	}
 }
 `
 const testAccVpcDedicatedConfig = `
 resource "aws_vpc" "bar" {
 	instance_tenancy = "dedicated"
-
 	cidr_block = "10.2.0.0/16"
+	tags {
+		Name = "terraform-testacc-vpc-dedicated"
+	}
 }
 `
 
@@ -434,37 +447,41 @@ provider "aws" {
 
 resource "aws_vpc" "bar" {
 	cidr_block = "10.2.0.0/16"
-
 	enable_dns_hostnames = true
 	enable_dns_support = true
+	tags {
+		Name = "terraform-testacc-vpc-both-dns-opts"
+	}
 }
 `
 
 const testAccVpcConfig_DisabledDnsSupport = `
-provider "aws" {
-	region = "us-west-2"
-}
-
 resource "aws_vpc" "bar" {
 	cidr_block = "10.2.0.0/16"
-
 	enable_dns_support = false
+	tags {
+		Name = "terraform-testacc-vpc-disabled-dns-support"
+	}
 }
 `
 
 const testAccVpcConfig_ClassiclinkOption = `
 resource "aws_vpc" "bar" {
 	cidr_block = "172.2.0.0/16"
-
 	enable_classiclink = true
+	tags {
+		Name = "terraform-testacc-vpc-classic-link"
+	}
 }
 `
 
 const testAccVpcConfig_ClassiclinkDnsSupportOption = `
 resource "aws_vpc" "bar" {
 	cidr_block = "172.2.0.0/16"
-
 	enable_classiclink = true
 	enable_classiclink_dns_support = true
+	tags {
+		Name = "terraform-testacc-vpc-classic-link-support"
+	}
 }
 `

--- a/aws/resource_aws_vpn_gateway_attachment_test.go
+++ b/aws/resource_aws_vpn_gateway_attachment_test.go
@@ -144,6 +144,9 @@ func testAccCheckVpnGatewayAttachmentDestroy(s *terraform.State) error {
 const testAccNoVpnGatewayAttachmentConfig = `
 resource "aws_vpc" "test" {
 	cidr_block = "10.0.0.0/16"
+	tags {
+		Name = "terraform-testacc-vpn-gateway-attachment-basic"
+	}
 }
 
 resource "aws_vpn_gateway" "test" { }
@@ -152,6 +155,9 @@ resource "aws_vpn_gateway" "test" { }
 const testAccVpnGatewayAttachmentConfig = `
 resource "aws_vpc" "test" {
 	cidr_block = "10.0.0.0/16"
+	tags {
+		Name = "terraform-testacc-vpn-gateway-attachment-deleted"
+	}
 }
 
 resource "aws_vpn_gateway" "test" { }

--- a/aws/resource_aws_vpn_gateway_route_propagation_test.go
+++ b/aws/resource_aws_vpn_gateway_route_propagation_test.go
@@ -73,6 +73,9 @@ func TestAccAWSVPNGatewayRoutePropagation_basic(t *testing.T) {
 const testAccAWSVPNGatewayRoutePropagation_basic = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
+	tags {
+		Name = "terraform-testacc-vpn-gateway-route-propagation"
+	}
 }
 
 resource "aws_vpn_gateway" "foo" {

--- a/aws/resource_aws_vpn_gateway_test.go
+++ b/aws/resource_aws_vpn_gateway_test.go
@@ -441,7 +441,7 @@ const testAccNoVpnGatewayConfig = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
   tags {
-    Name = "terraform-testacc-vpn-gateway"
+    Name = "terraform-testacc-vpn-gateway-removed"
   }
 }
 `
@@ -466,7 +466,7 @@ const testAccVpnGatewayConfigChangeVPC = `
 resource "aws_vpc" "bar" {
   cidr_block = "10.2.0.0/16"
   tags {
-    Name = "terraform-testacc-vpn-gateway"
+    Name = "terraform-testacc-vpn-gateway-change-vpc"
   }
 }
 
@@ -482,7 +482,7 @@ const testAccCheckVpnGatewayConfigTags = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
   tags {
-    Name = "terraform-testacc-vpn-gateway"
+    Name = "terraform-testacc-vpn-gateway-tags"
   }
 }
 
@@ -498,7 +498,7 @@ const testAccCheckVpnGatewayConfigTagsUpdate = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
   tags {
-    Name = "terraform-testacc-vpn-gateway"
+    Name = "terraform-testacc-vpn-gateway-tags"
   }
 }
 
@@ -514,14 +514,14 @@ const testAccCheckVpnGatewayConfigReattach = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
   tags {
-    Name = "terraform-testacc-vpn-gateway"
+    Name = "terraform-testacc-vpn-gateway-reattach-foo"
   }
 }
 
 resource "aws_vpc" "bar" {
   cidr_block = "10.2.0.0/16"
   tags {
-    Name = "terraform-testacc-vpn-gateway"
+    Name = "terraform-testacc-vpn-gateway-reattach-bar"
   }
 }
 
@@ -544,14 +544,14 @@ const testAccCheckVpnGatewayConfigReattachChange = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
   tags {
-    Name = "terraform-testacc-vpn-gateway"
+    Name = "terraform-testacc-vpn-gateway-reattach-foo"
   }
 }
 
 resource "aws_vpc" "bar" {
   cidr_block = "10.2.0.0/16"
   tags {
-    Name = "terraform-testacc-vpn-gateway"
+    Name = "terraform-testacc-vpn-gateway-reattach-bar"
   }
 }
 
@@ -574,7 +574,7 @@ const testAccVpnGatewayConfigWithAZ = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
   tags {
-    Name = "terraform-testacc-vpn-gateway"
+    Name = "terraform-testacc-vpn-gateway-with-az"
   }
 }
 
@@ -590,6 +590,9 @@ resource "aws_vpn_gateway" "foo" {
 const testAccVpnGatewayConfigWithASN = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
+  tags {
+    Name = "terraform-testacc-vpn-gateway-with-asn"
+  }
 }
 
 resource "aws_vpn_gateway" "foo" {


### PR DESCRIPTION
## Test results

```
=== RUN   TestAccAWSNetworkAclRule_missingParam
--- PASS: TestAccAWSNetworkAclRule_missingParam (17.15s)
=== RUN   TestAccAWSNetworkAcl_ipv6VpcRules
--- PASS: TestAccAWSNetworkAcl_ipv6VpcRules (21.87s)
=== RUN   TestAccAWSNetworkAclRule_deleteRule
--- PASS: TestAccAWSNetworkAclRule_deleteRule (28.38s)
=== RUN   TestAccAWSNetworkAclRule_basic
--- PASS: TestAccAWSNetworkAclRule_basic (28.83s)
=== RUN   TestAccAWSNetworkAcl_espProtocol
--- PASS: TestAccAWSNetworkAcl_espProtocol (62.61s)
=== RUN   TestAccAWSENI_sourceDestCheck
--- PASS: TestAccAWSENI_sourceDestCheck (53.93s)
=== RUN   TestAccAWSOpsworksStackNoVpc
--- PASS: TestAccAWSOpsworksStackNoVpc (27.13s)
=== RUN   TestAccAWSNetworkAcl_OnlyIngressRules_update
--- PASS: TestAccAWSNetworkAcl_OnlyIngressRules_update (113.57s)
=== RUN   TestAccAWSOpsworksStackNoVpcChangeServiceRoleForceNew
--- PASS: TestAccAWSOpsworksStackNoVpcChangeServiceRoleForceNew (46.72s)
=== RUN   TestAccAWSNetworkAcl_CaseSensitivityNoChanges
--- PASS: TestAccAWSNetworkAcl_CaseSensitivityNoChanges (133.93s)
=== RUN   TestAccAWSOpsworksStackNoVpcCreateTags
--- PASS: TestAccAWSOpsworksStackNoVpcCreateTags (38.75s)
=== RUN   TestAccAWSOpsWorksStack_classic_endpoints
--- PASS: TestAccAWSOpsWorksStack_classic_endpoints (34.18s)
=== RUN   TestAccAWSOpsworksStackVpc
--- PASS: TestAccAWSOpsworksStackVpc (151.36s)
=== RUN   TestAccAWSENI_basic
--- PASS: TestAccAWSENI_basic (242.16s)
=== RUN   TestAccAWSENI_computedIPs
--- PASS: TestAccAWSENI_computedIPs (227.59s)
=== RUN   TestAccAWSNetworkAcl_ipv6Rules
--- PASS: TestAccAWSNetworkAcl_ipv6Rules (258.60s)
=== RUN   TestAccAWSNetworkAcl_EgressAndIngressRules
--- PASS: TestAccAWSNetworkAcl_EgressAndIngressRules (261.49s)
=== RUN   TestAccAWSNetworkAcl_OnlyEgressRules
--- PASS: TestAccAWSNetworkAcl_OnlyEgressRules (287.52s)
=== RUN   TestAccAWSNetworkAclRule_allProtocol
--- PASS: TestAccAWSNetworkAclRule_allProtocol (295.03s)
=== RUN   TestAccAWSNetworkAcl_Subnets
--- PASS: TestAccAWSNetworkAcl_Subnets (306.17s)
=== RUN   TestAccAWSNetworkInterfaceAttachment_basic
--- PASS: TestAccAWSNetworkInterfaceAttachment_basic (341.16s)
=== RUN   TestAccAWSENI_ignoreExternalAttachment
--- PASS: TestAccAWSENI_ignoreExternalAttachment (319.35s)
=== RUN   TestAccAWSRDSCluster_missingUserNameCausesError
--- PASS: TestAccAWSRDSCluster_missingUserNameCausesError (2.46s)
=== RUN   TestAccAWSRDSCluster_basic
--- PASS: TestAccAWSRDSCluster_basic (100.44s)
=== RUN   TestAccAWSNatGateway_basic
--- PASS: TestAccAWSNatGateway_basic (368.23s)
=== RUN   TestAccAWSRDSCluster_namePrefix
--- PASS: TestAccAWSRDSCluster_namePrefix (108.62s)
=== RUN   TestAccAWSRDSCluster_generatedName
--- PASS: TestAccAWSRDSCluster_generatedName (105.09s)
=== RUN   TestAccAWSRDSCluster_takeFinalSnapshot
--- PASS: TestAccAWSRDSCluster_takeFinalSnapshot (98.88s)
=== RUN   TestAccAWSNetworkAcl_OnlyIngressRules_basic
--- PASS: TestAccAWSNetworkAcl_OnlyIngressRules_basic (407.09s)
=== RUN   TestAccAWSNetworkAcl_SubnetChange
--- PASS: TestAccAWSNetworkAcl_SubnetChange (416.59s)
=== RUN   TestAccAWSENI_attached
--- PASS: TestAccAWSENI_attached (421.53s)
=== RUN   TestAccAWSNatGateway_tags
--- PASS: TestAccAWSNatGateway_tags (446.31s)
=== RUN   TestAccAWSNetworkAclRule_ipv6
--- PASS: TestAccAWSNetworkAclRule_ipv6 (446.65s)
=== RUN   TestAccAWSRDSCluster_updateTags
--- PASS: TestAccAWSRDSCluster_updateTags (114.17s)
=== RUN   TestAccAWSRDSCluster_updateIamRoles
--- PASS: TestAccAWSRDSCluster_updateIamRoles (113.93s)
=== RUN   TestAccAWSRDSCluster_encrypted
--- PASS: TestAccAWSRDSCluster_encrypted (102.69s)
=== RUN   TestAccAWSRDSCluster_kmsKey
--- PASS: TestAccAWSRDSCluster_kmsKey (128.07s)
=== RUN   TestAccAWSRDSCluster_iamAuth
--- PASS: TestAccAWSRDSCluster_iamAuth (99.50s)
=== RUN   TestAccAWSRDSCluster_backupsUpdate
--- PASS: TestAccAWSRDSCluster_backupsUpdate (123.75s)
=== RUN   TestAccAWSENI_updatedDescription
--- PASS: TestAccAWSENI_updatedDescription (522.18s)
=== RUN   TestAccAWSRedshiftSubnetGroup_basic
--- PASS: TestAccAWSRedshiftSubnetGroup_basic (9.24s)
=== RUN   TestAccAWSRedshiftSubnetGroup_updateDescription
--- PASS: TestAccAWSRedshiftSubnetGroup_updateDescription (15.45s)
=== RUN   TestAccAWSRedshiftSubnetGroup_updateSubnetIds
--- PASS: TestAccAWSRedshiftSubnetGroup_updateSubnetIds (15.29s)
=== RUN   TestAccAWSRedshiftSubnetGroup_tags
--- PASS: TestAccAWSRedshiftSubnetGroup_tags (15.04s)
=== RUN   TestAccAWSRoute53ZoneAssociation_basic
--- PASS: TestAccAWSRoute53ZoneAssociation_basic (120.99s)
=== RUN   TestAccAWSRoute53ZoneAssociation_region
--- PASS: TestAccAWSRoute53ZoneAssociation_region (127.16s)
=== RUN   TestAccAWSRDSClusterInstance_disappears
--- PASS: TestAccAWSRDSClusterInstance_disappears (638.08s)
=== RUN   TestAccAWSRoute53Zone_basic
--- PASS: TestAccAWSRoute53Zone_basic (66.08s)
=== RUN   TestAccAWSRoute53Zone_updateComment
--- PASS: TestAccAWSRoute53Zone_updateComment (74.55s)
=== RUN   TestAccAWSRDSClusterInstance_generatedName
--- PASS: TestAccAWSRDSClusterInstance_generatedName (813.44s)
=== RUN   TestAccAWSRDSClusterInstance_kmsKey
--- PASS: TestAccAWSRDSClusterInstance_kmsKey (742.48s)
=== RUN   TestAccAWSRouteTableAssociation_basic
--- PASS: TestAccAWSRouteTableAssociation_basic (24.17s)
=== RUN   TestAccAWSRDSClusterInstance_withInstanceEnhancedMonitor
--- PASS: TestAccAWSRDSClusterInstance_withInstanceEnhancedMonitor (762.09s)
=== RUN   TestAccAWSRouteTable_basic
--- PASS: TestAccAWSRouteTable_basic (25.55s)
=== RUN   TestAccAWSRoute53Zone_private_basic
--- PASS: TestAccAWSRoute53Zone_private_basic (68.92s)
=== RUN   TestAccAWSRouteTable_ipv6
--- PASS: TestAccAWSRouteTable_ipv6 (8.17s)
=== RUN   TestAccAWSRouteTable_panicEmptyRoute
--- PASS: TestAccAWSRouteTable_panicEmptyRoute (8.58s)
=== RUN   TestAccAWSRouteTable_tags
--- PASS: TestAccAWSRouteTable_tags (20.26s)
=== RUN   TestAccAWSRoute53Zone_private_region
--- PASS: TestAccAWSRoute53Zone_private_region (79.65s)
=== RUN   TestAccAWSRedshiftCluster_basic
--- PASS: TestAccAWSRedshiftCluster_basic (718.51s)
=== RUN   TestAccAWSRouteTable_vgwRoutePropagation
--- PASS: TestAccAWSRouteTable_vgwRoutePropagation (68.64s)
=== RUN   TestAccAWSRouteTable_vpcPeering
--- PASS: TestAccAWSRouteTable_vpcPeering (76.13s)
=== RUN   TestAccAWSRoute_basic
--- PASS: TestAccAWSRoute_basic (74.26s)
=== RUN   TestAccAWSRDSClusterInstance_withInstancePerformanceInsights
--- PASS: TestAccAWSRDSClusterInstance_withInstancePerformanceInsights (894.28s)
=== RUN   TestAccAWSRouteTable_instance
--- PASS: TestAccAWSRouteTable_instance (143.04s)
=== RUN   TestAccAWSRoute_ipv6Support
--- PASS: TestAccAWSRoute_ipv6Support (72.31s)
=== RUN   TestAccAWSRoute_ipv6ToInternetGateway
--- PASS: TestAccAWSRoute_ipv6ToInternetGateway (76.54s)
=== RUN   TestAccAWSRedshiftCluster_kmsKey
--- PASS: TestAccAWSRedshiftCluster_kmsKey (788.76s)
=== RUN   TestAccAWSSecurityGroupRule_Ingress_VPC
--- PASS: TestAccAWSSecurityGroupRule_Ingress_VPC (36.24s)
=== RUN   TestAccAWSRedshiftCluster_loggingEnabled
--- PASS: TestAccAWSRedshiftCluster_loggingEnabled (799.43s)
=== RUN   TestAccAWSSecurityGroupRule_Ingress_Protocol
--- PASS: TestAccAWSSecurityGroupRule_Ingress_Protocol (25.29s)
=== RUN   TestAccAWSRedshiftCluster_loggingEnabledDeprecated
--- PASS: TestAccAWSRedshiftCluster_loggingEnabledDeprecated (828.41s)
=== RUN   TestAccAWSRedshiftCluster_snapshotCopy
--- PASS: TestAccAWSRedshiftCluster_snapshotCopy (826.27s)
=== RUN   TestAccAWSSecurityGroupRule_Ingress_Classic
--- PASS: TestAccAWSSecurityGroupRule_Ingress_Classic (15.71s)
=== RUN   TestAccAWSRoute_changeCidr
--- PASS: TestAccAWSRoute_changeCidr (123.87s)
=== RUN   TestAccAWSSecurityGroupRule_ExpectInvalidTypeError
--- PASS: TestAccAWSSecurityGroupRule_ExpectInvalidTypeError (0.82s)
=== RUN   TestAccAWSSecurityGroupRule_ExpectInvalidCIDR
--- PASS: TestAccAWSSecurityGroupRule_ExpectInvalidCIDR (0.84s)
=== RUN   TestAccAWSRedshiftCluster_tags
--- PASS: TestAccAWSRedshiftCluster_tags (814.05s)
=== RUN   TestAccAWSSecurityGroupRule_Egress
--- PASS: TestAccAWSSecurityGroupRule_Egress (40.26s)
=== RUN   TestAccAWSRedshiftCluster_publiclyAccessible
--- PASS: TestAccAWSRedshiftCluster_publiclyAccessible (856.98s)
=== RUN   TestAccAWSRoute_ipv6ToNetworkInterface
--- PASS: TestAccAWSRoute_ipv6ToNetworkInterface (201.88s)
=== RUN   TestAccAWSSecurityGroupRule_Issue5310
--- PASS: TestAccAWSSecurityGroupRule_Issue5310 (14.69s)
=== RUN   TestAccAWSRedshiftCluster_withFinalSnapshot
--- PASS: TestAccAWSRedshiftCluster_withFinalSnapshot (930.66s)
=== RUN   TestAccAWSSecurityGroupRule_SelfReference
--- PASS: TestAccAWSSecurityGroupRule_SelfReference (58.06s)
=== RUN   TestAccAWSRoute_doesNotCrashWithVPCEndpoint
--- PASS: TestAccAWSRoute_doesNotCrashWithVPCEndpoint (157.47s)
=== RUN   TestAccAWSRedshiftCluster_enhancedVpcRoutingEnabled
--- PASS: TestAccAWSRedshiftCluster_enhancedVpcRoutingEnabled (935.15s)
=== RUN   TestAccAWSSecurityGroupRule_EgressDescription
--- FAIL: TestAccAWSSecurityGroupRule_EgressDescription (35.02s)
	testing.go:573: Error destroying resource! WARNING: Dangling resources
		may exist. The full state and error is shown below.
		
		Error: Check failed: Security Group (sg-7a37b805) still exists.
		
		State: <no state>
FAIL
=== RUN   TestAccAWSSecurityGroupRule_IngressDescription
--- PASS: TestAccAWSSecurityGroupRule_IngressDescription (68.86s)
=== RUN   TestAccAWSSecurityGroupRule_EgressDescription_updates
--- PASS: TestAccAWSSecurityGroupRule_EgressDescription_updates (65.26s)
=== RUN   TestAccAWSRedshiftCluster_iamRoles
--- PASS: TestAccAWSRedshiftCluster_iamRoles (987.72s)
=== RUN   TestAccAWSRoute_ipv6ToInstance
--- PASS: TestAccAWSRoute_ipv6ToInstance (324.37s)
=== RUN   TestAccAWSSecurityGroupRule_PartialMatching_basic
--- PASS: TestAccAWSSecurityGroupRule_PartialMatching_basic (173.02s)
=== RUN   TestAccAWSSecurityGroupRule_PartialMatching_Source
--- PASS: TestAccAWSSecurityGroupRule_PartialMatching_Source (176.87s)
=== RUN   TestAccAWSSecurityGroupRule_IngressDescription_updates
--- PASS: TestAccAWSSecurityGroupRule_IngressDescription_updates (141.82s)
=== RUN   TestAccAWSSecurityGroup_namePrefix
--- PASS: TestAccAWSSecurityGroup_namePrefix (11.29s)
=== RUN   TestAccAWSSecurityGroup_basic
--- PASS: TestAccAWSSecurityGroup_basic (114.24s)
=== RUN   TestAccAWSRoute53Zone_forceDestroy
--- PASS: TestAccAWSRoute53Zone_forceDestroy (648.41s)
=== RUN   TestAccAWSRoute_noopdiff
--- PASS: TestAccAWSRoute_noopdiff (340.97s)
=== RUN   TestAccAWSSecurityGroup_basicRuleDescription
--- PASS: TestAccAWSSecurityGroup_basicRuleDescription (103.59s)
=== RUN   TestAccAWSSecurityGroupRule_Ingress_Ipv6
--- PASS: TestAccAWSSecurityGroupRule_Ingress_Ipv6 (328.97s)
=== RUN   TestAccAWSSecurityGroup_tagsCreatedFirst
--- PASS: TestAccAWSSecurityGroup_tagsCreatedFirst (85.75s)
=== RUN   TestAccAWSSecurityGroup_ipv6
--- PASS: TestAccAWSSecurityGroup_ipv6 (135.65s)
=== RUN   TestAccAWSRDSClusterInstance_basic
--- PASS: TestAccAWSRDSClusterInstance_basic (1462.90s)
=== RUN   TestAccAWSSecurityGroupRule_MultiIngress
--- FAIL: TestAccAWSSecurityGroupRule_MultiIngress (343.86s)
	testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
		
		* aws_security_group_rule.ingress_1: 1 error(s) occurred:
		
		* aws_security_group_rule.ingress_1: Error finding matching ingress Security Group Rule (sgrule-1591657911) for Group sg-b13cb3ce
=== RUN   TestAccAWSSecurityGroup_self
--- PASS: TestAccAWSSecurityGroup_self (120.42s)
=== RUN   TestAccAWSSecurityGroup_DefaultEgress_Classic
--- PASS: TestAccAWSSecurityGroup_DefaultEgress_Classic (14.50s)
=== RUN   TestAccAWSSecurityGroup_vpcProtoNumIngress
--- PASS: TestAccAWSSecurityGroup_vpcProtoNumIngress (112.14s)
=== RUN   TestAccAWSSecurityGroup_invalidCIDRBlock
--- PASS: TestAccAWSSecurityGroup_invalidCIDRBlock (0.96s)
=== RUN   TestAccAWSSecurityGroup_DefaultEgress_VPC
--- PASS: TestAccAWSSecurityGroup_DefaultEgress_VPC (68.23s)
=== RUN   TestAccAWSSecurityGroupRule_SelfSource
--- PASS: TestAccAWSSecurityGroupRule_SelfSource (341.10s)
=== RUN   TestAccAWSSecurityGroup_vpc
--- PASS: TestAccAWSSecurityGroup_vpc (161.63s)
=== RUN   TestAccAWSSecurityGroup_MultiIngress
--- PASS: TestAccAWSSecurityGroup_MultiIngress (133.16s)
=== RUN   TestAccAWSSecurityGroup_ingressWithCidrAndSGs_classic
--- PASS: TestAccAWSSecurityGroup_ingressWithCidrAndSGs_classic (16.45s)
=== RUN   TestAccAWSSecurityGroupRule_PrefixListEgress
--- PASS: TestAccAWSSecurityGroupRule_PrefixListEgress (393.56s)
=== RUN   TestAccAWSSecurityGroup_drift
--- PASS: TestAccAWSSecurityGroup_drift (129.63s)
=== RUN   TestAccAWSSecurityGroup_generatedName
--- PASS: TestAccAWSSecurityGroup_generatedName (169.14s)
=== RUN   TestAccAWSSecurityGroup_drift_complex
--- PASS: TestAccAWSSecurityGroup_drift_complex (137.89s)
=== RUN   TestAccAWSSecurityGroup_ingressWithCidrAndSGs
--- PASS: TestAccAWSSecurityGroup_ingressWithCidrAndSGs (131.56s)
=== RUN   TestAccAWSSecurityGroup_ChangeRuleDescription
--- PASS: TestAccAWSSecurityGroup_ChangeRuleDescription (233.13s)
=== RUN   TestAccAWSSecurityGroup_CIDRandGroups
--- PASS: TestAccAWSSecurityGroup_CIDRandGroups (151.47s)
=== RUN   TestAccAWSSecurityGroupRule_MultiDescription
--- PASS: TestAccAWSSecurityGroupRule_MultiDescription (452.27s)
=== RUN   TestAccAWSSecurityGroup_failWithDiffMismatch
--- PASS: TestAccAWSSecurityGroup_failWithDiffMismatch (98.16s)
=== RUN   TestAccAWSSecurityGroup_Change
--- PASS: TestAccAWSSecurityGroup_Change (253.88s)
=== RUN   TestAccAWSSecurityGroup_egressWithPrefixList
--- PASS: TestAccAWSSecurityGroup_egressWithPrefixList (146.37s)
=== RUN   TestAccAWSRDSClusterInstance_namePrefix
--- PASS: TestAccAWSRDSClusterInstance_namePrefix (1730.66s)
=== RUN   TestAccAwsServiceDiscoveryPrivateDnsNamespace_basic
--- PASS: TestAccAwsServiceDiscoveryPrivateDnsNamespace_basic (123.34s)
=== RUN   TestAccAwsServiceDiscoveryService_public
--- PASS: TestAccAwsServiceDiscoveryService_public (135.88s)
=== RUN   TestAccAwsServiceDiscoveryService_private
--- PASS: TestAccAwsServiceDiscoveryService_private (166.09s)
=== RUN   TestAccAwsServiceDiscoveryService_import
--- FAIL: TestAccAwsServiceDiscoveryService_import (142.90s)
	testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
		
		* aws_service_discovery_private_dns_namespace.test: 1 error(s) occurred:
		
		* aws_service_discovery_private_dns_namespace.test: unexpected state 'FAIL', wanted target 'SUCCESS'. last error: %!s(<nil>)
=== RUN   TestAccAWSSecurityGroup_ipv4andipv6Egress
--- PASS: TestAccAWSSecurityGroup_ipv4andipv6Egress (276.94s)
=== RUN   TestAccAWSRedshiftCluster_forceNewUsername
--- PASS: TestAccAWSRedshiftCluster_forceNewUsername (1509.32s)
=== RUN   TestAccAWSRoute_ipv6ToPeeringConnection
--- PASS: TestAccAWSRoute_ipv6ToPeeringConnection (885.26s)
=== RUN   TestAccAWSSecurityGroup_forceRevokeRules_true
--- PASS: TestAccAWSSecurityGroup_forceRevokeRules_true (599.24s)
=== RUN   TestAccAWSSpotFleetRequest_CannotUseEmptyKeyName
--- PASS: TestAccAWSSpotFleetRequest_CannotUseEmptyKeyName (0.00s)
=== RUN   TestAccAWSSecurityGroup_tags
--- PASS: TestAccAWSSecurityGroup_tags (433.20s)
=== RUN   TestAccAWSSpotFleetRequest_instanceInterruptionBehavior
--- PASS: TestAccAWSSpotFleetRequest_instanceInterruptionBehavior (289.36s)
=== RUN   TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion (281.11s)
=== RUN   TestAccAWSSpotFleetRequest_placementTenancy
--- PASS: TestAccAWSSpotFleetRequest_placementTenancy (84.51s)
=== RUN   TestAccAWSSpotInstanceRequest_basic
--- PASS: TestAccAWSSpotInstanceRequest_basic (114.22s)
=== RUN   TestAccAWSSpotInstanceRequest_withLaunchGroup
--- PASS: TestAccAWSSpotInstanceRequest_withLaunchGroup (87.60s)
=== RUN   TestAccAWSSubnet_basic
--- PASS: TestAccAWSSubnet_basic (42.80s)
=== RUN   TestAccAWSSpotFleetRequest_associatePublicIpAddress
--- PASS: TestAccAWSSpotFleetRequest_associatePublicIpAddress (407.41s)
=== RUN   TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet (334.36s)
=== RUN   TestAccAWSSpotInstanceRequest_withBlockDuration
--- PASS: TestAccAWSSpotInstanceRequest_withBlockDuration (146.37s)
=== RUN   TestAccAWSSpotInstanceRequest_vpc
--- PASS: TestAccAWSSpotInstanceRequest_vpc (151.46s)
=== RUN   TestAccAWSSpotFleetRequest_diversifiedAllocation
--- PASS: TestAccAWSSpotFleetRequest_diversifiedAllocation (358.87s)
=== RUN   TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz (410.40s)
=== RUN   TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList
--- FAIL: TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList (480.43s)
	testing.go:573: Error destroying resource! WARNING: Dangling resources
		may exist. The full state and error is shown below.
		
		Error: Error applying: 1 error(s) occurred:
		
		* aws_spot_fleet_request.foo (destroy): 1 error(s) occurred:
		
		* aws_spot_fleet_request.foo: fleet still has (2) running instances
		
...
=== RUN   TestAccAWSDHCPOptionsAssociation_basic
--- PASS: TestAccAWSDHCPOptionsAssociation_basic (99.07s)
=== RUN   TestAccAWSSpotInstanceRequest_SubnetAndSGAndPublicIpAddress
--- PASS: TestAccAWSSpotInstanceRequest_SubnetAndSGAndPublicIpAddress (199.05s)
=== RUN   TestAccAWSSecurityGroup_forceRevokeRules_false
--- PASS: TestAccAWSSecurityGroup_forceRevokeRules_false (877.02s)
=== RUN   TestAccAWSSpotFleetRequest_withWeightedCapacity
--- PASS: TestAccAWSSpotFleetRequest_withWeightedCapacity (400.53s)
=== RUN   TestAccAWSSpotFleetRequest_withEBSDisk
--- PASS: TestAccAWSSpotFleetRequest_withEBSDisk (383.07s)
=== RUN   TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList (526.76s)
=== RUN   TestAccAWSSpotFleetRequest_overriddingSpotPrice
--- FAIL: TestAccAWSSpotFleetRequest_overriddingSpotPrice (459.01s)
	testing.go:573: Error destroying resource! WARNING: Dangling resources
		may exist. The full state and error is shown below.
		
		Error: Error applying: 1 error(s) occurred:
		
		* aws_spot_fleet_request.foo (destroy): 1 error(s) occurred:
		
		* aws_spot_fleet_request.foo: fleet still has (2) running instances
		
...
=== RUN   TestAccAWSSpotFleetRequest_withTags
--- PASS: TestAccAWSSpotFleetRequest_withTags (341.15s)
=== RUN   TestAccAwsVpcEndpointRouteTableAssociation_basic
--- PASS: TestAccAwsVpcEndpointRouteTableAssociation_basic (112.87s)
=== RUN   TestAccAWSSubnet_enableIpv6
--- PASS: TestAccAWSSubnet_enableIpv6 (206.69s)
=== RUN   TestAccAWSSpotFleetRequest_changePriceForcesNewRequest
--- PASS: TestAccAWSSpotFleetRequest_changePriceForcesNewRequest (595.68s)
=== RUN   TestAccAWSSpotInstanceRequest_NetworkInterfaceAttributes
--- PASS: TestAccAWSSpotInstanceRequest_NetworkInterfaceAttributes (287.74s)
=== RUN   TestAccAWSVPCPeeringConnectionAccepter_sameRegion
--- PASS: TestAccAWSVPCPeeringConnectionAccepter_sameRegion (99.78s)
=== RUN   TestAccAWSVPCPeeringConnectionAccepter_differentRegion
--- PASS: TestAccAWSVPCPeeringConnectionAccepter_differentRegion (120.48s)
=== RUN   TestAccAwsVpcEndpoint_removed
--- PASS: TestAccAwsVpcEndpoint_removed (130.77s)
=== RUN   TestAccAWSVPCPeeringConnection_peerRegionAndAutoAccept
--- PASS: TestAccAWSVPCPeeringConnection_peerRegionAndAutoAccept (46.45s)
=== RUN   TestAccAwsVpcEndpoint_interfaceBasic
--- PASS: TestAccAwsVpcEndpoint_interfaceBasic (240.10s)
=== RUN   TestAccAWSVPCPeeringConnection_basic
--- PASS: TestAccAWSVPCPeeringConnection_basic (210.95s)
=== RUN   TestAccAwsVpcEndpointService_removed
--- PASS: TestAccAwsVpcEndpointService_removed (338.59s)
=== RUN   TestAccAWSVPCPeeringConnection_region
--- PASS: TestAccAWSVPCPeeringConnection_region (112.29s)
=== RUN   TestAccAWSVpc_dedicatedTenancy
--- PASS: TestAccAWSVpc_dedicatedTenancy (19.23s)
=== RUN   TestAccAWSVpc_basic
--- PASS: TestAccAWSVpc_basic (80.37s)
=== RUN   TestAccAwsVpcEndpoint_gatewayBasic
--- PASS: TestAccAwsVpcEndpoint_gatewayBasic (348.55s)
=== RUN   TestAccAwsVpcEndpoint_gatewayWithRouteTableAndPolicy
--- PASS: TestAccAwsVpcEndpoint_gatewayWithRouteTableAndPolicy (351.89s)
=== RUN   TestAccAWSSubnet_ipv6
--- PASS: TestAccAWSSubnet_ipv6 (472.09s)
=== RUN   TestAccAWSVpc_bothDnsOptionsSet
--- PASS: TestAccAWSVpc_bothDnsOptionsSet (33.94s)
=== RUN   TestAccAwsVpcEndpoint_interfaceWithSubnetAndSecurityGroup
--- PASS: TestAccAwsVpcEndpoint_interfaceWithSubnetAndSecurityGroup (346.23s)
=== RUN   TestAccAWSVpc_DisabledDnsSupport
--- PASS: TestAccAWSVpc_DisabledDnsSupport (36.23s)
=== RUN   TestAccAWSVPCPeeringConnection_tags
--- PASS: TestAccAWSVPCPeeringConnection_tags (268.63s)
=== RUN   TestAccAWSVPCPeeringConnection_plan
--- PASS: TestAccAWSVPCPeeringConnection_plan (305.60s)
=== RUN   TestAccAwsVpcEndpointServiceAllowedPrincipal_basic
--- PASS: TestAccAwsVpcEndpointServiceAllowedPrincipal_basic (474.21s)
=== RUN   TestAccAWSVpc_classiclinkOptionSet
--- PASS: TestAccAWSVpc_classiclinkOptionSet (110.96s)
=== RUN   TestAccAWSVPNGatewayRoutePropagation_basic
--- PASS: TestAccAWSVPNGatewayRoutePropagation_basic (110.57s)
=== RUN   TestAccAwsVpcEndpoint_interfaceNonAWSService
--- PASS: TestAccAwsVpcEndpoint_interfaceNonAWSService (460.37s)
=== RUN   TestAccAWSVpc_enableIpv6
--- PASS: TestAccAWSVpc_enableIpv6 (212.75s)
=== RUN   TestAccAWSVpc_tags
--- PASS: TestAccAWSVpc_tags (230.47s)
=== RUN   TestAccAWSVpnGateway_withAvailabilityZoneSetToState
--- PASS: TestAccAWSVpnGateway_withAvailabilityZoneSetToState (164.11s)
=== RUN   TestAccAWSVPCPeeringConnection_options
--- PASS: TestAccAWSVPCPeeringConnection_options (438.21s)
=== RUN   TestAccAWSVpc_classiclinkDnsSupportOptionSet
--- PASS: TestAccAWSVpc_classiclinkDnsSupportOptionSet (246.74s)
=== RUN   TestAccAWSVpnGateway_withAmazonSideAsnSetToState
--- PASS: TestAccAWSVpnGateway_withAmazonSideAsnSetToState (169.39s)
=== RUN   TestAccAWSVpc_update
--- PASS: TestAccAWSVpc_update (296.38s)
=== RUN   TestAccAWSVpnGatewayAttachment_basic
--- PASS: TestAccAWSVpnGatewayAttachment_basic (264.68s)
=== RUN   TestAccAwsVpcEndpointService_basic
--- PASS: TestAccAwsVpcEndpointService_basic (687.44s)
=== RUN   TestAccAWSVpnGateway_delete
--- PASS: TestAccAWSVpnGateway_delete (173.01s)
=== RUN   TestAccAWSSecurityGroupRule_Race
--- PASS: TestAccAWSSecurityGroupRule_Race (1703.09s)
=== RUN   TestAccAWSSecurityGroup_vpcNegOneIngress
--- PASS: TestAccAWSSecurityGroup_vpcNegOneIngress (1509.75s)
=== RUN   TestAccAWSVpnGateway_reattach
--- PASS: TestAccAWSVpnGateway_reattach (242.67s)
=== RUN   TestAccAWSVpnGateway_basic
--- PASS: TestAccAWSVpnGateway_basic (354.91s)
=== RUN   TestAccAwsVpcEndpointSubnetAssociation_basic
--- PASS: TestAccAwsVpcEndpointSubnetAssociation_basic (776.09s)
=== RUN   TestAccAWSVpnGateway_tags
--- PASS: TestAccAWSVpnGateway_tags (256.94s)
=== RUN   TestAccAWSVPCPeeringConnection_failedState
--- PASS: TestAccAWSVPCPeeringConnection_failedState (618.48s)
=== RUN   TestAccAWSVpnGatewayAttachment_deleted
--- PASS: TestAccAWSVpnGatewayAttachment_deleted (412.92s)
=== RUN   TestAccAWSRedshiftCluster_updateNodeCount
--- PASS: TestAccAWSRedshiftCluster_updateNodeCount (2634.49s)
=== RUN   TestAccAwsVpcEndpointConnectionNotification_basic
--- PASS: TestAccAwsVpcEndpointConnectionNotification_basic (943.37s)
=== RUN   TestAccAWSVpnGateway_disappears
--- PASS: TestAccAWSVpnGateway_disappears (429.53s)
```