### PR TITLE
resource/cloudfront_distribution: drop ValidateFunc for http_version

### DIFF
--- a/aws/resource_aws_cloudfront_distribution.go
+++ b/aws/resource_aws_cloudfront_distribution.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsCloudFrontDistribution() *schema.Resource {
@@ -314,7 +315,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "http2",
-				ValidateFunc: validateHTTP,
+				ValidateFunc: validation.StringInSlice([]string{"http1.1", "http2"}, false),
 			},
 			"logging_config": {
 				Type:     schema.TypeSet,
@@ -729,17 +730,4 @@ func resourceAwsCloudFrontWebDistributionStateRefreshFunc(id string, meta interf
 
 		return resp.Distribution, *resp.Distribution.Status, nil
 	}
-}
-
-// validateHTTP ensures that the http_version resource parameter is
-// correct.
-func validateHTTP(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-
-	if value != "http1.1" && value != "http2" {
-		errors = append(errors, fmt.Errorf(
-			"%q contains an invalid HTTP version parameter %q. Valid parameters are either %q or %q.",
-			k, value, "http1.1", "http2"))
-	}
-	return
 }

--- a/aws/resource_aws_cloudfront_distribution_test.go
+++ b/aws/resource_aws_cloudfront_distribution_test.go
@@ -337,23 +337,6 @@ func TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig(t *testing.T) 
 	})
 }
 
-func TestResourceAWSCloudFrontDistribution_validateHTTP(t *testing.T) {
-	var value string
-	var errors []error
-
-	value = "incorrect"
-	_, errors = validateHTTP(value, "http_version")
-	if len(errors) == 0 {
-		t.Fatalf("Expected %q to trigger a validation error", value)
-	}
-
-	value = "http1.1"
-	_, errors = validateHTTP(value, "http_version")
-	if len(errors) != 0 {
-		t.Fatalf("Expected %q not to trigger a validation error", value)
-	}
-}
-
 func testAccCheckCloudFrontDistributionDestroy(s *terraform.State) error {
 	for k, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_cloudfront_distribution" {


### PR DESCRIPTION
It's a serie of PRs to drop custom `ValidateFunc`. The goal is to use existing functions in `validation` package as much as possible. To minimize the scope and make it easy for review, one PR will be created per resource or data source.

This PR is for:

- [x] resource/cloudfront_distribution