### PR TITLE
docs/r/api_gateway_vpc_link: target_arn -> target_arns

### DIFF
--- a/aws/resource_aws_api_gateway_vpc_link.go
+++ b/aws/resource_aws_api_gateway_vpc_link.go
@@ -92,7 +92,7 @@ func resourceAwsApiGatewayVpcLinkRead(d *schema.ResourceData, meta interface{}) 
 
 	d.Set("name", resp.Name)
 	d.Set("description", resp.Description)
-	d.Set("target_arn", flattenStringList(resp.TargetArns))
+	d.Set("target_arns", flattenStringList(resp.TargetArns))
 	return nil
 }
 

--- a/website/docs/r/api_gateway_vpc_link.html.markdown
+++ b/website/docs/r/api_gateway_vpc_link.html.markdown
@@ -26,7 +26,7 @@ resource "aws_lb" "example" {
 resource "aws_api_gateway_vpc_link" "example" {
   name = "example"
   description = "example description"
-  target_arn = "${aws_lb.example.arn}"
+  target_arns = ["${aws_lb.example.arn}"]
 }
 ```
 
@@ -36,7 +36,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name used to label and identify the VPC link.
 * `description` - (Optional) The description of the VPC link.
-* `target_arn` - (Required, ForceNew) The ARN of a network load balancer in the VPC targeted by the VPC link.
+* `target_arns` - (Required, ForceNew) The list of network load balancer arns in the VPC targeted by the VPC link. Currently AWS only supports 1 target.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Seems like we forgot to update document when changing `target_arn` to `target_arns` during implementation.