### PR TITLE
Add edition parameter for MS AD

### DIFF
--- a/aws/resource_aws_directory_service_directory.go
+++ b/aws/resource_aws_directory_service_directory.go
@@ -155,6 +155,23 @@ func resourceAwsDirectoryServiceDirectory() *schema.Resource {
 					return
 				},
 			},
+			"edition": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "Enterprise",
+				ForceNew: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
+					validTypes := []string{"Enterprise", "Standard"}
+					value := v.(string)
+					for _, validType := range validTypes {
+						if validType == value {
+							return
+						}
+					}
+					es = append(es, fmt.Errorf("%q must be one of %q", k, validTypes))
+					return
+				},
+			},
 		},
 	}
 }
@@ -294,6 +311,9 @@ func createActiveDirectoryService(dsconn *directoryservice.DirectoryService, d *
 	}
 	if v, ok := d.GetOk("short_name"); ok {
 		input.ShortName = aws.String(v.(string))
+	}
+	if v, ok := d.GetOk("edition"); ok {
+		input.Edition = aws.String(v.(string))
 	}
 
 	input.VpcSettings, err = buildVpcSettings(d)
@@ -444,6 +464,9 @@ func resourceAwsDirectoryServiceDirectoryRead(d *schema.ResourceData, meta inter
 	}
 	if dir.Size != nil {
 		d.Set("size", *dir.Size)
+	}
+	if dir.Edition != nil {
+		d.Set("edition", *dir.Edition)
 	}
 	d.Set("type", *dir.Type)
 	d.Set("vpc_settings", flattenDSVpcSettings(dir.VpcSettings))

--- a/aws/resource_aws_directory_service_directory.go
+++ b/aws/resource_aws_directory_service_directory.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/directoryservice"
 	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 var directoryCreationFuncs = map[string]func(*directoryservice.DirectoryService, *schema.ResourceData) (string, error){
@@ -160,17 +161,10 @@ func resourceAwsDirectoryServiceDirectory() *schema.Resource {
 				Optional: true,
 				Default:  "Enterprise",
 				ForceNew: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
-					validTypes := []string{"Enterprise", "Standard"}
-					value := v.(string)
-					for _, validType := range validTypes {
-						if validType == value {
-							return
-						}
-					}
-					es = append(es, fmt.Errorf("%q must be one of %q", k, validTypes))
-					return
-				},
+				ValidateFunc: validation.StringInSlice([]string{
+					directoryservice.DirectoryEditionEnterprise,
+					directoryservice.DirectoryEditionStandard,
+				}, false),
 			},
 		},
 	}

--- a/aws/resource_aws_directory_service_directory.go
+++ b/aws/resource_aws_directory_service_directory.go
@@ -159,7 +159,7 @@ func resourceAwsDirectoryServiceDirectory() *schema.Resource {
 			"edition": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "Enterprise",
+				Default:  directoryservice.DirectoryEditionEnterprise,
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					directoryservice.DirectoryEditionEnterprise,

--- a/aws/resource_aws_directory_service_directory_test.go
+++ b/aws/resource_aws_directory_service_directory_test.go
@@ -132,6 +132,7 @@ func TestAccAWSDirectoryServiceDirectory_microsoft(t *testing.T) {
 				Config: testAccDirectoryServiceDirectoryConfig_microsoft,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceDirectoryExists("aws_directory_service_directory.bar"),
+                                        resource.TestCheckResourceAttr("aws_directory_service_discovery.bar", "edition", "Standard")
 				),
 			},
 		},
@@ -429,6 +430,7 @@ resource "aws_directory_service_directory" "bar" {
   name = "corp.notexample.com"
   password = "SuperSecretPassw0rd"
   type = "MicrosoftAD"
+  edition = "Standard"
 
   vpc_settings {
     vpc_id = "${aws_vpc.main.id}"

--- a/aws/resource_aws_directory_service_directory_test.go
+++ b/aws/resource_aws_directory_service_directory_test.go
@@ -132,7 +132,7 @@ func TestAccAWSDirectoryServiceDirectory_microsoft(t *testing.T) {
 				Config: testAccDirectoryServiceDirectoryConfig_microsoft,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceDirectoryExists("aws_directory_service_directory.bar"),
-                                        resource.TestCheckResourceAttr("aws_directory_service_discovery.bar", "edition", "Enterprise")
+					resource.TestCheckResourceAttr("aws_directory_service_discovery.bar", "edition", "Enterprise"),
 				),
 			},
 		},
@@ -149,7 +149,7 @@ func TestAccAWSDirectoryServiceDirectory_microsoftStandard(t *testing.T) {
 				Config: testAccDirectoryServiceDirectoryConfig_microsoftStandard,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceDirectoryExists("aws_directory_service_directory.bar"),
-                                        resource.TestCheckResourceAttr("aws_directory_service_discovery.bar", "edition", "Standard")
+					resource.TestCheckResourceAttr("aws_directory_service_discovery.bar", "edition", "Standard"),
 				),
 			},
 		},

--- a/aws/resource_aws_directory_service_directory_test.go
+++ b/aws/resource_aws_directory_service_directory_test.go
@@ -132,7 +132,7 @@ func TestAccAWSDirectoryServiceDirectory_microsoft(t *testing.T) {
 				Config: testAccDirectoryServiceDirectoryConfig_microsoft,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceDirectoryExists("aws_directory_service_directory.bar"),
-					resource.TestCheckResourceAttr("aws_directory_service_discovery.bar", "edition", "Enterprise"),
+					resource.TestCheckResourceAttr("aws_directory_service_discovery.bar", "edition", directoryservice.DirectoryEditionEnterprise),
 				),
 			},
 		},
@@ -149,7 +149,7 @@ func TestAccAWSDirectoryServiceDirectory_microsoftStandard(t *testing.T) {
 				Config: testAccDirectoryServiceDirectoryConfig_microsoftStandard,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceDirectoryExists("aws_directory_service_directory.bar"),
-					resource.TestCheckResourceAttr("aws_directory_service_discovery.bar", "edition", "Standard"),
+					resource.TestCheckResourceAttr("aws_directory_service_discovery.bar", "edition", directoryservice.DirectoryEditionStandard),
 				),
 			},
 		},

--- a/aws/resource_aws_directory_service_directory_test.go
+++ b/aws/resource_aws_directory_service_directory_test.go
@@ -132,6 +132,23 @@ func TestAccAWSDirectoryServiceDirectory_microsoft(t *testing.T) {
 				Config: testAccDirectoryServiceDirectoryConfig_microsoft,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceDirectoryExists("aws_directory_service_directory.bar"),
+                                        resource.TestCheckResourceAttr("aws_directory_service_discovery.bar", "edition", "Enterprise")
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDirectoryServiceDirectory_microsoftStandard(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDirectoryServiceDirectoryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDirectoryServiceDirectoryConfig_microsoftStandard,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceDirectoryExists("aws_directory_service_directory.bar"),
                                         resource.TestCheckResourceAttr("aws_directory_service_discovery.bar", "edition", "Standard")
 				),
 			},
@@ -426,6 +443,37 @@ resource "aws_subnet" "bar" {
 `
 
 const testAccDirectoryServiceDirectoryConfig_microsoft = `
+resource "aws_directory_service_directory" "bar" {
+  name = "corp.notexample.com"
+  password = "SuperSecretPassw0rd"
+  type = "MicrosoftAD"
+
+  vpc_settings {
+    vpc_id = "${aws_vpc.main.id}"
+    subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
+  }
+}
+
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+	tags {
+		Name = "terraform-testacc-directory-service-directory-microsoft"
+	}
+}
+
+resource "aws_subnet" "foo" {
+  vpc_id = "${aws_vpc.main.id}"
+  availability_zone = "us-west-2a"
+  cidr_block = "10.0.1.0/24"
+}
+resource "aws_subnet" "bar" {
+  vpc_id = "${aws_vpc.main.id}"
+  availability_zone = "us-west-2b"
+  cidr_block = "10.0.2.0/24"
+}
+`
+
+const testAccDirectoryServiceDirectoryConfig_microsoftStandard = `
 resource "aws_directory_service_directory" "bar" {
   name = "corp.notexample.com"
   password = "SuperSecretPassw0rd"

--- a/website/docs/r/directory_service_directory.html.markdown
+++ b/website/docs/r/directory_service_directory.html.markdown
@@ -60,6 +60,7 @@ The following arguments are supported:
 * `alias` - (Optional) The alias for the directory (must be unique amongst all aliases in AWS). Required for `enable_sso`.
 * `description` - (Optional) A textual description for the directory.
 * `short_name` - (Optional) The short name of the directory, such as `CORP`.
+* `edition` - (Optional) The AWS Directory Service for Microsoft Active Directory edition type (`Standard` or `Enterprise`). Defaults to `Enterprise`.
 * `enable_sso` - (Optional) Whether to enable single-sign on for the directory. Requires `alias`. Defaults to `false`.
 * `type` (Optional) - The directory type (`SimpleAD` or `MicrosoftAD` are accepted values). Defaults to `SimpleAD`.
 * `tags` - (Optional) A mapping of tags to assign to the resource.

--- a/website/docs/r/directory_service_directory.html.markdown
+++ b/website/docs/r/directory_service_directory.html.markdown
@@ -60,9 +60,9 @@ The following arguments are supported:
 * `alias` - (Optional) The alias for the directory (must be unique amongst all aliases in AWS). Required for `enable_sso`.
 * `description` - (Optional) A textual description for the directory.
 * `short_name` - (Optional) The short name of the directory, such as `CORP`.
-* `edition` - (Optional) The AWS Directory Service for Microsoft Active Directory edition type (`Standard` or `Enterprise`). Defaults to `Enterprise`.
 * `enable_sso` - (Optional) Whether to enable single-sign on for the directory. Requires `alias`. Defaults to `false`.
 * `type` (Optional) - The directory type (`SimpleAD` or `MicrosoftAD` are accepted values). Defaults to `SimpleAD`.
+* `edition` - (Optional) The MicrosoftAD edition (`Standard` or `Enterprise`). Defaults to `Enterprise` (applies to MicrosoftAD type only).
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 **vpc_settings** supports the following:


### PR DESCRIPTION
Closes #2192 
Closes #2357 

Add support for the AWS Microsoft AD `Edition` type (`Standard` or `Enterprise`)
https://github.com/aws/aws-sdk-go/blob/master/service/directoryservice/api.go#L8628-L8634

https://aws.amazon.com/about-aws/whats-new/2017/10/introducing-aws-directory-service-for-microsoft-active-directory-standard-edition/
https://aws.amazon.com/directoryservice/pricing/#editions

Note: This parameter only applies to the `type = "MicrosoftAD"`