### PR TITLE
resource/aws_opsworks_instance: Remove Optional from ec2_instance_id attribute and document it

### DIFF
--- a/aws/resource_aws_opsworks_instance.go
+++ b/aws/resource_aws_opsworks_instance.go
@@ -99,7 +99,6 @@ func resourceAwsOpsworksInstance() *schema.Resource {
 
 			"ec2_instance_id": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 

--- a/website/docs/r/opsworks_instance.html.markdown
+++ b/website/docs/r/opsworks_instance.html.markdown
@@ -120,6 +120,7 @@ The following attributes are exported:
 * `id` - The id of the OpsWorks instance.
 * `agent_version` - The AWS OpsWorks agent version.
 * `availability_zone` - The availability zone of the instance.
+* `ec2_instance_id` - EC2 instance ID
 * `ssh_key_name` - The key name of the instance
 * `public_dns` - The public DNS name assigned to the instance. For EC2-VPC, this
   is only available if you've enabled DNS hostnames for your VPC


### PR DESCRIPTION
Closes #3750 

https://github.com/terraform-providers/terraform-provider-aws/blob/6915ae6058a95e2781cc67920f0b607633deb4b0/aws/resource_aws_opsworks_instance.go#L100-L104