### PR TITLE
resource/cognito_user_pool_client: support USER_PASSWORD_AUTH for explicit_auth_flows

### DIFF
--- a/aws/resource_aws_cognito_user_pool_client.go
+++ b/aws/resource_aws_cognito_user_pool_client.go
@@ -53,6 +53,7 @@ func resourceAwsCognitoUserPoolClient() *schema.Resource {
 					ValidateFunc: validation.StringInSlice([]string{
 						cognitoidentityprovider.ExplicitAuthFlowsTypeAdminNoSrpAuth,
 						cognitoidentityprovider.ExplicitAuthFlowsTypeCustomAuthFlowOnly,
+						cognitoidentityprovider.ExplicitAuthFlowsTypeUserPasswordAuth,
 					}, false),
 				},
 			},

--- a/aws/resource_aws_cognito_user_pool_client_test.go
+++ b/aws/resource_aws_cognito_user_pool_client_test.go
@@ -47,7 +47,9 @@ func TestAccAWSCognitoUserPoolClient_allFields(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolClientExists("aws_cognito_user_pool_client.client"),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "name", name),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "explicit_auth_flows.#", "1"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "explicit_auth_flows.#", "3"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "explicit_auth_flows.1728632605", "CUSTOM_AUTH_FLOW_ONLY"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "explicit_auth_flows.1860959087", "USER_PASSWORD_AUTH"),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "explicit_auth_flows.245201344", "ADMIN_NO_SRP_AUTH"),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "generate_secret", "true"),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "read_attributes.#", "1"),
@@ -149,7 +151,7 @@ resource "aws_cognito_user_pool_client" "client" {
   name = "%s"
 
   user_pool_id = "${aws_cognito_user_pool.pool.id}"
-  explicit_auth_flows = [ "ADMIN_NO_SRP_AUTH" ]
+  explicit_auth_flows = ["ADMIN_NO_SRP_AUTH", "CUSTOM_AUTH_FLOW_ONLY", "USER_PASSWORD_AUTH"]
 
   generate_secret = "true"
 
@@ -161,7 +163,7 @@ resource "aws_cognito_user_pool_client" "client" {
   allowed_oauth_flows = ["code", "implicit"]
   allowed_oauth_flows_user_pool_client = "true"
   allowed_oauth_scopes = ["openid", "email"]
-  
+
   callback_urls = ["https://www.example.com/callback", "https://www.example.com/redirect"]
   default_redirect_uri = "https://www.example.com/redirect"
   logout_urls = ["https://www.example.com/login"]

--- a/website/docs/r/cognito_user_pool_client.markdown
+++ b/website/docs/r/cognito_user_pool_client.markdown
@@ -21,7 +21,7 @@ resource "aws_cognito_user_pool" "pool" {
 
 resource "aws_cognito_user_pool_client" "client" {
   name = "client"
-  
+
   user_pool_id = "${aws_cognito_user_pool.pool.id}"
 }
 ```
@@ -51,7 +51,7 @@ The following arguments are supported:
 * `allowed_oauth_scopes` - (Optional) List of allowed OAuth scopes (phone, email, openid, Cognito).
 * `callback_urls` - (Optional) List of allowed callback URLs for the identity providers.
 * `default_redirect_uri` - (Optional) The default redirect URI. Must be in the list of callback URLs.
-* `explicit_auth_flows` - (Optional) List of authentication flows (ADMIN_NO_SRP_AUTH, CUSTOM_AUTH_FLOW_ONLY).
+* `explicit_auth_flows` - (Optional) List of authentication flows (ADMIN_NO_SRP_AUTH, CUSTOM_AUTH_FLOW_ONLY, USER_PASSWORD_AUTH).
 * `generate_secret` - (Optional) Should an application secret be generated. AWS JavaScript SDK requires this to be false.
 * `logout_urls` - (Optional) List of allowed logout URLs for the identity providers.
 * `name` - (Required) The name of the application client.
@@ -59,7 +59,7 @@ The following arguments are supported:
 * `refresh_token_validity` - (Optional) The time limit in days refresh tokens are valid for.
 * `supported_identity_providers` - (Optional) List of provider names for the identity providers that are supported on this client.
 * `user_pool_id` - (Required) The user pool the client belongs to.
-* `write_attributes` - (Optional) List of user pool attributes the application client can write to. 
+* `write_attributes` - (Optional) List of user pool attributes the application client can write to.
 
 ## Attribute Reference
 


### PR DESCRIPTION
Fix #3397 
Documentation: https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateUserPoolClient.html#CognitoUserPools-CreateUserPoolClient-request-ExplicitAuthFlows