### PR TITLE
Adding processing_configuration to elasticsearch section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ BUG FIXES:
 
 * resource/aws_api_gateway_vpc_link: Ensure `target_arns` is properly read [GH-3569]
 * resource/aws_spot_instance_request: Retry for 1 minute instead of 15 seconds for IAM eventual consistency [GH-3561]
+* resource/aws_ssm_activation: Prevent crash with expiration_date [GH-3597]
 
 ## 1.10.0 (February 24, 2018)
 

--- a/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
+++ b/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
@@ -203,6 +203,23 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
     role_arn   = "${aws_iam_role.firehose_role.arn}"
     index_name = "test"
     type_name  = "test"
+
+    processing_configuration = [
+      {
+        enabled = "true"
+        processors = [
+          {
+            type = "Lambda"
+            parameters = [
+              {
+                parameter_name = "LambdaArn"
+                parameter_value = "${aws_lambda_function.lambda_processor.arn}:$LATEST"
+              }
+            ]
+          }
+        ]
+      }
+    ]
   }
 }
 ```
@@ -295,6 +312,7 @@ The `elasticsearch_configuration` object supports the following:
 * `s3_backup_mode` - (Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedDocumentsOnly` and `AllDocuments`.  Default value is `FailedDocumentsOnly`.
 * `type_name` - (Required) The Elasticsearch type name with maximum length of 100 characters.
 * `cloudwatch_logging_options` - (Optional) The CloudWatch Logging Options for the delivery stream. More details are given below
+* `processing_configuration` - (Optional) The data processing configuration.  More details are given below.
 
 The `splunk_configuration` objects supports the following:
 


### PR DESCRIPTION
This is a partial fix for the issue listed below. The problem currently is
that you can add an extended_s3_configuration to the
aws_kinesis_firehose_delivery_stream and set the destination to 'extended_s3'
if you want data transformation to be enabled for S3, but you can't do the
same if your destination is 'elastisearch' - this commit fixes that.

Support Kinesis Firehose Data Transformation #513
https://github.com/terraform-providers/terraform-provider-aws/issues/513