### PR TITLE
resource/elb: drop custom ValidateFunc for protocol and int

### DIFF
--- a/aws/resource_aws_elb.go
+++ b/aws/resource_aws_elb.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsElb() *schema.Resource {
@@ -110,7 +111,7 @@ func resourceAwsElb() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Default:      60,
-				ValidateFunc: validateIntegerInRange(1, 4000),
+				ValidateFunc: validation.IntBetween(1, 4000),
 			},
 
 			"connection_draining": &schema.Schema{
@@ -162,25 +163,25 @@ func resourceAwsElb() *schema.Resource {
 						"instance_port": &schema.Schema{
 							Type:         schema.TypeInt,
 							Required:     true,
-							ValidateFunc: validateIntegerInRange(1, 65535),
+							ValidateFunc: validation.IntBetween(1, 65535),
 						},
 
 						"instance_protocol": &schema.Schema{
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: validateListenerProtocol,
+							ValidateFunc: validateListenerProtocol(),
 						},
 
 						"lb_port": &schema.Schema{
 							Type:         schema.TypeInt,
 							Required:     true,
-							ValidateFunc: validateIntegerInRange(1, 65535),
+							ValidateFunc: validation.IntBetween(1, 65535),
 						},
 
 						"lb_protocol": &schema.Schema{
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: validateListenerProtocol,
+							ValidateFunc: validateListenerProtocol(),
 						},
 
 						"ssl_certificate_id": &schema.Schema{
@@ -203,13 +204,13 @@ func resourceAwsElb() *schema.Resource {
 						"healthy_threshold": &schema.Schema{
 							Type:         schema.TypeInt,
 							Required:     true,
-							ValidateFunc: validateIntegerInRange(2, 10),
+							ValidateFunc: validation.IntBetween(2, 10),
 						},
 
 						"unhealthy_threshold": &schema.Schema{
 							Type:         schema.TypeInt,
 							Required:     true,
-							ValidateFunc: validateIntegerInRange(2, 10),
+							ValidateFunc: validation.IntBetween(2, 10),
 						},
 
 						"target": &schema.Schema{
@@ -221,13 +222,13 @@ func resourceAwsElb() *schema.Resource {
 						"interval": &schema.Schema{
 							Type:         schema.TypeInt,
 							Required:     true,
-							ValidateFunc: validateIntegerInRange(5, 300),
+							ValidateFunc: validation.IntBetween(5, 300),
 						},
 
 						"timeout": &schema.Schema{
 							Type:         schema.TypeInt,
 							Required:     true,
-							ValidateFunc: validateIntegerInRange(2, 60),
+							ValidateFunc: validation.IntBetween(2, 60),
 						},
 					},
 				},
@@ -965,18 +966,6 @@ func validateHeathCheckTarget(v interface{}, k string) (ws []string, errors []er
 	return
 }
 
-func validateListenerProtocol(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-
-	if !isValidProtocol(value) {
-		errors = append(errors, fmt.Errorf(
-			"%q contains an invalid Listener protocol %q. "+
-				"Valid protocols are either %q, %q, %q, or %q.",
-			k, value, "TCP", "SSL", "HTTP", "HTTPS"))
-	}
-	return
-}
-
 func isValidProtocol(s string) bool {
 	if s == "" {
 		return false
@@ -995,6 +984,15 @@ func isValidProtocol(s string) bool {
 	}
 
 	return true
+}
+
+func validateListenerProtocol() schema.SchemaValidateFunc {
+	return validation.StringInSlice([]string{
+		"HTTP",
+		"HTTPS",
+		"SSL",
+		"TCP",
+	}, true)
 }
 
 // ELB automatically creates ENI(s) on creation

--- a/aws/resource_aws_elb_test.go
+++ b/aws/resource_aws_elb_test.go
@@ -909,57 +909,6 @@ func TestResourceAWSELB_validateAccessLogsInterval(t *testing.T) {
 
 }
 
-func TestResourceAWSELB_validateListenerProtocol(t *testing.T) {
-	type testCases struct {
-		Value    string
-		ErrCount int
-	}
-
-	invalidCases := []testCases{
-		{
-			Value:    "",
-			ErrCount: 1,
-		},
-		{
-			Value:    "incorrect",
-			ErrCount: 1,
-		},
-		{
-			Value:    "HTTP:",
-			ErrCount: 1,
-		},
-	}
-
-	for _, tc := range invalidCases {
-		_, errors := validateListenerProtocol(tc.Value, "protocol")
-		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected %q to trigger a validation error.", tc.Value)
-		}
-	}
-
-	validCases := []testCases{
-		{
-			Value:    "TCP",
-			ErrCount: 0,
-		},
-		{
-			Value:    "ssl",
-			ErrCount: 0,
-		},
-		{
-			Value:    "HTTP",
-			ErrCount: 0,
-		},
-	}
-
-	for _, tc := range validCases {
-		_, errors := validateListenerProtocol(tc.Value, "protocol")
-		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected %q not to trigger a validation error.", tc.Value)
-		}
-	}
-}
-
 func TestResourceAWSELB_validateHealthCheckTarget(t *testing.T) {
 	type testCase struct {
 		Value    string


### PR DESCRIPTION
It's a serie of PRs to drop custom `ValidateFunc`. The goal is to use existing functions in `validation` package as much as possible. To minimize the scope and make it easy for review, one PR will be created per resource or data source.

This PR is for:

- [x] resource/elb