### PR TITLE
tests/resource/aws_autoscaling_group: Sweep additional groups

### DIFF
--- a/aws/resource_aws_autoscaling_group_test.go
+++ b/aws/resource_aws_autoscaling_group_test.go
@@ -46,7 +46,7 @@ func testSweepAutoscalingGroups(region string) error {
 
 	for _, asg := range resp.AutoScalingGroups {
 		var testOptGroup bool
-		for _, testName := range []string{"foobar", "terraform-", "tf-test"} {
+		for _, testName := range []string{"foobar", "terraform-", "tf-test", "tf-asg-"} {
 			if strings.HasPrefix(*asg.AutoScalingGroupName, testName) {
 				testOptGroup = true
 				break
@@ -162,7 +162,7 @@ func TestAccAWSAutoScalingGroup_basic(t *testing.T) {
 }
 
 func TestAccAWSAutoScalingGroup_namePrefix(t *testing.T) {
-	nameRegexp := regexp.MustCompile("^test-")
+	nameRegexp := regexp.MustCompile("^tf-test-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -251,7 +251,7 @@ func TestAccAWSAutoScalingGroup_terminationPolicies(t *testing.T) {
 func TestAccAWSAutoScalingGroup_tags(t *testing.T) {
 	var group autoscaling.Group
 
-	randName := fmt.Sprintf("tfautotags-%s", acctest.RandString(5))
+	randName := fmt.Sprintf("tf-test-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -360,7 +360,7 @@ func TestAccAWSAutoScalingGroup_WithLoadBalancer(t *testing.T) {
 func TestAccAWSAutoScalingGroup_withPlacementGroup(t *testing.T) {
 	var group autoscaling.Group
 
-	randName := fmt.Sprintf("tf_placement_test-%s", acctest.RandString(5))
+	randName := fmt.Sprintf("tf-test-%s", acctest.RandString(5))
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -952,7 +952,7 @@ resource "aws_autoscaling_group" "test" {
   desired_capacity = 0
   max_size = 0
   min_size = 0
-  name_prefix = "test-"
+  name_prefix = "tf-test-"
   launch_configuration = "${aws_launch_configuration.test.name}"
 }
 `


### PR DESCRIPTION
Found some additional ASGs not picked up by the sweeper:
```
18 tests passed (all tests)
=== RUN   TestAccAWSAutoScalingGroup_namePrefix
--- PASS: TestAccAWSAutoScalingGroup_namePrefix (71.95s)
=== RUN   TestAccAWSAutoScalingGroup_serviceLinkedRoleARN
--- PASS: TestAccAWSAutoScalingGroup_serviceLinkedRoleARN (73.58s)
=== RUN   TestAccAWSAutoScalingGroup_autoGeneratedName
--- PASS: TestAccAWSAutoScalingGroup_autoGeneratedName (86.86s)
=== RUN   TestAccAWSAutoScalingGroup_classicVpcZoneIdentifier
--- PASS: TestAccAWSAutoScalingGroup_classicVpcZoneIdentifier (88.99s)
=== RUN   TestAccAWSAutoScalingGroup_emptyAvailabilityZones
--- PASS: TestAccAWSAutoScalingGroup_emptyAvailabilityZones (94.15s)
=== RUN   TestAccAWSAutoScalingGroup_ALB_TargetGroups
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups (124.21s)
=== RUN   TestAccAWSAutoScalingGroup_terminationPolicies
--- PASS: TestAccAWSAutoScalingGroup_terminationPolicies (138.37s)
=== RUN   TestAccAWSAutoScalingGroup_VpcUpdates
--- PASS: TestAccAWSAutoScalingGroup_VpcUpdates (142.90s)
=== RUN   TestAccAWSAutoScalingGroup_withMetrics
--- PASS: TestAccAWSAutoScalingGroup_withMetrics (167.10s)
=== RUN   TestAccAWSAutoScalingGroup_enablingMetrics
--- PASS: TestAccAWSAutoScalingGroup_enablingMetrics (207.58s)
=== RUN   TestAccAWSAutoScalingGroup_withPlacementGroup
--- PASS: TestAccAWSAutoScalingGroup_withPlacementGroup (208.84s)
=== RUN   TestAccAWSAutoScalingGroup_importBasic
--- PASS: TestAccAWSAutoScalingGroup_importBasic (209.86s)
=== RUN   TestAccAWSAutoScalingGroup_initialLifecycleHook
--- PASS: TestAccAWSAutoScalingGroup_initialLifecycleHook (259.26s)
=== RUN   TestAccAWSAutoScalingGroup_basic
--- PASS: TestAccAWSAutoScalingGroup_basic (272.57s)
=== RUN   TestAccAWSAutoScalingGroup_tags
--- PASS: TestAccAWSAutoScalingGroup_tags (272.98s)
=== RUN   TestAccAWSAutoScalingGroup_suspendingProcesses
--- PASS: TestAccAWSAutoScalingGroup_suspendingProcesses (294.78s)
=== RUN   TestAccAWSAutoScalingGroup_WithLoadBalancer
--- PASS: TestAccAWSAutoScalingGroup_WithLoadBalancer (303.01s)
=== RUN   TestAccAWSAutoScalingGroup_ALB_TargetGroups_ELBCapacity
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups_ELBCapacity (359.44s)
```