### PR TITLE
resource/lambda_function: fix crash when vpc_config is removed later

### DIFF
--- a/aws/import_aws_lambda_function_test.go
+++ b/aws/import_aws_lambda_function_test.go
@@ -103,7 +103,7 @@ func TestAccAWSLambdaFunction_importLocalFile_VPC(t *testing.T) {
 		CheckDestroy: testAccCheckLambdaFunctionDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSLambdaConfigWithVPC(funcName, policyName, roleName, sgName),
+				Config: testAccAWSLambdaConfigWithVpc(funcName, policyName, roleName, sgName),
 			},
 
 			resource.TestStep{

--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -653,7 +653,7 @@ func resourceAwsLambdaFunctionUpdate(d *schema.ResourceData, meta interface{}) e
 		log.Printf("[DEBUG] Send Update Lambda Function Configuration request: %#v", configReq)
 
 		err := resource.Retry(10*time.Minute, func() *resource.RetryError {
-			resp, err := conn.UpdateFunctionConfiguration(configReq)
+			_, err := conn.UpdateFunctionConfiguration(configReq)
 			if err != nil {
 				log.Printf("[DEBUG] Received error modifying Lambda Function Configuration %s: %s", d.Id(), err)
 

--- a/aws/resource_aws_lambda_function_test.go
+++ b/aws/resource_aws_lambda_function_test.go
@@ -447,7 +447,7 @@ func TestAccAWSLambdaFunction_VPC(t *testing.T) {
 		CheckDestroy: testAccCheckLambdaFunctionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLambdaConfigWithVPC(funcName, policyName, roleName, sgName),
+				Config: testAccAWSLambdaConfigWithVpc(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
@@ -463,7 +463,7 @@ func TestAccAWSLambdaFunction_VPC(t *testing.T) {
 	})
 }
 
-func TestAccAWSLambdaFunction_VPCUpdate(t *testing.T) {
+func TestAccAWSLambdaFunction_VpcChange(t *testing.T) {
 	var conf lambda.GetFunctionOutput
 
 	rString := acctest.RandString(8)
@@ -479,7 +479,7 @@ func TestAccAWSLambdaFunction_VPCUpdate(t *testing.T) {
 		CheckDestroy: testAccCheckLambdaFunctionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLambdaConfigWithVPC(funcName, policyName, roleName, sgName),
+				Config: testAccAWSLambdaConfigWithVpc(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
@@ -491,7 +491,7 @@ func TestAccAWSLambdaFunction_VPCUpdate(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSLambdaConfigWithVPCUpdated(funcName, policyName, roleName, sgName, sgName2),
+				Config: testAccAWSLambdaConfigWithVpcUpdated(funcName, policyName, roleName, sgName, sgName2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
@@ -500,6 +500,16 @@ func TestAccAWSLambdaFunction_VPCUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "vpc_config.#", "1"),
 					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "vpc_config.0.subnet_ids.#", "2"),
 					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "vpc_config.0.security_group_ids.#", "2"),
+				),
+			},
+			{
+				Config: testAccAWSLambdaConfigWithVpcRemoved(funcName, policyName, roleName, sgName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, funcName),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
+					testAccCheckAWSLambdaFunctionVersion(&conf, "$LATEST"),
+					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "vpc_config.#", "0"),
 				),
 			},
 		},
@@ -523,7 +533,7 @@ func TestAccAWSLambdaFunction_VPC_withInvocation(t *testing.T) {
 		CheckDestroy: testAccCheckLambdaFunctionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLambdaConfigWithVPC(funcName, policyName, roleName, sgName),
+				Config: testAccAWSLambdaConfigWithVpc(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
 					testAccAwsInvokeLambdaFunction(&conf),
@@ -1497,7 +1507,7 @@ resource "aws_lambda_function" "lambda_function_test" {
 `, funcName)
 }
 
-func testAccAWSLambdaConfigWithVPC(funcName, policyName, roleName, sgName string) string {
+func testAccAWSLambdaConfigWithVpc(funcName, policyName, roleName, sgName string) string {
 	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
 resource "aws_lambda_function" "lambda_function_test" {
     filename = "test-fixtures/lambdatest.zip"
@@ -1513,7 +1523,7 @@ resource "aws_lambda_function" "lambda_function_test" {
 }`, funcName)
 }
 
-func testAccAWSLambdaConfigWithVPCUpdated(funcName, policyName, roleName, sgName, sgName2 string) string {
+func testAccAWSLambdaConfigWithVpcUpdated(funcName, policyName, roleName, sgName, sgName2 string) string {
 	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
 resource "aws_lambda_function" "lambda_function_test" {
     filename = "test-fixtures/lambdatest.zip"
@@ -1556,9 +1566,18 @@ resource "aws_security_group" "sg_for_lambda_2" {
       cidr_blocks = ["0.0.0.0/0"]
   }
 }
-
-
 `, funcName, sgName2)
+}
+
+func testAccAWSLambdaConfigWithVpcRemoved(funcName, policyName, roleName, sgName string) string {
+	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
+resource "aws_lambda_function" "lambda_function_test" {
+    filename = "test-fixtures/lambdatest.zip"
+    function_name = "%s"
+    role = "${aws_iam_role.iam_for_lambda.arn}"
+    handler = "exports.example"
+    runtime = "nodejs4.3"
+}`, funcName)
 }
 
 func testAccAWSLambdaConfigS3(bucketName, roleName, funcName string) string {


### PR DESCRIPTION
Fix #2509

It is also the user case @radeksimko  mentioned in https://github.com/terraform-providers/terraform-provider-aws/pull/1341#issuecomment-336832548. I hope this PR could help move #1341 forward.

```
⎇  echo > aws/debug.log ; and make testacc TEST=./aws TESTARGS='-run=TestAccAWSLambdaFunction_VpcChange'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSLambdaFunction_VpcChange -timeout 120m
=== RUN   TestAccAWSLambdaFunction_VpcChange
--- PASS: TestAccAWSLambdaFunction_VpcChange (77.19s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	77.250s
```