### PR TITLE
duplicate preferred_backup_window attribute

### DIFF
--- a/website/docs/r/rds_cluster.html.markdown
+++ b/website/docs/r/rds_cluster.html.markdown
@@ -127,7 +127,7 @@ The following attributes are exported:
 * `allocated_storage` - The amount of allocated storage
 * `availability_zones` - The availability zone of the instance
 * `backup_retention_period` - The backup retention period
-* `preferred_backup_window` - The backup window
+* `preferred_backup_window` - The daily time range during which the backups happen
 * `preferred_maintenance_window` - The maintenance window
 * `endpoint` - The DNS address of the RDS instance
 * `reader_endpoint` - A read-only endpoint for the Aurora cluster, automatically
@@ -140,7 +140,6 @@ load-balanced across replicas
 * `status` - The RDS instance status
 * `master_username` - The master username for the database
 * `storage_encrypted` - Specifies whether the DB cluster is encrypted
-* `preferred_backup_window` - The daily time range during which the backups happen
 * `replication_source_identifier` - ARN  of the source DB cluster if this DB cluster is created as a Read Replica.
 * `hosted_zone_id` - The Route53 Hosted Zone ID of the endpoint
 


### PR DESCRIPTION
`preferred_backup_window` was duplicated in the exported attributes list. I remove the the dupe and kept the better description.

Not a big deal, but probably worth cleaning up.