### PR TITLE
doc updates for NLBs

### DIFF
--- a/website/docs/r/ecs_service.html.markdown
+++ b/website/docs/r/ecs_service.html.markdown
@@ -70,7 +70,7 @@ into consideration during task placement. The maximum number of
 Load balancers support the following:
 
 * `elb_name` - (Required for ELB Classic) The name of the ELB (Classic) to associate with the service.
-* `target_group_arn` - (Required for modern Load Balancers) The ARN of the Load Balancer target group to associate with the service.
+* `target_group_arn` - (Required for ALB/NLB) The ARN of the Load Balancer target group to associate with the service.
 * `container_name` - (Required) The name of the container to associate with the load balancer (as it appears in a container definition).
 * `container_port` - (Required) The port on the container to associate with the load balancer.
 

--- a/website/docs/r/ecs_service.html.markdown
+++ b/website/docs/r/ecs_service.html.markdown
@@ -31,9 +31,9 @@ resource "aws_ecs_service" "mongo" {
   }
 
   load_balancer {
-    elb_name       = "${aws_elb.foo.name}"
-    container_name = "mongo"
-    container_port = 8080
+    target_group_arn = "${aws_lb_target_group.foo.arn}"
+    container_name   = "mongo"
+    container_port   = 8080
   }
 
   placement_constraints {
@@ -70,7 +70,7 @@ into consideration during task placement. The maximum number of
 Load balancers support the following:
 
 * `elb_name` - (Required for ELB Classic) The name of the ELB (Classic) to associate with the service.
-* `target_group_arn` - (Required for ALB) The ARN of the ALB target group to associate with the service.
+* `target_group_arn` - (Required for modern Load Balancers) The ARN of the Load Balancer target group to associate with the service.
 * `container_name` - (Required) The name of the container to associate with the load balancer (as it appears in a container definition).
 * `container_port` - (Required) The port on the container to associate with the load balancer.
 

--- a/website/docs/r/lb.html.markdown
+++ b/website/docs/r/lb.html.markdown
@@ -17,10 +17,11 @@ Provides a Load Balancer resource.
 ```hcl
 # Create a new application load balancer
 resource "aws_lb" "test" {
-  name            = "test-lb-tf"
-  internal        = false
-  security_groups = ["${aws_security_group.lb_sg.id}"]
-  subnets         = ["${aws_subnet.public.*.id}"]
+  name               = "test-lb-tf"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = ["${aws_security_group.lb_sg.id}"]
+  subnets            = ["${aws_subnet.public.*.id}"]
 
   enable_deletion_protection = true
 
@@ -38,7 +39,24 @@ resource "aws_lb" "test" {
 
 ```hcl
 # Create a new network load balancer
+resource "aws_lb" "test" {
+  name               = "test-lb-tf"
+  internal           = false
+  load_balancer_type = "network"
+  subnets            = ["${aws_subnet.public.*.id}"]
 
+  enable_deletion_protection = true
+
+  access_logs {
+    bucket  = "${aws_s3_bucket.lb_logs.bucket}"
+    prefix  = "test-lb"
+    enabled = true
+  }
+
+  tags {
+    Environment = "production"
+  }
+}
 ```
 
 ## Argument Reference
@@ -57,7 +75,7 @@ Terraform will autogenerate a name beginning with `tf-lb`.
 cannot be updated for Load Balancers of type `network`. Changing this value 
 for load balancers of type `network` will force a recreation of the resource. 
 * `subnet_mapping` - (Optional) A subnet mapping block as documented below.
-* `idle_timeout` - (Optional) The time in seconds that the connection is allowed to be idle. Default: 60.
+* `idle_timeout` - (Optional) The time in seconds that the connection is allowed to be idle. Only valid for Load Balancers of type `application`. Default: 60.
 * `enable_deletion_protection` - (Optional) If true, deletion of the load balancer will be disabled via
    the AWS API. This will prevent Terraform from deleting the load balancer. Defaults to `false`.
 * `enable_cross_zone_load_balancing` - (Optional) If true, cross-zone load balancing of the load balancer will be enabled.

--- a/website/docs/r/lb.html.markdown
+++ b/website/docs/r/lb.html.markdown
@@ -47,12 +47,6 @@ resource "aws_lb" "test" {
 
   enable_deletion_protection = true
 
-  access_logs {
-    bucket  = "${aws_s3_bucket.lb_logs.bucket}"
-    prefix  = "test-lb"
-    enabled = true
-  }
-
   tags {
     Environment = "production"
   }
@@ -70,7 +64,7 @@ Terraform will autogenerate a name beginning with `tf-lb`.
 * `internal` - (Optional) If true, the LB will be internal.
 * `load_balancer_type` - (Optional) The type of load balancer to create. Possible values are `application` or `network`. The default value is `application`.
 * `security_groups` - (Optional) A list of security group IDs to assign to the LB. Only valid for Load Balancers of type `application`.
-* `access_logs` - (Optional) An Access Logs block. Access Logs documented below.
+* `access_logs` - (Optional) An Access Logs block. Access Logs documented below. Only valid for Load Balancers of type `application`.
 * `subnets` - (Optional) A list of subnet IDs to attach to the LB. Subnets
 cannot be updated for Load Balancers of type `network`. Changing this value 
 for load balancers of type `network` will force a recreation of the resource. 


### PR DESCRIPTION
 Reasoning for docs update: docs are a little inconsistent around the (relatively new) NLBs
 Relevant Terraform version: ready for immediate release