### PR TITLE
resource/db_instance: set SourceRegion based on source_db ARN

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -535,11 +535,12 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			opts.Iops = aws.Int64(int64(attr.(int)))
 		}
 
+		if arnParts := strings.Split(v.(string), ":"); len(arnParts) >= 4 {
+			opts.SourceRegion = aws.String(arnParts[3])
+		}
+
 		if attr, ok := d.GetOk("kms_key_id"); ok {
 			opts.KmsKeyId = aws.String(attr.(string))
-			if arnParts := strings.Split(v.(string), ":"); len(arnParts) >= 4 {
-				opts.SourceRegion = aws.String(arnParts[3])
-			}
 		}
 
 		if attr, ok := d.GetOk("maintenance_window"); ok {

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -115,8 +115,7 @@ identifier beginning with the specified prefix. Conflicts with `identifier`.
 * `instance_class` - (Required) The instance type of the RDS instance.
 * `iops` - (Optional) The amount of provisioned IOPS. Setting this implies a
 storage_type of "io1".
-* `kms_key_id` - (Optional) The ARN for the KMS encryption key. If creating an
-encrypted replica, set this to the destination KMS ARN.
+* `kms_key_id` - (Optional) The ARN for the KMS encryption key.
 * `license_model` - (Optional, but required for some DB engines, i.e. Oracle
 SE1) License model information for this DB instance.
 * `maintenance_window` - (Optional) The window to perform maintenance in.
@@ -147,8 +146,7 @@ accessible. Default is `false`.
 * `replicate_source_db` - (Optional) Specifies that this resource is a Replicate
 database, and to use this value as the source database. This correlates to the
 `identifier` of another Amazon RDS Database to replicate. Note that if you are
-creating a cross-region replica of an encrypted database you will also need to
-specify a `kms_key_id`. See [DB Instance Replication][1] and [Working with
+creating a cross-region replica it must be an arn. See [DB Instance Replication][1] and [Working with
 PostgreSQL and MySQL Read Replicas](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html)
 for more information on using Replication.
 * `security_group_names` - (Optional/Deprecated) List of DB Security Groups to
@@ -163,9 +161,7 @@ is `false`.
 database from a snapshot. This correlates to the snapshot ID you'd find in the
 RDS console, e.g: rds:production-2015-06-26-06-05.
 * `storage_encrypted` - (Optional) Specifies whether the DB instance is
-encrypted. Note that if you are creating a cross-region read replica this field
-is ignored and you should instead declare `kms_key_id` with a valid ARN. The
-default is `false` if not specified.
+encrypted. The default is `false` if not specified.
 * `storage_type` - (Optional) One of "standard" (magnetic), "gp2" (general
 purpose SSD), or "io1" (provisioned IOPS SSD). The default is "io1" if `iops` is
 specified, "gp2" if not.


### PR DESCRIPTION
As Per AmazonRDS/API/CreateDBInstanceReadReplica docs

		If you create an encrypted Read Replica in a different AWS Region,
		then you must specify a KMS key for the destination AWS Region.
		KMS encryption keys are specific to the AWS Region that they are
		created in, and you can't use encryption keys from one AWS Region
		in another AWS Region.

This commit sets the Read Replica Source Region based on the
replicate_source_db arn.

kms_key_id is managed as usual.
Fixes:  #518
Related: #3337, #865