### PR TITLE
tests: Unify aws_subnet tags (A-D)

### DIFF
--- a/aws/resource_aws_ami_copy_test.go
+++ b/aws/resource_aws_ami_copy_test.go
@@ -170,6 +170,9 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
+	tags {
+		Name = "tf-acc-ami-copy"
+	}
 }
 
 resource "aws_instance" "test" {

--- a/aws/resource_aws_api_gateway_vpc_link_test.go
+++ b/aws/resource_aws_api_gateway_vpc_link_test.go
@@ -107,6 +107,9 @@ resource "aws_subnet" "test" {
   vpc_id = "${aws_vpc.test.id}"
   cidr_block = "10.10.0.0/21"
   availability_zone = "${data.aws_availability_zones.test.names[0]}"
+  tags {
+    Name = "tf-acc-api-gateway-vpc-link"
+  }
 }
 `, rName)
 }

--- a/aws/resource_aws_appautoscaling_scheduled_action_test.go
+++ b/aws/resource_aws_appautoscaling_scheduled_action_test.go
@@ -288,6 +288,9 @@ resource "aws_vpc" "hoge" {
 resource "aws_subnet" "hoge" {
   vpc_id     = "${aws_vpc.hoge.id}"
   cidr_block = "168.31.0.0/20"
+  tags {
+    Name = "tf-acc-appautoscaling-scheduled-action"
+  }
 }
 
 resource "aws_internet_gateway" "hoge" {

--- a/aws/resource_aws_appautoscaling_target_test.go
+++ b/aws/resource_aws_appautoscaling_target_test.go
@@ -389,7 +389,7 @@ resource "aws_subnet" "main" {
   cidr_block = "168.31.0.0/20"
 
   tags {
-    Name = "emr_test_%d"
+    Name = "tf-acc-appautoscaling-target-emr-cluster"
   }
 }
 
@@ -606,7 +606,7 @@ resource "aws_appautoscaling_target" "bar" {
 	max_capacity = 8
 }
 
-`, rInt, rInt, rInt, rInt, rInt, rInt, rInt, rInt, rInt)
+`, rInt, rInt, rInt, rInt, rInt, rInt, rInt, rInt)
 }
 
 var testAccAWSAppautoscalingTargetSpotFleetRequestConfig = fmt.Sprintf(`

--- a/aws/resource_aws_autoscaling_group_test.go
+++ b/aws/resource_aws_autoscaling_group_test.go
@@ -1223,6 +1223,9 @@ resource "aws_internet_gateway" "gw" {
 resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
+	tags {
+		Name = "tf-acc-autoscaling-group-with-load-balancer"
+	}
 }
 
 resource "aws_security_group" "foo" {
@@ -1275,7 +1278,7 @@ resource "aws_launch_configuration" "foobar" {
 
 resource "aws_autoscaling_group" "bar" {
   availability_zones = ["${aws_subnet.foo.availability_zone}"]
-	vpc_zone_identifier = ["${aws_subnet.foo.id}"]
+  vpc_zone_identifier = ["${aws_subnet.foo.id}"]
   max_size = 2
   min_size = 2
   health_check_grace_period = 300
@@ -1301,7 +1304,7 @@ resource "aws_subnet" "main" {
   cidr_block = "10.0.1.0/24"
   availability_zone = "us-west-2a"
   tags {
-     Name = "terraform-test"
+    Name = "tf-acc-autoscaling-group-with-az"
   }
 }
 
@@ -1348,7 +1351,7 @@ resource "aws_subnet" "main" {
   cidr_block = "10.0.1.0/24"
   availability_zone = "us-west-2a"
   tags {
-     Name = "terraform-test"
+    Name = "tf-acc-autoscaling-group-with-vpc-id"
   }
 }
 
@@ -1535,7 +1538,7 @@ resource "aws_subnet" "main" {
   availability_zone = "us-west-2a"
 
   tags {
-    Name = "testAccAWSAutoScalingGroupConfig_ALB_TargetGroup"
+    Name = "tf-acc-autoscaling-group-alb-target-group-main"
   }
 }
 
@@ -1545,7 +1548,7 @@ resource "aws_subnet" "alt" {
   availability_zone = "us-west-2b"
 
   tags {
-    Name = "testAccAWSAutoScalingGroupConfig_ALB_TargetGroup"
+    Name = "tf-acc-autoscaling-group-alb-target-group-alt"
   }
 }
 
@@ -1626,7 +1629,7 @@ resource "aws_subnet" "main" {
   availability_zone = "us-west-2a"
 
   tags {
-    Name = "testAccAWSAutoScalingGroupConfig_ALB_TargetGroup"
+    Name = "tf-acc-autoscaling-group-alb-target-group-main"
   }
 }
 
@@ -1636,7 +1639,7 @@ resource "aws_subnet" "alt" {
   availability_zone = "us-west-2b"
 
   tags {
-    Name = "testAccAWSAutoScalingGroupConfig_ALB_TargetGroup"
+    Name = "tf-acc-autoscaling-group-alb-target-group-alt"
   }
 }
 
@@ -1730,7 +1733,7 @@ resource "aws_subnet" "main" {
   availability_zone = "us-west-2a"
 
   tags {
-    Name = "testAccAWSAutoScalingGroupConfig_ALB_TargetGroup"
+    Name = "tf-acc-autoscaling-group-alb-target-group-main"
   }
 }
 
@@ -1740,7 +1743,7 @@ resource "aws_subnet" "alt" {
   availability_zone = "us-west-2b"
 
   tags {
-    Name = "testAccAWSAutoScalingGroupConfig_ALB_TargetGroup"
+    Name = "tf-acc-autoscaling-group-alb-target-group-alt"
   }
 }
 
@@ -1906,7 +1909,7 @@ resource "aws_subnet" "main" {
   availability_zone = "us-west-2a"
 
   tags {
-    Name = "testAccAWSAutoScalingGroupConfig_ALB_TargetGroup_ELBCapacity"
+    Name = "tf-acc-autoscaling-group-alb-target-group-elb-capacity-main"
   }
 }
 
@@ -1916,7 +1919,7 @@ resource "aws_subnet" "alt" {
   availability_zone = "us-west-2b"
 
   tags {
-    Name = "testAccAWSAutoScalingGroupConfig_ALB_TargetGroup_ELBCapacity"
+    Name = "tf-acc-autoscaling-group-alb-target-group-elb-capacity-alt"
   }
 }
 
@@ -2131,6 +2134,9 @@ resource "aws_vpc" "test" {
 resource "aws_subnet" "test" {
   vpc_id     = "${aws_vpc.test.id}"
   cidr_block = "10.0.0.0/16"
+  tags {
+    Name = "tf-acc-autoscaling-group-empty-availability-zones"
+  }
 }
 
 resource "aws_autoscaling_group" "test" {

--- a/aws/resource_aws_batch_compute_environment_test.go
+++ b/aws/resource_aws_batch_compute_environment_test.go
@@ -373,6 +373,9 @@ resource "aws_vpc" "test_acc" {
 resource "aws_subnet" "test_acc" {
   vpc_id = "${aws_vpc.test_acc.id}"
   cidr_block = "10.1.1.0/24"
+  tags {
+    Name = "tf-acc-batch-compute-environment"
+  }
 }
 `, rInt, rInt, rInt, rInt, rInt)
 }

--- a/aws/resource_aws_batch_job_queue_test.go
+++ b/aws/resource_aws_batch_job_queue_test.go
@@ -206,6 +206,9 @@ resource "aws_vpc" "test_acc" {
 resource "aws_subnet" "test_acc" {
   vpc_id = "${aws_vpc.test_acc.id}"
   cidr_block = "10.1.1.0/24"
+  tags {
+    Name = "tf-acc-batch-job-queue"
+  }
 }
 
 resource "aws_batch_compute_environment" "test_environment" {

--- a/aws/resource_aws_cloud9_environment_ec2_test.go
+++ b/aws/resource_aws_cloud9_environment_ec2_test.go
@@ -211,6 +211,9 @@ resource "aws_vpc" "test" {
 resource "aws_subnet" "test" {
   vpc_id = "${aws_vpc.test.id}"
   cidr_block = "10.10.0.0/19"
+  tags {
+    Name = "tf-acc-cloud9-environment-ec2-all-fields"
+  }
 }
 
 resource "aws_internet_gateway" "test" {

--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -747,11 +747,17 @@ func testAccAWSCodeBuildProjectConfig_vpcResources() string {
 	resource "aws_subnet" "codebuild_subnet" {
 		vpc_id     = "${aws_vpc.codebuild_vpc.id}"
 		cidr_block = "10.0.0.0/24"
+		tags {
+			Name = "tf-acc-codebuild-project-1"
+		}
 	}
 
 	resource "aws_subnet" "codebuild_subnet_2" {
 		vpc_id     = "${aws_vpc.codebuild_vpc.id}"
 		cidr_block = "10.0.1.0/24"
+		tags {
+			Name = "tf-acc-codebuild-project-2"
+		}
 	}
 
 

--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -1141,7 +1141,7 @@ resource "aws_subnet" "foo" {
 	availability_zone = "us-west-2a"
 	vpc_id = "${aws_vpc.foo.id}"
 	tags {
-		Name = "tf-dbsubnet-test-1"
+		Name = "tf-acc-db-instance-with-subnet-group-1"
 	}
 }
 
@@ -1150,7 +1150,7 @@ resource "aws_subnet" "bar" {
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.foo.id}"
 	tags {
-		Name = "tf-dbsubnet-test-2"
+		Name = "tf-acc-db-instance-with-subnet-group-2"
 	}
 }
 
@@ -1202,7 +1202,7 @@ resource "aws_subnet" "foo" {
 	availability_zone = "us-west-2a"
 	vpc_id = "${aws_vpc.foo.id}"
 	tags {
-		Name = "tf-dbsubnet-test-1"
+		Name = "tf-acc-db-instance-with-subnet-group-1"
 	}
 }
 
@@ -1211,7 +1211,7 @@ resource "aws_subnet" "bar" {
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.foo.id}"
 	tags {
-		Name = "tf-dbsubnet-test-2"
+		Name = "tf-acc-db-instance-with-subnet-group-2"
 	}
 }
 
@@ -1220,7 +1220,7 @@ resource "aws_subnet" "test" {
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.bar.id}"
 	tags {
-		Name = "tf-dbsubnet-test-3"
+		Name = "tf-acc-db-instance-with-subnet-group-3"
 	}
 }
 
@@ -1229,7 +1229,7 @@ resource "aws_subnet" "another_test" {
 	availability_zone = "us-west-2a"
 	vpc_id = "${aws_vpc.bar.id}"
 	tags {
-		Name = "tf-dbsubnet-test-4"
+		Name = "tf-acc-db-instance-with-subnet-group-4"
 	}
 }
 
@@ -1290,12 +1290,18 @@ resource "aws_subnet" "main" {
   vpc_id            = "${aws_vpc.foo.id}"
   availability_zone = "us-west-2a"
   cidr_block        = "10.1.1.0/24"
+  tags {
+    Name = "tf-acc-db-instance-mssql-timezone-main"
+  }
 }
 
 resource "aws_subnet" "other" {
   vpc_id            = "${aws_vpc.foo.id}"
   availability_zone = "us-west-2b"
   cidr_block        = "10.1.2.0/24"
+  tags {
+    Name = "tf-acc-db-instance-mssql-timezone-other"
+  }
 }
 
 resource "aws_db_instance" "mssql" {
@@ -1356,12 +1362,18 @@ resource "aws_subnet" "main" {
   vpc_id            = "${aws_vpc.foo.id}"
   availability_zone = "us-west-2a"
   cidr_block        = "10.1.1.0/24"
+  tags {
+    Name = "tf-acc-db-instance-mssql-timezone-akst-main"
+  }
 }
 
 resource "aws_subnet" "other" {
   vpc_id            = "${aws_vpc.foo.id}"
   availability_zone = "us-west-2b"
   cidr_block        = "10.1.2.0/24"
+  tags {
+    Name = "tf-acc-db-instance-mssql-timezone-akst-other"
+  }
 }
 
 resource "aws_db_instance" "mssql" {

--- a/aws/resource_aws_db_subnet_group_test.go
+++ b/aws/resource_aws_db_subnet_group_test.go
@@ -219,7 +219,7 @@ resource "aws_subnet" "foo" {
 	availability_zone = "us-west-2a"
 	vpc_id = "${aws_vpc.foo.id}"
 	tags {
-		Name = "tf-dbsubnet-test-1"
+		Name = "tf-acc-db-subnet-group-1"
 	}
 }
 
@@ -228,7 +228,7 @@ resource "aws_subnet" "bar" {
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.foo.id}"
 	tags {
-		Name = "tf-dbsubnet-test-2"
+		Name = "tf-acc-db-subnet-group-2"
 	}
 }
 
@@ -255,7 +255,7 @@ resource "aws_subnet" "foo" {
 	availability_zone = "us-west-2a"
 	vpc_id = "${aws_vpc.foo.id}"
 	tags {
-		Name = "tf-dbsubnet-test-1"
+		Name = "tf-acc-db-subnet-group-1"
 	}
 }
 
@@ -264,7 +264,7 @@ resource "aws_subnet" "bar" {
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.foo.id}"
 	tags {
-		Name = "tf-dbsubnet-test-2"
+		Name = "tf-acc-db-subnet-group-2"
 	}
 }
 
@@ -290,12 +290,18 @@ resource "aws_subnet" "a" {
 	vpc_id = "${aws_vpc.test.id}"
 	cidr_block = "10.1.1.0/24"
 	availability_zone = "us-west-2a"
+	tags {
+		Name = "tf-acc-db-subnet-group-name-prefix-a"
+	}
 }
 
 resource "aws_subnet" "b" {
 	vpc_id = "${aws_vpc.test.id}"
 	cidr_block = "10.1.2.0/24"
 	availability_zone = "us-west-2b"
+	tags {
+		Name = "tf-acc-db-subnet-group-name-prefix-b"
+	}
 }
 
 resource "aws_db_subnet_group" "test" {
@@ -315,12 +321,18 @@ resource "aws_subnet" "a" {
 	vpc_id = "${aws_vpc.test.id}"
 	cidr_block = "10.1.1.0/24"
 	availability_zone = "us-west-2a"
+	tags {
+		Name = "tf-acc-db-subnet-group-generated-name-a"
+	}
 }
 
 resource "aws_subnet" "b" {
 	vpc_id = "${aws_vpc.test.id}"
 	cidr_block = "10.1.2.0/24"
 	availability_zone = "us-west-2b"
+	tags {
+		Name = "tf-acc-db-subnet-group-generated-name-a"
+	}
 }
 
 resource "aws_db_subnet_group" "test" {
@@ -339,12 +351,18 @@ resource "aws_subnet" "frontend" {
     vpc_id = "${aws_vpc.main.id}"
     availability_zone = "us-west-2b"
     cidr_block = "192.168.1.0/24"
+    tags {
+        Name = "tf-acc-db-subnet-group-w-underscores-etc-front"
+    }
 }
 
 resource "aws_subnet" "backend" {
     vpc_id = "${aws_vpc.main.id}"
     availability_zone = "us-west-2c"
     cidr_block = "192.168.2.0/24"
+    tags {
+        Name = "tf-acc-db-subnet-group-w-underscores-etc-back"
+    }
 }
 
 resource "aws_db_subnet_group" "underscores" {

--- a/aws/resource_aws_default_network_acl_test.go
+++ b/aws/resource_aws_default_network_acl_test.go
@@ -314,7 +314,7 @@ resource "aws_subnet" "one" {
   vpc_id     = "${aws_vpc.foo.id}"
 
   tags {
-    Name = "TestAccAWSDefaultNetworkAcl_SubnetRemoval"
+    Name = "tf-acc-default-network-acl-one"
   }
 }
 
@@ -323,7 +323,7 @@ resource "aws_subnet" "two" {
   vpc_id     = "${aws_vpc.foo.id}"
 
   tags {
-    Name = "TestAccAWSDefaultNetworkAcl_SubnetRemoval"
+    Name = "tf-acc-default-network-acl-two"
   }
 }
 
@@ -360,7 +360,7 @@ resource "aws_subnet" "one" {
   vpc_id     = "${aws_vpc.foo.id}"
 
   tags {
-    Name = "TestAccAWSDefaultNetworkAcl_SubnetRemoval"
+    Name = "tf-acc-default-network-acl-subnets-remove-one"
   }
 }
 
@@ -369,7 +369,7 @@ resource "aws_subnet" "two" {
   vpc_id     = "${aws_vpc.foo.id}"
 
   tags {
-    Name = "TestAccAWSDefaultNetworkAcl_SubnetRemoval"
+    Name = "tf-acc-default-network-acl-subnets-remove-two"
   }
 }
 
@@ -404,7 +404,7 @@ resource "aws_subnet" "one" {
   vpc_id     = "${aws_vpc.foo.id}"
 
   tags {
-    Name = "TestAccAWSDefaultNetworkAcl_SubnetRemoval"
+    Name = "tf-acc-default-network-acl-subnets-move-one"
   }
 }
 
@@ -413,7 +413,7 @@ resource "aws_subnet" "two" {
   vpc_id     = "${aws_vpc.foo.id}"
 
   tags {
-    Name = "TestAccAWSDefaultNetworkAcl_SubnetRemoval"
+    Name = "tf-acc-default-network-acl-subnets-move-two"
   }
 }
 

--- a/aws/resource_aws_directory_service_directory_test.go
+++ b/aws/resource_aws_directory_service_directory_test.go
@@ -353,11 +353,17 @@ resource "aws_subnet" "foo" {
   vpc_id = "${aws_vpc.main.id}"
   availability_zone = "us-west-2a"
   cidr_block = "10.0.1.0/24"
+  tags {
+    Name = "tf-acc-directory-service-directory-foo"
+  }
 }
 resource "aws_subnet" "bar" {
   vpc_id = "${aws_vpc.main.id}"
   availability_zone = "us-west-2b"
   cidr_block = "10.0.2.0/24"
+  tags {
+    Name = "tf-acc-directory-service-directory-bar"
+  }
 }
 `
 
@@ -389,11 +395,17 @@ resource "aws_subnet" "foo" {
   vpc_id = "${aws_vpc.main.id}"
   availability_zone = "us-west-2a"
   cidr_block = "10.0.1.0/24"
+  tags {
+    Name = "tf-acc-directory-service-directory-tags-foo"
+  }
 }
 resource "aws_subnet" "bar" {
   vpc_id = "${aws_vpc.main.id}"
   availability_zone = "us-west-2b"
   cidr_block = "10.0.2.0/24"
+  tags {
+    Name = "tf-acc-directory-service-directory-tags-bar"
+  }
 }
 `
 
@@ -434,11 +446,17 @@ resource "aws_subnet" "foo" {
   vpc_id = "${aws_vpc.main.id}"
   availability_zone = "us-west-2a"
   cidr_block = "10.0.1.0/24"
+  tags {
+    Name = "tf-acc-directory-service-directory-connector-foo"
+  }
 }
 resource "aws_subnet" "bar" {
   vpc_id = "${aws_vpc.main.id}"
   availability_zone = "us-west-2b"
   cidr_block = "10.0.2.0/24"
+  tags {
+    Name = "tf-acc-directory-service-directory-connector-bar"
+  }
 }
 `
 
@@ -465,11 +483,17 @@ resource "aws_subnet" "foo" {
   vpc_id = "${aws_vpc.main.id}"
   availability_zone = "us-west-2a"
   cidr_block = "10.0.1.0/24"
+  tags {
+    Name = "tf-acc-directory-service-directory-microsoft-foo"
+  }
 }
 resource "aws_subnet" "bar" {
   vpc_id = "${aws_vpc.main.id}"
   availability_zone = "us-west-2b"
   cidr_block = "10.0.2.0/24"
+  tags {
+    Name = "tf-acc-directory-service-directory-microsoft-bar"
+  }
 }
 `
 
@@ -497,11 +521,17 @@ resource "aws_subnet" "foo" {
   vpc_id = "${aws_vpc.main.id}"
   availability_zone = "us-west-2a"
   cidr_block = "10.0.1.0/24"
+  tags {
+    Name = "tf-acc-directory-service-directory-microsoft-foo"
+  }
 }
 resource "aws_subnet" "bar" {
   vpc_id = "${aws_vpc.main.id}"
   availability_zone = "us-west-2b"
   cidr_block = "10.0.2.0/24"
+  tags {
+    Name = "tf-acc-directory-service-directory-microsoft-bar"
+  }
 }
 `
 
@@ -530,11 +560,17 @@ resource "aws_subnet" "foo" {
   vpc_id = "${aws_vpc.main.id}"
   availability_zone = "us-west-2a"
   cidr_block = "10.0.1.0/24"
+  tags {
+    Name = "tf-acc-directory-service-directory-with-alias-foo"
+  }
 }
 resource "aws_subnet" "bar" {
   vpc_id = "${aws_vpc.main.id}"
   availability_zone = "us-west-2b"
   cidr_block = "10.0.2.0/24"
+  tags {
+    Name = "tf-acc-directory-service-directory-with-alias-bar"
+  }
 }
 `, randomInteger)
 
@@ -563,11 +599,17 @@ resource "aws_subnet" "foo" {
   vpc_id = "${aws_vpc.main.id}"
   availability_zone = "us-west-2a"
   cidr_block = "10.0.1.0/24"
+  tags {
+    Name = "tf-acc-directory-service-directory-with-sso-foo"
+  }
 }
 resource "aws_subnet" "bar" {
   vpc_id = "${aws_vpc.main.id}"
   availability_zone = "us-west-2b"
   cidr_block = "10.0.2.0/24"
+  tags {
+    Name = "tf-acc-directory-service-directory-with-sso-bar"
+  }
 }
 `, randomInteger)
 
@@ -596,10 +638,16 @@ resource "aws_subnet" "foo" {
   vpc_id = "${aws_vpc.main.id}"
   availability_zone = "us-west-2a"
   cidr_block = "10.0.1.0/24"
+  tags {
+    Name = "tf-acc-directory-service-directory-with-sso-foo"
+  }
 }
 resource "aws_subnet" "bar" {
   vpc_id = "${aws_vpc.main.id}"
   availability_zone = "us-west-2b"
   cidr_block = "10.0.2.0/24"
+  tags {
+    Name = "tf-acc-directory-service-directory-with-sso-bar"
+  }
 }
 `, randomInteger)

--- a/aws/resource_aws_dms_replication_instance_test.go
+++ b/aws/resource_aws_dms_replication_instance_test.go
@@ -105,7 +105,7 @@ resource "aws_subnet" "dms_subnet_1" {
 	availability_zone = "us-west-2a"
 	vpc_id = "${aws_vpc.dms_vpc.id}"
 	tags {
-		Name = "tf-test-dms-subnet-%[1]s"
+		Name = "tf-acc-dms-replication-instance-1"
 	}
 	depends_on = ["aws_vpc.dms_vpc"]
 }
@@ -115,7 +115,7 @@ resource "aws_subnet" "dms_subnet_2" {
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.dms_vpc.id}"
 	tags {
-		Name = "tf-test-dms-subnet-%[1]s"
+		Name = "tf-acc-dms-replication-instance-2"
 	}
 	depends_on = ["aws_vpc.dms_vpc"]
 }
@@ -161,7 +161,7 @@ resource "aws_subnet" "dms_subnet_1" {
 	availability_zone = "us-west-2a"
 	vpc_id = "${aws_vpc.dms_vpc.id}"
 	tags {
-		Name = "tf-test-dms-subnet-%[1]s"
+		Name = "tf-acc-dms-replication-instance-1"
 	}
 	depends_on = ["aws_vpc.dms_vpc"]
 }
@@ -171,7 +171,7 @@ resource "aws_subnet" "dms_subnet_2" {
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.dms_vpc.id}"
 	tags {
-		Name = "tf-test-dms-subnet-%[1]s"
+		Name = "tf-acc-dms-replication-instance-2"
 	}
 	depends_on = ["aws_vpc.dms_vpc"]
 }

--- a/aws/resource_aws_dms_replication_subnet_group_test.go
+++ b/aws/resource_aws_dms_replication_subnet_group_test.go
@@ -113,7 +113,7 @@ resource "aws_subnet" "dms_subnet_1" {
 	availability_zone = "us-west-2a"
 	vpc_id = "${aws_vpc.dms_vpc.id}"
 	tags {
-		Name = "tf-test-dms-subnet-%[1]s"
+		Name = "tf-acc-dms-replication-subnet-group-1"
 	}
 	depends_on = ["aws_vpc.dms_vpc"]
 }
@@ -123,7 +123,7 @@ resource "aws_subnet" "dms_subnet_2" {
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.dms_vpc.id}"
 	tags {
-		Name = "tf-test-dms-subnet-%[1]s"
+		Name = "tf-acc-dms-replication-subnet-group-2"
 	}
 	depends_on = ["aws_vpc.dms_vpc"]
 }
@@ -133,7 +133,7 @@ resource "aws_subnet" "dms_subnet_3" {
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.dms_vpc.id}"
 	tags {
-		Name = "tf-test-dms-subnet-%[1]s"
+		Name = "tf-acc-dms-replication-subnet-group-3"
 	}
 	depends_on = ["aws_vpc.dms_vpc"]
 }
@@ -165,7 +165,7 @@ resource "aws_subnet" "dms_subnet_1" {
 	availability_zone = "us-west-2a"
 	vpc_id = "${aws_vpc.dms_vpc.id}"
 	tags {
-		Name = "tf-test-dms-subnet-%[1]s"
+		Name = "tf-acc-dms-replication-subnet-group-1"
 	}
 	depends_on = ["aws_vpc.dms_vpc"]
 }
@@ -175,7 +175,7 @@ resource "aws_subnet" "dms_subnet_2" {
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.dms_vpc.id}"
 	tags {
-		Name = "tf-test-dms-subnet-%[1]s"
+		Name = "tf-acc-dms-replication-subnet-group-2"
 	}
 	depends_on = ["aws_vpc.dms_vpc"]
 }
@@ -185,7 +185,7 @@ resource "aws_subnet" "dms_subnet_3" {
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.dms_vpc.id}"
 	tags {
-		Name = "tf-test-dms-subnet-%[1]s"
+		Name = "tf-acc-dms-replication-subnet-group-3"
 	}
 	depends_on = ["aws_vpc.dms_vpc"]
 }

--- a/aws/resource_aws_dms_replication_task_test.go
+++ b/aws/resource_aws_dms_replication_task_test.go
@@ -116,7 +116,7 @@ resource "aws_subnet" "dms_subnet_1" {
 	availability_zone = "us-west-2a"
 	vpc_id = "${aws_vpc.dms_vpc.id}"
 	tags {
-		Name = "tf-test-dms-subnet-%[1]s"
+		Name = "tf-acc-dms-replication-task-1"
 	}
 	depends_on = ["aws_vpc.dms_vpc"]
 }
@@ -126,7 +126,7 @@ resource "aws_subnet" "dms_subnet_2" {
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.dms_vpc.id}"
 	tags {
-		Name = "tf-test-dms-subnet-%[1]s"
+		Name = "tf-acc-dms-replication-task-2"
 	}
 	depends_on = ["aws_vpc.dms_vpc"]
 }
@@ -200,7 +200,7 @@ resource "aws_subnet" "dms_subnet_1" {
 	availability_zone = "us-west-2a"
 	vpc_id = "${aws_vpc.dms_vpc.id}"
 	tags {
-		Name = "tf-test-dms-subnet-%[1]s"
+		Name = "tf-acc-dms-replication-task-1"
 	}
 	depends_on = ["aws_vpc.dms_vpc"]
 }
@@ -210,7 +210,7 @@ resource "aws_subnet" "dms_subnet_2" {
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.dms_vpc.id}"
 	tags {
-		Name = "tf-test-dms-subnet-%[1]s"
+		Name = "tf-acc-dms-replication-task-2"
 	}
 	depends_on = ["aws_vpc.dms_vpc"]
 }


### PR DESCRIPTION
## Test results

```
=== RUN   TestAccAWSAppautoScalingTarget_multipleTargets
--- PASS: TestAccAWSAppautoScalingTarget_multipleTargets (26.00s)
=== RUN   TestAccAWSAppautoScalingTarget_optionalRoleArn
--- PASS: TestAccAWSAppautoScalingTarget_optionalRoleArn (28.59s)
=== RUN   TestAccAWSAppautoscalingScheduledAction_dynamo
--- PASS: TestAccAWSAppautoscalingScheduledAction_dynamo (31.42s)
=== RUN   TestAccAWSAppautoscalingScheduledAction_ECS
--- PASS: TestAccAWSAppautoscalingScheduledAction_ECS (32.40s)
=== RUN   TestAccAWSAppautoScalingTarget_spotFleetRequest
--- PASS: TestAccAWSAppautoScalingTarget_spotFleetRequest (57.49s)
=== RUN   TestAccAWSAppautoscalingScheduledAction_SpotFleet
--- PASS: TestAccAWSAppautoscalingScheduledAction_SpotFleet (69.42s)
=== RUN   TestAccAWSAutoScalingGroup_namePrefix
--- PASS: TestAccAWSAutoScalingGroup_namePrefix (70.90s)
=== RUN   TestAccAWSAppautoScalingTarget_basic
--- PASS: TestAccAWSAppautoScalingTarget_basic (71.50s)
=== RUN   TestAccAWSAutoScalingGroup_autoGeneratedName
--- PASS: TestAccAWSAutoScalingGroup_autoGeneratedName (76.14s)
=== RUN   TestAccAWSAutoScalingGroup_classicVpcZoneIdentifier
--- PASS: TestAccAWSAutoScalingGroup_classicVpcZoneIdentifier (57.90s)
=== RUN   TestAccAWSAutoScalingGroup_VpcUpdates
--- PASS: TestAccAWSAutoScalingGroup_VpcUpdates (129.36s)
=== RUN   TestAccAWSAutoScalingGroup_terminationPolicies
--- PASS: TestAccAWSAutoScalingGroup_terminationPolicies (156.21s)
=== RUN   TestAccAWSAutoScalingGroup_withPlacementGroup
--- PASS: TestAccAWSAutoScalingGroup_withPlacementGroup (188.56s)
=== RUN   TestAccAWSAutoScalingGroup_withMetrics
--- PASS: TestAccAWSAutoScalingGroup_withMetrics (174.57s)
=== RUN   TestAccAWSAutoScalingGroup_emptyAvailabilityZones
--- PASS: TestAccAWSAutoScalingGroup_emptyAvailabilityZones (133.56s)
=== RUN   TestAccAWSBatchComputeEnvironment_createUnmanaged
--- PASS: TestAccAWSBatchComputeEnvironment_createUnmanaged (78.14s)
=== RUN   TestAccAWSAutoScalingGroup_ALB_TargetGroups
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups (178.64s)
=== RUN   TestAccAWSBatchComputeEnvironment_createSpot
--- PASS: TestAccAWSBatchComputeEnvironment_createSpot (90.74s)
=== RUN   TestAccAWSBatchComputeEnvironment_createSpotWithoutBidPercentage
--- PASS: TestAccAWSBatchComputeEnvironment_createSpotWithoutBidPercentage (36.93s)
=== RUN   TestAccAWSAutoScalingGroup_basic
--- PASS: TestAccAWSAutoScalingGroup_basic (261.27s)
=== RUN   TestAccAWSBatchComputeEnvironment_createEc2
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2 (200.09s)
=== RUN   TestAccAWSAutoScalingGroup_enablingMetrics
--- PASS: TestAccAWSAutoScalingGroup_enablingMetrics (283.00s)
=== RUN   TestAccAWSAutoScalingGroup_suspendingProcesses
--- PASS: TestAccAWSAutoScalingGroup_suspendingProcesses (287.41s)
=== RUN   TestAccAWSAutoScalingGroup_initialLifecycleHook
--- PASS: TestAccAWSAutoScalingGroup_initialLifecycleHook (290.15s)
=== RUN   TestAccAWSBatchComputeEnvironment_updateComputeEnvironmentName
--- PASS: TestAccAWSBatchComputeEnvironment_updateComputeEnvironmentName (123.14s)
=== RUN   TestAccAWSBatchComputeEnvironment_createEc2WithTags
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2WithTags (251.93s)
=== RUN   TestAccAWSCodeBuildProject_basic
--- PASS: TestAccAWSCodeBuildProject_basic (27.45s)
=== RUN   TestAccAWSCodeBuildProject_sourceAuth
--- PASS: TestAccAWSCodeBuildProject_sourceAuth (43.46s)
=== RUN   TestAccAWSBatchComputeEnvironment_updateInstanceType
--- PASS: TestAccAWSBatchComputeEnvironment_updateInstanceType (188.88s)
=== RUN   TestAccAWSCodeBuildProject_default_build_timeout
--- PASS: TestAccAWSCodeBuildProject_default_build_timeout (49.39s)
=== RUN   TestAccAWSAutoScalingGroup_tags
--- PASS: TestAccAWSAutoScalingGroup_tags (398.02s)
=== RUN   TestAccAWSAutoScalingGroup_WithLoadBalancer
--- PASS: TestAccAWSAutoScalingGroup_WithLoadBalancer (398.11s)
=== RUN   TestAccAWSBatchJobQueue_basic
--- PASS: TestAccAWSBatchJobQueue_basic (187.34s)
=== RUN   TestAccAWSCodeBuildProject_vpc
--- PASS: TestAccAWSCodeBuildProject_vpc (89.23s)
=== RUN   TestAccAWSCloud9EnvironmentEc2_basic
--- PASS: TestAccAWSCloud9EnvironmentEc2_basic (174.71s)
=== RUN   TestAccAWSBatchJobQueue_update
--- PASS: TestAccAWSBatchJobQueue_update (195.98s)
=== RUN   TestAccAWSBatchComputeEnvironment_updateMaxvCpus
--- PASS: TestAccAWSBatchComputeEnvironment_updateMaxvCpus (305.20s)
=== RUN   TestAccAWSCloud9EnvironmentEc2_importBasic
--- PASS: TestAccAWSCloud9EnvironmentEc2_importBasic (179.71s)
=== RUN   TestAccAWSAMICopy
--- PASS: TestAccAWSAMICopy (478.16s)
=== RUN   TestAccAWSAutoScalingGroup_ALB_TargetGroups_ELBCapacity
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups_ELBCapacity (448.51s)
=== RUN   TestAccAWSBatchComputeEnvironment_createUnmanagedWithComputeResources
--- PASS: TestAccAWSBatchComputeEnvironment_createUnmanagedWithComputeResources (318.56s)
=== RUN   TestAccAWSAppautoscalingScheduledAction_EMR
--- PASS: TestAccAWSAppautoscalingScheduledAction_EMR (545.56s)
=== RUN   TestAccAWSAppautoScalingTarget_emrCluster
--- PASS: TestAccAWSAppautoScalingTarget_emrCluster (546.71s)
=== RUN   TestAccAWSDBInstance_ec2Classic
--- SKIP: TestAccAWSDBInstance_ec2Classic (0.77s)
	provider_test.go:89: This test can only run in EC2 Classic, platforms available in us-west-2: ["VPC"]

=== RUN   TestAccAWSDBSubnetGroup_basic
--- PASS: TestAccAWSDBSubnetGroup_basic (9.09s)
=== RUN   TestAccAWSDBSubnetGroup_namePrefix
--- PASS: TestAccAWSDBSubnetGroup_namePrefix (9.75s)
=== RUN   TestAccAWSBatchComputeEnvironment_createEc2WithoutComputeResources
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2WithoutComputeResources (362.23s)
=== RUN   TestAccAWSCloud9EnvironmentEc2_allFields
--- FAIL: TestAccAWSCloud9EnvironmentEc2_allFields (308.07s)
	testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
		
		* aws_cloud9_environment_ec2.test: 1 error(s) occurred:
		
		* aws_cloud9_environment_ec2.test: NotFoundException: User arn:aws:iam::*******:user/tf_acc_cloud9_env_7kfkcqqz does not exist.
			status code: 400, request id: 3a531ada-2138-11e8-9203-1925f346b668

=== RUN   TestAccAWSDBSubnetGroup_generatedName
--- PASS: TestAccAWSDBSubnetGroup_generatedName (16.76s)
=== RUN   TestAccAWSDBSubnetGroup_withUndocumentedCharacters
--- PASS: TestAccAWSDBSubnetGroup_withUndocumentedCharacters (27.48s)
=== RUN   TestAccAWSDefaultNetworkAcl_basicIpv6Vpc
--- PASS: TestAccAWSDefaultNetworkAcl_basicIpv6Vpc (21.03s)
=== RUN   TestAccAWSAPIGatewayVpcLink_basic
--- PASS: TestAccAWSAPIGatewayVpcLink_basic (618.08s)
=== RUN   TestAccAWSDBSubnetGroup_updateDescription
--- PASS: TestAccAWSDBSubnetGroup_updateDescription (76.09s)
=== RUN   TestAccAWSDefaultNetworkAcl_withIpv6Ingress
--- PASS: TestAccAWSDefaultNetworkAcl_withIpv6Ingress (40.24s)
=== RUN   TestAccAWSDefaultNetworkAcl_basic
--- PASS: TestAccAWSDefaultNetworkAcl_basic (119.78s)
=== RUN   TestAccAWSDefaultNetworkAcl_deny_ingress
--- PASS: TestAccAWSDefaultNetworkAcl_deny_ingress (106.13s)
=== RUN   TestAccAWSDefaultNetworkAcl_SubnetRemoval
--- PASS: TestAccAWSDefaultNetworkAcl_SubnetRemoval (65.95s)
=== RUN   TestAccAWSDefaultNetworkAcl_SubnetReassign
--- PASS: TestAccAWSDefaultNetworkAcl_SubnetReassign (81.83s)
=== RUN   TestAccAWSDBInstance_namePrefix
--- PASS: TestAccAWSDBInstance_namePrefix (421.67s)
=== RUN   TestAccAWSDBInstance_generatedName
--- PASS: TestAccAWSDBInstance_generatedName (416.86s)
=== RUN   TestAccAWSDBInstance_iamAuth
--- PASS: TestAccAWSDBInstance_iamAuth (418.97s)
=== RUN   TestAccAWSDBInstance_basic
--- PASS: TestAccAWSDBInstance_basic (485.81s)
=== RUN   TestAccAWSDBInstance_optionGroup
--- PASS: TestAccAWSDBInstance_optionGroup (490.75s)
=== RUN   TestAccAWSDmsReplicationSubnetGroupBasic
--- PASS: TestAccAWSDmsReplicationSubnetGroupBasic (16.27s)
=== RUN   TestAccAWSDBInstance_MinorVersion
--- PASS: TestAccAWSDBInstance_MinorVersion (423.84s)
=== RUN   TestAccAWSDBInstance_kmsKey
--- PASS: TestAccAWSDBInstance_kmsKey (591.30s)
=== RUN   TestAccAWSDBInstance_diffSuppressInitialState
--- PASS: TestAccAWSDBInstance_diffSuppressInitialState (429.76s)
=== RUN   TestAccAWSDBInstance_portUpdate
--- PASS: TestAccAWSDBInstance_portUpdate (514.01s)
=== RUN   TestAccAWSDBInstance_separate_iops_update
--- PASS: TestAccAWSDBInstance_separate_iops_update (607.87s)
=== RUN   TestAccAWSDirectoryServiceDirectory_importBasic
--- PASS: TestAccAWSDirectoryServiceDirectory_importBasic (460.36s)
=== RUN   TestAccAWSDBInstance_noSnapshot
--- PASS: TestAccAWSDBInstance_noSnapshot (740.57s)
=== RUN   TestAccAWSDirectoryServiceDirectory_tags
--- PASS: TestAccAWSDirectoryServiceDirectory_tags (459.42s)
=== RUN   TestAccAWSDirectoryServiceDirectory_basic
--- PASS: TestAccAWSDirectoryServiceDirectory_basic (486.16s)
=== RUN   TestAccAWSDBInstance_subnetGroup
--- PASS: TestAccAWSDBInstance_subnetGroup (841.94s)
=== RUN   TestAccAWSDBInstance_enhancedMonitoring
--- PASS: TestAccAWSDBInstance_enhancedMonitoring (816.98s)
=== RUN   TestAccAWSDmsReplicationInstanceBasic
--- PASS: TestAccAWSDmsReplicationInstanceBasic (471.93s)
=== RUN   TestAccAWSDirectoryServiceDirectory_withAliasAndSso
--- PASS: TestAccAWSDirectoryServiceDirectory_withAliasAndSso (478.59s)
=== RUN   TestAccAWSDBInstance_snapshot
--- PASS: TestAccAWSDBInstance_snapshot (883.13s)
=== RUN   TestAccAWSDmsReplicationTaskBasic
--- FAIL: TestAccAWSDmsReplicationTaskBasic (592.58s)
	testing.go:513: Step 0 error: After applying this step, the plan was not empty:
		
		DIFF:
		
		UPDATE: aws_dms_replication_task.dms_replication_task
		  replication_task_settings: "{\"TargetMetadata\":{\"TargetSchema\":\"\",\"SupportLobs\":true,\"FullLobMode\":false,\"LobChunkSize\":0,\"LimitedSizeLobMode\":true,\"LobMaxSize\":32,\"LoadMaxFileSize\":0,\"ParallelLoadThreads\":0,\"ParallelLoadBufferSize\":0,\"BatchApplyEnabled\":false,\"TaskRecoveryTableEnabled\":false},\"FullLoadSettings\":{\"TargetTablePrepMode\":\"DROP_AND_CREATE\",\"CreatePkAfterFullLoad\":false,\"StopTaskCachedChangesApplied\":false,\"StopTaskCachedChangesNotApplied\":false,\"MaxFullLoadSubTasks\":8,\"TransactionConsistencyTimeout\":600,\"CommitRate\":10000},\"Logging\":{\"EnableLogging\":false,\"LogComponents\":[{\"Id\":\"SOURCE_UNLOAD\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"TARGET_LOAD\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"SOURCE_CAPTURE\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"TARGET_APPLY\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"TASK_MANAGER\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"}],\"CloudWatchLogGroup\":null,\"CloudWatchLogStream\":null},\"ControlTablesSettings\":{\"historyTimeslotInMinutes\":5,\"ControlSchema\":\"\",\"HistoryTimeslotInMinutes\":5,\"HistoryTableEnabled\":false,\"SuspendedTablesTableEnabled\":false,\"StatusTableEnabled\":false},\"StreamBufferSettings\":{\"StreamBufferCount\":3,\"StreamBufferSizeInMB\":8,\"CtrlStreamBufferSizeInMB\":5},\"ChangeProcessingDdlHandlingPolicy\":{\"HandleSourceTableDropped\":true,\"HandleSourceTableTruncated\":true,\"HandleSourceTableAltered\":true},\"ErrorBehavior\":{\"DataErrorPolicy\":\"LOG_ERROR\",\"DataTruncationErrorPolicy\":\"LOG_ERROR\",\"DataErrorEscalationPolicy\":\"SUSPEND_TABLE\",\"DataErrorEscalationCount\":0,\"TableErrorPolicy\":\"SUSPEND_TABLE\",\"TableErrorEscalationPolicy\":\"STOP_TASK\",\"TableErrorEscalationCount\":0,\"RecoverableErrorCount\":-1,\"RecoverableErrorInterval\":5,\"RecoverableErrorThrottling\":true,\"RecoverableErrorThrottlingMax\":1800,\"ApplyErrorDeletePolicy\":\"IGNORE_RECORD\",\"ApplyErrorInsertPolicy\":\"LOG_ERROR\",\"ApplyErrorUpdatePolicy\":\"LOG_ERROR\",\"ApplyErrorEscalationPolicy\":\"LOG_ERROR\",\"ApplyErrorEscalationCount\":0,\"ApplyErrorFailOnTruncationDdl\":false,\"FullLoadIgnoreConflicts\":true,\"FailOnTransactionConsistencyBreached\":false,\"FailOnNoTablesCaptured\":false},\"ChangeProcessingTuning\":{\"BatchApplyPreserveTransaction\":true,\"BatchApplyTimeoutMin\":1,\"BatchApplyTimeoutMax\":30,\"BatchApplyMemoryLimit\":500,\"BatchSplitSize\":0,\"MinTransactionSize\":1000,\"CommitTimeout\":1,\"MemoryLimitTotal\":1024,\"MemoryKeepTime\":60,\"StatementCacheSize\":50}}" => "{\"TargetMetadata\":{\"TargetSchema\":\"\",\"SupportLobs\":true,\"FullLobMode\":false,\"LobChunkSize\":0,\"LimitedSizeLobMode\":true,\"LobMaxSize\":32,\"LoadMaxFileSize\":0,\"ParallelLoadThreads\":0,\"BatchApplyEnabled\":false},\"FullLoadSettings\":{\"FullLoadEnabled\":true,\"ApplyChangesEnabled\":false,\"TargetTablePrepMode\":\"DROP_AND_CREATE\",\"CreatePkAfterFullLoad\":false,\"StopTaskCachedChangesApplied\":false,\"StopTaskCachedChangesNotApplied\":false,\"ResumeEnabled\":false,\"ResumeMinTableSize\":100000,\"ResumeOnlyClusteredPKTables\":true,\"MaxFullLoadSubTasks\":8,\"TransactionConsistencyTimeout\":600,\"CommitRate\":10000},\"Logging\":{\"EnableLogging\":false,\"LogComponents\":[{\"Id\":\"SOURCE_UNLOAD\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"TARGET_LOAD\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"SOURCE_CAPTURE\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"TARGET_APPLY\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"TASK_MANAGER\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"}],\"CloudWatchLogGroup\":null,\"CloudWatchLogStream\":null},\"ControlTablesSettings\":{\"historyTimeslotInMinutes\":5,\"ControlSchema\":\"\",\"HistoryTimeslotInMinutes\":5,\"HistoryTableEnabled\":false,\"SuspendedTablesTableEnabled\":false,\"StatusTableEnabled\":false},\"StreamBufferSettings\":{\"StreamBufferCount\":3,\"StreamBufferSizeInMB\":8,\"CtrlStreamBufferSizeInMB\":5},\"ChangeProcessingDdlHandlingPolicy\":{\"HandleSourceTableDropped\":true,\"HandleSourceTableTruncated\":true,\"HandleSourceTableAltered\":true},\"ErrorBehavior\":{\"DataErrorPolicy\":\"LOG_ERROR\",\"DataTruncationErrorPolicy\":\"LOG_ERROR\",\"DataErrorEscalationPolicy\":\"SUSPEND_TABLE\",\"DataErrorEscalationCount\":0,\"TableErrorPolicy\":\"SUSPEND_TABLE\",\"TableErrorEscalationPolicy\":\"STOP_TASK\",\"TableErrorEscalationCount\":0,\"RecoverableErrorCount\":-1,\"RecoverableErrorInterval\":5,\"RecoverableErrorThrottling\":true,\"RecoverableErrorThrottlingMax\":1800,\"ApplyErrorDeletePolicy\":\"IGNORE_RECORD\",\"ApplyErrorInsertPolicy\":\"LOG_ERROR\",\"ApplyErrorUpdatePolicy\":\"LOG_ERROR\",\"ApplyErrorEscalationPolicy\":\"LOG_ERROR\",\"ApplyErrorEscalationCount\":0,\"FullLoadIgnoreConflicts\":true},\"ChangeProcessingTuning\":{\"BatchApplyPreserveTransaction\":true,\"BatchApplyTimeoutMin\":1,\"BatchApplyTimeoutMax\":30,\"BatchApplyMemoryLimit\":500,\"BatchSplitSize\":0,\"MinTransactionSize\":1000,\"CommitTimeout\":1,\"MemoryLimitTotal\":1024,\"MemoryKeepTime\":60,\"StatementCacheSize\":50}}"

=== RUN   TestAccAWSDirectoryServiceDirectory_connector
--- PASS: TestAccAWSDirectoryServiceDirectory_connector (782.76s)
=== RUN   TestAccAWSDBInstance_replica
--- PASS: TestAccAWSDBInstance_replica (1466.43s)
=== RUN   TestAccAWSDBInstance_MSSQL_TZ
--- PASS: TestAccAWSDBInstance_MSSQL_TZ (1751.01s)
=== RUN   TestAccAWSDirectoryServiceDirectory_microsoft
--- PASS: TestAccAWSDirectoryServiceDirectory_microsoft (1645.58s)
=== RUN   TestAccAWSDirectoryServiceDirectory_microsoftStandard
--- PASS: TestAccAWSDirectoryServiceDirectory_microsoftStandard (1645.57s)
```