### PR TITLE
resource/appsync_graphql_api: Support import

### DIFF
--- a/aws/resource_aws_appsync_graphql_api.go
+++ b/aws/resource_aws_appsync_graphql_api.go
@@ -18,6 +18,10 @@ func resourceAwsAppsyncGraphqlApi() *schema.Resource {
 		Update: resourceAwsAppsyncGraphqlApiUpdate,
 		Delete: resourceAwsAppsyncGraphqlApiDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"authentication_type": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_appsync_graphql_api_test.go
+++ b/aws/resource_aws_appsync_graphql_api_test.go
@@ -62,6 +62,26 @@ func TestAccAWSAppsyncGraphqlApi_cognito(t *testing.T) {
 	})
 }
 
+func TestAccAWSAppsyncGraphqlApi_import(t *testing.T) {
+	resourceName := "aws_appsync_graphql_api.test_apikey"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAppsyncGraphqlApiConfig_apikey(acctest.RandString(5)),
+			},
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAwsAppsyncGraphqlApiDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).appsyncconn
 	for _, rs := range s.RootModule().Resources {

--- a/website/docs/r/appsync_graphql_api.html.markdown
+++ b/website/docs/r/appsync_graphql_api.html.markdown
@@ -42,3 +42,11 @@ The following attributes are exported:
 
 * `id` - API ID
 * `arn` - The ARN
+
+## Import
+
+AppSync GraphQL API can be imported using the GraphQL API ID, e.g.
+
+```
+$ terraform import aws_appsync_graphql_api.example 0123456789
+```


### PR DESCRIPTION
```
TF_ACC=1 go test ./aws -v -run=TestAccAWSAppsyncGraphqlApi_import -timeout 120m
=== RUN   TestAccAWSAppsyncGraphqlApi_import
--- PASS: TestAccAWSAppsyncGraphqlApi_import (38.68s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	38.719s
```