### PR TITLE
resource/aws_wafregional_size_constraint_set

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -556,7 +556,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_waf_geo_match_set":                        resourceAwsWafGeoMatchSet(),
 			"aws_wafregional_byte_match_set":               resourceAwsWafRegionalByteMatchSet(),
 			"aws_wafregional_ipset":                        resourceAwsWafRegionalIPSet(),
-			"aws_wafregional_size_constraint_set":      	resourceAwsWafRegionalSizeConstraintSet(),
+			"aws_wafregional_size_constraint_set":          resourceAwsWafRegionalSizeConstraintSet(),
 			"aws_wafregional_sql_injection_match_set":      resourceAwsWafRegionalSqlInjectionMatchSet(),
 			"aws_wafregional_xss_match_set":                resourceAwsWafRegionalXssMatchSet(),
 			"aws_wafregional_rule":                         resourceAwsWafRegionalRule(),

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -556,6 +556,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_waf_geo_match_set":                        resourceAwsWafGeoMatchSet(),
 			"aws_wafregional_byte_match_set":               resourceAwsWafRegionalByteMatchSet(),
 			"aws_wafregional_ipset":                        resourceAwsWafRegionalIPSet(),
+			"aws_wafregional_size_constraint_set":      	resourceAwsWafRegionalSizeConstraintSet(),
 			"aws_wafregional_sql_injection_match_set":      resourceAwsWafRegionalSqlInjectionMatchSet(),
 			"aws_wafregional_xss_match_set":                resourceAwsWafRegionalXssMatchSet(),
 			"aws_wafregional_rule":                         resourceAwsWafRegionalRule(),

--- a/aws/resource_aws_waf_size_constraint_set.go
+++ b/aws/resource_aws_waf_size_constraint_set.go
@@ -74,9 +74,9 @@ func resourceAwsWafSizeConstraintSetUpdate(d *schema.ResourceData, meta interfac
 
 	if d.HasChange("size_constraints") {
 		o, n := d.GetChange("size_constraints")
-		oldS, newS := o.(*schema.Set).List(), n.(*schema.Set).List()
+		oldConstraints, newConstraints := o.(*schema.Set).List(), n.(*schema.Set).List()
 
-		err := updateSizeConstraintSetResource(d.Id(), oldS, newS, conn)
+		err := updateSizeConstraintSetResource(d.Id(), oldConstraints, newConstraints, conn)
 		if err != nil {
 			return errwrap.Wrapf("[ERROR] Error updating SizeConstraintSet: {{err}}", err)
 		}

--- a/aws/resource_aws_waf_size_constraint_set_test.go
+++ b/aws/resource_aws_waf_size_constraint_set_test.go
@@ -162,7 +162,7 @@ func TestAccAWSWafSizeConstraintSet_changeConstraints(t *testing.T) {
 }
 
 func TestAccAWSWafSizeConstraintSet_noConstraints(t *testing.T) {
-	var ipset waf.SizeConstraintSet
+	var contraints waf.SizeConstraintSet
 	setName := fmt.Sprintf("sizeConstraintSet-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
@@ -173,7 +173,7 @@ func TestAccAWSWafSizeConstraintSet_noConstraints(t *testing.T) {
 			{
 				Config: testAccAWSWafSizeConstraintSetConfig_noConstraints(setName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafSizeConstraintSetExists("aws_waf_size_constraint_set.size_constraint_set", &ipset),
+					testAccCheckAWSWafSizeConstraintSetExists("aws_waf_size_constraint_set.size_constraint_set", &contraints),
 					resource.TestCheckResourceAttr(
 						"aws_waf_size_constraint_set.size_constraint_set", "name", setName),
 					resource.TestCheckResourceAttr(
@@ -258,9 +258,6 @@ func testAccCheckAWSWafSizeConstraintSetExists(n string, v *waf.SizeConstraintSe
 
 func testAccCheckAWSWafSizeConstraintSetDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_waf_byte_match_set" {
-			continue
-		}
 
 		conn := testAccProvider.Meta().(*AWSClient).wafconn
 		resp, err := conn.GetSizeConstraintSet(

--- a/aws/resource_aws_waf_size_constraint_set_test.go
+++ b/aws/resource_aws_waf_size_constraint_set_test.go
@@ -258,6 +258,9 @@ func testAccCheckAWSWafSizeConstraintSetExists(n string, v *waf.SizeConstraintSe
 
 func testAccCheckAWSWafSizeConstraintSetDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_waf_size_contraint_set" {
+			continue
+		}
 
 		conn := testAccProvider.Meta().(*AWSClient).wafconn
 		resp, err := conn.GetSizeConstraintSet(

--- a/aws/resource_aws_wafregional_size_constraint_set_test.go
+++ b/aws/resource_aws_wafregional_size_constraint_set_test.go
@@ -1,0 +1,341 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/waf"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/acctest"
+)
+
+func TestAccAWSWafRegionalSizeConstraintSet_basic(t *testing.T) {
+	var v waf.SizeConstraintSet
+	sizeConstraintSet := fmt.Sprintf("sizeConstraintSet-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafRegionalSizeConstraintSetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSWafRegionalSizeConstraintSetConfig(sizeConstraintSet),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSWafRegionalSizeConstraintSetExists("aws_wafregional_size_constraint_set.size_constraint_set", &v),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_size_constraint_set.size_constraint_set", "name", sizeConstraintSet),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.2029852522.comparison_operator", "EQ"),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.2029852522.field_to_match.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.2029852522.field_to_match.281401076.data", ""),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.2029852522.field_to_match.281401076.type", "BODY"),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.2029852522.size", "4096"),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.2029852522.text_transformation", "NONE"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSWafRegionalSizeConstraintSet_changeNameForceNew(t *testing.T) {
+	var before, after waf.SizeConstraintSet
+	sizeConstraintSet := fmt.Sprintf("sizeConstraintSet-%s", acctest.RandString(5))
+	sizeConstraintSetNewName := fmt.Sprintf("sizeConstraintSet-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafRegionalSizeConstraintSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSWafRegionalSizeConstraintSetConfig(sizeConstraintSet),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSWafRegionalSizeConstraintSetExists("aws_wafregional_size_constraint_set.size_constraint_set", &before),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_size_constraint_set.size_constraint_set", "name", sizeConstraintSet),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.#", "1"),
+				),
+			},
+			{
+				Config: testAccAWSWafRegionalSizeConstraintSetConfigChangeName(sizeConstraintSetNewName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSWafRegionalSizeConstraintSetExists("aws_wafregional_size_constraint_set.size_constraint_set", &after),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_size_constraint_set.size_constraint_set", "name", sizeConstraintSetNewName),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSWafRegionalSizeConstraintSet_disappears(t *testing.T) {
+	var v waf.SizeConstraintSet
+	sizeConstraintSet := fmt.Sprintf("sizeConstraintSet-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafRegionalSizeConstraintSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSWafRegionalSizeConstraintSetConfig(sizeConstraintSet),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSWafRegionalSizeConstraintSetExists("aws_wafregional_size_constraint_set.size_constraint_set", &v),
+					testAccCheckAWSWafRegionalSizeConstraintSetDisappears(&v),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSWafRegionalSizeConstraintSet_changeConstraints(t *testing.T) {
+	var before, after waf.SizeConstraintSet
+	setName := fmt.Sprintf("sizeConstraintSet-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafRegionalSizeConstraintSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSWafRegionalSizeConstraintSetConfig(setName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSWafRegionalSizeConstraintSetExists("aws_wafregional_size_constraint_set.size_constraint_set", &before),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_size_constraint_set.size_constraint_set", "name", setName),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.2029852522.comparison_operator", "EQ"),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.2029852522.field_to_match.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.2029852522.field_to_match.281401076.data", ""),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.2029852522.field_to_match.281401076.type", "BODY"),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.2029852522.size", "4096"),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.2029852522.text_transformation", "NONE"),
+				),
+			},
+			{
+				Config: testAccAWSWafRegionalSizeConstraintSetConfig_changeConstraints(setName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSWafRegionalSizeConstraintSetExists("aws_wafregional_size_constraint_set.size_constraint_set", &after),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_size_constraint_set.size_constraint_set", "name", setName),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.3222308386.comparison_operator", "GE"),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.3222308386.field_to_match.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.3222308386.field_to_match.281401076.data", ""),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.3222308386.field_to_match.281401076.type", "BODY"),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.3222308386.size", "1024"),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.3222308386.text_transformation", "NONE"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSWafRegionalSizeConstraintSet_noConstraints(t *testing.T) {
+	var ipset waf.SizeConstraintSet
+	setName := fmt.Sprintf("sizeConstraintSet-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafRegionalSizeConstraintSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSWafRegionalSizeConstraintSetConfig_noConstraints(setName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSWafRegionalSizeConstraintSetExists("aws_wafregional_size_constraint_set.size_constraint_set", &ipset),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_size_constraint_set.size_constraint_set", "name", setName),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_size_constraint_set.size_constraint_set", "size_constraints.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSWafRegionalSizeConstraintSetDisappears(v *waf.SizeConstraintSet) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).wafregionalconn
+		region := testAccProvider.Meta().(*AWSClient).region
+
+		wr := newWafRegionalRetryer(conn, region)
+		_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
+			req := &waf.UpdateSizeConstraintSetInput{
+				ChangeToken:         token,
+				SizeConstraintSetId: v.SizeConstraintSetId,
+			}
+
+			for _, sizeConstraint := range v.SizeConstraints {
+				sizeConstraintUpdate := &waf.SizeConstraintSetUpdate{
+					Action: aws.String("DELETE"),
+					SizeConstraint: &waf.SizeConstraint{
+						FieldToMatch:       sizeConstraint.FieldToMatch,
+						ComparisonOperator: sizeConstraint.ComparisonOperator,
+						Size:               sizeConstraint.Size,
+						TextTransformation: sizeConstraint.TextTransformation,
+					},
+				}
+				req.Updates = append(req.Updates, sizeConstraintUpdate)
+			}
+			return conn.UpdateSizeConstraintSet(req)
+		})
+		if err != nil {
+			return errwrap.Wrapf("[ERROR] Error updating SizeConstraintSet: {{err}}", err)
+		}
+
+		_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {
+			opts := &waf.DeleteSizeConstraintSetInput{
+				ChangeToken:         token,
+				SizeConstraintSetId: v.SizeConstraintSetId,
+			}
+			return conn.DeleteSizeConstraintSet(opts)
+		})
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+func testAccCheckAWSWafRegionalSizeConstraintSetExists(n string, v *waf.SizeConstraintSet) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No WAF SizeConstraintSet ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).wafregionalconn
+		resp, err := conn.GetSizeConstraintSet(&waf.GetSizeConstraintSetInput{
+			SizeConstraintSetId: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if *resp.SizeConstraintSet.SizeConstraintSetId == rs.Primary.ID {
+			*v = *resp.SizeConstraintSet
+			return nil
+		}
+
+		return fmt.Errorf("WAF SizeConstraintSet (%s) not found", rs.Primary.ID)
+	}
+}
+
+func testAccCheckAWSWafRegionalSizeConstraintSetDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_wafregional_byte_match_set" {
+			continue
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).wafregionalconn
+		resp, err := conn.GetSizeConstraintSet(
+			&waf.GetSizeConstraintSetInput{
+				SizeConstraintSetId: aws.String(rs.Primary.ID),
+			})
+
+		if err == nil {
+			if *resp.SizeConstraintSet.SizeConstraintSetId == rs.Primary.ID {
+				return fmt.Errorf("WAF SizeConstraintSet %s still exists", rs.Primary.ID)
+			}
+		}
+
+		// Return nil if the SizeConstraintSet is already destroyed
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == "WAFNonexistentItemException" {
+				return nil
+			}
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func testAccAWSWafRegionalSizeConstraintSetConfig(name string) string {
+	return fmt.Sprintf(`
+resource "aws_wafregional_size_constraint_set" "size_constraint_set" {
+  name = "%s"
+  size_constraints {
+    text_transformation = "NONE"
+    comparison_operator = "EQ"
+    size = "4096"
+    field_to_match {
+      type = "BODY"
+    }
+  }
+}`, name)
+}
+
+func testAccAWSWafRegionalSizeConstraintSetConfigChangeName(name string) string {
+	return fmt.Sprintf(`
+resource "aws_wafregional_size_constraint_set" "size_constraint_set" {
+  name = "%s"
+  size_constraints {
+    text_transformation = "NONE"
+    comparison_operator = "EQ"
+    size = "4096"
+    field_to_match {
+      type = "BODY"
+    }
+  }
+}`, name)
+}
+
+func testAccAWSWafRegionalSizeConstraintSetConfig_changeConstraints(name string) string {
+	return fmt.Sprintf(`
+resource "aws_wafregional_size_constraint_set" "size_constraint_set" {
+  name = "%s"
+  size_constraints {
+    text_transformation = "NONE"
+    comparison_operator = "GE"
+    size = "1024"
+    field_to_match {
+      type = "BODY"
+    }
+  }
+}`, name)
+}
+
+func testAccAWSWafRegionalSizeConstraintSetConfig_noConstraints(name string) string {
+	return fmt.Sprintf(`
+resource "aws_wafregional_size_constraint_set" "size_constraint_set" {
+  name = "%s"
+}`, name)
+}

--- a/aws/resource_aws_wafregional_size_constraint_set_test.go
+++ b/aws/resource_aws_wafregional_size_constraint_set_test.go
@@ -259,6 +259,9 @@ func testAccCheckAWSWafRegionalSizeConstraintSetExists(n string, constraints *wa
 
 func testAccCheckAWSWafRegionalSizeConstraintSetDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_wafregional_size_contraint_set" {
+			continue
+		}
 
 		conn := testAccProvider.Meta().(*AWSClient).wafregionalconn
 		resp, err := conn.GetSizeConstraintSet(

--- a/aws/waf_helpers.go
+++ b/aws/waf_helpers.go
@@ -1,0 +1,108 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/waf"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func wafSizeConstraintSetSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"name": &schema.Schema{
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"size_constraints": &schema.Schema{
+			Type:     schema.TypeSet,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"field_to_match": {
+						Type:     schema.TypeSet,
+						Required: true,
+						MaxItems: 1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"data": {
+									Type:     schema.TypeString,
+									Optional: true,
+								},
+								"type": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+							},
+						},
+					},
+					"comparison_operator": &schema.Schema{
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"size": &schema.Schema{
+						Type:     schema.TypeInt,
+						Required: true,
+					},
+					"text_transformation": &schema.Schema{
+						Type:     schema.TypeString,
+						Required: true,
+					},
+				},
+			},
+		},
+	}
+}
+
+func diffWafSizeConstraints(oldS, newS []interface{}) []*waf.SizeConstraintSetUpdate {
+	updates := make([]*waf.SizeConstraintSetUpdate, 0)
+
+	for _, os := range oldS {
+		constraint := os.(map[string]interface{})
+
+		if idx, contains := sliceContainsMap(newS, constraint); contains {
+			newS = append(newS[:idx], newS[idx+1:]...)
+			continue
+		}
+
+		updates = append(updates, &waf.SizeConstraintSetUpdate{
+			Action: aws.String(waf.ChangeActionDelete),
+			SizeConstraint: &waf.SizeConstraint{
+				FieldToMatch:       expandFieldToMatch(constraint["field_to_match"].(*schema.Set).List()[0].(map[string]interface{})),
+				ComparisonOperator: aws.String(constraint["comparison_operator"].(string)),
+				Size:               aws.Int64(int64(constraint["size"].(int))),
+				TextTransformation: aws.String(constraint["text_transformation"].(string)),
+			},
+		})
+	}
+
+	for _, ns := range newS {
+		constraint := ns.(map[string]interface{})
+
+		updates = append(updates, &waf.SizeConstraintSetUpdate{
+			Action: aws.String(waf.ChangeActionInsert),
+			SizeConstraint: &waf.SizeConstraint{
+				FieldToMatch:       expandFieldToMatch(constraint["field_to_match"].(*schema.Set).List()[0].(map[string]interface{})),
+				ComparisonOperator: aws.String(constraint["comparison_operator"].(string)),
+				Size:               aws.Int64(int64(constraint["size"].(int))),
+				TextTransformation: aws.String(constraint["text_transformation"].(string)),
+			},
+		})
+	}
+	return updates
+}
+
+func flattenWafSizeConstraints(sc []*waf.SizeConstraint) []interface{} {
+	out := make([]interface{}, len(sc), len(sc))
+	for i, c := range sc {
+		m := make(map[string]interface{})
+		m["comparison_operator"] = *c.ComparisonOperator
+		if c.FieldToMatch != nil {
+			m["field_to_match"] = flattenFieldToMatch(c.FieldToMatch)
+		}
+		m["size"] = *c.Size
+		m["text_transformation"] = *c.TextTransformation
+		out[i] = m
+	}
+	return out
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1515,6 +1515,10 @@
                     <a href="/docs/providers/aws/r/wafregional_ipset.html">aws_wafregional_ipset</a>
                   </li>
 
+                   <li<%= sidebar_current("docs-aws-resource-wafregional-size-constraint-set") %>>
+                    <a href="/docs/providers/aws/r/wafregional_size_constraint_set.html">aws_wafregional_size_constraint_set</a>
+                  </li>
+
                   <li<%= sidebar_current("docs-aws-resource-wafregional-sql-injection-match-set") %>>
                     <a href="/docs/providers/aws/r/wafregional_sql_injection_match_set.html">aws_wafregional_sql_injection_match_set</a>
                   </li>

--- a/website/docs/r/wafregional_size_constraint_set.html.markdown
+++ b/website/docs/r/wafregional_size_constraint_set.html.markdown
@@ -1,19 +1,19 @@
 ---
 layout: "aws"
-page_title: "AWS: waf_size_constraint_set"
-sidebar_current: "docs-aws-resource-waf-size-constraint-set"
+page_title: "AWS: wafregional_size_constraint_set"
+sidebar_current: "docs-aws-resource-wafregional-size-constraint-set"
 description: |-
-  Provides a AWS WAF Size Constraint Set resource.
+  Provides an AWS WAF Regional Size Constraint Set resource for use with ALB.
 ---
 
-# aws_waf_size_constraint_set
+# aws_wafregional_size_constraint_set
 
-Provides a WAF Size Constraint Set Resource
+Provides a WAF Regional Size Constraint Set Resource for use with Application Load Balancer.
 
 ## Example Usage
 
 ```hcl
-resource "aws_waf_size_constraint_set" "size_constraint_set" {
+resource "aws_wafregional_size_constraint_set" "size_constraint_set" {
   name = "tfsize_constraints"
 
   size_constraints {


### PR DESCRIPTION
This implements size constraints for WAF regional. Full disclosure, I tried my hardest to understand the API/how things worked, but this is mostly copy paste of size constraint set from global WAF. As a result this PR doesn't try and change anything really between the resources (regional vs global).

I did notice there are some validations missing from the schema (ranges, max sizes, enum's of allowable strings), that could be present. I've refactored the schema to a common helper and could add the validations but does that require more tests/docs that I need to replicate to waf and wafregional? Let me know and I am happy to implement them but it does lend to a larger discussion below.

The following is a discussion/commentary on the overall waf/wafregional codebase:

IMO the best course of action is to merge the less "robust" PR like so (implementing any feedback of course), but make note that WAF and WAF regional are very much 1 API with different client conns and could use some harmonizing. There is code that is shareable, for instance the docs is complete copypaste since the internal types/rules are the same between waf and wafregional. I suspect we could almost half the LOCs and account for the region/vs global differences with a special flag/conditional code, but this would make the 2 sets of resources completely coupled.

On the other hand if Amazon changes/evolves the service we would have to rip everything apart again. Something tells me that when it comes to provider code it's better to have copypaste/duplication for the sake of not modelling something that we don't control (and could break later). Feedback from more experienced developers on this would be greatly appreciated.... sorry for long write up

Tests:
```
TF_ACC=1 go test ./aws -v -run=TestAccAWSWafRegionalSizeConstraintSet -timeout 120m
=== RUN   TestAccAWSWafRegionalSizeConstraintSet_basic
--- PASS: TestAccAWSWafRegionalSizeConstraintSet_basic (26.65s)
=== RUN   TestAccAWSWafRegionalSizeConstraintSet_changeNameForceNew
--- PASS: TestAccAWSWafRegionalSizeConstraintSet_changeNameForceNew (52.43s)
=== RUN   TestAccAWSWafRegionalSizeConstraintSet_disappears
--- PASS: TestAccAWSWafRegionalSizeConstraintSet_disappears (21.33s)
=== RUN   TestAccAWSWafRegionalSizeConstraintSet_changeConstraints
--- PASS: TestAccAWSWafRegionalSizeConstraintSet_changeConstraints (39.25s)
=== RUN   TestAccAWSWafRegionalSizeConstraintSet_noConstraints
--- PASS: TestAccAWSWafRegionalSizeConstraintSet_noConstraints (18.64s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	158.363s
```
```
AWS_PROFILE=personal make testacc TEST=./aws TESTARGS='-run=TestAccAWSWafSizeConstraintSet'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSWafSizeConstraintSet -timeout 120m
=== RUN   TestAccAWSWafSizeConstraintSet_basic
--- PASS: TestAccAWSWafSizeConstraintSet_basic (21.21s)
=== RUN   TestAccAWSWafSizeConstraintSet_changeNameForceNew
--- PASS: TestAccAWSWafSizeConstraintSet_changeNameForceNew (32.32s)
=== RUN   TestAccAWSWafSizeConstraintSet_disappears
--- PASS: TestAccAWSWafSizeConstraintSet_disappears (18.54s)
=== RUN   TestAccAWSWafSizeConstraintSet_changeConstraints
--- PASS: TestAccAWSWafSizeConstraintSet_changeConstraints (29.28s)
=== RUN   TestAccAWSWafSizeConstraintSet_noConstraints
--- PASS: TestAccAWSWafSizeConstraintSet_noConstraints (15.51s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	116.898s
```