### PR TITLE
resource/aws_ses_domain_identity: Support trailing period in domain name

### DIFF
--- a/aws/resource_aws_ses_domain_identity.go
+++ b/aws/resource_aws_ses_domain_identity.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ses"
@@ -27,6 +28,9 @@ func resourceAwsSesDomainIdentity() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				StateFunc: func(v interface{}) string {
+					return strings.TrimSuffix(v.(string), ".")
+				},
 			},
 			"verification_token": {
 				Type:     schema.TypeString,
@@ -40,6 +44,7 @@ func resourceAwsSesDomainIdentityCreate(d *schema.ResourceData, meta interface{}
 	conn := meta.(*AWSClient).sesConn
 
 	domainName := d.Get("domain").(string)
+	domainName = strings.TrimSuffix(domainName, ".")
 
 	createOpts := &ses.VerifyDomainIdentityInput{
 		Domain: aws.String(domainName),


### PR DESCRIPTION
Closes #3836 

Previously:
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSSESDomainIdentity_trailingPeriod'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSSESDomainIdentity_trailingPeriod -timeout 120m
=== RUN   TestAccAWSSESDomainIdentity_trailingPeriod
--- FAIL: TestAccAWSSESDomainIdentity_trailingPeriod (5.42s)
	testing.go:518: Step 0 error: Error applying: 1 error(s) occurred:

		* aws_ses_domain_identity.test: 1 error(s) occurred:

		* aws_ses_domain_identity.test: Error requesting SES domain identity verification: InvalidParameterValue: Invalid domain name pkyjo4kn7f.terraformtesting.com..
			status code: 400, request id: a51106e2-2bed-11e8-8d72-954ea5c56c94
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	5.465s
make: *** [testacc] Error 1
```

Now:
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSSESDomainIdentity'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSSESDomainIdentity -timeout 120m
=== RUN   TestAccAWSSESDomainIdentity_basic
--- PASS: TestAccAWSSESDomainIdentity_basic (11.63s)
=== RUN   TestAccAWSSESDomainIdentity_trailingPeriod
--- PASS: TestAccAWSSESDomainIdentity_trailingPeriod (14.46s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	26.132s
```