### PR TITLE
resource/lb_*: drop custom ValidateFuncs

### DIFF
--- a/aws/resource_aws_lb_cookie_stickiness_policy.go
+++ b/aws/resource_aws_lb_cookie_stickiness_policy.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsLBCookieStickinessPolicy() *schema.Resource {
@@ -39,17 +40,10 @@ func resourceAwsLBCookieStickinessPolicy() *schema.Resource {
 			},
 
 			"cookie_expiration_period": &schema.Schema{
-				Type:     schema.TypeInt,
-				Optional: true,
-				ForceNew: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
-					value := v.(int)
-					if value <= 0 {
-						es = append(es, fmt.Errorf(
-							"LB Cookie Expiration Period must be greater than zero if specified"))
-					}
-					return
-				},
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IntAtLeast(1),
 			},
 		},
 	}

--- a/aws/resource_aws_lb_listener_rule.go
+++ b/aws/resource_aws_lb_listener_rule.go
@@ -56,7 +56,7 @@ func resourceAwsLbbListenerRule() *schema.Resource {
 						"type": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: validateAwsLbListenerActionType,
+							ValidateFunc: validateLbListenerActionType(),
 						},
 					},
 				},
@@ -69,7 +69,7 @@ func resourceAwsLbbListenerRule() *schema.Resource {
 						"field": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ValidateFunc: validateAwsListenerRuleField,
+							ValidateFunc: validateMaxLength(64),
 						},
 						"values": {
 							Type:     schema.TypeList,
@@ -309,14 +309,6 @@ func validateAwsLbListenerRulePriority(v interface{}, k string) (ws []string, er
 	value := v.(int)
 	if value < 1 || (value > 50000 && value != 99999) {
 		errors = append(errors, fmt.Errorf("%q must be in the range 1-50000 for normal rule or 99999 for default rule", k))
-	}
-	return
-}
-
-func validateAwsListenerRuleField(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if len(value) > 64 {
-		errors = append(errors, fmt.Errorf("%q must be a maximum of 64 characters", k))
 	}
 	return
 }

--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsLbTargetGroup() *schema.Resource {
@@ -46,27 +47,27 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 				Computed:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name_prefix"},
-				ValidateFunc:  validateAwsLbTargetGroupName,
+				ValidateFunc:  validateMaxLength(32),
 			},
 			"name_prefix": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
-				ValidateFunc: validateAwsLbTargetGroupNamePrefix,
+				ValidateFunc: validateMaxLength(32 - resource.UniqueIDSuffixLength),
 			},
 
 			"port": {
 				Type:         schema.TypeInt,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validateAwsLbTargetGroupPort,
+				ValidateFunc: validation.IntBetween(1, 65535),
 			},
 
 			"protocol": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validateAwsLbTargetGroupProtocol,
+				ValidateFunc: validateLbListenerProtocol(),
 			},
 
 			"vpc_id": {
@@ -79,7 +80,7 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Default:      300,
-				ValidateFunc: validateAwsLbTargetGroupDeregistrationDelay,
+				ValidateFunc: validation.IntBetween(0, 3600),
 			},
 
 			"target_type": {
@@ -102,15 +103,17 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 							Default:  true,
 						},
 						"type": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validateAwsLbTargetGroupStickinessType,
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"lb_cookie",
+							}, false),
 						},
 						"cookie_duration": {
 							Type:         schema.TypeInt,
 							Optional:     true,
 							Default:      86400,
-							ValidateFunc: validateAwsLbTargetGroupStickinessCookieDuration,
+							ValidateFunc: validation.IntBetween(0, 604800),
 						},
 					},
 				},
@@ -150,21 +153,21 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 							StateFunc: func(v interface{}) string {
 								return strings.ToUpper(v.(string))
 							},
-							ValidateFunc: validateAwsLbTargetGroupHealthCheckProtocol,
+							ValidateFunc: validateLbListenerProtocol(),
 						},
 
 						"timeout": {
 							Type:         schema.TypeInt,
 							Optional:     true,
 							Computed:     true,
-							ValidateFunc: validateAwsLbTargetGroupHealthCheckTimeout,
+							ValidateFunc: validation.IntBetween(2, 60),
 						},
 
 						"healthy_threshold": {
 							Type:         schema.TypeInt,
 							Optional:     true,
 							Default:      3,
-							ValidateFunc: validateAwsLbTargetGroupHealthCheckHealthyThreshold,
+							ValidateFunc: validation.IntBetween(2, 10),
 						},
 
 						"matcher": {
@@ -177,7 +180,7 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 							Type:         schema.TypeInt,
 							Optional:     true,
 							Default:      3,
-							ValidateFunc: validateAwsLbTargetGroupHealthCheckHealthyThreshold,
+							ValidateFunc: validation.IntBetween(2, 10),
 						},
 					},
 				},
@@ -422,74 +425,6 @@ func validateAwsLbTargetGroupHealthCheckPort(v interface{}, k string) (ws []stri
 		errors = append(errors, fmt.Errorf("%q must be a valid port number (1-65536) or %q", k, "traffic-port"))
 	}
 
-	return
-}
-
-func validateAwsLbTargetGroupHealthCheckHealthyThreshold(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(int)
-	if value < 2 || value > 10 {
-		errors = append(errors, fmt.Errorf("%q must be an integer between 2 and 10", k))
-	}
-	return
-}
-
-func validateAwsLbTargetGroupHealthCheckTimeout(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(int)
-	if value < 2 || value > 60 {
-		errors = append(errors, fmt.Errorf("%q must be an integer between 2 and 60", k))
-	}
-	return
-}
-
-func validateAwsLbTargetGroupHealthCheckProtocol(v interface{}, k string) (ws []string, errors []error) {
-	value := strings.ToLower(v.(string))
-	if value == "http" || value == "https" || value == "tcp" {
-		return
-	}
-
-	errors = append(errors, fmt.Errorf("%q must be either %q, %q or %q", k, "HTTP", "HTTPS", "TCP"))
-	return
-}
-
-func validateAwsLbTargetGroupPort(v interface{}, k string) (ws []string, errors []error) {
-	port := v.(int)
-	if port < 1 || port > 65536 {
-		errors = append(errors, fmt.Errorf("%q must be a valid port number (1-65536)", k))
-	}
-	return
-}
-
-func validateAwsLbTargetGroupProtocol(v interface{}, k string) (ws []string, errors []error) {
-	protocol := strings.ToLower(v.(string))
-	if protocol == "http" || protocol == "https" || protocol == "tcp" {
-		return
-	}
-
-	errors = append(errors, fmt.Errorf("%q must be either %q, %q or %q", k, "HTTP", "HTTPS", "TCP"))
-	return
-}
-
-func validateAwsLbTargetGroupDeregistrationDelay(v interface{}, k string) (ws []string, errors []error) {
-	delay := v.(int)
-	if delay < 0 || delay > 3600 {
-		errors = append(errors, fmt.Errorf("%q must be in the range 0-3600 seconds", k))
-	}
-	return
-}
-
-func validateAwsLbTargetGroupStickinessType(v interface{}, k string) (ws []string, errors []error) {
-	stickinessType := v.(string)
-	if stickinessType != "lb_cookie" {
-		errors = append(errors, fmt.Errorf("%q must have the value %q", k, "lb_cookie"))
-	}
-	return
-}
-
-func validateAwsLbTargetGroupStickinessCookieDuration(v interface{}, k string) (ws []string, errors []error) {
-	duration := v.(int)
-	if duration < 1 || duration > 604800 {
-		errors = append(errors, fmt.Errorf("%q must be a between 1 second and 1 week (1-604800 seconds))", k))
-	}
 	return
 }
 

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1040,22 +1040,6 @@ func validateDbOptionGroupNamePrefix(v interface{}, k string) (ws []string, erro
 	return
 }
 
-func validateAwsLbTargetGroupName(v interface{}, k string) (ws []string, errors []error) {
-	name := v.(string)
-	if len(name) > 32 {
-		errors = append(errors, fmt.Errorf("%q (%q) cannot be longer than '32' characters", k, name))
-	}
-	return
-}
-
-func validateAwsLbTargetGroupNamePrefix(v interface{}, k string) (ws []string, errors []error) {
-	name := v.(string)
-	if len(name) > 6 {
-		errors = append(errors, fmt.Errorf("%q (%q) cannot be longer than '6' characters", k, name))
-	}
-	return
-}
-
 func validateOpenIdURL(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	u, err := url.Parse(value)


### PR DESCRIPTION
It's a serie of PRs to drop custom `ValidateFunc`. The goal is to use existing functions in `validation` package as much as possible. To minimize the scope and make it easy for review, one PR will be created per resource or data source.

Acceptance tests might fail as I didn't run any of them at all. I'll fix it if you find any error during review.

This PR is for:

- [x] resource/lb_cookie_stickiness_policy
- [x] resource/lb_listener
- [x] resource/lb_listener_rule
- [x] resource/lb_target_group