### PR TITLE
r/aws_cognito_user_pool Detect auto_verified_attributes changes

### DIFF
--- a/aws/resource_aws_cognito_user_pool.go
+++ b/aws/resource_aws_cognito_user_pool.go
@@ -639,9 +639,8 @@ func resourceAwsCognitoUserPoolRead(d *schema.ResourceData, meta interface{}) er
 		Resource:  fmt.Sprintf("userpool/%s", d.Id()),
 	}
 	d.Set("arn", arn.String())
-	if resp.UserPool.AutoVerifiedAttributes != nil {
-		d.Set("auto_verified_attributes", flattenStringList(resp.UserPool.AutoVerifiedAttributes))
-	}
+	d.Set("auto_verified_attributes", flattenStringList(resp.UserPool.AutoVerifiedAttributes))
+
 	if resp.UserPool.EmailVerificationSubject != nil {
 		d.Set("email_verification_subject", *resp.UserPool.EmailVerificationSubject)
 	}

--- a/aws/resource_aws_cognito_user_pool_test.go
+++ b/aws/resource_aws_cognito_user_pool_test.go
@@ -274,7 +274,7 @@ func TestAccAWSCognitoUserPool_withAliasAttributes(t *testing.T) {
 					testAccCheckAWSCognitoUserPoolExists("aws_cognito_user_pool.pool"),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "alias_attributes.#", "1"),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "alias_attributes.1888159429", "preferred_username"),
-					resource.TestCheckNoResourceAttr("aws_cognito_user_pool.pool", "auto_verified_attributes.#"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "auto_verified_attributes.#", "0"),
 				),
 			},
 			{


### PR DESCRIPTION
Fixes #3009 #3780 closes #3029 
```
AWS_REGION=us-east-1 TF_ACC=1 go test ./... -v -run=TestAccAWSCognitoUserPool_ -timeout 120m -parallel=5
?     github.com/terraform-providers/terraform-provider-aws [no test files]
=== RUN   TestAccAWSCognitoUserPool_importBasic
--- PASS: TestAccAWSCognitoUserPool_importBasic (26.03s)
=== RUN   TestAccAWSCognitoUserPool_basic
--- PASS: TestAccAWSCognitoUserPool_basic (22.93s)
=== RUN   TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration
--- PASS: TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration (39.40s)
=== RUN   TestAccAWSCognitoUserPool_withDeviceConfiguration
--- PASS: TestAccAWSCognitoUserPool_withDeviceConfiguration (40.35s)
=== RUN   TestAccAWSCognitoUserPool_withEmailVerificationMessage
--- PASS: TestAccAWSCognitoUserPool_withEmailVerificationMessage (39.31s)
=== RUN   TestAccAWSCognitoUserPool_withSmsVerificationMessage
--- PASS: TestAccAWSCognitoUserPool_withSmsVerificationMessage (39.95s)
=== RUN   TestAccAWSCognitoUserPool_withEmailConfiguration
--- PASS: TestAccAWSCognitoUserPool_withEmailConfiguration (40.45s)
=== RUN   TestAccAWSCognitoUserPool_withSmsConfiguration
--- PASS: TestAccAWSCognitoUserPool_withSmsConfiguration (40.26s)
=== RUN   TestAccAWSCognitoUserPool_withSmsConfigurationUpdated
--- PASS: TestAccAWSCognitoUserPool_withSmsConfigurationUpdated (57.23s)
=== RUN   TestAccAWSCognitoUserPool_withTags
--- PASS: TestAccAWSCognitoUserPool_withTags (43.92s)
=== RUN   TestAccAWSCognitoUserPool_withAliasAttributes
--- PASS: TestAccAWSCognitoUserPool_withAliasAttributes (40.54s)
=== RUN   TestAccAWSCognitoUserPool_withPasswordPolicy
--- PASS: TestAccAWSCognitoUserPool_withPasswordPolicy (40.17s)
=== RUN   TestAccAWSCognitoUserPool_withLambdaConfig
--- PASS: TestAccAWSCognitoUserPool_withLambdaConfig (64.81s)
=== RUN   TestAccAWSCognitoUserPool_withSchemaAttributes
--- PASS: TestAccAWSCognitoUserPool_withSchemaAttributes (41.46s)
=== RUN   TestAccAWSCognitoUserPool_withVerificationMessageTemplate
--- PASS: TestAccAWSCognitoUserPool_withVerificationMessageTemplate (45.60s)
PASS
ok    github.com/terraform-providers/terraform-provider-aws/aws 622.442s
root@959383ac9df3:/go/src/github.com/terraform-providers/terraform-provider-aws# make test
==> Checking that code complies with gofmt requirements...
go test ./... -timeout=30s -parallel=4
?     github.com/terraform-providers/terraform-provider-aws [no test files]
ok    github.com/terraform-providers/terraform-provider-aws/aws 1.847s
root@959383ac9df3:/go/src/github.com/terraform-providers/terraform-provider-aws#
```