### PR TITLE
resource/aws_cloudformation_stack: Remove setting non-existent arn attribute

### DIFF
--- a/aws/resource_aws_cloudformation_stack.go
+++ b/aws/resource_aws_cloudformation_stack.go
@@ -308,7 +308,6 @@ func resourceAwsCloudFormationStackRead(d *schema.ResourceData, meta interface{}
 	log.Printf("[DEBUG] Received CloudFormation stack: %s", stack)
 
 	d.Set("name", stack.StackName)
-	d.Set("arn", stack.StackId)
 	d.Set("iam_role_arn", stack.RoleARN)
 
 	if stack.TimeoutInMinutes != nil {

--- a/aws/resource_aws_cloudformation_stack_test.go
+++ b/aws/resource_aws_cloudformation_stack_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSCloudFormation_importBasic(t *testing.T) {
+func TestAccAWSCloudFormationStack_importBasic(t *testing.T) {
 	stackName := fmt.Sprintf("tf-acc-test-basic-%s", acctest.RandString(10))
 
 	resourceName := "aws_cloudformation_stack.network"
@@ -22,7 +22,7 @@ func TestAccAWSCloudFormation_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudFormationConfig(stackName),
+				Config: testAccAWSCloudFormationStackConfig(stackName),
 			},
 			{
 				ResourceName:      resourceName,
@@ -33,7 +33,7 @@ func TestAccAWSCloudFormation_importBasic(t *testing.T) {
 	})
 }
 
-func TestAccAWSCloudFormation_basic(t *testing.T) {
+func TestAccAWSCloudFormationStack_basic(t *testing.T) {
 	var stack cloudformation.Stack
 	stackName := fmt.Sprintf("tf-acc-test-basic-%s", acctest.RandString(10))
 
@@ -43,7 +43,7 @@ func TestAccAWSCloudFormation_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudFormationConfig(stackName),
+				Config: testAccAWSCloudFormationStackConfig(stackName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.network", &stack),
 				),
@@ -52,7 +52,7 @@ func TestAccAWSCloudFormation_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSCloudFormation_yaml(t *testing.T) {
+func TestAccAWSCloudFormationStack_yaml(t *testing.T) {
 	var stack cloudformation.Stack
 	stackName := fmt.Sprintf("tf-acc-test-yaml-%s", acctest.RandString(10))
 
@@ -62,7 +62,7 @@ func TestAccAWSCloudFormation_yaml(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudFormationConfig_yaml(stackName),
+				Config: testAccAWSCloudFormationStackConfig_yaml(stackName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.yaml", &stack),
 				),
@@ -71,7 +71,7 @@ func TestAccAWSCloudFormation_yaml(t *testing.T) {
 	})
 }
 
-func TestAccAWSCloudFormation_defaultParams(t *testing.T) {
+func TestAccAWSCloudFormationStack_defaultParams(t *testing.T) {
 	var stack cloudformation.Stack
 	stackName := fmt.Sprintf("tf-acc-test-default-params-%s", acctest.RandString(10))
 
@@ -81,7 +81,7 @@ func TestAccAWSCloudFormation_defaultParams(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudFormationConfig_defaultParams(stackName),
+				Config: testAccAWSCloudFormationStackConfig_defaultParams(stackName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.asg-demo", &stack),
 				),
@@ -90,7 +90,7 @@ func TestAccAWSCloudFormation_defaultParams(t *testing.T) {
 	})
 }
 
-func TestAccAWSCloudFormation_allAttributes(t *testing.T) {
+func TestAccAWSCloudFormationStack_allAttributes(t *testing.T) {
 	var stack cloudformation.Stack
 	stackName := fmt.Sprintf("tf-acc-test-all-attributes-%s", acctest.RandString(10))
 
@@ -101,7 +101,7 @@ func TestAccAWSCloudFormation_allAttributes(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudFormationConfig_allAttributesWithBodies(stackName),
+				Config: testAccAWSCloudFormationStackConfig_allAttributesWithBodies(stackName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.full", &stack),
 					resource.TestCheckResourceAttr("aws_cloudformation_stack.full", "name", stackName),
@@ -119,7 +119,7 @@ func TestAccAWSCloudFormation_allAttributes(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSCloudFormationConfig_allAttributesWithBodies_modified(stackName),
+				Config: testAccAWSCloudFormationStackConfig_allAttributesWithBodies_modified(stackName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.full", &stack),
 					resource.TestCheckResourceAttr("aws_cloudformation_stack.full", "name", stackName),
@@ -141,7 +141,7 @@ func TestAccAWSCloudFormation_allAttributes(t *testing.T) {
 }
 
 // Regression for https://github.com/hashicorp/terraform/issues/4332
-func TestAccAWSCloudFormation_withParams(t *testing.T) {
+func TestAccAWSCloudFormationStack_withParams(t *testing.T) {
 	var stack cloudformation.Stack
 	stackName := fmt.Sprintf("tf-acc-test-with-params-%s", acctest.RandString(10))
 
@@ -151,13 +151,13 @@ func TestAccAWSCloudFormation_withParams(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudFormationConfig_withParams(stackName),
+				Config: testAccAWSCloudFormationStackConfig_withParams(stackName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.with_params", &stack),
 				),
 			},
 			{
-				Config: testAccAWSCloudFormationConfig_withParams_modified(stackName),
+				Config: testAccAWSCloudFormationStackConfig_withParams_modified(stackName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.with_params", &stack),
 				),
@@ -167,7 +167,7 @@ func TestAccAWSCloudFormation_withParams(t *testing.T) {
 }
 
 // Regression for https://github.com/hashicorp/terraform/issues/4534
-func TestAccAWSCloudFormation_withUrl_withParams(t *testing.T) {
+func TestAccAWSCloudFormationStack_withUrl_withParams(t *testing.T) {
 	var stack cloudformation.Stack
 	rName := fmt.Sprintf("tf-acc-test-with-url-and-params-%s", acctest.RandString(10))
 
@@ -177,13 +177,13 @@ func TestAccAWSCloudFormation_withUrl_withParams(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudFormationConfig_templateUrl_withParams(rName, "tf-cf-stack.json", "11.0.0.0/16"),
+				Config: testAccAWSCloudFormationStackConfig_templateUrl_withParams(rName, "tf-cf-stack.json", "11.0.0.0/16"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.with-url-and-params", &stack),
 				),
 			},
 			{
-				Config: testAccAWSCloudFormationConfig_templateUrl_withParams(rName, "tf-cf-stack.json", "13.0.0.0/16"),
+				Config: testAccAWSCloudFormationStackConfig_templateUrl_withParams(rName, "tf-cf-stack.json", "13.0.0.0/16"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.with-url-and-params", &stack),
 				),
@@ -192,7 +192,7 @@ func TestAccAWSCloudFormation_withUrl_withParams(t *testing.T) {
 	})
 }
 
-func TestAccAWSCloudFormation_withUrl_withParams_withYaml(t *testing.T) {
+func TestAccAWSCloudFormationStack_withUrl_withParams_withYaml(t *testing.T) {
 	var stack cloudformation.Stack
 	rName := fmt.Sprintf("tf-acc-test-with-params-and-yaml-%s", acctest.RandString(10))
 
@@ -202,7 +202,7 @@ func TestAccAWSCloudFormation_withUrl_withParams_withYaml(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudFormationConfig_templateUrl_withParams_withYaml(rName, "tf-cf-stack.yaml", "13.0.0.0/16"),
+				Config: testAccAWSCloudFormationStackConfig_templateUrl_withParams_withYaml(rName, "tf-cf-stack.yaml", "13.0.0.0/16"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.with-url-and-params-and-yaml", &stack),
 				),
@@ -212,7 +212,7 @@ func TestAccAWSCloudFormation_withUrl_withParams_withYaml(t *testing.T) {
 }
 
 // Test for https://github.com/hashicorp/terraform/issues/5653
-func TestAccAWSCloudFormation_withUrl_withParams_noUpdate(t *testing.T) {
+func TestAccAWSCloudFormationStack_withUrl_withParams_noUpdate(t *testing.T) {
 	var stack cloudformation.Stack
 	rName := fmt.Sprintf("tf-acc-test-with-params-no-update-%s", acctest.RandString(10))
 
@@ -222,13 +222,13 @@ func TestAccAWSCloudFormation_withUrl_withParams_noUpdate(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudFormationConfig_templateUrl_withParams(rName, "tf-cf-stack-1.json", "11.0.0.0/16"),
+				Config: testAccAWSCloudFormationStackConfig_templateUrl_withParams(rName, "tf-cf-stack-1.json", "11.0.0.0/16"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.with-url-and-params", &stack),
 				),
 			},
 			{
-				Config: testAccAWSCloudFormationConfig_templateUrl_withParams(rName, "tf-cf-stack-2.json", "11.0.0.0/16"),
+				Config: testAccAWSCloudFormationStackConfig_templateUrl_withParams(rName, "tf-cf-stack-2.json", "11.0.0.0/16"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.with-url-and-params", &stack),
 				),
@@ -288,7 +288,7 @@ func testAccCheckAWSCloudFormationDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAWSCloudFormationConfig(stackName string) string {
+func testAccAWSCloudFormationStackConfig(stackName string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudformation_stack" "network" {
   name = "%s"
@@ -320,7 +320,7 @@ STACK
 }`, stackName)
 }
 
-func testAccAWSCloudFormationConfig_yaml(stackName string) string {
+func testAccAWSCloudFormationStackConfig_yaml(stackName string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudformation_stack" "yaml" {
   name = "%s"
@@ -346,7 +346,7 @@ STACK
 }`, stackName)
 }
 
-func testAccAWSCloudFormationConfig_defaultParams(stackName string) string {
+func testAccAWSCloudFormationStackConfig_defaultParams(stackName string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudformation_stack" "asg-demo" {
   name = "%s"
@@ -402,7 +402,7 @@ BODY
 `, stackName)
 }
 
-var testAccAWSCloudFormationConfig_allAttributesWithBodies_tpl = `
+var testAccAWSCloudFormationStackConfig_allAttributesWithBodies_tpl = `
 resource "aws_cloudformation_stack" "full" {
   name = "%s"
   template_body = <<STACK
@@ -501,23 +501,23 @@ var policyBody = `
 }
 `
 
-func testAccAWSCloudFormationConfig_allAttributesWithBodies(stackName string) string {
+func testAccAWSCloudFormationStackConfig_allAttributesWithBodies(stackName string) string {
 	return fmt.Sprintf(
-		testAccAWSCloudFormationConfig_allAttributesWithBodies_tpl,
+		testAccAWSCloudFormationStackConfig_allAttributesWithBodies_tpl,
 		stackName,
 		"Primary_CF_VPC",
 		policyBody)
 }
 
-func testAccAWSCloudFormationConfig_allAttributesWithBodies_modified(stackName string) string {
+func testAccAWSCloudFormationStackConfig_allAttributesWithBodies_modified(stackName string) string {
 	return fmt.Sprintf(
-		testAccAWSCloudFormationConfig_allAttributesWithBodies_tpl,
+		testAccAWSCloudFormationStackConfig_allAttributesWithBodies_tpl,
 		stackName,
 		"Primary_CloudFormation_VPC",
 		policyBody)
 }
 
-var tpl_testAccAWSCloudFormationConfig_withParams = `
+var tpl_testAccAWSCloudFormationStackConfig_withParams = `
 resource "aws_cloudformation_stack" "with_params" {
   name = "%s"
   parameters {
@@ -550,21 +550,21 @@ STACK
 }
 `
 
-func testAccAWSCloudFormationConfig_withParams(stackName string) string {
+func testAccAWSCloudFormationStackConfig_withParams(stackName string) string {
 	return fmt.Sprintf(
-		tpl_testAccAWSCloudFormationConfig_withParams,
+		tpl_testAccAWSCloudFormationStackConfig_withParams,
 		stackName,
 		"10.0.0.0/16")
 }
 
-func testAccAWSCloudFormationConfig_withParams_modified(stackName string) string {
+func testAccAWSCloudFormationStackConfig_withParams_modified(stackName string) string {
 	return fmt.Sprintf(
-		tpl_testAccAWSCloudFormationConfig_withParams,
+		tpl_testAccAWSCloudFormationStackConfig_withParams,
 		stackName,
 		"12.0.0.0/16")
 }
 
-func testAccAWSCloudFormationConfig_templateUrl_withParams(rName, bucketKey, vpcCidr string) string {
+func testAccAWSCloudFormationStackConfig_templateUrl_withParams(rName, bucketKey, vpcCidr string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "b" {
   bucket = "%s"
@@ -610,7 +610,7 @@ resource "aws_cloudformation_stack" "with-url-and-params" {
 `, rName, rName, bucketKey, rName, vpcCidr)
 }
 
-func testAccAWSCloudFormationConfig_templateUrl_withParams_withYaml(rName, bucketKey, vpcCidr string) string {
+func testAccAWSCloudFormationStackConfig_templateUrl_withParams_withYaml(rName, bucketKey, vpcCidr string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "b" {
   bucket = "%s"

--- a/aws/resource_aws_cloudformation_stack_test.go
+++ b/aws/resource_aws_cloudformation_stack_test.go
@@ -300,7 +300,7 @@ resource "aws_cloudformation_stack" "network" {
       "Properties" : {
         "CidrBlock" : "10.0.0.0/16",
         "Tags" : [
-          {"Key": "Name", "Value": "%[1]s"}
+          {"Key": "Name", "Value": "Primary_CF_VPC"}
         ]
       }
     }
@@ -333,7 +333,7 @@ Resources:
       Tags:
         -
           Key: Name
-          Value: %[1]s
+          Value: Primary_CF_VPC
 
 Outputs:
   DefaultSgId:
@@ -379,7 +379,7 @@ resource "aws_cloudformation_stack" "asg-demo" {
                 "Tags": [
                     {
                         "Key": "Name",
-                        "Value": "%[1]s"
+                        "Value": "Primary_CF_VPC"
                     }
                 ]
             }
@@ -535,7 +535,7 @@ resource "aws_cloudformation_stack" "with_params" {
       "Properties" : {
         "CidrBlock" : {"Ref": "VpcCIDR"},
         "Tags" : [
-          {"Key": "Name", "Value": "%[1]s"}
+          {"Key": "Name", "Value": "Primary_CF_VPC"}
         ]
       }
     }


### PR DESCRIPTION
Other testing cleanup:
* Append `Stack` to test function names to distinguish from other CloudFormation resources
* Changed VPC name tags in CF templates from `Primary_CF_VPC ` to `tf-acc-test-` so `aws_vpc` sweeper can clean them up
* Added randomization to prevent:
```
=== RUN   TestAccAWSCloudFormationStack_defaultParams
--- FAIL: TestAccAWSCloudFormationStack_defaultParams (69.53s)
    testing.go:518: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_cloudformation_stack.asg-demo: 1 error(s) occurred:
        
        * aws_cloudformation_stack.asg-demo: ROLLBACK_COMPLETE: ["The following resource(s) failed to create: [NotificationTopic, MyVPC]. . Rollback requested by user." "Resource creation cancelled" "ExampleTopic already exists in stack arn:aws:cloudformation:us-west-2:*******:stack/tf-acc-test-default-params-b6qf176aaj/db8b6000-2871-11e8-8ba6-503ac9ec2499"]
FAIL
```

Found via `TF_SCHEMA_PANIC_ON_ERROR` testing:

```
TestAccAWSCloudFormationStack_dataSource_basic
TestAccAWSCloudFormation_allAttributes
... lots more ...
panic: Invalid address to set: []string{"arn"}
resource_aws_cloudformation_stack.go:311
```

Tests
```
11 tests passed (all tests)
=== RUN   TestAccAWSCloudFormationStack_basic
--- PASS: TestAccAWSCloudFormationStack_basic (64.94s)
=== RUN   TestAccAWSCloudFormationStack_defaultParams
--- PASS: TestAccAWSCloudFormationStack_defaultParams (68.78s)
=== RUN   TestAccAWSCloudFormationStack_yaml
--- PASS: TestAccAWSCloudFormationStack_yaml (70.66s)
=== RUN   TestAccAWSCloudFormationStack_importBasic
--- PASS: TestAccAWSCloudFormationStack_importBasic (72.63s)
=== RUN   TestAccAWSCloudFormationStack_dataSource_yaml
--- PASS: TestAccAWSCloudFormationStack_dataSource_yaml (77.84s)
=== RUN   TestAccAWSCloudFormationStack_withUrl_withParams_noUpdate
--- PASS: TestAccAWSCloudFormationStack_withUrl_withParams_noUpdate (86.21s)
=== RUN   TestAccAWSCloudFormationStack_withUrl_withParams_withYaml
--- PASS: TestAccAWSCloudFormationStack_withUrl_withParams_withYaml (87.65s)
=== RUN   TestAccAWSCloudFormationStack_dataSource_basic
--- PASS: TestAccAWSCloudFormationStack_dataSource_basic (94.78s)
=== RUN   TestAccAWSCloudFormationStack_allAttributes
--- PASS: TestAccAWSCloudFormationStack_allAttributes (97.96s)
=== RUN   TestAccAWSCloudFormationStack_withUrl_withParams
--- PASS: TestAccAWSCloudFormationStack_withUrl_withParams (116.60s)
=== RUN   TestAccAWSCloudFormationStack_withParams
--- PASS: TestAccAWSCloudFormationStack_withParams (119.84s)
```