### PR TITLE
WIP: Add Support for assumeRoles with enforced MFA 

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -286,6 +287,9 @@ func (c *Config) Client() (interface{}, error) {
 			log.Printf("[INFO] AWS Auth using Profile: %q", c.Profile)
 			opt.Profile = c.Profile
 			opt.SharedConfigState = session.SharedConfigEnable
+
+			// add Stdin Token Provider for MFA
+			opt.AssumeRoleTokenProvider = stscreds.StdinTokenProvider
 		} else {
 			return nil, fmt.Errorf("Error loading credentials for AWS Provider: %s", err)
 		}

--- a/aws/config.go
+++ b/aws/config.go
@@ -95,6 +95,7 @@ import (
 type Config struct {
 	AccessKey     string
 	SecretKey     string
+	MFA           bool
 	CredsFilename string
 	Profile       string
 	Token         string
@@ -308,8 +309,10 @@ func (c *Config) Client() (interface{}, error) {
 		}
 	}
 
-	// add Stdin Token Provider for MFA
-	opt.AssumeRoleTokenProvider = stscreds.StdinTokenProvider
+	if c.MFA {
+		// add StdinTokenProvider for MFA
+		opt.AssumeRoleTokenProvider = stscreds.StdinTokenProvider
+	}
 
 	// create base session with no retries. MaxRetries will be set later
 	sess, err := session.NewSessionWithOptions(opt)

--- a/aws/config.go
+++ b/aws/config.go
@@ -287,9 +287,6 @@ func (c *Config) Client() (interface{}, error) {
 			log.Printf("[INFO] AWS Auth using Profile: %q", c.Profile)
 			opt.Profile = c.Profile
 			opt.SharedConfigState = session.SharedConfigEnable
-
-			// add Stdin Token Provider for MFA
-			opt.AssumeRoleTokenProvider = stscreds.StdinTokenProvider
 		} else {
 			return nil, fmt.Errorf("Error loading credentials for AWS Provider: %s", err)
 		}
@@ -310,6 +307,9 @@ func (c *Config) Client() (interface{}, error) {
 			InsecureSkipVerify: true,
 		}
 	}
+
+	// add Stdin Token Provider for MFA
+	opt.AssumeRoleTokenProvider = stscreds.StdinTokenProvider
 
 	// create base session with no retries. MaxRetries will be set later
 	sess, err := session.NewSessionWithOptions(opt)

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -34,6 +34,13 @@ func Provider() terraform.ResourceProvider {
 				Description: descriptions["secret_key"],
 			},
 
+			"mfa": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: descriptions["mfa"],
+			},
+
 			"profile": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -599,6 +606,9 @@ func init() {
 		"secret_key": "The secret key for API operations. You can retrieve this\n" +
 			"from the 'Security & Credentials' section of the AWS console.",
 
+		"mfa": "Explicitly configure the provider to use MFA. If omitted," +
+			"default value is `false`",
+
 		"profile": "The profile for API operations. If not set, the default profile\n" +
 			"created with `aws configure` will be used.",
 
@@ -689,6 +699,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
 		AccessKey:               d.Get("access_key").(string),
 		SecretKey:               d.Get("secret_key").(string),
+		MFA:                     d.Get("mfa").(bool),
 		Profile:                 d.Get("profile").(string),
 		Token:                   d.Get("token").(string),
 		Region:                  d.Get("region").(string),


### PR DESCRIPTION
In order to deal with assumeRoles expecting to use MFA we could at least use stscreds.StdinTokenProvider.

This fixes #226 #2420 and enhances #1275
Also requested in https://github.com/hashicorp/terraform/issues/11270 and https://github.com/hashicorp/terraform/issues/1275