### PR TITLE
Update example to use new resource

### DIFF
--- a/website/docs/r/lb_listener_certificate.html.markdown
+++ b/website/docs/r/lb_listener_certificate.html.markdown
@@ -17,9 +17,8 @@ This resource is for additional certificates and does not replace the default ce
 ## Example Usage
 
 ```hcl
-data "aws_acm_certificate" "example" {
-  domain   = "example.com"
-  statuses = ["ISSUED"]
+resource "aws_acm_certificate" "example" {
+  # ...
 }
 
 resource "aws_lb" "front_end" {


### PR DESCRIPTION
With #2813, a resource was added for aws_acm_certificate. Update the
documentation's example for aws_lb_listener_certificate to utilise this
new resource instead of the data source that it was previously using.

Closes #3602.