### PR TITLE
Fix bug: route53_zone import saves name with trailing . in state causing plan to detect a change and try to recreate the zone

### DIFF
--- a/aws/diff_suppress_funcs.go
+++ b/aws/diff_suppress_funcs.go
@@ -85,3 +85,7 @@ func suppressAutoscalingGroupAvailabilityZoneDiffs(k, old, new string, d *schema
 
 	return false
 }
+
+func suppressRoute53ZoneNameWithTrailingDot(k, old, new string, d *schema.ResourceData) bool {
+	return strings.TrimSuffix(old, ".") == strings.TrimSuffix(new, ".")
+}

--- a/aws/resource_aws_route53_zone.go
+++ b/aws/resource_aws_route53_zone.go
@@ -28,9 +28,10 @@ func resourceAwsRoute53Zone() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: suppressRoute53ZoneNameWithTrailingDot,
 			},
 
 			"comment": &schema.Schema{


### PR DESCRIPTION
When creating a `aws_route53_zone` in terraform, you define the name of the domain as in the documentation:
```hcl
resource "aws_route53_zone" "primary" {
  name = "example.com"
}
```
However, when importing an existing `aws_route53_zone`, terraform is using the name returned by AWS which has a trailing "." in the end of it which is the name displayed in the web console. The name with the trailing "." gets saved into your state causing an inconsistency, so if you run a plan right after importing the zone you get something like:
```
-/+ aws_route53_zone.test_zone (new resource required)
      id:             "Z273SRWTYTM3GQ" => <computed> (forces new resource)
      comment:        "Managed by Terraform" => "Managed by Terraform"
      force_destroy:  "" => "false"
      name:           "example.com." => "example.com" (forces new resource)
      name_servers.#: "4" => <computed>
      tags.%:         "2" => "0"
      tags.team:      "foobar" => ""
      tags.vertical:  "foobar" => ""
      vpc_region:     "" => <computed>
      zone_id:        "Z1234567890123" => <computed>
```
due to the difference in name. This PR fixes it buy removing the trailing "." when reading the zone name during an import. I also removed it from the data used in the acceptance tests since it doesn't match the example suggested in the docs. 