### PR TITLE
tests/resource/aws_redshift_cluster: Do not retry deletion during sweep

### DIFF
--- a/aws/resource_aws_redshift_cluster_test.go
+++ b/aws/resource_aws_redshift_cluster_test.go
@@ -43,10 +43,11 @@ func testSweepRedshiftClusters(region string) error {
 				continue
 			}
 
-			_, err := deleteAwsRedshiftCluster(&redshift.DeleteClusterInput{
+			input := &redshift.DeleteClusterInput{
 				ClusterIdentifier:        c.ClusterIdentifier,
 				SkipFinalClusterSnapshot: aws.Bool(true),
-			}, conn)
+			}
+			_, err := conn.DeleteCluster(input)
 			if err != nil {
 				log.Printf("[ERROR] Failed deleting Redshift cluster (%s): %s",
 					*c.ClusterIdentifier, err)


### PR DESCRIPTION
To workaround "stuck" clusters requiring AWS support intervention, otherwise the "test" reaches its timeout.

```
[13:39:45]W:	 [Step 1/3] 2018/03/08 13:39:45 [DEBUG] [aws-sdk-go] DEBUG: Validate Response redshift/DeleteCluster failed, not retrying, error InvalidClusterState: There is an operation running on the Cluster. Please try to delete it at a later time.
[13:39:45]W:	 [Step 1/3] 	status code: 400, request id: 41aca7ee-22d6-11e8-9aa2-5b34bd641179
[13:39:45]W:	 [Step 1/3] 2018/03/08 13:39:45 [TRACE] Waiting 10s before next try
[13:39:53] :	 [Step 1/3] *** Test killed: ran too long (10m0s).
```