### PR TITLE
Fix what cannot import a correct description for AWS security group

### DIFF
--- a/aws/import_aws_security_group.go
+++ b/aws/import_aws_security_group.go
@@ -70,35 +70,39 @@ func resourceAwsSecurityGroupImportStatePerm(sg *ec2.SecurityGroup, ruleType str
 	var result []*schema.ResourceData
 
 	if perm.IpRanges != nil {
-		p := &ec2.IpPermission{
-			FromPort:      perm.FromPort,
-			IpProtocol:    perm.IpProtocol,
-			PrefixListIds: perm.PrefixListIds,
-			ToPort:        perm.ToPort,
-			IpRanges:      perm.IpRanges,
-		}
+		for _, pair := range perm.IpRanges {
+			p := &ec2.IpPermission{
+				FromPort:      perm.FromPort,
+				IpProtocol:    perm.IpProtocol,
+				PrefixListIds: perm.PrefixListIds,
+				ToPort:        perm.ToPort,
+				IpRanges:      []*ec2.IpRange{pair},
+			}
 
-		r, err := resourceAwsSecurityGroupImportStatePermPair(sg, ruleType, p)
-		if err != nil {
-			return nil, err
+			r, err := resourceAwsSecurityGroupImportStatePermPair(sg, ruleType, p)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, r)
 		}
-		result = append(result, r)
 	}
 
 	if perm.Ipv6Ranges != nil {
-		p := &ec2.IpPermission{
-			FromPort:      perm.FromPort,
-			IpProtocol:    perm.IpProtocol,
-			PrefixListIds: perm.PrefixListIds,
-			ToPort:        perm.ToPort,
-			Ipv6Ranges:    perm.Ipv6Ranges,
-		}
+		for _, pair := range perm.Ipv6Ranges {
+			p := &ec2.IpPermission{
+				FromPort:      perm.FromPort,
+				IpProtocol:    perm.IpProtocol,
+				PrefixListIds: perm.PrefixListIds,
+				ToPort:        perm.ToPort,
+				Ipv6Ranges:    []*ec2.Ipv6Range{pair},
+			}
 
-		r, err := resourceAwsSecurityGroupImportStatePermPair(sg, ruleType, p)
-		if err != nil {
-			return nil, err
+			r, err := resourceAwsSecurityGroupImportStatePermPair(sg, ruleType, p)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, r)
 		}
-		result = append(result, r)
 	}
 
 	if len(perm.UserIdGroupPairs) > 0 {


### PR DESCRIPTION
Fix what cannot import a correct description for AWS security group.

security group:

```
aws ec2 describe-security-groups --group-ids sg-xxxxxxxx
{
    "SecurityGroups": [
        {
            "IpPermissionsEgress": [
                {
                    "IpProtocol": "-1",
                    "PrefixListIds": [],
                    "IpRanges": [
                        {
                            "CidrIp": "0.0.0.0/0"
                        }
                    ],
                    "UserIdGroupPairs": [],
                    "Ipv6Ranges": []
                }
            ],
            "Description": "sample",
            "IpPermissions": [
                {
                    "PrefixListIds": [],
                    "FromPort": 80,
                    "IpRanges": [
                        {
                            "Description": "http dsecription",
                            "CidrIp": "127.0.0.0/32"
                        },
                        {
                            "Description": "http description 2",
                            "CidrIp": "127.0.0.1/32"
                        }
                    ],
                    "ToPort": 80,
                    "IpProtocol": "tcp",
                    "UserIdGroupPairs": [],
                    "Ipv6Ranges": []
                }
            ],
            "GroupName": "sample",
            "VpcId": "vpc-xxxxxxxx",
            "OwnerId": "12345678912",
            "GroupId": "sg-xxxxxxxx"
        }
    ]
}
```

imported aws_security_group_rule

```
"aws_security_group_rule.sample": {
    "type": "aws_security_group_rule",
    "depends_on": [],
    "primary": {
        "id": "sgrule-0000000001",
        "attributes": {
            "cidr_blocks.#": "2",
            "cidr_blocks.0": "127.0.0.0/32",
            "cidr_blocks.1": "127.0.0.1/32",
            "description": "http dsecription",
            "from_port": "80",
            "id": "sgrule-0000000001",
            "ipv6_cidr_blocks.#": "0",
            "prefix_list_ids.#": "0",
            "protocol": "tcp",
            "security_group_id": "sg-xxxxxxxx",
            "self": "false",
            "to_port": "80",
            "type": "ingress"
        },
        "meta": {
            "schema_version": "2"
        },
        "tainted": false
    },
    "deposed": [],
    "provider": "provider.aws"
},
"aws_security_group_rule.sample-1": {
    "type": "aws_security_group_rule",
    "depends_on": [],
    "primary": {
        "id": "sgrule-0000000000",
        "attributes": {
            "cidr_blocks.#": "1",
            "cidr_blocks.0": "0.0.0.0/0",
            "description": "",
            "from_port": "0",
            "id": "sgrule-0000000000",
            "ipv6_cidr_blocks.#": "0",
            "prefix_list_ids.#": "0",
            "protocol": "-1",
            "security_group_id": "sg-xxxxxxxx",
            "self": "false",
            "to_port": "0",
            "type": "egress"
        },
        "meta": {
            "schema_version": "2"
        },
        "tainted": false
    },
    "deposed": [],
    "provider": "provider.aws"
}
```

imported aws_security_group_rule(fixed version)

```
"aws_security_group_rule.sample": {
    "type": "aws_security_group_rule",
    "depends_on": [],
    "primary": {
        "id": "sgrule-0000000000",
        "attributes": {
            "cidr_blocks.#": "1",
            "cidr_blocks.0": "127.0.0.0/32",
            "description": "http dsecription",
            "from_port": "80",
            "id": "sgrule-0000000000",
            "ipv6_cidr_blocks.#": "0",
            "prefix_list_ids.#": "0",
            "protocol": "tcp",
            "security_group_id": "sg-xxxxxxxx",
            "self": "false",
            "to_port": "80",
            "type": "ingress"
        },
        "meta": {
            "schema_version": "2"
        },
        "tainted": false
    },
    "deposed": [],
    "provider": "provider.aws"
},
"aws_security_group_rule.sample-1": {
    "type": "aws_security_group_rule",
    "depends_on": [],
    "primary": {
        "id": "sgrule-0000000001",
        "attributes": {
            "cidr_blocks.#": "1",
            "cidr_blocks.0": "127.0.0.1/32",
            "description": "http description 2",
            "from_port": "80",
            "id": "sgrule-0000000001",
            "ipv6_cidr_blocks.#": "0",
            "prefix_list_ids.#": "0",
            "protocol": "tcp",
            "security_group_id": "sg-xxxxxxxx",
            "self": "false",
            "to_port": "80",
            "type": "ingress"
        },
        "meta": {
            "schema_version": "2"
        },
        "tainted": false
    },
    "deposed": [],
    "provider": "provider.aws"
},
"aws_security_group_rule.sample-2": {
    "type": "aws_security_group_rule",
    "depends_on": [],
    "primary": {
        "id": "sgrule-0000000002",
        "attributes": {
            "cidr_blocks.#": "1",
            "cidr_blocks.0": "0.0.0.0/0",
            "description": "",
            "from_port": "0",
            "id": "sgrule-0000000002",
            "ipv6_cidr_blocks.#": "0",
            "prefix_list_ids.#": "0",
            "protocol": "-1",
            "security_group_id": "sg-xxxxxxxx",
            "self": "false",
            "to_port": "0",
            "type": "egress"
        },
        "meta": {
            "schema_version": "2"
        },
        "tainted": false
    },
    "deposed": [],
    "provider": "provider.aws"
}
```

Test results

```
=== RUN   TestAccAWSSecurityGroup_importBasic
--- PASS: TestAccAWSSecurityGroup_importBasic (71.31s)
=== RUN   TestAccAWSSecurityGroup_importIpv6
--- PASS: TestAccAWSSecurityGroup_importIpv6 (72.87s)
=== RUN   TestAccAWSSecurityGroup_importSelf
--- PASS: TestAccAWSSecurityGroup_importSelf (80.18s)
=== RUN   TestAccAWSSecurityGroup_importSourceSecurityGroup
--- PASS: TestAccAWSSecurityGroup_importSourceSecurityGroup (81.61s)
=== RUN   TestAccAWSSecurityGroup_importIPRangeAndSecurityGroupWithSameRules
--- PASS: TestAccAWSSecurityGroup_importIPRangeAndSecurityGroupWithSameRules (87.40s)
=== RUN   TestAccAWSSecurityGroup_importIPRangesWithSameRules
--- PASS: TestAccAWSSecurityGroup_importIPRangesWithSameRules (80.04s)
=== RUN   TestAccAWSSecurityGroup_importPrefixList
--- PASS: TestAccAWSSecurityGroup_importPrefixList (103.04s)
PASS
ok    github.com/terraform-providers/terraform-provider-aws/aws 576.494s
```
