### PR TITLE
New Resource: aws_wafregional_rate_based_rule

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -559,6 +559,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_wafregional_byte_match_set":               resourceAwsWafRegionalByteMatchSet(),
 			"aws_wafregional_geo_match_set":                resourceAwsWafRegionalGeoMatchSet(),
 			"aws_wafregional_ipset":                        resourceAwsWafRegionalIPSet(),
+			"aws_wafregional_rate_based_rule":              resourceAwsWafRegionalRateBasedRule(),
 			"aws_wafregional_regex_pattern_set":            resourceAwsWafRegionalRegexPatternSet(),
 			"aws_wafregional_rule":                         resourceAwsWafRegionalRule(),
 			"aws_wafregional_size_constraint_set":          resourceAwsWafRegionalSizeConstraintSet(),

--- a/aws/resource_aws_waf_rule.go
+++ b/aws/resource_aws_waf_rule.go
@@ -173,39 +173,3 @@ func updateWafRuleResource(id string, oldP, newP []interface{}, conn *waf.WAF) e
 
 	return nil
 }
-
-func diffWafRulePredicates(oldP, newP []interface{}) []*waf.RuleUpdate {
-	updates := make([]*waf.RuleUpdate, 0)
-
-	for _, op := range oldP {
-		predicate := op.(map[string]interface{})
-
-		if idx, contains := sliceContainsMap(newP, predicate); contains {
-			newP = append(newP[:idx], newP[idx+1:]...)
-			continue
-		}
-
-		updates = append(updates, &waf.RuleUpdate{
-			Action: aws.String(waf.ChangeActionDelete),
-			Predicate: &waf.Predicate{
-				Negated: aws.Bool(predicate["negated"].(bool)),
-				Type:    aws.String(predicate["type"].(string)),
-				DataId:  aws.String(predicate["data_id"].(string)),
-			},
-		})
-	}
-
-	for _, np := range newP {
-		predicate := np.(map[string]interface{})
-
-		updates = append(updates, &waf.RuleUpdate{
-			Action: aws.String(waf.ChangeActionInsert),
-			Predicate: &waf.Predicate{
-				Negated: aws.Bool(predicate["negated"].(bool)),
-				Type:    aws.String(predicate["type"].(string)),
-				DataId:  aws.String(predicate["data_id"].(string)),
-			},
-		})
-	}
-	return updates
-}

--- a/aws/resource_aws_wafregional_rate_based_rule.go
+++ b/aws/resource_aws_wafregional_rate_based_rule.go
@@ -1,0 +1,195 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/waf"
+	"github.com/aws/aws-sdk-go/service/wafregional"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func resourceAwsWafRegionalRateBasedRule() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsWafRegionalRateBasedRuleCreate,
+		Read:   resourceAwsWafRegionalRateBasedRuleRead,
+		Update: resourceAwsWafRegionalRateBasedRuleUpdate,
+		Delete: resourceAwsWafRegionalRateBasedRuleDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"metric_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateWafMetricName,
+			},
+			"predicate": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"negated": {
+							Type:     schema.TypeBool,
+							Required: true,
+						},
+						"data_id": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateMaxLength(128),
+						},
+						"type": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateWafPredicatesType(),
+						},
+					},
+				},
+			},
+			"rate_key": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"rate_limit": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ValidateFunc: validation.IntAtLeast(2000),
+			},
+		},
+	}
+}
+
+func resourceAwsWafRegionalRateBasedRuleCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafregionalconn
+	region := meta.(*AWSClient).region
+
+	wr := newWafRegionalRetryer(conn, region)
+	out, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
+		params := &waf.CreateRateBasedRuleInput{
+			ChangeToken: token,
+			MetricName:  aws.String(d.Get("metric_name").(string)),
+			Name:        aws.String(d.Get("name").(string)),
+			RateKey:     aws.String(d.Get("rate_key").(string)),
+			RateLimit:   aws.Int64(int64(d.Get("rate_limit").(int))),
+		}
+
+		return conn.CreateRateBasedRule(params)
+	})
+	if err != nil {
+		return err
+	}
+	resp := out.(*waf.CreateRateBasedRuleOutput)
+	d.SetId(*resp.Rule.RuleId)
+	return resourceAwsWafRegionalRateBasedRuleUpdate(d, meta)
+}
+
+func resourceAwsWafRegionalRateBasedRuleRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafregionalconn
+
+	params := &waf.GetRateBasedRuleInput{
+		RuleId: aws.String(d.Id()),
+	}
+
+	resp, err := conn.GetRateBasedRule(params)
+	if err != nil {
+		if isAWSErr(err, wafregional.ErrCodeWAFNonexistentItemException, "") {
+			log.Printf("[WARN] WAF Regional Rate Based Rule (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+
+		return err
+	}
+
+	var predicates []map[string]interface{}
+
+	for _, predicateSet := range resp.Rule.MatchPredicates {
+		predicates = append(predicates, map[string]interface{}{
+			"negated": *predicateSet.Negated,
+			"type":    *predicateSet.Type,
+			"data_id": *predicateSet.DataId,
+		})
+	}
+
+	d.Set("predicate", predicates)
+	d.Set("name", resp.Rule.Name)
+	d.Set("metric_name", resp.Rule.MetricName)
+	d.Set("rate_key", resp.Rule.RateKey)
+	d.Set("rate_limit", resp.Rule.RateLimit)
+
+	return nil
+}
+
+func resourceAwsWafRegionalRateBasedRuleUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafregionalconn
+	region := meta.(*AWSClient).region
+
+	if d.HasChange("predicate") {
+		o, n := d.GetChange("predicate")
+		oldP, newP := o.(*schema.Set).List(), n.(*schema.Set).List()
+		rateLimit := d.Get("rate_limit")
+
+		err := updateWafRateBasedRuleResourceWR(d.Id(), oldP, newP, rateLimit, conn, region)
+		if err != nil {
+			return fmt.Errorf("Error Updating WAF Rule: %s", err)
+		}
+	}
+
+	return resourceAwsWafRegionalRateBasedRuleRead(d, meta)
+}
+
+func resourceAwsWafRegionalRateBasedRuleDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafregionalconn
+	region := meta.(*AWSClient).region
+
+	oldPredicates := d.Get("predicate").(*schema.Set).List()
+	if len(oldPredicates) > 0 {
+		noPredicates := []interface{}{}
+		rateLimit := d.Get("rate_limit")
+
+		err := updateWafRateBasedRuleResourceWR(d.Id(), oldPredicates, noPredicates, rateLimit, conn, region)
+		if err != nil {
+			return fmt.Errorf("Error updating WAF Regional Rate Based Rule Predicates: %s", err)
+		}
+	}
+
+	wr := newWafRegionalRetryer(conn, region)
+	_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
+		req := &waf.DeleteRateBasedRuleInput{
+			ChangeToken: token,
+			RuleId:      aws.String(d.Id()),
+		}
+		log.Printf("[INFO] Deleting WAF Regional Rate Based Rule")
+		return conn.DeleteRateBasedRule(req)
+	})
+	if err != nil {
+		return fmt.Errorf("Error deleting WAF Regional Rate Based Rule: %s", err)
+	}
+
+	return nil
+}
+
+func updateWafRateBasedRuleResourceWR(id string, oldP, newP []interface{}, rateLimit interface{}, conn *wafregional.WAFRegional, region string) error {
+	wr := newWafRegionalRetryer(conn, region)
+	_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
+		req := &waf.UpdateRateBasedRuleInput{
+			ChangeToken: token,
+			RuleId:      aws.String(id),
+			Updates:     diffWafRulePredicates(oldP, newP),
+			RateLimit:   aws.Int64(int64(rateLimit.(int))),
+		}
+
+		return conn.UpdateRateBasedRule(req)
+	})
+	if err != nil {
+		return fmt.Errorf("Error Updating WAF Regional Rate Based Rule: %s", err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_wafregional_rate_based_rule_test.go
+++ b/aws/resource_aws_wafregional_rate_based_rule_test.go
@@ -1,0 +1,404 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/waf"
+	"github.com/aws/aws-sdk-go/service/wafregional"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSWafRegionalRateBasedRule_basic(t *testing.T) {
+	var v waf.RateBasedRule
+	wafRuleName := fmt.Sprintf("wafrule%s", acctest.RandString(5))
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafRegionalRateBasedRuleDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSWafRegionalRateBasedRuleConfig(wafRuleName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSWafRegionalRateBasedRuleExists("aws_wafregional_rate_based_rule.wafrule", &v),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_rate_based_rule.wafrule", "name", wafRuleName),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_rate_based_rule.wafrule", "predicate.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_rate_based_rule.wafrule", "metric_name", wafRuleName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSWafRegionalRateBasedRule_changeNameForceNew(t *testing.T) {
+	var before, after waf.RateBasedRule
+	wafRuleName := fmt.Sprintf("wafrule%s", acctest.RandString(5))
+	wafRuleNewName := fmt.Sprintf("wafrulenew%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafRegionalRateBasedRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSWafRegionalRateBasedRuleConfig(wafRuleName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSWafRegionalRateBasedRuleExists("aws_wafregional_rate_based_rule.wafrule", &before),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_rate_based_rule.wafrule", "name", wafRuleName),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_rate_based_rule.wafrule", "predicate.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_rate_based_rule.wafrule", "metric_name", wafRuleName),
+				),
+			},
+			{
+				Config: testAccAWSWafRegionalRateBasedRuleConfigChangeName(wafRuleNewName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSWafRegionalRateBasedRuleExists("aws_wafregional_rate_based_rule.wafrule", &after),
+					testAccCheckAWSWafRateBasedRuleIdDiffers(&before, &after),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_rate_based_rule.wafrule", "name", wafRuleNewName),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_rate_based_rule.wafrule", "predicate.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_rate_based_rule.wafrule", "metric_name", wafRuleNewName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSWafRegionalRateBasedRule_disappears(t *testing.T) {
+	var v waf.RateBasedRule
+	wafRuleName := fmt.Sprintf("wafrule%s", acctest.RandString(5))
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafRegionalRateBasedRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSWafRegionalRateBasedRuleConfig(wafRuleName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSWafRegionalRateBasedRuleExists("aws_wafregional_rate_based_rule.wafrule", &v),
+					testAccCheckAWSWafRegionalRateBasedRuleDisappears(&v),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSWafRegionalRateBasedRule_changePredicates(t *testing.T) {
+	var ipset waf.IPSet
+	var byteMatchSet waf.ByteMatchSet
+
+	var before, after waf.RateBasedRule
+	var idx int
+	ruleName := fmt.Sprintf("wafrule%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafRegionalRateBasedRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSWafRegionalRateBasedRuleConfig(ruleName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSWafRegionalIPSetExists("aws_wafregional_ipset.ipset", &ipset),
+					testAccCheckAWSWafRegionalRateBasedRuleExists("aws_wafregional_rate_based_rule.wafrule", &before),
+					resource.TestCheckResourceAttr("aws_wafregional_rate_based_rule.wafrule", "name", ruleName),
+					resource.TestCheckResourceAttr("aws_wafregional_rate_based_rule.wafrule", "predicate.#", "1"),
+					computeWafRegionalRateBasedRulePredicateWithIpSet(&ipset, false, "IPMatch", &idx),
+					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rate_based_rule.wafrule", "predicate.%d.negated", &idx, "false"),
+					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rate_based_rule.wafrule", "predicate.%d.type", &idx, "IPMatch"),
+				),
+			},
+			{
+				Config: testAccAWSWafRegionalRateBasedRuleConfig_changePredicates(ruleName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSWafRegionalByteMatchSetExists("aws_wafregional_byte_match_set.set", &byteMatchSet),
+					testAccCheckAWSWafRegionalRateBasedRuleExists("aws_wafregional_rate_based_rule.wafrule", &after),
+					resource.TestCheckResourceAttr("aws_wafregional_rate_based_rule.wafrule", "name", ruleName),
+					resource.TestCheckResourceAttr("aws_wafregional_rate_based_rule.wafrule", "predicate.#", "1"),
+					computeWafRegionalRateBasedRulePredicateWithByteMatchSet(&byteMatchSet, true, "ByteMatch", &idx),
+					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rate_based_rule.wafrule", "predicate.%d.negated", &idx, "true"),
+					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rate_based_rule.wafrule", "predicate.%d.type", &idx, "ByteMatch"),
+				),
+			},
+		},
+	})
+}
+
+// computeWafRegionalRateBasedRulePredicateWithIpSet calculates index
+// which isn't static because dataId is generated as part of the test
+func computeWafRegionalRateBasedRulePredicateWithIpSet(ipSet *waf.IPSet, negated bool, pType string, idx *int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		predicateResource := resourceAwsWafRegionalRateBasedRule().Schema["predicate"].Elem.(*schema.Resource)
+
+		m := map[string]interface{}{
+			"data_id": *ipSet.IPSetId,
+			"negated": negated,
+			"type":    pType,
+		}
+
+		f := schema.HashResource(predicateResource)
+		*idx = f(m)
+
+		return nil
+	}
+}
+
+// computeWafRegionalRateBasedRulePredicateWithByteMatchSet calculates index
+// which isn't static because dataId is generated as part of the test
+func computeWafRegionalRateBasedRulePredicateWithByteMatchSet(set *waf.ByteMatchSet, negated bool, pType string, idx *int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		predicateResource := resourceAwsWafRegionalRateBasedRule().Schema["predicate"].Elem.(*schema.Resource)
+
+		m := map[string]interface{}{
+			"data_id": *set.ByteMatchSetId,
+			"negated": negated,
+			"type":    pType,
+		}
+
+		f := schema.HashResource(predicateResource)
+		*idx = f(m)
+
+		return nil
+	}
+}
+
+func TestAccAWSWafRegionalRateBasedRule_noPredicates(t *testing.T) {
+	var rule waf.RateBasedRule
+	ruleName := fmt.Sprintf("wafrule%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafRegionalRateBasedRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSWafRegionalRateBasedRuleConfig_noPredicates(ruleName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSWafRegionalRateBasedRuleExists("aws_wafregional_rate_based_rule.wafrule", &rule),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_rate_based_rule.wafrule", "name", ruleName),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_rate_based_rule.wafrule", "predicate.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSWafRateBasedRuleIdDiffers(before, after *waf.RateBasedRule) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if *before.RuleId == *after.RuleId {
+			return fmt.Errorf("Expected different IDs, given %q for both rules", *before.RuleId)
+		}
+		return nil
+	}
+}
+
+func testAccCheckAWSWafRegionalRateBasedRuleDisappears(v *waf.RateBasedRule) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).wafregionalconn
+		region := testAccProvider.Meta().(*AWSClient).region
+
+		wr := newWafRegionalRetryer(conn, region)
+		_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
+			req := &waf.UpdateRateBasedRuleInput{
+				ChangeToken: token,
+				RuleId:      v.RuleId,
+				RateLimit:   v.RateLimit,
+			}
+
+			for _, Predicate := range v.MatchPredicates {
+				Predicate := &waf.RuleUpdate{
+					Action: aws.String("DELETE"),
+					Predicate: &waf.Predicate{
+						Negated: Predicate.Negated,
+						Type:    Predicate.Type,
+						DataId:  Predicate.DataId,
+					},
+				}
+				req.Updates = append(req.Updates, Predicate)
+			}
+
+			return conn.UpdateRateBasedRule(req)
+		})
+		if err != nil {
+			return fmt.Errorf("Error Updating WAF Rule: %s", err)
+		}
+
+		_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {
+			opts := &waf.DeleteRateBasedRuleInput{
+				ChangeToken: token,
+				RuleId:      v.RuleId,
+			}
+			return conn.DeleteRateBasedRule(opts)
+		})
+		if err != nil {
+			return fmt.Errorf("Error Deleting WAF Rule: %s", err)
+		}
+		return nil
+	}
+}
+
+func testAccCheckAWSWafRegionalRateBasedRuleDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_wafregional_rate_based_rule" {
+			continue
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).wafregionalconn
+		resp, err := conn.GetRateBasedRule(
+			&waf.GetRateBasedRuleInput{
+				RuleId: aws.String(rs.Primary.ID),
+			})
+
+		if err == nil {
+			if *resp.Rule.RuleId == rs.Primary.ID {
+				return fmt.Errorf("WAF Rule %s still exists", rs.Primary.ID)
+			}
+		}
+
+		// Return nil if the Rule is already destroyed
+		if isAWSErr(err, wafregional.ErrCodeWAFNonexistentItemException, "") {
+			return nil
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func testAccCheckAWSWafRegionalRateBasedRuleExists(n string, v *waf.RateBasedRule) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No WAF Rule ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).wafregionalconn
+		resp, err := conn.GetRateBasedRule(&waf.GetRateBasedRuleInput{
+			RuleId: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if *resp.Rule.RuleId == rs.Primary.ID {
+			*v = *resp.Rule
+			return nil
+		}
+
+		return fmt.Errorf("WAF Regional Rule (%s) not found", rs.Primary.ID)
+	}
+}
+
+func testAccAWSWafRegionalRateBasedRuleConfig(name string) string {
+	return fmt.Sprintf(`
+resource "aws_wafregional_ipset" "ipset" {
+  name = "%s"
+  ip_set_descriptor {
+    type = "IPV4"
+    value = "192.0.7.0/24"
+  }
+}
+
+resource "aws_wafregional_rate_based_rule" "wafrule" {
+  name = "%s"
+  metric_name = "%s"
+  rate_key = "IP"
+  rate_limit = 2000
+  predicate {
+    data_id = "${aws_wafregional_ipset.ipset.id}"
+    negated = false
+    type = "IPMatch"
+  }
+}`, name, name, name)
+}
+
+func testAccAWSWafRegionalRateBasedRuleConfigChangeName(name string) string {
+	return fmt.Sprintf(`
+resource "aws_wafregional_ipset" "ipset" {
+  name = "%s"
+  ip_set_descriptor {
+    type = "IPV4"
+    value = "192.0.7.0/24"
+  }
+}
+
+resource "aws_wafregional_rate_based_rule" "wafrule" {
+  name = "%s"
+  metric_name = "%s"
+  rate_key = "IP"
+  rate_limit = 2000
+  predicate {
+    data_id = "${aws_wafregional_ipset.ipset.id}"
+    negated = false
+    type = "IPMatch"
+  }
+}`, name, name, name)
+}
+
+func testAccAWSWafRegionalRateBasedRuleConfig_changePredicates(name string) string {
+	return fmt.Sprintf(`
+resource "aws_wafregional_ipset" "ipset" {
+  name = "%s"
+  ip_set_descriptor {
+    type = "IPV4"
+    value = "192.0.7.0/24"
+  }
+}
+
+resource "aws_wafregional_byte_match_set" "set" {
+  name = "%s"
+  byte_match_tuple {
+    text_transformation   = "NONE"
+    target_string         = "badrefer1"
+    positional_constraint = "CONTAINS"
+
+    field_to_match {
+      type = "HEADER"
+      data = "referer"
+    }
+  }
+}
+
+resource "aws_wafregional_rate_based_rule" "wafrule" {
+  name = "%s"
+  metric_name = "%s"
+  rate_key = "IP"
+  rate_limit = 2000
+  predicate {
+    data_id = "${aws_wafregional_byte_match_set.set.id}"
+    negated = true
+    type = "ByteMatch"
+  }
+}`, name, name, name, name)
+}
+
+func testAccAWSWafRegionalRateBasedRuleConfig_noPredicates(name string) string {
+	return fmt.Sprintf(`
+resource "aws_wafregional_rate_based_rule" "wafrule" {
+  name = "%s"
+  metric_name = "%s"
+  rate_key = "IP"
+  rate_limit = 2000
+}`, name, name)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1527,6 +1527,10 @@
                     <a href="/docs/providers/aws/r/wafregional_ipset.html">aws_wafregional_ipset</a>
                   </li>
 
+                  <li<%= sidebar_current("docs-aws-resource-wafregional-rate-based-rule") %>>
+                    <a href="/docs/providers/aws/r/wafregional_rate_based_rule.html">aws_wafregional_rate_based_rule</a>
+                  </li>
+
                   <li<%= sidebar_current("docs-aws-resource-wafregional-regex-pattern-set") %>>
                     <a href="/docs/providers/aws/r/wafregional_regex_pattern_set.html">aws_wafregional_regex_pattern_set</a>
                   </li>

--- a/website/docs/r/wafregional_rate_based_rule.html.markdown
+++ b/website/docs/r/wafregional_rate_based_rule.html.markdown
@@ -1,0 +1,68 @@
+---
+layout: "aws"
+page_title: "AWS: wafregional_rate_based_rule"
+sidebar_current: "docs-aws-resource-wafregional-rate-based-rule"
+description: |-
+  Provides a AWS WAF Regional rate based rule resource.
+---
+
+# aws_wafregional_rate_based_rule
+
+Provides a WAF Rate Based Rule Resource
+
+## Example Usage
+
+```hcl
+resource "aws_wafregional_ipset" "ipset" {
+  name = "tfIPSet"
+
+  ip_set_descriptors {
+    type  = "IPV4"
+    value = "192.0.7.0/24"
+  }
+}
+
+resource "aws_wafregional_rate_based_rule" "wafrule" {
+  depends_on  = ["aws_wafregional_ipset.ipset"]
+  name        = "tfWAFRule"
+  metric_name = "tfWAFRule"
+
+  rate_key = "IP"
+  rate_limit = 2000
+
+  predicate {
+    data_id = "${aws_wafregional_ipset.ipset.id}"
+    negated = false
+    type    = "IPMatch"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `metric_name` - (Required) The name or description for the Amazon CloudWatch metric of this rule.
+* `name` - (Required) The name or description of the rule.
+* `rate_key` - (Required) Valid value is IP.
+* `rate_limit` - (Required) The maximum number of requests, which have an identical value in the field specified by the RateKey, allowed in a five-minute period. Minimum value is 2000.
+* `predicate` - (Optional) One of ByteMatchSet, IPSet, SizeConstraintSet, SqlInjectionMatchSet, or XssMatchSet objects to include in a rule.
+
+## Nested Blocks
+
+### `predicate`
+
+#### Arguments
+
+* `negated` - (Required) Set this to `false` if you want to allow, block, or count requests
+  based on the settings in the specified `ByteMatchSet`, `IPSet`, `SqlInjectionMatchSet`, `XssMatchSet`, or `SizeConstraintSet`.
+  For example, if an IPSet includes the IP address `192.0.2.44`, AWS WAF will allow or block requests based on that IP address.
+  If set to `true`, AWS WAF will allow, block, or count requests based on all IP addresses _except_ `192.0.2.44`.
+* `data_id` - (Required) A unique identifier for a predicate in the rule, such as Byte Match Set ID or IPSet ID.
+* `type` - (Required) The type of predicate in a rule, such as `ByteMatchSet` or `IPSet`
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the WAF Regional rate based rule.


### PR DESCRIPTION
## Test results

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSWafRegionalRateBasedRule_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSWafRegionalRateBasedRule_ -timeout 120m
=== RUN   TestAccAWSWafRegionalRateBasedRule_basic
--- PASS: TestAccAWSWafRegionalRateBasedRule_basic (48.24s)
=== RUN   TestAccAWSWafRegionalRateBasedRule_changeNameForceNew
--- PASS: TestAccAWSWafRegionalRateBasedRule_changeNameForceNew (91.79s)
=== RUN   TestAccAWSWafRegionalRateBasedRule_disappears
--- PASS: TestAccAWSWafRegionalRateBasedRule_disappears (47.80s)
=== RUN   TestAccAWSWafRegionalRateBasedRule_changePredicates
--- PASS: TestAccAWSWafRegionalRateBasedRule_changePredicates (77.09s)
=== RUN   TestAccAWSWafRegionalRateBasedRule_noPredicates
--- PASS: TestAccAWSWafRegionalRateBasedRule_noPredicates (28.84s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	293.792s
```