### PR TITLE
resource/aws_autoscaling_group: Fix updating of service_linked_role

### DIFF
--- a/aws/resource_aws_autoscaling_group.go
+++ b/aws/resource_aws_autoscaling_group.go
@@ -616,6 +616,10 @@ func resourceAwsAutoscalingGroupUpdate(d *schema.ResourceData, meta interface{})
 		}
 	}
 
+	if d.HasChange("service_linked_role_arn") {
+		opts.ServiceLinkedRoleARN = aws.String(d.Get("service_linked_role_arn").(string))
+	}
+
 	if err := setAutoscalingTags(conn, d); err != nil {
 		return err
 	}
@@ -723,10 +727,6 @@ func resourceAwsAutoscalingGroupUpdate(d *schema.ResourceData, meta interface{})
 		if err := updateASGSuspendedProcesses(d, conn); err != nil {
 			return errwrap.Wrapf("Error updating AutoScaling Group Suspended Processes: {{err}}", err)
 		}
-	}
-
-	if d.HasChange("service_linked_role_arn") {
-		opts.ServiceLinkedRoleARN = aws.String(d.Get("service_linked_role_arn").(string))
 	}
 
 	return resourceAwsAutoscalingGroupRead(d, meta)


### PR DESCRIPTION
Currently terraform plan/apply show changes to the ASG but no real modifications are done to the infrastructure because the `opts` struct is unused at line 729.