### PR TITLE
Allow configurable timeout when reading security group rule

### DIFF
--- a/aws/resource_aws_security_group_rule.go
+++ b/aws/resource_aws_security_group_rule.go
@@ -40,6 +40,10 @@ func resourceAwsSecurityGroupRule() *schema.Resource {
 		SchemaVersion: 2,
 		MigrateState:  resourceAwsSecurityGroupRuleMigrateState,
 
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"type": {
 				Type:        schema.TypeString,
@@ -225,7 +229,7 @@ information and instructions for recovery. Error message: %s`, sg_id, awsErr.Mes
 	id := ipPermissionIDHash(sg_id, ruleType, perm)
 	log.Printf("[DEBUG] Computed group rule ID %s", id)
 
-	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+	err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
 		sg, err := findResourceSecurityGroup(conn, sg_id)
 
 		if err != nil {

--- a/website/docs/r/security_group_rule.html.markdown
+++ b/website/docs/r/security_group_rule.html.markdown
@@ -136,3 +136,10 @@ Import a rule that has itself and an IPv6 CIDR block as sources:
 ```console
 $ terraform import aws_security_group_rule.rule_name sg-656c65616e6f72_ingress_tcp_80_80_self_2001:db8::/48
 ```
+
+## Timeouts
+
+`aws_security_group_rule` provides the following [Timeouts](/docs/configuration/resources.html#timeouts)
+configuration options:
+
+- `read` - (Default `5 minutes`) How long to wait for reading a rsecurity group rule.


### PR DESCRIPTION
When being throttled on AWS requests, read requests are the first ones
to be throttled, and reading security group rules can take longer than
5m to complete. Transform the hard timeout of 5m with a configurable
timeout to avoid this problem.

Fixes part of #3128