### PR TITLE
resource/aws_ami: Remove manage_ebs_block_devices (unused)

### DIFF
--- a/aws/resource_aws_ami.go
+++ b/aws/resource_aws_ami.go
@@ -116,10 +116,6 @@ func resourceAwsAmiCreate(d *schema.ResourceData, meta interface{}) error {
 
 	id := *res.ImageId
 	d.SetId(id)
-	d.Partial(true)
-	d.Set("manage_ebs_block_devices", false)
-	d.SetPartial("manage_ebs_block_devices")
-	d.Partial(false)
 
 	_, err = resourceAwsAmiWaitForAvailable(d.Timeout(schema.TimeoutCreate), id, client)
 	if err != nil {


### PR DESCRIPTION
This was uncovered in our recent test run with `TF_SCHEMA_PANIC_ON_ERROR=1`:

```
=== RUN   TestAccAWSAMI_basic

------- Stderr: -------
panic: Invalid address to set: []string{"manage_ebs_block_devices"}

goroutine 379 [running]:
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema.(*ResourceData).Set(0xc4202855e0, 0x2fbadf9, 0x18, 0x271a6a0, 0x4f84380, 0xc42000f8c8, 0x0)
    /opt/teamcity-agent/work/6025502d125bbe5e/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema/resource_data.go:191 +0x237
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsAmiCreate(0xc4202855e0, 0x2b5b4c0, 0xc420013180, 0xc4202855e0, 0x0)
    /opt/teamcity-agent/work/6025502d125bbe5e/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_ami.go:120 +0x122c
...
=== RUN   TestAccAWSAMI_snapshotSize

------- Stderr: -------
panic: Invalid address to set: []string{"manage_ebs_block_devices"}

goroutine 405 [running]:
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema.(*ResourceData).Set(0xc4202b09a0, 0x2fbadf9, 0x18, 0x271a6a0, 0x4f84380, 0xc42000f1d8, 0x0)
    /opt/teamcity-agent/work/6025502d125bbe5e/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema/resource_data.go:191 +0x237
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsAmiCreate(0xc4202b09a0, 0x2b5b4c0, 0xc4202a7900, 0xc4202b09a0, 0x0)
    /opt/teamcity-agent/work/6025502d125bbe5e/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_ami.go:120 +0x122c
```

## Test results

```
TF_ACC=1 go test ./aws -v -run=TestAccAWSAMI_ -timeout 120m
=== RUN   TestAccAWSAMI_basic
--- PASS: TestAccAWSAMI_basic (97.77s)
=== RUN   TestAccAWSAMI_snapshotSize
--- PASS: TestAccAWSAMI_snapshotSize (418.02s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	515.832s
```