### PR TITLE
deps: Bump aws-sdk-go@v1.13.4

### DIFF
--- a/vendor/github.com/aws/aws-sdk-go/aws/client/default_retryer.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/client/default_retryer.go
@@ -1,12 +1,11 @@
 package client
 
 import (
-	"math/rand"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/internal/sdkrand"
 )
 
 // DefaultRetryer implements basic retry logic using exponential backoff for
@@ -31,8 +30,6 @@ func (d DefaultRetryer) MaxRetries() int {
 	return d.NumMaxRetries
 }
 
-var seededRand = rand.New(&lockedSource{src: rand.NewSource(time.Now().UnixNano())})
-
 // RetryRules returns the delay duration before retrying this request again
 func (d DefaultRetryer) RetryRules(r *request.Request) time.Duration {
 	// Set the upper limit of delay in retrying at ~five minutes
@@ -53,7 +50,7 @@ func (d DefaultRetryer) RetryRules(r *request.Request) time.Duration {
 		retryCount = 13
 	}
 
-	delay := (1 << uint(retryCount)) * (seededRand.Intn(minTime) + minTime)
+	delay := (1 << uint(retryCount)) * (sdkrand.SeededRand.Intn(minTime) + minTime)
 	return time.Duration(delay) * time.Millisecond
 }
 
@@ -116,23 +113,4 @@ func canUseRetryAfterHeader(r *request.Request) bool {
 	}
 
 	return true
-}
-
-// lockedSource is a thread-safe implementation of rand.Source
-type lockedSource struct {
-	lk  sync.Mutex
-	src rand.Source
-}
-
-func (r *lockedSource) Int63() (n int64) {
-	r.lk.Lock()
-	n = r.src.Int63()
-	r.lk.Unlock()
-	return
-}
-
-func (r *lockedSource) Seed(seed int64) {
-	r.lk.Lock()
-	r.src.Seed(seed)
-	r.lk.Unlock()
 }

--- a/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
@@ -113,6 +113,9 @@ const (
 	LogsServiceID                         = "logs"                         // Logs.
 	MachinelearningServiceID              = "machinelearning"              // Machinelearning.
 	MarketplacecommerceanalyticsServiceID = "marketplacecommerceanalytics" // Marketplacecommerceanalytics.
+	MediaconvertServiceID                 = "mediaconvert"                 // Mediaconvert.
+	MedialiveServiceID                    = "medialive"                    // Medialive.
+	MediapackageServiceID                 = "mediapackage"                 // Mediapackage.
 	MeteringMarketplaceServiceID          = "metering.marketplace"         // MeteringMarketplace.
 	MghServiceID                          = "mgh"                          // Mgh.
 	MobileanalyticsServiceID              = "mobileanalytics"              // Mobileanalytics.
@@ -133,6 +136,7 @@ const (
 	S3ServiceID                           = "s3"                           // S3.
 	SdbServiceID                          = "sdb"                          // Sdb.
 	ServicecatalogServiceID               = "servicecatalog"               // Servicecatalog.
+	ServicediscoveryServiceID             = "servicediscovery"             // Servicediscovery.
 	ShieldServiceID                       = "shield"                       // Shield.
 	SmsServiceID                          = "sms"                          // Sms.
 	SnowballServiceID                     = "snowball"                     // Snowball.
@@ -420,6 +424,7 @@ var awsPartition = partition{
 			Endpoints: endpoints{
 				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
+				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"us-east-1":      endpoint{},
@@ -599,6 +604,7 @@ var awsPartition = partition{
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
+				"eu-west-3":      endpoint{},
 				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
@@ -610,6 +616,7 @@ var awsPartition = partition{
 
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
+				"ap-northeast-2": endpoint{},
 				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
 				"ca-central-1":   endpoint{},
@@ -711,6 +718,8 @@ var awsPartition = partition{
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
 				"ap-south-1":     endpoint{},
+				"ap-southeast-1": endpoint{},
+				"ap-southeast-2": endpoint{},
 				"eu-west-1":      endpoint{},
 				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
@@ -1333,6 +1342,44 @@ var awsPartition = partition{
 				"us-east-1": endpoint{},
 			},
 		},
+		"mediaconvert": service{
+
+			Endpoints: endpoints{
+				"ap-northeast-1": endpoint{},
+				"ap-south-1":     endpoint{},
+				"ap-southeast-1": endpoint{},
+				"ap-southeast-2": endpoint{},
+				"eu-central-1":   endpoint{},
+				"eu-west-1":      endpoint{},
+				"us-east-1":      endpoint{},
+				"us-west-1":      endpoint{},
+				"us-west-2":      endpoint{},
+			},
+		},
+		"medialive": service{
+
+			Endpoints: endpoints{
+				"ap-northeast-1": endpoint{},
+				"ap-southeast-1": endpoint{},
+				"ap-southeast-2": endpoint{},
+				"eu-west-1":      endpoint{},
+				"us-east-1":      endpoint{},
+				"us-west-2":      endpoint{},
+			},
+		},
+		"mediapackage": service{
+
+			Endpoints: endpoints{
+				"ap-northeast-1": endpoint{},
+				"ap-southeast-1": endpoint{},
+				"ap-southeast-2": endpoint{},
+				"eu-central-1":   endpoint{},
+				"eu-west-1":      endpoint{},
+				"eu-west-3":      endpoint{},
+				"us-east-1":      endpoint{},
+				"us-west-2":      endpoint{},
+			},
+		},
 		"metering.marketplace": service{
 			Defaults: endpoint{
 				CredentialScope: credentialScope{
@@ -1658,6 +1705,15 @@ var awsPartition = partition{
 				"us-west-2":      endpoint{},
 			},
 		},
+		"servicediscovery": service{
+
+			Endpoints: endpoints{
+				"eu-west-1": endpoint{},
+				"us-east-1": endpoint{},
+				"us-east-2": endpoint{},
+				"us-west-2": endpoint{},
+			},
+		},
 		"shield": service{
 			IsRegionalized: boxedFalse,
 			Defaults: endpoint{
@@ -1678,6 +1734,7 @@ var awsPartition = partition{
 				"ca-central-1":   endpoint{},
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
+				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
@@ -1691,6 +1748,7 @@ var awsPartition = partition{
 				"ap-northeast-1": endpoint{},
 				"ap-south-1":     endpoint{},
 				"ap-southeast-2": endpoint{},
+				"ca-central-1":   endpoint{},
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
@@ -2511,6 +2569,12 @@ var awsusgovPartition = partition{
 				"us-gov-west-1": endpoint{
 					Protocols: []string{"http", "https"},
 				},
+			},
+		},
+		"es": service{
+
+			Endpoints: endpoints{
+				"us-gov-west-1": endpoint{},
 			},
 		},
 		"events": service{

--- a/vendor/github.com/aws/aws-sdk-go/aws/request/request.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/request/request.go
@@ -224,6 +224,9 @@ func (r *Request) SetContext(ctx aws.Context) {
 
 // WillRetry returns if the request's can be retried.
 func (r *Request) WillRetry() bool {
+	if !aws.IsReaderSeekable(r.Body) && r.HTTPRequest.Body != NoBody {
+		return false
+	}
 	return r.Error != nil && aws.BoolValue(r.Retryable) && r.RetryCount < r.MaxRetries()
 }
 
@@ -255,6 +258,7 @@ func (r *Request) SetStringBody(s string) {
 // SetReaderBody will set the request's body reader.
 func (r *Request) SetReaderBody(reader io.ReadSeeker) {
 	r.Body = reader
+	r.BodyStart, _ = reader.Seek(0, 1) // Get the Bodies current offset.
 	r.ResetBody()
 }
 
@@ -393,7 +397,7 @@ func (r *Request) getNextRequestBody() (io.ReadCloser, error) {
 	// of the SDK if they used that field.
 	//
 	// Related golang/go#18257
-	l, err := computeBodyLength(r.Body)
+	l, err := aws.SeekerLen(r.Body)
 	if err != nil {
 		return nil, awserr.New(ErrCodeSerialization, "failed to compute request body size", err)
 	}
@@ -411,7 +415,8 @@ func (r *Request) getNextRequestBody() (io.ReadCloser, error) {
 		// Transfer-Encoding: chunked bodies for these methods.
 		//
 		// This would only happen if a aws.ReaderSeekerCloser was used with
-		// a io.Reader that was not also an io.Seeker.
+		// a io.Reader that was not also an io.Seeker, or did not implement
+		// Len() method.
 		switch r.Operation.HTTPMethod {
 		case "GET", "HEAD", "DELETE":
 			body = NoBody
@@ -421,42 +426,6 @@ func (r *Request) getNextRequestBody() (io.ReadCloser, error) {
 	}
 
 	return body, nil
-}
-
-// Attempts to compute the length of the body of the reader using the
-// io.Seeker interface. If the value is not seekable because of being
-// a ReaderSeekerCloser without an unerlying Seeker -1 will be returned.
-// If no error occurs the length of the body will be returned.
-func computeBodyLength(r io.ReadSeeker) (int64, error) {
-	seekable := true
-	// Determine if the seeker is actually seekable. ReaderSeekerCloser
-	// hides the fact that a io.Readers might not actually be seekable.
-	switch v := r.(type) {
-	case aws.ReaderSeekerCloser:
-		seekable = v.IsSeeker()
-	case *aws.ReaderSeekerCloser:
-		seekable = v.IsSeeker()
-	}
-	if !seekable {
-		return -1, nil
-	}
-
-	curOffset, err := r.Seek(0, 1)
-	if err != nil {
-		return 0, err
-	}
-
-	endOffset, err := r.Seek(0, 2)
-	if err != nil {
-		return 0, err
-	}
-
-	_, err = r.Seek(curOffset, 0)
-	if err != nil {
-		return 0, err
-	}
-
-	return endOffset - curOffset, nil
 }
 
 // GetBody will return an io.ReadSeeker of the Request's underlying

--- a/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/v4.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/v4.go
@@ -341,7 +341,9 @@ func (v4 Signer) signWithBody(r *http.Request, body io.ReadSeeker, service, regi
 
 	ctx.sanitizeHostForHeader()
 	ctx.assignAmzQueryValues()
-	ctx.build(v4.DisableHeaderHoisting)
+	if err := ctx.build(v4.DisableHeaderHoisting); err != nil {
+		return nil, err
+	}
 
 	// If the request is not presigned the body should be attached to it. This
 	// prevents the confusion of wanting to send a signed request without
@@ -503,11 +505,13 @@ func (v4 *Signer) logSigningInfo(ctx *signingCtx) {
 	v4.Logger.Log(msg)
 }
 
-func (ctx *signingCtx) build(disableHeaderHoisting bool) {
+func (ctx *signingCtx) build(disableHeaderHoisting bool) error {
 	ctx.buildTime()             // no depends
 	ctx.buildCredentialString() // no depends
 
-	ctx.buildBodyDigest()
+	if err := ctx.buildBodyDigest(); err != nil {
+		return err
+	}
 
 	unsignedHeaders := ctx.Request.Header
 	if ctx.isPresign {
@@ -535,6 +539,8 @@ func (ctx *signingCtx) build(disableHeaderHoisting bool) {
 		}
 		ctx.Request.Header.Set("Authorization", strings.Join(parts, ", "))
 	}
+
+	return nil
 }
 
 func (ctx *signingCtx) buildTime() {
@@ -661,7 +667,7 @@ func (ctx *signingCtx) buildSignature() {
 	ctx.signature = hex.EncodeToString(signature)
 }
 
-func (ctx *signingCtx) buildBodyDigest() {
+func (ctx *signingCtx) buildBodyDigest() error {
 	hash := ctx.Request.Header.Get("X-Amz-Content-Sha256")
 	if hash == "" {
 		if ctx.unsignedPayload || (ctx.isPresign && ctx.ServiceName == "s3") {
@@ -669,6 +675,9 @@ func (ctx *signingCtx) buildBodyDigest() {
 		} else if ctx.Body == nil {
 			hash = emptyStringSHA256
 		} else {
+			if !aws.IsReaderSeekable(ctx.Body) {
+				return fmt.Errorf("cannot use unseekable request body %T, for signed request with body", ctx.Body)
+			}
 			hash = hex.EncodeToString(makeSha256Reader(ctx.Body))
 		}
 		if ctx.unsignedPayload || ctx.ServiceName == "s3" || ctx.ServiceName == "glacier" {
@@ -676,6 +685,8 @@ func (ctx *signingCtx) buildBodyDigest() {
 		}
 	}
 	ctx.bodyDigest = hash
+
+	return nil
 }
 
 // isRequestSigned returns if the request is currently signed or presigned

--- a/vendor/github.com/aws/aws-sdk-go/aws/types.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/types.go
@@ -22,6 +22,22 @@ type ReaderSeekerCloser struct {
 	r io.Reader
 }
 
+// IsReaderSeekable returns if the underlying reader type can be seeked. A
+// io.Reader might not actually be seekable if it is the ReaderSeekerCloser
+// type.
+func IsReaderSeekable(r io.Reader) bool {
+	switch v := r.(type) {
+	case ReaderSeekerCloser:
+		return v.IsSeeker()
+	case *ReaderSeekerCloser:
+		return v.IsSeeker()
+	case io.ReadSeeker:
+		return true
+	default:
+		return false
+	}
+}
+
 // Read reads from the reader up to size of p. The number of bytes read, and
 // error if it occurred will be returned.
 //
@@ -54,6 +70,71 @@ func (r ReaderSeekerCloser) Seek(offset int64, whence int) (int64, error) {
 func (r ReaderSeekerCloser) IsSeeker() bool {
 	_, ok := r.r.(io.Seeker)
 	return ok
+}
+
+// HasLen returns the length of the underlying reader if the value implements
+// the Len() int method.
+func (r ReaderSeekerCloser) HasLen() (int, bool) {
+	type lenner interface {
+		Len() int
+	}
+
+	if lr, ok := r.r.(lenner); ok {
+		return lr.Len(), true
+	}
+
+	return 0, false
+}
+
+// GetLen returns the length of the bytes remaining in the underlying reader.
+// Checks first for Len(), then io.Seeker to determine the size of the
+// underlying reader.
+//
+// Will return -1 if the length cannot be determined.
+func (r ReaderSeekerCloser) GetLen() (int64, error) {
+	if l, ok := r.HasLen(); ok {
+		return int64(l), nil
+	}
+
+	if s, ok := r.r.(io.Seeker); ok {
+		return seekerLen(s)
+	}
+
+	return -1, nil
+}
+
+// SeekerLen attempts to get the number of bytes remaining at the seeker's
+// current position.  Returns the number of bytes remaining or error.
+func SeekerLen(s io.Seeker) (int64, error) {
+	// Determine if the seeker is actually seekable. ReaderSeekerCloser
+	// hides the fact that a io.Readers might not actually be seekable.
+	switch v := s.(type) {
+	case ReaderSeekerCloser:
+		return v.GetLen()
+	case *ReaderSeekerCloser:
+		return v.GetLen()
+	}
+
+	return seekerLen(s)
+}
+
+func seekerLen(s io.Seeker) (int64, error) {
+	curOffset, err := s.Seek(0, 1)
+	if err != nil {
+		return 0, err
+	}
+
+	endOffset, err := s.Seek(0, 2)
+	if err != nil {
+		return 0, err
+	}
+
+	_, err = s.Seek(curOffset, 0)
+	if err != nil {
+		return 0, err
+	}
+
+	return endOffset - curOffset, nil
 }
 
 // Close closes the ReaderSeekerCloser.

--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.12.75"
+const SDKVersion = "1.13.4"

--- a/vendor/github.com/aws/aws-sdk-go/internal/sdkrand/locked_source.go
+++ b/vendor/github.com/aws/aws-sdk-go/internal/sdkrand/locked_source.go
@@ -1,0 +1,29 @@
+package sdkrand
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+)
+
+// lockedSource is a thread-safe implementation of rand.Source
+type lockedSource struct {
+	lk  sync.Mutex
+	src rand.Source
+}
+
+func (r *lockedSource) Int63() (n int64) {
+	r.lk.Lock()
+	n = r.src.Int63()
+	r.lk.Unlock()
+	return
+}
+
+func (r *lockedSource) Seed(seed int64) {
+	r.lk.Lock()
+	r.src.Seed(seed)
+	r.lk.Unlock()
+}
+
+// SeededRand is a new RNG using a thread safe implementation of rand.Source
+var SeededRand = rand.New(&lockedSource{src: rand.NewSource(time.Now().UnixNano())})

--- a/vendor/github.com/aws/aws-sdk-go/service/appsync/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/appsync/api.go
@@ -86,6 +86,9 @@ func (c *AppSync) CreateApiKeyRequest(input *CreateApiKeyInput) (req *request.Re
 //   * ErrCodeApiKeyLimitExceededException "ApiKeyLimitExceededException"
 //   The API key exceeded a limit. Try your request again.
 //
+//   * ErrCodeApiKeyValidityOutOfBoundsException "ApiKeyValidityOutOfBoundsException"
+//   The API key expiration must be set to a value between 1 and 365 days.
+//
 // See also, https://docs.aws.amazon.com/goto/WebAPI/appsync-2017-07-25/CreateApiKey
 func (c *AppSync) CreateApiKey(input *CreateApiKeyInput) (*CreateApiKeyOutput, error) {
 	req, out := c.CreateApiKeyRequest(input)
@@ -2040,6 +2043,102 @@ func (c *AppSync) StartSchemaCreationWithContext(ctx aws.Context, input *StartSc
 	return out, req.Send()
 }
 
+const opUpdateApiKey = "UpdateApiKey"
+
+// UpdateApiKeyRequest generates a "aws/request.Request" representing the
+// client's request for the UpdateApiKey operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See UpdateApiKey for more information on using the UpdateApiKey
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the UpdateApiKeyRequest method.
+//    req, resp := client.UpdateApiKeyRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/appsync-2017-07-25/UpdateApiKey
+func (c *AppSync) UpdateApiKeyRequest(input *UpdateApiKeyInput) (req *request.Request, output *UpdateApiKeyOutput) {
+	op := &request.Operation{
+		Name:       opUpdateApiKey,
+		HTTPMethod: "POST",
+		HTTPPath:   "/v1/apis/{apiId}/apikeys/{id}",
+	}
+
+	if input == nil {
+		input = &UpdateApiKeyInput{}
+	}
+
+	output = &UpdateApiKeyOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// UpdateApiKey API operation for AWS AppSync.
+//
+// Updates an API key.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS AppSync's
+// API operation UpdateApiKey for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeBadRequestException "BadRequestException"
+//   The request is not well formed. For example, a value is invalid or a required
+//   field is missing. Check the field values, and try again.
+//
+//   * ErrCodeNotFoundException "NotFoundException"
+//   The resource specified in the request was not found. Check the resource and
+//   try again.
+//
+//   * ErrCodeUnauthorizedException "UnauthorizedException"
+//   You are not authorized to perform this operation.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   The request exceeded a limit. Try your request again.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An internal AWS AppSync error occurred. Try your request again.
+//
+//   * ErrCodeApiKeyValidityOutOfBoundsException "ApiKeyValidityOutOfBoundsException"
+//   The API key expiration must be set to a value between 1 and 365 days.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/appsync-2017-07-25/UpdateApiKey
+func (c *AppSync) UpdateApiKey(input *UpdateApiKeyInput) (*UpdateApiKeyOutput, error) {
+	req, out := c.UpdateApiKeyRequest(input)
+	return out, req.Send()
+}
+
+// UpdateApiKeyWithContext is the same as UpdateApiKey with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UpdateApiKey for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *AppSync) UpdateApiKeyWithContext(ctx aws.Context, input *UpdateApiKeyInput, opts ...request.Option) (*UpdateApiKeyOutput, error) {
+	req, out := c.UpdateApiKeyRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opUpdateDataSource = "UpdateDataSource"
 
 // UpdateDataSourceRequest generates a "aws/request.Request" representing the
@@ -2419,7 +2518,8 @@ type ApiKey struct {
 	// A description of the purpose of the API key.
 	Description *string `locationName:"description" type:"string"`
 
-	// The time when the API key expires.
+	// The time after which the API key expires. The date is represented as seconds
+	// since the epoch, rounded down to the nearest hour.
 	Expires *int64 `locationName:"expires" type:"long"`
 
 	// The API key ID.
@@ -2464,6 +2564,11 @@ type CreateApiKeyInput struct {
 
 	// A description of the purpose of the API key.
 	Description *string `locationName:"description" type:"string"`
+
+	// The time after which the API key expires. The date is represented as seconds
+	// since the epoch, rounded down to the nearest hour. The default value for
+	// this parameter is 7 days from creation time.
+	Expires *int64 `locationName:"expires" type:"long"`
 }
 
 // String returns the string representation
@@ -2498,6 +2603,12 @@ func (s *CreateApiKeyInput) SetApiId(v string) *CreateApiKeyInput {
 // SetDescription sets the Description field's value.
 func (s *CreateApiKeyInput) SetDescription(v string) *CreateApiKeyInput {
 	s.Description = &v
+	return s
+}
+
+// SetExpires sets the Expires field's value.
+func (s *CreateApiKeyInput) SetExpires(v int64) *CreateApiKeyInput {
+	s.Expires = &v
 	return s
 }
 
@@ -2783,7 +2894,7 @@ type CreateResolverInput struct {
 
 	// The mapping template to be used for requests.
 	//
-	// A resolver use a request mapping template to convert a GraphQL expression
+	// A resolver uses a request mapping template to convert a GraphQL expression
 	// into a format that a data source can understand. Mapping templates are written
 	// in Apache Velocity Template Language (VTL).
 	//
@@ -3011,6 +3122,16 @@ type DataSource struct {
 	ServiceRoleArn *string `locationName:"serviceRoleArn" type:"string"`
 
 	// The type of the data source.
+	//
+	//    * AMAZON_DYNAMODB: The data source is an Amazon DynamoDB table.
+	//
+	//    * AMAZON_ELASTICSEARCH: The data source is an Amazon Elasticsearch Service
+	//    domain.
+	//
+	//    * AWS_LAMBDA: The data source is an AWS Lambda function.
+	//
+	//    * NONE: There is no data source. This type is used when the required information
+	//    can be computed on the fly without connecting to a back-end data source.
 	Type *string `locationName:"type" type:"string" enum:"DataSourceType"`
 }
 
@@ -4748,6 +4869,100 @@ func (s *Type) SetName(v string) *Type {
 	return s
 }
 
+type UpdateApiKeyInput struct {
+	_ struct{} `type:"structure"`
+
+	// The ID for the GraphQL API
+	//
+	// ApiId is a required field
+	ApiId *string `location:"uri" locationName:"apiId" type:"string" required:"true"`
+
+	// A description of the purpose of the API key.
+	Description *string `locationName:"description" type:"string"`
+
+	// The time after which the API key expires. The date is represented as seconds
+	// since the epoch.
+	Expires *int64 `locationName:"expires" type:"long"`
+
+	// The API key ID.
+	//
+	// Id is a required field
+	Id *string `location:"uri" locationName:"id" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s UpdateApiKeyInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateApiKeyInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateApiKeyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateApiKeyInput"}
+	if s.ApiId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApiId"))
+	}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetApiId sets the ApiId field's value.
+func (s *UpdateApiKeyInput) SetApiId(v string) *UpdateApiKeyInput {
+	s.ApiId = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *UpdateApiKeyInput) SetDescription(v string) *UpdateApiKeyInput {
+	s.Description = &v
+	return s
+}
+
+// SetExpires sets the Expires field's value.
+func (s *UpdateApiKeyInput) SetExpires(v int64) *UpdateApiKeyInput {
+	s.Expires = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *UpdateApiKeyInput) SetId(v string) *UpdateApiKeyInput {
+	s.Id = &v
+	return s
+}
+
+type UpdateApiKeyOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The API key.
+	ApiKey *ApiKey `locationName:"apiKey" type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateApiKeyOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateApiKeyOutput) GoString() string {
+	return s.String()
+}
+
+// SetApiKey sets the ApiKey field's value.
+func (s *UpdateApiKeyOutput) SetApiKey(v *ApiKey) *UpdateApiKeyOutput {
+	s.ApiKey = v
+	return s
+}
+
 type UpdateDataSourceInput struct {
 	_ struct{} `type:"structure"`
 
@@ -4975,7 +5190,7 @@ func (s *UpdateGraphqlApiInput) SetUserPoolConfig(v *UserPoolConfig) *UpdateGrap
 type UpdateGraphqlApiOutput struct {
 	_ struct{} `type:"structure"`
 
-	// The udpated GraphqlApi object.
+	// The updated GraphqlApi object.
 	GraphqlApi *GraphqlApi `locationName:"graphqlApi" type:"structure"`
 }
 
@@ -5318,6 +5533,9 @@ const (
 
 	// DataSourceTypeAmazonElasticsearch is a DataSourceType enum value
 	DataSourceTypeAmazonElasticsearch = "AMAZON_ELASTICSEARCH"
+
+	// DataSourceTypeNone is a DataSourceType enum value
+	DataSourceTypeNone = "NONE"
 )
 
 const (

--- a/vendor/github.com/aws/aws-sdk-go/service/appsync/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/appsync/errors.go
@@ -10,6 +10,12 @@ const (
 	// The API key exceeded a limit. Try your request again.
 	ErrCodeApiKeyLimitExceededException = "ApiKeyLimitExceededException"
 
+	// ErrCodeApiKeyValidityOutOfBoundsException for service response error code
+	// "ApiKeyValidityOutOfBoundsException".
+	//
+	// The API key expiration must be set to a value between 1 and 365 days.
+	ErrCodeApiKeyValidityOutOfBoundsException = "ApiKeyValidityOutOfBoundsException"
+
 	// ErrCodeApiLimitExceededException for service response error code
 	// "ApiLimitExceededException".
 	//

--- a/vendor/github.com/aws/aws-sdk-go/service/autoscaling/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/autoscaling/api.go
@@ -87,6 +87,9 @@ func (c *AutoScaling) AttachInstancesRequest(input *AttachInstancesInput) (req *
 //   You already have a pending update to an Auto Scaling resource (for example,
 //   a group, instance, or load balancer).
 //
+//   * ErrCodeServiceLinkedRoleFailure "ServiceLinkedRoleFailure"
+//   The service-linked role is not yet ready for use.
+//
 // See also, https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/AttachInstances
 func (c *AutoScaling) AttachInstances(input *AttachInstancesInput) (*AttachInstancesOutput, error) {
 	req, out := c.AttachInstancesRequest(input)
@@ -173,6 +176,9 @@ func (c *AutoScaling) AttachLoadBalancerTargetGroupsRequest(input *AttachLoadBal
 //   * ErrCodeResourceContentionFault "ResourceContention"
 //   You already have a pending update to an Auto Scaling resource (for example,
 //   a group, instance, or load balancer).
+//
+//   * ErrCodeServiceLinkedRoleFailure "ServiceLinkedRoleFailure"
+//   The service-linked role is not yet ready for use.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/AttachLoadBalancerTargetGroups
 func (c *AutoScaling) AttachLoadBalancerTargetGroups(input *AttachLoadBalancerTargetGroupsInput) (*AttachLoadBalancerTargetGroupsOutput, error) {
@@ -263,6 +269,9 @@ func (c *AutoScaling) AttachLoadBalancersRequest(input *AttachLoadBalancersInput
 //   * ErrCodeResourceContentionFault "ResourceContention"
 //   You already have a pending update to an Auto Scaling resource (for example,
 //   a group, instance, or load balancer).
+//
+//   * ErrCodeServiceLinkedRoleFailure "ServiceLinkedRoleFailure"
+//   The service-linked role is not yet ready for use.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/AttachLoadBalancers
 func (c *AutoScaling) AttachLoadBalancers(input *AttachLoadBalancersInput) (*AttachLoadBalancersOutput, error) {
@@ -436,9 +445,10 @@ func (c *AutoScaling) CreateAutoScalingGroupRequest(input *CreateAutoScalingGrou
 //
 // Creates an Auto Scaling group with the specified name and attributes.
 //
-// If you exceed your maximum limit of Auto Scaling groups, which by default
-// is 20 per region, the call fails. For information about viewing and updating
-// this limit, see DescribeAccountLimits.
+// If you exceed your maximum limit of Auto Scaling groups, the call fails.
+// For information about viewing this limit, see DescribeAccountLimits. For
+// information about updating this limit, see Auto Scaling Limits (http://docs.aws.amazon.com/autoscaling/latest/userguide/as-account-limits.html)
+// in the Auto Scaling User Guide.
 //
 // For more information, see Auto Scaling Groups (http://docs.aws.amazon.com/autoscaling/latest/userguide/AutoScalingGroup.html)
 // in the Auto Scaling User Guide.
@@ -463,6 +473,9 @@ func (c *AutoScaling) CreateAutoScalingGroupRequest(input *CreateAutoScalingGrou
 //   * ErrCodeResourceContentionFault "ResourceContention"
 //   You already have a pending update to an Auto Scaling resource (for example,
 //   a group, instance, or load balancer).
+//
+//   * ErrCodeServiceLinkedRoleFailure "ServiceLinkedRoleFailure"
+//   The service-linked role is not yet ready for use.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/CreateAutoScalingGroup
 func (c *AutoScaling) CreateAutoScalingGroup(input *CreateAutoScalingGroupInput) (*CreateAutoScalingGroupOutput, error) {
@@ -534,9 +547,10 @@ func (c *AutoScaling) CreateLaunchConfigurationRequest(input *CreateLaunchConfig
 //
 // Creates a launch configuration.
 //
-// If you exceed your maximum limit of launch configurations, which by default
-// is 100 per region, the call fails. For information about viewing and updating
-// this limit, see DescribeAccountLimits.
+// If you exceed your maximum limit of launch configurations, the call fails.
+// For information about viewing this limit, see DescribeAccountLimits. For
+// information about updating this limit, see Auto Scaling Limits (http://docs.aws.amazon.com/autoscaling/latest/userguide/as-account-limits.html)
+// in the Auto Scaling User Guide.
 //
 // For more information, see Launch Configurations (http://docs.aws.amazon.com/autoscaling/latest/userguide/LaunchConfiguration.html)
 // in the Auto Scaling User Guide.
@@ -1104,6 +1118,9 @@ func (c *AutoScaling) DeletePolicyRequest(input *DeletePolicyInput) (req *reques
 //   You already have a pending update to an Auto Scaling resource (for example,
 //   a group, instance, or load balancer).
 //
+//   * ErrCodeServiceLinkedRoleFailure "ServiceLinkedRoleFailure"
+//   The service-linked role is not yet ready for use.
+//
 // See also, https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/DeletePolicy
 func (c *AutoScaling) DeletePolicy(input *DeletePolicyInput) (*DeletePolicyOutput, error) {
 	req, out := c.DeletePolicyRequest(input)
@@ -1339,9 +1356,9 @@ func (c *AutoScaling) DescribeAccountLimitsRequest(input *DescribeAccountLimitsI
 //
 // Describes the current Auto Scaling resource limits for your AWS account.
 //
-// For information about requesting an increase in these limits, see AWS Service
-// Limits (http://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html)
-// in the Amazon Web Services General Reference.
+// For information about requesting an increase in these limits, see Auto Scaling
+// Limits (http://docs.aws.amazon.com/autoscaling/latest/userguide/as-account-limits.html)
+// in the Auto Scaling User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2566,6 +2583,9 @@ func (c *AutoScaling) DescribePoliciesRequest(input *DescribePoliciesInput) (req
 //   * ErrCodeResourceContentionFault "ResourceContention"
 //   You already have a pending update to an Auto Scaling resource (for example,
 //   a group, instance, or load balancer).
+//
+//   * ErrCodeServiceLinkedRoleFailure "ServiceLinkedRoleFailure"
+//   The service-linked role is not yet ready for use.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/DescribePolicies
 func (c *AutoScaling) DescribePolicies(input *DescribePoliciesInput) (*DescribePoliciesOutput, error) {
@@ -4098,6 +4118,9 @@ func (c *AutoScaling) PutNotificationConfigurationRequest(input *PutNotification
 //   You already have a pending update to an Auto Scaling resource (for example,
 //   a group, instance, or load balancer).
 //
+//   * ErrCodeServiceLinkedRoleFailure "ServiceLinkedRoleFailure"
+//   The service-linked role is not yet ready for use.
+//
 // See also, https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/PutNotificationConfiguration
 func (c *AutoScaling) PutNotificationConfiguration(input *PutNotificationConfigurationInput) (*PutNotificationConfigurationOutput, error) {
 	req, out := c.PutNotificationConfigurationRequest(input)
@@ -4190,6 +4213,9 @@ func (c *AutoScaling) PutScalingPolicyRequest(input *PutScalingPolicyInput) (req
 //   * ErrCodeResourceContentionFault "ResourceContention"
 //   You already have a pending update to an Auto Scaling resource (for example,
 //   a group, instance, or load balancer).
+//
+//   * ErrCodeServiceLinkedRoleFailure "ServiceLinkedRoleFailure"
+//   The service-linked role is not yet ready for use.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/PutScalingPolicy
 func (c *AutoScaling) PutScalingPolicy(input *PutScalingPolicyInput) (*PutScalingPolicyOutput, error) {
@@ -5033,6 +5059,9 @@ func (c *AutoScaling) UpdateAutoScalingGroupRequest(input *UpdateAutoScalingGrou
 //   You already have a pending update to an Auto Scaling resource (for example,
 //   a group, instance, or load balancer).
 //
+//   * ErrCodeServiceLinkedRoleFailure "ServiceLinkedRoleFailure"
+//   The service-linked role is not yet ready for use.
+//
 // See also, https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/UpdateAutoScalingGroup
 func (c *AutoScaling) UpdateAutoScalingGroup(input *UpdateAutoScalingGroupInput) (*UpdateAutoScalingGroupOutput, error) {
 	req, out := c.UpdateAutoScalingGroupRequest(input)
@@ -5241,7 +5270,7 @@ type AttachInstancesInput struct {
 	// AutoScalingGroupName is a required field
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
 
-	// One or more instance IDs.
+	// The IDs of the instances. You can specify up to 20 instances.
 	InstanceIds []*string `type:"list"`
 }
 
@@ -5305,7 +5334,8 @@ type AttachLoadBalancerTargetGroupsInput struct {
 	// AutoScalingGroupName is a required field
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
 
-	// The Amazon Resource Names (ARN) of the target groups.
+	// The Amazon Resource Names (ARN) of the target groups. You can specify up
+	// to 10 target groups.
 	//
 	// TargetGroupARNs is a required field
 	TargetGroupARNs []*string `type:"list" required:"true"`
@@ -5374,7 +5404,7 @@ type AttachLoadBalancersInput struct {
 	// AutoScalingGroupName is a required field
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
 
-	// One or more load balancer names.
+	// The names of the load balancers. You can specify up to 10 load balancers.
 	//
 	// LoadBalancerNames is a required field
 	LoadBalancerNames []*string `type:"list" required:"true"`
@@ -5725,6 +5755,12 @@ type CreateAutoScalingGroupInput struct {
 	// in the Amazon Elastic Compute Cloud User Guide.
 	PlacementGroup *string `min:"1" type:"string"`
 
+	// The Amazon Resource Name (ARN) of the service-linked role that the Auto Scaling
+	// group uses to call other AWS services on your behalf. By default, Auto Scaling
+	// uses a service-linked role named AWSServiceRoleForAutoScaling, which it creates
+	// if it does not exist.
+	ServiceLinkedRoleARN *string `min:"1" type:"string"`
+
 	// One or more tags.
 	//
 	// For more information, see Tagging Auto Scaling Groups and Instances (http://docs.aws.amazon.com/autoscaling/latest/userguide/autoscaling-tagging.html)
@@ -5792,6 +5828,9 @@ func (s *CreateAutoScalingGroupInput) Validate() error {
 	}
 	if s.PlacementGroup != nil && len(*s.PlacementGroup) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("PlacementGroup", 1))
+	}
+	if s.ServiceLinkedRoleARN != nil && len(*s.ServiceLinkedRoleARN) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ServiceLinkedRoleARN", 1))
 	}
 	if s.VPCZoneIdentifier != nil && len(*s.VPCZoneIdentifier) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("VPCZoneIdentifier", 1))
@@ -5918,6 +5957,12 @@ func (s *CreateAutoScalingGroupInput) SetPlacementGroup(v string) *CreateAutoSca
 	return s
 }
 
+// SetServiceLinkedRoleARN sets the ServiceLinkedRoleARN field's value.
+func (s *CreateAutoScalingGroupInput) SetServiceLinkedRoleARN(v string) *CreateAutoScalingGroupInput {
+	s.ServiceLinkedRoleARN = &v
+	return s
+}
+
 // SetTags sets the Tags field's value.
 func (s *CreateAutoScalingGroupInput) SetTags(v []*Tag) *CreateAutoScalingGroupInput {
 	s.Tags = v
@@ -5968,9 +6013,8 @@ type CreateLaunchConfigurationInput struct {
 	// you create your group.
 	//
 	// Default: If the instance is launched into a default subnet, the default is
-	// true. If the instance is launched into a nondefault subnet, the default is
-	// false. For more information, see Supported Platforms (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-supported-platforms.html)
-	// in the Amazon Elastic Compute Cloud User Guide.
+	// to assign a public IP address. If the instance is launched into a nondefault
+	// subnet, the default is not to assign a public IP address.
 	AssociatePublicIpAddress *bool `type:"boolean"`
 
 	// One or more mappings that specify how block devices are exposed to the instance.
@@ -7106,7 +7150,7 @@ type DescribeAutoScalingInstancesInput struct {
 	InstanceIds []*string `type:"list"`
 
 	// The maximum number of items to return with this call. The default value is
-	// 50 and the maximum value is 100.
+	// 50 and the maximum value is 50.
 	MaxRecords *int64 `type:"integer"`
 
 	// The token for the next set of items to return. (You received this token from
@@ -7411,7 +7455,7 @@ type DescribeLoadBalancerTargetGroupsInput struct {
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
 
 	// The maximum number of items to return with this call. The default value is
-	// 50 and the maximum value is 100.
+	// 100 and the maximum value is 100.
 	MaxRecords *int64 `type:"integer"`
 
 	// The token for the next set of items to return. (You received this token from
@@ -7505,7 +7549,7 @@ type DescribeLoadBalancersInput struct {
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
 
 	// The maximum number of items to return with this call. The default value is
-	// 50 and the maximum value is 100.
+	// 100 and the maximum value is 100.
 	MaxRecords *int64 `type:"integer"`
 
 	// The token for the next set of items to return. (You received this token from
@@ -7838,7 +7882,7 @@ type DescribeScalingActivitiesInput struct {
 	AutoScalingGroupName *string `min:"1" type:"string"`
 
 	// The maximum number of items to return with this call. The default value is
-	// 100.
+	// 100 and the maximum value is 100.
 	MaxRecords *int64 `type:"integer"`
 
 	// The token for the next set of items to return. (You received this token from
@@ -8212,11 +8256,11 @@ type DetachInstancesInput struct {
 	// AutoScalingGroupName is a required field
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
 
-	// One or more instance IDs.
+	// The IDs of the instances. You can specify up to 20 instances.
 	InstanceIds []*string `type:"list"`
 
-	// If True, the Auto Scaling group decrements the desired capacity value by
-	// the number of instances detached.
+	// Indicates whether the Auto Scaling group decrements the desired capacity
+	// value by the number of instances detached.
 	//
 	// ShouldDecrementDesiredCapacity is a required field
 	ShouldDecrementDesiredCapacity *bool `type:"boolean" required:"true"`
@@ -8300,7 +8344,8 @@ type DetachLoadBalancerTargetGroupsInput struct {
 	// AutoScalingGroupName is a required field
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
 
-	// The Amazon Resource Names (ARN) of the target groups.
+	// The Amazon Resource Names (ARN) of the target groups. You can specify up
+	// to 10 target groups.
 	//
 	// TargetGroupARNs is a required field
 	TargetGroupARNs []*string `type:"list" required:"true"`
@@ -8369,7 +8414,7 @@ type DetachLoadBalancersInput struct {
 	// AutoScalingGroupName is a required field
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
 
-	// One or more load balancer names.
+	// The names of the load balancers. You can specify up to 10 load balancers.
 	//
 	// LoadBalancerNames is a required field
 	LoadBalancerNames []*string `type:"list" required:"true"`
@@ -8515,9 +8560,8 @@ func (s DisableMetricsCollectionOutput) GoString() string {
 type Ebs struct {
 	_ struct{} `type:"structure"`
 
-	// Indicates whether the volume is deleted on instance termination.
-	//
-	// Default: true
+	// Indicates whether the volume is deleted on instance termination. The default
+	// is true.
 	DeleteOnTermination *bool `type:"boolean"`
 
 	// Indicates whether the volume should be encrypted. Encrypted EBS volumes must
@@ -8779,14 +8823,11 @@ type EnterStandbyInput struct {
 	// AutoScalingGroupName is a required field
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
 
-	// One or more instances to move into Standby mode. You must specify at least
-	// one instance ID.
+	// The IDs of the instances. You can specify up to 20 instances.
 	InstanceIds []*string `type:"list"`
 
-	// Specifies whether the instances moved to Standby mode count as part of the
-	// Auto Scaling group's desired capacity. If set, the desired capacity for the
-	// Auto Scaling group decrements by the number of instances moved to Standby
-	// mode.
+	// Indicates whether to decrement the desired capacity of the Auto Scaling group
+	// by the number of instances moved to Standby mode.
 	//
 	// ShouldDecrementDesiredCapacity is a required field
 	ShouldDecrementDesiredCapacity *bool `type:"boolean" required:"true"`
@@ -8874,9 +8915,8 @@ type ExecutePolicyInput struct {
 	// otherwise.
 	BreachThreshold *float64 `type:"double"`
 
-	// If this parameter is true, Auto Scaling waits for the cooldown period to
-	// complete before executing the policy. Otherwise, Auto Scaling executes the
-	// policy without waiting for the cooldown period to complete.
+	// Indicates whether Auto Scaling waits for the cooldown period to complete
+	// before executing the policy.
 	//
 	// This parameter is not supported if the policy type is StepScaling.
 	//
@@ -8984,7 +9024,7 @@ type ExitStandbyInput struct {
 	// AutoScalingGroupName is a required field
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
 
-	// One or more instance IDs. You must specify at least one instance ID.
+	// The IDs of the instances. You can specify up to 20 instances.
 	InstanceIds []*string `type:"list"`
 }
 
@@ -9159,6 +9199,10 @@ type Group struct {
 	// in the Amazon Elastic Compute Cloud User Guide.
 	PlacementGroup *string `min:"1" type:"string"`
 
+	// The Amazon Resource Name (ARN) of the service-linked role that the Auto Scaling
+	// group uses to call other AWS services on your behalf.
+	ServiceLinkedRoleARN *string `min:"1" type:"string"`
+
 	// The current state of the group when DeleteAutoScalingGroup is in progress.
 	Status *string `min:"1" type:"string"`
 
@@ -9290,6 +9334,12 @@ func (s *Group) SetNewInstancesProtectedFromScaleIn(v bool) *Group {
 // SetPlacementGroup sets the PlacementGroup field's value.
 func (s *Group) SetPlacementGroup(v string) *Group {
 	s.PlacementGroup = &v
+	return s
+}
+
+// SetServiceLinkedRoleARN sets the ServiceLinkedRoleARN field's value.
+func (s *Group) SetServiceLinkedRoleARN(v string) *Group {
+	s.ServiceLinkedRoleARN = &v
 	return s
 }
 
@@ -9766,8 +9816,10 @@ type LaunchTemplateSpecification struct {
 	// or a template ID.
 	LaunchTemplateName *string `min:"3" type:"string"`
 
-	// The version number. By default, the default version of the launch template
-	// is used.
+	// The version number, $Latest, or $Default. If the value is $Latest, Auto Scaling
+	// selects the latest version of the launch template when launching instances.
+	// If the value is $Default, Auto Scaling selects the default version of the
+	// launch template when launching instances. The default value is $Default.
 	Version *string `min:"1" type:"string"`
 }
 
@@ -11542,10 +11594,10 @@ type SetDesiredCapacityInput struct {
 	// DesiredCapacity is a required field
 	DesiredCapacity *int64 `type:"integer" required:"true"`
 
-	// By default, SetDesiredCapacity overrides any cooldown period associated with
-	// the Auto Scaling group. Specify True to make Auto Scaling to wait for the
-	// cool-down period associated with the Auto Scaling group to complete before
-	// initiating a scaling activity to set your Auto Scaling group to its new capacity.
+	// Indicates whether Auto Scaling waits for the cooldown period to complete
+	// before initiating a scaling activity to set your Auto Scaling group to its
+	// new capacity. By default, Auto Scaling does not honor the cooldown period
+	// during manual scaling activities.
 	HonorCooldown *bool `type:"boolean"`
 }
 
@@ -12076,10 +12128,9 @@ type TargetTrackingConfiguration struct {
 	CustomizedMetricSpecification *CustomizedMetricSpecification `type:"structure"`
 
 	// Indicates whether scale in by the target tracking policy is disabled. If
-	// the value is true, scale in is disabled and the target tracking policy won't
-	// remove instances from the Auto Scaling group. Otherwise, scale in is enabled
-	// and the target tracking policy can remove instances from the Auto Scaling
-	// group. The default value is false.
+	// scale in is disabled, the target tracking policy won't remove instances from
+	// the Auto Scaling group. Otherwise, the target tracking policy can remove
+	// instances from the Auto Scaling group. The default is disabled.
 	DisableScaleIn *bool `type:"boolean"`
 
 	// A predefined metric. You can specify either a predefined metric or a customized
@@ -12157,8 +12208,8 @@ type TerminateInstanceInAutoScalingGroupInput struct {
 	// InstanceId is a required field
 	InstanceId *string `min:"1" type:"string" required:"true"`
 
-	// If true, terminating the instance also decrements the size of the Auto Scaling
-	// group.
+	// Indicates whether terminating the instance also decrements the size of the
+	// Auto Scaling group.
 	//
 	// ShouldDecrementDesiredCapacity is a required field
 	ShouldDecrementDesiredCapacity *bool `type:"boolean" required:"true"`
@@ -12262,12 +12313,12 @@ type UpdateAutoScalingGroupInput struct {
 	// The service to use for the health checks. The valid values are EC2 and ELB.
 	HealthCheckType *string `min:"1" type:"string"`
 
-	// The name of the launch configuration. You must specify either a launch configuration
-	// or a launch template.
+	// The name of the launch configuration. If you specify a launch configuration,
+	// you can't specify a launch template.
 	LaunchConfigurationName *string `min:"1" type:"string"`
 
-	// The launch template to use to specify the updates. You must specify a launch
-	// configuration or a launch template.
+	// The launch template to use to specify the updates. If you specify a launch
+	// template, you can't specify a launch configuration.
 	LaunchTemplate *LaunchTemplateSpecification `type:"structure"`
 
 	// The maximum size of the Auto Scaling group.
@@ -12284,6 +12335,10 @@ type UpdateAutoScalingGroupInput struct {
 	// if any. For more information, see Placement Groups (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html)
 	// in the Amazon Elastic Compute Cloud User Guide.
 	PlacementGroup *string `min:"1" type:"string"`
+
+	// The Amazon Resource Name (ARN) of the service-linked role that the Auto Scaling
+	// group uses to call other AWS services on your behalf.
+	ServiceLinkedRoleARN *string `min:"1" type:"string"`
 
 	// A standalone termination policy or a list of termination policies used to
 	// select the instance to terminate. The policies are executed in the order
@@ -12335,6 +12390,9 @@ func (s *UpdateAutoScalingGroupInput) Validate() error {
 	}
 	if s.PlacementGroup != nil && len(*s.PlacementGroup) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("PlacementGroup", 1))
+	}
+	if s.ServiceLinkedRoleARN != nil && len(*s.ServiceLinkedRoleARN) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ServiceLinkedRoleARN", 1))
 	}
 	if s.VPCZoneIdentifier != nil && len(*s.VPCZoneIdentifier) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("VPCZoneIdentifier", 1))
@@ -12420,6 +12478,12 @@ func (s *UpdateAutoScalingGroupInput) SetNewInstancesProtectedFromScaleIn(v bool
 // SetPlacementGroup sets the PlacementGroup field's value.
 func (s *UpdateAutoScalingGroupInput) SetPlacementGroup(v string) *UpdateAutoScalingGroupInput {
 	s.PlacementGroup = &v
+	return s
+}
+
+// SetServiceLinkedRoleARN sets the ServiceLinkedRoleARN field's value.
+func (s *UpdateAutoScalingGroupInput) SetServiceLinkedRoleARN(v string) *UpdateAutoScalingGroupInput {
+	s.ServiceLinkedRoleARN = &v
 	return s
 }
 

--- a/vendor/github.com/aws/aws-sdk-go/service/autoscaling/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/autoscaling/doc.go
@@ -3,9 +3,10 @@
 // Package autoscaling provides the client and types for making API
 // requests to Auto Scaling.
 //
-// Auto Scaling is designed to automatically launch or terminate EC2 instances
-// based on user-defined policies, schedules, and health checks. Use this service
-// in conjunction with the Amazon CloudWatch and Elastic Load Balancing services.
+// Amazon EC2 Auto Scaling is designed to automatically launch or terminate
+// EC2 instances based on user-defined policies, schedules, and health checks.
+// Use this service in conjunction with the AWS Auto Scaling, Amazon CloudWatch,
+// and Elastic Load Balancing services.
 //
 // See https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01 for more information on this service.
 //

--- a/vendor/github.com/aws/aws-sdk-go/service/autoscaling/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/autoscaling/errors.go
@@ -44,4 +44,10 @@ const (
 	// The operation can't be performed because there are scaling activities in
 	// progress.
 	ErrCodeScalingActivityInProgressFault = "ScalingActivityInProgress"
+
+	// ErrCodeServiceLinkedRoleFailure for service response error code
+	// "ServiceLinkedRoleFailure".
+	//
+	// The service-linked role is not yet ready for use.
+	ErrCodeServiceLinkedRoleFailure = "ServiceLinkedRoleFailure"
 )

--- a/vendor/github.com/aws/aws-sdk-go/service/codecommit/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/codecommit/api.go
@@ -3539,6 +3539,192 @@ func (c *CodeCommit) PostCommentReplyWithContext(ctx aws.Context, input *PostCom
 	return out, req.Send()
 }
 
+const opPutFile = "PutFile"
+
+// PutFileRequest generates a "aws/request.Request" representing the
+// client's request for the PutFile operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See PutFile for more information on using the PutFile
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the PutFileRequest method.
+//    req, resp := client.PutFileRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/PutFile
+func (c *CodeCommit) PutFileRequest(input *PutFileInput) (req *request.Request, output *PutFileOutput) {
+	op := &request.Operation{
+		Name:       opPutFile,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &PutFileInput{}
+	}
+
+	output = &PutFileOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// PutFile API operation for AWS CodeCommit.
+//
+// Adds or updates a file in an AWS CodeCommit repository.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS CodeCommit's
+// API operation PutFile for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeRepositoryNameRequiredException "RepositoryNameRequiredException"
+//   A repository name is required but was not specified.
+//
+//   * ErrCodeInvalidRepositoryNameException "InvalidRepositoryNameException"
+//   At least one specified repository name is not valid.
+//
+//   This exception only occurs when a specified repository name is not valid.
+//   Other exceptions occur when a required repository parameter is missing, or
+//   when a specified repository does not exist.
+//
+//   * ErrCodeRepositoryDoesNotExistException "RepositoryDoesNotExistException"
+//   The specified repository does not exist.
+//
+//   * ErrCodeParentCommitIdRequiredException "ParentCommitIdRequiredException"
+//   A parent commit ID is required. To view the full commit ID of a branch in
+//   a repository, use GetBranch or a Git command (for example, git pull or git
+//   log).
+//
+//   * ErrCodeInvalidParentCommitIdException "InvalidParentCommitIdException"
+//   The parent commit ID is not valid. The commit ID cannot be empty, and must
+//   match the head commit ID for the branch of the repository where you want
+//   to add or update a file.
+//
+//   * ErrCodeParentCommitDoesNotExistException "ParentCommitDoesNotExistException"
+//   The parent commit ID is not valid. The specified parent commit ID does not
+//   exist in the specified branch of the repository.
+//
+//   * ErrCodeParentCommitIdOutdatedException "ParentCommitIdOutdatedException"
+//   The file could not be added because the provided parent commit ID is not
+//   the current tip of the specified branch. To view the full commit ID of the
+//   current head of the branch, use GetBranch.
+//
+//   * ErrCodeFileContentRequiredException "FileContentRequiredException"
+//   The file cannot be added because it is empty. Empty files cannot be added
+//   to the repository with this API.
+//
+//   * ErrCodeFileContentSizeLimitExceededException "FileContentSizeLimitExceededException"
+//   The file cannot be added because it is too large. The maximum file size that
+//   can be added using PutFile is 6 MB. For files larger than 6 MB but smaller
+//   than 2 GB, add them using a Git client.
+//
+//   * ErrCodePathRequiredException "PathRequiredException"
+//   The filePath for a location cannot be empty or null.
+//
+//   * ErrCodeInvalidPathException "InvalidPathException"
+//   The specified path is not valid.
+//
+//   * ErrCodeBranchNameRequiredException "BranchNameRequiredException"
+//   A branch name is required but was not specified.
+//
+//   * ErrCodeInvalidBranchNameException "InvalidBranchNameException"
+//   The specified reference name is not valid.
+//
+//   * ErrCodeBranchDoesNotExistException "BranchDoesNotExistException"
+//   The specified branch does not exist.
+//
+//   * ErrCodeBranchNameIsTagNameException "BranchNameIsTagNameException"
+//   The specified branch name is not valid because it is a tag name. Type the
+//   name of a current branch in the repository. For a list of valid branch names,
+//   use ListBranches.
+//
+//   * ErrCodeInvalidFileModeException "InvalidFileModeException"
+//   The specified file mode permission is not valid. For a list of valid file
+//   mode permissions, see PutFile.
+//
+//   * ErrCodeNameLengthExceededException "NameLengthExceededException"
+//   The file name is not valid because it has exceeded the character limit for
+//   file names. File names, including the path to the file, cannot exceed the
+//   character limit.
+//
+//   * ErrCodeInvalidEmailException "InvalidEmailException"
+//   The specified email address either contains one or more characters that are
+//   not allowed, or it exceeds the maximum number of characters allowed for an
+//   email address.
+//
+//   * ErrCodeCommitMessageLengthExceededException "CommitMessageLengthExceededException"
+//   The commit message is too long. Provide a shorter string.
+//
+//   * ErrCodeEncryptionIntegrityChecksFailedException "EncryptionIntegrityChecksFailedException"
+//   An encryption integrity check failed.
+//
+//   * ErrCodeEncryptionKeyAccessDeniedException "EncryptionKeyAccessDeniedException"
+//   An encryption key could not be accessed.
+//
+//   * ErrCodeEncryptionKeyDisabledException "EncryptionKeyDisabledException"
+//   The encryption key is disabled.
+//
+//   * ErrCodeEncryptionKeyNotFoundException "EncryptionKeyNotFoundException"
+//   No encryption key was found.
+//
+//   * ErrCodeEncryptionKeyUnavailableException "EncryptionKeyUnavailableException"
+//   The encryption key is not available.
+//
+//   * ErrCodeSameFileContentException "SameFileContentException"
+//   The file was not added or updated because the content of the file is exactly
+//   the same as the content of that file in the repository and branch that you
+//   specified.
+//
+//   * ErrCodeFileNameConflictsWithDirectoryNameException "FileNameConflictsWithDirectoryNameException"
+//   A file cannot be added to the repository because the specified file name
+//   has the same name as a directory in this repository. Either provide another
+//   name for the file, or add the file in a directory that does not match the
+//   file name.
+//
+//   * ErrCodeDirectoryNameConflictsWithFileNameException "DirectoryNameConflictsWithFileNameException"
+//   A file cannot be added to the repository because the specified path name
+//   has the same name as a file that already exists in this repository. Either
+//   provide a different name for the file, or specify a different path for the
+//   file.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/codecommit-2015-04-13/PutFile
+func (c *CodeCommit) PutFile(input *PutFileInput) (*PutFileOutput, error) {
+	req, out := c.PutFileRequest(input)
+	return out, req.Send()
+}
+
+// PutFileWithContext is the same as PutFile with the addition of
+// the ability to pass a context and additional request options.
+//
+// See PutFile for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CodeCommit) PutFileWithContext(ctx aws.Context, input *PutFileInput, opts ...request.Option) (*PutFileOutput, error) {
+	req, out := c.PutFileRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opPutRepositoryTriggers = "PutRepositoryTriggers"
 
 // PutRepositoryTriggersRequest generates a "aws/request.Request" representing the
@@ -5032,7 +5218,8 @@ type Commit struct {
 	// The commit message associated with the specified commit.
 	Message *string `locationName:"message" type:"string"`
 
-	// The parent list for the specified commit.
+	// A list of parent commits for the specified commit. Each parent commit ID
+	// is the full commit ID.
 	Parents []*string `locationName:"parents" type:"list"`
 
 	// Tree information for the specified commit.
@@ -8083,6 +8270,198 @@ func (s *PullRequestTarget) SetSourceReference(v string) *PullRequestTarget {
 	return s
 }
 
+type PutFileInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the branch where you want to add or update the file.
+	//
+	// BranchName is a required field
+	BranchName *string `locationName:"branchName" min:"1" type:"string" required:"true"`
+
+	// A message about why this file was added or updated. While optional, adding
+	// a message is strongly encouraged in order to provide a more useful commit
+	// history for your repository.
+	CommitMessage *string `locationName:"commitMessage" type:"string"`
+
+	// An email address for the person adding or updating the file.
+	Email *string `locationName:"email" type:"string"`
+
+	// The content of the file, in binary object format.
+	//
+	// FileContent is automatically base64 encoded/decoded by the SDK.
+	//
+	// FileContent is a required field
+	FileContent []byte `locationName:"fileContent" type:"blob" required:"true"`
+
+	// The file mode permissions of the blob. Valid file mode permissions are listed
+	// below.
+	FileMode *string `locationName:"fileMode" type:"string" enum:"FileModeTypeEnum"`
+
+	// The name of the file you want to add or update, including the relative path
+	// to the file in the repository.
+	//
+	// If the path does not currently exist in the repository, the path will be
+	// created as part of adding the file.
+	//
+	// FilePath is a required field
+	FilePath *string `locationName:"filePath" type:"string" required:"true"`
+
+	// The name of the person adding or updating the file. While optional, adding
+	// a name is strongly encouraged in order to provide a more useful commit history
+	// for your repository.
+	Name *string `locationName:"name" type:"string"`
+
+	// The full commit ID of the head commit in the branch where you want to add
+	// or update the file. If the commit ID does not match the ID of the head commit
+	// at the time of the operation, an error will occur, and the file will not
+	// be added or updated.
+	ParentCommitId *string `locationName:"parentCommitId" type:"string"`
+
+	// The name of the repository where you want to add or update the file.
+	//
+	// RepositoryName is a required field
+	RepositoryName *string `locationName:"repositoryName" min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s PutFileInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PutFileInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutFileInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutFileInput"}
+	if s.BranchName == nil {
+		invalidParams.Add(request.NewErrParamRequired("BranchName"))
+	}
+	if s.BranchName != nil && len(*s.BranchName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("BranchName", 1))
+	}
+	if s.FileContent == nil {
+		invalidParams.Add(request.NewErrParamRequired("FileContent"))
+	}
+	if s.FilePath == nil {
+		invalidParams.Add(request.NewErrParamRequired("FilePath"))
+	}
+	if s.RepositoryName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RepositoryName"))
+	}
+	if s.RepositoryName != nil && len(*s.RepositoryName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RepositoryName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetBranchName sets the BranchName field's value.
+func (s *PutFileInput) SetBranchName(v string) *PutFileInput {
+	s.BranchName = &v
+	return s
+}
+
+// SetCommitMessage sets the CommitMessage field's value.
+func (s *PutFileInput) SetCommitMessage(v string) *PutFileInput {
+	s.CommitMessage = &v
+	return s
+}
+
+// SetEmail sets the Email field's value.
+func (s *PutFileInput) SetEmail(v string) *PutFileInput {
+	s.Email = &v
+	return s
+}
+
+// SetFileContent sets the FileContent field's value.
+func (s *PutFileInput) SetFileContent(v []byte) *PutFileInput {
+	s.FileContent = v
+	return s
+}
+
+// SetFileMode sets the FileMode field's value.
+func (s *PutFileInput) SetFileMode(v string) *PutFileInput {
+	s.FileMode = &v
+	return s
+}
+
+// SetFilePath sets the FilePath field's value.
+func (s *PutFileInput) SetFilePath(v string) *PutFileInput {
+	s.FilePath = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *PutFileInput) SetName(v string) *PutFileInput {
+	s.Name = &v
+	return s
+}
+
+// SetParentCommitId sets the ParentCommitId field's value.
+func (s *PutFileInput) SetParentCommitId(v string) *PutFileInput {
+	s.ParentCommitId = &v
+	return s
+}
+
+// SetRepositoryName sets the RepositoryName field's value.
+func (s *PutFileInput) SetRepositoryName(v string) *PutFileInput {
+	s.RepositoryName = &v
+	return s
+}
+
+type PutFileOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The ID of the blob, which is its SHA-1 pointer.
+	//
+	// BlobId is a required field
+	BlobId *string `locationName:"blobId" type:"string" required:"true"`
+
+	// The full SHA of the commit that contains this file change.
+	//
+	// CommitId is a required field
+	CommitId *string `locationName:"commitId" type:"string" required:"true"`
+
+	// Tree information for the commit that contains this file change.
+	//
+	// TreeId is a required field
+	TreeId *string `locationName:"treeId" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s PutFileOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PutFileOutput) GoString() string {
+	return s.String()
+}
+
+// SetBlobId sets the BlobId field's value.
+func (s *PutFileOutput) SetBlobId(v string) *PutFileOutput {
+	s.BlobId = &v
+	return s
+}
+
+// SetCommitId sets the CommitId field's value.
+func (s *PutFileOutput) SetCommitId(v string) *PutFileOutput {
+	s.CommitId = &v
+	return s
+}
+
+// SetTreeId sets the TreeId field's value.
+func (s *PutFileOutput) SetTreeId(v string) *PutFileOutput {
+	s.TreeId = &v
+	return s
+}
+
 // Represents the input ofa put repository triggers operation.
 type PutRepositoryTriggersInput struct {
 	_ struct{} `type:"structure"`
@@ -9132,7 +9511,8 @@ func (s UpdateRepositoryNameOutput) GoString() string {
 type UserInfo struct {
 	_ struct{} `type:"structure"`
 
-	// The date when the specified commit was pushed to the repository.
+	// The date when the specified commit was commited, in timestamp format with
+	// GMT offset.
 	Date *string `locationName:"date" type:"string"`
 
 	// The email address associated with the user who made the commit, if any.
@@ -9179,6 +9559,17 @@ const (
 
 	// ChangeTypeEnumD is a ChangeTypeEnum enum value
 	ChangeTypeEnumD = "D"
+)
+
+const (
+	// FileModeTypeEnumExecutable is a FileModeTypeEnum enum value
+	FileModeTypeEnumExecutable = "EXECUTABLE"
+
+	// FileModeTypeEnumNormal is a FileModeTypeEnum enum value
+	FileModeTypeEnumNormal = "NORMAL"
+
+	// FileModeTypeEnumSymlink is a FileModeTypeEnum enum value
+	FileModeTypeEnumSymlink = "SYMLINK"
 )
 
 const (

--- a/vendor/github.com/aws/aws-sdk-go/service/codecommit/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/codecommit/doc.go
@@ -43,6 +43,11 @@
 //
 //    * UpdateDefaultBranch, which changes the default branch for a repository.
 //
+// Files, by calling the following:
+//
+//    * PutFile, which adds or modifies a file in a specified repository and
+//    branch.
+//
 // Information about committed code in a repository, by calling the following:
 //
 //    * GetBlob, which returns the base-64 encoded content of an individual

--- a/vendor/github.com/aws/aws-sdk-go/service/codecommit/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/codecommit/errors.go
@@ -47,6 +47,14 @@ const (
 	// The specified branch name already exists.
 	ErrCodeBranchNameExistsException = "BranchNameExistsException"
 
+	// ErrCodeBranchNameIsTagNameException for service response error code
+	// "BranchNameIsTagNameException".
+	//
+	// The specified branch name is not valid because it is a tag name. Type the
+	// name of a current branch in the repository. For a list of valid branch names,
+	// use ListBranches.
+	ErrCodeBranchNameIsTagNameException = "BranchNameIsTagNameException"
+
 	// ErrCodeBranchNameRequiredException for service response error code
 	// "BranchNameRequiredException".
 	//
@@ -122,6 +130,12 @@ const (
 	// A commit ID was not specified.
 	ErrCodeCommitIdRequiredException = "CommitIdRequiredException"
 
+	// ErrCodeCommitMessageLengthExceededException for service response error code
+	// "CommitMessageLengthExceededException".
+	//
+	// The commit message is too long. Provide a shorter string.
+	ErrCodeCommitMessageLengthExceededException = "CommitMessageLengthExceededException"
+
 	// ErrCodeCommitRequiredException for service response error code
 	// "CommitRequiredException".
 	//
@@ -135,6 +149,15 @@ const (
 	// be deleted. To delete this branch, you must first set another branch as the
 	// default branch.
 	ErrCodeDefaultBranchCannotBeDeletedException = "DefaultBranchCannotBeDeletedException"
+
+	// ErrCodeDirectoryNameConflictsWithFileNameException for service response error code
+	// "DirectoryNameConflictsWithFileNameException".
+	//
+	// A file cannot be added to the repository because the specified path name
+	// has the same name as a file that already exists in this repository. Either
+	// provide a different name for the file, or specify a different path for the
+	// file.
+	ErrCodeDirectoryNameConflictsWithFileNameException = "DirectoryNameConflictsWithFileNameException"
 
 	// ErrCodeEncryptionIntegrityChecksFailedException for service response error code
 	// "EncryptionIntegrityChecksFailedException".
@@ -165,6 +188,30 @@ const (
 	//
 	// The encryption key is not available.
 	ErrCodeEncryptionKeyUnavailableException = "EncryptionKeyUnavailableException"
+
+	// ErrCodeFileContentRequiredException for service response error code
+	// "FileContentRequiredException".
+	//
+	// The file cannot be added because it is empty. Empty files cannot be added
+	// to the repository with this API.
+	ErrCodeFileContentRequiredException = "FileContentRequiredException"
+
+	// ErrCodeFileContentSizeLimitExceededException for service response error code
+	// "FileContentSizeLimitExceededException".
+	//
+	// The file cannot be added because it is too large. The maximum file size that
+	// can be added using PutFile is 6 MB. For files larger than 6 MB but smaller
+	// than 2 GB, add them using a Git client.
+	ErrCodeFileContentSizeLimitExceededException = "FileContentSizeLimitExceededException"
+
+	// ErrCodeFileNameConflictsWithDirectoryNameException for service response error code
+	// "FileNameConflictsWithDirectoryNameException".
+	//
+	// A file cannot be added to the repository because the specified file name
+	// has the same name as a directory in this repository. Either provide another
+	// name for the file, or add the file in a directory that does not match the
+	// file name.
+	ErrCodeFileNameConflictsWithDirectoryNameException = "FileNameConflictsWithDirectoryNameException"
 
 	// ErrCodeFileTooLargeException for service response error code
 	// "FileTooLargeException".
@@ -253,12 +300,27 @@ const (
 	// name, tag, or full commit ID.
 	ErrCodeInvalidDestinationCommitSpecifierException = "InvalidDestinationCommitSpecifierException"
 
+	// ErrCodeInvalidEmailException for service response error code
+	// "InvalidEmailException".
+	//
+	// The specified email address either contains one or more characters that are
+	// not allowed, or it exceeds the maximum number of characters allowed for an
+	// email address.
+	ErrCodeInvalidEmailException = "InvalidEmailException"
+
 	// ErrCodeInvalidFileLocationException for service response error code
 	// "InvalidFileLocationException".
 	//
 	// The location of the file is not valid. Make sure that you include the extension
 	// of the file as well as the file name.
 	ErrCodeInvalidFileLocationException = "InvalidFileLocationException"
+
+	// ErrCodeInvalidFileModeException for service response error code
+	// "InvalidFileModeException".
+	//
+	// The specified file mode permission is not valid. For a list of valid file
+	// mode permissions, see PutFile.
+	ErrCodeInvalidFileModeException = "InvalidFileModeException"
 
 	// ErrCodeInvalidFilePositionException for service response error code
 	// "InvalidFilePositionException".
@@ -284,6 +346,14 @@ const (
 	//
 	// The specified sort order is not valid.
 	ErrCodeInvalidOrderException = "InvalidOrderException"
+
+	// ErrCodeInvalidParentCommitIdException for service response error code
+	// "InvalidParentCommitIdException".
+	//
+	// The parent commit ID is not valid. The commit ID cannot be empty, and must
+	// match the head commit ID for the branch of the repository where you want
+	// to add or update a file.
+	ErrCodeInvalidParentCommitIdException = "InvalidParentCommitIdException"
 
 	// ErrCodeInvalidPathException for service response error code
 	// "InvalidPathException".
@@ -476,6 +546,37 @@ const (
 	// again.
 	ErrCodeMultipleRepositoriesInPullRequestException = "MultipleRepositoriesInPullRequestException"
 
+	// ErrCodeNameLengthExceededException for service response error code
+	// "NameLengthExceededException".
+	//
+	// The file name is not valid because it has exceeded the character limit for
+	// file names. File names, including the path to the file, cannot exceed the
+	// character limit.
+	ErrCodeNameLengthExceededException = "NameLengthExceededException"
+
+	// ErrCodeParentCommitDoesNotExistException for service response error code
+	// "ParentCommitDoesNotExistException".
+	//
+	// The parent commit ID is not valid. The specified parent commit ID does not
+	// exist in the specified branch of the repository.
+	ErrCodeParentCommitDoesNotExistException = "ParentCommitDoesNotExistException"
+
+	// ErrCodeParentCommitIdOutdatedException for service response error code
+	// "ParentCommitIdOutdatedException".
+	//
+	// The file could not be added because the provided parent commit ID is not
+	// the current tip of the specified branch. To view the full commit ID of the
+	// current head of the branch, use GetBranch.
+	ErrCodeParentCommitIdOutdatedException = "ParentCommitIdOutdatedException"
+
+	// ErrCodeParentCommitIdRequiredException for service response error code
+	// "ParentCommitIdRequiredException".
+	//
+	// A parent commit ID is required. To view the full commit ID of a branch in
+	// a repository, use GetBranch or a Git command (for example, git pull or git
+	// log).
+	ErrCodeParentCommitIdRequiredException = "ParentCommitIdRequiredException"
+
 	// ErrCodePathDoesNotExistException for service response error code
 	// "PathDoesNotExistException".
 	//
@@ -600,6 +701,14 @@ const (
 	//
 	// The list of triggers for the repository is required but was not specified.
 	ErrCodeRepositoryTriggersListRequiredException = "RepositoryTriggersListRequiredException"
+
+	// ErrCodeSameFileContentException for service response error code
+	// "SameFileContentException".
+	//
+	// The file was not added or updated because the content of the file is exactly
+	// the same as the content of that file in the repository and branch that you
+	// specified.
+	ErrCodeSameFileContentException = "SameFileContentException"
 
 	// ErrCodeSourceAndDestinationAreSameException for service response error code
 	// "SourceAndDestinationAreSameException".

--- a/vendor/github.com/aws/aws-sdk-go/service/configservice/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/configservice/api.go
@@ -6582,16 +6582,19 @@ const (
 
 const (
 	// ConfigurationItemStatusOk is a ConfigurationItemStatus enum value
-	ConfigurationItemStatusOk = "Ok"
+	ConfigurationItemStatusOk = "OK"
 
-	// ConfigurationItemStatusFailed is a ConfigurationItemStatus enum value
-	ConfigurationItemStatusFailed = "Failed"
+	// ConfigurationItemStatusResourceDiscovered is a ConfigurationItemStatus enum value
+	ConfigurationItemStatusResourceDiscovered = "ResourceDiscovered"
 
-	// ConfigurationItemStatusDiscovered is a ConfigurationItemStatus enum value
-	ConfigurationItemStatusDiscovered = "Discovered"
+	// ConfigurationItemStatusResourceNotRecorded is a ConfigurationItemStatus enum value
+	ConfigurationItemStatusResourceNotRecorded = "ResourceNotRecorded"
 
-	// ConfigurationItemStatusDeleted is a ConfigurationItemStatus enum value
-	ConfigurationItemStatusDeleted = "Deleted"
+	// ConfigurationItemStatusResourceDeleted is a ConfigurationItemStatus enum value
+	ConfigurationItemStatusResourceDeleted = "ResourceDeleted"
+
+	// ConfigurationItemStatusResourceDeletedNotRecorded is a ConfigurationItemStatus enum value
+	ConfigurationItemStatusResourceDeletedNotRecorded = "ResourceDeletedNotRecorded"
 )
 
 const (

--- a/vendor/github.com/aws/aws-sdk-go/service/ec2/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ec2/api.go
@@ -4650,6 +4650,9 @@ func (c *EC2) CreateSnapshotRequest(input *CreateSnapshotInput) (req *request.Re
 // encrypted. Your encrypted volumes and any associated snapshots always remain
 // protected.
 //
+// You can tag your snapshots during creation. For more information, see Tagging
+// Your Amazon EC2 Resources (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html).
+//
 // For more information, see Amazon Elastic Block Store (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AmazonEBS.html)
 // and Amazon EBS Encryption (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html)
 // in the Amazon Elastic Compute Cloud User Guide.
@@ -29174,6 +29177,9 @@ type CreateSnapshotInput struct {
 	// it is UnauthorizedOperation.
 	DryRun *bool `locationName:"dryRun" type:"boolean"`
 
+	// The tags to apply to the snapshot during creation.
+	TagSpecifications []*TagSpecification `locationName:"TagSpecification" locationNameList:"item" type:"list"`
+
 	// The ID of the EBS volume.
 	//
 	// VolumeId is a required field
@@ -29212,6 +29218,12 @@ func (s *CreateSnapshotInput) SetDescription(v string) *CreateSnapshotInput {
 // SetDryRun sets the DryRun field's value.
 func (s *CreateSnapshotInput) SetDryRun(v bool) *CreateSnapshotInput {
 	s.DryRun = &v
+	return s
+}
+
+// SetTagSpecifications sets the TagSpecifications field's value.
+func (s *CreateSnapshotInput) SetTagSpecifications(v []*TagSpecification) *CreateSnapshotInput {
+	s.TagSpecifications = v
 	return s
 }
 

--- a/vendor/github.com/aws/aws-sdk-go/service/ec2/customizations.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ec2/customizations.go
@@ -5,11 +5,64 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
+	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/internal/sdkrand"
 )
 
+type retryer struct {
+	client.DefaultRetryer
+}
+
+func (d retryer) RetryRules(r *request.Request) time.Duration {
+	switch r.Operation.Name {
+	case opModifyNetworkInterfaceAttribute:
+		fallthrough
+	case opAssignPrivateIpAddresses:
+		return customRetryRule(r)
+	default:
+		return d.DefaultRetryer.RetryRules(r)
+	}
+}
+
+func customRetryRule(r *request.Request) time.Duration {
+	retryTimes := []time.Duration{
+		time.Second,
+		3 * time.Second,
+		5 * time.Second,
+	}
+
+	count := r.RetryCount
+	if count >= len(retryTimes) {
+		count = len(retryTimes) - 1
+	}
+
+	minTime := int(retryTimes[count])
+	return time.Duration(sdkrand.SeededRand.Intn(minTime) + minTime)
+}
+
+func setCustomRetryer(c *client.Client) {
+	maxRetries := aws.IntValue(c.Config.MaxRetries)
+	if c.Config.MaxRetries == nil || maxRetries == aws.UseServiceDefaultRetries {
+		maxRetries = 3
+	}
+
+	c.Retryer = retryer{
+		DefaultRetryer: client.DefaultRetryer{
+			NumMaxRetries: maxRetries,
+		},
+	}
+}
+
 func init() {
+	initClient = func(c *client.Client) {
+		if c.Config.Retryer == nil {
+			// Only override the retryer with a custom one if the config
+			// does not already contain a retryer
+			setCustomRetryer(c)
+		}
+	}
 	initRequest = func(r *request.Request) {
 		if r.Operation.Name == opCopySnapshot { // fill the PresignedURL parameter
 			r.Handlers.Build.PushFront(fillPresignedURL)

--- a/vendor/github.com/aws/aws-sdk-go/service/elbv2/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/elbv2/api.go
@@ -245,11 +245,13 @@ func (c *ELBV2) CreateListenerRequest(input *CreateListenerInput) (req *request.
 // Creates a listener for the specified Application Load Balancer or Network
 // Load Balancer.
 //
-// You can create up to 10 listeners per load balancer.
-//
 // To update a listener, use ModifyListener. When you are finished with a listener,
 // you can delete it using DeleteListener. If you are finished with both the
 // listener and the load balancer, you can delete them both using DeleteLoadBalancer.
+//
+// This operation is idempotent, which means that it completes at most one time.
+// If you attempt to create multiple listeners with the same settings, each
+// call succeeds.
 //
 // For more information, see Listeners for Your Application Load Balancers (http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-listeners.html)
 // in the Application Load Balancers Guide and Listeners for Your Network Load
@@ -372,20 +374,22 @@ func (c *ELBV2) CreateLoadBalancerRequest(input *CreateLoadBalancerInput) (req *
 //
 // Creates an Application Load Balancer or a Network Load Balancer.
 //
-// When you create a load balancer, you can specify security groups, subnets,
-// IP address type, and tags. Otherwise, you could do so later using SetSecurityGroups,
-// SetSubnets, SetIpAddressType, and AddTags.
+// When you create a load balancer, you can specify security groups, public
+// subnets, IP address type, and tags. Otherwise, you could do so later using
+// SetSecurityGroups, SetSubnets, SetIpAddressType, and AddTags.
 //
 // To create listeners for your load balancer, use CreateListener. To describe
 // your current load balancers, see DescribeLoadBalancers. When you are finished
 // with a load balancer, you can delete it using DeleteLoadBalancer.
 //
-// You can create up to 20 load balancers per region per account. You can request
-// an increase for the number of load balancers for your account. For more information,
-// see Limits for Your Application Load Balancer (http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-limits.html)
+// For limit information, see Limits for Your Application Load Balancer (http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-limits.html)
 // in the Application Load Balancers Guide and Limits for Your Network Load
 // Balancer (http://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-limits.html)
 // in the Network Load Balancers Guide.
+//
+// This operation is idempotent, which means that it completes at most one time.
+// If you attempt to create multiple load balancers with the same settings,
+// each call succeeds.
 //
 // For more information, see Application Load Balancers (http://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html)
 // in the Application Load Balancers Guide and Network Load Balancers (http://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html)
@@ -632,6 +636,10 @@ func (c *ELBV2) CreateTargetGroupRequest(input *CreateTargetGroupInput) (req *re
 // in an action using CreateListener or CreateRule.
 //
 // To delete a target group, use DeleteTargetGroup.
+//
+// This operation is idempotent, which means that it completes at most one time.
+// If you attempt to create multiple target groups with the same settings, each
+// call succeeds.
 //
 // For more information, see Target Groups for Your Application Load Balancers
 // (http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html)
@@ -1078,8 +1086,8 @@ func (c *ELBV2) DeregisterTargetsRequest(input *DeregisterTargetsInput) (req *re
 //   The specified target group does not exist.
 //
 //   * ErrCodeInvalidTargetException "InvalidTarget"
-//   The specified target does not exist or is not in the same VPC as the target
-//   group.
+//   The specified target does not exist, is not in the same VPC as the target
+//   group, or has an unsupported instance type.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/DeregisterTargets
 func (c *ELBV2) DeregisterTargets(input *DeregisterTargetsInput) (*DeregisterTargetsOutput, error) {
@@ -2153,8 +2161,8 @@ func (c *ELBV2) DescribeTargetHealthRequest(input *DescribeTargetHealthInput) (r
 //
 // Returned Error Codes:
 //   * ErrCodeInvalidTargetException "InvalidTarget"
-//   The specified target does not exist or is not in the same VPC as the target
-//   group.
+//   The specified target does not exist, is not in the same VPC as the target
+//   group, or has an unsupported instance type.
 //
 //   * ErrCodeTargetGroupNotFoundException "TargetGroupNotFound"
 //   The specified target group does not exist.
@@ -2738,8 +2746,8 @@ func (c *ELBV2) RegisterTargetsRequest(input *RegisterTargetsInput) (req *reques
 //   You've reached the limit on the number of targets.
 //
 //   * ErrCodeInvalidTargetException "InvalidTarget"
-//   The specified target does not exist or is not in the same VPC as the target
-//   group.
+//   The specified target does not exist, is not in the same VPC as the target
+//   group, or has an unsupported instance type.
 //
 //   * ErrCodeTooManyRegistrationsForTargetIdException "TooManyRegistrationsForTargetId"
 //   You've reached the limit on the number of times a target can be registered
@@ -3257,7 +3265,7 @@ func (c *ELBV2) SetSubnetsRequest(input *SetSubnetsInput) (req *request.Request,
 
 // SetSubnets API operation for Elastic Load Balancing.
 //
-// Enables the Availability Zone for the specified subnets for the specified
+// Enables the Availability Zone for the specified public subnets for the specified
 // Application Load Balancer. The specified subnets replace the previously enabled
 // subnets.
 //
@@ -3797,32 +3805,34 @@ type CreateLoadBalancerInput struct {
 	// The default is an Internet-facing load balancer.
 	Scheme *string `type:"string" enum:"LoadBalancerSchemeEnum"`
 
-	// [Application Load Balancers] The IDs of the security groups to assign to
-	// the load balancer.
+	// [Application Load Balancers] The IDs of the security groups for the load
+	// balancer.
 	SecurityGroups []*string `type:"list"`
 
-	// The IDs of the subnets to attach to the load balancer. You can specify only
-	// one subnet per Availability Zone. You must specify either subnets or subnet
-	// mappings.
-	//
-	// [Network Load Balancers] You can specify one Elastic IP address per subnet.
-	//
-	// [Application Load Balancers] You cannot specify Elastic IP addresses for
-	// your subnets.
-	SubnetMappings []*SubnetMapping `type:"list"`
-
-	// The IDs of the subnets to attach to the load balancer. You can specify only
-	// one subnet per Availability Zone. You must specify either subnets or subnet
-	// mappings.
+	// The IDs of the public subnets. You can specify only one subnet per Availability
+	// Zone. You must specify either subnets or subnet mappings.
 	//
 	// [Application Load Balancers] You must specify subnets from at least two Availability
+	// Zones. You cannot specify Elastic IP addresses for your subnets.
+	//
+	// [Network Load Balancers] You can specify subnets from one or more Availability
+	// Zones. You can specify one Elastic IP address per subnet.
+	SubnetMappings []*SubnetMapping `type:"list"`
+
+	// The IDs of the public subnets. You can specify only one subnet per Availability
+	// Zone. You must specify either subnets or subnet mappings.
+	//
+	// [Application Load Balancers] You must specify subnets from at least two Availability
+	// Zones.
+	//
+	// [Network Load Balancers] You can specify subnets from one or more Availability
 	// Zones.
 	Subnets []*string `type:"list"`
 
 	// One or more tags to assign to the load balancer.
 	Tags []*Tag `min:"1" type:"list"`
 
-	// The type of load balancer to create. The default is application.
+	// The type of load balancer. The default is application.
 	Type *string `type:"string" enum:"LoadBalancerTypeEnum"`
 }
 
@@ -5548,6 +5558,10 @@ type Limit struct {
 	//    * target-groups
 	//
 	//    * targets-per-application-load-balancer
+	//
+	//    * targets-per-availability-zone-per-network-load-balancer
+	//
+	//    * targets-per-network-load-balancer
 	Name *string `type:"string"`
 }
 
@@ -5844,6 +5858,13 @@ type LoadBalancerAttribute struct {
 	//    * idle_timeout.timeout_seconds - [Application Load Balancers] The idle
 	//    timeout value, in seconds. The valid range is 1-4000. The default is 60
 	//    seconds.
+	//
+	//    * load_balancing.cross_zone.enabled - [Network Load Balancers] Indicates
+	//    whether cross-zone load balancing is enabled. The value is true or false.
+	//    The default is false.
+	//
+	//    * routing.http2.enabled - [Application Load Balancers] Indicates whether
+	//    HTTP/2 is enabled. The value is true or false. The default is true.
 	Key *string `type:"string"`
 
 	// The value of the attribute.
@@ -7085,17 +7106,16 @@ type SetSubnetsInput struct {
 	// LoadBalancerArn is a required field
 	LoadBalancerArn *string `type:"string" required:"true"`
 
-	// The IDs of the subnets. You must specify subnets from at least two Availability
-	// Zones. You can specify only one subnet per Availability Zone. You must specify
-	// either subnets or subnet mappings.
+	// The IDs of the public subnets. You must specify subnets from at least two
+	// Availability Zones. You can specify only one subnet per Availability Zone.
+	// You must specify either subnets or subnet mappings.
 	//
-	// The load balancer is allocated one static IP address per subnet. You cannot
-	// specify your own Elastic IP addresses.
+	// You cannot specify Elastic IP addresses for your subnets.
 	SubnetMappings []*SubnetMapping `type:"list"`
 
-	// The IDs of the subnets. You must specify subnets from at least two Availability
-	// Zones. You can specify only one subnet per Availability Zone. You must specify
-	// either subnets or subnet mappings.
+	// The IDs of the public subnets. You must specify subnets from at least two
+	// Availability Zones. You can specify only one subnet per Availability Zone.
+	// You must specify either subnets or subnet mappings.
 	//
 	// Subnets is a required field
 	Subnets []*string `type:"list" required:"true"`
@@ -7565,6 +7585,9 @@ type TargetGroupAttribute struct {
 	//    Balancing to wait before changing the state of a deregistering target
 	//    from draining to unused. The range is 0-3600 seconds. The default value
 	//    is 300 seconds.
+	//
+	//    * proxy_protocol_v2.enabled - [Network Load Balancers] Indicates whether
+	//    Proxy Protocol version 2 is enabled.
 	//
 	//    * stickiness.enabled - [Application Load Balancers] Indicates whether
 	//    sticky sessions are enabled. The value is true or false.

--- a/vendor/github.com/aws/aws-sdk-go/service/elbv2/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/elbv2/errors.go
@@ -86,8 +86,8 @@ const (
 	// ErrCodeInvalidTargetException for service response error code
 	// "InvalidTarget".
 	//
-	// The specified target does not exist or is not in the same VPC as the target
-	// group.
+	// The specified target does not exist, is not in the same VPC as the target
+	// group, or has an unsupported instance type.
 	ErrCodeInvalidTargetException = "InvalidTarget"
 
 	// ErrCodeListenerNotFoundException for service response error code

--- a/vendor/github.com/aws/aws-sdk-go/service/gamelift/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/gamelift/doc.go
@@ -94,18 +94,18 @@
 // CreateGameSession -- Start a new game session on a specific fleet. Available
 //    in Amazon GameLift Local.
 //
-//    * Start new game sessions with FlexMatch matchmaking
+//    * Match players to game sessions with FlexMatch matchmaking
 //
 // StartMatchmaking -- Request matchmaking for one players or a group who want
 //    to play together.
+//
+// StartMatchBackfill - Request additional player matches to fill empty slots
+//    in an existing game session.
 //
 // DescribeMatchmaking -- Get details on a matchmaking request, including status.
 //
 // AcceptMatch -- Register that a player accepts a proposed match, for matches
 //    that require player acceptance.
-//
-// StartMatchBackfill - Request additional player matches to fill empty slots
-//    in an existing game session.
 //
 // StopMatchmaking -- Cancel a matchmaking request.
 //

--- a/vendor/github.com/aws/aws-sdk-go/service/glacier/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/glacier/api.go
@@ -4988,7 +4988,7 @@ type Encryption struct {
 	EncryptionType *string `type:"string" enum:"EncryptionType"`
 
 	// Optional. If the encryption type is aws:kms, you can use this value to specify
-	// the encryption context for the restore results.
+	// the encryption context for the job results.
 	KMSContext *string `type:"string"`
 
 	// The AWS KMS key ID to use for object encryption. All GET and PUT requests
@@ -6256,7 +6256,7 @@ type JobDescription struct {
 	// An Amazon SNS topic that receives notification.
 	SNSTopic *string `type:"string"`
 
-	// Contains the parameters that define a select job.
+	// Contains the parameters used for a select.
 	SelectParameters *SelectParameters `type:"structure"`
 
 	// The status code can be InProgress, Succeeded, or Failed, and indicates the
@@ -6266,7 +6266,7 @@ type JobDescription struct {
 	// A friendly message that describes the job status.
 	StatusMessage *string `type:"string"`
 
-	// The retrieval option to use for the archive retrieval. Valid values are Expedited,
+	// The tier to use for a select or an archive retrieval. Valid values are Expedited,
 	// Standard, or Bulk. Standard is the default.
 	Tier *string `type:"string"`
 
@@ -6458,8 +6458,8 @@ type JobParameters struct {
 	// Contains the parameters that define a job.
 	SelectParameters *SelectParameters `type:"structure"`
 
-	// The retrieval option to use for a select or archive retrieval job. Valid
-	// values are Expedited, Standard, or Bulk. Standard is the default.
+	// The tier to use for a select or an archive retrieval job. Valid values are
+	// Expedited, Standard, or Bulk. Standard is the default.
 	Tier *string `type:"string"`
 
 	// The job type. You can initiate a job to perform a select query on an archive,
@@ -7235,7 +7235,7 @@ func (s *ListVaultsOutput) SetVaultList(v []*DescribeVaultOutput) *ListVaultsOut
 type OutputLocation struct {
 	_ struct{} `type:"structure"`
 
-	// Describes an S3 location that will receive the results of the restore request.
+	// Describes an S3 location that will receive the results of the job request.
 	S3 *S3Location `type:"structure"`
 }
 
@@ -7525,26 +7525,26 @@ type S3Location struct {
 	// A list of grants that control access to the staged results.
 	AccessControlList []*Grant `type:"list"`
 
-	// The name of the bucket where the restore results are stored.
+	// The name of the Amazon S3 bucket where the job results are stored.
 	BucketName *string `type:"string"`
 
-	// The canned ACL to apply to the restore results.
+	// The canned access control list (ACL) to apply to the job results.
 	CannedACL *string `type:"string" enum:"CannedACL"`
 
 	// Contains information about the encryption used to store the job results in
 	// Amazon S3.
 	Encryption *Encryption `type:"structure"`
 
-	// The prefix that is prepended to the restore results for this request.
+	// The prefix that is prepended to the results for this request.
 	Prefix *string `type:"string"`
 
-	// The storage class used to store the restore results.
+	// The storage class used to store the job results.
 	StorageClass *string `type:"string" enum:"StorageClass"`
 
-	// The tag-set that is applied to the restore results.
+	// The tag-set that is applied to the job results.
 	Tagging map[string]*string `type:"map"`
 
-	// A map of metadata to store with the restore results in Amazon S3.
+	// A map of metadata to store with the job results in Amazon S3.
 	UserMetadata map[string]*string `type:"map"`
 }
 

--- a/vendor/github.com/aws/aws-sdk-go/service/glacier/treehash.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/glacier/treehash.go
@@ -18,8 +18,8 @@ type Hash struct {
 //
 // See http://docs.aws.amazon.com/amazonglacier/latest/dev/checksum-calculations.html for more information.
 func ComputeHashes(r io.ReadSeeker) Hash {
-	r.Seek(0, 0)       // Read the whole stream
-	defer r.Seek(0, 0) // Rewind stream at end
+	start, _ := r.Seek(0, 1) // Read the whole stream
+	defer r.Seek(start, 0)   // Rewind stream at end
 
 	buf := make([]byte, bufsize)
 	hashes := [][]byte{}

--- a/vendor/github.com/aws/aws-sdk-go/service/lexmodelbuildingservice/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/lexmodelbuildingservice/api.go
@@ -2700,6 +2700,96 @@ func (c *LexModelBuildingService) GetExportWithContext(ctx aws.Context, input *G
 	return out, req.Send()
 }
 
+const opGetImport = "GetImport"
+
+// GetImportRequest generates a "aws/request.Request" representing the
+// client's request for the GetImport operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See GetImport for more information on using the GetImport
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the GetImportRequest method.
+//    req, resp := client.GetImportRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetImport
+func (c *LexModelBuildingService) GetImportRequest(input *GetImportInput) (req *request.Request, output *GetImportOutput) {
+	op := &request.Operation{
+		Name:       opGetImport,
+		HTTPMethod: "GET",
+		HTTPPath:   "/imports/{importId}",
+	}
+
+	if input == nil {
+		input = &GetImportInput{}
+	}
+
+	output = &GetImportOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// GetImport API operation for Amazon Lex Model Building Service.
+//
+// Gets information about an import job started with the StartImport operation.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Lex Model Building Service's
+// API operation GetImport for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeNotFoundException "NotFoundException"
+//   The resource specified in the request was not found. Check the resource and
+//   try again.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   The request exceeded a limit. Try your request again.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An internal Amazon Lex error occurred. Try your request again.
+//
+//   * ErrCodeBadRequestException "BadRequestException"
+//   The request is not well formed. For example, a value is invalid or a required
+//   field is missing. Check the field values, and try again.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetImport
+func (c *LexModelBuildingService) GetImport(input *GetImportInput) (*GetImportOutput, error) {
+	req, out := c.GetImportRequest(input)
+	return out, req.Send()
+}
+
+// GetImportWithContext is the same as GetImport with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetImport for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *LexModelBuildingService) GetImportWithContext(ctx aws.Context, input *GetImportInput, opts ...request.Option) (*GetImportOutput, error) {
+	req, out := c.GetImportRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opGetIntent = "GetIntent"
 
 // GetIntentRequest generates a "aws/request.Request" representing the
@@ -4054,6 +4144,92 @@ func (c *LexModelBuildingService) PutSlotType(input *PutSlotTypeInput) (*PutSlot
 // for more information on using Contexts.
 func (c *LexModelBuildingService) PutSlotTypeWithContext(ctx aws.Context, input *PutSlotTypeInput, opts ...request.Option) (*PutSlotTypeOutput, error) {
 	req, out := c.PutSlotTypeRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opStartImport = "StartImport"
+
+// StartImportRequest generates a "aws/request.Request" representing the
+// client's request for the StartImport operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See StartImport for more information on using the StartImport
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the StartImportRequest method.
+//    req, resp := client.StartImportRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/StartImport
+func (c *LexModelBuildingService) StartImportRequest(input *StartImportInput) (req *request.Request, output *StartImportOutput) {
+	op := &request.Operation{
+		Name:       opStartImport,
+		HTTPMethod: "POST",
+		HTTPPath:   "/imports/",
+	}
+
+	if input == nil {
+		input = &StartImportInput{}
+	}
+
+	output = &StartImportOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// StartImport API operation for Amazon Lex Model Building Service.
+//
+// Starts a job to import a resource to Amazon Lex.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Lex Model Building Service's
+// API operation StartImport for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   The request exceeded a limit. Try your request again.
+//
+//   * ErrCodeInternalFailureException "InternalFailureException"
+//   An internal Amazon Lex error occurred. Try your request again.
+//
+//   * ErrCodeBadRequestException "BadRequestException"
+//   The request is not well formed. For example, a value is invalid or a required
+//   field is missing. Check the field values, and try again.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/StartImport
+func (c *LexModelBuildingService) StartImport(input *StartImportInput) (*StartImportOutput, error) {
+	req, out := c.StartImportRequest(input)
+	return out, req.Send()
+}
+
+// StartImportWithContext is the same as StartImport with the addition of
+// the ability to pass a context and additional request options.
+//
+// See StartImport for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *LexModelBuildingService) StartImportWithContext(ctx aws.Context, input *StartImportInput, opts ...request.Option) (*StartImportOutput, error) {
+	req, out := c.StartImportRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -7344,6 +7520,123 @@ func (s *GetExportOutput) SetVersion(v string) *GetExportOutput {
 	return s
 }
 
+type GetImportInput struct {
+	_ struct{} `type:"structure"`
+
+	// The identifier of the import job information to return.
+	//
+	// ImportId is a required field
+	ImportId *string `location:"uri" locationName:"importId" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s GetImportInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetImportInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetImportInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetImportInput"}
+	if s.ImportId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ImportId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetImportId sets the ImportId field's value.
+func (s *GetImportInput) SetImportId(v string) *GetImportInput {
+	s.ImportId = &v
+	return s
+}
+
+type GetImportOutput struct {
+	_ struct{} `type:"structure"`
+
+	// A timestamp for the date and time that the import job was created.
+	CreatedDate *time.Time `locationName:"createdDate" type:"timestamp" timestampFormat:"unix"`
+
+	// A string that describes why an import job failed to complete.
+	FailureReason []*string `locationName:"failureReason" type:"list"`
+
+	// The identifier for the specific import job.
+	ImportId *string `locationName:"importId" type:"string"`
+
+	// The status of the import job. If the status is FAILED, you can get the reason
+	// for the failure from the failureReason field.
+	ImportStatus *string `locationName:"importStatus" type:"string" enum:"ImportStatus"`
+
+	// The action taken when there was a conflict between an existing resource and
+	// a resource in the import file.
+	MergeStrategy *string `locationName:"mergeStrategy" type:"string" enum:"MergeStrategy"`
+
+	// The name given to the import job.
+	Name *string `locationName:"name" min:"1" type:"string"`
+
+	// The type of resource imported.
+	ResourceType *string `locationName:"resourceType" type:"string" enum:"ResourceType"`
+}
+
+// String returns the string representation
+func (s GetImportOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetImportOutput) GoString() string {
+	return s.String()
+}
+
+// SetCreatedDate sets the CreatedDate field's value.
+func (s *GetImportOutput) SetCreatedDate(v time.Time) *GetImportOutput {
+	s.CreatedDate = &v
+	return s
+}
+
+// SetFailureReason sets the FailureReason field's value.
+func (s *GetImportOutput) SetFailureReason(v []*string) *GetImportOutput {
+	s.FailureReason = v
+	return s
+}
+
+// SetImportId sets the ImportId field's value.
+func (s *GetImportOutput) SetImportId(v string) *GetImportOutput {
+	s.ImportId = &v
+	return s
+}
+
+// SetImportStatus sets the ImportStatus field's value.
+func (s *GetImportOutput) SetImportStatus(v string) *GetImportOutput {
+	s.ImportStatus = &v
+	return s
+}
+
+// SetMergeStrategy sets the MergeStrategy field's value.
+func (s *GetImportOutput) SetMergeStrategy(v string) *GetImportOutput {
+	s.MergeStrategy = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *GetImportOutput) SetName(v string) *GetImportOutput {
+	s.Name = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *GetImportOutput) SetResourceType(v string) *GetImportOutput {
+	s.ResourceType = &v
+	return s
+}
+
 type GetIntentInput struct {
 	_ struct{} `type:"structure"`
 
@@ -8733,6 +9026,8 @@ type PutBotInput struct {
 	// can say 'Order a pizza' or 'Order a drink.'"
 	ClarificationPrompt *Prompt `locationName:"clarificationPrompt" type:"structure"`
 
+	CreateVersion *bool `locationName:"createVersion" type:"boolean"`
+
 	// A description of the bot.
 	Description *string `locationName:"description" type:"string"`
 
@@ -8773,11 +9068,11 @@ type PutBotInput struct {
 	// Name is a required field
 	Name *string `location:"uri" locationName:"name" min:"2" type:"string" required:"true"`
 
-	// If you set the processBehavior element to Build, Amazon Lex builds the bot
-	// so that it can be run. If you set the element to SaveAmazon Lex saves the
+	// If you set the processBehavior element to BUILD, Amazon Lex builds the bot
+	// so that it can be run. If you set the element to SAVE Amazon Lex saves the
 	// bot, but doesn't build it.
 	//
-	// If you don't specify this value, the default value is Save.
+	// If you don't specify this value, the default value is BUILD.
 	ProcessBehavior *string `locationName:"processBehavior" type:"string" enum:"ProcessBehavior"`
 
 	// The Amazon Polly voice ID that you want Amazon Lex to use for voice interactions
@@ -8866,6 +9161,12 @@ func (s *PutBotInput) SetClarificationPrompt(v *Prompt) *PutBotInput {
 	return s
 }
 
+// SetCreateVersion sets the CreateVersion field's value.
+func (s *PutBotInput) SetCreateVersion(v bool) *PutBotInput {
+	s.CreateVersion = &v
+	return s
+}
+
 // SetDescription sets the Description field's value.
 func (s *PutBotInput) SetDescription(v string) *PutBotInput {
 	s.Description = &v
@@ -8947,6 +9248,8 @@ type PutBotOutput struct {
 	// For more information, see PutBot.
 	ClarificationPrompt *Prompt `locationName:"clarificationPrompt" type:"structure"`
 
+	CreateVersion *bool `locationName:"createVersion" type:"boolean"`
+
 	// The date that the bot was created.
 	CreatedDate *time.Time `locationName:"createdDate" type:"timestamp" timestampFormat:"unix"`
 
@@ -9023,6 +9326,12 @@ func (s *PutBotOutput) SetChildDirected(v bool) *PutBotOutput {
 // SetClarificationPrompt sets the ClarificationPrompt field's value.
 func (s *PutBotOutput) SetClarificationPrompt(v *Prompt) *PutBotOutput {
 	s.ClarificationPrompt = v
+	return s
+}
+
+// SetCreateVersion sets the CreateVersion field's value.
+func (s *PutBotOutput) SetCreateVersion(v bool) *PutBotOutput {
+	s.CreateVersion = &v
 	return s
 }
 
@@ -9129,6 +9438,8 @@ type PutIntentInput struct {
 	// You you must provide both the rejectionStatement and the confirmationPrompt,
 	// or neither.
 	ConfirmationPrompt *Prompt `locationName:"confirmationPrompt" type:"structure"`
+
+	CreateVersion *bool `locationName:"createVersion" type:"boolean"`
 
 	// A description of the intent.
 	Description *string `locationName:"description" type:"string"`
@@ -9295,6 +9606,12 @@ func (s *PutIntentInput) SetConfirmationPrompt(v *Prompt) *PutIntentInput {
 	return s
 }
 
+// SetCreateVersion sets the CreateVersion field's value.
+func (s *PutIntentInput) SetCreateVersion(v bool) *PutIntentInput {
+	s.CreateVersion = &v
+	return s
+}
+
 // SetDescription sets the Description field's value.
 func (s *PutIntentInput) SetDescription(v string) *PutIntentInput {
 	s.Description = &v
@@ -9362,6 +9679,8 @@ type PutIntentOutput struct {
 	// If defined in the intent, Amazon Lex prompts the user to confirm the intent
 	// before fulfilling it.
 	ConfirmationPrompt *Prompt `locationName:"confirmationPrompt" type:"structure"`
+
+	CreateVersion *bool `locationName:"createVersion" type:"boolean"`
 
 	// The date that the intent was created.
 	CreatedDate *time.Time `locationName:"createdDate" type:"timestamp" timestampFormat:"unix"`
@@ -9431,6 +9750,12 @@ func (s *PutIntentOutput) SetConclusionStatement(v *Statement) *PutIntentOutput 
 // SetConfirmationPrompt sets the ConfirmationPrompt field's value.
 func (s *PutIntentOutput) SetConfirmationPrompt(v *Prompt) *PutIntentOutput {
 	s.ConfirmationPrompt = v
+	return s
+}
+
+// SetCreateVersion sets the CreateVersion field's value.
+func (s *PutIntentOutput) SetCreateVersion(v bool) *PutIntentOutput {
+	s.CreateVersion = &v
 	return s
 }
 
@@ -9520,6 +9845,8 @@ type PutSlotTypeInput struct {
 	// you get a PreconditionFailedException exception.
 	Checksum *string `locationName:"checksum" type:"string"`
 
+	CreateVersion *bool `locationName:"createVersion" type:"boolean"`
+
 	// A description of the slot type.
 	Description *string `locationName:"description" type:"string"`
 
@@ -9607,6 +9934,12 @@ func (s *PutSlotTypeInput) SetChecksum(v string) *PutSlotTypeInput {
 	return s
 }
 
+// SetCreateVersion sets the CreateVersion field's value.
+func (s *PutSlotTypeInput) SetCreateVersion(v bool) *PutSlotTypeInput {
+	s.CreateVersion = &v
+	return s
+}
+
 // SetDescription sets the Description field's value.
 func (s *PutSlotTypeInput) SetDescription(v string) *PutSlotTypeInput {
 	s.Description = &v
@@ -9636,6 +9969,8 @@ type PutSlotTypeOutput struct {
 
 	// Checksum of the $LATEST version of the slot type.
 	Checksum *string `locationName:"checksum" type:"string"`
+
+	CreateVersion *bool `locationName:"createVersion" type:"boolean"`
 
 	// The date that the slot type was created.
 	CreatedDate *time.Time `locationName:"createdDate" type:"timestamp" timestampFormat:"unix"`
@@ -9676,6 +10011,12 @@ func (s PutSlotTypeOutput) GoString() string {
 // SetChecksum sets the Checksum field's value.
 func (s *PutSlotTypeOutput) SetChecksum(v string) *PutSlotTypeOutput {
 	s.Checksum = &v
+	return s
+}
+
+// SetCreateVersion sets the CreateVersion field's value.
+func (s *PutSlotTypeOutput) SetCreateVersion(v bool) *PutSlotTypeOutput {
+	s.CreateVersion = &v
 	return s
 }
 
@@ -9963,6 +10304,160 @@ func (s *SlotTypeMetadata) SetVersion(v string) *SlotTypeMetadata {
 	return s
 }
 
+type StartImportInput struct {
+	_ struct{} `type:"structure"`
+
+	// Specifies the action that the StartImport operation should take when there
+	// is an existing resource with the same name.
+	//
+	//    * FAIL_ON_CONFLICT - The import operation is stopped on the first conflict
+	//    between a resource in the import file and an existing resource. The name
+	//    of the resource causing the conflict is in the failureReason field of
+	//    the response to the GetImport operation.
+	//
+	// OVERWRITE_LATEST - The import operation proceeds even if there is a conflict
+	//    with an existing resource. The $LASTEST version of the existing resource
+	//    is overwritten with the data from the import file.
+	//
+	// MergeStrategy is a required field
+	MergeStrategy *string `locationName:"mergeStrategy" type:"string" required:"true" enum:"MergeStrategy"`
+
+	// A zip archive in binary format. The archive should contain one file, a JSON
+	// file containing the resource to import. The resource should match the type
+	// specified in the resourceType field.
+	//
+	// Payload is automatically base64 encoded/decoded by the SDK.
+	//
+	// Payload is a required field
+	Payload []byte `locationName:"payload" type:"blob" required:"true"`
+
+	// Specifies the type of resource to export. Each resource also exports any
+	// resources that it depends on.
+	//
+	//    * A bot exports dependent intents.
+	//
+	//    * An intent exports dependent slot types.
+	//
+	// ResourceType is a required field
+	ResourceType *string `locationName:"resourceType" type:"string" required:"true" enum:"ResourceType"`
+}
+
+// String returns the string representation
+func (s StartImportInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s StartImportInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StartImportInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StartImportInput"}
+	if s.MergeStrategy == nil {
+		invalidParams.Add(request.NewErrParamRequired("MergeStrategy"))
+	}
+	if s.Payload == nil {
+		invalidParams.Add(request.NewErrParamRequired("Payload"))
+	}
+	if s.ResourceType == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceType"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetMergeStrategy sets the MergeStrategy field's value.
+func (s *StartImportInput) SetMergeStrategy(v string) *StartImportInput {
+	s.MergeStrategy = &v
+	return s
+}
+
+// SetPayload sets the Payload field's value.
+func (s *StartImportInput) SetPayload(v []byte) *StartImportInput {
+	s.Payload = v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *StartImportInput) SetResourceType(v string) *StartImportInput {
+	s.ResourceType = &v
+	return s
+}
+
+type StartImportOutput struct {
+	_ struct{} `type:"structure"`
+
+	// A timestamp for the date and time that the import job was requested.
+	CreatedDate *time.Time `locationName:"createdDate" type:"timestamp" timestampFormat:"unix"`
+
+	// The identifier for the specific import job.
+	ImportId *string `locationName:"importId" type:"string"`
+
+	// The status of the import job. If the status is FAILED, you can get the reason
+	// for the failure using the GetImport operation.
+	ImportStatus *string `locationName:"importStatus" type:"string" enum:"ImportStatus"`
+
+	// The action to take when there is a merge conflict.
+	MergeStrategy *string `locationName:"mergeStrategy" type:"string" enum:"MergeStrategy"`
+
+	// The name given to the import job.
+	Name *string `locationName:"name" min:"1" type:"string"`
+
+	// The type of resource to import.
+	ResourceType *string `locationName:"resourceType" type:"string" enum:"ResourceType"`
+}
+
+// String returns the string representation
+func (s StartImportOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s StartImportOutput) GoString() string {
+	return s.String()
+}
+
+// SetCreatedDate sets the CreatedDate field's value.
+func (s *StartImportOutput) SetCreatedDate(v time.Time) *StartImportOutput {
+	s.CreatedDate = &v
+	return s
+}
+
+// SetImportId sets the ImportId field's value.
+func (s *StartImportOutput) SetImportId(v string) *StartImportOutput {
+	s.ImportId = &v
+	return s
+}
+
+// SetImportStatus sets the ImportStatus field's value.
+func (s *StartImportOutput) SetImportStatus(v string) *StartImportOutput {
+	s.ImportStatus = &v
+	return s
+}
+
+// SetMergeStrategy sets the MergeStrategy field's value.
+func (s *StartImportOutput) SetMergeStrategy(v string) *StartImportOutput {
+	s.MergeStrategy = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *StartImportOutput) SetName(v string) *StartImportOutput {
+	s.Name = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *StartImportOutput) SetResourceType(v string) *StartImportOutput {
+	s.ResourceType = &v
+	return s
+}
+
 // A collection of messages that convey information to the user. At runtime,
 // Amazon Lex selects the message to convey.
 type Statement struct {
@@ -10177,6 +10672,9 @@ const (
 const (
 	// ExportTypeAlexaSkillsKit is a ExportType enum value
 	ExportTypeAlexaSkillsKit = "ALEXA_SKILLS_KIT"
+
+	// ExportTypeLex is a ExportType enum value
+	ExportTypeLex = "LEX"
 )
 
 const (
@@ -10188,8 +10686,33 @@ const (
 )
 
 const (
+	// ImportStatusInProgress is a ImportStatus enum value
+	ImportStatusInProgress = "IN_PROGRESS"
+
+	// ImportStatusComplete is a ImportStatus enum value
+	ImportStatusComplete = "COMPLETE"
+
+	// ImportStatusFailed is a ImportStatus enum value
+	ImportStatusFailed = "FAILED"
+)
+
+const (
 	// LocaleEnUs is a Locale enum value
 	LocaleEnUs = "en-US"
+
+	// LocaleEnGb is a Locale enum value
+	LocaleEnGb = "en-GB"
+
+	// LocaleDeDe is a Locale enum value
+	LocaleDeDe = "de-DE"
+)
+
+const (
+	// MergeStrategyOverwriteLatest is a MergeStrategy enum value
+	MergeStrategyOverwriteLatest = "OVERWRITE_LATEST"
+
+	// MergeStrategyFailOnConflict is a MergeStrategy enum value
+	MergeStrategyFailOnConflict = "FAIL_ON_CONFLICT"
 )
 
 const (
@@ -10217,6 +10740,12 @@ const (
 const (
 	// ResourceTypeBot is a ResourceType enum value
 	ResourceTypeBot = "BOT"
+
+	// ResourceTypeIntent is a ResourceType enum value
+	ResourceTypeIntent = "INTENT"
+
+	// ResourceTypeSlotType is a ResourceType enum value
+	ResourceTypeSlotType = "SLOT_TYPE"
 )
 
 const (

--- a/vendor/github.com/aws/aws-sdk-go/service/mediaconvert/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/mediaconvert/api.go
@@ -2155,7 +2155,7 @@ func (s *AudioCodecSettings) SetWavSettings(v *WavSettings) *AudioCodecSettings 
 type AudioDescription struct {
 	_ struct{} `type:"structure"`
 
-	// Settings for Audio Normalization
+	// Advanced audio normalization settings.
 	AudioNormalizationSettings *AudioNormalizationSettings `locationName:"audioNormalizationSettings" type:"structure"`
 
 	// Specifies which audio data to use from each input. In the simplest case,
@@ -2363,8 +2363,7 @@ type AudioSelector struct {
 	// as default, silence will be inserted for the duration of the input.
 	DefaultSelection *string `locationName:"defaultSelection" type:"string" enum:"AudioDefaultSelection"`
 
-	// Specifies audio data from an external file source. Auto populated when Infer
-	// External Filename is checked
+	// Specifies audio data from an external file source.
 	ExternalAudioFileInput *string `locationName:"externalAudioFileInput" type:"string"`
 
 	// Selects a specific language code from within an audio source.
@@ -4691,8 +4690,7 @@ type FileSourceSettings struct {
 	Convert608To708 *string `locationName:"convert608To708" type:"string" enum:"FileSourceConvert608To708"`
 
 	// External caption file used for loading captions. Accepted file extensions
-	// are 'scc', 'ttml', 'dfxp', 'stl', 'srt', and 'smi'. Auto-populated when Infer
-	// External Filename is checked.
+	// are 'scc', 'ttml', 'dfxp', 'stl', 'srt', and 'smi'.
 	SourceFile *string `locationName:"sourceFile" type:"string"`
 
 	// Specifies a time delta in seconds to offset the captions from the source
@@ -7257,7 +7255,7 @@ type JobTemplate struct {
 	Settings *JobTemplateSettings `locationName:"settings" type:"structure"`
 
 	// A job template can be of two types: system or custom. System or built-in
-	// job templates can’t be modified or deleted by the user.
+	// job templates can't be modified or deleted by the user.
 	Type *string `locationName:"type" type:"string" enum:"Type"`
 }
 
@@ -7828,7 +7826,7 @@ type M2tsSettings struct {
 
 	// Packet Identifier (PID) of the elementary audio stream(s) in the transport
 	// stream. Multiple values are accepted, and can be entered in ranges and/or
-	// by comma separation. Can be entered as decimal or hexadecimal values.
+	// by comma separation.
 	AudioPids []*int64 `locationName:"audioPids" type:"list"`
 
 	// The output bitrate of the transport stream in bits per second. Setting to
@@ -7851,14 +7849,13 @@ type M2tsSettings struct {
 
 	// Packet Identifier (PID) for input source DVB Subtitle data to this output.
 	// Multiple values are accepted, and can be entered in ranges and/or by comma
-	// separation. Can be entered as decimal or hexadecimal values.
+	// separation.
 	DvbSubPids []*int64 `locationName:"dvbSubPids" type:"list"`
 
 	// Inserts DVB Time and Date Table (TDT) at the specified table repetition interval.
 	DvbTdtSettings *DvbTdtSettings `locationName:"dvbTdtSettings" type:"structure"`
 
 	// Packet Identifier (PID) for input source DVB Teletext data to this output.
-	// Can be entered as a decimal or hexadecimal value.
 	DvbTeletextPid *int64 `locationName:"dvbTeletextPid" type:"integer"`
 
 	// When set to VIDEO_AND_FIXED_INTERVALS, audio EBP markers will be added to
@@ -7893,6 +7890,10 @@ type M2tsSettings struct {
 	// elsewhere to create sufficient latency to make the lookahead accurate.
 	MinEbpInterval *int64 `locationName:"minEbpInterval" type:"integer"`
 
+	// If INSERT, Nielsen inaudible tones for media tracking will be detected in
+	// the input audio and an equivalent ID3 tag will be inserted in the output.
+	NielsenId3 *string `locationName:"nielsenId3" type:"string" enum:"M2tsNielsenId3"`
+
 	// Value in bits per second of extra null packets to insert into the transport
 	// stream. This can be used if a downstream encryption system requires periodic
 	// null packets.
@@ -7909,7 +7910,7 @@ type M2tsSettings struct {
 
 	// Packet Identifier (PID) of the Program Clock Reference (PCR) in the transport
 	// stream. When no value is given, the encoder will assign the same value as
-	// the Video PID. Can be entered as a decimal or hexadecimal value.
+	// the Video PID.
 	PcrPid *int64 `locationName:"pcrPid" type:"integer"`
 
 	// The number of milliseconds between instances of this table in the output
@@ -7917,11 +7918,10 @@ type M2tsSettings struct {
 	PmtInterval *int64 `locationName:"pmtInterval" type:"integer"`
 
 	// Packet Identifier (PID) for the Program Map Table (PMT) in the transport
-	// stream. Can be entered as a decimal or hexadecimal value.
+	// stream.
 	PmtPid *int64 `locationName:"pmtPid" type:"integer"`
 
 	// Packet Identifier (PID) of the private metadata stream in the transport stream.
-	// Can be entered as a decimal or hexadecimal value.
 	PrivateMetadataPid *int64 `locationName:"privateMetadataPid" type:"integer"`
 
 	// The value of the program number field in the Program Map Table.
@@ -7932,12 +7932,11 @@ type M2tsSettings struct {
 	// but the output will not be padded up to that bitrate.
 	RateMode *string `locationName:"rateMode" type:"string" enum:"M2tsRateMode"`
 
-	// Packet Identifier (PID) of the SCTE-35 stream in the transport stream. Can
-	// be entered as a decimal or hexadecimal value.
+	// Packet Identifier (PID) of the SCTE-35 stream in the transport stream.
 	Scte35Pid *int64 `locationName:"scte35Pid" type:"integer"`
 
 	// Enables SCTE-35 passthrough (scte35Source) to pass any SCTE-35 signals from
-	// input to output. This is only available for certain containers.
+	// input to output.
 	Scte35Source *string `locationName:"scte35Source" type:"string" enum:"M2tsScte35Source"`
 
 	// Inserts segmentation markers at each segmentation_time period. rai_segstart
@@ -7966,11 +7965,13 @@ type M2tsSettings struct {
 	// _none_.
 	SegmentationTime *float64 `locationName:"segmentationTime" type:"double"`
 
+	// Packet Identifier (PID) of the timed metadata stream in the transport stream.
+	TimedMetadataPid *int64 `locationName:"timedMetadataPid" type:"integer"`
+
 	// The value of the transport stream ID field in the Program Map Table.
 	TransportStreamId *int64 `locationName:"transportStreamId" type:"integer"`
 
 	// Packet Identifier (PID) of the elementary video stream in the transport stream.
-	// Can be entered as a decimal or hexadecimal value.
 	VideoPid *int64 `locationName:"videoPid" type:"integer"`
 }
 
@@ -8080,6 +8081,12 @@ func (s *M2tsSettings) SetMinEbpInterval(v int64) *M2tsSettings {
 	return s
 }
 
+// SetNielsenId3 sets the NielsenId3 field's value.
+func (s *M2tsSettings) SetNielsenId3(v string) *M2tsSettings {
+	s.NielsenId3 = &v
+	return s
+}
+
 // SetNullPacketBitrate sets the NullPacketBitrate field's value.
 func (s *M2tsSettings) SetNullPacketBitrate(v float64) *M2tsSettings {
 	s.NullPacketBitrate = &v
@@ -8164,6 +8171,12 @@ func (s *M2tsSettings) SetSegmentationTime(v float64) *M2tsSettings {
 	return s
 }
 
+// SetTimedMetadataPid sets the TimedMetadataPid field's value.
+func (s *M2tsSettings) SetTimedMetadataPid(v int64) *M2tsSettings {
+	s.TimedMetadataPid = &v
+	return s
+}
+
 // SetTransportStreamId sets the TransportStreamId field's value.
 func (s *M2tsSettings) SetTransportStreamId(v int64) *M2tsSettings {
 	s.TransportStreamId = &v
@@ -8185,8 +8198,12 @@ type M3u8Settings struct {
 
 	// Packet Identifier (PID) of the elementary audio stream(s) in the transport
 	// stream. Multiple values are accepted, and can be entered in ranges and/or
-	// by comma separation. Can be entered as decimal or hexadecimal values.
+	// by comma separation.
 	AudioPids []*int64 `locationName:"audioPids" type:"list"`
+
+	// If INSERT, Nielsen inaudible tones for media tracking will be detected in
+	// the input audio and an equivalent ID3 tag will be inserted in the output.
+	NielsenId3 *string `locationName:"nielsenId3" type:"string" enum:"M3u8NielsenId3"`
 
 	// The number of milliseconds between instances of this table in the output
 	// transport stream.
@@ -8199,7 +8216,7 @@ type M3u8Settings struct {
 
 	// Packet Identifier (PID) of the Program Clock Reference (PCR) in the transport
 	// stream. When no value is given, the encoder will assign the same value as
-	// the Video PID. Can be entered as a decimal or hexadecimal value.
+	// the Video PID.
 	PcrPid *int64 `locationName:"pcrPid" type:"integer"`
 
 	// The number of milliseconds between instances of this table in the output
@@ -8207,37 +8224,33 @@ type M3u8Settings struct {
 	PmtInterval *int64 `locationName:"pmtInterval" type:"integer"`
 
 	// Packet Identifier (PID) for the Program Map Table (PMT) in the transport
-	// stream. Can be entered as a decimal or hexadecimal value.
+	// stream.
 	PmtPid *int64 `locationName:"pmtPid" type:"integer"`
 
 	// Packet Identifier (PID) of the private metadata stream in the transport stream.
-	// Can be entered as a decimal or hexadecimal value.
 	PrivateMetadataPid *int64 `locationName:"privateMetadataPid" type:"integer"`
 
 	// The value of the program number field in the Program Map Table.
 	ProgramNumber *int64 `locationName:"programNumber" type:"integer"`
 
-	// Packet Identifier (PID) of the SCTE-35 stream in the transport stream. Can
-	// be entered as a decimal or hexadecimal value.
+	// Packet Identifier (PID) of the SCTE-35 stream in the transport stream.
 	Scte35Pid *int64 `locationName:"scte35Pid" type:"integer"`
 
 	// Enables SCTE-35 passthrough (scte35Source) to pass any SCTE-35 signals from
-	// input to output. This is only available for certain containers.
+	// input to output.
 	Scte35Source *string `locationName:"scte35Source" type:"string" enum:"M3u8Scte35Source"`
 
 	// If PASSTHROUGH, inserts ID3 timed metadata from the timed_metadata REST command
-	// into this output. Only available for certain containers.
+	// into this output.
 	TimedMetadata *string `locationName:"timedMetadata" type:"string" enum:"TimedMetadata"`
 
 	// Packet Identifier (PID) of the timed metadata stream in the transport stream.
-	// Can be entered as a decimal or hexadecimal value.
 	TimedMetadataPid *int64 `locationName:"timedMetadataPid" type:"integer"`
 
 	// The value of the transport stream ID field in the Program Map Table.
 	TransportStreamId *int64 `locationName:"transportStreamId" type:"integer"`
 
 	// Packet Identifier (PID) of the elementary video stream in the transport stream.
-	// Can be entered as a decimal or hexadecimal value.
 	VideoPid *int64 `locationName:"videoPid" type:"integer"`
 }
 
@@ -8260,6 +8273,12 @@ func (s *M3u8Settings) SetAudioFramesPerPes(v int64) *M3u8Settings {
 // SetAudioPids sets the AudioPids field's value.
 func (s *M3u8Settings) SetAudioPids(v []*int64) *M3u8Settings {
 	s.AudioPids = v
+	return s
+}
+
+// SetNielsenId3 sets the NielsenId3 field's value.
+func (s *M3u8Settings) SetNielsenId3(v string) *M3u8Settings {
+	s.NielsenId3 = &v
 	return s
 }
 
@@ -9119,10 +9138,10 @@ type Output struct {
 	// Use Name modifier (NameModifier) to have the service add a string to the
 	// end of each output filename. You specify the base filename as part of your
 	// destination URI. When you create multiple outputs in the same output group,
-	// Name modifier is required. Name modifier also accepts format identifiers.
-	// For DASH ISO outputs, if you use the format identifiers $Number$ or $Time$
-	// in one output, you must use them in the same way in all outputs of the output
-	// group.
+	// Name modifier (NameModifier) is required. Name modifier also accepts format
+	// identifiers. For DASH ISO outputs, if you use the format identifiers $Number$
+	// or $Time$ in one output, you must use them in the same way in all outputs
+	// of the output group.
 	NameModifier *string `locationName:"nameModifier" type:"string"`
 
 	// Specific settings for this type of output.
@@ -9448,7 +9467,7 @@ type Preset struct {
 	Settings *PresetSettings `locationName:"settings" type:"structure"`
 
 	// A preset can be of two types: system or custom. System or built-in preset
-	// can’t be modified or deleted by the user.
+	// can't be modified or deleted by the user.
 	Type *string `locationName:"type" type:"string" enum:"Type"`
 }
 
@@ -9732,7 +9751,7 @@ type Queue struct {
 	Status *string `locationName:"status" type:"string" enum:"QueueStatus"`
 
 	// A queue can be of two types: system or custom. System or built-in queues
-	// can’t be modified or deleted by the user.
+	// can't be modified or deleted by the user.
 	Type *string `locationName:"type" type:"string" enum:"Type"`
 }
 
@@ -10270,7 +10289,8 @@ func (s *Timing) SetSubmitTime(v time.Time) *Timing {
 	return s
 }
 
-// Settings for TTML caption output
+// Settings specific to TTML caption outputs, including Pass style information
+// (TtmlStylePassthrough).
 type TtmlDestinationSettings struct {
 	_ struct{} `type:"structure"`
 
@@ -11491,6 +11511,8 @@ const (
 	BurninSubtitleTeletextSpacingProportional = "PROPORTIONAL"
 )
 
+// Type of Caption output, including Burn-In, Embedded, SCC, SRT, TTML, WebVTT,
+// DVB-Sub, Teletext.
 const (
 	// CaptionDestinationTypeBurnIn is a CaptionDestinationType enum value
 	CaptionDestinationTypeBurnIn = "BURN_IN"
@@ -13611,6 +13633,16 @@ const (
 	M2tsEsRateInPesExclude = "EXCLUDE"
 )
 
+// If INSERT, Nielsen inaudible tones for media tracking will be detected in
+// the input audio and an equivalent ID3 tag will be inserted in the output.
+const (
+	// M2tsNielsenId3Insert is a M2tsNielsenId3 enum value
+	M2tsNielsenId3Insert = "INSERT"
+
+	// M2tsNielsenId3None is a M2tsNielsenId3 enum value
+	M2tsNielsenId3None = "NONE"
+)
+
 // When set to PCR_EVERY_PES_PACKET, a Program Clock Reference value is inserted
 // for every Packetized Elementary Stream (PES) header. This is effective only
 // when the PCR PID is the same as the video or audio elementary stream.
@@ -13634,7 +13666,7 @@ const (
 )
 
 // Enables SCTE-35 passthrough (scte35Source) to pass any SCTE-35 signals from
-// input to output. This is only available for certain containers.
+// input to output.
 const (
 	// M2tsScte35SourcePassthrough is a M2tsScte35Source enum value
 	M2tsScte35SourcePassthrough = "PASSTHROUGH"
@@ -13689,6 +13721,16 @@ const (
 	M2tsSegmentationStyleResetCadence = "RESET_CADENCE"
 )
 
+// If INSERT, Nielsen inaudible tones for media tracking will be detected in
+// the input audio and an equivalent ID3 tag will be inserted in the output.
+const (
+	// M3u8NielsenId3Insert is a M3u8NielsenId3 enum value
+	M3u8NielsenId3Insert = "INSERT"
+
+	// M3u8NielsenId3None is a M3u8NielsenId3 enum value
+	M3u8NielsenId3None = "NONE"
+)
+
 // When set to PCR_EVERY_PES_PACKET a Program Clock Reference value is inserted
 // for every Packetized Elementary Stream (PES) header. This parameter is effective
 // only when the PCR PID is the same as the video or audio elementary stream.
@@ -13701,7 +13743,7 @@ const (
 )
 
 // Enables SCTE-35 passthrough (scte35Source) to pass any SCTE-35 signals from
-// input to output. This is only available for certain containers.
+// input to output.
 const (
 	// M3u8Scte35SourcePassthrough is a M3u8Scte35Source enum value
 	M3u8Scte35SourcePassthrough = "PASSTHROUGH"
@@ -14070,6 +14112,7 @@ const (
 	OrderDescending = "DESCENDING"
 )
 
+// Type of output group (File group, Apple HLS, DASH ISO, Microsoft Smooth Streaming)
 const (
 	// OutputGroupTypeHlsGroupSettings is a OutputGroupType enum value
 	OutputGroupTypeHlsGroupSettings = "HLS_GROUP_SETTINGS"
@@ -14344,7 +14387,7 @@ const (
 )
 
 // If PASSTHROUGH, inserts ID3 timed metadata from the timed_metadata REST command
-// into this output. Only available for certain containers.
+// into this output.
 const (
 	// TimedMetadataPassthrough is a TimedMetadata enum value
 	TimedMetadataPassthrough = "PASSTHROUGH"

--- a/vendor/github.com/aws/aws-sdk-go/service/rds/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/rds/api.go
@@ -12903,8 +12903,6 @@ type CreateDBInstanceReadReplicaInput struct {
 	// of your replica in another Availability Zone for failover support for the
 	// replica. Creating your Read Replica as a Multi-AZ DB instance is independent
 	// of whether the source database is a Multi-AZ DB instance.
-	//
-	// Currently, you can't create PostgreSQL Read Replicas as Multi-AZ DB instances.
 	MultiAZ *bool `type:"boolean"`
 
 	// The option group the DB instance is associated with. If omitted, the default
@@ -14842,6 +14840,9 @@ type DBEngineVersion struct {
 	// log types specified by ExportableLogTypes to CloudWatch Logs.
 	SupportsLogExportsToCloudwatchLogs *bool `type:"boolean"`
 
+	// Indicates whether the database engine version supports read replicas.
+	SupportsReadReplica *bool `type:"boolean"`
+
 	// A list of engine versions that this database engine version can be upgraded
 	// to.
 	ValidUpgradeTarget []*UpgradeTarget `locationNameList:"UpgradeTarget" type:"list"`
@@ -14914,6 +14915,12 @@ func (s *DBEngineVersion) SetSupportedTimezones(v []*Timezone) *DBEngineVersion 
 // SetSupportsLogExportsToCloudwatchLogs sets the SupportsLogExportsToCloudwatchLogs field's value.
 func (s *DBEngineVersion) SetSupportsLogExportsToCloudwatchLogs(v bool) *DBEngineVersion {
 	s.SupportsLogExportsToCloudwatchLogs = &v
+	return s
+}
+
+// SetSupportsReadReplica sets the SupportsReadReplica field's value.
+func (s *DBEngineVersion) SetSupportsReadReplica(v bool) *DBEngineVersion {
+	s.SupportsReadReplica = &v
 	return s
 }
 

--- a/vendor/github.com/aws/aws-sdk-go/service/route53/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/route53/api.go
@@ -14680,6 +14680,9 @@ const (
 	// CloudWatchRegionApNortheast2 is a CloudWatchRegion enum value
 	CloudWatchRegionApNortheast2 = "ap-northeast-2"
 
+	// CloudWatchRegionApNortheast3 is a CloudWatchRegion enum value
+	CloudWatchRegionApNortheast3 = "ap-northeast-3"
+
 	// CloudWatchRegionSaEast1 is a CloudWatchRegion enum value
 	CloudWatchRegionSaEast1 = "sa-east-1"
 )
@@ -14948,6 +14951,9 @@ const (
 
 	// VPCRegionApNortheast2 is a VPCRegion enum value
 	VPCRegionApNortheast2 = "ap-northeast-2"
+
+	// VPCRegionApNortheast3 is a VPCRegion enum value
+	VPCRegionApNortheast3 = "ap-northeast-3"
 
 	// VPCRegionSaEast1 is a VPCRegion enum value
 	VPCRegionSaEast1 = "sa-east-1"

--- a/vendor/github.com/aws/aws-sdk-go/service/waf/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/waf/api.go
@@ -2094,6 +2094,95 @@ func (c *WAF) DeleteIPSetWithContext(ctx aws.Context, input *DeleteIPSetInput, o
 	return out, req.Send()
 }
 
+const opDeletePermissionPolicy = "DeletePermissionPolicy"
+
+// DeletePermissionPolicyRequest generates a "aws/request.Request" representing the
+// client's request for the DeletePermissionPolicy operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DeletePermissionPolicy for more information on using the DeletePermissionPolicy
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DeletePermissionPolicyRequest method.
+//    req, resp := client.DeletePermissionPolicyRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/DeletePermissionPolicy
+func (c *WAF) DeletePermissionPolicyRequest(input *DeletePermissionPolicyInput) (req *request.Request, output *DeletePermissionPolicyOutput) {
+	op := &request.Operation{
+		Name:       opDeletePermissionPolicy,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DeletePermissionPolicyInput{}
+	}
+
+	output = &DeletePermissionPolicyOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DeletePermissionPolicy API operation for AWS WAF.
+//
+// Permanently deletes an IAM policy from the specified RuleGroup.
+//
+// The user making the request must be the owner of the RuleGroup.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS WAF's
+// API operation DeletePermissionPolicy for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalErrorException "InternalErrorException"
+//   The operation failed because of a system problem, even though the request
+//   was valid. Retry your request.
+//
+//   * ErrCodeStaleDataException "StaleDataException"
+//   The operation failed because you tried to create, update, or delete an object
+//   by using a change token that has already been used.
+//
+//   * ErrCodeNonexistentItemException "NonexistentItemException"
+//   The operation failed because the referenced object doesn't exist.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/DeletePermissionPolicy
+func (c *WAF) DeletePermissionPolicy(input *DeletePermissionPolicyInput) (*DeletePermissionPolicyOutput, error) {
+	req, out := c.DeletePermissionPolicyRequest(input)
+	return out, req.Send()
+}
+
+// DeletePermissionPolicyWithContext is the same as DeletePermissionPolicy with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeletePermissionPolicy for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *WAF) DeletePermissionPolicyWithContext(ctx aws.Context, input *DeletePermissionPolicyInput, opts ...request.Option) (*DeletePermissionPolicyOutput, error) {
+	req, out := c.DeletePermissionPolicyRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opDeleteRateBasedRule = "DeleteRateBasedRule"
 
 // DeleteRateBasedRuleRequest generates a "aws/request.Request" representing the
@@ -3659,6 +3748,89 @@ func (c *WAF) GetIPSet(input *GetIPSetInput) (*GetIPSetOutput, error) {
 // for more information on using Contexts.
 func (c *WAF) GetIPSetWithContext(ctx aws.Context, input *GetIPSetInput, opts ...request.Option) (*GetIPSetOutput, error) {
 	req, out := c.GetIPSetRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opGetPermissionPolicy = "GetPermissionPolicy"
+
+// GetPermissionPolicyRequest generates a "aws/request.Request" representing the
+// client's request for the GetPermissionPolicy operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See GetPermissionPolicy for more information on using the GetPermissionPolicy
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the GetPermissionPolicyRequest method.
+//    req, resp := client.GetPermissionPolicyRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/GetPermissionPolicy
+func (c *WAF) GetPermissionPolicyRequest(input *GetPermissionPolicyInput) (req *request.Request, output *GetPermissionPolicyOutput) {
+	op := &request.Operation{
+		Name:       opGetPermissionPolicy,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &GetPermissionPolicyInput{}
+	}
+
+	output = &GetPermissionPolicyOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// GetPermissionPolicy API operation for AWS WAF.
+//
+// Returns the IAM policy attached to the RuleGroup.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS WAF's
+// API operation GetPermissionPolicy for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalErrorException "InternalErrorException"
+//   The operation failed because of a system problem, even though the request
+//   was valid. Retry your request.
+//
+//   * ErrCodeNonexistentItemException "NonexistentItemException"
+//   The operation failed because the referenced object doesn't exist.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/GetPermissionPolicy
+func (c *WAF) GetPermissionPolicy(input *GetPermissionPolicyInput) (*GetPermissionPolicyOutput, error) {
+	req, out := c.GetPermissionPolicyRequest(input)
+	return out, req.Send()
+}
+
+// GetPermissionPolicyWithContext is the same as GetPermissionPolicy with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetPermissionPolicy for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *WAF) GetPermissionPolicyWithContext(ctx aws.Context, input *GetPermissionPolicyInput, opts ...request.Option) (*GetPermissionPolicyOutput, error) {
+	req, out := c.GetPermissionPolicyRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -5854,6 +6026,141 @@ func (c *WAF) ListXssMatchSets(input *ListXssMatchSetsInput) (*ListXssMatchSetsO
 // for more information on using Contexts.
 func (c *WAF) ListXssMatchSetsWithContext(ctx aws.Context, input *ListXssMatchSetsInput, opts ...request.Option) (*ListXssMatchSetsOutput, error) {
 	req, out := c.ListXssMatchSetsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opPutPermissionPolicy = "PutPermissionPolicy"
+
+// PutPermissionPolicyRequest generates a "aws/request.Request" representing the
+// client's request for the PutPermissionPolicy operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See PutPermissionPolicy for more information on using the PutPermissionPolicy
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the PutPermissionPolicyRequest method.
+//    req, resp := client.PutPermissionPolicyRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/PutPermissionPolicy
+func (c *WAF) PutPermissionPolicyRequest(input *PutPermissionPolicyInput) (req *request.Request, output *PutPermissionPolicyOutput) {
+	op := &request.Operation{
+		Name:       opPutPermissionPolicy,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &PutPermissionPolicyInput{}
+	}
+
+	output = &PutPermissionPolicyOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// PutPermissionPolicy API operation for AWS WAF.
+//
+// Attaches a IAM policy to the specified resource. The only supported use for
+// this action is to share a RuleGroup across accounts.
+//
+// The PutPermissionPolicy is subject to the following restrictions:
+//
+//    * You can attach only one policy with each PutPermissionPolicy request.
+//
+//    * The policy must include an Effect, Action and Principal.
+//
+//    * Effect must specify Allow.
+//
+//    * The Action in the policy must be waf:UpdateWebACL and waf-regional:UpdateWebACL.
+//    Any extra or wildcard actions in the policy will be rejected.
+//
+//    * The policy cannot include a Resource parameter.
+//
+//    * The ARN in the request must be a valid WAF RuleGroup ARN and the RuleGroup
+//    must exist in the same region.
+//
+//    * The user making the request must be the owner of the RuleGroup.
+//
+//    * Your policy must be composed using IAM Policy version 2012-10-17.
+//
+// For more information, see IAM Policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html).
+//
+// An example of a valid policy parameter is shown in the Examples section below.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS WAF's
+// API operation PutPermissionPolicy for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalErrorException "InternalErrorException"
+//   The operation failed because of a system problem, even though the request
+//   was valid. Retry your request.
+//
+//   * ErrCodeStaleDataException "StaleDataException"
+//   The operation failed because you tried to create, update, or delete an object
+//   by using a change token that has already been used.
+//
+//   * ErrCodeNonexistentItemException "NonexistentItemException"
+//   The operation failed because the referenced object doesn't exist.
+//
+//   * ErrCodeInvalidPermissionPolicyException "InvalidPermissionPolicyException"
+//   The operation failed because the specified policy is not in the proper format.
+//
+//   The policy is subject to the following restrictions:
+//
+//      * You can attach only one policy with each PutPermissionPolicy request.
+//
+//      * The policy must include an Effect, Action and Principal.
+//
+//      * Effect must specify Allow.
+//
+//      * The Action in the policy must be waf:UpdateWebACL or waf-regional:UpdateWebACL.
+//      Any extra or wildcard actions in the policy will be rejected.
+//
+//      * The policy cannot include a Resource parameter.
+//
+//      * The ARN in the request must be a valid WAF RuleGroup ARN and the RuleGroup
+//      must exist in the same region.
+//
+//      * The user making the request must be the owner of the RuleGroup.
+//
+//      * Your policy must be composed using IAM Policy version 2012-10-17.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/waf-2015-08-24/PutPermissionPolicy
+func (c *WAF) PutPermissionPolicy(input *PutPermissionPolicyInput) (*PutPermissionPolicyOutput, error) {
+	req, out := c.PutPermissionPolicyRequest(input)
+	return out, req.Send()
+}
+
+// PutPermissionPolicyWithContext is the same as PutPermissionPolicy with the addition of
+// the ability to pass a context and additional request options.
+//
+// See PutPermissionPolicy for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *WAF) PutPermissionPolicyWithContext(ctx aws.Context, input *PutPermissionPolicyInput, opts ...request.Option) (*PutPermissionPolicyOutput, error) {
+	req, out := c.PutPermissionPolicyRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -8243,9 +8550,9 @@ type ActivatedRule struct {
 	//    in the rule and then continues to inspect the web request based on the
 	//    remaining rules in the web ACL.
 	//
-	// The Action data type within ActivatedRule is used only when submitting an
-	// UpdateWebACL request. ActivatedRule|Action is not applicable and therefore
-	// not available for UpdateRuleGroup.
+	// ActivatedRule|OverrideAction applies only when updating or adding a RuleGroup
+	// to a WebACL. In this case you do not use ActivatedRule|Action. For all other
+	// update requests, ActivatedRule|Action is used instead of ActivatedRule|OverrideAction.
 	Action *WafAction `type:"structure"`
 
 	// Use the OverrideAction to test your RuleGroup.
@@ -8259,9 +8566,9 @@ type ActivatedRule struct {
 	// those requests will be counted. You can view a record of counted requests
 	// using GetSampledRequests.
 	//
-	// The OverrideAction data type within ActivatedRule is used only when submitting
-	// an UpdateRuleGroup request. ActivatedRule|OverrideAction is not applicable
-	// and therefore not available for UpdateWebACL.
+	// ActivatedRule|OverrideAction applies only when updating or adding a RuleGroup
+	// to a WebACL. In this case you do not use ActivatedRule|Action. For all other
+	// update requests, ActivatedRule|Action is used instead of ActivatedRule|OverrideAction.
 	OverrideAction *WafOverrideAction `type:"structure"`
 
 	// Specifies the order in which the Rules in a WebACL are evaluated. Rules with
@@ -10276,6 +10583,64 @@ func (s *DeleteIPSetOutput) SetChangeToken(v string) *DeleteIPSetOutput {
 	return s
 }
 
+type DeletePermissionPolicyInput struct {
+	_ struct{} `type:"structure"`
+
+	// The Amazon Resource Name (ARN) of the RuleGroup from which you want to delete
+	// the policy.
+	//
+	// The user making the request must be the owner of the RuleGroup.
+	//
+	// ResourceArn is a required field
+	ResourceArn *string `min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DeletePermissionPolicyInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeletePermissionPolicyInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeletePermissionPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeletePermissionPolicyInput"}
+	if s.ResourceArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceArn"))
+	}
+	if s.ResourceArn != nil && len(*s.ResourceArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceArn", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetResourceArn sets the ResourceArn field's value.
+func (s *DeletePermissionPolicyInput) SetResourceArn(v string) *DeletePermissionPolicyInput {
+	s.ResourceArn = &v
+	return s
+}
+
+type DeletePermissionPolicyOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeletePermissionPolicyOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeletePermissionPolicyOutput) GoString() string {
+	return s.String()
+}
+
 type DeleteRateBasedRuleInput struct {
 	_ struct{} `type:"structure"`
 
@@ -11629,6 +11994,71 @@ func (s GetIPSetOutput) GoString() string {
 // SetIPSet sets the IPSet field's value.
 func (s *GetIPSetOutput) SetIPSet(v *IPSet) *GetIPSetOutput {
 	s.IPSet = v
+	return s
+}
+
+type GetPermissionPolicyInput struct {
+	_ struct{} `type:"structure"`
+
+	// The Amazon Resource Name (ARN) of the RuleGroup for which you want to get
+	// the policy.
+	//
+	// ResourceArn is a required field
+	ResourceArn *string `min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s GetPermissionPolicyInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetPermissionPolicyInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetPermissionPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetPermissionPolicyInput"}
+	if s.ResourceArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceArn"))
+	}
+	if s.ResourceArn != nil && len(*s.ResourceArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceArn", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetResourceArn sets the ResourceArn field's value.
+func (s *GetPermissionPolicyInput) SetResourceArn(v string) *GetPermissionPolicyInput {
+	s.ResourceArn = &v
+	return s
+}
+
+type GetPermissionPolicyOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The IAM policy attached to the specified RuleGroup.
+	Policy *string `min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s GetPermissionPolicyOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetPermissionPolicyOutput) GoString() string {
+	return s.String()
+}
+
+// SetPolicy sets the Policy field's value.
+func (s *GetPermissionPolicyOutput) SetPolicy(v string) *GetPermissionPolicyOutput {
+	s.Policy = &v
 	return s
 }
 
@@ -14192,6 +14622,79 @@ func (s *Predicate) SetType(v string) *Predicate {
 	return s
 }
 
+type PutPermissionPolicyInput struct {
+	_ struct{} `type:"structure"`
+
+	// The policy to attach to the specified RuleGroup.
+	//
+	// Policy is a required field
+	Policy *string `min:"1" type:"string" required:"true"`
+
+	// The Amazon Resource Name (ARN) of the RuleGroup to which you want to attach
+	// the policy.
+	//
+	// ResourceArn is a required field
+	ResourceArn *string `min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s PutPermissionPolicyInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PutPermissionPolicyInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutPermissionPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutPermissionPolicyInput"}
+	if s.Policy == nil {
+		invalidParams.Add(request.NewErrParamRequired("Policy"))
+	}
+	if s.Policy != nil && len(*s.Policy) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Policy", 1))
+	}
+	if s.ResourceArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceArn"))
+	}
+	if s.ResourceArn != nil && len(*s.ResourceArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceArn", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetPolicy sets the Policy field's value.
+func (s *PutPermissionPolicyInput) SetPolicy(v string) *PutPermissionPolicyInput {
+	s.Policy = &v
+	return s
+}
+
+// SetResourceArn sets the ResourceArn field's value.
+func (s *PutPermissionPolicyInput) SetResourceArn(v string) *PutPermissionPolicyInput {
+	s.ResourceArn = &v
+	return s
+}
+
+type PutPermissionPolicyOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutPermissionPolicyOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PutPermissionPolicyOutput) GoString() string {
+	return s.String()
+}
+
 // A RateBasedRule is identical to a regular Rule, with one addition: a RateBasedRule
 // counts the number of requests that arrive from a specified IP address every
 // five minutes. For example, based on recent requests that you've seen from
@@ -16697,9 +17200,9 @@ type UpdateRuleGroupInput struct {
 	//
 	// You can only insert REGULAR rules into a rule group.
 	//
-	// The Action data type within ActivatedRule is used only when submitting an
-	// UpdateWebACL request. ActivatedRule|Action is not applicable and therefore
-	// not available for UpdateRuleGroup.
+	// ActivatedRule|OverrideAction applies only when updating or adding a RuleGroup
+	// to a WebACL. In this case you do not use ActivatedRule|Action. For all other
+	// update requests, ActivatedRule|Action is used instead of ActivatedRule|OverrideAction.
 	//
 	// Updates is a required field
 	Updates []*RuleGroupUpdate `min:"1" type:"list" required:"true"`
@@ -17172,10 +17675,11 @@ type UpdateWebACLInput struct {
 	//
 	//    * WebACLUpdate: Contains Action and ActivatedRule
 	//
-	//    * ActivatedRule: Contains Action, Priority, RuleId, and Type. The OverrideAction
-	//    data type within ActivatedRule is used only when submitting an UpdateRuleGroup
-	//    request. ActivatedRule|OverrideAction is not applicable and therefore
-	//    not available for UpdateWebACL.
+	//    * ActivatedRule: Contains Action, OverrideAction, Priority, RuleId, and
+	//    Type. ActivatedRule|OverrideAction applies only when updating or adding
+	//    a RuleGroup to a WebACL. In this case you do not use ActivatedRule|Action.
+	//    For all other update requests, ActivatedRule|Action is used instead of
+	//    ActivatedRule|OverrideAction.
 	//
 	//    * WafAction: Contains Type
 	Updates []*WebACLUpdate `type:"list"`

--- a/vendor/github.com/aws/aws-sdk-go/service/waf/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/waf/errors.go
@@ -80,6 +80,32 @@ const (
 	//    a resource with which a web ACL cannot be associated.
 	ErrCodeInvalidParameterException = "InvalidParameterException"
 
+	// ErrCodeInvalidPermissionPolicyException for service response error code
+	// "InvalidPermissionPolicyException".
+	//
+	// The operation failed because the specified policy is not in the proper format.
+	//
+	// The policy is subject to the following restrictions:
+	//
+	//    * You can attach only one policy with each PutPermissionPolicy request.
+	//
+	//    * The policy must include an Effect, Action and Principal.
+	//
+	//    * Effect must specify Allow.
+	//
+	//    * The Action in the policy must be waf:UpdateWebACL or waf-regional:UpdateWebACL.
+	//    Any extra or wildcard actions in the policy will be rejected.
+	//
+	//    * The policy cannot include a Resource parameter.
+	//
+	//    * The ARN in the request must be a valid WAF RuleGroup ARN and the RuleGroup
+	//    must exist in the same region.
+	//
+	//    * The user making the request must be the owner of the RuleGroup.
+	//
+	//    * Your policy must be composed using IAM Policy version 2012-10-17.
+	ErrCodeInvalidPermissionPolicyException = "InvalidPermissionPolicyException"
+
 	// ErrCodeInvalidRegexPatternException for service response error code
 	// "InvalidRegexPatternException".
 	//

--- a/vendor/github.com/aws/aws-sdk-go/service/wafregional/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/wafregional/api.go
@@ -2212,6 +2212,95 @@ func (c *WAFRegional) DeleteIPSetWithContext(ctx aws.Context, input *waf.DeleteI
 	return out, req.Send()
 }
 
+const opDeletePermissionPolicy = "DeletePermissionPolicy"
+
+// DeletePermissionPolicyRequest generates a "aws/request.Request" representing the
+// client's request for the DeletePermissionPolicy operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DeletePermissionPolicy for more information on using the DeletePermissionPolicy
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DeletePermissionPolicyRequest method.
+//    req, resp := client.DeletePermissionPolicyRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/waf-regional-2016-11-28/DeletePermissionPolicy
+func (c *WAFRegional) DeletePermissionPolicyRequest(input *waf.DeletePermissionPolicyInput) (req *request.Request, output *waf.DeletePermissionPolicyOutput) {
+	op := &request.Operation{
+		Name:       opDeletePermissionPolicy,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &waf.DeletePermissionPolicyInput{}
+	}
+
+	output = &waf.DeletePermissionPolicyOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DeletePermissionPolicy API operation for AWS WAF Regional.
+//
+// Permanently deletes an IAM policy from the specified RuleGroup.
+//
+// The user making the request must be the owner of the RuleGroup.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS WAF Regional's
+// API operation DeletePermissionPolicy for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeWAFInternalErrorException "WAFInternalErrorException"
+//   The operation failed because of a system problem, even though the request
+//   was valid. Retry your request.
+//
+//   * ErrCodeWAFStaleDataException "WAFStaleDataException"
+//   The operation failed because you tried to create, update, or delete an object
+//   by using a change token that has already been used.
+//
+//   * ErrCodeWAFNonexistentItemException "WAFNonexistentItemException"
+//   The operation failed because the referenced object doesn't exist.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/waf-regional-2016-11-28/DeletePermissionPolicy
+func (c *WAFRegional) DeletePermissionPolicy(input *waf.DeletePermissionPolicyInput) (*waf.DeletePermissionPolicyOutput, error) {
+	req, out := c.DeletePermissionPolicyRequest(input)
+	return out, req.Send()
+}
+
+// DeletePermissionPolicyWithContext is the same as DeletePermissionPolicy with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeletePermissionPolicy for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *WAFRegional) DeletePermissionPolicyWithContext(ctx aws.Context, input *waf.DeletePermissionPolicyInput, opts ...request.Option) (*waf.DeletePermissionPolicyOutput, error) {
+	req, out := c.DeletePermissionPolicyRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opDeleteRateBasedRule = "DeleteRateBasedRule"
 
 // DeleteRateBasedRuleRequest generates a "aws/request.Request" representing the
@@ -3893,6 +3982,89 @@ func (c *WAFRegional) GetIPSet(input *waf.GetIPSetInput) (*waf.GetIPSetOutput, e
 // for more information on using Contexts.
 func (c *WAFRegional) GetIPSetWithContext(ctx aws.Context, input *waf.GetIPSetInput, opts ...request.Option) (*waf.GetIPSetOutput, error) {
 	req, out := c.GetIPSetRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opGetPermissionPolicy = "GetPermissionPolicy"
+
+// GetPermissionPolicyRequest generates a "aws/request.Request" representing the
+// client's request for the GetPermissionPolicy operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See GetPermissionPolicy for more information on using the GetPermissionPolicy
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the GetPermissionPolicyRequest method.
+//    req, resp := client.GetPermissionPolicyRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/waf-regional-2016-11-28/GetPermissionPolicy
+func (c *WAFRegional) GetPermissionPolicyRequest(input *waf.GetPermissionPolicyInput) (req *request.Request, output *waf.GetPermissionPolicyOutput) {
+	op := &request.Operation{
+		Name:       opGetPermissionPolicy,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &waf.GetPermissionPolicyInput{}
+	}
+
+	output = &waf.GetPermissionPolicyOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// GetPermissionPolicy API operation for AWS WAF Regional.
+//
+// Returns the IAM policy attached to the RuleGroup.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS WAF Regional's
+// API operation GetPermissionPolicy for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeWAFInternalErrorException "WAFInternalErrorException"
+//   The operation failed because of a system problem, even though the request
+//   was valid. Retry your request.
+//
+//   * ErrCodeWAFNonexistentItemException "WAFNonexistentItemException"
+//   The operation failed because the referenced object doesn't exist.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/waf-regional-2016-11-28/GetPermissionPolicy
+func (c *WAFRegional) GetPermissionPolicy(input *waf.GetPermissionPolicyInput) (*waf.GetPermissionPolicyOutput, error) {
+	req, out := c.GetPermissionPolicyRequest(input)
+	return out, req.Send()
+}
+
+// GetPermissionPolicyWithContext is the same as GetPermissionPolicy with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetPermissionPolicy for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *WAFRegional) GetPermissionPolicyWithContext(ctx aws.Context, input *waf.GetPermissionPolicyInput, opts ...request.Option) (*waf.GetPermissionPolicyOutput, error) {
+	req, out := c.GetPermissionPolicyRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -6295,6 +6467,141 @@ func (c *WAFRegional) ListXssMatchSets(input *waf.ListXssMatchSetsInput) (*waf.L
 // for more information on using Contexts.
 func (c *WAFRegional) ListXssMatchSetsWithContext(ctx aws.Context, input *waf.ListXssMatchSetsInput, opts ...request.Option) (*waf.ListXssMatchSetsOutput, error) {
 	req, out := c.ListXssMatchSetsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opPutPermissionPolicy = "PutPermissionPolicy"
+
+// PutPermissionPolicyRequest generates a "aws/request.Request" representing the
+// client's request for the PutPermissionPolicy operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See PutPermissionPolicy for more information on using the PutPermissionPolicy
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the PutPermissionPolicyRequest method.
+//    req, resp := client.PutPermissionPolicyRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/waf-regional-2016-11-28/PutPermissionPolicy
+func (c *WAFRegional) PutPermissionPolicyRequest(input *waf.PutPermissionPolicyInput) (req *request.Request, output *waf.PutPermissionPolicyOutput) {
+	op := &request.Operation{
+		Name:       opPutPermissionPolicy,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &waf.PutPermissionPolicyInput{}
+	}
+
+	output = &waf.PutPermissionPolicyOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// PutPermissionPolicy API operation for AWS WAF Regional.
+//
+// Attaches a IAM policy to the specified resource. The only supported use for
+// this action is to share a RuleGroup across accounts.
+//
+// The PutPermissionPolicy is subject to the following restrictions:
+//
+//    * You can attach only one policy with each PutPermissionPolicy request.
+//
+//    * The policy must include an Effect, Action and Principal.
+//
+//    * Effect must specify Allow.
+//
+//    * The Action in the policy must be waf:UpdateWebACL and waf-regional:UpdateWebACL.
+//    Any extra or wildcard actions in the policy will be rejected.
+//
+//    * The policy cannot include a Resource parameter.
+//
+//    * The ARN in the request must be a valid WAF RuleGroup ARN and the RuleGroup
+//    must exist in the same region.
+//
+//    * The user making the request must be the owner of the RuleGroup.
+//
+//    * Your policy must be composed using IAM Policy version 2012-10-17.
+//
+// For more information, see IAM Policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html).
+//
+// An example of a valid policy parameter is shown in the Examples section below.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS WAF Regional's
+// API operation PutPermissionPolicy for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeWAFInternalErrorException "WAFInternalErrorException"
+//   The operation failed because of a system problem, even though the request
+//   was valid. Retry your request.
+//
+//   * ErrCodeWAFStaleDataException "WAFStaleDataException"
+//   The operation failed because you tried to create, update, or delete an object
+//   by using a change token that has already been used.
+//
+//   * ErrCodeWAFNonexistentItemException "WAFNonexistentItemException"
+//   The operation failed because the referenced object doesn't exist.
+//
+//   * ErrCodeWAFInvalidPermissionPolicyException "WAFInvalidPermissionPolicyException"
+//   The operation failed because the specified policy is not in the proper format.
+//
+//   The policy is subject to the following restrictions:
+//
+//      * You can attach only one policy with each PutPermissionPolicy request.
+//
+//      * The policy must include an Effect, Action and Principal.
+//
+//      * Effect must specify Allow.
+//
+//      * The Action in the policy must be waf:UpdateWebACL or waf-regional:UpdateWebACL.
+//      Any extra or wildcard actions in the policy will be rejected.
+//
+//      * The policy cannot include a Resource parameter.
+//
+//      * The ARN in the request must be a valid WAF RuleGroup ARN and the RuleGroup
+//      must exist in the same region.
+//
+//      * The user making the request must be the owner of the RuleGroup.
+//
+//      * Your policy must be composed using IAM Policy version 2012-10-17.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/waf-regional-2016-11-28/PutPermissionPolicy
+func (c *WAFRegional) PutPermissionPolicy(input *waf.PutPermissionPolicyInput) (*waf.PutPermissionPolicyOutput, error) {
+	req, out := c.PutPermissionPolicyRequest(input)
+	return out, req.Send()
+}
+
+// PutPermissionPolicyWithContext is the same as PutPermissionPolicy with the addition of
+// the ability to pass a context and additional request options.
+//
+// See PutPermissionPolicy for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *WAFRegional) PutPermissionPolicyWithContext(ctx aws.Context, input *waf.PutPermissionPolicyInput, opts ...request.Option) (*waf.PutPermissionPolicyOutput, error) {
+	req, out := c.PutPermissionPolicyRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()

--- a/vendor/github.com/aws/aws-sdk-go/service/wafregional/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/wafregional/errors.go
@@ -80,6 +80,32 @@ const (
 	//    a resource with which a web ACL cannot be associated.
 	ErrCodeWAFInvalidParameterException = "WAFInvalidParameterException"
 
+	// ErrCodeWAFInvalidPermissionPolicyException for service response error code
+	// "WAFInvalidPermissionPolicyException".
+	//
+	// The operation failed because the specified policy is not in the proper format.
+	//
+	// The policy is subject to the following restrictions:
+	//
+	//    * You can attach only one policy with each PutPermissionPolicy request.
+	//
+	//    * The policy must include an Effect, Action and Principal.
+	//
+	//    * Effect must specify Allow.
+	//
+	//    * The Action in the policy must be waf:UpdateWebACL or waf-regional:UpdateWebACL.
+	//    Any extra or wildcard actions in the policy will be rejected.
+	//
+	//    * The policy cannot include a Resource parameter.
+	//
+	//    * The ARN in the request must be a valid WAF RuleGroup ARN and the RuleGroup
+	//    must exist in the same region.
+	//
+	//    * The user making the request must be the owner of the RuleGroup.
+	//
+	//    * Your policy must be composed using IAM Policy version 2012-10-17.
+	ErrCodeWAFInvalidPermissionPolicyException = "WAFInvalidPermissionPolicyException"
+
 	// ErrCodeWAFInvalidRegexPatternException for service response error code
 	// "WAFInvalidRegexPatternException".
 	//

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -39,868 +39,876 @@
 			"revisionTime": "2017-07-27T15:54:43Z"
 		},
 		{
-			"checksumSHA1": "fQFz9TVTFLzLZBBTL/3nXt0PepA=",
+			"checksumSHA1": "uMrarrd/UjcGWEK5bBQmaPx0nyQ=",
 			"path": "github.com/aws/aws-sdk-go/aws",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "DtuTqKH29YnLjrIJkRYX0HQtXY0=",
 			"path": "github.com/aws/aws-sdk-go/aws/arn",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "Y9W+4GimK4Fuxq+vyIskVYFRnX4=",
 			"path": "github.com/aws/aws-sdk-go/aws/awserr",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "yyYr41HZ1Aq0hWc3J5ijXwYEcac=",
 			"path": "github.com/aws/aws-sdk-go/aws/awsutil",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
-			"checksumSHA1": "9nE/FjZ4pYrT883KtV2/aI+Gayo=",
+			"checksumSHA1": "wGf8GkrbZe2VFXOo28K0jq68A+g=",
 			"path": "github.com/aws/aws-sdk-go/aws/client",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "ieAJ+Cvp/PKv1LpUEnUXpc3OI6E=",
 			"path": "github.com/aws/aws-sdk-go/aws/client/metadata",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
-			"checksumSHA1": "7/8j/q0TWtOgXyvEcv4B2Dhl00o=",
+			"checksumSHA1": "U2W3pMTHfONS6R/QP/Zg18+89TQ=",
 			"path": "github.com/aws/aws-sdk-go/aws/corehandlers",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "Y+cPwQL0dZMyqp3wI+KJWmA9KQ8=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "u3GOAJLmdvbuNUeUEcZSEAOeL/0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "NUJUTWlc1sV8b7WjfiYc4JZbXl0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/endpointcreds",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "JEYqmF83O5n5bHkupAzA6STm0no=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "OnU/n7R33oYXiB4SAGd5pK7I0Bs=",
 			"path": "github.com/aws/aws-sdk-go/aws/defaults",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
-			"checksumSHA1": "/EXbk/z2TWjWc1Hvb4QYs3Wmhb8=",
+			"checksumSHA1": "pDnK93CqjQ4ROSW8Y/RuHXjv52M=",
 			"path": "github.com/aws/aws-sdk-go/aws/ec2metadata",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
-			"checksumSHA1": "LRonWcnvI95HVKs5fLa+wBU9A+E=",
+			"checksumSHA1": "dUurC4Vz9SYV3ZSSP+aM+DH4F14=",
 			"path": "github.com/aws/aws-sdk-go/aws/endpoints",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
-			"checksumSHA1": "657ICMok3uC5dm5e9bKcVF2HaxE=",
+			"checksumSHA1": "FpjCPoRNsVKM1hOg9EpC7jn5pRI=",
 			"path": "github.com/aws/aws-sdk-go/aws/request",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "DIn7B+oP++/nw603OB95fmupzu8=",
 			"path": "github.com/aws/aws-sdk-go/aws/session",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
-			"checksumSHA1": "iU00ZjhAml/13g+1YXT21IqoXqg=",
+			"checksumSHA1": "4gwCpxPnVQISJGF/skyWpzzxFAc=",
 			"path": "github.com/aws/aws-sdk-go/aws/signer/v4",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
+		},
+		{
+			"checksumSHA1": "MYLldFRnsZh21TfCkgkXCT3maPU=",
+			"path": "github.com/aws/aws-sdk-go/internal/sdkrand",
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "04ypv4x12l4q0TksA1zEVsmgpvw=",
 			"path": "github.com/aws/aws-sdk-go/internal/shareddefaults",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "NStHCXEvYqG72GknZyv1jaKaeH0=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "1QmQ3FqV37w0Zi44qv8pA1GeR0A=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/ec2query",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "yHfT5DTbeCLs4NE2Rgnqrhe15ls=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/json/jsonutil",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "R00RL5jJXRYq1iiK1+PGvMfvXyM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/jsonrpc",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "ZqY5RWavBLWTo6j9xqdyBEaNFRk=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "9V1PvtFQ9MObZTc3sa86WcuOtOU=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "pkeoOfZpHRvFG/AOZeTf0lwtsFg=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/rest",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "Rpu8KBtHZgvhkwHxUfaky+qW+G4=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restjson",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "ODo+ko8D6unAxZuN1jGzMcN4QCc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restxml",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "0qYPUga28aQVkxZgBR3Z86AbGUQ=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "F6mth+G7dXN1GI+nktaGo8Lx8aE=",
 			"path": "github.com/aws/aws-sdk-go/private/signer/v2",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "Ih4il2OyFyaSuoMv6hhvPUN8Gn4=",
 			"path": "github.com/aws/aws-sdk-go/service/acm",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "DPl/OkvEUjrd+XKqX73l6nUNw3U=",
 			"path": "github.com/aws/aws-sdk-go/service/apigateway",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "edPLU/Lb9QzcB2tFBgkKvF/WdY8=",
 			"path": "github.com/aws/aws-sdk-go/service/applicationautoscaling",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
-			"checksumSHA1": "zXFZtpt4wA834ihX1gEAEwSGwio=",
+			"checksumSHA1": "eXdYovPaIY64heZE1nczTsNRvtw=",
 			"path": "github.com/aws/aws-sdk-go/service/appsync",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "wrOVdI/6ZTZ/H0Kxjh3bBEZtVzk=",
 			"path": "github.com/aws/aws-sdk-go/service/athena",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
-			"checksumSHA1": "q4j8cW2zBulU/xx16A8/NxexXKE=",
+			"checksumSHA1": "GhemRVzpnrN6HAgm1NdAgESY8CQ=",
 			"path": "github.com/aws/aws-sdk-go/service/autoscaling",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "P5gDOoqIdVjMU77e5Nhy48QLpS4=",
 			"path": "github.com/aws/aws-sdk-go/service/batch",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "BrC9UCeefniH5UN7x0PFr8A9l6Y=",
 			"path": "github.com/aws/aws-sdk-go/service/budgets",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "EoaTzMilW+OIi5eETJUpd+giyTc=",
 			"path": "github.com/aws/aws-sdk-go/service/cloud9",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "yuFNzmUIWppfji/Xx6Aao0EE4cY=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudformation",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "0nPnGWlegQG7bn/iIIfjJFoljyU=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudfront",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "XJAlmauOOHsHEUW7n0XO/eEpcWI=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudsearch",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "VTc9UOMqIwuhWJ6oGQDsMkTW09I=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudtrail",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "ItXljM1vG/0goVleodRgbfYgyxQ=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatch",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "5lmoDceAWT0vrUTf3wKAaZRXwbg=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchevents",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "HHct8eQygkIJ+vrQpKhB0IEDymQ=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "22txzj8ItH1+lzyyLlFz/vtRV2I=",
 			"path": "github.com/aws/aws-sdk-go/service/codebuild",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
-			"checksumSHA1": "RRQCgy4s3k6CJQae3ueLepkK4PI=",
+			"checksumSHA1": "AQwpqKKc52nnI5F50K73Zx5luoQ=",
 			"path": "github.com/aws/aws-sdk-go/service/codecommit",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "wvXGTyWPjtgC4OjXb80IxYdpqmE=",
 			"path": "github.com/aws/aws-sdk-go/service/codedeploy",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "V1Y05qfjN4xOCy+GnPWSCqIeZb4=",
 			"path": "github.com/aws/aws-sdk-go/service/codepipeline",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "Ju8efcqcIgggB7N8io/as9ERVdc=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentity",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "jeCyZm4iJmOLbVOe/70QNkII+qU=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentityprovider",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
-			"checksumSHA1": "kt8wGmAKAo+iC1dR/g9iJn46nDo=",
+			"checksumSHA1": "fPHmnn5kgs8BB73v8Pz/7frfnmo=",
 			"path": "github.com/aws/aws-sdk-go/service/configservice",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "45sgs1urdRiXDb35iuAhQPzl0e4=",
 			"path": "github.com/aws/aws-sdk-go/service/databasemigrationservice",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "bu1R1eKCK2fc5+hMcXmagr3iIik=",
 			"path": "github.com/aws/aws-sdk-go/service/dax",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "EaEfUc3nt1sS/cdfSYGq+JtSVKs=",
 			"path": "github.com/aws/aws-sdk-go/service/devicefarm",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "LRdh5oXUe2yURIk5FDH6ceEZGMo=",
 			"path": "github.com/aws/aws-sdk-go/service/directconnect",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "a7itHIwtyXtOGQ0KsiefmsHgu4s=",
 			"path": "github.com/aws/aws-sdk-go/service/directoryservice",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "8JiVrxMjFSdBOfVWCy1QU+JzB08=",
 			"path": "github.com/aws/aws-sdk-go/service/dynamodb",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
-			"checksumSHA1": "Wt2FgZmez84iZmcDjR2pof13dTQ=",
+			"checksumSHA1": "roq8pXva49Jq13gh5n6iiZ+LXBc=",
 			"path": "github.com/aws/aws-sdk-go/service/ec2",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "kEgV0dSAj3M3M1waEkC27JS7VnU=",
 			"path": "github.com/aws/aws-sdk-go/service/ecr",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "WeevJuELH3BFpUQJC4cqZODz4c0=",
 			"path": "github.com/aws/aws-sdk-go/service/ecs",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "4XmkiujbDA68x39KGgURR1+uPiQ=",
 			"path": "github.com/aws/aws-sdk-go/service/efs",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "o73xT1zFo3C+giQwKcRj02OAZhM=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticache",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "1U0w3+W7kvH901jSftehitrRHCg=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticbeanstalk",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "VYGtTaSiajfKOVTbi9/SNmbiIac=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticsearchservice",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "SZ7yLDZ6RvMhpWe0Goyem64kgyA=",
 			"path": "github.com/aws/aws-sdk-go/service/elastictranscoder",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "iRI32eUYQfumh0LybzZ+5iWV3jE=",
 			"path": "github.com/aws/aws-sdk-go/service/elb",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
-			"checksumSHA1": "SvXeFtI3yR9UmamKEYKY/diBWDY=",
+			"checksumSHA1": "ufCsoZUQK13j8Y+m25yxhC2XteQ=",
 			"path": "github.com/aws/aws-sdk-go/service/elbv2",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "5x77vwxya74Qu5YEq75/lhyYkqY=",
 			"path": "github.com/aws/aws-sdk-go/service/emr",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "t7BmfpJqmQ7Y0EYcj/CR9Aup9go=",
 			"path": "github.com/aws/aws-sdk-go/service/firehose",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
-			"checksumSHA1": "iHyMxl+rkonWCTlysoO4ISkumCA=",
+			"checksumSHA1": "h37wXo80exgME9QqHkeLTyG88ZM=",
 			"path": "github.com/aws/aws-sdk-go/service/gamelift",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
-			"checksumSHA1": "oDoGvSfmO2Z099ixV2HXn+SDeHE=",
+			"checksumSHA1": "FoC6cWmqCUifc4pps3+HG03zl2Y=",
 			"path": "github.com/aws/aws-sdk-go/service/glacier",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "M01rYrldc6zwbpAeaLX5UJ6b25g=",
 			"path": "github.com/aws/aws-sdk-go/service/glue",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "VRaMYP1928z+aLVk2qX5OPFaobk=",
 			"path": "github.com/aws/aws-sdk-go/service/guardduty",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "I8CWKTI9BLrIF9ZKf6SpWhG+LXM=",
 			"path": "github.com/aws/aws-sdk-go/service/iam",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "45gdBZuM7PWLQzWuBasytvZZpK0=",
 			"path": "github.com/aws/aws-sdk-go/service/inspector",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "pZwCI4DpP5hcMa/ItKhiwo/ukd0=",
 			"path": "github.com/aws/aws-sdk-go/service/iot",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "DfzNze8B3ME2tV3TtXP7eQXUjD0=",
 			"path": "github.com/aws/aws-sdk-go/service/kinesis",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "Vqq049R2eveVD15emT9vKTyBsIg=",
 			"path": "github.com/aws/aws-sdk-go/service/kms",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "lAgaKbwpyflY7+t4V3EeH18RwgA=",
 			"path": "github.com/aws/aws-sdk-go/service/lambda",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
-			"checksumSHA1": "71/w80mCFLPvnL0GtOwv6kER/tg=",
+			"checksumSHA1": "j89kyJh2GGvR24TptSP3OsO2fho=",
 			"path": "github.com/aws/aws-sdk-go/service/lexmodelbuildingservice",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "4yGrGQatXcr8eGRWUoBg3KqAHK8=",
 			"path": "github.com/aws/aws-sdk-go/service/lightsail",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
-			"checksumSHA1": "ucK45ZI1VbasqgeAo9/D96XXsUA=",
+			"checksumSHA1": "8qaF9hO9gXBfjhqcgPKx9yrz9wk=",
 			"path": "github.com/aws/aws-sdk-go/service/mediaconvert",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "eqgtjNmN9OC4YhZ6TXv5PG9+L0Y=",
 			"path": "github.com/aws/aws-sdk-go/service/medialive",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "Uc40skINWoBmH5LglPNfoKxET0g=",
 			"path": "github.com/aws/aws-sdk-go/service/mediapackage",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "kEZmPI9Y9+05SWuRCdtt+QkqwLI=",
 			"path": "github.com/aws/aws-sdk-go/service/mediastore",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "1hKLl5dLV28iH5rMfOPlWmD+oXk=",
 			"path": "github.com/aws/aws-sdk-go/service/mediastoredata",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "3QV+ZVkQ8g8JkNkftwHaOCevyqM=",
 			"path": "github.com/aws/aws-sdk-go/service/mq",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "QuOSKqV8nFvvzN4wcsToltMFI1Y=",
 			"path": "github.com/aws/aws-sdk-go/service/opsworks",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "FebVAmRZZjhzA4+wq71PTS+avf0=",
 			"path": "github.com/aws/aws-sdk-go/service/organizations",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
-			"checksumSHA1": "LI+fV4xrVf/bHYHt3nCb3rhc7+c=",
+			"checksumSHA1": "r0yhTvtEdRJmXDgaFbChtTcarf8=",
 			"path": "github.com/aws/aws-sdk-go/service/rds",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "Pj9IgrR635tqA0YamoSC1GaHeao=",
 			"path": "github.com/aws/aws-sdk-go/service/redshift",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
-			"checksumSHA1": "EaDeOWEVUQ21y3cFDyDuZPaK470=",
+			"checksumSHA1": "KPRDrVt4hrFBmJ2le8HebKphfjE=",
 			"path": "github.com/aws/aws-sdk-go/service/route53",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "fXQn3V0ZRBZpTXUEHl4/yOjR4mQ=",
 			"path": "github.com/aws/aws-sdk-go/service/s3",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "OvcZyDFahfuNIdFU/A/f/9G18ic=",
 			"path": "github.com/aws/aws-sdk-go/service/sagemaker",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "rtKbVK1uZVIdkTR7yJIhAte97XQ=",
 			"path": "github.com/aws/aws-sdk-go/service/servicecatalog",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "erg+1BSdtfOk1KFXmnJ2bFHJpBY=",
 			"path": "github.com/aws/aws-sdk-go/service/servicediscovery",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "8LeTeLzNs+0vNxTeOjMCtSrSwqo=",
 			"path": "github.com/aws/aws-sdk-go/service/ses",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "u3AMeFxtHGtiJCxDeIm4dAwzBIc=",
 			"path": "github.com/aws/aws-sdk-go/service/sfn",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "B3CgAFSREebpsFoFOo4vrQ6u04w=",
 			"path": "github.com/aws/aws-sdk-go/service/simpledb",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "9Qj8yLl67q9uxBUCc0PT20YiP1M=",
 			"path": "github.com/aws/aws-sdk-go/service/sns",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "XmEJe50M8MddNEkwbZoC+YvRjgg=",
 			"path": "github.com/aws/aws-sdk-go/service/sqs",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "jl3IYnqe0OFL2bemYhF5tLOwvvs=",
 			"path": "github.com/aws/aws-sdk-go/service/ssm",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "x7HCNPJnQi+4P6FKpBTY1hm3m6o=",
 			"path": "github.com/aws/aws-sdk-go/service/sts",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "Uw4pOUxSMbx4xBHUcOUkNhtnywE=",
 			"path": "github.com/aws/aws-sdk-go/service/swf",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
-			"checksumSHA1": "ZKwkpd+UVwEKTOMhsbNpfXGUIvI=",
+			"checksumSHA1": "dBDZ2w/7ZEdk2UZ6PWFmk/cGSPw=",
 			"path": "github.com/aws/aws-sdk-go/service/waf",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
-			"checksumSHA1": "Uk2A+lTH7aAlQlkj7WIm2RFZV8A=",
+			"checksumSHA1": "hOobCqlfwCl/iPGetELNIDsns1U=",
 			"path": "github.com/aws/aws-sdk-go/service/wafregional",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "FVK4fHBkjOIaCRIY4DleqSKtZKs=",
 			"path": "github.com/aws/aws-sdk-go/service/workspaces",
-			"revision": "ebc8a649dc2a7c78c9237c2575a63b3efd6d0a2d",
-			"revisionTime": "2018-02-12T21:53:52Z",
-			"version": "v1.12.75",
-			"versionExact": "v1.12.75"
+			"revision": "f7f1ee9550cc76ceea731d99c8dbe00a0c39f66d",
+			"revisionTime": "2018-02-23T18:40:04Z",
+			"version": "v1.13.4",
+			"versionExact": "v1.13.4"
 		},
 		{
 			"checksumSHA1": "usT4LCSQItkFvFOQT7cBlkCuGaE=",


### PR DESCRIPTION
```
govendor fetch github.com/aws/aws-sdk-go/...@v1.13.4
make test TEST=./aws
==> Checking that code complies with gofmt requirements...
go test ./aws -timeout=30s -parallel=4
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1.716s

# specifically config service was the reason for v1.12 to v1.13

=== RUN   TestAccAWSConfig
=== RUN   TestAccAWSConfig/ConfigurationRecorder
=== RUN   TestAccAWSConfig/ConfigurationRecorder/allParams
=== RUN   TestAccAWSConfig/ConfigurationRecorder/importBasic
=== RUN   TestAccAWSConfig/ConfigurationRecorder/basic
=== RUN   TestAccAWSConfig/DeliveryChannel
=== RUN   TestAccAWSConfig/DeliveryChannel/basic
=== RUN   TestAccAWSConfig/DeliveryChannel/allParams
=== RUN   TestAccAWSConfig/DeliveryChannel/importBasic
=== RUN   TestAccAWSConfig/Config
=== RUN   TestAccAWSConfig/Config/customlambda
=== RUN   TestAccAWSConfig/Config/importAws
=== RUN   TestAccAWSConfig/Config/importLambda
=== RUN   TestAccAWSConfig/Config/basic
=== RUN   TestAccAWSConfig/Config/ownerAws
=== RUN   TestAccAWSConfig/ConfigurationRecorderStatus
=== RUN   TestAccAWSConfig/ConfigurationRecorderStatus/importBasic
=== RUN   TestAccAWSConfig/ConfigurationRecorderStatus/basic
=== RUN   TestAccAWSConfig/ConfigurationRecorderStatus/startEnabled
--- PASS: TestAccAWSConfig (737.64s)
```