### PR TITLE
resource/aws_eip_association: Prevent deletion error InvalidAssociationID.NotFound

### DIFF
--- a/aws/resource_aws_eip_association.go
+++ b/aws/resource_aws_eip_association.go
@@ -172,6 +172,9 @@ func resourceAwsEipAssociationDelete(d *schema.ResourceData, meta interface{}) e
 
 	_, err := conn.DisassociateAddress(opts)
 	if err != nil {
+		if isAWSErr(err, "InvalidAssociationID.NotFound", "") {
+			return nil
+		}
 		return fmt.Errorf("Error deleting Elastic IP association: %s", err)
 	}
 


### PR DESCRIPTION
Fixes #1682

```
aws_eip_association.eip_assoc: Destroying... (ID: eipassoc-c4186cf0)
Error applying plan:

1 error(s) occurred:

* aws_eip_association.eip_assoc (destroy): 1 error(s) occurred:

* aws_eip_association.eip_assoc: Error deleting Elastic IP association: InvalidAssociationID.NotFound: The association ID 'eipassoc-c4186cf0' does not exist
        status code: 400, request id: bd68f61b-c8df-4781-a756-35449101af92
```

Tests:
```
=== RUN   TestAccAWSEIPAssociation_disappears
--- PASS: TestAccAWSEIPAssociation_disappears (95.60s)
=== RUN   TestAccAWSEIPAssociation_ec2Classic
--- PASS: TestAccAWSEIPAssociation_ec2Classic (104.41s)
=== RUN   TestAccAWSEIPAssociation_basic
--- PASS: TestAccAWSEIPAssociation_basic (116.12s)
=== RUN   TestAccAWSEIPAssociation_spotInstance
--- PASS: TestAccAWSEIPAssociation_spotInstance (305.50s)
```