### PR TITLE
changed docs of aws_appautoscaling_target

### DIFF
--- a/website/docs/r/appautoscaling_target.html.markdown
+++ b/website/docs/r/appautoscaling_target.html.markdown
@@ -18,7 +18,7 @@ Provides an Application AutoScaling ScalableTarget resource.
 resource "aws_appautoscaling_target" "dynamodb_table_read_target" {
   max_capacity       = 100
   min_capacity       = 5
-  resource_id        = "table/tableName"
+  resource_id        = "table/${aws_dynamodb_table.table_name.name}"
   role_arn           = "${data.aws_iam_role.DynamoDBAutoscaleRole.arn}"
   scalable_dimension = "dynamodb:table:ReadCapacityUnits"
   service_namespace  = "dynamodb"
@@ -31,7 +31,7 @@ resource "aws_appautoscaling_target" "dynamodb_table_read_target" {
 resource "aws_appautoscaling_target" "dynamodb_index_read_target" {
   max_capacity       = 100
   min_capacity       = 5
-  resource_id        = "table/tableName/index/indexName"
+  resource_id        = "table/${aws_dynamodb_table.table.name}/index/${var.index_name}"
   role_arn           = "${data.aws_iam_role.DynamoDBAutoscaleRole.arn}"
   scalable_dimension = "dynamodb:index:ReadCapacityUnits"
   service_namespace  = "dynamodb"
@@ -44,7 +44,7 @@ resource "aws_appautoscaling_target" "dynamodb_index_read_target" {
 resource "aws_appautoscaling_target" "ecs_target" {
   max_capacity       = 4
   min_capacity       = 1
-  resource_id        = "service/clusterName/serviceName"
+  resource_id        = "service/${var.cluster_name}/${var.service_name}"
   role_arn           = "${var.ecs_iam_role}"
   scalable_dimension = "ecs:service:DesiredCount"
   service_namespace  = "ecs"

--- a/website/docs/r/appautoscaling_target.html.markdown
+++ b/website/docs/r/appautoscaling_target.html.markdown
@@ -18,7 +18,7 @@ Provides an Application AutoScaling ScalableTarget resource.
 resource "aws_appautoscaling_target" "dynamodb_table_read_target" {
   max_capacity       = 100
   min_capacity       = 5
-  resource_id        = "table/${aws_dynamodb_table.table_name.name}"
+  resource_id        = "table/${aws_dynamodb_table.example.name}"
   role_arn           = "${data.aws_iam_role.DynamoDBAutoscaleRole.arn}"
   scalable_dimension = "dynamodb:table:ReadCapacityUnits"
   service_namespace  = "dynamodb"
@@ -31,7 +31,7 @@ resource "aws_appautoscaling_target" "dynamodb_table_read_target" {
 resource "aws_appautoscaling_target" "dynamodb_index_read_target" {
   max_capacity       = 100
   min_capacity       = 5
-  resource_id        = "table/${aws_dynamodb_table.table.name}/index/${var.index_name}"
+  resource_id        = "table/${aws_dynamodb_table.example.name}/index/${var.index_name}"
   role_arn           = "${data.aws_iam_role.DynamoDBAutoscaleRole.arn}"
   scalable_dimension = "dynamodb:index:ReadCapacityUnits"
   service_namespace  = "dynamodb"
@@ -44,7 +44,7 @@ resource "aws_appautoscaling_target" "dynamodb_index_read_target" {
 resource "aws_appautoscaling_target" "ecs_target" {
   max_capacity       = 4
   min_capacity       = 1
-  resource_id        = "service/${var.cluster_name}/${var.service_name}"
+  resource_id        = "service/${aws_ecs_cluster.example.name}/${aws_ecs_service.example.name}"
   role_arn           = "${var.ecs_iam_role}"
   scalable_dimension = "ecs:service:DesiredCount"
   service_namespace  = "ecs"


### PR DESCRIPTION
changed docs of aws_appautoscaling_target to show which parts of the resource_id need to be inputed by the user