### PR TITLE
Document additional allowed source type GITHUB_ENTERPRISE

### DIFF
--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -153,7 +153,7 @@ The following arguments are supported:
 
 `source` supports the following:
 
-* `type` - (Required) The type of repository that contains the source code to be built. Valid values for this parameter are: `CODECOMMIT`, `CODEPIPELINE`, `GITHUB`, `BITBUCKET` or `S3`.
+* `type` - (Required) The type of repository that contains the source code to be built. Valid values for this parameter are: `CODECOMMIT`, `CODEPIPELINE`, `GITHUB`, `GITHUB_ENTERPRISE`, `BITBUCKET` or `S3`.
 * `auth` - (Optional) Information about the authorization settings for AWS CodeBuild to access the source code to be built. Auth blocks are documented below.
 * `buildspec` - (Optional) The build spec declaration to use for this build project's related builds.
 * `location` - (Optional) The location of the source code from git or s3.


### PR DESCRIPTION
Now that the most recent commit snuck in support for source type GITHUB_ENTERPRISE...

https://github.com/terraform-providers/terraform-provider-aws/commit/e69f97543e09ed42da63678d7516e175d32724cf#diff-c96a6fa59f39978bec1013238a523f60R184
vs
https://github.com/terraform-providers/terraform-provider-aws/commit/e69f97543e09ed42da63678d7516e175d32724cf#diff-c96a6fa59f39978bec1013238a523f60L794

... document that it's a valid source type.