### PR TITLE
tests: Unify aws_subnet tags (M-Z)

### DIFF
--- a/aws/resource_aws_main_route_table_association_test.go
+++ b/aws/resource_aws_main_route_table_association_test.go
@@ -112,6 +112,9 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
 	cidr_block = "10.1.1.0/24"
+	tags {
+		Name = "tf-acc-main-route-table-association"
+	}
 }
 
 resource "aws_internet_gateway" "foo" {
@@ -143,6 +146,9 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
 	cidr_block = "10.1.1.0/24"
+	tags {
+		Name = "tf-acc-main-route-table-association-update"
+	}
 }
 
 resource "aws_internet_gateway" "foo" {

--- a/aws/resource_aws_mq_broker_test.go
+++ b/aws/resource_aws_mq_broker_test.go
@@ -678,7 +678,7 @@ resource "aws_subnet" "private" {
   availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
   vpc_id = "${aws_vpc.main.id}"
   tags {
-    Name = "TfAccTest-MqBroker"
+    Name = "tf-acc-mq-broker-all-fields-custom-vpc-${count.index}"
   }
 }
 

--- a/aws/resource_aws_nat_gateway_test.go
+++ b/aws/resource_aws_nat_gateway_test.go
@@ -188,12 +188,18 @@ resource "aws_subnet" "private" {
   vpc_id = "${aws_vpc.vpc.id}"
   cidr_block = "10.0.1.0/24"
   map_public_ip_on_launch = false
+  tags {
+    Name = "tf-acc-nat-gw-basic-private"
+  }
 }
 
 resource "aws_subnet" "public" {
   vpc_id = "${aws_vpc.vpc.id}"
   cidr_block = "10.0.2.0/24"
   map_public_ip_on_launch = true
+  tags {
+    Name = "tf-acc-nat-gw-basic-public"
+  }
 }
 
 resource "aws_internet_gateway" "gw" {
@@ -257,12 +263,18 @@ resource "aws_subnet" "private" {
   vpc_id = "${aws_vpc.vpc.id}"
   cidr_block = "10.0.1.0/24"
   map_public_ip_on_launch = false
+  tags {
+    Name = "tf-acc-nat-gw-tags-private"
+  }
 }
 
 resource "aws_subnet" "public" {
   vpc_id = "${aws_vpc.vpc.id}"
   cidr_block = "10.0.2.0/24"
   map_public_ip_on_launch = true
+  tags {
+    Name = "tf-acc-nat-gw-tags-public"
+  }
 }
 
 resource "aws_internet_gateway" "gw" {
@@ -327,12 +339,18 @@ resource "aws_subnet" "private" {
   vpc_id = "${aws_vpc.vpc.id}"
   cidr_block = "10.0.1.0/24"
   map_public_ip_on_launch = false
+  tags {
+    Name = "tf-acc-nat-gw-tags-private"
+  }
 }
 
 resource "aws_subnet" "public" {
   vpc_id = "${aws_vpc.vpc.id}"
   cidr_block = "10.0.2.0/24"
   map_public_ip_on_launch = true
+  tags {
+    Name = "tf-acc-nat-gw-tags-public"
+  }
 }
 
 resource "aws_internet_gateway" "gw" {

--- a/aws/resource_aws_network_acl_test.go
+++ b/aws/resource_aws_network_acl_test.go
@@ -560,7 +560,11 @@ resource "aws_subnet" "blob" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
 	map_public_ip_on_launch = true
+	tags {
+		Name = "tf-acc-network-acl-ipv6"
+	}
 }
+
 resource "aws_network_acl" "foos" {
 	vpc_id = "${aws_vpc.foo.id}"
 	ingress = {
@@ -621,6 +625,9 @@ resource "aws_subnet" "blob" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
 	map_public_ip_on_launch = true
+	tags {
+		Name = "tf-acc-network-acl-ingress"
+	}
 }
 
 resource "aws_network_acl" "foos" {
@@ -661,6 +668,9 @@ resource "aws_subnet" "blob" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
 	map_public_ip_on_launch = true
+	tags {
+		Name = "tf-acc-network-acl-ingress"
+	}
 }
 
 resource "aws_network_acl" "foos" {
@@ -692,6 +702,9 @@ resource "aws_subnet" "blob" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
 	map_public_ip_on_launch = true
+	tags {
+		Name = "tf-acc-network-acl-ingress"
+	}
 }
 
 resource "aws_network_acl" "foos" {
@@ -723,6 +736,9 @@ resource "aws_subnet" "blob" {
 	cidr_block = "10.2.0.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
 	map_public_ip_on_launch = true
+	tags {
+		Name = "tf-acc-network-acl-egress"
+	}
 }
 
 resource "aws_network_acl" "bond" {
@@ -782,6 +798,9 @@ resource "aws_subnet" "blob" {
 	cidr_block = "10.3.0.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
 	map_public_ip_on_launch = true
+	tags {
+		Name = "tf-acc-network-acl-egress-and-ingress"
+	}
 }
 
 resource "aws_network_acl" "bar" {
@@ -820,12 +839,18 @@ resource "aws_subnet" "old" {
 	cidr_block = "10.1.111.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
 	map_public_ip_on_launch = true
+	tags {
+		Name = "tf-acc-network-acl-subnet-change-old"
+	}
 }
 
 resource "aws_subnet" "new" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
 	map_public_ip_on_launch = true
+	tags {
+		Name = "tf-acc-network-acl-subnet-change-new"
+	}
 }
 
 resource "aws_network_acl" "roll" {
@@ -857,12 +882,18 @@ resource "aws_subnet" "old" {
 	cidr_block = "10.1.111.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
 	map_public_ip_on_launch = true
+	tags {
+		Name = "tf-acc-network-acl-subnet-change-old"
+	}
 }
 
 resource "aws_subnet" "new" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
 	map_public_ip_on_launch = true
+	tags {
+		Name = "tf-acc-network-acl-subnet-change-new"
+	}
 }
 
 resource "aws_network_acl" "bar" {
@@ -886,7 +917,7 @@ resource "aws_subnet" "one" {
 	cidr_block = "10.1.111.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
 	tags {
-		Name = "acl-subnets-test"
+		Name = "tf-acc-network-acl-subnet-ids-one"
 	}
 }
 
@@ -894,7 +925,7 @@ resource "aws_subnet" "two" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
 	tags {
-		Name = "acl-subnets-test"
+		Name = "tf-acc-network-acl-subnet-ids-two"
 	}
 }
 
@@ -919,7 +950,7 @@ resource "aws_subnet" "one" {
 	cidr_block = "10.1.111.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
 	tags {
-		Name = "acl-subnets-test"
+		Name = "tf-acc-network-acl-subnet-ids-one"
 	}
 }
 
@@ -927,7 +958,7 @@ resource "aws_subnet" "two" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
 	tags {
-		Name = "acl-subnets-test"
+		Name = "tf-acc-network-acl-subnet-ids-two"
 	}
 }
 
@@ -935,7 +966,7 @@ resource "aws_subnet" "three" {
 	cidr_block = "10.1.222.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
 	tags {
-		Name = "acl-subnets-test"
+		Name = "tf-acc-network-acl-subnet-ids-three"
 	}
 }
 
@@ -943,7 +974,7 @@ resource "aws_subnet" "four" {
 	cidr_block = "10.1.4.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
 	tags {
-		Name = "acl-subnets-test"
+		Name = "tf-acc-network-acl-subnet-ids-four"
 	}
 }
 

--- a/aws/resource_aws_network_interface_attachment_test.go
+++ b/aws/resource_aws_network_interface_attachment_test.go
@@ -52,6 +52,9 @@ resource "aws_subnet" "foo" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "172.16.10.0/24"
     availability_zone = "us-west-2a"
+    tags {
+        Name = "tf-acc-network-iface-attachment-basic"
+    }
 }
 
 resource "aws_security_group" "foo" {

--- a/aws/resource_aws_network_interface_test.go
+++ b/aws/resource_aws_network_interface_test.go
@@ -311,6 +311,9 @@ resource "aws_subnet" "foo" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "172.16.10.0/24"
     availability_zone = "us-west-2a"
+    tags {
+        Name = "tf-acc-network-interface"
+    }
 }
 
 resource "aws_security_group" "foo" {
@@ -350,6 +353,9 @@ resource "aws_subnet" "foo" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "172.16.10.0/24"
     availability_zone = "us-west-2a"
+    tags {
+        Name = "tf-acc-network-interface-update-desc"
+    }
 }
 
 resource "aws_security_group" "foo" {
@@ -389,6 +395,9 @@ resource "aws_subnet" "foo" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "172.16.10.0/24"
     availability_zone = "us-west-2a"
+    tags {
+        Name = "tf-acc-network-interface-w-source-dest-check"
+    }
 }
 
 resource "aws_network_interface" "bar" {
@@ -411,6 +420,9 @@ resource "aws_subnet" "foo" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "172.16.10.0/24"
     availability_zone = "us-west-2a"
+    tags {
+        Name = "tf-acc-network-interface-w-no-private-ips"
+    }
 }
 
 resource "aws_network_interface" "bar" {
@@ -433,7 +445,7 @@ resource "aws_subnet" "foo" {
     cidr_block = "172.16.10.0/24"
     availability_zone = "us-west-2a"
         tags {
-            Name = "tf-foo-eni-test"
+            Name = "tf-acc-network-interface-w-attachment-foo"
         }
 }
 
@@ -442,7 +454,7 @@ resource "aws_subnet" "bar" {
     cidr_block = "172.16.11.0/24"
     availability_zone = "us-west-2a"
         tags {
-            Name = "tf-bar-eni-test"
+            Name = "tf-acc-network-interface-w-attachment-bar"
         }
 }
 
@@ -491,7 +503,7 @@ resource "aws_subnet" "foo" {
     cidr_block = "172.16.10.0/24"
     availability_zone = "us-west-2a"
     tags {
-        Name = "tf-eni-test"
+        Name = "tf-acc-network-interface-external-attachment-foo"
     }
 }
 
@@ -500,7 +512,7 @@ resource "aws_subnet" "bar" {
     cidr_block = "172.16.11.0/24"
     availability_zone = "us-west-2a"
     tags {
-        Name = "tf-eni-test"
+        Name = "tf-acc-network-interface-external-attachment-bar"
     }
 }
 

--- a/aws/resource_aws_opsworks_stack_test.go
+++ b/aws/resource_aws_opsworks_stack_test.go
@@ -1012,6 +1012,9 @@ resource "aws_subnet" "tf-acc" {
   vpc_id = "${aws_vpc.tf-acc.id}"
   cidr_block = "${aws_vpc.tf-acc.cidr_block}"
   availability_zone = "us-west-2a"
+  tags {
+    Name = "tf-acc-opsworks-stack-vpc-create"
+  }
 }
 resource "aws_opsworks_stack" "tf-acc" {
   name = "%s"
@@ -1106,6 +1109,9 @@ resource "aws_subnet" "tf-acc" {
   vpc_id = "${aws_vpc.tf-acc.id}"
   cidr_block = "${aws_vpc.tf-acc.cidr_block}"
   availability_zone = "us-west-2a"
+  tags {
+    Name = "tf-acc-opsworks-stack-vpc-update"
+  }
 }
 resource "aws_opsworks_stack" "tf-acc" {
   name = "%s"

--- a/aws/resource_aws_rds_cluster_instance_test.go
+++ b/aws/resource_aws_rds_cluster_instance_test.go
@@ -415,12 +415,18 @@ resource "aws_subnet" "a" {
   vpc_id = "${aws_vpc.test.id}"
   cidr_block = "10.0.0.0/24"
   availability_zone = "us-west-2a"
+  tags {
+    Name = "tf-acc-rds-cluster-instance-name-prefix-a"
+  }
 }
 
 resource "aws_subnet" "b" {
   vpc_id = "${aws_vpc.test.id}"
   cidr_block = "10.0.1.0/24"
   availability_zone = "us-west-2b"
+  tags {
+    Name = "tf-acc-rds-cluster-instance-name-prefix-b"
+  }
 }
 
 resource "aws_db_subnet_group" "test" {
@@ -456,12 +462,18 @@ resource "aws_subnet" "a" {
   vpc_id = "${aws_vpc.test.id}"
   cidr_block = "10.0.0.0/24"
   availability_zone = "us-west-2a"
+  tags {
+    Name = "tf-acc-rds-cluster-instance-generated-name-a"
+  }
 }
 
 resource "aws_subnet" "b" {
   vpc_id = "${aws_vpc.test.id}"
   cidr_block = "10.0.1.0/24"
   availability_zone = "us-west-2b"
+  tags {
+    Name = "tf-acc-rds-cluster-instance-generated-name-b"
+  }
 }
 
 resource "aws_db_subnet_group" "test" {

--- a/aws/resource_aws_rds_cluster_test.go
+++ b/aws/resource_aws_rds_cluster_test.go
@@ -483,18 +483,18 @@ resource "aws_subnet" "a" {
   vpc_id = "${aws_vpc.test.id}"
   cidr_block = "10.0.0.0/24"
   availability_zone = "us-west-2a"
-	tags {
-		Name = "testAccAWSClusterConfig_namePrefix"
-	}
+  tags {
+    Name = "tf-acc-rds-cluster-name-prefix-a"
+  }
 }
 
 resource "aws_subnet" "b" {
   vpc_id = "${aws_vpc.test.id}"
   cidr_block = "10.0.1.0/24"
   availability_zone = "us-west-2b"
-	tags {
-		Name = "testAccAWSClusterConfig_namePrefix"
-	}
+  tags {
+    Name = "tf-acc-rds-cluster-name-prefix-b"
+  }
 }
 
 resource "aws_db_subnet_group" "test" {
@@ -524,12 +524,18 @@ resource "aws_subnet" "a" {
   vpc_id = "${aws_vpc.test.id}"
   cidr_block = "10.0.0.0/24"
   availability_zone = "us-west-2a"
+  tags {
+    Name = "tf-acc-rds-cluster-generated-name-a"
+  }
 }
 
 resource "aws_subnet" "b" {
   vpc_id = "${aws_vpc.test.id}"
   cidr_block = "10.0.1.0/24"
   availability_zone = "us-west-2b"
+  tags {
+    Name = "tf-acc-rds-cluster-generated-name-b"
+  }
 }
 
 resource "aws_db_subnet_group" "test" {
@@ -987,6 +993,9 @@ resource "aws_subnet" "db" {
   vpc_id            = "${aws_vpc.main.id}"
   availability_zone = "${data.aws_availability_zones.us-east-1.names[count.index]}"
   cidr_block        = "10.0.${count.index}.0/24"
+  tags {
+    Name = "tf-acc-rds-cluster-encrypted-cross-region-replica-${count.index}"
+  }
 }
 
 resource "aws_db_subnet_group" "replica" {

--- a/aws/resource_aws_redshift_cluster_test.go
+++ b/aws/resource_aws_redshift_cluster_test.go
@@ -1055,7 +1055,7 @@ func testAccAWSRedshiftClusterConfig_notPubliclyAccessible(rInt int) string {
 	resource "aws_vpc" "foo" {
 		cidr_block = "10.1.0.0/16"
 		tags {
-			Name = "terraform-testacc-redshift-cluster-no-publicly-accessible"
+			Name = "terraform-testacc-redshift-cluster-not-publicly-accessible"
 		}
 	}
 	resource "aws_internet_gateway" "foo" {
@@ -1069,7 +1069,7 @@ func testAccAWSRedshiftClusterConfig_notPubliclyAccessible(rInt int) string {
 		availability_zone = "us-west-2a"
 		vpc_id = "${aws_vpc.foo.id}"
 		tags {
-			Name = "tf-dbsubnet-test-1"
+			Name = "tf-acc-redshift-cluster-not-publicly-accessible-foo"
 		}
 	}
 	resource "aws_subnet" "bar" {
@@ -1077,7 +1077,7 @@ func testAccAWSRedshiftClusterConfig_notPubliclyAccessible(rInt int) string {
 		availability_zone = "us-west-2b"
 		vpc_id = "${aws_vpc.foo.id}"
 		tags {
-			Name = "tf-dbsubnet-test-2"
+			Name = "tf-acc-redshift-cluster-not-publicly-accessible-bar"
 		}
 	}
 	resource "aws_subnet" "foobar" {
@@ -1085,7 +1085,7 @@ func testAccAWSRedshiftClusterConfig_notPubliclyAccessible(rInt int) string {
 		availability_zone = "us-west-2c"
 		vpc_id = "${aws_vpc.foo.id}"
 		tags {
-			Name = "tf-dbsubnet-test-3"
+			Name = "tf-acc-redshift-cluster-not-publicly-accessible-foobar"
 		}
 	}
 	resource "aws_redshift_subnet_group" "foo" {
@@ -1129,7 +1129,7 @@ func testAccAWSRedshiftClusterConfig_updatePubliclyAccessible(rInt int) string {
 		availability_zone = "us-west-2a"
 		vpc_id = "${aws_vpc.foo.id}"
 		tags {
-			Name = "tf-dbsubnet-test-1"
+			Name = "tf-acc-redshift-cluster-upd-publicly-accessible-foo"
 		}
 	}
 	resource "aws_subnet" "bar" {
@@ -1137,7 +1137,7 @@ func testAccAWSRedshiftClusterConfig_updatePubliclyAccessible(rInt int) string {
 		availability_zone = "us-west-2b"
 		vpc_id = "${aws_vpc.foo.id}"
 		tags {
-			Name = "tf-dbsubnet-test-2"
+			Name = "tf-acc-redshift-cluster-upd-publicly-accessible-bar"
 		}
 	}
 	resource "aws_subnet" "foobar" {
@@ -1145,7 +1145,7 @@ func testAccAWSRedshiftClusterConfig_updatePubliclyAccessible(rInt int) string {
 		availability_zone = "us-west-2c"
 		vpc_id = "${aws_vpc.foo.id}"
 		tags {
-			Name = "tf-dbsubnet-test-3"
+			Name = "tf-acc-redshift-cluster-upd-publicly-accessible-foobar"
 		}
 	}
 	resource "aws_redshift_subnet_group" "foo" {

--- a/aws/resource_aws_redshift_subnet_group_test.go
+++ b/aws/resource_aws_redshift_subnet_group_test.go
@@ -240,7 +240,7 @@ resource "aws_subnet" "foo" {
 	availability_zone = "us-west-2a"
 	vpc_id = "${aws_vpc.foo.id}"
 	tags {
-		Name = "tf-dbsubnet-test-1"
+		Name = "tf-acc-redshift-subnet-group-foo"
 	}
 }
 
@@ -249,7 +249,7 @@ resource "aws_subnet" "bar" {
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.foo.id}"
 	tags {
-		Name = "tf-dbsubnet-test-2"
+		Name = "tf-acc-redshift-subnet-group-bar"
 	}
 }
 
@@ -275,7 +275,7 @@ resource "aws_subnet" "foo" {
 	availability_zone = "us-west-2a"
 	vpc_id = "${aws_vpc.foo.id}"
 	tags {
-		Name = "tf-dbsubnet-test-1"
+		Name = "tf-acc-redshift-subnet-group-upd-description-foo"
 	}
 }
 
@@ -284,7 +284,7 @@ resource "aws_subnet" "bar" {
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.foo.id}"
 	tags {
-		Name = "tf-dbsubnet-test-2"
+		Name = "tf-acc-redshift-subnet-group-upd-description-bar"
 	}
 }
 
@@ -310,7 +310,7 @@ resource "aws_subnet" "foo" {
 	availability_zone = "us-west-2a"
 	vpc_id = "${aws_vpc.foo.id}"
 	tags {
-		Name = "tf-dbsubnet-test-1"
+		Name = "tf-acc-redshift-subnet-group-with-tags-foo"
 	}
 }
 
@@ -319,7 +319,7 @@ resource "aws_subnet" "bar" {
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.foo.id}"
 	tags {
-		Name = "tf-dbsubnet-test-2"
+		Name = "tf-acc-redshift-subnet-group-with-tags-bar"
 	}
 }
 
@@ -347,7 +347,7 @@ resource "aws_subnet" "foo" {
 	availability_zone = "us-west-2a"
 	vpc_id = "${aws_vpc.foo.id}"
 	tags {
-		Name = "tf-dbsubnet-test-1"
+		Name = "tf-acc-redshift-subnet-group-with-tags-foo"
 	}
 }
 
@@ -356,7 +356,7 @@ resource "aws_subnet" "bar" {
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.foo.id}"
 	tags {
-		Name = "tf-dbsubnet-test-2"
+		Name = "tf-acc-redshift-subnet-group-with-tags-bar"
 	}
 }
 
@@ -386,7 +386,7 @@ resource "aws_subnet" "foo" {
 	availability_zone = "us-west-2a"
 	vpc_id = "${aws_vpc.foo.id}"
 	tags {
-		Name = "tf-dbsubnet-test-1"
+		Name = "tf-acc-redshift-subnet-group-upd-subnet-ids-foo"
 	}
 }
 
@@ -395,7 +395,7 @@ resource "aws_subnet" "bar" {
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.foo.id}"
 	tags {
-		Name = "tf-dbsubnet-test-2"
+		Name = "tf-acc-redshift-subnet-group-upd-subnet-ids-bar"
 	}
 }
 
@@ -404,7 +404,7 @@ resource "aws_subnet" "foobar" {
 	availability_zone = "us-west-2c"
 	vpc_id = "${aws_vpc.foo.id}"
 	tags {
-		Name = "tf-dbsubnet-test-3"
+		Name = "tf-acc-redshift-subnet-group-upd-subnet-ids-foobar"
 	}
 }
 

--- a/aws/resource_aws_route_table_association_test.go
+++ b/aws/resource_aws_route_table_association_test.go
@@ -116,6 +116,9 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
 	cidr_block = "10.1.1.0/24"
+	tags {
+		Name = "tf-acc-route-table-association"
+	}
 }
 
 resource "aws_internet_gateway" "foo" {
@@ -151,6 +154,9 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
 	cidr_block = "10.1.1.0/24"
+	tags {
+		Name = "tf-acc-route-table-association"
+	}
 }
 
 resource "aws_internet_gateway" "foo" {

--- a/aws/resource_aws_route_table_test.go
+++ b/aws/resource_aws_route_table_test.go
@@ -436,6 +436,9 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
+	tags {
+		Name = "tf-acc-route-table-instance"
+	}
 }
 
 resource "aws_instance" "foo" {

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -447,6 +447,9 @@ resource "aws_subnet" "router-network" {
   assign_ipv6_address_on_creation = true
   map_public_ip_on_launch = true
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  tags {
+    Name = "tf-acc-route-ipv6-network-interface-router"
+  }
 }
 
 resource "aws_subnet" "client-network" {
@@ -456,6 +459,9 @@ resource "aws_subnet" "client-network" {
   assign_ipv6_address_on_creation = true
   map_public_ip_on_launch = false
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  tags {
+    Name = "tf-acc-route-ipv6-network-interface-client"
+  }
 }
 
 resource "aws_route_table" "client-routes" {
@@ -550,6 +556,9 @@ resource "aws_subnet" "router-network" {
   assign_ipv6_address_on_creation = true
   map_public_ip_on_launch = true
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  tags {
+    Name = "tf-acc-route-ipv6-instance-router"
+  }
 }
 
 resource "aws_subnet" "client-network" {
@@ -559,6 +568,9 @@ resource "aws_subnet" "client-network" {
   assign_ipv6_address_on_creation = true
   map_public_ip_on_launch = false
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  tags {
+    Name = "tf-acc-route-ipv6-instance-client"
+  }
 }
 
 resource "aws_route_table" "client-routes" {
@@ -725,7 +737,7 @@ var testAccAWSRouteNoopChange = fmt.Sprint(`
 resource "aws_vpc" "test" {
   cidr_block = "10.10.0.0/16"
   tags {
-    Name = "terraform-testacc-route-route-noop-change"
+    Name = "terraform-testacc-route-noop-change"
   }
 }
 
@@ -736,6 +748,9 @@ resource "aws_route_table" "test" {
 resource "aws_subnet" "test" {
   vpc_id = "${aws_vpc.test.id}"
   cidr_block = "10.10.10.0/24"
+  tags {
+    Name = "tf-acc-route-noop-change"
+  }
 }
 
 resource "aws_route" "test" {

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -942,12 +942,18 @@ resource "aws_subnet" "foo" {
     cidr_block = "10.1.1.0/24"
     vpc_id = "${aws_vpc.foo.id}"
     availability_zone = "us-west-2a"
+    tags {
+        Name = "tf-acc-spot-fleet-request-w-subnet-foo"
+    }
 }
 
 resource "aws_subnet" "bar" {
     cidr_block = "10.1.20.0/24"
     vpc_id = "${aws_vpc.foo.id}"
     availability_zone = "us-west-2b"
+    tags {
+        Name = "tf-acc-spot-fleet-request-w-subnet-bar"
+    }
 }
 
 resource "aws_spot_fleet_request" "foo" {
@@ -1040,12 +1046,18 @@ resource "aws_subnet" "foo" {
     cidr_block = "10.1.1.0/24"
     vpc_id = "${aws_vpc.foo.id}"
     availability_zone = "us-west-2a"
+    tags {
+        Name = "tf-acc-spot-fleet-request-with-elb-foo"
+    }
 }
 
 resource "aws_subnet" "bar" {
     cidr_block = "10.1.20.0/24"
     vpc_id = "${aws_vpc.foo.id}"
     availability_zone = "us-west-2b"
+    tags {
+        Name = "tf-acc-spot-fleet-request-with-elb-bar"
+    }
 }
 
 resource "aws_elb" "elb" {
@@ -1146,12 +1158,18 @@ resource "aws_subnet" "foo" {
     cidr_block = "10.1.1.0/24"
     vpc_id = "${aws_vpc.foo.id}"
     availability_zone = "us-west-2a"
+    tags {
+        Name = "tf-acc-spot-fleet-request-with-target-groups-foo"
+    }
 }
 
 resource "aws_subnet" "bar" {
     cidr_block = "10.1.20.0/24"
     vpc_id = "${aws_vpc.foo.id}"
     availability_zone = "us-west-2b"
+    tags {
+        Name = "tf-acc-spot-fleet-request-with-target-groups-bar"
+    }
 }
 
 resource "aws_alb" "alb" {
@@ -1348,6 +1366,9 @@ resource "aws_subnet" "foo" {
     cidr_block = "10.1.1.0/24"
     vpc_id = "${aws_vpc.foo.id}"
     availability_zone = "us-west-2a"
+    tags {
+        Name = "tf-acc-spot-fleet-request-multi-instance-types"
+    }
 }
 
 resource "aws_spot_fleet_request" "foo" {

--- a/aws/resource_aws_spot_instance_request_test.go
+++ b/aws/resource_aws_spot_instance_request_test.go
@@ -462,6 +462,9 @@ func testAccAWSSpotInstanceRequestConfigVPC(rInt int) string {
 	resource "aws_subnet" "foo_VPC" {
 		cidr_block = "10.1.1.0/24"
 		vpc_id = "${aws_vpc.foo_VPC.id}"
+		tags {
+			Name = "tf-acc-spot-instance-request-vpc"
+		}
 	}
 
 	resource "aws_key_pair" "debugging" {
@@ -518,7 +521,7 @@ func testAccAWSSpotInstanceRequestConfig_SubnetAndSGAndPublicIpAddress(rInt int)
 		map_public_ip_on_launch = true
 
 		tags {
-			Name = "tf_test_subnet-%d"
+			Name = "tf-acc-spot-instance-request-subnet-and-sg-public-ip"
 		}
 	}
 
@@ -530,5 +533,5 @@ func testAccAWSSpotInstanceRequestConfig_SubnetAndSGAndPublicIpAddress(rInt int)
 		tags {
 			Name = "tf_test_sg_ssh-%d"
 		}
-	}`, rInt, rInt, rInt)
+	}`, rInt, rInt)
 }

--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -32,8 +32,7 @@ func testSweepSubnets(region string) error {
 			{
 				Name: aws.String("tag-value"),
 				Values: []*string{
-					aws.String("tf-acc-revoke*"),
-					aws.String("terraform-testacc-subnet-data-source*"),
+					aws.String("tf-acc-*"),
 				},
 			},
 		},
@@ -269,7 +268,7 @@ resource "aws_subnet" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
 	map_public_ip_on_launch = true
 	tags {
-		Name = "tf-subnet-acc-test"
+		Name = "tf-acc-subnet"
 	}
 }
 `
@@ -288,7 +287,7 @@ resource "aws_subnet" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
 	map_public_ip_on_launch = true
 	tags {
-		Name = "tf-subnet-acc-test"
+		Name = "tf-acc-subnet-ipv6"
 	}
 }
 `
@@ -309,7 +308,7 @@ resource "aws_subnet" "foo" {
 	map_public_ip_on_launch = true
 	assign_ipv6_address_on_creation = true
 	tags {
-		Name = "tf-subnet-acc-test"
+		Name = "tf-acc-subnet-ipv6"
 	}
 }
 `
@@ -330,7 +329,7 @@ resource "aws_subnet" "foo" {
 	map_public_ip_on_launch = true
 	assign_ipv6_address_on_creation = false
 	tags {
-		Name = "tf-subnet-acc-test"
+		Name = "tf-acc-subnet-assign-ipv6-on-creation"
 	}
 }
 `
@@ -340,7 +339,7 @@ resource "aws_vpc" "foo" {
 	cidr_block = "10.10.0.0/16"
 	assign_generated_ipv6_cidr_block = true
 	tags {
-		Name = "terraform-testacc-ipv6-update-cidr"
+		Name = "terraform-testacc-subnet-ipv6-update-cidr"
 	}
 }
 
@@ -351,7 +350,7 @@ resource "aws_subnet" "foo" {
 	map_public_ip_on_launch = true
 	assign_ipv6_address_on_creation = false
 	tags {
-		Name = "tf-subnet-acc-test"
+		Name = "tf-acc-subnet-ipv6-update-cidr"
 	}
 }
 `

--- a/aws/resource_aws_vpc_endpoint_connection_notification_test.go
+++ b/aws/resource_aws_vpc_endpoint_connection_notification_test.go
@@ -134,7 +134,7 @@ resource "aws_subnet" "nlb_test_1" {
   availability_zone = "us-west-2a"
 
   tags {
-    Name = "testAccVpcEndpointConnectionNotificationBasicConfig_subnet1"
+    Name = "tf-acc-vpc-endpoint-connection-notification-1"
   }
 }
 
@@ -144,7 +144,7 @@ resource "aws_subnet" "nlb_test_2" {
   availability_zone = "us-west-2b"
 
   tags {
-    Name = "testAccVpcEndpointConnectionNotificationBasicConfig_subnet2"
+    Name = "tf-acc-vpc-endpoint-connection-notification-2"
   }
 }
 
@@ -223,7 +223,7 @@ func testAccVpcEndpointConnectionNotificationModifiedConfig(lbName string) strin
 			availability_zone = "us-west-2a"
 
 			tags {
-				Name = "testAccVpcEndpointConnectionNotificationBasicConfig_subnet1"
+				Name = "tf-acc-vpc-endpoint-connection-notification-1"
 			}
 		}
 
@@ -233,7 +233,7 @@ func testAccVpcEndpointConnectionNotificationModifiedConfig(lbName string) strin
 			availability_zone = "us-west-2b"
 
 			tags {
-				Name = "testAccVpcEndpointConnectionNotificationBasicConfig_subnet2"
+				Name = "tf-acc-vpc-endpoint-connection-notification-2"
 			}
 		}
 

--- a/aws/resource_aws_vpc_endpoint_service_allowed_principal_test.go
+++ b/aws/resource_aws_vpc_endpoint_service_allowed_principal_test.go
@@ -129,7 +129,7 @@ resource "aws_subnet" "nlb_test_1" {
   availability_zone = "us-west-2a"
 
   tags {
-    Name = "testAccVpcEndpointServiceBasicConfig_subnet1"
+    Name = "tf-acc-vpc-endpoint-service-allowed-principal-1"
   }
 }
 
@@ -139,7 +139,7 @@ resource "aws_subnet" "nlb_test_2" {
   availability_zone = "us-west-2b"
 
   tags {
-    Name = "testAccVpcEndpointServiceBasicConfig_subnet2"
+    Name = "tf-acc-vpc-endpoint-service-allowed-principal-2"
   }
 }
 

--- a/aws/resource_aws_vpc_endpoint_service_test.go
+++ b/aws/resource_aws_vpc_endpoint_service_test.go
@@ -171,7 +171,7 @@ resource "aws_subnet" "nlb_test_1" {
   availability_zone = "us-west-2a"
 
   tags {
-    Name = "testAccVpcEndpointServiceBasicConfig_subnet1"
+    Name = "tf-acc-vpc-endpoint-service-1"
   }
 }
 
@@ -181,7 +181,7 @@ resource "aws_subnet" "nlb_test_2" {
   availability_zone = "us-west-2b"
 
   tags {
-    Name = "testAccVpcEndpointServiceBasicConfig_subnet2"
+    Name = "tf-acc-vpc-endpoint-service-2"
   }
 }
 
@@ -254,7 +254,7 @@ resource "aws_subnet" "nlb_test_1" {
   availability_zone = "us-west-2a"
 
   tags {
-    Name = "testAccVpcEndpointServiceBasicConfig_subnet1"
+    Name = "tf-acc-vpc-endpoint-service-1"
   }
 }
 
@@ -264,7 +264,7 @@ resource "aws_subnet" "nlb_test_2" {
   availability_zone = "us-west-2b"
 
   tags {
-    Name = "testAccVpcEndpointServiceBasicConfig_subnet2"
+    Name = "tf-acc-vpc-endpoint-service-2"
   }
 }
 

--- a/aws/resource_aws_vpc_endpoint_subnet_association_test.go
+++ b/aws/resource_aws_vpc_endpoint_subnet_association_test.go
@@ -131,6 +131,9 @@ resource "aws_subnet" "sn" {
   vpc_id = "${aws_vpc.foo.id}"
   availability_zone = "us-west-2a"
   cidr_block = "10.0.0.0/17"
+  tags {
+    Name = "tf-acc-vpc-endpoint-subnet-association"
+  }
 }
 
 resource "aws_vpc_endpoint_subnet_association" "a" {

--- a/aws/resource_aws_vpc_endpoint_test.go
+++ b/aws/resource_aws_vpc_endpoint_test.go
@@ -304,6 +304,9 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
   vpc_id = "${aws_vpc.foo.id}"
   cidr_block = "10.0.1.0/24"
+  tags {
+    Name = "tf-acc-vpc-endpoint-gw-w-route-table-and-policy"
+  }
 }
 
 resource "aws_vpc_endpoint" "s3" {
@@ -345,6 +348,9 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
   vpc_id = "${aws_vpc.foo.id}"
   cidr_block = "10.0.1.0/24"
+  tags {
+    Name = "tf-acc-vpc-endpoint-gw-w-route-table-and-policy"
+  }
 }
 
 resource "aws_vpc_endpoint" "s3" {
@@ -422,12 +428,18 @@ resource "aws_subnet" "sn1" {
   vpc_id = "${aws_vpc.foo.id}"
   cidr_block = "10.0.0.0/17"
   availability_zone = "us-west-2a"
+  tags {
+    Name = "tf-acc-vpc-endpoint-iface-w-subnet-1"
+  }
 }
 
 resource "aws_subnet" "sn2" {
   vpc_id = "${aws_vpc.foo.id}"
   cidr_block = "10.0.128.0/17"
   availability_zone = "us-west-2b"
+  tags {
+    Name = "tf-acc-vpc-endpoint-iface-w-subnet-2"
+  }
 }
 
 resource "aws_security_group" "sg1" {
@@ -462,12 +474,18 @@ resource "aws_subnet" "sn1" {
   vpc_id = "${aws_vpc.foo.id}"
   cidr_block = "10.0.0.0/17"
   availability_zone = "us-west-2a"
+  tags {
+    Name = "tf-acc-vpc-endpoint-iface-w-subnet-1"
+  }
 }
 
 resource "aws_subnet" "sn2" {
   vpc_id = "${aws_vpc.foo.id}"
   cidr_block = "10.0.128.0/17"
   availability_zone = "us-west-2b"
+  tags {
+    Name = "tf-acc-vpc-endpoint-iface-w-subnet-2"
+  }
 }
 
 resource "aws_security_group" "sg1" {
@@ -522,7 +540,7 @@ resource "aws_subnet" "nlb_test_1" {
   availability_zone = "us-west-2a"
 
   tags {
-    Name = "testAccVpcEndpointServiceBasicConfig_subnet1"
+    Name = "tf-acc-vpc-endpoint-iface-non-aws-svc-1"
   }
 }
 
@@ -532,7 +550,7 @@ resource "aws_subnet" "nlb_test_2" {
   availability_zone = "us-west-2b"
 
   tags {
-    Name = "testAccVpcEndpointServiceBasicConfig_subnet2"
+    Name = "tf-acc-vpc-endpoint-iface-non-aws-svc-2"
   }
 }
 


### PR DESCRIPTION
## Test results
```
=== RUN   TestAccAWSNetworkAcl_ipv6VpcRules
--- PASS: TestAccAWSNetworkAcl_ipv6VpcRules (23.48s)
=== RUN   TestAccAWSNetworkAcl_OnlyEgressRules
--- PASS: TestAccAWSNetworkAcl_OnlyEgressRules (96.19s)
=== RUN   TestAccAWSNetworkAcl_EgressAndIngressRules
--- PASS: TestAccAWSNetworkAcl_EgressAndIngressRules (96.30s)
=== RUN   TestAccAWSNetworkAcl_espProtocol
--- PASS: TestAccAWSNetworkAcl_espProtocol (114.68s)
=== RUN   TestAccAWSNetworkAcl_CaseSensitivityNoChanges
--- PASS: TestAccAWSNetworkAcl_CaseSensitivityNoChanges (120.42s)
=== RUN   TestAccAWSNetworkAcl_ipv6Rules
--- PASS: TestAccAWSNetworkAcl_ipv6Rules (130.83s)
=== RUN   TestAccAWSMainRouteTableAssociation_basic
--- PASS: TestAccAWSMainRouteTableAssociation_basic (136.53s)
=== RUN   TestAccAWSOpsworksStackNoVpc
--- PASS: TestAccAWSOpsworksStackNoVpc (25.61s)
=== RUN   TestAccAWSENI_basic
--- PASS: TestAccAWSENI_basic (173.66s)
=== RUN   TestAccAWSOpsworksStackNoVpcChangeServiceRoleForceNew
--- PASS: TestAccAWSOpsworksStackNoVpcChangeServiceRoleForceNew (47.38s)
=== RUN   TestAccAWSENI_sourceDestCheck
--- PASS: TestAccAWSENI_sourceDestCheck (93.04s)
=== RUN   TestAccAWSOpsworksStackNoVpcCreateTags
--- PASS: TestAccAWSOpsworksStackNoVpcCreateTags (61.52s)
=== RUN   TestAccAWSOpsWorksStack_classic_endpoints
--- PASS: TestAccAWSOpsWorksStack_classic_endpoints (37.48s)
=== RUN   TestAccAWSNetworkAcl_Subnets
--- PASS: TestAccAWSNetworkAcl_Subnets (223.74s)
=== RUN   TestAccAWSENI_computedIPs
--- PASS: TestAccAWSENI_computedIPs (133.74s)
=== RUN   TestAccAWSENI_updatedDescription
--- PASS: TestAccAWSENI_updatedDescription (252.16s)
=== RUN   TestAccAWSNetworkAcl_OnlyIngressRules_basic
--- PASS: TestAccAWSNetworkAcl_OnlyIngressRules_basic (253.52s)
=== RUN   TestAccAWSENI_ignoreExternalAttachment
--- PASS: TestAccAWSENI_ignoreExternalAttachment (210.50s)
=== RUN   TestAccAWSNetworkInterfaceAttachment_basic
--- PASS: TestAccAWSNetworkInterfaceAttachment_basic (322.98s)
=== RUN   TestAccAWSNatGateway_basic
--- PASS: TestAccAWSNatGateway_basic (337.82s)
=== RUN   TestAccAWSOpsworksStackVpc
--- PASS: TestAccAWSOpsworksStackVpc (201.77s)
=== RUN   TestAccAWSNetworkAcl_SubnetChange
--- PASS: TestAccAWSNetworkAcl_SubnetChange (347.87s)
=== RUN   TestAccAWSRDSCluster_missingUserNameCausesError
--- PASS: TestAccAWSRDSCluster_missingUserNameCausesError (2.30s)
=== RUN   TestAccAWSRDSCluster_basic
--- PASS: TestAccAWSRDSCluster_basic (108.26s)
=== RUN   TestAccAWSRDSCluster_namePrefix
--- PASS: TestAccAWSRDSCluster_namePrefix (119.34s)
=== RUN   TestAccAWSRDSCluster_generatedName
--- PASS: TestAccAWSRDSCluster_generatedName (122.31s)
=== RUN   TestAccAWSNetworkAcl_OnlyIngressRules_update
--- PASS: TestAccAWSNetworkAcl_OnlyIngressRules_update (472.58s)
=== RUN   TestAccAWSRDSCluster_updateTags
--- PASS: TestAccAWSRDSCluster_updateTags (133.77s)
=== RUN   TestAccAWSRDSCluster_takeFinalSnapshot
--- PASS: TestAccAWSRDSCluster_takeFinalSnapshot (179.69s)
=== RUN   TestAccAWSRDSCluster_updateIamRoles
--- PASS: TestAccAWSRDSCluster_updateIamRoles (133.48s)
=== RUN   TestAccAWSRDSCluster_encrypted
--- PASS: TestAccAWSRDSCluster_encrypted (99.25s)
=== RUN   TestAccAWSNatGateway_tags
--- PASS: TestAccAWSNatGateway_tags (562.38s)
=== RUN   TestAccAWSRDSCluster_kmsKey
--- PASS: TestAccAWSRDSCluster_kmsKey (138.79s)
=== RUN   TestAccAWSRDSCluster_backupsUpdate
--- PASS: TestAccAWSRDSCluster_backupsUpdate (122.79s)
=== RUN   TestAccAWSRDSCluster_iamAuth
--- PASS: TestAccAWSRDSCluster_iamAuth (128.27s)
=== RUN   TestAccAWSENI_attached
--- PASS: TestAccAWSENI_attached (677.95s)
=== RUN   TestAccAWSRDSClusterInstance_generatedName
--- PASS: TestAccAWSRDSClusterInstance_generatedName (659.36s)
=== RUN   TestAccAWSRDSClusterInstance_namePrefix
--- PASS: TestAccAWSRDSClusterInstance_namePrefix (733.69s)
=== RUN   TestAccAWSRDSClusterInstance_withInstanceEnhancedMonitor
--- PASS: TestAccAWSRDSClusterInstance_withInstanceEnhancedMonitor (714.54s)
=== RUN   TestAccAWSRDSClusterInstance_kmsKey
--- PASS: TestAccAWSRDSClusterInstance_kmsKey (760.34s)
=== RUN   TestAccAWSRDSClusterInstance_az
--- PASS: TestAccAWSRDSClusterInstance_az (842.66s)
=== RUN   TestAccAWSRDSClusterInstance_withInstancePerformanceInsights
--- PASS: TestAccAWSRDSClusterInstance_withInstancePerformanceInsights (890.72s)
=== RUN   TestAccAWSRedshiftSubnetGroup_basic
--- PASS: TestAccAWSRedshiftSubnetGroup_basic (8.83s)
=== RUN   TestAccAWSRedshiftSubnetGroup_updateDescription
--- PASS: TestAccAWSRedshiftSubnetGroup_updateDescription (15.85s)
=== RUN   TestAccAWSRedshiftSubnetGroup_updateSubnetIds
--- PASS: TestAccAWSRedshiftSubnetGroup_updateSubnetIds (25.20s)
=== RUN   TestAccAWSRedshiftSubnetGroup_tags
--- PASS: TestAccAWSRedshiftSubnetGroup_tags (16.95s)
=== RUN   TestAccAWSRouteTableAssociation_basic
--- PASS: TestAccAWSRouteTableAssociation_basic (38.75s)
=== RUN   TestAccAWSRedshiftCluster_basic
--- PASS: TestAccAWSRedshiftCluster_basic (717.80s)
=== RUN   TestAccAWSRouteTable_basic
--- PASS: TestAccAWSRouteTable_basic (39.09s)
=== RUN   TestAccAWSRDSClusterInstance_disappears
--- PASS: TestAccAWSRDSClusterInstance_disappears (1055.09s)
=== RUN   TestAccAWSRouteTable_ipv6
--- PASS: TestAccAWSRouteTable_ipv6 (22.29s)
=== RUN   TestAccAWSRouteTable_panicEmptyRoute
--- PASS: TestAccAWSRouteTable_panicEmptyRoute (14.18s)
=== RUN   TestAccAWSRouteTable_tags
--- PASS: TestAccAWSRouteTable_tags (49.22s)
=== RUN   TestAccAWSRouteTable_vpcPeering
--- PASS: TestAccAWSRouteTable_vpcPeering (35.15s)
=== RUN   TestAccAWSRoute_basic
--- PASS: TestAccAWSRoute_basic (47.85s)
=== RUN   TestAccAWSRouteTable_vgwRoutePropagation
--- PASS: TestAccAWSRouteTable_vgwRoutePropagation (70.80s)
=== RUN   TestAccAWSRoute_ipv6Support
--- PASS: TestAccAWSRoute_ipv6Support (37.71s)
=== RUN   TestAccAWSRoute_ipv6ToInternetGateway
--- PASS: TestAccAWSRoute_ipv6ToInternetGateway (32.30s)
=== RUN   TestAccAWSRouteTable_instance
--- PASS: TestAccAWSRouteTable_instance (235.49s)
=== RUN   TestAccAWSRoute_ipv6ToPeeringConnection
--- PASS: TestAccAWSRoute_ipv6ToPeeringConnection (30.70s)
=== RUN   TestAccAWSRoute_ipv6ToInstance
--- PASS: TestAccAWSRoute_ipv6ToInstance (150.43s)
=== RUN   TestAccAWSRDSClusterInstance_basic
--- PASS: TestAccAWSRDSClusterInstance_basic (1419.50s)
=== RUN   TestAccAWSRoute_changeCidr
--- PASS: TestAccAWSRoute_changeCidr (65.85s)
=== RUN   TestAccAWSRoute_doesNotCrashWithVPCEndpoint
--- PASS: TestAccAWSRoute_doesNotCrashWithVPCEndpoint (42.40s)
=== RUN   TestAccAWSRedshiftCluster_loggingEnabledDeprecated
--- PASS: TestAccAWSRedshiftCluster_loggingEnabledDeprecated (1061.87s)
=== RUN   TestAccAWSRoute_ipv6ToNetworkInterface
--- PASS: TestAccAWSRoute_ipv6ToNetworkInterface (223.62s)
=== RUN   TestAccAWSRedshiftCluster_kmsKey
--- PASS: TestAccAWSRedshiftCluster_kmsKey (1120.10s)
=== RUN   TestAccAWSMqBroker_basic
--- PASS: TestAccAWSMqBroker_basic (1724.73s)
=== RUN   TestAccAWSRedshiftCluster_loggingEnabled
--- FAIL: TestAccAWSRedshiftCluster_loggingEnabled (1096.57s)
	testing.go:513: Step 1 error: Error applying: 1 error(s) occurred:
		
		* aws_redshift_cluster.default: 1 error(s) occurred:
		
		* aws_redshift_cluster.default: InsufficientS3BucketPolicyFault: Cannot write to bucket tf-redshift-logging-2021633666205214569. Please ensure that your IAM permissions are set up correctly.
			status code: 400, request id: 0bb7b9d4-27af-11e8-af70-fb488e290d0f
FAIL
=== RUN   TestAccAWSRedshiftCluster_withFinalSnapshot
--- PASS: TestAccAWSRedshiftCluster_withFinalSnapshot (1189.84s)
=== RUN   TestAccAWSRedshiftCluster_enhancedVpcRoutingEnabled
--- PASS: TestAccAWSRedshiftCluster_enhancedVpcRoutingEnabled (1197.54s)
=== RUN   TestAccAWSMqBroker_updateUsers
--- PASS: TestAccAWSMqBroker_updateUsers (1793.94s)
=== RUN   TestAccAWSRoute_noopdiff
--- PASS: TestAccAWSRoute_noopdiff (204.92s)
=== RUN   TestAccAWSSpotFleetRequest_associatePublicIpAddress
--- PASS: TestAccAWSSpotFleetRequest_associatePublicIpAddress (237.45s)
=== RUN   TestAccAWSRedshiftCluster_snapshotCopy
--- PASS: TestAccAWSRedshiftCluster_snapshotCopy (1163.50s)
=== RUN   TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion (226.15s)
=== RUN   TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList (226.99s)
=== RUN   TestAccAWSSpotFleetRequest_instanceInterruptionBehavior
--- PASS: TestAccAWSSpotFleetRequest_instanceInterruptionBehavior (270.39s)
=== RUN   TestAccAWSRedshiftCluster_publiclyAccessible
--- PASS: TestAccAWSRedshiftCluster_publiclyAccessible (976.42s)
=== RUN   TestAccAWSSpotFleetRequest_placementTenancy
--- PASS: TestAccAWSSpotFleetRequest_placementTenancy (59.23s)
=== RUN   TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet (216.41s)
=== RUN   TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz (225.18s)
=== RUN   TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList (245.57s)
=== RUN   TestAccAWSSpotInstanceRequest_basic
--- PASS: TestAccAWSSpotInstanceRequest_basic (107.79s)
=== RUN   TestAccAWSSpotFleetRequest_overriddingSpotPrice
--- PASS: TestAccAWSSpotFleetRequest_overriddingSpotPrice (258.67s)
=== RUN   TestAccAWSSpotFleetRequest_diversifiedAllocation
--- PASS: TestAccAWSSpotFleetRequest_diversifiedAllocation (248.35s)
=== RUN   TestAccAWSSpotInstanceRequest_SubnetAndSGAndPublicIpAddress
--- PASS: TestAccAWSSpotInstanceRequest_SubnetAndSGAndPublicIpAddress (85.56s)
=== RUN   TestAccAWSSpotInstanceRequest_withBlockDuration
--- PASS: TestAccAWSSpotInstanceRequest_withBlockDuration (99.57s)
=== RUN   TestAccAWSSubnet_basic
--- PASS: TestAccAWSSubnet_basic (31.38s)
=== RUN   TestAccAWSSpotInstanceRequest_withLaunchGroup
--- PASS: TestAccAWSSpotInstanceRequest_withLaunchGroup (103.90s)
=== RUN   TestAccAWSSpotFleetRequest_withEBSDisk
--- PASS: TestAccAWSSpotFleetRequest_withEBSDisk (259.85s)
=== RUN   TestAccAWSSpotFleetRequest_withWeightedCapacity
--- PASS: TestAccAWSSpotFleetRequest_withWeightedCapacity (297.45s)
=== RUN   TestAccAWSRedshiftCluster_tags
--- PASS: TestAccAWSRedshiftCluster_tags (1129.84s)
=== RUN   TestAccAWSSpotInstanceRequest_NetworkInterfaceAttributes
--- PASS: TestAccAWSSpotInstanceRequest_NetworkInterfaceAttributes (101.10s)
=== RUN   TestAccAWSRedshiftCluster_iamRoles
--- PASS: TestAccAWSRedshiftCluster_iamRoles (1291.38s)
=== RUN   TestAccAWSSpotFleetRequest_WithELBs
--- PASS: TestAccAWSSpotFleetRequest_WithELBs (260.92s)
=== RUN   TestAccAWSSpotFleetRequest_withTags
--- PASS: TestAccAWSSpotFleetRequest_withTags (310.15s)
=== RUN   TestAccAWSVpcEndpoint_gatewayBasic
--- PASS: TestAccAWSVpcEndpoint_gatewayBasic (111.51s)
=== RUN   TestAccAWSSpotFleetRequest_changePriceForcesNewRequest
--- PASS: TestAccAWSSpotFleetRequest_changePriceForcesNewRequest (568.02s)
=== RUN   TestAccAWSSubnet_ipv6
--- PASS: TestAccAWSSubnet_ipv6 (195.94s)
=== RUN   TestAccAWSVpcEndpointSubnetAssociation_basic
--- PASS: TestAccAWSVpcEndpointSubnetAssociation_basic (148.15s)
=== RUN   TestAccAWSVpcEndpoint_interfaceBasic
--- PASS: TestAccAWSVpcEndpoint_interfaceBasic (89.82s)
=== RUN   TestAccAWSVpcEndpoint_gatewayWithRouteTableAndPolicy
--- PASS: TestAccAWSVpcEndpoint_gatewayWithRouteTableAndPolicy (125.70s)
=== RUN   TestAccAWSSubnet_enableIpv6
--- PASS: TestAccAWSSubnet_enableIpv6 (206.39s)
=== RUN   TestAccAWSVpcEndpoint_removed
--- PASS: TestAccAWSVpcEndpoint_removed (62.40s)
=== RUN   TestAccAWSSpotInstanceRequest_vpc
--- PASS: TestAccAWSSpotInstanceRequest_vpc (420.18s)
=== RUN   TestAccAWSVpcEndpointServiceAllowedPrincipal_basic
--- PASS: TestAccAWSVpcEndpointServiceAllowedPrincipal_basic (350.95s)
=== RUN   TestAccAWSVpcEndpoint_interfaceWithSubnetAndSecurityGroup
--- PASS: TestAccAWSVpcEndpoint_interfaceWithSubnetAndSecurityGroup (266.71s)
=== RUN   TestAccAWSSpotFleetRequest_WithTargetGroups
--- PASS: TestAccAWSSpotFleetRequest_WithTargetGroups (539.18s)
=== RUN   TestAccAWSVpcEndpointService_removed
--- PASS: TestAccAWSVpcEndpointService_removed (362.46s)
=== RUN   TestAccAWSVpcEndpointConnectionNotification_basic
--- PASS: TestAccAWSVpcEndpointConnectionNotification_basic (467.46s)
=== RUN   TestAccAWSVpcEndpoint_interfaceNonAWSService
--- PASS: TestAccAWSVpcEndpoint_interfaceNonAWSService (387.15s)
=== RUN   TestAccAWSVpcEndpointService_basic
--- PASS: TestAccAWSVpcEndpointService_basic (496.25s)
=== RUN   TestAccAWSRedshiftCluster_forceNewUsername
--- PASS: TestAccAWSRedshiftCluster_forceNewUsername (1567.80s)
=== RUN   TestAccAWSRDSCluster_EncryptedCrossRegionReplication
--- PASS: TestAccAWSRDSCluster_EncryptedCrossRegionReplication (2252.71s)
=== RUN   TestAccAWSMqBroker_allFieldsDefaultVpc
--- PASS: TestAccAWSMqBroker_allFieldsDefaultVpc (2769.48s)
=== RUN   TestAccAWSMqBroker_allFieldsCustomVpc
--- PASS: TestAccAWSMqBroker_allFieldsCustomVpc (2840.34s)
=== RUN   TestAccAWSRedshiftCluster_updateNodeCount
--- PASS: TestAccAWSRedshiftCluster_updateNodeCount (3379.14s)
```