### PR TITLE
resource/cognito_identity_pool_roles_attachment: drop custom ValidateFuncs

### DIFF
--- a/aws/resource_aws_cognito_identity_pool_roles_attachment.go
+++ b/aws/resource_aws_cognito_identity_pool_roles_attachment.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsCognitoIdentityPoolRolesAttachment() *schema.Resource {
@@ -39,9 +40,12 @@ func resourceAwsCognitoIdentityPoolRolesAttachment() *schema.Resource {
 							Required: true,
 						},
 						"ambiguous_role_resolution": {
-							Type:         schema.TypeString,
-							ValidateFunc: validateCognitoRoleMappingsAmbiguousRoleResolution,
-							Optional:     true, // Required if Type equals Token or Rules.
+							Type:     schema.TypeString,
+							Optional: true, // Required if Type equals Token or Rules.
+							ValidateFunc: validation.StringInSlice([]string{
+								cognitoidentity.AmbiguousRoleResolutionTypeAuthenticatedRole,
+								cognitoidentity.AmbiguousRoleResolutionTypeDeny,
+							}, false),
 						},
 						"mapping_rule": {
 							Type:     schema.TypeList,
@@ -55,9 +59,14 @@ func resourceAwsCognitoIdentityPoolRolesAttachment() *schema.Resource {
 										ValidateFunc: validateCognitoRoleMappingsRulesClaim,
 									},
 									"match_type": {
-										Type:         schema.TypeString,
-										Required:     true,
-										ValidateFunc: validateCognitoRoleMappingsRulesMatchType,
+										Type:     schema.TypeString,
+										Required: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											cognitoidentity.MappingRuleMatchTypeEquals,
+											cognitoidentity.MappingRuleMatchTypeContains,
+											cognitoidentity.MappingRuleMatchTypeStartsWith,
+											cognitoidentity.MappingRuleMatchTypeNotEqual,
+										}, false),
 									},
 									"role_arn": {
 										Type:         schema.TypeString,
@@ -67,15 +76,18 @@ func resourceAwsCognitoIdentityPoolRolesAttachment() *schema.Resource {
 									"value": {
 										Type:         schema.TypeString,
 										Required:     true,
-										ValidateFunc: validateCognitoRoleMappingsRulesValue,
+										ValidateFunc: validation.StringLenBetween(1, 128),
 									},
 								},
 							},
 						},
 						"type": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validateCognitoRoleMappingsType,
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								cognitoidentity.RoleMappingTypeToken,
+								cognitoidentity.RoleMappingTypeRules,
+							}, false),
 						},
 					},
 				},

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -2018,23 +2018,6 @@ func validateCognitoRoleMappingsRulesConfiguration(v map[string]interface{}) (er
 	return
 }
 
-func validateCognitoRoleMappingsAmbiguousRoleResolution(v interface{}, k string) (ws []string, errors []error) {
-	validValues := []string{
-		cognitoidentity.AmbiguousRoleResolutionTypeAuthenticatedRole,
-		cognitoidentity.AmbiguousRoleResolutionTypeDeny,
-	}
-	value := v.(string)
-	for _, s := range validValues {
-		if value == s {
-			return
-		}
-	}
-	errors = append(errors, fmt.Errorf(
-		"%q contains an invalid value %q. Valid values are %q.",
-		k, value, validValues))
-	return
-}
-
 func validateCognitoRoleMappingsRulesClaim(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 
@@ -2042,55 +2025,6 @@ func validateCognitoRoleMappingsRulesClaim(v interface{}, k string) (ws []string
 		errors = append(errors, fmt.Errorf("%q must contain only alphanumeric characters, dots, underscores, colons, slashes and hyphens", k))
 	}
 
-	return
-}
-
-func validateCognitoRoleMappingsRulesMatchType(v interface{}, k string) (ws []string, errors []error) {
-	validValues := []string{
-		cognitoidentity.MappingRuleMatchTypeEquals,
-		cognitoidentity.MappingRuleMatchTypeContains,
-		cognitoidentity.MappingRuleMatchTypeStartsWith,
-		cognitoidentity.MappingRuleMatchTypeNotEqual,
-	}
-	value := v.(string)
-	for _, s := range validValues {
-		if value == s {
-			return
-		}
-	}
-	errors = append(errors, fmt.Errorf(
-		"%q contains an invalid value %q. Valid values are %q.",
-		k, value, validValues))
-	return
-}
-
-func validateCognitoRoleMappingsRulesValue(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if len(value) < 1 {
-		errors = append(errors, fmt.Errorf("%q cannot be less than 1 character", k))
-	}
-
-	if len(value) > 128 {
-		errors = append(errors, fmt.Errorf("%q cannot be longer than 1 characters", k))
-	}
-
-	return
-}
-
-func validateCognitoRoleMappingsType(v interface{}, k string) (ws []string, errors []error) {
-	validValues := []string{
-		cognitoidentity.RoleMappingTypeToken,
-		cognitoidentity.RoleMappingTypeRules,
-	}
-	value := v.(string)
-	for _, s := range validValues {
-		if value == s {
-			return
-		}
-	}
-	errors = append(errors, fmt.Errorf(
-		"%q contains an invalid value %q. Valid values are %q.",
-		k, value, validValues))
 	return
 }
 

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -2795,64 +2795,6 @@ func TestValidateCognitoRoleMappingsRulesConfiguration(t *testing.T) {
 	}
 }
 
-func TestValidateCognitoRoleMappingsAmbiguousRoleResolution(t *testing.T) {
-	validValues := []string{
-		cognitoidentity.AmbiguousRoleResolutionTypeAuthenticatedRole,
-		cognitoidentity.AmbiguousRoleResolutionTypeDeny,
-	}
-
-	for _, s := range validValues {
-		_, errors := validateCognitoRoleMappingsAmbiguousRoleResolution(s, "ambiguous_role_resolution")
-		if len(errors) > 0 {
-			t.Fatalf("%q should be a valid Cognito Ambiguous Role Resolution type: %v", s, errors)
-		}
-	}
-
-	invalidValues := []string{
-		"foo",
-		"123",
-		"foo-bar",
-		"foo_bar123",
-	}
-
-	for _, s := range invalidValues {
-		_, errors := validateCognitoRoleMappingsAmbiguousRoleResolution(s, "ambiguous_role_resolution")
-		if len(errors) == 0 {
-			t.Fatalf("%q should not be a valid Cognito Ambiguous Role Resolution type: %v", s, errors)
-		}
-	}
-}
-
-func TestValidateCognitoRoleMappingsRulesMatchType(t *testing.T) {
-	validValues := []string{
-		cognitoidentity.MappingRuleMatchTypeEquals,
-		cognitoidentity.MappingRuleMatchTypeContains,
-		cognitoidentity.MappingRuleMatchTypeStartsWith,
-		cognitoidentity.MappingRuleMatchTypeNotEqual,
-	}
-
-	for _, s := range validValues {
-		_, errors := validateCognitoRoleMappingsRulesMatchType(s, "match_type")
-		if len(errors) > 0 {
-			t.Fatalf("%q should be a valid Cognito Role Mappings Rules Match Type: %v", s, errors)
-		}
-	}
-
-	invalidValues := []string{
-		"foo",
-		"123",
-		"foo-bar",
-		"foo_bar123",
-	}
-
-	for _, s := range invalidValues {
-		_, errors := validateCognitoRoleMappingsRulesMatchType(s, "match_type")
-		if len(errors) == 0 {
-			t.Fatalf("%q should not be a valid Cognito Role Mappings Rules Match Type: %v", s, errors)
-		}
-	}
-}
-
 func TestValidateSecurityGroupRuleDescription(t *testing.T) {
 	validDescriptions := []string{
 		"testrule",
@@ -2875,34 +2817,6 @@ func TestValidateSecurityGroupRuleDescription(t *testing.T) {
 		_, errors := validateSecurityGroupRuleDescription(v, "description")
 		if len(errors) == 0 {
 			t.Fatalf("%q should be an invalid security group rule description", v)
-		}
-	}
-}
-
-func TestValidateCognitoRoleMappingsType(t *testing.T) {
-	validValues := []string{
-		cognitoidentity.RoleMappingTypeToken,
-		cognitoidentity.RoleMappingTypeRules,
-	}
-
-	for _, s := range validValues {
-		_, errors := validateCognitoRoleMappingsType(s, "match_type")
-		if len(errors) > 0 {
-			t.Fatalf("%q should be a valid Cognito Role Mappings Type: %v", s, errors)
-		}
-	}
-
-	invalidValues := []string{
-		"foo",
-		"123",
-		"foo-bar",
-		"foo_bar123",
-	}
-
-	for _, s := range invalidValues {
-		_, errors := validateCognitoRoleMappingsType(s, "match_type")
-		if len(errors) == 0 {
-			t.Fatalf("%q should not be a valid Cognito Role Mappings Type: %v", s, errors)
 		}
 	}
 }


### PR DESCRIPTION
It's a serie of PRs to drop custom `ValidateFunc`. The goal is to use existing functions in `validation` package as much as possible. To minimize the scope and make it easy for review, one PR will be created per resource or data source.

This PR is for:

- [x] resource/cognito_identity_pool_roles_attachment
   + role_mapping.ambiguous_role_resolution
   + role_mapping.mapping_rule.match_type
   + role_mapping.mapping_rule.value
   + role_mapping.type