### PR TITLE
resource/efs_file_system: drop custom ValidateFunc for performance_mode

### DIFF
--- a/aws/resource_aws_efs_file_system.go
+++ b/aws/resource_aws_efs_file_system.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/efs"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsEfsFileSystem() *schema.Resource {
@@ -42,11 +43,14 @@ func resourceAwsEfsFileSystem() *schema.Resource {
 			},
 
 			"performance_mode": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: validatePerformanceModeType,
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					efs.PerformanceModeGeneralPurpose,
+					efs.PerformanceModeMaxIo,
+				}, false),
 			},
 
 			"encrypted": {
@@ -296,16 +300,6 @@ func validateReferenceName(v interface{}, k string) (ws []string, errors []error
 	if len(creationToken) > 64 {
 		errors = append(errors, fmt.Errorf(
 			"%q cannot take the Creation Token over the limit of 64 characters: %q", k, value))
-	}
-	return
-}
-
-func validatePerformanceModeType(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if value != efs.PerformanceModeGeneralPurpose && value != efs.PerformanceModeMaxIo {
-		errors = append(errors, fmt.Errorf(
-			"%q contains an invalid Performance Mode %q. Valid modes are either %q or %q.",
-			k, value, efs.PerformanceModeGeneralPurpose, efs.PerformanceModeMaxIo))
 	}
 	return
 }

--- a/aws/resource_aws_efs_file_system_test.go
+++ b/aws/resource_aws_efs_file_system_test.go
@@ -32,34 +32,6 @@ func TestResourceAWSEFSFileSystem_validateReferenceName(t *testing.T) {
 	}
 }
 
-func TestResourceAWSEFSFileSystem_validatePerformanceModeType(t *testing.T) {
-	_, errors := validatePerformanceModeType("incorrect", "performance_mode")
-	if len(errors) == 0 {
-		t.Fatalf("Expected to trigger a validation error")
-	}
-
-	var testCases = []struct {
-		Value    string
-		ErrCount int
-	}{
-		{
-			Value:    "generalPurpose",
-			ErrCount: 0,
-		},
-		{
-			Value:    "maxIO",
-			ErrCount: 0,
-		},
-	}
-
-	for _, tc := range testCases {
-		_, errors := validatePerformanceModeType(tc.Value, "performance_mode")
-		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected not to trigger a validation error")
-		}
-	}
-}
-
 func TestResourceAWSEFSFileSystem_hasEmptyFileSystems(t *testing.T) {
 	fs := &efs.DescribeFileSystemsOutput{
 		FileSystems: []*efs.FileSystemDescription{},


### PR DESCRIPTION
It's a serie of PRs to drop custom `ValidateFunc`. The goal is to use existing functions in `validation` package as much as possible. To minimize the scope and make it easy for review, one PR will be created per resource or data source.

This PR is for:

- [x] resource/efs_file_system