### PR TITLE
resource/aws_media_store_container: Support import and modify test

### DIFF
--- a/aws/resource_aws_media_store_container.go
+++ b/aws/resource_aws_media_store_container.go
@@ -16,7 +16,9 @@ func resourceAwsMediaStoreContainer() *schema.Resource {
 		Create: resourceAwsMediaStoreContainerCreate,
 		Read:   resourceAwsMediaStoreContainerRead,
 		Delete: resourceAwsMediaStoreContainerDelete,
-
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
@@ -82,6 +84,7 @@ func resourceAwsMediaStoreContainerRead(d *schema.ResourceData, meta interface{}
 		return err
 	}
 	d.Set("arn", resp.Container.ARN)
+	d.Set("name", resp.Container.Name)
 	d.Set("endpoint", resp.Container.Endpoint)
 	return nil
 }

--- a/aws/resource_aws_media_store_container_test.go
+++ b/aws/resource_aws_media_store_container_test.go
@@ -27,6 +27,26 @@ func TestAccAWSMediaStoreContainer_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSMediaStoreContainer_import(t *testing.T) {
+	resourceName := "aws_media_store_container.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsMediaStoreContainerDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccMediaStoreContainerConfig(acctest.RandString(5)),
+			},
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAwsMediaStoreContainerDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).mediastoreconn
 
@@ -56,9 +76,20 @@ func testAccCheckAwsMediaStoreContainerDestroy(s *terraform.State) error {
 
 func testAccCheckAwsMediaStoreContainerExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		_, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[name]
 		if !ok {
 			return fmt.Errorf("Not found: %s", name)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).mediastoreconn
+
+		input := &mediastore.DescribeContainerInput{
+			ContainerName: aws.String(rs.Primary.ID),
+		}
+
+		_, err := conn.DescribeContainer(input)
+		if err != nil {
+			return err
 		}
 
 		return nil

--- a/website/docs/r/media_store_container.html.markdown
+++ b/website/docs/r/media_store_container.html.markdown
@@ -30,3 +30,11 @@ The following attributes are exported:
 
 * `arn` - The ARN of the container.
 * `endpoint` - The DNS endpoint of the container.
+
+## Import
+
+MediaStore Container can be imported using the MediaStore Container Name, e.g.
+
+```
+$ terraform import aws_media_store_container.example example
+```


### PR DESCRIPTION
```
TF_ACC=1 go test ./aws -v -run=TestAccAWSMediaStoreContainer_* -timeout 120m
=== RUN   TestAccAWSMediaStoreContainer_basic
--- PASS: TestAccAWSMediaStoreContainer_basic (109.13s)
=== RUN   TestAccAWSMediaStoreContainer_import
--- PASS: TestAccAWSMediaStoreContainer_import (78.95s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	188.129s
```