### PR TITLE
tests: Unify aws_subnet tags (E-L)

### DIFF
--- a/aws/resource_aws_ecs_service_test.go
+++ b/aws/resource_aws_ecs_service_test.go
@@ -850,6 +850,9 @@ resource "aws_subnet" "main" {
   cidr_block = "${cidrsubnet(aws_vpc.main.cidr_block, 8, count.index)}"
   availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
   vpc_id = "${aws_vpc.main.id}"
+  tags {
+    Name = "tf-acc-ecs-service-with-launch-type-fargate"
+  }
 }
 
 resource "aws_security_group" "allow_all_a" {
@@ -935,6 +938,9 @@ resource "aws_subnet" "main" {
   cidr_block = "${cidrsubnet(aws_vpc.main.cidr_block, 8, count.index)}"
   availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
   vpc_id = "${aws_vpc.main.id}"
+  tags {
+    Name = "tf-acc-ecs-service-health-check-grace-period"
+  }
 }
 
 resource "aws_ecs_cluster" "main" {
@@ -1418,6 +1424,9 @@ resource "aws_subnet" "main" {
   cidr_block = "${cidrsubnet(aws_vpc.main.cidr_block, 8, count.index)}"
   availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
   vpc_id = "${aws_vpc.main.id}"
+  tags {
+    Name = "tf-acc-ecs-service-with-alb"
+  }
 }
 
 resource "aws_ecs_cluster" "main" {
@@ -1562,6 +1571,9 @@ resource "aws_subnet" "main" {
   cidr_block = "${cidrsubnet(aws_vpc.main.cidr_block, 8, count.index)}"
   availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
   vpc_id = "${aws_vpc.main.id}"
+  tags {
+    Name = "tf-acc-ecs-service-with-network-config"
+  }
 }
 
 resource "aws_security_group" "allow_all_a" {

--- a/aws/resource_aws_efs_mount_target_test.go
+++ b/aws/resource_aws_efs_mount_target_test.go
@@ -243,6 +243,9 @@ resource "aws_subnet" "alpha" {
 	vpc_id = "${aws_vpc.foo.id}"
 	availability_zone = "us-west-2a"
 	cidr_block = "10.0.1.0/24"
+	tags {
+		Name = "tf-acc-efs-mount-target-alpha"
+	}
 }
 `, ct)
 }
@@ -274,12 +277,18 @@ resource "aws_subnet" "alpha" {
 	vpc_id = "${aws_vpc.foo.id}"
 	availability_zone = "us-west-2a"
 	cidr_block = "10.0.1.0/24"
+	tags {
+		Name = "tf-acc-efs-mount-target-alpha"
+	}
 }
 
 resource "aws_subnet" "beta" {
 	vpc_id = "${aws_vpc.foo.id}"
 	availability_zone = "us-west-2b"
 	cidr_block = "10.0.2.0/24"
+	tags {
+		Name = "tf-acc-efs-mount-target-beta"
+	}
 }
 `, ct)
 }

--- a/aws/resource_aws_eip_association_test.go
+++ b/aws/resource_aws_eip_association_test.go
@@ -220,6 +220,9 @@ resource "aws_subnet" "sub" {
 	vpc_id = "${aws_vpc.main.id}"
 	cidr_block = "192.168.0.0/25"
 	availability_zone = "us-west-2a"
+	tags {
+		Name = "tf-acc-eip-association"
+	}
 }
 resource "aws_internet_gateway" "igw" {
 	vpc_id = "${aws_vpc.main.id}"
@@ -272,6 +275,9 @@ resource "aws_subnet" "sub" {
 	vpc_id = "${aws_vpc.main.id}"
 	cidr_block = "192.168.0.0/25"
 	availability_zone = "us-west-2a"
+	tags {
+		Name = "tf-acc-eip-association-disappears"
+	}
 }
 resource "aws_internet_gateway" "igw" {
 	vpc_id = "${aws_vpc.main.id}"

--- a/aws/resource_aws_eip_test.go
+++ b/aws/resource_aws_eip_test.go
@@ -517,7 +517,7 @@ resource "aws_subnet" "tf_test_subnet" {
   depends_on = ["aws_internet_gateway.gw"]
 
   tags {
-    Name = "tf_test_subnet"
+    Name = "tf-acc-eip-instance-associated"
   }
 }
 
@@ -582,7 +582,7 @@ resource "aws_subnet" "tf_test_subnet" {
   depends_on = ["aws_internet_gateway.gw"]
 
   tags {
-    Name = "tf_test_subnet"
+    Name = "tf-acc-eip-instance-associated"
   }
 }
 
@@ -641,19 +641,26 @@ resource "aws_vpc" "bar" {
 		Name = "terraform-testacc-eip-network-interface"
 	}
 }
+
 resource "aws_internet_gateway" "bar" {
 	vpc_id = "${aws_vpc.bar.id}"
 }
+
 resource "aws_subnet" "bar" {
   vpc_id = "${aws_vpc.bar.id}"
   availability_zone = "us-west-2a"
   cidr_block = "10.0.0.0/24"
+  tags {
+  	Name = "tf-acc-eip-network-interface"
+  }
 }
+
 resource "aws_network_interface" "bar" {
   subnet_id = "${aws_subnet.bar.id}"
 	private_ips = ["10.0.0.10"]
   security_groups = [ "${aws_vpc.bar.default_security_group_id}" ]
 }
+
 resource "aws_eip" "bar" {
 	vpc = "true"
 	network_interface = "${aws_network_interface.bar.id}"
@@ -677,6 +684,9 @@ resource "aws_subnet" "bar" {
   vpc_id            = "${aws_vpc.bar.id}"
   availability_zone = "us-west-2a"
   cidr_block        = "10.0.0.0/24"
+  tags {
+  	Name = "tf-acc-eip-multi-network-interface"
+  }
 }
 
 resource "aws_network_interface" "bar" {
@@ -750,6 +760,9 @@ resource "aws_subnet" "us-east-1b-public" {
 
   cidr_block        = "10.0.0.0/24"
   availability_zone = "us-east-1b"
+  tags {
+    Name = "tf-acc-eip-classic-disassociate"
+  }
 }
 
 resource "aws_route_table" "us-east-1-public" {

--- a/aws/resource_aws_elastic_beanstalk_configuration_template_test.go
+++ b/aws/resource_aws_elastic_beanstalk_configuration_template_test.go
@@ -171,7 +171,7 @@ resource "aws_subnet" "main" {
   cidr_block = "10.0.0.0/24"
 
   tags {
-    Name = "subnet-count-test"
+    Name = "tf-acc-elastic-beanstalk-cfg-tpl-vpc"
   }
 }
 

--- a/aws/resource_aws_elastic_beanstalk_environment_test.go
+++ b/aws/resource_aws_elastic_beanstalk_environment_test.go
@@ -1053,6 +1053,9 @@ resource "aws_route" "r" {
 resource "aws_subnet" "main" {
   vpc_id     = "${aws_vpc.tf_b_test.id}"
   cidr_block = "10.0.0.0/24"
+  tags {
+    Name = "tf-acc-elastic-beanstalk-env-vpc"
+  }
 }
 
 resource "aws_security_group" "default" {

--- a/aws/resource_aws_elasticache_cluster_test.go
+++ b/aws/resource_aws_elasticache_cluster_test.go
@@ -419,7 +419,7 @@ resource "aws_subnet" "foo" {
     cidr_block = "192.168.0.0/20"
     availability_zone = "us-west-2a"
     tags {
-            Name = "tf-test"
+        Name = "tf-acc-elasticache-cluster-in-vpc"
     }
 }
 
@@ -476,7 +476,7 @@ resource "aws_subnet" "foo" {
     cidr_block = "192.168.0.0/20"
     availability_zone = "us-west-2a"
     tags {
-            Name = "tf-test-%03d"
+        Name = "tf-acc-elasticache-cluster-multi-az-in-vpc-foo"
     }
 }
 
@@ -485,7 +485,7 @@ resource "aws_subnet" "bar" {
     cidr_block = "192.168.16.0/20"
     availability_zone = "us-west-2b"
     tags {
-            Name = "tf-test-%03d"
+        Name = "tf-acc-elasticache-cluster-multi-az-in-vpc-bar"
     }
 }
 
@@ -525,4 +525,4 @@ resource "aws_elasticache_cluster" "bar" {
         "us-west-2b"
     ]
 }
-`, acctest.RandInt(), acctest.RandInt(), acctest.RandInt(), acctest.RandInt(), acctest.RandString(10))
+`, acctest.RandInt(), acctest.RandInt(), acctest.RandString(10))

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -747,7 +747,7 @@ resource "aws_subnet" "foo" {
     cidr_block = "192.168.0.0/20"
     availability_zone = "us-west-2a"
     tags {
-            Name = "tf-test"
+        Name = "tf-acc-elasticache-replication-group-in-vpc"
     }
 }
 
@@ -797,7 +797,7 @@ resource "aws_subnet" "foo" {
     cidr_block = "192.168.0.0/20"
     availability_zone = "us-west-2a"
     tags {
-            Name = "tf-test-%03d"
+        Name = "tf-acc-elasticache-replication-group-multi-az-in-vpc-foo"
     }
 }
 
@@ -806,7 +806,7 @@ resource "aws_subnet" "bar" {
     cidr_block = "192.168.16.0/20"
     availability_zone = "us-west-2b"
     tags {
-            Name = "tf-test-%03d"
+        Name = "tf-acc-elasticache-replication-group-multi-az-in-vpc-bar"
     }
 }
 
@@ -845,7 +845,7 @@ resource "aws_elasticache_replication_group" "bar" {
     snapshot_window = "02:00-03:00"
     snapshot_retention_limit = 7
 }
-`, acctest.RandInt(), acctest.RandInt(), acctest.RandInt(), acctest.RandInt(), acctest.RandString(10))
+`, acctest.RandInt(), acctest.RandInt(), acctest.RandString(10))
 
 var testAccAWSElasticacheReplicationGroupRedisClusterInVPCConfig = fmt.Sprintf(`
 resource "aws_vpc" "foo" {
@@ -860,7 +860,7 @@ resource "aws_subnet" "foo" {
     cidr_block = "192.168.0.0/20"
     availability_zone = "us-west-2a"
     tags {
-            Name = "tf-test-%03d"
+        Name = "tf-acc-elasticache-replication-group-redis-cluster-in-vpc-foo"
     }
 }
 
@@ -869,7 +869,7 @@ resource "aws_subnet" "bar" {
     cidr_block = "192.168.16.0/20"
     availability_zone = "us-west-2b"
     tags {
-            Name = "tf-test-%03d"
+        Name = "tf-acc-elasticache-replication-group-redis-cluster-in-vpc-bar"
     }
 }
 
@@ -910,7 +910,7 @@ resource "aws_elasticache_replication_group" "bar" {
     engine_version = "3.2.4"
     maintenance_window = "thu:03:00-thu:04:00"
 }
-`, acctest.RandInt(), acctest.RandInt(), acctest.RandInt(), acctest.RandInt(), acctest.RandString(10))
+`, acctest.RandInt(), acctest.RandInt(), acctest.RandString(10))
 
 func testAccAWSElasticacheReplicationGroupNativeRedisClusterErrorConfig(rInt int, rName string) string {
 	return fmt.Sprintf(`
@@ -926,7 +926,7 @@ resource "aws_subnet" "foo" {
     cidr_block = "192.168.0.0/20"
     availability_zone = "us-west-2a"
     tags {
-        Name = "tf-test-%03d"
+        Name = "tf-acc-elasticache-replication-group-native-redis-cluster-err-foo"
     }
 }
 
@@ -935,7 +935,7 @@ resource "aws_subnet" "bar" {
     cidr_block = "192.168.16.0/20"
     availability_zone = "us-west-2b"
     tags {
-        Name = "tf-test-%03d"
+        Name = "tf-acc-elasticache-replication-group-native-redis-cluster-err-bar"
     }
 }
 
@@ -974,7 +974,7 @@ resource "aws_elasticache_replication_group" "bar" {
       num_node_groups = 2
     }
     number_cache_clusters = 3
-}`, rInt, rInt, rInt, rInt, rName)
+}`, rInt, rInt, rName)
 }
 
 func testAccAWSElasticacheReplicationGroupNativeRedisClusterConfig(rInt int, rName string) string {
@@ -991,7 +991,7 @@ resource "aws_subnet" "foo" {
     cidr_block = "192.168.0.0/20"
     availability_zone = "us-west-2a"
     tags {
-        Name = "tf-test-%03d"
+        Name = "tf-acc-elasticache-replication-group-native-redis-cluster-foo"
     }
 }
 
@@ -1000,7 +1000,7 @@ resource "aws_subnet" "bar" {
     cidr_block = "192.168.16.0/20"
     availability_zone = "us-west-2b"
     tags {
-        Name = "tf-test-%03d"
+        Name = "tf-acc-elasticache-replication-group-native-redis-cluster-bar"
     }
 }
 
@@ -1038,7 +1038,7 @@ resource "aws_elasticache_replication_group" "bar" {
       replicas_per_node_group = 1
       num_node_groups = 2
     }
-}`, rInt, rInt, rInt, rInt, rName)
+}`, rInt, rInt, rName)
 }
 
 func testAccAWSElasticacheReplicationGroup_EnableAtRestEncryptionConfig(rInt int, rString string) string {
@@ -1055,7 +1055,7 @@ resource "aws_subnet" "foo" {
   cidr_block = "192.168.0.0/20"
   availability_zone = "us-west-2a"
   tags {
-    Name = "tf-test-%03d"
+    Name = "tf-acc-elasticache-replication-group-at-rest-encryption"
   }
 }
 
@@ -1092,7 +1092,7 @@ resource "aws_elasticache_replication_group" "bar" {
   engine_version = "3.2.6"
   at_rest_encryption_enabled = true
 }
-`, rInt, rInt, rInt, rString)
+`, rInt, rInt, rString)
 }
 
 func testAccAWSElasticacheReplicationGroup_EnableAuthTokenTransitEncryptionConfig(rInt int, rString10 string, rString16 string) string {
@@ -1109,7 +1109,7 @@ resource "aws_subnet" "foo" {
   cidr_block = "192.168.0.0/20"
   availability_zone = "us-west-2a"
   tags {
-    Name = "tf-test-%03d"
+    Name = "tf-acc-elasticache-replication-group-auth-token-transit-encryption"
   }
 }
 
@@ -1147,5 +1147,5 @@ resource "aws_elasticache_replication_group" "bar" {
   transit_encryption_enabled = true
   auth_token = "%s"
 }
-`, rInt, rInt, rInt, rString10, rString16)
+`, rInt, rInt, rString10, rString16)
 }

--- a/aws/resource_aws_elasticache_subnet_group_test.go
+++ b/aws/resource_aws_elasticache_subnet_group_test.go
@@ -153,7 +153,7 @@ resource "aws_subnet" "foo" {
     cidr_block = "192.168.0.0/20"
     availability_zone = "us-west-2a"
     tags {
-        Name = "tf-test"
+        Name = "tf-acc-elasticache-subnet-group"
     }
 }
 
@@ -178,7 +178,7 @@ resource "aws_subnet" "foo" {
     cidr_block = "10.0.1.0/24"
     availability_zone = "us-west-2a"
     tags {
-        Name = "tf-test"
+        Name = "tf-acc-elasticache-subnet-group-update-foo"
     }
 }
 
@@ -202,7 +202,7 @@ resource "aws_subnet" "foo" {
     cidr_block = "10.0.1.0/24"
     availability_zone = "us-west-2a"
     tags {
-        Name = "tf-test"
+        Name = "tf-acc-elasticache-subnet-group-update-foo"
     }
 }
 
@@ -211,7 +211,7 @@ resource "aws_subnet" "bar" {
     cidr_block = "10.0.2.0/24"
     availability_zone = "us-west-2a"
     tags {
-        Name = "tf-test-foo-update"
+        Name = "tf-acc-elasticache-subnet-group-update-bar"
     }
 }
 

--- a/aws/resource_aws_elasticsearch_domain_test.go
+++ b/aws/resource_aws_elasticsearch_domain_test.go
@@ -669,12 +669,18 @@ resource "aws_subnet" "first" {
   vpc_id            = "${aws_vpc.elasticsearch_in_vpc.id}"
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   cidr_block        = "192.168.0.0/24"
+  tags {
+    Name = "tf-acc-elasticsearch-domain-in-vpc-first"
+  }
 }
 
 resource "aws_subnet" "second" {
   vpc_id            = "${aws_vpc.elasticsearch_in_vpc.id}"
   availability_zone = "${data.aws_availability_zones.available.names[1]}"
   cidr_block        = "192.168.1.0/24"
+  tags {
+    Name = "tf-acc-elasticsearch-domain-in-vpc-second"
+  }
 }
 
 resource "aws_security_group" "first" {
@@ -732,24 +738,36 @@ resource "aws_subnet" "az1_first" {
   vpc_id            = "${aws_vpc.elasticsearch_in_vpc.id}"
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   cidr_block        = "192.168.0.0/24"
+  tags {
+    Name = "tf-acc-elasticsearch-domain-in-vpc-update-az1-first"
+  }
 }
 
 resource "aws_subnet" "az2_first" {
   vpc_id            = "${aws_vpc.elasticsearch_in_vpc.id}"
   availability_zone = "${data.aws_availability_zones.available.names[1]}"
   cidr_block        = "192.168.1.0/24"
+  tags {
+    Name = "tf-acc-elasticsearch-domain-in-vpc-update-az2-first"
+  }
 }
 
 resource "aws_subnet" "az1_second" {
   vpc_id            = "${aws_vpc.elasticsearch_in_vpc.id}"
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   cidr_block        = "192.168.2.0/24"
+  tags {
+    Name = "tf-acc-elasticsearch-domain-in-vpc-update-az1-second"
+  }
 }
 
 resource "aws_subnet" "az2_second" {
   vpc_id            = "${aws_vpc.elasticsearch_in_vpc.id}"
   availability_zone = "${data.aws_availability_zones.available.names[1]}"
   cidr_block        = "192.168.3.0/24"
+  tags {
+    Name = "tf-acc-elasticsearch-domain-in-vpc-update-az2-second"
+  }
 }
 
 resource "aws_security_group" "first" {
@@ -798,12 +816,18 @@ resource "aws_subnet" "first" {
   vpc_id            = "${aws_vpc.elasticsearch_in_vpc.id}"
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   cidr_block        = "192.168.0.0/24"
+  tags {
+    Name = "tf-acc-elasticsearch-domain-internet-to-vpc-endpoint-first"
+  }
 }
 
 resource "aws_subnet" "second" {
   vpc_id            = "${aws_vpc.elasticsearch_in_vpc.id}"
   availability_zone = "${data.aws_availability_zones.available.names[1]}"
   cidr_block        = "192.168.1.0/24"
+  tags {
+    Name = "tf-acc-elasticsearch-domain-internet-to-vpc-endpoint-second"
+  }
 }
 
 resource "aws_security_group" "first" {

--- a/aws/resource_aws_elb_test.go
+++ b/aws/resource_aws_elb_test.go
@@ -1618,6 +1618,9 @@ resource "aws_subnet" "public_a_one" {
 
   cidr_block        = "10.1.1.0/24"
   availability_zone = "us-west-2a"
+  tags {
+    Name = "tf-acc-elb-subnets-a-one"
+  }
 }
 
 resource "aws_subnet" "public_b_one" {
@@ -1625,6 +1628,9 @@ resource "aws_subnet" "public_b_one" {
 
   cidr_block        = "10.1.7.0/24"
   availability_zone = "us-west-2b"
+  tags {
+    Name = "tf-acc-elb-subnets-b-one"
+  }
 }
 
 resource "aws_subnet" "public_a_two" {
@@ -1632,6 +1638,9 @@ resource "aws_subnet" "public_a_two" {
 
   cidr_block        = "10.1.2.0/24"
   availability_zone = "us-west-2a"
+  tags {
+    Name = "tf-acc-elb-subnets-a-two"
+  }
 }
 
 resource "aws_elb" "ourapp" {
@@ -1680,6 +1689,9 @@ resource "aws_subnet" "public_a_one" {
 
   cidr_block        = "10.1.1.0/24"
   availability_zone = "us-west-2a"
+  tags {
+    Name = "tf-acc-elb-subnet-swap-a-one"
+  }
 }
 
 resource "aws_subnet" "public_b_one" {
@@ -1687,6 +1699,9 @@ resource "aws_subnet" "public_b_one" {
 
   cidr_block        = "10.1.7.0/24"
   availability_zone = "us-west-2b"
+  tags {
+    Name = "tf-acc-elb-subnet-swap-b-one"
+  }
 }
 
 resource "aws_subnet" "public_a_two" {
@@ -1694,6 +1709,9 @@ resource "aws_subnet" "public_a_two" {
 
   cidr_block        = "10.1.2.0/24"
   availability_zone = "us-west-2a"
+  tags {
+    Name = "tf-acc-elb-subnet-swap-a-two"
+  }
 }
 
 resource "aws_elb" "ourapp" {

--- a/aws/resource_aws_emr_cluster_test.go
+++ b/aws/resource_aws_emr_cluster_test.go
@@ -626,7 +626,7 @@ resource "aws_subnet" "main" {
   cidr_block = "168.31.0.0/20"
 
   tags {
-    Name = "emr_test_cts"
+    Name = "tf-acc-emr-cluster-bootstrap"
   }
 }
 
@@ -794,7 +794,7 @@ resource "aws_subnet" "main" {
   cidr_block = "168.31.0.0/20"
 
   tags {
-    Name = "emr_test_%[1]d"
+    Name = "tf-acc-emr-cluster"
   }
 }
 
@@ -1106,7 +1106,7 @@ resource "aws_subnet" "main" {
   vpc_id            = "${aws_vpc.main.id}"
 
   tags {
-    Name = "terraform-testacc-emr-cluster-kerberos-cluster-dedicated-kdc"
+    Name = "tf-acc-emr-cluster-kerberos-cluster-dedicated-kdc"
   }
 }
 
@@ -1226,7 +1226,7 @@ resource "aws_subnet" "main" {
   cidr_block = "168.31.0.0/20"
 
   tags {
-    Name = "emr_test_%d"
+    Name = "tf-acc-emr-cluster-security-configuration"
   }
 }
 
@@ -1481,7 +1481,7 @@ resource "aws_kms_key" "foo" {
 }
 POLICY
 }
-`, r, r, r, r, r, r, r, r, r, r)
+`, r, r, r, r, r, r, r, r, r)
 }
 
 func testAccAWSEmrClusterConfigInstanceGroups(r int) string {
@@ -1618,7 +1618,7 @@ resource "aws_subnet" "main" {
   cidr_block = "168.31.0.0/20"
 
   tags {
-    Name = "emr_test_%[1]d"
+    Name = "tf-acc-emr-cluster-instance-groups"
   }
 }
 
@@ -1920,7 +1920,7 @@ resource "aws_subnet" "main" {
   cidr_block = "168.31.0.0/20"
 
   tags {
-    Name = "emr_test_%[1]d"
+    Name = "tf-acc-emr-cluster-termination-policy"
   }
 }
 
@@ -2227,7 +2227,7 @@ resource "aws_subnet" "main" {
   cidr_block = "168.31.0.0/20"
 
   tags {
-    Name = "emr_test_%d"
+    Name = "tf-acc-emr-cluster-visible-to-all-users"
   }
 }
 
@@ -2441,7 +2441,7 @@ resource "aws_iam_role_policy_attachment" "emr-autoscaling-role" {
   role       = "${aws_iam_role.emr-autoscaling-role.name}"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceforAutoScalingRole"
 }
-`, r, r, r, r, r, r, r, r, r)
+`, r, r, r, r, r, r, r, r)
 }
 
 func testAccAWSEmrClusterConfigUpdatedTags(r int) string {
@@ -2529,7 +2529,7 @@ resource "aws_subnet" "main" {
   cidr_block = "168.31.0.0/20"
 
   tags {
-    Name = "emr_test_%[1]d"
+    Name = "tf-acc-emr-cluster-updated-tags"
   }
 }
 
@@ -2837,7 +2837,7 @@ resource "aws_subnet" "main" {
   cidr_block = "168.31.0.0/20"
 
   tags {
-    Name = "emr_test_%d"
+    Name = "tf-acc-emr-cluster-updated-root-volume-size"
   }
 }
 
@@ -3050,7 +3050,7 @@ resource "aws_iam_role_policy_attachment" "emr-autoscaling-role" {
   role       = "${aws_iam_role.emr-autoscaling-role.name}"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceforAutoScalingRole"
 }
-`, r, r, r, r, r, r, r, r, r)
+`, r, r, r, r, r, r, r, r)
 }
 
 func testAccAWSEmrClusterConfigS3Logging(rInt int) string {
@@ -3070,6 +3070,9 @@ resource "aws_vpc" "test" {
 resource "aws_subnet" "test" {
   vpc_id = "${aws_vpc.test.id}"
   cidr_block = "10.0.0.0/24"
+  tags {
+    Name = "tf-acc-emr-cluster-s3-logging"
+  }
 }
 
 resource "aws_internet_gateway" "main" {
@@ -3219,7 +3222,7 @@ resource "aws_vpc" "main" {
   enable_dns_hostnames = true
 
   tags {
-    Name = "emr_test_%d"
+    Name = "terraform-testacc-emr-cluster-custom-ami-id"
   }
 }
 
@@ -3228,7 +3231,7 @@ resource "aws_subnet" "main" {
   cidr_block = "168.31.0.0/20"
 
   tags {
-    Name = "emr_test_%d"
+    Name = "tf-acc-emr-cluster-custom-ami-id"
   }
 }
 
@@ -3467,5 +3470,5 @@ data "aws_ami" "emr-custom-ami" {
     values = ["hvm"]
   }
 }
-`, r, r, r, r, r, r, r, r, r, r)
+`, r, r, r, r, r, r, r, r)
 }

--- a/aws/resource_aws_emr_instance_group_test.go
+++ b/aws/resource_aws_emr_instance_group_test.go
@@ -208,7 +208,9 @@ resource "aws_subnet" "main" {
   vpc_id     = "${aws_vpc.main.id}"
   cidr_block = "168.31.0.0/20"
 
-  #  map_public_ip_on_launch = true
+  tags {
+    Name = "tf-acc-emr-instance-group"
+  }
 }
 
 resource "aws_internet_gateway" "gw" {

--- a/aws/resource_aws_flow_log_test.go
+++ b/aws/resource_aws_flow_log_test.go
@@ -122,7 +122,7 @@ resource "aws_subnet" "test_subnet" {
     cidr_block = "10.0.1.0/24"
 
     tags {
-        Name = "tf-flow-test"
+        Name = "tf-acc-flow-log-basic"
     }
 }
 
@@ -181,7 +181,7 @@ resource "aws_subnet" "test_subnet" {
     cidr_block = "10.0.1.0/24"
 
     tags {
-        Name = "tf-flow-test"
+        Name = "tf-acc-flow-log-subnet"
     }
 }
 

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -1692,6 +1692,9 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
+	tags {
+		Name = "tf-acc-instance-source-dest-enable"
+	}
 }
 
 resource "aws_instance" "foo" {
@@ -1713,6 +1716,9 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
+	tags {
+		Name = "tf-acc-instance-source-dest-disable"
+	}
 }
 
 resource "aws_instance" "foo" {
@@ -1736,6 +1742,9 @@ func testAccInstanceConfigDisableAPITermination(val bool) string {
 	resource "aws_subnet" "foo" {
 		cidr_block = "10.1.1.0/24"
 		vpc_id = "${aws_vpc.foo.id}"
+		tags {
+			Name = "tf-acc-instance-disable-api-termination"
+		}
 	}
 
 	resource "aws_instance" "foo" {
@@ -1759,6 +1768,9 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
+	tags {
+		Name = "tf-acc-instance-vpc"
+	}
 }
 
 resource "aws_instance" "foo" {
@@ -1785,6 +1797,9 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
   cidr_block = "10.1.1.0/24"
   vpc_id = "${aws_vpc.foo.id}"
+  tags {
+  	Name = "tf-acc-instance-placement-group"
+  }
 }
 
 resource "aws_placement_group" "foo" {
@@ -1820,7 +1835,7 @@ resource "aws_subnet" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
 	ipv6_cidr_block = "${cidrsubnet(aws_vpc.foo.ipv6_cidr_block, 8, 1)}"
 	tags {
-		Name = "tf-ipv6-instance-acc-test"
+		Name = "tf-acc-instance-ipv6-err"
 	}
 }
 
@@ -1851,7 +1866,7 @@ resource "aws_subnet" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
 	ipv6_cidr_block = "${cidrsubnet(aws_vpc.foo.ipv6_cidr_block, 8, 1)}"
 	tags {
-		Name = "tf-ipv6-instance-acc-test"
+		Name = "tf-acc-instance-ipv6-support"
 	}
 }
 
@@ -1882,7 +1897,7 @@ resource "aws_subnet" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
 	ipv6_cidr_block = "${cidrsubnet(aws_vpc.foo.ipv6_cidr_block, 8, 1)}"
 	tags {
-		Name = "tf-ipv6-instance-acc-test"
+		Name = "tf-acc-instance-ipv6-support-with-ipv4"
 	}
 }
 
@@ -2169,6 +2184,9 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
+	tags {
+		Name = "tf-acc-instance-private-ip"
+	}
 }
 
 resource "aws_instance" "foo" {
@@ -2190,6 +2208,9 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
+	tags {
+		Name = "tf-acc-instance-public-ip-and-private-ip"
+	}
 }
 
 resource "aws_instance" "foo" {
@@ -2230,6 +2251,9 @@ resource "aws_security_group" "tf_test_foo" {
 resource "aws_subnet" "foo" {
   cidr_block = "10.1.1.0/24"
   vpc_id = "${aws_vpc.foo.id}"
+  tags {
+  	Name = "tf-acc-instance-network-security-groups"
+  }
 }
 
 resource "aws_instance" "foo_instance" {
@@ -2278,6 +2302,9 @@ resource "aws_security_group" "tf_test_foo" {
 resource "aws_subnet" "foo" {
   cidr_block = "10.1.1.0/24"
   vpc_id = "${aws_vpc.foo.id}"
+  tags {
+  	Name = "tf-acc-instance-network-vpc-sg-ids"
+  }
 }
 
 resource "aws_instance" "foo_instance" {
@@ -2305,7 +2332,7 @@ resource "aws_internet_gateway" "gw" {
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
     tags {
-        Name = "tf-network-test"
+        Name = "terraform-testacc-instance-network-vpc-sg-ids"
     }
 }
 
@@ -2325,6 +2352,9 @@ resource "aws_security_group" "tf_test_foo" {
 resource "aws_subnet" "foo" {
   cidr_block = "10.1.1.0/24"
   vpc_id = "${aws_vpc.foo.id}"
+  tags {
+  	Name = "tf-acc-instance-network-vpc-sg-ids"
+  }
 }
 
 resource "aws_instance" "foo_instance" {
@@ -2376,6 +2406,9 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
+	tags {
+		Name = "tf-acc-instance-root-block-device-mismatch"
+	}
 }
 
 resource "aws_instance" "foo" {
@@ -2400,6 +2433,9 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
+	tags {
+		Name = "tf-acc-instance-force-new-and-tags-drift"
+	}
 }
 
 resource "aws_instance" "foo" {
@@ -2420,6 +2456,9 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
+	tags {
+		Name = "tf-acc-instance-force-new-and-tags-drift"
+	}
 }
 
 resource "aws_instance" "foo" {
@@ -2442,7 +2481,7 @@ resource "aws_subnet" "foo" {
   cidr_block = "172.16.10.0/24"
   availability_zone = "us-west-2a"
   tags {
-    Name = "tf-instance-test"
+    Name = "tf-acc-instance-primary-network-iface"
   }
 }
 
@@ -2477,7 +2516,7 @@ resource "aws_subnet" "foo" {
   cidr_block = "172.16.10.0/24"
   availability_zone = "us-west-2a"
   tags {
-    Name = "tf-instance-test"
+    Name = "tf-acc-instance-primary-network-iface-source-dest-check"
   }
 }
 
@@ -2513,7 +2552,7 @@ resource "aws_subnet" "foo" {
   cidr_block = "172.16.10.0/24"
   availability_zone = "us-west-2a"
   tags {
-    Name = "tf-instance-test"
+    Name = "tf-acc-instance-add-secondary-network-iface"
   }
 }
 
@@ -2556,7 +2595,7 @@ resource "aws_subnet" "foo" {
   cidr_block = "172.16.10.0/24"
   availability_zone = "us-west-2a"
   tags {
-    Name = "tf-instance-test"
+    Name = "tf-acc-instance-add-secondary-network-iface"
   }
 }
 
@@ -2603,18 +2642,18 @@ resource "aws_subnet" "foo" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "172.16.10.0/24"
     availability_zone = "us-west-2a"
-        tags {
-            Name = "tf-foo-instance-add-sg-test"
-        }
+    tags {
+        Name = "tf-acc-instance-add-security-group-foo"
+    }
 }
 
 resource "aws_subnet" "bar" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "172.16.11.0/24"
     availability_zone = "us-west-2a"
-        tags {
-            Name = "tf-bar-instance-add-sg-test"
-        }
+    tags {
+        Name = "tf-acc-instance-add-security-group-bar"
+    }
 }
 
 resource "aws_security_group" "foo" {
@@ -2668,18 +2707,18 @@ resource "aws_subnet" "foo" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "172.16.10.0/24"
     availability_zone = "us-west-2a"
-        tags {
-            Name = "tf-foo-instance-add-sg-test"
-        }
+    tags {
+        Name = "tf-acc-instance-add-security-group-foo"
+    }
 }
 
 resource "aws_subnet" "bar" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "172.16.11.0/24"
     availability_zone = "us-west-2a"
-        tags {
-            Name = "tf-bar-instance-add-sg-test"
-        }
+    tags {
+        Name = "tf-acc-instance-add-security-group-bar"
+    }
 }
 
 resource "aws_security_group" "foo" {
@@ -2736,6 +2775,9 @@ resource "aws_subnet" "public_subnet" {
   cidr_block = "172.16.20.0/24"
   availability_zone = "us-west-2a"
   map_public_ip_on_launch = false
+  tags {
+    Name = "tf-acc-instance-associate-public-default-private"
+  }
 }
 
 resource "aws_instance" "foo" {
@@ -2762,6 +2804,9 @@ resource "aws_subnet" "public_subnet" {
   cidr_block = "172.16.20.0/24"
   availability_zone = "us-west-2a"
   map_public_ip_on_launch = true
+  tags {
+    Name = "tf-acc-instance-associate-public-default-public"
+  }
 }
 
 resource "aws_instance" "foo" {
@@ -2788,6 +2833,9 @@ resource "aws_subnet" "public_subnet" {
   cidr_block = "172.16.20.0/24"
   availability_zone = "us-west-2a"
   map_public_ip_on_launch = true
+  tags {
+    Name = "tf-acc-instance-associate-public-explicit-public"
+  }
 }
 
 resource "aws_instance" "foo" {
@@ -2815,6 +2863,9 @@ resource "aws_subnet" "public_subnet" {
   cidr_block = "172.16.20.0/24"
   availability_zone = "us-west-2a"
   map_public_ip_on_launch = false
+  tags {
+    Name = "tf-acc-instance-associate-public-explicit-private"
+  }
 }
 
 resource "aws_instance" "foo" {
@@ -2842,6 +2893,9 @@ resource "aws_subnet" "public_subnet" {
   cidr_block = "172.16.20.0/24"
   availability_zone = "us-west-2a"
   map_public_ip_on_launch = false
+  tags {
+    Name = "tf-acc-instance-associate-public-override-public"
+  }
 }
 
 resource "aws_instance" "foo" {
@@ -2869,6 +2923,9 @@ resource "aws_subnet" "public_subnet" {
   cidr_block = "172.16.20.0/24"
   availability_zone = "us-west-2a"
   map_public_ip_on_launch = true
+  tags {
+    Name = "tf-acc-instance-associate-public-override-private"
+  }
 }
 
 resource "aws_instance" "foo" {

--- a/aws/resource_aws_lambda_function_test.go
+++ b/aws/resource_aws_lambda_function_test.go
@@ -1260,7 +1260,7 @@ resource "aws_subnet" "subnet_for_lambda" {
     cidr_block = "10.0.1.0/24"
 
     tags {
-        Name = "lambda"
+        Name = "tf-acc-lambda-function-1"
     }
 }
 
@@ -1640,7 +1640,7 @@ resource "aws_subnet" "subnet_for_lambda_2" {
     cidr_block = "10.0.2.0/24"
 
     tags {
-        Name = "lambda"
+        Name = "tf-acc-lambda-function-2"
     }
 }
 

--- a/aws/resource_aws_lb_listener_certificate_test.go
+++ b/aws/resource_aws_lb_listener_certificate_test.go
@@ -424,6 +424,9 @@ data "aws_availability_zones" "available" {}
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
+  tags {
+  	Name = "terraform-testacc-lb-listener-certificate"
+  }
 }
 
 variable "subnets" {
@@ -435,6 +438,9 @@ resource "aws_subnet" "test" {
   vpc_id            = "${aws_vpc.test.id}"
   cidr_block        = "${element(var.subnets, count.index)}"
   availability_zone = "${element(data.aws_availability_zones.available.names, count.index)}"
+  tags {
+    Name = "tf-acc-lb-listener-certificate-${count.index}"
+  }
 }`, rName, suffix, suffix, suffix, suffix)
 }
 

--- a/aws/resource_aws_lb_listener_rule_test.go
+++ b/aws/resource_aws_lb_listener_rule_test.go
@@ -418,7 +418,7 @@ resource "aws_subnet" "alb_test" {
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "tf-acc-lb-listener-rule-multiple-conditions-${count.index}"
   }
 }
 
@@ -529,7 +529,7 @@ resource "aws_subnet" "alb_test" {
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "tf-acc-lb-listener-rule-basic-${count.index}"
   }
 }
 
@@ -640,7 +640,7 @@ resource "aws_subnet" "alb_test" {
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "tf-acc-lb-listener-rule-bc-${count.index}"
   }
 }
 
@@ -752,7 +752,7 @@ resource "aws_subnet" "alb_test" {
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "tf-acc-lb-listener-rule-update-rule-priority-${count.index}"
   }
 }
 
@@ -875,7 +875,7 @@ resource "aws_subnet" "alb_test" {
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "tf-acc-lb-listener-rule-change-rule-arn-${count.index}"
   }
 }
 
@@ -960,7 +960,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "terraform-testacc-lb-listener-rule-priority"
   }
 }
 
@@ -972,7 +972,7 @@ resource "aws_subnet" "alb_test" {
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "tf-acc-lb-listener-rule-priority-${count.index}"
   }
 }
 

--- a/aws/resource_aws_lb_listener_test.go
+++ b/aws/resource_aws_lb_listener_test.go
@@ -229,7 +229,7 @@ resource "aws_subnet" "alb_test" {
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "tf-acc-lb-listener-basic-${count.index}"
   }
 }
 
@@ -325,7 +325,7 @@ resource "aws_subnet" "alb_test" {
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "tf-acc-lb-listener-bc-${count.index}"
   }
 }
 
@@ -433,7 +433,7 @@ resource "aws_subnet" "alb_test" {
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "tf-acc-lb-listener-https-${count.index}"
   }
 }
 

--- a/aws/resource_aws_lb_target_group_attachment_test.go
+++ b/aws/resource_aws_lb_target_group_attachment_test.go
@@ -209,6 +209,9 @@ resource "aws_lb_target_group" "test" {
 resource "aws_subnet" "subnet" {
   cidr_block = "10.0.1.0/24"
   vpc_id = "${aws_vpc.test.id}"
+  tags {
+    Name = "tf-acc-lb-target-group-attachment-without-port"
+  }
 }
 
 resource "aws_vpc" "test" {
@@ -258,6 +261,9 @@ resource "aws_lb_target_group" "test" {
 resource "aws_subnet" "subnet" {
   cidr_block = "10.0.1.0/24"
   vpc_id = "${aws_vpc.test.id}"
+  tags {
+    Name = "tf-acc-lb-target-group-attachment-basic"
+  }
 }
 
 resource "aws_vpc" "test" {
@@ -307,6 +313,9 @@ resource "aws_alb_target_group" "test" {
 resource "aws_subnet" "subnet" {
   cidr_block = "10.0.1.0/24"
   vpc_id = "${aws_vpc.test.id}"
+  tags {
+    Name = "tf-acc-lb-target-group-attachment-bc"
+  }
 }
 
 resource "aws_vpc" "test" {
@@ -354,6 +363,9 @@ resource "aws_lb_target_group" "test" {
 resource "aws_subnet" "subnet" {
   cidr_block = "10.0.1.0/24"
   vpc_id = "${aws_vpc.test.id}"
+  tags {
+    Name = "tf-acc-lb-target-group-attachment-with-ip-address"
+  }
 }
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"

--- a/aws/resource_aws_lb_test.go
+++ b/aws/resource_aws_lb_test.go
@@ -744,7 +744,7 @@ resource "aws_subnet" "alb_test_1" {
   ipv6_cidr_block = "${cidrsubnet(aws_vpc.alb_test.ipv6_cidr_block, 8, 1)}"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "tf-acc-lb-with-ip-address-type-updated-1"
   }
 }
 
@@ -756,7 +756,7 @@ resource "aws_subnet" "alb_test_2" {
   ipv6_cidr_block = "${cidrsubnet(aws_vpc.alb_test.ipv6_cidr_block, 8, 2)}"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "tf-acc-lb-with-ip-address-type-updated-2"
   }
 }
 
@@ -855,7 +855,7 @@ resource "aws_subnet" "alb_test_1" {
   ipv6_cidr_block = "${cidrsubnet(aws_vpc.alb_test.ipv6_cidr_block, 8, 1)}"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "tf-acc-lb-with-ip-address-type-1"
   }
 }
 
@@ -867,7 +867,7 @@ resource "aws_subnet" "alb_test_2" {
   ipv6_cidr_block = "${cidrsubnet(aws_vpc.alb_test.ipv6_cidr_block, 8, 2)}"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "tf-acc-lb-with-ip-address-type-2"
   }
 }
 
@@ -927,7 +927,7 @@ resource "aws_subnet" "alb_test" {
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "tf-acc-lb-basic"
   }
 }
 
@@ -996,7 +996,7 @@ resource "aws_subnet" "alb_test" {
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "tf-acc-lb-basic-${count.index}"
   }
 }
 
@@ -1063,7 +1063,7 @@ resource "aws_subnet" "alb_test" {
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "tf-acc-lb-basic-${count.index}"
   }
 }
 
@@ -1127,7 +1127,7 @@ resource "aws_subnet" "alb_test_1" {
   availability_zone = "us-west-2a"
 
   tags {
-    Name = "testAccAWSLBConfig_networkLoadbalancer_subnets"
+    Name = "tf-acc-lb-network-load-balancer-subnets-1"
   }
 }
 
@@ -1137,7 +1137,7 @@ resource "aws_subnet" "alb_test_2" {
   availability_zone = "us-west-2b"
 
   tags {
-    Name = "testAccAWSLBConfig_networkLoadbalancer_subnets"
+    Name = "tf-acc-lb-network-load-balancer-subnets-2"
   }
 }
 
@@ -1147,7 +1147,7 @@ resource "aws_subnet" "alb_test_3" {
   availability_zone = "us-west-2c"
 
   tags {
-    Name = "testAccAWSLBConfig_networkLoadbalancer_subnets"
+    Name = "tf-acc-lb-network-load-balancer-subnets-3"
   }
 }
 `, lbName)
@@ -1186,7 +1186,7 @@ resource "aws_subnet" "alb_test" {
   availability_zone       = "us-west-2a"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "tf-acc-network-load-balancer"
   }
 }
 
@@ -1209,6 +1209,9 @@ resource "aws_subnet" "public" {
   availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
   cidr_block = "10.10.${count.index}.0/24"
   vpc_id = "${aws_vpc.main.id}"
+  tags {
+    Name = "tf-acc-lb-network-load-balancer-eip-${count.index}"
+  }
 }
 
 resource "aws_internet_gateway" "default" {
@@ -1288,7 +1291,7 @@ resource "aws_subnet" "alb_test" {
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "tf-acc-lb-bc-${count.index}"
   }
 }
 
@@ -1355,7 +1358,7 @@ resource "aws_subnet" "alb_test" {
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "tf-acc-lb-update-subnets-${count.index}"
   }
 }
 
@@ -1430,7 +1433,7 @@ resource "aws_subnet" "alb_test" {
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "tf-acc-lb-generated-name-${count.index}"
   }
 }
 
@@ -1511,7 +1514,7 @@ resource "aws_subnet" "alb_test" {
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "tf-acc-lb-zero-value-name-${count.index}"
   }
 }
 
@@ -1579,7 +1582,7 @@ resource "aws_subnet" "alb_test" {
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "tf-acc-lb-name-prefix-${count.index}"
   }
 }
 
@@ -1646,7 +1649,7 @@ resource "aws_subnet" "alb_test" {
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "tf-acc-lb-updated-tags-${count.index}"
   }
 }
 
@@ -1757,7 +1760,7 @@ resource "aws_subnet" "alb_test" {
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "tf-acc-lb-access-logs-${count.index}"
   }
 }
 
@@ -1823,7 +1826,7 @@ resource "aws_subnet" "alb_test" {
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "tf-acc-lb-no-sg-${count.index}"
   }
 }`, lbName)
 }
@@ -1866,7 +1869,7 @@ resource "aws_subnet" "alb_test" {
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
   tags {
-    Name = "TestAccAWSALB_basic"
+    Name = "tf-acc-lb-update-security-groups-${count.index}"
   }
 }
 


### PR DESCRIPTION
## Test results

```
=== RUN   TestAccAWSEcsService_importBasic
--- PASS: TestAccAWSEcsService_importBasic (10.67s)
=== RUN   TestAccAWSEcsService_withPlacementConstraints_emptyExpression
--- PASS: TestAccAWSEcsService_withPlacementConstraints_emptyExpression (11.12s)
=== RUN   TestAccAWSEcsService_withDeploymentValues
--- PASS: TestAccAWSEcsService_withDeploymentValues (23.94s)
=== RUN   TestAccAWSEcsService_withEcsClusterName
--- PASS: TestAccAWSEcsService_withEcsClusterName (34.14s)
=== RUN   TestAccAWSEcsService_withARN
--- PASS: TestAccAWSEcsService_withARN (35.63s)
=== RUN   TestAccAWSEcsService_withPlacementConstraints
--- PASS: TestAccAWSEcsService_withPlacementConstraints (44.24s)
=== RUN   TestAccAWSEcsService_withPlacementStrategy
--- PASS: TestAccAWSEcsService_withPlacementStrategy (48.08s)
=== RUN   TestAccAWSEcsService_withFamilyAndRevision
--- PASS: TestAccAWSEcsService_withFamilyAndRevision (54.80s)
=== RUN   TestAccAWSEcsService_withRenamedCluster
--- PASS: TestAccAWSEcsService_withRenamedCluster (78.00s)
=== RUN   TestAccAWSEIP_network_interface
--- PASS: TestAccAWSEIP_network_interface (50.99s)
=== RUN   TestAccAWSEIP_classic_disassociate
--- SKIP: TestAccAWSEIP_classic_disassociate (5.82s)
	provider_test.go:89: This test can only run in EC2 Classic, platforms available in us-west-2: ["VPC"]
=== RUN   TestAccAWSEIP_basic
--- PASS: TestAccAWSEIP_basic (74.51s)
=== RUN   TestAccAWSEcsService_withIamRole
--- PASS: TestAccAWSEcsService_withIamRole (116.84s)
=== RUN   TestAccAWSEIP_disappears
--- PASS: TestAccAWSEIP_disappears (15.38s)
=== RUN   TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration
--- FAIL: TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration (128.96s)
	testing.go:513: Step 1 error: Check failed: Check 3/4 error: aws_ecs_service.main: Attribute 'network_configuration.0.security_groups.#' expected "1", got "2"
=== RUN   TestAccAWSEIP_importEc2Classic
--- PASS: TestAccAWSEIP_importEc2Classic (122.58s)
=== RUN   TestAccAWSBeanstalkConfigurationTemplate_Setting
--- PASS: TestAccAWSBeanstalkConfigurationTemplate_Setting (16.05s)
=== RUN   TestAccAWSEIP_tags
--- PASS: TestAccAWSEIP_tags (63.44s)
=== RUN   TestAccAWSEcsService_withUnnormalizedPlacementStrategy
--- PASS: TestAccAWSEcsService_withUnnormalizedPlacementStrategy (184.65s)
=== RUN   TestAccAWSEIP_twoEIPsOneNetworkInterface
--- PASS: TestAccAWSEIP_twoEIPsOneNetworkInterface (144.65s)
=== RUN   TestAccAWSEIPAssociation_ec2Classic
--- PASS: TestAccAWSEIPAssociation_ec2Classic (202.69s)
=== RUN   TestAccAWSBeanstalkConfigurationTemplate_basic
--- PASS: TestAccAWSBeanstalkConfigurationTemplate_basic (88.95s)
=== RUN   TestAccAWSEIP_importVpc
--- PASS: TestAccAWSEIP_importVpc (178.11s)
=== RUN   TestAccAWSEcsService_withLaunchTypeFargate
--- PASS: TestAccAWSEcsService_withLaunchTypeFargate (214.22s)
=== RUN   TestAccAWSEcsService_withLbChanges
--- PASS: TestAccAWSEcsService_withLbChanges (236.62s)
=== RUN   TestAccAWSEcsService_withAlb
--- PASS: TestAccAWSEcsService_withAlb (249.77s)
=== RUN   TestAccAWSEFSMountTarget_disappears
--- PASS: TestAccAWSEFSMountTarget_disappears (255.55s)
=== RUN   TestAccAWSEIPAssociate_not_associated
--- PASS: TestAccAWSEIPAssociate_not_associated (166.80s)
=== RUN   TestAccAWSEIP_instance
--- PASS: TestAccAWSEIP_instance (243.34s)
=== RUN   TestAccAWSEIPAssociation_disappears
--- PASS: TestAccAWSEIPAssociation_disappears (343.89s)
=== RUN   TestAccAWSEcsService_healthCheckGracePeriodSeconds
--- PASS: TestAccAWSEcsService_healthCheckGracePeriodSeconds (355.83s)
=== RUN   TestAccAWSBeanstalkConfigurationTemplate_VPC
--- PASS: TestAccAWSBeanstalkConfigurationTemplate_VPC (235.92s)
=== RUN   TestAccAWSEIP_associated_user_private_ip
--- PASS: TestAccAWSEIP_associated_user_private_ip (327.37s)
=== RUN   TestAccAWSEIPAssociation_basic
--- PASS: TestAccAWSEIPAssociation_basic (422.82s)
=== RUN   TestAccAWSEFSMountTarget_basic
--- PASS: TestAccAWSEFSMountTarget_basic (441.78s)
=== RUN   TestAccAWSEIPAssociation_spotInstance
--- FAIL: TestAccAWSEIPAssociation_spotInstance (575.58s)
	testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
		
		* aws_eip_association.test: 1 error(s) occurred:
		
		* aws_eip_association.test: Error associating EIP: InvalidInstanceID: The pending instance 'i-0c5f3b28d3908fb50' is not in a valid state for this operation.
			status code: 400, request id: 02b3fb23-faa7-4b33-b903-14d19fd30eb9
=== RUN   TestAccAWSBeanstalkEnv_basic
--- PASS: TestAccAWSBeanstalkEnv_basic (481.47s)
=== RUN   TestAccAWSBeanstalkEnv_resource
--- PASS: TestAccAWSBeanstalkEnv_resource (464.32s)
=== RUN   TestAccAWSBeanstalkEnv_config
--- PASS: TestAccAWSBeanstalkEnv_config (509.99s)
=== RUN   TestAccAWSBeanstalkEnv_outputs
--- PASS: TestAccAWSBeanstalkEnv_outputs (535.36s)
=== RUN   TestAccAWSBeanstalkEnv_vpc
--- PASS: TestAccAWSBeanstalkEnv_vpc (550.70s)
=== RUN   TestAccAWSBeanstalkEnv_template_change
--- PASS: TestAccAWSBeanstalkEnv_template_change (556.42s)
=== RUN   TestAccAWSBeanstalkEnv_version_label
--- PASS: TestAccAWSBeanstalkEnv_version_label (538.16s)
=== RUN   TestAccAWSElasticacheCluster_basic
--- PASS: TestAccAWSElasticacheCluster_basic (528.58s)
=== RUN   TestAccAWSElasticacheReplicationGroup_clusteringAndCacheNodesCausesError
--- PASS: TestAccAWSElasticacheReplicationGroup_clusteringAndCacheNodesCausesError (8.45s)
=== RUN   TestAccAWSBeanstalkEnv_tags
--- PASS: TestAccAWSBeanstalkEnv_tags (699.19s)
=== RUN   TestAccAWSBeanstalkEnv_cname_prefix
--- PASS: TestAccAWSBeanstalkEnv_cname_prefix (742.84s)
=== RUN   TestAccAWSBeanstalkEnv_tier
--- PASS: TestAccAWSBeanstalkEnv_tier (777.66s)
=== RUN   TestAccAWSElasticacheSubnetGroup_basic
--- PASS: TestAccAWSElasticacheSubnetGroup_basic (9.18s)
=== RUN   TestAccAWSElasticacheSubnetGroup_update
--- PASS: TestAccAWSElasticacheSubnetGroup_update (14.39s)
=== RUN   TestAccAWSBeanstalkEnv_basic_settings_update
--- PASS: TestAccAWSBeanstalkEnv_basic_settings_update (773.19s)
=== RUN   TestAccAWSElasticacheCluster_vpc
--- PASS: TestAccAWSElasticacheCluster_vpc (698.85s)
=== RUN   TestAccAWSElasticacheCluster_multiAZInVpc
--- PASS: TestAccAWSElasticacheCluster_multiAZInVpc (686.62s)
=== RUN   TestAccAWSElasticacheReplicationGroup_Uppercase
--- PASS: TestAccAWSElasticacheReplicationGroup_Uppercase (703.03s)
=== RUN   TestAccAWSBeanstalkEnv_settingWithJsonValue
--- PASS: TestAccAWSBeanstalkEnv_settingWithJsonValue (908.61s)
=== RUN   TestAccAWSElasticacheCluster_snapshotsWithUpdates
--- PASS: TestAccAWSElasticacheCluster_snapshotsWithUpdates (1038.50s)
=== RUN   TestAccAWSElasticacheReplicationGroup_basic
--- PASS: TestAccAWSElasticacheReplicationGroup_basic (984.58s)
=== RUN   TestAccAWSElasticacheReplicationGroup_vpc
--- PASS: TestAccAWSElasticacheReplicationGroup_vpc (767.05s)
=== RUN   TestAccAWSElasticacheCluster_decreasingCacheNodes
--- PASS: TestAccAWSElasticacheCluster_decreasingCacheNodes (1183.23s)
=== RUN   TestAccAWSElasticacheReplicationGroup_updateDescription
--- PASS: TestAccAWSElasticacheReplicationGroup_updateDescription (1028.30s)
=== RUN   TestAccAWSElasticacheReplicationGroup_enableAuthTokenTransitEncryption
--- PASS: TestAccAWSElasticacheReplicationGroup_enableAuthTokenTransitEncryption (716.33s)
=== RUN   TestAccAWSElasticacheReplicationGroup_enableAtRestEncryption
--- PASS: TestAccAWSElasticacheReplicationGroup_enableAtRestEncryption (695.86s)
=== RUN   TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow
--- PASS: TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow (1070.26s)
=== RUN   TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2
--- PASS: TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2 (950.00s)
=== RUN   TestAccAWSELB_basic
--- PASS: TestAccAWSELB_basic (7.52s)
=== RUN   TestAccAWSELB_fullCharacterRange
--- PASS: TestAccAWSELB_fullCharacterRange (6.82s)
=== RUN   TestAccAWSElasticacheReplicationGroup_updateParameterGroup
--- PASS: TestAccAWSElasticacheReplicationGroup_updateParameterGroup (1060.06s)
=== RUN   TestAccAWSElasticSearchDomain_basic
--- PASS: TestAccAWSElasticSearchDomain_basic (796.72s)
=== RUN   TestAccAWSELB_AccessLogs_enabled
--- PASS: TestAccAWSELB_AccessLogs_enabled (21.20s)
=== RUN   TestAccAWSELB_namePrefix
--- PASS: TestAccAWSELB_namePrefix (7.08s)
=== RUN   TestAccAWSELB_generatedName
--- PASS: TestAccAWSELB_generatedName (7.97s)
=== RUN   TestAccAWSELB_generatesNameForZeroValue
--- PASS: TestAccAWSELB_generatesNameForZeroValue (8.01s)
=== RUN   TestAccAWSELB_AccessLogs_disabled
--- PASS: TestAccAWSELB_AccessLogs_disabled (22.71s)
=== RUN   TestAccAWSELB_availabilityZones
--- PASS: TestAccAWSELB_availabilityZones (12.03s)
=== RUN   TestAccAWSELB_tags
--- PASS: TestAccAWSELB_tags (13.85s)
=== RUN   TestAccAWSElasticSearchDomain_duplicate
--- PASS: TestAccAWSElasticSearchDomain_duplicate (805.34s)
=== RUN   TestAccAWSELB_swap_subnets
--- PASS: TestAccAWSELB_swap_subnets (44.64s)
=== RUN   TestAccAWSElasticSearchDomain_v23
--- PASS: TestAccAWSElasticSearchDomain_v23 (752.60s)
=== RUN   TestAccAWSElasticacheReplicationGroup_nativeRedisCluster
--- PASS: TestAccAWSElasticacheReplicationGroup_nativeRedisCluster (1062.60s)
=== RUN   TestAccAWSELB_HealthCheck
--- PASS: TestAccAWSELB_HealthCheck (17.62s)
=== RUN   TestAccAWSELBUpdate_HealthCheck
--- PASS: TestAccAWSELBUpdate_HealthCheck (36.18s)
=== RUN   TestAccAWSELB_ConnectionDraining
--- PASS: TestAccAWSELB_ConnectionDraining (7.11s)
=== RUN   TestAccAWSELB_Timeout
--- PASS: TestAccAWSELB_Timeout (38.25s)
=== RUN   TestAccAWSELB_iam_server_cert
--- PASS: TestAccAWSELB_iam_server_cert (107.62s)
=== RUN   TestAccAWSELBUpdate_ConnectionDraining
--- PASS: TestAccAWSELBUpdate_ConnectionDraining (16.12s)
=== RUN   TestAccAWSELB_SecurityGroups
--- PASS: TestAccAWSELB_SecurityGroups (21.36s)
=== RUN   TestAccAWSELBUpdate_Timeout
--- PASS: TestAccAWSELBUpdate_Timeout (63.33s)
=== RUN   TestAccAWSELB_listener
--- PASS: TestAccAWSELB_listener (121.61s)
=== RUN   TestAccAWSElasticacheReplicationGroup_multiAzInVpc
--- PASS: TestAccAWSElasticacheReplicationGroup_multiAzInVpc (1191.96s)
=== RUN   TestAccAWSELB_InstanceAttaching
--- PASS: TestAccAWSELB_InstanceAttaching (215.91s)
=== RUN   TestAccAWSElasticSearchDomain_complex
--- PASS: TestAccAWSElasticSearchDomain_complex (919.60s)
=== RUN   TestAccAWSElasticSearchDomain_importBasic
--- PASS: TestAccAWSElasticSearchDomain_importBasic (1089.82s)
=== RUN   TestAccAWSElasticSearchDomain_LogPublishingOptions
--- PASS: TestAccAWSElasticSearchDomain_LogPublishingOptions (811.95s)
=== RUN   TestAccAWSEMRCluster_basic
--- PASS: TestAccAWSEMRCluster_basic (407.30s)
=== RUN   TestAccAWSEMRCluster_Kerberos_ClusterDedicatedKdc
--- PASS: TestAccAWSEMRCluster_Kerberos_ClusterDedicatedKdc (431.82s)
=== RUN   TestAccAWSEMRCluster_terminationProtected
--- PASS: TestAccAWSEMRCluster_terminationProtected (411.59s)
=== RUN   TestAccAWSEMRCluster_bootstrap_ordering
--- PASS: TestAccAWSEMRCluster_bootstrap_ordering (423.21s)
=== RUN   TestAccAWSEMRCluster_instance_group
--- PASS: TestAccAWSEMRCluster_instance_group (484.82s)
=== RUN   TestAccAWSFlowLog_basic
--- PASS: TestAccAWSFlowLog_basic (10.21s)
=== RUN   TestAccAWSFlowLog_subnet
--- PASS: TestAccAWSFlowLog_subnet (9.07s)
=== RUN   TestAccAWSElasticSearchDomain_encrypt_at_rest_default_key
--- PASS: TestAccAWSElasticSearchDomain_encrypt_at_rest_default_key (832.63s)
=== RUN   TestAccAWSElasticSearchDomain_tags
--- PASS: TestAccAWSElasticSearchDomain_tags (835.28s)
=== RUN   TestAccAWSElasticSearchDomain_policy
--- PASS: TestAccAWSElasticSearchDomain_policy (976.59s)
=== RUN   TestAccAWSEMRCluster_security_config
--- PASS: TestAccAWSEMRCluster_security_config (603.22s)
=== RUN   TestAccAWSElasticSearchDomain_vpc
--- PASS: TestAccAWSElasticSearchDomain_vpc (1435.79s)
=== RUN   TestAccAWSElasticSearchDomain_encrypt_at_rest_specify_key
--- PASS: TestAccAWSElasticSearchDomain_encrypt_at_rest_specify_key (994.26s)
=== RUN   TestAccAWSInstance_basic
--- PASS: TestAccAWSInstance_basic (222.08s)
=== RUN   TestAccAWSEMRCluster_s3Logging
--- PASS: TestAccAWSEMRCluster_s3Logging (573.25s)
=== RUN   TestAccAWSInstance_GP2IopsDevice
--- PASS: TestAccAWSInstance_GP2IopsDevice (170.91s)
=== RUN   TestAccAWSInstance_userDataBase64
--- PASS: TestAccAWSInstance_userDataBase64 (208.35s)
=== RUN   TestAccAWSInstance_noAMIEphemeralDevices
--- PASS: TestAccAWSInstance_noAMIEphemeralDevices (51.50s)
=== RUN   TestAccAWSInstance_GP2WithIopsValue
--- PASS: TestAccAWSInstance_GP2WithIopsValue (166.11s)
=== RUN   TestAccAWSInstance_rootInstanceStore
--- PASS: TestAccAWSInstance_rootInstanceStore (78.89s)
=== RUN   TestAccAWSInstance_blockDevices
--- PASS: TestAccAWSInstance_blockDevices (182.66s)
=== RUN   TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError
--- PASS: TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError (28.70s)
=== RUN   TestAccAWSElasticacheReplicationGroup_enableSnapshotting
--- PASS: TestAccAWSElasticacheReplicationGroup_enableSnapshotting (1964.70s)
=== RUN   TestAccAWSInstance_ipv6_supportAddressCount
--- PASS: TestAccAWSInstance_ipv6_supportAddressCount (173.01s)
=== RUN   TestAccAWSInstance_placementGroup
--- PASS: TestAccAWSInstance_placementGroup (200.36s)
=== RUN   TestAccAWSInstance_disableApiTermination
--- PASS: TestAccAWSInstance_disableApiTermination (269.99s)
=== RUN   TestAccAWSInstance_multipleRegions
--- PASS: TestAccAWSInstance_multipleRegions (217.74s)
=== RUN   TestAccAWSInstance_sourceDestCheck
--- PASS: TestAccAWSInstance_sourceDestCheck (315.88s)
=== RUN   TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs
--- PASS: TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs (135.45s)
=== RUN   TestAccAWSInstance_vpc
--- PASS: TestAccAWSInstance_vpc (363.64s)
=== RUN   TestAccAWSInstance_tags
--- PASS: TestAccAWSInstance_tags (152.14s)
=== RUN   TestAccAWSInstance_NetworkInstanceSecurityGroups
--- PASS: TestAccAWSInstance_NetworkInstanceSecurityGroups (305.59s)
=== RUN   TestAccAWSEMRCluster_custom_ami_id
--- PASS: TestAccAWSEMRCluster_custom_ami_id (712.19s)
=== RUN   TestAccAWSInstance_volumeTags
--- PASS: TestAccAWSInstance_volumeTags (125.08s)
=== RUN   TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups
--- PASS: TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups (246.57s)
=== RUN   TestAccAWSEMRInstanceGroup_ebsBasic
--- PASS: TestAccAWSEMRInstanceGroup_ebsBasic (709.00s)
=== RUN   TestAccAWSInstance_volumeTagsComputed
--- PASS: TestAccAWSInstance_volumeTagsComputed (154.39s)
=== RUN   TestAccAWSEMRCluster_tags
--- PASS: TestAccAWSEMRCluster_tags (931.36s)
=== RUN   TestAccAWSEMRCluster_visibleToAllUsers
--- PASS: TestAccAWSEMRCluster_visibleToAllUsers (1065.64s)
=== RUN   TestAccAWSInstance_instanceProfileChange
--- PASS: TestAccAWSInstance_instanceProfileChange (155.17s)
=== RUN   TestAccAWSInstance_withIamInstanceProfile
--- PASS: TestAccAWSInstance_withIamInstanceProfile (120.95s)
=== RUN   TestAccAWSElasticacheReplicationGroup_updateNodeSize
--- PASS: TestAccAWSElasticacheReplicationGroup_updateNodeSize (2448.48s)
=== RUN   TestAccAWSEMRInstanceGroup_basic
--- PASS: TestAccAWSEMRInstanceGroup_basic (791.90s)
=== RUN   TestAccAWSInstance_associatePublicIPAndPrivateIP
--- PASS: TestAccAWSInstance_associatePublicIPAndPrivateIP (152.34s)
=== RUN   TestAccAWSInstance_changeInstanceType
--- PASS: TestAccAWSInstance_changeInstanceType (150.81s)
=== RUN   TestAccAWSEMRInstanceGroup_zero_count
--- PASS: TestAccAWSEMRInstanceGroup_zero_count (820.80s)
=== RUN   TestAccAWSInstance_keyPairCheck
--- PASS: TestAccAWSInstance_keyPairCheck (182.81s)
=== RUN   TestAccAWSEMRCluster_root_volume_size
--- PASS: TestAccAWSEMRCluster_root_volume_size (913.51s)
=== RUN   TestAccAWSInstance_privateIP
--- PASS: TestAccAWSInstance_privateIP (243.29s)
=== RUN   TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck
--- PASS: TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck (184.21s)
=== RUN   TestAccAWSLambdaFunction_basic
--- PASS: TestAccAWSLambdaFunction_basic (113.43s)
=== RUN   TestAccAWSInstance_forceNewAndTagsDrift
--- PASS: TestAccAWSInstance_forceNewAndTagsDrift (352.03s)
=== RUN   TestAccAWSInstance_rootBlockDeviceMismatch
--- PASS: TestAccAWSInstance_rootBlockDeviceMismatch (399.55s)
=== RUN   TestAccAWSLambdaFunction_updateRuntime
--- PASS: TestAccAWSLambdaFunction_updateRuntime (155.98s)
=== RUN   TestAccAWSLambdaFunction_expectFilenameAndS3Attributes
--- PASS: TestAccAWSLambdaFunction_expectFilenameAndS3Attributes (106.79s)
=== RUN   TestAccAWSInstance_primaryNetworkInterface
--- PASS: TestAccAWSInstance_primaryNetworkInterface (437.61s)
=== RUN   TestAccAWSInstance_associatePublic_explicitPrivate
--- PASS: TestAccAWSInstance_associatePublic_explicitPrivate (416.30s)
=== RUN   TestAccAWSInstance_addSecondaryInterface
--- PASS: TestAccAWSInstance_addSecondaryInterface (485.58s)
=== RUN   TestAccAWSElasticSearchDomain_update
--- PASS: TestAccAWSElasticSearchDomain_update (1892.86s)
=== RUN   TestAccAWSInstance_getPasswordData_trueToFalse
--- PASS: TestAccAWSInstance_getPasswordData_trueToFalse (412.83s)
=== RUN   TestAccAWSLambdaFunction_versioned
--- PASS: TestAccAWSLambdaFunction_versioned (124.46s)
=== RUN   TestAccAWSLambdaFunction_concurrencyCycle
--- PASS: TestAccAWSLambdaFunction_concurrencyCycle (387.71s)
=== RUN   TestAccAWSLambdaFunction_concurrency
--- PASS: TestAccAWSLambdaFunction_concurrency (410.48s)
=== RUN   TestAccAWSLambdaFunction_VPC
--- FAIL: TestAccAWSLambdaFunction_VPC (62.75s)
	testing.go:513: Step 0 error: After applying this step, the plan was not empty:
		
		DIFF:
		
		UPDATE: aws_security_group.sg_for_lambda
		  egress.#:                            "0" => "1"
		  egress.482069346.cidr_blocks.#:      "0" => "1"
		  egress.482069346.cidr_blocks.0:      "" => "0.0.0.0/0"
		  egress.482069346.description:        "" => ""
		  egress.482069346.from_port:          "" => "0"
		  egress.482069346.ipv6_cidr_blocks.#: "0" => "0"
		  egress.482069346.prefix_list_ids.#:  "0" => "0"
		  egress.482069346.protocol:           "" => "-1"
		  egress.482069346.security_groups.#:  "0" => "0"
		  egress.482069346.self:               "" => "false"
		  egress.482069346.to_port:            "" => "0"

=== RUN   TestAccAWSInstance_ipv6_supportAddressCountWithIpv4
--- PASS: TestAccAWSInstance_ipv6_supportAddressCountWithIpv4 (989.22s)
=== RUN   TestAccAWSLambdaFunction_DeadLetterConfig
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfig (135.53s)
=== RUN   TestAccAWSLambdaFunction_DeadLetterConfigUpdated
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfigUpdated (122.13s)
=== RUN   TestAccAWSLambdaFunction_encryptedEnvVariables
--- PASS: TestAccAWSLambdaFunction_encryptedEnvVariables (229.87s)
=== RUN   TestAccAWSLambdaFunction_s3
--- PASS: TestAccAWSLambdaFunction_s3 (33.46s)
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_noRuntime
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_noRuntime (0.83s)
=== RUN   TestAccAWSLambdaFunction_VPCUpdate
--- PASS: TestAccAWSLambdaFunction_VPCUpdate (77.58s)
=== RUN   TestAccAWSLambdaFunction_localUpdate
--- PASS: TestAccAWSLambdaFunction_localUpdate (54.29s)
=== RUN   TestAccAWSLambdaFunction_versionedUpdate
--- PASS: TestAccAWSLambdaFunction_versionedUpdate (224.37s)
=== RUN   TestAccAWSLambdaFunction_s3Update_unversioned
--- PASS: TestAccAWSLambdaFunction_s3Update_unversioned (36.48s)
=== RUN   TestAccAWSLambdaFunction_tracingConfig
--- PASS: TestAccAWSLambdaFunction_tracingConfig (137.02s)
=== RUN   TestAccAWSInstance_associatePublic_overridePublic
--- PASS: TestAccAWSInstance_associatePublic_overridePublic (595.42s)
=== RUN   TestAccAWSLambdaFunction_localUpdate_nameOnly
--- PASS: TestAccAWSLambdaFunction_localUpdate_nameOnly (69.92s)
=== RUN   TestAccAWSLambdaFunction_s3Update_basic
--- PASS: TestAccAWSLambdaFunction_s3Update_basic (75.30s)
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_nodeJs43
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_nodeJs43 (100.91s)
=== RUN   TestAccAWSInstance_associatePublic_overridePrivate
--- PASS: TestAccAWSInstance_associatePublic_overridePrivate (631.19s)
=== RUN   TestAccAWSLambdaFunction_nilDeadLetterConfig
--- PASS: TestAccAWSLambdaFunction_nilDeadLetterConfig (225.05s)
=== RUN   TestAccAWSLBListenerRule_multipleConditionThrowsError
--- PASS: TestAccAWSLBListenerRule_multipleConditionThrowsError (0.83s)
=== RUN   TestAccAWSElasticSearchDomain_internetToVpcEndpoint
--- PASS: TestAccAWSElasticSearchDomain_internetToVpcEndpoint (2433.16s)
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_python36
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python36 (102.23s)
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_java8
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_java8 (121.65s)
=== RUN   TestAccAWSLambdaFunction_tags
--- PASS: TestAccAWSLambdaFunction_tags (183.06s)
=== RUN   TestAccAWSLambdaFunction_VPC_withInvocation
--- PASS: TestAccAWSLambdaFunction_VPC_withInvocation (269.22s)
=== RUN   TestAccAWSInstance_getPasswordData_falseToTrue
--- PASS: TestAccAWSInstance_getPasswordData_falseToTrue (756.20s)
=== RUN   TestAccAWSInstance_associatePublic_defaultPublic
--- PASS: TestAccAWSInstance_associatePublic_defaultPublic (866.00s)
=== RUN   TestAccAWSLambdaFunction_envVariables
--- PASS: TestAccAWSLambdaFunction_envVariables (566.47s)
=== RUN   TestAccAWSInstance_associatePublic_explicitPublic
--- PASS: TestAccAWSInstance_associatePublic_explicitPublic (876.94s)
=== RUN   TestAccAWSLBTargetGroupAttachment_basic
--- PASS: TestAccAWSLBTargetGroupAttachment_basic (73.91s)
=== RUN   TestAccAWSLBTargetGroupAttachmentBackwardsCompatibility
--- PASS: TestAccAWSLBTargetGroupAttachmentBackwardsCompatibility (81.16s)
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_python27
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python27 (315.31s)
=== RUN   TestAccAWSLBTargetGroupAttachment_withoutPort
--- PASS: TestAccAWSLBTargetGroupAttachment_withoutPort (109.67s)
=== RUN   TestAccAWSLBListener_https
--- PASS: TestAccAWSLBListener_https (224.73s)
=== RUN   TestAccAWSLBListenerRule_basic
--- PASS: TestAccAWSLBListenerRule_basic (344.91s)
=== RUN   TestAccAWSElasticSearchDomain_vpc_update
--- PASS: TestAccAWSElasticSearchDomain_vpc_update (2727.14s)
=== RUN   TestAccAWSInstance_associatePublic_defaultPrivate
--- PASS: TestAccAWSInstance_associatePublic_defaultPrivate (1034.48s)
=== RUN   TestAccAwsLbListenerCertificate_basic
--- PASS: TestAccAwsLbListenerCertificate_basic (436.69s)
=== RUN   TestAccAWSInstance_addSecurityGroupNetworkInterface
--- PASS: TestAccAWSInstance_addSecurityGroupNetworkInterface (1099.16s)
=== RUN   TestAccAWSLBListenerRuleBackwardsCompatibility
--- PASS: TestAccAWSLBListenerRuleBackwardsCompatibility (469.63s)
=== RUN   TestAccAWSLB_basic
--- PASS: TestAccAWSLB_basic (279.36s)
=== RUN   TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew
--- FAIL: TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew (465.03s)
	testing.go:513: Step 1 error: Error applying: 1 error(s) occurred:
		
		* aws_lb_listener_rule.static: Resource 'aws_lb_listener.front_end_ruleupdate' does not have attribute 'arn' for variable 'aws_lb_listener.front_end_ruleupdate.arn'
	testing.go:573: Error destroying resource! WARNING: Dangling resources
		may exist. The full state and error is shown below.
		
		Error: Error applying: 1 error(s) occurred:
		
		* aws_lb_target_group.test (destroy): 1 error(s) occurred:
		
		* aws_lb_target_group.test: Error deleting Target Group: ResourceInUse: Target group 'arn:aws:elasticloadbalancing:us-west-2:*******:targetgroup/testtargetgroup-mevzqank9h/89f0c8582e48833a' is currently in use by a listener or a rule
			status code: 400, request id: 93989cef-2796-11e8-9e38-0b6038484bd3

=== RUN   TestAccAWSLBListenerBackwardsCompatibility
--- PASS: TestAccAWSLBListenerBackwardsCompatibility (432.62s)
=== RUN   TestAccAWSLBListenerRule_updateRulePriority
--- PASS: TestAccAWSLBListenerRule_updateRulePriority (475.70s)
=== RUN   TestAccAwsLbListenerCertificate_cycle
--- PASS: TestAccAwsLbListenerCertificate_cycle (563.94s)
=== RUN   TestAccAWSLBListenerRule_priority
--- FAIL: TestAccAWSLBListenerRule_priority (489.35s)
	testing.go:513: Step 4 error: Check failed: Check 3/11 error: Not found: aws_lb_listener_rule.parallelism.1 in [root]
=== RUN   TestAccAWSLBListener_basic
--- PASS: TestAccAWSLBListener_basic (517.08s)
=== RUN   TestAccAWSLB_generatesNameForZeroValue
--- PASS: TestAccAWSLB_generatesNameForZeroValue (316.64s)
=== RUN   TestAccAWSLBBackwardsCompatibility
--- PASS: TestAccAWSLBBackwardsCompatibility (361.69s)
=== RUN   TestAccAWSLB_namePrefix
--- PASS: TestAccAWSLB_namePrefix (290.37s)
=== RUN   TestAccAWSLB_networkLoadbalancerBasic
--- PASS: TestAccAWSLB_networkLoadbalancerBasic (395.31s)
=== RUN   TestAccAWSLB_updatedIpAddressType
--- FAIL: TestAccAWSLB_updatedIpAddressType (133.01s)
	testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
		
		* aws_lb.lb_test: 1 error(s) occurred:
		
		* aws_lb.lb_test: Error creating Application Load Balancer: InvalidSubnet: VPC vpc-8387f3fa has no internet gateway
			status code: 400, request id: bd87049c-2796-11e8-ae46-45cbb1960894

=== RUN   TestAccAWSLB_generatedName
--- PASS: TestAccAWSLB_generatedName (354.73s)
=== RUN   TestAccAWSLB_tags
--- PASS: TestAccAWSLB_tags (360.74s)
=== RUN   TestAccAWSLB_updatedSecurityGroups
--- PASS: TestAccAWSLB_updatedSecurityGroups (283.63s)
=== RUN   TestAccAWSLB_networkLoadbalancerEIP
--- PASS: TestAccAWSLB_networkLoadbalancerEIP (490.56s)
=== RUN   TestAccAWSLB_networkLoadbalancer_updateCrossZone
--- PASS: TestAccAWSLB_networkLoadbalancer_updateCrossZone (380.34s)
=== RUN   TestAccAWSLB_noSecurityGroup
--- PASS: TestAccAWSLB_noSecurityGroup (224.63s)
=== RUN   TestAccAWSALBTargetGroupAttachment_ipAddress
--- PASS: TestAccAWSALBTargetGroupAttachment_ipAddress (540.36s)
=== RUN   TestAccAWSLB_applicationLoadBalancer_updateHttp2
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateHttp2 (397.76s)
=== RUN   TestAccAWSLB_applicationLoadBalancer_updateDeletionProtection
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateDeletionProtection (353.01s)
=== RUN   TestAccAWSLB_updatedSubnets
--- PASS: TestAccAWSLB_updatedSubnets (352.94s)
=== RUN   TestAccAWSLB_networkLoadbalancer_subnet_change
--- PASS: TestAccAWSLB_networkLoadbalancer_subnet_change (339.75s)
=== RUN   TestAccAWSLB_accesslogs
--- PASS: TestAccAWSLB_accesslogs (390.42s)
```