### PR TITLE
Trigger destructive update of resource_aws_dynamodb_table_item if range_key has changed

### DIFF
--- a/aws/resource_aws_dynamodb_table_item.go
+++ b/aws/resource_aws_dynamodb_table_item.go
@@ -105,9 +105,9 @@ func resourceAwsDynamoDbTableItemUpdate(d *schema.ResourceData, meta interface{}
 
 		updates := map[string]*dynamodb.AttributeValueUpdate{}
 		for key, value := range attributes {
-			// Hash keys are not updatable, so we'll basically create
+			// Hash keys and range keys are not updatable, so we'll basically create
 			// a new record and delete the old one below
-			if key == hashKey {
+			if key == hashKey || key == rangeKey {
 				continue
 			}
 			updates[key] = &dynamodb.AttributeValueUpdate{


### PR DESCRIPTION
Version 1.11 of terraform-provider-aws generates invalid parameters for DynamoDB changes when aws_dynamodb_table_item range_key has changed due to attempting update in-place. This PR changes the provider behaviour to recreate such resources instead. This is useful especially in cases where DynamoDB table uses a composite key, items are created from lists and items in middle of the list are removed.