### PR TITLE
d/ssm_parameter: Return a default value if parameter cannot be found in AWS (optional)

### DIFF
--- a/aws/data_source_aws_ssm_parameter.go
+++ b/aws/data_source_aws_ssm_parameter.go
@@ -72,7 +72,8 @@ func dataAwsSsmParameterRead(d *schema.ResourceData, meta interface{}) error {
 	if len(resp.InvalidParameters) > 0 && d.Get("with_default").(bool) == true {
 		d.SetId(name)
 		d.Set("arn", "")
-		d.Set("name", d.Get("type").(string))
+		d.Set("name", name)
+		d.Set("type", "String")
 		d.Set("value", d.Get("default").(string))
 		return nil
 	} else if len(resp.InvalidParameters) > 0 {

--- a/aws/data_source_aws_ssm_parameter.go
+++ b/aws/data_source_aws_ssm_parameter.go
@@ -38,15 +38,9 @@ func dataSourceAwsSsmParameter() *schema.Resource {
 				Optional: true,
 				Default:  true,
 			},
-			"with_default": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
 			"default": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "",
 			},
 		},
 	}
@@ -68,13 +62,13 @@ func dataAwsSsmParameterRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return errwrap.Wrapf("[ERROR] Error describing SSM parameter: {{err}}", err)
 	}
-
-	if len(resp.InvalidParameters) > 0 && d.Get("with_default").(bool) == true {
+	v, ok := d.GetOkExists("default")
+	if len(resp.InvalidParameters) > 0 && ok {
 		d.SetId(name)
 		d.Set("arn", "")
 		d.Set("name", name)
 		d.Set("type", "String")
-		d.Set("value", d.Get("default").(string))
+		d.Set("value", v)
 		return nil
 	} else if len(resp.InvalidParameters) > 0 {
 		return fmt.Errorf("[ERROR] SSM Parameter %s is invalid", name)

--- a/aws/data_source_aws_ssm_parameter_test.go
+++ b/aws/data_source_aws_ssm_parameter_test.go
@@ -55,14 +55,13 @@ func TestAccAWSSsmParameterDataSource_defaultValue(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAwsSsmParameterDataSourceConfigNotExist(name, "false", "true", "foo"),
+				Config: testAccCheckAwsSsmParameterDataSourceConfigNotExist(name, "false", "foo"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "type", "String"),
 					resource.TestCheckResourceAttr(resourceName, "value", "foo"),
 					resource.TestCheckResourceAttr(resourceName, "with_decryption", "false"),
-					resource.TestCheckResourceAttr(resourceName, "with_default", "true"),
 				),
 			},
 		},
@@ -109,13 +108,12 @@ data "aws_ssm_parameter" "test" {
 `, name, withDecryption)
 }
 
-func testAccCheckAwsSsmParameterDataSourceConfigNotExist(name string, withDecryption string, withDefault string, defaultValue string) string {
+func testAccCheckAwsSsmParameterDataSourceConfigNotExist(name string, withDecryption string, defaultValue string) string {
 	return fmt.Sprintf(`
 data "aws_ssm_parameter" "test" {
 	name = "%s"
 	with_decryption = %s
-	with_default = %s
 	default = "%s"
 }
-`, name, withDecryption, withDefault, defaultValue)
+`, name, withDecryption, defaultValue)
 }

--- a/aws/data_source_aws_ssm_parameter_test.go
+++ b/aws/data_source_aws_ssm_parameter_test.go
@@ -11,7 +11,7 @@ import (
 func TestAccAWSSsmParameterDataSource_basic(t *testing.T) {
 	resourceName := "data.aws_ssm_parameter.test"
 	name := "test.parameter"
-	
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -19,7 +19,7 @@ func TestAccAWSSsmParameterDataSource_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAwsSsmParameterDataSourceConfig(name, "false", "false"),
+				Config: testAccCheckAwsSsmParameterDataSourceConfig(name, "false"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr(resourceName, "arn",
 						regexp.MustCompile(fmt.Sprintf("^arn:aws:ssm:[a-z0-9-]+:[0-9]{12}:parameter/%s$", name))),
@@ -30,7 +30,7 @@ func TestAccAWSSsmParameterDataSource_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckAwsSsmParameterDataSourceConfig(name, "true", "false"),
+				Config: testAccCheckAwsSsmParameterDataSourceConfig(name, "true"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr(resourceName, "arn",
 						regexp.MustCompile(fmt.Sprintf("^arn:aws:ssm:[a-z0-9-]+:[0-9]{12}:parameter/%s$", name))),
@@ -40,11 +40,25 @@ func TestAccAWSSsmParameterDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "with_decryption", "true"),
 				),
 			},
+		},
+	})
+}
+
+func TestAccAWSSsmParameterDataSource_defaultValue(t *testing.T) {
+	resourceName := "data.aws_ssm_parameter.test"
+	name := "doesnotexist"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAwsSsmParameterDataSourceConfig("doesnotexist", "false", "true"),
+				Config: testAccCheckAwsSsmParameterDataSourceConfigNotExist(name, "false", "true", "foo"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "arn", ""),
-					resource.TestCheckResourceAttr(resourceName, "name", "doesnotexist"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "type", "String"),
 					resource.TestCheckResourceAttr(resourceName, "value", "foo"),
 					resource.TestCheckResourceAttr(resourceName, "with_decryption", "false"),
@@ -66,7 +80,7 @@ func TestAccAWSSsmParameterDataSource_fullPath(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAwsSsmParameterDataSourceConfig(name, "false", "false"),
+				Config: testAccCheckAwsSsmParameterDataSourceConfig(name, "false"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr(resourceName, "arn",
 						regexp.MustCompile(fmt.Sprintf("^arn:aws:ssm:[a-z0-9-]+:[0-9]{12}:parameter%s$", name))),
@@ -80,7 +94,7 @@ func TestAccAWSSsmParameterDataSource_fullPath(t *testing.T) {
 	})
 }
 
-func testAccCheckAwsSsmParameterDataSourceConfig(name string, withDecryption string, withDefault string) string {
+func testAccCheckAwsSsmParameterDataSourceConfig(name string, withDecryption string) string {
 	return fmt.Sprintf(`
 resource "aws_ssm_parameter" "test" {
 	name = "%s"
@@ -91,8 +105,17 @@ resource "aws_ssm_parameter" "test" {
 data "aws_ssm_parameter" "test" {
 	name = "${aws_ssm_parameter.test.name}"
 	with_decryption = %s
-	with_default = %s
-	default = "foo"
 }
-`, name, withDecryption, withDefault)
+`, name, withDecryption)
+}
+
+func testAccCheckAwsSsmParameterDataSourceConfigNotExist(name string, withDecryption string, withDefault string, defaultValue string) string {
+	return fmt.Sprintf(`
+data "aws_ssm_parameter" "test" {
+	name = "%s"
+	with_decryption = %s
+	with_default = %s
+	default = "%s"
+}
+`, name, withDecryption, withDefault, defaultValue)
 }

--- a/website/docs/d/ssm_parameter.html.markdown
+++ b/website/docs/d/ssm_parameter.html.markdown
@@ -33,7 +33,8 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the parameter.
 * `with_decryption` - (Optional) Whether to return decrypted `SecureString` value. Defaults to `true`.
-
+* `with_default` - (Optional) Whether to return a default value if no parameter can be found. Defaults to `false`.
+* `default` - (Optional) Default return value if no parameter can be found. Defaults to `""`.
 
 In addition to all arguments above, the following attributes are exported:
 

--- a/website/docs/d/ssm_parameter.html.markdown
+++ b/website/docs/d/ssm_parameter.html.markdown
@@ -33,8 +33,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the parameter.
 * `with_decryption` - (Optional) Whether to return decrypted `SecureString` value. Defaults to `true`.
-* `with_default` - (Optional) Whether to return a default value if no parameter can be found. Defaults to `false`.
-* `default` - (Optional) Default return value if no parameter can be found. Defaults to `""`.
+* `default` - (Optional) Default return value if no parameter can be found.
 
 In addition to all arguments above, the following attributes are exported:
 


### PR DESCRIPTION
I tried to make it comparable with the behavior of d/consul_keys (https://www.terraform.io/docs/providers/consul/d/keys.html) but with an option to enable/disable this behavior to avoid any compatibility issues

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSSsmParameterDataSource'
TF_ACC=1 go test ./aws -v -run=TestAccAWSSsmParameterDataSource -timeout 120m
=== RUN   TestAccAWSSsmParameterDataSource_basic
--- PASS: TestAccAWSSsmParameterDataSource_basic (85.00s)
=== RUN   TestAccAWSSsmParameterDataSource_defaultValue
--- PASS: TestAccAWSSsmParameterDataSource_defaultValue (37.30s)
=== RUN   TestAccAWSSsmParameterDataSource_fullPath
--- PASS: TestAccAWSSsmParameterDataSource_fullPath (53.61s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       178.397s
```

### Use case description
I only want to build a AWS resource if a parameter was configured by operations or terraform.