### PR TITLE
Update RDS documentation to use instance type t2 instead of t1

### DIFF
--- a/website/docs/d/db_snapshot.html.markdown
+++ b/website/docs/d/db_snapshot.html.markdown
@@ -19,7 +19,7 @@ resource "aws_db_instance" "prod" {
   allocated_storage    = 10
   engine               = "mysql"
   engine_version       = "5.6.17"
-  instance_class       = "db.t1.micro"
+  instance_class       = "db.t2.micro"
   name                 = "mydb"
   username             = "foo"
   password             = "bar"
@@ -34,7 +34,7 @@ data "aws_db_snapshot" "latest_prod_snapshot" {
 
 # Use the latest production snapshot to create a dev instance.
 resource "aws_db_instance" "dev" {
-  instance_class      = "db.t1.micro"
+  instance_class      = "db.t2.micro"
   name                = "mydb-dev"
   snapshot_identifier = "${data.aws_db_snapshot.latest_prod_snapshot.id}"
   lifecycle {

--- a/website/docs/r/db_event_subscription.html.markdown
+++ b/website/docs/r/db_event_subscription.html.markdown
@@ -15,7 +15,7 @@ resource "aws_db_instance" "default" {
   allocated_storage    = 10
   engine               = "mysql"
   engine_version       = "5.6.17"
-  instance_class       = "db.t1.micro"
+  instance_class       = "db.t2.micro"
   name                 = "mydb"
   username             = "foo"
   password             = "bar"

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -29,6 +29,11 @@ server reboots. See the AWS Docs on [RDS Maintenance][2] for more information.
 the raw state as plain-text. [Read more about sensitive data in
 state](/docs/state/sensitive-data.html).
 
+## RDS Instance Class Types
+Amazon RDS supports three types of instance classes: Standard, Memory Optimized,
+and Burstable Performance. For more information please read the AWS RDS documentation
+about [DB Instance Class Types](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html)
+
 ## Example Usage
 
 ```hcl
@@ -36,13 +41,12 @@ resource "aws_db_instance" "default" {
   allocated_storage    = 10
   storage_type         = "gp2"
   engine               = "mysql"
-  engine_version       = "5.6.17"
-  instance_class       = "db.t1.micro"
+  engine_version       = "5.7"
+  instance_class       = "db.t2.micro"
   name                 = "mydb"
   username             = "foo"
-  password             = "bar"
-  db_subnet_group_name = "my_database_subnet_group"
-  parameter_group_name = "default.mysql5.6"
+  password             = "foobarbaz"
+  parameter_group_name = "default.mysql5.7"
 }
 ```
 

--- a/website/docs/r/db_snapshot.html.markdown
+++ b/website/docs/r/db_snapshot.html.markdown
@@ -17,7 +17,7 @@ resource "aws_db_instance" "bar" {
 	allocated_storage = 10
 	engine = "MySQL"
 	engine_version = "5.6.21"
-	instance_class = "db.t1.micro"
+	instance_class = "db.t2.micro"
 	name = "baz"
 	password = "barbarbarbar"
 	username = "foo"


### PR DESCRIPTION
Hi,

This commit adds 3 improvements to the RDS documentation:

* Replaces all references to the unsupported instance type "t1" with "t2".
* Updates the aws_db_instance example to actually work as is. 
* Adds a link to the RDS supported instance types in the documentation.

If anything is unclear please don't hesitate to ask. 

Regards Oscar