### PR TITLE
Adds filter to data.aws_eip 

### DIFF
--- a/aws/data_source_aws_eip.go
+++ b/aws/data_source_aws_eip.go
@@ -55,7 +55,13 @@ func dataSourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 
 	eip := resp.Addresses[0]
 
-	d.SetId(*eip.AllocationId)
+	if *eip.Domain == "vpc" {
+		d.SetId(*eip.AllocationId)
+	} else {
+		log.Printf("[DEBUG] Reading EIP, has no AllocationId, this means we have a Classic EIP, the id will also be the public ip : %s", req)
+		d.SetId(*eip.PublicIp)
+	}
+
 	d.Set("public_ip", eip.PublicIp)
 
 	return nil

--- a/aws/data_source_aws_eip_test.go
+++ b/aws/data_source_aws_eip_test.go
@@ -39,6 +39,21 @@ func TestAccDataSourceAwsEip_vpc(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAwsEip_filter(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDataSourceAwsEipFilterConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsEipCheck("data.aws_eip.by_filter", "aws_eip.test"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDataSourceAwsEipCheck(data_path string, resource_path string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[data_path]
@@ -101,5 +116,26 @@ data "aws_eip" "test_vpc_by_id" {
 
 data "aws_eip" "test_vpc_by_public_ip" {
   public_ip = "${aws_eip.test_vpc.public_ip}"
+}
+`
+
+const testAccDataSourceAwsEipFilterConfig = `
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_eip" "test" {
+	vpc = true
+
+	tags {
+    	Name = "testeip"
+  	}
+}
+
+data "aws_eip" "by_filter" {
+  filter {
+    name   = "tag:Name"
+    values = ["${aws_eip.test.tags.Name}"]
+  }
 }
 `

--- a/website/docs/d/eip.html.markdown
+++ b/website/docs/d/eip.html.markdown
@@ -18,6 +18,7 @@ public IP as an input variable and needs to determine the other.
 The following example shows how one might accept a public IP as a variable
 and use this data source to obtain the allocation ID when using an VPC EIP.
 
+### ip or id
 ```hcl
 variable "instance_id" {}
 variable "public_ip" {}
@@ -32,6 +33,35 @@ resource "aws_eip_association" "proxy_eip" {
 }
 ```
 
+### filter
+
+```hcl
+variable "instance_id" {}
+
+resource "aws_eip" "proxy_ip" {
+  vpc = true
+
+  tags {
+      Name = "proxy"
+    }
+}
+
+data "aws_eip" "by_filter" {
+  filter {
+    name   = "tag:Name"
+    values = ["${aws_eip.test.tags.Name}"]
+  }
+}
+
+resource "aws_eip_association" "proxy_eip" {
+  instance_id   = "${var.instance_id}"
+  allocation_id = "${data.aws_eip.proxy_ip.id}"
+}
+
+```
+
+~> **NOTE:** if using `data "aws_eip"` on a none pre exsiting EIP, ensure you reference the tag of the EIP by interpolation as shown in the example.
+
 Classic EIP's do not have an allocation_id, only use `public_ip` in the `data "aws_eip"` block.
 
 ## Argument Reference
@@ -43,6 +73,12 @@ Elastic IP whose data will be exported as attributes.
 * `id` - (Optional) The allocation id of the specific VPC EIP to retrieve. If a classic EIP is required, do NOT set `id`, only set `public_ip`
 
 * `public_ip` - (Optional) The public IP of the specific EIP to retrieve.
+
+* `filter` - (Optional) One or more name/value pairs to use as filters. There are
+several valid keys, for a full reference, check out
+[describe-addresses in the AWS CLI reference][1].
+
+~> **NOTE:** `filter` cannot be used when `id` or `public_ip` is being used.
 
 ## Attributes Reference
 

--- a/website/docs/d/eip.html.markdown
+++ b/website/docs/d/eip.html.markdown
@@ -16,7 +16,7 @@ public IP as an input variable and needs to determine the other.
 ## Example Usage
 
 The following example shows how one might accept a public IP as a variable
-and use this data source to obtain the allocation ID.
+and use this data source to obtain the allocation ID when using an VPC EIP.
 
 ```hcl
 variable "instance_id" {}
@@ -32,13 +32,15 @@ resource "aws_eip_association" "proxy_eip" {
 }
 ```
 
+Classic EIP's do not have an allocation_id, only use `public_ip` in the `data "aws_eip"` block.
+
 ## Argument Reference
 
 The arguments of this data source act as filters for querying the available
 Elastic IPs in the current region. The given filters must match exactly one
 Elastic IP whose data will be exported as attributes.
 
-* `id` - (Optional) The allocation id of the specific EIP to retrieve.
+* `id` - (Optional) The allocation id of the specific VPC EIP to retrieve. If a classic EIP is required, do NOT set `id`, only set `public_ip`
 
 * `public_ip` - (Optional) The public IP of the specific EIP to retrieve.
 


### PR DESCRIPTION
fixes issue #3423 

this is based of PR "https://github.com/terraform-providers/terraform-provider-aws/pull/3522"

Had to fix the failing tests before I could submit this PR.



this addes the ability to search for EIP’s via tags or other attribute that EIP’s can use in a filter.

This did highlight a known issue with regrads to how terraform eval’s data sources before they should if be the resourse is a computed value. This is only an issue if the data block is referencing a resource that is created at the same time. If referencing a pre exiting resource this does not happen.

the test config testAccDataSourceAwsEipFilterConfig makes a interpol ref to force terraform to eval the data block after the resource has either been created or read in `values = ["${aws_eip.test.tags.Name}”]` see the following links

hashicorp/terraform#10603
hashicorp/terraform#17173