### PR TITLE
resource/aws_ecs_task_definition: Correctly set volume in state

### DIFF
--- a/aws/resource_aws_ecs_task_definition.go
+++ b/aws/resource_aws_ecs_task_definition.go
@@ -277,7 +277,11 @@ func resourceAwsEcsTaskDefinitionRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("cpu", taskDefinition.Cpu)
 	d.Set("memory", taskDefinition.Memory)
 	d.Set("network_mode", taskDefinition.NetworkMode)
-	d.Set("volumes", flattenEcsVolumes(taskDefinition.Volumes))
+
+	if err := d.Set("volume", flattenEcsVolumes(taskDefinition.Volumes)); err != nil {
+		return fmt.Errorf("error setting volume: %s", err)
+	}
+
 	if err := d.Set("placement_constraints", flattenPlacementConstraints(taskDefinition.PlacementConstraints)); err != nil {
 		log.Printf("[ERR] Error setting placement_constraints for (%s): %s", d.Id(), err)
 	}


### PR DESCRIPTION
Found via `TF_SCHEMA_PANIC_ON_ERROR=1` testing:

```
TestAccAWSAppautoScalingPolicy_basic
TestAccAWSCloudWatchEventTarget_ecs
... lots more ...
panic: Invalid address to set: []string{"volumes"}
resource_aws_ecs_task_definition.go:280
```

Tests
```
10 tests passed (all tests)
=== RUN   TestAccAWSEcsTaskDefinition_withScratchVolume
--- PASS: TestAccAWSEcsTaskDefinition_withScratchVolume (6.54s)
=== RUN   TestAccAWSEcsTaskDefinition_constraint
--- PASS: TestAccAWSEcsTaskDefinition_constraint (6.62s)
=== RUN   TestAccAWSEcsTaskDefinition_Fargate
--- PASS: TestAccAWSEcsTaskDefinition_Fargate (6.68s)
=== RUN   TestAccAWSEcsTaskDefinition_arrays
--- PASS: TestAccAWSEcsTaskDefinition_arrays (6.68s)
=== RUN   TestAccAWSEcsTaskDefinition_withTaskRoleArn
--- PASS: TestAccAWSEcsTaskDefinition_withTaskRoleArn (9.74s)
=== RUN   TestAccAWSEcsTaskDefinition_withNetworkMode
--- PASS: TestAccAWSEcsTaskDefinition_withNetworkMode (10.02s)
=== RUN   TestAccAWSEcsTaskDefinition_changeVolumesForcesNewResource
--- PASS: TestAccAWSEcsTaskDefinition_changeVolumesForcesNewResource (10.94s)
=== RUN   TestAccAWSEcsTaskDefinition_basic
--- PASS: TestAccAWSEcsTaskDefinition_basic (11.06s)
=== RUN   TestAccAWSEcsTaskDefinition_ExecutionRole
--- PASS: TestAccAWSEcsTaskDefinition_ExecutionRole (11.95s)
=== RUN   TestAccAWSEcsTaskDefinition_withEcsService
--- PASS: TestAccAWSEcsTaskDefinition_withEcsService (47.58s)
```