### PR TITLE
resource/aws_lb_target_group: Prevent crash from missing matcher during read

### DIFF
--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -465,7 +465,7 @@ func flattenAwsLbTargetGroupResource(d *schema.ResourceData, meta interface{}, t
 	if targetGroup.HealthCheckPath != nil {
 		healthCheck["path"] = *targetGroup.HealthCheckPath
 	}
-	if targetGroup.Matcher.HttpCode != nil {
+	if targetGroup.Matcher != nil && targetGroup.Matcher.HttpCode != nil {
 		healthCheck["matcher"] = *targetGroup.Matcher.HttpCode
 	}
 


### PR DESCRIPTION
Fixes #3949 

Interestingly enough, its not reproducible in us-west-2, but does crash in sa-east-1. Maybe they're testing a new service release? Sample config that panics:

```
provider "aws" {
  region = "sa-east-1"
}

resource "aws_lb_target_group" "example" {
  name     = "example"
  port     = 8082
  protocol = "TCP"
  vpc_id   = "${aws_vpc.example.id}"
}

resource "aws_vpc" "example" {
  cidr_block = "10.0.0.0/16"
}
```