### PR TITLE
added document for source_region argument

### DIFF
--- a/website/docs/r/rds_cluster.html.markdown
+++ b/website/docs/r/rds_cluster.html.markdown
@@ -114,7 +114,7 @@ Default: A 30-minute window selected at random from an 8-hour block of time per 
 * `iam_database_authentication_enabled` - (Optional) Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled.
 * `engine` - (Optional) The name of the database engine to be used for this DB cluster. Defaults to `aurora`.
 * `engine_version` - (Optional) The database engine version.
-
+* `source_region` - (Optional) The source region for an encrypted replica DB cluster.
 
 ## Attributes Reference
 


### PR DESCRIPTION
The issue https://github.com/terraform-providers/terraform-provider-aws/issues/630 has been fixed, but its missing the argument in the document. 