### PR TITLE
data-source/iam_policy_document: drop custom ValidateFunc for statement.effect

### DIFF
--- a/aws/data_source_aws_iam_policy_document.go
+++ b/aws/data_source_aws_iam_policy_document.go
@@ -2,12 +2,12 @@ package aws
 
 import (
 	"encoding/json"
-	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 var dataSourceAwsIamPolicyDocumentVarReplacer = strings.NewReplacer("&{", "${")
@@ -47,18 +47,10 @@ func dataSourceAwsIamPolicyDocument() *schema.Resource {
 							Optional: true,
 						},
 						"effect": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  "Allow",
-							ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
-								switch v.(string) {
-								case "Allow", "Deny":
-									return
-								default:
-									es = append(es, fmt.Errorf("%q must be either \"Allow\" or \"Deny\"", k))
-									return
-								}
-							},
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "Allow",
+							ValidateFunc: validation.StringInSlice([]string{"Allow", "Deny"}, false),
 						},
 						"actions":        setOfString,
 						"not_actions":    setOfString,


### PR DESCRIPTION
It's a serie of PRs to drop custom `ValidateFunc`. The goal is to use existing functions in `validation` package as much as possible. To minimize the scope and make it easy for review, one PR will be created per resource or data source.

This PR is for:

- [x] data_source_aws_iam_policy_document