### PR TITLE
deps: Bump aws-sdk-go@v1.13.23

### DIFF
--- a/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
@@ -1218,6 +1218,7 @@ var awsPartition = partition{
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
+				"eu-west-3":      endpoint{},
 				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
@@ -1929,6 +1930,7 @@ var awsPartition = partition{
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
 				"ap-south-1":     endpoint{},
+				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
 				"ca-central-1":   endpoint{},
 				"eu-central-1":   endpoint{},
@@ -2238,11 +2240,13 @@ var awsPartition = partition{
 
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
+				"ap-northeast-2": endpoint{},
 				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
+				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-west-2":      endpoint{},
 			},

--- a/vendor/github.com/aws/aws-sdk-go/aws/request/request.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/request/request.go
@@ -342,7 +342,7 @@ func debugLogReqError(r *Request, stage string, retrying bool, err error) {
 
 // Build will build the request's object so it can be signed and sent
 // to the service. Build will also validate all the request's parameters.
-// Anny additional build Handlers set on this request will be run
+// Any additional build Handlers set on this request will be run
 // in the order they were set.
 //
 // The request will only be built once. Multiple calls to build will have

--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.13.21"
+const SDKVersion = "1.13.23"

--- a/vendor/github.com/aws/aws-sdk-go/service/acm/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/acm/api.go
@@ -59,7 +59,7 @@ func (c *ACM) AddTagsToCertificateRequest(input *AddTagsToCertificateInput) (req
 
 // AddTagsToCertificate API operation for AWS Certificate Manager.
 //
-// Adds one or more tags to an ACM Certificate. Tags are labels that you can
+// Adds one or more tags to an ACM certificate. Tags are labels that you can
 // use to identify and organize your AWS resources. Each tag consists of a key
 // and an optional value. You specify the certificate on input by its Amazon
 // Resource Name (ARN). You specify the tag by using a key-value pair.
@@ -69,9 +69,9 @@ func (c *ACM) AddTagsToCertificateRequest(input *AddTagsToCertificateInput) (req
 // certificates if you want to filter for a common relationship among those
 // certificates. Similarly, you can apply the same tag to multiple resources
 // if you want to specify a relationship among those resources. For example,
-// you can add the same tag to an ACM Certificate and an Elastic Load Balancing
+// you can add the same tag to an ACM certificate and an Elastic Load Balancing
 // load balancer to indicate that they are both used by the same website. For
-// more information, see Tagging ACM Certificates (http://docs.aws.amazon.com/acm/latest/userguide/tags.html).
+// more information, see Tagging ACM certificates (http://docs.aws.amazon.com/acm/latest/userguide/tags.html).
 //
 // To remove one or more tags, use the RemoveTagsFromCertificate action. To
 // view all of the tags that have been applied to the certificate, use the ListTagsForCertificate
@@ -86,7 +86,7 @@ func (c *ACM) AddTagsToCertificateRequest(input *AddTagsToCertificateInput) (req
 //
 // Returned Error Codes:
 //   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
-//   The specified certificate cannot be found in the caller's account, or the
+//   The specified certificate cannot be found in the caller's account or the
 //   caller's account cannot be found.
 //
 //   * ErrCodeInvalidArnException "InvalidArnException"
@@ -173,7 +173,7 @@ func (c *ACM) DeleteCertificateRequest(input *DeleteCertificateInput) (req *requ
 // action. The certificate will not be available for use by AWS services integrated
 // with ACM.
 //
-// You cannot delete an ACM Certificate that is being used by another AWS service.
+// You cannot delete an ACM certificate that is being used by another AWS service.
 // To delete a certificate that is in use, the certificate association must
 // first be removed.
 //
@@ -186,7 +186,7 @@ func (c *ACM) DeleteCertificateRequest(input *DeleteCertificateInput) (req *requ
 //
 // Returned Error Codes:
 //   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
-//   The specified certificate cannot be found in the caller's account, or the
+//   The specified certificate cannot be found in the caller's account or the
 //   caller's account cannot be found.
 //
 //   * ErrCodeResourceInUseException "ResourceInUseException"
@@ -262,7 +262,7 @@ func (c *ACM) DescribeCertificateRequest(input *DescribeCertificateInput) (req *
 
 // DescribeCertificate API operation for AWS Certificate Manager.
 //
-// Returns detailed metadata about the specified ACM Certificate.
+// Returns detailed metadata about the specified ACM certificate.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -273,7 +273,7 @@ func (c *ACM) DescribeCertificateRequest(input *DescribeCertificateInput) (req *
 //
 // Returned Error Codes:
 //   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
-//   The specified certificate cannot be found in the caller's account, or the
+//   The specified certificate cannot be found in the caller's account or the
 //   caller's account cannot be found.
 //
 //   * ErrCodeInvalidArnException "InvalidArnException"
@@ -361,7 +361,7 @@ func (c *ACM) GetCertificateRequest(input *GetCertificateInput) (req *request.Re
 //
 // Returned Error Codes:
 //   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
-//   The specified certificate cannot be found in the caller's account, or the
+//   The specified certificate cannot be found in the caller's account or the
 //   caller's account cannot be found.
 //
 //   * ErrCodeRequestInProgressException "RequestInProgressException"
@@ -494,15 +494,11 @@ func (c *ACM) ImportCertificateRequest(input *ImportCertificateInput) (req *requ
 //
 // Returned Error Codes:
 //   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
-//   The specified certificate cannot be found in the caller's account, or the
+//   The specified certificate cannot be found in the caller's account or the
 //   caller's account cannot be found.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   An ACM limit has been exceeded. For example, you may have input more domains
-//   than are allowed or you've requested too many certificates for your account.
-//   See the exception message returned by ACM to determine which limit you have
-//   violated. For more information about ACM limits, see the Limits (http://docs.aws.amazon.com/acm/latest/userguide/acm-limits.html)
-//   topic.
+//   An ACM limit has been exceeded.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/acm-2015-12-08/ImportCertificate
 func (c *ACM) ImportCertificate(input *ImportCertificateInput) (*ImportCertificateOutput, error) {
@@ -702,9 +698,9 @@ func (c *ACM) ListTagsForCertificateRequest(input *ListTagsForCertificateInput) 
 
 // ListTagsForCertificate API operation for AWS Certificate Manager.
 //
-// Lists the tags that have been applied to the ACM Certificate. Use the certificate's
+// Lists the tags that have been applied to the ACM certificate. Use the certificate's
 // Amazon Resource Name (ARN) to specify the certificate. To add a tag to an
-// ACM Certificate, use the AddTagsToCertificate action. To delete a tag, use
+// ACM certificate, use the AddTagsToCertificate action. To delete a tag, use
 // the RemoveTagsFromCertificate action.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -716,7 +712,7 @@ func (c *ACM) ListTagsForCertificateRequest(input *ListTagsForCertificateInput) 
 //
 // Returned Error Codes:
 //   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
-//   The specified certificate cannot be found in the caller's account, or the
+//   The specified certificate cannot be found in the caller's account or the
 //   caller's account cannot be found.
 //
 //   * ErrCodeInvalidArnException "InvalidArnException"
@@ -790,13 +786,13 @@ func (c *ACM) RemoveTagsFromCertificateRequest(input *RemoveTagsFromCertificateI
 
 // RemoveTagsFromCertificate API operation for AWS Certificate Manager.
 //
-// Remove one or more tags from an ACM Certificate. A tag consists of a key-value
+// Remove one or more tags from an ACM certificate. A tag consists of a key-value
 // pair. If you do not specify the value portion of the tag when calling this
 // function, the tag will be removed regardless of value. If you specify a value,
 // the tag is removed only if it is associated with the specified value.
 //
 // To add tags to a certificate, use the AddTagsToCertificate action. To view
-// all of the tags that have been applied to a specific ACM Certificate, use
+// all of the tags that have been applied to a specific ACM certificate, use
 // the ListTagsForCertificate action.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -808,7 +804,7 @@ func (c *ACM) RemoveTagsFromCertificateRequest(input *RemoveTagsFromCertificateI
 //
 // Returned Error Codes:
 //   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
-//   The specified certificate cannot be found in the caller's account, or the
+//   The specified certificate cannot be found in the caller's account or the
 //   caller's account cannot be found.
 //
 //   * ErrCodeInvalidArnException "InvalidArnException"
@@ -884,8 +880,8 @@ func (c *ACM) RequestCertificateRequest(input *RequestCertificateInput) (req *re
 
 // RequestCertificate API operation for AWS Certificate Manager.
 //
-// Requests an ACM Certificate for use with other AWS services. To request an
-// ACM Certificate, you must specify the fully qualified domain name (FQDN)
+// Requests an ACM certificate for use with other AWS services. To request an
+// ACM certificate, you must specify the fully qualified domain name (FQDN)
 // for your site in the DomainName parameter. You can also specify additional
 // FQDNs in the SubjectAlternativeNames parameter if users can reach your site
 // by using other names.
@@ -896,7 +892,7 @@ func (c *ACM) RequestCertificateRequest(input *RequestCertificateInput) (req *re
 // addresses formed from the DomainName you enter or the optional ValidationDomain
 // parameter. For more information, see Validate Domain Ownership (http://docs.aws.amazon.com/acm/latest/userguide/gs-acm-validate.html).
 //
-// After receiving approval from the domain owner, the ACM Certificate is issued.
+// After receiving approval from the domain owner, the ACM certificate is issued.
 // For more information, see the AWS Certificate Manager User Guide (http://docs.aws.amazon.com/acm/latest/userguide/).
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -908,11 +904,7 @@ func (c *ACM) RequestCertificateRequest(input *RequestCertificateInput) (req *re
 //
 // Returned Error Codes:
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   An ACM limit has been exceeded. For example, you may have input more domains
-//   than are allowed or you've requested too many certificates for your account.
-//   See the exception message returned by ACM to determine which limit you have
-//   violated. For more information about ACM limits, see the Limits (http://docs.aws.amazon.com/acm/latest/userguide/acm-limits.html)
-//   topic.
+//   An ACM limit has been exceeded.
 //
 //   * ErrCodeInvalidDomainValidationOptionsException "InvalidDomainValidationOptionsException"
 //   One or more values in the DomainValidationOption structure is incorrect.
@@ -986,12 +978,12 @@ func (c *ACM) ResendValidationEmailRequest(input *ResendValidationEmailInput) (r
 // ResendValidationEmail API operation for AWS Certificate Manager.
 //
 // Resends the email that requests domain ownership validation. The domain owner
-// or an authorized representative must approve the ACM Certificate before it
+// or an authorized representative must approve the ACM certificate before it
 // can be issued. The certificate can be approved by clicking a link in the
 // mail to navigate to the Amazon certificate approval website and then clicking
 // I Approve. However, the validation email can be blocked by spam filters.
 // Therefore, if you do not receive the original mail, you can request that
-// the mail be resent within 72 hours of requesting the ACM Certificate. If
+// the mail be resent within 72 hours of requesting the ACM certificate. If
 // more than 72 hours have elapsed since your original request or since your
 // last attempt to resend validation mail, you must request a new certificate.
 // For more information about setting up your contact email addresses, see Configure
@@ -1006,14 +998,11 @@ func (c *ACM) ResendValidationEmailRequest(input *ResendValidationEmailInput) (r
 //
 // Returned Error Codes:
 //   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
-//   The specified certificate cannot be found in the caller's account, or the
+//   The specified certificate cannot be found in the caller's account or the
 //   caller's account cannot be found.
 //
 //   * ErrCodeInvalidStateException "InvalidStateException"
-//   Processing has reached an invalid state. For example, this exception can
-//   occur if the specified domain is not using email validation, or the current
-//   certificate status does not permit the requested operation. See the exception
-//   message returned by ACM to determine which state is not valid.
+//   Processing has reached an invalid state.
 //
 //   * ErrCodeInvalidArnException "InvalidArnException"
 //   The requested Amazon Resource Name (ARN) does not refer to an existing resource.
@@ -1043,10 +1032,107 @@ func (c *ACM) ResendValidationEmailWithContext(ctx aws.Context, input *ResendVal
 	return out, req.Send()
 }
 
+const opUpdateCertificateOptions = "UpdateCertificateOptions"
+
+// UpdateCertificateOptionsRequest generates a "aws/request.Request" representing the
+// client's request for the UpdateCertificateOptions operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See UpdateCertificateOptions for more information on using the UpdateCertificateOptions
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the UpdateCertificateOptionsRequest method.
+//    req, resp := client.UpdateCertificateOptionsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/acm-2015-12-08/UpdateCertificateOptions
+func (c *ACM) UpdateCertificateOptionsRequest(input *UpdateCertificateOptionsInput) (req *request.Request, output *UpdateCertificateOptionsOutput) {
+	op := &request.Operation{
+		Name:       opUpdateCertificateOptions,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &UpdateCertificateOptionsInput{}
+	}
+
+	output = &UpdateCertificateOptionsOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(jsonrpc.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// UpdateCertificateOptions API operation for AWS Certificate Manager.
+//
+// Updates a certificate. Currently, you can use this function to specify whether
+// to opt in to or out of recording your certificate in a certificate transparency
+// log. For more information, see  Opting Out of Certificate Transparency Logging
+// (acm/latest/userguide/acm-bestpractices.html#best-practices-transparency).
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Certificate Manager's
+// API operation UpdateCertificateOptions for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified certificate cannot be found in the caller's account or the
+//   caller's account cannot be found.
+//
+//   * ErrCodeInvalidArnException "InvalidArnException"
+//   The requested Amazon Resource Name (ARN) does not refer to an existing resource.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   An ACM limit has been exceeded.
+//
+//   * ErrCodeInvalidStateException "InvalidStateException"
+//   Processing has reached an invalid state.
+//
+//   * ErrCodeInvalidArnException "InvalidArnException"
+//   The requested Amazon Resource Name (ARN) does not refer to an existing resource.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/acm-2015-12-08/UpdateCertificateOptions
+func (c *ACM) UpdateCertificateOptions(input *UpdateCertificateOptionsInput) (*UpdateCertificateOptionsOutput, error) {
+	req, out := c.UpdateCertificateOptionsRequest(input)
+	return out, req.Send()
+}
+
+// UpdateCertificateOptionsWithContext is the same as UpdateCertificateOptions with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UpdateCertificateOptions for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ACM) UpdateCertificateOptionsWithContext(ctx aws.Context, input *UpdateCertificateOptionsInput, opts ...request.Option) (*UpdateCertificateOptionsOutput, error) {
+	req, out := c.UpdateCertificateOptionsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 type AddTagsToCertificateInput struct {
 	_ struct{} `type:"structure"`
 
-	// String that contains the ARN of the ACM Certificate to which the tag is to
+	// String that contains the ARN of the ACM certificate to which the tag is to
 	// be applied. This must be of the form:
 	//
 	// arn:aws:acm:region:123456789012:certificate/12345678-1234-1234-1234-123456789012
@@ -1195,6 +1281,13 @@ type CertificateDetail struct {
 	// The time before which the certificate is not valid.
 	NotBefore *time.Time `type:"timestamp" timestampFormat:"unix"`
 
+	// Value that specifies whether to add the certificate to a transparency log.
+	// Certificate transparency makes it possible to detect SSL certificates that
+	// have been mistakenly or maliciously issued. A browser might respond to certificate
+	// that has not been logged by showing an error message. The logs are cryptographicaly
+	// secure.
+	Options *CertificateOptions `type:"structure"`
+
 	// Contains information about the status of ACM's managed renewal (http://docs.aws.amazon.com/acm/latest/userguide/acm-renewal.html)
 	// for the certificate. This field exists only when the certificate type is
 	// AMAZON_ISSUED.
@@ -1332,6 +1425,12 @@ func (s *CertificateDetail) SetNotBefore(v time.Time) *CertificateDetail {
 	return s
 }
 
+// SetOptions sets the Options field's value.
+func (s *CertificateDetail) SetOptions(v *CertificateOptions) *CertificateDetail {
+	s.Options = v
+	return s
+}
+
 // SetRenewalSummary sets the RenewalSummary field's value.
 func (s *CertificateDetail) SetRenewalSummary(v *RenewalSummary) *CertificateDetail {
 	s.RenewalSummary = v
@@ -1386,6 +1485,37 @@ func (s *CertificateDetail) SetType(v string) *CertificateDetail {
 	return s
 }
 
+// Structure that contains options for your certificate. Currently, you can
+// use this only to specify whether to opt in to or out of certificate transparency
+// logging. Some browsers require that public certificates issued for your domain
+// be recorded in a log. Certificates that are not logged typically generate
+// a browser error. Transparency makes it possible for you to detect SSL/TLS
+// certificates that have been mistakenly or maliciously issued for your domain.
+// For general information, see ACM Concepts (acm/latest/userguide/acm-concepts.html).
+type CertificateOptions struct {
+	_ struct{} `type:"structure"`
+
+	// You can opt out of certificate transparency logging by specifying the DISABLED
+	// option. Opt in by specifying ENABLED.
+	CertificateTransparencyLoggingPreference *string `type:"string" enum:"CertificateTransparencyLoggingPreference"`
+}
+
+// String returns the string representation
+func (s CertificateOptions) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CertificateOptions) GoString() string {
+	return s.String()
+}
+
+// SetCertificateTransparencyLoggingPreference sets the CertificateTransparencyLoggingPreference field's value.
+func (s *CertificateOptions) SetCertificateTransparencyLoggingPreference(v string) *CertificateOptions {
+	s.CertificateTransparencyLoggingPreference = &v
+	return s
+}
+
 // This structure is returned in the response object of ListCertificates action.
 type CertificateSummary struct {
 	_ struct{} `type:"structure"`
@@ -1428,7 +1558,7 @@ func (s *CertificateSummary) SetDomainName(v string) *CertificateSummary {
 type DeleteCertificateInput struct {
 	_ struct{} `type:"structure"`
 
-	// String that contains the ARN of the ACM Certificate to be deleted. This must
+	// String that contains the ARN of the ACM certificate to be deleted. This must
 	// be of the form:
 	//
 	// arn:aws:acm:region:123456789012:certificate/12345678-1234-1234-1234-123456789012
@@ -1489,7 +1619,7 @@ func (s DeleteCertificateOutput) GoString() string {
 type DescribeCertificateInput struct {
 	_ struct{} `type:"structure"`
 
-	// The Amazon Resource Name (ARN) of the ACM Certificate. The ARN must have
+	// The Amazon Resource Name (ARN) of the ACM certificate. The ARN must have
 	// the following form:
 	//
 	// arn:aws:acm:region:123456789012:certificate/12345678-1234-1234-1234-123456789012
@@ -1858,7 +1988,7 @@ func (s *GetCertificateInput) SetCertificateArn(v string) *GetCertificateInput {
 type GetCertificateOutput struct {
 	_ struct{} `type:"structure"`
 
-	// String that contains the ACM Certificate represented by the ARN specified
+	// String that contains the ACM certificate represented by the ARN specified
 	// at input.
 	Certificate *string `min:"1" type:"string"`
 
@@ -2102,7 +2232,7 @@ func (s *ListCertificatesInput) SetNextToken(v string) *ListCertificatesInput {
 type ListCertificatesOutput struct {
 	_ struct{} `type:"structure"`
 
-	// A list of ACM Certificates.
+	// A list of ACM certificates.
 	CertificateSummaryList []*CertificateSummary `type:"list"`
 
 	// When the list is truncated, this value is present and contains the value
@@ -2135,7 +2265,7 @@ func (s *ListCertificatesOutput) SetNextToken(v string) *ListCertificatesOutput 
 type ListTagsForCertificateInput struct {
 	_ struct{} `type:"structure"`
 
-	// String that contains the ARN of the ACM Certificate for which you want to
+	// String that contains the ARN of the ACM certificate for which you want to
 	// list the tags. This must have the following form:
 	//
 	// arn:aws:acm:region:123456789012:certificate/12345678-1234-1234-1234-123456789012
@@ -2361,11 +2491,19 @@ type RequestCertificateInput struct {
 	// requesting multiple certificates.
 	IdempotencyToken *string `min:"1" type:"string"`
 
+	// Currently, you can use this parameter to specify whether to add the certificate
+	// to a certificate transparency log. Certificate transparency makes it possible
+	// to detect SSL/TLS certificates that have been mistakenly or maliciously issued.
+	// Certificates that have not been logged typically produce an error message
+	// in a browser. For more information, see  Opting Out of Certificate Transparency
+	// Logging (acm/latest/userguide/acm-bestpractices.html#best-practices-transparency).
+	Options *CertificateOptions `type:"structure"`
+
 	// Additional FQDNs to be included in the Subject Alternative Name extension
-	// of the ACM Certificate. For example, add the name www.example.net to a certificate
+	// of the ACM certificate. For example, add the name www.example.net to a certificate
 	// for which the DomainName field is www.example.com if users can reach your
 	// site by using either name. The maximum number of domain names that you can
-	// add to an ACM Certificate is 100. However, the initial limit is 10 domain
+	// add to an ACM certificate is 100. However, the initial limit is 10 domain
 	// names. If you need more than 10 names, you must request a limit increase.
 	// For more information, see Limits (http://docs.aws.amazon.com/acm/latest/userguide/acm-limits.html).
 	//
@@ -2449,6 +2587,12 @@ func (s *RequestCertificateInput) SetDomainValidationOptions(v []*DomainValidati
 // SetIdempotencyToken sets the IdempotencyToken field's value.
 func (s *RequestCertificateInput) SetIdempotencyToken(v string) *RequestCertificateInput {
 	s.IdempotencyToken = &v
+	return s
+}
+
+// SetOptions sets the Options field's value.
+func (s *RequestCertificateInput) SetOptions(v *CertificateOptions) *RequestCertificateInput {
+	s.Options = v
 	return s
 }
 
@@ -2703,6 +2847,81 @@ func (s *Tag) SetValue(v string) *Tag {
 	return s
 }
 
+type UpdateCertificateOptionsInput struct {
+	_ struct{} `type:"structure"`
+
+	// ARN of the requested certificate to update. This must be of the form:
+	//
+	// arn:aws:acm:us-east-1:account:certificate/12345678-1234-1234-1234-123456789012
+	//
+	// CertificateArn is a required field
+	CertificateArn *string `min:"20" type:"string" required:"true"`
+
+	// Use to update the options for your certificate. Currently, you can specify
+	// whether to add your certificate to a transparency log. Certificate transparency
+	// makes it possible to detect SSL/TLS certificates that have been mistakenly
+	// or maliciously issued. Certificates that have not been logged typically produce
+	// an error message in a browser.
+	//
+	// Options is a required field
+	Options *CertificateOptions `type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s UpdateCertificateOptionsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateCertificateOptionsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateCertificateOptionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateCertificateOptionsInput"}
+	if s.CertificateArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("CertificateArn"))
+	}
+	if s.CertificateArn != nil && len(*s.CertificateArn) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("CertificateArn", 20))
+	}
+	if s.Options == nil {
+		invalidParams.Add(request.NewErrParamRequired("Options"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetCertificateArn sets the CertificateArn field's value.
+func (s *UpdateCertificateOptionsInput) SetCertificateArn(v string) *UpdateCertificateOptionsInput {
+	s.CertificateArn = &v
+	return s
+}
+
+// SetOptions sets the Options field's value.
+func (s *UpdateCertificateOptionsInput) SetOptions(v *CertificateOptions) *UpdateCertificateOptionsInput {
+	s.Options = v
+	return s
+}
+
+type UpdateCertificateOptionsOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateCertificateOptionsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateCertificateOptionsOutput) GoString() string {
+	return s.String()
+}
+
 const (
 	// CertificateStatusPendingValidation is a CertificateStatus enum value
 	CertificateStatusPendingValidation = "PENDING_VALIDATION"
@@ -2724,6 +2943,14 @@ const (
 
 	// CertificateStatusFailed is a CertificateStatus enum value
 	CertificateStatusFailed = "FAILED"
+)
+
+const (
+	// CertificateTransparencyLoggingPreferenceEnabled is a CertificateTransparencyLoggingPreference enum value
+	CertificateTransparencyLoggingPreferenceEnabled = "ENABLED"
+
+	// CertificateTransparencyLoggingPreferenceDisabled is a CertificateTransparencyLoggingPreference enum value
+	CertificateTransparencyLoggingPreferenceDisabled = "DISABLED"
 )
 
 const (

--- a/vendor/github.com/aws/aws-sdk-go/service/acm/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/acm/errors.go
@@ -19,10 +19,7 @@ const (
 	// ErrCodeInvalidStateException for service response error code
 	// "InvalidStateException".
 	//
-	// Processing has reached an invalid state. For example, this exception can
-	// occur if the specified domain is not using email validation, or the current
-	// certificate status does not permit the requested operation. See the exception
-	// message returned by ACM to determine which state is not valid.
+	// Processing has reached an invalid state.
 	ErrCodeInvalidStateException = "InvalidStateException"
 
 	// ErrCodeInvalidTagException for service response error code
@@ -35,11 +32,7 @@ const (
 	// ErrCodeLimitExceededException for service response error code
 	// "LimitExceededException".
 	//
-	// An ACM limit has been exceeded. For example, you may have input more domains
-	// than are allowed or you've requested too many certificates for your account.
-	// See the exception message returned by ACM to determine which limit you have
-	// violated. For more information about ACM limits, see the Limits (http://docs.aws.amazon.com/acm/latest/userguide/acm-limits.html)
-	// topic.
+	// An ACM limit has been exceeded.
 	ErrCodeLimitExceededException = "LimitExceededException"
 
 	// ErrCodeRequestInProgressException for service response error code
@@ -59,7 +52,7 @@ const (
 	// ErrCodeResourceNotFoundException for service response error code
 	// "ResourceNotFoundException".
 	//
-	// The specified certificate cannot be found in the caller's account, or the
+	// The specified certificate cannot be found in the caller's account or the
 	// caller's account cannot be found.
 	ErrCodeResourceNotFoundException = "ResourceNotFoundException"
 

--- a/vendor/github.com/aws/aws-sdk-go/service/iam/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/iam/api.go
@@ -62,8 +62,8 @@ func (c *IAM) AddClientIDToOpenIDConnectProviderRequest(input *AddClientIDToOpen
 // Adds a new client ID (also known as audience) to the list of client IDs already
 // registered for the specified IAM OpenID Connect (OIDC) provider resource.
 //
-// This action is idempotent; it does not fail or return an error if you add
-// an existing client ID to the provider.
+// This operation is idempotent; it does not fail or return an error if you
+// add an existing client ID to the provider.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -158,7 +158,13 @@ func (c *IAM) AddRoleToInstanceProfileRequest(input *AddRoleToInstanceProfileInp
 // AddRoleToInstanceProfile API operation for AWS Identity and Access Management.
 //
 // Adds the specified IAM role to the specified instance profile. An instance
-// profile can contain only one role, and this limit cannot be increased.
+// profile can contain only one role, and this limit cannot be increased. You
+// can remove the existing role and then add a different role to an instance
+// profile. You must then wait for the change to appear across all of AWS because
+// of eventual consistency (https://en.wikipedia.org/wiki/Eventual_consistency).
+// To force the change, you must disassociate the instance profile (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DisassociateIamInstanceProfile.html)
+// and then associate the instance profile (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AssociateIamInstanceProfile.html),
+// or you can stop your instance and then restart it.
 //
 // The caller of this API must be granted the PassRole permission on the IAM
 // role by a permission policy.
@@ -680,8 +686,8 @@ func (c *IAM) ChangePasswordRequest(input *ChangePasswordInput) (req *request.Re
 
 // ChangePassword API operation for AWS Identity and Access Management.
 //
-// Changes the password of the IAM user who is calling this action. The root
-// account password is not affected by this action.
+// Changes the password of the IAM user who is calling this operation. The AWS
+// account root user password is not affected by this operation.
 //
 // To change the password for a different user, see UpdateLoginProfile. For
 // more information about modifying passwords, see Managing Passwords (http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_ManagingLogins.html)
@@ -791,9 +797,10 @@ func (c *IAM) CreateAccessKeyRequest(input *CreateAccessKeyInput) (req *request.
 // the specified user. The default status for new keys is Active.
 //
 // If you do not specify a user name, IAM determines the user name implicitly
-// based on the AWS access key ID signing the request. Because this action works
-// for access keys under the AWS account, you can use this action to manage
-// root credentials even if the AWS account has no associated users.
+// based on the AWS access key ID signing the request. Because this operation
+// works for access keys under the AWS account, you can use this operation to
+// manage AWS account root user credentials. This is true even if the AWS account
+// has no associated users.
 //
 // For information about limits on the number of keys you can create, see Limitations
 // on IAM Entities (http://docs.aws.amazon.com/IAM/latest/UserGuide/LimitationsOnEntities.html)
@@ -1275,19 +1282,24 @@ func (c *IAM) CreateOpenIDConnectProviderRequest(input *CreateOpenIDConnectProvi
 // OpenID Connect (OIDC) (http://openid.net/connect/).
 //
 // The OIDC provider that you create with this operation can be used as a principal
-// in a role's trust policy to establish a trust relationship between AWS and
-// the OIDC provider.
+// in a role's trust policy. Such a policy establishes a trust relationship
+// between AWS and the OIDC provider.
 //
-// When you create the IAM OIDC provider, you specify the URL of the OIDC identity
-// provider (IdP) to trust, a list of client IDs (also known as audiences) that
-// identify the application or applications that are allowed to authenticate
-// using the OIDC provider, and a list of thumbprints of the server certificate(s)
-// that the IdP uses. You get all of this information from the OIDC IdP that
-// you want to use for access to AWS.
+// When you create the IAM OIDC provider, you specify the following:
 //
-// Because trust for the OIDC provider is ultimately derived from the IAM provider
-// that this action creates, it is a best practice to limit access to the CreateOpenIDConnectProvider
-// action to highly-privileged users.
+//    * The URL of the OIDC identity provider (IdP) to trust
+//
+//    * A list of client IDs (also known as audiences) that identify the application
+//    or applications that are allowed to authenticate using the OIDC provider
+//
+//    * A list of thumbprints of the server certificate(s) that the IdP uses.
+//
+// You get all of this information from the OIDC IdP that you want to use to
+// access AWS.
+//
+// Because trust for the OIDC provider is derived from the IAM provider that
+// this operation creates, it is best to limit access to the CreateOpenIDConnectProvider
+// operation to highly privileged users.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1592,7 +1604,7 @@ func (c *IAM) CreateRoleRequest(input *CreateRoleInput) (req *request.Request, o
 // CreateRole API operation for AWS Identity and Access Management.
 //
 // Creates a new role for your AWS account. For more information about roles,
-// go to Working with Roles (http://docs.aws.amazon.com/IAM/latest/UserGuide/WorkingWithRoles.html).
+// go to IAM Roles (http://docs.aws.amazon.com/IAM/latest/UserGuide/WorkingWithRoles.html).
 // For information about limitations on role names and the number of roles you
 // can create, go to Limitations on IAM Entities (http://docs.aws.amazon.com/IAM/latest/UserGuide/LimitationsOnEntities.html)
 // in the IAM User Guide.
@@ -1695,14 +1707,14 @@ func (c *IAM) CreateSAMLProviderRequest(input *CreateSAMLProviderInput) (req *re
 // SAML 2.0.
 //
 // The SAML provider resource that you create with this operation can be used
-// as a principal in an IAM role's trust policy to enable federated users who
-// sign-in using the SAML IdP to assume the role. You can create an IAM role
-// that supports Web-based single sign-on (SSO) to the AWS Management Console
-// or one that supports API access to AWS.
+// as a principal in an IAM role's trust policy. Such a policy can enable federated
+// users who sign-in using the SAML IdP to assume the role. You can create an
+// IAM role that supports Web-based single sign-on (SSO) to the AWS Management
+// Console or one that supports API access to AWS.
 //
-// When you create the SAML provider resource, you upload an a SAML metadata
-// document that you get from your IdP and that includes the issuer's name,
-// expiration information, and keys that can be used to validate the SAML authentication
+// When you create the SAML provider resource, you upload a SAML metadata document
+// that you get from your IdP. That document includes the issuer's name, expiration
+// information, and keys that can be used to validate the SAML authentication
 // response (assertions) that the IdP sends. You must generate the metadata
 // document using the identity management software that is used as your organization's
 // IdP.
@@ -1811,7 +1823,7 @@ func (c *IAM) CreateServiceLinkedRoleRequest(input *CreateServiceLinkedRoleInput
 // the service to control the role helps improve service stability and proper
 // cleanup when a service and its role are no longer needed.
 //
-// The name of the role is autogenerated by combining the string that you specify
+// The name of the role is generated by combining the string that you specify
 // for the AWSServiceName parameter with the string that you specify for the
 // CustomSuffix parameter. The resulting name must be unique in your account
 // or the request fails.
@@ -2312,9 +2324,10 @@ func (c *IAM) DeleteAccessKeyRequest(input *DeleteAccessKeyInput) (req *request.
 // Deletes the access key pair associated with the specified IAM user.
 //
 // If you do not specify a user name, IAM determines the user name implicitly
-// based on the AWS access key ID signing the request. Because this action works
-// for access keys under the AWS account, you can use this action to manage
-// root credentials even if the AWS account has no associated users.
+// based on the AWS access key ID signing the request. Because this operation
+// works for access keys under the AWS account, you can use this operation to
+// manage AWS account root user credentials even if the AWS account has no associated
+// users.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2780,9 +2793,9 @@ func (c *IAM) DeleteInstanceProfileRequest(input *DeleteInstanceProfileInput) (r
 // Deletes the specified instance profile. The instance profile must not have
 // an associated role.
 //
-// Make sure you do not have any Amazon EC2 instances running with the instance
-// profile you are about to delete. Deleting a role or instance profile that
-// is associated with a running instance will break any applications running
+// Make sure that you do not have any Amazon EC2 instances running with the
+// instance profile you are about to delete. Deleting a role or instance profile
+// that is associated with a running instance will break any applications running
 // on the instance.
 //
 // For more information about instance profiles, go to About Instance Profiles
@@ -2988,8 +3001,8 @@ func (c *IAM) DeleteOpenIDConnectProviderRequest(input *DeleteOpenIDConnectProvi
 // the provider as a principal in their trust policies. Any attempt to assume
 // a role that references a deleted provider fails.
 //
-// This action is idempotent; it does not fail or return an error if you call
-// the action for a provider that does not exist.
+// This operation is idempotent; it does not fail or return an error if you
+// call the operation for a provider that does not exist.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3082,14 +3095,14 @@ func (c *IAM) DeletePolicyRequest(input *DeletePolicyInput) (req *request.Reques
 // Deletes the specified managed policy.
 //
 // Before you can delete a managed policy, you must first detach the policy
-// from all users, groups, and roles that it is attached to, and you must delete
-// all of the policy's versions. The following steps describe the process for
-// deleting a managed policy:
+// from all users, groups, and roles that it is attached to. In addition you
+// must delete all the policy's versions. The following steps describe the process
+// for deleting a managed policy:
 //
 //    * Detach the policy from all users, groups, and roles that the policy
 //    is attached to, using the DetachUserPolicy, DetachGroupPolicy, or DetachRolePolicy
-//    APIs. To list all the users, groups, and roles that a policy is attached
-//    to, use ListEntitiesForPolicy.
+//    API operations. To list all the users, groups, and roles that a policy
+//    is attached to, use ListEntitiesForPolicy.
 //
 //    * Delete all versions of the policy using DeletePolicyVersion. To list
 //    the policy's versions, use ListPolicyVersions. You cannot use DeletePolicyVersion
@@ -3308,9 +3321,10 @@ func (c *IAM) DeleteRoleRequest(input *DeleteRoleInput) (req *request.Request, o
 // Deletes the specified role. The role must not have any policies attached.
 // For more information about roles, go to Working with Roles (http://docs.aws.amazon.com/IAM/latest/UserGuide/WorkingWithRoles.html).
 //
-// Make sure you do not have any Amazon EC2 instances running with the role
-// you are about to delete. Deleting a role or instance profile that is associated
-// with a running instance will break any applications running on the instance.
+// Make sure that you do not have any Amazon EC2 instances running with the
+// role you are about to delete. Deleting a role or instance profile that is
+// associated with a running instance will break any applications running on
+// the instance.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3615,7 +3629,7 @@ func (c *IAM) DeleteSSHPublicKeyRequest(input *DeleteSSHPublicKeyInput) (req *re
 //
 // Deletes the specified SSH public key.
 //
-// The SSH public key deleted by this action is used only for authenticating
+// The SSH public key deleted by this operation is used only for authenticating
 // the associated IAM user to an AWS CodeCommit repository. For more information
 // about using SSH keys to authenticate to an AWS CodeCommit repository, see
 // Set up AWS CodeCommit for SSH Connections (http://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-credentials-ssh.html)
@@ -3703,10 +3717,10 @@ func (c *IAM) DeleteServerCertificateRequest(input *DeleteServerCertificateInput
 //
 // Deletes the specified server certificate.
 //
-// For more information about working with server certificates, including a
-// list of AWS services that can use the server certificates that you manage
-// with IAM, go to Working with Server Certificates (http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html)
-// in the IAM User Guide.
+// For more information about working with server certificates, see Working
+// with Server Certificates (http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html)
+// in the IAM User Guide. This topic also includes a list of AWS services that
+// can use the server certificates that you manage with IAM.
 //
 // If you are using a server certificate with Elastic Load Balancing, deleting
 // the certificate could have implications for your application. If Elastic
@@ -3818,8 +3832,8 @@ func (c *IAM) DeleteServiceLinkedRoleRequest(input *DeleteServiceLinkedRoleInput
 // If you submit a deletion request for a service-linked role whose linked service
 // is still accessing a resource, then the deletion task fails. If it fails,
 // the GetServiceLinkedRoleDeletionStatus API operation returns the reason for
-// the failure, including the resources that must be deleted. To delete the
-// service-linked role, you must first remove those resources from the linked
+// the failure, usually including the resources that must be deleted. To delete
+// the service-linked role, you must first remove those resources from the linked
 // service and then submit the deletion request again. Resources are specific
 // to the service that is linked to the role. For more information about removing
 // resources from a service, see the AWS documentation (http://docs.aws.amazon.com/)
@@ -4002,9 +4016,10 @@ func (c *IAM) DeleteSigningCertificateRequest(input *DeleteSigningCertificateInp
 // Deletes a signing certificate associated with the specified IAM user.
 //
 // If you do not specify a user name, IAM determines the user name implicitly
-// based on the AWS access key ID signing the request. Because this action works
-// for access keys under the AWS account, you can use this action to manage
-// root credentials even if the AWS account has no associated IAM users.
+// based on the AWS access key ID signing the request. Because this operation
+// works for access keys under the AWS account, you can use this operation to
+// manage AWS account root user credentials even if the AWS account has no associated
+// IAM users.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -4969,6 +4984,12 @@ func (c *IAM) GetAccountAuthorizationDetailsRequest(input *GetAccountAuthorizati
 // API to obtain a snapshot of the configuration of IAM permissions (users,
 // groups, roles, and policies) in your account.
 //
+// Policies returned by this API are URL-encoded compliant with RFC 3986 (https://tools.ietf.org/html/rfc3986).
+// You can use a URL decoding method to convert the policy back to plain JSON
+// text. For example, if you use Java, you can use the decode method of the
+// java.net.URLDecoder utility class in the Java SDK. Other languages and SDKs
+// provide similar functionality.
+//
 // You can optionally filter the results using the Filter parameter. You can
 // paginate the results using the MaxItems and Marker parameters.
 //
@@ -5274,10 +5295,10 @@ func (c *IAM) GetContextKeysForCustomPolicyRequest(input *GetContextKeysForCusto
 // keys from policies associated with an IAM user, group, or role, use GetContextKeysForPrincipalPolicy.
 //
 // Context keys are variables maintained by AWS and its services that provide
-// details about the context of an API query request, and can be evaluated by
-// testing against a value specified in an IAM policy. Use GetContextKeysForCustomPolicy
+// details about the context of an API query request. Context keys can be evaluated
+// by testing against a value specified in an IAM policy. Use GetContextKeysForCustomPolicy
 // to understand what key names and values you must supply when you call SimulateCustomPolicy.
-// Note that all parameters are shown in unencoded form here for clarity, but
+// Note that all parameters are shown in unencoded form here for clarity but
 // must be URL encoded to be included as a part of a real HTML request.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -5358,10 +5379,10 @@ func (c *IAM) GetContextKeysForPrincipalPolicyRequest(input *GetContextKeysForPr
 
 // GetContextKeysForPrincipalPolicy API operation for AWS Identity and Access Management.
 //
-// Gets a list of all of the context keys referenced in all of the IAM policies
-// attached to the specified IAM entity. The entity can be an IAM user, group,
-// or role. If you specify a user, then the request also includes all of the
-// policies attached to groups that the user is a member of.
+// Gets a list of all of the context keys referenced in all the IAM policies
+// that are attached to the specified IAM entity. The entity can be an IAM user,
+// group, or role. If you specify a user, then the request also includes all
+// of the policies attached to groups that the user is a member of.
 //
 // You can optionally include a list of one or more additional policies, specified
 // as strings. If you want to include only a list of policies by string, use
@@ -5372,8 +5393,8 @@ func (c *IAM) GetContextKeysForPrincipalPolicyRequest(input *GetContextKeysForPr
 // allowing them to use GetContextKeysForCustomPolicy instead.
 //
 // Context keys are variables maintained by AWS and its services that provide
-// details about the context of an API query request, and can be evaluated by
-// testing against a value in an IAM policy. Use GetContextKeysForPrincipalPolicy
+// details about the context of an API query request. Context keys can be evaluated
+// by testing against a value in an IAM policy. Use GetContextKeysForPrincipalPolicy
 // to understand what key names and values you must supply when you call SimulatePrincipalPolicy.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -5883,8 +5904,8 @@ func (c *IAM) GetLoginProfileRequest(input *GetLoginProfileInput) (req *request.
 // GetLoginProfile API operation for AWS Identity and Access Management.
 //
 // Retrieves the user name and password-creation date for the specified IAM
-// user. If the user has not been assigned a password, the action returns a
-// 404 (NoSuchEntity) error.
+// user. If the user has not been assigned a password, the operation returns
+// a 404 (NoSuchEntity) error.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -6555,7 +6576,7 @@ func (c *IAM) GetSSHPublicKeyRequest(input *GetSSHPublicKeyInput) (req *request.
 //
 // Retrieves the specified SSH public key, including metadata about the key.
 //
-// The SSH public key retrieved by this action is used only for authenticating
+// The SSH public key retrieved by this operation is used only for authenticating
 // the associated IAM user to an AWS CodeCommit repository. For more information
 // about using SSH keys to authenticate to an AWS CodeCommit repository, see
 // Set up AWS CodeCommit for SSH Connections (http://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-credentials-ssh.html)
@@ -6645,10 +6666,10 @@ func (c *IAM) GetServerCertificateRequest(input *GetServerCertificateInput) (req
 //
 // Retrieves information about the specified server certificate stored in IAM.
 //
-// For more information about working with server certificates, including a
-// list of AWS services that can use the server certificates that you manage
-// with IAM, go to Working with Server Certificates (http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html)
-// in the IAM User Guide.
+// For more information about working with server certificates, see Working
+// with Server Certificates (http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html)
+// in the IAM User Guide. This topic includes a list of AWS services that can
+// use the server certificates that you manage with IAM.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -6736,7 +6757,8 @@ func (c *IAM) GetServiceLinkedRoleDeletionStatusRequest(input *GetServiceLinkedR
 // the DeleteServiceLinkedRole API operation to submit a service-linked role
 // for deletion, you can use the DeletionTaskId parameter in GetServiceLinkedRoleDeletionStatus
 // to check the status of the deletion. If the deletion fails, this operation
-// returns the reason that it failed.
+// returns the reason that it failed, if that information is returned by the
+// service.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -7019,15 +7041,16 @@ func (c *IAM) ListAccessKeysRequest(input *ListAccessKeysInput) (req *request.Re
 // ListAccessKeys API operation for AWS Identity and Access Management.
 //
 // Returns information about the access key IDs associated with the specified
-// IAM user. If there are none, the action returns an empty list.
+// IAM user. If there are none, the operation returns an empty list.
 //
 // Although each user is limited to a small number of keys, you can still paginate
 // the results using the MaxItems and Marker parameters.
 //
-// If the UserName field is not specified, the UserName is determined implicitly
-// based on the AWS access key ID used to sign the request. Because this action
-// works for access keys under the AWS account, you can use this action to manage
-// root credentials even if the AWS account has no associated users.
+// If the UserName field is not specified, the user name is determined implicitly
+// based on the AWS access key ID used to sign the request. Because this operation
+// works for access keys under the AWS account, you can use this operation to
+// manage AWS account root user credentials even if the AWS account has no associated
+// users.
 //
 // To ensure the security of your AWS account, the secret access key is accessible
 // only during key and user creation.
@@ -7319,7 +7342,7 @@ func (c *IAM) ListAttachedGroupPoliciesRequest(input *ListAttachedGroupPoliciesI
 // You can paginate the results using the MaxItems and Marker parameters. You
 // can use the PathPrefix parameter to limit the list of policies to only those
 // matching the specified path prefix. If there are no policies attached to
-// the specified group (or none that match the specified path prefix), the action
+// the specified group (or none that match the specified path prefix), the operation
 // returns an empty list.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -7474,7 +7497,7 @@ func (c *IAM) ListAttachedRolePoliciesRequest(input *ListAttachedRolePoliciesInp
 // You can paginate the results using the MaxItems and Marker parameters. You
 // can use the PathPrefix parameter to limit the list of policies to only those
 // matching the specified path prefix. If there are no policies attached to
-// the specified role (or none that match the specified path prefix), the action
+// the specified role (or none that match the specified path prefix), the operation
 // returns an empty list.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -7629,7 +7652,7 @@ func (c *IAM) ListAttachedUserPoliciesRequest(input *ListAttachedUserPoliciesInp
 // You can paginate the results using the MaxItems and Marker parameters. You
 // can use the PathPrefix parameter to limit the list of policies to only those
 // matching the specified path prefix. If there are no policies attached to
-// the specified group (or none that match the specified path prefix), the action
+// the specified group (or none that match the specified path prefix), the operation
 // returns an empty list.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -7936,7 +7959,7 @@ func (c *IAM) ListGroupPoliciesRequest(input *ListGroupPoliciesInput) (req *requ
 // in the IAM User Guide.
 //
 // You can paginate the results using the MaxItems and Marker parameters. If
-// there are no inline policies embedded with the specified group, the action
+// there are no inline policies embedded with the specified group, the operation
 // returns an empty list.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -8358,8 +8381,8 @@ func (c *IAM) ListInstanceProfilesRequest(input *ListInstanceProfilesInput) (req
 // ListInstanceProfiles API operation for AWS Identity and Access Management.
 //
 // Lists the instance profiles that have the specified path prefix. If there
-// are none, the action returns an empty list. For more information about instance
-// profiles, go to About Instance Profiles (http://docs.aws.amazon.com/IAM/latest/UserGuide/AboutInstanceProfiles.html).
+// are none, the operation returns an empty list. For more information about
+// instance profiles, go to About Instance Profiles (http://docs.aws.amazon.com/IAM/latest/UserGuide/AboutInstanceProfiles.html).
 //
 // You can paginate the results using the MaxItems and Marker parameters.
 //
@@ -8498,7 +8521,7 @@ func (c *IAM) ListInstanceProfilesForRoleRequest(input *ListInstanceProfilesForR
 // ListInstanceProfilesForRole API operation for AWS Identity and Access Management.
 //
 // Lists the instance profiles that have the specified associated IAM role.
-// If there are none, the action returns an empty list. For more information
+// If there are none, the operation returns an empty list. For more information
 // about instance profiles, go to About Instance Profiles (http://docs.aws.amazon.com/IAM/latest/UserGuide/AboutInstanceProfiles.html).
 //
 // You can paginate the results using the MaxItems and Marker parameters.
@@ -8642,7 +8665,7 @@ func (c *IAM) ListMFADevicesRequest(input *ListMFADevicesInput) (req *request.Re
 // ListMFADevices API operation for AWS Identity and Access Management.
 //
 // Lists the MFA devices for an IAM user. If the request includes a IAM user
-// name, then this action lists all the MFA devices associated with the specified
+// name, then this operation lists all the MFA devices associated with the specified
 // user. If you do not specify a user name, IAM determines the user name implicitly
 // based on the AWS access key ID signing the request for this API.
 //
@@ -9173,7 +9196,7 @@ func (c *IAM) ListRolePoliciesRequest(input *ListRolePoliciesInput) (req *reques
 // in the IAM User Guide.
 //
 // You can paginate the results using the MaxItems and Marker parameters. If
-// there are no inline policies embedded with the specified role, the action
+// there are no inline policies embedded with the specified role, the operation
 // returns an empty list.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -9315,8 +9338,8 @@ func (c *IAM) ListRolesRequest(input *ListRolesInput) (req *request.Request, out
 // ListRoles API operation for AWS Identity and Access Management.
 //
 // Lists the IAM roles that have the specified path prefix. If there are none,
-// the action returns an empty list. For more information about roles, go to
-// Working with Roles (http://docs.aws.amazon.com/IAM/latest/UserGuide/WorkingWithRoles.html).
+// the operation returns an empty list. For more information about roles, go
+// to Working with Roles (http://docs.aws.amazon.com/IAM/latest/UserGuide/WorkingWithRoles.html).
 //
 // You can paginate the results using the MaxItems and Marker parameters.
 //
@@ -9537,9 +9560,9 @@ func (c *IAM) ListSSHPublicKeysRequest(input *ListSSHPublicKeysInput) (req *requ
 // ListSSHPublicKeys API operation for AWS Identity and Access Management.
 //
 // Returns information about the SSH public keys associated with the specified
-// IAM user. If there are none, the action returns an empty list.
+// IAM user. If there are none, the operation returns an empty list.
 //
-// The SSH public keys returned by this action are used only for authenticating
+// The SSH public keys returned by this operation are used only for authenticating
 // the IAM user to an AWS CodeCommit repository. For more information about
 // using SSH keys to authenticate to an AWS CodeCommit repository, see Set up
 // AWS CodeCommit for SSH Connections (http://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-credentials-ssh.html)
@@ -9683,14 +9706,14 @@ func (c *IAM) ListServerCertificatesRequest(input *ListServerCertificatesInput) 
 // ListServerCertificates API operation for AWS Identity and Access Management.
 //
 // Lists the server certificates stored in IAM that have the specified path
-// prefix. If none exist, the action returns an empty list.
+// prefix. If none exist, the operation returns an empty list.
 //
 // You can paginate the results using the MaxItems and Marker parameters.
 //
-// For more information about working with server certificates, including a
-// list of AWS services that can use the server certificates that you manage
-// with IAM, go to Working with Server Certificates (http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html)
-// in the IAM User Guide.
+// For more information about working with server certificates, see Working
+// with Server Certificates (http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html)
+// in the IAM User Guide. This topic also includes a list of AWS services that
+// can use the server certificates that you manage with IAM.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -9821,11 +9844,11 @@ func (c *IAM) ListServiceSpecificCredentialsRequest(input *ListServiceSpecificCr
 // ListServiceSpecificCredentials API operation for AWS Identity and Access Management.
 //
 // Returns information about the service-specific credentials associated with
-// the specified IAM user. If there are none, the action returns an empty list.
-// The service-specific credentials returned by this action are used only for
-// authenticating the IAM user to a specific service. For more information about
-// using service-specific credentials to authenticate to an AWS service, see
-// Set Up service-specific credentials (http://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-gc.html)
+// the specified IAM user. If there are none, the operation returns an empty
+// list. The service-specific credentials returned by this operation are used
+// only for authenticating the IAM user to a specific service. For more information
+// about using service-specific credentials to authenticate to an AWS service,
+// see Set Up service-specific credentials (http://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-gc.html)
 // in the AWS CodeCommit User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -9916,16 +9939,16 @@ func (c *IAM) ListSigningCertificatesRequest(input *ListSigningCertificatesInput
 // ListSigningCertificates API operation for AWS Identity and Access Management.
 //
 // Returns information about the signing certificates associated with the specified
-// IAM user. If there are none, the action returns an empty list.
+// IAM user. If there are none, the operation returns an empty list.
 //
 // Although each user is limited to a small number of signing certificates,
 // you can still paginate the results using the MaxItems and Marker parameters.
 //
 // If the UserName field is not specified, the user name is determined implicitly
 // based on the AWS access key ID used to sign the request for this API. Because
-// this action works for access keys under the AWS account, you can use this
-// action to manage root credentials even if the AWS account has no associated
-// users.
+// this operation works for access keys under the AWS account, you can use this
+// operation to manage AWS account root user credentials even if the AWS account
+// has no associated users.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -10073,7 +10096,7 @@ func (c *IAM) ListUserPoliciesRequest(input *ListUserPoliciesInput) (req *reques
 // in the IAM User Guide.
 //
 // You can paginate the results using the MaxItems and Marker parameters. If
-// there are no inline policies embedded with the specified user, the action
+// there are no inline policies embedded with the specified user, the operation
 // returns an empty list.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -10215,8 +10238,8 @@ func (c *IAM) ListUsersRequest(input *ListUsersInput) (req *request.Request, out
 // ListUsers API operation for AWS Identity and Access Management.
 //
 // Lists the IAM users that have the specified path prefix. If no path prefix
-// is specified, the action returns all users in the AWS account. If there are
-// none, the action returns an empty list.
+// is specified, the operation returns all users in the AWS account. If there
+// are none, the operation returns an empty list.
 //
 // You can paginate the results using the MaxItems and Marker parameters.
 //
@@ -10355,9 +10378,9 @@ func (c *IAM) ListVirtualMFADevicesRequest(input *ListVirtualMFADevicesInput) (r
 // ListVirtualMFADevices API operation for AWS Identity and Access Management.
 //
 // Lists the virtual MFA devices defined in the AWS account by assignment status.
-// If you do not specify an assignment status, the action returns a list of
-// all virtual MFA devices. Assignment status can be Assigned, Unassigned, or
-// Any.
+// If you do not specify an assignment status, the operation returns a list
+// of all virtual MFA devices. Assignment status can be Assigned, Unassigned,
+// or Any.
 //
 // You can paginate the results using the MaxItems and Marker parameters.
 //
@@ -10831,8 +10854,8 @@ func (c *IAM) RemoveClientIDFromOpenIDConnectProviderRequest(input *RemoveClient
 // client IDs registered for the specified IAM OpenID Connect (OIDC) provider
 // resource object.
 //
-// This action is idempotent; it does not fail or return an error if you try
-// to remove a client ID that does not exist.
+// This operation is idempotent; it does not fail or return an error if you
+// try to remove a client ID that does not exist.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -10924,10 +10947,10 @@ func (c *IAM) RemoveRoleFromInstanceProfileRequest(input *RemoveRoleFromInstance
 //
 // Removes the specified IAM role from the specified EC2 instance profile.
 //
-// Make sure you do not have any Amazon EC2 instances running with the role
-// you are about to remove from the instance profile. Removing a role from an
-// instance profile that is associated with a running instance might break any
-// applications running on the instance.
+// Make sure that you do not have any Amazon EC2 instances running with the
+// role you are about to remove from the instance profile. Removing a role from
+// an instance profile that is associated with a running instance might break
+// any applications running on the instance.
 //
 // For more information about IAM roles, go to Working with Roles (http://docs.aws.amazon.com/IAM/latest/UserGuide/WorkingWithRoles.html).
 // For more information about instance profiles, go to About Instance Profiles
@@ -11302,7 +11325,7 @@ func (c *IAM) SetDefaultPolicyVersionRequest(input *SetDefaultPolicyVersionInput
 // Sets the specified version of the specified policy as the policy's default
 // (operative) version.
 //
-// This action affects all users, groups, and roles that the policy is attached
+// This operation affects all users, groups, and roles that the policy is attached
 // to. To list the users, groups, and roles that the policy is attached to,
 // use the ListEntitiesForPolicy API.
 //
@@ -11407,11 +11430,11 @@ func (c *IAM) SimulateCustomPolicyRequest(input *SimulateCustomPolicyInput) (req
 // SimulateCustomPolicy API operation for AWS Identity and Access Management.
 //
 // Simulate how a set of IAM policies and optionally a resource-based policy
-// works with a list of API actions and AWS resources to determine the policies'
+// works with a list of API operations and AWS resources to determine the policies'
 // effective permissions. The policies are provided as strings.
 //
-// The simulation does not perform the API actions; it only checks the authorization
-// to determine if the simulated policies allow or deny the actions.
+// The simulation does not perform the API operations; it only checks the authorization
+// to determine if the simulated policies allow or deny the operations.
 //
 // If you want to simulate existing policies attached to an IAM user, group,
 // or role, use SimulatePrincipalPolicy instead.
@@ -11563,10 +11586,10 @@ func (c *IAM) SimulatePrincipalPolicyRequest(input *SimulatePrincipalPolicyInput
 // SimulatePrincipalPolicy API operation for AWS Identity and Access Management.
 //
 // Simulate how a set of IAM policies attached to an IAM entity works with a
-// list of API actions and AWS resources to determine the policies' effective
+// list of API operations and AWS resources to determine the policies' effective
 // permissions. The entity can be an IAM user, group, or role. If you specify
 // a user, then the simulation also includes all of the policies that are attached
-// to groups that the user belongs to .
+// to groups that the user belongs to.
 //
 // You can optionally include a list of one or more additional policies specified
 // as strings to include in the simulation. If you want to simulate only policies
@@ -11575,8 +11598,8 @@ func (c *IAM) SimulatePrincipalPolicyRequest(input *SimulatePrincipalPolicyInput
 // You can also optionally include one resource-based policy to be evaluated
 // with each of the resources included in the simulation.
 //
-// The simulation does not perform the API actions, it only checks the authorization
-// to determine if the simulated policies allow or deny the actions.
+// The simulation does not perform the API operations, it only checks the authorization
+// to determine if the simulated policies allow or deny the operations.
 //
 // Note: This API discloses information about the permissions granted to other
 // users. If you do not want users to see other user's permissions, then consider
@@ -11729,13 +11752,14 @@ func (c *IAM) UpdateAccessKeyRequest(input *UpdateAccessKeyInput) (req *request.
 // UpdateAccessKey API operation for AWS Identity and Access Management.
 //
 // Changes the status of the specified access key from Active to Inactive, or
-// vice versa. This action can be used to disable a user's key as part of a
-// key rotation work flow.
+// vice versa. This operation can be used to disable a user's key as part of
+// a key rotation workflow.
 //
-// If the UserName field is not specified, the UserName is determined implicitly
-// based on the AWS access key ID used to sign the request. Because this action
-// works for access keys under the AWS account, you can use this action to manage
-// root credentials even if the AWS account has no associated users.
+// If the UserName field is not specified, the user name is determined implicitly
+// based on the AWS access key ID used to sign the request. Because this operation
+// works for access keys under the AWS account, you can use this operation to
+// manage AWS account root user credentials even if the AWS account has no associated
+// users.
 //
 // For information about rotating keys, see Managing Keys and Certificates (http://docs.aws.amazon.com/IAM/latest/UserGuide/ManagingCredentials.html)
 // in the IAM User Guide.
@@ -11830,10 +11854,12 @@ func (c *IAM) UpdateAccountPasswordPolicyRequest(input *UpdateAccountPasswordPol
 //
 // Updates the password policy settings for the AWS account.
 //
-// This action does not support partial updates. No parameters are required,
+// This operation does not support partial updates. No parameters are required,
 // but if you do not specify a parameter, that parameter's value reverts to
 // its default value. See the Request Parameters section for each parameter's
-// default value.
+// default value. Also note that some parameters do not allow the default parameter
+// to be explicitly set. Instead, to invoke the default value, do not include
+// that parameter when you invoke the operation.
 //
 // For more information about using a password policy, see Managing an IAM Password
 // Policy (http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_ManagingPasswordPolicies.html)
@@ -12040,11 +12066,12 @@ func (c *IAM) UpdateGroupRequest(input *UpdateGroupInput) (req *request.Request,
 // For more information, see Renaming Users and Groups (http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_WorkingWithGroupsAndUsers.html)
 // in the IAM User Guide.
 //
-// To change an IAM group name the requester must have appropriate permissions
-// on both the source object and the target object. For example, to change "Managers"
-// to "MGRs", the entity making the request must have permission on both "Managers"
-// and "MGRs", or must have permission on all (*). For more information about
-// permissions, see Permissions and Policies (http://docs.aws.amazon.com/IAM/latest/UserGuide/PermissionsAndPolicies.html).
+// The person making the request (the principal), must have permission to change
+// the role group with the old name and the new name. For example, to change
+// the group named Managers to MGRs, the principal must have a policy that allows
+// them to update both groups. If the principal has permission to update the
+// Managers group, but not the MGRs group, then the update fails. For more information
+// about permissions, see Access Management (http://docs.aws.amazon.com/IAM/latest/UserGuide/access.html).
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -12245,7 +12272,7 @@ func (c *IAM) UpdateOpenIDConnectProviderThumbprintRequest(input *UpdateOpenIDCo
 // Replaces the existing list of server certificate thumbprints associated with
 // an OpenID Connect (OIDC) provider resource object with a new list of thumbprints.
 //
-// The list that you pass with this action completely replaces the existing
+// The list that you pass with this operation completely replaces the existing
 // list of thumbprints. (The lists are not merged.)
 //
 // Typically, you need to update a thumbprint only when the identity provider's
@@ -12253,10 +12280,9 @@ func (c *IAM) UpdateOpenIDConnectProviderThumbprintRequest(input *UpdateOpenIDCo
 // does change, any attempt to assume an IAM role that specifies the OIDC provider
 // as a principal fails until the certificate thumbprint is updated.
 //
-// Because trust for the OIDC provider is ultimately derived from the provider's
-// certificate and is validated by the thumbprint, it is a best practice to
-// limit access to the UpdateOpenIDConnectProviderThumbprint action to highly-privileged
-// users.
+// Because trust for the OIDC provider is derived from the provider's certificate
+// and is validated by the thumbprint, it is best to limit access to the UpdateOpenIDConnectProviderThumbprint
+// operation to highly privileged users.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -12295,6 +12321,96 @@ func (c *IAM) UpdateOpenIDConnectProviderThumbprint(input *UpdateOpenIDConnectPr
 // for more information on using Contexts.
 func (c *IAM) UpdateOpenIDConnectProviderThumbprintWithContext(ctx aws.Context, input *UpdateOpenIDConnectProviderThumbprintInput, opts ...request.Option) (*UpdateOpenIDConnectProviderThumbprintOutput, error) {
 	req, out := c.UpdateOpenIDConnectProviderThumbprintRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opUpdateRole = "UpdateRole"
+
+// UpdateRoleRequest generates a "aws/request.Request" representing the
+// client's request for the UpdateRole operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See UpdateRole for more information on using the UpdateRole
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the UpdateRoleRequest method.
+//    req, resp := client.UpdateRoleRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/iam-2010-05-08/UpdateRole
+func (c *IAM) UpdateRoleRequest(input *UpdateRoleInput) (req *request.Request, output *UpdateRoleOutput) {
+	op := &request.Operation{
+		Name:       opUpdateRole,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &UpdateRoleInput{}
+	}
+
+	output = &UpdateRoleOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// UpdateRole API operation for AWS Identity and Access Management.
+//
+// Updates the description or maximum session duration setting of a role.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Identity and Access Management's
+// API operation UpdateRole for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeUnmodifiableEntityException "UnmodifiableEntity"
+//   The request was rejected because only the service that depends on the service-linked
+//   role can modify or delete the role on your behalf. The error message includes
+//   the name of the service that depends on this service-linked role. You must
+//   request the change through that service.
+//
+//   * ErrCodeNoSuchEntityException "NoSuchEntity"
+//   The request was rejected because it referenced an entity that does not exist.
+//   The error message describes the entity.
+//
+//   * ErrCodeServiceFailureException "ServiceFailure"
+//   The request processing has failed because of an unknown error, exception
+//   or failure.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/iam-2010-05-08/UpdateRole
+func (c *IAM) UpdateRole(input *UpdateRoleInput) (*UpdateRoleOutput, error) {
+	req, out := c.UpdateRoleRequest(input)
+	return out, req.Send()
+}
+
+// UpdateRoleWithContext is the same as UpdateRole with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UpdateRole for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IAM) UpdateRoleWithContext(ctx aws.Context, input *UpdateRoleInput, opts ...request.Option) (*UpdateRoleOutput, error) {
+	req, out := c.UpdateRoleRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -12344,7 +12460,10 @@ func (c *IAM) UpdateRoleDescriptionRequest(input *UpdateRoleDescriptionInput) (r
 
 // UpdateRoleDescription API operation for AWS Identity and Access Management.
 //
-// Modifies the description of a role.
+// Use instead.
+//
+// Modifies only the description of a role. This operation performs the same
+// function as the Description parameter in the UpdateRole operation.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -12531,11 +12650,11 @@ func (c *IAM) UpdateSSHPublicKeyRequest(input *UpdateSSHPublicKeyInput) (req *re
 // UpdateSSHPublicKey API operation for AWS Identity and Access Management.
 //
 // Sets the status of an IAM user's SSH public key to active or inactive. SSH
-// public keys that are inactive cannot be used for authentication. This action
+// public keys that are inactive cannot be used for authentication. This operation
 // can be used to disable a user's SSH public key as part of a key rotation
 // work flow.
 //
-// The SSH public key affected by this action is used only for authenticating
+// The SSH public key affected by this operation is used only for authenticating
 // the associated IAM user to an AWS CodeCommit repository. For more information
 // about using SSH keys to authenticate to an AWS CodeCommit repository, see
 // Set up AWS CodeCommit for SSH Connections (http://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-credentials-ssh.html)
@@ -12624,22 +12743,23 @@ func (c *IAM) UpdateServerCertificateRequest(input *UpdateServerCertificateInput
 // Updates the name and/or the path of the specified server certificate stored
 // in IAM.
 //
-// For more information about working with server certificates, including a
-// list of AWS services that can use the server certificates that you manage
-// with IAM, go to Working with Server Certificates (http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html)
-// in the IAM User Guide.
+// For more information about working with server certificates, see Working
+// with Server Certificates (http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html)
+// in the IAM User Guide. This topic also includes a list of AWS services that
+// can use the server certificates that you manage with IAM.
 //
 // You should understand the implications of changing a server certificate's
 // path or name. For more information, see Renaming a Server Certificate (http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs_manage.html#RenamingServerCerts)
 // in the IAM User Guide.
 //
-// To change a server certificate name the requester must have appropriate permissions
-// on both the source object and the target object. For example, to change the
-// name from "ProductionCert" to "ProdCert", the entity making the request must
-// have permission on "ProductionCert" and "ProdCert", or must have permission
-// on all (*). For more information about permissions, see Access Management
-// (http://docs.aws.amazon.com/IAM/latest/UserGuide/access.html) in the IAM
-// User Guide.
+// The person making the request (the principal), must have permission to change
+// the server certificate with the old name and the new name. For example, to
+// change the certificate named ProductionCert to ProdCert, the principal must
+// have a policy that allows them to update both certificates. If the principal
+// has permission to update the ProductionCert group, but not the ProdCert certificate,
+// then the update fails. For more information about permissions, see Access
+// Management (http://docs.aws.amazon.com/IAM/latest/UserGuide/access.html)
+// in the IAM User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -12735,8 +12855,8 @@ func (c *IAM) UpdateServiceSpecificCredentialRequest(input *UpdateServiceSpecifi
 //
 // Sets the status of a service-specific credential to Active or Inactive. Service-specific
 // credentials that are inactive cannot be used for authentication to the service.
-// This action can be used to disable a user’s service-specific credential as
-// part of a credential rotation work flow.
+// This operation can be used to disable a user’s service-specific credential
+// as part of a credential rotation work flow.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -12819,13 +12939,14 @@ func (c *IAM) UpdateSigningCertificateRequest(input *UpdateSigningCertificateInp
 // UpdateSigningCertificate API operation for AWS Identity and Access Management.
 //
 // Changes the status of the specified user signing certificate from active
-// to disabled, or vice versa. This action can be used to disable an IAM user's
-// signing certificate as part of a certificate rotation work flow.
+// to disabled, or vice versa. This operation can be used to disable an IAM
+// user's signing certificate as part of a certificate rotation work flow.
 //
-// If the UserName field is not specified, the UserName is determined implicitly
-// based on the AWS access key ID used to sign the request. Because this action
-// works for access keys under the AWS account, you can use this action to manage
-// root credentials even if the AWS account has no associated users.
+// If the UserName field is not specified, the user name is determined implicitly
+// based on the AWS access key ID used to sign the request. Because this operation
+// works for access keys under the AWS account, you can use this operation to
+// manage AWS account root user credentials even if the AWS account has no associated
+// users.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -12922,7 +13043,7 @@ func (c *IAM) UpdateUserRequest(input *UpdateUserInput) (req *request.Request, o
 // and Renaming an IAM Group (http://docs.aws.amazon.com/IAM/latest/UserGuide/id_groups_manage_rename.html)
 // in the IAM User Guide.
 //
-// To change a user name the requester must have appropriate permissions on
+// To change a user name, the requester must have appropriate permissions on
 // both the source object and the target object. For example, to change Bob
 // to Robert, the entity making the request must have permission on Bob and
 // Robert, or must have permission on all (*). For more information about permissions,
@@ -13026,7 +13147,7 @@ func (c *IAM) UploadSSHPublicKeyRequest(input *UploadSSHPublicKeyInput) (req *re
 //
 // Uploads an SSH public key and associates it with the specified IAM user.
 //
-// The SSH public key uploaded by this action can be used only for authenticating
+// The SSH public key uploaded by this operation can be used only for authenticating
 // the associated IAM user to an AWS CodeCommit repository. For more information
 // about using SSH keys to authenticate to an AWS CodeCommit repository, see
 // Set up AWS CodeCommit for SSH Connections (http://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-credentials-ssh.html)
@@ -13136,10 +13257,10 @@ func (c *IAM) UploadServerCertificateRequest(input *UploadServerCertificateInput
 // renewals for you. Certificates provided by ACM are free. For more information
 // about using ACM, see the AWS Certificate Manager User Guide (http://docs.aws.amazon.com/acm/latest/userguide/).
 //
-// For more information about working with server certificates, including a
-// list of AWS services that can use the server certificates that you manage
-// with IAM, go to Working with Server Certificates (http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html)
-// in the IAM User Guide.
+// For more information about working with server certificates, see Working
+// with Server Certificates (http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html)
+// in the IAM User Guide. This topic includes a list of AWS services that can
+// use the server certificates that you manage with IAM.
 //
 // For information about the number of server certificates you can upload, see
 // Limitations on IAM Entities and Objects (http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-limits.html)
@@ -13253,11 +13374,12 @@ func (c *IAM) UploadSigningCertificateRequest(input *UploadSigningCertificateInp
 // its default status is Active.
 //
 // If the UserName field is not specified, the IAM user name is determined implicitly
-// based on the AWS access key ID used to sign the request. Because this action
-// works for access keys under the AWS account, you can use this action to manage
-// root credentials even if the AWS account has no associated users.
+// based on the AWS access key ID used to sign the request. Because this operation
+// works for access keys under the AWS account, you can use this operation to
+// manage AWS account root user credentials even if the AWS account has no associated
+// users.
 //
-// Because the body of a X.509 certificate can be large, you should use POST
+// Because the body of an X.509 certificate can be large, you should use POST
 // rather than GET when calling UploadSigningCertificate. For information about
 // setting up signatures and authorization through the API, go to Signing AWS
 // API Requests (http://docs.aws.amazon.com/general/latest/gr/signing_aws_api_requests.html)
@@ -13325,7 +13447,7 @@ func (c *IAM) UploadSigningCertificateWithContext(ctx aws.Context, input *Upload
 // Contains information about an AWS access key.
 //
 // This data type is used as a response element in the CreateAccessKey and ListAccessKeys
-// actions.
+// operations.
 //
 // The SecretAccessKey value is returned only in response to CreateAccessKey.
 // You can get a secret access key only when you first create an access key;
@@ -13347,8 +13469,8 @@ type AccessKey struct {
 	// SecretAccessKey is a required field
 	SecretAccessKey *string `type:"string" required:"true"`
 
-	// The status of the access key. Active means the key is valid for API calls,
-	// while Inactive means it is not.
+	// The status of the access key. Active means that the key is valid for API
+	// calls, while Inactive means it is not.
 	//
 	// Status is a required field
 	Status *string `type:"string" required:"true" enum:"statusType"`
@@ -13402,12 +13524,13 @@ func (s *AccessKey) SetUserName(v string) *AccessKey {
 // Contains information about the last time an AWS access key was used.
 //
 // This data type is used as a response element in the GetAccessKeyLastUsed
-// action.
+// operation.
 type AccessKeyLastUsed struct {
 	_ struct{} `type:"structure"`
 
 	// The date and time, in ISO 8601 date-time format (http://www.iso.org/iso/iso8601),
-	// when the access key was most recently used. This field is null when:
+	// when the access key was most recently used. This field is null in the following
+	// situations:
 	//
 	//    * The user does not have an access key.
 	//
@@ -13420,7 +13543,7 @@ type AccessKeyLastUsed struct {
 	LastUsedDate *time.Time `type:"timestamp" timestampFormat:"iso8601" required:"true"`
 
 	// The AWS region where this access key was most recently used. This field is
-	// displays "N/A" when:
+	// displays "N/A" in the following situations:
 	//
 	//    * The user does not have an access key.
 	//
@@ -13436,7 +13559,7 @@ type AccessKeyLastUsed struct {
 	Region *string `type:"string" required:"true"`
 
 	// The name of the AWS service with which this access key was most recently
-	// used. This field displays "N/A" when:
+	// used. This field displays "N/A" in the following situations:
 	//
 	//    * The user does not have an access key.
 	//
@@ -13479,7 +13602,7 @@ func (s *AccessKeyLastUsed) SetServiceName(v string) *AccessKeyLastUsed {
 
 // Contains information about an AWS access key, without its secret key.
 //
-// This data type is used as a response element in the ListAccessKeys action.
+// This data type is used as a response element in the ListAccessKeys operation.
 type AccessKeyMetadata struct {
 	_ struct{} `type:"structure"`
 
@@ -13542,7 +13665,7 @@ type AddClientIDToOpenIDConnectProviderInput struct {
 
 	// The Amazon Resource Name (ARN) of the IAM OpenID Connect (OIDC) provider
 	// resource to add the client ID to. You can get a list of OIDC provider ARNs
-	// by using the ListOpenIDConnectProviders action.
+	// by using the ListOpenIDConnectProviders operation.
 	//
 	// OpenIDConnectProviderArn is a required field
 	OpenIDConnectProviderArn *string `min:"20" type:"string" required:"true"`
@@ -13613,7 +13736,7 @@ type AddRoleToInstanceProfileInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// InstanceProfileName is a required field
 	InstanceProfileName *string `min:"1" type:"string" required:"true"`
@@ -13693,7 +13816,7 @@ type AddUserToGroupInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// GroupName is a required field
 	GroupName *string `min:"1" type:"string" required:"true"`
@@ -13702,7 +13825,7 @@ type AddUserToGroupInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// UserName is a required field
 	UserName *string `min:"1" type:"string" required:"true"`
@@ -13773,7 +13896,7 @@ type AttachGroupPolicyInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// GroupName is a required field
 	GroupName *string `min:"1" type:"string" required:"true"`
@@ -13942,7 +14065,7 @@ type AttachUserPolicyInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// UserName is a required field
 	UserName *string `min:"1" type:"string" required:"true"`
@@ -14011,7 +14134,7 @@ func (s AttachUserPolicyOutput) GoString() string {
 // An attached policy is a managed policy that has been attached to a user,
 // group, or role. This data type is used as a response element in the ListAttachedGroupPolicies,
 // ListAttachedRolePolicies, ListAttachedUserPolicies, and GetAccountAuthorizationDetails
-// actions.
+// operations.
 //
 // For more information about managed policies, refer to Managed Policies and
 // Inline Policies (http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
@@ -14058,14 +14181,14 @@ type ChangePasswordInput struct {
 	// The new password. The new password must conform to the AWS account's password
 	// policy, if one exists.
 	//
-	// The regex pattern (http://wikipedia.org/wiki/regex) used to validate this
-	// parameter is a string of characters consisting of almost any printable ASCII
-	// character from the space (\u0020) through the end of the ASCII character
-	// range (\u00FF). You can also include the tab (\u0009), line feed (\u000A),
-	// and carriage return (\u000D) characters. Although any of these characters
-	// are valid in a password, note that many tools, such as the AWS Management
-	// Console, might restrict the ability to enter certain characters because they
-	// have special meaning within that tool.
+	// The regex pattern (http://wikipedia.org/wiki/regex) that is used to validate
+	// this parameter is a string of characters. That string can include almost
+	// any printable ASCII character from the space (\u0020) through the end of
+	// the ASCII character range (\u00FF). You can also include the tab (\u0009),
+	// line feed (\u000A), and carriage return (\u000D) characters. Any of these
+	// characters are valid in a password. However, many tools, such as the AWS
+	// Management Console, might restrict the ability to type certain characters
+	// because they have special meaning within that tool.
 	//
 	// NewPassword is a required field
 	NewPassword *string `min:"1" type:"string" required:"true"`
@@ -14153,8 +14276,8 @@ type ContextEntry struct {
 	ContextKeyType *string `type:"string" enum:"ContextKeyTypeEnum"`
 
 	// The value (or values, if the condition context key supports multiple values)
-	// to provide to the simulation for use when the key is referenced by a Condition
-	// element in an input policy.
+	// to provide to the simulation when the key is referenced by a Condition element
+	// in an input policy.
 	ContextKeyValues []*string `type:"list"`
 }
 
@@ -14206,7 +14329,7 @@ type CreateAccessKeyInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	UserName *string `min:"1" type:"string"`
 }
 
@@ -14332,7 +14455,7 @@ type CreateGroupInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-.
+	// with no spaces. You can also include any of the following characters: _+=,.@-.
 	// The group name must be unique within the account. Group names are not distinguished
 	// by case. For example, you cannot create groups named both "ADMINS" and "admins".
 	//
@@ -14346,11 +14469,12 @@ type CreateGroupInput struct {
 	// This parameter is optional. If it is not included, it defaults to a slash
 	// (/).
 	//
-	// This paramater allows (per its regex pattern (http://wikipedia.org/wiki/regex))
+	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of either a forward slash (/) by itself
-	// or a string that must begin and end with forward slashes, containing any
-	// ASCII character from the ! (\u0021) thru the DEL character (\u007F), including
-	// most punctuation characters, digits, and upper and lowercased letters.
+	// or a string that must begin and end with forward slashes. In addition, it
+	// can contain any ASCII character from the ! (\u0021) through the DEL character
+	// (\u007F), including most punctuation characters, digits, and upper and lowercased
+	// letters.
 	Path *string `min:"1" type:"string"`
 }
 
@@ -14428,7 +14552,7 @@ type CreateInstanceProfileInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// InstanceProfileName is a required field
 	InstanceProfileName *string `min:"1" type:"string" required:"true"`
@@ -14440,11 +14564,12 @@ type CreateInstanceProfileInput struct {
 	// This parameter is optional. If it is not included, it defaults to a slash
 	// (/).
 	//
-	// This paramater allows (per its regex pattern (http://wikipedia.org/wiki/regex))
+	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of either a forward slash (/) by itself
-	// or a string that must begin and end with forward slashes, containing any
-	// ASCII character from the ! (\u0021) thru the DEL character (\u007F), including
-	// most punctuation characters, digits, and upper and lowercased letters.
+	// or a string that must begin and end with forward slashes. In addition, it
+	// can contain any ASCII character from the ! (\u0021) through the DEL character
+	// (\u007F), including most punctuation characters, digits, and upper and lowercased
+	// letters.
 	Path *string `min:"1" type:"string"`
 }
 
@@ -14520,14 +14645,14 @@ type CreateLoginProfileInput struct {
 
 	// The new password for the user.
 	//
-	// The regex pattern (http://wikipedia.org/wiki/regex) used to validate this
-	// parameter is a string of characters consisting of almost any printable ASCII
-	// character from the space (\u0020) through the end of the ASCII character
-	// range (\u00FF). You can also include the tab (\u0009), line feed (\u000A),
-	// and carriage return (\u000D) characters. Although any of these characters
-	// are valid in a password, note that many tools, such as the AWS Management
-	// Console, might restrict the ability to enter certain characters because they
-	// have special meaning within that tool.
+	// The regex pattern (http://wikipedia.org/wiki/regex) that is used to validate
+	// this parameter is a string of characters. That string can include almost
+	// any printable ASCII character from the space (\u0020) through the end of
+	// the ASCII character range (\u00FF). You can also include the tab (\u0009),
+	// line feed (\u000A), and carriage return (\u000D) characters. Any of these
+	// characters are valid in a password. However, many tools, such as the AWS
+	// Management Console, might restrict the ability to type certain characters
+	// because they have special meaning within that tool.
 	//
 	// Password is a required field
 	Password *string `min:"1" type:"string" required:"true"`
@@ -14540,7 +14665,7 @@ type CreateLoginProfileInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// UserName is a required field
 	UserName *string `min:"1" type:"string" required:"true"`
@@ -14635,11 +14760,11 @@ type CreateOpenIDConnectProviderInput struct {
 	// cannot register more than 100 client IDs with a single IAM OIDC provider.
 	//
 	// There is no defined format for a client ID. The CreateOpenIDConnectProviderRequest
-	// action accepts client IDs up to 255 characters long.
+	// operation accepts client IDs up to 255 characters long.
 	ClientIDList []*string `type:"list"`
 
 	// A list of server certificate thumbprints for the OpenID Connect (OIDC) identity
-	// provider's server certificate(s). Typically this list includes only one entry.
+	// provider's server certificates. Typically this list includes only one entry.
 	// However, IAM lets you have up to five thumbprints for an OIDC provider. This
 	// lets you maintain multiple thumbprints if the identity provider is rotating
 	// certificates.
@@ -14649,10 +14774,10 @@ type CreateOpenIDConnectProviderInput struct {
 	// makes its keys available. It is always a 40-character string.
 	//
 	// You must provide at least one thumbprint when creating an IAM OIDC provider.
-	// For example, if the OIDC provider is server.example.com and the provider
-	// stores its keys at "https://keys.server.example.com/openid-connect", the
-	// thumbprint string would be the hex-encoded SHA-1 hash value of the certificate
-	// used by https://keys.server.example.com.
+	// For example, assume that the OIDC provider is server.example.com and the
+	// provider stores its keys at https://keys.server.example.com/openid-connect.
+	// In that case, the thumbprint string would be the hex-encoded SHA-1 hash value
+	// of the certificate used by https://keys.server.example.com.
 	//
 	// For more information about obtaining the OIDC provider's thumbprint, see
 	// Obtaining the Thumbprint for an OpenID Connect Provider (http://docs.aws.amazon.com/IAM/latest/UserGuide/identity-providers-oidc-obtain-thumbprint.html)
@@ -14661,11 +14786,11 @@ type CreateOpenIDConnectProviderInput struct {
 	// ThumbprintList is a required field
 	ThumbprintList []*string `type:"list" required:"true"`
 
-	// The URL of the identity provider. The URL must begin with "https://" and
-	// should correspond to the iss claim in the provider's OpenID Connect ID tokens.
-	// Per the OIDC standard, path components are allowed but query parameters are
-	// not. Typically the URL consists of only a host name, like "https://server.example.org"
-	// or "https://example.com".
+	// The URL of the identity provider. The URL must begin with https:// and should
+	// correspond to the iss claim in the provider's OpenID Connect ID tokens. Per
+	// the OIDC standard, path components are allowed but query parameters are not.
+	// Typically the URL consists of only a hostname, like https://server.example.org
+	// or https://example.com.
 	//
 	// You cannot register the same provider multiple times in a single AWS account.
 	// If you try to submit a URL that has already been used for an OpenID Connect
@@ -14767,22 +14892,28 @@ type CreatePolicyInput struct {
 	// This parameter is optional. If it is not included, it defaults to a slash
 	// (/).
 	//
-	// This paramater allows (per its regex pattern (http://wikipedia.org/wiki/regex))
+	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of either a forward slash (/) by itself
-	// or a string that must begin and end with forward slashes, containing any
-	// ASCII character from the ! (\u0021) thru the DEL character (\u007F), including
-	// most punctuation characters, digits, and upper and lowercased letters.
+	// or a string that must begin and end with forward slashes. In addition, it
+	// can contain any ASCII character from the ! (\u0021) through the DEL character
+	// (\u007F), including most punctuation characters, digits, and upper and lowercased
+	// letters.
 	Path *string `type:"string"`
 
 	// The JSON policy document that you want to use as the content for the new
 	// policy.
 	//
 	// The regex pattern (http://wikipedia.org/wiki/regex) used to validate this
-	// parameter is a string of characters consisting of any printable ASCII character
-	// ranging from the space character (\u0020) through end of the ASCII character
-	// range as well as the printable characters in the Basic Latin and Latin-1
-	// Supplement character set (through \u00FF). It also includes the special characters
-	// tab (\u0009), line feed (\u000A), and carriage return (\u000D).
+	// parameter is a string of characters consisting of the following:
+	//
+	//    * Any printable ASCII character ranging from the space character (\u0020)
+	//    through the end of the ASCII character range
+	//
+	//    * The printable characters in the Basic Latin and Latin-1 Supplement character
+	//    set (through \u00FF)
+	//
+	//    * The special characters tab (\u0009), line feed (\u000A), and carriage
+	//    return (\u000D)
 	//
 	// PolicyDocument is a required field
 	PolicyDocument *string `min:"1" type:"string" required:"true"`
@@ -14791,7 +14922,7 @@ type CreatePolicyInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-+
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// PolicyName is a required field
 	PolicyName *string `min:"1" type:"string" required:"true"`
@@ -14894,11 +15025,16 @@ type CreatePolicyVersionInput struct {
 	// version of the policy.
 	//
 	// The regex pattern (http://wikipedia.org/wiki/regex) used to validate this
-	// parameter is a string of characters consisting of any printable ASCII character
-	// ranging from the space character (\u0020) through end of the ASCII character
-	// range as well as the printable characters in the Basic Latin and Latin-1
-	// Supplement character set (through \u00FF). It also includes the special characters
-	// tab (\u0009), line feed (\u000A), and carriage return (\u000D).
+	// parameter is a string of characters consisting of the following:
+	//
+	//    * Any printable ASCII character ranging from the space character (\u0020)
+	//    through the end of the ASCII character range
+	//
+	//    * The printable characters in the Basic Latin and Latin-1 Supplement character
+	//    set (through \u00FF)
+	//
+	//    * The special characters tab (\u0009), line feed (\u000A), and carriage
+	//    return (\u000D)
 	//
 	// PolicyDocument is a required field
 	PolicyDocument *string `min:"1" type:"string" required:"true"`
@@ -14906,8 +15042,8 @@ type CreatePolicyVersionInput struct {
 	// Specifies whether to set this version as the policy's default version.
 	//
 	// When this parameter is true, the new policy version becomes the operative
-	// version; that is, the version that is in effect for the IAM users, groups,
-	// and roles that the policy is attached to.
+	// version. That is, it becomes the version that is in effect for the IAM users,
+	// groups, and roles that the policy is attached to.
 	//
 	// For more information about managed policy versions, see Versioning for Managed
 	// Policies (http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-versions.html)
@@ -14996,17 +15132,38 @@ type CreateRoleInput struct {
 	// assume the role.
 	//
 	// The regex pattern (http://wikipedia.org/wiki/regex) used to validate this
-	// parameter is a string of characters consisting of any printable ASCII character
-	// ranging from the space character (\u0020) through end of the ASCII character
-	// range as well as the printable characters in the Basic Latin and Latin-1
-	// Supplement character set (through \u00FF). It also includes the special characters
-	// tab (\u0009), line feed (\u000A), and carriage return (\u000D).
+	// parameter is a string of characters consisting of the following:
+	//
+	//    * Any printable ASCII character ranging from the space character (\u0020)
+	//    through the end of the ASCII character range
+	//
+	//    * The printable characters in the Basic Latin and Latin-1 Supplement character
+	//    set (through \u00FF)
+	//
+	//    * The special characters tab (\u0009), line feed (\u000A), and carriage
+	//    return (\u000D)
 	//
 	// AssumeRolePolicyDocument is a required field
 	AssumeRolePolicyDocument *string `min:"1" type:"string" required:"true"`
 
-	// A customer-provided description of the role.
+	// A description of the role.
 	Description *string `type:"string"`
+
+	// The maximum session duration (in seconds) that you want to set for the specified
+	// role. If you do not specify a value for this setting, the default maximum
+	// of one hour is applied. This setting can have a value from 1 hour to 12 hours.
+	//
+	// Anyone who assumes the role from the AWS CLI or API can use the DurationSeconds
+	// API parameter or the duration-seconds CLI parameter to request a longer session.
+	// The MaxSessionDuration setting determines the maximum duration that can be
+	// requested using the DurationSeconds parameter. If users don't specify a value
+	// for the DurationSeconds parameter, their security credentials are valid for
+	// one hour by default. This applies when you use the AssumeRole* API operations
+	// or the assume-role* CLI operations but does not apply when you use those
+	// operations to create a console URL. For more information, see Using IAM Roles
+	// (http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html) in the
+	// IAM User Guide.
+	MaxSessionDuration *int64 `min:"3600" type:"integer"`
 
 	// The path to the role. For more information about paths, see IAM Identifiers
 	// (http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html)
@@ -15015,11 +15172,12 @@ type CreateRoleInput struct {
 	// This parameter is optional. If it is not included, it defaults to a slash
 	// (/).
 	//
-	// This paramater allows (per its regex pattern (http://wikipedia.org/wiki/regex))
+	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of either a forward slash (/) by itself
-	// or a string that must begin and end with forward slashes, containing any
-	// ASCII character from the ! (\u0021) thru the DEL character (\u007F), including
-	// most punctuation characters, digits, and upper and lowercased letters.
+	// or a string that must begin and end with forward slashes. In addition, it
+	// can contain any ASCII character from the ! (\u0021) through the DEL character
+	// (\u007F), including most punctuation characters, digits, and upper and lowercased
+	// letters.
 	Path *string `min:"1" type:"string"`
 
 	// The name of the role to create.
@@ -15054,6 +15212,9 @@ func (s *CreateRoleInput) Validate() error {
 	if s.AssumeRolePolicyDocument != nil && len(*s.AssumeRolePolicyDocument) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("AssumeRolePolicyDocument", 1))
 	}
+	if s.MaxSessionDuration != nil && *s.MaxSessionDuration < 3600 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxSessionDuration", 3600))
+	}
 	if s.Path != nil && len(*s.Path) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("Path", 1))
 	}
@@ -15079,6 +15240,12 @@ func (s *CreateRoleInput) SetAssumeRolePolicyDocument(v string) *CreateRoleInput
 // SetDescription sets the Description field's value.
 func (s *CreateRoleInput) SetDescription(v string) *CreateRoleInput {
 	s.Description = &v
+	return s
+}
+
+// SetMaxSessionDuration sets the MaxSessionDuration field's value.
+func (s *CreateRoleInput) SetMaxSessionDuration(v int64) *CreateRoleInput {
+	s.MaxSessionDuration = &v
 	return s
 }
 
@@ -15127,7 +15294,7 @@ type CreateSAMLProviderInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// Name is a required field
 	Name *string `min:"1" type:"string" required:"true"`
@@ -15319,7 +15486,7 @@ type CreateServiceSpecificCredentialInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// UserName is a required field
 	UserName *string `min:"1" type:"string" required:"true"`
@@ -15404,18 +15571,19 @@ type CreateUserInput struct {
 	// This parameter is optional. If it is not included, it defaults to a slash
 	// (/).
 	//
-	// This paramater allows (per its regex pattern (http://wikipedia.org/wiki/regex))
+	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of either a forward slash (/) by itself
-	// or a string that must begin and end with forward slashes, containing any
-	// ASCII character from the ! (\u0021) thru the DEL character (\u007F), including
-	// most punctuation characters, digits, and upper and lowercased letters.
+	// or a string that must begin and end with forward slashes. In addition, it
+	// can contain any ASCII character from the ! (\u0021) through the DEL character
+	// (\u007F), including most punctuation characters, digits, and upper and lowercased
+	// letters.
 	Path *string `min:"1" type:"string"`
 
 	// The name of the user to create.
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-.
+	// with no spaces. You can also include any of the following characters: _+=,.@-.
 	// User names are not distinguished by case. For example, you cannot create
 	// users named both "TESTUSER" and "testuser".
 	//
@@ -15498,11 +15666,12 @@ type CreateVirtualMFADeviceInput struct {
 	// This parameter is optional. If it is not included, it defaults to a slash
 	// (/).
 	//
-	// This paramater allows (per its regex pattern (http://wikipedia.org/wiki/regex))
+	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of either a forward slash (/) by itself
-	// or a string that must begin and end with forward slashes, containing any
-	// ASCII character from the ! (\u0021) thru the DEL character (\u007F), including
-	// most punctuation characters, digits, and upper and lowercased letters.
+	// or a string that must begin and end with forward slashes. In addition, it
+	// can contain any ASCII character from the ! (\u0021) through the DEL character
+	// (\u007F), including most punctuation characters, digits, and upper and lowercased
+	// letters.
 	Path *string `min:"1" type:"string"`
 
 	// The name of the virtual MFA device. Use with path to uniquely identify a
@@ -15510,7 +15679,7 @@ type CreateVirtualMFADeviceInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// VirtualMFADeviceName is a required field
 	VirtualMFADeviceName *string `min:"1" type:"string" required:"true"`
@@ -15600,7 +15769,7 @@ type DeactivateMFADeviceInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// UserName is a required field
 	UserName *string `min:"1" type:"string" required:"true"`
@@ -15681,7 +15850,7 @@ type DeleteAccessKeyInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	UserName *string `min:"1" type:"string"`
 }
 
@@ -15835,7 +16004,7 @@ type DeleteGroupInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// GroupName is a required field
 	GroupName *string `min:"1" type:"string" required:"true"`
@@ -15895,7 +16064,7 @@ type DeleteGroupPolicyInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// GroupName is a required field
 	GroupName *string `min:"1" type:"string" required:"true"`
@@ -15904,7 +16073,7 @@ type DeleteGroupPolicyInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-+
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// PolicyName is a required field
 	PolicyName *string `min:"1" type:"string" required:"true"`
@@ -15975,7 +16144,7 @@ type DeleteInstanceProfileInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// InstanceProfileName is a required field
 	InstanceProfileName *string `min:"1" type:"string" required:"true"`
@@ -16034,7 +16203,7 @@ type DeleteLoginProfileInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// UserName is a required field
 	UserName *string `min:"1" type:"string" required:"true"`
@@ -16091,7 +16260,7 @@ type DeleteOpenIDConnectProviderInput struct {
 
 	// The Amazon Resource Name (ARN) of the IAM OpenID Connect provider resource
 	// object to delete. You can get a list of OpenID Connect provider resource
-	// ARNs by using the ListOpenIDConnectProviders action.
+	// ARNs by using the ListOpenIDConnectProviders operation.
 	//
 	// OpenIDConnectProviderArn is a required field
 	OpenIDConnectProviderArn *string `min:"20" type:"string" required:"true"`
@@ -16351,7 +16520,7 @@ type DeleteRolePolicyInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-+
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// PolicyName is a required field
 	PolicyName *string `min:"1" type:"string" required:"true"`
@@ -16496,7 +16665,7 @@ type DeleteSSHPublicKeyInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// UserName is a required field
 	UserName *string `min:"1" type:"string" required:"true"`
@@ -16567,7 +16736,7 @@ type DeleteServerCertificateInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// ServerCertificateName is a required field
 	ServerCertificateName *string `min:"1" type:"string" required:"true"`
@@ -16705,7 +16874,7 @@ type DeleteServiceSpecificCredentialInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	UserName *string `min:"1" type:"string"`
 }
 
@@ -16780,7 +16949,7 @@ type DeleteSigningCertificateInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	UserName *string `min:"1" type:"string"`
 }
 
@@ -16846,7 +17015,7 @@ type DeleteUserInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// UserName is a required field
 	UserName *string `min:"1" type:"string" required:"true"`
@@ -16905,7 +17074,7 @@ type DeleteUserPolicyInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-+
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// PolicyName is a required field
 	PolicyName *string `min:"1" type:"string" required:"true"`
@@ -16915,7 +17084,7 @@ type DeleteUserPolicyInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// UserName is a required field
 	UserName *string `min:"1" type:"string" required:"true"`
@@ -17050,11 +17219,11 @@ type DeletionTaskFailureReasonType struct {
 	Reason *string `type:"string"`
 
 	// A list of objects that contains details about the service-linked role deletion
-	// failure. If the service-linked role has active sessions or if any resources
-	// that were used by the role have not been deleted from the linked service,
-	// the role can't be deleted. This parameter includes a list of the resources
-	// that are associated with the role and the region in which the resources are
-	// being used.
+	// failure, if that information is returned by the service. If the service-linked
+	// role has active sessions or if any resources that were used by the role have
+	// not been deleted from the linked service, the role can't be deleted. This
+	// parameter includes a list of the resources that are associated with the role
+	// and the region in which the resources are being used.
 	RoleUsageList []*RoleUsageType `type:"list"`
 }
 
@@ -17087,7 +17256,7 @@ type DetachGroupPolicyInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// GroupName is a required field
 	GroupName *string `min:"1" type:"string" required:"true"`
@@ -17256,7 +17425,7 @@ type DetachUserPolicyInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// UserName is a required field
 	UserName *string `min:"1" type:"string" required:"true"`
@@ -17325,7 +17494,7 @@ type EnableMFADeviceInput struct {
 
 	// An authentication code emitted by the device.
 	//
-	// The format for this parameter is a string of 6 digits.
+	// The format for this parameter is a string of six digits.
 	//
 	// Submit your request immediately after generating the authentication codes.
 	// If you generate the codes and then wait too long to submit the request, the
@@ -17339,7 +17508,7 @@ type EnableMFADeviceInput struct {
 
 	// A subsequent authentication code emitted by the device.
 	//
-	// The format for this parameter is a string of 6 digits.
+	// The format for this parameter is a string of six digits.
 	//
 	// Submit your request immediately after generating the authentication codes.
 	// If you generate the codes and then wait too long to submit the request, the
@@ -17365,7 +17534,7 @@ type EnableMFADeviceInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// UserName is a required field
 	UserName *string `min:"1" type:"string" required:"true"`
@@ -17460,7 +17629,7 @@ func (s EnableMFADeviceOutput) GoString() string {
 type EvaluationResult struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the API action tested on the indicated resource.
+	// The name of the API operation tested on the indicated resource.
 	//
 	// EvalActionName is a required field
 	EvalActionName *string `min:"3" type:"string" required:"true"`
@@ -17478,12 +17647,12 @@ type EvaluationResult struct {
 	// Policies (http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_compare-resource-policies.html)
 	EvalDecisionDetails map[string]*string `type:"map"`
 
-	// The ARN of the resource that the indicated API action was tested on.
+	// The ARN of the resource that the indicated API operation was tested on.
 	EvalResourceName *string `min:"1" type:"string"`
 
 	// A list of the statements in the input policies that determine the result
-	// for this scenario. Remember that even if multiple statements allow the action
-	// on the resource, if only one statement denies that action, then the explicit
+	// for this scenario. Remember that even if multiple statements allow the operation
+	// on the resource, if only one statement denies that operation, then the explicit
 	// deny overrides any allow, and the deny statement is the only entry included
 	// in the result.
 	MatchedStatements []*Statement `type:"list"`
@@ -17502,8 +17671,8 @@ type EvaluationResult struct {
 	// account is part of an organization.
 	OrganizationsDecisionDetail *OrganizationsDecisionDetail `type:"structure"`
 
-	// The individual results of the simulation of the API action specified in EvalActionName
-	// on each resource.
+	// The individual results of the simulation of the API operation specified in
+	// EvalActionName on each resource.
 	ResourceSpecificResults []*ResourceSpecificResult `type:"list"`
 }
 
@@ -17928,11 +18097,16 @@ type GetContextKeysForCustomPolicyInput struct {
 	// complete, valid JSON text of an IAM policy.
 	//
 	// The regex pattern (http://wikipedia.org/wiki/regex) used to validate this
-	// parameter is a string of characters consisting of any printable ASCII character
-	// ranging from the space character (\u0020) through end of the ASCII character
-	// range as well as the printable characters in the Basic Latin and Latin-1
-	// Supplement character set (through \u00FF). It also includes the special characters
-	// tab (\u0009), line feed (\u000A), and carriage return (\u000D).
+	// parameter is a string of characters consisting of the following:
+	//
+	//    * Any printable ASCII character ranging from the space character (\u0020)
+	//    through the end of the ASCII character range
+	//
+	//    * The printable characters in the Basic Latin and Latin-1 Supplement character
+	//    set (through \u00FF)
+	//
+	//    * The special characters tab (\u0009), line feed (\u000A), and carriage
+	//    return (\u000D)
 	//
 	// PolicyInputList is a required field
 	PolicyInputList []*string `type:"list" required:"true"`
@@ -17999,20 +18173,26 @@ type GetContextKeysForPrincipalPolicyInput struct {
 	// keys that are referenced.
 	//
 	// The regex pattern (http://wikipedia.org/wiki/regex) used to validate this
-	// parameter is a string of characters consisting of any printable ASCII character
-	// ranging from the space character (\u0020) through end of the ASCII character
-	// range as well as the printable characters in the Basic Latin and Latin-1
-	// Supplement character set (through \u00FF). It also includes the special characters
-	// tab (\u0009), line feed (\u000A), and carriage return (\u000D).
+	// parameter is a string of characters consisting of the following:
+	//
+	//    * Any printable ASCII character ranging from the space character (\u0020)
+	//    through the end of the ASCII character range
+	//
+	//    * The printable characters in the Basic Latin and Latin-1 Supplement character
+	//    set (through \u00FF)
+	//
+	//    * The special characters tab (\u0009), line feed (\u000A), and carriage
+	//    return (\u000D)
 	PolicyInputList []*string `type:"list"`
 
 	// The ARN of a user, group, or role whose policies contain the context keys
 	// that you want listed. If you specify a user, the list includes context keys
-	// that are found in all policies attached to the user as well as to all groups
-	// that the user is a member of. If you pick a group or a role, then it includes
-	// only those context keys that are found in policies attached to that entity.
-	// Note that all parameters are shown in unencoded form here for clarity, but
-	// must be URL encoded to be included as a part of a real HTML request.
+	// that are found in all policies that are attached to the user. The list also
+	// includes all groups that the user is a member of. If you pick a group or
+	// a role, then it includes only those context keys that are found in policies
+	// attached to that entity. Note that all parameters are shown in unencoded
+	// form here for clarity, but must be URL encoded to be included as a part of
+	// a real HTML request.
 	//
 	// For more information about ARNs, see Amazon Resource Names (ARNs) and AWS
 	// Service Namespaces (http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
@@ -18126,7 +18306,7 @@ type GetGroupInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// GroupName is a required field
 	GroupName *string `min:"1" type:"string" required:"true"`
@@ -18267,7 +18447,7 @@ type GetGroupPolicyInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// GroupName is a required field
 	GroupName *string `min:"1" type:"string" required:"true"`
@@ -18276,7 +18456,7 @@ type GetGroupPolicyInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-+
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// PolicyName is a required field
 	PolicyName *string `min:"1" type:"string" required:"true"`
@@ -18381,7 +18561,7 @@ type GetInstanceProfileInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// InstanceProfileName is a required field
 	InstanceProfileName *string `min:"1" type:"string" required:"true"`
@@ -18452,7 +18632,7 @@ type GetLoginProfileInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// UserName is a required field
 	UserName *string `min:"1" type:"string" required:"true"`
@@ -18521,7 +18701,7 @@ type GetOpenIDConnectProviderInput struct {
 
 	// The Amazon Resource Name (ARN) of the OIDC provider resource object in IAM
 	// to get information for. You can get a list of OIDC provider resource ARNs
-	// by using the ListOpenIDConnectProviders action.
+	// by using the ListOpenIDConnectProviders operation.
 	//
 	// For more information about ARNs, see Amazon Resource Names (ARNs) and AWS
 	// Service Namespaces (http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
@@ -18855,7 +19035,7 @@ type GetRolePolicyInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-+
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// PolicyName is a required field
 	PolicyName *string `min:"1" type:"string" required:"true"`
@@ -19073,7 +19253,7 @@ type GetSSHPublicKeyInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// UserName is a required field
 	UserName *string `min:"1" type:"string" required:"true"`
@@ -19163,7 +19343,7 @@ type GetServerCertificateInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// ServerCertificateName is a required field
 	ServerCertificateName *string `min:"1" type:"string" required:"true"`
@@ -19311,7 +19491,7 @@ type GetUserInput struct {
 	// This parameter is optional. If it is not included, it defaults to the user
 	// making the request. This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	UserName *string `min:"1" type:"string"`
 }
 
@@ -19377,7 +19557,7 @@ type GetUserPolicyInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-+
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// PolicyName is a required field
 	PolicyName *string `min:"1" type:"string" required:"true"`
@@ -19386,7 +19566,7 @@ type GetUserPolicyInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// UserName is a required field
 	UserName *string `min:"1" type:"string" required:"true"`
@@ -19486,7 +19666,7 @@ func (s *GetUserPolicyOutput) SetUserName(v string) *GetUserPolicyOutput {
 
 // Contains information about an IAM group entity.
 //
-// This data type is used as a response element in the following actions:
+// This data type is used as a response element in the following operations:
 //
 //    * CreateGroup
 //
@@ -19572,7 +19752,7 @@ func (s *Group) SetPath(v string) *Group {
 // Contains information about an IAM group, including all of the group's policies.
 //
 // This data type is used as a response element in the GetAccountAuthorizationDetails
-// action.
+// operation.
 type GroupDetail struct {
 	_ struct{} `type:"structure"`
 
@@ -19661,7 +19841,7 @@ func (s *GroupDetail) SetPath(v string) *GroupDetail {
 
 // Contains information about an instance profile.
 //
-// This data type is used as a response element in the following actions:
+// This data type is used as a response element in the following operations:
 //
 //    * CreateInstanceProfile
 //
@@ -19781,7 +19961,7 @@ type ListAccessKeysInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	UserName *string `min:"1" type:"string"`
 }
 
@@ -20000,7 +20180,7 @@ type ListAttachedGroupPoliciesInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// GroupName is a required field
 	GroupName *string `min:"1" type:"string" required:"true"`
@@ -20025,11 +20205,12 @@ type ListAttachedGroupPoliciesInput struct {
 	// The path prefix for filtering the results. This parameter is optional. If
 	// it is not included, it defaults to a slash (/), listing all policies.
 	//
-	// This paramater allows (per its regex pattern (http://wikipedia.org/wiki/regex))
+	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of either a forward slash (/) by itself
-	// or a string that must begin and end with forward slashes, containing any
-	// ASCII character from the ! (\u0021) thru the DEL character (\u007F), including
-	// most punctuation characters, digits, and upper and lowercased letters.
+	// or a string that must begin and end with forward slashes. In addition, it
+	// can contain any ASCII character from the ! (\u0021) through the DEL character
+	// (\u007F), including most punctuation characters, digits, and upper and lowercased
+	// letters.
 	PathPrefix *string `type:"string"`
 }
 
@@ -20160,11 +20341,12 @@ type ListAttachedRolePoliciesInput struct {
 	// The path prefix for filtering the results. This parameter is optional. If
 	// it is not included, it defaults to a slash (/), listing all policies.
 	//
-	// This paramater allows (per its regex pattern (http://wikipedia.org/wiki/regex))
+	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of either a forward slash (/) by itself
-	// or a string that must begin and end with forward slashes, containing any
-	// ASCII character from the ! (\u0021) thru the DEL character (\u007F), including
-	// most punctuation characters, digits, and upper and lowercased letters.
+	// or a string that must begin and end with forward slashes. In addition, it
+	// can contain any ASCII character from the ! (\u0021) through the DEL character
+	// (\u007F), including most punctuation characters, digits, and upper and lowercased
+	// letters.
 	PathPrefix *string `type:"string"`
 
 	// The name (friendly name, not ARN) of the role to list attached policies for.
@@ -20304,18 +20486,19 @@ type ListAttachedUserPoliciesInput struct {
 	// The path prefix for filtering the results. This parameter is optional. If
 	// it is not included, it defaults to a slash (/), listing all policies.
 	//
-	// This paramater allows (per its regex pattern (http://wikipedia.org/wiki/regex))
+	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of either a forward slash (/) by itself
-	// or a string that must begin and end with forward slashes, containing any
-	// ASCII character from the ! (\u0021) thru the DEL character (\u007F), including
-	// most punctuation characters, digits, and upper and lowercased letters.
+	// or a string that must begin and end with forward slashes. In addition, it
+	// can contain any ASCII character from the ! (\u0021) through the DEL character
+	// (\u007F), including most punctuation characters, digits, and upper and lowercased
+	// letters.
 	PathPrefix *string `type:"string"`
 
 	// The name (friendly name, not ARN) of the user to list attached policies for.
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// UserName is a required field
 	UserName *string `min:"1" type:"string" required:"true"`
@@ -20456,11 +20639,12 @@ type ListEntitiesForPolicyInput struct {
 	// The path prefix for filtering the results. This parameter is optional. If
 	// it is not included, it defaults to a slash (/), listing all entities.
 	//
-	// This paramater allows (per its regex pattern (http://wikipedia.org/wiki/regex))
+	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of either a forward slash (/) by itself
-	// or a string that must begin and end with forward slashes, containing any
-	// ASCII character from the ! (\u0021) thru the DEL character (\u007F), including
-	// most punctuation characters, digits, and upper and lowercased letters.
+	// or a string that must begin and end with forward slashes. In addition, it
+	// can contain any ASCII character from the ! (\u0021) through the DEL character
+	// (\u007F), including most punctuation characters, digits, and upper and lowercased
+	// letters.
 	PathPrefix *string `min:"1" type:"string"`
 
 	// The Amazon Resource Name (ARN) of the IAM policy for which you want the versions.
@@ -20611,7 +20795,7 @@ type ListGroupPoliciesInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// GroupName is a required field
 	GroupName *string `min:"1" type:"string" required:"true"`
@@ -20704,7 +20888,7 @@ type ListGroupPoliciesOutput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-+
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// PolicyNames is a required field
 	PolicyNames []*string `type:"list" required:"true"`
@@ -20762,7 +20946,7 @@ type ListGroupsForUserInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// UserName is a required field
 	UserName *string `min:"1" type:"string" required:"true"`
@@ -20892,11 +21076,12 @@ type ListGroupsInput struct {
 	// gets all groups whose path starts with /division_abc/subdivision_xyz/.
 	//
 	// This parameter is optional. If it is not included, it defaults to a slash
-	// (/), listing all groups. This paramater allows (per its regex pattern (http://wikipedia.org/wiki/regex))
+	// (/), listing all groups. This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of either a forward slash (/) by itself
-	// or a string that must begin and end with forward slashes, containing any
-	// ASCII character from the ! (\u0021) thru the DEL character (\u007F), including
-	// most punctuation characters, digits, and upper and lowercased letters.
+	// or a string that must begin and end with forward slashes. In addition, it
+	// can contain any ASCII character from the ! (\u0021) through the DEL character
+	// (\u007F), including most punctuation characters, digits, and upper and lowercased
+	// letters.
 	PathPrefix *string `min:"1" type:"string"`
 }
 
@@ -21151,12 +21336,12 @@ type ListInstanceProfilesInput struct {
 	// gets all instance profiles whose path starts with /application_abc/component_xyz/.
 	//
 	// This parameter is optional. If it is not included, it defaults to a slash
-	// (/), listing all instance profiles. This paramater allows (per its regex
+	// (/), listing all instance profiles. This parameter allows (per its regex
 	// pattern (http://wikipedia.org/wiki/regex)) a string of characters consisting
 	// of either a forward slash (/) by itself or a string that must begin and end
-	// with forward slashes, containing any ASCII character from the ! (\u0021)
-	// thru the DEL character (\u007F), including most punctuation characters, digits,
-	// and upper and lowercased letters.
+	// with forward slashes. In addition, it can contain any ASCII character from
+	// the ! (\u0021) through the DEL character (\u007F), including most punctuation
+	// characters, digits, and upper and lowercased letters.
 	PathPrefix *string `min:"1" type:"string"`
 }
 
@@ -21281,7 +21466,7 @@ type ListMFADevicesInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	UserName *string `min:"1" type:"string"`
 }
 
@@ -21449,11 +21634,12 @@ type ListPoliciesInput struct {
 
 	// The path prefix for filtering the results. This parameter is optional. If
 	// it is not included, it defaults to a slash (/), listing all policies. This
-	// paramater allows (per its regex pattern (http://wikipedia.org/wiki/regex))
+	// parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of either a forward slash (/) by itself
-	// or a string that must begin and end with forward slashes, containing any
-	// ASCII character from the ! (\u0021) thru the DEL character (\u007F), including
-	// most punctuation characters, digits, and upper and lowercased letters.
+	// or a string that must begin and end with forward slashes. In addition, it
+	// can contain any ASCII character from the ! (\u0021) through the DEL character
+	// (\u007F), including most punctuation characters, digits, and upper and lowercased
+	// letters.
 	PathPrefix *string `type:"string"`
 
 	// The scope to use for filtering the results.
@@ -21856,11 +22042,12 @@ type ListRolesInput struct {
 	// gets all roles whose path starts with /application_abc/component_xyz/.
 	//
 	// This parameter is optional. If it is not included, it defaults to a slash
-	// (/), listing all roles. This paramater allows (per its regex pattern (http://wikipedia.org/wiki/regex))
+	// (/), listing all roles. This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of either a forward slash (/) by itself
-	// or a string that must begin and end with forward slashes, containing any
-	// ASCII character from the ! (\u0021) thru the DEL character (\u007F), including
-	// most punctuation characters, digits, and upper and lowercased letters.
+	// or a string that must begin and end with forward slashes. In addition, it
+	// can contain any ASCII character from the ! (\u0021) through the DEL character
+	// (\u007F), including most punctuation characters, digits, and upper and lowercased
+	// letters.
 	PathPrefix *string `min:"1" type:"string"`
 }
 
@@ -22025,7 +22212,7 @@ type ListSSHPublicKeysInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	UserName *string `min:"1" type:"string"`
 }
 
@@ -22148,12 +22335,12 @@ type ListServerCertificatesInput struct {
 	// would get all server certificates for which the path starts with /company/servercerts.
 	//
 	// This parameter is optional. If it is not included, it defaults to a slash
-	// (/), listing all server certificates. This paramater allows (per its regex
+	// (/), listing all server certificates. This parameter allows (per its regex
 	// pattern (http://wikipedia.org/wiki/regex)) a string of characters consisting
 	// of either a forward slash (/) by itself or a string that must begin and end
-	// with forward slashes, containing any ASCII character from the ! (\u0021)
-	// thru the DEL character (\u007F), including most punctuation characters, digits,
-	// and upper and lowercased letters.
+	// with forward slashes. In addition, it can contain any ASCII character from
+	// the ! (\u0021) through the DEL character (\u007F), including most punctuation
+	// characters, digits, and upper and lowercased letters.
 	PathPrefix *string `min:"1" type:"string"`
 }
 
@@ -22262,12 +22449,12 @@ type ListServiceSpecificCredentialsInput struct {
 	ServiceName *string `type:"string"`
 
 	// The name of the user whose service-specific credentials you want information
-	// about. If this value is not specified then the operation assumes the user
+	// about. If this value is not specified, then the operation assumes the user
 	// whose credentials are used to call the operation.
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	UserName *string `min:"1" type:"string"`
 }
 
@@ -22353,7 +22540,7 @@ type ListSigningCertificatesInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	UserName *string `min:"1" type:"string"`
 }
 
@@ -22478,7 +22665,7 @@ type ListUserPoliciesInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// UserName is a required field
 	UserName *string `min:"1" type:"string" required:"true"`
@@ -22608,12 +22795,12 @@ type ListUsersInput struct {
 	// which would get all user names whose path starts with /division_abc/subdivision_xyz/.
 	//
 	// This parameter is optional. If it is not included, it defaults to a slash
-	// (/), listing all user names. This paramater allows (per its regex pattern
+	// (/), listing all user names. This parameter allows (per its regex pattern
 	// (http://wikipedia.org/wiki/regex)) a string of characters consisting of either
 	// a forward slash (/) by itself or a string that must begin and end with forward
-	// slashes, containing any ASCII character from the ! (\u0021) thru the DEL
-	// character (\u007F), including most punctuation characters, digits, and upper
-	// and lowercased letters.
+	// slashes. In addition, it can contain any ASCII character from the ! (\u0021)
+	// through the DEL character (\u007F), including most punctuation characters,
+	// digits, and upper and lowercased letters.
 	PathPrefix *string `min:"1" type:"string"`
 }
 
@@ -22718,7 +22905,7 @@ type ListVirtualMFADevicesInput struct {
 	_ struct{} `type:"structure"`
 
 	// The status (Unassigned or Assigned) of the devices to list. If you do not
-	// specify an AssignmentStatus, the action defaults to Any which lists both
+	// specify an AssignmentStatus, the operation defaults to Any which lists both
 	// assigned and unassigned virtual MFA devices.
 	AssignmentStatus *string `type:"string" enum:"assignmentStatusType"`
 
@@ -22838,7 +23025,7 @@ func (s *ListVirtualMFADevicesOutput) SetVirtualMFADevices(v []*VirtualMFADevice
 // Contains the user name and password create date for a user.
 //
 // This data type is used as a response element in the CreateLoginProfile and
-// GetLoginProfile actions.
+// GetLoginProfile operations.
 type LoginProfile struct {
 	_ struct{} `type:"structure"`
 
@@ -22887,7 +23074,7 @@ func (s *LoginProfile) SetUserName(v string) *LoginProfile {
 
 // Contains information about an MFA device.
 //
-// This data type is used as a response element in the ListMFADevices action.
+// This data type is used as a response element in the ListMFADevices operation.
 type MFADevice struct {
 	_ struct{} `type:"structure"`
 
@@ -22941,7 +23128,7 @@ func (s *MFADevice) SetUserName(v string) *MFADevice {
 // that the policy is attached to.
 //
 // This data type is used as a response element in the GetAccountAuthorizationDetails
-// action.
+// operation.
 //
 // For more information about managed policies, see Managed Policies and Inline
 // Policies (http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
@@ -23110,11 +23297,11 @@ func (s *OpenIDConnectProviderListEntry) SetArn(v string) *OpenIDConnectProvider
 	return s
 }
 
-// Contains information about AWS Organizations's affect on a policy simulation.
+// Contains information about AWS Organizations's effect on a policy simulation.
 type OrganizationsDecisionDetail struct {
 	_ struct{} `type:"structure"`
 
-	// Specifies whether the simulated action is allowed by the AWS Organizations
+	// Specifies whether the simulated operation is allowed by the AWS Organizations
 	// service control policies that impact the simulated user's account.
 	AllowedByOrganizations *bool `type:"boolean"`
 }
@@ -23138,7 +23325,7 @@ func (s *OrganizationsDecisionDetail) SetAllowedByOrganizations(v bool) *Organiz
 // Contains information about the account password policy.
 //
 // This data type is used as a response element in the GetAccountPasswordPolicy
-// action.
+// operation.
 type PasswordPolicy struct {
 	_ struct{} `type:"structure"`
 
@@ -23146,8 +23333,8 @@ type PasswordPolicy struct {
 	AllowUsersToChangePassword *bool `type:"boolean"`
 
 	// Indicates whether passwords in the account expire. Returns true if MaxPasswordAge
-	// is contains a value greater than 0. Returns false if MaxPasswordAge is 0
-	// or not present.
+	// contains a value greater than 0. Returns false if MaxPasswordAge is 0 or
+	// not present.
 	ExpirePasswords *bool `type:"boolean"`
 
 	// Specifies whether IAM users are prevented from setting a new password after
@@ -23250,7 +23437,7 @@ func (s *PasswordPolicy) SetRequireUppercaseCharacters(v bool) *PasswordPolicy {
 // Contains information about a managed policy.
 //
 // This data type is used as a response element in the CreatePolicy, GetPolicy,
-// and ListPolicies actions.
+// and ListPolicies operations.
 //
 // For more information about managed policies, refer to Managed Policies and
 // Inline Policies (http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
@@ -23383,7 +23570,7 @@ func (s *Policy) SetUpdateDate(v time.Time) *Policy {
 // Contains information about an IAM policy, including the policy document.
 //
 // This data type is used as a response element in the GetAccountAuthorizationDetails
-// action.
+// operation.
 type PolicyDetail struct {
 	_ struct{} `type:"structure"`
 
@@ -23419,7 +23606,7 @@ func (s *PolicyDetail) SetPolicyName(v string) *PolicyDetail {
 // Contains information about a group that a managed policy is attached to.
 //
 // This data type is used as a response element in the ListEntitiesForPolicy
-// action.
+// operation.
 //
 // For more information about managed policies, refer to Managed Policies and
 // Inline Policies (http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
@@ -23461,7 +23648,7 @@ func (s *PolicyGroup) SetGroupName(v string) *PolicyGroup {
 // Contains information about a role that a managed policy is attached to.
 //
 // This data type is used as a response element in the ListEntitiesForPolicy
-// action.
+// operation.
 //
 // For more information about managed policies, refer to Managed Policies and
 // Inline Policies (http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
@@ -23503,7 +23690,7 @@ func (s *PolicyRole) SetRoleName(v string) *PolicyRole {
 // Contains information about a user that a managed policy is attached to.
 //
 // This data type is used as a response element in the ListEntitiesForPolicy
-// action.
+// operation.
 //
 // For more information about managed policies, refer to Managed Policies and
 // Inline Policies (http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
@@ -23546,7 +23733,7 @@ func (s *PolicyUser) SetUserName(v string) *PolicyUser {
 //
 // This data type is used as a response element in the CreatePolicyVersion,
 // GetPolicyVersion, ListPolicyVersions, and GetAccountAuthorizationDetails
-// actions.
+// operations.
 //
 // For more information about managed policies, refer to Managed Policies and
 // Inline Policies (http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html)
@@ -23563,6 +23750,12 @@ type PolicyVersion struct {
 	// The policy document is returned in the response to the GetPolicyVersion and
 	// GetAccountAuthorizationDetails operations. It is not returned in the response
 	// to the CreatePolicyVersion or ListPolicyVersions operations.
+	//
+	// The policy document returned in this structure is URL-encoded compliant with
+	// RFC 3986 (https://tools.ietf.org/html/rfc3986). You can use a URL decoding
+	// method to convert the policy back to plain JSON text. For example, if you
+	// use Java, you can use the decode method of the java.net.URLDecoder utility
+	// class in the Java SDK. Other languages and SDKs provide similar functionality.
 	Document *string `min:"1" type:"string"`
 
 	// Specifies whether the policy version is set as the policy's default version.
@@ -23652,7 +23845,7 @@ type PutGroupPolicyInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// GroupName is a required field
 	GroupName *string `min:"1" type:"string" required:"true"`
@@ -23660,11 +23853,16 @@ type PutGroupPolicyInput struct {
 	// The policy document.
 	//
 	// The regex pattern (http://wikipedia.org/wiki/regex) used to validate this
-	// parameter is a string of characters consisting of any printable ASCII character
-	// ranging from the space character (\u0020) through end of the ASCII character
-	// range as well as the printable characters in the Basic Latin and Latin-1
-	// Supplement character set (through \u00FF). It also includes the special characters
-	// tab (\u0009), line feed (\u000A), and carriage return (\u000D).
+	// parameter is a string of characters consisting of the following:
+	//
+	//    * Any printable ASCII character ranging from the space character (\u0020)
+	//    through the end of the ASCII character range
+	//
+	//    * The printable characters in the Basic Latin and Latin-1 Supplement character
+	//    set (through \u00FF)
+	//
+	//    * The special characters tab (\u0009), line feed (\u000A), and carriage
+	//    return (\u000D)
 	//
 	// PolicyDocument is a required field
 	PolicyDocument *string `min:"1" type:"string" required:"true"`
@@ -23673,7 +23871,7 @@ type PutGroupPolicyInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-+
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// PolicyName is a required field
 	PolicyName *string `min:"1" type:"string" required:"true"`
@@ -23755,11 +23953,16 @@ type PutRolePolicyInput struct {
 	// The policy document.
 	//
 	// The regex pattern (http://wikipedia.org/wiki/regex) used to validate this
-	// parameter is a string of characters consisting of any printable ASCII character
-	// ranging from the space character (\u0020) through end of the ASCII character
-	// range as well as the printable characters in the Basic Latin and Latin-1
-	// Supplement character set (through \u00FF). It also includes the special characters
-	// tab (\u0009), line feed (\u000A), and carriage return (\u000D).
+	// parameter is a string of characters consisting of the following:
+	//
+	//    * Any printable ASCII character ranging from the space character (\u0020)
+	//    through the end of the ASCII character range
+	//
+	//    * The printable characters in the Basic Latin and Latin-1 Supplement character
+	//    set (through \u00FF)
+	//
+	//    * The special characters tab (\u0009), line feed (\u000A), and carriage
+	//    return (\u000D)
 	//
 	// PolicyDocument is a required field
 	PolicyDocument *string `min:"1" type:"string" required:"true"`
@@ -23768,7 +23971,7 @@ type PutRolePolicyInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-+
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// PolicyName is a required field
 	PolicyName *string `min:"1" type:"string" required:"true"`
@@ -23859,11 +24062,16 @@ type PutUserPolicyInput struct {
 	// The policy document.
 	//
 	// The regex pattern (http://wikipedia.org/wiki/regex) used to validate this
-	// parameter is a string of characters consisting of any printable ASCII character
-	// ranging from the space character (\u0020) through end of the ASCII character
-	// range as well as the printable characters in the Basic Latin and Latin-1
-	// Supplement character set (through \u00FF). It also includes the special characters
-	// tab (\u0009), line feed (\u000A), and carriage return (\u000D).
+	// parameter is a string of characters consisting of the following:
+	//
+	//    * Any printable ASCII character ranging from the space character (\u0020)
+	//    through the end of the ASCII character range
+	//
+	//    * The printable characters in the Basic Latin and Latin-1 Supplement character
+	//    set (through \u00FF)
+	//
+	//    * The special characters tab (\u0009), line feed (\u000A), and carriage
+	//    return (\u000D)
 	//
 	// PolicyDocument is a required field
 	PolicyDocument *string `min:"1" type:"string" required:"true"`
@@ -23872,7 +24080,7 @@ type PutUserPolicyInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-+
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// PolicyName is a required field
 	PolicyName *string `min:"1" type:"string" required:"true"`
@@ -23881,7 +24089,7 @@ type PutUserPolicyInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// UserName is a required field
 	UserName *string `min:"1" type:"string" required:"true"`
@@ -23968,7 +24176,7 @@ type RemoveClientIDFromOpenIDConnectProviderInput struct {
 
 	// The Amazon Resource Name (ARN) of the IAM OIDC provider resource to remove
 	// the client ID from. You can get a list of OIDC provider ARNs by using the
-	// ListOpenIDConnectProviders action.
+	// ListOpenIDConnectProviders operation.
 	//
 	// For more information about ARNs, see Amazon Resource Names (ARNs) and AWS
 	// Service Namespaces (http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
@@ -24043,7 +24251,7 @@ type RemoveRoleFromInstanceProfileInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// InstanceProfileName is a required field
 	InstanceProfileName *string `min:"1" type:"string" required:"true"`
@@ -24123,7 +24331,7 @@ type RemoveUserFromGroupInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// GroupName is a required field
 	GroupName *string `min:"1" type:"string" required:"true"`
@@ -24132,7 +24340,7 @@ type RemoveUserFromGroupInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// UserName is a required field
 	UserName *string `min:"1" type:"string" required:"true"`
@@ -24214,7 +24422,7 @@ type ResetServiceSpecificCredentialInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	UserName *string `min:"1" type:"string"`
 }
 
@@ -24286,8 +24494,8 @@ func (s *ResetServiceSpecificCredentialOutput) SetServiceSpecificCredential(v *S
 	return s
 }
 
-// Contains the result of the simulation of a single API action call on a single
-// resource.
+// Contains the result of the simulation of a single API operation call on a
+// single resource.
 //
 // This data type is used by a member of the EvaluationResult data type.
 type ResourceSpecificResult struct {
@@ -24300,7 +24508,7 @@ type ResourceSpecificResult struct {
 	// caller's IAM policy must grant access.
 	EvalDecisionDetails map[string]*string `type:"map"`
 
-	// The result of the simulation of the simulated API action on the resource
+	// The result of the simulation of the simulated API operation on the resource
 	// specified in EvalResourceName.
 	//
 	// EvalResourceDecision is a required field
@@ -24313,9 +24521,9 @@ type ResourceSpecificResult struct {
 
 	// A list of the statements in the input policies that determine the result
 	// for this part of the simulation. Remember that even if multiple statements
-	// allow the action on the resource, if any statement denies that action, then
-	// the explicit deny overrides any allow, and the deny statement is the only
-	// entry included in the result.
+	// allow the operation on the resource, if any statement denies that operation,
+	// then the explicit deny overrides any allow, and the deny statement is the
+	// only entry included in the result.
 	MatchedStatements []*Statement `type:"list"`
 
 	// A list of context keys that are required by the included input policies but
@@ -24390,7 +24598,7 @@ type ResyncMFADeviceInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// SerialNumber is a required field
 	SerialNumber *string `min:"9" type:"string" required:"true"`
@@ -24399,7 +24607,7 @@ type ResyncMFADeviceInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// UserName is a required field
 	UserName *string `min:"1" type:"string" required:"true"`
@@ -24488,7 +24696,7 @@ func (s ResyncMFADeviceOutput) GoString() string {
 }
 
 // Contains information about an IAM role. This structure is returned as a response
-// element in several APIs that interact with roles.
+// element in several API operations that interact with roles.
 type Role struct {
 	_ struct{} `type:"structure"`
 
@@ -24510,6 +24718,11 @@ type Role struct {
 
 	// A description of the role that you provide.
 	Description *string `type:"string"`
+
+	// The maximum session duration (in seconds) for the specified role. Anyone
+	// who uses the AWS CLI or API to assume the role can specify the duration using
+	// the optional DurationSeconds API parameter or duration-seconds CLI parameter.
+	MaxSessionDuration *int64 `min:"3600" type:"integer"`
 
 	// The path to the role. For more information about paths, see IAM Identifiers
 	// (http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html)
@@ -24565,6 +24778,12 @@ func (s *Role) SetDescription(v string) *Role {
 	return s
 }
 
+// SetMaxSessionDuration sets the MaxSessionDuration field's value.
+func (s *Role) SetMaxSessionDuration(v int64) *Role {
+	s.MaxSessionDuration = &v
+	return s
+}
+
 // SetPath sets the Path field's value.
 func (s *Role) SetPath(v string) *Role {
 	s.Path = &v
@@ -24586,7 +24805,7 @@ func (s *Role) SetRoleName(v string) *Role {
 // Contains information about an IAM role, including all of the role's policies.
 //
 // This data type is used as a response element in the GetAccountAuthorizationDetails
-// action.
+// operation.
 type RoleDetail struct {
 	_ struct{} `type:"structure"`
 
@@ -24693,7 +24912,8 @@ func (s *RoleDetail) SetRolePolicyList(v []*PolicyDetail) *RoleDetail {
 	return s
 }
 
-// An object that contains details about how a service-linked role is used.
+// An object that contains details about how a service-linked role is used,
+// if that information is returned by the service.
 //
 // This data type is used as a response element in the GetServiceLinkedRoleDeletionStatus
 // operation.
@@ -24774,7 +24994,7 @@ func (s *SAMLProviderListEntry) SetValidUntil(v time.Time) *SAMLProviderListEntr
 // Contains information about an SSH public key.
 //
 // This data type is used as a response element in the GetSSHPublicKey and UploadSSHPublicKey
-// actions.
+// operations.
 type SSHPublicKey struct {
 	_ struct{} `type:"structure"`
 
@@ -24793,8 +25013,9 @@ type SSHPublicKey struct {
 	// SSHPublicKeyId is a required field
 	SSHPublicKeyId *string `min:"20" type:"string" required:"true"`
 
-	// The status of the SSH public key. Active means the key can be used for authentication
-	// with an AWS CodeCommit repository. Inactive means the key cannot be used.
+	// The status of the SSH public key. Active means that the key can be used for
+	// authentication with an AWS CodeCommit repository. Inactive means that the
+	// key cannot be used.
 	//
 	// Status is a required field
 	Status *string `type:"string" required:"true" enum:"statusType"`
@@ -24857,7 +25078,7 @@ func (s *SSHPublicKey) SetUserName(v string) *SSHPublicKey {
 
 // Contains information about an SSH public key, without the key's body or fingerprint.
 //
-// This data type is used as a response element in the ListSSHPublicKeys action.
+// This data type is used as a response element in the ListSSHPublicKeys operation.
 type SSHPublicKeyMetadata struct {
 	_ struct{} `type:"structure"`
 
@@ -24866,8 +25087,9 @@ type SSHPublicKeyMetadata struct {
 	// SSHPublicKeyId is a required field
 	SSHPublicKeyId *string `min:"20" type:"string" required:"true"`
 
-	// The status of the SSH public key. Active means the key can be used for authentication
-	// with an AWS CodeCommit repository. Inactive means the key cannot be used.
+	// The status of the SSH public key. Active means that the key can be used for
+	// authentication with an AWS CodeCommit repository. Inactive means that the
+	// key cannot be used.
 	//
 	// Status is a required field
 	Status *string `type:"string" required:"true" enum:"statusType"`
@@ -24921,7 +25143,7 @@ func (s *SSHPublicKeyMetadata) SetUserName(v string) *SSHPublicKeyMetadata {
 // Contains information about a server certificate.
 //
 // This data type is used as a response element in the GetServerCertificate
-// action.
+// operation.
 type ServerCertificate struct {
 	_ struct{} `type:"structure"`
 
@@ -24972,7 +25194,7 @@ func (s *ServerCertificate) SetServerCertificateMetadata(v *ServerCertificateMet
 // certificate chain, and private key.
 //
 // This data type is used as a response element in the UploadServerCertificate
-// and ListServerCertificates actions.
+// and ListServerCertificates operations.
 type ServerCertificateMetadata struct {
 	_ struct{} `type:"structure"`
 
@@ -25056,7 +25278,7 @@ func (s *ServerCertificateMetadata) SetUploadDate(v time.Time) *ServerCertificat
 	return s
 }
 
-// Contains the details of a service specific credential.
+// Contains the details of a service-specific credential.
 type ServiceSpecificCredential struct {
 	_ struct{} `type:"structure"`
 
@@ -25089,8 +25311,8 @@ type ServiceSpecificCredential struct {
 	// ServiceUserName is a required field
 	ServiceUserName *string `min:"17" type:"string" required:"true"`
 
-	// The status of the service-specific credential. Active means the key is valid
-	// for API calls, while Inactive means it is not.
+	// The status of the service-specific credential. Active means that the key
+	// is valid for API calls, while Inactive means it is not.
 	//
 	// Status is a required field
 	Status *string `type:"string" required:"true" enum:"statusType"`
@@ -25178,8 +25400,8 @@ type ServiceSpecificCredentialMetadata struct {
 	// ServiceUserName is a required field
 	ServiceUserName *string `min:"17" type:"string" required:"true"`
 
-	// The status of the service-specific credential. Active means the key is valid
-	// for API calls, while Inactive means it is not.
+	// The status of the service-specific credential. Active means that the key
+	// is valid for API calls, while Inactive means it is not.
 	//
 	// Status is a required field
 	Status *string `type:"string" required:"true" enum:"statusType"`
@@ -25317,7 +25539,7 @@ func (s SetDefaultPolicyVersionOutput) GoString() string {
 // Contains information about an X.509 signing certificate.
 //
 // This data type is used as a response element in the UploadSigningCertificate
-// and ListSigningCertificates actions.
+// and ListSigningCertificates operations.
 type SigningCertificate struct {
 	_ struct{} `type:"structure"`
 
@@ -25331,8 +25553,8 @@ type SigningCertificate struct {
 	// CertificateId is a required field
 	CertificateId *string `min:"24" type:"string" required:"true"`
 
-	// The status of the signing certificate. Active means the key is valid for
-	// API calls, while Inactive means it is not.
+	// The status of the signing certificate. Active means that the key is valid
+	// for API calls, while Inactive means it is not.
 	//
 	// Status is a required field
 	Status *string `type:"string" required:"true" enum:"statusType"`
@@ -25389,16 +25611,17 @@ func (s *SigningCertificate) SetUserName(v string) *SigningCertificate {
 type SimulateCustomPolicyInput struct {
 	_ struct{} `type:"structure"`
 
-	// A list of names of API actions to evaluate in the simulation. Each action
-	// is evaluated against each resource. Each action must include the service
+	// A list of names of API operations to evaluate in the simulation. Each operation
+	// is evaluated against each resource. Each operation must include the service
 	// identifier, such as iam:CreateUser.
 	//
 	// ActionNames is a required field
 	ActionNames []*string `type:"list" required:"true"`
 
 	// The ARN of the IAM user that you want to use as the simulated caller of the
-	// APIs. CallerArn is required if you include a ResourcePolicy so that the policy's
-	// Principal element has a value to use in evaluating the policy.
+	// API operations. CallerArn is required if you include a ResourcePolicy so
+	// that the policy's Principal element has a value to use in evaluating the
+	// policy.
 	//
 	// You can specify only the ARN of an IAM user. You cannot specify the ARN of
 	// an assumed role, federated user, or a service principal.
@@ -25433,14 +25656,20 @@ type SimulateCustomPolicyInput struct {
 	// The policies cannot be "scope-down" policies, such as you could include in
 	// a call to GetFederationToken (http://docs.aws.amazon.com/IAM/latest/APIReference/API_GetFederationToken.html)
 	// or one of the AssumeRole (http://docs.aws.amazon.com/IAM/latest/APIReference/API_AssumeRole.html)
-	// APIs to restrict what a user can do while using the temporary credentials.
+	// API operations. In other words, do not use policies designed to restrict
+	// what a user can do while using the temporary credentials.
 	//
 	// The regex pattern (http://wikipedia.org/wiki/regex) used to validate this
-	// parameter is a string of characters consisting of any printable ASCII character
-	// ranging from the space character (\u0020) through end of the ASCII character
-	// range as well as the printable characters in the Basic Latin and Latin-1
-	// Supplement character set (through \u00FF). It also includes the special characters
-	// tab (\u0009), line feed (\u000A), and carriage return (\u000D).
+	// parameter is a string of characters consisting of the following:
+	//
+	//    * Any printable ASCII character ranging from the space character (\u0020)
+	//    through the end of the ASCII character range
+	//
+	//    * The printable characters in the Basic Latin and Latin-1 Supplement character
+	//    set (through \u00FF)
+	//
+	//    * The special characters tab (\u0009), line feed (\u000A), and carriage
+	//    return (\u000D)
 	//
 	// PolicyInputList is a required field
 	PolicyInputList []*string `type:"list" required:"true"`
@@ -25463,13 +25692,13 @@ type SimulateCustomPolicyInput struct {
 	// in the AWS General Reference.
 	ResourceArns []*string `type:"list"`
 
-	// Specifies the type of simulation to run. Different APIs that support resource-based
-	// policies require different combinations of resources. By specifying the type
-	// of simulation to run, you enable the policy simulator to enforce the presence
-	// of the required resources to ensure reliable simulation results. If your
-	// simulation does not match one of the following scenarios, then you can omit
-	// this parameter. The following list shows each of the supported scenario values
-	// and the resources that you must define to run the simulation.
+	// Specifies the type of simulation to run. Different API operations that support
+	// resource-based policies require different combinations of resources. By specifying
+	// the type of simulation to run, you enable the policy simulator to enforce
+	// the presence of the required resources to ensure reliable simulation results.
+	// If your simulation does not match one of the following scenarios, then you
+	// can omit this parameter. The following list shows each of the supported scenario
+	// values and the resources that you must define to run the simulation.
 	//
 	// Each of the EC2 scenarios requires that you specify instance, image, and
 	// security-group resources. If your scenario includes an EBS volume, then you
@@ -25477,7 +25706,7 @@ type SimulateCustomPolicyInput struct {
 	// then you must supply the network-interface resource. If it includes an IP
 	// subnet, then you must specify the subnet resource. For more information on
 	// the EC2 scenario options, see Supported Platforms (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-supported-platforms.html)
-	// in the AWS EC2 User Guide.
+	// in the Amazon EC2 User Guide.
 	//
 	//    * EC2-Classic-InstanceStore
 	//
@@ -25520,11 +25749,16 @@ type SimulateCustomPolicyInput struct {
 	// You can include only one resource-based policy in a simulation.
 	//
 	// The regex pattern (http://wikipedia.org/wiki/regex) used to validate this
-	// parameter is a string of characters consisting of any printable ASCII character
-	// ranging from the space character (\u0020) through end of the ASCII character
-	// range as well as the printable characters in the Basic Latin and Latin-1
-	// Supplement character set (through \u00FF). It also includes the special characters
-	// tab (\u0009), line feed (\u000A), and carriage return (\u000D).
+	// parameter is a string of characters consisting of the following:
+	//
+	//    * Any printable ASCII character ranging from the space character (\u0020)
+	//    through the end of the ASCII character range
+	//
+	//    * The printable characters in the Basic Latin and Latin-1 Supplement character
+	//    set (through \u00FF)
+	//
+	//    * The special characters tab (\u0009), line feed (\u000A), and carriage
+	//    return (\u000D)
 	ResourcePolicy *string `min:"1" type:"string"`
 }
 
@@ -25694,19 +25928,20 @@ func (s *SimulatePolicyResponse) SetMarker(v string) *SimulatePolicyResponse {
 type SimulatePrincipalPolicyInput struct {
 	_ struct{} `type:"structure"`
 
-	// A list of names of API actions to evaluate in the simulation. Each action
-	// is evaluated for each resource. Each action must include the service identifier,
+	// A list of names of API operations to evaluate in the simulation. Each operation
+	// is evaluated for each resource. Each operation must include the service identifier,
 	// such as iam:CreateUser.
 	//
 	// ActionNames is a required field
 	ActionNames []*string `type:"list" required:"true"`
 
 	// The ARN of the IAM user that you want to specify as the simulated caller
-	// of the APIs. If you do not specify a CallerArn, it defaults to the ARN of
-	// the user that you specify in PolicySourceArn, if you specified a user. If
-	// you include both a PolicySourceArn (for example, arn:aws:iam::123456789012:user/David)
+	// of the API operations. If you do not specify a CallerArn, it defaults to
+	// the ARN of the user that you specify in PolicySourceArn, if you specified
+	// a user. If you include both a PolicySourceArn (for example, arn:aws:iam::123456789012:user/David)
 	// and a CallerArn (for example, arn:aws:iam::123456789012:user/Bob), the result
-	// is that you simulate calling the APIs as Bob, as if Bob had David's policies.
+	// is that you simulate calling the API operations as Bob, as if Bob had David's
+	// policies.
 	//
 	// You can specify only the ARN of an IAM user. You cannot specify the ARN of
 	// an assumed role, federated user, or a service principal.
@@ -25747,11 +25982,16 @@ type SimulatePrincipalPolicyInput struct {
 	// text of an IAM policy.
 	//
 	// The regex pattern (http://wikipedia.org/wiki/regex) used to validate this
-	// parameter is a string of characters consisting of any printable ASCII character
-	// ranging from the space character (\u0020) through end of the ASCII character
-	// range as well as the printable characters in the Basic Latin and Latin-1
-	// Supplement character set (through \u00FF). It also includes the special characters
-	// tab (\u0009), line feed (\u000A), and carriage return (\u000D).
+	// parameter is a string of characters consisting of the following:
+	//
+	//    * Any printable ASCII character ranging from the space character (\u0020)
+	//    through the end of the ASCII character range
+	//
+	//    * The printable characters in the Basic Latin and Latin-1 Supplement character
+	//    set (through \u00FF)
+	//
+	//    * The special characters tab (\u0009), line feed (\u000A), and carriage
+	//    return (\u000D)
 	PolicyInputList []*string `type:"list"`
 
 	// The Amazon Resource Name (ARN) of a user, group, or role whose policies you
@@ -25768,7 +26008,7 @@ type SimulatePrincipalPolicyInput struct {
 	PolicySourceArn *string `min:"20" type:"string" required:"true"`
 
 	// A list of ARNs of AWS resources to include in the simulation. If this parameter
-	// is not provided then the value defaults to * (all resources). Each API in
+	// is not provided, then the value defaults to * (all resources). Each API in
 	// the ActionNames parameter is evaluated for each resource in this list. The
 	// simulation determines the access result (allowed or denied) of each combination
 	// and reports it in the response.
@@ -25782,13 +26022,13 @@ type SimulatePrincipalPolicyInput struct {
 	// in the AWS General Reference.
 	ResourceArns []*string `type:"list"`
 
-	// Specifies the type of simulation to run. Different APIs that support resource-based
-	// policies require different combinations of resources. By specifying the type
-	// of simulation to run, you enable the policy simulator to enforce the presence
-	// of the required resources to ensure reliable simulation results. If your
-	// simulation does not match one of the following scenarios, then you can omit
-	// this parameter. The following list shows each of the supported scenario values
-	// and the resources that you must define to run the simulation.
+	// Specifies the type of simulation to run. Different API operations that support
+	// resource-based policies require different combinations of resources. By specifying
+	// the type of simulation to run, you enable the policy simulator to enforce
+	// the presence of the required resources to ensure reliable simulation results.
+	// If your simulation does not match one of the following scenarios, then you
+	// can omit this parameter. The following list shows each of the supported scenario
+	// values and the resources that you must define to run the simulation.
 	//
 	// Each of the EC2 scenarios requires that you specify instance, image, and
 	// security-group resources. If your scenario includes an EBS volume, then you
@@ -25796,7 +26036,7 @@ type SimulatePrincipalPolicyInput struct {
 	// then you must supply the network-interface resource. If it includes an IP
 	// subnet, then you must specify the subnet resource. For more information on
 	// the EC2 scenario options, see Supported Platforms (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-supported-platforms.html)
-	// in the AWS EC2 User Guide.
+	// in the Amazon EC2 User Guide.
 	//
 	//    * EC2-Classic-InstanceStore
 	//
@@ -25839,11 +26079,16 @@ type SimulatePrincipalPolicyInput struct {
 	// You can include only one resource-based policy in a simulation.
 	//
 	// The regex pattern (http://wikipedia.org/wiki/regex) used to validate this
-	// parameter is a string of characters consisting of any printable ASCII character
-	// ranging from the space character (\u0020) through end of the ASCII character
-	// range as well as the printable characters in the Basic Latin and Latin-1
-	// Supplement character set (through \u00FF). It also includes the special characters
-	// tab (\u0009), line feed (\u000A), and carriage return (\u000D).
+	// parameter is a string of characters consisting of the following:
+	//
+	//    * Any printable ASCII character ranging from the space character (\u0020)
+	//    through the end of the ASCII character range
+	//
+	//    * The printable characters in the Basic Latin and Latin-1 Supplement character
+	//    set (through \u00FF)
+	//
+	//    * The special characters tab (\u0009), line feed (\u000A), and carriage
+	//    return (\u000D)
 	ResourcePolicy *string `min:"1" type:"string"`
 }
 
@@ -26037,9 +26282,9 @@ type UpdateAccessKeyInput struct {
 	// AccessKeyId is a required field
 	AccessKeyId *string `min:"16" type:"string" required:"true"`
 
-	// The status you want to assign to the secret access key. Active means the
-	// key can be used for API calls to AWS, while Inactive means the key cannot
-	// be used.
+	// The status you want to assign to the secret access key. Active means that
+	// the key can be used for API calls to AWS, while Inactive means that the key
+	// cannot be used.
 	//
 	// Status is a required field
 	Status *string `type:"string" required:"true" enum:"statusType"`
@@ -26048,7 +26293,7 @@ type UpdateAccessKeyInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	UserName *string `min:"1" type:"string"`
 }
 
@@ -26124,42 +26369,53 @@ type UpdateAccountPasswordPolicyInput struct {
 	// Their Own Passwords (http://docs.aws.amazon.com/IAM/latest/UserGuide/HowToPwdIAMUser.html)
 	// in the IAM User Guide.
 	//
-	// Default value: false
+	// If you do not specify a value for this parameter, then the operation uses
+	// the default value of false. The result is that IAM users in the account do
+	// not automatically have permissions to change their own password.
 	AllowUsersToChangePassword *bool `type:"boolean"`
 
 	// Prevents IAM users from setting a new password after their password has expired.
+	// The IAM user cannot be accessed until an administrator resets the password.
 	//
-	// Default value: false
+	// If you do not specify a value for this parameter, then the operation uses
+	// the default value of false. The result is that IAM users can change their
+	// passwords after they expire and continue to sign in as the user.
 	HardExpiry *bool `type:"boolean"`
 
-	// The number of days that an IAM user password is valid. The default value
-	// of 0 means IAM user passwords never expire.
+	// The number of days that an IAM user password is valid.
 	//
-	// Default value: 0
+	// If you do not specify a value for this parameter, then the operation uses
+	// the default value of 0. The result is that IAM user passwords never expire.
 	MaxPasswordAge *int64 `min:"1" type:"integer"`
 
 	// The minimum number of characters allowed in an IAM user password.
 	//
-	// Default value: 6
+	// If you do not specify a value for this parameter, then the operation uses
+	// the default value of 6.
 	MinimumPasswordLength *int64 `min:"6" type:"integer"`
 
 	// Specifies the number of previous passwords that IAM users are prevented from
-	// reusing. The default value of 0 means IAM users are not prevented from reusing
-	// previous passwords.
+	// reusing.
 	//
-	// Default value: 0
+	// If you do not specify a value for this parameter, then the operation uses
+	// the default value of 0. The result is that IAM users are not prevented from
+	// reusing previous passwords.
 	PasswordReusePrevention *int64 `min:"1" type:"integer"`
 
 	// Specifies whether IAM user passwords must contain at least one lowercase
 	// character from the ISO basic Latin alphabet (a to z).
 	//
-	// Default value: false
+	// If you do not specify a value for this parameter, then the operation uses
+	// the default value of false. The result is that passwords do not require at
+	// least one lowercase character.
 	RequireLowercaseCharacters *bool `type:"boolean"`
 
 	// Specifies whether IAM user passwords must contain at least one numeric character
 	// (0 to 9).
 	//
-	// Default value: false
+	// If you do not specify a value for this parameter, then the operation uses
+	// the default value of false. The result is that passwords do not require at
+	// least one numeric character.
 	RequireNumbers *bool `type:"boolean"`
 
 	// Specifies whether IAM user passwords must contain at least one of the following
@@ -26167,13 +26423,17 @@ type UpdateAccountPasswordPolicyInput struct {
 	//
 	// ! @ # $ % ^ & * ( ) _ + - = [ ] { } | '
 	//
-	// Default value: false
+	// If you do not specify a value for this parameter, then the operation uses
+	// the default value of false. The result is that passwords do not require at
+	// least one symbol character.
 	RequireSymbols *bool `type:"boolean"`
 
 	// Specifies whether IAM user passwords must contain at least one uppercase
 	// character from the ISO basic Latin alphabet (A to Z).
 	//
-	// Default value: false
+	// If you do not specify a value for this parameter, then the operation uses
+	// the default value of false. The result is that passwords do not require at
+	// least one uppercase character.
 	RequireUppercaseCharacters *bool `type:"boolean"`
 }
 
@@ -26280,11 +26540,16 @@ type UpdateAssumeRolePolicyInput struct {
 	// The policy that grants an entity permission to assume the role.
 	//
 	// The regex pattern (http://wikipedia.org/wiki/regex) used to validate this
-	// parameter is a string of characters consisting of any printable ASCII character
-	// ranging from the space character (\u0020) through end of the ASCII character
-	// range as well as the printable characters in the Basic Latin and Latin-1
-	// Supplement character set (through \u00FF). It also includes the special characters
-	// tab (\u0009), line feed (\u000A), and carriage return (\u000D).
+	// parameter is a string of characters consisting of the following:
+	//
+	//    * Any printable ASCII character ranging from the space character (\u0020)
+	//    through the end of the ASCII character range
+	//
+	//    * The printable characters in the Basic Latin and Latin-1 Supplement character
+	//    set (through \u00FF)
+	//
+	//    * The special characters tab (\u0009), line feed (\u000A), and carriage
+	//    return (\u000D)
 	//
 	// PolicyDocument is a required field
 	PolicyDocument *string `min:"1" type:"string" required:"true"`
@@ -26365,7 +26630,7 @@ type UpdateGroupInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// GroupName is a required field
 	GroupName *string `min:"1" type:"string" required:"true"`
@@ -26374,16 +26639,17 @@ type UpdateGroupInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	NewGroupName *string `min:"1" type:"string"`
 
 	// New path for the IAM group. Only include this if changing the group's path.
 	//
-	// This paramater allows (per its regex pattern (http://wikipedia.org/wiki/regex))
+	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of either a forward slash (/) by itself
-	// or a string that must begin and end with forward slashes, containing any
-	// ASCII character from the ! (\u0021) thru the DEL character (\u007F), including
-	// most punctuation characters, digits, and upper and lowercased letters.
+	// or a string that must begin and end with forward slashes. In addition, it
+	// can contain any ASCII character from the ! (\u0021) through the DEL character
+	// (\u007F), including most punctuation characters, digits, and upper and lowercased
+	// letters.
 	NewPath *string `min:"1" type:"string"`
 }
 
@@ -26457,13 +26723,20 @@ type UpdateLoginProfileInput struct {
 	// The new password for the specified IAM user.
 	//
 	// The regex pattern (http://wikipedia.org/wiki/regex) used to validate this
-	// parameter is a string of characters consisting of any printable ASCII character
-	// ranging from the space character (\u0020) through end of the ASCII character
-	// range as well as the printable characters in the Basic Latin and Latin-1
-	// Supplement character set (through \u00FF). It also includes the special characters
-	// tab (\u0009), line feed (\u000A), and carriage return (\u000D). However,
-	// the format can be further restricted by the account administrator by setting
-	// a password policy on the AWS account. For more information, see UpdateAccountPasswordPolicy.
+	// parameter is a string of characters consisting of the following:
+	//
+	//    * Any printable ASCII character ranging from the space character (\u0020)
+	//    through the end of the ASCII character range
+	//
+	//    * The printable characters in the Basic Latin and Latin-1 Supplement character
+	//    set (through \u00FF)
+	//
+	//    * The special characters tab (\u0009), line feed (\u000A), and carriage
+	//    return (\u000D)
+	//
+	// However, the format can be further restricted by the account administrator
+	// by setting a password policy on the AWS account. For more information, see
+	// UpdateAccountPasswordPolicy.
 	Password *string `min:"1" type:"string"`
 
 	// Allows this new password to be used only once by requiring the specified
@@ -26474,7 +26747,7 @@ type UpdateLoginProfileInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// UserName is a required field
 	UserName *string `min:"1" type:"string" required:"true"`
@@ -26546,7 +26819,7 @@ type UpdateOpenIDConnectProviderThumbprintInput struct {
 
 	// The Amazon Resource Name (ARN) of the IAM OIDC provider resource object for
 	// which you want to update the thumbprint. You can get a list of OIDC provider
-	// ARNs by using the ListOpenIDConnectProviders action.
+	// ARNs by using the ListOpenIDConnectProviders operation.
 	//
 	// For more information about ARNs, see Amazon Resource Names (ARNs) and AWS
 	// Service Namespaces (http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
@@ -26695,6 +26968,95 @@ func (s *UpdateRoleDescriptionOutput) SetRole(v *Role) *UpdateRoleDescriptionOut
 	return s
 }
 
+type UpdateRoleInput struct {
+	_ struct{} `type:"structure"`
+
+	// The new description that you want to apply to the specified role.
+	Description *string `type:"string"`
+
+	// The maximum session duration (in seconds) that you want to set for the specified
+	// role. If you do not specify a value for this setting, the default maximum
+	// of one hour is applied. This setting can have a value from 1 hour to 12 hours.
+	//
+	// Anyone who assumes the role from the AWS CLI or API can use the DurationSeconds
+	// API parameter or the duration-seconds CLI parameter to request a longer session.
+	// The MaxSessionDuration setting determines the maximum duration that can be
+	// requested using the DurationSeconds parameter. If users don't specify a value
+	// for the DurationSeconds parameter, their security credentials are valid for
+	// one hour by default. This applies when you use the AssumeRole* API operations
+	// or the assume-role* CLI operations but does not apply when you use those
+	// operations to create a console URL. For more information, see Using IAM Roles
+	// (http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html) in the
+	// IAM User Guide.
+	MaxSessionDuration *int64 `min:"3600" type:"integer"`
+
+	// The name of the role that you want to modify.
+	//
+	// RoleName is a required field
+	RoleName *string `min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s UpdateRoleInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateRoleInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateRoleInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateRoleInput"}
+	if s.MaxSessionDuration != nil && *s.MaxSessionDuration < 3600 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxSessionDuration", 3600))
+	}
+	if s.RoleName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleName"))
+	}
+	if s.RoleName != nil && len(*s.RoleName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDescription sets the Description field's value.
+func (s *UpdateRoleInput) SetDescription(v string) *UpdateRoleInput {
+	s.Description = &v
+	return s
+}
+
+// SetMaxSessionDuration sets the MaxSessionDuration field's value.
+func (s *UpdateRoleInput) SetMaxSessionDuration(v int64) *UpdateRoleInput {
+	s.MaxSessionDuration = &v
+	return s
+}
+
+// SetRoleName sets the RoleName field's value.
+func (s *UpdateRoleInput) SetRoleName(v string) *UpdateRoleInput {
+	s.RoleName = &v
+	return s
+}
+
+type UpdateRoleOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateRoleOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateRoleOutput) GoString() string {
+	return s.String()
+}
+
 type UpdateSAMLProviderInput struct {
 	_ struct{} `type:"structure"`
 
@@ -26797,9 +27159,9 @@ type UpdateSSHPublicKeyInput struct {
 	// SSHPublicKeyId is a required field
 	SSHPublicKeyId *string `min:"20" type:"string" required:"true"`
 
-	// The status to assign to the SSH public key. Active means the key can be used
-	// for authentication with an AWS CodeCommit repository. Inactive means the
-	// key cannot be used.
+	// The status to assign to the SSH public key. Active means that the key can
+	// be used for authentication with an AWS CodeCommit repository. Inactive means
+	// that the key cannot be used.
 	//
 	// Status is a required field
 	Status *string `type:"string" required:"true" enum:"statusType"`
@@ -26808,7 +27170,7 @@ type UpdateSSHPublicKeyInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// UserName is a required field
 	UserName *string `min:"1" type:"string" required:"true"`
@@ -26887,11 +27249,12 @@ type UpdateServerCertificateInput struct {
 	// The new path for the server certificate. Include this only if you are updating
 	// the server certificate's path.
 	//
-	// This paramater allows (per its regex pattern (http://wikipedia.org/wiki/regex))
+	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of either a forward slash (/) by itself
-	// or a string that must begin and end with forward slashes, containing any
-	// ASCII character from the ! (\u0021) thru the DEL character (\u007F), including
-	// most punctuation characters, digits, and upper and lowercased letters.
+	// or a string that must begin and end with forward slashes. In addition, it
+	// can contain any ASCII character from the ! (\u0021) through the DEL character
+	// (\u007F), including most punctuation characters, digits, and upper and lowercased
+	// letters.
 	NewPath *string `min:"1" type:"string"`
 
 	// The new name for the server certificate. Include this only if you are updating
@@ -26900,14 +27263,14 @@ type UpdateServerCertificateInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	NewServerCertificateName *string `min:"1" type:"string"`
 
 	// The name of the server certificate that you want to update.
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// ServerCertificateName is a required field
 	ServerCertificateName *string `min:"1" type:"string" required:"true"`
@@ -27000,7 +27363,7 @@ type UpdateServiceSpecificCredentialInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	UserName *string `min:"1" type:"string"`
 }
 
@@ -27080,8 +27443,8 @@ type UpdateSigningCertificateInput struct {
 	// CertificateId is a required field
 	CertificateId *string `min:"24" type:"string" required:"true"`
 
-	// The status you want to assign to the certificate. Active means the certificate
-	// can be used for API calls to AWS, while Inactive means the certificate cannot
+	// The status you want to assign to the certificate. Active means that the certificate
+	// can be used for API calls to AWS Inactive means that the certificate cannot
 	// be used.
 	//
 	// Status is a required field
@@ -27091,7 +27454,7 @@ type UpdateSigningCertificateInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	UserName *string `min:"1" type:"string"`
 }
 
@@ -27165,11 +27528,12 @@ type UpdateUserInput struct {
 	// New path for the IAM user. Include this parameter only if you're changing
 	// the user's path.
 	//
-	// This paramater allows (per its regex pattern (http://wikipedia.org/wiki/regex))
+	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of either a forward slash (/) by itself
-	// or a string that must begin and end with forward slashes, containing any
-	// ASCII character from the ! (\u0021) thru the DEL character (\u007F), including
-	// most punctuation characters, digits, and upper and lowercased letters.
+	// or a string that must begin and end with forward slashes. In addition, it
+	// can contain any ASCII character from the ! (\u0021) through the DEL character
+	// (\u007F), including most punctuation characters, digits, and upper and lowercased
+	// letters.
 	NewPath *string `min:"1" type:"string"`
 
 	// New name for the user. Include this parameter only if you're changing the
@@ -27177,7 +27541,7 @@ type UpdateUserInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	NewUserName *string `min:"1" type:"string"`
 
 	// Name of the user to update. If you're changing the name of the user, this
@@ -27185,7 +27549,7 @@ type UpdateUserInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// UserName is a required field
 	UserName *string `min:"1" type:"string" required:"true"`
@@ -27262,11 +27626,16 @@ type UploadSSHPublicKeyInput struct {
 	// format.
 	//
 	// The regex pattern (http://wikipedia.org/wiki/regex) used to validate this
-	// parameter is a string of characters consisting of any printable ASCII character
-	// ranging from the space character (\u0020) through end of the ASCII character
-	// range as well as the printable characters in the Basic Latin and Latin-1
-	// Supplement character set (through \u00FF). It also includes the special characters
-	// tab (\u0009), line feed (\u000A), and carriage return (\u000D).
+	// parameter is a string of characters consisting of the following:
+	//
+	//    * Any printable ASCII character ranging from the space character (\u0020)
+	//    through the end of the ASCII character range
+	//
+	//    * The printable characters in the Basic Latin and Latin-1 Supplement character
+	//    set (through \u00FF)
+	//
+	//    * The special characters tab (\u0009), line feed (\u000A), and carriage
+	//    return (\u000D)
 	//
 	// SSHPublicKeyBody is a required field
 	SSHPublicKeyBody *string `min:"1" type:"string" required:"true"`
@@ -27275,7 +27644,7 @@ type UploadSSHPublicKeyInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// UserName is a required field
 	UserName *string `min:"1" type:"string" required:"true"`
@@ -27355,11 +27724,16 @@ type UploadServerCertificateInput struct {
 	// The contents of the public key certificate in PEM-encoded format.
 	//
 	// The regex pattern (http://wikipedia.org/wiki/regex) used to validate this
-	// parameter is a string of characters consisting of any printable ASCII character
-	// ranging from the space character (\u0020) through end of the ASCII character
-	// range as well as the printable characters in the Basic Latin and Latin-1
-	// Supplement character set (through \u00FF). It also includes the special characters
-	// tab (\u0009), line feed (\u000A), and carriage return (\u000D).
+	// parameter is a string of characters consisting of the following:
+	//
+	//    * Any printable ASCII character ranging from the space character (\u0020)
+	//    through the end of the ASCII character range
+	//
+	//    * The printable characters in the Basic Latin and Latin-1 Supplement character
+	//    set (through \u00FF)
+	//
+	//    * The special characters tab (\u0009), line feed (\u000A), and carriage
+	//    return (\u000D)
 	//
 	// CertificateBody is a required field
 	CertificateBody *string `min:"1" type:"string" required:"true"`
@@ -27368,11 +27742,16 @@ type UploadServerCertificateInput struct {
 	// of the PEM-encoded public key certificates of the chain.
 	//
 	// The regex pattern (http://wikipedia.org/wiki/regex) used to validate this
-	// parameter is a string of characters consisting of any printable ASCII character
-	// ranging from the space character (\u0020) through end of the ASCII character
-	// range as well as the printable characters in the Basic Latin and Latin-1
-	// Supplement character set (through \u00FF). It also includes the special characters
-	// tab (\u0009), line feed (\u000A), and carriage return (\u000D).
+	// parameter is a string of characters consisting of the following:
+	//
+	//    * Any printable ASCII character ranging from the space character (\u0020)
+	//    through the end of the ASCII character range
+	//
+	//    * The printable characters in the Basic Latin and Latin-1 Supplement character
+	//    set (through \u00FF)
+	//
+	//    * The special characters tab (\u0009), line feed (\u000A), and carriage
+	//    return (\u000D)
 	CertificateChain *string `min:"1" type:"string"`
 
 	// The path for the server certificate. For more information about paths, see
@@ -27380,14 +27759,15 @@ type UploadServerCertificateInput struct {
 	// in the IAM User Guide.
 	//
 	// This parameter is optional. If it is not included, it defaults to a slash
-	// (/). This paramater allows (per its regex pattern (http://wikipedia.org/wiki/regex))
+	// (/). This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of either a forward slash (/) by itself
-	// or a string that must begin and end with forward slashes, containing any
-	// ASCII character from the ! (\u0021) thru the DEL character (\u007F), including
-	// most punctuation characters, digits, and upper and lowercased letters.
+	// or a string that must begin and end with forward slashes. In addition, it
+	// can contain any ASCII character from the ! (\u0021) through the DEL character
+	// (\u007F), including most punctuation characters, digits, and upper and lowercased
+	// letters.
 	//
 	// If you are uploading a server certificate specifically for use with Amazon
-	// CloudFront distributions, you must specify a path using the --path option.
+	// CloudFront distributions, you must specify a path using the path parameter.
 	// The path must begin with /cloudfront and must include a trailing slash (for
 	// example, /cloudfront/test/).
 	Path *string `min:"1" type:"string"`
@@ -27395,11 +27775,16 @@ type UploadServerCertificateInput struct {
 	// The contents of the private key in PEM-encoded format.
 	//
 	// The regex pattern (http://wikipedia.org/wiki/regex) used to validate this
-	// parameter is a string of characters consisting of any printable ASCII character
-	// ranging from the space character (\u0020) through end of the ASCII character
-	// range as well as the printable characters in the Basic Latin and Latin-1
-	// Supplement character set (through \u00FF). It also includes the special characters
-	// tab (\u0009), line feed (\u000A), and carriage return (\u000D).
+	// parameter is a string of characters consisting of the following:
+	//
+	//    * Any printable ASCII character ranging from the space character (\u0020)
+	//    through the end of the ASCII character range
+	//
+	//    * The printable characters in the Basic Latin and Latin-1 Supplement character
+	//    set (through \u00FF)
+	//
+	//    * The special characters tab (\u0009), line feed (\u000A), and carriage
+	//    return (\u000D)
 	//
 	// PrivateKey is a required field
 	PrivateKey *string `min:"1" type:"string" required:"true"`
@@ -27409,7 +27794,7 @@ type UploadServerCertificateInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	//
 	// ServerCertificateName is a required field
 	ServerCertificateName *string `min:"1" type:"string" required:"true"`
@@ -27520,11 +27905,16 @@ type UploadSigningCertificateInput struct {
 	// The contents of the signing certificate.
 	//
 	// The regex pattern (http://wikipedia.org/wiki/regex) used to validate this
-	// parameter is a string of characters consisting of any printable ASCII character
-	// ranging from the space character (\u0020) through end of the ASCII character
-	// range as well as the printable characters in the Basic Latin and Latin-1
-	// Supplement character set (through \u00FF). It also includes the special characters
-	// tab (\u0009), line feed (\u000A), and carriage return (\u000D).
+	// parameter is a string of characters consisting of the following:
+	//
+	//    * Any printable ASCII character ranging from the space character (\u0020)
+	//    through the end of the ASCII character range
+	//
+	//    * The printable characters in the Basic Latin and Latin-1 Supplement character
+	//    set (through \u00FF)
+	//
+	//    * The special characters tab (\u0009), line feed (\u000A), and carriage
+	//    return (\u000D)
 	//
 	// CertificateBody is a required field
 	CertificateBody *string `min:"1" type:"string" required:"true"`
@@ -27533,7 +27923,7 @@ type UploadSigningCertificateInput struct {
 	//
 	// This parameter allows (per its regex pattern (http://wikipedia.org/wiki/regex))
 	// a string of characters consisting of upper and lowercase alphanumeric characters
-	// with no spaces. You can also include any of the following characters: =,.@-
+	// with no spaces. You can also include any of the following characters: _+=,.@-
 	UserName *string `min:"1" type:"string"`
 }
 
@@ -27606,7 +27996,7 @@ func (s *UploadSigningCertificateOutput) SetCertificate(v *SigningCertificate) *
 
 // Contains information about an IAM user entity.
 //
-// This data type is used as a response element in the following actions:
+// This data type is used as a response element in the following operations:
 //
 //    * CreateUser
 //
@@ -27647,7 +28037,7 @@ type User struct {
 	// does not currently have a password, but had one in the past, then this field
 	// contains the date and time the most recent password was used.
 	//
-	// This value is returned only in the GetUser and ListUsers actions.
+	// This value is returned only in the GetUser and ListUsers operations.
 	PasswordLastUsed *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
 	// The path to the user. For more information about paths, see IAM Identifiers
@@ -27720,7 +28110,7 @@ func (s *User) SetUserName(v string) *User {
 // and all the IAM groups the user is in.
 //
 // This data type is used as a response element in the GetAccountAuthorizationDetails
-// action.
+// operation.
 type UserDetail struct {
 	_ struct{} `type:"structure"`
 

--- a/vendor/github.com/aws/aws-sdk-go/service/sts/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/sts/api.go
@@ -88,9 +88,18 @@ func (c *STS) AssumeRoleRequest(input *AssumeRoleInput) (req *request.Request, o
 // Scenarios for Temporary Credentials (http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html#sts-introduction)
 // in the IAM User Guide.
 //
-// The temporary security credentials are valid for the duration that you specified
-// when calling AssumeRole, which can be from 900 seconds (15 minutes) to a
-// maximum of 3600 seconds (1 hour). The default is 1 hour.
+// By default, the temporary security credentials created by AssumeRole last
+// for one hour. However, you can use the optional DurationSeconds parameter
+// to specify the duration of your session. You can provide a value from 900
+// seconds (15 minutes) up to the maximum session duration setting for the role.
+// This setting can have a value from 1 hour to 12 hours. To learn how to view
+// the maximum value for your role, see View the Maximum Session Duration Setting
+// for a Role (http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html#id_roles_use_view-role-max-session)
+// in the IAM User Guide. The maximum session duration limit applies when you
+// use the AssumeRole* API operations or the assume-role* CLI operations but
+// does not apply when you use those operations to create a console URL. For
+// more information, see Using IAM Roles (http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html)
+// in the IAM User Guide.
 //
 // The temporary security credentials created by AssumeRole can be used to make
 // API calls to any AWS service with the following exception: you cannot call
@@ -252,11 +261,20 @@ func (c *STS) AssumeRoleWithSAMLRequest(input *AssumeRoleWithSAMLInput) (req *re
 // an access key ID, a secret access key, and a security token. Applications
 // can use these temporary security credentials to sign calls to AWS services.
 //
-// The temporary security credentials are valid for the duration that you specified
-// when calling AssumeRole, or until the time specified in the SAML authentication
-// response's SessionNotOnOrAfter value, whichever is shorter. The duration
-// can be from 900 seconds (15 minutes) to a maximum of 3600 seconds (1 hour).
-// The default is 1 hour.
+// By default, the temporary security credentials created by AssumeRoleWithSAML
+// last for one hour. However, you can use the optional DurationSeconds parameter
+// to specify the duration of your session. Your role session lasts for the
+// duration that you specify, or until the time specified in the SAML authentication
+// response's SessionNotOnOrAfter value, whichever is shorter. You can provide
+// a DurationSeconds value from 900 seconds (15 minutes) up to the maximum session
+// duration setting for the role. This setting can have a value from 1 hour
+// to 12 hours. To learn how to view the maximum value for your role, see View
+// the Maximum Session Duration Setting for a Role (http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html#id_roles_use_view-role-max-session)
+// in the IAM User Guide. The maximum session duration limit applies when you
+// use the AssumeRole* API operations or the assume-role* CLI operations but
+// does not apply when you use those operations to create a console URL. For
+// more information, see Using IAM Roles (http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html)
+// in the IAM User Guide.
 //
 // The temporary security credentials created by AssumeRoleWithSAML can be used
 // to make API calls to any AWS service with the following exception: you cannot
@@ -443,9 +461,18 @@ func (c *STS) AssumeRoleWithWebIdentityRequest(input *AssumeRoleWithWebIdentityI
 // key ID, a secret access key, and a security token. Applications can use these
 // temporary security credentials to sign calls to AWS service APIs.
 //
-// The credentials are valid for the duration that you specified when calling
-// AssumeRoleWithWebIdentity, which can be from 900 seconds (15 minutes) to
-// a maximum of 3600 seconds (1 hour). The default is 1 hour.
+// By default, the temporary security credentials created by AssumeRoleWithWebIdentity
+// last for one hour. However, you can use the optional DurationSeconds parameter
+// to specify the duration of your session. You can provide a value from 900
+// seconds (15 minutes) up to the maximum session duration setting for the role.
+// This setting can have a value from 1 hour to 12 hours. To learn how to view
+// the maximum value for your role, see View the Maximum Session Duration Setting
+// for a Role (http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html#id_roles_use_view-role-max-session)
+// in the IAM User Guide. The maximum session duration limit applies when you
+// use the AssumeRole* API operations or the assume-role* CLI operations but
+// does not apply when you use those operations to create a console URL. For
+// more information, see Using IAM Roles (http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html)
+// in the IAM User Guide.
 //
 // The temporary security credentials created by AssumeRoleWithWebIdentity can
 // be used to make API calls to any AWS service with the following exception:
@@ -1058,15 +1085,23 @@ type AssumeRoleInput struct {
 	_ struct{} `type:"structure"`
 
 	// The duration, in seconds, of the role session. The value can range from 900
-	// seconds (15 minutes) to 3600 seconds (1 hour). By default, the value is set
-	// to 3600 seconds.
+	// seconds (15 minutes) up to the maximum session duration setting for the role.
+	// This setting can have a value from 1 hour to 12 hours. If you specify a value
+	// higher than this setting, the operation fails. For example, if you specify
+	// a session duration of 12 hours, but your administrator set the maximum session
+	// duration to 6 hours, your operation fails. To learn how to view the maximum
+	// value for your role, see View the Maximum Session Duration Setting for a
+	// Role (http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html#id_roles_use_view-role-max-session)
+	// in the IAM User Guide.
 	//
-	// This is separate from the duration of a console session that you might request
-	// using the returned credentials. The request to the federation endpoint for
-	// a console sign-in token takes a SessionDuration parameter that specifies
-	// the maximum length of the console session, separately from the DurationSeconds
-	// parameter on this API. For more information, see Creating a URL that Enables
-	// Federated Users to Access the AWS Management Console (http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-custom-url.html)
+	// By default, the value is set to 3600 seconds.
+	//
+	// The DurationSeconds parameter is separate from the duration of a console
+	// session that you might request using the returned credentials. The request
+	// to the federation endpoint for a console sign-in token takes a SessionDuration
+	// parameter that specifies the maximum length of the console session. For more
+	// information, see Creating a URL that Enables Federated Users to Access the
+	// AWS Management Console (http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-custom-url.html)
 	// in the IAM User Guide.
 	DurationSeconds *int64 `min:"900" type:"integer"`
 
@@ -1301,18 +1336,27 @@ func (s *AssumeRoleOutput) SetPackedPolicySize(v int64) *AssumeRoleOutput {
 type AssumeRoleWithSAMLInput struct {
 	_ struct{} `type:"structure"`
 
-	// The duration, in seconds, of the role session. The value can range from 900
-	// seconds (15 minutes) to 3600 seconds (1 hour). By default, the value is set
-	// to 3600 seconds. An expiration can also be specified in the SAML authentication
-	// response's SessionNotOnOrAfter value. The actual expiration time is whichever
-	// value is shorter.
+	// The duration, in seconds, of the role session. Your role session lasts for
+	// the duration that you specify for the DurationSeconds parameter, or until
+	// the time specified in the SAML authentication response's SessionNotOnOrAfter
+	// value, whichever is shorter. You can provide a DurationSeconds value from
+	// 900 seconds (15 minutes) up to the maximum session duration setting for the
+	// role. This setting can have a value from 1 hour to 12 hours. If you specify
+	// a value higher than this setting, the operation fails. For example, if you
+	// specify a session duration of 12 hours, but your administrator set the maximum
+	// session duration to 6 hours, your operation fails. To learn how to view the
+	// maximum value for your role, see View the Maximum Session Duration Setting
+	// for a Role (http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html#id_roles_use_view-role-max-session)
+	// in the IAM User Guide.
 	//
-	// This is separate from the duration of a console session that you might request
-	// using the returned credentials. The request to the federation endpoint for
-	// a console sign-in token takes a SessionDuration parameter that specifies
-	// the maximum length of the console session, separately from the DurationSeconds
-	// parameter on this API. For more information, see Enabling SAML 2.0 Federated
-	// Users to Access the AWS Management Console (http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-saml.html)
+	// By default, the value is set to 3600 seconds.
+	//
+	// The DurationSeconds parameter is separate from the duration of a console
+	// session that you might request using the returned credentials. The request
+	// to the federation endpoint for a console sign-in token takes a SessionDuration
+	// parameter that specifies the maximum length of the console session. For more
+	// information, see Creating a URL that Enables Federated Users to Access the
+	// AWS Management Console (http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-custom-url.html)
 	// in the IAM User Guide.
 	DurationSeconds *int64 `min:"900" type:"integer"`
 
@@ -1553,15 +1597,23 @@ type AssumeRoleWithWebIdentityInput struct {
 	_ struct{} `type:"structure"`
 
 	// The duration, in seconds, of the role session. The value can range from 900
-	// seconds (15 minutes) to 3600 seconds (1 hour). By default, the value is set
-	// to 3600 seconds.
+	// seconds (15 minutes) up to the maximum session duration setting for the role.
+	// This setting can have a value from 1 hour to 12 hours. If you specify a value
+	// higher than this setting, the operation fails. For example, if you specify
+	// a session duration of 12 hours, but your administrator set the maximum session
+	// duration to 6 hours, your operation fails. To learn how to view the maximum
+	// value for your role, see View the Maximum Session Duration Setting for a
+	// Role (http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html#id_roles_use_view-role-max-session)
+	// in the IAM User Guide.
 	//
-	// This is separate from the duration of a console session that you might request
-	// using the returned credentials. The request to the federation endpoint for
-	// a console sign-in token takes a SessionDuration parameter that specifies
-	// the maximum length of the console session, separately from the DurationSeconds
-	// parameter on this API. For more information, see Creating a URL that Enables
-	// Federated Users to Access the AWS Management Console (http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-custom-url.html)
+	// By default, the value is set to 3600 seconds.
+	//
+	// The DurationSeconds parameter is separate from the duration of a console
+	// session that you might request using the returned credentials. The request
+	// to the federation endpoint for a console sign-in token takes a SessionDuration
+	// parameter that specifies the maximum length of the console session. For more
+	// information, see Creating a URL that Enables Federated Users to Access the
+	// AWS Management Console (http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-custom-url.html)
 	// in the IAM User Guide.
 	DurationSeconds *int64 `min:"900" type:"integer"`
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -39,884 +39,884 @@
 			"revisionTime": "2017-07-27T15:54:43Z"
 		},
 		{
-			"checksumSHA1": "y1bmVkrw6lKwgq8z+S3GzO1F5JE=",
+			"checksumSHA1": "cerwk42woNAlSP9r65gthJcuhzo=",
 			"path": "github.com/aws/aws-sdk-go/aws",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "DtuTqKH29YnLjrIJkRYX0HQtXY0=",
 			"path": "github.com/aws/aws-sdk-go/aws/arn",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "Y9W+4GimK4Fuxq+vyIskVYFRnX4=",
 			"path": "github.com/aws/aws-sdk-go/aws/awserr",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "yyYr41HZ1Aq0hWc3J5ijXwYEcac=",
 			"path": "github.com/aws/aws-sdk-go/aws/awsutil",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "hicPtITUionsA+dgs1SpsZUkQu4=",
 			"path": "github.com/aws/aws-sdk-go/aws/client",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "ieAJ+Cvp/PKv1LpUEnUXpc3OI6E=",
 			"path": "github.com/aws/aws-sdk-go/aws/client/metadata",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "vVSUnICaD9IaBQisCfw0n8zLwig=",
 			"path": "github.com/aws/aws-sdk-go/aws/corehandlers",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "Y+cPwQL0dZMyqp3wI+KJWmA9KQ8=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "u3GOAJLmdvbuNUeUEcZSEAOeL/0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "NUJUTWlc1sV8b7WjfiYc4JZbXl0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/endpointcreds",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "JEYqmF83O5n5bHkupAzA6STm0no=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "HogDW/Wu6ZKTDrQ2HSzG8/vj9Ag=",
 			"path": "github.com/aws/aws-sdk-go/aws/defaults",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "pDnK93CqjQ4ROSW8Y/RuHXjv52M=",
 			"path": "github.com/aws/aws-sdk-go/aws/ec2metadata",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
-			"checksumSHA1": "taM7fdw8T0L8klF96JgAHvKobIw=",
+			"checksumSHA1": "OLJvnxcwAKaL2t7Vv3jQ5v9JXxA=",
 			"path": "github.com/aws/aws-sdk-go/aws/endpoints",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
-			"checksumSHA1": "xXfBg4kOE6+Z4sABLqdR49OlSNA=",
+			"checksumSHA1": "CntJM8T3dRgC0e1i66CIbP8uCSY=",
 			"path": "github.com/aws/aws-sdk-go/aws/request",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "J66FLqo++F1PXLUU8XQqYaageSc=",
 			"path": "github.com/aws/aws-sdk-go/aws/session",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "BqDC+Sxo3hrC6WYvwx1U4OObaT4=",
 			"path": "github.com/aws/aws-sdk-go/aws/signer/v4",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "wjxQlU1PYxrDRFoL1Vek8Wch7jk=",
 			"path": "github.com/aws/aws-sdk-go/internal/sdkio",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "MYLldFRnsZh21TfCkgkXCT3maPU=",
 			"path": "github.com/aws/aws-sdk-go/internal/sdkrand",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "04ypv4x12l4q0TksA1zEVsmgpvw=",
 			"path": "github.com/aws/aws-sdk-go/internal/shareddefaults",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "NStHCXEvYqG72GknZyv1jaKaeH0=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "GQuRJY72iGQrufDqIaB50zG27u0=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/ec2query",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "yHfT5DTbeCLs4NE2Rgnqrhe15ls=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/json/jsonutil",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "R00RL5jJXRYq1iiK1+PGvMfvXyM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/jsonrpc",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "SBBVYdLcocjdPzMWgDuR8vcOfDQ=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "9V1PvtFQ9MObZTc3sa86WcuOtOU=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "pkeoOfZpHRvFG/AOZeTf0lwtsFg=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/rest",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "Rpu8KBtHZgvhkwHxUfaky+qW+G4=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restjson",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "ODo+ko8D6unAxZuN1jGzMcN4QCc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restxml",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "0qYPUga28aQVkxZgBR3Z86AbGUQ=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "F6mth+G7dXN1GI+nktaGo8Lx8aE=",
 			"path": "github.com/aws/aws-sdk-go/private/signer/v2",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
-			"checksumSHA1": "Ih4il2OyFyaSuoMv6hhvPUN8Gn4=",
+			"checksumSHA1": "s9OHHvPVH/wRqcIpNNDxIa4FYv0=",
 			"path": "github.com/aws/aws-sdk-go/service/acm",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "DPl/OkvEUjrd+XKqX73l6nUNw3U=",
 			"path": "github.com/aws/aws-sdk-go/service/apigateway",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "tsOPYVkOiuYDJTziSRkP7p1TL70=",
 			"path": "github.com/aws/aws-sdk-go/service/applicationautoscaling",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "lyjaWzlpAp6CacdNZTe351CRp5c=",
 			"path": "github.com/aws/aws-sdk-go/service/appsync",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "wrOVdI/6ZTZ/H0Kxjh3bBEZtVzk=",
 			"path": "github.com/aws/aws-sdk-go/service/athena",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "GhemRVzpnrN6HAgm1NdAgESY8CQ=",
 			"path": "github.com/aws/aws-sdk-go/service/autoscaling",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "P5gDOoqIdVjMU77e5Nhy48QLpS4=",
 			"path": "github.com/aws/aws-sdk-go/service/batch",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "BrC9UCeefniH5UN7x0PFr8A9l6Y=",
 			"path": "github.com/aws/aws-sdk-go/service/budgets",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "EoaTzMilW+OIi5eETJUpd+giyTc=",
 			"path": "github.com/aws/aws-sdk-go/service/cloud9",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "yuFNzmUIWppfji/Xx6Aao0EE4cY=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudformation",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "0nPnGWlegQG7bn/iIIfjJFoljyU=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudfront",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "XJAlmauOOHsHEUW7n0XO/eEpcWI=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudsearch",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "VTc9UOMqIwuhWJ6oGQDsMkTW09I=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudtrail",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "ItXljM1vG/0goVleodRgbfYgyxQ=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatch",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "x25KEvGmuQ0Uuoduo/CVe37ELC8=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchevents",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "HHct8eQygkIJ+vrQpKhB0IEDymQ=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "LHcxaQJ77WMlug2cnyXlTzJJUSo=",
 			"path": "github.com/aws/aws-sdk-go/service/codebuild",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "AQwpqKKc52nnI5F50K73Zx5luoQ=",
 			"path": "github.com/aws/aws-sdk-go/service/codecommit",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "wvXGTyWPjtgC4OjXb80IxYdpqmE=",
 			"path": "github.com/aws/aws-sdk-go/service/codedeploy",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "V1Y05qfjN4xOCy+GnPWSCqIeZb4=",
 			"path": "github.com/aws/aws-sdk-go/service/codepipeline",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "Ju8efcqcIgggB7N8io/as9ERVdc=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentity",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "jeCyZm4iJmOLbVOe/70QNkII+qU=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentityprovider",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "OhbpZoCd+Vg3pLOEE0MVH9T22eY=",
 			"path": "github.com/aws/aws-sdk-go/service/configservice",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "45sgs1urdRiXDb35iuAhQPzl0e4=",
 			"path": "github.com/aws/aws-sdk-go/service/databasemigrationservice",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "bu1R1eKCK2fc5+hMcXmagr3iIik=",
 			"path": "github.com/aws/aws-sdk-go/service/dax",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "EaEfUc3nt1sS/cdfSYGq+JtSVKs=",
 			"path": "github.com/aws/aws-sdk-go/service/devicefarm",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "LRdh5oXUe2yURIk5FDH6ceEZGMo=",
 			"path": "github.com/aws/aws-sdk-go/service/directconnect",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "a7itHIwtyXtOGQ0KsiefmsHgu4s=",
 			"path": "github.com/aws/aws-sdk-go/service/directoryservice",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "D93YWdEE2D9HtggwUKUNmV7J86E=",
 			"path": "github.com/aws/aws-sdk-go/service/dynamodb",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "SOmBkudpfGbt3Pb3I1bzuXV9FvQ=",
 			"path": "github.com/aws/aws-sdk-go/service/ec2",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "PcnSiFF2p2xOsvITrsglyWp20YA=",
 			"path": "github.com/aws/aws-sdk-go/service/ecr",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "VRx8MtqfED2uZVOi6ldb5P145TI=",
 			"path": "github.com/aws/aws-sdk-go/service/ecs",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "4XmkiujbDA68x39KGgURR1+uPiQ=",
 			"path": "github.com/aws/aws-sdk-go/service/efs",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "o73xT1zFo3C+giQwKcRj02OAZhM=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticache",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "C6OWsuCjBYnqjR5PwDFEA8l1hWg=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticbeanstalk",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "VYGtTaSiajfKOVTbi9/SNmbiIac=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticsearchservice",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "SZ7yLDZ6RvMhpWe0Goyem64kgyA=",
 			"path": "github.com/aws/aws-sdk-go/service/elastictranscoder",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "iRI32eUYQfumh0LybzZ+5iWV3jE=",
 			"path": "github.com/aws/aws-sdk-go/service/elb",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "ufCsoZUQK13j8Y+m25yxhC2XteQ=",
 			"path": "github.com/aws/aws-sdk-go/service/elbv2",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "5x77vwxya74Qu5YEq75/lhyYkqY=",
 			"path": "github.com/aws/aws-sdk-go/service/emr",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "t7BmfpJqmQ7Y0EYcj/CR9Aup9go=",
 			"path": "github.com/aws/aws-sdk-go/service/firehose",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "h37wXo80exgME9QqHkeLTyG88ZM=",
 			"path": "github.com/aws/aws-sdk-go/service/gamelift",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "20HMsQ2tH47zknjFIUQLi/ZOBvc=",
 			"path": "github.com/aws/aws-sdk-go/service/glacier",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "K1s4cEA/LcK+NAZAFUDOr/dW9IY=",
 			"path": "github.com/aws/aws-sdk-go/service/glue",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "tU7rdC0LAUOKNp2uERUXi3hU1sQ=",
 			"path": "github.com/aws/aws-sdk-go/service/guardduty",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
-			"checksumSHA1": "I8CWKTI9BLrIF9ZKf6SpWhG+LXM=",
+			"checksumSHA1": "Wvm1FT8oj2kKLBAdXUoFPERqll8=",
 			"path": "github.com/aws/aws-sdk-go/service/iam",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "45gdBZuM7PWLQzWuBasytvZZpK0=",
 			"path": "github.com/aws/aws-sdk-go/service/inspector",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "skj7upwPc4zfJbYT+iPY+cmumG0=",
 			"path": "github.com/aws/aws-sdk-go/service/iot",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "DfzNze8B3ME2tV3TtXP7eQXUjD0=",
 			"path": "github.com/aws/aws-sdk-go/service/kinesis",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "Vqq049R2eveVD15emT9vKTyBsIg=",
 			"path": "github.com/aws/aws-sdk-go/service/kms",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "lAgaKbwpyflY7+t4V3EeH18RwgA=",
 			"path": "github.com/aws/aws-sdk-go/service/lambda",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "shckWClBSciJH+cFYCY5kDCbBXI=",
 			"path": "github.com/aws/aws-sdk-go/service/lexmodelbuildingservice",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "2dy15/1bnS80cwKZiwnEai1d7O8=",
 			"path": "github.com/aws/aws-sdk-go/service/lightsail",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "998zv0rs9SBCd9EoAnIi9cKv7uo=",
 			"path": "github.com/aws/aws-sdk-go/service/mediaconvert",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "/Oo64hSOdIKbN4dmZ7EAQRfr12w=",
 			"path": "github.com/aws/aws-sdk-go/service/medialive",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "mzoPurfrAAB102onq4FPlwZ5Bec=",
 			"path": "github.com/aws/aws-sdk-go/service/mediapackage",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "yXPMyEsghtSFxu9AbiTFCzisGrQ=",
 			"path": "github.com/aws/aws-sdk-go/service/mediastore",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "wU7VITDzy1ubXo+zrG4HNyl5GJI=",
 			"path": "github.com/aws/aws-sdk-go/service/mediastoredata",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "kMMVqLsxKIzBQeDyWJ0N2U/PKLc=",
 			"path": "github.com/aws/aws-sdk-go/service/mq",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "QuOSKqV8nFvvzN4wcsToltMFI1Y=",
 			"path": "github.com/aws/aws-sdk-go/service/opsworks",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "vSNXu8VAbPuFoTTjtVEpldKDZHA=",
 			"path": "github.com/aws/aws-sdk-go/service/organizations",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "g5UtpGido/A6wsB7pDwY+RQ3Ha8=",
 			"path": "github.com/aws/aws-sdk-go/service/rds",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "/F1EdnLahy5V5+EjvRQ3C0JhIyw=",
 			"path": "github.com/aws/aws-sdk-go/service/redshift",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "p2x3SXLzi1PXnyMpPUJUntpS1hQ=",
 			"path": "github.com/aws/aws-sdk-go/service/route53",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "/MR2uoycqymJLdO3Bu1pTkZCpDY=",
 			"path": "github.com/aws/aws-sdk-go/service/s3",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "XSHs3VHLi/mXGDN0zLO/NNCVpw4=",
 			"path": "github.com/aws/aws-sdk-go/service/sagemaker",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "JrQMIue45k6Nk738T347pe9X0c0=",
 			"path": "github.com/aws/aws-sdk-go/service/servicecatalog",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "fmnQo2GajqI9eEn6tcEGiJ9A66E=",
 			"path": "github.com/aws/aws-sdk-go/service/servicediscovery",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "j+R3E5MeBM87zbLVQhcuqlHsxes=",
 			"path": "github.com/aws/aws-sdk-go/service/ses",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "u3AMeFxtHGtiJCxDeIm4dAwzBIc=",
 			"path": "github.com/aws/aws-sdk-go/service/sfn",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "B3CgAFSREebpsFoFOo4vrQ6u04w=",
 			"path": "github.com/aws/aws-sdk-go/service/simpledb",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "9Qj8yLl67q9uxBUCc0PT20YiP1M=",
 			"path": "github.com/aws/aws-sdk-go/service/sns",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "XmEJe50M8MddNEkwbZoC+YvRjgg=",
 			"path": "github.com/aws/aws-sdk-go/service/sqs",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "ULmsQAt5z5ZxGHZC/r7enBs1HvM=",
 			"path": "github.com/aws/aws-sdk-go/service/ssm",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
-			"checksumSHA1": "tH1Pzc7jUUGJv47Cy6uuWl/86bU=",
+			"checksumSHA1": "pfCrWb7hw3stOoiv7G7ALm2HCy8=",
 			"path": "github.com/aws/aws-sdk-go/service/sts",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "Uw4pOUxSMbx4xBHUcOUkNhtnywE=",
 			"path": "github.com/aws/aws-sdk-go/service/swf",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "dBDZ2w/7ZEdk2UZ6PWFmk/cGSPw=",
 			"path": "github.com/aws/aws-sdk-go/service/waf",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "hOobCqlfwCl/iPGetELNIDsns1U=",
 			"path": "github.com/aws/aws-sdk-go/service/wafregional",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "FVK4fHBkjOIaCRIY4DleqSKtZKs=",
 			"path": "github.com/aws/aws-sdk-go/service/workspaces",
-			"revision": "fb28e64a158b01377883badcc176216ac0fde3dd",
-			"revisionTime": "2018-03-26T21:59:32Z",
-			"version": "v1.13.21",
-			"versionExact": "v1.13.21"
+			"revision": "bb206ce0d6a50da7807694a823aed5c601c57ce0",
+			"revisionTime": "2018-03-28T22:21:06Z",
+			"version": "v1.13.23",
+			"versionExact": "v1.13.23"
 		},
 		{
 			"checksumSHA1": "usT4LCSQItkFvFOQT7cBlkCuGaE=",


### PR DESCRIPTION
`govendor fetch github.com/aws/aws-sdk-go/...@v1.13.23`

- adds support for #3976 