### PR TITLE
docs/resource/aws_elasticache_*: Cross reference cluster and replication group resources

### DIFF
--- a/website/docs/r/elasticache_cluster.html.markdown
+++ b/website/docs/r/elasticache_cluster.html.markdown
@@ -9,6 +9,8 @@ description: |-
 # aws_elasticache_cluster
 
 Provides an ElastiCache Cluster resource, which manages a Memcached cluster or Redis instance.
+For working with Redis (Cluster Mode Enabled) replication groups, see the
+[`aws_elasticache_replication_group` resource](/docs/providers/aws/r/elasticache_replication_group.html).
 
 ~> **Note:** When you change an attribute, such as `node_type`, by default
 it is applied in the next maintenance window. Because of this, Terraform may report

--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -9,6 +9,8 @@ description: |-
 # aws_elasticache_replication_group
 
 Provides an ElastiCache Replication Group resource.
+For working with Memcached or single primary Redis instances (Cluster Mode Disabled), see the
+[`aws_elasticache_cluster` resource](/docs/providers/aws/r/elasticache_cluster.html).
 
 ## Example Usage
 


### PR DESCRIPTION
Closes #691 by cross referencing the types of Elasticache service resources provided by Terraform and the API.