### PR TITLE
Fix broken documentation for organisation

### DIFF
--- a/website/docs/r/organizations_organization.html.markdown
+++ b/website/docs/r/organizations_organization.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: aws_organizations_organization
+page_title: "AWS: aws_organizations_organization"
 sidebar_current: "docs-aws-resource-organizations-organization|"
 description: |-
   Provides a resource to create an organization.


### PR DESCRIPTION
This PR should fix issue #3736 which brokes the menu in the docs for the ressource `organizations_organization`