### PR TITLE
Update Autoscaling Group with enabled_metrics

### DIFF
--- a/aws/resource_aws_autoscaling_group.go
+++ b/aws/resource_aws_autoscaling_group.go
@@ -534,6 +534,8 @@ func resourceAwsAutoscalingGroupRead(d *schema.ResourceData, meta interface{}) e
 			log.Printf("[WARN] Error setting metrics for (%s): %s", d.Id(), err)
 		}
 		d.Set("metrics_granularity", g.EnabledMetrics[0].Granularity)
+	} else {
+		d.Set("enabled_metrics", nil)
 	}
 
 	return nil

--- a/aws/resource_aws_autoscaling_group_test.go
+++ b/aws/resource_aws_autoscaling_group_test.go
@@ -128,6 +128,8 @@ func TestAccAWSAutoScalingGroup_basic(t *testing.T) {
 						"aws_autoscaling_group.bar", "termination_policies.1", "ClosestToNextInstanceHour"),
 					resource.TestCheckResourceAttr(
 						"aws_autoscaling_group.bar", "protect_from_scale_in", "false"),
+					resource.TestCheckResourceAttr(
+						"aws_autoscaling_group.bar", "enabled_metrics.#", "0"),
 				),
 			},
 


### PR DESCRIPTION
Fixed bug where the update step did not detect changes to the enabled_metrics list if it was empty.

https://github.com/terraform-providers/terraform-provider-aws/issues/1098

```
  ~ module.us_east_2.aws_autoscaling_group.worker
      enabled_metrics.#:                         "0" => "8"
      enabled_metrics.119681000:                 "" => "GroupStandbyInstances"
      enabled_metrics.1940933563:                "" => "GroupTotalInstances"
      enabled_metrics.308948767:                 "" => "GroupPendingInstances"
      enabled_metrics.3267518000:                "" => "GroupTerminatingInstances"
      enabled_metrics.3394537085:                "" => "GroupDesiredCapacity"
      enabled_metrics.3551801763:                "" => "GroupInServiceInstances"
      enabled_metrics.4118539418:                "" => "GroupMinSize"
      enabled_metrics.4136111317:                "" => "GroupMaxSize"
```