### PR TITLE
Add configurable timeouts to aws_route

### DIFF
--- a/website/docs/r/route.html.markdown
+++ b/website/docs/r/route.html.markdown
@@ -81,3 +81,11 @@ will be exported as an attribute once the resource is created.
 * `nat_gateway_id` - An ID of a VPC NAT gateway.
 * `instance_id` - An ID of a NAT instance.
 * `network_interface_id` - An ID of a network interface.
+
+## Timeouts
+
+`aws_route` provides the following
+[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+- `create` - (Default `2 minutes`) Used for route creation
+- `delete` - (Default `5 minutes`) Used for route deletion


### PR DESCRIPTION
Turns out the 2 minutes timeout for route creation is pretty tight as we are hitting it quite a lot lately.

Instead of bumping it I just made it configurable for others.

Cheers!