### PR TITLE
tests: Add sweeper for aws_elb

### DIFF
--- a/aws/resource_aws_elb_test.go
+++ b/aws/resource_aws_elb_test.go
@@ -2,10 +2,12 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"math/rand"
 	"reflect"
 	"regexp"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -16,6 +18,60 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_elb", &resource.Sweeper{
+		Name: "aws_elb",
+		F:    testSweepELBs,
+	})
+}
+
+func testSweepELBs(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).elbconn
+
+	prefixes := []string{
+		"test-elb-",
+	}
+
+	return conn.DescribeLoadBalancersPages(&elb.DescribeLoadBalancersInput{}, func(out *elb.DescribeLoadBalancersOutput, isLast bool) bool {
+		if len(out.LoadBalancerDescriptions) == 0 {
+			log.Println("[INFO] No ELBs found for sweeping")
+			return false
+		}
+
+		for _, lb := range out.LoadBalancerDescriptions {
+			skip := true
+			for _, prefix := range prefixes {
+				if strings.HasPrefix(*lb.LoadBalancerName, prefix) {
+					skip = false
+					break
+				}
+			}
+			if skip {
+				log.Printf("[INFO] Skipping ELB: %s", *lb.LoadBalancerName)
+				continue
+			}
+			log.Printf("[INFO] Deleting ELB: %s", *lb.LoadBalancerName)
+
+			_, err := conn.DeleteLoadBalancer(&elb.DeleteLoadBalancerInput{
+				LoadBalancerName: lb.LoadBalancerName,
+			})
+			if err != nil {
+				log.Printf("[ERROR] Failed to delete ELB %s: %s", *lb.LoadBalancerName, err)
+				continue
+			}
+			err = cleanupELBNetworkInterfaces(client.(*AWSClient).ec2conn, *lb.LoadBalancerName)
+			if err != nil {
+				log.Printf("[WARN] Failed to cleanup ENIs for ELB %q: %s", *lb.LoadBalancerName, err)
+			}
+		}
+		return !isLast
+	})
+}
 
 func TestAccAWSELB_basic(t *testing.T) {
 	var conf elb.LoadBalancerDescription

--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -17,6 +17,9 @@ func init() {
 	resource.AddTestSweepers("aws_subnet", &resource.Sweeper{
 		Name: "aws_subnet",
 		F:    testSweepSubnets,
+		Dependencies: []string{
+			"aws_elb",
+		},
 	})
 }
 


### PR DESCRIPTION
```
make sweep SWEEP=us-west-2 SWEEPARGS='-sweep-run=aws_elb'
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./... -v -sweep=us-west-2 -sweep-run=aws_elb
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
2018/03/20 13:40:01 [DEBUG] Running Sweepers for region (us-west-2):
2018/03/20 13:40:01 [INFO] Building AWS region structure
2018/03/20 13:40:01 [INFO] Building AWS auth structure
2018/03/20 13:40:01 [INFO] Setting AWS metadata API timeout to 100ms
2018/03/20 13:40:02 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2018/03/20 13:40:02 [INFO] AWS Auth provider used: "EnvProvider"
2018/03/20 13:40:02 [INFO] Initializing DeviceFarm SDK connection
2018/03/20 13:40:03 [DEBUG] Trying to get account ID via iam:GetUser
2018/03/20 13:37:14 [INFO] Deleting ELB: test-elb-yf7diaw0k9
2018/03/20 13:37:15 Sweeper Tests ran:
	- aws_elb
ok  	github.com/terraform-providers/terraform-provider-aws/aws	5.194s
```
The pattern will most likely need some tuning, but this PR is just a first iteration in covering all ELBs.
