### PR TITLE
Service details not yet available in GovCloud.

### DIFF
--- a/aws/data_source_aws_vpc_endpoint_service.go
+++ b/aws/data_source_aws_vpc_endpoint_service.go
@@ -65,7 +65,6 @@ func dataSourceAwsVpcEndpointService() *schema.Resource {
 
 func dataSourceAwsVpcEndpointServiceRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
-	isGovCloud := meta.(*AWSClient).IsGovCloud()
 
 	var serviceName string
 	if v, ok := d.GetOk("service_name"); ok {
@@ -87,25 +86,20 @@ func dataSourceAwsVpcEndpointServiceRead(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error fetching VPC Endpoint Services: %s", err)
 	}
 
+	if resp == nil || len(resp.ServiceNames) == 0 {
+		return fmt.Errorf("no matching VPC Endpoint Service found")
+	}
+
+	if len(resp.ServiceNames) > 1 {
+		return fmt.Errorf("multiple VPC Endpoint Services matched; use additional constraints to reduce matches to a single VPC Endpoint Service")
+	}
+
 	// Note: AWS Commercial now returns a response with `ServiceNames` and
 	// `ServiceDetails`, but GovCloud responses only include `ServiceNames`
-	if isGovCloud && resp.ServiceDetails == nil {
-		if resp == nil || len(resp.ServiceNames) == 0 {
-			return fmt.Errorf("no matching VPC Endpoint Service found")
-		}
-		if len(resp.ServiceNames) > 1 {
-			return fmt.Errorf("multiple VPC Endpoint Services matched; use additional constraints to reduce matches to a single VPC Endpoint Service")
-		}
+	if len(resp.ServiceDetails) == 0 {
 		d.SetId(strconv.Itoa(hashcode.String(*resp.ServiceNames[0])))
 		d.Set("service_name", resp.ServiceNames[0])
 		return nil
-	}
-
-	if resp == nil || len(resp.ServiceDetails) == 0 {
-		return fmt.Errorf("no matching VPC Endpoint Service found")
-	}
-	if len(resp.ServiceDetails) > 1 {
-		return fmt.Errorf("multiple VPC Endpoint Services matched; use additional constraints to reduce matches to a single VPC Endpoint Service")
 	}
 
 	sd := resp.ServiceDetails[0]


### PR DESCRIPTION
Revert to logic from 1.8 for GovCloud until service details are
supported.

Resolves #3506.

Note: I haven't had time to test this thoroughly, so it would be great to get help testing this out. cc @lorengordon @bflad 