### PR TITLE
docs/resource/aws_lb_listener: Add link to aws_lb_listener_certificate resource

### DIFF
--- a/website/docs/r/lb_listener.html.markdown
+++ b/website/docs/r/lb_listener.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
 * `port` - (Required) The port on which the load balancer is listening.
 * `protocol` - (Optional) The protocol for connections from clients to the load balancer. Valid values are `TCP`, `HTTP` and `HTTPS`. Defaults to `HTTP`.
 * `ssl_policy` - (Optional) The name of the SSL Policy for the listener. Required if `protocol` is `HTTPS`.
-* `certificate_arn` - (Optional) The ARN of the default SSL server certificate. Exactly one certificate is required if the protocol is HTTPS.
+* `certificate_arn` - (Optional) The ARN of the default SSL server certificate. Exactly one certificate is required if the protocol is HTTPS. For adding additional SSL certificates, see the [`aws_lb_listener_certificate` resource](/docs/providers/aws/r/lb_listener_certificate.html).
 * `default_action` - (Required) An Action block. Action blocks are documented below.
 
 Action Blocks (for `default_action`) support the following:


### PR DESCRIPTION
Closes #3843 