### PR TITLE
test: Add sweeper for NACLs

### DIFF
--- a/aws/resource_aws_default_network_acl_test.go
+++ b/aws/resource_aws_default_network_acl_test.go
@@ -241,7 +241,7 @@ resource "aws_default_network_acl" "default" {
   default_network_acl_id = "${aws_vpc.tftestvpc.default_network_acl_id}"
 
   tags {
-    Name = "TestAccAWSDefaultNetworkAcl_basic"
+    Name = "tf-acc-default-acl-basic"
   }
 }
 `
@@ -268,7 +268,7 @@ resource "aws_default_network_acl" "default" {
   }
 
   tags {
-    Name = "TestAccAWSDefaultNetworkAcl_basic"
+    Name = "tf-acc-default-acl-basic-including-ipv6-rule"
   }
 }
 `
@@ -295,7 +295,7 @@ resource "aws_default_network_acl" "default" {
   }
 
   tags {
-    Name = "TestAccAWSDefaultNetworkAcl_basic"
+    Name = "tf-acc-default-acl-deny-ingress"
   }
 }
 `
@@ -331,7 +331,7 @@ resource "aws_network_acl" "bar" {
   vpc_id = "${aws_vpc.foo.id}"
 
   tags {
-    Name = "TestAccAWSDefaultNetworkAcl_SubnetRemoval"
+    Name = "tf-acc-default-acl-subnets"
   }
 }
 
@@ -341,7 +341,7 @@ resource "aws_default_network_acl" "default" {
   subnet_ids = ["${aws_subnet.one.id}", "${aws_subnet.two.id}"]
 
   tags {
-    Name = "TestAccAWSDefaultNetworkAcl_SubnetRemoval"
+    Name = "tf-acc-default-acl-subnets"
   }
 }
 `
@@ -377,7 +377,7 @@ resource "aws_network_acl" "bar" {
   vpc_id = "${aws_vpc.foo.id}"
 
   tags {
-    Name = "TestAccAWSDefaultNetworkAcl_SubnetRemoval"
+    Name = "tf-acc-default-acl-subnets-remove"
   }
 }
 
@@ -385,7 +385,7 @@ resource "aws_default_network_acl" "default" {
   default_network_acl_id = "${aws_vpc.foo.default_network_acl_id}"
 
   tags {
-    Name = "TestAccAWSDefaultNetworkAcl_SubnetRemoval"
+    Name = "tf-acc-default-acl-subnets-remove"
   }
 }
 `
@@ -423,7 +423,7 @@ resource "aws_network_acl" "bar" {
   subnet_ids = ["${aws_subnet.one.id}", "${aws_subnet.two.id}"]
 
   tags {
-    Name = "TestAccAWSDefaultNetworkAcl_SubnetRemoval"
+    Name = "tf-acc-default-acl-subnets-move"
   }
 }
 
@@ -433,7 +433,7 @@ resource "aws_default_network_acl" "default" {
   depends_on = ["aws_network_acl.bar"]
 
   tags {
-    Name = "TestAccAWSDefaultNetworkAcl_SubnetRemoval"
+    Name = "tf-acc-default-acl-subnets-move"
   }
 }
 `
@@ -456,7 +456,7 @@ resource "aws_default_network_acl" "default" {
   default_network_acl_id = "${aws_vpc.tftestvpc.default_network_acl_id}"
 
   tags {
-    Name = "TestAccAWSDefaultNetworkAcl_basicIpv6Vpc"
+    Name = "tf-acc-default-acl-subnets-basic-ipv6-vpc"
   }
 }
 `

--- a/aws/resource_aws_network_acl_rule_test.go
+++ b/aws/resource_aws_network_acl_rule_test.go
@@ -277,6 +277,9 @@ resource "aws_vpc" "foo" {
 
 resource "aws_network_acl" "bar" {
 	vpc_id = "${aws_vpc.foo.id}"
+	tags {
+		Name = "tf-acc-acl-rule-basic"
+	}
 }
 
 resource "aws_network_acl_rule" "baz" {
@@ -325,6 +328,9 @@ resource "aws_vpc" "foo" {
 
 resource "aws_network_acl" "bar" {
 	vpc_id = "${aws_vpc.foo.id}"
+	tags {
+		Name = "tf-acc-acl-rule-missing-param"
+	}
 }
 
 resource "aws_network_acl_rule" "baz" {
@@ -348,6 +354,9 @@ resource "aws_vpc" "foo" {
 
 resource "aws_network_acl" "bar" {
 	vpc_id = "${aws_vpc.foo.id}"
+	tags {
+		Name = "tf-acc-acl-rule-no-real-update"
+	}
 }
 
 resource "aws_network_acl_rule" "baz" {
@@ -372,6 +381,9 @@ resource "aws_vpc" "foo" {
 
 resource "aws_network_acl" "bar" {
 	vpc_id = "${aws_vpc.foo.id}"
+	tags {
+		Name = "tf-acc-acl-rule-all-protocol"
+	}
 }
 
 resource "aws_network_acl_rule" "baz" {
@@ -396,6 +408,9 @@ resource "aws_vpc" "foo" {
 
 resource "aws_network_acl" "bar" {
 	vpc_id = "${aws_vpc.foo.id}"
+	tags {
+		Name = "tf-acc-acl-rule-ipv6"
+	}
 }
 
 resource "aws_network_acl_rule" "baz" {

--- a/aws/resource_aws_vpc_test.go
+++ b/aws/resource_aws_vpc_test.go
@@ -17,6 +17,7 @@ func init() {
 	resource.AddTestSweepers("aws_vpc", &resource.Sweeper{
 		Name: "aws_vpc",
 		Dependencies: []string{
+			"aws_network_acl",
 			"aws_security_group",
 			"aws_subnet",
 			"aws_vpn_gateway",


### PR DESCRIPTION
**Why:** Our VPC sweeper was failing because NACLs weren't deleted.

## Test results

```
TF_ACC=1 go test ./aws -v -run="(TestAccAWSDefaultNetworkAcl_|TestAccAWSNetworkAclRule_|TestAccAWSNetworkAcl_)" -timeout 120m
=== RUN   TestAccAWSNetworkAcl_importBasic
--- PASS: TestAccAWSNetworkAcl_importBasic (240.65s)
=== RUN   TestAccAWSDefaultNetworkAcl_basic
--- PASS: TestAccAWSDefaultNetworkAcl_basic (146.25s)
=== RUN   TestAccAWSDefaultNetworkAcl_basicIpv6Vpc
--- PASS: TestAccAWSDefaultNetworkAcl_basicIpv6Vpc (54.73s)
=== RUN   TestAccAWSDefaultNetworkAcl_deny_ingress
--- PASS: TestAccAWSDefaultNetworkAcl_deny_ingress (256.24s)
=== RUN   TestAccAWSDefaultNetworkAcl_withIpv6Ingress
--- PASS: TestAccAWSDefaultNetworkAcl_withIpv6Ingress (145.16s)
=== RUN   TestAccAWSDefaultNetworkAcl_SubnetRemoval
--- PASS: TestAccAWSDefaultNetworkAcl_SubnetRemoval (141.80s)
=== RUN   TestAccAWSDefaultNetworkAcl_SubnetReassign
--- PASS: TestAccAWSDefaultNetworkAcl_SubnetReassign (160.37s)
=== RUN   TestAccAWSNetworkAclRule_basic
--- PASS: TestAccAWSNetworkAclRule_basic (56.67s)
=== RUN   TestAccAWSNetworkAclRule_missingParam
--- PASS: TestAccAWSNetworkAclRule_missingParam (33.09s)
=== RUN   TestAccAWSNetworkAclRule_ipv6
--- PASS: TestAccAWSNetworkAclRule_ipv6 (76.83s)
=== RUN   TestAccAWSNetworkAclRule_allProtocol
--- PASS: TestAccAWSNetworkAclRule_allProtocol (133.94s)
=== RUN   TestAccAWSNetworkAclRule_deleteRule
--- PASS: TestAccAWSNetworkAclRule_deleteRule (55.56s)
=== RUN   TestAccAWSNetworkAcl_EgressAndIngressRules
--- PASS: TestAccAWSNetworkAcl_EgressAndIngressRules (70.71s)
=== RUN   TestAccAWSNetworkAcl_OnlyIngressRules_basic
--- PASS: TestAccAWSNetworkAcl_OnlyIngressRules_basic (86.80s)
=== RUN   TestAccAWSNetworkAcl_OnlyIngressRules_update
--- PASS: TestAccAWSNetworkAcl_OnlyIngressRules_update (263.74s)
=== RUN   TestAccAWSNetworkAcl_CaseSensitivityNoChanges
--- PASS: TestAccAWSNetworkAcl_CaseSensitivityNoChanges (102.64s)
=== RUN   TestAccAWSNetworkAcl_OnlyEgressRules
--- PASS: TestAccAWSNetworkAcl_OnlyEgressRules (93.00s)
=== RUN   TestAccAWSNetworkAcl_SubnetChange
--- PASS: TestAccAWSNetworkAcl_SubnetChange (382.43s)
=== RUN   TestAccAWSNetworkAcl_Subnets
--- PASS: TestAccAWSNetworkAcl_Subnets (257.53s)
=== RUN   TestAccAWSNetworkAcl_ipv6Rules
--- PASS: TestAccAWSNetworkAcl_ipv6Rules (105.00s)
=== RUN   TestAccAWSNetworkAcl_ipv6VpcRules
--- PASS: TestAccAWSNetworkAcl_ipv6VpcRules (51.61s)
=== RUN   TestAccAWSNetworkAcl_espProtocol
--- PASS: TestAccAWSNetworkAcl_espProtocol (67.16s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2981.953s
```