### PR TITLE
resource/codebuild_project: support git_clone_depth

### DIFF
--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -168,6 +168,10 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+						"git_clone_depth": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
 						"location": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -408,11 +412,13 @@ func expandProjectSource(d *schema.ResourceData) codebuild.ProjectSource {
 		sourceType := data["type"].(string)
 		location := data["location"].(string)
 		buildspec := data["buildspec"].(string)
+		gitCloneDepth := int64(data["git_clone_depth"].(int))
 
 		projectSource = codebuild.ProjectSource{
-			Type:      &sourceType,
-			Location:  &location,
-			Buildspec: &buildspec,
+			Type:          &sourceType,
+			Location:      &location,
+			Buildspec:     &buildspec,
+			GitCloneDepth: &gitCloneDepth,
 		}
 
 		if v, ok := data["auth"]; ok {
@@ -619,6 +625,10 @@ func flattenAwsCodeBuildProjectSource(source *codebuild.ProjectSource) []interfa
 		m["buildspec"] = *source.Buildspec
 	}
 
+	if source.GitCloneDepth != nil {
+		m["git_clone_depth"] = *source.GitCloneDepth
+	}
+
 	if source.Location != nil {
 		m["location"] = *source.Location
 	}
@@ -682,6 +692,9 @@ func resourceAwsCodeBuildProjectSourceHash(v interface{}) int {
 	buf.WriteString(fmt.Sprintf("%s-", m["type"].(string)))
 	if v, ok := m["buildspec"]; ok {
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+	}
+	if v, ok := m["git_clone_depth"]; ok {
+		buf.WriteString(fmt.Sprintf("%d-", v.(int)))
 	}
 	if v, ok := m["location"]; ok {
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))

--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -180,12 +180,12 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 							ValidateFunc: validation.StringInSlice([]string{
+								codebuild.SourceTypeBitbucket,
 								codebuild.SourceTypeCodecommit,
 								codebuild.SourceTypeCodepipeline,
 								codebuild.SourceTypeGithub,
-								codebuild.SourceTypeS3,
-								codebuild.SourceTypeBitbucket,
 								codebuild.SourceTypeGithubEnterprise,
+								codebuild.SourceTypeS3,
 							}, false),
 						},
 					},
@@ -718,7 +718,7 @@ func resourceAwsCodeBuildProjectSourceAuthHash(v interface{}) int {
 
 func environmentVariablesToMap(environmentVariables []*codebuild.EnvironmentVariable) []interface{} {
 
-	envVariables := []interface{}{}
+	var envVariables []interface{}
 	if len(environmentVariables) > 0 {
 		for _, env := range environmentVariables {
 			item := map[string]interface{}{}

--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -71,7 +71,6 @@ func TestAccAWSCodeBuildProject_vpc(t *testing.T) {
 					testAccCheckAWSCodeBuildProjectExists("aws_codebuild_project.foo"),
 					resource.TestCheckResourceAttr("aws_codebuild_project.foo", "build_timeout", "50"),
 					resource.TestCheckNoResourceAttr("aws_codebuild_project.foo", "vpc_config"),
-					resource.TestCheckResourceAttr("aws_codebuild_project.foo", "build_timeout", "50"),
 					resource.TestCheckResourceAttr("aws_codebuild_project.foo", "source.3031565546.git_clone_depth", "1"),
 				),
 			},
@@ -98,8 +97,8 @@ func TestAccAWSCodeBuildProject_sourceAuth(t *testing.T) {
 				Config: testAccAWSCodeBuildProjectConfig_sourceAuth(name, authResource, authType),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeBuildProjectExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "source.361463812.auth.2706882902.resource", authResource),
-					resource.TestCheckResourceAttr(resourceName, "source.361463812.auth.2706882902.type", authType),
+					resource.TestCheckResourceAttr(resourceName, "source.1060593600.auth.2706882902.resource", authResource),
+					resource.TestCheckResourceAttr(resourceName, "source.1060593600.auth.2706882902.type", authType),
 				),
 			},
 		},
@@ -404,6 +403,7 @@ resource "aws_codebuild_project" "foo" {
   source {
     type     = "GITHUB"
     location = "https://github.com/hashicorp/packer.git"
+    git_clone_depth = 1
   }
 
   tags {
@@ -485,9 +485,8 @@ resource "aws_codebuild_project" "foo" {
   }
 
   source {
-    type            = "GITHUB"
-    location        = "https://github.com/hashicorp/packer.git"
-		git_clone_depth = 1
+    type     = "GITHUB"
+    location = "https://github.com/hashicorp/packer.git"
   }
 
   tags {
@@ -587,30 +586,30 @@ resource "aws_codebuild_project" "foo" {
 
 func testAccAWSCodeBuildProjectConfig_vpcResources() string {
 	return fmt.Sprintf(`
-	resource "aws_vpc" "codebuild_vpc" {
-		cidr_block = "10.0.0.0/16"
-	}
+  resource "aws_vpc" "codebuild_vpc" {
+    cidr_block = "10.0.0.0/16"
+  }
 
-	resource "aws_subnet" "codebuild_subnet" {
-		vpc_id     = "${aws_vpc.codebuild_vpc.id}"
-		cidr_block = "10.0.0.0/24"
-		tags {
-			Name = "tf-acc-codebuild-project-1"
-		}
-	}
+  resource "aws_subnet" "codebuild_subnet" {
+    vpc_id     = "${aws_vpc.codebuild_vpc.id}"
+    cidr_block = "10.0.0.0/24"
+    tags {
+      Name = "tf-acc-codebuild-project-1"
+    }
+  }
 
-	resource "aws_subnet" "codebuild_subnet_2" {
-		vpc_id     = "${aws_vpc.codebuild_vpc.id}"
-		cidr_block = "10.0.1.0/24"
-		tags {
-			Name = "tf-acc-codebuild-project-2"
-		}
-	}
+  resource "aws_subnet" "codebuild_subnet_2" {
+    vpc_id     = "${aws_vpc.codebuild_vpc.id}"
+    cidr_block = "10.0.1.0/24"
+    tags {
+      Name = "tf-acc-codebuild-project-2"
+    }
+  }
 
 
-	resource "aws_security_group" "codebuild_security_group" {
-		vpc_id = "${aws_vpc.codebuild_vpc.id}"
-	}
+  resource "aws_security_group" "codebuild_security_group" {
+    vpc_id = "${aws_vpc.codebuild_vpc.id}"
+  }
 `)
 }
 

--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -26,8 +26,8 @@ func TestAccAWSCodeBuildProject_basic(t *testing.T) {
 				Config: testAccAWSCodeBuildProjectConfig_basic(name, "", ""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeBuildProjectExists("aws_codebuild_project.foo"),
-					resource.TestCheckResourceAttr(
-						"aws_codebuild_project.foo", "build_timeout", "5"),
+					resource.TestCheckResourceAttr("aws_codebuild_project.foo", "build_timeout", "5"),
+					resource.TestCheckResourceAttr("aws_codebuild_project.foo", "source.361463812.git_clone_depth", "0"),
 				),
 			},
 		},
@@ -69,9 +69,10 @@ func TestAccAWSCodeBuildProject_vpc(t *testing.T) {
 				Config: testAccAWSCodeBuildProjectConfig_basicUpdated(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeBuildProjectExists("aws_codebuild_project.foo"),
-					resource.TestCheckResourceAttr(
-						"aws_codebuild_project.foo", "build_timeout", "50"),
+					resource.TestCheckResourceAttr("aws_codebuild_project.foo", "build_timeout", "50"),
 					resource.TestCheckNoResourceAttr("aws_codebuild_project.foo", "vpc_config"),
+					resource.TestCheckResourceAttr("aws_codebuild_project.foo", "build_timeout", "50"),
+					resource.TestCheckResourceAttr("aws_codebuild_project.foo", "source.3031565546.git_clone_depth", "1"),
 				),
 			},
 		},
@@ -97,8 +98,8 @@ func TestAccAWSCodeBuildProject_sourceAuth(t *testing.T) {
 				Config: testAccAWSCodeBuildProjectConfig_sourceAuth(name, authResource, authType),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeBuildProjectExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "source.1060593600.auth.2706882902.resource", authResource),
-					resource.TestCheckResourceAttr(resourceName, "source.1060593600.auth.2706882902.type", authType),
+					resource.TestCheckResourceAttr(resourceName, "source.361463812.auth.2706882902.resource", authResource),
+					resource.TestCheckResourceAttr(resourceName, "source.361463812.auth.2706882902.type", authType),
 				),
 			},
 		},
@@ -484,8 +485,9 @@ resource "aws_codebuild_project" "foo" {
   }
 
   source {
-    type     = "GITHUB"
-    location = "https://github.com/hashicorp/packer.git"
+    type            = "GITHUB"
+    location        = "https://github.com/hashicorp/packer.git"
+		git_clone_depth = 1
   }
 
   tags {

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -156,6 +156,7 @@ The following arguments are supported:
 * `type` - (Required) The type of repository that contains the source code to be built. Valid values for this parameter are: `CODECOMMIT`, `CODEPIPELINE`, `GITHUB`, `BITBUCKET` or `S3`.
 * `auth` - (Optional) Information about the authorization settings for AWS CodeBuild to access the source code to be built. Auth blocks are documented below.
 * `buildspec` - (Optional) The build spec declaration to use for this build project's related builds.
+* `git_clone_depth` - (Optional) Information about the git clone depth for the build project.
 * `location` - (Optional) The location of the source code from git or s3.
 
 `auth` supports the following:


### PR DESCRIPTION
Fix #3457 

Also did little cleanup to drop custom validation functions. 

The error below doesn't matter, I think?
```
⎇  echo > aws/debug.log ; and make testacc TEST=./aws TESTARGS='-run=TestAccAWSCodeBuildProject_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCodeBuildProject_ -timeout 120m
=== RUN   TestAccAWSCodeBuildProject_basic
--- PASS: TestAccAWSCodeBuildProject_basic (56.12s)
=== RUN   TestAccAWSCodeBuildProject_sourceAuth
--- FAIL: TestAccAWSCodeBuildProject_sourceAuth (18.01s)
	testing.go:513: Step 1 error: Error applying: 1 error(s) occurred:

		* aws_codebuild_project.foo: 1 error(s) occurred:

		* aws_codebuild_project.foo: [ERROR] Error creating CodeBuild project: InvalidInputException: No Access token found, please visit AWS CodeBuild console to connect to GitHub
			status code: 400, request id: 9f26ba07-169a-11e8-b903-894ab4f5539f
	testing.go:573: Error destroying resource! WARNING: Dangling resources
		may exist. The full state and error is shown below.

		Error: Check failed: Default error in CodeBuild Test

		State: <no state>
=== RUN   TestAccAWSCodeBuildProject_default_build_timeout
--- PASS: TestAccAWSCodeBuildProject_default_build_timeout (58.74s)
FAIL
exit status 1
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	132.912s
make: *** [testacc] Error 1
```