### PR TITLE
resource/cognito_user_pool_*: drop custom ValidateFuncs

### DIFF
--- a/aws/resource_aws_cognito_user_pool.go
+++ b/aws/resource_aws_cognito_user_pool.go
@@ -68,7 +68,7 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 							Type:         schema.TypeInt,
 							Optional:     true,
 							Default:      7,
-							ValidateFunc: validateIntegerInRange(0, 90),
+							ValidateFunc: validation.IntBetween(0, 90),
 						},
 					},
 				},
@@ -79,8 +79,12 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 				Elem: &schema.Schema{
-					Type:         schema.TypeString,
-					ValidateFunc: validateCognitoUserPoolAliasAttribute,
+					Type: schema.TypeString,
+					ValidateFunc: validation.StringInSlice([]string{
+						cognitoidentityprovider.AliasAttributeTypeEmail,
+						cognitoidentityprovider.AliasAttributeTypePhoneNumber,
+						cognitoidentityprovider.AliasAttributeTypePreferredUsername,
+					}, false),
 				},
 				ConflictsWith: []string{"username_attributes"},
 			},
@@ -94,8 +98,11 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
-					Type:         schema.TypeString,
-					ValidateFunc: validateCognitoUserPoolAutoVerifiedAttribute,
+					Type: schema.TypeString,
+					ValidateFunc: validation.StringInSlice([]string{
+						cognitoidentityprovider.VerifiedAttributeTypePhoneNumber,
+						cognitoidentityprovider.VerifiedAttributeTypeEmail,
+					}, false),
 				},
 			},
 
@@ -218,10 +225,14 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 			},
 
 			"mfa_configuration": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Default:      cognitoidentityprovider.UserPoolMfaTypeOff,
-				ValidateFunc: validateCognitoUserPoolMfaConfiguration,
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  cognitoidentityprovider.UserPoolMfaTypeOff,
+				ValidateFunc: validation.StringInSlice([]string{
+					cognitoidentityprovider.UserPoolMfaTypeOff,
+					cognitoidentityprovider.UserPoolMfaTypeOn,
+					cognitoidentityprovider.UserPoolMfaTypeOptional,
+				}, false),
 			},
 
 			"name": {
@@ -240,7 +251,7 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 						"minimum_length": {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							ValidateFunc: validateIntegerInRange(6, 99),
+							ValidateFunc: validation.IntBetween(6, 99),
 						},
 						"require_lowercase": {
 							Type:     schema.TypeBool,
@@ -390,10 +401,13 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"default_email_option": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Default:      cognitoidentityprovider.DefaultEmailOptionTypeConfirmWithCode,
-							ValidateFunc: validateCognitoUserPoolTemplateDefaultEmailOption,
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  cognitoidentityprovider.DefaultEmailOptionTypeConfirmWithCode,
+							ValidateFunc: validation.StringInSlice([]string{
+								cognitoidentityprovider.DefaultEmailOptionTypeConfirmWithLink,
+								cognitoidentityprovider.DefaultEmailOptionTypeConfirmWithCode,
+							}, false),
 						},
 						"email_message": {
 							Type:         schema.TypeString,

--- a/aws/resource_aws_cognito_user_pool_client.go
+++ b/aws/resource_aws_cognito_user_pool_client.go
@@ -78,7 +78,7 @@ func resourceAwsCognitoUserPoolClient() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Default:      30,
-				ValidateFunc: validateIntegerInRange(0, 3650),
+				ValidateFunc: validation.IntBetween(0, 3650),
 			},
 
 			"allowed_oauth_flows": {

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1455,21 +1455,6 @@ func validateCognitoUserPoolId(v interface{}, k string) (ws []string, es []error
 	return
 }
 
-func validateCognitoUserPoolMfaConfiguration(v interface{}, k string) (ws []string, es []error) {
-	value := v.(string)
-
-	valid := map[string]bool{
-		cognitoidentityprovider.UserPoolMfaTypeOff:      true,
-		cognitoidentityprovider.UserPoolMfaTypeOn:       true,
-		cognitoidentityprovider.UserPoolMfaTypeOptional: true,
-	}
-	if !valid[value] {
-		es = append(es, fmt.Errorf(
-			"%q must be equal to OFF, ON, or OPTIONAL", k))
-	}
-	return
-}
-
 func validateCognitoUserPoolSmsAuthenticationMessage(v interface{}, k string) (ws []string, es []error) {
 	value := v.(string)
 	if len(value) < 6 {
@@ -1502,41 +1487,6 @@ func validateCognitoUserPoolSmsVerificationMessage(v interface{}, k string) (ws 
 	return
 }
 
-func validateCognitoUserPoolAliasAttribute(v interface{}, k string) (ws []string, es []error) {
-	validValues := []string{
-		cognitoidentityprovider.AliasAttributeTypeEmail,
-		cognitoidentityprovider.AliasAttributeTypePhoneNumber,
-		cognitoidentityprovider.AliasAttributeTypePreferredUsername,
-	}
-	period := v.(string)
-	for _, f := range validValues {
-		if period == f {
-			return
-		}
-	}
-	es = append(es, fmt.Errorf(
-		"%q contains an invalid alias attribute %q. Valid alias attributes are %q.",
-		k, period, validValues))
-	return
-}
-
-func validateCognitoUserPoolAutoVerifiedAttribute(v interface{}, k string) (ws []string, es []error) {
-	validValues := []string{
-		cognitoidentityprovider.VerifiedAttributeTypePhoneNumber,
-		cognitoidentityprovider.VerifiedAttributeTypeEmail,
-	}
-	period := v.(string)
-	for _, f := range validValues {
-		if period == f {
-			return
-		}
-	}
-	es = append(es, fmt.Errorf(
-		"%q contains an invalid verified attribute %q. Valid verified attributes are %q.",
-		k, period, validValues))
-	return
-}
-
 func validateCognitoUserPoolClientAuthFlows(v interface{}, k string) (ws []string, es []error) {
 	validValues := []string{
 		cognitoidentityprovider.AuthFlowTypeAdminNoSrpAuth,
@@ -1550,23 +1500,6 @@ func validateCognitoUserPoolClientAuthFlows(v interface{}, k string) (ws []strin
 	}
 	es = append(es, fmt.Errorf(
 		"%q contains an invalid auth flow %q. Valid auth flows are %q.",
-		k, period, validValues))
-	return
-}
-
-func validateCognitoUserPoolTemplateDefaultEmailOption(v interface{}, k string) (ws []string, es []error) {
-	validValues := []string{
-		cognitoidentityprovider.DefaultEmailOptionTypeConfirmWithLink,
-		cognitoidentityprovider.DefaultEmailOptionTypeConfirmWithCode,
-	}
-	period := v.(string)
-	for _, f := range validValues {
-		if period == f {
-			return
-		}
-	}
-	es = append(es, fmt.Errorf(
-		"%q contains an invalid template default email option %q. Valid template default email options are %q.",
 		k, period, validValues))
 	return
 }


### PR DESCRIPTION
It's a serie of PRs to drop custom `ValidateFunc`. The goal is to use existing functions in `validation` package as much as possible. To minimize the scope and make it easy for review, one PR will be created per resource or data source.

This PR is for:

- [x] resource/cognito_user_pool
+ admin_create_user_config.unused_account_validity_days
+ alias_attributes
+ auto_verified_attributes
+ mfa_configuration
+ password_policy.minimum_length
+ verification_message_template.default_email_option

- [x] resource/cognito_user_pool_client
+ refresh_token_validity