### PR TITLE
resource/ecs_service: fix crash when importing non-existing service

### DIFF
--- a/aws/resource_aws_ecs_service.go
+++ b/aws/resource_aws_ecs_service.go
@@ -357,8 +357,11 @@ func resourceAwsEcsServiceRead(d *schema.ResourceData, meta interface{}) error {
 			return resource.NonRetryableError(err)
 		}
 
-		if d.IsNewResource() && len(out.Services) < 1 {
-			return resource.RetryableError(fmt.Errorf("No ECS service found: %q", d.Id()))
+		if len(out.Services) < 1 {
+			if d.IsNewResource() {
+				return resource.RetryableError(fmt.Errorf("ECS service not created yet: %q", d.Id()))
+			}
+			return resource.NonRetryableError(fmt.Errorf("No ECS service found: %q", d.Id()))
 		}
 
 		service := out.Services[0]

--- a/aws/resource_aws_ecs_service_test.go
+++ b/aws/resource_aws_ecs_service_test.go
@@ -131,11 +131,20 @@ func TestAccAWSEcsService_importBasic(t *testing.T) {
 			{
 				Config: testAccAWSEcsServiceWithFamilyAndRevision(clusterName, tdName, svcName),
 			},
+			// Test existent resource import
 			{
 				ResourceName:      resourceName,
 				ImportStateId:     importInput,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			// Test non-existent resource import
+			{
+				ResourceName:      resourceName,
+				ImportStateId:     fmt.Sprintf("%s/nonexistent", clusterName),
+				ImportState:       true,
+				ImportStateVerify: false,
+				ExpectError:       regexp.MustCompile(`No ECS service found`),
 			},
 		},
 	})

--- a/aws/resource_aws_ecs_service_test.go
+++ b/aws/resource_aws_ecs_service_test.go
@@ -113,7 +113,7 @@ func TestAccAWSEcsService_withARN(t *testing.T) {
 	})
 }
 
-func TestAccAWSEcsService_basicImport(t *testing.T) {
+func TestAccAWSEcsService_importBasic(t *testing.T) {
 	rString := acctest.RandString(8)
 
 	clusterName := fmt.Sprintf("tf-acc-cluster-svc-%s", rString)


### PR DESCRIPTION
Fix #3671 

One thing unsure though. Do we test such scenario as import error?