### PR TITLE
Fix the example bucket policy for detailed billing

### DIFF
--- a/website/docs/d/billing_service_account.html.markdown
+++ b/website/docs/d/billing_service_account.html.markdown
@@ -41,7 +41,7 @@ resource "aws_s3_bucket" "billing_logs" {
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::my-billing-tf-test-bucket/AWSLogs/*",
+      "Resource": "arn:aws:s3:::my-billing-tf-test-bucket/*",
       "Principal": {
         "AWS": [
           "${data.aws_billing_service_account.main.arn}"


### PR DESCRIPTION
The example policy doesn't work because AWS writes a test object at the root of the bucket.

Also, the example policy show in the billing preferences omits the "AWSLogs".