### PR TITLE
resource/opsworks: drop custom ValidateFuncs

### DIFF
--- a/aws/resource_aws_opsworks_application.go
+++ b/aws/resource_aws_opsworks_application.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/opsworks"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsOpsworksApplication() *schema.Resource {
@@ -30,27 +31,18 @@ func resourceAwsOpsworksApplication() *schema.Resource {
 				Computed: true,
 				Optional: true,
 			},
-			// aws-flow-ruby | java | rails | php | nodejs | static | other
 			"type": {
 				Type:     schema.TypeString,
 				Required: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(string)
-
-					expected := [7]string{"aws-flow-ruby", "java", "rails", "php", "nodejs", "static", "other"}
-
-					found := false
-					for _, b := range expected {
-						if b == value {
-							found = true
-						}
-					}
-					if !found {
-						errors = append(errors, fmt.Errorf(
-							"%q has to be one of [aws-flow-ruby, java, rails, php, nodejs, static, other]", k))
-					}
-					return
-				},
+				ValidateFunc: validation.StringInSlice([]string{
+					opsworks.AppTypeAwsFlowRuby,
+					opsworks.AppTypeJava,
+					opsworks.AppTypeRails,
+					opsworks.AppTypePhp,
+					opsworks.AppTypeNodejs,
+					opsworks.AppTypeStatic,
+					opsworks.AppTypeOther,
+				}, false),
 			},
 			"stack_id": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_opsworks_instance.go
+++ b/aws/resource_aws_opsworks_instance.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -46,16 +47,22 @@ func resourceAwsOpsworksInstance() *schema.Resource {
 			},
 
 			"architecture": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Default:      "x86_64",
-				ValidateFunc: validateArchitecture,
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "x86_64",
+				ValidateFunc: validation.StringInSlice([]string{
+					opsworks.ArchitectureX8664,
+					opsworks.ArchitectureI386,
+				}, false),
 			},
 
 			"auto_scaling_type": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validateAutoScalingType,
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					opsworks.AutoScalingTypeLoad,
+					opsworks.AutoScalingTypeTimer,
+				}, false),
 			},
 
 			"availability_zone": {
@@ -218,11 +225,14 @@ func resourceAwsOpsworksInstance() *schema.Resource {
 			},
 
 			"root_device_type": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				Computed:     true,
-				ValidateFunc: validateRootDeviceType,
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					opsworks.RootDeviceTypeEbs,
+					opsworks.RootDeviceTypeInstanceStore,
+				}, false),
 			},
 
 			"root_device_volume_id": {
@@ -263,9 +273,12 @@ func resourceAwsOpsworksInstance() *schema.Resource {
 			},
 
 			"state": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validateState,
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"running",
+					"stopped",
+				}, false),
 			},
 
 			"status": {
@@ -282,19 +295,26 @@ func resourceAwsOpsworksInstance() *schema.Resource {
 			},
 
 			"tenancy": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: validateTenancy,
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"dedicated",
+					"default",
+					"host",
+				}, false),
 			},
 
 			"virtualization_type": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: validateVirtualizationType,
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					opsworks.VirtualizationTypeParavirtual,
+					opsworks.VirtualizationTypeHvm,
+				}, false),
 			},
 
 			"ebs_block_device": {
@@ -431,60 +451,6 @@ func resourceAwsOpsworksInstance() *schema.Resource {
 			},
 		},
 	}
-}
-
-func validateArchitecture(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if value != "x86_64" && value != "i386" {
-		errors = append(errors, fmt.Errorf(
-			"%q must be one of \"x86_64\" or \"i386\"", k))
-	}
-	return
-}
-
-func validateTenancy(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if value != "dedicated" && value != "default" && value != "host" {
-		errors = append(errors, fmt.Errorf(
-			"%q must be one of \"dedicated\", \"default\" or \"host\"", k))
-	}
-	return
-}
-
-func validateAutoScalingType(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if value != "load" && value != "timer" {
-		errors = append(errors, fmt.Errorf(
-			"%q must be one of \"load\" or \"timer\"", k))
-	}
-	return
-}
-
-func validateRootDeviceType(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if value != "ebs" && value != "instance-store" {
-		errors = append(errors, fmt.Errorf(
-			"%q must be one of \"ebs\" or \"instance-store\"", k))
-	}
-	return
-}
-
-func validateState(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if value != "running" && value != "stopped" {
-		errors = append(errors, fmt.Errorf(
-			"%q must be one of \"running\" or \"stopped\"", k))
-	}
-	return
-}
-
-func validateVirtualizationType(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if value != "paravirtual" && value != "hvm" {
-		errors = append(errors, fmt.Errorf(
-			"%q must be one of \"paravirtual\" or \"hvm\"", k))
-	}
-	return
 }
 
 func resourceAwsOpsworksInstanceValidate(d *schema.ResourceData) error {

--- a/aws/resource_aws_opsworks_permission.go
+++ b/aws/resource_aws_opsworks_permission.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"fmt"
 	"log"
 	"time"
 
@@ -10,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/opsworks"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsOpsworksPermission() *schema.Resource {
@@ -34,28 +34,17 @@ func resourceAwsOpsworksPermission() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			// one of deny, show, deploy, manage, iam_only
 			"level": {
 				Type:     schema.TypeString,
 				Computed: true,
 				Optional: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(string)
-
-					expected := [5]string{"deny", "show", "deploy", "manage", "iam_only"}
-
-					found := false
-					for _, b := range expected {
-						if b == value {
-							found = true
-						}
-					}
-					if !found {
-						errors = append(errors, fmt.Errorf(
-							"%q has to be one of [deny, show, deploy, manage, iam_only]", k))
-					}
-					return
-				},
+				ValidateFunc: validation.StringInSlice([]string{
+					"deny",
+					"show",
+					"deploy",
+					"manage",
+					"iam_only",
+				}, false),
 			},
 			"stack_id": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
It's a serie of PRs to drop custom `ValidateFunc`. The goal is to use existing functions in `validation` package as much as possible. To minimize the scope and make it easy for review, one PR will be created per resource or data source.

Acceptance tests might fail as I didn't run any of them at all. I'll fix it if you find any error during review.

This PR is for:

- [x] resource/opsworks_application
- [x] resource/opsworks_instance
- [x] resource/opsworks_permission