### PR TITLE
resource/ecs_*: drop custom ValidateFuncs

### DIFF
--- a/aws/resource_aws_ecs_service.go
+++ b/aws/resource_aws_ecs_service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 var taskDefinitionRE = regexp.MustCompile("^([a-zA-Z0-9_-]+):([0-9]+)$")
@@ -54,7 +55,7 @@ func resourceAwsEcsService() *schema.Resource {
 			"health_check_grace_period_seconds": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				ValidateFunc: validateAwsEcsServiceHealthCheckGracePeriodSeconds,
+				ValidateFunc: validation.IntBetween(0, 1800),
 			},
 
 			"launch_type": {
@@ -700,12 +701,4 @@ func parseTaskDefinition(taskDefinition string) (string, string, error) {
 	}
 
 	return matches[0][1], matches[0][2], nil
-}
-
-func validateAwsEcsServiceHealthCheckGracePeriodSeconds(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(int)
-	if (value < 0) || (value > 1800) {
-		errors = append(errors, fmt.Errorf("%q must be between 0 and 1800", k))
-	}
-	return
 }

--- a/aws/resource_aws_ecs_service_test.go
+++ b/aws/resource_aws_ecs_service_test.go
@@ -254,12 +254,12 @@ func TestAccAWSEcsService_healthCheckGracePeriodSeconds(t *testing.T) {
 			{
 				Config: testAccAWSEcsService_healthCheckGracePeriodSeconds(vpcNameTag, clusterName, tdName,
 					roleName, policyName, tgName, lbName, svcName, -1),
-				ExpectError: regexp.MustCompile(`must be between 0 and 1800`),
+				ExpectError: regexp.MustCompile(`expected health_check_grace_period_seconds to be in the range`),
 			},
 			{
 				Config: testAccAWSEcsService_healthCheckGracePeriodSeconds(vpcNameTag, clusterName, tdName,
 					roleName, policyName, tgName, lbName, svcName, 1801),
-				ExpectError: regexp.MustCompile(`must be between 0 and 1800`),
+				ExpectError: regexp.MustCompile(`expected health_check_grace_period_seconds to be in the range`),
 			},
 			{
 				Config: testAccAWSEcsService_healthCheckGracePeriodSeconds(vpcNameTag, clusterName, tdName,

--- a/aws/resource_aws_ecs_task_definition.go
+++ b/aws/resource_aws_ecs_task_definition.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/structure"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsEcsTaskDefinition() *schema.Resource {
@@ -79,11 +79,16 @@ func resourceAwsEcsTaskDefinition() *schema.Resource {
 			},
 
 			"network_mode": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: validateAwsEcsTaskDefinitionNetworkMode,
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					ecs.NetworkModeBridge,
+					ecs.NetworkModeHost,
+					ecs.NetworkModeAwsvpc,
+					ecs.NetworkModeNone,
+				}, false),
 			},
 
 			"volume": {
@@ -137,21 +142,6 @@ func resourceAwsEcsTaskDefinition() *schema.Resource {
 			},
 		},
 	}
-}
-
-func validateAwsEcsTaskDefinitionNetworkMode(v interface{}, k string) (ws []string, errors []error) {
-	value := strings.ToLower(v.(string))
-	validTypes := map[string]struct{}{
-		"bridge": {},
-		"host":   {},
-		"awsvpc": {},
-		"none":   {},
-	}
-
-	if _, ok := validTypes[value]; !ok {
-		errors = append(errors, fmt.Errorf("ECS Task Definition network_mode %q is invalid, must be `bridge`, `host`, `awsvpc` or `none`", value))
-	}
-	return
 }
 
 func validateAwsEcsTaskDefinitionContainerDefinitions(v interface{}, k string) (ws []string, errors []error) {

--- a/aws/resource_aws_ecs_task_definition_test.go
+++ b/aws/resource_aws_ecs_task_definition_test.go
@@ -279,31 +279,6 @@ func testAccCheckAWSTaskDefinitionConstraintsAttrs(def *ecs.TaskDefinition) reso
 		return nil
 	}
 }
-func TestValidateAwsEcsTaskDefinitionNetworkMode(t *testing.T) {
-	validNames := []string{
-		"bridge",
-		"host",
-		"none",
-	}
-	for _, v := range validNames {
-		_, errors := validateAwsEcsTaskDefinitionNetworkMode(v, "network_mode")
-		if len(errors) != 0 {
-			t.Fatalf("%q should be a valid AWS ECS Task Definition Network Mode: %q", v, errors)
-		}
-	}
-
-	invalidNames := []string{
-		"bridged",
-		"-docker",
-	}
-	for _, v := range invalidNames {
-		_, errors := validateAwsEcsTaskDefinitionNetworkMode(v, "network_mode")
-		if len(errors) == 0 {
-			t.Fatalf("%q should be an invalid AWS ECS Task Definition Network Mode", v)
-		}
-	}
-}
-
 func TestValidateAwsEcsTaskDefinitionContainerDefinitions(t *testing.T) {
 	validDefinitions := []string{
 		testValidateAwsEcsTaskDefinitionValidContainerDefinitions,


### PR DESCRIPTION
It's a serie of PRs to drop custom `ValidateFunc`. The goal is to use existing functions in `validation` package as much as possible. To minimize the scope and make it easy for review, one PR will be created per resource or data source.

This PR is for:

- [x] resource/ecs_service
- [x] resource/ecs_task_definition