### PR TITLE
Consider replication destination for modifications in S3 bucket

### DIFF
--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -2086,6 +2086,11 @@ func rulesHash(v interface{}) int {
 	if v, ok := m["status"]; ok {
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
 	}
+	if v, ok := m["destination"]; ok {
+		destination := v.(*schema.Set).List()
+		d := destination[0].(map[string]interface{})
+		buf.WriteString(fmt.Sprintf("%d-", destinationHash(d)))
+	}
 	return hashcode.String(buf.String())
 }
 


### PR DESCRIPTION
Currently, if you modify the destination in a replication_config, it is not listed in a plan and applies do not modify it.