### PR TITLE
Add public_dns to Elastic Ips

### DIFF
--- a/aws/data_source_aws_eip.go
+++ b/aws/data_source_aws_eip.go
@@ -24,6 +24,10 @@ func dataSourceAwsEip() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"public_dns": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -57,6 +61,7 @@ func dataSourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.SetId(*eip.AllocationId)
 	d.Set("public_ip", eip.PublicIp)
+	d.Set("public_dns", reverseLookup(*eip.PublicIp))
 
 	return nil
 }

--- a/aws/dns.go
+++ b/aws/dns.go
@@ -1,0 +1,10 @@
+package aws
+
+import "net"
+
+func reverseLookup(ip string) (name string) {
+	if names, err := net.LookupAddr(ip); err == nil && len(names) > 0 {
+		name = names[0]
+	}
+	return
+}

--- a/aws/resource_aws_eip.go
+++ b/aws/resource_aws_eip.go
@@ -64,6 +64,11 @@ func resourceAwsEip() *schema.Resource {
 				Computed: true,
 			},
 
+			"public_dns": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"private_ip": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
@@ -199,6 +204,7 @@ func resourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	d.Set("private_ip", address.PrivateIpAddress)
 	d.Set("public_ip", address.PublicIp)
+	d.Set("public_dns", reverseLookup(*address.PublicIp))
 
 	// On import (domain never set, which it must've been if we created),
 	// set the 'vpc' attribute depending on if we're in a VPC.

--- a/aws/resource_aws_eip_test.go
+++ b/aws/resource_aws_eip_test.go
@@ -72,6 +72,7 @@ func TestAccAWSEIP_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEIPExists("aws_eip.bar", &conf),
 					testAccCheckAWSEIPAttributes(&conf),
+					resource.TestCheckResourceAttrSet("aws_eip.bar", "public_dns"),
 				),
 			},
 		},

--- a/website/docs/d/eip.html.markdown
+++ b/website/docs/d/eip.html.markdown
@@ -48,3 +48,6 @@ All of the argument attributes are also exported as result attributes. This
 data source will complete the data by populating any fields that are not
 included in the configuration with the data for the selected Elastic IP.
 
+* `public_dns` - DNS name of the allocated EIP
+
+__Note__: The `public_dns` attribute is provided as a convenience, it is computed via Go's built-in reverse lookup and we select only the first result returned. Depending on how and where Terraform is run this lookup may fail, in which case we simply leave it as an empty string `""`.

--- a/website/docs/r/eip.html.markdown
+++ b/website/docs/r/eip.html.markdown
@@ -110,6 +110,9 @@ The following additional attributes are exported:
 * `public_ip` - Contains the public IP address.
 * `instance` - Contains the ID of the attached instance.
 * `network_interface` - Contains the ID of the attached network interface.
+* `public_dns` - DNS name of the allocated EIP
+
+__Note__: The `public_dns` attribute is provided as a convenience, it is computed via Go's built-in reverse lookup and we select only the first result returned. Depending on how and where Terraform is run this lookup may fail, in which case we simply leave it as an empty string `""`.
 
 ## Import
 


### PR DESCRIPTION
Fix #1149
Fix #3474 (modify config to reference the eip)

Uses net.LookupAddr to find public dns name based on ip address. In scenarios where DNS is not working correctly simply set to empty string (soft failure).

Also included minor refactor and cleanup of the data source acceptance tests.
