### PR TITLE
resource/aws_dynamodb_table: Fix DynamoDB TTL state detection

### DIFF
--- a/aws/data_source_aws_dynamodb_table_test.go
+++ b/aws/data_source_aws_dynamodb_table_test.go
@@ -25,6 +25,7 @@ func TestAccDataSourceAwsDynamoDbTable_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.aws_dynamodb_table.dynamodb_table_test", "range_key", "GameTitle"),
 					resource.TestCheckResourceAttr("data.aws_dynamodb_table.dynamodb_table_test", "attribute.#", "3"),
 					resource.TestCheckResourceAttr("data.aws_dynamodb_table.dynamodb_table_test", "global_secondary_index.#", "1"),
+					resource.TestCheckResourceAttr("data.aws_dynamodb_table.dynamodb_table_test", "ttl.#", "1"),
 					resource.TestCheckResourceAttr("data.aws_dynamodb_table.dynamodb_table_test", "tags.%", "2"),
 					resource.TestCheckResourceAttr("data.aws_dynamodb_table.dynamodb_table_test", "tags.Name", "dynamodb-table-1"),
 					resource.TestCheckResourceAttr("data.aws_dynamodb_table.dynamodb_table_test", "tags.Environment", "test"),
@@ -66,6 +67,11 @@ func testAccDataSourceAwsDynamoDbTableConfigBasic(tableName string) string {
     read_capacity      = 10
     projection_type    = "INCLUDE"
     non_key_attributes = ["UserId"]
+  }
+
+  ttl {
+    enabled        = "true"
+    attribute_name = "GameTimeTTL"
   }
 
   tags {

--- a/aws/resource_aws_dynamodb_table.go
+++ b/aws/resource_aws_dynamodb_table.go
@@ -134,6 +134,7 @@ func resourceAwsDynamoDbTable() *schema.Resource {
 						},
 					},
 				},
+				DiffSuppressFunc: suppressEquivalentDynamodbTableTtlDiffs,
 			},
 			"local_secondary_index": {
 				Type:     schema.TypeSet,


### PR DESCRIPTION
Fixes #3463 

DynamoDB has TTL state always set to DISABLED unless it is otherwise enabled.  The terraform logic decided that this meant if TTL is set to DISABLED, then there should be no `ttl {}` block at all.  This is incorrect, as there can be a `ttl {}` block with the setting `enabled = false`.  This change fixes that issue.

DynamoDB acceptance tests have been updated and run.