### PR TITLE
tests: Tag AWSRoute aws_internet_gateway resources for sweeping

### DIFF
--- a/aws/import_aws_route_table_test.go
+++ b/aws/import_aws_route_table_test.go
@@ -93,7 +93,7 @@ resource "aws_internet_gateway" "gw" {
   vpc_id = "${aws_vpc.default.id}"
 
   tags {
-    Name = "tf-rt-import-test"
+    Name = "terraform-testacc-route-table-import-complex-default"
   }
 }
 
@@ -154,7 +154,7 @@ resource "aws_internet_gateway" "ogw" {
   vpc_id = "${aws_vpc.bar.id}"
 
   tags {
-    Name = "tf-rt-import-test"
+    Name = "terraform-testacc-route-table-import-complex-bar"
   }
 }
 

--- a/aws/resource_aws_route_table_association_test.go
+++ b/aws/resource_aws_route_table_association_test.go
@@ -120,6 +120,10 @@ resource "aws_subnet" "foo" {
 
 resource "aws_internet_gateway" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
+
+	tags {
+		Name = "terraform-testacc-route-table-association"
+	}
 }
 
 resource "aws_route_table" "foo" {
@@ -151,6 +155,10 @@ resource "aws_subnet" "foo" {
 
 resource "aws_internet_gateway" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
+
+	tags {
+		Name = "terraform-testacc-route-table-association"
+	}
 }
 
 resource "aws_route_table" "bar" {

--- a/aws/resource_aws_route_table_test.go
+++ b/aws/resource_aws_route_table_test.go
@@ -355,6 +355,10 @@ resource "aws_vpc" "foo" {
 
 resource "aws_internet_gateway" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
+
+	tags {
+		Name = "terraform-testacc-route-table"
+	}
 }
 
 resource "aws_route_table" "foo" {
@@ -377,6 +381,10 @@ resource "aws_vpc" "foo" {
 
 resource "aws_internet_gateway" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
+
+	tags {
+		Name = "terraform-testacc-route-table"
+	}
 }
 
 resource "aws_route_table" "foo" {
@@ -492,6 +500,10 @@ resource "aws_vpc" "foo" {
 
 resource "aws_internet_gateway" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
+
+	tags {
+		Name = "terraform-testacc-route-table-vpc-peering-foo"
+	}
 }
 
 resource "aws_vpc" "bar" {
@@ -503,6 +515,10 @@ resource "aws_vpc" "bar" {
 
 resource "aws_internet_gateway" "bar" {
 	vpc_id = "${aws_vpc.bar.id}"
+
+	tags {
+		Name = "terraform-testacc-route-table-vpc-peering-bar"
+	}
 }
 
 resource "aws_vpc_peering_connection" "foo" {

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -358,6 +358,10 @@ resource "aws_vpc" "foo" {
 
 resource "aws_internet_gateway" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
+
+	tags {
+		Name = "terraform-testacc-route-basic"
+	}
 }
 
 resource "aws_route_table" "foo" {
@@ -385,7 +389,11 @@ resource "aws_egress_only_internet_gateway" "foo" {
 }
 
 resource "aws_internet_gateway" "foo" {
-  vpc_id = "${aws_vpc.foo.id}"
+	vpc_id = "${aws_vpc.foo.id}"
+
+	tags {
+		Name = "terraform-testacc-route-ipv6-igw"
+	}
 }
 
 resource "aws_route_table" "external" {
@@ -414,6 +422,10 @@ data "aws_availability_zones" "available" {}
 
 resource "aws_internet_gateway" "internet" {
   vpc_id = "${aws_vpc.examplevpc.id}"
+
+  tags {
+    Name = "terraform-testacc-route-ipv6-network-interface"
+  }
 }
 
 resource "aws_route" "igw" {
@@ -513,6 +525,10 @@ data "aws_availability_zones" "available" {}
 
 resource "aws_internet_gateway" "internet" {
   vpc_id = "${aws_vpc.examplevpc.id}"
+
+  tags {
+    Name = "terraform-testacc-route-ipv6-instance"
+  }
 }
 
 resource "aws_route" "igw" {
@@ -655,6 +671,10 @@ resource "aws_vpc" "foo" {
 
 resource "aws_internet_gateway" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
+
+	tags {
+		Name = "terraform-testacc-route-change-cidr"
+	}
 }
 
 resource "aws_route_table" "foo" {
@@ -679,6 +699,10 @@ resource "aws_vpc" "foo" {
 
 resource "aws_internet_gateway" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
+
+	tags {
+		Name = "terraform-testacc-route-route-mix"
+	}
 }
 
 resource "aws_route_table" "foo" {
@@ -737,6 +761,10 @@ resource "aws_vpc" "foo" {
 
 resource "aws_internet_gateway" "foo" {
   vpc_id = "${aws_vpc.foo.id}"
+
+  tags {
+    Name = "terraform-testacc-route-with-vpc-endpoint"
+  }
 }
 
 resource "aws_route_table" "foo" {


### PR DESCRIPTION
```
64 tests passed (all tests)
=== RUN   TestAccAWSRoute53HealthCheck_CloudWatchAlarmCheck
=== RUN   TestAccAWSRoute53HealthCheck_IpConfig
=== RUN   TestAccAWSRoute53HealthCheck_withHealthCheckRegions
=== RUN   TestAccAWSRoute53HealthCheck_importBasic
--- PASS: TestAccAWSRoute53HealthCheck_importBasic (18.54s)
=== RUN   TestAccAWSRoute53DelegationSet_importBasic
--- PASS: TestAccAWSRoute53DelegationSet_importBasic (24.36s)
=== RUN   TestAccAWSRoute53HealthCheck_withChildHealthChecks
=== RUN   TestAccAWSRoute53DelegationSet_basic
--- PASS: TestAccAWSRoute53DelegationSet_basic (32.97s)
=== RUN   TestAccAWSRouteTable_importBasic
--- PASS: TestAccAWSRouteTable_importBasic (36.81s)
=== RUN   TestAccAWSRoute53HealthCheck_withSNI
=== RUN   TestAccAWSRoute53HealthCheck_basic
=== RUN   TestAccAWSRoute53HealthCheck_withSearchString
=== RUN   TestAccAWSRoute53Zone_importBasic
--- PASS: TestAccAWSRoute53Zone_importBasic (58.88s)
=== RUN   TestAccAWSRoute53QueryLog_Basic
--- PASS: TestAccAWSRoute53QueryLog_Basic (90.71s)
=== RUN   TestAccAWSRoute53DelegationSet_withZones
--- PASS: TestAccAWSRoute53DelegationSet_withZones (91.69s)
=== RUN   TestAccAWSRoute53QueryLog_Import
--- PASS: TestAccAWSRoute53QueryLog_Import (104.44s)
=== RUN   TestAccAWSRouteTable_complex
--- PASS: TestAccAWSRouteTable_complex (179.53s)
=== RUN   TestAccAWSRoute53Record_spfSupport
--- PASS: TestAccAWSRoute53Record_spfSupport (166.94s)
=== RUN   TestAccAWSRoute53Record_txtSupport
--- PASS: TestAccAWSRoute53Record_txtSupport (176.76s)
=== RUN   TestAccAWSRoute53Record_basic
--- PASS: TestAccAWSRoute53Record_basic (194.22s)
=== RUN   TestAccAWSRoute53Record_caaSupport
--- PASS: TestAccAWSRoute53Record_caaSupport (180.43s)
=== RUN   TestAccAWSRoute53Record_importBasic
--- PASS: TestAccAWSRoute53Record_importBasic (200.41s)
=== RUN   TestAccAWSRoute53Record_basic_fqdn
--- PASS: TestAccAWSRoute53Record_basic_fqdn (201.48s)
=== RUN   TestAccAWSRoute53Record_alias
--- PASS: TestAccAWSRoute53Record_alias (176.60s)
=== RUN   TestAccAWSRoute53Record_importUnderscored
--- PASS: TestAccAWSRoute53Record_importUnderscored (221.39s)
=== RUN   TestAccAWSRoute53Record_weighted_basic
--- PASS: TestAccAWSRoute53Record_weighted_basic (193.43s)
=== RUN   TestAccAWSRoute53Record_failover
--- PASS: TestAccAWSRoute53Record_failover (207.41s)
=== RUN   TestAccAWSRoute53Record_aliasUppercase
--- PASS: TestAccAWSRoute53Record_aliasUppercase (203.28s)
=== RUN   TestAccAWSRoute53Record_geolocation_basic
--- PASS: TestAccAWSRoute53Record_geolocation_basic (192.59s)
=== RUN   TestAccAWSRoute53Record_s3_alias
--- PASS: TestAccAWSRoute53Record_s3_alias (212.14s)
=== RUN   TestAccAWSRoute53Record_generatesSuffix
--- PASS: TestAccAWSRoute53Record_generatesSuffix (248.99s)
=== RUN   TestAccAWSRoute53Zone_basic
--- PASS: TestAccAWSRoute53Zone_basic (58.90s)
=== RUN   TestAccAWSRoute53Record_latency_basic
--- PASS: TestAccAWSRoute53Record_latency_basic (181.74s)
=== RUN   TestAccAWSRoute53Record_wildcard
--- PASS: TestAccAWSRoute53Record_wildcard (250.01s)
=== RUN   TestAccAWSRouteTable_panicEmptyRoute
--- PASS: TestAccAWSRouteTable_panicEmptyRoute (12.94s)
=== RUN   TestAccAWSRouteTableAssociation_basic
--- PASS: TestAccAWSRouteTableAssociation_basic (36.70s)
=== RUN   TestAccAWSRouteTable_basic
--- PASS: TestAccAWSRouteTable_basic (35.15s)
=== RUN   TestAccAWSRoute53Zone_updateComment
--- PASS: TestAccAWSRoute53Zone_updateComment (104.91s)
=== RUN   TestAccAWSRoute53Zone_private_region
--- PASS: TestAccAWSRoute53Zone_private_region (91.83s)
=== RUN   TestAccAWSRouteTable_ipv6
--- PASS: TestAccAWSRouteTable_ipv6 (73.18s)
=== RUN   TestAccAWSRoute53Record_TypeChange
--- PASS: TestAccAWSRoute53Record_TypeChange (259.34s)
=== RUN   TestAccAWSRoute53Record_empty
--- PASS: TestAccAWSRoute53Record_empty (193.00s)
=== RUN   TestAccAWSRoute53ZoneAssociation_basic
--- PASS: TestAccAWSRoute53ZoneAssociation_basic (183.51s)
=== RUN   TestAccAWSRoute53Record_SetIdentiferChange
--- PASS: TestAccAWSRoute53Record_SetIdentiferChange (292.19s)
=== RUN   TestAccAWSRouteTable_tags
--- PASS: TestAccAWSRouteTable_tags (146.62s)
=== RUN   TestAccAWSRoute53Record_weighted_alias
--- PASS: TestAccAWSRoute53Record_weighted_alias (393.29s)
=== RUN   TestAccAWSRouteTable_vgwRoutePropagation
--- PASS: TestAccAWSRouteTable_vgwRoutePropagation (154.87s)
=== RUN   TestAccAWSRoute_ipv6Support
--- PASS: TestAccAWSRoute_ipv6Support (112.05s)
=== RUN   TestAccAWSRouteTable_instance
--- PASS: TestAccAWSRouteTable_instance (178.67s)
=== RUN   TestAccAWSRouteTable_vpcPeering
--- PASS: TestAccAWSRouteTable_vpcPeering (170.07s)
=== RUN   TestAccAWSRoute53Record_allowOverwrite
--- PASS: TestAccAWSRoute53Record_allowOverwrite (265.33s)
=== RUN   TestAccAWSRoute_ipv6ToPeeringConnection
--- PASS: TestAccAWSRoute_ipv6ToPeeringConnection (100.39s)
=== RUN   TestAccAWSRoute_ipv6ToInternetGateway
--- PASS: TestAccAWSRoute_ipv6ToInternetGateway (151.13s)
=== RUN   TestAccAWSRoute_doesNotCrashWithVPCEndpoint
--- PASS: TestAccAWSRoute_doesNotCrashWithVPCEndpoint (78.68s)
=== RUN   TestAccAWSRoute_basic
--- PASS: TestAccAWSRoute_basic (213.61s)
=== RUN   TestAccAWSRoute_changeCidr
--- PASS: TestAccAWSRoute_changeCidr (128.24s)
=== RUN   TestAccAWSRoute53Record_AliasChange
--- PASS: TestAccAWSRoute53Record_AliasChange (356.88s)
=== RUN   TestAccAWSRoute53Record_multivalue_answer_basic
--- PASS: TestAccAWSRoute53Record_multivalue_answer_basic (350.73s)
=== RUN   TestAccAWSRoute53Record_longTXTrecord
--- PASS: TestAccAWSRoute53Record_longTXTrecord (368.40s)
=== RUN   TestAccAWSRoute_ipv6ToInstance
--- PASS: TestAccAWSRoute_ipv6ToInstance (263.04s)
=== RUN   TestAccAWSRoute53Zone_forceDestroy
--- PASS: TestAccAWSRoute53Zone_forceDestroy (400.57s)
=== RUN   TestAccAWSRoute_noopdiff
--- PASS: TestAccAWSRoute_noopdiff (225.91s)
=== RUN   TestAccAWSRoute_ipv6ToNetworkInterface
--- PASS: TestAccAWSRoute_ipv6ToNetworkInterface (334.92s)
=== RUN   TestAccAWSRoute53Zone_private_basic
--- PASS: TestAccAWSRoute53Zone_private_basic (507.16s)
=== RUN   TestAccAWSRoute53ZoneAssociation_region
--- PASS: TestAccAWSRoute53ZoneAssociation_region (562.78s)
```