### PR TITLE
resource/aws_ssm_activation: Prevent crash with expiration_date

### DIFF
--- a/aws/resource_aws_ssm_activation.go
+++ b/aws/resource_aws_ssm_activation.go
@@ -34,17 +34,10 @@ func resourceAwsSsmActivation() *schema.Resource {
 				Computed: true,
 			},
 			"expiration_date": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				// When released, replace with upstream validation function:
-				// https://github.com/hashicorp/terraform/pull/17484
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					if _, err := time.Parse(time.RFC3339, v.(string)); err != nil {
-						errors = append(errors, fmt.Errorf("%q: %s", k, err))
-					}
-					return
-				},
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateRFC3339TimeString,
 			},
 			"iam_role": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_ssm_activation_test.go
+++ b/aws/resource_aws_ssm_activation_test.go
@@ -2,7 +2,9 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
@@ -23,6 +25,32 @@ func TestAccAWSSSMActivation_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMActivationExists("aws_ssm_activation.foo"),
 					resource.TestCheckResourceAttrSet("aws_ssm_activation.foo", "activation_code"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSSMActivation_expirationDate(t *testing.T) {
+	rName := acctest.RandString(10)
+	expirationTime := time.Now().Add(48 * time.Hour)
+	expirationDateS := expirationTime.Format(time.RFC3339)
+	resourceName := "aws_ssm_activation.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMActivationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSSSMActivationConfig_expirationDate(rName, "2018-03-01"),
+				ExpectError: regexp.MustCompile(`cannot parse`),
+			},
+			{
+				Config: testAccAWSSSMActivationConfig_expirationDate(rName, expirationDateS),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMActivationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "expiration_date", expirationDateS),
 				),
 			},
 		},
@@ -129,4 +157,40 @@ resource "aws_ssm_activation" "foo" {
   depends_on         = ["aws_iam_role_policy_attachment.test_attach"]
 }
 `, rName, rName)
+}
+
+func testAccAWSSSMActivationConfig_expirationDate(rName, expirationDate string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test_role" {
+  name = "test_role-%[1]s"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ssm.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "test_attach" {
+  role = "${aws_iam_role.test_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+}
+
+resource "aws_ssm_activation" "foo" {
+  name               = "test_ssm_activation-%[1]s",
+  description        = "Test"
+  expiration_date    = "%[2]s"
+  iam_role           = "${aws_iam_role.test_role.name}"
+  registration_limit = "5"
+  depends_on         = ["aws_iam_role_policy_attachment.test_attach"]
+}
+`, rName, expirationDate)
 }

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -22,6 +22,15 @@ import (
 	"github.com/hashicorp/terraform/helper/structure"
 )
 
+// When released, replace all usage with upstream validation function:
+// https://github.com/hashicorp/terraform/pull/17484
+func validateRFC3339TimeString(v interface{}, k string) (ws []string, errors []error) {
+	if _, err := time.Parse(time.RFC3339, v.(string)); err != nil {
+		errors = append(errors, fmt.Errorf("%q: %s", k, err))
+	}
+	return
+}
+
 func validateInstanceUserDataSize(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	length := len(value)

--- a/website/docs/r/ssm_activation.html.markdown
+++ b/website/docs/r/ssm_activation.html.markdown
@@ -48,7 +48,7 @@ The following arguments are supported:
 
 * `name` - (Optional) The default name of the registerd managed instance.
 * `description` - (Optional) The description of the resource that you want to register.
-* `expiration_date` - (Optional) The date by which this activation request should expire. The default value is 24 hours.
+* `expiration_date` - (Optional) A timestamp in [RFC3339 format](https://tools.ietf.org/html/rfc3339#section-5.8) by which this activation request should expire. The default value is 24 hours from resource creation time.
 * `iam_role` - (Required) The IAM Role to attach to the managed instance.
 * `registration_limit` - (Optional) The maximum number of managed instances you want to register. The default value is 1 instance.
 


### PR DESCRIPTION
Fixes #3594 

Previously (new test, no code changes):

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSSSMActivation_expirationDate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSSSMActivation_expirationDate -timeout 120m
=== RUN   TestAccAWSSSMActivation_expirationDate
panic: interface conversion: interface {} is string, not time.Time

goroutine 313 [running]:
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsSsmActivationCreate(0xc4204d33b0, 0x3457ce0, 0xc420218500, 0xc4204d33b0, 0x0)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_ssm_activation.go:81 +0x89a
...
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	5.728s
make: *** [testacc] Error 1
```

Now passes:
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSSSMActivation_expirationDate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSSSMActivation_expirationDate -timeout 120m
=== RUN   TestAccAWSSSMActivation_expirationDate
--- PASS: TestAccAWSSSMActivation_expirationDate (31.05s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	31.094s
```