### PR TITLE
resource/aws_rds_cluster_instance: Prevent crash on importing non-cluster instances

### DIFF
--- a/aws/resource_aws_rds_cluster_instance.go
+++ b/aws/resource_aws_rds_cluster_instance.go
@@ -307,6 +307,10 @@ func resourceAwsRDSClusterInstanceRead(d *schema.ResourceData, meta interface{})
 		d.SetId("")
 		return nil
 	}
+	// Database instance is not in RDS Cluster
+	if db.DBClusterIdentifier == nil {
+		return fmt.Errorf("Cluster identifier is missing from instance (%s). The aws_db_instance resource should be used for non-Aurora instances", d.Id())
+	}
 
 	// Retrieve DB Cluster information, to determine if this Instance is a writer
 	conn := meta.(*AWSClient).rdsconn


### PR DESCRIPTION
Reference: #3959 

I'm not sure its possible to test importing the wrong resource type in the provider acceptance testing framework, but this nil check is to prevent:

```
panic: runtime error: invalid memory address or nil pointer dereference
2018-03-28T21:54:57.071+0300 [DEBUG] plugin.terraform-provider-aws_v1.12.0_x4: [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x29b326b]
2018-03-28T21:54:57.071+0300 [DEBUG] plugin.terraform-provider-aws_v1.12.0_x4:
2018-03-28T21:54:57.071+0300 [DEBUG] plugin.terraform-provider-aws_v1.12.0_x4: goroutine 105 [running]:
2018-03-28T21:54:57.071+0300 [DEBUG] plugin.terraform-provider-aws_v1.12.0_x4: github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsRDSClusterInstanceRead(0xc42030e3f0, 0x324f740, 0xc420095180, 0xc42030e3f0, 0x0)
2018-03-28T21:54:57.071+0300 [DEBUG] plugin.terraform-provider-aws_v1.12.0_x4: 	/opt/teamcity-agent/work/222ea50a1b4f75f4/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_rds_cluster_instance.go:319 +0x17b
```