### PR TITLE
tests: Tag data source aws_internet_gateway resources for sweeping

### DIFF
--- a/aws/data_source_aws_instance_test.go
+++ b/aws/data_source_aws_instance_test.go
@@ -517,6 +517,10 @@ data "aws_instance" "foo" {
 const testAccInstanceDataSourceConfig_VPCSecurityGroups = `
 resource "aws_internet_gateway" "gw" {
   vpc_id = "${aws_vpc.foo.id}"
+
+  tags {
+    Name = "terraform-testacc-instance-data-source-vpc-sgs"
+  }
 }
 
 resource "aws_vpc" "foo" {

--- a/aws/data_source_aws_lb_listener_test.go
+++ b/aws/data_source_aws_lb_listener_test.go
@@ -386,6 +386,7 @@ resource "aws_internet_gateway" "gw" {
   vpc_id = "${aws_vpc.alb_test.id}"
 
   tags {
+    Name     = "terraform-testacc-lb-listener-data-source-https"
     TestName = "TestAccAWSALB_basic"
   }
 }


### PR DESCRIPTION
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSInstanceDataSource_VPCSecurityGroups'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSInstanceDataSource_VPCSecurityGroups -timeout 120m
=== RUN   TestAccAWSInstanceDataSource_VPCSecurityGroups
--- PASS: TestAccAWSInstanceDataSource_VPCSecurityGroups (128.21s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	128.255s

make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAWSLBListener_https'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccDataSourceAWSLBListener_https -timeout 120m
=== RUN   TestAccDataSourceAWSLBListener_https
--- PASS: TestAccDataSourceAWSLBListener_https (422.82s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	422.863s
```