### PR TITLE
resource/sfn_*: drop custom ValidateFuncs

### DIFF
--- a/aws/resource_aws_sfn_activity.go
+++ b/aws/resource_aws_sfn_activity.go
@@ -26,7 +26,7 @@ func resourceAwsSfnActivity() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validateSfnActivityName,
+				ValidateFunc: validateMaxLength(80),
 			},
 
 			"creation_date": {

--- a/aws/resource_aws_sfn_state_machine.go
+++ b/aws/resource_aws_sfn_state_machine.go
@@ -27,7 +27,7 @@ func resourceAwsSfnStateMachine() *schema.Resource {
 			"definition": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validateSfnStateMachineDefinition,
+				ValidateFunc: validateMaxLength(1024 * 1024), // 1048576
 			},
 
 			"name": {

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -953,23 +953,6 @@ func validateAwsEmrCustomAmiId(v interface{}, k string) (ws []string, errors []e
 	return
 }
 
-func validateSfnActivityName(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if len(value) > 80 {
-		errors = append(errors, fmt.Errorf("%q cannot be longer than 80 characters", k))
-	}
-
-	return
-}
-
-func validateSfnStateMachineDefinition(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if len(value) > 1048576 {
-		errors = append(errors, fmt.Errorf("%q cannot be longer than 1048576 characters", k))
-	}
-	return
-}
-
 func validateSfnStateMachineName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if len(value) > 80 {

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -1389,56 +1389,6 @@ func TestValidateEcsPlacementStrategy(t *testing.T) {
 	}
 }
 
-func TestValidateStepFunctionActivityName(t *testing.T) {
-	validTypes := []string{
-		"foo",
-		"FooBar123",
-	}
-
-	invalidTypes := []string{
-		strings.Repeat("W", 81), // length > 80
-	}
-
-	for _, v := range validTypes {
-		_, errors := validateSfnActivityName(v, "name")
-		if len(errors) != 0 {
-			t.Fatalf("%q should be a valid Step Function Activity name: %v", v, errors)
-		}
-	}
-
-	for _, v := range invalidTypes {
-		_, errors := validateSfnActivityName(v, "name")
-		if len(errors) == 0 {
-			t.Fatalf("%q should not be a valid Step Function Activity name", v)
-		}
-	}
-}
-
-func TestValidateStepFunctionStateMachineDefinition(t *testing.T) {
-	validDefinitions := []string{
-		"foobar",
-		strings.Repeat("W", 1048576),
-	}
-
-	invalidDefinitions := []string{
-		strings.Repeat("W", 1048577), // length > 1048576
-	}
-
-	for _, v := range validDefinitions {
-		_, errors := validateSfnStateMachineDefinition(v, "definition")
-		if len(errors) != 0 {
-			t.Fatalf("%q should be a valid Step Function State Machine definition: %v", v, errors)
-		}
-	}
-
-	for _, v := range invalidDefinitions {
-		_, errors := validateSfnStateMachineDefinition(v, "definition")
-		if len(errors) == 0 {
-			t.Fatalf("%q should not be a valid Step Function State Machine definition", v)
-		}
-	}
-}
-
 func TestValidateStepFunctionStateMachineName(t *testing.T) {
 	validTypes := []string{
 		"foo",


### PR DESCRIPTION
It's a serie of PRs to drop custom `ValidateFunc`. The goal is to use existing functions in `validation` package as much as possible. To minimize the scope and make it easy for review, one PR will be created per resource or data source.

Acceptance tests might fail as I didn't run any of them at all. I'll fix it if you find any error during review.

This PR is for:

- [x] resource/sfn_activity
- [x] resource/sfn_state_machine