### PR TITLE
resource/elasticache_cluster: drop custom ValidateFunc for snapshot_retention_limit

### DIFF
--- a/aws/resource_aws_elasticache_cluster.go
+++ b/aws/resource_aws_elasticache_cluster.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsElastiCacheCommonSchema() map[string]*schema.Schema {
@@ -110,16 +111,9 @@ func resourceAwsElastiCacheCommonSchema() map[string]*schema.Schema {
 		},
 
 		"snapshot_retention_limit": {
-			Type:     schema.TypeInt,
-			Optional: true,
-			ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
-				value := v.(int)
-				if value > 35 {
-					es = append(es, fmt.Errorf(
-						"snapshot retention limit cannot be more than 35 days"))
-				}
-				return
-			},
+			Type:         schema.TypeInt,
+			Optional:     true,
+			ValidateFunc: validation.IntAtMost(35),
 		},
 
 		"apply_immediately": {


### PR DESCRIPTION
It's a serie of PRs to drop custom `ValidateFunc`. The goal is to use existing functions in `validation` package as much as possible. To minimize the scope and make it easy for review, one PR will be created per resource or data source.

This PR is for:

- [x] resource/elasticache_cluster