### PR TITLE
resource/aws_spot_instance_request: Bump delete timeout to 20mins

### DIFF
--- a/aws/resource_aws_spot_instance_request.go
+++ b/aws/resource_aws_spot_instance_request.go
@@ -21,7 +21,7 @@ func resourceAwsSpotInstanceRequest() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
-			Delete: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
 		Schema: func() map[string]*schema.Schema {

--- a/website/docs/r/spot_instance_request.html.markdown
+++ b/website/docs/r/spot_instance_request.html.markdown
@@ -67,7 +67,7 @@ Spot Instance Requests support all the same arguments as
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 10 mins) Used when requesting the spot instance (only valid if `wait_for_fulfillment = true`)
-* `delete` - (Defaults to 10 mins) Used when terminating all instances launched via the given spot instance request
+* `delete` - (Defaults to 20 mins) Used when terminating all instances launched via the given spot instance request
 
 ## Attributes Reference
 


### PR DESCRIPTION
This is mainly to address the following test failure:

```
=== RUN   TestAccAWSSpotInstanceRequest_NetworkInterfaceAttributes
--- FAIL: TestAccAWSSpotInstanceRequest_NetworkInterfaceAttributes (679.58s)
    testing.go:573: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Error applying: 1 error(s) occurred:
        
        * aws_spot_instance_request.foo (destroy): 1 error(s) occurred:
        
        * aws_spot_instance_request.foo: Error terminating spot instance: Error waiting for instance (i-094860585f9ba7567) to terminate: timeout while waiting for state to become 'terminated' (last state: 'shutting-down', timeout: 10m0s)
```

I was playing with the idea of setting custom, higher timeout inside the test config, but since we get some guarantees that the instance is _actually_ shutting down (i.e. transitioning from `shutting-down` to `terminated`) I can't think of any downside of bumping this for everyone.

I'm generally against cranking timeouts so high if it is error-based retry where the risk of false positive is much higher. This isn't the case though.