### PR TITLE
resource/iam_*: drop custom ValidateFuncs

### DIFF
--- a/aws/data_source_aws_iam_server_certificate.go
+++ b/aws/data_source_aws_iam_server_certificate.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -32,7 +33,7 @@ func dataSourceAwsIAMServerCertificate() *schema.Resource {
 				Optional:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name"},
-				ValidateFunc:  validateMaxLength(128 - 26),
+				ValidateFunc:  validateMaxLength(128 - resource.UniqueIDSuffixLength),
 			},
 
 			"latest": {
@@ -101,7 +102,7 @@ func dataSourceAwsIAMServerCertificateRead(d *schema.ResourceData, meta interfac
 		}
 	}
 
-	var metadatas = []*iam.ServerCertificateMetadata{}
+	var metadatas []*iam.ServerCertificateMetadata
 	log.Printf("[DEBUG] Reading IAM Server Certificate")
 	err := iamconn.ListServerCertificatesPages(&iam.ListServerCertificatesInput{}, func(p *iam.ListServerCertificatesOutput, lastPage bool) bool {
 		for _, cert := range p.ServerCertificateMetadataList {

--- a/aws/resource_aws_autoscaling_group.go
+++ b/aws/resource_aws_autoscaling_group.go
@@ -44,7 +44,7 @@ func resourceAwsAutoscalingGroup() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
-				ValidateFunc: validateMaxLength(255 - 26),
+				ValidateFunc: validateMaxLength(255 - resource.UniqueIDSuffixLength),
 			},
 
 			"launch_configuration": {

--- a/aws/resource_aws_iam_policy_attachment.go
+++ b/aws/resource_aws_iam_policy_attachment.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsIamPolicyAttachment() *schema.Resource {
@@ -22,16 +23,10 @@ func resourceAwsIamPolicyAttachment() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					if v.(string) == "" {
-						errors = append(errors, fmt.Errorf(
-							"%q cannot be an empty string", k))
-					}
-					return
-				},
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.NoZeroValues,
 			},
 			"users": &schema.Schema{
 				Type:     schema.TypeSet,

--- a/aws/resource_aws_iam_server_certificate.go
+++ b/aws/resource_aws_iam_server_certificate.go
@@ -62,28 +62,14 @@ func resourceAwsIAMServerCertificate() *schema.Resource {
 				Computed:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name_prefix"},
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(string)
-					if len(value) > 128 {
-						errors = append(errors, fmt.Errorf(
-							"%q cannot be longer than 128 characters", k))
-					}
-					return
-				},
+				ValidateFunc:  validateMaxLength(128),
 			},
 
 			"name_prefix": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(string)
-					if len(value) > 102 {
-						errors = append(errors, fmt.Errorf(
-							"%q cannot be longer than 102 characters, name is limited to 128", k))
-					}
-					return
-				},
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateMaxLength(128 - 26),
 			},
 
 			"arn": {

--- a/aws/resource_aws_iam_server_certificate.go
+++ b/aws/resource_aws_iam_server_certificate.go
@@ -69,7 +69,7 @@ func resourceAwsIAMServerCertificate() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
-				ValidateFunc: validateMaxLength(128 - 26),
+				ValidateFunc: validateMaxLength(128 - resource.UniqueIDSuffixLength),
 			},
 
 			"arn": {

--- a/aws/resource_aws_iam_server_certificate_test.go
+++ b/aws/resource_aws_iam_server_certificate_test.go
@@ -144,7 +144,7 @@ func TestAccAWSIAMServerCertificate_disappears(t *testing.T) {
 }
 
 func TestAccAWSIAMServerCertificate_file(t *testing.T) {
-	var _cert iam.ServerCertificate
+	var cert iam.ServerCertificate
 
 	rInt := acctest.RandInt()
 	unixFile := "test-fixtures/iam-ssl-unix-line-endings.pem"
@@ -158,13 +158,13 @@ func TestAccAWSIAMServerCertificate_file(t *testing.T) {
 			{
 				Config: testAccIAMServerCertConfig_file(rInt, unixFile),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCertExists("aws_iam_server_certificate.test_cert", &_cert),
+					testAccCheckCertExists("aws_iam_server_certificate.test_cert", &cert),
 				),
 			},
 			{
 				Config: testAccIAMServerCertConfig_file(rInt, winFile),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCertExists("aws_iam_server_certificate.test_cert", &_cert),
+					testAccCheckCertExists("aws_iam_server_certificate.test_cert", &cert),
 				),
 			},
 		},

--- a/aws/resource_aws_iam_user_login_profile.go
+++ b/aws/resource_aws_iam_user_login_profile.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"math/rand"
@@ -13,6 +12,7 @@ import (
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/encryption"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsIamUserLoginProfile() *schema.Resource {
@@ -40,7 +40,7 @@ func resourceAwsIamUserLoginProfile() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Default:      20,
-				ValidateFunc: validateAwsIamLoginProfilePasswordLength,
+				ValidateFunc: validation.StringLenBetween(4, 128),
 			},
 
 			"key_fingerprint": {
@@ -53,17 +53,6 @@ func resourceAwsIamUserLoginProfile() *schema.Resource {
 			},
 		},
 	}
-}
-
-func validateAwsIamLoginProfilePasswordLength(v interface{}, _ string) (_ []string, es []error) {
-	length := v.(int)
-	if length < 4 {
-		es = append(es, errors.New("minimum password_length is 4 characters"))
-	}
-	if length > 128 {
-		es = append(es, errors.New("maximum password_length is 128 characters"))
-	}
-	return
 }
 
 // generatePassword generates a random password of a given length using

--- a/aws/resource_aws_iam_user_policy.go
+++ b/aws/resource_aws_iam_user_policy.go
@@ -17,14 +17,13 @@ func resourceAwsIamUserPolicy() *schema.Resource {
 	return &schema.Resource{
 		// PutUserPolicy API is idempotent, so these can be the same.
 		Create: resourceAwsIamUserPolicyPut,
+		Read:   resourceAwsIamUserPolicyRead,
 		Update: resourceAwsIamUserPolicyPut,
+		Delete: resourceAwsIamUserPolicyDelete,
 
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
-
-		Read:   resourceAwsIamUserPolicyRead,
-		Delete: resourceAwsIamUserPolicyDelete,
 
 		Schema: map[string]*schema.Schema{
 			"policy": &schema.Schema{

--- a/aws/resource_aws_iam_user_ssh_key.go
+++ b/aws/resource_aws_iam_user_ssh_key.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsIamUserSshKey() *schema.Resource {
@@ -38,9 +39,12 @@ func resourceAwsIamUserSshKey() *schema.Resource {
 			},
 
 			"encoding": &schema.Schema{
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validateIamUserSSHKeyEncoding,
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					iam.EncodingTypeSsh,
+					iam.EncodingTypePem,
+				}, false),
 			},
 
 			"status": &schema.Schema{
@@ -135,17 +139,4 @@ func resourceAwsIamUserSshKeyDelete(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Error deleting IAM User SSH Key %s: %s", d.Id(), err)
 	}
 	return nil
-}
-
-func validateIamUserSSHKeyEncoding(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	encodingTypes := map[string]bool{
-		"PEM": true,
-		"SSH": true,
-	}
-
-	if !encodingTypes[value] {
-		errors = append(errors, fmt.Errorf("IAM User SSH Key Encoding can only be PEM or SSH"))
-	}
-	return
 }

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -127,7 +127,7 @@ func resourceAwsInstance() *schema.Resource {
 						return ""
 					}
 				},
-				ValidateFunc: validateInstanceUserDataSize,
+				ValidateFunc: validateMaxLength(16384),
 			},
 
 			"user_data_base64": {

--- a/aws/resource_aws_launch_configuration.go
+++ b/aws/resource_aws_launch_configuration.go
@@ -99,7 +99,7 @@ func resourceAwsLaunchConfiguration() *schema.Resource {
 						return ""
 					}
 				},
-				ValidateFunc: validateInstanceUserDataSize,
+				ValidateFunc: validateMaxLength(16384),
 			},
 
 			"security_groups": {

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -31,16 +31,6 @@ func validateRFC3339TimeString(v interface{}, k string) (ws []string, errors []e
 	return
 }
 
-func validateInstanceUserDataSize(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	length := len(value)
-
-	if length > 16384 {
-		errors = append(errors, fmt.Errorf("%q is %d bytes, cannot be longer than 16384 bytes", k, length))
-	}
-	return
-}
-
 func validateRdsIdentifier(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if !regexp.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -81,34 +81,6 @@ func TestValidateRFC3339TimeString(t *testing.T) {
 	}
 }
 
-func TestValidateInstanceUserDataSize(t *testing.T) {
-	validValues := []string{
-		"#!/bin/bash",
-		"#!/bin/bash\n" + strings.Repeat("#", 16372), // = 16384
-	}
-
-	for _, s := range validValues {
-		_, errors := validateInstanceUserDataSize(s, "user_data")
-		if len(errors) > 0 {
-			t.Fatalf("%q should be valid user data with limited size: %v", s, errors)
-		}
-	}
-
-	invalidValues := []string{
-		"#!/bin/bash\n" + strings.Repeat("#", 16373), // = 16385
-	}
-
-	for _, s := range invalidValues {
-		_, errors := validateInstanceUserDataSize(s, "user_data")
-		if len(errors) != 1 {
-			t.Fatalf("%q should not be valid user data with limited size: %v", s, errors)
-		}
-		if !strings.Contains(errors[0].Error(), "16385") {
-			t.Fatalf("%q should trigger error message with actual size: %v", s, errors)
-		}
-	}
-}
-
 func TestValidateEcrRepositoryName(t *testing.T) {
 	validNames := []string{
 		"nginx-web-app",


### PR DESCRIPTION
It's a serie of PRs to drop custom `ValidateFunc`. The goal is to use existing functions in `validation` package as much as possible. To minimize the scope and make it easy for review, one PR will be created per resource or data source.

Acceptance tests might fail as I didn't run any of them at all. I'll fix it if you find any error during review.

This PR is for:

- [x] resource/iam_policy_attachment
- [x] resource/iam_server_certificate
- [x] resource/iam_user_login_profile
- [x] resource/iam_user_policy
- [x] resource/iam_user_ssh_key
- [x] resource/instance(included here by mistake)