### PR TITLE
resource/api_gateway_authorizer: drop custom ValidateFunc for authorizer_result_ttl_in_seconds

### DIFF
--- a/aws/resource_aws_api_gateway_authorizer.go
+++ b/aws/resource_aws_api_gateway_authorizer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/apigateway"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsApiGatewayAuthorizer() *schema.Resource {
@@ -49,7 +50,7 @@ func resourceAwsApiGatewayAuthorizer() *schema.Resource {
 			"authorizer_result_ttl_in_seconds": &schema.Schema{
 				Type:         schema.TypeInt,
 				Optional:     true,
-				ValidateFunc: validateIntegerInRange(0, 3600),
+				ValidateFunc: validation.IntBetween(0, 3600),
 			},
 			"identity_validation_expression": &schema.Schema{
 				Type:     schema.TypeString,


### PR DESCRIPTION
It's a serie of PRs to drop custom `ValidateFunc`. The goal is to use existing functions in `validation` package as much as possible. To minimize the scope and make it easy for review, one PR will be created per resource or data source.

This PR is for:

- [x] resource/api_gateway_authorizer