### PR TITLE
tests: Serialize WAF Regex Match Set acceptance testing

### DIFF
--- a/aws/resource_aws_waf_regex_match_set_test.go
+++ b/aws/resource_aws_waf_regex_match_set_test.go
@@ -72,7 +72,25 @@ func testSweepWafRegexMatchSet(region string) error {
 	return nil
 }
 
-func TestAccAWSWafRegexMatchSet_basic(t *testing.T) {
+// Serialized acceptance tests due to WAF account limits
+// https://docs.aws.amazon.com/waf/latest/developerguide/limits.html
+func TestAccAWSWafRegexMatchSet(t *testing.T) {
+	testCases := map[string]func(t *testing.T){
+		"basic":          testAccAWSWafRegexMatchSet_basic,
+		"changePatterns": testAccAWSWafRegexMatchSet_changePatterns,
+		"noPatterns":     testAccAWSWafRegexMatchSet_noPatterns,
+		"disappears":     testAccAWSWafRegexMatchSet_disappears,
+	}
+
+	for name, tc := range testCases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			tc(t)
+		})
+	}
+}
+
+func testAccAWSWafRegexMatchSet_basic(t *testing.T) {
 	var matchSet waf.RegexMatchSet
 	var patternSet waf.RegexPatternSet
 	var idx int
@@ -108,7 +126,7 @@ func TestAccAWSWafRegexMatchSet_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSWafRegexMatchSet_changePatterns(t *testing.T) {
+func testAccAWSWafRegexMatchSet_changePatterns(t *testing.T) {
 	var before, after waf.RegexMatchSet
 	var patternSet waf.RegexPatternSet
 	var idx1, idx2 int
@@ -153,7 +171,7 @@ func TestAccAWSWafRegexMatchSet_changePatterns(t *testing.T) {
 	})
 }
 
-func TestAccAWSWafRegexMatchSet_noPatterns(t *testing.T) {
+func testAccAWSWafRegexMatchSet_noPatterns(t *testing.T) {
 	var matchSet waf.RegexMatchSet
 	matchSetName := fmt.Sprintf("tfacc-%s", acctest.RandString(5))
 
@@ -174,7 +192,7 @@ func TestAccAWSWafRegexMatchSet_noPatterns(t *testing.T) {
 	})
 }
 
-func TestAccAWSWafRegexMatchSet_disappears(t *testing.T) {
+func testAccAWSWafRegexMatchSet_disappears(t *testing.T) {
 	var matchSet waf.RegexMatchSet
 	matchSetName := fmt.Sprintf("tfacc-%s", acctest.RandString(5))
 	patternSetName := fmt.Sprintf("tfacc-%s", acctest.RandString(5))

--- a/aws/resource_aws_wafregional_regex_match_set_test.go
+++ b/aws/resource_aws_wafregional_regex_match_set_test.go
@@ -73,7 +73,25 @@ func testSweepWafRegionalRegexMatchSet(region string) error {
 	return nil
 }
 
-func TestAccAWSWafRegionalRegexMatchSet_basic(t *testing.T) {
+// Serialized acceptance tests due to WAF account limits
+// https://docs.aws.amazon.com/waf/latest/developerguide/limits.html
+func TestAccAWSWafRegionalRegexMatchSet(t *testing.T) {
+	testCases := map[string]func(t *testing.T){
+		"basic":          testAccAWSWafRegionalRegexMatchSet_basic,
+		"changePatterns": testAccAWSWafRegionalRegexMatchSet_changePatterns,
+		"noPatterns":     testAccAWSWafRegionalRegexMatchSet_noPatterns,
+		"disappears":     testAccAWSWafRegionalRegexMatchSet_disappears,
+	}
+
+	for name, tc := range testCases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			tc(t)
+		})
+	}
+}
+
+func testAccAWSWafRegionalRegexMatchSet_basic(t *testing.T) {
 	var matchSet waf.RegexMatchSet
 	var patternSet waf.RegexPatternSet
 	var idx int
@@ -109,7 +127,7 @@ func TestAccAWSWafRegionalRegexMatchSet_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSWafRegionalRegexMatchSet_changePatterns(t *testing.T) {
+func testAccAWSWafRegionalRegexMatchSet_changePatterns(t *testing.T) {
 	var before, after waf.RegexMatchSet
 	var patternSet waf.RegexPatternSet
 	var idx1, idx2 int
@@ -154,7 +172,7 @@ func TestAccAWSWafRegionalRegexMatchSet_changePatterns(t *testing.T) {
 	})
 }
 
-func TestAccAWSWafRegionalRegexMatchSet_noPatterns(t *testing.T) {
+func testAccAWSWafRegionalRegexMatchSet_noPatterns(t *testing.T) {
 	var matchSet waf.RegexMatchSet
 	matchSetName := fmt.Sprintf("tfacc-%s", acctest.RandString(5))
 
@@ -175,7 +193,7 @@ func TestAccAWSWafRegionalRegexMatchSet_noPatterns(t *testing.T) {
 	})
 }
 
-func TestAccAWSWafRegionalRegexMatchSet_disappears(t *testing.T) {
+func testAccAWSWafRegionalRegexMatchSet_disappears(t *testing.T) {
 	var matchSet waf.RegexMatchSet
 	matchSetName := fmt.Sprintf("tfacc-%s", acctest.RandString(5))
 	patternSetName := fmt.Sprintf("tfacc-%s", acctest.RandString(5))


### PR DESCRIPTION
There is a 10 per account limit: https://docs.aws.amazon.com/waf/latest/developerguide/limits.html

Previously:
```
=== RUN   TestAccAWSWafRegexMatchSet_changePatterns
--- FAIL: TestAccAWSWafRegexMatchSet_changePatterns (33.44s)
    testing.go:518: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_waf_regex_pattern_set.test: 1 error(s) occurred:
        
        * aws_waf_regex_pattern_set.test: Failed creating WAF Regex Pattern Set: WAFLimitsExceededException: Operation would result in exceeding resource limits.
            status code: 400, request id: e5f3b800-3338-11e8-85ad-af5e733a12fd
```

Now:
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSWafRegexMatchSet'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSWafRegexMatchSet -timeout 120m
=== RUN   TestAccAWSWafRegexMatchSet
=== RUN   TestAccAWSWafRegexMatchSet/basic
=== RUN   TestAccAWSWafRegexMatchSet/changePatterns
=== RUN   TestAccAWSWafRegexMatchSet/noPatterns
=== RUN   TestAccAWSWafRegexMatchSet/disappears
--- PASS: TestAccAWSWafRegexMatchSet (58.60s)
    --- PASS: TestAccAWSWafRegexMatchSet/basic (13.71s)
    --- PASS: TestAccAWSWafRegexMatchSet/changePatterns (20.84s)
    --- PASS: TestAccAWSWafRegexMatchSet/noPatterns (9.03s)
    --- PASS: TestAccAWSWafRegexMatchSet/disappears (15.03s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	58.637s

make testacc TEST=./aws TESTARGS='-run=TestAccAWSWafRegionalRegexMatchSet'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSWafRegionalRegexMatchSet -timeout 120m
=== RUN   TestAccAWSWafRegionalRegexMatchSet
=== RUN   TestAccAWSWafRegionalRegexMatchSet/noPatterns
=== RUN   TestAccAWSWafRegionalRegexMatchSet/disappears
=== RUN   TestAccAWSWafRegionalRegexMatchSet/basic
=== RUN   TestAccAWSWafRegionalRegexMatchSet/changePatterns
--- PASS: TestAccAWSWafRegionalRegexMatchSet (81.78s)
    --- PASS: TestAccAWSWafRegionalRegexMatchSet/noPatterns (12.85s)
    --- PASS: TestAccAWSWafRegionalRegexMatchSet/disappears (19.64s)
    --- PASS: TestAccAWSWafRegionalRegexMatchSet/basic (19.73s)
    --- PASS: TestAccAWSWafRegionalRegexMatchSet/changePatterns (29.57s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	81.822s
```