### PR TITLE
resource/api_gateway_usage_plan: drop custom ValidateFunc for quota_settings.period

### DIFF
--- a/aws/resource_aws_api_gateway_usage_plan.go
+++ b/aws/resource_aws_api_gateway_usage_plan.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/apigateway"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsApiGatewayUsagePlan() *schema.Resource {
@@ -71,9 +72,13 @@ func resourceAwsApiGatewayUsagePlan() *schema.Resource {
 						},
 
 						"period": {
-							Type:         schema.TypeString,
-							Required:     true, // Required as not removable
-							ValidateFunc: validateApiGatewayUsagePlanQuotaSettingsPeriod,
+							Type:     schema.TypeString,
+							Required: true, // Required as not removable
+							ValidateFunc: validation.StringInSlice([]string{
+								apigateway.QuotaPeriodTypeDay,
+								apigateway.QuotaPeriodTypeWeek,
+								apigateway.QuotaPeriodTypeMonth,
+							}, false),
 						},
 					},
 				},

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1268,24 +1268,6 @@ func validateIamRolePolicyNamePrefix(v interface{}, k string) (ws []string, erro
 	return
 }
 
-func validateApiGatewayUsagePlanQuotaSettingsPeriod(v interface{}, k string) (ws []string, errors []error) {
-	validPeriods := []string{
-		apigateway.QuotaPeriodTypeDay,
-		apigateway.QuotaPeriodTypeWeek,
-		apigateway.QuotaPeriodTypeMonth,
-	}
-	period := v.(string)
-	for _, f := range validPeriods {
-		if period == f {
-			return
-		}
-	}
-	errors = append(errors, fmt.Errorf(
-		"%q contains an invalid period %q. Valid period are %q.",
-		k, period, validPeriods))
-	return
-}
-
 func validateApiGatewayUsagePlanQuotaSettings(v map[string]interface{}) (errors []error) {
 	period := v["period"].(string)
 	offset := v["offset"].(int)

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -1875,34 +1875,6 @@ func TestValidateIamRoleProfileNamePrefix(t *testing.T) {
 	}
 }
 
-func TestValidateApiGatewayUsagePlanQuotaSettingsPeriod(t *testing.T) {
-	validEntries := []string{
-		"DAY",
-		"WEEK",
-		"MONTH",
-	}
-
-	invalidEntries := []string{
-		"fooBAR",
-		"foobar45Baz",
-		"foobar45Baz@!",
-	}
-
-	for _, v := range validEntries {
-		_, errors := validateApiGatewayUsagePlanQuotaSettingsPeriod(v, "name")
-		if len(errors) != 0 {
-			t.Fatalf("%q should be a valid API Gateway Quota Settings Period: %v", v, errors)
-		}
-	}
-
-	for _, v := range invalidEntries {
-		_, errors := validateApiGatewayUsagePlanQuotaSettingsPeriod(v, "name")
-		if len(errors) == 0 {
-			t.Fatalf("%q should not be a API Gateway Quota Settings Period", v)
-		}
-	}
-}
-
 func TestValidateApiGatewayUsagePlanQuotaSettings(t *testing.T) {
 	cases := []struct {
 		Offset   int


### PR DESCRIPTION
It's a serie of PRs to drop custom `ValidateFunc`. The goal is to use existing functions in `validation` package as much as possible. To minimize the scope and make it easy for review, one PR will be created per resource or data source.

This PR is for:

- [x] resource/api_gateway_usage_plan