### PR TITLE
resource/sns_*: drop custom ValidateFuncs

### DIFF
--- a/aws/resource_aws_sns_topic.go
+++ b/aws/resource_aws_sns_topic.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/structure"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 // Mutable attributes
@@ -88,7 +89,7 @@ func resourceAwsSnsTopic() *schema.Resource {
 			"application_success_feedback_sample_rate": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				ValidateFunc: validateIntegerInRange(0, 100),
+				ValidateFunc: validation.IntBetween(0, 100),
 			},
 			"application_failure_feedback_role_arn": {
 				Type:     schema.TypeString,
@@ -101,7 +102,7 @@ func resourceAwsSnsTopic() *schema.Resource {
 			"http_success_feedback_sample_rate": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				ValidateFunc: validateIntegerInRange(0, 100),
+				ValidateFunc: validation.IntBetween(0, 100),
 			},
 			"http_failure_feedback_role_arn": {
 				Type:     schema.TypeString,
@@ -114,7 +115,7 @@ func resourceAwsSnsTopic() *schema.Resource {
 			"lambda_success_feedback_sample_rate": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				ValidateFunc: validateIntegerInRange(0, 100),
+				ValidateFunc: validation.IntBetween(0, 100),
 			},
 			"lambda_failure_feedback_role_arn": {
 				Type:     schema.TypeString,
@@ -127,7 +128,7 @@ func resourceAwsSnsTopic() *schema.Resource {
 			"sqs_success_feedback_sample_rate": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				ValidateFunc: validateIntegerInRange(0, 100),
+				ValidateFunc: validation.IntBetween(0, 100),
 			},
 			"sqs_failure_feedback_role_arn": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_sns_topic_subscription.go
+++ b/aws/resource_aws_sns_topic_subscription.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/structure"
+	"github.com/hashicorp/terraform/helper/validation"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -40,10 +41,18 @@ func resourceAwsSnsTopicSubscription() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"protocol": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validateSNSSubscriptionProtocol,
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					// email and email-json not supported
+					"application",
+					"http",
+					"https",
+					"lambda",
+					"sms",
+					"sqs",
+				}, true),
 			},
 			"endpoint": {
 				Type:     schema.TypeString,

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -771,20 +771,6 @@ func validateSQSFifoQueueName(v interface{}, k string) (errors []error) {
 	return
 }
 
-func validateSNSSubscriptionProtocol(v interface{}, k string) (ws []string, errors []error) {
-	value := strings.ToLower(v.(string))
-	forbidden := []string{"email"}
-	for _, f := range forbidden {
-		if strings.Contains(value, f) {
-			errors = append(
-				errors,
-				fmt.Errorf("Unsupported protocol (%s) for SNS Topic", value),
-			)
-		}
-	}
-	return
-}
-
 func validateSecurityRuleType(v interface{}, k string) (ws []string, errors []error) {
 	value := strings.ToLower(v.(string))
 

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -1124,35 +1124,6 @@ func TestValidateSQSFifoQueueName(t *testing.T) {
 	}
 }
 
-func TestValidateSNSSubscriptionProtocol(t *testing.T) {
-	validProtocols := []string{
-		"lambda",
-		"sqs",
-		"sqs",
-		"application",
-		"http",
-		"https",
-		"sms",
-	}
-	for _, v := range validProtocols {
-		if _, errors := validateSNSSubscriptionProtocol(v, "protocol"); len(errors) > 0 {
-			t.Fatalf("%q should be a valid SNS Subscription protocol: %v", v, errors)
-		}
-	}
-
-	invalidProtocols := []string{
-		"Email",
-		"email",
-		"Email-JSON",
-		"email-json",
-	}
-	for _, v := range invalidProtocols {
-		if _, errors := validateSNSSubscriptionProtocol(v, "protocol"); len(errors) == 0 {
-			t.Fatalf("%q should be an invalid SNS Subscription protocol: %v", v, errors)
-		}
-	}
-}
-
 func TestValidateSecurityRuleType(t *testing.T) {
 	validTypes := []string{
 		"ingress",


### PR DESCRIPTION
It's a serie of PRs to drop custom `ValidateFunc`. The goal is to use existing functions in `validation` package as much as possible. To minimize the scope and make it easy for review, one PR will be created per resource or data source.

Acceptance tests might fail as I didn't run any of them at all. I'll fix it if you find any error during review.

This PR is for:

- [x] resource/sns_topic
- [x] resource/sns_topic_subscription