### PR TITLE
New Resource: aws_default_internet_gateway

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -406,6 +406,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_inspector_assessment_template":            resourceAWSInspectorAssessmentTemplate(),
 			"aws_inspector_resource_group":                 resourceAWSInspectorResourceGroup(),
 			"aws_instance":                                 resourceAwsInstance(),
+			"aws_default_internet_gateway":                 resourceAwsDefaultInternetGateway(),
 			"aws_internet_gateway":                         resourceAwsInternetGateway(),
 			"aws_iot_certificate":                          resourceAwsIotCertificate(),
 			"aws_iot_policy":                               resourceAwsIotPolicy(),

--- a/aws/resource_aws_default_internet_gateway.go
+++ b/aws/resource_aws_default_internet_gateway.go
@@ -1,0 +1,81 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsDefaultInternetGateway() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsDefaultInternetGatewayCreate,
+		Read:   resourceAwsInternetGatewayRead,
+		Update: resourceAwsDefaultInternetGatewayUpdate,
+		Delete: resourceAwsDefaultInternetGatewayDelete,
+
+		Schema: map[string]*schema.Schema{
+			"vpc_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceAwsDefaultInternetGatewayCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	// The Default Internet Gateway is the sole attached gateway in the default VPC.
+	descVpcReq := &ec2.DescribeVpcsInput{}
+	descVpcReq.Filters = buildEC2AttributeFilterList(map[string]string{
+		"isDefault": "true",
+	})
+	descVpcResp, err := conn.DescribeVpcs(descVpcReq)
+	if err != nil {
+		return err
+	}
+	if descVpcResp.Vpcs == nil || len(descVpcResp.Vpcs) == 0 {
+		return fmt.Errorf("No default VPC found in this region")
+	}
+
+	vpcId := aws.StringValue(descVpcResp.Vpcs[0].VpcId)
+
+	descIgwReq := &ec2.DescribeInternetGatewaysInput{}
+	descIgwReq.Filters = buildEC2AttributeFilterList(map[string]string{
+		"attachment.vpc-id": vpcId,
+		"attachment.state":  "available",
+	})
+	descIgwResp, err := conn.DescribeInternetGateways(descIgwReq)
+	if err != nil {
+		return err
+	}
+	if descIgwResp.InternetGateways == nil || len(descIgwResp.InternetGateways) == 0 {
+		return fmt.Errorf("No attached Internet Gateways found in VPC: %s", vpcId)
+	}
+	if len(descIgwResp.InternetGateways) > 1 {
+		return fmt.Errorf("Multiple attached Internet Gateways found in VPC: %s", vpcId)
+	}
+
+	d.SetId(aws.StringValue(descIgwResp.InternetGateways[0].InternetGatewayId))
+	return resourceAwsDefaultInternetGatewayUpdate(d, meta)
+}
+
+func resourceAwsDefaultInternetGatewayUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	if err := setTags(conn, d); err != nil {
+		return err
+	}
+
+	return resourceAwsInternetGatewayRead(d, meta)
+}
+
+func resourceAwsDefaultInternetGatewayDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[WARN] Cannot destroy Default Internet Gateway. Terraform will remove this resource from the state file, however resources may remain.")
+	d.SetId("")
+	return nil
+}

--- a/aws/resource_aws_default_internet_gateway_test.go
+++ b/aws/resource_aws_default_internet_gateway_test.go
@@ -1,0 +1,66 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAwsDefaultInternetGateway_basic(t *testing.T) {
+	var igw ec2.InternetGateway
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsDefaultInternetGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsDefaultInternetGatewayConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInternetGatewayExists("aws_default_internet_gateway.foo", &igw),
+					resource.TestCheckResourceAttr(
+						"aws_default_internet_gateway.foo", "tags.%", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_default_internet_gateway.foo", "tags.Name", "terraform-testacc-default-igw"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsDefaultInternetGatewayDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_default_internet_gateway" {
+			continue
+		}
+
+		// Try to find the resource
+		resp, err := conn.DescribeInternetGateways(&ec2.DescribeInternetGatewaysInput{
+			InternetGatewayIds: []*string{aws.String(rs.Primary.ID)},
+		})
+		if err != nil {
+			return err
+		}
+		if len(resp.InternetGateways) != 1 {
+			return fmt.Errorf("does not exist")
+		}
+
+		return nil
+	}
+
+	return nil
+}
+
+const testAccAwsDefaultInternetGatewayConfig = `
+resource "aws_default_internet_gateway" "foo" {
+  tags {
+    Name = "terraform-testacc-default-igw"
+  }
+}
+`

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1835,6 +1835,10 @@
                             <a href="/docs/providers/aws/r/customer_gateway.html">aws_customer_gateway</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-default-internet-gateway") %>>
+                            <a href="/docs/providers/aws/r/default_internet_gateway.html">aws_default_internet_gateway</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-aws-resource-default-network-acl") %>>
                             <a href="/docs/providers/aws/r/default_network_acl.html">aws_default_network_acl</a>
                         </li>

--- a/website/docs/r/default_internet_gateway.html.markdown
+++ b/website/docs/r/default_internet_gateway.html.markdown
@@ -1,0 +1,49 @@
+---
+layout: "aws"
+page_title: "AWS: aws_default_internet_gateway"
+sidebar_current: "docs-aws-resource-default-internet-gateway"
+description: |-
+  Provides a resource to manage a default VPC Internet Gateway.
+---
+
+# aws_default_internet_gateway
+
+Provides a resource to manage a [default VPC Internet Gateway](https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/default-vpc.html#default-vpc-components)
+in the current region.
+
+The `aws_default_internet_gateway` behaves differently from normal resources, in that
+Terraform does not _create_ this resource, but instead "adopts" it into management.
+
+## Example Usage
+
+Basic usage with tags:
+
+```hcl
+resource "aws_default_internet_gateway" "default" {
+  tags {
+    Name = "Default IGW"
+  }
+}
+```
+
+## Argument Reference
+
+The arguments of an `aws_default_internet_gateway` differ from [`aws_internet_gateway`](internet_gateway.html) resources.
+Namely, the `vpc_id` argument is computed.
+The following arguments are still supported:
+
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
+### Removing `aws_default_internet_gateway` from your configuration
+
+The `aws_default_internet_gateway` resource allows you to manage a region's default VPC Internet Gateway,
+but Terraform cannot destroy it. Removing this resource from your configuration
+will remove it from your statefile and management, but will not destroy the Internet Gateway.
+You can resume managing the Internet Gateway via the AWS Console.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the Internet Gateway.
+* `vpc_id` - The VPC ID.


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/2436.

The default Internet Gateway in an AWS region is the sole attached Internet Gateway in that region's default VPC.

Acceptance tests:
```
 make testacc TEST=./aws/ TESTARGS='-run=TestAccAwsDefaultInternetGateway_'==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAwsDefaultInternetGateway_ -timeout 120m
=== RUN   TestAccAwsDefaultInternetGateway_basic
--- PASS: TestAccAwsDefaultInternetGateway_basic (14.24s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	14.255s
```