### PR TITLE
doc/resource/waf_rule: correct predicate  type value

### DIFF
--- a/website/docs/r/waf_rule.html.markdown
+++ b/website/docs/r/waf_rule.html.markdown
@@ -50,11 +50,11 @@ The following arguments are supported:
 #### Arguments
 
 * `negated` - (Required) Set this to `false` if you want to allow, block, or count requests
-  based on the settings in the specified `ByteMatchSet`, `IPSet`, `SqlInjectionMatchSet`, `XssMatchSet`, or `SizeConstraintSet`.
+  based on the settings in the specified [waf_byte_match_set](/docs/providers/aws/r/waf_byte_match_set.html), [waf_ipset](/docs/providers/aws/r/waf_ipset.html), [aws_waf_size_constraint_set](/docs/providers/aws/r/aws_waf_size_constraint_set.html), [aws_waf_sql_injection_match_set](/docs/providers/aws/r/aws_waf_sql_injection_match_set.html) or [aws_waf_xss_match_set](/docs/providers/aws/r/aws_waf_xss_match_set.html).
   For example, if an IPSet includes the IP address `192.0.2.44`, AWS WAF will allow or block requests based on that IP address.
   If set to `true`, AWS WAF will allow, block, or count requests based on all IP addresses _except_ `192.0.2.44`.
 * `data_id` - (Required) A unique identifier for a predicate in the rule, such as Byte Match Set ID or IPSet ID.
-* `type` - (Required) The type of predicate in a rule, such as `ByteMatchSet` or `IPSet`
+* `type` - (Required) The type of predicate in a rule. Valid value is one of `ByteMatch`, `IPMatch`, `SizeConstraint`, `SqlInjectionMatch` or `XssMatch`.
 
 ## Remarks
 


### PR DESCRIPTION
Fix #3486 

The initial intent is only to update document to remove confusion. 

```
Type
The type of predicate in a Rule, such as ByteMatchSet or IPSet.

Type: String

Valid Values: IPMatch | ByteMatch | SqlInjectionMatch | GeoMatch | SizeConstraint | XssMatch | RegexMatch

Required: Yes
```