### PR TITLE
resource/route53_*: drop custom ValidateFuncs

### DIFF
--- a/aws/resource_aws_route53_health_check.go
+++ b/aws/resource_aws_route53_health_check.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -84,16 +85,9 @@ func resourceAwsRoute53HealthCheck() *schema.Resource {
 				Set:      schema.HashString,
 			},
 			"child_health_threshold": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
-					value := v.(int)
-					if value > 256 {
-						es = append(es, fmt.Errorf(
-							"Child HealthThreshold cannot be more than 256"))
-					}
-					return
-				},
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntAtMost(256),
 			},
 
 			"cloudwatch_alarm_name": {

--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -51,22 +52,29 @@ func resourceAwsRoute53Record() *schema.Resource {
 			},
 
 			"type": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validateRoute53RecordType,
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					route53.RRTypeSoa,
+					route53.RRTypeA,
+					route53.RRTypeTxt,
+					route53.RRTypeNs,
+					route53.RRTypeCname,
+					route53.RRTypeMx,
+					route53.RRTypeNaptr,
+					route53.RRTypePtr,
+					route53.RRTypeSrv,
+					route53.RRTypeSpf,
+					route53.RRTypeAaaa,
+					route53.RRTypeCaa,
+				}, false),
 			},
 
 			"zone_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
-					value := v.(string)
-					if value == "" {
-						es = append(es, fmt.Errorf("Cannot have empty zone_id"))
-					}
-					return
-				},
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.NoZeroValues,
 			},
 
 			"ttl": {

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -827,32 +827,6 @@ func validateOnceADayWindowFormat(v interface{}, k string) (ws []string, errors 
 	return
 }
 
-func validateRoute53RecordType(v interface{}, k string) (ws []string, errors []error) {
-	// Valid Record types
-	// SOA, A, TXT, NS, CNAME, MX, NAPTR, PTR, SRV, SPF, AAAA, CAA
-	validTypes := map[string]struct{}{
-		"SOA":   {},
-		"A":     {},
-		"TXT":   {},
-		"NS":    {},
-		"CNAME": {},
-		"MX":    {},
-		"NAPTR": {},
-		"PTR":   {},
-		"SRV":   {},
-		"SPF":   {},
-		"AAAA":  {},
-		"CAA":   {},
-	}
-
-	value := v.(string)
-	if _, ok := validTypes[value]; !ok {
-		errors = append(errors, fmt.Errorf(
-			"%q must be one of [SOA, A, TXT, NS, CNAME, MX, NAPTR, PTR, SRV, SPF, AAAA, CAA]", k))
-	}
-	return
-}
-
 // Validates that ECS Placement Constraints are set correctly
 // Takes type, and expression as strings
 func validateAwsEcsPlacementConstraint(constType, constExpr string) error {

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -1267,45 +1267,6 @@ func TestValidateOnceADayWindowFormat(t *testing.T) {
 	}
 }
 
-func TestValidateRoute53RecordType(t *testing.T) {
-	validTypes := []string{
-		"AAAA",
-		"SOA",
-		"A",
-		"TXT",
-		"CNAME",
-		"MX",
-		"NAPTR",
-		"PTR",
-		"SPF",
-		"SRV",
-		"NS",
-		"CAA",
-	}
-
-	invalidTypes := []string{
-		"a",
-		"alias",
-		"SpF",
-		"Txt",
-		"AaAA",
-	}
-
-	for _, v := range validTypes {
-		_, errors := validateRoute53RecordType(v, "route53_record")
-		if len(errors) != 0 {
-			t.Fatalf("%q should be a valid Route53 record type: %v", v, errors)
-		}
-	}
-
-	for _, v := range invalidTypes {
-		_, errors := validateRoute53RecordType(v, "route53_record")
-		if len(errors) == 0 {
-			t.Fatalf("%q should not be a valid Route53 record type", v)
-		}
-	}
-}
-
 func TestValidateEcsPlacementConstraint(t *testing.T) {
 	cases := []struct {
 		constType string


### PR DESCRIPTION
It's a serie of PRs to drop custom `ValidateFunc`. The goal is to use existing functions in `validation` package as much as possible. To minimize the scope and make it easy for review, one PR will be created per resource or data source.

Acceptance tests might fail as I didn't run any of them at all. I'll fix it if you find any error during review.

This PR is for:

- [x] resource/route53_health_check
- [x] resource/route53_record