### PR TITLE
resource/waf_*: drop custom ValidateFuncs

### DIFF
--- a/aws/resource_aws_vpc_endpoint.go
+++ b/aws/resource_aws_vpc_endpoint.go
@@ -32,11 +32,14 @@ func resourceAwsVpcEndpoint() *schema.Resource {
 				ForceNew: true,
 			},
 			"vpc_endpoint_type": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				Default:      ec2.VpcEndpointTypeGateway,
-				ValidateFunc: validation.StringInSlice([]string{ec2.VpcEndpointTypeGateway, ec2.VpcEndpointTypeInterface}, false),
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  ec2.VpcEndpointTypeGateway,
+				ValidateFunc: validation.StringInSlice([]string{
+					ec2.VpcEndpointTypeGateway,
+					ec2.VpcEndpointTypeInterface,
+				}, false),
 			},
 			"service_name": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_waf_rate_based_rule.go
+++ b/aws/resource_aws_waf_rate_based_rule.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsWafRateBasedRule() *schema.Resource {
@@ -39,28 +40,14 @@ func resourceAwsWafRateBasedRule() *schema.Resource {
 							Required: true,
 						},
 						"data_id": &schema.Schema{
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-								value := v.(string)
-								if len(value) > 128 {
-									errors = append(errors, fmt.Errorf(
-										"%q cannot be longer than 128 characters", k))
-								}
-								return
-							},
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateMaxLength(128),
 						},
 						"type": &schema.Schema{
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-								value := v.(string)
-								if value != "IPMatch" && value != "ByteMatch" && value != "SqlInjectionMatch" && value != "SizeConstraint" && value != "XssMatch" {
-									errors = append(errors, fmt.Errorf(
-										"%q must be one of IPMatch | ByteMatch | SqlInjectionMatch | SizeConstraint | XssMatch", k))
-								}
-								return
-							},
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateWafPredicatesType(),
 						},
 					},
 				},
@@ -70,15 +57,9 @@ func resourceAwsWafRateBasedRule() *schema.Resource {
 				Required: true,
 			},
 			"rate_limit": &schema.Schema{
-				Type:     schema.TypeInt,
-				Required: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(int)
-					if value < 2000 {
-						errors = append(errors, fmt.Errorf("%q cannot be less than 2000", k))
-					}
-					return
-				},
+				Type:         schema.TypeInt,
+				Required:     true,
+				ValidateFunc: validation.IntAtLeast(2000),
 			},
 		},
 	}

--- a/aws/resource_aws_waf_rule.go
+++ b/aws/resource_aws_waf_rule.go
@@ -39,28 +39,14 @@ func resourceAwsWafRule() *schema.Resource {
 							Required: true,
 						},
 						"data_id": &schema.Schema{
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-								value := v.(string)
-								if len(value) > 128 {
-									errors = append(errors, fmt.Errorf(
-										"%q cannot be longer than 128 characters", k))
-								}
-								return
-							},
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateMaxLength(128),
 						},
 						"type": &schema.Schema{
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-								value := v.(string)
-								if value != "IPMatch" && value != "ByteMatch" && value != "SqlInjectionMatch" && value != "SizeConstraint" && value != "XssMatch" {
-									errors = append(errors, fmt.Errorf(
-										"%q must be one of IPMatch | ByteMatch | SqlInjectionMatch | SizeConstraint | XssMatch", k))
-								}
-								return
-							},
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateWafPredicatesType(),
 						},
 					},
 				},

--- a/aws/resource_aws_waf_web_acl.go
+++ b/aws/resource_aws_waf_web_acl.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsWafWebAcl() *schema.Resource {
@@ -68,14 +69,10 @@ func resourceAwsWafWebAcl() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							Default:  waf.WafRuleTypeRegular,
-							ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-								value := v.(string)
-								if value != waf.WafRuleTypeRegular && value != waf.WafRuleTypeRateBased {
-									errors = append(errors, fmt.Errorf(
-										"%q must be one of %s | %s", k, waf.WafRuleTypeRegular, waf.WafRuleTypeRateBased))
-								}
-								return
-							},
+							ValidateFunc: validation.StringInSlice([]string{
+								waf.WafRuleTypeRegular,
+								waf.WafRuleTypeRateBased,
+							}, false),
 						},
 						"rule_id": &schema.Schema{
 							Type:     schema.TypeString,

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/gamelift"
 	"github.com/aws/aws-sdk-go/service/guardduty"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/structure"
 	"github.com/hashicorp/terraform/helper/validation"
@@ -1612,6 +1613,16 @@ func validateWafMetricName(v interface{}, k string) (ws []string, errors []error
 			k, value))
 	}
 	return
+}
+
+func validateWafPredicatesType() schema.SchemaValidateFunc {
+	return validation.StringInSlice([]string{
+		waf.PredicateTypeIpmatch,
+		waf.PredicateTypeByteMatch,
+		waf.PredicateTypeSqlInjectionMatch,
+		waf.PredicateTypeSizeConstraint,
+		waf.PredicateTypeXssMatch,
+	}, false)
 }
 
 func validateIamRoleDescription(v interface{}, k string) (ws []string, errors []error) {


### PR DESCRIPTION
It's a serie of PRs to drop custom `ValidateFunc`. The goal is to use existing functions in `validation` package as much as possible. To minimize the scope and make it easy for review, one PR will be created per resource or data source.

Acceptance tests might fail as I didn't run any of them at all. I'll fix it if you find any error during review.

This PR is for:

- [x] resource/vpc_endpoint(fmt only)
- [x] resource/waf_rate_based_rule
- [x] resource/waf_rule
- [x] resource/waf_web_acl