### PR TITLE
data-source/elastic_beanstalk_solution_stack: drop custom ValidateFunc for name_regex

### DIFF
--- a/aws/data_source_aws_elastic_beanstalk_solution_stack.go
+++ b/aws/data_source_aws_elastic_beanstalk_solution_stack.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/elasticbeanstalk"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func dataSourceAwsElasticBeanstalkSolutionStack() *schema.Resource {
@@ -18,7 +19,7 @@ func dataSourceAwsElasticBeanstalkSolutionStack() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validateSolutionStackNameRegex,
+				ValidateFunc: validation.ValidateRegexp,
 			},
 			"most_recent": {
 				Type:     schema.TypeBool,
@@ -92,15 +93,4 @@ func solutionStackDescriptionAttributes(d *schema.ResourceData, solutionStack *s
 	d.SetId(*solutionStack)
 	d.Set("name", solutionStack)
 	return nil
-}
-
-func validateSolutionStackNameRegex(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-
-	if _, err := regexp.Compile(value); err != nil {
-		errors = append(errors, fmt.Errorf(
-			"%q contains an invalid regular expression: %s",
-			k, err))
-	}
-	return
 }

--- a/aws/data_source_aws_elastic_beanstalk_solution_stack_test.go
+++ b/aws/data_source_aws_elastic_beanstalk_solution_stack_test.go
@@ -25,57 +25,6 @@ func TestAccAWSElasticBeanstalkSolutionStackDataSource(t *testing.T) {
 	})
 }
 
-func TestResourceValidateSolutionStackNameRegex(t *testing.T) {
-	type testCases struct {
-		Value    string
-		ErrCount int
-	}
-
-	invalidCases := []testCases{
-		{
-			Value:    `\`,
-			ErrCount: 1,
-		},
-		{
-			Value:    `**`,
-			ErrCount: 1,
-		},
-		{
-			Value:    `(.+`,
-			ErrCount: 1,
-		},
-	}
-
-	for _, tc := range invalidCases {
-		_, errors := validateSolutionStackNameRegex(tc.Value, "name_regex")
-		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected %q to trigger a validation error.", tc.Value)
-		}
-	}
-
-	validCases := []testCases{
-		{
-			Value:    `\/`,
-			ErrCount: 0,
-		},
-		{
-			Value:    `.*`,
-			ErrCount: 0,
-		},
-		{
-			Value:    `\b(?:\d{1,3}\.){3}\d{1,3}\b`,
-			ErrCount: 0,
-		},
-	}
-
-	for _, tc := range validCases {
-		_, errors := validateSolutionStackNameRegex(tc.Value, "name_regex")
-		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected %q not to trigger a validation error.", tc.Value)
-		}
-	}
-}
-
 func testAccCheckAwsElasticBeanstalkSolutionStackDataSourceDestroy(s *terraform.State) error {
 	return nil
 }


### PR DESCRIPTION
It's a serie of PRs to drop custom `ValidateFunc`. The goal is to use existing functions in `validation` package as much as possible. To minimize the scope and make it easy for review, one PR will be created per resource or data source.

This PR is for:

- [x] data_source_aws_elastic_beanstalk_solution_stack