### PR TITLE
resource/aws_security_group: Fix Missing Id Error

### DIFF
--- a/aws/resource_aws_security_group.go
+++ b/aws/resource_aws_security_group.go
@@ -332,10 +332,18 @@ func resourceAwsSecurityGroupCreate(d *schema.ResourceData, meta interface{}) er
 func resourceAwsSecurityGroupRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	sgRaw, err := waitForSgToExist(conn, d.Id(), d.Timeout(schema.TimeoutRead))
+	var sgRaw interface{}
+	var err error
+	if d.IsNewResource() {
+		sgRaw, err = waitForSgToExist(conn, d.Id(), d.Timeout(schema.TimeoutRead))
+	} else {
+		sgRaw, _, err = SGStateRefreshFunc(conn, d.Id())()
+	}
+
 	if err != nil {
 		return err
 	}
+
 	if sgRaw == nil {
 		log.Printf("[WARN] Security group (%s) not found, removing from state", d.Id())
 		d.SetId("")
@@ -384,7 +392,14 @@ func resourceAwsSecurityGroupRead(d *schema.ResourceData, meta interface{}) erro
 func resourceAwsSecurityGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	sgRaw, err := waitForSgToExist(conn, d.Id(), d.Timeout(schema.TimeoutRead))
+	var sgRaw interface{}
+	var err error
+	if d.IsNewResource() {
+		sgRaw, err = waitForSgToExist(conn, d.Id(), d.Timeout(schema.TimeoutRead))
+	} else {
+		sgRaw, _, err = SGStateRefreshFunc(conn, d.Id())()
+	}
+
 	if err != nil {
 		return err
 	}

--- a/aws/resource_aws_security_group.go
+++ b/aws/resource_aws_security_group.go
@@ -257,17 +257,7 @@ func resourceAwsSecurityGroupCreate(d *schema.ResourceData, meta interface{}) er
 	log.Printf("[INFO] Security Group ID: %s", d.Id())
 
 	// Wait for the security group to truly exist
-	log.Printf(
-		"[DEBUG] Waiting for Security Group (%s) to exist",
-		d.Id())
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{""},
-		Target:  []string{"exists"},
-		Refresh: SGStateRefreshFunc(conn, d.Id()),
-		Timeout: d.Timeout(schema.TimeoutCreate),
-	}
-
-	resp, err := stateConf.WaitForState()
+	resp, err := waitForSgToExist(conn, d.Id(), d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return fmt.Errorf(
 			"Error waiting for Security Group (%s) to become available: %s",
@@ -342,11 +332,12 @@ func resourceAwsSecurityGroupCreate(d *schema.ResourceData, meta interface{}) er
 func resourceAwsSecurityGroupRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	sgRaw, _, err := SGStateRefreshFunc(conn, d.Id())()
+	sgRaw, err := waitForSgToExist(conn, d.Id(), d.Timeout(schema.TimeoutRead))
 	if err != nil {
 		return err
 	}
 	if sgRaw == nil {
+		log.Printf("[WARN] Security group (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
@@ -393,11 +384,12 @@ func resourceAwsSecurityGroupRead(d *schema.ResourceData, meta interface{}) erro
 func resourceAwsSecurityGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	sgRaw, _, err := SGStateRefreshFunc(conn, d.Id())()
+	sgRaw, err := waitForSgToExist(conn, d.Id(), d.Timeout(schema.TimeoutRead))
 	if err != nil {
 		return err
 	}
 	if sgRaw == nil {
+		log.Printf("[WARN] Security group (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
@@ -838,6 +830,18 @@ func SGStateRefreshFunc(conn *ec2.EC2, id string) resource.StateRefreshFunc {
 		group := resp.SecurityGroups[0]
 		return group, "exists", nil
 	}
+}
+
+func waitForSgToExist(conn *ec2.EC2, id string, timeout time.Duration) (interface{}, error) {
+	log.Printf("[DEBUG] Waiting for Security Group (%s) to exist", id)
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{""},
+		Target:  []string{"exists"},
+		Refresh: SGStateRefreshFunc(conn, id),
+		Timeout: timeout,
+	}
+
+	return stateConf.WaitForState()
 }
 
 // matchRules receives the group id, type of rules, and the local / remote maps


### PR DESCRIPTION
## Issue Details

I've been running into an error with security groups quite frequently recently, where I have one security group referencing the id of another and then causing terraform to fail due to an error like this:

```
Resource 'aws_security_gorup.blah-sg' does not have attribute 'id' for variable 'aws_security_group.blah-sg.id'
```

This issue is documented here: https://github.com/hashicorp/terraform/issues/6991 and has been open for two years. I have a debug log from a failure, and it seems like the following is causing the issue:

1. The create function attempts to ensure the SG exists before returning the update function [here](https://github.com/terraform-providers/terraform-provider-aws/blob/a612760ddb385281346bad84ad681d3f67bbd925/aws/resource_aws_security_group.go#L270)
2. Then in the update and read function which are called after the create function, only call the refresh function `SGStateRefreshFunc` without any retries [here](https://github.com/terraform-providers/terraform-provider-aws/blob/a612760ddb385281346bad84ad681d3f67bbd925/aws/resource_aws_security_group.go#L396)

However, if AWS is having a bad day `1.` could return the SG, but then `2.` will return `nil` (since it has no retries) which will then cause the SG to be removed from the state [here](https://github.com/terraform-providers/terraform-provider-aws/blob/a612760ddb385281346bad84ad681d3f67bbd925/aws/resource_aws_security_group.go#L401).

I tested this was the issue by moving the `d.SetId("")` outside of the `if` statement, and it produced the above error.

## PR Details

So to fix this have added a call to the `waitForState()` function encapsulated in a common function shared amongst `Create, Read, and Update`, which basically adds retries to the previous call sites to `SGStateRefreshFunc`.


## Testing

I ran the unit tests and acceptance tests, however my VPC is not setup properly and some acceptance tests fail with failures such as:

```
--- FAIL: TestAccAWSSecurityGroupRule_EgressDescription (0.67s)
	testing.go:518: Step 0 error: Error applying: 1 error(s) occurred:
		
		* aws_security_group.web: 1 error(s) occurred:
		
		* aws_security_group.web: Error creating Security Group: VPCIdNotSpecified: No default VPC for this user
--- FAIL: TestAccAWSSecurityGroupRule_PrefixListEgress (5.30s)
	testing.go:518: Step 0 error: Error applying: 1 error(s) occurred:
		
		* aws_vpc_endpoint.s3-us-west-2: 1 error(s) occurred:
		
		* aws_vpc_endpoint.s3-us-west-2: Error creating VPC Endpoint: InvalidServiceName: The Vpc Endpoint Service 'com.amazonaws.us-west-2.s3' does not exist
```

I'd appreciate if you could run the acceptance tests for me.