### PR TITLE
r/aws_vpc_endpoint_subnet_association: Fix issue with concurrent calls to 'ModifyVpcEndpoint'

### DIFF
--- a/aws/resource_aws_vpc_endpoint_subnet_association.go
+++ b/aws/resource_aws_vpc_endpoint_subnet_association.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/hashcode"
-	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -34,6 +33,11 @@ func resourceAwsVpcEndpointSubnetAssociation() *schema.Resource {
 				ForceNew: true,
 			},
 		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
 	}
 }
 
@@ -48,30 +52,19 @@ func resourceAwsVpcEndpointSubnetAssociationCreate(d *schema.ResourceData, meta 
 		return err
 	}
 
-	// See https://github.com/terraform-providers/terraform-provider-aws/issues/3382.
-	// Prevent concurrent subnet association requests and delay between requests.
-	mk := "vpc_endpoint_subnet_association_" + endpointId
-	awsMutexKV.Lock(mk)
-	defer awsMutexKV.Unlock(mk)
-
-	c := &resource.StateChangeConf{
-		Delay:   1 * time.Minute,
-		Timeout: 3 * time.Minute,
-		Target:  []string{"ok"},
-		Refresh: func() (interface{}, string, error) {
-			res, err := conn.ModifyVpcEndpoint(&ec2.ModifyVpcEndpointInput{
-				VpcEndpointId: aws.String(endpointId),
-				AddSubnetIds:  aws.StringSlice([]string{snId}),
-			})
-			return res, "ok", err
-		},
-	}
-	_, err = c.WaitForState()
+	_, err = conn.ModifyVpcEndpoint(&ec2.ModifyVpcEndpointInput{
+		VpcEndpointId: aws.String(endpointId),
+		AddSubnetIds:  aws.StringSlice([]string{snId}),
+	})
 	if err != nil {
-		return fmt.Errorf("Error creating Vpc Endpoint/Subnet association: %s", err.Error())
+		return fmt.Errorf("Error creating Vpc Endpoint/Subnet association: %s", err)
 	}
 
-	d.SetId(vpcEndpointIdSubnetIdHash(endpointId, snId))
+	d.SetId(vpcEndpointSubnetAssociationId(endpointId, snId))
+
+	if err := vpcEndpointWaitUntilAvailable(conn, endpointId, d.Timeout(schema.TimeoutCreate)); err != nil {
+		return err
+	}
 
 	return resourceAwsVpcEndpointSubnetAssociationRead(d, meta)
 }
@@ -122,24 +115,26 @@ func resourceAwsVpcEndpointSubnetAssociationDelete(d *schema.ResourceData, meta 
 	if err != nil {
 		ec2err, ok := err.(awserr.Error)
 		if !ok {
-			return fmt.Errorf("Error deleting Vpc Endpoint/Subnet association: %s", err.Error())
+			return fmt.Errorf("Error deleting Vpc Endpoint/Subnet association: %s", err)
 		}
 
 		switch ec2err.Code() {
 		case "InvalidVpcEndpointId.NotFound":
 			fallthrough
-		case "InvalidRouteTableId.NotFound":
-			fallthrough
 		case "InvalidParameter":
 			log.Printf("[DEBUG] Vpc Endpoint/Subnet association is already gone")
 		default:
-			return fmt.Errorf("Error deleting Vpc Endpoint/Subnet association: %s", err.Error())
+			return fmt.Errorf("Error deleting Vpc Endpoint/Subnet association: %s", err)
 		}
+	}
+
+	if err := vpcEndpointWaitUntilAvailable(conn, endpointId, d.Timeout(schema.TimeoutDelete)); err != nil {
+		return err
 	}
 
 	return nil
 }
 
-func vpcEndpointIdSubnetIdHash(endpointId, snId string) string {
+func vpcEndpointSubnetAssociationId(endpointId, snId string) string {
 	return fmt.Sprintf("a-%s%d", endpointId, hashcode.String(snId))
 }

--- a/aws/resource_aws_vpc_endpoint_subnet_association.go
+++ b/aws/resource_aws_vpc_endpoint_subnet_association.go
@@ -3,11 +3,13 @@ package aws
 import (
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -46,10 +48,25 @@ func resourceAwsVpcEndpointSubnetAssociationCreate(d *schema.ResourceData, meta 
 		return err
 	}
 
-	_, err = conn.ModifyVpcEndpoint(&ec2.ModifyVpcEndpointInput{
-		VpcEndpointId: aws.String(endpointId),
-		AddSubnetIds:  aws.StringSlice([]string{snId}),
-	})
+	// See https://github.com/terraform-providers/terraform-provider-aws/issues/3382.
+	// Prevent concurrent subnet association requests and delay between requests.
+	mk := "vpc_endpoint_subnet_association_" + endpointId
+	awsMutexKV.Lock(mk)
+	defer awsMutexKV.Unlock(mk)
+
+	c := &resource.StateChangeConf{
+		Delay:   1 * time.Minute,
+		Timeout: 3 * time.Minute,
+		Target:  []string{"ok"},
+		Refresh: func() (interface{}, string, error) {
+			res, err := conn.ModifyVpcEndpoint(&ec2.ModifyVpcEndpointInput{
+				VpcEndpointId: aws.String(endpointId),
+				AddSubnetIds:  aws.StringSlice([]string{snId}),
+			})
+			return res, "ok", err
+		},
+	}
+	_, err = c.WaitForState()
 	if err != nil {
 		return fmt.Errorf("Error creating Vpc Endpoint/Subnet association: %s", err.Error())
 	}

--- a/aws/resource_aws_vpc_endpoint_subnet_association_test.go
+++ b/aws/resource_aws_vpc_endpoint_subnet_association_test.go
@@ -30,7 +30,7 @@ func TestAccAWSVpcEndpointSubnetAssociation_basic(t *testing.T) {
 	})
 }
 
-func TestAccAwsVpcEndpointSubnetAssociation_multiple(t *testing.T) {
+func TestAccAWSVpcEndpointSubnetAssociation_multiple(t *testing.T) {
 	var vpce ec2.VpcEndpoint
 
 	resource.Test(t, resource.TestCase{
@@ -126,10 +126,6 @@ func testAccCheckVpcEndpointSubnetAssociationExists(n string, vpce *ec2.VpcEndpo
 }
 
 const testAccVpcEndpointSubnetAssociationConfig_basic = `
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_vpc" "foo" {
   cidr_block = "10.0.0.0/16"
   tags {
@@ -142,12 +138,14 @@ data "aws_security_group" "default" {
   name   = "default"
 }
 
+data "aws_region" "current" {}
+
 data "aws_availability_zones" "available" {}
 
 resource "aws_vpc_endpoint" "ec2" {
   vpc_id              = "${aws_vpc.foo.id}"
   vpc_endpoint_type   = "Interface"
-  service_name        = "com.amazonaws.us-west-2.ec2"
+  service_name        = "com.amazonaws.${data.aws_region.current.name}.ec2"
   security_group_ids  = ["${data.aws_security_group.default.id}"]
   private_dns_enabled = false
 }
@@ -155,7 +153,7 @@ resource "aws_vpc_endpoint" "ec2" {
 resource "aws_subnet" "sn" {
   vpc_id            = "${aws_vpc.foo.id}"
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
-	cidr_block        = "10.0.0.0/17"
+  cidr_block        = "10.0.0.0/17"
   tags {
     Name = "tf-acc-vpc-endpoint-subnet-association"
   }
@@ -168,12 +166,8 @@ resource "aws_vpc_endpoint_subnet_association" "a" {
 `
 
 const testAccVpcEndpointSubnetAssociationConfig_multiple = `
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_vpc" "foo" {
-	cidr_block = "10.0.0.0/16"
+  cidr_block = "10.0.0.0/16"
   tags {
     Name = "terraform-testacc-vpc-endpoint-subnet-association"
   }
@@ -184,12 +178,14 @@ data "aws_security_group" "default" {
   name   = "default"
 }
 
+data "aws_region" "current" {}
+
 data "aws_availability_zones" "available" {}
 
 resource "aws_vpc_endpoint" "ec2" {
   vpc_id              = "${aws_vpc.foo.id}"
   vpc_endpoint_type   = "Interface"
-  service_name        = "com.amazonaws.us-west-2.ec2"
+  service_name        = "com.amazonaws.${data.aws_region.current.name}.ec2"
   security_group_ids  = ["${data.aws_security_group.default.id}"]
   private_dns_enabled = false
 }
@@ -199,9 +195,9 @@ resource "aws_subnet" "sn" {
 
   vpc_id            = "${aws_vpc.foo.id}"
   availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
-	cidr_block        = "${cidrsubnet(aws_vpc.foo.cidr_block, 2, count.index)}"
+  cidr_block        = "${cidrsubnet(aws_vpc.foo.cidr_block, 2, count.index)}"
   tags {
-    Name = "tf-acc-vpc-endpoint-subnet-association"
+		Name = "${format("tf-acc-vpc-endpoint-subnet-association-%d", count.index + 1)}"
   }
 }
 

--- a/aws/resource_aws_vpc_endpoint_subnet_association_test.go
+++ b/aws/resource_aws_vpc_endpoint_subnet_association_test.go
@@ -30,6 +30,29 @@ func TestAccAWSVpcEndpointSubnetAssociation_basic(t *testing.T) {
 	})
 }
 
+func TestAccAwsVpcEndpointSubnetAssociation_multiple(t *testing.T) {
+	var vpce ec2.VpcEndpoint
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVpcEndpointSubnetAssociationDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccVpcEndpointSubnetAssociationConfig_multiple,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVpcEndpointSubnetAssociationExists(
+						"aws_vpc_endpoint_subnet_association.a.0", &vpce),
+					testAccCheckVpcEndpointSubnetAssociationExists(
+						"aws_vpc_endpoint_subnet_association.a.1", &vpce),
+					testAccCheckVpcEndpointSubnetAssociationExists(
+						"aws_vpc_endpoint_subnet_association.a.2", &vpce),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckVpcEndpointSubnetAssociationDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).ec2conn
 
@@ -116,21 +139,23 @@ resource "aws_vpc" "foo" {
 
 data "aws_security_group" "default" {
   vpc_id = "${aws_vpc.foo.id}"
-  name = "default"
+  name   = "default"
 }
 
+data "aws_availability_zones" "available" {}
+
 resource "aws_vpc_endpoint" "ec2" {
-  vpc_id = "${aws_vpc.foo.id}"
-  vpc_endpoint_type = "Interface"
-  service_name = "com.amazonaws.us-west-2.ec2"
-  security_group_ids = ["${data.aws_security_group.default.id}"]
+  vpc_id              = "${aws_vpc.foo.id}"
+  vpc_endpoint_type   = "Interface"
+  service_name        = "com.amazonaws.us-west-2.ec2"
+  security_group_ids  = ["${data.aws_security_group.default.id}"]
   private_dns_enabled = false
 }
 
 resource "aws_subnet" "sn" {
-  vpc_id = "${aws_vpc.foo.id}"
-  availability_zone = "us-west-2a"
-  cidr_block = "10.0.0.0/17"
+  vpc_id            = "${aws_vpc.foo.id}"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+	cidr_block        = "10.0.0.0/17"
   tags {
     Name = "tf-acc-vpc-endpoint-subnet-association"
   }
@@ -138,6 +163,52 @@ resource "aws_subnet" "sn" {
 
 resource "aws_vpc_endpoint_subnet_association" "a" {
   vpc_endpoint_id = "${aws_vpc_endpoint.ec2.id}"
-  subnet_id  = "${aws_subnet.sn.id}"
+  subnet_id       = "${aws_subnet.sn.id}"
+}
+`
+
+const testAccVpcEndpointSubnetAssociationConfig_multiple = `
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_vpc" "foo" {
+	cidr_block = "10.0.0.0/16"
+  tags {
+    Name = "terraform-testacc-vpc-endpoint-subnet-association"
+  }
+}
+
+data "aws_security_group" "default" {
+  vpc_id = "${aws_vpc.foo.id}"
+  name   = "default"
+}
+
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc_endpoint" "ec2" {
+  vpc_id              = "${aws_vpc.foo.id}"
+  vpc_endpoint_type   = "Interface"
+  service_name        = "com.amazonaws.us-west-2.ec2"
+  security_group_ids  = ["${data.aws_security_group.default.id}"]
+  private_dns_enabled = false
+}
+
+resource "aws_subnet" "sn" {
+  count = 3
+
+  vpc_id            = "${aws_vpc.foo.id}"
+  availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
+	cidr_block        = "${cidrsubnet(aws_vpc.foo.cidr_block, 2, count.index)}"
+  tags {
+    Name = "tf-acc-vpc-endpoint-subnet-association"
+  }
+}
+
+resource "aws_vpc_endpoint_subnet_association" "a" {
+  count = 3
+
+  vpc_endpoint_id = "${aws_vpc_endpoint.ec2.id}"
+  subnet_id       = "${aws_subnet.sn.*.id[count.index]}"
 }
 `

--- a/aws/resource_aws_vpc_endpoint_subnet_association_test.go
+++ b/aws/resource_aws_vpc_endpoint_subnet_association_test.go
@@ -197,7 +197,7 @@ resource "aws_subnet" "sn" {
   availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
   cidr_block        = "${cidrsubnet(aws_vpc.foo.cidr_block, 2, count.index)}"
   tags {
-		Name = "${format("tf-acc-vpc-endpoint-subnet-association-%d", count.index + 1)}"
+    Name = "${format("tf-acc-vpc-endpoint-subnet-association-%d", count.index + 1)}"
   }
 }
 

--- a/aws/resource_aws_vpc_endpoint_test.go
+++ b/aws/resource_aws_vpc_endpoint_test.go
@@ -135,7 +135,7 @@ func TestAccAWSVpcEndpoint_interfaceWithSubnetAndSecurityGroup(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_vpc_endpoint.ec2", "cidr_blocks.#", "0"),
 					resource.TestCheckResourceAttr("aws_vpc_endpoint.ec2", "vpc_endpoint_type", "Interface"),
 					resource.TestCheckResourceAttr("aws_vpc_endpoint.ec2", "route_table_ids.#", "0"),
-					resource.TestCheckResourceAttr("aws_vpc_endpoint.ec2", "subnet_ids.#", "2"),
+					resource.TestCheckResourceAttr("aws_vpc_endpoint.ec2", "subnet_ids.#", "3"),
 					resource.TestCheckResourceAttr("aws_vpc_endpoint.ec2", "security_group_ids.#", "1"),
 					resource.TestCheckResourceAttr("aws_vpc_endpoint.ec2", "private_dns_enabled", "true"),
 				),
@@ -438,7 +438,7 @@ data "aws_availability_zones" "available" {}
 
 resource "aws_subnet" "sn1" {
   vpc_id = "${aws_vpc.foo.id}"
-  cidr_block = "10.0.0.0/17"
+  cidr_block = "${cidrsubnet(aws_vpc.foo.cidr_block, 2, 0)}"
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   tags {
     Name = "tf-acc-vpc-endpoint-iface-w-subnet-1"
@@ -447,10 +447,19 @@ resource "aws_subnet" "sn1" {
 
 resource "aws_subnet" "sn2" {
   vpc_id = "${aws_vpc.foo.id}"
-  cidr_block = "10.0.128.0/17"
+  cidr_block = "${cidrsubnet(aws_vpc.foo.cidr_block, 2, 1)}"
   availability_zone = "${data.aws_availability_zones.available.names[1]}"
   tags {
     Name = "tf-acc-vpc-endpoint-iface-w-subnet-2"
+  }
+}
+
+resource "aws_subnet" "sn3" {
+  vpc_id = "${aws_vpc.foo.id}"
+  cidr_block = "${cidrsubnet(aws_vpc.foo.cidr_block, 2, 2)}"
+  availability_zone = "${data.aws_availability_zones.available.names[2]}"
+  tags {
+    Name = "tf-acc-vpc-endpoint-iface-w-subnet-3"
   }
 }
 
@@ -488,7 +497,7 @@ data "aws_availability_zones" "available" {}
 
 resource "aws_subnet" "sn1" {
   vpc_id = "${aws_vpc.foo.id}"
-  cidr_block = "10.0.0.0/17"
+  cidr_block = "${cidrsubnet(aws_vpc.foo.cidr_block, 2, 0)}"
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   tags {
     Name = "tf-acc-vpc-endpoint-iface-w-subnet-1"
@@ -497,10 +506,19 @@ resource "aws_subnet" "sn1" {
 
 resource "aws_subnet" "sn2" {
   vpc_id = "${aws_vpc.foo.id}"
-  cidr_block = "10.0.128.0/17"
+  cidr_block = "${cidrsubnet(aws_vpc.foo.cidr_block, 2, 1)}"
   availability_zone = "${data.aws_availability_zones.available.names[1]}"
   tags {
     Name = "tf-acc-vpc-endpoint-iface-w-subnet-2"
+  }
+}
+
+resource "aws_subnet" "sn3" {
+  vpc_id = "${aws_vpc.foo.id}"
+  cidr_block = "${cidrsubnet(aws_vpc.foo.cidr_block, 2, 2)}"
+  availability_zone = "${data.aws_availability_zones.available.names[2]}"
+  tags {
+    Name = "tf-acc-vpc-endpoint-iface-w-subnet-3"
   }
 }
 
@@ -516,7 +534,7 @@ resource "aws_vpc_endpoint" "ec2" {
   vpc_id = "${aws_vpc.foo.id}"
   service_name = "com.amazonaws.${data.aws_region.current.name}.ec2"
   vpc_endpoint_type = "Interface"
-  subnet_ids = ["${aws_subnet.sn1.id}", "${aws_subnet.sn2.id}"]
+  subnet_ids = ["${aws_subnet.sn1.id}", "${aws_subnet.sn2.id}", "${aws_subnet.sn3.id}"]
   security_group_ids = ["${aws_security_group.sg1.id}"]
   private_dns_enabled = true
 }

--- a/aws/resource_aws_vpc_endpoint_test.go
+++ b/aws/resource_aws_vpc_endpoint_test.go
@@ -309,9 +309,11 @@ resource "aws_subnet" "foo" {
   }
 }
 
+data "aws_region" "current" {}
+
 resource "aws_vpc_endpoint" "s3" {
   vpc_id = "${aws_vpc.foo.id}"
-  service_name = "com.amazonaws.us-west-2.s3"
+  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
   route_table_ids = ["${aws_route_table.default.id}"]
   policy = <<POLICY
 {
@@ -353,9 +355,11 @@ resource "aws_subnet" "foo" {
   }
 }
 
+data "aws_region" "current" {}
+
 resource "aws_vpc_endpoint" "s3" {
   vpc_id = "${aws_vpc.foo.id}"
-  service_name = "com.amazonaws.us-west-2.s3"
+  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
   route_table_ids = []
   policy = ""
 }
@@ -387,9 +391,11 @@ resource "aws_vpc" "foo" {
   }
 }
 
+data "aws_region" "current" {}
+
 resource "aws_vpc_endpoint" "s3" {
   vpc_id = "${aws_vpc.foo.id}"
-  service_name = "com.amazonaws.us-west-2.s3"
+  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
 }
 `
 
@@ -406,28 +412,34 @@ data "aws_security_group" "default" {
   name = "default"
 }
 
+data "aws_region" "current" {}
+
 resource "aws_vpc_endpoint" "ec2" {
   vpc_id = "${aws_vpc.foo.id}"
-	service_name = "com.amazonaws.us-west-2.ec2"
-	vpc_endpoint_type = "Interface"
-	security_group_ids = ["${data.aws_security_group.default.id}"]
+  service_name = "com.amazonaws.${data.aws_region.current.name}.ec2"
+  vpc_endpoint_type = "Interface"
+  security_group_ids = ["${data.aws_security_group.default.id}"]
 }
 `
 
 const testAccVpcEndpointConfig_interfaceWithSubnet = `
 resource "aws_vpc" "foo" {
-	cidr_block = "10.0.0.0/16"
-	enable_dns_support = true
-	enable_dns_hostnames = true
-	tags {
-		Name = "terraform-testacc-vpc-endpoint-iface-w-subnet"
-	}
+  cidr_block = "10.0.0.0/16"
+  enable_dns_support = true
+  enable_dns_hostnames = true
+  tags {
+    Name = "terraform-testacc-vpc-endpoint-iface-w-subnet"
+  }
 }
+
+data "aws_region" "current" {}
+
+data "aws_availability_zones" "available" {}
 
 resource "aws_subnet" "sn1" {
   vpc_id = "${aws_vpc.foo.id}"
   cidr_block = "10.0.0.0/17"
-  availability_zone = "us-west-2a"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
   tags {
     Name = "tf-acc-vpc-endpoint-iface-w-subnet-1"
   }
@@ -436,7 +448,7 @@ resource "aws_subnet" "sn1" {
 resource "aws_subnet" "sn2" {
   vpc_id = "${aws_vpc.foo.id}"
   cidr_block = "10.0.128.0/17"
-  availability_zone = "us-west-2b"
+  availability_zone = "${data.aws_availability_zones.available.names[1]}"
   tags {
     Name = "tf-acc-vpc-endpoint-iface-w-subnet-2"
   }
@@ -452,28 +464,32 @@ resource "aws_security_group" "sg2" {
 
 resource "aws_vpc_endpoint" "ec2" {
   vpc_id = "${aws_vpc.foo.id}"
-	service_name = "com.amazonaws.us-west-2.ec2"
-	vpc_endpoint_type = "Interface"
+  service_name = "com.amazonaws.${data.aws_region.current.name}.ec2"
+  vpc_endpoint_type = "Interface"
   subnet_ids = ["${aws_subnet.sn1.id}"]
-	security_group_ids = ["${aws_security_group.sg1.id}", "${aws_security_group.sg2.id}"]
-	private_dns_enabled = false
+  security_group_ids = ["${aws_security_group.sg1.id}", "${aws_security_group.sg2.id}"]
+  private_dns_enabled = false
 }
 `
 
 const testAccVpcEndpointConfig_interfaceWithSubnetModified = `
 resource "aws_vpc" "foo" {
-	cidr_block = "10.0.0.0/16"
-	enable_dns_support = true
-	enable_dns_hostnames = true
-	tags {
-		Name = "terraform-testacc-vpc-endpoint-iface-w-subnet"
-	}
+  cidr_block = "10.0.0.0/16"
+  enable_dns_support = true
+  enable_dns_hostnames = true
+  tags {
+    Name = "terraform-testacc-vpc-endpoint-iface-w-subnet"
+  }
 }
+
+data "aws_region" "current" {}
+
+data "aws_availability_zones" "available" {}
 
 resource "aws_subnet" "sn1" {
   vpc_id = "${aws_vpc.foo.id}"
   cidr_block = "10.0.0.0/17"
-  availability_zone = "us-west-2a"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
   tags {
     Name = "tf-acc-vpc-endpoint-iface-w-subnet-1"
   }
@@ -482,7 +498,7 @@ resource "aws_subnet" "sn1" {
 resource "aws_subnet" "sn2" {
   vpc_id = "${aws_vpc.foo.id}"
   cidr_block = "10.0.128.0/17"
-  availability_zone = "us-west-2b"
+  availability_zone = "${data.aws_availability_zones.available.names[1]}"
   tags {
     Name = "tf-acc-vpc-endpoint-iface-w-subnet-2"
   }
@@ -498,11 +514,11 @@ resource "aws_security_group" "sg2" {
 
 resource "aws_vpc_endpoint" "ec2" {
   vpc_id = "${aws_vpc.foo.id}"
-	service_name = "com.amazonaws.us-west-2.ec2"
-	vpc_endpoint_type = "Interface"
+  service_name = "com.amazonaws.${data.aws_region.current.name}.ec2"
+  vpc_endpoint_type = "Interface"
   subnet_ids = ["${aws_subnet.sn1.id}", "${aws_subnet.sn2.id}"]
-	security_group_ids = ["${aws_security_group.sg1.id}"]
-	private_dns_enabled = true
+  security_group_ids = ["${aws_security_group.sg1.id}"]
+  private_dns_enabled = true
 }
 `
 
@@ -534,10 +550,14 @@ resource "aws_lb" "nlb_test_1" {
   }
 }
 
+data "aws_region" "current" {}
+
+data "aws_availability_zones" "available" {}
+
 resource "aws_subnet" "nlb_test_1" {
   vpc_id            = "${aws_vpc.foo.id}"
   cidr_block        = "10.0.1.0/24"
-  availability_zone = "us-west-2a"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
 
   tags {
     Name = "tf-acc-vpc-endpoint-iface-non-aws-svc-1"
@@ -547,7 +567,7 @@ resource "aws_subnet" "nlb_test_1" {
 resource "aws_subnet" "nlb_test_2" {
   vpc_id            = "${aws_vpc.foo.id}"
   cidr_block        = "10.0.2.0/24"
-  availability_zone = "us-west-2b"
+  availability_zone = "${data.aws_availability_zones.available.names[1]}"
 
   tags {
     Name = "tf-acc-vpc-endpoint-iface-non-aws-svc-2"
@@ -568,11 +588,11 @@ resource "aws_security_group" "sg1" {
 
 resource "aws_vpc_endpoint" "foo" {
   vpc_id = "${aws_vpc.foo.id}"
-	service_name = "${aws_vpc_endpoint_service.foo.service_name}"
-	vpc_endpoint_type = "Interface"
-	security_group_ids = ["${aws_security_group.sg1.id}"]
-	private_dns_enabled = false
-	auto_accept = true
+  service_name = "${aws_vpc_endpoint_service.foo.service_name}"
+  vpc_endpoint_type = "Interface"
+  security_group_ids = ["${aws_security_group.sg1.id}"]
+  private_dns_enabled = false
+  auto_accept = true
 }
   `, lbName)
 }

--- a/website/docs/r/vpc_endpoint.html.markdown
+++ b/website/docs/r/vpc_endpoint.html.markdown
@@ -93,6 +93,15 @@ Defaults to full access.
 * `private_dns_enabled` - (Optional) Whether or not to associate a private hosted zone with the specified VPC. Applicable for endpoints of type `Interface`.
 Defaults to `false`.
 
+### Timeouts
+
+`aws_vpc_endpoint` provides the following
+[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+- `create` - (Default `10 minutes`) Used for creating a VPC endpoint
+- `update` - (Default `10 minutes`) Used for VPC endpoint modifications
+- `delete` - (Default `10 minutes`) Used for destroying VPC endpoints
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/website/docs/r/vpc_endpoint_subnet_association.html.markdown
+++ b/website/docs/r/vpc_endpoint_subnet_association.html.markdown
@@ -34,6 +34,14 @@ The following arguments are supported:
 * `vpc_endpoint_id` - (Required) The ID of the VPC endpoint with which the subnet will be associated.
 * `subnet_id` - (Required) The ID of the subnet to be associated with the VPC endpoint.
 
+### Timeouts
+
+`aws_vpc_endpoint_subnet_association` provides the following
+[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+- `create` - (Default `10 minutes`) Used for creating the association
+- `delete` - (Default `10 minutes`) Used for destroying the association
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/3382.
Requires both a lock to prevent multiple concurrent calls to `ModifyVpcEndpoint` and a delay between the calls to ensure success.

Acceptance tests:
```
make testacc TEST=./aws/ TESTARGS='-run=TestAccAwsVpcEndpointSubnetAssociation_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAwsVpcEndpointSubnetAssociation_basic -timeout 120m
=== RUN   TestAccAwsVpcEndpointSubnetAssociation_basic
--- PASS: TestAccAwsVpcEndpointSubnetAssociation_basic (113.23s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	113.246s
```
```
make testacc TEST=./aws/ TESTARGS='-run=TestAccAwsVpcEndpointSubnetAssociation_multiple'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAwsVpcEndpointSubnetAssociation_multiple -timeout 120m
=== RUN   TestAccAwsVpcEndpointSubnetAssociation_multiple
--- PASS: TestAccAwsVpcEndpointSubnetAssociation_multiple (250.18s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	250.191s
```