### PR TITLE
update iam password generation

### DIFF
--- a/aws/resource_aws_iam_user_login_profile.go
+++ b/aws/resource_aws_iam_user_login_profile.go
@@ -63,9 +63,9 @@ const (
 	charSymbols = "!@#$%^&*()_+-=[]{}|'"
 )
 
-// generatePassword generates a random password of a given length, matching the
+// generateIAMPassword generates a random password of a given length, matching the
 // most restrictive iam password policy.
-func generatePassword(length int) string {
+func generateIAMPassword(length int) string {
 	const charset = charLower + charUpper + charNumbers + charSymbols
 
 	result := make([]byte, length)
@@ -91,7 +91,7 @@ func generatePassword(length int) string {
 			result[i] = charset[r.Int64()]
 		}
 
-		if !checkPwdPolicy(result) {
+		if !checkIAMPwdPolicy(result) {
 			continue
 		}
 
@@ -103,7 +103,7 @@ func generatePassword(length int) string {
 
 // Check the generated password contains all character classes listed in the
 // IAM password policy.
-func checkPwdPolicy(pass []byte) bool {
+func checkIAMPwdPolicy(pass []byte) bool {
 	if !(bytes.ContainsAny(pass, charLower) &&
 		bytes.ContainsAny(pass, charNumbers) &&
 		bytes.ContainsAny(pass, charSymbols) &&
@@ -141,7 +141,7 @@ func resourceAwsIamUserLoginProfileCreate(d *schema.ResourceData, meta interface
 		}
 	}
 
-	initialPassword := generatePassword(passwordLength)
+	initialPassword := generateIAMPassword(passwordLength)
 
 	fingerprint, encrypted, err := encryption.EncryptValue(encryptionKey, initialPassword, "Password")
 	if err != nil {

--- a/aws/resource_aws_iam_user_login_profile_test.go
+++ b/aws/resource_aws_iam_user_login_profile_test.go
@@ -20,6 +20,18 @@ import (
 	"github.com/hashicorp/vault/helper/pgpkeys"
 )
 
+func TestGenerateIAMPassword(t *testing.T) {
+	p := generatePassword(6)
+	if len(p) != 6 {
+		t.Fatalf("expected a 6 character password, got: %q", p)
+	}
+
+	p = generatePassword(128)
+	if len(p) != 128 {
+		t.Fatalf("expected a 128 character password, got: %q", p)
+	}
+}
+
 func TestAccAWSUserLoginProfile_basic(t *testing.T) {
 	var conf iam.GetLoginProfileOutput
 

--- a/aws/resource_aws_iam_user_login_profile_test.go
+++ b/aws/resource_aws_iam_user_login_profile_test.go
@@ -21,12 +21,12 @@ import (
 )
 
 func TestGenerateIAMPassword(t *testing.T) {
-	p := generatePassword(6)
+	p := generateIAMPassword(6)
 	if len(p) != 6 {
 		t.Fatalf("expected a 6 character password, got: %q", p)
 	}
 
-	p = generatePassword(128)
+	p = generateIAMPassword(128)
 	if len(p) != 128 {
 		t.Fatalf("expected a 128 character password, got: %q", p)
 	}
@@ -48,7 +48,7 @@ func TestIAMPasswordPolicyCheck(t *testing.T) {
 		{pass: "abCD11#$", valid: true},
 	} {
 		t.Run(tc.pass, func(t *testing.T) {
-			valid := checkPwdPolicy([]byte(tc.pass))
+			valid := checkIAMPwdPolicy([]byte(tc.pass))
 			if valid != tc.valid {
 				t.Fatalf("expected %q to be valid==%t, got %t", tc.pass, tc.valid, valid)
 			}
@@ -225,7 +225,7 @@ func testDecryptPasswordAndTest(nProfile, nAccessKey, key string) resource.TestC
 			iamAsCreatedUser := iam.New(iamAsCreatedUserSession)
 			_, err = iamAsCreatedUser.ChangePassword(&iam.ChangePasswordInput{
 				OldPassword: aws.String(decryptedPassword.String()),
-				NewPassword: aws.String(generatePassword(20)),
+				NewPassword: aws.String(generateIAMPassword(20)),
 			})
 			if err != nil {
 				if awserr, ok := err.(awserr.Error); ok && awserr.Code() == "InvalidClientTokenId" {

--- a/aws/resource_aws_iam_user_login_profile_test.go
+++ b/aws/resource_aws_iam_user_login_profile_test.go
@@ -32,6 +32,30 @@ func TestGenerateIAMPassword(t *testing.T) {
 	}
 }
 
+func TestIAMPasswordPolicyCheck(t *testing.T) {
+	for _, tc := range []struct {
+		pass  string
+		valid bool
+	}{
+		// no symbol
+		{pass: "abCD12", valid: false},
+		// no number
+		{pass: "abCD%$", valid: false},
+		// no upper
+		{pass: "abcd1#", valid: false},
+		// no lower
+		{pass: "ABCD1#", valid: false},
+		{pass: "abCD11#$", valid: true},
+	} {
+		t.Run(tc.pass, func(t *testing.T) {
+			valid := checkPwdPolicy([]byte(tc.pass))
+			if valid != tc.valid {
+				t.Fatalf("expected %q to be valid==%t, got %t", tc.pass, tc.valid, valid)
+			}
+		})
+	}
+}
+
 func TestAccAWSUserLoginProfile_basic(t *testing.T) {
 	var conf iam.GetLoginProfileOutput
 


### PR DESCRIPTION
There are 2 major issues with the previous generatePassword() function:
- It does not use a cryptographically-secure RNG, meaning that its output
  is not guaranteed to be secret;
- It is seeded only from the current time, making it very easy to bruteforce
  the password for an adversary with (limited) information on the creation
  time of the account.

resource_aws_iam_user_login_profile: Make uniformly random passwords

This maximises the entropy of the resulting password, given a fixed
charset and length; given that the charset contains 2*26 + 10 + 20
distinct charactes, using length-21 passwords results in password
entropy above 128 bits.

Check that generated IAM passwords pass any specified
iam.PasswordPolicy. IAM password policies cannot set specific numbers of each characters
classes, nor can the forbid specific characters. Since the policy
restrictions are minimal, rejection sampling will quickly find even the
shortest passwords containning all characters classes. This can be
extended to lookup the account policy, but in practice that is probably
not required. The only real unknown in this case is the minimum password
length, which will be validated when setting the password, and catching
it earlier won't do any good.

Update the validation for password length, since the minimum is 6
characters.

