### PR TITLE
New Resource: aws_appsync_api_key

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -275,6 +275,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_appautoscaling_policy":                    resourceAwsAppautoscalingPolicy(),
 			"aws_appautoscaling_scheduled_action":          resourceAwsAppautoscalingScheduledAction(),
 			"aws_appsync_graphql_api":                      resourceAwsAppsyncGraphqlApi(),
+			"aws_appsync_api_key":                          resourceAwsAppsyncApiKey(),
 			"aws_athena_database":                          resourceAwsAthenaDatabase(),
 			"aws_athena_named_query":                       resourceAwsAthenaNamedQuery(),
 			"aws_autoscaling_attachment":                   resourceAwsAutoscalingAttachment(),

--- a/aws/resource_aws_appsync_api_key.go
+++ b/aws/resource_aws_appsync_api_key.go
@@ -144,7 +144,7 @@ func resourceAwsAppsyncApiKeyUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	return resourceAwsAppsyncApiKeyRead(d, meta)
-	return nil
+
 }
 
 func resourceAwsAppsyncApiKeyDelete(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_appsync_api_key.go
+++ b/aws/resource_aws_appsync_api_key.go
@@ -1,0 +1,166 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/appsync"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsAppsyncApiKey() *schema.Resource {
+
+	return &schema.Resource{
+		Create: resourceAwsAppsyncApiKeyCreate,
+		Read:   resourceAwsAppsyncApiKeyRead,
+		Update: resourceAwsAppsyncApiKeyUpdate,
+		Delete: resourceAwsAppsyncApiKeyDelete,
+
+		Schema: map[string]*schema.Schema{
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "Managed by Terraform",
+			},
+			"appsync_api_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"valid_till_date": {
+				Type:          schema.TypeString,
+				ConflictsWith: []string{"validity_period_days"},
+				Optional:      true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
+					value := v.(string)
+					// reference - http://www.regexlib.com/REDetails.aspx?regexp_id=409
+					if !regexp.MustCompile(`^(((0[1-9]|[12]\d|3[01])\/(0[13578]|1[02])\/((1[6-9]|[2-9]\d)\d{2}))|((0[1-9]|[12]\d|30)\/(0[13456789]|1[012])\/((1[6-9]|[2-9]\d)\d{2}))|((0[1-9]|1\d|2[0-8])\/02\/((1[6-9]|[2-9]\d)\d{2}))|(29\/02\/((1[6-9]|[2-9]\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00))))$`).MatchString(value) {
+						es = append(es, fmt.Errorf(
+							"only dd/mm/yyyy in %q", k))
+					}
+					return
+				},
+			},
+			"validity_period_days": {
+				Type:          schema.TypeInt,
+				ConflictsWith: []string{"valid_till_date"},
+				Optional:      true,
+			},
+			"expiry_date": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"key": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+		},
+	}
+}
+
+func resourceAwsAppsyncApiKeyCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).appsyncconn
+	params := &appsync.CreateApiKeyInput{
+		ApiId:       aws.String(d.Get("appsync_api_id").(string)),
+		Description: aws.String(d.Get("description").(string)),
+	}
+	layout := "02/01/2006 15:04:05 -0700 MST"
+	if v, ok := d.GetOk("validity_period_days"); ok {
+		params.Expires = aws.Int64(time.Now().Add(time.Hour * 24 * time.Duration(v.(int))).Unix())
+	}
+	if v, ok := d.GetOk("valid_till_date"); ok {
+		tx := strings.Split(time.Now().Format(layout), " ")
+		tx[0] = v.(string)
+		t, _ := time.Parse(layout, strings.Join(tx, " "))
+		params.Expires = aws.Int64(t.Unix())
+	}
+
+	resp, err := conn.CreateApiKey(params)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(*resp.ApiKey.Id)
+	return resourceAwsAppsyncApiKeyRead(d, meta)
+}
+
+func resourceAwsAppsyncApiKeyRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).appsyncconn
+
+	input := &appsync.ListApiKeysInput{
+		ApiId: aws.String(d.Get("appsync_api_id").(string)),
+	}
+
+	resp, err := conn.ListApiKeys(input)
+	if err != nil {
+		return err
+	}
+	var key appsync.ApiKey
+	for _, v := range resp.ApiKeys {
+		if *v.Id == d.Id() {
+			key = *v
+		}
+	}
+
+	d.Set("key", key.Id)
+	d.Set("description", key.Description)
+	d.Set("expiry_date", time.Unix(*key.Expires, 0).String())
+	return nil
+}
+
+func resourceAwsAppsyncApiKeyUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).appsyncconn
+
+	params := &appsync.UpdateApiKeyInput{
+		ApiId: aws.String(d.Get("appsync_api_id").(string)),
+		Id:    aws.String(d.Id()),
+	}
+	if d.HasChange("description") {
+		params.Description = aws.String(d.Get("description").(string))
+	}
+	if v, ok := d.GetOk("validity_period_days"); ok {
+
+		if d.HasChange("validity_period_days") {
+			params.Expires = aws.Int64(time.Now().Add(time.Hour * 24 * time.Duration(v.(int))).Unix())
+		}
+	}
+	if v, ok := d.GetOk("valid_till_date"); ok {
+		layout := "02/01/2006 15:04:05 -0700 MST"
+		if d.HasChange("valid_till_date") {
+			tx := strings.Split(time.Now().Format(layout), " ")
+			tx[0] = v.(string)
+			t, _ := time.Parse(layout, strings.Join(tx, " "))
+			params.Expires = aws.Int64(t.Unix())
+
+		}
+	}
+
+	_, err := conn.UpdateApiKey(params)
+	if err != nil {
+		return err
+	}
+
+	return resourceAwsAppsyncApiKeyRead(d, meta)
+	return nil
+}
+
+func resourceAwsAppsyncApiKeyDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).appsyncconn
+
+	input := &appsync.DeleteApiKeyInput{
+		ApiId: aws.String(d.Get("appsync_api_id").(string)),
+		Id:    aws.String(d.Id()),
+	}
+	_, err := conn.DeleteApiKey(input)
+	if err != nil {
+		if isAWSErr(err, appsync.ErrCodeNotFoundException, "") {
+			return nil
+		}
+		return err
+	}
+
+	return nil
+}

--- a/aws/resource_aws_appsync_api_key_test.go
+++ b/aws/resource_aws_appsync_api_key_test.go
@@ -1,0 +1,145 @@
+package aws
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/appsync"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAwsAppsyncApiKey_basic(t *testing.T) {
+	// sample date to test
+	dateAfterOneYear := time.Now().Add(time.Hour * 24 * time.Duration(360)).Format("02/01/2006")
+	// test sample date against time of expiry
+	layout := "02/01/2006 15:04:05 -0700 MST"
+	tx := strings.Split(time.Now().Format(layout), " ")
+	tx[0] = dateAfterOneYear
+	timeAfterOneYear, _ := time.Parse(layout, strings.Join(tx, " "))
+
+	thirtyDays := "30"
+	timeAfterThirdyDays := time.Now().Add(time.Hour * 24 * 30)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsAppsyncApiKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppsyncApiKeyConfigValidTillDate(dateAfterOneYear),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncApiKeyExistsTillDate(
+						"aws_appsync_graphql_api.test1",
+						"aws_appsync_api_key.test_valid_till_date",
+						timeAfterOneYear.Unix(),
+					),
+				),
+			},
+			{
+				Config: testAccAppsyncApiKeyConfigValidityPeriodDays(thirtyDays),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncApiKeyExistsTillDate(
+						"aws_appsync_graphql_api.test2",
+						"aws_appsync_api_key.test_validity_period_days",
+						timeAfterThirdyDays.Unix(),
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsAppsyncApiKeyDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).appsyncconn
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_appsync_api_key" {
+			continue
+		}
+
+		describe, err := conn.ListApiKeys(&appsync.ListApiKeysInput{})
+
+		if err == nil {
+			if len(describe.ApiKeys) != 0 &&
+				*describe.ApiKeys[0].Id == rs.Primary.ID {
+				return fmt.Errorf("Appsync ApiKey still exists")
+			}
+			return err
+		}
+
+	}
+	return nil
+}
+
+func testAccCheckAwsAppsyncApiKeyExistsTillDate(GqlApiName string, ApiKeyName string, date int64) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rsGql, ok := s.RootModule().Resources[GqlApiName]
+		if !ok {
+			return fmt.Errorf("Gql Not found in state: %s", GqlApiName)
+		}
+
+		rsApiKey, ok := s.RootModule().Resources[ApiKeyName]
+		if !ok {
+			return fmt.Errorf("Key Not found in state: %s", ApiKeyName)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).appsyncconn
+
+		input := &appsync.ListApiKeysInput{
+			ApiId: aws.String(rsGql.Primary.ID),
+		}
+
+		resp, err := conn.ListApiKeys(input)
+		if err != nil {
+			return err
+		}
+		var key appsync.ApiKey
+		for _, v := range resp.ApiKeys {
+			if *v.Id == *aws.String(rsApiKey.Primary.ID) {
+				key = *v
+			}
+		}
+		if key.Id == nil {
+			return fmt.Errorf("Key Not found: %s  %s", ApiKeyName, *aws.String(rsApiKey.Primary.ID))
+		}
+		// aws when they create, slight difference will be in the minutes, so better check date
+		if time.Unix(*key.Expires, 0).Format("02/01/2006") != time.Unix(date, 0).Format("02/01/2006") {
+
+			return fmt.Errorf("Expiry date got is: %s and expected is %s", time.Unix(*key.Expires, 0).Format("02/01/2006"),
+				time.Unix(date, 0).Format("02/01/2006"))
+		}
+
+		return nil
+	}
+}
+
+func testAccAppsyncApiKeyConfigValidTillDate(rDate string) string {
+	return fmt.Sprintf(`
+resource "aws_appsync_graphql_api" "test1" {
+  authentication_type = "API_KEY"
+  name = "tf_appsync_test1"
+}
+resource "aws_appsync_api_key" "test_valid_till_date" {
+	appsync_api_id = "${aws_appsync_graphql_api.test1.id}"
+	valid_till_date = "%s"
+}
+
+`, rDate)
+}
+
+func testAccAppsyncApiKeyConfigValidityPeriodDays(rDays string) string {
+	return fmt.Sprintf(`
+resource "aws_appsync_graphql_api" "test2" {
+  authentication_type = "API_KEY"
+  name = "tf_appsync_test2"
+}
+
+resource "aws_appsync_api_key" "test_validity_period_days" {
+	appsync_api_id = "${aws_appsync_graphql_api.test2.id}"
+	validity_period_days = %s
+}
+
+`, rDays)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -361,6 +361,9 @@
                         <li<%= sidebar_current("docs-aws-resource-appsync-graphql-api") %>>
                             <a href="/docs/providers/aws/r/appsync_graphql_api.html">aws_appsync_graphql_api</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-resource-appsync-api-key") %>>
+                            <a href="/docs/providers/aws/r/appsync_api_key.html">aws_appsync_api_key</a>
+                        </li>
                     </ul>
                 </li>
 

--- a/website/docs/r/appsync_api_key.html.markdown
+++ b/website/docs/r/appsync_api_key.html.markdown
@@ -37,5 +37,5 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `id` - API ID
+* `id` - API Key ID (Formatted as ApiId:Key)
 * `key` - The API key

--- a/website/docs/r/appsync_api_key.html.markdown
+++ b/website/docs/r/appsync_api_key.html.markdown
@@ -1,0 +1,45 @@
+---
+layout: "aws"
+page_title: "AWS: aws_appsync_api_key"
+sidebar_current: "docs-aws-resource-appsync-api-key"
+description: |-
+  Provides an AppSync API Key.
+---
+
+# aws_appsync_api_key
+
+Provides an AppSync API Key.
+
+## Example Usage
+
+```hcl
+resource "aws_appsync_graphql_api" "example" {
+  authentication_type = "API_KEY"
+  name = "example"
+}
+resource "aws_appsync_api_key" "self" {
+ appsync_api_id = "${aws_appsync_graphql_api.example.id}"
+ validity_period_days = 364
+}
+resource "aws_appsync_api_key" "partner" {
+ appsync_api_id = "${aws_appsync_graphql_api.example.id}"
+ valid_till_date = "30/11/2018"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `appsync_api_id` - (Required) The ID of the associated AppSync API
+* `description` - (Optional) The API key description. Defaults to "Managed by Terraform".
+* `validity_period_days` - (Optional) The number of days of validity from date of creation, (aws supports less than 365 days). By default, it is 7 days.
+* `valid_till_date` - (Optional) The date till the key should be valid, use the format dd/mm/yyyy.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - API ID
+* `key` - The API key

--- a/website/docs/r/appsync_api_key.html.markdown
+++ b/website/docs/r/appsync_api_key.html.markdown
@@ -18,13 +18,10 @@ resource "aws_appsync_graphql_api" "example" {
   name = "example"
 }
 resource "aws_appsync_api_key" "self" {
- appsync_api_id = "${aws_appsync_graphql_api.example.id}"
- validity_period_days = 364
+ api_id = "${aws_appsync_graphql_api.example.id}"
+ expires = "2018-05-03T04:21:15+01:00"
 }
-resource "aws_appsync_api_key" "partner" {
- appsync_api_id = "${aws_appsync_graphql_api.example.id}"
- valid_till_date = "30/11/2018"
-}
+
 ```
 
 ## Argument Reference

--- a/website/docs/r/appsync_api_key.html.markdown
+++ b/website/docs/r/appsync_api_key.html.markdown
@@ -31,10 +31,9 @@ resource "aws_appsync_api_key" "partner" {
 
 The following arguments are supported:
 
-* `appsync_api_id` - (Required) The ID of the associated AppSync API
+* `api_id` - (Required) The ID of the associated AppSync API
 * `description` - (Optional) The API key description. Defaults to "Managed by Terraform".
-* `validity_period_days` - (Optional) The number of days of validity from date of creation, (aws supports less than 365 days). By default, it is 7 days.
-* `valid_till_date` - (Optional) The date till the key should be valid, use the format dd/mm/yyyy.
+* `expires` - (Optional)  RFC3339 string representation of the expiry date. By default, it is 7 days from the date of creation.
 
 
 ## Attributes Reference


### PR DESCRIPTION
Supporting the creation of appsync api key. Either a specific date or number of days.

resource "aws_appsync_graphql_api" "example" {
  authentication_type = "API_KEY"
  name = "example"
}


resource "aws_appsync_api_key" "ex1" {
 appsync_api_id = "${aws_appsync_graphql_api.example.id}"
 validity_period_days = 364
}

resource "aws_appsync_api_key" "ex2" {
 appsync_api_id = "${aws_appsync_graphql_api.example.id}"
 valid_till_date = "30/11/2018"
}