### PR TITLE
resource/codedeploy_deployment_config: drop custom ValidateFunc for minimum_healthy_hosts.type 

### DIFF
--- a/aws/resource_aws_codedeploy_deployment_config.go
+++ b/aws/resource_aws_codedeploy_deployment_config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/codedeploy"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsCodeDeployDeploymentConfig() *schema.Resource {
@@ -31,11 +32,13 @@ func resourceAwsCodeDeployDeploymentConfig() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"type": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validateMinimumHealtyHostsType,
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								codedeploy.MinimumHealthyHostsTypeHostCount,
+								codedeploy.MinimumHealthyHostsTypeFleetPercent,
+							}, false),
 						},
-
 						"value": {
 							Type:     schema.TypeInt,
 							Optional: true,
@@ -140,13 +143,4 @@ func flattenAwsCodeDeployConfigMinimumHealthHosts(hosts *codedeploy.MinimumHealt
 	result = append(result, item)
 
 	return result
-}
-
-func validateMinimumHealtyHostsType(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if value != "FLEET_PERCENT" && value != "HOST_COUNT" {
-		errors = append(errors, fmt.Errorf(
-			"%q must be one of \"FLEET_PERCENT\" or \"HOST_COUNT\"", k))
-	}
-	return
 }

--- a/aws/resource_aws_codedeploy_deployment_config_test.go
+++ b/aws/resource_aws_codedeploy_deployment_config_test.go
@@ -60,49 +60,6 @@ func TestAccAWSCodeDeployDeploymentConfig_hostCount(t *testing.T) {
 	})
 }
 
-func TestValidateAWSCodeDeployMinimumHealthyHostsType(t *testing.T) {
-	cases := []struct {
-		Value    string
-		ErrCount int
-	}{
-		{
-			Value:    "FLEET_PERCENT",
-			ErrCount: 0,
-		},
-		{
-			Value:    "HOST_COUNT",
-			ErrCount: 0,
-		},
-		{
-			Value:    "host_count",
-			ErrCount: 1,
-		},
-		{
-			Value:    "hostcount",
-			ErrCount: 1,
-		},
-		{
-			Value:    "FleetPercent",
-			ErrCount: 1,
-		},
-		{
-			Value:    "Foo",
-			ErrCount: 1,
-		},
-		{
-			Value:    "",
-			ErrCount: 1,
-		},
-	}
-
-	for _, tc := range cases {
-		_, errors := validateMinimumHealtyHostsType(tc.Value, "minimum_healthy_hosts_type")
-		if len(errors) != tc.ErrCount {
-			t.Fatalf("Minimum Healthy Hosts validation failed for type %q: %q", tc.Value, errors)
-		}
-	}
-}
-
 func testAccCheckAWSCodeDeployDeploymentConfigDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).codedeployconn
 


### PR DESCRIPTION
It's a serie of PRs to drop custom `ValidateFunc`. The goal is to use existing functions in `validation` package as much as possible. To minimize the scope and make it easy for review, one PR will be created per resource or data source.

This PR is for:

- [x] resource/codedeploy_deployment_config