### PR TITLE
resource/aws_lb_listener_certificate: Retry read on new resources for eventual consistency

### DIFF
--- a/aws/resource_aws_lb_listener_certificate.go
+++ b/aws/resource_aws_lb_listener_certificate.go
@@ -141,7 +141,6 @@ func findAwsLbListenerCertificate(certificateArn, listenerArn string, skipDefaul
 	}
 
 	for _, cert := range resp.Certificates {
-		// We don't care about the default certificate.
 		if skipDefault && *cert.IsDefault {
 			continue
 		}

--- a/aws/resource_aws_lb_listener_certificate.go
+++ b/aws/resource_aws_lb_listener_certificate.go
@@ -2,11 +2,14 @@ package aws
 
 import (
 	"errors"
+	"fmt"
 	"log"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/resource"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elbv2"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -46,7 +49,7 @@ func resourceAwsLbListenerCertificateCreate(d *schema.ResourceData, meta interfa
 	log.Printf("[DEBUG] Adding certificate: %s of listener: %s", d.Get("certificate_arn").(string), d.Get("listener_arn").(string))
 	resp, err := conn.AddListenerCertificates(params)
 	if err != nil {
-		return errwrap.Wrapf("Error creating LB Listener Certificate: {{err}}", err)
+		return fmt.Errorf("Error creating LB Listener Certificate: %s", err)
 	}
 
 	if len(resp.Certificates) == 0 {
@@ -60,43 +63,37 @@ func resourceAwsLbListenerCertificateCreate(d *schema.ResourceData, meta interfa
 
 func resourceAwsLbListenerCertificateRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).elbv2conn
-	log.Printf("[DEBUG] Reading certificate: %s of listener: %s", d.Get("certificate_arn").(string), d.Get("listener_arn").(string))
 
-	params := &elbv2.DescribeListenerCertificatesInput{
-		ListenerArn: aws.String(d.Get("listener_arn").(string)),
-		PageSize:    aws.Int64(400),
-	}
+	certificateArn := d.Get("certificate_arn").(string)
+	listenerArn := d.Get("listener_arn").(string)
 
-	morePages := true
-	found := false
-	for morePages && !found {
-		resp, err := conn.DescribeListenerCertificates(params)
+	log.Printf("[DEBUG] Reading certificate: %s of listener: %s", certificateArn, listenerArn)
+
+	var certificate *elbv2.Certificate
+	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+		var err error
+		certificate, err = findAwsLbListenerCertificate(certificateArn, listenerArn, nil, conn)
 		if err != nil {
-			return err
+			return resource.NonRetryableError(err)
 		}
 
-		for _, cert := range resp.Certificates {
-			// We don't care about the default certificate.
-			if *cert.IsDefault {
-				continue
+		if certificate == nil {
+			err = fmt.Errorf("certificate not found: %s", certificateArn)
+			if d.IsNewResource() {
+				return resource.RetryableError(err)
 			}
-
-			if *cert.CertificateArn == d.Get("certificate_arn").(string) {
-				found = true
-			}
+			return resource.NonRetryableError(err)
 		}
 
-		if resp.NextMarker != nil {
-			params.Marker = resp.NextMarker
-		} else {
-			morePages = false
-		}
-	}
-
-	if !found {
-		log.Printf("[WARN] DescribeListenerCertificates - removing %s from state", d.Id())
-		d.SetId("")
 		return nil
+	})
+	if err != nil {
+		if certificate == nil {
+			log.Printf("[WARN] %s - removing from state", err)
+			d.SetId("")
+			return nil
+		}
+		return err
 	}
 
 	return nil
@@ -117,8 +114,45 @@ func resourceAwsLbListenerCertificateDelete(d *schema.ResourceData, meta interfa
 
 	_, err := conn.RemoveListenerCertificates(params)
 	if err != nil {
-		return errwrap.Wrapf("Error removing LB Listener Certificate: {{err}}", err)
+		if isAWSErr(err, elbv2.ErrCodeCertificateNotFoundException, "") {
+			return nil
+		}
+		if isAWSErr(err, elbv2.ErrCodeListenerNotFoundException, "") {
+			return nil
+		}
+		return fmt.Errorf("Error removing LB Listener Certificate: %s", err)
 	}
 
 	return nil
+}
+
+func findAwsLbListenerCertificate(certificateArn, listenerArn string, nextMarker *string, conn *elbv2.ELBV2) (*elbv2.Certificate, error) {
+	params := &elbv2.DescribeListenerCertificatesInput{
+		ListenerArn: aws.String(listenerArn),
+		PageSize:    aws.Int64(400),
+	}
+	if nextMarker != nil {
+		params.Marker = nextMarker
+	}
+
+	resp, err := conn.DescribeListenerCertificates(params)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, cert := range resp.Certificates {
+		// We don't care about the default certificate.
+		if *cert.IsDefault {
+			continue
+		}
+
+		if *cert.CertificateArn == certificateArn {
+			return cert, nil
+		}
+	}
+
+	if resp.NextMarker != nil {
+		return findAwsLbListenerCertificate(certificateArn, listenerArn, resp.NextMarker, conn)
+	}
+	return nil, nil
 }


### PR DESCRIPTION
Found via daily acceptance testing:
```
=== RUN   TestAccAwsLbListenerCertificate_cycle
--- FAIL: TestAccAwsLbListenerCertificate_cycle (197.22s)
    testing.go:513: Step 0 error: Check failed: Check 1/9 error: Not found: aws_lb_listener_certificate.default
```

Sometimes an immediate read does not see newly added certificates (`terraform-default-cert-s7to0` `<IsDefault>false</IsDefault>` in this case the testing is adding):

```
2018/02/22 07:31:49 [DEBUG] [aws-sdk-go] <DescribeListenerCertificatesResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
  <DescribeListenerCertificatesResult>
    <Certificates>
      <member>
        <CertificateArn>arn:aws:iam::123456789012:server-certificate/terraform-additional-cert-2-s7to0</CertificateArn>
        <IsDefault>false</IsDefault>
      </member>
      <member>
        <CertificateArn>arn:aws:iam::123456789012:server-certificate/terraform-default-cert-s7to0</CertificateArn>
        <IsDefault>true</IsDefault>
      </member>
    </Certificates>
  </DescribeListenerCertificatesResult>
  <ResponseMetadata>
    <RequestId>7d16635e-17a2-11e8-ac31-65c082dfda11</RequestId>
  </ResponseMetadata>
</DescribeListenerCertificatesResponse>
2018/02/22 07:31:49 [WARN] DescribeListenerCertificates - removing arn:aws:elasticloadbalancing:us-west-2:123456789012:listener/app/2kh2c20180222072938677000000002/5f38157cda23529f/323dc5ff30594311_arn:aws:iam::123456789012:server-certificate/terraform-default-cert-s7to0 from state
```

Next read found it:
```
2018/02/22 07:31:49 [DEBUG] [aws-sdk-go] <DescribeListenerCertificatesResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
  <DescribeListenerCertificatesResult>
    <Certificates>
      <member>
        <CertificateArn>arn:aws:iam::187416307283:server-certificate/terraform-default-cert-s7to0</CertificateArn>
        <IsDefault>false</IsDefault>
      </member>
      <member>
        <CertificateArn>arn:aws:iam::187416307283:server-certificate/terraform-additional-cert-2-s7to0</CertificateArn>
        <IsDefault>false</IsDefault>
      </member>
      <member>
        <CertificateArn>arn:aws:iam::187416307283:server-certificate/terraform-default-cert-s7to0</CertificateArn>
        <IsDefault>true</IsDefault>
      </member>
    </Certificates>
  </DescribeListenerCertificatesResult>
  <ResponseMetadata>
    <RequestId>7d32c474-17a2-11e8-90bc-abcc27e790f4</RequestId>
  </ResponseMetadata>
</DescribeListenerCertificatesResponse>
```


Testing passes:
```
make testacc TEST=./aws TESTARGS='-run=TestAccAwsLbListenerCertificate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAwsLbListenerCertificate -timeout 120m
=== RUN   TestAccAwsLbListenerCertificate_basic
--- PASS: TestAccAwsLbListenerCertificate_basic (222.06s)
=== RUN   TestAccAwsLbListenerCertificate_cycle
--- PASS: TestAccAwsLbListenerCertificate_cycle (229.88s)
PASS
ok    github.com/terraform-providers/terraform-provider-aws/aws 451.987s
```
