### PR TITLE
iam_account_alias: Pass awserr in returned error

### DIFF
--- a/aws/resource_aws_iam_account_alias.go
+++ b/aws/resource_aws_iam_account_alias.go
@@ -41,7 +41,7 @@ func resourceAwsIamAccountAliasCreate(d *schema.ResourceData, meta interface{}) 
 	_, err := conn.CreateAccountAlias(params)
 
 	if err != nil {
-		return fmt.Errorf("Error creating account alias with name %s", account_alias)
+		return fmt.Errorf("Error creating account alias with name '%s': %s", account_alias, err)
 	}
 
 	d.SetId(account_alias)
@@ -57,7 +57,7 @@ func resourceAwsIamAccountAliasRead(d *schema.ResourceData, meta interface{}) er
 	resp, err := conn.ListAccountAliases(params)
 
 	if err != nil {
-		return err
+		return fmt.Errorf("Error listing account aliases: %s", err)
 	}
 
 	if resp == nil || len(resp.AccountAliases) == 0 {
@@ -85,7 +85,7 @@ func resourceAwsIamAccountAliasDelete(d *schema.ResourceData, meta interface{}) 
 	_, err := conn.DeleteAccountAlias(params)
 
 	if err != nil {
-		return fmt.Errorf("Error deleting account alias with name %s", account_alias)
+		return fmt.Errorf("Error deleting account alias with name '%s': %s", account_alias, err)
 	}
 
 	d.SetId("")


### PR DESCRIPTION
This will display helpful error messages like

    The account alias ... already exists. (EntityAlreadyExists)

The error message is not red as it is common and useful in Terraform. Is there a setting for a `resource` that all returned `error`s are displayed in red? 
Always setting the [colorstring](https://github.com/hashicorp/terraform/blob/master/vendor/github.com/mitchellh/colorstring/README.md)'s `[red]`, etc. on each error message is unnecessary boilerplate, I think.