### PR TITLE
resource/spot_fleet_request: validate arn for argument iam_fleet_role

### DIFF
--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -31,9 +31,10 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"iam_fleet_role": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArn,
 			},
 			"replace_unhealthy_instances": {
 				Type:     schema.TypeBool,


### PR DESCRIPTION
Quick fix #3430 

I think it's sufficient to just validate format of arn, which the minimal change required for #3430 .