### PR TITLE
resource/aws_batch_compute_environment: Correctly set compute_resources in state

### DIFF
--- a/aws/resource_aws_batch_compute_environment.go
+++ b/aws/resource_aws_batch_compute_environment.go
@@ -266,8 +266,10 @@ func resourceAwsBatchComputeEnvironmentRead(d *schema.ResourceData, meta interfa
 	d.Set("state", computeEnvironment.State)
 	d.Set("type", computeEnvironment.Type)
 
-	if *(computeEnvironment.Type) == "MANAGED" {
-		d.Set("compute_resources", flattenComputeResources(computeEnvironment.ComputeResources))
+	if aws.StringValue(computeEnvironment.Type) == batch.CETypeManaged {
+		if err := d.Set("compute_resources", flattenBatchComputeResources(computeEnvironment.ComputeResources)); err != nil {
+			return fmt.Errorf("error setting compute_resources: %s", err)
+		}
 	}
 
 	d.Set("arn", computeEnvironment.ComputeEnvironmentArn)
@@ -279,23 +281,23 @@ func resourceAwsBatchComputeEnvironmentRead(d *schema.ResourceData, meta interfa
 	return nil
 }
 
-func flattenComputeResources(computeResource *batch.ComputeResource) []map[string]interface{} {
+func flattenBatchComputeResources(computeResource *batch.ComputeResource) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0)
 	m := make(map[string]interface{})
 
-	m["bid_percentage"] = computeResource.BidPercentage
-	m["desired_vcpus"] = computeResource.DesiredvCpus
-	m["ec2_key_pair"] = computeResource.Ec2KeyPair
-	m["image_id"] = computeResource.ImageId
-	m["instance_role"] = computeResource.InstanceRole
+	m["bid_percentage"] = int(aws.Int64Value(computeResource.BidPercentage))
+	m["desired_vcpus"] = int(aws.Int64Value(computeResource.DesiredvCpus))
+	m["ec2_key_pair"] = aws.StringValue(computeResource.Ec2KeyPair)
+	m["image_id"] = aws.StringValue(computeResource.ImageId)
+	m["instance_role"] = aws.StringValue(computeResource.InstanceRole)
 	m["instance_type"] = schema.NewSet(schema.HashString, flattenStringList(computeResource.InstanceTypes))
-	m["max_vcpus"] = computeResource.MaxvCpus
-	m["min_vcpus"] = computeResource.MinvCpus
+	m["max_vcpus"] = int(aws.Int64Value(computeResource.MaxvCpus))
+	m["min_vcpus"] = int(aws.Int64Value(computeResource.MinvCpus))
 	m["security_group_ids"] = schema.NewSet(schema.HashString, flattenStringList(computeResource.SecurityGroupIds))
-	m["spot_iam_fleet_role"] = computeResource.SpotIamFleetRole
+	m["spot_iam_fleet_role"] = aws.StringValue(computeResource.SpotIamFleetRole)
 	m["subnets"] = schema.NewSet(schema.HashString, flattenStringList(computeResource.Subnets))
 	m["tags"] = tagsToMapGeneric(computeResource.Tags)
-	m["type"] = computeResource.Type
+	m["type"] = aws.StringValue(computeResource.Type)
 
 	result = append(result, m)
 	return result


### PR DESCRIPTION
Found via `TF_SCHEMA_PANIC_ON_ERROR=1` testing

```
TestAccAWSBatchComputeEnvironment_createEc2
panic: compute_resources.0.max_vcpus: '' expected type 'int', got unconvertible type '*int64'
resource_aws_batch_compute_environment.go:270

TestAccAWSBatchComputeEnvironment_createEc2WithTags
panic: compute_resources.0.instance_role: '' expected type 'string', got unconvertible type '*string'
resource_aws_batch_compute_environment.go:270

TestAccAWSBatchComputeEnvironment_createSpot
panic: compute_resources.0.spot_iam_fleet_role: '' expected type 'string', got unconvertible type '*string'
resource_aws_batch_compute_environment.go:270

TestAccAWSBatchComputeEnvironment_updateMaxvCpus
panic: compute_resources.0.min_vcpus: '' expected type 'int', got unconvertible type '*int64'
resource_aws_batch_compute_environment.go:270

TestAccAWSBatchJobQueue_basic
panic: compute_resources.0.desired_vcpus: '' expected type 'int', got unconvertible type '*int64'
resource_aws_batch_compute_environment.go:270
```

Tests
```
11 tests passed (all tests)
=== RUN   TestAccAWSBatchComputeEnvironment_createSpotWithoutBidPercentage
--- PASS: TestAccAWSBatchComputeEnvironment_createSpotWithoutBidPercentage (21.35s)
=== RUN   TestAccAWSBatchComputeEnvironment_createSpot
--- PASS: TestAccAWSBatchComputeEnvironment_createSpot (46.40s)
=== RUN   TestAccAWSBatchComputeEnvironment_createUnmanagedWithComputeResources
--- PASS: TestAccAWSBatchComputeEnvironment_createUnmanagedWithComputeResources (73.11s)
=== RUN   TestAccAWSBatchComputeEnvironment_createEc2WithTags
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2WithTags (74.06s)
=== RUN   TestAccAWSBatchComputeEnvironment_createEc2
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2 (85.05s)
=== RUN   TestAccAWSBatchComputeEnvironment_createEc2WithoutComputeResources
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2WithoutComputeResources (88.15s)
=== RUN   TestAccAWSBatchComputeEnvironment_createUnmanaged
--- PASS: TestAccAWSBatchComputeEnvironment_createUnmanaged (89.51s)
=== RUN   TestAccAWSBatchComputeEnvironment_updateComputeEnvironmentName
--- PASS: TestAccAWSBatchComputeEnvironment_updateComputeEnvironmentName (92.24s)
=== RUN   TestAccAWSBatchComputeEnvironment_updateInstanceType
--- PASS: TestAccAWSBatchComputeEnvironment_updateInstanceType (94.23s)
=== RUN   TestAccAWSBatchComputeEnvironment_updateState
--- PASS: TestAccAWSBatchComputeEnvironment_updateState (112.04s)
=== RUN   TestAccAWSBatchComputeEnvironment_updateMaxvCpus
--- PASS: TestAccAWSBatchComputeEnvironment_updateMaxvCpus (118.05s)
```