### PR TITLE
resource/aws_cloudfront_distribution: Make default_ttl, max_ttl, and min_ttl attributes as optional

### DIFF
--- a/aws/cloudfront_distribution_configuration_structure.go
+++ b/aws/cloudfront_distribution_configuration_structure.go
@@ -270,10 +270,11 @@ func expandCacheBehavior(m map[string]interface{}) *cloudfront.CacheBehavior {
 		ViewerProtocolPolicy: aws.String(m["viewer_protocol_policy"].(string)),
 		TargetOriginId:       aws.String(m["target_origin_id"].(string)),
 		ForwardedValues:      expandForwardedValues(m["forwarded_values"].(*schema.Set).List()[0].(map[string]interface{})),
-		MinTTL:               aws.Int64(int64(m["min_ttl"].(int))),
-		MaxTTL:               aws.Int64(int64(m["max_ttl"].(int))),
 		DefaultTTL:           aws.Int64(int64(m["default_ttl"].(int))),
+		MaxTTL:               aws.Int64(int64(m["max_ttl"].(int))),
+		MinTTL:               aws.Int64(int64(m["min_ttl"].(int))),
 	}
+
 	if v, ok := m["trusted_signers"]; ok {
 		cb.TrustedSigners = expandTrustedSigners(v.([]interface{}))
 	} else {

--- a/aws/cloudfront_distribution_configuration_structure_test.go
+++ b/aws/cloudfront_distribution_configuration_structure_test.go
@@ -14,10 +14,10 @@ func defaultCacheBehaviorConf() map[string]interface{} {
 		"viewer_protocol_policy":      "allow-all",
 		"target_origin_id":            "myS3Origin",
 		"forwarded_values":            schema.NewSet(forwardedValuesHash, []interface{}{forwardedValuesConf()}),
-		"min_ttl":                     86400,
+		"min_ttl":                     0,
 		"trusted_signers":             trustedSignersConf(),
 		"lambda_function_association": lambdaFunctionAssociationsConf(),
-		"max_ttl":                     365000000,
+		"max_ttl":                     31536000,
 		"smooth_streaming":            false,
 		"default_ttl":                 86400,
 		"allowed_methods":             allowedMethodsConf(),
@@ -384,14 +384,14 @@ func TestCloudFrontStructure_flattenCacheBehavior(t *testing.T) {
 	if len(diff.List()) > 0 {
 		t.Fatalf("Expected out[forwarded_values] to be %v, got %v, diff: %v", out["forwarded_values"], in["forwarded_values"], diff)
 	}
-	if out["min_ttl"] != int(86400) {
-		t.Fatalf("Expected out[min_ttl] to be 86400 (int), got %v", out["forwarded_values"])
+	if out["min_ttl"] != int(0) {
+		t.Fatalf("Expected out[min_ttl] to be 0 (int), got %v", out["min_ttl"])
 	}
 	if reflect.DeepEqual(out["trusted_signers"], in["trusted_signers"]) != true {
 		t.Fatalf("Expected out[trusted_signers] to be %v, got %v", in["trusted_signers"], out["trusted_signers"])
 	}
-	if out["max_ttl"] != int(365000000) {
-		t.Fatalf("Expected out[max_ttl] to be 365000000 (int), got %v", out["max_ttl"])
+	if out["max_ttl"] != int(31536000) {
+		t.Fatalf("Expected out[max_ttl] to be 31536000 (int), got %v", out["max_ttl"])
 	}
 	if out["smooth_streaming"] != false {
 		t.Fatalf("Expected out[smooth_streaming] to be false, got %v", out["smooth_streaming"])

--- a/aws/cloudfront_distribution_configuration_structure_test.go
+++ b/aws/cloudfront_distribution_configuration_structure_test.go
@@ -270,14 +270,14 @@ func TestCloudFrontStructure_expandDefaultCacheBehavior(t *testing.T) {
 	if reflect.DeepEqual(dcb.ForwardedValues.Headers.Items, expandStringList(headersConf())) != true {
 		t.Fatalf("Expected Items to be %v, got %v", headersConf(), dcb.ForwardedValues.Headers.Items)
 	}
-	if *dcb.MinTTL != 86400 {
-		t.Fatalf("Expected MinTTL to be 86400, got %v", *dcb.MinTTL)
+	if *dcb.MinTTL != 0 {
+		t.Fatalf("Expected MinTTL to be 0, got %v", *dcb.MinTTL)
 	}
 	if reflect.DeepEqual(dcb.TrustedSigners.Items, expandStringList(trustedSignersConf())) != true {
 		t.Fatalf("Expected TrustedSigners.Items to be %v, got %v", trustedSignersConf(), dcb.TrustedSigners.Items)
 	}
-	if *dcb.MaxTTL != 365000000 {
-		t.Fatalf("Expected MaxTTL to be 365000000, got %v", *dcb.MaxTTL)
+	if *dcb.MaxTTL != 31536000 {
+		t.Fatalf("Expected MaxTTL to be 31536000, got %v", *dcb.MaxTTL)
 	}
 	if *dcb.SmoothStreaming != false {
 		t.Fatalf("Expected SmoothStreaming to be false, got %v", *dcb.SmoothStreaming)
@@ -322,14 +322,14 @@ func TestCloudFrontStructure_expandCacheBehavior(t *testing.T) {
 	if reflect.DeepEqual(cb.ForwardedValues.Headers.Items, expandStringList(headersConf())) != true {
 		t.Fatalf("Expected Items to be %v, got %v", headersConf(), cb.ForwardedValues.Headers.Items)
 	}
-	if *cb.MinTTL != 86400 {
-		t.Fatalf("Expected MinTTL to be 86400, got %v", *cb.MinTTL)
+	if *cb.MinTTL != 0 {
+		t.Fatalf("Expected MinTTL to be 0, got %v", *cb.MinTTL)
 	}
 	if reflect.DeepEqual(cb.TrustedSigners.Items, expandStringList(trustedSignersConf())) != true {
 		t.Fatalf("Expected TrustedSigners.Items to be %v, got %v", trustedSignersConf(), cb.TrustedSigners.Items)
 	}
-	if *cb.MaxTTL != 365000000 {
-		t.Fatalf("Expected MaxTTL to be 365000000, got %v", *cb.MaxTTL)
+	if *cb.MaxTTL != 31536000 {
+		t.Fatalf("Expected MaxTTL to be 31536000, got %v", *cb.MaxTTL)
 	}
 	if *cb.SmoothStreaming != false {
 		t.Fatalf("Expected SmoothStreaming to be false, got %v", *cb.SmoothStreaming)

--- a/aws/resource_aws_cloudfront_distribution.go
+++ b/aws/resource_aws_cloudfront_distribution.go
@@ -57,7 +57,8 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 						},
 						"default_ttl": {
 							Type:     schema.TypeInt,
-							Required: true,
+							Optional: true,
+							Default:  86400,
 						},
 						"forwarded_values": {
 							Type:     schema.TypeSet,
@@ -122,11 +123,13 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 						},
 						"max_ttl": {
 							Type:     schema.TypeInt,
-							Required: true,
+							Optional: true,
+							Default:  31536000,
 						},
 						"min_ttl": {
 							Type:     schema.TypeInt,
-							Required: true,
+							Optional: true,
+							Default:  0,
 						},
 						"path_pattern": {
 							Type:     schema.TypeString,
@@ -205,7 +208,8 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 						},
 						"default_ttl": {
 							Type:     schema.TypeInt,
-							Required: true,
+							Optional: true,
+							Default:  86400,
 						},
 						"forwarded_values": {
 							Type:     schema.TypeSet,
@@ -270,11 +274,13 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 						},
 						"max_ttl": {
 							Type:     schema.TypeInt,
-							Required: true,
+							Optional: true,
+							Default:  31536000,
 						},
 						"min_ttl": {
 							Type:     schema.TypeInt,
-							Required: true,
+							Optional: true,
+							Default:  0,
 						},
 						"smooth_streaming": {
 							Type:     schema.TypeBool,

--- a/aws/resource_aws_cloudfront_distribution_test.go
+++ b/aws/resource_aws_cloudfront_distribution_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"regexp"
 	"testing"
 	"time"
 
@@ -136,6 +137,7 @@ func TestAccAWSCloudFrontDistribution_multiOrigin(t *testing.T) {
 // If you are testing manually and can't wait for deletion, set the
 // TF_TEST_CLOUDFRONT_RETAIN environment variable.
 func TestAccAWSCloudFrontDistribution_noOptionalItemsConfig(t *testing.T) {
+	resourceName := "aws_cloudfront_distribution.no_optional_items"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -144,9 +146,69 @@ func TestAccAWSCloudFrontDistribution_noOptionalItemsConfig(t *testing.T) {
 			{
 				Config: testAccAWSCloudFrontDistributionNoOptionalItemsConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFrontDistributionExistence(
-						"aws_cloudfront_distribution.no_optional_items",
-					),
+					testAccCheckCloudFrontDistributionExistence(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "aliases.#", "0"),
+					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(`^arn:[^:]+:cloudfront::[^:]+:distribution/[A-Z0-9]+$`)),
+					resource.TestCheckResourceAttr(resourceName, "custom_error_response.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.allowed_methods.#", "7"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.allowed_methods.0", "HEAD"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.allowed_methods.1", "DELETE"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.allowed_methods.2", "POST"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.allowed_methods.3", "GET"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.allowed_methods.4", "OPTIONS"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.allowed_methods.5", "PUT"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.allowed_methods.6", "PATCH"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.cached_methods.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.cached_methods.0", "HEAD"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.cached_methods.1", "GET"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.compress", "false"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.default_ttl", "86400"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.forwarded_values.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.forwarded_values.2510654351.cookies.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.forwarded_values.2510654351.cookies.1870923232.forward", "all"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.forwarded_values.2510654351.cookies.1870923232.whitelisted_names.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.forwarded_values.2510654351.headers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.forwarded_values.2510654351.query_string", "false"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.forwarded_values.2510654351.query_string_cache_keys.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.lambda_function_association.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.max_ttl", "31536000"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.min_ttl", "0"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.smooth_streaming", "false"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.target_origin_id", "myCustomOrigin"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.trusted_signers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.viewer_protocol_policy", "allow-all"),
+					resource.TestMatchResourceAttr(resourceName, "domain_name", regexp.MustCompile(`^[a-z0-9]+\.cloudfront\.net$`)),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestMatchResourceAttr(resourceName, "etag", regexp.MustCompile(`^[A-Z0-9]+$`)),
+					resource.TestCheckResourceAttr(resourceName, "hosted_zone_id", "Z2FDTNDATAQYW2"),
+					resource.TestCheckResourceAttrSet(resourceName, "http_version"),
+					resource.TestCheckResourceAttr(resourceName, "is_ipv6_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "logging_config.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "origin.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "origin.1857972443.custom_header.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "origin.1857972443.custom_origin_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "origin.1857972443.custom_origin_config.3832794885.http_port", "80"),
+					resource.TestCheckResourceAttr(resourceName, "origin.1857972443.custom_origin_config.3832794885.https_port", "443"),
+					resource.TestCheckResourceAttr(resourceName, "origin.1857972443.custom_origin_config.3832794885.origin_keepalive_timeout", "5"),
+					resource.TestCheckResourceAttr(resourceName, "origin.1857972443.custom_origin_config.3832794885.origin_protocol_policy", "http-only"),
+					resource.TestCheckResourceAttr(resourceName, "origin.1857972443.custom_origin_config.3832794885.origin_read_timeout", "30"),
+					resource.TestCheckResourceAttr(resourceName, "origin.1857972443.custom_origin_config.3832794885.origin_ssl_protocols.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "origin.1857972443.custom_origin_config.3832794885.origin_ssl_protocols.0", "SSLv3"),
+					resource.TestCheckResourceAttr(resourceName, "origin.1857972443.custom_origin_config.3832794885.origin_ssl_protocols.1", "TLSv1"),
+					resource.TestCheckResourceAttr(resourceName, "origin.1857972443.domain_name", "www.example.com"),
+					resource.TestCheckResourceAttr(resourceName, "price_class", "PriceClass_All"),
+					resource.TestCheckResourceAttr(resourceName, "restrictions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "restrictions.811065190.geo_restriction.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "restrictions.811065190.geo_restriction.1303118592.locations.#", "4"),
+					resource.TestCheckResourceAttr(resourceName, "restrictions.811065190.geo_restriction.1303118592.locations.0", "CA"),
+					resource.TestCheckResourceAttr(resourceName, "restrictions.811065190.geo_restriction.1303118592.locations.1", "DE"),
+					resource.TestCheckResourceAttr(resourceName, "restrictions.811065190.geo_restriction.1303118592.locations.2", "GB"),
+					resource.TestCheckResourceAttr(resourceName, "restrictions.811065190.geo_restriction.1303118592.locations.3", "US"),
+					resource.TestCheckResourceAttr(resourceName, "restrictions.811065190.geo_restriction.1303118592.restriction_type", "whitelist"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "viewer_certificate.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "viewer_certificate.69840937.cloudfront_default_certificate", "true"),
 				),
 			},
 		},
@@ -692,7 +754,6 @@ resource "aws_cloudfront_distribution" "no_optional_items" {
 		}
 	}
 	enabled = true
-	comment = "Some comment"
 	default_cache_behavior {
 		allowed_methods = [ "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT" ]
 		cached_methods = [ "GET", "HEAD" ]
@@ -705,9 +766,6 @@ resource "aws_cloudfront_distribution" "no_optional_items" {
 			}
 		}
 		viewer_protocol_policy = "allow-all"
-		min_ttl = 0
-		default_ttl = 3600
-		max_ttl = 86400
 	}
 	restrictions {
 		geo_restriction {

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -167,9 +167,10 @@ of several sub-resources - these resources are laid out below.
     compress content for web requests that include `Accept-Encoding: gzip` in
     the request header (default: `false`).
 
-  * `default_ttl` (Required) - The default amount of time (in seconds) that an
+  * `default_ttl` (Optional) - The default amount of time (in seconds) that an
     object is in a CloudFront cache before CloudFront forwards another request
-    in the absence of an `Cache-Control max-age` or `Expires` header.
+    in the absence of an `Cache-Control max-age` or `Expires` header. Defaults to
+    1 day.
 
   * `forwarded_values` (Required) - The [forwarded values configuration](#forwarded-values-arguments) that specifies how CloudFront
     handles query strings, cookies and headers (maximum one).
@@ -177,15 +178,15 @@ of several sub-resources - these resources are laid out below.
   * `lambda_function_association` (Optional) - A config block that triggers a lambda function with
   specific actions. Defined below, maximum 4.
 
-  * `max_ttl` (Required) - The maximum amount of time (in seconds) that an
+  * `max_ttl` (Optional) - The maximum amount of time (in seconds) that an
     object is in a CloudFront cache before CloudFront forwards another request
     to your origin to determine whether the object has been updated. Only
     effective in the presence of `Cache-Control max-age`, `Cache-Control
-    s-maxage`, and `Expires` headers.
+    s-maxage`, and `Expires` headers. Defaults to 365 days.
 
-  * `min_ttl` (Required) - The minimum amount of time that you want objects to
+  * `min_ttl` (Optional) - The minimum amount of time that you want objects to
     stay in CloudFront caches before CloudFront queries your origin to see
-    whether the object has been updated.
+    whether the object has been updated. Defaults to 0 seconds.
 
   * `path_pattern` (Required) - The pattern (for example, `images/*.jpg)` that
     specifies which requests you want this cache behavior to apply to.


### PR DESCRIPTION
Closes #1472
Closes #1994 

The `Default` values match:
* `default_ttl` API response when no value is provided during creation
* `max_ttl` API response when no value is provided during creation
* `min_ttl` Web console default (e.g. `Use Origin Cache Headers`)

```
9 tests passed (all tests)
=== RUN   TestAccAWSCloudFrontDistribution_HTTP11Config
--- PASS: TestAccAWSCloudFrontDistribution_HTTP11Config (1275.68s)
=== RUN   TestAccAWSCloudFrontDistribution_S3Origin
--- PASS: TestAccAWSCloudFrontDistribution_S3Origin (1276.50s)
=== RUN   TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig
--- PASS: TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig (1278.12s)
=== RUN   TestAccAWSCloudFrontDistribution_importBasic
--- PASS: TestAccAWSCloudFrontDistribution_importBasic (1278.84s)
=== RUN   TestAccAWSCloudFrontDistribution_S3OriginWithTags
--- PASS: TestAccAWSCloudFrontDistribution_S3OriginWithTags (1279.02s)
=== RUN   TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig
--- PASS: TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig (1279.69s)
=== RUN   TestAccAWSCloudFrontDistribution_noOptionalItemsConfig
--- PASS: TestAccAWSCloudFrontDistribution_noOptionalItemsConfig (1283.54s)
=== RUN   TestAccAWSCloudFrontDistribution_multiOrigin
--- PASS: TestAccAWSCloudFrontDistribution_multiOrigin (1303.90s)
=== RUN   TestAccAWSCloudFrontDistribution_customOrigin
--- PASS: TestAccAWSCloudFrontDistribution_customOrigin (1306.06s)
```