### PR TITLE
docs/aws_organizations_organization: Fix header

### DIFF
--- a/website/docs/r/organizations_organization.html.markdown
+++ b/website/docs/r/organizations_organization.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "aws"
-page_title: "AWS: aws_organizations_organization
-sidebar_current: "docs-aws-resource-organizations-organization|"
+page_title: "AWS: aws_organizations_organization"
+sidebar_current: "docs-aws-resource-organizations-organization"
 description: |-
   Provides a resource to create an organization.
 ---


### PR DESCRIPTION
Should fix: https://www.terraform.io/docs/providers/aws/r/organizations_organization.html

Will merge into `stable-website` after `master` and release.