### PR TITLE
deps: Bump aws-sdk-go@v1.13.20

### DIFF
--- a/vendor/github.com/aws/aws-sdk-go/aws/client/client.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/client/client.go
@@ -15,6 +15,12 @@ type Config struct {
 	Endpoint      string
 	SigningRegion string
 	SigningName   string
+
+	// States that the signing name did not come from a modeled source but
+	// was derived based on other data. Used by service client constructors
+	// to determine if the signin name can be overriden based on metadata the
+	// service has.
+	SigningNameDerived bool
 }
 
 // ConfigProvider provides a generic way for a service client to receive

--- a/vendor/github.com/aws/aws-sdk-go/aws/config.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/config.go
@@ -151,6 +151,9 @@ type Config struct {
 	// with accelerate.
 	S3UseAccelerate *bool
 
+	// S3DisableContentMD5Validation config option is temporarily disabled,
+	// For S3 GetObject API calls, #1837.
+	//
 	// Set this to `true` to disable the S3 service client from automatically
 	// adding the ContentMD5 to S3 Object Put and Upload API calls. This option
 	// will also disable the SDK from performing object ContentMD5 validation

--- a/vendor/github.com/aws/aws-sdk-go/aws/endpoints/decode.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/endpoints/decode.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 )
@@ -85,33 +84,9 @@ func decodeV3Endpoints(modelDef modelDefinition, opts DecodeModelOptions) (Resol
 		custAddEC2Metadata(p)
 		custAddS3DualStack(p)
 		custRmIotDataService(p)
-
-		custFixCloudHSMv2SigningName(p)
-		custFixRuntimeSagemakerSigningName(p)
 	}
 
 	return ps, nil
-}
-
-func custFixCloudHSMv2SigningName(p *partition) {
-	// Workaround for aws/aws-sdk-go#1745 until the endpoint model can be
-	// fixed upstream. TODO remove this once the endpoints model is updated.
-
-	s, ok := p.Services["cloudhsmv2"]
-	if !ok {
-		return
-	}
-
-	if len(s.Defaults.CredentialScope.Service) != 0 {
-		fmt.Fprintf(os.Stderr, "cloudhsmv2 signing name already set, ignoring override.\n")
-		// If the value is already set don't override
-		return
-	}
-
-	s.Defaults.CredentialScope.Service = "cloudhsm"
-	fmt.Fprintf(os.Stderr, "cloudhsmv2 signing name not set, overriding.\n")
-
-	p.Services["cloudhsmv2"] = s
 }
 
 func custAddS3DualStack(p *partition) {
@@ -145,26 +120,6 @@ func custAddEC2Metadata(p *partition) {
 
 func custRmIotDataService(p *partition) {
 	delete(p.Services, "data.iot")
-}
-
-func custFixRuntimeSagemakerSigningName(p *partition) {
-	// Workaround for aws/aws-sdk-go#1836
-
-	s, ok := p.Services["runtime.sagemaker"]
-	if !ok {
-		return
-	}
-
-	if len(s.Defaults.CredentialScope.Service) != 0 {
-		fmt.Fprintf(os.Stderr, "runtime.sagemaker signing name already set, ignoring override.\n")
-		// If the value is already set don't override
-		return
-	}
-
-	s.Defaults.CredentialScope.Service = "sagemaker"
-	fmt.Fprintf(os.Stderr, "sagemaker signing name not set, overriding.\n")
-
-	p.Services["runtime.sagemaker"] = s
 }
 
 type decodeModelError struct {

--- a/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
@@ -1002,6 +1002,7 @@ var awsPartition = partition{
 				"eu-west-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
+				"us-west-1":      endpoint{},
 				"us-west-2":      endpoint{},
 			},
 		},
@@ -1422,12 +1423,17 @@ var awsPartition = partition{
 
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
+				"ap-northeast-2": endpoint{},
 				"ap-south-1":     endpoint{},
 				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
+				"ca-central-1":   endpoint{},
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
+				"eu-west-2":      endpoint{},
+				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
+				"us-east-2":      endpoint{},
 				"us-west-1":      endpoint{},
 				"us-west-2":      endpoint{},
 			},
@@ -1447,11 +1453,13 @@ var awsPartition = partition{
 
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
+				"ap-northeast-2": endpoint{},
 				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-3":      endpoint{},
+				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-west-2":      endpoint{},
 			},
@@ -1715,11 +1723,7 @@ var awsPartition = partition{
 			},
 		},
 		"runtime.sagemaker": service{
-			Defaults: endpoint{
-				CredentialScope: credentialScope{
-					Service: "sagemaker",
-				},
-			},
+
 			Endpoints: endpoints{
 				"eu-west-1": endpoint{},
 				"us-east-1": endpoint{},
@@ -1907,6 +1911,7 @@ var awsPartition = partition{
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
 				"ap-south-1":     endpoint{},
+				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
 				"ca-central-1":   endpoint{},
 				"eu-central-1":   endpoint{},

--- a/vendor/github.com/aws/aws-sdk-go/aws/endpoints/endpoints.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/endpoints/endpoints.go
@@ -347,6 +347,10 @@ type ResolvedEndpoint struct {
 	// The service name that should be used for signing requests.
 	SigningName string
 
+	// States that the signing name for this endpoint was derived from metadata
+	// passed in, but was not explicitly modeled.
+	SigningNameDerived bool
+
 	// The signing method that should be used for signing requests.
 	SigningMethod string
 }

--- a/vendor/github.com/aws/aws-sdk-go/aws/endpoints/v3model.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/endpoints/v3model.go
@@ -226,16 +226,20 @@ func (e endpoint) resolve(service, region, dnsSuffix string, defs []endpoint, op
 	if len(signingRegion) == 0 {
 		signingRegion = region
 	}
+
 	signingName := e.CredentialScope.Service
+	var signingNameDerived bool
 	if len(signingName) == 0 {
 		signingName = service
+		signingNameDerived = true
 	}
 
 	return ResolvedEndpoint{
-		URL:           u,
-		SigningRegion: signingRegion,
-		SigningName:   signingName,
-		SigningMethod: getByPriority(e.SignatureVersions, signerPriority, defaultSigner),
+		URL:                u,
+		SigningRegion:      signingRegion,
+		SigningName:        signingName,
+		SigningNameDerived: signingNameDerived,
+		SigningMethod:      getByPriority(e.SignatureVersions, signerPriority, defaultSigner),
 	}
 }
 

--- a/vendor/github.com/aws/aws-sdk-go/aws/session/session.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/session/session.go
@@ -571,11 +571,12 @@ func (s *Session) clientConfigWithErr(serviceName string, cfgs ...*aws.Config) (
 	}
 
 	return client.Config{
-		Config:        s.Config,
-		Handlers:      s.Handlers,
-		Endpoint:      resolved.URL,
-		SigningRegion: resolved.SigningRegion,
-		SigningName:   resolved.SigningName,
+		Config:             s.Config,
+		Handlers:           s.Handlers,
+		Endpoint:           resolved.URL,
+		SigningRegion:      resolved.SigningRegion,
+		SigningNameDerived: resolved.SigningNameDerived,
+		SigningName:        resolved.SigningName,
 	}, err
 }
 
@@ -595,10 +596,11 @@ func (s *Session) ClientConfigNoResolveEndpoint(cfgs ...*aws.Config) client.Conf
 	}
 
 	return client.Config{
-		Config:        s.Config,
-		Handlers:      s.Handlers,
-		Endpoint:      resolved.URL,
-		SigningRegion: resolved.SigningRegion,
-		SigningName:   resolved.SigningName,
+		Config:             s.Config,
+		Handlers:           s.Handlers,
+		Endpoint:           resolved.URL,
+		SigningRegion:      resolved.SigningRegion,
+		SigningNameDerived: resolved.SigningNameDerived,
+		SigningName:        resolved.SigningName,
 	}
 }

--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.13.15"
+const SDKVersion = "1.13.20"

--- a/vendor/github.com/aws/aws-sdk-go/service/applicationautoscaling/service.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/applicationautoscaling/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := applicationautoscaling.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *ApplicationAutoScaling {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
+		c.SigningName = "application-autoscaling"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *ApplicationAutoScaling {
-	if len(signingName) == 0 {
-		signingName = "application-autoscaling"
-	}
 	svc := &ApplicationAutoScaling{
 		Client: client.New(
 			cfg,

--- a/vendor/github.com/aws/aws-sdk-go/service/appsync/service.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/appsync/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := appsync.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *AppSync {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
+		c.SigningName = "appsync"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *AppSync {
-	if len(signingName) == 0 {
-		signingName = "appsync"
-	}
 	svc := &AppSync{
 		Client: client.New(
 			cfg,

--- a/vendor/github.com/aws/aws-sdk-go/service/cloudwatchevents/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/cloudwatchevents/api.go
@@ -1054,7 +1054,7 @@ func (c *CloudWatchEvents) PutTargetsRequest(input *PutTargetsInput) (req *reque
 //
 //    * Amazon SNS topics
 //
-//    * Amazon SQS queues
+//    * Amazon SQS queues, including FIFO queues
 //
 //    * The default event bus of another AWS account
 //
@@ -3275,6 +3275,31 @@ func (s *RunCommandTarget) SetValues(v []*string) *RunCommandTarget {
 	return s
 }
 
+// This structure includes the custom parameter to be used when the target is
+// an SQS FIFO queue.
+type SqsParameters struct {
+	_ struct{} `type:"structure"`
+
+	// The FIFO message group ID to use as the target.
+	MessageGroupId *string `type:"string"`
+}
+
+// String returns the string representation
+func (s SqsParameters) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SqsParameters) GoString() string {
+	return s.String()
+}
+
+// SetMessageGroupId sets the MessageGroupId field's value.
+func (s *SqsParameters) SetMessageGroupId(v string) *SqsParameters {
+	s.MessageGroupId = &v
+	return s
+}
+
 // Targets are the resources to be invoked when a rule is triggered. Target
 // types include EC2 instances, AWS Lambda functions, Amazon Kinesis streams,
 // Amazon ECS tasks, AWS Step Functions state machines, Run Command, and built-in
@@ -3331,6 +3356,9 @@ type Target struct {
 
 	// Parameters used when you are using the rule to invoke Amazon EC2 Run Command.
 	RunCommandParameters *RunCommandParameters `type:"structure"`
+
+	// Contains the message group ID to use when the target is a FIFO queue.
+	SqsParameters *SqsParameters `type:"structure"`
 }
 
 // String returns the string representation
@@ -3450,6 +3478,12 @@ func (s *Target) SetRoleArn(v string) *Target {
 // SetRunCommandParameters sets the RunCommandParameters field's value.
 func (s *Target) SetRunCommandParameters(v *RunCommandParameters) *Target {
 	s.RunCommandParameters = v
+	return s
+}
+
+// SetSqsParameters sets the SqsParameters field's value.
+func (s *Target) SetSqsParameters(v *SqsParameters) *Target {
+	s.SqsParameters = v
 	return s
 }
 

--- a/vendor/github.com/aws/aws-sdk-go/service/codebuild/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/codebuild/api.go
@@ -1247,6 +1247,91 @@ func (c *CodeBuild) UpdateProjectWithContext(ctx aws.Context, input *UpdateProje
 	return out, req.Send()
 }
 
+const opUpdateWebhook = "UpdateWebhook"
+
+// UpdateWebhookRequest generates a "aws/request.Request" representing the
+// client's request for the UpdateWebhook operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See UpdateWebhook for more information on using the UpdateWebhook
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the UpdateWebhookRequest method.
+//    req, resp := client.UpdateWebhookRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/codebuild-2016-10-06/UpdateWebhook
+func (c *CodeBuild) UpdateWebhookRequest(input *UpdateWebhookInput) (req *request.Request, output *UpdateWebhookOutput) {
+	op := &request.Operation{
+		Name:       opUpdateWebhook,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &UpdateWebhookInput{}
+	}
+
+	output = &UpdateWebhookOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// UpdateWebhook API operation for AWS CodeBuild.
+//
+// Updates the webhook associated with an AWS CodeBuild build project.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS CodeBuild's
+// API operation UpdateWebhook for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidInputException "InvalidInputException"
+//   The input value that was provided is not valid.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified AWS resource cannot be found.
+//
+//   * ErrCodeOAuthProviderException "OAuthProviderException"
+//   There was a problem with the underlying OAuth provider.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/codebuild-2016-10-06/UpdateWebhook
+func (c *CodeBuild) UpdateWebhook(input *UpdateWebhookInput) (*UpdateWebhookOutput, error) {
+	req, out := c.UpdateWebhookRequest(input)
+	return out, req.Send()
+}
+
+// UpdateWebhookWithContext is the same as UpdateWebhook with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UpdateWebhook for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CodeBuild) UpdateWebhookWithContext(ctx aws.Context, input *UpdateWebhookInput, opts ...request.Option) (*UpdateWebhookOutput, error) {
+	req, out := c.UpdateWebhookRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 type BatchDeleteBuildsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -1531,7 +1616,7 @@ type Build struct {
 	// about any current build phase that is not yet complete.
 	Phases []*BuildPhase `locationName:"phases" type:"list"`
 
-	// The name of the build project.
+	// The name of the AWS CodeBuild project.
 	ProjectName *string `locationName:"projectName" min:"1" type:"string"`
 
 	// Information about the source code to be built.
@@ -2107,7 +2192,13 @@ func (s *CreateProjectOutput) SetProject(v *Project) *CreateProjectOutput {
 type CreateWebhookInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the build project.
+	// A regular expression used to determine which branches in a repository are
+	// built when a webhook is triggered. If the name of a branch matches the regular
+	// expression, then it is built. If it doesn't match, then it is not. If branchFilter
+	// is empty, then all branches are built.
+	BranchFilter *string `locationName:"branchFilter" type:"string"`
+
+	// The name of the AWS CodeBuild project.
 	//
 	// ProjectName is a required field
 	ProjectName *string `locationName:"projectName" min:"2" type:"string" required:"true"`
@@ -2137,6 +2228,12 @@ func (s *CreateWebhookInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetBranchFilter sets the BranchFilter field's value.
+func (s *CreateWebhookInput) SetBranchFilter(v string) *CreateWebhookInput {
+	s.BranchFilter = &v
+	return s
 }
 
 // SetProjectName sets the ProjectName field's value.
@@ -2227,7 +2324,7 @@ func (s DeleteProjectOutput) GoString() string {
 type DeleteWebhookInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the build project.
+	// The name of the AWS CodeBuild project.
 	//
 	// ProjectName is a required field
 	ProjectName *string `locationName:"projectName" min:"2" type:"string" required:"true"`
@@ -2467,7 +2564,8 @@ func (s *EnvironmentVariable) SetValue(v string) *EnvironmentVariable {
 type InvalidateProjectCacheInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the build project that the cache will be reset for.
+	// The name of the AWS CodeBuild build project that the cache will be reset
+	// for.
 	//
 	// ProjectName is a required field
 	ProjectName *string `locationName:"projectName" min:"1" type:"string" required:"true"`
@@ -2530,7 +2628,7 @@ type ListBuildsForProjectInput struct {
 	// until no more next tokens are returned.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	// The name of the build project.
+	// The name of the AWS CodeBuild project.
 	//
 	// ProjectName is a required field
 	ProjectName *string `locationName:"projectName" min:"1" type:"string" required:"true"`
@@ -3414,17 +3512,15 @@ type ProjectEnvironment struct {
 	// Image is a required field
 	Image *string `locationName:"image" min:"1" type:"string" required:"true"`
 
-	// If set to true, enables running the Docker daemon inside a Docker container;
-	// otherwise, false or not specified (the default). This value must be set to
-	// true only if this build project will be used to build Docker images, and
-	// the specified build environment image is not one provided by AWS CodeBuild
-	// with Docker support. Otherwise, all associated builds that attempt to interact
-	// with the Docker daemon will fail. Note that you must also start the Docker
-	// daemon so that your builds can interact with it as needed. One way to do
-	// this is to initialize the Docker daemon in the install phase of your build
-	// spec by running the following build commands. (Do not run the following build
-	// commands if the specified build environment image is provided by AWS CodeBuild
-	// with Docker support.)
+	// Enables running the Docker daemon inside a Docker container. Set to true
+	// only if the build project is be used to build Docker images, and the specified
+	// build environment image is not provided by AWS CodeBuild with Docker support.
+	// Otherwise, all associated builds that attempt to interact with the Docker
+	// daemon will fail. Note that you must also start the Docker daemon so that
+	// builds can interact with it. One way to do this is to initialize the Docker
+	// daemon during the install phase of your build spec by running the following
+	// build commands. (Do not run the following build commands if the specified
+	// build environment image is provided by AWS CodeBuild with Docker support.)
 	//
 	// - nohup /usr/local/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://0.0.0.0:2375
 	// --storage-driver=overlay& - timeout -t 15 sh -c "until docker info; do echo
@@ -3737,7 +3833,7 @@ type StartBuildInput struct {
 	// for this build only, any previous depth of history defined in the build project.
 	GitCloneDepthOverride *int64 `locationName:"gitCloneDepthOverride" type:"integer"`
 
-	// The name of the build project to start running a build.
+	// The name of the AWS CodeBuild build project to start running a build.
 	//
 	// ProjectName is a required field
 	ProjectName *string `locationName:"projectName" min:"1" type:"string" required:"true"`
@@ -4215,6 +4311,93 @@ func (s *UpdateProjectOutput) SetProject(v *Project) *UpdateProjectOutput {
 	return s
 }
 
+type UpdateWebhookInput struct {
+	_ struct{} `type:"structure"`
+
+	// A regular expression used to determine which branches in a repository are
+	// built when a webhook is triggered. If the name of a branch matches the regular
+	// expression, then it is built. If it doesn't match, then it is not. If branchFilter
+	// is empty, then all branches are built.
+	BranchFilter *string `locationName:"branchFilter" type:"string"`
+
+	// The name of the AWS CodeBuild project.
+	//
+	// ProjectName is a required field
+	ProjectName *string `locationName:"projectName" min:"2" type:"string" required:"true"`
+
+	// A boolean value that specifies whether the associated repository's secret
+	// token should be updated.
+	RotateSecret *bool `locationName:"rotateSecret" type:"boolean"`
+}
+
+// String returns the string representation
+func (s UpdateWebhookInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateWebhookInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateWebhookInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateWebhookInput"}
+	if s.ProjectName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ProjectName"))
+	}
+	if s.ProjectName != nil && len(*s.ProjectName) < 2 {
+		invalidParams.Add(request.NewErrParamMinLen("ProjectName", 2))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetBranchFilter sets the BranchFilter field's value.
+func (s *UpdateWebhookInput) SetBranchFilter(v string) *UpdateWebhookInput {
+	s.BranchFilter = &v
+	return s
+}
+
+// SetProjectName sets the ProjectName field's value.
+func (s *UpdateWebhookInput) SetProjectName(v string) *UpdateWebhookInput {
+	s.ProjectName = &v
+	return s
+}
+
+// SetRotateSecret sets the RotateSecret field's value.
+func (s *UpdateWebhookInput) SetRotateSecret(v bool) *UpdateWebhookInput {
+	s.RotateSecret = &v
+	return s
+}
+
+type UpdateWebhookOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about a repository's webhook that is associated with a project
+	// in AWS CodeBuild.
+	Webhook *Webhook `locationName:"webhook" type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateWebhookOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateWebhookOutput) GoString() string {
+	return s.String()
+}
+
+// SetWebhook sets the Webhook field's value.
+func (s *UpdateWebhookOutput) SetWebhook(v *Webhook) *UpdateWebhookOutput {
+	s.Webhook = v
+	return s
+}
+
 // Information about the VPC configuration that AWS CodeBuild will access.
 type VpcConfig struct {
 	_ struct{} `type:"structure"`
@@ -4275,12 +4458,19 @@ func (s *VpcConfig) SetVpcId(v string) *VpcConfig {
 type Webhook struct {
 	_ struct{} `type:"structure"`
 
-	// This is the server endpoint that will receive the webhook payload.
+	// A regular expression used to determine which branches in a repository are
+	// built when a webhook is triggered. If the name of a branch matches the regular
+	// expression, then it is built. If it doesn't match, then it is not. If branchFilter
+	// is empty, then all branches are built.
+	BranchFilter *string `locationName:"branchFilter" type:"string"`
+
+	// A timestamp indicating the last time a repository's secret token was modified.
+	LastModifiedSecret *time.Time `locationName:"lastModifiedSecret" type:"timestamp" timestampFormat:"unix"`
+
+	// The CodeBuild endpoint where webhook events are sent.
 	PayloadUrl *string `locationName:"payloadUrl" min:"1" type:"string"`
 
-	// Use this secret while creating a webhook in GitHub for Enterprise. The secret
-	// allows webhook requests sent by GitHub for Enterprise to be authenticated
-	// by AWS CodeBuild.
+	// The secret token of the associated repository.
 	Secret *string `locationName:"secret" min:"1" type:"string"`
 
 	// The URL to the webhook.
@@ -4295,6 +4485,18 @@ func (s Webhook) String() string {
 // GoString returns the string representation
 func (s Webhook) GoString() string {
 	return s.String()
+}
+
+// SetBranchFilter sets the BranchFilter field's value.
+func (s *Webhook) SetBranchFilter(v string) *Webhook {
+	s.BranchFilter = &v
+	return s
+}
+
+// SetLastModifiedSecret sets the LastModifiedSecret field's value.
+func (s *Webhook) SetLastModifiedSecret(v time.Time) *Webhook {
+	s.LastModifiedSecret = &v
+	return s
 }
 
 // SetPayloadUrl sets the PayloadUrl field's value.

--- a/vendor/github.com/aws/aws-sdk-go/service/codebuild/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/codebuild/doc.go
@@ -33,6 +33,8 @@
 //    begin automatically rebuilding the source code every time a code change
 //    is pushed to the repository.
 //
+//    * UpdateWebhook: Changes the settings of an existing webhook.
+//
 //    * DeleteProject: Deletes a build project.
 //
 //    * DeleteWebhook: For an existing AWS CodeBuild build project that has

--- a/vendor/github.com/aws/aws-sdk-go/service/configservice/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/configservice/api.go
@@ -13,6 +13,97 @@ import (
 	"github.com/aws/aws-sdk-go/private/protocol/jsonrpc"
 )
 
+const opBatchGetResourceConfig = "BatchGetResourceConfig"
+
+// BatchGetResourceConfigRequest generates a "aws/request.Request" representing the
+// client's request for the BatchGetResourceConfig operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See BatchGetResourceConfig for more information on using the BatchGetResourceConfig
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the BatchGetResourceConfigRequest method.
+//    req, resp := client.BatchGetResourceConfigRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/BatchGetResourceConfig
+func (c *ConfigService) BatchGetResourceConfigRequest(input *BatchGetResourceConfigInput) (req *request.Request, output *BatchGetResourceConfigOutput) {
+	op := &request.Operation{
+		Name:       opBatchGetResourceConfig,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &BatchGetResourceConfigInput{}
+	}
+
+	output = &BatchGetResourceConfigOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// BatchGetResourceConfig API operation for AWS Config.
+//
+// Returns the current configuration for one or more requested resources. The
+// operation also returns a list of resources that are not processed in the
+// current request. If there are no unprocessed resources, the operation returns
+// an empty unprocessedResourceKeys list.
+//
+// The API does not return results for deleted resources.
+//
+//  The API does not return any tags for the requested resources. This information
+// is filtered out of the supplementaryConfiguration section of the API response.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Config's
+// API operation BatchGetResourceConfig for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeValidationException "ValidationException"
+//   The requested action is not valid.
+//
+//   * ErrCodeNoAvailableConfigurationRecorderException "NoAvailableConfigurationRecorderException"
+//   There are no configuration recorders available to provide the role needed
+//   to describe your resources. Create a configuration recorder.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/BatchGetResourceConfig
+func (c *ConfigService) BatchGetResourceConfig(input *BatchGetResourceConfigInput) (*BatchGetResourceConfigOutput, error) {
+	req, out := c.BatchGetResourceConfigRequest(input)
+	return out, req.Send()
+}
+
+// BatchGetResourceConfigWithContext is the same as BatchGetResourceConfig with the addition of
+// the ability to pass a context and additional request options.
+//
+// See BatchGetResourceConfig for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ConfigService) BatchGetResourceConfigWithContext(ctx aws.Context, input *BatchGetResourceConfigInput, opts ...request.Option) (*BatchGetResourceConfigOutput, error) {
+	req, out := c.BatchGetResourceConfigRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opDeleteConfigRule = "DeleteConfigRule"
 
 // DeleteConfigRuleRequest generates a "aws/request.Request" representing the
@@ -2639,6 +2730,237 @@ func (c *ConfigService) StopConfigurationRecorderWithContext(ctx aws.Context, in
 	return out, req.Send()
 }
 
+// The detailed configuration of a specified resource.
+type BaseConfigurationItem struct {
+	_ struct{} `type:"structure"`
+
+	// The 12 digit AWS account ID associated with the resource.
+	AccountId *string `locationName:"accountId" type:"string"`
+
+	// The Amazon Resource Name (ARN) of the resource.
+	Arn *string `locationName:"arn" type:"string"`
+
+	// The Availability Zone associated with the resource.
+	AvailabilityZone *string `locationName:"availabilityZone" type:"string"`
+
+	// The region where the resource resides.
+	AwsRegion *string `locationName:"awsRegion" type:"string"`
+
+	// The description of the resource configuration.
+	Configuration *string `locationName:"configuration" type:"string"`
+
+	// The time when the configuration recording was initiated.
+	ConfigurationItemCaptureTime *time.Time `locationName:"configurationItemCaptureTime" type:"timestamp" timestampFormat:"unix"`
+
+	// The configuration item status.
+	ConfigurationItemStatus *string `locationName:"configurationItemStatus" type:"string" enum:"ConfigurationItemStatus"`
+
+	// An identifier that indicates the ordering of the configuration items of a
+	// resource.
+	ConfigurationStateId *string `locationName:"configurationStateId" type:"string"`
+
+	// The time stamp when the resource was created.
+	ResourceCreationTime *time.Time `locationName:"resourceCreationTime" type:"timestamp" timestampFormat:"unix"`
+
+	// The ID of the resource (for example., sg-xxxxxx).
+	ResourceId *string `locationName:"resourceId" type:"string"`
+
+	// The custom name of the resource, if available.
+	ResourceName *string `locationName:"resourceName" type:"string"`
+
+	// The type of AWS resource.
+	ResourceType *string `locationName:"resourceType" type:"string" enum:"ResourceType"`
+
+	// Configuration attributes that AWS Config returns for certain resource types
+	// to supplement the information returned for the configuration parameter.
+	SupplementaryConfiguration map[string]*string `locationName:"supplementaryConfiguration" type:"map"`
+
+	// The version number of the resource configuration.
+	Version *string `locationName:"version" type:"string"`
+}
+
+// String returns the string representation
+func (s BaseConfigurationItem) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s BaseConfigurationItem) GoString() string {
+	return s.String()
+}
+
+// SetAccountId sets the AccountId field's value.
+func (s *BaseConfigurationItem) SetAccountId(v string) *BaseConfigurationItem {
+	s.AccountId = &v
+	return s
+}
+
+// SetArn sets the Arn field's value.
+func (s *BaseConfigurationItem) SetArn(v string) *BaseConfigurationItem {
+	s.Arn = &v
+	return s
+}
+
+// SetAvailabilityZone sets the AvailabilityZone field's value.
+func (s *BaseConfigurationItem) SetAvailabilityZone(v string) *BaseConfigurationItem {
+	s.AvailabilityZone = &v
+	return s
+}
+
+// SetAwsRegion sets the AwsRegion field's value.
+func (s *BaseConfigurationItem) SetAwsRegion(v string) *BaseConfigurationItem {
+	s.AwsRegion = &v
+	return s
+}
+
+// SetConfiguration sets the Configuration field's value.
+func (s *BaseConfigurationItem) SetConfiguration(v string) *BaseConfigurationItem {
+	s.Configuration = &v
+	return s
+}
+
+// SetConfigurationItemCaptureTime sets the ConfigurationItemCaptureTime field's value.
+func (s *BaseConfigurationItem) SetConfigurationItemCaptureTime(v time.Time) *BaseConfigurationItem {
+	s.ConfigurationItemCaptureTime = &v
+	return s
+}
+
+// SetConfigurationItemStatus sets the ConfigurationItemStatus field's value.
+func (s *BaseConfigurationItem) SetConfigurationItemStatus(v string) *BaseConfigurationItem {
+	s.ConfigurationItemStatus = &v
+	return s
+}
+
+// SetConfigurationStateId sets the ConfigurationStateId field's value.
+func (s *BaseConfigurationItem) SetConfigurationStateId(v string) *BaseConfigurationItem {
+	s.ConfigurationStateId = &v
+	return s
+}
+
+// SetResourceCreationTime sets the ResourceCreationTime field's value.
+func (s *BaseConfigurationItem) SetResourceCreationTime(v time.Time) *BaseConfigurationItem {
+	s.ResourceCreationTime = &v
+	return s
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *BaseConfigurationItem) SetResourceId(v string) *BaseConfigurationItem {
+	s.ResourceId = &v
+	return s
+}
+
+// SetResourceName sets the ResourceName field's value.
+func (s *BaseConfigurationItem) SetResourceName(v string) *BaseConfigurationItem {
+	s.ResourceName = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *BaseConfigurationItem) SetResourceType(v string) *BaseConfigurationItem {
+	s.ResourceType = &v
+	return s
+}
+
+// SetSupplementaryConfiguration sets the SupplementaryConfiguration field's value.
+func (s *BaseConfigurationItem) SetSupplementaryConfiguration(v map[string]*string) *BaseConfigurationItem {
+	s.SupplementaryConfiguration = v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *BaseConfigurationItem) SetVersion(v string) *BaseConfigurationItem {
+	s.Version = &v
+	return s
+}
+
+type BatchGetResourceConfigInput struct {
+	_ struct{} `type:"structure"`
+
+	// A list of resource keys to be processed with the current request. Each element
+	// in the list consists of the resource type and resource ID.
+	//
+	// ResourceKeys is a required field
+	ResourceKeys []*ResourceKey `locationName:"resourceKeys" min:"1" type:"list" required:"true"`
+}
+
+// String returns the string representation
+func (s BatchGetResourceConfigInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s BatchGetResourceConfigInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *BatchGetResourceConfigInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "BatchGetResourceConfigInput"}
+	if s.ResourceKeys == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceKeys"))
+	}
+	if s.ResourceKeys != nil && len(s.ResourceKeys) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceKeys", 1))
+	}
+	if s.ResourceKeys != nil {
+		for i, v := range s.ResourceKeys {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "ResourceKeys", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetResourceKeys sets the ResourceKeys field's value.
+func (s *BatchGetResourceConfigInput) SetResourceKeys(v []*ResourceKey) *BatchGetResourceConfigInput {
+	s.ResourceKeys = v
+	return s
+}
+
+type BatchGetResourceConfigOutput struct {
+	_ struct{} `type:"structure"`
+
+	// A list that contains the current configuration of one or more resources.
+	BaseConfigurationItems []*BaseConfigurationItem `locationName:"baseConfigurationItems" type:"list"`
+
+	// A list of resource keys that were not processed with the current response.
+	// The unprocessesResourceKeys value is in the same form as ResourceKeys, so
+	// the value can be directly provided to a subsequent BatchGetResourceConfig
+	// operation. If there are no unprocessed resource keys, the response contains
+	// an empty unprocessedResourceKeys list.
+	UnprocessedResourceKeys []*ResourceKey `locationName:"unprocessedResourceKeys" min:"1" type:"list"`
+}
+
+// String returns the string representation
+func (s BatchGetResourceConfigOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s BatchGetResourceConfigOutput) GoString() string {
+	return s.String()
+}
+
+// SetBaseConfigurationItems sets the BaseConfigurationItems field's value.
+func (s *BatchGetResourceConfigOutput) SetBaseConfigurationItems(v []*BaseConfigurationItem) *BatchGetResourceConfigOutput {
+	s.BaseConfigurationItems = v
+	return s
+}
+
+// SetUnprocessedResourceKeys sets the UnprocessedResourceKeys field's value.
+func (s *BatchGetResourceConfigOutput) SetUnprocessedResourceKeys(v []*ResourceKey) *BatchGetResourceConfigOutput {
+	s.UnprocessedResourceKeys = v
+	return s
+}
+
 // Indicates whether an AWS resource or AWS Config rule is compliant and provides
 // the number of contributors that affect the compliance.
 type Compliance struct {
@@ -4231,7 +4553,7 @@ type DescribeComplianceByResourceInput struct {
 
 	// Filters the results by compliance.
 	//
-	// The allowed values are COMPLIANT, NON_COMPLIANT, and INSUFFICIENT_DATA.
+	// The allowed values are COMPLIANT and NON_COMPLIANT.
 	ComplianceTypes []*string `type:"list"`
 
 	// The maximum number of evaluation results returned on each page. The default
@@ -6154,6 +6476,60 @@ func (s *ResourceIdentifier) SetResourceType(v string) *ResourceIdentifier {
 	return s
 }
 
+// The details that identify a resource within AWS Config, including the resource
+// type and resource ID.
+type ResourceKey struct {
+	_ struct{} `type:"structure"`
+
+	// The ID of the resource (for example., sg-xxxxxx).
+	//
+	// ResourceId is a required field
+	ResourceId *string `locationName:"resourceId" type:"string" required:"true"`
+
+	// The resource type.
+	//
+	// ResourceType is a required field
+	ResourceType *string `locationName:"resourceType" type:"string" required:"true" enum:"ResourceType"`
+}
+
+// String returns the string representation
+func (s ResourceKey) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ResourceKey) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ResourceKey) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ResourceKey"}
+	if s.ResourceId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.ResourceType == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceType"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetResourceId sets the ResourceId field's value.
+func (s *ResourceKey) SetResourceId(v string) *ResourceKey {
+	s.ResourceId = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *ResourceKey) SetResourceType(v string) *ResourceKey {
+	s.ResourceType = &v
+	return s
+}
+
 // Defines which resources trigger an evaluation for an AWS Config rule. The
 // scope can include one or more resource types, a combination of a tag key
 // and value, or a combination of one resource type and one resource ID. Specify
@@ -6327,6 +6703,11 @@ type SourceDetail struct {
 	// By default, rules with a periodic trigger are evaluated every 24 hours. To
 	// change the frequency, specify a valid value for the MaximumExecutionFrequency
 	// parameter.
+	//
+	// Based on the valid value you choose, AWS Config runs evaluations once for
+	// each valid value. For example, if you choose Three_Hours, AWS Config runs
+	// evaluations once every three hours. In this case, Three_Hours is the frequency
+	// of this rule.
 	MaximumExecutionFrequency *string `type:"string" enum:"MaximumExecutionFrequency"`
 
 	// The type of notification that triggers AWS Config to run an evaluation for
@@ -6347,7 +6728,8 @@ type SourceDetail struct {
 	//    when AWS Config delivers a configuration snapshot.
 	//
 	// If you want your custom rule to be triggered by configuration changes, specify
-	// both ConfigurationItemChangeNotification and OversizedConfigurationItemChangeNotification.
+	// two SourceDetail objects, one for ConfigurationItemChangeNotification and
+	// one for OversizedConfigurationItemChangeNotification.
 	MessageType *string `type:"string" enum:"MessageType"`
 }
 

--- a/vendor/github.com/aws/aws-sdk-go/service/ecs/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ecs/api.go
@@ -3439,8 +3439,17 @@ func (c *ECS) UpdateServiceRequest(input *UpdateServiceInput) (req *request.Requ
 // in a service by specifying the cluster that the service is running in and
 // a new desiredCount parameter.
 //
-// You can use UpdateService to modify your task definition and deploy a new
-// version of your service.
+// If you have updated the Docker image of your application, you can create
+// a new task definition with that image and deploy it to your service. The
+// service scheduler uses the minimum healthy percent and maximum percent parameters
+// (in the service's deployment configuration) to determine the deployment strategy.
+//
+// If your updated Docker image uses the same tag as what is in the existing
+// task definition for your service (for example, my_image:latest), you do not
+// need to create a new revision of your task definition. You can update the
+// service using the forceNewDeployment option. The new tasks launched by the
+// deployment pull the current image/tag combination from your repository when
+// they start.
 //
 // You can also update the deployment configuration of a service. When a deployment
 // is triggered by updating the task definition of a service, the service scheduler
@@ -3754,10 +3763,12 @@ type AwsVpcConfiguration struct {
 	AssignPublicIp *string `locationName:"assignPublicIp" type:"string" enum:"AssignPublicIp"`
 
 	// The security groups associated with the task or service. If you do not specify
-	// a security group, the default security group for the VPC is used.
+	// a security group, the default security group for the VPC is used. There is
+	// a limit of 5 security groups able to be specified per AwsVpcConfiguration.
 	SecurityGroups []*string `locationName:"securityGroups" type:"list"`
 
-	// The subnets associated with the task or service.
+	// The subnets associated with the task or service. There is a limit of 10 subnets
+	// able to be specified per AwsVpcConfiguration.
 	//
 	// Subnets is a required field
 	Subnets []*string `locationName:"subnets" type:"list" required:"true"`
@@ -4686,18 +4697,22 @@ type ContainerInstance struct {
 	// The Unix time stamp for when the container instance was registered.
 	RegisteredAt *time.Time `locationName:"registeredAt" type:"timestamp" timestampFormat:"unix"`
 
-	// For most resource types, this parameter describes the registered resources
-	// on the container instance that are in use by current tasks. For port resource
-	// types, this parameter describes the ports that were reserved by the Amazon
-	// ECS container agent when it registered the container instance with Amazon
-	// ECS.
+	// For CPU and memory resource types, this parameter describes the amount of
+	// each resource that was available on the container instance when the container
+	// agent registered it with Amazon ECS; this value represents the total amount
+	// of CPU and memory that can be allocated on this container instance to tasks.
+	// For port resource types, this parameter describes the ports that were reserved
+	// by the Amazon ECS container agent when it registered the container instance
+	// with Amazon ECS.
 	RegisteredResources []*Resource `locationName:"registeredResources" type:"list"`
 
-	// For most resource types, this parameter describes the remaining resources
-	// of the container instance that are available for new tasks. For port resource
-	// types, this parameter describes the ports that are reserved by the Amazon
-	// ECS container agent and any containers that have reserved port mappings;
-	// any port that is not specified here is available for new tasks.
+	// For CPU and memory resource types, this parameter describes the remaining
+	// CPU and memory on the that has not already been allocated to tasks (and is
+	// therefore available for new tasks). For port resource types, this parameter
+	// describes the ports that were reserved by the Amazon ECS container agent
+	// (at instance registration time) and any task containers that have reserved
+	// port mappings on the host (with the host or bridge network mode). Any port
+	// that is not specified here is available for new tasks.
 	RemainingResources []*Resource `locationName:"remainingResources" type:"list"`
 
 	// The number of tasks on the container instance that are in the RUNNING status.
@@ -5114,6 +5129,10 @@ type CreateServiceInput struct {
 	// ServiceName is a required field
 	ServiceName *string `locationName:"serviceName" type:"string" required:"true"`
 
+	// The details of the service discovery registries you want to assign to this
+	// service. For more information, see Service Discovery (http://docs.aws.amazon.com/AmazonECS/latest/developerguideservice-discovery.html).
+	ServiceRegistries []*ServiceRegistry `locationName:"serviceRegistries" type:"list"`
+
 	// The family and revision (family:revision) or full ARN of the task definition
 	// to run in your service. If a revision is not specified, the latest ACTIVE
 	// revision is used.
@@ -5231,6 +5250,12 @@ func (s *CreateServiceInput) SetRole(v string) *CreateServiceInput {
 // SetServiceName sets the ServiceName field's value.
 func (s *CreateServiceInput) SetServiceName(v string) *CreateServiceInput {
 	s.ServiceName = &v
+	return s
+}
+
+// SetServiceRegistries sets the ServiceRegistries field's value.
+func (s *CreateServiceInput) SetServiceRegistries(v []*ServiceRegistry) *CreateServiceInput {
+	s.ServiceRegistries = v
 	return s
 }
 
@@ -6663,6 +6688,14 @@ type LinuxParameters struct {
 	// container instance, log in to your container instance and run the following
 	// command: sudo docker version | grep "Server API version"
 	InitProcessEnabled *bool `locationName:"initProcessEnabled" type:"boolean"`
+
+	// The value for the size of the /dev/shm volume. This parameter maps to the
+	// --shm-size option to docker run (https://docs.docker.com/engine/reference/run/).
+	SharedMemorySize *int64 `locationName:"sharedMemorySize" type:"integer"`
+
+	// The container path, mount options, and size of the tmpfs mount. This parameter
+	// maps to the --tmpfs option to docker run (https://docs.docker.com/engine/reference/run/).
+	Tmpfs []*Tmpfs `locationName:"tmpfs" type:"list"`
 }
 
 // String returns the string representation
@@ -6688,6 +6721,16 @@ func (s *LinuxParameters) Validate() error {
 			}
 		}
 	}
+	if s.Tmpfs != nil {
+		for i, v := range s.Tmpfs {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Tmpfs", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -6710,6 +6753,18 @@ func (s *LinuxParameters) SetDevices(v []*Device) *LinuxParameters {
 // SetInitProcessEnabled sets the InitProcessEnabled field's value.
 func (s *LinuxParameters) SetInitProcessEnabled(v bool) *LinuxParameters {
 	s.InitProcessEnabled = &v
+	return s
+}
+
+// SetSharedMemorySize sets the SharedMemorySize field's value.
+func (s *LinuxParameters) SetSharedMemorySize(v int64) *LinuxParameters {
+	s.SharedMemorySize = &v
+	return s
+}
+
+// SetTmpfs sets the Tmpfs field's value.
+func (s *LinuxParameters) SetTmpfs(v []*Tmpfs) *LinuxParameters {
+	s.Tmpfs = v
 	return s
 }
 
@@ -8816,6 +8871,8 @@ type Service struct {
 	// within a region or across multiple regions.
 	ServiceName *string `locationName:"serviceName" type:"string"`
 
+	ServiceRegistries []*ServiceRegistry `locationName:"serviceRegistries" type:"list"`
+
 	// The status of the service. The valid values are ACTIVE, DRAINING, or INACTIVE.
 	Status *string `locationName:"status" type:"string"`
 
@@ -8943,6 +9000,12 @@ func (s *Service) SetServiceName(v string) *Service {
 	return s
 }
 
+// SetServiceRegistries sets the ServiceRegistries field's value.
+func (s *Service) SetServiceRegistries(v []*ServiceRegistry) *Service {
+	s.ServiceRegistries = v
+	return s
+}
+
 // SetStatus sets the Status field's value.
 func (s *Service) SetStatus(v string) *Service {
 	s.Status = &v
@@ -8994,6 +9057,41 @@ func (s *ServiceEvent) SetId(v string) *ServiceEvent {
 // SetMessage sets the Message field's value.
 func (s *ServiceEvent) SetMessage(v string) *ServiceEvent {
 	s.Message = &v
+	return s
+}
+
+// Details of the service registry.
+type ServiceRegistry struct {
+	_ struct{} `type:"structure"`
+
+	// The port value used if your Service Discovery service specified an SRV record.
+	Port *int64 `locationName:"port" type:"integer"`
+
+	// The Amazon Resource Name (ARN) of the Service Registry. The currently supported
+	// service registry is Amazon Route 53 Auto Naming Service. For more information,
+	// see Service (https://docs.aws.amazon.com/Route53/latest/APIReference/API_autonaming_Service.html).
+	RegistryArn *string `locationName:"registryArn" type:"string"`
+}
+
+// String returns the string representation
+func (s ServiceRegistry) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ServiceRegistry) GoString() string {
+	return s.String()
+}
+
+// SetPort sets the Port field's value.
+func (s *ServiceRegistry) SetPort(v int64) *ServiceRegistry {
+	s.Port = &v
+	return s
+}
+
+// SetRegistryArn sets the RegistryArn field's value.
+func (s *ServiceRegistry) SetRegistryArn(v string) *ServiceRegistry {
+	s.RegistryArn = &v
 	return s
 }
 
@@ -10145,6 +10243,74 @@ func (s *TaskOverride) SetTaskRoleArn(v string) *TaskOverride {
 	return s
 }
 
+// The container path, mount options, and size of the tmpfs mount.
+type Tmpfs struct {
+	_ struct{} `type:"structure"`
+
+	// The absolute file path where the tmpfs volume will be mounted.
+	//
+	// ContainerPath is a required field
+	ContainerPath *string `locationName:"containerPath" type:"string" required:"true"`
+
+	// The list of tmpfs volume mount options.
+	//
+	// Valid values: "defaults" | "ro" | "rw" | "suid" | "nosuid" | "dev" | "nodev"
+	// | "exec" | "noexec" | "sync" | "async" | "dirsync" | "remount" | "mand" |
+	// "nomand" | "atime" | "noatime" | "diratime" | "nodiratime" | "bind" | "rbind"
+	// | "unbindable" | "runbindable" | "private" | "rprivate" | "shared" | "rshared"
+	// | "slave" | "rslave" | "relatime" | "norelatime" | "strictatime" | "nostrictatime"
+	MountOptions []*string `locationName:"mountOptions" type:"list"`
+
+	// The size of the tmpfs volume.
+	//
+	// Size is a required field
+	Size *int64 `locationName:"size" type:"integer" required:"true"`
+}
+
+// String returns the string representation
+func (s Tmpfs) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s Tmpfs) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Tmpfs) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Tmpfs"}
+	if s.ContainerPath == nil {
+		invalidParams.Add(request.NewErrParamRequired("ContainerPath"))
+	}
+	if s.Size == nil {
+		invalidParams.Add(request.NewErrParamRequired("Size"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetContainerPath sets the ContainerPath field's value.
+func (s *Tmpfs) SetContainerPath(v string) *Tmpfs {
+	s.ContainerPath = &v
+	return s
+}
+
+// SetMountOptions sets the MountOptions field's value.
+func (s *Tmpfs) SetMountOptions(v []*string) *Tmpfs {
+	s.MountOptions = v
+	return s
+}
+
+// SetSize sets the Size field's value.
+func (s *Tmpfs) SetSize(v int64) *Tmpfs {
+	s.Size = &v
+	return s
+}
+
 // The ulimit settings to pass to the container.
 type Ulimit struct {
 	_ struct{} `type:"structure"`
@@ -10396,8 +10562,11 @@ type UpdateServiceInput struct {
 	// service.
 	DesiredCount *int64 `locationName:"desiredCount" type:"integer"`
 
-	// Whether to force a new deployment of the service. By default, --no-force-new-deployment
-	// is assumed unless otherwise specified.
+	// Whether to force a new deployment of the service. Deployments are not forced
+	// by default. You can use this option to trigger a new deployment with no service
+	// definition changes. For example, you can update a service's tasks to use
+	// a newer Docker image with the same image/tag combination (my_image:latest)
+	// or to roll Fargate tasks onto a newer platform version.
 	ForceNewDeployment *bool `locationName:"forceNewDeployment" type:"boolean"`
 
 	// The period of time, in seconds, that the Amazon ECS service scheduler should

--- a/vendor/github.com/aws/aws-sdk-go/service/elasticbeanstalk/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/elasticbeanstalk/api.go
@@ -71,7 +71,7 @@ func (c *ElasticBeanstalk) AbortEnvironmentUpdateRequest(input *AbortEnvironment
 //
 // Returned Error Codes:
 //   * ErrCodeInsufficientPrivilegesException "InsufficientPrivilegesException"
-//   The specified account does not have sufficient privileges for one of more
+//   The specified account does not have sufficient privileges for one or more
 //   AWS services.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/elasticbeanstalk-2010-12-01/AbortEnvironmentUpdate
@@ -318,7 +318,7 @@ func (c *ElasticBeanstalk) ComposeEnvironmentsRequest(input *ComposeEnvironments
 //   The specified account has reached its limit of environments.
 //
 //   * ErrCodeInsufficientPrivilegesException "InsufficientPrivilegesException"
-//   The specified account does not have sufficient privileges for one of more
+//   The specified account does not have sufficient privileges for one or more
 //   AWS services.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/elasticbeanstalk-2010-12-01/ComposeEnvironments
@@ -500,7 +500,7 @@ func (c *ElasticBeanstalk) CreateApplicationVersionRequest(input *CreateApplicat
 //   The specified account has reached its limit of application versions.
 //
 //   * ErrCodeInsufficientPrivilegesException "InsufficientPrivilegesException"
-//   The specified account does not have sufficient privileges for one of more
+//   The specified account does not have sufficient privileges for one or more
 //   AWS services.
 //
 //   * ErrCodeS3LocationNotInServiceRegionException "S3LocationNotInServiceRegionException"
@@ -603,7 +603,7 @@ func (c *ElasticBeanstalk) CreateConfigurationTemplateRequest(input *CreateConfi
 //
 // Returned Error Codes:
 //   * ErrCodeInsufficientPrivilegesException "InsufficientPrivilegesException"
-//   The specified account does not have sufficient privileges for one of more
+//   The specified account does not have sufficient privileges for one or more
 //   AWS services.
 //
 //   * ErrCodeTooManyBucketsException "TooManyBucketsException"
@@ -693,7 +693,7 @@ func (c *ElasticBeanstalk) CreateEnvironmentRequest(input *CreateEnvironmentInpu
 //   The specified account has reached its limit of environments.
 //
 //   * ErrCodeInsufficientPrivilegesException "InsufficientPrivilegesException"
-//   The specified account does not have sufficient privileges for one of more
+//   The specified account does not have sufficient privileges for one or more
 //   AWS services.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/elasticbeanstalk-2010-12-01/CreateEnvironment
@@ -773,7 +773,7 @@ func (c *ElasticBeanstalk) CreatePlatformVersionRequest(input *CreatePlatformVer
 //
 // Returned Error Codes:
 //   * ErrCodeInsufficientPrivilegesException "InsufficientPrivilegesException"
-//   The specified account does not have sufficient privileges for one of more
+//   The specified account does not have sufficient privileges for one or more
 //   AWS services.
 //
 //   * ErrCodeServiceException "ServiceException"
@@ -870,7 +870,7 @@ func (c *ElasticBeanstalk) CreateStorageLocationRequest(input *CreateStorageLoca
 //   The specified account does not have a subscription to Amazon S3.
 //
 //   * ErrCodeInsufficientPrivilegesException "InsufficientPrivilegesException"
-//   The specified account does not have sufficient privileges for one of more
+//   The specified account does not have sufficient privileges for one or more
 //   AWS services.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/elasticbeanstalk-2010-12-01/CreateStorageLocation
@@ -1045,7 +1045,7 @@ func (c *ElasticBeanstalk) DeleteApplicationVersionRequest(input *DeleteApplicat
 //   version. The application version was deleted successfully.
 //
 //   * ErrCodeInsufficientPrivilegesException "InsufficientPrivilegesException"
-//   The specified account does not have sufficient privileges for one of more
+//   The specified account does not have sufficient privileges for one or more
 //   AWS services.
 //
 //   * ErrCodeOperationInProgressException "OperationInProgressFailure"
@@ -1312,7 +1312,7 @@ func (c *ElasticBeanstalk) DeletePlatformVersionRequest(input *DeletePlatformVer
 //   effects an element in this activity is already in progress.
 //
 //   * ErrCodeInsufficientPrivilegesException "InsufficientPrivilegesException"
-//   The specified account does not have sufficient privileges for one of more
+//   The specified account does not have sufficient privileges for one or more
 //   AWS services.
 //
 //   * ErrCodeServiceException "ServiceException"
@@ -1339,6 +1339,89 @@ func (c *ElasticBeanstalk) DeletePlatformVersion(input *DeletePlatformVersionInp
 // for more information on using Contexts.
 func (c *ElasticBeanstalk) DeletePlatformVersionWithContext(ctx aws.Context, input *DeletePlatformVersionInput, opts ...request.Option) (*DeletePlatformVersionOutput, error) {
 	req, out := c.DeletePlatformVersionRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDescribeAccountAttributes = "DescribeAccountAttributes"
+
+// DescribeAccountAttributesRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeAccountAttributes operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeAccountAttributes for more information on using the DescribeAccountAttributes
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeAccountAttributesRequest method.
+//    req, resp := client.DescribeAccountAttributesRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/elasticbeanstalk-2010-12-01/DescribeAccountAttributes
+func (c *ElasticBeanstalk) DescribeAccountAttributesRequest(input *DescribeAccountAttributesInput) (req *request.Request, output *DescribeAccountAttributesOutput) {
+	op := &request.Operation{
+		Name:       opDescribeAccountAttributes,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DescribeAccountAttributesInput{}
+	}
+
+	output = &DescribeAccountAttributesOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeAccountAttributes API operation for AWS Elastic Beanstalk.
+//
+// Returns attributes related to AWS Elastic Beanstalk that are associated with
+// the calling AWS account.
+//
+// The result currently has one set of attributes—resource quotas.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Elastic Beanstalk's
+// API operation DescribeAccountAttributes for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInsufficientPrivilegesException "InsufficientPrivilegesException"
+//   The specified account does not have sufficient privileges for one or more
+//   AWS services.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/elasticbeanstalk-2010-12-01/DescribeAccountAttributes
+func (c *ElasticBeanstalk) DescribeAccountAttributes(input *DescribeAccountAttributesInput) (*DescribeAccountAttributesOutput, error) {
+	req, out := c.DescribeAccountAttributesRequest(input)
+	return out, req.Send()
+}
+
+// DescribeAccountAttributesWithContext is the same as DescribeAccountAttributes with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeAccountAttributes for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ElasticBeanstalk) DescribeAccountAttributesWithContext(ctx aws.Context, input *DescribeAccountAttributesInput, opts ...request.Option) (*DescribeAccountAttributesOutput, error) {
+	req, out := c.DescribeAccountAttributesRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -1964,7 +2047,7 @@ func (c *ElasticBeanstalk) DescribeEnvironmentResourcesRequest(input *DescribeEn
 //
 // Returned Error Codes:
 //   * ErrCodeInsufficientPrivilegesException "InsufficientPrivilegesException"
-//   The specified account does not have sufficient privileges for one of more
+//   The specified account does not have sufficient privileges for one or more
 //   AWS services.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/elasticbeanstalk-2010-12-01/DescribeEnvironmentResources
@@ -2334,7 +2417,7 @@ func (c *ElasticBeanstalk) DescribePlatformVersionRequest(input *DescribePlatfor
 //
 // Returned Error Codes:
 //   * ErrCodeInsufficientPrivilegesException "InsufficientPrivilegesException"
-//   The specified account does not have sufficient privileges for one of more
+//   The specified account does not have sufficient privileges for one or more
 //   AWS services.
 //
 //   * ErrCodeServiceException "ServiceException"
@@ -2492,7 +2575,7 @@ func (c *ElasticBeanstalk) ListPlatformVersionsRequest(input *ListPlatformVersio
 //
 // Returned Error Codes:
 //   * ErrCodeInsufficientPrivilegesException "InsufficientPrivilegesException"
-//   The specified account does not have sufficient privileges for one of more
+//   The specified account does not have sufficient privileges for one or more
 //   AWS services.
 //
 //   * ErrCodeServiceException "ServiceException"
@@ -2580,7 +2663,7 @@ func (c *ElasticBeanstalk) ListTagsForResourceRequest(input *ListTagsForResource
 //
 // Returned Error Codes:
 //   * ErrCodeInsufficientPrivilegesException "InsufficientPrivilegesException"
-//   The specified account does not have sufficient privileges for one of more
+//   The specified account does not have sufficient privileges for one or more
 //   AWS services.
 //
 //   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
@@ -2670,7 +2753,7 @@ func (c *ElasticBeanstalk) RebuildEnvironmentRequest(input *RebuildEnvironmentIn
 //
 // Returned Error Codes:
 //   * ErrCodeInsufficientPrivilegesException "InsufficientPrivilegesException"
-//   The specified account does not have sufficient privileges for one of more
+//   The specified account does not have sufficient privileges for one or more
 //   AWS services.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/elasticbeanstalk-2010-12-01/RebuildEnvironment
@@ -3071,7 +3154,7 @@ func (c *ElasticBeanstalk) TerminateEnvironmentRequest(input *TerminateEnvironme
 //
 // Returned Error Codes:
 //   * ErrCodeInsufficientPrivilegesException "InsufficientPrivilegesException"
-//   The specified account does not have sufficient privileges for one of more
+//   The specified account does not have sufficient privileges for one or more
 //   AWS services.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/elasticbeanstalk-2010-12-01/TerminateEnvironment
@@ -3228,7 +3311,7 @@ func (c *ElasticBeanstalk) UpdateApplicationResourceLifecycleRequest(input *Upda
 //
 // Returned Error Codes:
 //   * ErrCodeInsufficientPrivilegesException "InsufficientPrivilegesException"
-//   The specified account does not have sufficient privileges for one of more
+//   The specified account does not have sufficient privileges for one or more
 //   AWS services.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/elasticbeanstalk-2010-12-01/UpdateApplicationResourceLifecycle
@@ -3393,7 +3476,7 @@ func (c *ElasticBeanstalk) UpdateConfigurationTemplateRequest(input *UpdateConfi
 //
 // Returned Error Codes:
 //   * ErrCodeInsufficientPrivilegesException "InsufficientPrivilegesException"
-//   The specified account does not have sufficient privileges for one of more
+//   The specified account does not have sufficient privileges for one or more
 //   AWS services.
 //
 //   * ErrCodeTooManyBucketsException "TooManyBucketsException"
@@ -3486,7 +3569,7 @@ func (c *ElasticBeanstalk) UpdateEnvironmentRequest(input *UpdateEnvironmentInpu
 //
 // Returned Error Codes:
 //   * ErrCodeInsufficientPrivilegesException "InsufficientPrivilegesException"
-//   The specified account does not have sufficient privileges for one of more
+//   The specified account does not have sufficient privileges for one or more
 //   AWS services.
 //
 //   * ErrCodeTooManyBucketsException "TooManyBucketsException"
@@ -3589,7 +3672,7 @@ func (c *ElasticBeanstalk) UpdateTagsForResourceRequest(input *UpdateTagsForReso
 //
 // Returned Error Codes:
 //   * ErrCodeInsufficientPrivilegesException "InsufficientPrivilegesException"
-//   The specified account does not have sufficient privileges for one of more
+//   The specified account does not have sufficient privileges for one or more
 //   AWS services.
 //
 //   * ErrCodeOperationInProgressException "OperationInProgressFailure"
@@ -3691,7 +3774,7 @@ func (c *ElasticBeanstalk) ValidateConfigurationSettingsRequest(input *ValidateC
 //
 // Returned Error Codes:
 //   * ErrCodeInsufficientPrivilegesException "InsufficientPrivilegesException"
-//   The specified account does not have sufficient privileges for one of more
+//   The specified account does not have sufficient privileges for one or more
 //   AWS services.
 //
 //   * ErrCodeTooManyBucketsException "TooManyBucketsException"
@@ -6189,6 +6272,43 @@ func (s *Deployment) SetStatus(v string) *Deployment {
 // SetVersionLabel sets the VersionLabel field's value.
 func (s *Deployment) SetVersionLabel(v string) *Deployment {
 	s.VersionLabel = &v
+	return s
+}
+
+type DescribeAccountAttributesInput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeAccountAttributesInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAccountAttributesInput) GoString() string {
+	return s.String()
+}
+
+type DescribeAccountAttributesOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The Elastic Beanstalk resource quotas associated with the calling AWS account.
+	ResourceQuotas *ResourceQuotas `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeAccountAttributesOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAccountAttributesOutput) GoString() string {
+	return s.String()
+}
+
+// SetResourceQuotas sets the ResourceQuotas field's value.
+func (s *DescribeAccountAttributesOutput) SetResourceQuotas(v *ResourceQuotas) *DescribeAccountAttributesOutput {
+	s.ResourceQuotas = v
 	return s
 }
 
@@ -9525,6 +9645,93 @@ func (s RequestEnvironmentInfoOutput) String() string {
 // GoString returns the string representation
 func (s RequestEnvironmentInfoOutput) GoString() string {
 	return s.String()
+}
+
+// The AWS Elastic Beanstalk quota information for a single resource type in
+// an AWS account. It reflects the resource's limits for this account.
+type ResourceQuota struct {
+	_ struct{} `type:"structure"`
+
+	// The maximum number of instances of this Elastic Beanstalk resource type that
+	// an AWS account can use.
+	Maximum *int64 `type:"integer"`
+}
+
+// String returns the string representation
+func (s ResourceQuota) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ResourceQuota) GoString() string {
+	return s.String()
+}
+
+// SetMaximum sets the Maximum field's value.
+func (s *ResourceQuota) SetMaximum(v int64) *ResourceQuota {
+	s.Maximum = &v
+	return s
+}
+
+// A set of per-resource AWS Elastic Beanstalk quotas associated with an AWS
+// account. They reflect Elastic Beanstalk resource limits for this account.
+type ResourceQuotas struct {
+	_ struct{} `type:"structure"`
+
+	// The quota for applications in the AWS account.
+	ApplicationQuota *ResourceQuota `type:"structure"`
+
+	// The quota for application versions in the AWS account.
+	ApplicationVersionQuota *ResourceQuota `type:"structure"`
+
+	// The quota for configuration templates in the AWS account.
+	ConfigurationTemplateQuota *ResourceQuota `type:"structure"`
+
+	// The quota for custom platforms in the AWS account.
+	CustomPlatformQuota *ResourceQuota `type:"structure"`
+
+	// The quota for environments in the AWS account.
+	EnvironmentQuota *ResourceQuota `type:"structure"`
+}
+
+// String returns the string representation
+func (s ResourceQuotas) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ResourceQuotas) GoString() string {
+	return s.String()
+}
+
+// SetApplicationQuota sets the ApplicationQuota field's value.
+func (s *ResourceQuotas) SetApplicationQuota(v *ResourceQuota) *ResourceQuotas {
+	s.ApplicationQuota = v
+	return s
+}
+
+// SetApplicationVersionQuota sets the ApplicationVersionQuota field's value.
+func (s *ResourceQuotas) SetApplicationVersionQuota(v *ResourceQuota) *ResourceQuotas {
+	s.ApplicationVersionQuota = v
+	return s
+}
+
+// SetConfigurationTemplateQuota sets the ConfigurationTemplateQuota field's value.
+func (s *ResourceQuotas) SetConfigurationTemplateQuota(v *ResourceQuota) *ResourceQuotas {
+	s.ConfigurationTemplateQuota = v
+	return s
+}
+
+// SetCustomPlatformQuota sets the CustomPlatformQuota field's value.
+func (s *ResourceQuotas) SetCustomPlatformQuota(v *ResourceQuota) *ResourceQuotas {
+	s.CustomPlatformQuota = v
+	return s
+}
+
+// SetEnvironmentQuota sets the EnvironmentQuota field's value.
+func (s *ResourceQuotas) SetEnvironmentQuota(v *ResourceQuota) *ResourceQuotas {
+	s.EnvironmentQuota = v
+	return s
 }
 
 type RestartAppServerInput struct {

--- a/vendor/github.com/aws/aws-sdk-go/service/elasticbeanstalk/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/elasticbeanstalk/errors.go
@@ -13,7 +13,7 @@ const (
 	// ErrCodeInsufficientPrivilegesException for service response error code
 	// "InsufficientPrivilegesException".
 	//
-	// The specified account does not have sufficient privileges for one of more
+	// The specified account does not have sufficient privileges for one or more
 	// AWS services.
 	ErrCodeInsufficientPrivilegesException = "InsufficientPrivilegesException"
 

--- a/vendor/github.com/aws/aws-sdk-go/service/glue/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/glue/api.go
@@ -9893,9 +9893,7 @@ type CreateDevEndpointInput struct {
 	NumberOfNodes *int64 `type:"integer"`
 
 	// The public key to use for authentication.
-	//
-	// PublicKey is a required field
-	PublicKey *string `type:"string" required:"true"`
+	PublicKey *string `type:"string"`
 
 	// The IAM role for the DevEndpoint.
 	//
@@ -9924,9 +9922,6 @@ func (s *CreateDevEndpointInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "CreateDevEndpointInput"}
 	if s.EndpointName == nil {
 		invalidParams.Add(request.NewErrParamRequired("EndpointName"))
-	}
-	if s.PublicKey == nil {
-		invalidParams.Add(request.NewErrParamRequired("PublicKey"))
 	}
 	if s.RoleArn == nil {
 		invalidParams.Add(request.NewErrParamRequired("RoleArn"))
@@ -12011,7 +12006,10 @@ type DevEndpoint struct {
 	// The number of AWS Glue Data Processing Units (DPUs) allocated to this DevEndpoint.
 	NumberOfNodes *int64 `type:"integer"`
 
-	// The public address used by this DevEndpoint.
+	// The private address used by this DevEndpoint.
+	PrivateAddress *string `type:"string"`
+
+	// The public VPC address used by this DevEndpoint.
 	PublicAddress *string `type:"string"`
 
 	// The public key to be used by this DevEndpoint for authentication.
@@ -12100,6 +12098,12 @@ func (s *DevEndpoint) SetLastUpdateStatus(v string) *DevEndpoint {
 // SetNumberOfNodes sets the NumberOfNodes field's value.
 func (s *DevEndpoint) SetNumberOfNodes(v int64) *DevEndpoint {
 	s.NumberOfNodes = &v
+	return s
+}
+
+// SetPrivateAddress sets the PrivateAddress field's value.
+func (s *DevEndpoint) SetPrivateAddress(v string) *DevEndpoint {
+	s.PrivateAddress = &v
 	return s
 }
 

--- a/vendor/github.com/aws/aws-sdk-go/service/guardduty/service.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/guardduty/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := guardduty.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *GuardDuty {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
+		c.SigningName = "guardduty"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *GuardDuty {
-	if len(signingName) == 0 {
-		signingName = "guardduty"
-	}
 	svc := &GuardDuty{
 		Client: client.New(
 			cfg,

--- a/vendor/github.com/aws/aws-sdk-go/service/iot/service.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/iot/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := iot.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *IoT {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
+		c.SigningName = "execute-api"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *IoT {
-	if len(signingName) == 0 {
-		signingName = "execute-api"
-	}
 	svc := &IoT{
 		Client: client.New(
 			cfg,

--- a/vendor/github.com/aws/aws-sdk-go/service/lexmodelbuildingservice/service.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/lexmodelbuildingservice/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := lexmodelbuildingservice.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *LexModelBuildingService {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
+		c.SigningName = "lex"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *LexModelBuildingService {
-	if len(signingName) == 0 {
-		signingName = "lex"
-	}
 	svc := &LexModelBuildingService{
 		Client: client.New(
 			cfg,

--- a/vendor/github.com/aws/aws-sdk-go/service/mediaconvert/service.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/mediaconvert/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := mediaconvert.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *MediaConvert {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
+		c.SigningName = "mediaconvert"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *MediaConvert {
-	if len(signingName) == 0 {
-		signingName = "mediaconvert"
-	}
 	svc := &MediaConvert{
 		Client: client.New(
 			cfg,

--- a/vendor/github.com/aws/aws-sdk-go/service/medialive/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/medialive/api.go
@@ -64,9 +64,9 @@ func (c *MediaLive) CreateChannelRequest(input *CreateChannelInput) (req *reques
 // API operation CreateChannel for usage and error information.
 //
 // Returned Error Codes:
-//   * ErrCodeBadRequestException "BadRequestException"
-//
 //   * ErrCodeUnprocessableEntityException "UnprocessableEntityException"
+//
+//   * ErrCodeBadRequestException "BadRequestException"
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
 //
@@ -1492,9 +1492,9 @@ func (c *MediaLive) UpdateChannelRequest(input *UpdateChannelInput) (req *reques
 // API operation UpdateChannel for usage and error information.
 //
 // Returned Error Codes:
-//   * ErrCodeBadRequestException "BadRequestException"
-//
 //   * ErrCodeUnprocessableEntityException "UnprocessableEntityException"
+//
+//   * ErrCodeBadRequestException "BadRequestException"
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
 //
@@ -1523,6 +1523,186 @@ func (c *MediaLive) UpdateChannel(input *UpdateChannelInput) (*UpdateChannelOutp
 // for more information on using Contexts.
 func (c *MediaLive) UpdateChannelWithContext(ctx aws.Context, input *UpdateChannelInput, opts ...request.Option) (*UpdateChannelOutput, error) {
 	req, out := c.UpdateChannelRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opUpdateInput = "UpdateInput"
+
+// UpdateInputRequest generates a "aws/request.Request" representing the
+// client's request for the UpdateInput operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See UpdateInput for more information on using the UpdateInput
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the UpdateInputRequest method.
+//    req, resp := client.UpdateInputRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/UpdateInput
+func (c *MediaLive) UpdateInputRequest(input *UpdateInputInput) (req *request.Request, output *UpdateInputOutput) {
+	op := &request.Operation{
+		Name:       opUpdateInput,
+		HTTPMethod: "PUT",
+		HTTPPath:   "/prod/inputs/{inputId}",
+	}
+
+	if input == nil {
+		input = &UpdateInputInput{}
+	}
+
+	output = &UpdateInputOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// UpdateInput API operation for AWS Elemental MediaLive.
+//
+// Updates an input.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Elemental MediaLive's
+// API operation UpdateInput for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeBadRequestException "BadRequestException"
+//
+//   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//
+//   * ErrCodeForbiddenException "ForbiddenException"
+//
+//   * ErrCodeBadGatewayException "BadGatewayException"
+//
+//   * ErrCodeNotFoundException "NotFoundException"
+//
+//   * ErrCodeGatewayTimeoutException "GatewayTimeoutException"
+//
+//   * ErrCodeConflictException "ConflictException"
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/UpdateInput
+func (c *MediaLive) UpdateInput(input *UpdateInputInput) (*UpdateInputOutput, error) {
+	req, out := c.UpdateInputRequest(input)
+	return out, req.Send()
+}
+
+// UpdateInputWithContext is the same as UpdateInput with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UpdateInput for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *MediaLive) UpdateInputWithContext(ctx aws.Context, input *UpdateInputInput, opts ...request.Option) (*UpdateInputOutput, error) {
+	req, out := c.UpdateInputRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opUpdateInputSecurityGroup = "UpdateInputSecurityGroup"
+
+// UpdateInputSecurityGroupRequest generates a "aws/request.Request" representing the
+// client's request for the UpdateInputSecurityGroup operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See UpdateInputSecurityGroup for more information on using the UpdateInputSecurityGroup
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the UpdateInputSecurityGroupRequest method.
+//    req, resp := client.UpdateInputSecurityGroupRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/UpdateInputSecurityGroup
+func (c *MediaLive) UpdateInputSecurityGroupRequest(input *UpdateInputSecurityGroupInput) (req *request.Request, output *UpdateInputSecurityGroupOutput) {
+	op := &request.Operation{
+		Name:       opUpdateInputSecurityGroup,
+		HTTPMethod: "PUT",
+		HTTPPath:   "/prod/inputSecurityGroups/{inputSecurityGroupId}",
+	}
+
+	if input == nil {
+		input = &UpdateInputSecurityGroupInput{}
+	}
+
+	output = &UpdateInputSecurityGroupOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// UpdateInputSecurityGroup API operation for AWS Elemental MediaLive.
+//
+// Update an Input Security Group's Whilelists.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Elemental MediaLive's
+// API operation UpdateInputSecurityGroup for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeBadRequestException "BadRequestException"
+//
+//   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//
+//   * ErrCodeForbiddenException "ForbiddenException"
+//
+//   * ErrCodeBadGatewayException "BadGatewayException"
+//
+//   * ErrCodeNotFoundException "NotFoundException"
+//
+//   * ErrCodeGatewayTimeoutException "GatewayTimeoutException"
+//
+//   * ErrCodeConflictException "ConflictException"
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/UpdateInputSecurityGroup
+func (c *MediaLive) UpdateInputSecurityGroup(input *UpdateInputSecurityGroupInput) (*UpdateInputSecurityGroupOutput, error) {
+	req, out := c.UpdateInputSecurityGroupRequest(input)
+	return out, req.Send()
+}
+
+// UpdateInputSecurityGroupWithContext is the same as UpdateInputSecurityGroup with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UpdateInputSecurityGroup for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *MediaLive) UpdateInputSecurityGroupWithContext(ctx aws.Context, input *UpdateInputSecurityGroupInput, opts ...request.Option) (*UpdateInputSecurityGroupOutput, error) {
+	req, out := c.UpdateInputSecurityGroupRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -4447,6 +4627,10 @@ type DescribeInputSecurityGroupOutput struct {
 
 	Id *string `locationName:"id" type:"string"`
 
+	Inputs []*string `locationName:"inputs" type:"list"`
+
+	State *string `locationName:"state" type:"string" enum:"InputSecurityGroupState"`
+
 	WhitelistRules []*InputWhitelistRule `locationName:"whitelistRules" type:"list"`
 }
 
@@ -4469,6 +4653,18 @@ func (s *DescribeInputSecurityGroupOutput) SetArn(v string) *DescribeInputSecuri
 // SetId sets the Id field's value.
 func (s *DescribeInputSecurityGroupOutput) SetId(v string) *DescribeInputSecurityGroupOutput {
 	s.Id = &v
+	return s
+}
+
+// SetInputs sets the Inputs field's value.
+func (s *DescribeInputSecurityGroupOutput) SetInputs(v []*string) *DescribeInputSecurityGroupOutput {
+	s.Inputs = v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *DescribeInputSecurityGroupOutput) SetState(v string) *DescribeInputSecurityGroupOutput {
+	s.State = &v
 	return s
 }
 
@@ -7305,6 +7501,12 @@ type InputSecurityGroup struct {
 	// The Id of the Input Security Group
 	Id *string `locationName:"id" type:"string"`
 
+	// The list of inputs currently using this Input Security Group.
+	Inputs []*string `locationName:"inputs" type:"list"`
+
+	// The current state of the Input Security Group.
+	State *string `locationName:"state" type:"string" enum:"InputSecurityGroupState"`
+
 	// Whitelist rules and their sync status
 	WhitelistRules []*InputWhitelistRule `locationName:"whitelistRules" type:"list"`
 }
@@ -7328,6 +7530,18 @@ func (s *InputSecurityGroup) SetArn(v string) *InputSecurityGroup {
 // SetId sets the Id field's value.
 func (s *InputSecurityGroup) SetId(v string) *InputSecurityGroup {
 	s.Id = &v
+	return s
+}
+
+// SetInputs sets the Inputs field's value.
+func (s *InputSecurityGroup) SetInputs(v []*string) *InputSecurityGroup {
+	s.Inputs = v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *InputSecurityGroup) SetState(v string) *InputSecurityGroup {
+	s.State = &v
 	return s
 }
 
@@ -7624,7 +7838,7 @@ func (s *InputWhitelistRule) SetCidr(v string) *InputWhitelistRule {
 type InputWhitelistRuleCidr struct {
 	_ struct{} `type:"structure"`
 
-	// The IPv4 CIDR to whitelist
+	// The IPv4 CIDR to whitelist.
 	Cidr *string `locationName:"cidr" type:"string"`
 }
 
@@ -10347,6 +10561,8 @@ type UpdateChannelInput struct {
 
 	EncoderSettings *EncoderSettings `locationName:"encoderSettings" type:"structure"`
 
+	InputAttachments []*InputAttachment `locationName:"inputAttachments" type:"list"`
+
 	InputSpecification *InputSpecification `locationName:"inputSpecification" type:"structure"`
 
 	Name *string `locationName:"name" type:"string"`
@@ -10375,6 +10591,16 @@ func (s *UpdateChannelInput) Validate() error {
 			invalidParams.AddNested("EncoderSettings", err.(request.ErrInvalidParams))
 		}
 	}
+	if s.InputAttachments != nil {
+		for i, v := range s.InputAttachments {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "InputAttachments", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -10397,6 +10623,12 @@ func (s *UpdateChannelInput) SetDestinations(v []*OutputDestination) *UpdateChan
 // SetEncoderSettings sets the EncoderSettings field's value.
 func (s *UpdateChannelInput) SetEncoderSettings(v *EncoderSettings) *UpdateChannelInput {
 	s.EncoderSettings = v
+	return s
+}
+
+// SetInputAttachments sets the InputAttachments field's value.
+func (s *UpdateChannelInput) SetInputAttachments(v []*InputAttachment) *UpdateChannelInput {
+	s.InputAttachments = v
 	return s
 }
 
@@ -10437,6 +10669,163 @@ func (s UpdateChannelOutput) GoString() string {
 // SetChannel sets the Channel field's value.
 func (s *UpdateChannelOutput) SetChannel(v *Channel) *UpdateChannelOutput {
 	s.Channel = v
+	return s
+}
+
+type UpdateInputInput struct {
+	_ struct{} `type:"structure"`
+
+	Destinations []*InputDestinationRequest `locationName:"destinations" type:"list"`
+
+	// InputId is a required field
+	InputId *string `location:"uri" locationName:"inputId" type:"string" required:"true"`
+
+	InputSecurityGroups []*string `locationName:"inputSecurityGroups" type:"list"`
+
+	Name *string `locationName:"name" type:"string"`
+
+	Sources []*InputSourceRequest `locationName:"sources" type:"list"`
+}
+
+// String returns the string representation
+func (s UpdateInputInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateInputInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateInputInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateInputInput"}
+	if s.InputId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InputId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDestinations sets the Destinations field's value.
+func (s *UpdateInputInput) SetDestinations(v []*InputDestinationRequest) *UpdateInputInput {
+	s.Destinations = v
+	return s
+}
+
+// SetInputId sets the InputId field's value.
+func (s *UpdateInputInput) SetInputId(v string) *UpdateInputInput {
+	s.InputId = &v
+	return s
+}
+
+// SetInputSecurityGroups sets the InputSecurityGroups field's value.
+func (s *UpdateInputInput) SetInputSecurityGroups(v []*string) *UpdateInputInput {
+	s.InputSecurityGroups = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *UpdateInputInput) SetName(v string) *UpdateInputInput {
+	s.Name = &v
+	return s
+}
+
+// SetSources sets the Sources field's value.
+func (s *UpdateInputInput) SetSources(v []*InputSourceRequest) *UpdateInputInput {
+	s.Sources = v
+	return s
+}
+
+type UpdateInputOutput struct {
+	_ struct{} `type:"structure"`
+
+	Input *Input `locationName:"input" type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateInputOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateInputOutput) GoString() string {
+	return s.String()
+}
+
+// SetInput sets the Input field's value.
+func (s *UpdateInputOutput) SetInput(v *Input) *UpdateInputOutput {
+	s.Input = v
+	return s
+}
+
+type UpdateInputSecurityGroupInput struct {
+	_ struct{} `type:"structure"`
+
+	// InputSecurityGroupId is a required field
+	InputSecurityGroupId *string `location:"uri" locationName:"inputSecurityGroupId" type:"string" required:"true"`
+
+	WhitelistRules []*InputWhitelistRuleCidr `locationName:"whitelistRules" type:"list"`
+}
+
+// String returns the string representation
+func (s UpdateInputSecurityGroupInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateInputSecurityGroupInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateInputSecurityGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateInputSecurityGroupInput"}
+	if s.InputSecurityGroupId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InputSecurityGroupId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetInputSecurityGroupId sets the InputSecurityGroupId field's value.
+func (s *UpdateInputSecurityGroupInput) SetInputSecurityGroupId(v string) *UpdateInputSecurityGroupInput {
+	s.InputSecurityGroupId = &v
+	return s
+}
+
+// SetWhitelistRules sets the WhitelistRules field's value.
+func (s *UpdateInputSecurityGroupInput) SetWhitelistRules(v []*InputWhitelistRuleCidr) *UpdateInputSecurityGroupInput {
+	s.WhitelistRules = v
+	return s
+}
+
+type UpdateInputSecurityGroupOutput struct {
+	_ struct{} `type:"structure"`
+
+	// An Input Security Group
+	SecurityGroup *InputSecurityGroup `locationName:"securityGroup" type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateInputSecurityGroupOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateInputSecurityGroupOutput) GoString() string {
+	return s.String()
+}
+
+// SetSecurityGroup sets the SecurityGroup field's value.
+func (s *UpdateInputSecurityGroupOutput) SetSecurityGroup(v *InputSecurityGroup) *UpdateInputSecurityGroupOutput {
+	s.SecurityGroup = v
 	return s
 }
 
@@ -11925,6 +12314,20 @@ const (
 
 	// InputResolutionUhd is a InputResolution enum value
 	InputResolutionUhd = "UHD"
+)
+
+const (
+	// InputSecurityGroupStateIdle is a InputSecurityGroupState enum value
+	InputSecurityGroupStateIdle = "IDLE"
+
+	// InputSecurityGroupStateInUse is a InputSecurityGroupState enum value
+	InputSecurityGroupStateInUse = "IN_USE"
+
+	// InputSecurityGroupStateUpdating is a InputSecurityGroupState enum value
+	InputSecurityGroupStateUpdating = "UPDATING"
+
+	// InputSecurityGroupStateDeleted is a InputSecurityGroupState enum value
+	InputSecurityGroupStateDeleted = "DELETED"
 )
 
 const (

--- a/vendor/github.com/aws/aws-sdk-go/service/medialive/service.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/medialive/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := medialive.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *MediaLive {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
+		c.SigningName = "medialive"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *MediaLive {
-	if len(signingName) == 0 {
-		signingName = "medialive"
-	}
 	svc := &MediaLive{
 		Client: client.New(
 			cfg,

--- a/vendor/github.com/aws/aws-sdk-go/service/mediapackage/service.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/mediapackage/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := mediapackage.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *MediaPackage {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
+		c.SigningName = "mediapackage"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *MediaPackage {
-	if len(signingName) == 0 {
-		signingName = "mediapackage"
-	}
 	svc := &MediaPackage{
 		Client: client.New(
 			cfg,

--- a/vendor/github.com/aws/aws-sdk-go/service/mediastore/service.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/mediastore/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := mediastore.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *MediaStore {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
+		c.SigningName = "mediastore"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *MediaStore {
-	if len(signingName) == 0 {
-		signingName = "mediastore"
-	}
 	svc := &MediaStore{
 		Client: client.New(
 			cfg,

--- a/vendor/github.com/aws/aws-sdk-go/service/mediastoredata/service.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/mediastoredata/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := mediastoredata.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *MediaStoreData {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
+		c.SigningName = "mediastore"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *MediaStoreData {
-	if len(signingName) == 0 {
-		signingName = "mediastore"
-	}
 	svc := &MediaStoreData{
 		Client: client.New(
 			cfg,

--- a/vendor/github.com/aws/aws-sdk-go/service/mq/service.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/mq/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := mq.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *MQ {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
+		c.SigningName = "mq"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *MQ {
-	if len(signingName) == 0 {
-		signingName = "mq"
-	}
 	svc := &MQ{
 		Client: client.New(
 			cfg,

--- a/vendor/github.com/aws/aws-sdk-go/service/rds/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/rds/api.go
@@ -12060,15 +12060,21 @@ type CreateDBInstanceInput struct {
 	//
 	// MariaDB
 	//
+	//    * 10.2.12 (supported in all AWS Regions)
+	//
 	//    * 10.2.11 (supported in all AWS Regions)
 	//
-	// 10.1.26 (supported in all AWS Regions)
+	// 10.1.31 (supported in all AWS Regions)
+	//
+	//    * 10.1.26 (supported in all AWS Regions)
 	//
 	//    * 10.1.23 (supported in all AWS Regions)
 	//
 	//    * 10.1.19 (supported in all AWS Regions)
 	//
 	//    * 10.1.14 (supported in all AWS Regions except us-east-2)
+	//
+	//    * 10.0.34 (supported in all AWS Regions)
 	//
 	//    * 10.0.32 (supported in all AWS Regions)
 	//
@@ -12127,11 +12133,15 @@ type CreateDBInstanceInput struct {
 	//
 	// MySQL
 	//
+	//    * 5.7.21 (supported in all AWS regions)
+	//
 	//    * 5.7.19 (supported in all AWS regions)
 	//
 	//    * 5.7.17 (supported in all AWS regions)
 	//
 	//    * 5.7.16 (supported in all AWS regions)
+	//
+	// 5.6.39(supported in all AWS Regions)
 	//
 	// 5.6.37(supported in all AWS Regions)
 	//

--- a/vendor/github.com/aws/aws-sdk-go/service/s3/customizations.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/s3/customizations.go
@@ -44,9 +44,10 @@ func defaultInitRequestFn(r *request.Request) {
 		r.Handlers.Unmarshal.PushFront(copyMultipartStatusOKUnmarhsalError)
 	case opPutObject, opUploadPart:
 		r.Handlers.Build.PushBack(computeBodyHashes)
-	case opGetObject:
-		r.Handlers.Build.PushBack(askForTxEncodingAppendMD5)
-		r.Handlers.Unmarshal.PushBack(useMD5ValidationReader)
+		// Disabled until #1837 root issue is resolved.
+		//	case opGetObject:
+		//		r.Handlers.Build.PushBack(askForTxEncodingAppendMD5)
+		//		r.Handlers.Unmarshal.PushBack(useMD5ValidationReader)
 	}
 }
 

--- a/vendor/github.com/aws/aws-sdk-go/service/sagemaker/service.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/sagemaker/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := sagemaker.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *SageMaker {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
+		c.SigningName = "sagemaker"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *SageMaker {
-	if len(signingName) == 0 {
-		signingName = "sagemaker"
-	}
 	svc := &SageMaker{
 		Client: client.New(
 			cfg,

--- a/vendor/github.com/aws/aws-sdk-go/service/ses/service.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ses/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := ses.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *SES {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
+		c.SigningName = "ses"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *SES {
-	if len(signingName) == 0 {
-		signingName = "ses"
-	}
 	svc := &SES{
 		Client: client.New(
 			cfg,

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -39,884 +39,884 @@
 			"revisionTime": "2017-07-27T15:54:43Z"
 		},
 		{
-			"checksumSHA1": "q4osc1RWwXEKwVApYRUuSwMdxkU=",
+			"checksumSHA1": "oS1f9+6Y4byjgyIKEpnzkxYU1MY=",
 			"path": "github.com/aws/aws-sdk-go/aws",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "DtuTqKH29YnLjrIJkRYX0HQtXY0=",
 			"path": "github.com/aws/aws-sdk-go/aws/arn",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "Y9W+4GimK4Fuxq+vyIskVYFRnX4=",
 			"path": "github.com/aws/aws-sdk-go/aws/awserr",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "yyYr41HZ1Aq0hWc3J5ijXwYEcac=",
 			"path": "github.com/aws/aws-sdk-go/aws/awsutil",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
-			"checksumSHA1": "qPamnqpz6piw78HJjvluOegQfGE=",
+			"checksumSHA1": "hicPtITUionsA+dgs1SpsZUkQu4=",
 			"path": "github.com/aws/aws-sdk-go/aws/client",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "ieAJ+Cvp/PKv1LpUEnUXpc3OI6E=",
 			"path": "github.com/aws/aws-sdk-go/aws/client/metadata",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "vVSUnICaD9IaBQisCfw0n8zLwig=",
 			"path": "github.com/aws/aws-sdk-go/aws/corehandlers",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "Y+cPwQL0dZMyqp3wI+KJWmA9KQ8=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "u3GOAJLmdvbuNUeUEcZSEAOeL/0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "NUJUTWlc1sV8b7WjfiYc4JZbXl0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/endpointcreds",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "JEYqmF83O5n5bHkupAzA6STm0no=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "HogDW/Wu6ZKTDrQ2HSzG8/vj9Ag=",
 			"path": "github.com/aws/aws-sdk-go/aws/defaults",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "pDnK93CqjQ4ROSW8Y/RuHXjv52M=",
 			"path": "github.com/aws/aws-sdk-go/aws/ec2metadata",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
-			"checksumSHA1": "YAa4mUoL6J81yCT+QzeWF3EEo8A=",
+			"checksumSHA1": "taM7fdw8T0L8klF96JgAHvKobIw=",
 			"path": "github.com/aws/aws-sdk-go/aws/endpoints",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "xXfBg4kOE6+Z4sABLqdR49OlSNA=",
 			"path": "github.com/aws/aws-sdk-go/aws/request",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
-			"checksumSHA1": "NSUxDbxBtCToRUoMRUKn61WJWmE=",
+			"checksumSHA1": "J66FLqo++F1PXLUU8XQqYaageSc=",
 			"path": "github.com/aws/aws-sdk-go/aws/session",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "BqDC+Sxo3hrC6WYvwx1U4OObaT4=",
 			"path": "github.com/aws/aws-sdk-go/aws/signer/v4",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "wjxQlU1PYxrDRFoL1Vek8Wch7jk=",
 			"path": "github.com/aws/aws-sdk-go/internal/sdkio",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "MYLldFRnsZh21TfCkgkXCT3maPU=",
 			"path": "github.com/aws/aws-sdk-go/internal/sdkrand",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "04ypv4x12l4q0TksA1zEVsmgpvw=",
 			"path": "github.com/aws/aws-sdk-go/internal/shareddefaults",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "NStHCXEvYqG72GknZyv1jaKaeH0=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "GQuRJY72iGQrufDqIaB50zG27u0=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/ec2query",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "yHfT5DTbeCLs4NE2Rgnqrhe15ls=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/json/jsonutil",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "R00RL5jJXRYq1iiK1+PGvMfvXyM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/jsonrpc",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "SBBVYdLcocjdPzMWgDuR8vcOfDQ=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "9V1PvtFQ9MObZTc3sa86WcuOtOU=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "pkeoOfZpHRvFG/AOZeTf0lwtsFg=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/rest",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "Rpu8KBtHZgvhkwHxUfaky+qW+G4=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restjson",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "ODo+ko8D6unAxZuN1jGzMcN4QCc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restxml",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "0qYPUga28aQVkxZgBR3Z86AbGUQ=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "F6mth+G7dXN1GI+nktaGo8Lx8aE=",
 			"path": "github.com/aws/aws-sdk-go/private/signer/v2",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "Ih4il2OyFyaSuoMv6hhvPUN8Gn4=",
 			"path": "github.com/aws/aws-sdk-go/service/acm",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "DPl/OkvEUjrd+XKqX73l6nUNw3U=",
 			"path": "github.com/aws/aws-sdk-go/service/apigateway",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
-			"checksumSHA1": "Lhn7o6Ua6s/dgjol0ATOiRBIMxA=",
+			"checksumSHA1": "tsOPYVkOiuYDJTziSRkP7p1TL70=",
 			"path": "github.com/aws/aws-sdk-go/service/applicationautoscaling",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
-			"checksumSHA1": "eXdYovPaIY64heZE1nczTsNRvtw=",
+			"checksumSHA1": "lyjaWzlpAp6CacdNZTe351CRp5c=",
 			"path": "github.com/aws/aws-sdk-go/service/appsync",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "wrOVdI/6ZTZ/H0Kxjh3bBEZtVzk=",
 			"path": "github.com/aws/aws-sdk-go/service/athena",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "GhemRVzpnrN6HAgm1NdAgESY8CQ=",
 			"path": "github.com/aws/aws-sdk-go/service/autoscaling",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "P5gDOoqIdVjMU77e5Nhy48QLpS4=",
 			"path": "github.com/aws/aws-sdk-go/service/batch",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "BrC9UCeefniH5UN7x0PFr8A9l6Y=",
 			"path": "github.com/aws/aws-sdk-go/service/budgets",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "EoaTzMilW+OIi5eETJUpd+giyTc=",
 			"path": "github.com/aws/aws-sdk-go/service/cloud9",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "yuFNzmUIWppfji/Xx6Aao0EE4cY=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudformation",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "0nPnGWlegQG7bn/iIIfjJFoljyU=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudfront",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "XJAlmauOOHsHEUW7n0XO/eEpcWI=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudsearch",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "VTc9UOMqIwuhWJ6oGQDsMkTW09I=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudtrail",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "ItXljM1vG/0goVleodRgbfYgyxQ=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatch",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
-			"checksumSHA1": "e23yBAf38AKW/Fve77BO4WgMq4c=",
+			"checksumSHA1": "x25KEvGmuQ0Uuoduo/CVe37ELC8=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchevents",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "HHct8eQygkIJ+vrQpKhB0IEDymQ=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
-			"checksumSHA1": "22txzj8ItH1+lzyyLlFz/vtRV2I=",
+			"checksumSHA1": "LHcxaQJ77WMlug2cnyXlTzJJUSo=",
 			"path": "github.com/aws/aws-sdk-go/service/codebuild",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "AQwpqKKc52nnI5F50K73Zx5luoQ=",
 			"path": "github.com/aws/aws-sdk-go/service/codecommit",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "wvXGTyWPjtgC4OjXb80IxYdpqmE=",
 			"path": "github.com/aws/aws-sdk-go/service/codedeploy",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "V1Y05qfjN4xOCy+GnPWSCqIeZb4=",
 			"path": "github.com/aws/aws-sdk-go/service/codepipeline",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "Ju8efcqcIgggB7N8io/as9ERVdc=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentity",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "jeCyZm4iJmOLbVOe/70QNkII+qU=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentityprovider",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
-			"checksumSHA1": "fPHmnn5kgs8BB73v8Pz/7frfnmo=",
+			"checksumSHA1": "OhbpZoCd+Vg3pLOEE0MVH9T22eY=",
 			"path": "github.com/aws/aws-sdk-go/service/configservice",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "45sgs1urdRiXDb35iuAhQPzl0e4=",
 			"path": "github.com/aws/aws-sdk-go/service/databasemigrationservice",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "bu1R1eKCK2fc5+hMcXmagr3iIik=",
 			"path": "github.com/aws/aws-sdk-go/service/dax",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "EaEfUc3nt1sS/cdfSYGq+JtSVKs=",
 			"path": "github.com/aws/aws-sdk-go/service/devicefarm",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "LRdh5oXUe2yURIk5FDH6ceEZGMo=",
 			"path": "github.com/aws/aws-sdk-go/service/directconnect",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "a7itHIwtyXtOGQ0KsiefmsHgu4s=",
 			"path": "github.com/aws/aws-sdk-go/service/directoryservice",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "8JiVrxMjFSdBOfVWCy1QU+JzB08=",
 			"path": "github.com/aws/aws-sdk-go/service/dynamodb",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "SOmBkudpfGbt3Pb3I1bzuXV9FvQ=",
 			"path": "github.com/aws/aws-sdk-go/service/ec2",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "PcnSiFF2p2xOsvITrsglyWp20YA=",
 			"path": "github.com/aws/aws-sdk-go/service/ecr",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
-			"checksumSHA1": "T38/mnajk0fqAPXT1Qq1DG+cJ6g=",
+			"checksumSHA1": "VRx8MtqfED2uZVOi6ldb5P145TI=",
 			"path": "github.com/aws/aws-sdk-go/service/ecs",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "4XmkiujbDA68x39KGgURR1+uPiQ=",
 			"path": "github.com/aws/aws-sdk-go/service/efs",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "o73xT1zFo3C+giQwKcRj02OAZhM=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticache",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
-			"checksumSHA1": "1U0w3+W7kvH901jSftehitrRHCg=",
+			"checksumSHA1": "C6OWsuCjBYnqjR5PwDFEA8l1hWg=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticbeanstalk",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "VYGtTaSiajfKOVTbi9/SNmbiIac=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticsearchservice",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "SZ7yLDZ6RvMhpWe0Goyem64kgyA=",
 			"path": "github.com/aws/aws-sdk-go/service/elastictranscoder",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "iRI32eUYQfumh0LybzZ+5iWV3jE=",
 			"path": "github.com/aws/aws-sdk-go/service/elb",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "ufCsoZUQK13j8Y+m25yxhC2XteQ=",
 			"path": "github.com/aws/aws-sdk-go/service/elbv2",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "5x77vwxya74Qu5YEq75/lhyYkqY=",
 			"path": "github.com/aws/aws-sdk-go/service/emr",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "t7BmfpJqmQ7Y0EYcj/CR9Aup9go=",
 			"path": "github.com/aws/aws-sdk-go/service/firehose",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "h37wXo80exgME9QqHkeLTyG88ZM=",
 			"path": "github.com/aws/aws-sdk-go/service/gamelift",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "20HMsQ2tH47zknjFIUQLi/ZOBvc=",
 			"path": "github.com/aws/aws-sdk-go/service/glacier",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
-			"checksumSHA1": "M01rYrldc6zwbpAeaLX5UJ6b25g=",
+			"checksumSHA1": "K1s4cEA/LcK+NAZAFUDOr/dW9IY=",
 			"path": "github.com/aws/aws-sdk-go/service/glue",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
-			"checksumSHA1": "VRaMYP1928z+aLVk2qX5OPFaobk=",
+			"checksumSHA1": "tU7rdC0LAUOKNp2uERUXi3hU1sQ=",
 			"path": "github.com/aws/aws-sdk-go/service/guardduty",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "I8CWKTI9BLrIF9ZKf6SpWhG+LXM=",
 			"path": "github.com/aws/aws-sdk-go/service/iam",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "45gdBZuM7PWLQzWuBasytvZZpK0=",
 			"path": "github.com/aws/aws-sdk-go/service/inspector",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
-			"checksumSHA1": "88bf507ASfaFmQHmjidwQ6uRPJ8=",
+			"checksumSHA1": "skj7upwPc4zfJbYT+iPY+cmumG0=",
 			"path": "github.com/aws/aws-sdk-go/service/iot",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "DfzNze8B3ME2tV3TtXP7eQXUjD0=",
 			"path": "github.com/aws/aws-sdk-go/service/kinesis",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "Vqq049R2eveVD15emT9vKTyBsIg=",
 			"path": "github.com/aws/aws-sdk-go/service/kms",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "lAgaKbwpyflY7+t4V3EeH18RwgA=",
 			"path": "github.com/aws/aws-sdk-go/service/lambda",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
-			"checksumSHA1": "j89kyJh2GGvR24TptSP3OsO2fho=",
+			"checksumSHA1": "shckWClBSciJH+cFYCY5kDCbBXI=",
 			"path": "github.com/aws/aws-sdk-go/service/lexmodelbuildingservice",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "2dy15/1bnS80cwKZiwnEai1d7O8=",
 			"path": "github.com/aws/aws-sdk-go/service/lightsail",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
-			"checksumSHA1": "8qaF9hO9gXBfjhqcgPKx9yrz9wk=",
+			"checksumSHA1": "998zv0rs9SBCd9EoAnIi9cKv7uo=",
 			"path": "github.com/aws/aws-sdk-go/service/mediaconvert",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
-			"checksumSHA1": "TJfSeycacPHDkVi7by9+qkpS2Rg=",
+			"checksumSHA1": "/Oo64hSOdIKbN4dmZ7EAQRfr12w=",
 			"path": "github.com/aws/aws-sdk-go/service/medialive",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
-			"checksumSHA1": "Uc40skINWoBmH5LglPNfoKxET0g=",
+			"checksumSHA1": "mzoPurfrAAB102onq4FPlwZ5Bec=",
 			"path": "github.com/aws/aws-sdk-go/service/mediapackage",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
-			"checksumSHA1": "kEZmPI9Y9+05SWuRCdtt+QkqwLI=",
+			"checksumSHA1": "yXPMyEsghtSFxu9AbiTFCzisGrQ=",
 			"path": "github.com/aws/aws-sdk-go/service/mediastore",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
-			"checksumSHA1": "1hKLl5dLV28iH5rMfOPlWmD+oXk=",
+			"checksumSHA1": "wU7VITDzy1ubXo+zrG4HNyl5GJI=",
 			"path": "github.com/aws/aws-sdk-go/service/mediastoredata",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
-			"checksumSHA1": "3QV+ZVkQ8g8JkNkftwHaOCevyqM=",
+			"checksumSHA1": "kMMVqLsxKIzBQeDyWJ0N2U/PKLc=",
 			"path": "github.com/aws/aws-sdk-go/service/mq",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "QuOSKqV8nFvvzN4wcsToltMFI1Y=",
 			"path": "github.com/aws/aws-sdk-go/service/opsworks",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "vSNXu8VAbPuFoTTjtVEpldKDZHA=",
 			"path": "github.com/aws/aws-sdk-go/service/organizations",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
-			"checksumSHA1": "HUlP17axe1KXCHIc8vHlrvQPD2s=",
+			"checksumSHA1": "g5UtpGido/A6wsB7pDwY+RQ3Ha8=",
 			"path": "github.com/aws/aws-sdk-go/service/rds",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "/F1EdnLahy5V5+EjvRQ3C0JhIyw=",
 			"path": "github.com/aws/aws-sdk-go/service/redshift",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "p2x3SXLzi1PXnyMpPUJUntpS1hQ=",
 			"path": "github.com/aws/aws-sdk-go/service/route53",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
-			"checksumSHA1": "8p50HAyOFQoF/q0uQaNLKFt+AXA=",
+			"checksumSHA1": "/MR2uoycqymJLdO3Bu1pTkZCpDY=",
 			"path": "github.com/aws/aws-sdk-go/service/s3",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
-			"checksumSHA1": "ft2RlaOgFMy5hkGg6okKx01eBFs=",
+			"checksumSHA1": "XSHs3VHLi/mXGDN0zLO/NNCVpw4=",
 			"path": "github.com/aws/aws-sdk-go/service/sagemaker",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "JrQMIue45k6Nk738T347pe9X0c0=",
 			"path": "github.com/aws/aws-sdk-go/service/servicecatalog",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "fmnQo2GajqI9eEn6tcEGiJ9A66E=",
 			"path": "github.com/aws/aws-sdk-go/service/servicediscovery",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
-			"checksumSHA1": "8LeTeLzNs+0vNxTeOjMCtSrSwqo=",
+			"checksumSHA1": "j+R3E5MeBM87zbLVQhcuqlHsxes=",
 			"path": "github.com/aws/aws-sdk-go/service/ses",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "u3AMeFxtHGtiJCxDeIm4dAwzBIc=",
 			"path": "github.com/aws/aws-sdk-go/service/sfn",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "B3CgAFSREebpsFoFOo4vrQ6u04w=",
 			"path": "github.com/aws/aws-sdk-go/service/simpledb",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "9Qj8yLl67q9uxBUCc0PT20YiP1M=",
 			"path": "github.com/aws/aws-sdk-go/service/sns",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "XmEJe50M8MddNEkwbZoC+YvRjgg=",
 			"path": "github.com/aws/aws-sdk-go/service/sqs",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "ULmsQAt5z5ZxGHZC/r7enBs1HvM=",
 			"path": "github.com/aws/aws-sdk-go/service/ssm",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "tH1Pzc7jUUGJv47Cy6uuWl/86bU=",
 			"path": "github.com/aws/aws-sdk-go/service/sts",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "Uw4pOUxSMbx4xBHUcOUkNhtnywE=",
 			"path": "github.com/aws/aws-sdk-go/service/swf",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "dBDZ2w/7ZEdk2UZ6PWFmk/cGSPw=",
 			"path": "github.com/aws/aws-sdk-go/service/waf",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "hOobCqlfwCl/iPGetELNIDsns1U=",
 			"path": "github.com/aws/aws-sdk-go/service/wafregional",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "FVK4fHBkjOIaCRIY4DleqSKtZKs=",
 			"path": "github.com/aws/aws-sdk-go/service/workspaces",
-			"revision": "62465d4996f172ae426fdcec7a6a053062cf8995",
-			"revisionTime": "2018-03-15T19:52:51Z",
-			"version": "v1.13.15",
-			"versionExact": "v1.13.15"
+			"revision": "c8c4e0c0514d87f930c1342fef390db5329928b7",
+			"revisionTime": "2018-03-23T20:51:09Z",
+			"version": "v1.13.20",
+			"versionExact": "v1.13.20"
 		},
 		{
 			"checksumSHA1": "usT4LCSQItkFvFOQT7cBlkCuGaE=",


### PR DESCRIPTION
```
govendor fetch github.com/aws/aws-sdk-go/...@v1.13.20
```

To support the integration of ECS and Route53 Auto Naming, in my case.