### PR TITLE
documentation for acm alternative names dns validation

### DIFF
--- a/website/docs/r/acm_certificate_validation.html.markdown
+++ b/website/docs/r/acm_certificate_validation.html.markdown
@@ -52,6 +52,64 @@ resource "aws_lb_listener" "front_end" {
 }
 ```
 
+### Alternative Domains DNS Validation with Route 53
+
+```hcl
+resource "aws_acm_certificate" "cert" {
+  domain_name = "example.com"
+  subject_alternative_names = ["www.example.com","example.org"]
+  validation_method = "DNS"
+}
+
+data "aws_route53_zone" "zone" {
+  name = "example.com."
+  private_zone = false
+}
+
+data "aws_route53_zone" "zone_alt" {
+  name = "example.org."
+  private_zone = false
+}
+
+resource "aws_route53_record" "cert_validation" {
+  name = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_name}"
+  type = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_type}"
+  zone_id = "${data.aws_route53_zone.zone.id}"
+  records = ["${aws_acm_certificate.cert.domain_validation_options.0.resource_record_value}"]
+  ttl = 60
+}
+
+resource "aws_route53_record" "cert_validation_alt1" {
+  name = "${aws_acm_certificate.cert.domain_validation_options.1.resource_record_name}"
+  type = "${aws_acm_certificate.cert.domain_validation_options.1.resource_record_type}"
+  zone_id = "${data.aws_route53_zone.zone.id}"
+  records = ["${aws_acm_certificate.cert.domain_validation_options.1.resource_record_value}"]
+  ttl = 60
+}
+
+resource "aws_route53_record" "cert_validation_alt2" {
+  name = "${aws_acm_certificate.cert.domain_validation_options.2.resource_record_name}"
+  type = "${aws_acm_certificate.cert.domain_validation_options.2.resource_record_type}"
+  zone_id = "${data.aws_route53_zone.zone_alt.id}"
+  records = ["${aws_acm_certificate.cert.domain_validation_options.2.resource_record_value}"]
+  ttl = 60
+}
+
+resource "aws_acm_certificate_validation" "cert" {
+  certificate_arn = "${aws_acm_certificate.cert.arn}"
+  validation_record_fqdns = [
+    "${aws_route53_record.cert_validation.fqdn}",
+    "${aws_route53_record.cert_validation_alt1.fqdn}",
+    "${aws_route53_record.cert_validation_alt2.fqdn}"
+  ]
+}
+
+resource "aws_lb_listener" "front_end" {
+  # [...]
+  certificate_arn   = "${aws_acm_certificate_validation.cert.certificate_arn}"
+}
+```
+
 ### Email Validation
 
 In this situation, the resource is simply a waiter for manual email approval of ACM certificates.


### PR DESCRIPTION
I know a few people I've spoken to have been wondering how to do alternative names dns validation with the new `aws_acm_certificate_validation` resource, it may be obvious to some but it's not to others.

This is a feature that came out in 1.9.0 so if you are happy with this doc improvement it can go out now.