### PR TITLE
tests/resource/aws_db_instance: Always run TestAccAWSDBInstance_ec2Classic in us-east-1

### DIFF
--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -472,6 +473,11 @@ func TestAccAWSDBInstance_diffSuppressInitialState(t *testing.T) {
 
 func TestAccAWSDBInstance_ec2Classic(t *testing.T) {
 	var v rds.DBInstance
+
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
@@ -1418,10 +1424,6 @@ resource "aws_db_instance" "bar" {
 
 func testAccAWSDBInstanceConfigEc2Classic(rInt int) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
 resource "aws_db_instance" "bar" {
   identifier = "foobarbaz-test-terraform-%d"
   allocated_storage = 10


### PR DESCRIPTION
TeamCity daily testing currently skips the test erroneously (since it uses AWS_DEFAULT_REGION=us-west-2 and testAccEC2ClassicPreCheck requires us-east-1).

Passes just fine:
```
 make testacc TEST=./aws TESTARGS='-run=TestAccAWSDBInstance_ec2Classic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSDBInstance_ec2Classic -timeout 120m
=== RUN   TestAccAWSDBInstance_ec2Classic
--- PASS: TestAccAWSDBInstance_ec2Classic (423.10s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	423.137s
```