### PR TITLE
New Resource: aws_vpc_peering_connection_options

### DIFF
--- a/aws/data_source_aws_vpc_peering_connection.go
+++ b/aws/data_source_aws_vpc_peering_connection.go
@@ -140,13 +140,13 @@ func dataSourceAwsVpcPeeringConnectionRead(d *schema.ResourceData, meta interfac
 	d.Set("tags", tagsToMap(pcx.Tags))
 
 	if pcx.AccepterVpcInfo.PeeringOptions != nil {
-		if err := d.Set("accepter", flattenPeeringOptions(pcx.AccepterVpcInfo.PeeringOptions)[0]); err != nil {
+		if err := d.Set("accepter", flattenVpcPeeringConnectionOptions(pcx.AccepterVpcInfo.PeeringOptions)[0]); err != nil {
 			return err
 		}
 	}
 
 	if pcx.RequesterVpcInfo.PeeringOptions != nil {
-		if err := d.Set("requester", flattenPeeringOptions(pcx.RequesterVpcInfo.PeeringOptions)[0]); err != nil {
+		if err := d.Set("requester", flattenVpcPeeringConnectionOptions(pcx.RequesterVpcInfo.PeeringOptions)[0]); err != nil {
 			return err
 		}
 	}

--- a/aws/import_aws_vpc_peering_connection_options_test.go
+++ b/aws/import_aws_vpc_peering_connection_options_test.go
@@ -1,0 +1,28 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSVpcPeeringConnectionOptions_importBasic(t *testing.T) {
+	resourceName := "aws_vpc_peering_connection_options.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSVpcPeeringConnectionDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccVpcPeeringConnectionOptionsConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -558,6 +558,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_vpc_dhcp_options":                         resourceAwsVpcDhcpOptions(),
 			"aws_vpc_peering_connection":                   resourceAwsVpcPeeringConnection(),
 			"aws_vpc_peering_connection_accepter":          resourceAwsVpcPeeringConnectionAccepter(),
+			"aws_vpc_peering_connection_options":           resourceAwsVpcPeeringConnectionOptions(),
 			"aws_default_vpc":                              resourceAwsDefaultVpc(),
 			"aws_vpc":                                      resourceAwsVpc(),
 			"aws_vpc_endpoint":                             resourceAwsVpcEndpoint(),

--- a/aws/resource_aws_vpc_peering_connection.go
+++ b/aws/resource_aws_vpc_peering_connection.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -22,6 +21,12 @@ func resourceAwsVpcPeeringConnection() *schema.Resource {
 		Delete: resourceAwsVPCPeeringDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(1 * time.Minute),
+			Update: schema.DefaultTimeout(1 * time.Minute),
+			Delete: schema.DefaultTimeout(1 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -94,7 +99,7 @@ func resourceAwsVPCPeeringCreate(d *schema.ResourceData, meta interface{}) error
 	d.SetId(*rt.VpcPeeringConnectionId)
 	log.Printf("[INFO] VPC Peering Connection ID: %s", d.Id())
 
-	vpcAvailableErr := checkVpcPeeringConnectionAvailable(conn, d.Id())
+	vpcAvailableErr := vpcPeeringConnectionWaitUntilAvailable(conn, d.Id(), d.Timeout(schema.TimeoutCreate))
 	if vpcAvailableErr != nil {
 		return errwrap.Wrapf("Error waiting for VPC Peering Connection to become available: {{err}}", vpcAvailableErr)
 	}
@@ -104,40 +109,31 @@ func resourceAwsVPCPeeringCreate(d *schema.ResourceData, meta interface{}) error
 
 func resourceAwsVPCPeeringRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*AWSClient)
-	conn := client.ec2conn
 
-	pcRaw, status, err := resourceAwsVPCPeeringConnectionStateRefreshFunc(conn, d.Id())()
+	pcRaw, statusCode, err := vpcPeeringConnectionRefreshState(client.ec2conn, d.Id())()
 	// Allow a failed VPC Peering Connection to fallthrough,
 	// to allow rest of the logic below to do its work.
-	if err != nil && status != ec2.VpcPeeringConnectionStateReasonCodeFailed {
-		return err
+	if err != nil && statusCode != ec2.VpcPeeringConnectionStateReasonCodeFailed {
+		return errwrap.Wrapf("Error reading VPC Peering Connection: {{err}}", err)
 	}
 
-	if pcRaw == nil {
+	// The failed status is a status that we can assume just means the
+	// connection is gone. Destruction isn't allowed, and it eventually
+	// just "falls off" the console. See GH-2322
+	status := map[string]bool{
+		ec2.VpcPeeringConnectionStateReasonCodeDeleted:  true,
+		ec2.VpcPeeringConnectionStateReasonCodeDeleting: true,
+		ec2.VpcPeeringConnectionStateReasonCodeExpired:  true,
+		ec2.VpcPeeringConnectionStateReasonCodeFailed:   true,
+		ec2.VpcPeeringConnectionStateReasonCodeRejected: true,
+	}
+	if _, ok := status[statusCode]; ok {
+		log.Printf("[WARN] VPC Peering Connection (%s) has status code %s, removing from state", d.Id(), statusCode)
 		d.SetId("")
 		return nil
 	}
 
 	pc := pcRaw.(*ec2.VpcPeeringConnection)
-
-	// The failed status is a status that we can assume just means the
-	// connection is gone. Destruction isn't allowed, and it eventually
-	// just "falls off" the console. See GH-2322
-	if pc.Status != nil {
-		status := map[string]bool{
-			ec2.VpcPeeringConnectionStateReasonCodeDeleted:  true,
-			ec2.VpcPeeringConnectionStateReasonCodeDeleting: true,
-			ec2.VpcPeeringConnectionStateReasonCodeExpired:  true,
-			ec2.VpcPeeringConnectionStateReasonCodeFailed:   true,
-			ec2.VpcPeeringConnectionStateReasonCodeRejected: true,
-		}
-		if _, ok := status[*pc.Status.Code]; ok {
-			log.Printf("[DEBUG] VPC Peering Connection (%s) in state (%s), removing.",
-				d.Id(), *pc.Status.Code)
-			d.SetId("")
-			return nil
-		}
-	}
 	log.Printf("[DEBUG] VPC Peering Connection response: %#v", pc)
 
 	log.Printf("[DEBUG] Account ID %s, VPC PeerConn Requester %s, Accepter %s",
@@ -162,14 +158,14 @@ func resourceAwsVPCPeeringRead(d *schema.ResourceData, meta interface{}) error {
 	// the details about accepter and/or requester peering
 	// options would not be included in the response.
 	if pc.AccepterVpcInfo.PeeringOptions != nil {
-		err := d.Set("accepter", flattenPeeringOptions(pc.AccepterVpcInfo.PeeringOptions))
+		err := d.Set("accepter", flattenVpcPeeringConnectionOptions(pc.AccepterVpcInfo.PeeringOptions))
 		if err != nil {
 			return errwrap.Wrapf("Error setting VPC Peering Connection accepter information: {{err}}", err)
 		}
 	}
 
 	if pc.RequesterVpcInfo.PeeringOptions != nil {
-		err := d.Set("requester", flattenPeeringOptions(pc.RequesterVpcInfo.PeeringOptions))
+		err := d.Set("requester", flattenVpcPeeringConnectionOptions(pc.RequesterVpcInfo.PeeringOptions))
 		if err != nil {
 			return errwrap.Wrapf("Error setting VPC Peering Connection requester information: {{err}}", err)
 		}
@@ -199,29 +195,25 @@ func resourceVPCPeeringConnectionAccept(conn *ec2.EC2, id string) (string, error
 	return *pc.Status.Code, nil
 }
 
-func resourceVPCPeeringConnectionOptionsModify(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsVpcPeeringConnectionModifyOptions(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	modifyOpts := &ec2.ModifyVpcPeeringConnectionOptionsInput{
+	req := &ec2.ModifyVpcPeeringConnectionOptionsInput{
 		VpcPeeringConnectionId: aws.String(d.Id()),
 	}
 
-	if v, ok := d.GetOk("accepter"); ok {
-		if s := v.(*schema.Set); len(s.List()) > 0 {
-			co := s.List()[0].(map[string]interface{})
-			modifyOpts.AccepterPeeringConnectionOptions = expandPeeringOptions(co)
-		}
+	v := d.Get("accepter").(*schema.Set).List()
+	if len(v) > 0 {
+		req.AccepterPeeringConnectionOptions = expandVpcPeeringConnectionOptions(v[0].(map[string]interface{}))
 	}
 
-	if v, ok := d.GetOk("requester"); ok {
-		if s := v.(*schema.Set); len(s.List()) > 0 {
-			co := s.List()[0].(map[string]interface{})
-			modifyOpts.RequesterPeeringConnectionOptions = expandPeeringOptions(co)
-		}
+	v = d.Get("requester").(*schema.Set).List()
+	if len(v) > 0 {
+		req.RequesterPeeringConnectionOptions = expandVpcPeeringConnectionOptions(v[0].(map[string]interface{}))
 	}
 
-	log.Printf("[DEBUG] VPC Peering Connection modify options: %#v", modifyOpts)
-	if _, err := conn.ModifyVpcPeeringConnectionOptions(modifyOpts); err != nil {
+	log.Printf("[DEBUG] Modifying VPC Peering Connection options: %#v", req)
+	if _, err := conn.ModifyVpcPeeringConnectionOptions(req); err != nil {
 		return err
 	}
 
@@ -237,15 +229,17 @@ func resourceAwsVPCPeeringUpdate(d *schema.ResourceData, meta interface{}) error
 		d.SetPartial("tags")
 	}
 
-	pcRaw, _, err := resourceAwsVPCPeeringConnectionStateRefreshFunc(conn, d.Id())()
+	pcRaw, _, err := vpcPeeringConnectionRefreshState(conn, d.Id())()
 	if err != nil {
-		return err
+		return errwrap.Wrapf("Error reading VPC Peering Connection: {{err}}", err)
 	}
 
 	if pcRaw == nil {
+		log.Printf("[WARN] VPC Peering Connection (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
+
 	pc := pcRaw.(*ec2.VpcPeeringConnection)
 
 	if _, ok := d.GetOk("auto_accept"); ok {
@@ -266,12 +260,12 @@ func resourceAwsVPCPeeringUpdate(d *schema.ResourceData, meta interface{}) error
 				"or activate VPC Peering Connection manually.", d.Id())
 		}
 
-		if err := resourceVPCPeeringConnectionOptionsModify(d, meta); err != nil {
+		if err := resourceAwsVpcPeeringConnectionModifyOptions(d, meta); err != nil {
 			return errwrap.Wrapf("Error modifying VPC Peering Connection options: {{err}}", err)
 		}
 	}
 
-	vpcAvailableErr := checkVpcPeeringConnectionAvailable(conn, d.Id())
+	vpcAvailableErr := vpcPeeringConnectionWaitUntilAvailable(conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
 	if vpcAvailableErr != nil {
 		return errwrap.Wrapf("Error waiting for VPC Peering Connection to become available: {{err}}", vpcAvailableErr)
 	}
@@ -306,8 +300,8 @@ func resourceAwsVPCPeeringDelete(d *schema.ResourceData, meta interface{}) error
 			ec2.VpcPeeringConnectionStateReasonCodeRejected,
 			ec2.VpcPeeringConnectionStateReasonCodeDeleted,
 		},
-		Refresh: resourceAwsVPCPeeringConnectionStateRefreshFunc(conn, d.Id()),
-		Timeout: 1 * time.Minute,
+		Refresh: vpcPeeringConnectionRefreshState(conn, d.Id()),
+		Timeout: d.Timeout(schema.TimeoutDelete),
 	}
 	if _, err := stateConf.WaitForState(); err != nil {
 		return fmt.Errorf("Error waiting for VPC Peering Connection (%s) to be deleted: %s", d.Id(), err)
@@ -316,38 +310,30 @@ func resourceAwsVPCPeeringDelete(d *schema.ResourceData, meta interface{}) error
 	return nil
 }
 
-// resourceAwsVPCPeeringConnectionStateRefreshFunc returns a resource.StateRefreshFunc that is used to watch
-// a VPCPeeringConnection.
-func resourceAwsVPCPeeringConnectionStateRefreshFunc(conn *ec2.EC2, id string) resource.StateRefreshFunc {
+func vpcPeeringConnectionRefreshState(conn *ec2.EC2, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		resp, err := conn.DescribeVpcPeeringConnections(&ec2.DescribeVpcPeeringConnectionsInput{
-			VpcPeeringConnectionIds: []*string{aws.String(id)},
+			VpcPeeringConnectionIds: aws.StringSlice([]string{id}),
 		})
 		if err != nil {
-			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidVpcPeeringConnectionID.NotFound" {
-				resp = nil
-			} else {
-				log.Printf("Error reading VPC Peering Connection details: %s", err)
-				return nil, "error", err
+			if isNoSuchVpcPeeringConnectionErr(err) {
+				return nil, ec2.VpcPeeringConnectionStateReasonCodeDeleted, nil
 			}
-		}
 
-		if resp == nil {
-			// Sometimes AWS just has consistency issues and doesn't see
-			// our instance yet. Return an empty state.
-			return nil, "", nil
+			return nil, "", err
 		}
 
 		pc := resp.VpcPeeringConnections[0]
+		statusCode := aws.StringValue(pc.Status.Code)
 
 		// A VPC Peering Connection can exist in a failed state due to
 		// incorrect VPC ID, account ID, or overlapping IP address range,
 		// thus we short circuit before the time out would occur.
-		if pc != nil && *pc.Status.Code == "failed" {
-			return nil, "failed", errors.New(*pc.Status.Message)
+		if statusCode == ec2.VpcPeeringConnectionStateReasonCodeFailed {
+			return nil, statusCode, errors.New(aws.StringValue(pc.Status.Message))
 		}
 
-		return pc, *pc.Status.Code, nil
+		return pc, statusCode, nil
 	}
 }
 
@@ -379,44 +365,7 @@ func vpcPeeringConnectionOptionsSchema() *schema.Schema {
 	}
 }
 
-func flattenPeeringOptions(options *ec2.VpcPeeringConnectionOptionsDescription) (results []map[string]interface{}) {
-	m := make(map[string]interface{})
-
-	if options.AllowDnsResolutionFromRemoteVpc != nil {
-		m["allow_remote_vpc_dns_resolution"] = *options.AllowDnsResolutionFromRemoteVpc
-	}
-
-	if options.AllowEgressFromLocalClassicLinkToRemoteVpc != nil {
-		m["allow_classic_link_to_remote_vpc"] = *options.AllowEgressFromLocalClassicLinkToRemoteVpc
-	}
-
-	if options.AllowEgressFromLocalVpcToRemoteClassicLink != nil {
-		m["allow_vpc_to_remote_classic_link"] = *options.AllowEgressFromLocalVpcToRemoteClassicLink
-	}
-
-	results = append(results, m)
-	return
-}
-
-func expandPeeringOptions(m map[string]interface{}) *ec2.PeeringConnectionOptionsRequest {
-	r := &ec2.PeeringConnectionOptionsRequest{}
-
-	if v, ok := m["allow_remote_vpc_dns_resolution"]; ok {
-		r.AllowDnsResolutionFromRemoteVpc = aws.Bool(v.(bool))
-	}
-
-	if v, ok := m["allow_classic_link_to_remote_vpc"]; ok {
-		r.AllowEgressFromLocalClassicLinkToRemoteVpc = aws.Bool(v.(bool))
-	}
-
-	if v, ok := m["allow_vpc_to_remote_classic_link"]; ok {
-		r.AllowEgressFromLocalVpcToRemoteClassicLink = aws.Bool(v.(bool))
-	}
-
-	return r
-}
-
-func checkVpcPeeringConnectionAvailable(conn *ec2.EC2, id string) error {
+func vpcPeeringConnectionWaitUntilAvailable(conn *ec2.EC2, id string, timeout time.Duration) error {
 	// Wait for the vpc peering connection to become available
 	log.Printf("[DEBUG] Waiting for VPC Peering Connection (%s) to become available.", id)
 	stateConf := &resource.StateChangeConf{
@@ -428,8 +377,8 @@ func checkVpcPeeringConnectionAvailable(conn *ec2.EC2, id string) error {
 			ec2.VpcPeeringConnectionStateReasonCodePendingAcceptance,
 			ec2.VpcPeeringConnectionStateReasonCodeActive,
 		},
-		Refresh: resourceAwsVPCPeeringConnectionStateRefreshFunc(conn, id),
-		Timeout: 1 * time.Minute,
+		Refresh: vpcPeeringConnectionRefreshState(conn, id),
+		Timeout: timeout,
 	}
 	if _, err := stateConf.WaitForState(); err != nil {
 		return errwrap.Wrapf(fmt.Sprintf(
@@ -437,4 +386,8 @@ func checkVpcPeeringConnectionAvailable(conn *ec2.EC2, id string) error {
 			id), err)
 	}
 	return nil
+}
+
+func isNoSuchVpcPeeringConnectionErr(err error) bool {
+	return isAWSErr(err, "InvalidVpcPeeringConnectionID.NotFound", "")
 }

--- a/aws/resource_aws_vpc_peering_connection.go
+++ b/aws/resource_aws_vpc_peering_connection.go
@@ -315,7 +315,7 @@ func vpcPeeringConnectionRefreshState(conn *ec2.EC2, id string) resource.StateRe
 			VpcPeeringConnectionIds: aws.StringSlice([]string{id}),
 		})
 		if err != nil {
-			if isNoSuchVpcPeeringConnectionErr(err) {
+			if isAWSErr(err, "InvalidVpcPeeringConnectionID.NotFound", "") {
 				return nil, ec2.VpcPeeringConnectionStateReasonCodeDeleted, nil
 			}
 
@@ -383,8 +383,4 @@ func vpcPeeringConnectionWaitUntilAvailable(conn *ec2.EC2, id string, timeout ti
 		return fmt.Errorf("Error waiting for VPC Peering Connection (%s) to become available: %s", id, err)
 	}
 	return nil
-}
-
-func isNoSuchVpcPeeringConnectionErr(err error) bool {
-	return isAWSErr(err, "InvalidVpcPeeringConnectionID.NotFound", "")
 }

--- a/aws/resource_aws_vpc_peering_connection_options.go
+++ b/aws/resource_aws_vpc_peering_connection_options.go
@@ -1,0 +1,85 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsVpcPeeringConnectionOptions() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsVpcPeeringConnectionOptionsCreate,
+		Read:   resourceAwsVpcPeeringConnectionOptionsRead,
+		Update: resourceAwsVpcPeeringConnectionOptionsUpdate,
+		Delete: resourceAwsVpcPeeringConnectionOptionsDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"vpc_peering_connection_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"accepter":  vpcPeeringConnectionOptionsSchema(),
+			"requester": vpcPeeringConnectionOptionsSchema(),
+		},
+	}
+}
+
+func resourceAwsVpcPeeringConnectionOptionsCreate(d *schema.ResourceData, meta interface{}) error {
+	d.SetId(d.Get("vpc_peering_connection_id").(string))
+	return resourceAwsVpcPeeringConnectionOptionsUpdate(d, meta)
+}
+
+func resourceAwsVpcPeeringConnectionOptionsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	pcRaw, _, err := vpcPeeringConnectionRefreshState(conn, d.Id())()
+	if err != nil {
+		return fmt.Errorf("Error reading VPC Peering Connection: %s", err.Error())
+	}
+
+	if pcRaw == nil {
+		log.Printf("[WARN] VPC Peering Connection (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	pc := pcRaw.(*ec2.VpcPeeringConnection)
+
+	d.Set("vpc_peering_connection_id", aws.StringValue(pc.VpcPeeringConnectionId))
+
+	if pc.AccepterVpcInfo.PeeringOptions != nil {
+		err := d.Set("accepter", flattenVpcPeeringConnectionOptions(pc.AccepterVpcInfo.PeeringOptions))
+		if err != nil {
+			return fmt.Errorf("Error setting VPC Peering Connection Options accepter information: %s", err.Error())
+		}
+	}
+
+	if pc.RequesterVpcInfo.PeeringOptions != nil {
+		err := d.Set("requester", flattenVpcPeeringConnectionOptions(pc.RequesterVpcInfo.PeeringOptions))
+		if err != nil {
+			return fmt.Errorf("Error setting VPC Peering Connection Options requester information: %s", err.Error())
+		}
+	}
+
+	return nil
+}
+
+func resourceAwsVpcPeeringConnectionOptionsUpdate(d *schema.ResourceData, meta interface{}) error {
+	if err := resourceAwsVpcPeeringConnectionModifyOptions(d, meta); err != nil {
+		return fmt.Errorf("Error modifying VPC Peering Connection Options: %s", err.Error())
+	}
+
+	return resourceAwsVpcPeeringConnectionOptionsRead(d, meta)
+}
+
+func resourceAwsVpcPeeringConnectionOptionsDelete(d *schema.ResourceData, meta interface{}) error {
+	// Don't do anything with the underlying VPC peering connection.
+	return nil
+}

--- a/aws/resource_aws_vpc_peering_connection_options.go
+++ b/aws/resource_aws_vpc_peering_connection_options.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -52,7 +51,7 @@ func resourceAwsVpcPeeringConnectionOptionsRead(d *schema.ResourceData, meta int
 
 	pc := pcRaw.(*ec2.VpcPeeringConnection)
 
-	d.Set("vpc_peering_connection_id", aws.StringValue(pc.VpcPeeringConnectionId))
+	d.Set("vpc_peering_connection_id", pc.VpcPeeringConnectionId)
 
 	if pc.AccepterVpcInfo.PeeringOptions != nil {
 		err := d.Set("accepter", flattenVpcPeeringConnectionOptions(pc.AccepterVpcInfo.PeeringOptions))

--- a/aws/resource_aws_vpc_peering_connection_options.go
+++ b/aws/resource_aws_vpc_peering_connection_options.go
@@ -53,14 +53,14 @@ func resourceAwsVpcPeeringConnectionOptionsRead(d *schema.ResourceData, meta int
 
 	d.Set("vpc_peering_connection_id", pc.VpcPeeringConnectionId)
 
-	if pc.AccepterVpcInfo.PeeringOptions != nil {
+	if pc != nil && pc.AccepterVpcInfo != nil && pc.AccepterVpcInfo.PeeringOptions != nil {
 		err := d.Set("accepter", flattenVpcPeeringConnectionOptions(pc.AccepterVpcInfo.PeeringOptions))
 		if err != nil {
 			return fmt.Errorf("Error setting VPC Peering Connection Options accepter information: %s", err.Error())
 		}
 	}
 
-	if pc.RequesterVpcInfo.PeeringOptions != nil {
+	if pc != nil && pc.RequesterVpcInfo != nil && pc.RequesterVpcInfo.PeeringOptions != nil {
 		err := d.Set("requester", flattenVpcPeeringConnectionOptions(pc.RequesterVpcInfo.PeeringOptions))
 		if err != nil {
 			return fmt.Errorf("Error setting VPC Peering Connection Options requester information: %s", err.Error())

--- a/aws/resource_aws_vpc_peering_connection_options_test.go
+++ b/aws/resource_aws_vpc_peering_connection_options_test.go
@@ -1,0 +1,103 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSVpcPeeringConnectionOptions_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSVpcPeeringConnectionDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccVpcPeeringConnectionOptionsConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"aws_vpc_peering_connection_options.foo",
+						"accepter.#",
+						"1",
+					),
+					resource.TestCheckResourceAttr(
+						"aws_vpc_peering_connection_options.foo",
+						"accepter.1102046665.allow_remote_vpc_dns_resolution",
+						"true",
+					),
+					testAccCheckAWSVpcPeeringConnectionOptions(
+						"aws_vpc_peering_connection.foo",
+						"accepter",
+						&ec2.VpcPeeringConnectionOptionsDescription{
+							AllowDnsResolutionFromRemoteVpc:            aws.Bool(true),
+							AllowEgressFromLocalClassicLinkToRemoteVpc: aws.Bool(false),
+							AllowEgressFromLocalVpcToRemoteClassicLink: aws.Bool(false),
+						},
+					),
+					resource.TestCheckResourceAttr(
+						"aws_vpc_peering_connection_options.foo",
+						"requester.#",
+						"1",
+					),
+					resource.TestCheckResourceAttr(
+						"aws_vpc_peering_connection_options.foo",
+						"requester.41753983.allow_classic_link_to_remote_vpc",
+						"true",
+					),
+					resource.TestCheckResourceAttr(
+						"aws_vpc_peering_connection_options.foo",
+						"requester.41753983.allow_vpc_to_remote_classic_link",
+						"true",
+					),
+					testAccCheckAWSVpcPeeringConnectionOptions(
+						"aws_vpc_peering_connection.foo",
+						"requester",
+						&ec2.VpcPeeringConnectionOptionsDescription{
+							AllowDnsResolutionFromRemoteVpc:            aws.Bool(false),
+							AllowEgressFromLocalClassicLinkToRemoteVpc: aws.Bool(true),
+							AllowEgressFromLocalVpcToRemoteClassicLink: aws.Bool(true),
+						},
+					),
+				),
+			},
+		},
+	})
+}
+
+const testAccVpcPeeringConnectionOptionsConfig = `
+resource "aws_vpc" "foo" {
+  cidr_block = "10.0.0.0/16"
+  tags {
+    Name = "terraform-testacc-vpc-peering-conn-options-foo"
+  }
+}
+
+resource "aws_vpc" "bar" {
+  cidr_block = "10.1.0.0/16"
+  enable_dns_hostnames = true
+  tags {
+    Name = "terraform-testacc-vpc-peering-conn-options-bar"
+  }
+}
+
+resource "aws_vpc_peering_connection" "foo" {
+  vpc_id      = "${aws_vpc.foo.id}"
+  peer_vpc_id = "${aws_vpc.bar.id}"
+  auto_accept = true
+}
+
+resource "aws_vpc_peering_connection_options" "foo" {
+  vpc_peering_connection_id = "${aws_vpc_peering_connection.foo.id}"
+
+  accepter {
+    allow_remote_vpc_dns_resolution = true
+  }
+
+  requester {
+    allow_vpc_to_remote_classic_link = true
+    allow_classic_link_to_remote_vpc = true
+  }
+}
+`

--- a/aws/resource_aws_vpc_peering_connection_test.go
+++ b/aws/resource_aws_vpc_peering_connection_test.go
@@ -358,171 +358,171 @@ func TestAccAWSVPCPeeringConnection_region(t *testing.T) {
 
 const testAccVpcPeeringConfig = `
 resource "aws_vpc" "foo" {
-	cidr_block = "10.0.0.0/16"
-	tags {
-		Name = "terraform-testacc-vpc-peering-conn-foo"
-	}
+  cidr_block = "10.0.0.0/16"
+  tags {
+    Name = "terraform-testacc-vpc-peering-conn-foo"
+  }
 }
 
 resource "aws_vpc" "bar" {
-	cidr_block = "10.1.0.0/16"
-	tags {
-		Name = "terraform-testacc-vpc-peering-conn-bar"
-	}
+  cidr_block = "10.1.0.0/16"
+  tags {
+    Name = "terraform-testacc-vpc-peering-conn-bar"
+  }
 }
 
 resource "aws_vpc_peering_connection" "foo" {
-	vpc_id = "${aws_vpc.foo.id}"
-	peer_vpc_id = "${aws_vpc.bar.id}"
-	auto_accept = true
+  vpc_id = "${aws_vpc.foo.id}"
+  peer_vpc_id = "${aws_vpc.bar.id}"
+  auto_accept = true
 }
 `
 
 const testAccVpcPeeringConfigTags = `
 resource "aws_vpc" "foo" {
-	cidr_block = "10.0.0.0/16"
-	tags {
-		Name = "terraform-testacc-vpc-peering-conn-tags-foo"
-	}
+  cidr_block = "10.0.0.0/16"
+  tags {
+    Name = "terraform-testacc-vpc-peering-conn-tags-foo"
+  }
 }
 
 resource "aws_vpc" "bar" {
-	cidr_block = "10.1.0.0/16"
-	tags {
-		Name = "terraform-testacc-vpc-peering-conn-tags-bar"
-	}
+  cidr_block = "10.1.0.0/16"
+  tags {
+    Name = "terraform-testacc-vpc-peering-conn-tags-bar"
+  }
 }
 
 resource "aws_vpc_peering_connection" "foo" {
-	vpc_id = "${aws_vpc.foo.id}"
-	peer_vpc_id = "${aws_vpc.bar.id}"
-	auto_accept = true
-	tags {
-		foo = "bar"
-	}
+  vpc_id = "${aws_vpc.foo.id}"
+  peer_vpc_id = "${aws_vpc.bar.id}"
+  auto_accept = true
+  tags {
+    foo = "bar"
+  }
 }
 `
 
 const testAccVpcPeeringConfigOptions = `
 resource "aws_vpc" "foo" {
-	cidr_block = "10.0.0.0/16"
-	tags {
-		Name = "terraform-testacc-vpc-peering-conn-options-foo"
-	}
+  cidr_block = "10.0.0.0/16"
+  tags {
+    Name = "terraform-testacc-vpc-peering-conn-options-foo"
+  }
 }
 
 resource "aws_vpc" "bar" {
-	cidr_block = "10.1.0.0/16"
-	enable_dns_hostnames = true
-	tags {
-		Name = "terraform-testacc-vpc-peering-conn-options-bar"
-	}
+  cidr_block = "10.1.0.0/16"
+  enable_dns_hostnames = true
+  tags {
+    Name = "terraform-testacc-vpc-peering-conn-options-bar"
+  }
 }
 
 resource "aws_vpc_peering_connection" "foo" {
-	vpc_id = "${aws_vpc.foo.id}"
-	peer_vpc_id = "${aws_vpc.bar.id}"
-	auto_accept = true
+  vpc_id = "${aws_vpc.foo.id}"
+  peer_vpc_id = "${aws_vpc.bar.id}"
+  auto_accept = true
 
-	accepter {
-		allow_remote_vpc_dns_resolution = true
-	}
+  accepter {
+    allow_remote_vpc_dns_resolution = true
+  }
 
-	requester {
-		allow_vpc_to_remote_classic_link = true
-		allow_classic_link_to_remote_vpc = true
-	}
+  requester {
+    allow_vpc_to_remote_classic_link = true
+    allow_classic_link_to_remote_vpc = true
+  }
 }
 `
 
 const testAccVpcPeeringConfigFailedState = `
 resource "aws_vpc" "foo" {
-	cidr_block = "10.0.0.0/16"
-	tags {
-		Name = "terraform-testacc-vpc-peering-conn-failed-state-foo"
-	}
+  cidr_block = "10.0.0.0/16"
+  tags {
+    Name = "terraform-testacc-vpc-peering-conn-failed-state-foo"
+  }
 }
 
 resource "aws_vpc" "bar" {
-	cidr_block = "10.0.0.0/16"
-	tags {
-		Name = "terraform-testacc-vpc-peering-conn-failed-state-bar"
-	}
+  cidr_block = "10.0.0.0/16"
+  tags {
+    Name = "terraform-testacc-vpc-peering-conn-failed-state-bar"
+  }
 }
 
 resource "aws_vpc_peering_connection" "foo" {
-	vpc_id = "${aws_vpc.foo.id}"
-	peer_vpc_id = "${aws_vpc.bar.id}"
+  vpc_id = "${aws_vpc.foo.id}"
+  peer_vpc_id = "${aws_vpc.bar.id}"
 }
 `
 
 const testAccVpcPeeringConfigRegionAutoAccept = `
 provider "aws" {
-	alias = "main"
+  alias = "main"
   region = "us-west-2"
 }
 
 provider "aws" {
-	alias = "peer"
+  alias = "peer"
   region = "us-east-1"
 }
 
 resource "aws_vpc" "foo" {
-	provider = "aws.main"
-	cidr_block = "10.0.0.0/16"
-	tags {
-		Name = "terraform-testacc-vpc-peering-conn-region-auto-accept-foo"
-	}
+  provider = "aws.main"
+  cidr_block = "10.0.0.0/16"
+  tags {
+    Name = "terraform-testacc-vpc-peering-conn-region-auto-accept-foo"
+  }
 }
 
 resource "aws_vpc" "bar" {
-	provider = "aws.peer"
-	cidr_block = "10.1.0.0/16"
-	tags {
-		Name = "terraform-testacc-vpc-peering-conn-region-auto-accept-bar"
-	}
+  provider = "aws.peer"
+  cidr_block = "10.1.0.0/16"
+  tags {
+    Name = "terraform-testacc-vpc-peering-conn-region-auto-accept-bar"
+  }
 }
 
 resource "aws_vpc_peering_connection" "foo" {
-	provider = "aws.main"
-	vpc_id = "${aws_vpc.foo.id}"
-	peer_vpc_id = "${aws_vpc.bar.id}"
-	peer_region = "us-east-1"
-	auto_accept = true
+  provider = "aws.main"
+  vpc_id = "${aws_vpc.foo.id}"
+  peer_vpc_id = "${aws_vpc.bar.id}"
+  peer_region = "us-east-1"
+  auto_accept = true
 }
 `
 
 const testAccVpcPeeringConfigRegion = `
 provider "aws" {
-	alias = "main"
+  alias = "main"
   region = "us-west-2"
 }
 
 provider "aws" {
-	alias = "peer"
+  alias = "peer"
   region = "us-east-1"
 }
 
 resource "aws_vpc" "foo" {
-	provider = "aws.main"
-	cidr_block = "10.0.0.0/16"
-	tags {
-		Name = "terraform-testacc-vpc-peering-conn-region-foo"
-	}
+  provider = "aws.main"
+  cidr_block = "10.0.0.0/16"
+  tags {
+    Name = "terraform-testacc-vpc-peering-conn-region-foo"
+  }
 }
 
 resource "aws_vpc" "bar" {
-	provider = "aws.peer"
-	cidr_block = "10.1.0.0/16"
-	tags {
-		Name = "terraform-testacc-vpc-peering-conn-region-bar"
-	}
+  provider = "aws.peer"
+  cidr_block = "10.1.0.0/16"
+  tags {
+    Name = "terraform-testacc-vpc-peering-conn-region-bar"
+  }
 }
 
 resource "aws_vpc_peering_connection" "foo" {
-	provider = "aws.main"
-	vpc_id = "${aws_vpc.foo.id}"
-	peer_vpc_id = "${aws_vpc.bar.id}"
-	peer_region = "us-east-1"
+  provider = "aws.main"
+  vpc_id = "${aws_vpc.foo.id}"
+  peer_vpc_id = "${aws_vpc.bar.id}"
+  peer_region = "us-east-1"
 }
 `

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -4050,3 +4050,39 @@ func flattenLaunchTemplateSpecification(lt *autoscaling.LaunchTemplateSpecificat
 
 	return result
 }
+
+func flattenVpcPeeringConnectionOptions(options *ec2.VpcPeeringConnectionOptionsDescription) []map[string]interface{} {
+	m := map[string]interface{}{}
+
+	if options.AllowDnsResolutionFromRemoteVpc != nil {
+		m["allow_remote_vpc_dns_resolution"] = *options.AllowDnsResolutionFromRemoteVpc
+	}
+
+	if options.AllowEgressFromLocalClassicLinkToRemoteVpc != nil {
+		m["allow_classic_link_to_remote_vpc"] = *options.AllowEgressFromLocalClassicLinkToRemoteVpc
+	}
+
+	if options.AllowEgressFromLocalVpcToRemoteClassicLink != nil {
+		m["allow_vpc_to_remote_classic_link"] = *options.AllowEgressFromLocalVpcToRemoteClassicLink
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func expandVpcPeeringConnectionOptions(m map[string]interface{}) *ec2.PeeringConnectionOptionsRequest {
+	options := &ec2.PeeringConnectionOptionsRequest{}
+
+	if v, ok := m["allow_remote_vpc_dns_resolution"]; ok {
+		options.AllowDnsResolutionFromRemoteVpc = aws.Bool(v.(bool))
+	}
+
+	if v, ok := m["allow_classic_link_to_remote_vpc"]; ok {
+		options.AllowEgressFromLocalClassicLinkToRemoteVpc = aws.Bool(v.(bool))
+	}
+
+	if v, ok := m["allow_vpc_to_remote_classic_link"]; ok {
+		options.AllowEgressFromLocalVpcToRemoteClassicLink = aws.Bool(v.(bool))
+	}
+
+	return options
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -2055,6 +2055,10 @@
                             <a href="/docs/providers/aws/r/vpc_peering_accepter.html">aws_vpc_peering_connection_accepter</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-vpc-peering-options") %>>
+                            <a href="/docs/providers/aws/r/vpc_peering_options.html">aws_vpc_peering_connection_options</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-aws-resource-vpn-connection") %>>
                             <a href="/docs/providers/aws/r/vpn_connection.html">aws_vpn_connection</a>
                         </li>

--- a/website/docs/r/vpc_peering.html.markdown
+++ b/website/docs/r/vpc_peering.html.markdown
@@ -11,10 +11,12 @@ description: |-
 Provides a resource to manage a VPC peering connection.
 
 ~> **NOTE on VPC Peering Connections and VPC Peering Connection Options:** Terraform provides
-both a standalone [VPC Peering Connection Options](vpc_peering_options) and a VPC Peering Connection
+both a standalone [VPC Peering Connection Options](vpc_peering_options.html) and a VPC Peering Connection
 resource with `accepter` and `requester` attributes. Do not manage options for the same VPC peering
 connection in both a VPC Peering Connection resource and a VPC Peering Connection Options resource.
 Doing so will cause a conflict of options and will overwrite the options.
+Using a VPC Peering Connection Options resource decouples management of the connection options from
+management of the VPC Peering Connection and allows options to be set correctly in cross-account scenarios.
 
 -> **Note:** For cross-account (requester's AWS account differs from the accepter's AWS account) or inter-region
 VPC Peering Connections use the `aws_vpc_peering_connection` resource to manage the requester's side of the

--- a/website/docs/r/vpc_peering.html.markdown
+++ b/website/docs/r/vpc_peering.html.markdown
@@ -3,12 +3,18 @@ layout: "aws"
 page_title: "AWS: aws_vpc_peering_connection"
 sidebar_current: "docs-aws-resource-vpc-peering"
 description: |-
-  Manage a VPC Peering Connection resource.
+  Provides a resource to manage a VPC peering connection.
 ---
 
 # aws_vpc_peering_connection
 
-Provides a resource to manage a VPC Peering Connection resource.
+Provides a resource to manage a VPC peering connection.
+
+~> **NOTE on VPC Peering Connections and VPC Peering Connection Options:** Terraform provides
+both a standalone [VPC Peering Connection Options](vpc_peering_options) and a VPC Peering Connection
+resource with `accepter` and `requester` attributes. Do not manage options for the same VPC peering
+connection in both a VPC Peering Connection resource and a VPC Peering Connection Options resource.
+Doing so will cause a conflict of options and will overwrite the options.
 
 -> **Note:** For cross-account (requester's AWS account differs from the accepter's AWS account) or inter-region
 VPC Peering Connections use the `aws_vpc_peering_connection` resource to manage the requester's side of the
@@ -126,6 +132,15 @@ to the remote VPC.
 * `allow_vpc_to_remote_classic_link` - (Optional) Allow a local VPC to communicate with a linked EC2-Classic
 instance in a peer VPC. This enables an outbound communication from the local VPC to the remote ClassicLink
 connection.
+
+### Timeouts
+
+`aws_vpc_peering_connection` provides the following
+[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+- `create` - (Default `1 minute`) Used for creating a peering connection
+- `update` - (Default `1 minute`) Used for peering connection modifications
+- `delete` - (Default `1 minute`) Used for destroying peering connections
 
 ## Attributes Reference
 

--- a/website/docs/r/vpc_peering_accepter.html.markdown
+++ b/website/docs/r/vpc_peering_accepter.html.markdown
@@ -110,3 +110,9 @@ private IP addresses when queried from instances in a peer VPC.
 with the peer VPC over the VPC Peering Connection.
 * `allow_vpc_to_remote_classic_link` - Indicates whether a local VPC can communicate with a ClassicLink
 connection in the peer VPC over the VPC Peering Connection.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the VPC Peering Connection.

--- a/website/docs/r/vpc_peering_options.html.markdown
+++ b/website/docs/r/vpc_peering_options.html.markdown
@@ -1,0 +1,166 @@
+---
+layout: "aws"
+page_title: "AWS: aws_vpc_peering_connection_options"
+sidebar_current: "docs-aws-resource-vpc-peering-options"
+description: |-
+  Provides a resource to manage VPC peering connection options.
+---
+
+# aws_vpc_peering_connection_options
+
+Provides a resource to manage VPC peering connection options.
+
+~> **NOTE on VPC Peering Connections and VPC Peering Connection Options:** Terraform provides
+both a standalone VPC Peering Connection Options and a [VPC Peering Connection](vpc_peering.html)
+resource with `accepter` and `requester` attributes. Do not manage options for the same VPC peering
+connection in both a VPC Peering Connection resource and a VPC Peering Connection Options resource.
+Doing so will cause a conflict of options and will overwrite the options.
+
+Basic usage:
+
+```hcl
+resource "aws_vpc" "foo" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_vpc" "bar" {
+  cidr_block = "10.1.0.0/16"
+}
+
+resource "aws_vpc_peering_connection" "foo" {
+  vpc_id        = "${aws_vpc.foo.id}"
+  peer_vpc_id   = "${aws_vpc.bar.id}"
+  auto_accept   = true
+}
+
+resource "aws_vpc_peering_connection_options" "foo" {
+  vpc_peering_connection_id = "${aws_vpc_peering_connection.foo.id}"
+
+  accepter {
+    allow_remote_vpc_dns_resolution = true
+  }
+
+  requester {
+    allow_vpc_to_remote_classic_link = true
+    allow_classic_link_to_remote_vpc = true
+  }
+}
+```
+
+Basic cross-account usage:
+
+```hcl
+provider "aws" {
+  # Requester's credentials.
+}
+
+provider "aws" {
+  alias = "peer"
+
+  # Accepter's credentials.
+}
+
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+}
+
+resource "aws_vpc" "peer" {
+  provider   = "aws.peer"
+  cidr_block = "10.1.0.0/16"
+
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+}
+
+data "aws_caller_identity" "peer" {
+  provider = "aws.peer"
+}
+
+# Requester's side of the connection.
+resource "aws_vpc_peering_connection" "peer" {
+  vpc_id        = "${aws_vpc.main.id}"
+  peer_vpc_id   = "${aws_vpc.peer.id}"
+  peer_owner_id = "${data.aws_caller_identity.peer.account_id}"
+  auto_accept   = false
+
+  tags {
+    Side = "Requester"
+  }
+}
+
+# Accepter's side of the connection.
+resource "aws_vpc_peering_connection_accepter" "peer" {
+  provider                  = "aws.peer"
+  vpc_peering_connection_id = "${aws_vpc_peering_connection.peer.id}"
+  auto_accept               = true
+
+  tags {
+    Side = "Accepter"
+  }
+}
+
+# As options can't be set until the connection has been accepted
+# create an explicit dependency on the accepter.
+
+resource "aws_vpc_peering_connection_options" "requester" {
+  vpc_peering_connection_id = "${aws_vpc_peering_connection_accepter.peer.id}"
+
+  requester {
+    allow_remote_vpc_dns_resolution = true
+  }
+}
+
+resource "aws_vpc_peering_connection_options" "accepter" {
+  provider                  = "aws.peer"
+  vpc_peering_connection_id = "${aws_vpc_peering_connection_accepter.peer.id}"
+
+  accepter {
+    allow_remote_vpc_dns_resolution = true
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `vpc_peering_connection_id` - (Required) The ID of the requester VPC.
+* `accepter` (Optional) - An optional configuration block that allows for [VPC Peering Connection]
+(http://docs.aws.amazon.com/AmazonVPC/latest/PeeringGuide) options to be set for the VPC that accepts
+the peering connection (a maximum of one).
+* `requester` (Optional) - A optional configuration block that allows for [VPC Peering Connection]
+(http://docs.aws.amazon.com/AmazonVPC/latest/PeeringGuide) options to be set for the VPC that requests
+the peering connection (a maximum of one).
+
+#### Accepter and Requester Arguments
+
+-> **Note:** When enabled, the DNS resolution feature requires that VPCs participating in the peering
+must have support for the DNS hostnames enabled. This can be done using the [`enable_dns_hostnames`]
+(vpc.html#enable_dns_hostnames) attribute in the [`aws_vpc`](vpc.html) resource. See [Using DNS with Your VPC]
+(http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-dns.html) user guide for more information.
+
+* `allow_remote_vpc_dns_resolution` - (Optional) Allow a local VPC to resolve public DNS hostnames to private
+IP addresses when queried from instances in the peer VPC.
+* `allow_classic_link_to_remote_vpc` - (Optional) Allow a local linked EC2-Classic instance to communicate
+with instances in a peer VPC. This enables an outbound communication from the local ClassicLink connection
+to the remote VPC.
+* `allow_vpc_to_remote_classic_link` - (Optional) Allow a local VPC to communicate with a linked EC2-Classic
+instance in a peer VPC. This enables an outbound communication from the local VPC to the remote ClassicLink
+connection.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the VPC Peering Connection Options.
+
+## Import
+
+VPC Peering Connection Options can be imported using the `vpc peering id`, e.g.
+
+```
+$ terraform import aws_vpc_peering_connection_options.foo pcx-111aaa111
+```


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/3069, https://github.com/terraform-providers/terraform-provider-aws/issues/3676 and https://github.com/terraform-providers/terraform-provider-aws/issues/3850.

Add a new resource `aws_vpc_peering_connection_options` that manages VPC peering connection options.
This resource decouples management of the connection options from management of the connection and allows options to be set correctly in cross-account scenarios:
```hcl
provider "aws" {
  # Requester's credentials.
}

provider "aws" {
  alias = "peer"

  # Accepter's credentials.
}

resource "aws_vpc" "main" {
  cidr_block = "10.0.0.0/16"

  enable_dns_support   = true
  enable_dns_hostnames = true
}

resource "aws_vpc" "peer" {
  provider   = "aws.peer"
  cidr_block = "10.1.0.0/16"

  enable_dns_support   = true
  enable_dns_hostnames = true
}

data "aws_caller_identity" "peer" {
  provider = "aws.peer"
}

# Requester's side of the connection.
resource "aws_vpc_peering_connection" "peer" {
  vpc_id        = "${aws_vpc.main.id}"
  peer_vpc_id   = "${aws_vpc.peer.id}"
  peer_owner_id = "${data.aws_caller_identity.peer.account_id}"
  auto_accept   = false

  tags {
    Side = "Requester"
  }
}

# Accepter's side of the connection.
resource "aws_vpc_peering_connection_accepter" "peer" {
  provider                  = "aws.peer"
  vpc_peering_connection_id = "${aws_vpc_peering_connection.peer.id}"
  auto_accept               = true

  tags {
    Side = "Accepter"
  }
}

# As options can't be set until the connection has been accepted
# create an explicit dependency on the accepter.

resource "aws_vpc_peering_connection_options" "requester" {
  vpc_peering_connection_id = "${aws_vpc_peering_connection_accepter.peer.id}"

  requester {
    allow_remote_vpc_dns_resolution = true
  }
}

resource "aws_vpc_peering_connection_options" "accepter" {
  provider                  = "aws.peer"
  vpc_peering_connection_id = "${aws_vpc_peering_connection_accepter.peer.id}"

  accepter {
    allow_remote_vpc_dns_resolution = true
  }
}
```
```
terraform apply
data.aws_caller_identity.peer: Refreshing state...
aws_vpc.peer: Creating...
  assign_generated_ipv6_cidr_block: "" => "false"
  cidr_block:                       "" => "10.1.0.0/16"
  default_network_acl_id:           "" => "<computed>"
  default_route_table_id:           "" => "<computed>"
  default_security_group_id:        "" => "<computed>"
  dhcp_options_id:                  "" => "<computed>"
  enable_classiclink:               "" => "<computed>"
  enable_classiclink_dns_support:   "" => "<computed>"
  enable_dns_hostnames:             "" => "true"
  enable_dns_support:               "" => "true"
  instance_tenancy:                 "" => "<computed>"
  ipv6_association_id:              "" => "<computed>"
  ipv6_cidr_block:                  "" => "<computed>"
  main_route_table_id:              "" => "<computed>"
aws_vpc.main: Creating...
  assign_generated_ipv6_cidr_block: "" => "false"
  cidr_block:                       "" => "10.0.0.0/16"
  default_network_acl_id:           "" => "<computed>"
  default_route_table_id:           "" => "<computed>"
  default_security_group_id:        "" => "<computed>"
  dhcp_options_id:                  "" => "<computed>"
  enable_classiclink:               "" => "<computed>"
  enable_classiclink_dns_support:   "" => "<computed>"
  enable_dns_hostnames:             "" => "true"
  enable_dns_support:               "" => "true"
  instance_tenancy:                 "" => "<computed>"
  ipv6_association_id:              "" => "<computed>"
  ipv6_cidr_block:                  "" => "<computed>"
  main_route_table_id:              "" => "<computed>"
aws_vpc.main: Creation complete after 5s (ID: vpc-11111111)
aws_vpc.peer: Creation complete after 5s (ID: vpc-22222222)
aws_vpc_peering_connection.peer: Creating...
  accept_status: "" => "<computed>"
  accepter.#:    "" => "<computed>"
  auto_accept:   "" => "false"
  peer_owner_id: "" => "999999999999"
  peer_region:   "" => "us-west-2"
  peer_vpc_id:   "" => "vpc-22222222"
  requester.#:   "" => "<computed>"
  tags.%:        "" => "1"
  tags.Side:     "" => "Requester"
  vpc_id:        "" => "vpc-11111111"
aws_vpc_peering_connection.peer: Creation complete after 2s (ID: pcx-33333333)
aws_vpc_peering_connection_accepter.peer: Creating...
  accept_status:             "" => "<computed>"
  accepter.#:                "" => "<computed>"
  auto_accept:               "" => "true"
  peer_owner_id:             "" => "<computed>"
  peer_region:               "" => "<computed>"
  peer_vpc_id:               "" => "<computed>"
  requester.#:               "" => "<computed>"
  tags.%:                    "" => "1"
  tags.Side:                 "" => "Accepter"
  vpc_id:                    "" => "<computed>"
  vpc_peering_connection_id: "" => "pcx-33333333"
aws_vpc_peering_connection_accepter.peer: Creation complete after 2s (ID: pcx-33333333)
aws_vpc_peering_connection_options.accepter: Creating...
  accepter.#:                                           "" => "1"
  accepter.1102046665.allow_classic_link_to_remote_vpc: "" => "false"
  accepter.1102046665.allow_remote_vpc_dns_resolution:  "" => "true"
  accepter.1102046665.allow_vpc_to_remote_classic_link: "" => "false"
  requester.#:                                          "" => "<computed>"
  vpc_peering_connection_id:                            "" => "pcx-33333333"
aws_vpc_peering_connection_options.requester: Creating...
  accepter.#:                                            "" => "<computed>"
  requester.#:                                           "" => "1"
  requester.1102046665.allow_classic_link_to_remote_vpc: "" => "false"
  requester.1102046665.allow_remote_vpc_dns_resolution:  "" => "true"
  requester.1102046665.allow_vpc_to_remote_classic_link: "" => "false"
  vpc_peering_connection_id:                             "" => "pcx-33333333"
aws_vpc_peering_connection_options.requester: Creation complete after 0s (ID: pcx-33333333)
aws_vpc_peering_connection_options.accepter: Creation complete after 1s (ID: pcx-33333333)

Apply complete! Resources: 6 added, 0 changed, 0 destroyed.
```