### PR TITLE
resource/aws_lambda_function: Add missing IAM retry in update

### DIFF
--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -710,6 +710,10 @@ func resourceAwsLambdaFunctionUpdate(d *schema.ResourceData, meta interface{}) e
 			if err != nil {
 				log.Printf("[DEBUG] Received error modifying Lambda Function Configuration %s: %s", d.Id(), err)
 
+				if isAWSErr(err, "InvalidParameterValueException", "The role defined for the function cannot be assumed by Lambda") {
+					log.Printf("[DEBUG] Received %s, retrying UpdateFunctionConfiguration", err)
+					return resource.RetryableError(err)
+				}
 				if isAWSErr(err, "InvalidParameterValueException", "The provided execution role does not have permissions") {
 					log.Printf("[DEBUG] Received %s, retrying UpdateFunctionConfiguration", err)
 					return resource.RetryableError(err)


### PR DESCRIPTION
Closes #3972 

This IAM retry is present during creation, but missing from updates:

https://github.com/terraform-providers/terraform-provider-aws/blob/0938826e1f34e9bfaabb3e03c9791035ed37529d/aws/resource_aws_lambda_function.go#L369-L372