### PR TITLE
resource/emr_*: drop custom ValidateFuncs

### DIFF
--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -198,7 +198,7 @@ func resourceAwsEMRCluster() *schema.Resource {
 									"type": {
 										Type:         schema.TypeString,
 										Required:     true,
-										ValidateFunc: validateAwsEmrEbsVolumeType,
+										ValidateFunc: validateAwsEmrEbsVolumeType(),
 									},
 									"volumes_per_instance": {
 										Type:     schema.TypeInt,
@@ -224,9 +224,13 @@ func resourceAwsEMRCluster() *schema.Resource {
 							},
 						},
 						"instance_role": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validateAwsEmrInstanceGroupRole,
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								emr.InstanceFleetTypeMaster,
+								emr.InstanceFleetTypeCore,
+								emr.InstanceFleetTypeTask,
+							}, false),
 						},
 						"instance_type": {
 							Type:     schema.TypeString,

--- a/aws/resource_aws_emr_instance_group.go
+++ b/aws/resource_aws_emr_instance_group.go
@@ -72,7 +72,7 @@ func resourceAwsEMRInstanceGroup() *schema.Resource {
 						"type": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: validateAwsEmrEbsVolumeType,
+							ValidateFunc: validateAwsEmrEbsVolumeType(),
 						},
 						"volumes_per_instance": {
 							Type:     schema.TypeInt,

--- a/aws/resource_aws_emr_security_configuration.go
+++ b/aws/resource_aws_emr_security_configuration.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -20,33 +19,19 @@ func resourceAwsEMRSecurityConfiguration() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Computed:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name_prefix"},
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(string)
-					if len(value) > 10280 {
-						errors = append(errors, fmt.Errorf(
-							"%q cannot be longer than 10280 characters", k))
-					}
-					return
-				},
+				ValidateFunc:  validateMaxLength(10280),
 			},
-			"name_prefix": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(string)
-					if len(value) > 10000 {
-						errors = append(errors, fmt.Errorf(
-							"%q cannot be longer than 10000 characters, name is limited to 10280", k))
-					}
-					return
-				},
+			"name_prefix": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateMaxLength(10280 - resource.UniqueIDSuffixLength),
 			},
 
 			"configuration": {

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -741,36 +741,12 @@ func validateAwsEcsPlacementStrategy(stratType, stratField string) error {
 	return nil
 }
 
-func validateAwsEmrEbsVolumeType(v interface{}, k string) (ws []string, errors []error) {
-	validTypes := map[string]struct{}{
-		"gp2":      {},
-		"io1":      {},
-		"standard": {},
-	}
-
-	value := v.(string)
-
-	if _, ok := validTypes[value]; !ok {
-		errors = append(errors, fmt.Errorf(
-			"%q must be one of ['gp2', 'io1', 'standard']", k))
-	}
-	return
-}
-
-func validateAwsEmrInstanceGroupRole(v interface{}, k string) (ws []string, errors []error) {
-	validRoles := map[string]struct{}{
-		"MASTER": {},
-		"CORE":   {},
-		"TASK":   {},
-	}
-
-	value := v.(string)
-
-	if _, ok := validRoles[value]; !ok {
-		errors = append(errors, fmt.Errorf(
-			"%q must be one of ['MASTER', 'CORE', 'TASK']", k))
-	}
-	return
+func validateAwsEmrEbsVolumeType() schema.SchemaValidateFunc {
+	return validation.StringInSlice([]string{
+		"gp2",
+		"io1",
+		"standard",
+	}, false)
 }
 
 func validateAwsEmrCustomAmiId(v interface{}, k string) (ws []string, errors []error) {

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -1132,50 +1132,6 @@ func TestValidateStepFunctionStateMachineName(t *testing.T) {
 	}
 }
 
-func TestValidateEmrEbsVolumeType(t *testing.T) {
-	cases := []struct {
-		VolType  string
-		ErrCount int
-	}{
-		{
-			VolType:  "gp2",
-			ErrCount: 0,
-		},
-		{
-			VolType:  "io1",
-			ErrCount: 0,
-		},
-		{
-			VolType:  "standard",
-			ErrCount: 0,
-		},
-		{
-			VolType:  "stand",
-			ErrCount: 1,
-		},
-		{
-			VolType:  "io",
-			ErrCount: 1,
-		},
-		{
-			VolType:  "gp1",
-			ErrCount: 1,
-		},
-		{
-			VolType:  "fast-disk",
-			ErrCount: 1,
-		},
-	}
-
-	for _, tc := range cases {
-		_, errors := validateAwsEmrEbsVolumeType(tc.VolType, "volume")
-
-		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected %d errors, got %d: %s", tc.ErrCount, len(errors), errors)
-		}
-	}
-}
-
 func TestValidateEmrCustomAmiId(t *testing.T) {
 	cases := []struct {
 		Value    string


### PR DESCRIPTION
It's a serie of PRs to drop custom `ValidateFunc`. The goal is to use existing functions in `validation` package as much as possible. To minimize the scope and make it easy for review, one PR will be created per resource or data source.

Acceptance tests might fail since I didn't run any of them at all. I'll fix it if you find any error during review.

This PR is for:

- [x] resource/emr_cluster
- [x] resource/emr_instance_group
- [x] resource/emr_instance_security_configuration