### PR TITLE
resource/dms_*: drop custom ValidateFuncs

### DIFF
--- a/aws/resource_aws_dms_endpoint.go
+++ b/aws/resource_aws_dms_endpoint.go
@@ -53,8 +53,8 @@ func resourceAwsDmsEndpoint() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					"source",
-					"target",
+					dms.ReplicationEndpointTypeValueSource,
+					dms.ReplicationEndpointTypeValueTarget,
 				}, false),
 			},
 			"engine_name": {
@@ -103,10 +103,10 @@ func resourceAwsDmsEndpoint() *schema.Resource {
 				Computed: true,
 				Optional: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					"none",
-					"require",
-					"verify-ca",
-					"verify-full",
+					dms.DmsSslModeValueNone,
+					dms.DmsSslModeValueRequire,
+					dms.DmsSslModeValueVerifyCa,
+					dms.DmsSslModeValueVerifyFull,
 				}, false),
 			},
 			"tags": {

--- a/aws/resource_aws_dms_replication_instance.go
+++ b/aws/resource_aws_dms_replication_instance.go
@@ -10,6 +10,7 @@ import (
 	dms "github.com/aws/aws-sdk-go/service/databasemigrationservice"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsDmsReplicationInstance() *schema.Resource {
@@ -34,7 +35,7 @@ func resourceAwsDmsReplicationInstance() *schema.Resource {
 				Type:         schema.TypeInt,
 				Computed:     true,
 				Optional:     true,
-				ValidateFunc: validateIntegerInRange(5, 6144),
+				ValidateFunc: validation.IntBetween(5, 6144),
 			},
 			"apply_immediately": {
 				Type:     schema.TypeBool,

--- a/aws/resource_aws_dms_replication_task.go
+++ b/aws/resource_aws_dms_replication_task.go
@@ -35,9 +35,9 @@ func resourceAwsDmsReplicationTask() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					"full-load",
-					"cdc",
-					"full-load-and-cdc",
+					dms.MigrationTypeValueFullLoad,
+					dms.MigrationTypeValueCdc,
+					dms.MigrationTypeValueFullLoadAndCdc,
 				}, false),
 			},
 			"replication_instance_arn": {


### PR DESCRIPTION
It's a serie of PRs to drop custom `ValidateFunc`. The goal is to use existing functions in `validation` package as much as possible. To minimize the scope and make it easy for review, one PR will be created per resource or data source.

This PR is for:

- [x] resource/dms_endpoint
- [x] resource/dms_endpoint_instance
- [x] resource/dms_replication_task
