### PR TITLE
deps: Bump jen20/awspolicyequivalence@9fbcaca9

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1444,10 +1444,10 @@
 			"revisionTime": "2016-07-20T23:31:40Z"
 		},
 		{
-			"checksumSHA1": "sVczcCYWr12ttrbXRFz/QOyDyWg=",
+			"checksumSHA1": "77PKgZO4nQy8w8CKOQAc9/vrAmo=",
 			"path": "github.com/jen20/awspolicyequivalence",
-			"revision": "3d48364a137a7847c1191b83740052dc7695878e",
-			"revisionTime": "2017-08-31T20:16:02Z"
+			"revision": "9fbcaca9f9f868b9560463d0790aae33b2322945",
+			"revisionTime": "2018-03-16T12:05:52Z"
 		},
 		{
 			"checksumSHA1": "0ZrwvB6KoGPj2PoDNSEJwxQ6Mog=",


### PR DESCRIPTION
`govendor fetch github.com/jen20/awspolicyequivalence/...@9fbcaca9f9f868b9560463d0790aae33b2322945`

Changes:
* Handle AWS converting account ID principal to root IAM user ARN
* Fix equality check for different use cases of empty respectively missing Principal trees which all have the same effect

Closes #286
Closes #596 
Closes #719
Closes #720 