### PR TITLE
resource/cognito_user_pool_client: update allowed_oauth_scopes

### DIFF
--- a/aws/resource_aws_cognito_user_pool_client.go
+++ b/aws/resource_aws_cognito_user_pool_client.go
@@ -103,8 +103,13 @@ func resourceAwsCognitoUserPoolClient() *schema.Resource {
 			"allowed_oauth_scopes": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				MaxItems: 25,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
+					// https://docs.aws.amazon.com/cognito/latest/developerguide/authorization-endpoint.html
+					// System reserved scopes are openid, email, phone, profile, and aws.cognito.signin.user.admin.
+					// https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateUserPoolClient.html#CognitoUserPools-CreateUserPoolClient-request-AllowedOAuthScopes
+					// Constraints seem like to be designed for custom scopes which are not supported yet?
 				},
 			},
 

--- a/aws/resource_aws_cognito_user_pool_client_test.go
+++ b/aws/resource_aws_cognito_user_pool_client_test.go
@@ -14,7 +14,8 @@ import (
 )
 
 func TestAccAWSCognitoUserPoolClient_basic(t *testing.T) {
-	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	userPoolName := fmt.Sprintf("tf-acc-cognito-user-pool-%s", acctest.RandString(7))
+	clientName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -22,10 +23,10 @@ func TestAccAWSCognitoUserPoolClient_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCognitoUserPoolClientDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCognitoUserPoolClientConfig_basic(name),
+				Config: testAccAWSCognitoUserPoolClientConfig_basic(userPoolName, clientName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolClientExists("aws_cognito_user_pool_client.client"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "name", name),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "name", clientName),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "explicit_auth_flows.#", "1"),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "explicit_auth_flows.245201344", "ADMIN_NO_SRP_AUTH"),
 				),
@@ -35,7 +36,8 @@ func TestAccAWSCognitoUserPoolClient_basic(t *testing.T) {
 }
 
 func TestAccAWSCognitoUserPoolClient_allFields(t *testing.T) {
-	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	userPoolName := fmt.Sprintf("tf-acc-cognito-user-pool-%s", acctest.RandString(7))
+	clientName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -43,10 +45,10 @@ func TestAccAWSCognitoUserPoolClient_allFields(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCognitoUserPoolClientDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCognitoUserPoolClientConfig_allFields(name),
+				Config: testAccAWSCognitoUserPoolClientConfig_allFields(userPoolName, clientName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolClientExists("aws_cognito_user_pool_client.client"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "name", name),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "name", clientName),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "explicit_auth_flows.#", "3"),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "explicit_auth_flows.1728632605", "CUSTOM_AUTH_FLOW_ONLY"),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "explicit_auth_flows.1860959087", "USER_PASSWORD_AUTH"),
@@ -61,9 +63,12 @@ func TestAccAWSCognitoUserPoolClient_allFields(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_flows.2645166319", "code"),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_flows.3465961881", "implicit"),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_flows_user_pool_client", "true"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_scopes.#", "2"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_scopes.#", "5"),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_scopes.2517049750", "openid"),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_scopes.881205744", "email"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_scopes.2603607895", "phone"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_scopes.380129571", "aws.cognito.signin.user.admin"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_scopes.4080487570", "profile"),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "callback_urls.#", "2"),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "callback_urls.0", "https://www.example.com/callback"),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "callback_urls.1", "https://www.example.com/redirect"),
@@ -130,8 +135,12 @@ func testAccCheckAWSCognitoUserPoolClientExists(name string) resource.TestCheckF
 	}
 }
 
-func testAccAWSCognitoUserPoolClientConfig_basic(clientName string) string {
+func testAccAWSCognitoUserPoolClientConfig_basic(userPoolName, clientName string) string {
 	return fmt.Sprintf(`
+resource "aws_cognito_user_pool" "pool" {
+  name = "%s"
+}
+
 resource "aws_cognito_user_pool_client" "client" {
   name = "%s"
 
@@ -139,14 +148,15 @@ resource "aws_cognito_user_pool_client" "client" {
   explicit_auth_flows = [ "ADMIN_NO_SRP_AUTH" ]
 }
 
-resource "aws_cognito_user_pool" "pool" {
-  name = "test-pool"
-}
-`, clientName)
+`, userPoolName, clientName)
 }
 
-func testAccAWSCognitoUserPoolClientConfig_allFields(clientName string) string {
+func testAccAWSCognitoUserPoolClientConfig_allFields(userPoolName, clientName string) string {
 	return fmt.Sprintf(`
+resource "aws_cognito_user_pool" "pool" {
+  name = "%s"
+}
+
 resource "aws_cognito_user_pool_client" "client" {
   name = "%s"
 
@@ -162,15 +172,11 @@ resource "aws_cognito_user_pool_client" "client" {
 
   allowed_oauth_flows = ["code", "implicit"]
   allowed_oauth_flows_user_pool_client = "true"
-  allowed_oauth_scopes = ["openid", "email"]
+  allowed_oauth_scopes = ["phone", "email", "openid", "profile", "aws.cognito.signin.user.admin"]
 
   callback_urls = ["https://www.example.com/callback", "https://www.example.com/redirect"]
   default_redirect_uri = "https://www.example.com/redirect"
   logout_urls = ["https://www.example.com/login"]
 }
-
-resource "aws_cognito_user_pool" "pool" {
-  name = "test-pool"
-}
-`, clientName)
+`, userPoolName, clientName)
 }

--- a/website/docs/r/cognito_user_pool_client.markdown
+++ b/website/docs/r/cognito_user_pool_client.markdown
@@ -48,7 +48,7 @@ The following arguments are supported:
 
 * `allowed_oauth_flows` - (Optional) List of allowed OAuth flows (code, implicit, client_credentials).
 * `allowed_oauth_flows_user_pool_client` - (Optional) Whether the client is allowed to follow the OAuth protocol when interacting with Cognito user pools.
-* `allowed_oauth_scopes` - (Optional) List of allowed OAuth scopes (phone, email, openid, Cognito).
+* `allowed_oauth_scopes` - (Optional) List of allowed OAuth scopes (phone, email, openid, profile, and aws.cognito.signin.user.admin).
 * `callback_urls` - (Optional) List of allowed callback URLs for the identity providers.
 * `default_redirect_uri` - (Optional) The default redirect URI. Must be in the list of callback URLs.
 * `explicit_auth_flows` - (Optional) List of authentication flows (ADMIN_NO_SRP_AUTH, CUSTOM_AUTH_FLOW_ONLY, USER_PASSWORD_AUTH).


### PR DESCRIPTION
fix #3690 

The behavior of `allowed_oauth_scopes` is not consistent between aws api reference and actual api call. I updated according to developer guide and added those in acceptance test. How do we usually deal with such cases in terraform?

https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateUserPoolClient.html#CognitoUserPools-CreateUserPoolClient-request-AllowedOAuthScopes
https://docs.aws.amazon.com/cognito/latest/developerguide/authorization-endpoint.html

One more thing about ValidateFunc. The constraints from [api reference](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateUserPoolClient.html#CognitoUserPools-CreateUserPoolClient-request-AllowedOAuthScopes) seem like to be designed for custom scopes, which are not supported yet. So I was only validating currently supported values. Or should be follow the constraints so that we don't need to update validation in the future?
