### PR TITLE
resource/cognito_user_pool_client: fix import with user pool id

### DIFF
--- a/aws/resource_aws_cognito_user_pool_client.go
+++ b/aws/resource_aws_cognito_user_pool_client.go
@@ -344,7 +344,7 @@ func resourceAwsCognitoUserPoolClientDelete(d *schema.ResourceData, meta interfa
 }
 
 func resourceAwsCognitoUserPoolClientImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	if len(strings.Split(d.Id(), "/")) != 2 {
+	if len(strings.Split(d.Id(), "/")) != 2 || len(d.Id()) < 3 {
 		return []*schema.ResourceData{}, fmt.Errorf("[ERR] Wrong format of resource: %s. Please follow 'user-pool-id/client-id'", d.Id())
 	}
 	userPoolId := strings.Split(d.Id(), "/")[0]

--- a/aws/resource_aws_cognito_user_pool_client.go
+++ b/aws/resource_aws_cognito_user_pool_client.go
@@ -1,7 +1,9 @@
 package aws
 
 import (
+	"fmt"
 	"log"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
@@ -18,7 +20,7 @@ func resourceAwsCognitoUserPoolClient() *schema.Resource {
 		Delete: resourceAwsCognitoUserPoolClientDelete,
 
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: resourceAwsCognitoUserPoolClientImport,
 		},
 
 		// https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateUserPoolClient.html
@@ -339,4 +341,17 @@ func resourceAwsCognitoUserPoolClientDelete(d *schema.ResourceData, meta interfa
 	}
 
 	return nil
+}
+
+func resourceAwsCognitoUserPoolClientImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	if len(strings.Split(d.Id(), "/")) != 2 {
+		return []*schema.ResourceData{}, fmt.Errorf("[ERR] Wrong format of resource: %s. Please follow 'user-pool-id/client-id'", d.Id())
+	}
+	userPoolId := strings.Split(d.Id(), "/")[0]
+	clientId := strings.Split(d.Id(), "/")[1]
+	d.SetId(clientId)
+	d.Set("user_pool_id", userPoolId)
+	log.Printf("[DEBUG] Importing client %s for user pool %s", clientId, userPoolId)
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/aws/resource_aws_cognito_user_pool_client_test.go
+++ b/aws/resource_aws_cognito_user_pool_client_test.go
@@ -35,6 +35,30 @@ func TestAccAWSCognitoUserPoolClient_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSCognitoUserPoolClient_importBasic(t *testing.T) {
+	userPoolName := fmt.Sprintf("tf-acc-cognito-user-pool-%s", acctest.RandString(7))
+	clientName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resourceName := "aws_cognito_user_pool_client.client"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCognitoUserPoolClientConfig_basic(userPoolName, clientName),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateId:     "user_pool_id/client_id", // how to get both ids here?
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSCognitoUserPoolClient_allFields(t *testing.T) {
 	userPoolName := fmt.Sprintf("tf-acc-cognito-user-pool-%s", acctest.RandString(7))
 	clientName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
@@ -142,12 +166,10 @@ resource "aws_cognito_user_pool" "pool" {
 }
 
 resource "aws_cognito_user_pool_client" "client" {
-  name = "%s"
-
-  user_pool_id = "${aws_cognito_user_pool.pool.id}"
-  explicit_auth_flows = [ "ADMIN_NO_SRP_AUTH" ]
+  name                = "%s"
+  user_pool_id        = "${aws_cognito_user_pool.pool.id}"
+  explicit_auth_flows = ["ADMIN_NO_SRP_AUTH"]
 }
-
 `, userPoolName, clientName)
 }
 


### PR DESCRIPTION
fix #3753 

When describing user pool client, `user_pool_id` is required.

1. Currently `id` is set as `client_id`, which makes it unable to import by default. Changing `id` to `user_pool_id/client_id` should be the best as I think. But that would be a breaking change?

2. Instead, I updated import function to parse `user_pool_id` and `client_id` during import.
