### PR TITLE
resource/aws_s3_bucket_object: mark version_id as recomputed if a new object will be uploaded

### DIFF
--- a/aws/resource_aws_lambda_function_test.go
+++ b/aws/resource_aws_lambda_function_test.go
@@ -751,16 +751,10 @@ func TestAccAWSLambdaFunction_s3Update_basic(t *testing.T) {
 				),
 			},
 			{
-				ExpectNonEmptyPlan: true,
 				PreConfig: func() {
 					// Upload 2nd version
 					testAccCreateZipFromFiles(map[string]string{"test-fixtures/lambda_func_modified.js": "lambda.js"}, zipFile)
 				},
-				Config: genAWSLambdaFunctionConfig_s3(bucketName, key, path, roleName, funcName),
-			},
-			// Extra step because of missing ComputedWhen
-			// See https://github.com/hashicorp/terraform/pull/4846 & https://github.com/hashicorp/terraform/pull/5330
-			{
 				Config: genAWSLambdaFunctionConfig_s3(bucketName, key, path, roleName, funcName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_s3", funcName, &conf),

--- a/aws/resource_aws_s3_bucket_object.go
+++ b/aws/resource_aws_s3_bucket_object.go
@@ -27,6 +27,8 @@ func resourceAwsS3BucketObject() *schema.Resource {
 		Update: resourceAwsS3BucketObjectPut,
 		Delete: resourceAwsS3BucketObjectDelete,
 
+		CustomizeDiff: updateComputedAttributes,
+
 		Schema: map[string]*schema.Schema{
 			"bucket": {
 				Type:     schema.TypeString,
@@ -149,6 +151,13 @@ func resourceAwsS3BucketObject() *schema.Resource {
 			},
 		},
 	}
+}
+
+func updateComputedAttributes(d *schema.ResourceDiff, meta interface{}) error {
+	if d.HasChange("etag") {
+		d.SetNewComputed("version_id")
+	}
+	return nil
 }
 
 func resourceAwsS3BucketObjectPut(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
The version_id attribute of s3 objects should be marked as recomputed when new content will be uploaded so that dependent resources can pick up the change. One example of this is a lambda function that uses versioned resources as the source of the code

Fixes #1696 
Fixes #4522