### PR TITLE
resource/ses_*: drop custom ValidateFuncs

### DIFF
--- a/aws/resource_aws_ses_template.go
+++ b/aws/resource_aws_ses_template.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ses"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsSesTemplate() *schema.Resource {
@@ -25,12 +26,12 @@ func resourceAwsSesTemplate() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validateSesTemplateName,
+				ValidateFunc: validation.StringLenBetween(1, 64),
 			},
 			"html": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validateSesTemplateHtml,
+				ValidateFunc: validateMaxLength(512000),
 			},
 			"subject": {
 				Type:     schema.TypeString,
@@ -39,7 +40,7 @@ func resourceAwsSesTemplate() *schema.Resource {
 			"text": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validateSesTemplateText,
+				ValidateFunc: validateMaxLength(512000),
 			},
 		},
 	}

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1759,31 +1759,6 @@ func validateServiceCatalogPortfolioProviderName(v interface{}, k string) (ws []
 	return
 }
 
-func validateSesTemplateName(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if (len(value) > 64) || (len(value) == 0) {
-		errors = append(errors, fmt.Errorf("SES template name must be between 1 and 64 characters."))
-	}
-	return
-}
-
-func validateSesTemplateHtml(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if len(value) > 512000 {
-		errors = append(errors, fmt.Errorf("SES template must be less than 500KB in size, including both the text and HTML parts."))
-	}
-	return
-}
-
-func validateSesTemplateText(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if len(value) > 512000 {
-		errors = append(errors, fmt.Errorf("SES template must be less than 500KB in size, including both the text and HTML parts."))
-	}
-
-	return
-}
-
 func validateCognitoRoleMappingsAmbiguousRoleResolutionAgainstType(v map[string]interface{}) (errors []error) {
 	t := v["type"].(string)
 	isRequired := t == cognitoidentity.RoleMappingTypeToken || t == cognitoidentity.RoleMappingTypeRules


### PR DESCRIPTION
It's a serie of PRs to drop custom `ValidateFunc`. The goal is to use existing functions in `validation` package as much as possible. To minimize the scope and make it easy for review, one PR will be created per resource or data source.

Acceptance tests might fail as I didn't run any of them at all. I'll fix it if you find any error during review.

This PR is for:

- [x] resource/ses_event_destination
- [x] resource/ses_template