### PR TITLE
tests/resource/aws_subnet: Add sweeper dependencies

### DIFF
--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -17,9 +17,18 @@ func init() {
 	resource.AddTestSweepers("aws_subnet", &resource.Sweeper{
 		Name: "aws_subnet",
 		F:    testSweepSubnets,
+		// When implemented, these should be moved to aws_network_interface
+		// and aws_network_interface set as dependency here.
 		Dependencies: []string{
+			"aws_autoscaling_group",
 			"aws_batch_compute_environment",
+			"aws_beanstalk_environment",
+			"aws_db_instance",
+			"aws_elasticsearch_domain",
 			"aws_elb",
+			"aws_lambda_function",
+			"aws_mq_broker",
+			"aws_redshift_cluster",
 		},
 	})
 }


### PR DESCRIPTION
♻️  Catching subnet utilizing resources that currently have sweepers implemented.

Please note a few changes should take place after:
* Consistency: rename `aws_beanstalk_environment` to `aws_elastic_beanstalk_environment`
* Implement `aws_redshift_subnet_group` which depends on `aws_redshift_cluster` (fixing `aws_subnet` dependency to point at that)
* Implement `aws_db_subnet_group` which depends on `aws_db_instance` (fixing `aws_subnet` dependency to point at that)