### PR TITLE
Add MaxSesessionDuration to iam_role for federated users

### DIFF
--- a/aws/resource_aws_iam_role_test.go
+++ b/aws/resource_aws_iam_role_test.go
@@ -180,7 +180,7 @@ func TestAccAWSIAMRole_MaxSessionDuration(t *testing.T) {
 					testAccCheckAWSRoleExists("aws_iam_role.test", &conf),
 					testAccAddAwsIAMRolePolicy("aws_iam_role.test"),
 				),
-				ExpectError: regexp.MustCompile(`*.Max Session Duration: 43201`),
+				ExpectError: regexp.MustCompile(`.*Max Session Duration: 43201`),
 			},
 			{
 				Config: testAccCheckIAMRoleConfig_MaxSessionDuration(rName, 3599),
@@ -188,7 +188,7 @@ func TestAccAWSIAMRole_MaxSessionDuration(t *testing.T) {
 					testAccCheckAWSRoleExists("aws_iam_role.test", &conf),
 					testAccAddAwsIAMRolePolicy("aws_iam_role.test"),
 				),
-				ExpectError: regexp.MustCompile(`*.Max Session Duration: 3599`),
+				ExpectError: regexp.MustCompile(`.*Max Session Duration: 3599`),
 			},
 		},
 	})

--- a/website/docs/r/iam_role.html.markdown
+++ b/website/docs/r/iam_role.html.markdown
@@ -49,6 +49,8 @@ The following arguments are supported:
   See [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) for more information.
 * `description` - (Optional) The description of the role.
 
+* `max_session_duration` - (Optional) Max duration of a federated role 
+
 ## Attributes Reference
 
 The following attributes are exported:

--- a/website/docs/r/iam_role.html.markdown
+++ b/website/docs/r/iam_role.html.markdown
@@ -49,7 +49,7 @@ The following arguments are supported:
   See [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) for more information.
 * `description` - (Optional) The description of the role.
 
-* `max_session_duration` - (Optional) Max duration of a federated role 
+* `max_session_duration` - (Optional) The maximum session duration (in seconds) that you want to set for the specified role. If you do not specify a value for this setting, the default maximum of one hour is applied. This setting can have a value from 1 hour to 12 hours.
 
 ## Attributes Reference
 


### PR DESCRIPTION
# Description
Adding `max_session_duration` to `iam_role` fixes https://github.com/terraform-providers/terraform-provider-aws/issues/3976

# Changes
- bump aws provider
- add `max_session_duration`
