### PR TITLE
r/autoscaling_group Add support for service linked roles

### DIFF
--- a/aws/resource_aws_autoscaling_group.go
+++ b/aws/resource_aws_autoscaling_group.go
@@ -246,6 +246,7 @@ func resourceAwsAutoscalingGroup() *schema.Resource {
 			"service_linked_role_arn": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 		},
 	}

--- a/website/docs/r/autoscaling_group.html.markdown
+++ b/website/docs/r/autoscaling_group.html.markdown
@@ -172,6 +172,7 @@ Note that if you suspend either the `Launch` or `Terminate` process types, it ca
 * `protect_from_scale_in` (Optional) Allows setting instance protection. The
    autoscaling group will not select instances with this setting for terminination
    during scale in events.
+*  `service_linked_role_arn` (Optional) The ARN of the service-linked role that the ASG will use to call other AWS services
 
 Tags support the following:
 


### PR DESCRIPTION
Closes #3587 

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSAutoScalingGroup_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSAutoScalingGroup_ -timeout 120m
=== RUN   TestAccAWSAutoScalingGroup_importBasic
--- PASS: TestAccAWSAutoScalingGroup_importBasic (224.38s)
=== RUN   TestAccAWSAutoScalingGroup_basic
--- PASS: TestAccAWSAutoScalingGroup_basic (328.20s)
=== RUN   TestAccAWSAutoScalingGroup_namePrefix
--- PASS: TestAccAWSAutoScalingGroup_namePrefix (100.43s)
=== RUN   TestAccAWSAutoScalingGroup_autoGeneratedName
--- PASS: TestAccAWSAutoScalingGroup_autoGeneratedName (67.28s)
=== RUN   TestAccAWSAutoScalingGroup_terminationPolicies
--- PASS: TestAccAWSAutoScalingGroup_terminationPolicies (158.46s)
=== RUN   TestAccAWSAutoScalingGroup_tags
--- PASS: TestAccAWSAutoScalingGroup_tags (321.11s)
=== RUN   TestAccAWSAutoScalingGroup_VpcUpdates
--- PASS: TestAccAWSAutoScalingGroup_VpcUpdates (154.30s)
=== RUN   TestAccAWSAutoScalingGroup_WithLoadBalancer
--- PASS: TestAccAWSAutoScalingGroup_WithLoadBalancer (259.30s)
=== RUN   TestAccAWSAutoScalingGroup_withPlacementGroup
--- PASS: TestAccAWSAutoScalingGroup_withPlacementGroup (201.79s)
=== RUN   TestAccAWSAutoScalingGroup_enablingMetrics
--- PASS: TestAccAWSAutoScalingGroup_enablingMetrics (220.74s)
=== RUN   TestAccAWSAutoScalingGroup_suspendingProcesses
--- PASS: TestAccAWSAutoScalingGroup_suspendingProcesses (289.77s)
=== RUN   TestAccAWSAutoScalingGroup_withMetrics
--- PASS: TestAccAWSAutoScalingGroup_withMetrics (127.91s)
=== RUN   TestAccAWSAutoScalingGroup_serviceLinkedRoleARN
--- PASS: TestAccAWSAutoScalingGroup_serviceLinkedRoleARN (64.32s)
=== RUN   TestAccAWSAutoScalingGroup_ALB_TargetGroups
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups (199.96s)
=== RUN   TestAccAWSAutoScalingGroup_initialLifecycleHook
--- PASS: TestAccAWSAutoScalingGroup_initialLifecycleHook (305.06s)
=== RUN   TestAccAWSAutoScalingGroup_ALB_TargetGroups_ELBCapacity
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups_ELBCapacity (386.35s)
=== RUN   TestAccAWSAutoScalingGroup_classicVpcZoneIdentifier
--- PASS: TestAccAWSAutoScalingGroup_classicVpcZoneIdentifier (99.87s)
=== RUN   TestAccAWSAutoScalingGroup_emptyAvailabilityZones
--- PASS: TestAccAWSAutoScalingGroup_emptyAvailabilityZones (106.33s)
PASS
ok    github.com/terraform-providers/terraform-provider-aws/aws 3615.562s
```