### PR TITLE
resource/rds_cluster: drop custom ValidateFuncs

### DIFF
--- a/aws/resource_aws_organizations_organization.go
+++ b/aws/resource_aws_organizations_organization.go
@@ -37,11 +37,14 @@ func resourceAwsOrganizationsOrganization() *schema.Resource {
 				Computed: true,
 			},
 			"feature_set": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				Default:      organizations.OrganizationFeatureSetAll,
-				ValidateFunc: validation.StringInSlice([]string{organizations.OrganizationFeatureSetAll, organizations.OrganizationFeatureSetConsolidatedBilling}, true),
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  organizations.OrganizationFeatureSetAll,
+				ValidateFunc: validation.StringInSlice([]string{
+					organizations.OrganizationFeatureSetAll,
+					organizations.OrganizationFeatureSetConsolidatedBilling,
+				}, true),
 			},
 		},
 	}

--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsRDSCluster() *schema.Resource {
@@ -105,7 +106,7 @@ func resourceAwsRDSCluster() *schema.Resource {
 				Optional:     true,
 				Default:      "aurora",
 				ForceNew:     true,
-				ValidateFunc: validateRdsEngine,
+				ValidateFunc: validateRdsEngine(),
 			},
 
 			"engine_version": {
@@ -211,17 +212,10 @@ func resourceAwsRDSCluster() *schema.Resource {
 			},
 
 			"backup_retention_period": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  1,
-				ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
-					value := v.(int)
-					if value > 35 {
-						es = append(es, fmt.Errorf(
-							"backup retention period cannot be more than 35 days"))
-					}
-					return
-				},
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      1,
+				ValidateFunc: validation.IntAtMost(35),
 			},
 
 			"kms_key_id": {

--- a/aws/resource_aws_rds_cluster_instance.go
+++ b/aws/resource_aws_rds_cluster_instance.go
@@ -89,7 +89,7 @@ func resourceAwsRDSClusterInstance() *schema.Resource {
 				Optional:     true,
 				ForceNew:     true,
 				Default:      "aurora",
-				ValidateFunc: validateRdsEngine,
+				ValidateFunc: validateRdsEngine(),
 			},
 
 			"engine_version": {

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -81,21 +81,12 @@ func validateRdsIdentifierPrefix(v interface{}, k string) (ws []string, errors [
 	return
 }
 
-func validateRdsEngine(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-
-	validTypes := map[string]bool{
-		"aurora":            true,
-		"aurora-mysql":      true,
-		"aurora-postgresql": true,
-	}
-
-	if _, ok := validTypes[value]; !ok {
-		errors = append(errors, fmt.Errorf(
-			"%q contains an invalid engine type %q. Valid types are either %q, %q or %q.",
-			k, value, "aurora", "aurora-mysql", "aurora-postgresql"))
-	}
-	return
+func validateRdsEngine() schema.SchemaValidateFunc {
+	return validation.StringInSlice([]string{
+		"aurora",
+		"aurora-mysql",
+		"aurora-postgresql",
+	}, false)
 }
 
 func validateElastiCacheClusterId(v interface{}, k string) (ws []string, errors []error) {


### PR DESCRIPTION
It's a serie of PRs to drop custom `ValidateFunc`. The goal is to use existing functions in `validation` package as much as possible. To minimize the scope and make it easy for review, one PR will be created per resource or data source.

Acceptance tests might fail as I didn't run any of them at all. I'll fix it if you find any error during review.

This PR is for:

- [x] resource/organizations_organization(fmt only)
- [x] resource/rds_cluster
- [x] resource/rds_cluster_instance
