### PR TITLE
data-source/availalibity_zones: drop custom ValidateFunc for state

### DIFF
--- a/aws/data_source_aws_availability_zones.go
+++ b/aws/data_source_aws_availability_zones.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func dataSourceAwsAvailabilityZones() *schema.Resource {
@@ -22,9 +23,14 @@ func dataSourceAwsAvailabilityZones() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"state": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validateStateType,
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					ec2.AvailabilityZoneStateAvailable,
+					ec2.AvailabilityZoneStateInformation,
+					ec2.AvailabilityZoneStateImpaired,
+					ec2.AvailabilityZoneStateUnavailable,
+				}, false),
 			},
 		},
 	}
@@ -65,22 +71,4 @@ func dataSourceAwsAvailabilityZonesRead(d *schema.ResourceData, meta interface{}
 	}
 
 	return nil
-}
-
-func validateStateType(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-
-	validState := map[string]bool{
-		"available":   true,
-		"information": true,
-		"impaired":    true,
-		"unavailable": true,
-	}
-
-	if !validState[value] {
-		errors = append(errors, fmt.Errorf(
-			"%q contains an invalid Availability Zone state %q. Valid states are: %q, %q, %q and %q.",
-			k, value, "available", "information", "impaired", "unavailable"))
-	}
-	return
 }

--- a/aws/data_source_aws_availability_zones_test.go
+++ b/aws/data_source_aws_availability_zones_test.go
@@ -41,34 +41,6 @@ func TestAccAWSAvailabilityZones_stateFilter(t *testing.T) {
 	})
 }
 
-func TestResourceCheckAwsAvailabilityZones_validateStateType(t *testing.T) {
-	_, errors := validateStateType("incorrect", "state")
-	if len(errors) == 0 {
-		t.Fatalf("Expected to trigger a validation error")
-	}
-
-	var testCases = []struct {
-		Value    string
-		ErrCount int
-	}{
-		{
-			Value:    "available",
-			ErrCount: 0,
-		},
-		{
-			Value:    "unavailable",
-			ErrCount: 0,
-		},
-	}
-
-	for _, tc := range testCases {
-		_, errors := validateStateType(tc.Value, "state")
-		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected %q not to trigger a validation error.", tc.Value)
-		}
-	}
-}
-
 func testAccCheckAwsAvailabilityZonesMeta(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]


### PR DESCRIPTION
It's a serie of PRs to drop custom `ValidateFunc`. The goal is to use existing functions in `validation` package as much as possible. To minimize the scope and make it easy for review, one PR will be created per resource or data source.

This PR is for:

- [x] data_source_aws_availalibity_zones
