### PR TITLE
resource/aws_cognito_user_pool: Fix schema attribute handling

### DIFF
--- a/aws/resource_aws_cognito_user_pool.go
+++ b/aws/resource_aws_cognito_user_pool.go
@@ -284,6 +284,7 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 						"attribute_data_type": {
 							Type:     schema.TypeString,
 							Required: true,
+							ForceNew: true,
 							ValidateFunc: validation.StringInSlice([]string{
 								cognitoidentityprovider.AttributeDataTypeString,
 								cognitoidentityprovider.AttributeDataTypeNumber,
@@ -294,29 +295,35 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 						"developer_only_attribute": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							ForceNew: true,
 						},
 						"mutable": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							ForceNew: true,
 						},
 						"name": {
 							Type:         schema.TypeString,
 							Required:     true,
+							ForceNew:     true,
 							ValidateFunc: validateCognitoUserPoolSchemaName,
 						},
 						"number_attribute_constraints": {
 							Type:     schema.TypeList,
 							Optional: true,
+							ForceNew: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"min_value": {
 										Type:     schema.TypeString,
 										Optional: true,
+										ForceNew: true,
 									},
 									"max_value": {
 										Type:     schema.TypeString,
 										Optional: true,
+										ForceNew: true,
 									},
 								},
 							},
@@ -324,20 +331,24 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 						"required": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							ForceNew: true,
 						},
 						"string_attribute_constraints": {
 							Type:     schema.TypeList,
 							Optional: true,
+							ForceNew: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"min_length": {
 										Type:     schema.TypeString,
 										Optional: true,
+										ForceNew: true,
 									},
 									"max_length": {
 										Type:     schema.TypeString,
 										Optional: true,
+										ForceNew: true,
 									},
 								},
 							},
@@ -673,6 +684,14 @@ func resourceAwsCognitoUserPoolRead(d *schema.ResourceData, meta interface{}) er
 		if err := d.Set("password_policy", flattenCognitoUserPoolPasswordPolicy(resp.UserPool.Policies.PasswordPolicy)); err != nil {
 			return fmt.Errorf("Failed setting password_policy: %s", err)
 		}
+	}
+
+	var configuredSchema []interface{}
+	if v, ok := d.GetOk("schema"); ok {
+		configuredSchema = v.(*schema.Set).List()
+	}
+	if err := d.Set("schema", flattenCognitoUserPoolSchema(expandCognitoUserPoolSchema(configuredSchema), resp.UserPool.SchemaAttributes)); err != nil {
+		return fmt.Errorf("Failed setting schema: %s", err)
 	}
 
 	if err := d.Set("sms_configuration", flattenCognitoUserPoolSmsConfiguration(resp.UserPool.SmsConfiguration)); err != nil {

--- a/aws/resource_aws_cognito_user_pool_test.go
+++ b/aws/resource_aws_cognito_user_pool_test.go
@@ -404,7 +404,6 @@ func TestAccAWSCognitoUserPool_withSchemaAttributes(t *testing.T) {
 				Config: testAccAWSCognitoUserPoolConfig_withSchemaAttributesUpdated(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.#", "2"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.#", "2"),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2078884933.attribute_data_type", "String"),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2078884933.developer_only_attribute", "false"),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2078884933.mutable", "false"),
@@ -424,6 +423,11 @@ func TestAccAWSCognitoUserPool_withSchemaAttributes(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2718111653.required", "false"),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2718111653.string_attribute_constraints.#", "0"),
 				),
+			},
+			{
+				ResourceName:      "aws_cognito_user_pool.main",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -2767,65 +2767,294 @@ func expandCognitoUserPoolSchema(inputs []interface{}) []*cognitoidentityprovide
 	return configs
 }
 
-func flattenCognitoUserPoolSchema(inputs []*cognitoidentityprovider.SchemaAttributeType) []map[string]interface{} {
-	values := make([]map[string]interface{}, len(inputs), len(inputs))
+func cognitoUserPoolSchemaAttributeMatchesStandardAttribute(input *cognitoidentityprovider.SchemaAttributeType) bool {
+	if input == nil {
+		return false
+	}
 
-	for i, input := range inputs {
-		value := make(map[string]interface{})
+	// All standard attributes always returned by API
+	// https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-attributes.html#cognito-user-pools-standard-attributes
+	var standardAttributes = []cognitoidentityprovider.SchemaAttributeType{
+		{
+			AttributeDataType:      aws.String(cognitoidentityprovider.AttributeDataTypeString),
+			DeveloperOnlyAttribute: aws.Bool(false),
+			Mutable:                aws.Bool(true),
+			Name:                   aws.String("address"),
+			Required:               aws.Bool(false),
+			StringAttributeConstraints: &cognitoidentityprovider.StringAttributeConstraintsType{
+				MaxLength: aws.String("2048"),
+				MinLength: aws.String("0"),
+			},
+		},
+		{
+			AttributeDataType:      aws.String(cognitoidentityprovider.AttributeDataTypeString),
+			DeveloperOnlyAttribute: aws.Bool(false),
+			Mutable:                aws.Bool(true),
+			Name:                   aws.String("birthdate"),
+			Required:               aws.Bool(false),
+			StringAttributeConstraints: &cognitoidentityprovider.StringAttributeConstraintsType{
+				MaxLength: aws.String("10"),
+				MinLength: aws.String("10"),
+			},
+		},
+		{
+			AttributeDataType:      aws.String(cognitoidentityprovider.AttributeDataTypeString),
+			DeveloperOnlyAttribute: aws.Bool(false),
+			Mutable:                aws.Bool(false),
+			Name:                   aws.String("email"),
+			Required:               aws.Bool(false),
+			StringAttributeConstraints: &cognitoidentityprovider.StringAttributeConstraintsType{
+				MaxLength: aws.String("2048"),
+				MinLength: aws.String("0"),
+			},
+		},
+		{
+			AttributeDataType:      aws.String(cognitoidentityprovider.AttributeDataTypeBoolean),
+			DeveloperOnlyAttribute: aws.Bool(false),
+			Mutable:                aws.Bool(true),
+			Name:                   aws.String("email_verified"),
+			Required:               aws.Bool(false),
+		},
+		{
+			AttributeDataType:      aws.String(cognitoidentityprovider.AttributeDataTypeString),
+			DeveloperOnlyAttribute: aws.Bool(false),
+			Mutable:                aws.Bool(true),
+			Name:                   aws.String("gender"),
+			Required:               aws.Bool(false),
+			StringAttributeConstraints: &cognitoidentityprovider.StringAttributeConstraintsType{
+				MaxLength: aws.String("2048"),
+				MinLength: aws.String("0"),
+			},
+		},
+		{
+			AttributeDataType:      aws.String(cognitoidentityprovider.AttributeDataTypeString),
+			DeveloperOnlyAttribute: aws.Bool(false),
+			Mutable:                aws.Bool(true),
+			Name:                   aws.String("given_name"),
+			Required:               aws.Bool(false),
+			StringAttributeConstraints: &cognitoidentityprovider.StringAttributeConstraintsType{
+				MaxLength: aws.String("2048"),
+				MinLength: aws.String("0"),
+			},
+		},
+		{
+			AttributeDataType:      aws.String(cognitoidentityprovider.AttributeDataTypeString),
+			DeveloperOnlyAttribute: aws.Bool(false),
+			Mutable:                aws.Bool(true),
+			Name:                   aws.String("family_name"),
+			Required:               aws.Bool(false),
+			StringAttributeConstraints: &cognitoidentityprovider.StringAttributeConstraintsType{
+				MaxLength: aws.String("2048"),
+				MinLength: aws.String("0"),
+			},
+		},
+		{
+			AttributeDataType:      aws.String(cognitoidentityprovider.AttributeDataTypeString),
+			DeveloperOnlyAttribute: aws.Bool(false),
+			Mutable:                aws.Bool(true),
+			Name:                   aws.String("locale"),
+			Required:               aws.Bool(false),
+			StringAttributeConstraints: &cognitoidentityprovider.StringAttributeConstraintsType{
+				MaxLength: aws.String("2048"),
+				MinLength: aws.String("0"),
+			},
+		},
+		{
+			AttributeDataType:      aws.String(cognitoidentityprovider.AttributeDataTypeString),
+			DeveloperOnlyAttribute: aws.Bool(false),
+			Mutable:                aws.Bool(true),
+			Name:                   aws.String("middle_name"),
+			Required:               aws.Bool(false),
+			StringAttributeConstraints: &cognitoidentityprovider.StringAttributeConstraintsType{
+				MaxLength: aws.String("2048"),
+				MinLength: aws.String("0"),
+			},
+		},
+		{
+			AttributeDataType:      aws.String(cognitoidentityprovider.AttributeDataTypeString),
+			DeveloperOnlyAttribute: aws.Bool(false),
+			Mutable:                aws.Bool(true),
+			Name:                   aws.String("name"),
+			Required:               aws.Bool(false),
+			StringAttributeConstraints: &cognitoidentityprovider.StringAttributeConstraintsType{
+				MaxLength: aws.String("2048"),
+				MinLength: aws.String("0"),
+			},
+		},
+		{
+			AttributeDataType:      aws.String(cognitoidentityprovider.AttributeDataTypeString),
+			DeveloperOnlyAttribute: aws.Bool(false),
+			Mutable:                aws.Bool(true),
+			Name:                   aws.String("nickname"),
+			Required:               aws.Bool(false),
+			StringAttributeConstraints: &cognitoidentityprovider.StringAttributeConstraintsType{
+				MaxLength: aws.String("2048"),
+				MinLength: aws.String("0"),
+			},
+		},
+		{
+			AttributeDataType:      aws.String(cognitoidentityprovider.AttributeDataTypeString),
+			DeveloperOnlyAttribute: aws.Bool(false),
+			Mutable:                aws.Bool(true),
+			Name:                   aws.String("phone_number"),
+			Required:               aws.Bool(false),
+			StringAttributeConstraints: &cognitoidentityprovider.StringAttributeConstraintsType{
+				MaxLength: aws.String("2048"),
+				MinLength: aws.String("0"),
+			},
+		},
+		{
+			AttributeDataType:      aws.String(cognitoidentityprovider.AttributeDataTypeBoolean),
+			DeveloperOnlyAttribute: aws.Bool(false),
+			Mutable:                aws.Bool(true),
+			Name:                   aws.String("phone_number_verified"),
+			Required:               aws.Bool(false),
+		},
+		{
+			AttributeDataType:      aws.String(cognitoidentityprovider.AttributeDataTypeString),
+			DeveloperOnlyAttribute: aws.Bool(false),
+			Mutable:                aws.Bool(true),
+			Name:                   aws.String("picture"),
+			Required:               aws.Bool(false),
+			StringAttributeConstraints: &cognitoidentityprovider.StringAttributeConstraintsType{
+				MaxLength: aws.String("2048"),
+				MinLength: aws.String("0"),
+			},
+		},
+		{
+			AttributeDataType:      aws.String(cognitoidentityprovider.AttributeDataTypeString),
+			DeveloperOnlyAttribute: aws.Bool(false),
+			Mutable:                aws.Bool(true),
+			Name:                   aws.String("preferred_username"),
+			Required:               aws.Bool(false),
+			StringAttributeConstraints: &cognitoidentityprovider.StringAttributeConstraintsType{
+				MaxLength: aws.String("2048"),
+				MinLength: aws.String("0"),
+			},
+		},
+		{
+			AttributeDataType:      aws.String(cognitoidentityprovider.AttributeDataTypeString),
+			DeveloperOnlyAttribute: aws.Bool(false),
+			Mutable:                aws.Bool(true),
+			Name:                   aws.String("profile"),
+			Required:               aws.Bool(false),
+			StringAttributeConstraints: &cognitoidentityprovider.StringAttributeConstraintsType{
+				MaxLength: aws.String("2048"),
+				MinLength: aws.String("0"),
+			},
+		},
+		{
+			AttributeDataType:      aws.String(cognitoidentityprovider.AttributeDataTypeString),
+			DeveloperOnlyAttribute: aws.Bool(false),
+			Mutable:                aws.Bool(false),
+			Name:                   aws.String("sub"),
+			Required:               aws.Bool(true),
+			StringAttributeConstraints: &cognitoidentityprovider.StringAttributeConstraintsType{
+				MaxLength: aws.String("2048"),
+				MinLength: aws.String("1"),
+			},
+		},
+		{
+			AttributeDataType:      aws.String(cognitoidentityprovider.AttributeDataTypeNumber),
+			DeveloperOnlyAttribute: aws.Bool(false),
+			Mutable:                aws.Bool(true),
+			Name:                   aws.String("updated_at"),
+			NumberAttributeConstraints: &cognitoidentityprovider.NumberAttributeConstraintsType{
+				MinValue: aws.String("0"),
+			},
+			Required: aws.Bool(false),
+		},
+		{
+			AttributeDataType:      aws.String(cognitoidentityprovider.AttributeDataTypeString),
+			DeveloperOnlyAttribute: aws.Bool(false),
+			Mutable:                aws.Bool(true),
+			Name:                   aws.String("website"),
+			Required:               aws.Bool(false),
+			StringAttributeConstraints: &cognitoidentityprovider.StringAttributeConstraintsType{
+				MaxLength: aws.String("2048"),
+				MinLength: aws.String("0"),
+			},
+		},
+		{
+			AttributeDataType:      aws.String(cognitoidentityprovider.AttributeDataTypeString),
+			DeveloperOnlyAttribute: aws.Bool(false),
+			Mutable:                aws.Bool(true),
+			Name:                   aws.String("zoneinfo"),
+			Required:               aws.Bool(false),
+			StringAttributeConstraints: &cognitoidentityprovider.StringAttributeConstraintsType{
+				MaxLength: aws.String("2048"),
+				MinLength: aws.String("0"),
+			},
+		},
+	}
+	for _, standardAttribute := range standardAttributes {
+		if reflect.DeepEqual(*input, standardAttribute) {
+			return true
+		}
+	}
+	return false
+}
 
+func flattenCognitoUserPoolSchema(configuredAttributes, inputs []*cognitoidentityprovider.SchemaAttributeType) []map[string]interface{} {
+	values := make([]map[string]interface{}, 0)
+
+	for _, input := range inputs {
 		if input == nil {
-			return nil
+			continue
 		}
 
-		if input.AttributeDataType != nil {
-			value["attribute_data_type"] = *input.AttributeDataType
+		// The API returns all standard attributes
+		// https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-attributes.html#cognito-user-pools-standard-attributes
+		// Ignore setting them in state if they are unconfigured to prevent a huge and unexpected diff
+		configured := false
+		if configuredAttributes != nil {
+			for _, configuredAttribute := range configuredAttributes {
+				if reflect.DeepEqual(input, configuredAttribute) {
+					configured = true
+				}
+			}
+		}
+		if !configured && cognitoUserPoolSchemaAttributeMatchesStandardAttribute(input) {
+			continue
 		}
 
-		if input.DeveloperOnlyAttribute != nil {
-			value["developer_only_attribute"] = *input.DeveloperOnlyAttribute
-		}
-
-		if input.Mutable != nil {
-			value["mutable"] = *input.Mutable
-		}
-
-		if input.Name != nil {
-			value["name"] = *input.Name
+		var value = map[string]interface{}{
+			"attribute_data_type":      aws.StringValue(input.AttributeDataType),
+			"developer_only_attribute": aws.BoolValue(input.DeveloperOnlyAttribute),
+			"mutable":                  aws.BoolValue(input.Mutable),
+			"name":                     strings.TrimPrefix(aws.StringValue(input.Name), "dev:custom:"),
+			"required":                 aws.BoolValue(input.Required),
 		}
 
 		if input.NumberAttributeConstraints != nil {
 			subvalue := make(map[string]interface{})
 
 			if input.NumberAttributeConstraints.MinValue != nil {
-				subvalue["min_value"] = input.NumberAttributeConstraints.MinValue
+				subvalue["min_value"] = aws.StringValue(input.NumberAttributeConstraints.MinValue)
 			}
 
 			if input.NumberAttributeConstraints.MaxValue != nil {
-				subvalue["max_value"] = input.NumberAttributeConstraints.MaxValue
+				subvalue["max_value"] = aws.StringValue(input.NumberAttributeConstraints.MaxValue)
 			}
 
-			value["number_attribute_constraints"] = subvalue
-		}
-
-		if input.Required != nil {
-			value["required"] = *input.Required
+			value["number_attribute_constraints"] = []map[string]interface{}{subvalue}
 		}
 
 		if input.StringAttributeConstraints != nil {
 			subvalue := make(map[string]interface{})
 
 			if input.StringAttributeConstraints.MinLength != nil {
-				subvalue["min_length"] = input.StringAttributeConstraints.MinLength
+				subvalue["min_length"] = aws.StringValue(input.StringAttributeConstraints.MinLength)
 			}
 
 			if input.StringAttributeConstraints.MaxLength != nil {
-				subvalue["max_length"] = input.StringAttributeConstraints.MaxLength
+				subvalue["max_length"] = aws.StringValue(input.StringAttributeConstraints.MaxLength)
 			}
 
-			value["string_attribute_constraints"] = subvalue
+			value["string_attribute_constraints"] = []map[string]interface{}{subvalue}
 		}
 
-		values[i] = value
+		values = append(values, value)
 	}
 
 	return values

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -2800,7 +2800,7 @@ func cognitoUserPoolSchemaAttributeMatchesStandardAttribute(input *cognitoidenti
 		{
 			AttributeDataType:      aws.String(cognitoidentityprovider.AttributeDataTypeString),
 			DeveloperOnlyAttribute: aws.Bool(false),
-			Mutable:                aws.Bool(false),
+			Mutable:                aws.Bool(true),
 			Name:                   aws.String("email"),
 			Required:               aws.Bool(false),
 			StringAttributeConstraints: &cognitoidentityprovider.StringAttributeConstraintsType{


### PR DESCRIPTION
Fixes #3405 

This one was pretty gnarly! 😄  Looks like this was skipped in the initial implementation for pretty good reason as the API has a bunch of "standard" attributes it always returns by default. This implementation skips any of those that are not configured in the Terraform configuration. This also properly sets `ForceNew` on all the schema attributes for now as Cognito does not support updating the schema beyond adding new custom attributes (not previously supported or in this PR).

Tests:
```
19 tests passed (all tests)
=== RUN   TestAccAWSCognitoUserPool_importBasic
--- PASS: TestAccAWSCognitoUserPool_importBasic (11.05s)
=== RUN   TestAccAWSCognitoUserPoolClient_allFields
--- PASS: TestAccAWSCognitoUserPoolClient_allFields (12.76s)
=== RUN   TestAccAWSCognitoUserPoolDomain_basic
--- PASS: TestAccAWSCognitoUserPoolDomain_basic (14.18s)
=== RUN   TestAccAWSCognitoUserPool_basic
--- PASS: TestAccAWSCognitoUserPool_basic (14.83s)
=== RUN   TestAccAWSCognitoUserPool_withSmsVerificationMessage
--- PASS: TestAccAWSCognitoUserPool_withSmsVerificationMessage (16.17s)
=== RUN   TestAccAWSCognitoUserPool_withPasswordPolicy
--- PASS: TestAccAWSCognitoUserPool_withPasswordPolicy (16.37s)
=== RUN   TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration
--- PASS: TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration (17.43s)
=== RUN   TestAccAWSCognitoUserPool_withDeviceConfiguration
--- PASS: TestAccAWSCognitoUserPool_withDeviceConfiguration (18.17s)
=== RUN   TestAccAWSCognitoUserPool_withEmailConfiguration
--- PASS: TestAccAWSCognitoUserPool_withEmailConfiguration (18.18s)
=== RUN   TestAccAWSCognitoUserPool_withVerificationMessageTemplate
--- PASS: TestAccAWSCognitoUserPool_withVerificationMessageTemplate (18.38s)
=== RUN   TestAccAWSCognitoUserPool_withSchemaAttributes
--- PASS: TestAccAWSCognitoUserPool_withSchemaAttributes (20.56s)
=== RUN   TestAccAWSCognitoUserPoolClient_basic
--- PASS: TestAccAWSCognitoUserPoolClient_basic (20.82s)
=== RUN   TestAccAWSCognitoUserPool_withAliasAttributes
--- PASS: TestAccAWSCognitoUserPool_withAliasAttributes (22.57s)
=== RUN   TestAccAWSCognitoUserPoolDomain_import
--- PASS: TestAccAWSCognitoUserPoolDomain_import (23.30s)
=== RUN   TestAccAWSCognitoUserPool_withEmailVerificationMessage
--- PASS: TestAccAWSCognitoUserPool_withEmailVerificationMessage (27.59s)
=== RUN   TestAccAWSCognitoUserPool_withSmsConfiguration
--- PASS: TestAccAWSCognitoUserPool_withSmsConfiguration (28.73s)
=== RUN   TestAccAWSCognitoUserPool_withLambdaConfig
--- PASS: TestAccAWSCognitoUserPool_withLambdaConfig (33.35s)
=== RUN   TestAccAWSCognitoUserPool_withSmsConfigurationUpdated
--- PASS: TestAccAWSCognitoUserPool_withSmsConfigurationUpdated (37.11s)
=== RUN   TestAccAWSCognitoUserPool_withTags
--- PASS: TestAccAWSCognitoUserPool_withTags (40.34s)
```