### PR TITLE
Retry ECS create/update when target group isn't yet attached

### DIFF
--- a/aws/resource_aws_ecs_service.go
+++ b/aws/resource_aws_ecs_service.go
@@ -443,6 +443,9 @@ func resourceAwsEcsServiceCreate(d *schema.ResourceData, meta interface{}) error
 			if isAWSErr(err, ecs.ErrCodeInvalidParameterException, "Please verify that the ECS service role being passed has the proper permissions.") {
 				return resource.RetryableError(err)
 			}
+			if isAWSErr(err, ecs.ErrCodeInvalidParameterException, "does not have an associated load balancer") {
+				return resource.RetryableError(err)
+			}
 			return resource.NonRetryableError(err)
 		}
 
@@ -778,6 +781,9 @@ func resourceAwsEcsServiceUpdate(d *schema.ResourceData, meta interface{}) error
 		out, err := conn.UpdateService(&input)
 		if err != nil {
 			if isAWSErr(err, ecs.ErrCodeInvalidParameterException, "Please verify that the ECS service role being passed has the proper permissions.") {
+				return resource.RetryableError(err)
+			}
+			if isAWSErr(err, ecs.ErrCodeInvalidParameterException, "does not have an associated load balancer") {
 				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)


### PR DESCRIPTION
The ECS service can be attached to a load balancer's target group but at that point it may not yet be attached to a load balancer as the dependency graph Terraform generates normally will create the ECS service at the same time as the load balancer listener/listener rule.
This could be avoided by setting the ECS service 'depends_on' to include the load balancer listener/listener rule but this is not usable if the load balancer listener/listener rule is created in another module.

The target group in the acceptance test now gets the name from the load balancer, forcing a dependency between the load balancer and the target group.
Unfortunately it's not possible to use something from the listener to force the dependency as the listener already has a dependency on the target group.

Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/3495