### PR TITLE
allow some aws_db_instance changes on "storage-full" state

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -1180,6 +1180,7 @@ var resourceAwsDbInstanceDeletePendingStates = []string{
 	"modifying",
 	"starting",
 	"stopping",
+	"storage-full",
 	"storage-optimization",
 }
 
@@ -1195,5 +1196,6 @@ var resourceAwsDbInstanceUpdatePendingStates = []string{
 	"resetting-master-credentials",
 	"starting",
 	"stopping",
+	"storage-full",
 	"upgrading",
 }

--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -1177,6 +1177,7 @@ var resourceAwsDbInstanceDeletePendingStates = []string{
 	"configuring-enhanced-monitoring",
 	"creating",
 	"deleting",
+	"incompatible-parameters",
 	"modifying",
 	"starting",
 	"stopping",


### PR DESCRIPTION
Currently, terraform will error if the following are true:

* The user is increasing the `allocated_storage` of an aws_db_instance
* The instance is in the `storage-full` state
* `apply_immediately` is set to false

However, this is a perfectly valid operation to perform for most db engines.

See https://aws.amazon.com/premiumsupport/knowledge-center/rds-out-of-storage/

This change allows `allocated_storage` and `iops` to be changed (and
not applied immediately).

--- 
For reference, here is the change and error produced (resource name and ID are changed):

```
  ~ aws_db_instance.db-name
      allocated_storage: "100" => "120"

aws_db_instance.db-name: Modifying... (ID: <removed>)
  allocated_storage: "100" => "120"
...
1 error(s) occurred:

* aws_db_instance.db-name: 1 error(s) occurred:

* aws_db_instance.db-name: unexpected state 'storage-full', wanted target 'available, storage-optimization'. last error: %!s(<nil>)
```

There are currently no tests in this PR. I don't have a good idea of how to write an Acceptance test for this, and I didn't see any tests for the `storage-optimization` state that was added previously.

