### PR TITLE
data-source/aws_db_instance: Prevent crash with EC2 Classic

### DIFF
--- a/aws/data_source_aws_db_instance.go
+++ b/aws/data_source_aws_db_instance.go
@@ -252,7 +252,12 @@ func dataSourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("[DEBUG] Error setting db_security_groups attribute: %#v, error: %#v", dbSecurityGroups, err)
 	}
 
-	d.Set("db_subnet_group", dbInstance.DBSubnetGroup.DBSubnetGroupName)
+	if dbInstance.DBSubnetGroup != nil {
+		d.Set("db_subnet_group", dbInstance.DBSubnetGroup.DBSubnetGroupName)
+	} else {
+		d.Set("db_subnet_group", "")
+	}
+
 	d.Set("db_instance_port", dbInstance.DbInstancePort)
 	d.Set("engine", dbInstance.Engine)
 	d.Set("engine_version", dbInstance.EngineVersion)


### PR DESCRIPTION
Previously (before code changes):
```
 make testacc TEST=./aws TESTARGS='-run=TestAccAWSDbInstanceDataSource_ec2Classic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSDbInstanceDataSource_ec2Classic -timeout 120m
=== RUN   TestAccAWSDbInstanceDataSource_ec2Classic
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x24a79af]

goroutine 305 [running]:
github.com/terraform-providers/terraform-provider-aws/aws.dataSourceAwsDbInstanceRead(0xc420b9e9a0, 0x345c2a0, 0xc4201ef400, 0xc420b9e9a0, 0x0)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/aws/data_source_aws_db_instance.go:255 +0x77f
...
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	264.867s
make: *** [testacc] Error 1
```

Now passes (including consolidation of endpoint/basic acceptance testing):
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSDbInstanceDataSource_ec2Classic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSDbInstanceDataSource_ec2Classic -timeout 120m
=== RUN   TestAccAWSDbInstanceDataSource_ec2Classic
--- PASS: TestAccAWSDbInstanceDataSource_ec2Classic (403.07s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	403.113s

make testacc TEST=./aws TESTARGS='-run=TestAccAWSDbInstanceDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSDbInstanceDataSource_ -timeout 120m
=== RUN   TestAccAWSDbInstanceDataSource_basic
--- PASS: TestAccAWSDbInstanceDataSource_basic (439.64s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	439.64s
```