### PR TITLE
New Data Source: aws_arn

### DIFF
--- a/aws/data_source_aws_arn.go
+++ b/aws/data_source_aws_arn.go
@@ -1,0 +1,59 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsArn() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsArnRead,
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateArn,
+			},
+			"partition": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"service": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"region": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"account": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resource": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsArnRead(d *schema.ResourceData, meta interface{}) error {
+	v := d.Get("arn").(string)
+	arn, err := arn.Parse(v)
+	if err != nil {
+		return fmt.Errorf("Error parsing '%s': %s", v, err.Error())
+	}
+
+	d.SetId(arn.String())
+	d.Set("partition", arn.Partition)
+	d.Set("service", arn.Service)
+	d.Set("region", arn.Region)
+	d.Set("account", arn.AccountID)
+	d.Set("resource", arn.Resource)
+
+	return nil
+}

--- a/aws/data_source_aws_arn_test.go
+++ b/aws/data_source_aws_arn_test.go
@@ -1,0 +1,48 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataSourceAwsArn_basic(t *testing.T) {
+	resourceName := "data.aws_arn.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDataSourceAwsArnConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsArn(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "partition", "aws"),
+					resource.TestCheckResourceAttr(resourceName, "service", "rds"),
+					resource.TestCheckResourceAttr(resourceName, "region", "eu-west-1"),
+					resource.TestCheckResourceAttr(resourceName, "account", "123456789012"),
+					resource.TestCheckResourceAttr(resourceName, "resource", "db:mysql-db"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsArn(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("root module has no resource called %s", name)
+		}
+
+		return nil
+	}
+}
+
+const testAccDataSourceAwsArnConfig = `
+data "aws_arn" "test" {
+  arn = "arn:aws:rds:eu-west-1:123456789012:db:mysql-db"
+}
+`

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -163,6 +163,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_acm_certificate":                  dataSourceAwsAcmCertificate(),
 			"aws_ami":                              dataSourceAwsAmi(),
 			"aws_ami_ids":                          dataSourceAwsAmiIds(),
+			"aws_arn":                              dataSourceAwsArn(),
 			"aws_autoscaling_groups":               dataSourceAwsAutoscalingGroups(),
 			"aws_availability_zone":                dataSourceAwsAvailabilityZone(),
 			"aws_availability_zones":               dataSourceAwsAvailabilityZones(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -43,6 +43,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-ami-ids") %>>
                             <a href="/docs/providers/aws/d/ami_ids.html">aws_ami_ids</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-arn") %>>
+                            <a href="/docs/providers/aws/d/arn.html">aws_arn</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-autoscaling-groups") %>>
                             <a href="/docs/providers/aws/d/autoscaling_groups.html">aws_autoscaling_groups</a>
                         </li>

--- a/website/docs/d/arn.html.markdown
+++ b/website/docs/d/arn.html.markdown
@@ -1,0 +1,41 @@
+---
+layout: "aws"
+page_title: "AWS: aws_arn"
+sidebar_current: "docs-aws-datasource-arn"
+description: |-
+    Parses an ARN into its constituent parts.
+---
+
+# Data Source: aws_arn
+
+Parses an Amazon Resource Name (ARN) into its constituent parts.
+
+## Example Usage
+
+```hcl
+data "aws_arn" "db_instance" {
+  arn = "arn:aws:rds:eu-west-1:123456789012:db:mysql-db"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `arn` - (Required) The ARN to parse.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `partition` - The partition that the resource is in.
+
+* `service` - The [service namespace](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-aws-service-namespaces) that identifies the AWS product.
+
+* `region` - The region the resource resides in.
+Note that the ARNs for some resources do not require a region, so this component might be omitted.
+
+* `account` - The [ID](https://docs.aws.amazon.com/general/latest/gr/acct-identifiers.html) of the AWS account that owns the resource, without the hyphens.
+
+* `resource` - The content of this part of the ARN varies by service.
+It often includes an indicator of the type of resource—for example, an IAM user or Amazon RDS database —followed by a slash (/) or a colon (:), followed by the resource name itself.


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/3995.
Add a data source that parses an Amazon Resource Name (ARN) into its constituent parts.

Acceptance tests:
```
make testacc TEST=./aws/ TESTARGS='-run=TestAccDataSourceAwsArn_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccDataSourceAwsArn_ -timeout 120m
=== RUN   TestAccDataSourceAwsArn_basic
--- PASS: TestAccDataSourceAwsArn_basic (12.50s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	12.510s
```