### PR TITLE
resource/aws_kinesis_firehose_delivery_stream: Prevent crash on malformed ID for import

### DIFF
--- a/aws/import_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/import_aws_kinesis_firehose_delivery_stream_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -32,6 +33,19 @@ func TestAccAWSKinesisFirehoseDeliveryStream_importBasic(t *testing.T) {
 				ResourceName:      resName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			// Ensure we properly error on malformed import IDs
+			{
+				ResourceName:  resName,
+				ImportState:   true,
+				ImportStateId: "just-a-name",
+				ExpectError:   regexp.MustCompile(`Expected ID in format`),
+			},
+			{
+				ResourceName:  resName,
+				ImportState:   true,
+				ImportStateId: "arn:aws:firehose:us-east-1:123456789012:missing-slash",
+				ExpectError:   regexp.MustCompile(`Expected ID in format`),
 			},
 		},
 	})

--- a/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -376,11 +376,16 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 
 		Importer: &schema.ResourceImporter{
 			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				idErr := fmt.Errorf("Expected ID in format of arn:PARTITION:firehose:REGION:ACCOUNTID:deliverystream/NAME and provided: %s", d.Id())
 				resARN, err := arn.Parse(d.Id())
 				if err != nil {
-					return nil, err
+					return nil, idErr
 				}
-				d.Set("name", strings.Split(resARN.Resource, "/")[1])
+				resourceParts := strings.Split(resARN.Resource, "/")
+				if len(resourceParts) != 2 {
+					return nil, idErr
+				}
+				d.Set("name", resourceParts[1])
 				return []*schema.ResourceData{d}, nil
 			},
 		},


### PR DESCRIPTION
Fixes #3833

Also provides a friendlier error on ARN parsing errors.

Before code change:

```
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_importBasic
panic: runtime error: index out of range
```

After code change:

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSKinesisFirehoseDeliveryStream_importBasic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSKinesisFirehoseDeliveryStream_importBasic -timeout 120m
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_importBasic
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_importBasic (118.16s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	118.202s
```