### PR TITLE
docs/instance: Update docs to reflect API behavior

### DIFF
--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -173,7 +173,6 @@ Each `network_interface` block supports the following:
 
 * `device_index` - (Required) The integer index of the network interface attachment. Limited by instance type.
 * `network_interface_id` - (Required) The ID of the network interface to attach.
-* `delete_on_termination` - (Optional) Whether or not to delete the network interface on instance termination. Defaults to `false`.
 
 ### Example
 

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -173,6 +173,7 @@ Each `network_interface` block supports the following:
 
 * `device_index` - (Required) The integer index of the network interface attachment. Limited by instance type.
 * `network_interface_id` - (Required) The ID of the network interface to attach.
+* `delete_on_termination` - (Optional) Whether or not to delete the network interface on instance termination. Defaults to `false`. Currently, the only valid value is `false`, as this is only supported when creating new network interfaces when launching an instance.
 
 ### Example
 


### PR DESCRIPTION
The documentation stated that `delete_on_termination` field for each `network_interface` could be set to `true` or `false`. However the behavior of the API does not allow this, specifically the API will respond with an error if `delete_on_termination` is set to true with a `network_interface_id` being specified:

Example:
```
...
  network_interface {
    network_interface_id  = <interface_id>
    device_index          = 0
    delete_on_termination = true
  }
...
```

Error:
```
* aws_instance.node.1: Error launching source instance: InvalidParameterCombination: A network interface may not specify a network interface ID and delete on termination as true
```

Currently it is documented that `network_interface_id` is a required field, which implies that there is no way to successfully apply with `delete_on_termination` set to true. 
