### PR TITLE
tests: Serialize WAF Regex Pattern Set acceptance testing

### DIFF
--- a/aws/resource_aws_waf_regex_pattern_set_test.go
+++ b/aws/resource_aws_waf_regex_pattern_set_test.go
@@ -11,7 +11,25 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSWafRegexPatternSet_basic(t *testing.T) {
+// Serialized acceptance tests due to WAF account limits
+// https://docs.aws.amazon.com/waf/latest/developerguide/limits.html
+func TestAccAWSWafRegexPatternSet(t *testing.T) {
+	testCases := map[string]func(t *testing.T){
+		"basic":          testAccAWSWafRegexPatternSet_basic,
+		"changePatterns": testAccAWSWafRegexPatternSet_changePatterns,
+		"noPatterns":     testAccAWSWafRegexPatternSet_noPatterns,
+		"disappears":     testAccAWSWafRegexPatternSet_disappears,
+	}
+
+	for name, tc := range testCases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			tc(t)
+		})
+	}
+}
+
+func testAccAWSWafRegexPatternSet_basic(t *testing.T) {
 	var v waf.RegexPatternSet
 	patternSetName := fmt.Sprintf("tfacc-%s", acctest.RandString(5))
 
@@ -34,7 +52,7 @@ func TestAccAWSWafRegexPatternSet_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSWafRegexPatternSet_changePatterns(t *testing.T) {
+func testAccAWSWafRegexPatternSet_changePatterns(t *testing.T) {
 	var before, after waf.RegexPatternSet
 	patternSetName := fmt.Sprintf("tfacc-%s", acctest.RandString(5))
 
@@ -68,7 +86,7 @@ func TestAccAWSWafRegexPatternSet_changePatterns(t *testing.T) {
 	})
 }
 
-func TestAccAWSWafRegexPatternSet_noPatterns(t *testing.T) {
+func testAccAWSWafRegexPatternSet_noPatterns(t *testing.T) {
 	var patternSet waf.RegexPatternSet
 	patternSetName := fmt.Sprintf("tfacc-%s", acctest.RandString(5))
 
@@ -89,7 +107,7 @@ func TestAccAWSWafRegexPatternSet_noPatterns(t *testing.T) {
 	})
 }
 
-func TestAccAWSWafRegexPatternSet_disappears(t *testing.T) {
+func testAccAWSWafRegexPatternSet_disappears(t *testing.T) {
 	var v waf.RegexPatternSet
 	patternSetName := fmt.Sprintf("tfacc-%s", acctest.RandString(5))
 

--- a/aws/resource_aws_wafregional_regex_pattern_set_test.go
+++ b/aws/resource_aws_wafregional_regex_pattern_set_test.go
@@ -12,7 +12,25 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSWafRegionalRegexPatternSet_basic(t *testing.T) {
+// Serialized acceptance tests due to WAF account limits
+// https://docs.aws.amazon.com/waf/latest/developerguide/limits.html
+func TestAccAWSWafRegionalRegexPatternSet(t *testing.T) {
+	testCases := map[string]func(t *testing.T){
+		"basic":          testAccAWSWafRegionalRegexPatternSet_basic,
+		"changePatterns": testAccAWSWafRegionalRegexPatternSet_changePatterns,
+		"noPatterns":     testAccAWSWafRegionalRegexPatternSet_noPatterns,
+		"disappears":     testAccAWSWafRegionalRegexPatternSet_disappears,
+	}
+
+	for name, tc := range testCases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			tc(t)
+		})
+	}
+}
+
+func testAccAWSWafRegionalRegexPatternSet_basic(t *testing.T) {
 	var patternSet waf.RegexPatternSet
 	patternSetName := fmt.Sprintf("tfacc-%s", acctest.RandString(5))
 
@@ -35,7 +53,7 @@ func TestAccAWSWafRegionalRegexPatternSet_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSWafRegionalRegexPatternSet_changePatterns(t *testing.T) {
+func testAccAWSWafRegionalRegexPatternSet_changePatterns(t *testing.T) {
 	var before, after waf.RegexPatternSet
 	patternSetName := fmt.Sprintf("tfacc-%s", acctest.RandString(5))
 
@@ -69,7 +87,7 @@ func TestAccAWSWafRegionalRegexPatternSet_changePatterns(t *testing.T) {
 	})
 }
 
-func TestAccAWSWafRegionalRegexPatternSet_noPatterns(t *testing.T) {
+func testAccAWSWafRegionalRegexPatternSet_noPatterns(t *testing.T) {
 	var patternSet waf.RegexPatternSet
 	patternSetName := fmt.Sprintf("tfacc-%s", acctest.RandString(5))
 
@@ -90,7 +108,7 @@ func TestAccAWSWafRegionalRegexPatternSet_noPatterns(t *testing.T) {
 	})
 }
 
-func TestAccAWSWafRegionalRegexPatternSet_disappears(t *testing.T) {
+func testAccAWSWafRegionalRegexPatternSet_disappears(t *testing.T) {
 	var patternSet waf.RegexPatternSet
 	patternSetName := fmt.Sprintf("tfacc-%s", acctest.RandString(5))
 


### PR DESCRIPTION
There is a 10 per account limit: https://docs.aws.amazon.com/waf/latest/developerguide/limits.html

Previously:
```
=== RUN   TestAccAWSWafRegexPatternSet_changePatterns
--- FAIL: TestAccAWSWafRegexPatternSet_changePatterns (9.65s)
    testing.go:518: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_waf_regex_pattern_set.test: 1 error(s) occurred:
        
        * aws_waf_regex_pattern_set.test: Failed creating WAF Regex Pattern Set: WAFLimitsExceededException: Operation would result in exceeding resource limits.
            status code: 400, request id: e27f9f9b-3338-11e8-ab7f-75b035610369
```

Now:
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSWafRegexPatternSet'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSWafRegexPatternSet -timeout 120m
=== RUN   TestAccAWSWafRegexPatternSet
=== RUN   TestAccAWSWafRegexPatternSet/noPatterns
=== RUN   TestAccAWSWafRegexPatternSet/disappears
=== RUN   TestAccAWSWafRegexPatternSet/basic
=== RUN   TestAccAWSWafRegexPatternSet/changePatterns
--- PASS: TestAccAWSWafRegexPatternSet (48.90s)
    --- PASS: TestAccAWSWafRegexPatternSet/noPatterns (9.87s)
    --- PASS: TestAccAWSWafRegexPatternSet/disappears (11.10s)
    --- PASS: TestAccAWSWafRegexPatternSet/basic (11.77s)
    --- PASS: TestAccAWSWafRegexPatternSet/changePatterns (16.15s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	48.948s

make testacc TEST=./aws TESTARGS='-run=TestAccAWSWafRegionalRegexPatternSet'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSWafRegionalRegexPatternSet -timeout 120m
=== RUN   TestAccAWSWafRegionalRegexPatternSet
=== RUN   TestAccAWSWafRegionalRegexPatternSet/disappears
=== RUN   TestAccAWSWafRegionalRegexPatternSet/basic
=== RUN   TestAccAWSWafRegionalRegexPatternSet/changePatterns
=== RUN   TestAccAWSWafRegionalRegexPatternSet/noPatterns
--- PASS: TestAccAWSWafRegionalRegexPatternSet (60.81s)
    --- PASS: TestAccAWSWafRegionalRegexPatternSet/disappears (12.78s)
    --- PASS: TestAccAWSWafRegionalRegexPatternSet/basic (13.12s)
    --- PASS: TestAccAWSWafRegionalRegexPatternSet/changePatterns (22.91s)
    --- PASS: TestAccAWSWafRegionalRegexPatternSet/noPatterns (11.99s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	60.850s
```