### PR TITLE
Flag required aws_appautoscaling_policy attributes in doc

### DIFF
--- a/website/docs/r/appautoscaling_policy.html.markdown
+++ b/website/docs/r/appautoscaling_policy.html.markdown
@@ -130,7 +130,7 @@ The following arguments are supported:
 
 ### `target_tracking_scaling_policy_configuration`
 
-* `target_value` - (Optional) The target value for the metric.
+* `target_value` - (Required) The target value for the metric.
 * `disable_scale_in` - (Optional) Indicates whether scale in by the target tracking policy is disabled. If the value is true, scale in is disabled and the target tracking policy won't remove capacity from the scalable resource. Otherwise, scale in is enabled and the target tracking policy can remove capacity from the scalable resource. The default value is `false`.
 * `scale_in_cooldown` - (Optional) The amount of time, in seconds, after a scale in activity completes before another scale in activity can start.
 * `scale_out_cooldown` - (Optional) The amount of time, in seconds, after a scale out activity completes before another scale out activity can start.
@@ -140,9 +140,9 @@ The following arguments are supported:
 ### `customized_metric_specification`
 
 * `dimensions` - (Optional) The dimensions of the metric.
-* `metric_name` - (Optional) The name of the metric.
-* `namespace` - (Optional) The namespace of the metric.
-* `statistic` - (Optional) The statistic of the metric.
+* `metric_name` - (Required) The name of the metric.
+* `namespace` - (Required) The namespace of the metric.
+* `statistic` - (Required) The statistic of the metric.
 * `unit` - (Optional) The unit of the metric.
 
 ### `predefined_metric_specification`


### PR DESCRIPTION
Currently some required fields are shown as optional in the documentation for the `aws_appautoscaling_policy`. I updated this to reduce confusion here