### PR TITLE
Amend the RDS cluster docs in reference to snapshot_identifier

### DIFF
--- a/website/docs/r/rds_cluster.html.markdown
+++ b/website/docs/r/rds_cluster.html.markdown
@@ -102,7 +102,7 @@ Default: A 30-minute window selected at random from an 8-hour block of time per 
 * `port` - (Optional) The port on which the DB accepts connections
 * `vpc_security_group_ids` - (Optional) List of VPC security groups to associate
   with the Cluster
-* `snapshot_identifier` - (Optional) Specifies whether or not to create this cluster from a snapshot. This correlates to the snapshot's ARN you'd find in the RDS console, e.g: `arn:aws:rds:region:123456789012:snapshot:rds:db-snapshot-name`.
+* `snapshot_identifier` - (Optional) Specifies whether or not to create this cluster from a snapshot. You can use either the name or ARN when specifying a DB cluster snapshot, or the ARN when specifying a DB snapshot.
 * `storage_encrypted` - (Optional) Specifies whether the DB cluster is encrypted. The default is `false` if not specified.
 * `apply_immediately` - (Optional) Specifies whether any cluster modifications
      are applied immediately, or during the next maintenance window. Default is

--- a/website/docs/r/rds_cluster.html.markdown
+++ b/website/docs/r/rds_cluster.html.markdown
@@ -102,7 +102,7 @@ Default: A 30-minute window selected at random from an 8-hour block of time per 
 * `port` - (Optional) The port on which the DB accepts connections
 * `vpc_security_group_ids` - (Optional) List of VPC security groups to associate
   with the Cluster
-* `snapshot_identifier` - (Optional) Specifies whether or not to create this cluster from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05.
+* `snapshot_identifier` - (Optional) Specifies whether or not to create this cluster from a snapshot. This correlates to the snapshot's ARN you'd find in the RDS console, e.g: `arn:aws:rds:region:123456789012:snapshot:rds:db-snapshot-name`.
 * `storage_encrypted` - (Optional) Specifies whether the DB cluster is encrypted. The default is `false` if not specified.
 * `apply_immediately` - (Optional) Specifies whether any cluster modifications
      are applied immediately, or during the next maintenance window. Default is


### PR DESCRIPTION
Hey 👋 

I recently tried to create an RDS cluster from a snapshot using the identifier/name (e.g. `rds:production-2015-06-26-06-05`), and received an error message saying a snapshot ARN was required to create an RDS cluster from a snapshot.

I switched to an ARN, and it all worked as expected. With a `db_instance` a name was sufficient.  Anyways, I thought I'd submit this to try and make it a little clearer for the next reader.  fyi, I'm on Terraform v0.11.3.

Cheers!