### PR TITLE
docs/resource/aws_autoscaling_group: Clarify usage of availability_zones

### DIFF
--- a/website/docs/r/autoscaling_group.html.markdown
+++ b/website/docs/r/autoscaling_group.html.markdown
@@ -19,7 +19,6 @@ resource "aws_placement_group" "test" {
 }
 
 resource "aws_autoscaling_group" "bar" {
-  availability_zones        = ["us-east-1a"]
   name                      = "foobar3-terraform-test"
   max_size                  = 5
   min_size                  = 2
@@ -29,6 +28,7 @@ resource "aws_autoscaling_group" "bar" {
   force_delete              = true
   placement_group           = "${aws_placement_group.test.id}"
   launch_configuration      = "${aws_launch_configuration.foobar.name}"
+  vpc_zone_identifier       = ["${aws_subnet.example1.id}", "${aws_subnet.example2.id}"]
 
   initial_lifecycle_hook {
     name                 = "foobar"
@@ -83,11 +83,11 @@ variable extra_tags {
 }
 
 resource "aws_autoscaling_group" "bar" {
-  availability_zones        = ["us-east-1a"]
   name                      = "foobar3-terraform-test"
   max_size                  = 5
   min_size                  = 2
   launch_configuration      = "${aws_launch_configuration.foobar.name}"
+  vpc_zone_identifier       = ["${aws_subnet.example1.id}", "${aws_subnet.example2.id}"]
 
   tags = [
     {
@@ -122,8 +122,7 @@ The following arguments are supported:
 * `max_size` - (Required) The maximum size of the auto scale group.
 * `min_size` - (Required) The minimum size of the auto scale group.
     (See also [Waiting for Capacity](#waiting-for-capacity) below.)
-* `availability_zones` - (Optional) A list of AZs to launch resources in.
-   Required only if you do not specify any `vpc_zone_identifier`
+* `availability_zones` - (Required only for EC2-Classic) A list of one or more availability zones for the group. This parameter should not be specified when using `vpc_zone_identifier`.
 * `default_cooldown` - (Optional) The amount of time, in seconds, after a scaling activity completes before another scaling activity can start.
 * `launch_configuration` - (Required) The name of the launch configuration to use.
 * `initial_lifecycle_hook` - (Optional) One or more


### PR DESCRIPTION
Also updates the examples to use `vpc_zone_identifier` instead of `availability_zones` as VPC usage should be more common than EC2-Classic usage.

Followup documentation update for #1190
Closes #3863
Closes #3449
Closes #3440
Closes #3439
Closes #3186
Closes #2953
Closes #2880
Closes #2797
Closes #2435
Closes #2252
Closes #1990
Closes #1931
Closes #1784
Closes #1630
Closes #1527
Closes #1376