### PR TITLE
resource/servicecatalog_portfolio: drop custom ValidateFuncs

### DIFF
--- a/aws/resource_aws_servicecatalog_portfolio.go
+++ b/aws/resource_aws_servicecatalog_portfolio.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/servicecatalog"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsServiceCatalogPortfolio() *schema.Resource {
@@ -40,18 +41,18 @@ func resourceAwsServiceCatalogPortfolio() *schema.Resource {
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validateServiceCatalogPortfolioName,
+				ValidateFunc: validation.StringLenBetween(1, 20),
 			},
 			"description": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validateServiceCatalogPortfolioDescription,
+				ValidateFunc: validateMaxLength(2000),
 			},
 			"provider_name": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validateServiceCatalogPortfolioProviderName,
+				ValidateFunc: validation.StringLenBetween(1, 20),
 			},
 			"tags": tagsSchema(),
 		},

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1735,30 +1735,6 @@ func validateIoTTopicRuleElasticSearchEndpoint(v interface{}, k string) (ws []st
 	return
 }
 
-func validateServiceCatalogPortfolioName(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if (len(value) > 20) || (len(value) == 0) {
-		errors = append(errors, fmt.Errorf("Service catalog name must be between 1 and 20 characters."))
-	}
-	return
-}
-
-func validateServiceCatalogPortfolioDescription(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if len(value) > 2000 {
-		errors = append(errors, fmt.Errorf("Service catalog description must be less than 2000 characters."))
-	}
-	return
-}
-
-func validateServiceCatalogPortfolioProviderName(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if (len(value) > 20) || (len(value) == 0) {
-		errors = append(errors, fmt.Errorf("Service catalog provider name must be between 1 and 20 characters."))
-	}
-	return
-}
-
 func validateSesTemplateName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if (len(value) > 64) || (len(value) == 0) {


### PR DESCRIPTION
It's a serie of PRs to drop custom `ValidateFunc`. The goal is to use existing functions in `validation` package as much as possible. To minimize the scope and make it easy for review, one PR will be created per resource or data source.

Acceptance tests might fail as I didn't run any of them at all. I'll fix it if you find any error during review.

This PR is for:

- [x] resource/servicecatalog_portfolio