### PR TITLE
resource/aws_api_gateway_deployment: Do not delete stages in use by other deployments

### DIFF
--- a/aws/resource_aws_api_gateway_deployment_test.go
+++ b/aws/resource_aws_api_gateway_deployment_test.go
@@ -37,6 +37,49 @@ func TestAccAWSAPIGatewayDeployment_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSAPIGatewayDeployment_createBeforeDestoryUpdate(t *testing.T) {
+	var conf apigateway.Deployment
+	var stage apigateway.Stage
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayDeploymentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayDeploymentCreateBeforeDestroyConfig("description1", "https://www.google.com"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayDeploymentExists("aws_api_gateway_deployment.test", &conf),
+					resource.TestCheckResourceAttr(
+						"aws_api_gateway_deployment.test", "stage_name", "test"),
+					resource.TestCheckResourceAttr(
+						"aws_api_gateway_deployment.test", "description", "description1"),
+					resource.TestCheckResourceAttr(
+						"aws_api_gateway_deployment.test", "variables.a", "2"),
+					resource.TestCheckResourceAttrSet(
+						"aws_api_gateway_deployment.test", "created_date"),
+					testAccCheckAWSAPIGatewayDeploymentStageExists("test", &stage),
+				),
+			},
+			{
+				Config: testAccAWSAPIGatewayDeploymentCreateBeforeDestroyConfig("description2", "https://www.google.de"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayDeploymentExists("aws_api_gateway_deployment.test", &conf),
+					resource.TestCheckResourceAttr(
+						"aws_api_gateway_deployment.test", "stage_name", "test"),
+					resource.TestCheckResourceAttr(
+						"aws_api_gateway_deployment.test", "description", "description2"),
+					resource.TestCheckResourceAttr(
+						"aws_api_gateway_deployment.test", "variables.a", "2"),
+					resource.TestCheckResourceAttrSet(
+						"aws_api_gateway_deployment.test", "created_date"),
+					testAccCheckAWSAPIGatewayDeploymentStageExists("test", &stage),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSAPIGatewayDeploymentExists(n string, res *apigateway.Deployment) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -64,6 +107,27 @@ func testAccCheckAWSAPIGatewayDeploymentExists(n string, res *apigateway.Deploym
 		}
 
 		*res = *describe
+
+		return nil
+	}
+}
+
+func testAccCheckAWSAPIGatewayDeploymentStageExists(stageName string, res *apigateway.Stage) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).apigateway
+
+		restApiId := aws.String(s.RootModule().Resources["aws_api_gateway_rest_api.test"].Primary.ID)
+
+		req := &apigateway.GetStageInput{
+			StageName: &stageName,
+			RestApiId: restApiId,
+		}
+		stage, err := conn.GetStage(req)
+		if err != nil {
+			return err
+		}
+
+		*res = *stage
 
 		return nil
 	}
@@ -103,7 +167,8 @@ func testAccCheckAWSAPIGatewayDeploymentDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccAWSAPIGatewayDeploymentConfig = `
+func buildAPIGatewayDeploymentConfig(description, url, extras string) string {
+	return fmt.Sprintf(`
 resource "aws_api_gateway_rest_api" "test" {
   name = "test"
 }
@@ -134,7 +199,7 @@ resource "aws_api_gateway_integration" "test" {
   http_method = "${aws_api_gateway_method.test.http_method}"
 
   type = "HTTP"
-  uri = "https://www.google.de"
+  uri = "%s"
   integration_http_method = "GET"
 }
 
@@ -150,10 +215,24 @@ resource "aws_api_gateway_deployment" "test" {
 
   rest_api_id = "${aws_api_gateway_rest_api.test.id}"
   stage_name = "test"
-  description = "This is a test"
+	description = "%s"
+	stage_description = "%s"
+
+	%s
 
   variables = {
     "a" = "2"
   }
 }
-`
+`, url, description, description, extras)
+}
+
+var testAccAWSAPIGatewayDeploymentConfig = buildAPIGatewayDeploymentConfig("This is a test", "https://www.google.de", "")
+
+func testAccAWSAPIGatewayDeploymentCreateBeforeDestroyConfig(description string, url string) string {
+	return buildAPIGatewayDeploymentConfig(description, url, `
+		lifecycle {
+			create_before_destroy = true
+		}
+	`)
+}


### PR DESCRIPTION
When a deployment has been updated in a way that forces a create/delete, the newly deployed deployment can be left in a bad state. Here how the code used to work:

1.  A new deployment is created that points to stage 'test'
2. The old deployment is marked for deletion and was associated with 'test'
3. The 'test' stage is deleted
4. The deposed deployment is deleted
5. The new deployment is now pointing at a stage that does not exist

Here is how the code works now:

1.  A new deployment is created that points to stage 'test'
2. The old deployment is marked for deletion and was associated with 'test'
3. The 'test' stage is not deleted because it is no longer associated with the deposed deployment
4. The deposed deployment is deleted
5. The new deployment is still happy =)

