### PR TITLE
Fix password generation in resourceAwsIamUserLoginProfile

### DIFF
--- a/aws/resource_aws_iam_user_login_profile.go
+++ b/aws/resource_aws_iam_user_login_profile.go
@@ -59,27 +59,14 @@ func resourceAwsIamUserLoginProfile() *schema.Resource {
 // characters that are likely to satisfy any possible AWS password policy
 // (given sufficient length).
 func generatePassword(length int) string {
-	charsets := []string{
-		"abcdefghijklmnopqrstuvwxyz",
-		"ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-		"012346789",
-		"!@#$%^&*()_+-=[]{}|'",
-	}
+	charset := `abcdefghijklmnopqrstuvwxyz
+ABCDEFGHIJKLMNOPQRSTUVWXYZ
+012346789
+!@#$%^&*()_+-=[]{}|'`
 
-	// Use all character sets
-	components := make(map[int]byte, length)
-	for i := 0; i < length; i++ {
-		charset := charsets[i%len(charsets)]
-		components[i] = charset[rand.Int(len(charset))]
-	}
-
-	// Randomise the ordering so we don't end up with a predictable
-	// lower case, upper case, numeric, symbol pattern
 	result := make([]byte, length)
-	i := 0
-	for _, b := range components {
-		result[i] = b
-		i = i + 1
+	for i := 0; i < length; i++ {
+		result[i] = charset[rand.Int(len(charset))]
 	}
 
 	return string(result)

--- a/aws/resource_aws_iam_user_login_profile.go
+++ b/aws/resource_aws_iam_user_login_profile.go
@@ -1,9 +1,9 @@
 package aws
 
 import (
+	"crypto/rand"
 	"fmt"
 	"log"
-	"math/rand"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -67,11 +67,10 @@ func generatePassword(length int) string {
 	}
 
 	// Use all character sets
-	random := rand.New(rand.NewSource(time.Now().UTC().UnixNano()))
 	components := make(map[int]byte, length)
 	for i := 0; i < length; i++ {
 		charset := charsets[i%len(charsets)]
-		components[i] = charset[random.Intn(len(charset))]
+		components[i] = charset[rand.Int(len(charset))]
 	}
 
 	// Randomise the ordering so we don't end up with a predictable


### PR DESCRIPTION
The current `generatePassword()` has massive issues:
- it uses the PRNG from `math/rand`, which is *not* secure;
- it seeds said PRNG with non-random data (the current time);
- the password generation method samples one character from each charset, then shuffles the results; this results in suboptimal password entropy, as for a 20-character long (for example), one would know it contains exactly 5 lowercase letters, 5 uppercase letters, 5 digits and 5 “special characters”.

I strongly suggest publishing an advisory after merging this (and updating the vendor-ed source in terraform), as it means that Terraform users have had IAM accounts provisionned with weak, easily-bruteforceable password.