### PR TITLE
New Resource: aws_wafregional_regex_match_set

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -561,6 +561,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_wafregional_geo_match_set":                resourceAwsWafRegionalGeoMatchSet(),
 			"aws_wafregional_ipset":                        resourceAwsWafRegionalIPSet(),
 			"aws_wafregional_rate_based_rule":              resourceAwsWafRegionalRateBasedRule(),
+			"aws_wafregional_regex_match_set":              resourceAwsWafRegionalRegexMatchSet(),
 			"aws_wafregional_regex_pattern_set":            resourceAwsWafRegionalRegexPatternSet(),
 			"aws_wafregional_rule":                         resourceAwsWafRegionalRule(),
 			"aws_wafregional_rule_group":                   resourceAwsWafRegionalRuleGroup(),

--- a/aws/resource_aws_wafregional_regex_match_set.go
+++ b/aws/resource_aws_wafregional_regex_match_set.go
@@ -1,0 +1,179 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/waf"
+	"github.com/aws/aws-sdk-go/service/wafregional"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsWafRegionalRegexMatchSet() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsWafRegionalRegexMatchSetCreate,
+		Read:   resourceAwsWafRegionalRegexMatchSetRead,
+		Update: resourceAwsWafRegionalRegexMatchSetUpdate,
+		Delete: resourceAwsWafRegionalRegexMatchSetDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"regex_match_tuple": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Set:      resourceAwsWafRegexMatchSetTupleHash,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"field_to_match": {
+							Type:     schema.TypeList,
+							Required: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"data": {
+										Type:     schema.TypeString,
+										Optional: true,
+										StateFunc: func(v interface{}) string {
+											return strings.ToLower(v.(string))
+										},
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+						"regex_pattern_set_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"text_transformation": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsWafRegionalRegexMatchSetCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafregionalconn
+	region := meta.(*AWSClient).region
+
+	log.Printf("[INFO] Creating WAF Regional Regex Match Set: %s", d.Get("name").(string))
+
+	wr := newWafRegionalRetryer(conn, region)
+	out, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
+		params := &waf.CreateRegexMatchSetInput{
+			ChangeToken: token,
+			Name:        aws.String(d.Get("name").(string)),
+		}
+		return conn.CreateRegexMatchSet(params)
+	})
+	if err != nil {
+		return fmt.Errorf("Failed creating WAF Regional Regex Match Set: %s", err)
+	}
+	resp := out.(*waf.CreateRegexMatchSetOutput)
+
+	d.SetId(*resp.RegexMatchSet.RegexMatchSetId)
+
+	return resourceAwsWafRegionalRegexMatchSetUpdate(d, meta)
+}
+
+func resourceAwsWafRegionalRegexMatchSetRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafregionalconn
+	log.Printf("[INFO] Reading WAF Regional Regex Match Set: %s", d.Get("name").(string))
+	params := &waf.GetRegexMatchSetInput{
+		RegexMatchSetId: aws.String(d.Id()),
+	}
+
+	resp, err := conn.GetRegexMatchSet(params)
+	if err != nil {
+		if isAWSErr(err, wafregional.ErrCodeWAFNonexistentItemException, "") {
+			log.Printf("[WARN] WAF Regional Regex Match Set (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+
+		return err
+	}
+
+	d.Set("name", resp.RegexMatchSet.Name)
+	d.Set("regex_match_tuple", flattenWafRegexMatchTuples(resp.RegexMatchSet.RegexMatchTuples))
+
+	return nil
+}
+
+func resourceAwsWafRegionalRegexMatchSetUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafregionalconn
+	region := meta.(*AWSClient).region
+
+	log.Printf("[INFO] Updating WAF Regional Regex Match Set: %s", d.Get("name").(string))
+
+	if d.HasChange("regex_match_tuple") {
+		o, n := d.GetChange("regex_match_tuple")
+		oldT, newT := o.(*schema.Set).List(), n.(*schema.Set).List()
+		err := updateRegexMatchSetResourceWR(d.Id(), oldT, newT, conn, region)
+		if err != nil {
+			return fmt.Errorf("Failed updating WAF Regional Regex Match Set: %s", err)
+		}
+	}
+
+	return resourceAwsWafRegionalRegexMatchSetRead(d, meta)
+}
+
+func resourceAwsWafRegionalRegexMatchSetDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafregionalconn
+	region := meta.(*AWSClient).region
+
+	oldTuples := d.Get("regex_match_tuple").(*schema.Set).List()
+	if len(oldTuples) > 0 {
+		noTuples := []interface{}{}
+		err := updateRegexMatchSetResourceWR(d.Id(), oldTuples, noTuples, conn, region)
+		if err != nil {
+			return fmt.Errorf("Error updating WAF Regional Regex Match Set: %s", err)
+		}
+	}
+
+	wr := newWafRegionalRetryer(conn, "global")
+	_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
+		req := &waf.DeleteRegexMatchSetInput{
+			ChangeToken:     token,
+			RegexMatchSetId: aws.String(d.Id()),
+		}
+		log.Printf("[INFO] Deleting WAF Regional Regex Match Set: %s", req)
+		return conn.DeleteRegexMatchSet(req)
+	})
+	if err != nil {
+		return fmt.Errorf("Failed deleting WAF Regional Regex Match Set: %s", err)
+	}
+
+	return nil
+}
+
+func updateRegexMatchSetResourceWR(id string, oldT, newT []interface{}, conn *wafregional.WAFRegional, region string) error {
+	wr := newWafRegionalRetryer(conn, region)
+	_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
+		req := &waf.UpdateRegexMatchSetInput{
+			ChangeToken:     token,
+			RegexMatchSetId: aws.String(id),
+			Updates:         diffWafRegexMatchSetTuples(oldT, newT),
+		}
+
+		return conn.UpdateRegexMatchSet(req)
+	})
+	if err != nil {
+		return fmt.Errorf("Failed updating WAF Regional Regex Match Set: %s", err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_wafregional_regex_match_set_test.go
+++ b/aws/resource_aws_wafregional_regex_match_set_test.go
@@ -1,0 +1,345 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/waf"
+	"github.com/aws/aws-sdk-go/service/wafregional"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_wafregional_regex_match_set", &resource.Sweeper{
+		Name: "aws_wafregional_regex_match_set",
+		F:    testSweepWafRegionalRegexMatchSet,
+	})
+}
+
+func testSweepWafRegionalRegexMatchSet(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).wafregionalconn
+
+	req := &waf.ListRegexMatchSetsInput{}
+	resp, err := conn.ListRegexMatchSets(req)
+	if err != nil {
+		return fmt.Errorf("Error describing WAF Regional Regex Match Sets: %s", err)
+	}
+
+	if len(resp.RegexMatchSets) == 0 {
+		log.Print("[DEBUG] No AWS WAF Regional Regex Match Sets to sweep")
+		return nil
+	}
+
+	for _, s := range resp.RegexMatchSets {
+		if !strings.HasPrefix(*s.Name, "tfacc") {
+			continue
+		}
+
+		resp, err := conn.GetRegexMatchSet(&waf.GetRegexMatchSetInput{
+			RegexMatchSetId: s.RegexMatchSetId,
+		})
+		if err != nil {
+			return err
+		}
+		set := resp.RegexMatchSet
+
+		oldTuples := flattenWafRegexMatchTuples(set.RegexMatchTuples)
+		noTuples := []interface{}{}
+		err = updateRegexMatchSetResourceWR(*set.RegexMatchSetId, oldTuples, noTuples, conn, region)
+		if err != nil {
+			return fmt.Errorf("Error updating WAF Regional Regex Match Set: %s", err)
+		}
+
+		wr := newWafRegionalRetryer(conn, region)
+		_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {
+			req := &waf.DeleteRegexMatchSetInput{
+				ChangeToken:     token,
+				RegexMatchSetId: aws.String(*set.RegexMatchSetId),
+			}
+			log.Printf("[INFO] Deleting WAF Regional Regex Match Set: %s", req)
+			return conn.DeleteRegexMatchSet(req)
+		})
+	}
+
+	return nil
+}
+
+func TestAccAWSWafRegionalRegexMatchSet_basic(t *testing.T) {
+	var matchSet waf.RegexMatchSet
+	var patternSet waf.RegexPatternSet
+	var idx int
+
+	matchSetName := fmt.Sprintf("tfacc-%s", acctest.RandString(5))
+	patternSetName := fmt.Sprintf("tfacc-%s", acctest.RandString(5))
+
+	fieldToMatch := waf.FieldToMatch{
+		Data: aws.String("User-Agent"),
+		Type: aws.String("HEADER"),
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafRegionalRegexMatchSetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSWafRegionalRegexMatchSetConfig(matchSetName, patternSetName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSWafRegionalRegexMatchSetExists("aws_wafregional_regex_match_set.test", &matchSet),
+					testAccCheckAWSWafRegionalRegexPatternSetExists("aws_wafregional_regex_pattern_set.test", &patternSet),
+					computeWafRegexMatchSetTuple(&patternSet, &fieldToMatch, "NONE", &idx),
+					resource.TestCheckResourceAttr("aws_wafregional_regex_match_set.test", "name", matchSetName),
+					resource.TestCheckResourceAttr("aws_wafregional_regex_match_set.test", "regex_match_tuple.#", "1"),
+					testCheckResourceAttrWithIndexesAddr("aws_wafregional_regex_match_set.test", "regex_match_tuple.%d.field_to_match.#", &idx, "1"),
+					testCheckResourceAttrWithIndexesAddr("aws_wafregional_regex_match_set.test", "regex_match_tuple.%d.field_to_match.0.data", &idx, "user-agent"),
+					testCheckResourceAttrWithIndexesAddr("aws_wafregional_regex_match_set.test", "regex_match_tuple.%d.field_to_match.0.type", &idx, "HEADER"),
+					testCheckResourceAttrWithIndexesAddr("aws_wafregional_regex_match_set.test", "regex_match_tuple.%d.text_transformation", &idx, "NONE"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSWafRegionalRegexMatchSet_changePatterns(t *testing.T) {
+	var before, after waf.RegexMatchSet
+	var patternSet waf.RegexPatternSet
+	var idx1, idx2 int
+
+	matchSetName := fmt.Sprintf("tfacc-%s", acctest.RandString(5))
+	patternSetName := fmt.Sprintf("tfacc-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafRegionalRegexMatchSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSWafRegionalRegexMatchSetConfig(matchSetName, patternSetName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSWafRegionalRegexMatchSetExists("aws_wafregional_regex_match_set.test", &before),
+					testAccCheckAWSWafRegionalRegexPatternSetExists("aws_wafregional_regex_pattern_set.test", &patternSet),
+					computeWafRegexMatchSetTuple(&patternSet, &waf.FieldToMatch{Data: aws.String("User-Agent"), Type: aws.String("HEADER")}, "NONE", &idx1),
+					resource.TestCheckResourceAttr("aws_wafregional_regex_match_set.test", "name", matchSetName),
+					resource.TestCheckResourceAttr("aws_wafregional_regex_match_set.test", "regex_match_tuple.#", "1"),
+					testCheckResourceAttrWithIndexesAddr("aws_wafregional_regex_match_set.test", "regex_match_tuple.%d.field_to_match.#", &idx1, "1"),
+					testCheckResourceAttrWithIndexesAddr("aws_wafregional_regex_match_set.test", "regex_match_tuple.%d.field_to_match.0.data", &idx1, "user-agent"),
+					testCheckResourceAttrWithIndexesAddr("aws_wafregional_regex_match_set.test", "regex_match_tuple.%d.field_to_match.0.type", &idx1, "HEADER"),
+					testCheckResourceAttrWithIndexesAddr("aws_wafregional_regex_match_set.test", "regex_match_tuple.%d.text_transformation", &idx1, "NONE"),
+				),
+			},
+			{
+				Config: testAccAWSWafRegionalRegexMatchSetConfig_changePatterns(matchSetName, patternSetName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSWafRegionalRegexMatchSetExists("aws_wafregional_regex_match_set.test", &after),
+					resource.TestCheckResourceAttr("aws_wafregional_regex_match_set.test", "name", matchSetName),
+					resource.TestCheckResourceAttr("aws_wafregional_regex_match_set.test", "regex_match_tuple.#", "1"),
+
+					computeWafRegexMatchSetTuple(&patternSet, &waf.FieldToMatch{Data: aws.String("Referer"), Type: aws.String("HEADER")}, "COMPRESS_WHITE_SPACE", &idx2),
+					testCheckResourceAttrWithIndexesAddr("aws_wafregional_regex_match_set.test", "regex_match_tuple.%d.field_to_match.#", &idx2, "1"),
+					testCheckResourceAttrWithIndexesAddr("aws_wafregional_regex_match_set.test", "regex_match_tuple.%d.field_to_match.0.data", &idx2, "referer"),
+					testCheckResourceAttrWithIndexesAddr("aws_wafregional_regex_match_set.test", "regex_match_tuple.%d.field_to_match.0.type", &idx2, "HEADER"),
+					testCheckResourceAttrWithIndexesAddr("aws_wafregional_regex_match_set.test", "regex_match_tuple.%d.text_transformation", &idx2, "COMPRESS_WHITE_SPACE"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSWafRegionalRegexMatchSet_noPatterns(t *testing.T) {
+	var matchSet waf.RegexMatchSet
+	matchSetName := fmt.Sprintf("tfacc-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafRegionalRegexMatchSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSWafRegionalRegexMatchSetConfig_noPatterns(matchSetName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSWafRegionalRegexMatchSetExists("aws_wafregional_regex_match_set.test", &matchSet),
+					resource.TestCheckResourceAttr("aws_wafregional_regex_match_set.test", "name", matchSetName),
+					resource.TestCheckResourceAttr("aws_wafregional_regex_match_set.test", "regex_match_tuple.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSWafRegionalRegexMatchSet_disappears(t *testing.T) {
+	var matchSet waf.RegexMatchSet
+	matchSetName := fmt.Sprintf("tfacc-%s", acctest.RandString(5))
+	patternSetName := fmt.Sprintf("tfacc-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafRegionalRegexMatchSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSWafRegionalRegexMatchSetConfig(matchSetName, patternSetName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSWafRegionalRegexMatchSetExists("aws_wafregional_regex_match_set.test", &matchSet),
+					testAccCheckAWSWafRegionalRegexMatchSetDisappears(&matchSet),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSWafRegionalRegexMatchSetDisappears(set *waf.RegexMatchSet) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).wafregionalconn
+		region := testAccProvider.Meta().(*AWSClient).region
+
+		wr := newWafRegionalRetryer(conn, region)
+		_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
+			req := &waf.UpdateRegexMatchSetInput{
+				ChangeToken:     token,
+				RegexMatchSetId: set.RegexMatchSetId,
+			}
+
+			for _, tuple := range set.RegexMatchTuples {
+				req.Updates = append(req.Updates, &waf.RegexMatchSetUpdate{
+					Action:          aws.String("DELETE"),
+					RegexMatchTuple: tuple,
+				})
+			}
+
+			return conn.UpdateRegexMatchSet(req)
+		})
+		if err != nil {
+			return fmt.Errorf("Failed updating WAF Regional Regex Match Set: %s", err)
+		}
+
+		_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {
+			opts := &waf.DeleteRegexMatchSetInput{
+				ChangeToken:     token,
+				RegexMatchSetId: set.RegexMatchSetId,
+			}
+			return conn.DeleteRegexMatchSet(opts)
+		})
+		if err != nil {
+			return fmt.Errorf("Failed deleting WAF Regional Regex Match Set: %s", err)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSWafRegionalRegexMatchSetExists(n string, v *waf.RegexMatchSet) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No WAF Regional Regex Match Set ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).wafregionalconn
+		resp, err := conn.GetRegexMatchSet(&waf.GetRegexMatchSetInput{
+			RegexMatchSetId: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if *resp.RegexMatchSet.RegexMatchSetId == rs.Primary.ID {
+			*v = *resp.RegexMatchSet
+			return nil
+		}
+
+		return fmt.Errorf("WAF Regional Regex Match Set (%s) not found", rs.Primary.ID)
+	}
+}
+
+func testAccCheckAWSWafRegionalRegexMatchSetDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_wafregional_regex_match_set" {
+			continue
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).wafregionalconn
+		resp, err := conn.GetRegexMatchSet(&waf.GetRegexMatchSetInput{
+			RegexMatchSetId: aws.String(rs.Primary.ID),
+		})
+
+		if err == nil {
+			if *resp.RegexMatchSet.RegexMatchSetId == rs.Primary.ID {
+				return fmt.Errorf("WAF Regional Regex Match Set %s still exists", rs.Primary.ID)
+			}
+		}
+
+		// Return nil if the Regex Pattern Set is already destroyed
+		if isAWSErr(err, wafregional.ErrCodeWAFNonexistentItemException, "") {
+			return nil
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func testAccAWSWafRegionalRegexMatchSetConfig(matchSetName, patternSetName string) string {
+	return fmt.Sprintf(`
+resource "aws_wafregional_regex_match_set" "test" {
+  name = "%s"
+  regex_match_tuple {
+    field_to_match {
+      data = "User-Agent"
+      type = "HEADER"
+    }
+    regex_pattern_set_id = "${aws_wafregional_regex_pattern_set.test.id}"
+    text_transformation = "NONE"
+  }
+}
+
+resource "aws_wafregional_regex_pattern_set" "test" {
+  name = "%s"
+  regex_pattern_strings = ["one", "two"]
+}
+`, matchSetName, patternSetName)
+}
+
+func testAccAWSWafRegionalRegexMatchSetConfig_changePatterns(matchSetName, patternSetName string) string {
+	return fmt.Sprintf(`
+resource "aws_wafregional_regex_match_set" "test" {
+  name = "%s"
+
+  regex_match_tuple {
+    field_to_match {
+      data = "Referer"
+      type = "HEADER"
+    }
+    regex_pattern_set_id = "${aws_wafregional_regex_pattern_set.test.id}"
+    text_transformation = "COMPRESS_WHITE_SPACE"
+  }
+}
+
+resource "aws_wafregional_regex_pattern_set" "test" {
+  name = "%s"
+  regex_pattern_strings = ["one", "two"]
+}
+`, matchSetName, patternSetName)
+}
+
+func testAccAWSWafRegionalRegexMatchSetConfig_noPatterns(matchSetName string) string {
+	return fmt.Sprintf(`
+resource "aws_wafregional_regex_match_set" "test" {
+  name = "%s"
+}`, matchSetName)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1535,6 +1535,10 @@
                     <a href="/docs/providers/aws/r/wafregional_rate_based_rule.html">aws_wafregional_rate_based_rule</a>
                   </li>
 
+                  <li<%= sidebar_current("docs-aws-resource-wafregional-regex-match-set") %>>
+                    <a href="/docs/providers/aws/r/wafregional_regex_match_set.html">aws_wafregional_regex_match_set</a>
+                  </li>
+
                   <li<%= sidebar_current("docs-aws-resource-wafregional-regex-pattern-set") %>>
                     <a href="/docs/providers/aws/r/wafregional_regex_pattern_set.html">aws_wafregional_regex_pattern_set</a>
                   </li>

--- a/website/docs/r/wafregional_regex_match_set.html.markdown
+++ b/website/docs/r/wafregional_regex_match_set.html.markdown
@@ -1,0 +1,66 @@
+---
+layout: "aws"
+page_title: "AWS: wafregional_regex_match_set"
+sidebar_current: "docs-aws-resource-wafregional-regex-match-set"
+description: |-
+  Provides a AWS WAF Regional Regex Match Set resource.
+---
+
+# aws_wafregional_regex_match_set
+
+Provides a WAF Regional Regex Match Set Resource
+
+## Example Usage
+
+```hcl
+resource "aws_wafregional_regex_match_set" "example" {
+  name = "example"
+  regex_match_tuple {
+    field_to_match {
+      data = "User-Agent"
+      type = "HEADER"
+    }
+    regex_pattern_set_id = "${aws_wafregional_regex_pattern_set.example.id}"
+    text_transformation = "NONE"
+  }
+}
+
+resource "aws_wafregional_regex_pattern_set" "example" {
+  name = "example"
+  regex_pattern_strings = ["one", "two"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name or description of the Regex Match Set.
+* `regex_match_tuple` - (Required) The regular expression pattern that you want AWS WAF to search for in web requests,
+	the location in requests that you want AWS WAF to search, and other settings. See below.
+
+### Nested Arguments
+
+#### `regex_match_tuple`
+
+ * `field_to_match` - (Required) The part of a web request that you want to search, such as a specified header or a query string.
+ * `regex_pattern_set_id` - (Required) The ID of a [Regex Pattern Set](/docs/r/waf_regex_pattern_set.html).
+ * `text_transformation` - (Required) Text transformations used to eliminate unusual formatting that attackers use in web requests in an effort to bypass AWS WAF.
+  e.g. `CMD_LINE`, `HTML_ENTITY_DECODE` or `NONE`.
+  See [docs](http://docs.aws.amazon.com/waf/latest/APIReference/API_ByteMatchTuple.html#WAF-Type-ByteMatchTuple-TextTransformation)
+  for all supported values.
+
+#### `field_to_match`
+
+* `data` - (Optional) When `type` is `HEADER`, enter the name of the header that you want to search, e.g. `User-Agent` or `Referer`.
+  If `type` is any other value, omit this field.
+* `type` - (Required) The part of the web request that you want AWS WAF to search for a specified string.
+  e.g. `HEADER`, `METHOD` or `BODY`.
+  See [docs](http://docs.aws.amazon.com/waf/latest/APIReference/API_FieldToMatch.html)
+  for all supported values.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the WAF Regional Regex Match Set.


### PR DESCRIPTION
## Test results

```
TF_ACC=1 go test ./aws -v -run=TestAccAWSWafRegionalRegexMatchSet_ -timeout 120m
=== RUN   TestAccAWSWafRegionalRegexMatchSet_basic
--- PASS: TestAccAWSWafRegionalRegexMatchSet_basic (62.04s)
=== RUN   TestAccAWSWafRegionalRegexMatchSet_changePatterns
--- PASS: TestAccAWSWafRegionalRegexMatchSet_changePatterns (94.01s)
=== RUN   TestAccAWSWafRegionalRegexMatchSet_noPatterns
--- PASS: TestAccAWSWafRegionalRegexMatchSet_noPatterns (36.10s)
=== RUN   TestAccAWSWafRegionalRegexMatchSet_disappears
--- PASS: TestAccAWSWafRegionalRegexMatchSet_disappears (55.51s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	247.702s
```