### PR TITLE
service/s3: setting S3 object content as base64

### DIFF
--- a/website/docs/r/s3_bucket_object.html.markdown
+++ b/website/docs/r/s3_bucket_object.html.markdown
@@ -62,14 +62,15 @@ resource "aws_s3_bucket_object" "examplebucket_object" {
 
 ## Argument Reference
 
--> **Note:** If you specify `content_encoding` you are responsible for encoding the body appropriately (i.e. `source` and `content` both expect already encoded/compressed bytes)
+-> **Note:** If you specify `content_encoding` you are responsible for encoding the body appropriately. `source`, `content`, and `content_base64` all expect already encoded/compressed bytes.
 
 The following arguments are supported:
 
 * `bucket` - (Required) The name of the bucket to put the file in.
 * `key` - (Required) The name of the object once it is in the bucket.
-* `source` - (Required) The path to the source file being uploaded to the bucket.
-* `content` - (Required unless `source` given) The literal content being uploaded to the bucket.
+* `source` - (Required unless `content` or `content_base64` is set) The path to a file that will be read and uploaded as raw bytes for the object content.
+* `content` - (Required unless `source` or `content_base64` is set) Literal string value to use as the object content, which will be uploaded as UTF-8-encoded text.
+* `content_base64` - (Required unless `source` or `content` is set) Base64-encoded data that will be decoded and uploaded as raw bytes for the object content. This allows safely uploading non-UTF8 binary data, but is recommended only for small content such as the result of the `gzipbase64` function with small text strings. For larger objects, use `source` to stream the content from a disk file.
 * `acl` - (Optional) The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Defaults to "private".
 * `cache_control` - (Optional) Specifies caching behavior along the request/reply chain Read [w3c cache_control](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9) for further details.
 * `content_disposition` - (Optional) Specifies presentational information for the object. Read [wc3 content_disposition](http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1) for further information.


### PR DESCRIPTION
Generally we recommend using `content` for small text strings generated within config (e.g. rendered templates) and `source` for larger binary content loaded from disk.

This new argument allows a third case of uploading small raw binary content generated in configuration, such as the result of passing a rendered template through the `base64gzip(...)` interpolation function
in conjunction with a `content_encoding = "gzip"` argument.

Terraform Core does not guarantee safe passage for raw binary strings that are not valid UTF-8, so base64 is an emerging convention for the rare cases where raw byte buffers must be manipulated within the configuration language, similar to the `user_data_base64` argument to aws_instance.
