### PR TITLE
tests/resource/aws_lb: Add aws_internet_gateway dependency in EIP configuration

### DIFF
--- a/aws/resource_aws_lb_test.go
+++ b/aws/resource_aws_lb_test.go
@@ -988,6 +988,8 @@ resource "aws_lb" "test" {
     subnet_id = "${aws_subnet.public.1.id}"
     allocation_id = "${aws_eip.lb.1.id}"
   }
+
+  depends_on = ["aws_internet_gateway.default"]
 }
 
 resource "aws_eip" "lb" {


### PR DESCRIPTION
To fix this flaky acceptance test:
```
=== RUN   TestAccAWSLB_networkLoadbalancerEIP
--- FAIL: TestAccAWSLB_networkLoadbalancerEIP (82.97s)
    testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_lb.test: 1 error(s) occurred:
        
        * aws_lb.test: Error creating Application Load Balancer: InvalidSubnet: VPC vpc-6e5dc517 has no internet gateway
            status code: 400, request id: 96d5c07f-1cd6-11e8-a9f2-bf9b3e914cab
```


```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSLB_networkLoadbalancerEIP'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSLB_networkLoadbalancerEIP -timeout 120m
=== RUN   TestAccAWSLB_networkLoadbalancerEIP
--- PASS: TestAccAWSLB_networkLoadbalancerEIP (272.94s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	272.992s
```