### PR TITLE
resource/aws_lb: Add Cross Zone Load Balancing support for NLBs

### DIFF
--- a/aws/resource_aws_lb.go
+++ b/aws/resource_aws_lb.go
@@ -372,7 +372,7 @@ func resourceAwsLbUpdate(d *schema.ResourceData, meta interface{}) error {
 	if d.Get("load_balancer_type").(string) == "network" && d.HasChange("enable_cross_zone_load_balancing") {
 		attributes = append(attributes, &elbv2.LoadBalancerAttribute{
 			Key:   aws.String("load_balancing.cross_zone.enabled"),
-			Value: aws.String(fmt.Sprintf("%d", d.Get("enable_cross_zone_load_balancing").(int))),
+			Value: aws.String(fmt.Sprintf("%t", d.Get("enable_cross_zone_load_balancing").(bool))),
 		})
 	}
 

--- a/aws/resource_aws_lb.go
+++ b/aws/resource_aws_lb.go
@@ -385,7 +385,7 @@ func resourceAwsLbUpdate(d *schema.ResourceData, meta interface{}) error {
 		log.Printf("[DEBUG] ALB Modify Load Balancer Attributes Request: %#v", input)
 		_, err := elbconn.ModifyLoadBalancerAttributes(input)
 		if err != nil {
-			return fmt.Errorf("Failure configuring ALB attributes: %s", err)
+			return fmt.Errorf("Failure configuring LB attributes: %s", err)
 		}
 	}
 
@@ -398,7 +398,7 @@ func resourceAwsLbUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 		_, err := elbconn.SetSecurityGroups(params)
 		if err != nil {
-			return fmt.Errorf("Failure Setting ALB Security Groups: %s", err)
+			return fmt.Errorf("Failure Setting LB Security Groups: %s", err)
 		}
 
 	}
@@ -417,7 +417,7 @@ func resourceAwsLbUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		_, err := elbconn.SetSubnets(params)
 		if err != nil {
-			return fmt.Errorf("Failure Setting ALB Subnets: %s", err)
+			return fmt.Errorf("Failure Setting LB Subnets: %s", err)
 		}
 	}
 
@@ -430,7 +430,7 @@ func resourceAwsLbUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		_, err := elbconn.SetIpAddressType(params)
 		if err != nil {
-			return fmt.Errorf("Failure Setting ALB IP Address Type: %s", err)
+			return fmt.Errorf("Failure Setting LB IP Address Type: %s", err)
 		}
 
 	}
@@ -451,7 +451,7 @@ func resourceAwsLbUpdate(d *schema.ResourceData, meta interface{}) error {
 			}
 			dLb := describeResp.LoadBalancers[0]
 
-			log.Printf("[INFO] ALB state: %s", *dLb.State.Code)
+			log.Printf("[INFO] LB state: %s", *dLb.State.Code)
 
 			return describeResp, *dLb.State.Code, nil
 		},
@@ -470,14 +470,14 @@ func resourceAwsLbUpdate(d *schema.ResourceData, meta interface{}) error {
 func resourceAwsLbDelete(d *schema.ResourceData, meta interface{}) error {
 	lbconn := meta.(*AWSClient).elbv2conn
 
-	log.Printf("[INFO] Deleting ALB: %s", d.Id())
+	log.Printf("[INFO] Deleting LB: %s", d.Id())
 
 	// Destroy the load balancer
 	deleteElbOpts := elbv2.DeleteLoadBalancerInput{
 		LoadBalancerArn: aws.String(d.Id()),
 	}
 	if _, err := lbconn.DeleteLoadBalancer(&deleteElbOpts); err != nil {
-		return fmt.Errorf("Error deleting ALB: %s", err)
+		return fmt.Errorf("Error deleting LB: %s", err)
 	}
 
 	conn := meta.(*AWSClient).ec2conn
@@ -656,7 +656,7 @@ func flattenAwsLbResource(d *schema.ResourceData, meta interface{}, lb *elbv2.Lo
 		ResourceArns: []*string{lb.LoadBalancerArn},
 	})
 	if err != nil {
-		return errwrap.Wrapf("Error retrieving ALB Tags: {{err}}", err)
+		return errwrap.Wrapf("Error retrieving LB Tags: {{err}}", err)
 	}
 
 	var et []*elbv2.Tag
@@ -672,7 +672,7 @@ func flattenAwsLbResource(d *schema.ResourceData, meta interface{}, lb *elbv2.Lo
 		LoadBalancerArn: aws.String(d.Id()),
 	})
 	if err != nil {
-		return errwrap.Wrapf("Error retrieving ALB Attributes: {{err}}", err)
+		return errwrap.Wrapf("Error retrieving LB Attributes: {{err}}", err)
 	}
 
 	accessLogMap := map[string]interface{}{}

--- a/aws/resource_aws_lb.go
+++ b/aws/resource_aws_lb.go
@@ -21,7 +21,7 @@ import (
 func resourceAwsLb() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsLbCreate,
-		Read:   resoureAwsLbRead,
+		Read:   resourceAwsLbRead,
 		Update: resourceAwsLbUpdate,
 		Delete: resourceAwsLbDelete,
 		// Subnets are ForceNew for Network Load Balancers
@@ -253,7 +253,7 @@ func resourceAwsLbCreate(d *schema.ResourceData, meta interface{}) error {
 
 	lb := resp.LoadBalancers[0]
 	d.SetId(*lb.LoadBalancerArn)
-	log.Printf("[INFO] ALB ID: %s", d.Id())
+	log.Printf("[INFO] LB ID: %s", d.Id())
 
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"provisioning", "failed"},
@@ -271,7 +271,7 @@ func resourceAwsLbCreate(d *schema.ResourceData, meta interface{}) error {
 			}
 			dLb := describeResp.LoadBalancers[0]
 
-			log.Printf("[INFO] ALB state: %s", *dLb.State.Code)
+			log.Printf("[INFO] LB state: %s", *dLb.State.Code)
 
 			return describeResp, *dLb.State.Code, nil
 		},
@@ -287,7 +287,7 @@ func resourceAwsLbCreate(d *schema.ResourceData, meta interface{}) error {
 	return resourceAwsLbUpdate(d, meta)
 }
 
-func resoureAwsLbRead(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsLbRead(d *schema.ResourceData, meta interface{}) error {
 	elbconn := meta.(*AWSClient).elbv2conn
 	lbArn := d.Id()
 
@@ -464,7 +464,7 @@ func resourceAwsLbUpdate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	return resoureAwsLbRead(d, meta)
+	return resourceAwsLbRead(d, meta)
 }
 
 func resourceAwsLbDelete(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_lb_test.go
+++ b/aws/resource_aws_lb_test.go
@@ -128,6 +128,7 @@ func TestAccAWSLB_networkLoadbalancerEIP(t *testing.T) {
 					resource.TestCheckResourceAttrSet("aws_lb.test", "zone_id"),
 					resource.TestCheckResourceAttrSet("aws_lb.test", "dns_name"),
 					resource.TestCheckResourceAttrSet("aws_lb.test", "arn"),
+					resource.TestCheckResourceAttr("aws_alb.test", "enable_cross_zone_load_balancing", "true"),
 					resource.TestCheckResourceAttr("aws_lb.test", "load_balancer_type", "network"),
 					resource.TestCheckResourceAttr("aws_lb.test", "subnet_mapping.#", "2"),
 				),
@@ -983,6 +984,7 @@ resource "aws_route_table_association" "a" {
 resource "aws_lb" "test" {
   name            = "%s"
   load_balancer_type = "network"
+  enable_cross_zone_load_balancing = true
   subnet_mapping {
     subnet_id = "${aws_subnet.public.0.id}"
     allocation_id = "${aws_eip.lb.0.id}"

--- a/aws/resource_aws_lb_test.go
+++ b/aws/resource_aws_lb_test.go
@@ -157,6 +157,7 @@ func TestAccAWSLBBackwardsCompatibility(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_alb.lb_test", "tags.%", "1"),
 					resource.TestCheckResourceAttr("aws_alb.lb_test", "tags.Name", "TestAccAWSALB_basic"),
 					resource.TestCheckResourceAttr("aws_alb.lb_test", "enable_deletion_protection", "false"),
+					resource.TestCheckResourceAttr("aws_alb.lb_test", "enable_cross_zone_load_balancing", "false"),
 					resource.TestCheckResourceAttr("aws_alb.lb_test", "idle_timeout", "30"),
 					resource.TestCheckResourceAttr("aws_alb.lb_test", "ip_address_type", "ipv4"),
 					resource.TestCheckResourceAttr("aws_alb.lb_test", "load_balancer_type", "application"),
@@ -861,10 +862,11 @@ resource "aws_lb" "lb_test" {
     "${aws_subnet.alb_test_3.id}",
   ]
 
-  load_balancer_type         = "network"
-  internal                   = true
-  idle_timeout               = 60
-  enable_deletion_protection = false
+  load_balancer_type               = "network"
+  internal                         = true
+  idle_timeout                     = 60
+  enable_deletion_protection       = false
+  enable_cross_zone_load_balancing = false
 
   tags {
     Name = "testAccAWSLBConfig_networkLoadbalancer_subnets"
@@ -908,7 +910,8 @@ func testAccAWSLBConfig_networkLoadbalancer(lbName string) string {
   internal        = true
   load_balancer_type = "network"
 
-  enable_deletion_protection = false
+  enable_deletion_protection      = false
+  enable_cross_zone_load_balancing = false
 
   subnet_mapping {
   	subnet_id = "${aws_subnet.alb_test.id}"

--- a/aws/resource_aws_lb_test.go
+++ b/aws/resource_aws_lb_test.go
@@ -128,7 +128,7 @@ func TestAccAWSLB_networkLoadbalancerEIP(t *testing.T) {
 					resource.TestCheckResourceAttrSet("aws_lb.test", "zone_id"),
 					resource.TestCheckResourceAttrSet("aws_lb.test", "dns_name"),
 					resource.TestCheckResourceAttrSet("aws_lb.test", "arn"),
-					resource.TestCheckResourceAttr("aws_alb.test", "enable_cross_zone_load_balancing", "true"),
+					resource.TestCheckResourceAttr("aws_lb.test", "enable_cross_zone_load_balancing", "true"),
 					resource.TestCheckResourceAttr("aws_lb.test", "load_balancer_type", "network"),
 					resource.TestCheckResourceAttr("aws_lb.test", "subnet_mapping.#", "2"),
 				),

--- a/website/docs/r/lb.html.markdown
+++ b/website/docs/r/lb.html.markdown
@@ -60,6 +60,8 @@ will for load balancers of type `network` will force a recreation of the resourc
 * `idle_timeout` - (Optional) The time in seconds that the connection is allowed to be idle. Default: 60.
 * `enable_deletion_protection` - (Optional) If true, deletion of the load balancer will be disabled via
    the AWS API. This will prevent Terraform from deleting the load balancer. Defaults to `false`.
+* `enable_cross_zone_load_balancing` - (Optional) If true, cross-zone load balancing of the load balancer will be enabled.
+   This is a `network` load balancer feature. Defaults to `false`.
 * `ip_address_type` - (Optional) The type of IP addresses used by the subnets for your load balancer. The possible values are `ipv4` and `dualstack`
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
Closes #3574 

Enable Cross Zone load balancing support for NLBs:
Just allows setting the `load_balancing.cross_zone.enabled` Attribute. 
Docs: 
https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_LoadBalancerAttribute.html
https://docs.aws.amazon.com/sdk-for-go/api/service/elbv2/#LoadBalancerAttribute

```
TF_ACC=1 go test ./aws -v -run=TestAccAWSLB_networkLoadbalancer -timeout 120m 
=== RUN   TestAccAWSLB_networkLoadbalancer
--- PASS: TestAccAWSLB_networkLoadbalancer (245.89s)
=== RUN   TestAccAWSLB_networkLoadbalancerEIP
--- PASS: TestAccAWSLB_networkLoadbalancerEIP (262.47s)
=== RUN   TestAccAWSLB_networkLoadbalancer_subnet_change
--- PASS: TestAccAWSLB_networkLoadbalancer_subnet_change (277.25s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	786.288s```