### PR TITLE
resource/api_gateway_api_key: drop custom ValidateFunc for value

### DIFF
--- a/aws/resource_aws_api_gateway_api_key.go
+++ b/aws/resource_aws_api_gateway_api_key.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/apigateway"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsApiGatewayApiKey() *schema.Resource {
@@ -76,7 +77,7 @@ func resourceAwsApiGatewayApiKey() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				Sensitive:    true,
-				ValidateFunc: validateApiGatewayApiKeyValue,
+				ValidateFunc: validation.StringLenBetween(30, 128),
 			},
 		},
 	}

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1230,19 +1230,6 @@ func validateAccountAlias(v interface{}, k string) (ws []string, es []error) {
 	return
 }
 
-func validateApiGatewayApiKeyValue(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if len(value) < 30 {
-		errors = append(errors, fmt.Errorf(
-			"%q must be at least 30 characters long", k))
-	}
-	if len(value) > 128 {
-		errors = append(errors, fmt.Errorf(
-			"%q cannot be longer than 128 characters", k))
-	}
-	return
-}
-
 func validateIamRolePolicyName(v interface{}, k string) (ws []string, errors []error) {
 	// https://github.com/boto/botocore/blob/2485f5c/botocore/data/iam/2010-05-08/service-2.json#L8291-L8296
 	value := v.(string)


### PR DESCRIPTION
It's a serie of PRs to drop custom `ValidateFunc`. The goal is to use existing functions in `validation` package as much as possible. To minimize the scope and make it easy for review, one PR will be created per resource or data source.

This PR is for:

- [x] resourc/api_gateway_api_key