### PR TITLE
Fix link to aws lifecycle policy parameters docs

### DIFF
--- a/website/docs/r/ecr_lifecycle_policy.html.markdown
+++ b/website/docs/r/ecr_lifecycle_policy.html.markdown
@@ -81,7 +81,7 @@ EOF
 The following arguments are supported:
 
 * `repository` - (Required) Name of the repository to apply the policy.
-* `policy` - (Required) The policy document. This is a JSON formatted string. See more details about [Policy Parameters](http://docs.aws.amazon.com/ja_jp/AmazonECR/latest/userguide/LifecyclePolicies.html#lifecycle_policy_parameters) in the official AWS docs.
+* `policy` - (Required) The policy document. This is a JSON formatted string. See more details about [Policy Parameters](http://docs.aws.amazon.com/AmazonECR/latest/userguide/LifecyclePolicies.html#lifecycle_policy_parameters) in the official AWS docs.
 
 ## Attributes Reference
 


### PR DESCRIPTION
The link was pointing to the Japanese version of the docs.