### PR TITLE
resource/aws_inspector_assessment_target: subscribe-to-event

### DIFF
--- a/aws/resource_aws_inspector_assessment_event_subscriptions_template_test.go
+++ b/aws/resource_aws_inspector_assessment_event_subscriptions_template_test.go
@@ -1,0 +1,188 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSInspectorTemplateEventSubscriptions_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSInspectorTemplateDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSInspectorTemplateAssessmentConfigTwoEventSubscritpions(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSInspectorTemplateExists("aws_inspector_assessment_template.test"),
+					resource.TestCheckResourceAttr("aws_inspector_assessment_template.test", "subscribe_to_event.#", "2"),
+					resource.TestCheckResourceAttr("aws_inspector_assessment_template.test", "subscribe_to_event.1757678435.event", "ASSESSMENT_RUN_STARTED"),
+					resource.TestCheckResourceAttrSet("aws_inspector_assessment_template.test", "subscribe_to_event.1757678435.topic_arn"),
+					resource.TestCheckResourceAttr("aws_inspector_assessment_template.test", "subscribe_to_event.3071367774.event", "ASSESSMENT_RUN_COMPLETED"),
+					resource.TestCheckResourceAttrSet("aws_inspector_assessment_template.test", "subscribe_to_event.3071367774.topic_arn"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSInspectorTemplateEventSubscriptions_update(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSInspectorTemplateDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSInspectorTemplateAssessmentConfigBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSInspectorTemplateExists("aws_inspector_assessment_template.test"),
+					resource.TestCheckResourceAttr("aws_inspector_assessment_template.test", "subscribe_to_event.#", "0"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSInspectorTemplateAssessmentConfigTwoEventSubscritpions(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSInspectorTargetExists("aws_inspector_assessment_template.test"),
+					resource.TestCheckResourceAttr("aws_inspector_assessment_template.test", "subscribe_to_event.#", "2"),
+					resource.TestCheckResourceAttr("aws_inspector_assessment_template.test", "subscribe_to_event.1757678435.event", "ASSESSMENT_RUN_STARTED"),
+					resource.TestCheckResourceAttrSet("aws_inspector_assessment_template.test", "subscribe_to_event.1757678435.topic_arn"),
+					resource.TestCheckResourceAttr("aws_inspector_assessment_template.test", "subscribe_to_event.3071367774.event", "ASSESSMENT_RUN_COMPLETED"),
+					resource.TestCheckResourceAttrSet("aws_inspector_assessment_template.test", "subscribe_to_event.3071367774.topic_arn"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSInspectorTemplateAssessmentConfigReplaceOneEventSubscription(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSInspectorTargetExists("aws_inspector_assessment_template.test"),
+					resource.TestCheckResourceAttr("aws_inspector_assessment_template.test", "subscribe_to_event.#", "2"),
+					resource.TestCheckResourceAttr("aws_inspector_assessment_template.test", "subscribe_to_event.1757678435.event", "ASSESSMENT_RUN_STARTED"),
+					resource.TestCheckResourceAttrSet("aws_inspector_assessment_template.test", "subscribe_to_event.1757678435.topic_arn"),
+					resource.TestCheckResourceAttr("aws_inspector_assessment_template.test", "subscribe_to_event.3886651376.event", "FINDING_REPORTED"),
+					resource.TestCheckResourceAttrSet("aws_inspector_assessment_template.test", "subscribe_to_event.3886651376.topic_arn"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSInspectorTemplateAssessmentConfigBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSInspectorTargetExists("aws_inspector_assessment_template.test"),
+					resource.TestCheckResourceAttr("aws_inspector_assessment_template.test", "subscribe_to_event.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAWSInspectorTemplateAssessmentConfigBasic() string {
+	return fmt.Sprintf(testAccAWSInspectorTemplateAssessmentConfig, "", "")
+}
+
+func testAccAWSInspectorTemplateAssessmentConfigTwoEventSubscritpions() string {
+	return fmt.Sprintf(testAccAWSInspectorTemplateAssessmentConfig,
+		AWSInspectorEventSubscriptionsSNSTopicAndIAMPolicy,
+		AWSInspectorTwoEventSubscriptions)
+}
+
+func testAccAWSInspectorTemplateAssessmentConfigReplaceOneEventSubscription() string {
+	return fmt.Sprintf(testAccAWSInspectorTemplateAssessmentConfig,
+		AWSInspectorEventSubscriptionsSNSTopicAndIAMPolicy,
+		AWSInspectorReplacedEventSubscriptions)
+}
+
+var testAccAWSInspectorTemplateAssessmentConfig = `
+data "aws_inspector_rules_packages" "rules" {}
+
+resource "aws_inspector_resource_group" "test" {
+  tags {
+    Name = "bar"
+  }
+}
+
+resource "aws_inspector_assessment_target" "test" {
+  name               = "test"
+  resource_group_arn = "${aws_inspector_resource_group.test.arn}"
+}
+
+%s
+
+resource "aws_inspector_assessment_template" "test" {
+  name       = "test template"
+  target_arn = "${aws_inspector_assessment_target.test.arn}"
+  duration   = 3600
+
+  rules_package_arns = ["${data.aws_inspector_rules_packages.rules.arns}"]
+
+  %s
+}`
+
+var AWSInspectorTwoEventSubscriptions = `
+subscribe_to_event {
+  event     = "ASSESSMENT_RUN_STARTED"
+  topic_arn = "${aws_sns_topic.test_sns_topic_for_inspector.arn}"
+}
+
+subscribe_to_event {
+  event     = "ASSESSMENT_RUN_COMPLETED"
+  topic_arn = "${aws_sns_topic.test_sns_topic_for_inspector.arn}"
+}
+`
+
+var AWSInspectorReplacedEventSubscriptions = `
+subscribe_to_event {
+  event     = "ASSESSMENT_RUN_STARTED"
+  topic_arn = "${aws_sns_topic.test_sns_topic_for_inspector.arn}"
+}
+
+subscribe_to_event {
+  event     = "FINDING_REPORTED"
+  topic_arn = "${aws_sns_topic.test_sns_topic_for_inspector.arn}"
+}
+`
+
+var AWSInspectorEventSubscriptionsSNSTopicAndIAMPolicy = `
+data "aws_caller_identity" "current" { }
+
+resource "aws_sns_topic" "test_sns_topic_for_inspector" {
+  name = "test_sns_topic_for_inspector"
+}
+
+resource "aws_sns_topic_policy" "test_sns_topic_for_inspector" {
+  arn    = "${aws_sns_topic.test_sns_topic_for_inspector.arn}"
+  policy = "${data.aws_iam_policy_document.inspector-allow-write-to-test-sns-topic.json}"
+}
+
+data "aws_iam_policy_document" "inspector-allow-write-to-test-sns-topic" {
+  policy_id = "__default_policy_ID"
+
+  statement {
+    sid = "inspector"
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+		"arn:aws:iam::162588757376:root",
+		"arn:aws:iam::526946625049:root",
+		"arn:aws:iam::454640832652:root",
+		"arn:aws:iam::406045910587:root",
+		"arn:aws:iam::537503971621:root",
+		"arn:aws:iam::357557129151:root",
+		"arn:aws:iam::316112463485:root",
+		"arn:aws:iam::646659390643:root",
+		"arn:aws:iam::166987590008:root",
+		"arn:aws:iam::758058086616:root"
+      ]
+    }
+
+    actions = [
+      "SNS:Subscribe",
+      "SNS:Receive",
+      "SNS:Publish",
+    ]
+
+    effect    = "Allow"
+    resources = ["${aws_sns_topic.test_sns_topic_for_inspector.arn}"]
+  }
+}
+`

--- a/aws/resource_aws_inspector_assessment_template.go
+++ b/aws/resource_aws_inspector_assessment_template.go
@@ -1,11 +1,14 @@
 package aws
 
 import (
+	"bytes"
+	"fmt"
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/inspector"
+	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -13,6 +16,7 @@ func resourceAWSInspectorAssessmentTemplate() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsInspectorAssessmentTemplateCreate,
 		Read:   resourceAwsInspectorAssessmentTemplateRead,
+		Update: resourceAwsInspectorAssessmentTemplateUpdate,
 		Delete: resourceAwsInspectorAssessmentTemplateDelete,
 
 		Schema: map[string]*schema.Schema{
@@ -42,6 +46,29 @@ func resourceAWSInspectorAssessmentTemplate() *schema.Resource {
 				Set:      schema.HashString,
 				Required: true,
 				ForceNew: true,
+			},
+			"subscribe_to_event": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"event": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateSubscribeToEvent,
+						},
+						"topic_arn": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+				Set: func(v interface{}) int {
+					var buf bytes.Buffer
+					m := v.(map[string]interface{})
+					buf.WriteString(fmt.Sprintf("%s-%s", m["event"].(string), m["topic_arn"].(string)))
+					return hashcode.String(buf.String())
+				},
 			},
 		},
 	}
@@ -74,6 +101,26 @@ func resourceAwsInspectorAssessmentTemplateCreate(d *schema.ResourceData, meta i
 
 	d.SetId(*resp.AssessmentTemplateArn)
 
+	subscriptions := d.Get("subscribe_to_event").(*schema.Set)
+
+	for _, s := range subscriptions.List() {
+		m := s.(map[string]interface{})
+		event := m["event"].(string)
+		topicArn := m["topic_arn"].(string)
+
+		_, err = retryOnAwsCode("AccessDeniedException", func() (interface{}, error) {
+			return conn.SubscribeToEvent(&inspector.SubscribeToEventInput{
+				Event:       &event,
+				TopicArn:    &topicArn,
+				ResourceArn: resp.AssessmentTemplateArn,
+			})
+		})
+
+		if err != nil {
+			return err
+		}
+	}
+
 	return resourceAwsInspectorAssessmentTemplateRead(d, meta)
 }
 
@@ -98,11 +145,73 @@ func resourceAwsInspectorAssessmentTemplateRead(d *schema.ResourceData, meta int
 	if resp.AssessmentTemplates != nil && len(resp.AssessmentTemplates) > 0 {
 		d.Set("name", resp.AssessmentTemplates[0].Name)
 	}
+
+	ste, err := flattenSubscribeToEvents(d, conn)
+	if err != nil {
+		return nil
+	}
+	d.Set("subscribe_to_event", ste)
+
+	return nil
+}
+
+func resourceAwsInspectorAssessmentTemplateUpdate(d *schema.ResourceData, meta interface{}) error {
+	if d.HasChange("subscribe_to_event") {
+		conn := meta.(*AWSClient).inspectorconn
+
+		var new []map[string]interface{}
+		var old []map[string]interface{}
+		oldSubscribeToEvents, newSubscribeToEvents := d.GetChange("subscribe_to_event")
+
+		for _, o := range oldSubscribeToEvents.(*schema.Set).List() {
+			old = append(old, o.(map[string]interface{}))
+		}
+		for _, n := range newSubscribeToEvents.(*schema.Set).List() {
+			new = append(new, n.(map[string]interface{}))
+		}
+
+		for _, s := range substractEventSubscriptions(new, old) {
+			e := s["event"].(string)
+			t := s["topic_arn"].(string)
+			r := d.Id()
+
+			_, err := retryOnAwsCode("AccessDeniedException", func() (interface{}, error) {
+				return conn.SubscribeToEvent(&inspector.SubscribeToEventInput{
+					Event:       &e,
+					ResourceArn: &r,
+					TopicArn:    &t,
+				})
+			})
+
+			if err != nil {
+				return err
+			}
+		}
+
+		for _, s := range substractEventSubscriptions(old, new) {
+			e := s["event"].(string)
+			t := s["topic_arn"].(string)
+			r := d.Id()
+
+			_, err := conn.UnsubscribeFromEvent(&inspector.UnsubscribeFromEventInput{
+				Event:       &e,
+				ResourceArn: &r,
+				TopicArn:    &t,
+			})
+			if err != nil {
+				return err
+			}
+		}
+
+		return resourceAwsInspectorAssessmentTemplateRead(d, meta)
+	}
 	return nil
 }
 
 func resourceAwsInspectorAssessmentTemplateDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).inspectorconn
+
+	// subscriptions to events are removed together with the template automatically
 
 	_, err := conn.DeleteAssessmentTemplate(&inspector.DeleteAssessmentTemplateInput{
 		AssessmentTemplateArn: aws.String(d.Id()),
@@ -118,4 +227,69 @@ func resourceAwsInspectorAssessmentTemplateDelete(d *schema.ResourceData, meta i
 	}
 
 	return nil
+}
+
+// validateSubscribeToEvent validates the string is a known keyword
+func validateSubscribeToEvent(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+
+	// Support for "OTHER" is documented but the API returns 400s. See
+	// http://docs.aws.amazon.com/inspector/latest/APIReference/API_SubscribeToEvent.html
+	switch value {
+	case "ASSESSMENT_RUN_STARTED", "ASSESSMENT_RUN_COMPLETED", "ASSESSMENT_RUN_STATE_CHANGED", "FINDING_REPORTED":
+		return
+	default:
+		errors = append(errors, fmt.Errorf("unknown subscription event: %v", v))
+	}
+	return
+}
+
+func flattenSubscribeToEvents(d *schema.ResourceData, conn *inspector.Inspector) ([]map[string]interface{}, error) {
+	arn := d.Id()
+	var results []map[string]interface{}
+	var err error = nil
+	var nextToken *string = nil
+	var maxResults int64 = 100
+
+	for {
+		outPut, err := conn.ListEventSubscriptions(&inspector.ListEventSubscriptionsInput{MaxResults: &maxResults, NextToken: nextToken, ResourceArn: &arn})
+		if err != nil {
+			return results, err
+		}
+
+		for _, s := range outPut.Subscriptions {
+			for _, es := range s.EventSubscriptions {
+				m := make(map[string]interface{})
+				m["event"] = *es.Event
+				m["topic_arn"] = *s.TopicArn
+				results = append(results, m)
+			}
+		}
+
+		nextToken = outPut.NextToken
+		if nextToken == nil {
+			break
+		}
+	}
+
+	return results, err
+}
+
+// substractEventSubscriptions return elements of 'a' which are not contained in 'b'
+func substractEventSubscriptions(a []map[string]interface{}, b []map[string]interface{}) (result []map[string]interface{}) {
+	for _, e := range a {
+		if !containsEventSubscription(b, e) {
+			result = append(result, e)
+		}
+	}
+	return
+}
+
+func containsEventSubscription(s []map[string]interface{}, e map[string]interface{}) bool {
+	for _, a := range s {
+		if a["event"] == e["event"] && a["topic_arn"] == e["topic_arn"] {
+			return true
+		}
+	}
+	return false
 }

--- a/website/docs/r/inspector_assessment_target.html.markdown
+++ b/website/docs/r/inspector_assessment_target.html.markdown
@@ -6,13 +6,13 @@ description: |-
   Provides a Inspector assessment target.
 ---
 
-# aws_inspector_assessment_target
+# aws\_inspector\_assessment\_target
 
 Provides a Inspector assessment target
 
 ## Example Usage
 
-```hcl
+```
 resource "aws_inspector_resource_group" "bar" {
   tags {
     Name = "foo"
@@ -31,7 +31,12 @@ resource "aws_inspector_assessment_target" "foo" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the assessment target.
-* `resource_group_arn` (Required )- The resource group ARN stating tags for instance matching.
+* `resource_group_arn` (Required) - The resource group ARN stating tags for instance matching.
+* `subscribe_to_event` (Optional) - A list of objects representing a subscription of an SNS topic to life-cycle events. The keys are documented below.
+
+The `subscribe_to_event` object supports the following arguments:
+* `event` - (Required) The name (or names) of the event (or events) the SNS topic is subscribing to. Allowed values are: `ASSESSMENT_RUN_STARTED`, `ASSESSMENT_RUN_COMPLETED`, `ASSESSMENT_RUN_STATE_CHANGED`, and `FINDING_REPORTED`.
+* `topic_arn` - (Required) The ARN of the subscribing SNS topic.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Based on PR: https://github.com/hashicorp/terraform/pull/13534
Fixes: https://github.com/terraform-providers/terraform-provider-aws/issues/843
Fixed tests and added retries to avoid SNS Topic policy eventual consistency issues.

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSInspectorTemplate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSInspectorTemplate -timeout 120m
=== RUN   TestAccAWSInspectorTemplateEventSubscriptions_basic
--- PASS: TestAccAWSInspectorTemplateEventSubscriptions_basic (47.16s)
=== RUN   TestAccAWSInspectorTemplateEventSubscriptions_update
--- PASS: TestAccAWSInspectorTemplateEventSubscriptions_update (128.64s)
=== RUN   TestAccAWSInspectorTemplate_basic
--- PASS: TestAccAWSInspectorTemplate_basic (57.17s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	233.018s
```