### PR TITLE
resource/aws_emr_cluster: Add Kerberos support

### DIFF
--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -802,7 +802,7 @@ func flattenEc2Attributes(ia *emr.Ec2InstanceAttributes) []map[string]interface{
 func flattenEmrKerberosAttributes(d *schema.ResourceData, kerberosAttributes *emr.KerberosAttributes) []map[string]interface{} {
 	l := make([]map[string]interface{}, 0)
 
-	if kerberosAttributes == nil {
+	if kerberosAttributes == nil || kerberosAttributes.Realm == nil {
 		return l
 	}
 
@@ -813,7 +813,7 @@ func flattenEmrKerberosAttributes(d *schema.ResourceData, kerberosAttributes *em
 
 	m := map[string]interface{}{
 		"kdc_admin_password": d.Get("kerberos_attributes.0.kdc_admin_password").(string),
-		"realm":              aws.StringValue(kerberosAttributes.Realm),
+		"realm":              *kerberosAttributes.Realm,
 	}
 
 	if v, ok := d.GetOk("kerberos_attributes.0.ad_domain_join_password"); ok {

--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -577,7 +577,7 @@ func resourceAwsEMRClusterRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err := d.Set("kerberos_attributes", flattenEmrKerberosAttributes(d, cluster.KerberosAttributes)); err != nil {
-		log.Printf("[ERR] Error setting EMR Kerberos Attributes: %s", err)
+		return fmt.Errorf("error setting kerberos_attributes: %s", err)
 	}
 
 	respBootstraps, err := emrconn.ListBootstrapActions(&emr.ListBootstrapActionsInput{

--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -813,7 +813,7 @@ func flattenEmrKerberosAttributes(d *schema.ResourceData, kerberosAttributes *em
 
 	m := map[string]interface{}{
 		"kdc_admin_password": d.Get("kerberos_attributes.0.kdc_admin_password").(string),
-		"realm":              *kerberosAttributes.Realm,
+		"realm":              aws.StringValue(kerberosAttributes.Realm),
 	}
 
 	if v, ok := d.GetOk("kerberos_attributes.0.ad_domain_join_password"); ok {

--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -132,6 +132,44 @@ func resourceAwsEMRCluster() *schema.Resource {
 					},
 				},
 			},
+			"kerberos_attributes": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ad_domain_join_password": {
+							Type:      schema.TypeString,
+							Optional:  true,
+							Sensitive: true,
+							ForceNew:  true,
+						},
+						"ad_domain_join_user": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"cross_realm_trust_principal_password": {
+							Type:      schema.TypeString,
+							Optional:  true,
+							Sensitive: true,
+							ForceNew:  true,
+						},
+						"kdc_admin_password": {
+							Type:      schema.TypeString,
+							Required:  true,
+							Sensitive: true,
+							ForceNew:  true,
+						},
+						"realm": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
 			"instance_group": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -412,6 +450,12 @@ func resourceAwsEMRClusterCreate(d *schema.ResourceData, meta interface{}) error
 		params.Configurations = expandConfigures(confUrl)
 	}
 
+	if v, ok := d.GetOk("kerberos_attributes"); ok {
+		kerberosAttributesList := v.([]interface{})
+		kerberosAttributesMap := kerberosAttributesList[0].(map[string]interface{})
+		params.KerberosAttributes = expandEmrKerberosAttributes(kerberosAttributesMap)
+	}
+
 	log.Printf("[DEBUG] EMR Cluster create options: %s", params)
 
 	var resp *emr.RunJobFlowOutput
@@ -530,6 +574,10 @@ func resourceAwsEMRClusterRead(d *schema.ResourceData, meta interface{}) error {
 
 	if err := d.Set("ec2_attributes", flattenEc2Attributes(cluster.Ec2InstanceAttributes)); err != nil {
 		log.Printf("[ERR] Error setting EMR Ec2 Attributes: %s", err)
+	}
+
+	if err := d.Set("kerberos_attributes", flattenEmrKerberosAttributes(d, cluster.KerberosAttributes)); err != nil {
+		log.Printf("[ERR] Error setting EMR Kerberos Attributes: %s", err)
 	}
 
 	respBootstraps, err := emrconn.ListBootstrapActions(&emr.ListBootstrapActionsInput{
@@ -751,6 +799,40 @@ func flattenEc2Attributes(ia *emr.Ec2InstanceAttributes) []map[string]interface{
 	return result
 }
 
+func flattenEmrKerberosAttributes(d *schema.ResourceData, kerberosAttributes *emr.KerberosAttributes) []map[string]interface{} {
+	l := make([]map[string]interface{}, 0)
+
+	if kerberosAttributes == nil {
+		return l
+	}
+
+	// Do not set from API:
+	// * ad_domain_join_password
+	// * cross_realm_trust_principal_password
+	// * kdc_admin_password
+
+	m := map[string]interface{}{
+		"kdc_admin_password": d.Get("kerberos_attributes.0.kdc_admin_password").(string),
+		"realm":              *kerberosAttributes.Realm,
+	}
+
+	if v, ok := d.GetOk("kerberos_attributes.0.ad_domain_join_password"); ok {
+		m["ad_domain_join_password"] = v.(string)
+	}
+
+	if kerberosAttributes.ADDomainJoinUser != nil {
+		m["ad_domain_join_user"] = *kerberosAttributes.ADDomainJoinUser
+	}
+
+	if v, ok := d.GetOk("kerberos_attributes.0.cross_realm_trust_principal_password"); ok {
+		m["cross_realm_trust_principal_password"] = v.(string)
+	}
+
+	l = append(l, m)
+
+	return l
+}
+
 func flattenInstanceGroups(igs []*emr.InstanceGroup) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0)
 
@@ -930,6 +1012,23 @@ func expandBootstrapActions(bootstrapActions []interface{}) []*emr.BootstrapActi
 	}
 
 	return actionsOut
+}
+
+func expandEmrKerberosAttributes(m map[string]interface{}) *emr.KerberosAttributes {
+	kerberosAttributes := &emr.KerberosAttributes{
+		KdcAdminPassword: aws.String(m["kdc_admin_password"].(string)),
+		Realm:            aws.String(m["realm"].(string)),
+	}
+	if v, ok := m["ad_domain_join_password"]; ok && v.(string) != "" {
+		kerberosAttributes.ADDomainJoinPassword = aws.String(v.(string))
+	}
+	if v, ok := m["ad_domain_join_user"]; ok && v.(string) != "" {
+		kerberosAttributes.ADDomainJoinUser = aws.String(v.(string))
+	}
+	if v, ok := m["cross_realm_trust_principal_password"]; ok && v.(string) != "" {
+		kerberosAttributes.CrossRealmTrustPrincipalPassword = aws.String(v.(string))
+	}
+	return kerberosAttributes
 }
 
 func expandInstanceGroupConfigs(instanceGroupConfigs []interface{}) []*emr.InstanceGroupConfig {

--- a/website/docs/r/emr_cluster.html.markdown
+++ b/website/docs/r/emr_cluster.html.markdown
@@ -125,6 +125,7 @@ The following arguments are supported:
 * `keep_job_flow_alive_when_no_steps` - (Optional) Switch on/off run cluster with no steps or when all steps are complete (default is on)
 * `ec2_attributes` - (Optional) Attributes for the EC2 instances running the job
 flow. Defined below
+* `kerberos_attributes` - (Optional) Kerberos configuration for the cluster. Defined below
 * `ebs_root_volume_size` - (Optional) Size in GiB of the EBS root device volume of the Linux AMI that is used for each EC2 instance. Available in Amazon EMR version 4.x and later.
 * `custom_ami_id` - (Optional) A custom Amazon Linux AMI for the cluster (instead of an EMR-owned AMI). Available in Amazon EMR version 5.7.0 and later.
 * `bootstrap_action` - (Optional) List of bootstrap actions that will be run before Hadoop is started on
@@ -165,6 +166,15 @@ any Security Group used in `emr_managed_master_security_group` and
 Groups](http://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-man-sec-groups.html)
 for more information about the EMR-managed security group rules.
 
+## kerberos_attributes
+
+Attributes for Kerberos configuration
+
+* `ad_domain_join_password` - (Optional) The Active Directory password for `ad_domain_join_user`
+* `ad_domain_join_user` - (Optional) Required only when establishing a cross-realm trust with an Active Directory domain. A user with sufficient privileges to join resources to the domain.
+* `cross_realm_trust_principal_password` - (Optional) Required only when establishing a cross-realm trust with a KDC in a different realm. The cross-realm principal password, which must be identical across realms.
+* `kdc_admin_password` - (Required) The password used within the cluster for the kadmin service on the cluster-dedicated KDC, which maintains Kerberos principals, password policies, and keytabs for the cluster.
+* `realm` - (Required) The name of the Kerberos realm to which all nodes in a cluster belong. For example, `EC2.INTERNAL`
 
 ## instance_group
 


### PR DESCRIPTION
Closes #3477 

This will require a lot more time to setup a proper Active Directory acceptance test.

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSEMRCluster_Kerberos_ClusterDedicatedKdc'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSEMRCluster_Kerberos_ClusterDedicatedKdc -timeout 120m
=== RUN   TestAccAWSEMRCluster_Kerberos_ClusterDedicatedKdc
--- PASS: TestAccAWSEMRCluster_Kerberos_ClusterDedicatedKdc (406.15s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	406.202s
```