### PR TITLE
tests/resource/aws_elasticsearch_domain: Add sweeper

### DIFF
--- a/aws/resource_aws_elasticsearch_domain_test.go
+++ b/aws/resource_aws_elasticsearch_domain_test.go
@@ -59,7 +59,10 @@ func testSweepElasticSearchDomains(region string) error {
 			log.Printf("[ERROR] Failed to delete Elasticsearch Domain %s: %s", *domain.DomainName, err)
 			continue
 		}
-		resourceAwsElasticSearchDomainDeleteWaiter(*domain.DomainName, conn)
+		err = resourceAwsElasticSearchDomainDeleteWaiter(*domain.DomainName, conn)
+		if err != nil {
+			log.Printf("[ERROR] Failed to wait for deletion of Elasticsearch Domain %s: %s", *domain.DomainName, err)
+		}
 	}
 
 	return nil

--- a/aws/resource_aws_elasticsearch_domain_test.go
+++ b/aws/resource_aws_elasticsearch_domain_test.go
@@ -2,7 +2,9 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -12,6 +14,55 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_elasticsearch_domain", &resource.Sweeper{
+		Name: "aws_elasticsearch_domain",
+		F:    testSweepElasticSearchDomains,
+	})
+}
+
+func testSweepElasticSearchDomains(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).esconn
+
+	prefixes := []string{
+		"tf-test-",
+		"tf-acc-test-",
+	}
+
+	out, err := conn.ListDomainNames(&elasticsearch.ListDomainNamesInput{})
+	if err != nil {
+		return fmt.Errorf("Error retrieving Elasticsearch Domains: %s", err)
+	}
+	for _, domain := range out.DomainNames {
+		skip := false
+		for _, prefix := range prefixes {
+			if !strings.HasPrefix(*domain.DomainName, prefix) {
+				skip = true
+				break
+			}
+		}
+		if skip {
+			log.Printf("[INFO] Skipping Elasticsearch Domain: %s", *domain.DomainName)
+			continue
+		}
+		log.Printf("[INFO] Deleting Elasticsearch Domain: %s", *domain.DomainName)
+
+		_, err := conn.DeleteElasticsearchDomain(&elasticsearch.DeleteElasticsearchDomainInput{
+			DomainName: domain.DomainName,
+		})
+		if err != nil {
+			log.Printf("[ERROR] Failed to delete Elasticsearch Domain %s: %s", *domain.DomainName, err)
+			continue
+		}
+	}
+
+	return nil
+}
 
 func TestAccAWSElasticSearchDomain_basic(t *testing.T) {
 	var domain elasticsearch.ElasticsearchDomainStatus

--- a/aws/resource_aws_elasticsearch_domain_test.go
+++ b/aws/resource_aws_elasticsearch_domain_test.go
@@ -39,10 +39,10 @@ func testSweepElasticSearchDomains(region string) error {
 		return fmt.Errorf("Error retrieving Elasticsearch Domains: %s", err)
 	}
 	for _, domain := range out.DomainNames {
-		skip := false
+		skip := true
 		for _, prefix := range prefixes {
-			if !strings.HasPrefix(*domain.DomainName, prefix) {
-				skip = true
+			if strings.HasPrefix(*domain.DomainName, prefix) {
+				skip = false
 				break
 			}
 		}
@@ -59,6 +59,7 @@ func testSweepElasticSearchDomains(region string) error {
 			log.Printf("[ERROR] Failed to delete Elasticsearch Domain %s: %s", *domain.DomainName, err)
 			continue
 		}
+		resourceAwsElasticSearchDomainDeleteWaiter(*domain.DomainName, conn)
 	}
 
 	return nil


### PR DESCRIPTION
♻️ 

```
$ aws es list-domain-names | jq '.DomainNames | length'
16

$ make sweep SWEEPARGS='-sweep-run=aws_elasticsearch_domain'
...
2018/03/15 19:46:43 Sweeper Tests ran:
	- aws_elasticsearch_domain
ok  	github.com/terraform-providers/terraform-provider-aws/aws	16.029s

$ aws es list-domain-names | jq '.DomainNames | length'
1
```
