### PR TITLE
resource/kms_*: drop custom ValidateFuncs

### DIFF
--- a/aws/resource_aws_kms_alias.go
+++ b/aws/resource_aws_kms_alias.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"regexp"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -38,17 +37,10 @@ func resourceAwsKmsAlias() *schema.Resource {
 				ValidateFunc:  validateAwsKmsName,
 			},
 			"name_prefix": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
-					value := v.(string)
-					if !regexp.MustCompile(`^(alias\/)[a-zA-Z0-9:/_-]+$`).MatchString(value) {
-						es = append(es, fmt.Errorf(
-							"%q must begin with 'alias/' and be comprised of only [a-zA-Z0-9:/_-]", k))
-					}
-					return
-				},
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateAwsKmsName,
 			},
 			"target_key_id": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_kms_key.go
+++ b/aws/resource_aws_kms_key.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/structure"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsKmsKey() *schema.Resource {
@@ -45,14 +46,10 @@ func resourceAwsKmsKey() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
-					value := v.(string)
-					if !(value == "ENCRYPT_DECRYPT" || value == "") {
-						es = append(es, fmt.Errorf(
-							"%q must be ENCRYPT_DECRYPT or not specified", k))
-					}
-					return
-				},
+				ValidateFunc: validation.StringInSlice([]string{
+					"",
+					kms.KeyUsageTypeEncryptDecrypt,
+				}, false),
 			},
 			"policy": {
 				Type:             schema.TypeString,
@@ -72,16 +69,9 @@ func resourceAwsKmsKey() *schema.Resource {
 				Default:  false,
 			},
 			"deletion_window_in_days": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
-					value := v.(int)
-					if value > 30 || value < 7 {
-						es = append(es, fmt.Errorf(
-							"%q must be between 7 and 30 days inclusive", k))
-					}
-					return
-				},
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(7, 30),
 			},
 			"tags": tagsSchema(),
 		},


### PR DESCRIPTION
It's a serie of PRs to drop custom `ValidateFunc`. The goal is to use existing functions in `validation` package as much as possible. To minimize the scope and make it easy for review, one PR will be created per resource or data source.

Acceptance tests might fail as I didn't run any of them at all. I'll fix it if you find any error during review.

This PR is for:

- [x] resource/kms_alias
- [x] resource/kms_key