### PR TITLE
resource/aws_api_gateway_rest_api: Add support for content encoding

### DIFF
--- a/website/docs/r/api_gateway_rest_api.html.markdown
+++ b/website/docs/r/api_gateway_rest_api.html.markdown
@@ -26,6 +26,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the REST API
 * `description` - (Optional) The description of the REST API
 * `binary_media_types` - (Optional) The list of binary media types supported by the RestApi. By default, the RestApi supports only UTF-8-encoded text payloads.
+* `minimum_compression_size` - (Optional) Minimum response size to compress for the REST API. Integer between -1 and 10485760 (10MB). Setting a value greater than -1 will enable compression, -1 disables compression (default).
 * `body` - (Optional) An OpenAPI specification that defines the set of routes and integrations to create as part of the REST API.
 
 __Note__: If the `body` argument is provided, the OpenAPI specification will be used to configure the resources, methods and integrations for the Rest API. If this argument is provided, the following resources should not be managed as separate ones, as updates may cause manual resource updates to be overwritten:


### PR DESCRIPTION
Fix #3144 

It appears there is a bug with the method `GetOkExists` which prevents it from being useful in this situation (can't detect set --> unset/disable in config). Regardless it was decided using a special value of `-1` keeps the code to 1 variable, and makes the implementation quite clean.

~~The tests finally pass by manually waiting and then reading the apigw. I imagine there might be a more "official" way of getting around the eventual consistency.~~ No eventual consistency issues
