### PR TITLE
resource/dx_*: drop custom ValidateFunc for bandwidth

### DIFF
--- a/aws/resource_aws_dx_connection.go
+++ b/aws/resource_aws_dx_connection.go
@@ -36,7 +36,7 @@ func resourceAwsDxConnection() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validateDxConnectionBandWidth,
+				ValidateFunc: validateDxConnectionBandWidth(),
 			},
 			"location": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_dx_lag.go
+++ b/aws/resource_aws_dx_lag.go
@@ -35,7 +35,7 @@ func resourceAwsDxLag() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validateDxConnectionBandWidth,
+				ValidateFunc: validateDxConnectionBandWidth(),
 			},
 			"location": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_dynamodb_table.go
+++ b/aws/resource_aws_dynamodb_table.go
@@ -88,9 +88,13 @@ func resourceAwsDynamoDbTable() *schema.Resource {
 							Required: true,
 						},
 						"type": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validateDynamoAttributeType,
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								dynamodb.ScalarAttributeTypeB,
+								dynamodb.ScalarAttributeTypeN,
+								dynamodb.ScalarAttributeTypeS,
+							}, false),
 						},
 					},
 				},

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1844,22 +1844,8 @@ func validateCognitoUserPoolDomain(v interface{}, k string) (ws []string, errors
 	return
 }
 
-func validateDxConnectionBandWidth(v interface{}, k string) (ws []string, errors []error) {
-	val, ok := v.(string)
-	if !ok {
-		errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
-		return
-	}
-
-	validBandWidth := []string{"1Gbps", "10Gbps"}
-	for _, str := range validBandWidth {
-		if val == str {
-			return
-		}
-	}
-
-	errors = append(errors, fmt.Errorf("expected %s to be one of %v, got %s", k, validBandWidth, val))
-	return
+func validateDxConnectionBandWidth() schema.SchemaValidateFunc {
+	return validation.StringInSlice([]string{"1Gbps", "10Gbps"}, false)
 }
 
 func validateKmsKey(v interface{}, k string) (ws []string, errors []error) {

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/cognitoidentity"
 	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
 	"github.com/aws/aws-sdk-go/service/configservice"
-	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/gamelift"
 	"github.com/aws/aws-sdk-go/service/guardduty"
@@ -188,25 +187,6 @@ func validateDbParamGroupNamePrefix(v interface{}, k string) (ws []string, error
 		errors = append(errors, fmt.Errorf(
 			"%q cannot be greater than 226 characters", k))
 	}
-	return
-}
-
-func validateDynamoAttributeType(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	validTypes := []string{
-		dynamodb.ScalarAttributeTypeB,
-		dynamodb.ScalarAttributeTypeN,
-		dynamodb.ScalarAttributeTypeS,
-	}
-
-	for _, t := range validTypes {
-		if t == value {
-			return
-		}
-	}
-
-	errors = append(errors, fmt.Errorf("%q must be a valid DynamoDB attribute type", k))
-
 	return
 }
 

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -2730,33 +2730,6 @@ func TestValidateCognitoRoles(t *testing.T) {
 	}
 }
 
-func TestValidateDxConnectionBandWidth(t *testing.T) {
-	validValues := []string{
-		"1Gbps",
-		"10Gbps",
-	}
-
-	for _, s := range validValues {
-		_, errors := validateDxConnectionBandWidth(s, "match_type")
-		if len(errors) > 0 {
-			t.Fatalf("%s should be a valid Direct Connect Connection Bandwidth: %v", s, errors)
-		}
-	}
-
-	invalidValues := []string{
-		"1gbps",
-		"10GBPS",
-		"invalid character",
-	}
-
-	for _, s := range invalidValues {
-		_, errors := validateDxConnectionBandWidth(s, "match_type")
-		if len(errors) == 0 {
-			t.Fatalf("%s should not be a valid Direct Connect Connection Bandwidth: %v", s, errors)
-		}
-	}
-}
-
 func TestValidateKmsKey(t *testing.T) {
 	cases := []struct {
 		Value    string

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -1860,25 +1860,6 @@ func TestValidateApiGatewayUsagePlanQuotaSettings(t *testing.T) {
 	}
 }
 
-func TestValidateDynamoAttributeType(t *testing.T) {
-	validTypes := []string{"B", "N", "S"}
-
-	for _, s := range validTypes {
-		_, errors := validateDynamoAttributeType(s, "attribute")
-		if len(errors) > 0 {
-			t.Fatalf("%q should be a valid DynamoDB Attribute Type: %v", s, errors)
-		}
-	}
-
-	invalidTypes := []string{"A", "0", "DERP", "SO"}
-	for _, s := range invalidTypes {
-		_, errors := validateDynamoAttributeType(s, "attribute")
-		if len(errors) == 0 {
-			t.Fatalf("%q should not be a valid DynamoDB Attribute Type", s)
-		}
-	}
-}
-
 func TestValidateElbName(t *testing.T) {
 	validNames := []string{
 		"tf-test-elb",


### PR DESCRIPTION
It's a serie of PRs to drop custom `ValidateFunc`. The goal is to use existing functions in `validation` package as much as possible. To minimize the scope and make it easy for review, one PR will be created per resource or data source.

This PR is for:

- [x] resource/dx_connection
- [x] resource/dx_lag
- [x] resource/dynamodb_table(included here by mistake:sweat_smile:)