### PR TITLE
resource/autoscaling_policy: fix conditional logic based on policy type

### DIFF
--- a/aws/resource_aws_autoscaling_policy.go
+++ b/aws/resource_aws_autoscaling_policy.go
@@ -21,73 +21,73 @@ func resourceAwsAutoscalingPolicy() *schema.Resource {
 		Delete: resourceAwsAutoscalingPolicyDelete,
 
 		Schema: map[string]*schema.Schema{
-			"arn": &schema.Schema{
+			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"adjustment_type": &schema.Schema{
+			"adjustment_type": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"autoscaling_group_name": &schema.Schema{
+			"autoscaling_group_name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"policy_type": &schema.Schema{
+			"policy_type": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "SimpleScaling", // preserve AWS's default to make validation easier.
 			},
-			"cooldown": &schema.Schema{
+			"cooldown": {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
-			"estimated_instance_warmup": &schema.Schema{
+			"estimated_instance_warmup": {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
-			"metric_aggregation_type": &schema.Schema{
+			"metric_aggregation_type": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
-			"min_adjustment_magnitude": &schema.Schema{
+			"min_adjustment_magnitude": {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				ValidateFunc: validation.IntAtLeast(1),
 			},
-			"min_adjustment_step": &schema.Schema{
+			"min_adjustment_step": {
 				Type:          schema.TypeInt,
 				Optional:      true,
 				Deprecated:    "Use min_adjustment_magnitude instead, otherwise you may see a perpetual diff on this resource.",
 				ConflictsWith: []string{"min_adjustment_magnitude"},
 			},
-			"scaling_adjustment": &schema.Schema{
+			"scaling_adjustment": {
 				Type:          schema.TypeInt,
 				Optional:      true,
 				ConflictsWith: []string{"step_adjustment"},
 			},
-			"step_adjustment": &schema.Schema{
+			"step_adjustment": {
 				Type:          schema.TypeSet,
 				Optional:      true,
 				ConflictsWith: []string{"scaling_adjustment"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"metric_interval_lower_bound": &schema.Schema{
+						"metric_interval_lower_bound": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
-						"metric_interval_upper_bound": &schema.Schema{
+						"metric_interval_upper_bound": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
-						"scaling_adjustment": &schema.Schema{
+						"scaling_adjustment": {
 							Type:     schema.TypeInt,
 							Required: true,
 						},
@@ -95,77 +95,77 @@ func resourceAwsAutoscalingPolicy() *schema.Resource {
 				},
 				Set: resourceAwsAutoscalingScalingAdjustmentHash,
 			},
-			"target_tracking_configuration": &schema.Schema{
+			"target_tracking_configuration": {
 				Type:     schema.TypeList,
 				Optional: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"predefined_metric_specification": &schema.Schema{
+						"predefined_metric_specification": {
 							Type:          schema.TypeList,
 							Optional:      true,
 							MaxItems:      1,
 							ConflictsWith: []string{"target_tracking_configuration.0.customized_metric_specification"},
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"predefined_metric_type": &schema.Schema{
+									"predefined_metric_type": {
 										Type:     schema.TypeString,
 										Required: true,
 									},
-									"resource_label": &schema.Schema{
+									"resource_label": {
 										Type:     schema.TypeString,
 										Optional: true,
 									},
 								},
 							},
 						},
-						"customized_metric_specification": &schema.Schema{
+						"customized_metric_specification": {
 							Type:          schema.TypeList,
 							Optional:      true,
 							MaxItems:      1,
 							ConflictsWith: []string{"target_tracking_configuration.0.predefined_metric_specification"},
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"metric_dimension": &schema.Schema{
+									"metric_dimension": {
 										Type:     schema.TypeList,
 										Optional: true,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
-												"name": &schema.Schema{
+												"name": {
 													Type:     schema.TypeString,
 													Required: true,
 												},
-												"value": &schema.Schema{
+												"value": {
 													Type:     schema.TypeString,
 													Required: true,
 												},
 											},
 										},
 									},
-									"metric_name": &schema.Schema{
+									"metric_name": {
 										Type:     schema.TypeString,
 										Required: true,
 									},
-									"namespace": &schema.Schema{
+									"namespace": {
 										Type:     schema.TypeString,
 										Required: true,
 									},
-									"statistic": &schema.Schema{
+									"statistic": {
 										Type:     schema.TypeString,
 										Required: true,
 									},
-									"unit": &schema.Schema{
+									"unit": {
 										Type:     schema.TypeString,
 										Optional: true,
 									},
 								},
 							},
 						},
-						"target_value": &schema.Schema{
+						"target_value": {
 							Type:     schema.TypeFloat,
 							Required: true,
 						},
-						"disable_scale_in": &schema.Schema{
+						"disable_scale_in": {
 							Type:     schema.TypeBool,
 							Optional: true,
 							Default:  false,

--- a/aws/resource_aws_autoscaling_policy_test.go
+++ b/aws/resource_aws_autoscaling_policy_test.go
@@ -25,7 +25,7 @@ func TestAccAWSAutoscalingPolicy_basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAutoscalingPolicyDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSAutoscalingPolicyConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScalingPolicyExists("aws_autoscaling_policy.foobar_simple", &policy),
@@ -58,7 +58,7 @@ func TestAccAWSAutoscalingPolicy_disappears(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAutoscalingPolicyDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSAutoscalingPolicyConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScalingPolicyExists("aws_autoscaling_policy.foobar_simple", &policy),
@@ -118,7 +118,7 @@ func TestAccAWSAutoscalingPolicy_upgrade(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAutoscalingPolicyDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSAutoscalingPolicyConfig_upgrade_614(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScalingPolicyExists("aws_autoscaling_policy.foobar_simple", &policy),
@@ -128,7 +128,7 @@ func TestAccAWSAutoscalingPolicy_upgrade(t *testing.T) {
 				ExpectNonEmptyPlan: true,
 			},
 
-			resource.TestStep{
+			{
 				Config: testAccAWSAutoscalingPolicyConfig_upgrade_615(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScalingPolicyExists("aws_autoscaling_policy.foobar_simple", &policy),
@@ -150,7 +150,7 @@ func TestAccAWSAutoscalingPolicy_TargetTrack_Predefined(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAutoscalingPolicyDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAwsAutoscalingPolicyConfig_TargetTracking_Predefined(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScalingPolicyExists("aws_autoscaling_policy.test", &policy),
@@ -170,7 +170,7 @@ func TestAccAWSAutoscalingPolicy_TargetTrack_Custom(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAutoscalingPolicyDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAwsAutoscalingPolicyConfig_TargetTracking_Custom(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScalingPolicyExists("aws_autoscaling_policy.test", &policy),
@@ -189,7 +189,7 @@ func TestAccAWSAutoscalingPolicy_zerovalue(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAutoscalingPolicyDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSAutoscalingPolicyConfig_zerovalue(acctest.RandString(5)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScalingPolicyExists("aws_autoscaling_policy.foobar_simple", &simplepolicy),
@@ -391,7 +391,7 @@ func TestAccAWSAutoscalingPolicy_SimpleScalingStepAdjustment(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAutoscalingPolicyDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSAutoscalingPolicyConfig_SimpleScalingStepAdjustment(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScalingPolicyExists("aws_autoscaling_policy.foobar_simple", &policy),


### PR DESCRIPTION
fix #3715  
fix #3689 

Issue with current approach is that even user doesn't set the argument, it will be set to `zero` in terraform state from aws api response as placeholder. Later on during update, `zero` value is used thus trigger the error. One way to fix is to add conditional logic in read function as well. I'm not feeling comfortable with this because multiple conditions are introduced to handle the same situation.

Instead, I'm changing the logic in the same place to set arguments only for valid policy types. With checking policy type before setting input parameter, it's also easily compare each parameter with api specification.

I didn't figure out how to distinguish `zero` value between user input and terraform state value in current logic but that's not the focus here.