### PR TITLE
d/aws_subnet_ids: filter by availability zone

### DIFF
--- a/aws/data_source_aws_subnet_ids.go
+++ b/aws/data_source_aws_subnet_ids.go
@@ -26,6 +26,11 @@ func dataSourceAwsSubnetIDs() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
+
+			"availability_zone": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -58,7 +63,10 @@ func dataSourceAwsSubnetIDsRead(d *schema.ResourceData, meta interface{}) error 
 	subnets := make([]string, 0)
 
 	for _, subnet := range resp.Subnets {
-		subnets = append(subnets, *subnet.SubnetId)
+		az := d.Get("availability_zone")
+		if az.(string) == "" || az.(string) == *subnet.AvailabilityZone {
+			subnets = append(subnets, *subnet.SubnetId)
+		}
 	}
 
 	d.SetId(d.Get("vpc_id").(string))

--- a/aws/data_source_aws_subnet_ids_test.go
+++ b/aws/data_source_aws_subnet_ids_test.go
@@ -29,6 +29,24 @@ func TestAccDataSourceAwsSubnetIDs(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAwsSubnetIDsAvailabilityZone(t *testing.T) {
+	rInt := acctest.RandIntRange(0, 256)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVpcDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsSubnetIDsConfigWithAvailabilityZone(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_subnet_ids.test_a", "ids.#", "2"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDataSourceAwsSubnetIDsConfigWithDataSource(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
@@ -126,6 +144,60 @@ resource "aws_subnet" "test_private_b" {
     Name = "tf-acc-subnet-ids-data-source-private-b"
     Tier = "Private"
   }
+}
+`, rInt, rInt, rInt, rInt)
+}
+
+func testAccDataSourceAwsSubnetIDsConfigWithAvailabilityZone(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "172.%d.0.0/16"
+
+  tags {
+    Name = "terraform-testacc-subnet-ids-availability-zone"
+  }
+}
+
+resource "aws_subnet" "test_a_one" {
+  vpc_id = "${aws_vpc.test.id}"
+  cidr_block = "172.%d.123.0/24"
+  availability_zone = "us-west-2a"
+
+  tags {
+    Name = "terraform-testacc-subnet-ids-availability-zone-a-one"
+  }
+}
+
+resource "aws_subnet" "test_a_two" {
+  vpc_id            = "${aws_vpc.test.id}"
+  cidr_block        = "172.%d.124.0/24"
+  availability_zone = "us-west-2a"
+
+  tags {
+    Name = "terraform-testacc-subnet-ids-availability-zone-a-two"
+  }
+}
+
+resource "aws_subnet" "test_b_one" {
+  vpc_id            = "${aws_vpc.test.id}"
+  cidr_block        = "172.%d.125.0/24"
+  availability_zone = "us-west-2b"
+
+  tags {
+    Name = "terraform-testacc-subnet-ids-availability-zone-b-one"
+  }
+}
+
+data "aws_subnet_ids" "test_a" {
+  vpc_id            = "${aws_vpc.test.id}"
+
+  // using this to imply implicit dependency rather than depends_on
+  // https://github.com/hashicorp/terraform/issues/17034
+  availability_zone = "${element(list(
+     aws_subnet.test_a_one.availability_zone,
+     aws_subnet.test_a_two.availability_zone,
+     aws_subnet.test_b_one.availability_zone,
+  ), 0)}"
 }
 `, rInt, rInt, rInt, rInt)
 }


### PR DESCRIPTION
This should help with https://github.com/terraform-providers/terraform-provider-aws/issues/3471

```
make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsSubnetIDs'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccDataSourceAwsSubnetIDs -timeout 120m
=== RUN   TestAccDataSourceAwsSubnetIDs
--- PASS: TestAccDataSourceAwsSubnetIDs (34.54s)
=== RUN   TestAccDataSourceAwsSubnetIDsAvailabilityZone
--- PASS: TestAccDataSourceAwsSubnetIDsAvailabilityZone (23.73s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	58.312s
```