### PR TITLE
resource/gamelift_build: drop custom ValidateFunc for operating_system

### DIFF
--- a/aws/resource_aws_gamelift_build.go
+++ b/aws/resource_aws_gamelift_build.go
@@ -25,10 +25,13 @@ func resourceAwsGameliftBuild() *schema.Resource {
 				ValidateFunc: validation.StringLenBetween(1, 1024),
 			},
 			"operating_system": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validateGameliftOperatingSystem,
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					gamelift.OperatingSystemAmazonLinux,
+					gamelift.OperatingSystemWindows2012,
+				}, false),
 			},
 			"storage_location": {
 				Type:     schema.TypeList,

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -16,7 +16,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/configservice"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/gamelift"
 	"github.com/aws/aws-sdk-go/service/guardduty"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -1887,19 +1886,6 @@ func validateAwsElastiCacheReplicationGroupAuthToken(v interface{}, k string) (w
 	if !regexp.MustCompile(`^[^@"\/]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
 			"only alphanumeric characters or symbols (excluding @, \", and /) allowed in %q", k))
-	}
-	return
-}
-
-func validateGameliftOperatingSystem(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	operatingSystems := map[string]bool{
-		gamelift.OperatingSystemAmazonLinux: true,
-		gamelift.OperatingSystemWindows2012: true,
-	}
-
-	if !operatingSystems[value] {
-		errors = append(errors, fmt.Errorf("%q must be a valid operating system value: %q", k, value))
 	}
 	return
 }


### PR DESCRIPTION
It's a serie of PRs to drop custom `ValidateFunc`. The goal is to use existing functions in `validation` package as much as possible. To minimize the scope and make it easy for review, one PR will be created per resource or data source.

Acceptance tests might fail since I didn't run any of them at all. I'll fix it if you find any error during review.

This PR is for:

- [x] resource/gamelift_build