### PR TITLE
resource/spot_fleet_request: drop custom ValidateFunc

### DIFF
--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsSpotFleetRequest() *schema.Resource {
@@ -204,7 +205,7 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 							Optional:     true,
 							ForceNew:     true,
 							Computed:     true,
-							ValidateFunc: validateSpotFleetRequestKeyName,
+							ValidateFunc: validation.NoZeroValues,
 						},
 						"monitoring": {
 							Type:     schema.TypeBool,
@@ -454,16 +455,6 @@ func buildSpotFleetLaunchSpecification(d map[string]interface{}, meta interface{
 	}
 
 	return opts, nil
-}
-
-func validateSpotFleetRequestKeyName(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-
-	if value == "" {
-		errors = append(errors, fmt.Errorf("Key name cannot be empty."))
-	}
-
-	return
 }
 
 func readSpotFleetBlockDeviceMappingsFromConfig(

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -424,13 +424,6 @@ func TestAccAWSSpotFleetRequest_placementTenancy(t *testing.T) {
 	})
 }
 
-func TestAccAWSSpotFleetRequest_CannotUseEmptyKeyName(t *testing.T) {
-	_, errs := validateSpotFleetRequestKeyName("", "key_name")
-	if len(errs) == 0 {
-		t.Fatal("Expected the key name to trigger a validation error")
-	}
-}
-
 func testAccCheckAWSSpotFleetRequestConfigRecreated(t *testing.T,
 	before, after *ec2.SpotFleetRequestConfig) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -1706,7 +1699,7 @@ resource "aws_spot_fleet_request" "foo" {
 	    volume_type = "gp2"
 	    volume_size = "8"
         }
-	
+
 	ebs_block_device {
             device_name = "/dev/xvdcz"
 	    volume_type = "gp2"


### PR DESCRIPTION
It's a serie of PRs to drop custom `ValidateFunc`. The goal is to use existing functions in `validation` package as much as possible. To minimize the scope and make it easy for review, one PR will be created per resource or data source.

Acceptance tests might fail as I didn't run any of them at all. I'll fix it if you find any error during review.

This PR is for:

- [x] resource/spot_fleet_request