### PR TITLE
resource/aws_cloudfront_distribution: Validate origin domain_name and origin_id at plan time

### DIFF
--- a/aws/resource_aws_cloudfront_distribution.go
+++ b/aws/resource_aws_cloudfront_distribution.go
@@ -386,8 +386,9 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 							},
 						},
 						"domain_name": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.NoZeroValues,
 						},
 						"custom_header": {
 							Type:     schema.TypeSet,
@@ -407,8 +408,9 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 							},
 						},
 						"origin_id": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.NoZeroValues,
 						},
 						"origin_path": {
 							Type:     schema.TypeString,

--- a/aws/resource_aws_cloudfront_distribution_test.go
+++ b/aws/resource_aws_cloudfront_distribution_test.go
@@ -191,6 +191,34 @@ func TestAccAWSCloudFrontDistribution_multiOrigin(t *testing.T) {
 	})
 }
 
+func TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSCloudFrontDistributionConfig_Origin_EmptyDomainName,
+				ExpectError: regexp.MustCompile(`domain_name must not be empty`),
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSCloudFrontDistributionConfig_Origin_EmptyOriginID,
+				ExpectError: regexp.MustCompile(`origin_id must not be empty`),
+			},
+		},
+	})
+}
+
 // TestAccAWSCloudFrontDistribution_noOptionalItemsConfig runs an
 // aws_cloudfront_distribution acceptance test with no optional items set.
 //
@@ -822,6 +850,84 @@ resource "aws_cloudfront_distribution" "no_optional_items" {
 	%s
 }
 `, rand.New(rand.NewSource(time.Now().UnixNano())).Int(), testAccAWSCloudFrontDistributionRetainConfig())
+
+var testAccAWSCloudFrontDistributionConfig_Origin_EmptyDomainName = fmt.Sprintf(`
+resource "aws_cloudfront_distribution" "Origin_EmptyDomainName" {
+  origin {
+    domain_name = ""
+    origin_id   = "myCustomOrigin"
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "http-only"
+      origin_ssl_protocols   = [ "SSLv3", "TLSv1" ]
+    }
+  }
+  enabled = true
+  default_cache_behavior {
+    allowed_methods  = [ "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT" ]
+    cached_methods   = [ "GET", "HEAD" ]
+    target_origin_id = "myCustomOrigin"
+    smooth_streaming = false
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "all"
+      }
+    }
+    viewer_protocol_policy = "allow-all"
+  }
+  restrictions {
+    geo_restriction {
+      restriction_type = "whitelist"
+      locations        = [ "US", "CA", "GB", "DE" ]
+    }
+  }
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+  %s
+}
+`, testAccAWSCloudFrontDistributionRetainConfig())
+
+var testAccAWSCloudFrontDistributionConfig_Origin_EmptyOriginID = fmt.Sprintf(`
+resource "aws_cloudfront_distribution" "Origin_EmptyOriginID" {
+  origin {
+    domain_name = "www.example.com"
+    origin_id   = ""
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "http-only"
+      origin_ssl_protocols   = [ "SSLv3", "TLSv1" ]
+    }
+  }
+  enabled = true
+  default_cache_behavior {
+    allowed_methods  = [ "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT" ]
+    cached_methods   = [ "GET", "HEAD" ]
+    target_origin_id = "myCustomOrigin"
+    smooth_streaming = false
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "all"
+      }
+    }
+    viewer_protocol_policy = "allow-all"
+  }
+  restrictions {
+    geo_restriction {
+      restriction_type = "whitelist"
+      locations        = [ "US", "CA", "GB", "DE" ]
+    }
+  }
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+  %s
+}
+`, testAccAWSCloudFrontDistributionRetainConfig())
 
 var testAccAWSCloudFrontDistributionHTTP11Config = fmt.Sprintf(`
 variable rand_id {


### PR DESCRIPTION
Possibly related: #3766 

Previously:
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSCloudFrontDistribution_emptyDomainName'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCloudFrontDistribution_emptyDomainName -timeout 120m
=== RUN   TestAccAWSCloudFrontDistribution_emptyDomainName
--- FAIL: TestAccAWSCloudFrontDistribution_emptyDomainName (3.33s)
	testing.go:506: Step 0, expected error:

		Error applying: 1 error(s) occurred:

		* aws_cloudfront_distribution.emptyDomainName: 1 error(s) occurred:

		* aws_cloudfront_distribution.emptyDomainName: InvalidArgument: The parameter origin name cannot be null or empty.
			status code: 400, request id: e9192d20-26fe-11e8-9203-d143c667b144

make testacc TEST=./aws TESTARGS='-run=TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID -timeout 120m
=== RUN   TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID
--- FAIL: TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID (3.46s)
	testing.go:506: Step 0, expected error:

		Error applying: 1 error(s) occurred:

		* aws_cloudfront_distribution.Origin_EmptyOriginID: 1 error(s) occurred:

		* aws_cloudfront_distribution.Origin_EmptyOriginID: NoSuchOrigin: One or more of your origins do not exist.
			status code: 404, request id: 485540a6-2700-11e8-94ed-dda08547c7d9
```

Now:
```
 make testacc TEST=./aws TESTARGS='-run=TestAccAWSCloudFrontDistribution_Origin_Empty'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCloudFrontDistribution_Origin_Empty -timeout 120m
=== RUN   TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName (1.63s)
=== RUN   TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID (0.84s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2.511s
```