### PR TITLE
#3626 Display Invalid Value During InvalidParameterValue

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -674,7 +674,7 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			return nil
 		})
 		if err != nil {
-			return fmt.Errorf("Error creating DB Instance: %s", err)
+			return fmt.Errorf("Error creating DB Instance: provided name: %v, %s", *opts.DBName, err)
 		}
 	}
 


### PR DESCRIPTION
Hi, 

This commit adds the aws_db_instance name argument to the error message as requested in issue #3626 