### PR TITLE
resource/aws_api_gateway_client_certificate: Export date fields correctly

### DIFF
--- a/aws/resource_aws_api_gateway_client_certificate.go
+++ b/aws/resource_aws_api_gateway_client_certificate.go
@@ -77,8 +77,8 @@ func resourceAwsApiGatewayClientCertificateRead(d *schema.ResourceData, meta int
 	log.Printf("[DEBUG] Received API Gateway Client Certificate: %s", out)
 
 	d.Set("description", out.Description)
-	d.Set("created_date", out.CreatedDate)
-	d.Set("expiration_date", out.ExpirationDate)
+	d.Set("created_date", out.CreatedDate.String())
+	d.Set("expiration_date", out.ExpirationDate.String())
 	d.Set("pem_encoded_certificate", out.PemEncodedCertificate)
 
 	return nil


### PR DESCRIPTION
This was uncovered in our recent test run with `TF_SCHEMA_PANIC_ON_ERROR=1`:
```
=== RUN   TestAccAWSAPIGatewayClientCertificate_basic

------- Stderr: -------
panic: created_date: '' expected type 'string', got unconvertible type '*time.Time'

goroutine 113 [running]:
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema.(*ResourceData).Set(0xc4202a8070, 0x2f8ec87, 0xc, 0x2f4dd40, 0xc420544960, 0x0, 0x0)
    /opt/teamcity-agent/work/6025502d125bbe5e/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema/resource_data.go:191 +0x237
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsApiGatewayClientCertificateRead(0xc4202a8070, 0x2b5b4c0, 0xc420286500, 0x0, 0x0)
    /opt/teamcity-agent/work/6025502d125bbe5e/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_api_gateway_client_certificate.go:80 +0x3a5
...
=== RUN   TestAccAWSAPIGatewayClientCertificate_importBasic

------- Stderr: -------
panic: created_date: '' expected type 'string', got unconvertible type '*time.Time'

goroutine 152 [running]:
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema.(*ResourceData).Set(0xc42010f490, 0x2f8ec87, 0xc, 0x2f4dd40, 0xc420596200, 0x0, 0x0)
    /opt/teamcity-agent/work/6025502d125bbe5e/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema/resource_data.go:191 +0x237
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsApiGatewayClientCertificateRead(0xc42010f490, 0x2b5b4c0, 0xc420279900, 0x0, 0x0)
    /opt/teamcity-agent/work/6025502d125bbe5e/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_api_gateway_client_certificate.go:80 +0x3a5
```

## Test results

```
TF_ACC=1 go test ./aws -v -run=TestAccAWSAPIGatewayClientCertificate_ -timeout 120m
=== RUN   TestAccAWSAPIGatewayClientCertificate_basic
--- PASS: TestAccAWSAPIGatewayClientCertificate_basic (49.03s)
=== RUN   TestAccAWSAPIGatewayClientCertificate_importBasic
--- PASS: TestAccAWSAPIGatewayClientCertificate_importBasic (32.10s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	81.182s
```