### PR TITLE
tests: Add sweepers for aws_internet_gateway and aws_nat_gateway

### DIFF
--- a/aws/data_source_aws_nat_gateway_test.go
+++ b/aws/data_source_aws_nat_gateway_test.go
@@ -78,6 +78,10 @@ resource "aws_nat_gateway" "test" {
   subnet_id     = "${aws_subnet.test.id}"
   allocation_id = "${aws_eip.test.id}"
 
+  tags {
+    Name = "terraform-testacc-nat-gw-data-source"
+  }
+
   depends_on = ["aws_internet_gateway.test"]
 }
 

--- a/aws/import_aws_route_table_test.go
+++ b/aws/import_aws_route_table_test.go
@@ -105,6 +105,10 @@ resource "aws_nat_gateway" "nat" {
   count         = "${length(split(",", var.private_subnet_cidrs))}"
   allocation_id = "${element(aws_eip.nat.*.id, count.index)}"
   subnet_id     = "${aws_subnet.tf_test_subnet.id}"
+
+  tags {
+    Name = "terraform-testacc-route-table-import-complex-default"
+  }
 }
 
 resource "aws_route_table" "mod" {

--- a/aws/resource_aws_internet_gateway_test.go
+++ b/aws/resource_aws_internet_gateway_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -10,6 +11,54 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_internet_gateway", &resource.Sweeper{
+		Name: "aws_internet_gateway",
+		F:    testSweepInternetGateways,
+	})
+}
+
+func testSweepInternetGateways(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).ec2conn
+
+	req := &ec2.DescribeInternetGatewaysInput{
+		Filters: []*ec2.Filter{
+			{
+				Name: aws.String("tag-value"),
+				Values: []*string{
+					aws.String("terraform-testacc-*"),
+				},
+			},
+		},
+	}
+	resp, err := conn.DescribeInternetGateways(req)
+	if err != nil {
+		return fmt.Errorf("Error describing Internet Gateways: %s", err)
+	}
+
+	if len(resp.InternetGateways) == 0 {
+		log.Print("[DEBUG] No AWS Internet Gateways to sweep")
+		return nil
+	}
+
+	for _, internetGateway := range resp.InternetGateways {
+		_, err := conn.DeleteInternetGateway(&ec2.DeleteInternetGatewayInput{
+			InternetGatewayId: internetGateway.InternetGatewayId,
+		})
+		if err != nil {
+			return fmt.Errorf(
+				"Error deleting Internet Gateway (%s): %s",
+				*internetGateway.InternetGatewayId, err)
+		}
+	}
+
+	return nil
+}
 
 func TestAccAWSInternetGateway_basic(t *testing.T) {
 	var v, v2 ec2.InternetGateway
@@ -102,6 +151,7 @@ func TestAccAWSInternetGateway_tags(t *testing.T) {
 				Config: testAccCheckInternetGatewayConfigTags,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInternetGatewayExists("aws_internet_gateway.foo", &v),
+					testAccCheckTags(&v.Tags, "Name", "terraform-testacc-internet-gateway-tags"),
 					testAccCheckTags(&v.Tags, "foo", "bar"),
 				),
 			},
@@ -110,6 +160,7 @@ func TestAccAWSInternetGateway_tags(t *testing.T) {
 				Config: testAccCheckInternetGatewayConfigTagsUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInternetGatewayExists("aws_internet_gateway.foo", &v),
+					testAccCheckTags(&v.Tags, "Name", "terraform-testacc-internet-gateway-tags"),
 					testAccCheckTags(&v.Tags, "foo", ""),
 					testAccCheckTags(&v.Tags, "bar", "baz"),
 				),
@@ -198,6 +249,9 @@ resource "aws_vpc" "foo" {
 
 resource "aws_internet_gateway" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
+	tags {
+		Name = "terraform-testacc-internet-gateway"
+	}
 }
 `
 
@@ -218,6 +272,9 @@ resource "aws_vpc" "bar" {
 
 resource "aws_internet_gateway" "foo" {
 	vpc_id = "${aws_vpc.bar.id}"
+	tags {
+		Name = "terraform-testacc-internet-gateway-change-vpc-other"
+	}
 }
 `
 
@@ -232,6 +289,7 @@ resource "aws_vpc" "foo" {
 resource "aws_internet_gateway" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
 	tags {
+		Name = "terraform-testacc-internet-gateway-tags"
 		foo = "bar"
 	}
 }
@@ -248,6 +306,7 @@ resource "aws_vpc" "foo" {
 resource "aws_internet_gateway" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
 	tags {
+		Name = "terraform-testacc-internet-gateway-tags"
 		bar = "baz"
 	}
 }

--- a/aws/resource_aws_nat_gateway_test.go
+++ b/aws/resource_aws_nat_gateway_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"strings"
 	"testing"
 
@@ -11,6 +12,54 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_nat_gateway", &resource.Sweeper{
+		Name: "aws_nat_gateway",
+		F:    testSweepNatGateways,
+	})
+}
+
+func testSweepNatGateways(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).ec2conn
+
+	req := &ec2.DescribeNatGatewaysInput{
+		Filter: []*ec2.Filter{
+			{
+				Name: aws.String("tag-value"),
+				Values: []*string{
+					aws.String("terraform-testacc-*"),
+				},
+			},
+		},
+	}
+	resp, err := conn.DescribeNatGateways(req)
+	if err != nil {
+		return fmt.Errorf("Error describing NAT Gateways: %s", err)
+	}
+
+	if len(resp.NatGateways) == 0 {
+		log.Print("[DEBUG] No AWS NAT Gateways to sweep")
+		return nil
+	}
+
+	for _, natGateway := range resp.NatGateways {
+		_, err := conn.DeleteNatGateway(&ec2.DeleteNatGatewayInput{
+			NatGatewayId: natGateway.NatGatewayId,
+		})
+		if err != nil {
+			return fmt.Errorf(
+				"Error deleting NAT Gateway (%s): %s",
+				*natGateway.NatGatewayId, err)
+		}
+	}
+
+	return nil
+}
 
 func TestAccAWSNatGateway_basic(t *testing.T) {
 	var natGateway ec2.NatGateway
@@ -43,6 +92,7 @@ func TestAccAWSNatGateway_tags(t *testing.T) {
 				Config: testAccNatGatewayConfigTags,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNatGatewayExists("aws_nat_gateway.gateway", &natGateway),
+					testAccCheckTags(&natGateway.Tags, "Name", "terraform-testacc-nat-gw-tags"),
 					testAccCheckTags(&natGateway.Tags, "foo", "bar"),
 				),
 			},
@@ -51,6 +101,7 @@ func TestAccAWSNatGateway_tags(t *testing.T) {
 				Config: testAccNatGatewayConfigTagsUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNatGatewayExists("aws_nat_gateway.gateway", &natGateway),
+					testAccCheckTags(&natGateway.Tags, "Name", "terraform-testacc-nat-gw-tags"),
 					testAccCheckTags(&natGateway.Tags, "foo", ""),
 					testAccCheckTags(&natGateway.Tags, "bar", "baz"),
 				),
@@ -158,6 +209,10 @@ resource "aws_nat_gateway" "gateway" {
   allocation_id = "${aws_eip.nat_gateway.id}"
   subnet_id = "${aws_subnet.public.id}"
 
+  tags {
+    Name = "terraform-testacc-nat-gw-basic"
+  }
+
   depends_on = ["aws_internet_gateway.gw"]
 }
 
@@ -224,6 +279,7 @@ resource "aws_nat_gateway" "gateway" {
   subnet_id = "${aws_subnet.public.id}"
 
   tags {
+    Name = "terraform-testacc-nat-gw-tags"
     foo = "bar"
   }
 
@@ -293,6 +349,7 @@ resource "aws_nat_gateway" "gateway" {
   subnet_id = "${aws_subnet.public.id}"
 
   tags {
+    Name = "terraform-testacc-nat-gw-tags"
     bar = "baz"
   }
 

--- a/aws/resource_aws_vpc_test.go
+++ b/aws/resource_aws_vpc_test.go
@@ -17,6 +17,8 @@ func init() {
 	resource.AddTestSweepers("aws_vpc", &resource.Sweeper{
 		Name: "aws_vpc",
 		Dependencies: []string{
+			"aws_internet_gateway",
+			"aws_nat_gateway",
 			"aws_network_acl",
 			"aws_security_group",
 			"aws_subnet",


### PR DESCRIPTION
Got bit by a lingering NAT Gateway this morning so adding test sweepers. ♻️ 

This appropriately tags all the existing `aws_nat_gateway` test resources, but only starts the tagging process for `aws_internet_gateway` (I don't have time right now to tag and acceptance test the other few dozen test `aws_internet_gateway` resources).

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWS\(Internet\|Nat\)Gateway_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWS\(Internet\|Nat\)Gateway_ -timeout 120m
=== RUN   TestAccAWSInternetGateway_importBasic
--- PASS: TestAccAWSInternetGateway_importBasic (37.75s)
=== RUN   TestAccAWSNatGateway_importBasic
--- PASS: TestAccAWSNatGateway_importBasic (198.62s)
=== RUN   TestAccAWSInternetGateway_basic
--- PASS: TestAccAWSInternetGateway_basic (66.11s)
=== RUN   TestAccAWSInternetGateway_delete
--- PASS: TestAccAWSInternetGateway_delete (48.25s)
=== RUN   TestAccAWSInternetGateway_tags
--- PASS: TestAccAWSInternetGateway_tags (52.73s)
=== RUN   TestAccAWSNatGateway_basic
--- PASS: TestAccAWSNatGateway_basic (218.29s)
=== RUN   TestAccAWSNatGateway_tags
--- PASS: TestAccAWSNatGateway_tags (203.83s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	825.628s
```

```
make sweep
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./... -v -sweep=us-east-1,us-west-2
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
2018/02/27 09:49:08 [DEBUG] Running Sweepers for region (us-east-1):
...
2018/02/27 09:55:52 Sweeper Tests ran:
	- aws_beanstalk_application
	- aws_subnet
	- aws_redshift_cluster
	- aws_iam_server_certificate
	- aws_dynamodb_table
	- aws_beanstalk_environment
	- aws_autoscaling_group
	- aws_nat_gateway
	- aws_vpc
	- aws_kms_key
	- aws_mq_broker
	- aws_db_option_group
	- aws_gamelift_alias
	- aws_gamelift_build
	- aws_security_group
	- aws_lambda_function
	- aws_network_acl
	- aws_db_instance
	- aws_vpn_gateway
	- aws_gamelift_fleet
	- aws_key_pair
	- aws_internet_gateway
	- aws_launch_configuration
	- aws_dax_cluster
ok  	github.com/terraform-providers/terraform-provider-aws/aws	404.036s
```