### PR TITLE
resource/codecommit_repository: drop custom ValidateFunc for repository_name and description

### DIFF
--- a/aws/resource_aws_codecommit_repository.go
+++ b/aws/resource_aws_codecommit_repository.go
@@ -21,30 +21,16 @@ func resourceAwsCodeCommitRepository() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"repository_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(string)
-					if len(value) > 100 {
-						errors = append(errors, fmt.Errorf(
-							"%q cannot be longer than 100 characters", k))
-					}
-					return
-				},
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateMaxLength(100),
 			},
 
 			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(string)
-					if len(value) > 1000 {
-						errors = append(errors, fmt.Errorf(
-							"%q cannot be longer than 1000 characters", k))
-					}
-					return
-				},
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateMaxLength(1000),
 			},
 
 			"arn": {


### PR DESCRIPTION
It's a serie of PRs to drop custom `ValidateFunc`. The goal is to use existing functions in `validation` package as much as possible. To minimize the scope and make it easy for review, one PR will be created per resource or data source.

This PR is for:

- [x] resource/codecommit_repository