### PR TITLE
Fix markdown on Autoscaling Schedule documentation

### DIFF
--- a/website/docs/r/autoscaling_schedule.html.markdown
+++ b/website/docs/r/autoscaling_schedule.html.markdown
@@ -46,10 +46,10 @@ The following arguments are supported:
 * `end_time` - (Optional) The time for this action to end, in "YYYY-MM-DDThh:mm:ssZ" format in UTC/GMT only (for example, 2014-06-01T00:00:00Z ).
                           If you try to schedule your action in the past, Auto Scaling returns an error message.
 * `recurrence` - (Optional) The time when recurring future actions will start. Start time is specified by the user following the Unix cron syntax format.
-* `min_size` - (Optional) The minimum size for the Auto Scaling group. Default
-0. Set to -1 if you don't want to change the minimum size at the scheduled time.
-* `max_size` - (Optional) The maximum size for the Auto Scaling group. Default
-0. Set to -1 if you don't want to change the maximum size at the scheduled time.
+* `min_size` - (Optional) The minimum size for the Auto Scaling group. Default 0.
+Set to -1 if you don't want to change the minimum size at the scheduled time.
+* `max_size` - (Optional) The maximum size for the Auto Scaling group. Default 0.
+Set to -1 if you don't want to change the maximum size at the scheduled time.
 * `desired_capacity` - (Optional) The number of EC2 instances that should be running in the group. Default 0.  Set to -1 if you don't want to change the desired capacity at the scheduled time.
 
 ~> **NOTE:** When `start_time` and `end_time` are specified with `recurrence` , they form the boundaries of when the recurring action will start and stop.


### PR DESCRIPTION
Hello,
This fixes the argument reference section for the autoscaling schedule resource. There were additional bullet points after the `min_size` and `max_size` arguments that were unnecessary. I matched the style for the `desired_capacity` argument.

-Richard