### PR TITLE
resource/aws_elasticache_replication_group: Support Cluster Mode Enabled online shard reconfiguration

### DIFF
--- a/aws/resource_aws_elasticache_replication_group.go
+++ b/aws/resource_aws_elasticache_replication_group.go
@@ -65,6 +65,11 @@ func resourceAwsElasticacheReplicationGroup() *schema.Resource {
 	resourceSchema["cluster_mode"] = &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
+		// We allow Computed: true here since using number_cache_clusters
+		// and a cluster mode enabled parameter_group_name will create
+		// a single shard replication group with number_cache_clusters - 1
+		// read replicas. Otherwise, the resource is marked ForceNew.
+		Computed: true,
 		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{

--- a/aws/resource_aws_elasticache_replication_group.go
+++ b/aws/resource_aws_elasticache_replication_group.go
@@ -63,7 +63,7 @@ func resourceAwsElasticacheReplicationGroup() *schema.Resource {
 	}
 
 	resourceSchema["cluster_mode"] = &schema.Schema{
-		Type:     schema.TypeSet,
+		Type:     schema.TypeList,
 		Optional: true,
 		MaxItems: 1,
 		Elem: &schema.Resource{
@@ -76,7 +76,6 @@ func resourceAwsElasticacheReplicationGroup() *schema.Resource {
 				"num_node_groups": {
 					Type:     schema.TypeInt,
 					Required: true,
-					ForceNew: true,
 				},
 			},
 		},
@@ -118,7 +117,14 @@ func resourceAwsElasticacheReplicationGroup() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
-		Schema: resourceSchema,
+		Schema:        resourceSchema,
+		SchemaVersion: 1,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(50 * time.Minute),
+			Delete: schema.DefaultTimeout(40 * time.Minute),
+			Update: schema.DefaultTimeout(40 * time.Minute),
+		},
 	}
 }
 
@@ -213,8 +219,8 @@ func resourceAwsElasticacheReplicationGroupCreate(d *schema.ResourceData, meta i
 	}
 
 	if clusterModeOk {
-		clusterModeAttributes := clusterMode.(*schema.Set).List()
-		attributes := clusterModeAttributes[0].(map[string]interface{})
+		clusterModeList := clusterMode.([]interface{})
+		attributes := clusterModeList[0].(map[string]interface{})
 
 		if v, ok := attributes["num_node_groups"]; ok {
 			params.NumNodeGroups = aws.Int64(int64(v.(int)))
@@ -241,7 +247,7 @@ func resourceAwsElasticacheReplicationGroupCreate(d *schema.ResourceData, meta i
 		Pending:    pending,
 		Target:     []string{"available"},
 		Refresh:    cacheReplicationGroupStateRefreshFunc(conn, d.Id(), "available", pending),
-		Timeout:    50 * time.Minute,
+		Timeout:    d.Timeout(schema.TimeoutCreate),
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second,
 	}
@@ -304,6 +310,13 @@ func resourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta int
 
 	d.Set("replication_group_description", rgp.Description)
 	d.Set("number_cache_clusters", len(rgp.MemberClusters))
+	if aws.BoolValue(rgp.ClusterEnabled) {
+		if err := d.Set("cluster_mode", flattenElasticacheNodeGroupsToClusterMode(rgp.NodeGroups)); err != nil {
+			return fmt.Errorf("error setting cluster_mode attribute: %s", err)
+		}
+	} else {
+		d.Set("cluster_mode", []interface{}{})
+	}
 	d.Set("replication_group_id", rgp.ReplicationGroupId)
 
 	if rgp.NodeGroups != nil {
@@ -363,6 +376,51 @@ func resourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta int
 
 func resourceAwsElasticacheReplicationGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).elasticacheconn
+
+	if d.HasChange("cluster_mode.0.num_node_groups") {
+		o, n := d.GetChange("cluster_mode.0.num_node_groups")
+		oldNumNodeGroups := o.(int)
+		newNumNodeGroups := n.(int)
+
+		input := &elasticache.ModifyReplicationGroupShardConfigurationInput{
+			ApplyImmediately:   aws.Bool(true),
+			NodeGroupCount:     aws.Int64(int64(newNumNodeGroups)),
+			ReplicationGroupId: aws.String(d.Id()),
+		}
+
+		if oldNumNodeGroups > newNumNodeGroups {
+			// Node Group IDs are 1 indexed: 0001 through 0015
+			// Loop from highest old ID until we reach highest new ID
+			nodeGroupsToRemove := []string{}
+			for i := oldNumNodeGroups; i > newNumNodeGroups; i-- {
+				nodeGroupID := fmt.Sprintf("%04d", i)
+				nodeGroupsToRemove = append(nodeGroupsToRemove, nodeGroupID)
+			}
+			input.NodeGroupsToRemove = aws.StringSlice(nodeGroupsToRemove)
+		}
+
+		log.Printf("[DEBUG] Modifying Elasticache Replication Group (%s) shard configuration: %s", d.Id(), input)
+		_, err := conn.ModifyReplicationGroupShardConfiguration(input)
+		if err != nil {
+			return fmt.Errorf("error modifying Elasticache Replication Group shard configuration: %s", err)
+		}
+
+		pending := []string{"creating", "modifying", "snapshotting"}
+		stateConf := &resource.StateChangeConf{
+			Pending:    pending,
+			Target:     []string{"available"},
+			Refresh:    cacheReplicationGroupStateRefreshFunc(conn, d.Id(), "available", pending),
+			Timeout:    d.Timeout(schema.TimeoutUpdate),
+			MinTimeout: 10 * time.Second,
+			Delay:      30 * time.Second,
+		}
+
+		log.Printf("[DEBUG] Waiting for Elasticache Replication Group (%s) shard reconfiguration completion", d.Id())
+		_, err = stateConf.WaitForState()
+		if err != nil {
+			return fmt.Errorf("error waiting for Elasticache Replication Group (%s) shard reconfiguration completion: %s", d.Id(), err)
+		}
+	}
 
 	requestUpdate := false
 	params := &elasticache.ModifyReplicationGroupInput{
@@ -451,7 +509,7 @@ func resourceAwsElasticacheReplicationGroupUpdate(d *schema.ResourceData, meta i
 			Pending:    pending,
 			Target:     []string{"available"},
 			Refresh:    cacheReplicationGroupStateRefreshFunc(conn, d.Id(), "available", pending),
-			Timeout:    40 * time.Minute,
+			Timeout:    d.Timeout(schema.TimeoutUpdate),
 			MinTimeout: 10 * time.Second,
 			Delay:      30 * time.Second,
 		}
@@ -487,7 +545,7 @@ func resourceAwsElasticacheReplicationGroupDelete(d *schema.ResourceData, meta i
 		Pending:    []string{"creating", "available", "deleting"},
 		Target:     []string{},
 		Refresh:    cacheReplicationGroupStateRefreshFunc(conn, d.Id(), "", []string{}),
-		Timeout:    40 * time.Minute,
+		Timeout:    d.Timeout(schema.TimeoutDelete),
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second,
 	}
@@ -545,6 +603,21 @@ func cacheReplicationGroupStateRefreshFunc(conn *elasticache.ElastiCache, replic
 
 		return rg, *rg.Status, nil
 	}
+}
+
+func flattenElasticacheNodeGroupsToClusterMode(nodeGroups []*elasticache.NodeGroup) []map[string]interface{} {
+	m := map[string]interface{}{
+		"num_node_groups":         0,
+		"replicas_per_node_group": 0,
+	}
+
+	if len(nodeGroups) == 0 {
+		return []map[string]interface{}{m}
+	}
+
+	m["num_node_groups"] = len(nodeGroups)
+	m["replicas_per_node_group"] = (len(nodeGroups[0].NodeGroupMembers) - 1)
+	return []map[string]interface{}{m}
 }
 
 func validateAwsElastiCacheReplicationGroupEngine(v interface{}, k string) (ws []string, errors []error) {

--- a/aws/resource_aws_elasticache_replication_group_migrate.go
+++ b/aws/resource_aws_elasticache_replication_group_migrate.go
@@ -1,0 +1,59 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func resourceAwsElasticacheReplicationGroupMigrateState(v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	switch v {
+	case 0:
+		log.Println("[INFO] Found AWS Elasticache Replication Group State v0; migrating to v1")
+		return migrateAwsElasticacheReplicationGroupStateV0toV1(is)
+	default:
+		return is, fmt.Errorf("Unexpected schema version: %d", v)
+	}
+}
+
+func migrateAwsElasticacheReplicationGroupStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
+	if is.Empty() || is.Attributes == nil {
+		log.Println("[DEBUG] Empty InstanceState; nothing to migrate.")
+		return is, nil
+	}
+
+	numCountStr, ok := is.Attributes["cluster_mode.#"]
+	if !ok || numCountStr == "0" {
+		log.Println("[DEBUG] Empty cluster_mode in InstanceState; no need to migrate.")
+		return is, nil
+	}
+
+	for k, v := range is.Attributes {
+		if !strings.HasPrefix(k, "cluster_mode.") || strings.HasPrefix(k, "cluster_mode.#") {
+			continue
+		}
+
+		// cluster_mode.HASHCODE.attr
+		path := strings.Split(k, ".")
+		if len(path) != 3 {
+			return is, fmt.Errorf("Found unexpected cluster_mode field: %#v", k)
+		}
+		hashcode, attr := path[1], path[2]
+		if hashcode == "0" {
+			// Skip already migrated attribute
+			continue
+		}
+
+		if attr == "replicas_per_node_group" {
+			is.Attributes["cluster_mode.0.replicas_per_node_group"] = v
+		}
+		if attr == "num_node_groups" {
+			is.Attributes["cluster_mode.0.num_node_groups"] = v
+		}
+		delete(is.Attributes, k)
+	}
+	log.Printf("[DEBUG] Attributes after migration: %#v", is.Attributes)
+	return is, nil
+}

--- a/aws/resource_aws_elasticache_replication_group_migrate_test.go
+++ b/aws/resource_aws_elasticache_replication_group_migrate_test.go
@@ -1,0 +1,73 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAwsElasticacheReplicationGroupMigrateState(t *testing.T) {
+	cases := map[string]struct {
+		StateVersion int
+		Attributes   map[string]string
+		Expected     map[string]string
+		Meta         interface{}
+	}{
+		"v0Tov1": {
+			StateVersion: 0,
+			Attributes: map[string]string{
+				"cluster_mode.#":                                  "1",
+				"cluster_mode.4170186206.num_node_groups":         "2",
+				"cluster_mode.4170186206.replicas_per_node_group": "1",
+			},
+			Expected: map[string]string{
+				"cluster_mode.#":                         "1",
+				"cluster_mode.0.num_node_groups":         "2",
+				"cluster_mode.0.replicas_per_node_group": "1",
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		is := &terraform.InstanceState{
+			ID:         "rg-migration",
+			Attributes: tc.Attributes,
+		}
+		is, err := resourceAwsElasticacheReplicationGroupMigrateState(tc.StateVersion, is, tc.Meta)
+
+		if err != nil {
+			t.Fatalf("bad: %s, err: %#v", tn, err)
+		}
+
+		for k, v := range tc.Expected {
+			if is.Attributes[k] != v {
+				t.Fatalf(
+					"bad: %s\n\n expected: %#v -> %#v\n got: %#v -> %#v\n in: %#v",
+					tn, k, v, k, is.Attributes[k], is.Attributes)
+			}
+		}
+	}
+}
+
+func TestAwsElasticacheReplicationGroupMigrateState_empty(t *testing.T) {
+	var is *terraform.InstanceState
+	var meta interface{}
+
+	// should handle nil
+	is, err := resourceAwsElasticacheReplicationGroupMigrateState(0, is, meta)
+
+	if err != nil {
+		t.Fatalf("err: %#v", err)
+	}
+	if is != nil {
+		t.Fatalf("expected nil instancestate, got: %#v", is)
+	}
+
+	// should handle non-nil but empty
+	is = &terraform.InstanceState{}
+	is, err = resourceAwsElasticacheReplicationGroupMigrateState(0, is, meta)
+
+	if err != nil {
+		t.Fatalf("err: %#v", err)
+	}
+}

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -322,7 +322,7 @@ func TestAccAWSElasticacheReplicationGroup_ClusterMode_NumNodeGroups(t *testing.
 				Config: testAccAWSElasticacheReplicationGroupNativeRedisClusterConfig(rName, 2, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "6"),
+					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "4"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_mode.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.num_node_groups", "2"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.replicas_per_node_group", "1"),

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -1075,8 +1075,8 @@ resource "aws_elasticache_replication_group" "bar" {
     parameter_group_name = "default.redis3.2.cluster.on"
     automatic_failover_enabled = true
     cluster_mode {
-      num_node_groups         = %[2]d
-      replicas_per_node_group = %[3]d
+      num_node_groups         = %d
+      replicas_per_node_group = %d
     }
 }`, rName, numNodeGroups, replicasPerNodeGroup)
 }

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -26,6 +26,8 @@ func TestAccAWSElasticacheReplicationGroup_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
 					resource.TestCheckResourceAttr(
+						"aws_elasticache_replication_group.bar", "cluster_mode.#", "0"),
+					resource.TestCheckResourceAttr(
 						"aws_elasticache_replication_group.bar", "number_cache_clusters", "2"),
 					resource.TestCheckResourceAttr(
 						"aws_elasticache_replication_group.bar", "auto_minor_version_upgrade", "false"),
@@ -260,10 +262,10 @@ func TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2(t *testing.T) {
 	})
 }
 
-func TestAccAWSElasticacheReplicationGroup_nativeRedisCluster(t *testing.T) {
+func TestAccAWSElasticacheReplicationGroup_ClusterMode_Basic(t *testing.T) {
 	var rg elasticache.ReplicationGroup
-	rInt := acctest.RandInt()
 	rName := acctest.RandString(10)
+	resourceName := "aws_elasticache_replication_group.bar"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -271,21 +273,59 @@ func TestAccAWSElasticacheReplicationGroup_nativeRedisCluster(t *testing.T) {
 		CheckDestroy: testAccCheckAWSElasticacheReplicationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSElasticacheReplicationGroupNativeRedisClusterConfig(rInt, rName),
+				Config: testAccAWSElasticacheReplicationGroupNativeRedisClusterConfig(rName, 2, 1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
-					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "number_cache_clusters", "4"),
-					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "cluster_mode.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "cluster_mode.4170186206.num_node_groups", "2"),
-					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "cluster_mode.4170186206.replicas_per_node_group", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "port", "6379"),
-					resource.TestCheckResourceAttrSet(
-						"aws_elasticache_replication_group.bar", "configuration_endpoint_address"),
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
+					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "4"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_mode.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.num_node_groups", "2"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.replicas_per_node_group", "1"),
+					resource.TestCheckResourceAttr(resourceName, "port", "6379"),
+					resource.TestCheckResourceAttrSet(resourceName, "configuration_endpoint_address"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSElasticacheReplicationGroup_ClusterMode_NumNodeGroups(t *testing.T) {
+	var rg elasticache.ReplicationGroup
+	rName := acctest.RandString(10)
+	resourceName := "aws_elasticache_replication_group.bar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheReplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSElasticacheReplicationGroupNativeRedisClusterConfig(rName, 3, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
+					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "6"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_mode.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.num_node_groups", "3"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.replicas_per_node_group", "1"),
+				),
+			},
+			{
+				Config: testAccAWSElasticacheReplicationGroupNativeRedisClusterConfig(rName, 1, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
+					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "2"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_mode.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.num_node_groups", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.replicas_per_node_group", "1"),
+				),
+			},
+			{
+				Config: testAccAWSElasticacheReplicationGroupNativeRedisClusterConfig(rName, 2, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
+					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "6"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_mode.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.num_node_groups", "2"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.replicas_per_node_group", "1"),
 				),
 			},
 		},
@@ -977,7 +1017,7 @@ resource "aws_elasticache_replication_group" "bar" {
 }`, rInt, rInt, rName)
 }
 
-func testAccAWSElasticacheReplicationGroupNativeRedisClusterConfig(rInt int, rName string) string {
+func testAccAWSElasticacheReplicationGroupNativeRedisClusterConfig(rName string, numNodeGroups, replicasPerNodeGroup int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "foo" {
     cidr_block = "192.168.0.0/16"
@@ -1005,7 +1045,7 @@ resource "aws_subnet" "bar" {
 }
 
 resource "aws_elasticache_subnet_group" "bar" {
-    name = "tf-test-cache-subnet-%03d"
+    name = "tf-test-%[1]s"
     description = "tf-test-cache-subnet-group-descr"
     subnet_ids = [
         "${aws_subnet.foo.id}",
@@ -1014,7 +1054,7 @@ resource "aws_elasticache_subnet_group" "bar" {
 }
 
 resource "aws_security_group" "bar" {
-    name = "tf-test-security-group-%03d"
+    name = "tf-test-%[1]s"
     description = "tf-test-security-group-descr"
     vpc_id = "${aws_vpc.foo.id}"
     ingress {
@@ -1026,7 +1066,7 @@ resource "aws_security_group" "bar" {
 }
 
 resource "aws_elasticache_replication_group" "bar" {
-    replication_group_id = "tf-%s"
+    replication_group_id = "tf-%[1]s"
     replication_group_description = "test description"
     node_type = "cache.t2.micro"
     port = 6379
@@ -1035,10 +1075,10 @@ resource "aws_elasticache_replication_group" "bar" {
     parameter_group_name = "default.redis3.2.cluster.on"
     automatic_failover_enabled = true
     cluster_mode {
-      replicas_per_node_group = 1
-      num_node_groups = 2
+      num_node_groups         = %[2]d
+      replicas_per_node_group = %[3]d
     }
-}`, rInt, rInt, rName)
+}`, rName, numNodeGroups, replicasPerNodeGroup)
 }
 
 func testAccAWSElasticacheReplicationGroup_EnableAtRestEncryptionConfig(rInt int, rString string) string {

--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -127,7 +127,7 @@ Please note that setting a `snapshot_retention_limit` is not supported on cache.
 Cluster Mode (`cluster_mode`) supports the following:
 
 * `replicas_per_node_group` - (Required) Specify the number of replica nodes in each node group. Valid values are 0 to 5. Changing this number will force a new resource.
-* `num_node_groups` - (Required) Specify the number of node groups (shards) for this Redis replication group. Changing this number will force a new resource.
+* `num_node_groups` - (Required) Specify the number of node groups (shards) for this Redis replication group. Changing this number will trigger an online resizing operation before other settings modifications.
 
 ## Attributes Reference
 
@@ -136,6 +136,15 @@ The following attributes are exported:
 * `id` - The ID of the ElastiCache Replication Group.
 * `configuration_endpoint_address` - The address of the replication group configuration endpoint when cluster mode is enabled.
 * `primary_endpoint_address` - (Redis only) The address of the endpoint for the primary node in the replication group, if the cluster mode is disabled.
+
+## Timeouts
+
+`aws_elasticache_replication_group` provides the following [Timeouts](/docs/configuration/resources.html#timeouts)
+configuration options:
+
+* `create` - (Default `50m`) How long to wait for a replication group to be created.
+* `delete` - (Default `40m`) How long to wait for a replication group to be deleted.
+* `update` - (Default `40m`) How long to wait for replication group settings to be updated. This is also separately used for online resize operation completion, if necessary.
 
 ## Import
 


### PR DESCRIPTION
Closes #2904 

* Properly read cluster_mode back into Terraform state
* Improves cluster_mode update plan output by migrating state from TypeSet to TypeList
* Allows configurable timeouts for create, delete, and update

```
 16 tests passed (all tests)
=== RUN   TestAccAWSElasticacheReplicationGroup_clusteringAndCacheNodesCausesError
--- PASS: TestAccAWSElasticacheReplicationGroup_clusteringAndCacheNodesCausesError (21.18s)
=== RUN   TestAccAWSElasticacheReplicationGroup_Uppercase
--- PASS: TestAccAWSElasticacheReplicationGroup_Uppercase (906.19s)
=== RUN   TestAccAWSElasticacheReplicationGroup_basic
--- PASS: TestAccAWSElasticacheReplicationGroup_basic (966.37s)
=== RUN   TestAccAWSElasticacheReplicationGroup_importBasic
--- PASS: TestAccAWSElasticacheReplicationGroup_importBasic (972.76s)
=== RUN   TestAccAWSElasticacheReplicationGroup_enableSnapshotting
--- PASS: TestAccAWSElasticacheReplicationGroup_enableSnapshotting (1007.92s)
=== RUN   TestAccAWSElasticacheReplicationGroup_updateParameterGroup
--- PASS: TestAccAWSElasticacheReplicationGroup_updateParameterGroup (1009.62s)
=== RUN   TestAccAWSElasticacheReplicationGroup_enableAtRestEncryption
--- PASS: TestAccAWSElasticacheReplicationGroup_enableAtRestEncryption (1128.85s)
=== RUN   TestAccAWSElasticacheReplicationGroup_enableAuthTokenTransitEncryption
--- PASS: TestAccAWSElasticacheReplicationGroup_enableAuthTokenTransitEncryption (1132.64s)
=== RUN   TestAccAWSElasticacheReplicationGroup_updateDescription
--- PASS: TestAccAWSElasticacheReplicationGroup_updateDescription (1140.29s)
=== RUN   TestAccAWSElasticacheReplicationGroup_vpc
--- PASS: TestAccAWSElasticacheReplicationGroup_vpc (1171.57s)
=== RUN   TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow
--- PASS: TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow (1247.89s)
=== RUN   TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2
--- PASS: TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2 (1444.62s)
=== RUN   TestAccAWSElasticacheReplicationGroup_ClusterMode_Basic
--- PASS: TestAccAWSElasticacheReplicationGroup_ClusterMode_Basic (1472.17s)
=== RUN   TestAccAWSElasticacheReplicationGroup_multiAzInVpc
--- PASS: TestAccAWSElasticacheReplicationGroup_multiAzInVpc (1665.92s)
=== RUN   TestAccAWSElasticacheReplicationGroup_updateNodeSize
--- PASS: TestAccAWSElasticacheReplicationGroup_updateNodeSize (1907.65s)
=== RUN   TestAccAWSElasticacheReplicationGroup_ClusterMode_NumNodeGroups
--- PASS: TestAccAWSElasticacheReplicationGroup_ClusterMode_NumNodeGroups (4394.47s)
```