### PR TITLE
resource/aws_route53_record: Fix import acc tests

### DIFF
--- a/aws/import_aws_route53_record_test.go
+++ b/aws/import_aws_route53_record_test.go
@@ -21,7 +21,7 @@ func TestAccAwsRoute53Record_importBasic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"weight"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "weight"},
 			},
 		},
 	})
@@ -42,7 +42,7 @@ func TestAccAwsRoute53Record_importUnderscored(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"weight"},
+				ImportStateVerifyIgnore: []string{"allow_overwrite", "weight"},
 			},
 		},
 	})


### PR DESCRIPTION
This it to address the following test failures which were probably just missed in https://github.com/terraform-providers/terraform-provider-aws/pull/2926

```
=== RUN   TestAccAwsRoute53Record_importBasic
--- FAIL: TestAccAwsRoute53Record_importBasic (213.54s)
    testing.go:513: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.
        
        (map[string]string) {
        }
        
        
        (map[string]string) (len=1) {
         (string) (len=15) "allow_overwrite": (string) (len=4) "true"
        }
=== RUN   TestAccAwsRoute53Record_importUnderscored
--- FAIL: TestAccAwsRoute53Record_importUnderscored (195.83s)
    testing.go:513: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.
        
        (map[string]string) {
        }
        
        
        (map[string]string) (len=1) {
         (string) (len=15) "allow_overwrite": (string) (len=4) "true"
        }
```

## Test results

```
=== RUN   TestAccAwsRoute53Record_importUnderscored
--- PASS: TestAccAwsRoute53Record_importUnderscored (184.43s)
=== RUN   TestAccAwsRoute53Record_importBasic
--- PASS: TestAccAwsRoute53Record_importBasic (184.80s)
```