### PR TITLE
resource/aws_ssm_document: Add document_format argument

### DIFF
--- a/aws/resource_aws_ssm_document.go
+++ b/aws/resource_aws_ssm_document.go
@@ -41,6 +41,15 @@ func resourceAwsSsmDocument() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"document_format": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  ssm.DocumentFormatJson,
+				ValidateFunc: validation.StringInSlice([]string{
+					ssm.DocumentFormatJson,
+					ssm.DocumentFormatYaml,
+				}, false),
+			},
 			"document_type": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -141,9 +150,10 @@ func resourceAwsSsmDocumentCreate(d *schema.ResourceData, meta interface{}) erro
 	log.Printf("[INFO] Creating SSM Document: %s", d.Get("name").(string))
 
 	docInput := &ssm.CreateDocumentInput{
-		Name:         aws.String(d.Get("name").(string)),
-		Content:      aws.String(d.Get("content").(string)),
-		DocumentType: aws.String(d.Get("document_type").(string)),
+		Name:           aws.String(d.Get("name").(string)),
+		Content:        aws.String(d.Get("content").(string)),
+		DocumentFormat: aws.String(d.Get("document_format").(string)),
+		DocumentType:   aws.String(d.Get("document_type").(string)),
 	}
 
 	log.Printf("[DEBUG] Waiting for SSM Document %q to be created", d.Get("name").(string))
@@ -202,6 +212,7 @@ func resourceAwsSsmDocumentRead(d *schema.ResourceData, meta interface{}) error 
 		d.Set("document_type", doc.DocumentType)
 	}
 
+	d.Set("document_format", doc.DocumentFormat)
 	d.Set("document_version", doc.DocumentVersion)
 	d.Set("hash", doc.Hash)
 	d.Set("hash_type", doc.HashType)
@@ -439,6 +450,7 @@ func updateAwsSSMDocument(d *schema.ResourceData, meta interface{}) error {
 	updateDocInput := &ssm.UpdateDocumentInput{
 		Name:            aws.String(name),
 		Content:         aws.String(d.Get("content").(string)),
+		DocumentFormat:  aws.String(d.Get("document_format").(string)),
 		DocumentVersion: aws.String(d.Get("default_version").(string)),
 	}
 

--- a/aws/resource_aws_ssm_document_test.go
+++ b/aws/resource_aws_ssm_document_test.go
@@ -23,6 +23,7 @@ func TestAccAWSSSMDocument_basic(t *testing.T) {
 				Config: testAccAWSSSMDocumentBasicConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMDocumentExists("aws_ssm_document.foo"),
+					resource.TestCheckResourceAttr("aws_ssm_document.foo", "document_format", "JSON"),
 				),
 			},
 		},
@@ -125,6 +126,55 @@ func TestAccAWSSSMDocument_automation(t *testing.T) {
 					testAccCheckAWSSSMDocumentExists("aws_ssm_document.foo"),
 					resource.TestCheckResourceAttr(
 						"aws_ssm_document.foo", "document_type", "Automation"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSSMDocument_DocumentFormat_YAML(t *testing.T) {
+	name := acctest.RandString(10)
+	content1 := `
+---
+schemaVersion: '2.2'
+description: Sample document
+mainSteps:
+- action: aws:runPowerShellScript
+  name: runPowerShellScript
+  inputs:
+    runCommand:
+      - hostname
+`
+	content2 := `
+---
+schemaVersion: '2.2'
+description: Sample document
+mainSteps:
+- action: aws:runPowerShellScript
+  name: runPowerShellScript
+  inputs:
+    runCommand:
+      - Get-Process
+`
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMDocumentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSSMDocumentConfig_DocumentFormat_YAML(name, content1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMDocumentExists("aws_ssm_document.foo"),
+					resource.TestCheckResourceAttr("aws_ssm_document.foo", "content", content1+"\n"),
+					resource.TestCheckResourceAttr("aws_ssm_document.foo", "document_format", "YAML"),
+				),
+			},
+			{
+				Config: testAccAWSSSMDocumentConfig_DocumentFormat_YAML(name, content2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMDocumentExists("aws_ssm_document.foo"),
+					resource.TestCheckResourceAttr("aws_ssm_document.foo", "content", content2+"\n"),
+					resource.TestCheckResourceAttr("aws_ssm_document.foo", "document_format", "YAML"),
 				),
 			},
 		},
@@ -450,4 +500,18 @@ DOC
 }
 
 `, rName, rName, rName)
+}
+
+func testAccAWSSSMDocumentConfig_DocumentFormat_YAML(rName, content string) string {
+	return fmt.Sprintf(`
+resource "aws_ssm_document" "foo" {
+  document_format = "YAML"
+  document_type   = "Command"
+  name            = "test_document-%s"
+
+  content = <<DOC
+%s
+DOC
+}
+`, rName, content)
 }

--- a/website/docs/r/ssm_document.html.markdown
+++ b/website/docs/r/ssm_document.html.markdown
@@ -48,20 +48,18 @@ DOC
 The following arguments are supported:
 
 * `name` - (Required) The name of the document.
-* `content` - (Required) The json content of the document.
+* `content` - (Required) The JSON or YAML content of the document.
+* `document_format` - (Optional, defaults to JSON) The format of the document. Valid document types include: `JSON` and `YAML`
 * `document_type` - (Required) The type of the document. Valid document types include: `Command`, `Policy` and `Automation`
 * `permissions` - (Optional) Additional Permissions to attach to the document. See [Permissions](#permissions) below for details.
 
 ## Attributes Reference
 
-The following attributes are exported:
+The following additional attributes are exported:
 
-* `name` - The name of the document.
-* `content` -  The json content of the document.
 * `created_date` - The date the document was created.
 * `description` - The description of the document.
 * `schema_version` - The schema version of the document.
-* `document_type` - The type of document created.
 * `default_version` - The default version of the document.
 * `hash` - The sha1 or sha256 of the document content
 * `hash_type` - "Sha1" "Sha256". The hashing algorithm used when hashing the content.
@@ -69,7 +67,6 @@ The following attributes are exported:
 * `owner` - The AWS user account of the person who created the document.
 * `status` - "Creating", "Active" or "Deleting". The current status of the document.
 * `parameter` - The parameters that are available to this document.
-* `permissions` - The permissions of how this document should be shared.
 * `platform_types` - A list of OS platforms compatible with this SSM document, either "Windows" or "Linux".
 
 [1]: http://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-ssm-docs.html#document-schemas-features


### PR DESCRIPTION
Adds support for YAML!

Closes #3810

Tests
```
6 tests passed (all tests)
=== RUN   TestAccAWSSSMDocument_basic
--- PASS: TestAccAWSSSMDocument_basic (10.32s)
=== RUN   TestAccAWSSSMDocument_params
--- PASS: TestAccAWSSSMDocument_params (10.73s)
=== RUN   TestAccAWSSSMDocument_update
--- PASS: TestAccAWSSSMDocument_update (15.99s)
=== RUN   TestAccAWSSSMDocument_permission
--- PASS: TestAccAWSSSMDocument_permission (17.39s)
=== RUN   TestAccAWSSSMDocument_DocumentFormat_YAML
--- PASS: TestAccAWSSSMDocument_DocumentFormat_YAML (20.94s)
=== RUN   TestAccAWSSSMDocument_automation
--- PASS: TestAccAWSSSMDocument_automation (31.70s)
```