### PR TITLE
tests/resource/aws_lb_listener_rule: Remove TooManyRules testing

### DIFF
--- a/aws/resource_aws_lb_listener_rule_test.go
+++ b/aws/resource_aws_lb_listener_rule_test.go
@@ -247,10 +247,6 @@ func TestAccAWSLBListenerRule_priority(t *testing.T) {
 				),
 			},
 			{
-				Config:      testAccAWSLBListenerRuleConfig_priorityRuleNumberLimit(lbName, targetGroupName),
-				ExpectError: regexp.MustCompile(`Error creating LB Listener Rule: TooManyRules`),
-			},
-			{
 				Config: testAccAWSLBListenerRuleConfig_priority50000(lbName, targetGroupName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSLBListenerRuleExists("aws_lb_listener_rule.50000", &rule),
@@ -1081,28 +1077,6 @@ func testAccAWSLBListenerRuleConfig_priorityParallelism(lbName, targetGroupName 
 	return testAccAWSLBListenerRuleConfig_priorityStatic(lbName, targetGroupName) + fmt.Sprintf(`
 resource "aws_lb_listener_rule" "parallelism" {
   count = 10
-
-  listener_arn = "${aws_lb_listener.front_end.arn}"
-
-  action {
-    type = "forward"
-    target_group_arn = "${aws_lb_target_group.test.arn}"
-  }
-
-  condition {
-    field = "path-pattern"
-    values = ["/${count.index}/*"]
-  }
-}
-`)
-}
-
-// Rules per load balancer (not counting default rules): 100
-// https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-limits.html
-func testAccAWSLBListenerRuleConfig_priorityRuleNumberLimit(lbName, targetGroupName string) string {
-	return testAccAWSLBListenerRuleConfig_priorityParallelism(lbName, targetGroupName) + fmt.Sprintf(`
-resource "aws_lb_listener_rule" "limit" {
-  count = 88
 
   listener_arn = "${aws_lb_listener.front_end.arn}"
 


### PR DESCRIPTION
We don't need this (previous to the failure below) acceptance test step anyways, it just taxes our API rate usage for little benefit.
```
=== RUN   TestAccAWSLBListenerRule_priority
--- FAIL: TestAccAWSLBListenerRule_priority (619.38s)
    testing.go:513: Step 6 error: Error applying: 1 error(s) occurred:
        
        * aws_lb_listener_rule.50000: 1 error(s) occurred:
        
        * aws_lb_listener_rule.50000: Error creating LB Listener Rule: TooManyRules: The maximum number of rules on load balancer arn:aws:elasticloadbalancing:us-west-2:*******:loadbalancer/app/testrule-basic-4b3zpgx9fkgz9/61ae48c790e1bcc6 has been reached
            status code: 400, request id: 01d4325f-1cd7-11e8-9320-432145fe8875
```

```
 make testacc TEST=./aws TESTARGS='-run=TestAccAWSLBListenerRule_priority'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSLBListenerRule_priority -timeout 120m
=== RUN   TestAccAWSLBListenerRule_priority
--- PASS: TestAccAWSLBListenerRule_priority (392.64s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	392.684s
```