### PR TITLE
resource/aws_kms_alias: Fix perpetual plan when target_key_id is ARN

### DIFF
--- a/aws/resource_aws_kms_alias.go
+++ b/aws/resource_aws_kms_alias.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -43,8 +44,9 @@ func resourceAwsKmsAlias() *schema.Resource {
 				ValidateFunc: validateAwsKmsName,
 			},
 			"target_key_id": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:             schema.TypeString,
+				Required:         true,
+				DiffSuppressFunc: suppressEquivalentTargetKeyIdAndARN,
 			},
 			"target_key_arn": {
 				Type:     schema.TypeString,
@@ -219,4 +221,15 @@ func findKmsAliasByName(conn *kms.KMS, name string, marker *string) (*kms.AliasL
 func resourceAwsKmsAliasImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	d.Set("name", d.Id())
 	return []*schema.ResourceData{d}, nil
+}
+
+func suppressEquivalentTargetKeyIdAndARN(k, old, new string, d *schema.ResourceData) bool {
+	newARN, err := arn.Parse(new)
+	if err != nil {
+		log.Printf("[DEBUG] %q can not be parsed as an ARN: %q", new, err)
+		return false
+	}
+
+	resource := strings.TrimPrefix(newARN.Resource, "key/")
+	return old == resource
 }


### PR DESCRIPTION
An `aws_kms_alias` resource `target_key_id` can be set to either `key_id` or `ARN`. When it's set to ARN, then the resource is correctly created, but then a perpetual plan exists.

 ```
  ~ aws_kms_alias.mykey
      target_key_id: "abcde123-1234-1234-1234-12345678901" => "arn:aws:kms:eu-west-1:123456789123:key/abcde123-1234-1234-1234-12345678901"
```
