### PR TITLE
Add support for timeouts on aws_eip resource

### DIFF
--- a/website/docs/r/eip.html.markdown
+++ b/website/docs/r/eip.html.markdown
@@ -111,6 +111,13 @@ The following additional attributes are exported:
 * `instance` - Contains the ID of the attached instance.
 * `network_interface` - Contains the ID of the attached network interface.
 
+## Timeouts
+`aws_eip` provides the following [Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+- `read` - (Default `15 minutes`) How long to wait querying for information about EIPs.
+- `update` - (Default `5 minutes`) How long to wait for an EIP to be updated.
+- `delete` - (Default `3 minutes`) How long to wait for an EIP to be deleted.
+
 ## Import
 
 EIPs in a VPC can be imported using their Allocation ID, e.g.


### PR DESCRIPTION
Adds the ability to override timeouts for the `aws_eip` resource.

Would be nice to have https://github.com/terraform-providers/terraform-provider-aws/pull/3586 along with this change, as we're running into something similar as reported in https://github.com/terraform-providers/terraform-provider-aws/issues/3128 but with EIPs instead of security groups.

Open to suggestions on the timeouts here.  