### PR TITLE
resource/aws_instance: Bump deletion timeout to 20mins

### DIFF
--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -35,7 +35,7 @@ func resourceAwsInstance() *schema.Resource {
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
 			Update: schema.DefaultTimeout(10 * time.Minute),
-			Delete: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -96,7 +96,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 
 * `create` - (Defaults to 10 mins) Used when launching the instance (until it reaches the initial `running` state)
 * `update` - (Defaults to 10 mins) Used when stopping and starting the instance when necessary during update - e.g. when changing instance type
-* `delete` - (Defaults to 10 mins) Used when terminating the instance
+* `delete` - (Defaults to 20 mins) Used when terminating the instance
 
 ### Block devices
 


### PR DESCRIPTION
Similar to #3435

This is to address the following test failures:

```
=== RUN   TestAccAWSInstance_sourceDestCheck
--- FAIL: TestAccAWSInstance_sourceDestCheck (1416.49s)
    testing.go:573: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Error applying: 1 error(s) occurred:
        
        * aws_instance.foo (destroy): 1 error(s) occurred:
        
        * aws_instance.foo: Error waiting for instance (i-0fa76ebc595aa2792) to terminate: timeout while waiting for state to become 'terminated' (last state: 'shutting-down', timeout: 10m0s)

=== RUN   TestAccAWSInstancesDataSource_tags
--- FAIL: TestAccAWSInstancesDataSource_tags (760.44s)
    testing.go:573: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Error applying: 1 error(s) occurred:
        
        * aws_instance.test[3] (destroy): 1 error(s) occurred:
        
        * aws_instance.test.3: Error waiting for instance (i-0aac9db15df3d1648) to terminate: timeout while waiting for state to become 'terminated' (timeout: 10m0s)

```