### PR TITLE
resourc/codebuild_project: drop custom ValidateFunc

### DIFF
--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -91,7 +91,7 @@ func TestAccAWSCodeBuildProject_sourceAuth(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAWSCodeBuildProjectConfig_sourceAuth(name, authResource, "INVALID"),
-				ExpectError: regexp.MustCompile(`Source Auth Type can only be`),
+				ExpectError: regexp.MustCompile(`expected source.0.auth.0.type to be one of`),
 			},
 			{
 				Config: testAccAWSCodeBuildProjectConfig_sourceAuth(name, authResource, authType),
@@ -133,45 +133,6 @@ func TestAccAWSCodeBuildProject_default_build_timeout(t *testing.T) {
 	})
 }
 
-func TestAWSCodeBuildProject_artifactsTypeValidation(t *testing.T) {
-	cases := []struct {
-		Value    string
-		ErrCount int
-	}{
-		{Value: "CODEPIPELINE", ErrCount: 0},
-		{Value: "NO_ARTIFACTS", ErrCount: 0},
-		{Value: "S3", ErrCount: 0},
-		{Value: "XYZ", ErrCount: 1},
-	}
-
-	for _, tc := range cases {
-		_, errors := validateAwsCodeBuildArifactsType(tc.Value, "aws_codebuild_project")
-
-		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected the AWS CodeBuild project artifacts type to trigger a validation error")
-		}
-	}
-}
-
-func TestAWSCodeBuildProject_artifactsNamespaceTypeValidation(t *testing.T) {
-	cases := []struct {
-		Value    string
-		ErrCount int
-	}{
-		{Value: "NONE", ErrCount: 0},
-		{Value: "BUILD_ID", ErrCount: 0},
-		{Value: "XYZ", ErrCount: 1},
-	}
-
-	for _, tc := range cases {
-		_, errors := validateAwsCodeBuildArifactsNamespaceType(tc.Value, "aws_codebuild_project")
-
-		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected the AWS CodeBuild project artifacts namepsace_type to trigger a validation error")
-		}
-	}
-}
-
 func longTestData() string {
 	data := `
 	test-test-test-test-test-test-test-test-test-test-
@@ -207,122 +168,6 @@ func TestAWSCodeBuildProject_nameValidation(t *testing.T) {
 
 		if len(errors) != tc.ErrCount {
 			t.Fatalf("Expected the AWS CodeBuild project name to trigger a validation error - %s", errors)
-		}
-	}
-}
-
-func TestAWSCodeBuildProject_descriptionValidation(t *testing.T) {
-	cases := []struct {
-		Value    string
-		ErrCount int
-	}{
-		{Value: "test", ErrCount: 0},
-		{Value: longTestData(), ErrCount: 1},
-	}
-
-	for _, tc := range cases {
-		_, errors := validateAwsCodeBuildProjectDescription(tc.Value, "aws_codebuild_project")
-
-		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected the AWS CodeBuild project description to trigger a validation error")
-		}
-	}
-}
-
-func TestAWSCodeBuildProject_environmentComputeTypeValidation(t *testing.T) {
-	cases := []struct {
-		Value    string
-		ErrCount int
-	}{
-		{Value: "BUILD_GENERAL1_SMALL", ErrCount: 0},
-		{Value: "BUILD_GENERAL1_MEDIUM", ErrCount: 0},
-		{Value: "BUILD_GENERAL1_LARGE", ErrCount: 0},
-		{Value: "BUILD_GENERAL1_VERYLARGE", ErrCount: 1},
-	}
-
-	for _, tc := range cases {
-		_, errors := validateAwsCodeBuildEnvironmentComputeType(tc.Value, "aws_codebuild_project")
-
-		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected the AWS CodeBuild project environment compute_type to trigger a validation error")
-		}
-	}
-}
-
-func TestAWSCodeBuildProject_environmentTypeValidation(t *testing.T) {
-	cases := []struct {
-		Value    string
-		ErrCount int
-	}{
-		{Value: "LINUX_CONTAINER", ErrCount: 0},
-		{Value: "WINDOWS_CONTAINER", ErrCount: 1},
-	}
-
-	for _, tc := range cases {
-		_, errors := validateAwsCodeBuildEnvironmentType(tc.Value, "aws_codebuild_project")
-
-		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected the AWS CodeBuild project environment type to trigger a validation error")
-		}
-	}
-}
-
-func TestAWSCodeBuildProject_sourceTypeValidation(t *testing.T) {
-	cases := []struct {
-		Value    string
-		ErrCount int
-	}{
-		{Value: "CODECOMMIT", ErrCount: 0},
-		{Value: "CODEPIPELINE", ErrCount: 0},
-		{Value: "GITHUB", ErrCount: 0},
-		{Value: "S3", ErrCount: 0},
-		{Value: "BITBUCKET", ErrCount: 0},
-		{Value: "GITLAB", ErrCount: 1},
-	}
-
-	for _, tc := range cases {
-		_, errors := validateAwsCodeBuildSourceType(tc.Value, "aws_codebuild_project")
-
-		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected the AWS CodeBuild project source type to trigger a validation error")
-		}
-	}
-}
-
-func TestAWSCodeBuildProject_sourceAuthTypeValidation(t *testing.T) {
-	cases := []struct {
-		Value    string
-		ErrCount int
-	}{
-		{Value: "OAUTH", ErrCount: 0},
-		{Value: "PASSWORD", ErrCount: 1},
-	}
-
-	for _, tc := range cases {
-		_, errors := validateAwsCodeBuildSourceAuthType(tc.Value, "aws_codebuild_project")
-
-		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected the AWS CodeBuild project source auth to trigger a validation error")
-		}
-	}
-}
-
-func TestAWSCodeBuildProject_timeoutValidation(t *testing.T) {
-	cases := []struct {
-		Value    int
-		ErrCount int
-	}{
-		{Value: 10, ErrCount: 0},
-		{Value: 200, ErrCount: 0},
-		{Value: 1, ErrCount: 1},
-		{Value: 500, ErrCount: 1},
-	}
-
-	for _, tc := range cases {
-		_, errors := validateAwsCodeBuildTimeout(tc.Value, "aws_codebuild_project")
-
-		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected the AWS CodeBuild project timeout to trigger a validation error")
 		}
 	}
 }


### PR DESCRIPTION
It's a serie of PRs to drop custom `ValidateFunc`. The goal is to use existing functions in `validation` package as much as possible. To minimize the scope and make it easy for review, one PR will be created per resource or data source.

This PR is for:

- [x] resourc/codebuild_project
+ artifacts.namespace_type
+ artifacts.type
+ environment.compute_type
+ environment.type
+ source.auth.type
+ source.type
+ build_timeout