### PR TITLE
resource/aws_batch_*: Add test sweepers

### DIFF
--- a/aws/resource_aws_batch_compute_environment.go
+++ b/aws/resource_aws_batch_compute_environment.go
@@ -228,7 +228,7 @@ func resourceAwsBatchComputeEnvironmentCreate(d *schema.ResourceData, meta inter
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{batch.CEStatusCreating},
 		Target:     []string{batch.CEStatusValid},
-		Refresh:    resourceAwsBatchComputeEnvironmentStatusRefreshFunc(d, meta),
+		Refresh:    resourceAwsBatchComputeEnvironmentStatusRefreshFunc(computeEnvironmentName, conn),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
 		MinTimeout: 5 * time.Second,
 	}
@@ -320,7 +320,7 @@ func resourceAwsBatchComputeEnvironmentDelete(d *schema.ResourceData, meta inter
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{batch.CEStatusUpdating},
 		Target:     []string{batch.CEStatusValid},
-		Refresh:    resourceAwsBatchComputeEnvironmentStatusRefreshFunc(d, meta),
+		Refresh:    resourceAwsBatchComputeEnvironmentStatusRefreshFunc(computeEnvironmentName, conn),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
 		MinTimeout: 5 * time.Second,
 	}
@@ -339,7 +339,7 @@ func resourceAwsBatchComputeEnvironmentDelete(d *schema.ResourceData, meta inter
 	stateConfForDelete := &resource.StateChangeConf{
 		Pending:    []string{batch.CEStatusDeleting},
 		Target:     []string{batch.CEStatusDeleted},
-		Refresh:    resourceAwsBatchComputeEnvironmentDeleteRefreshFunc(d, meta),
+		Refresh:    resourceAwsBatchComputeEnvironmentDeleteRefreshFunc(computeEnvironmentName, conn),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
 		MinTimeout: 5 * time.Second,
 	}
@@ -390,12 +390,8 @@ func resourceAwsBatchComputeEnvironmentUpdate(d *schema.ResourceData, meta inter
 	return resourceAwsBatchComputeEnvironmentRead(d, meta)
 }
 
-func resourceAwsBatchComputeEnvironmentStatusRefreshFunc(d *schema.ResourceData, meta interface{}) resource.StateRefreshFunc {
+func resourceAwsBatchComputeEnvironmentStatusRefreshFunc(computeEnvironmentName string, conn *batch.Batch) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		conn := meta.(*AWSClient).batchconn
-
-		computeEnvironmentName := d.Get("compute_environment_name").(string)
-
 		result, err := conn.DescribeComputeEnvironments(&batch.DescribeComputeEnvironmentsInput{
 			ComputeEnvironments: []*string{
 				aws.String(computeEnvironmentName),
@@ -414,12 +410,8 @@ func resourceAwsBatchComputeEnvironmentStatusRefreshFunc(d *schema.ResourceData,
 	}
 }
 
-func resourceAwsBatchComputeEnvironmentDeleteRefreshFunc(d *schema.ResourceData, meta interface{}) resource.StateRefreshFunc {
+func resourceAwsBatchComputeEnvironmentDeleteRefreshFunc(computeEnvironmentName string, conn *batch.Batch) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		conn := meta.(*AWSClient).batchconn
-
-		computeEnvironmentName := d.Get("compute_environment_name").(string)
-
 		result, err := conn.DescribeComputeEnvironments(&batch.DescribeComputeEnvironmentsInput{
 			ComputeEnvironments: []*string{
 				aws.String(computeEnvironmentName),

--- a/aws/resource_aws_batch_compute_environment_test.go
+++ b/aws/resource_aws_batch_compute_environment_test.go
@@ -2,8 +2,11 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"regexp"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/batch"
@@ -11,6 +14,93 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_batch_compute_environment", &resource.Sweeper{
+		Name: "aws_batch_compute_environment",
+		Dependencies: []string{
+			"aws_batch_job_queue",
+		},
+		F: testSweepBatchComputeEnvironments,
+	})
+}
+
+func testSweepBatchComputeEnvironments(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).batchconn
+
+	prefixes := []string{
+		"tf_acc",
+	}
+
+	out, err := conn.DescribeComputeEnvironments(&batch.DescribeComputeEnvironmentsInput{})
+	if err != nil {
+		return fmt.Errorf("Error retrieving Batch Compute Environments: %s", err)
+	}
+	for _, computeEnvironment := range out.ComputeEnvironments {
+		name := computeEnvironment.ComputeEnvironmentName
+		skip := true
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(*name, prefix) {
+				skip = false
+				break
+			}
+		}
+		if skip {
+			log.Printf("[INFO] Skipping Batch Compute Environment: %s", *name)
+			continue
+		}
+
+		log.Printf("[INFO] Disabling Batch Compute Environment: %s", *name)
+
+		updateInput := &batch.UpdateComputeEnvironmentInput{
+			ComputeEnvironment: name,
+			State:              aws.String(batch.CEStateDisabled),
+		}
+		if _, err := conn.UpdateComputeEnvironment(updateInput); err != nil {
+			log.Printf("[ERROR] Failed to disable Batch Compute Environment %s: %s", *name, err)
+			continue
+		}
+
+		stateConfForDisable := &resource.StateChangeConf{
+			Pending:    []string{batch.CEStatusUpdating},
+			Target:     []string{batch.CEStatusValid},
+			Refresh:    resourceAwsBatchComputeEnvironmentStatusRefreshFunc(*name, conn),
+			Timeout:    20 * time.Minute,
+			MinTimeout: 5 * time.Second,
+		}
+		if _, err := stateConfForDisable.WaitForState(); err != nil {
+			log.Printf("[ERROR] Failed to wait for disable of Batch Compute Environment %s: %s", *name, err)
+			continue
+		}
+
+		log.Printf("[INFO] Deleting Batch Compute Environment: %s", *name)
+
+		deleteInput := &batch.DeleteComputeEnvironmentInput{
+			ComputeEnvironment: name,
+		}
+		if _, err := conn.DeleteComputeEnvironment(deleteInput); err != nil {
+			log.Printf("[ERROR] Failed to delete Batch Compute Environment %s: %s", *name, err)
+			continue
+		}
+
+		stateConfForDelete := &resource.StateChangeConf{
+			Pending:    []string{batch.CEStatusDeleting},
+			Target:     []string{batch.CEStatusDeleted},
+			Refresh:    resourceAwsBatchComputeEnvironmentDeleteRefreshFunc(*name, conn),
+			Timeout:    20 * time.Minute,
+			MinTimeout: 5 * time.Second,
+		}
+		if _, err := stateConfForDelete.WaitForState(); err != nil {
+			log.Printf("[ERROR] Failed to wait for deletion of Batch Compute Environment %s: %s", *name, err)
+		}
+	}
+
+	return nil
+}
 
 func TestAccAWSBatchComputeEnvironment_createEc2(t *testing.T) {
 	rInt := acctest.RandInt()


### PR DESCRIPTION
♻️  To help prevent:
```
=== RUN   TestAccAWSBatchComputeEnvironment_updateInstanceType
--- FAIL: TestAccAWSBatchComputeEnvironment_updateInstanceType (7.69s)
    testing.go:518: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_batch_compute_environment.ec2: 1 error(s) occurred:
        
        * aws_batch_compute_environment.ec2: : Error executing request, Exception : Limits Error : Only 18 Compute Environments allowed, RequestId: 7206eae0-2cec-11e8-9d0d-891d1a5a6818
            status code: 400, request id: 7206eae0-2cec-11e8-9d0d-891d1a5a6818
```

```
$ aws batch describe-compute-environments | jq '.computeEnvironments | length'
13

$ make sweep SWEEPARGS='-sweep-run=aws_batch_compute_environment'
...
2018/03/21 13:57:30 Sweeper Tests ran:
	- aws_batch_job_queue
	- aws_batch_compute_environment
ok  	github.com/terraform-providers/terraform-provider-aws/aws	40.023s

$ aws batch describe-compute-environments | jq '.computeEnvironments | length'
0
```
