### PR TITLE
[WIP] network_acl_rule: conflicts: `cidr_block` <-> `ipv6_cidr_block`

### DIFF
--- a/aws/resource_aws_network_acl_rule.go
+++ b/aws/resource_aws_network_acl_rule.go
@@ -54,14 +54,16 @@ func resourceAwsNetworkAclRule() *schema.Resource {
 				ForceNew: true,
 			},
 			"cidr_block": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"ipv6_cidr_block"},
 			},
 			"ipv6_cidr_block": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"cidr_block"},
 			},
 			"from_port": {
 				Type:     schema.TypeInt,


### PR DESCRIPTION
Tried setting it on `resource_aws_network_acl.go` as well, but:

    1 error(s) occurred:

    * resource aws_network_acl: cidr_block: ConflictsWith references unknown attribute (ipv6_cidr_block)