### PR TITLE
New Resource: aws_glue_connection

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -377,6 +377,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_gamelift_fleet":                           resourceAwsGameliftFleet(),
 			"aws_glacier_vault":                            resourceAwsGlacierVault(),
 			"aws_glue_catalog_database":                    resourceAwsGlueCatalogDatabase(),
+			"aws_glue_connection":                          resourceAwsGlueConnection(),
 			"aws_guardduty_detector":                       resourceAwsGuardDutyDetector(),
 			"aws_guardduty_ipset":                          resourceAwsGuardDutyIpset(),
 			"aws_guardduty_member":                         resourceAwsGuardDutyMember(),

--- a/aws/resource_aws_glue_connection.go
+++ b/aws/resource_aws_glue_connection.go
@@ -1,0 +1,274 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/glue"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func resourceAwsGlueConnection() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsGlueConnectionCreate,
+		Read:   resourceAwsGlueConnectionRead,
+		Update: resourceAwsGlueConnectionUpdate,
+		Delete: resourceAwsGlueConnectionDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"catalog_id": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+				Computed: true,
+			},
+			"connection_properties": {
+				Type:     schema.TypeMap,
+				Required: true,
+			},
+			"connection_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  glue.ConnectionTypeJdbc,
+				ValidateFunc: validation.StringInSlice([]string{
+					glue.ConnectionTypeJdbc,
+					glue.ConnectionTypeSftp,
+				}, false),
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"match_criteria": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+			"physical_connection_requirements": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"security_group_id_list": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"subnet_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsGlueConnectionCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).glueconn
+	var catalogID string
+	if v, ok := d.GetOkExists("catalog_id"); ok {
+		catalogID = v.(string)
+	} else {
+		catalogID = meta.(*AWSClient).accountid
+	}
+	name := d.Get("name").(string)
+
+	input := &glue.CreateConnectionInput{
+		CatalogId:       aws.String(catalogID),
+		ConnectionInput: expandGlueConnectionInput(d),
+	}
+
+	log.Printf("[DEBUG] Creating Glue Connection: %s", input)
+	_, err := conn.CreateConnection(input)
+	if err != nil {
+		return fmt.Errorf("error creating Glue Connection (%s): %s", name, err)
+	}
+
+	d.SetId(fmt.Sprintf("%s:%s", catalogID, name))
+
+	return resourceAwsGlueConnectionRead(d, meta)
+}
+
+func resourceAwsGlueConnectionRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).glueconn
+
+	catalogID, connectionName, err := decodeGlueConnectionID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	input := &glue.GetConnectionInput{
+		CatalogId: aws.String(catalogID),
+		Name:      aws.String(connectionName),
+	}
+
+	log.Printf("[DEBUG] Reading Glue Connection: %s", input)
+	output, err := conn.GetConnection(input)
+	if err != nil {
+		if isAWSErr(err, glue.ErrCodeEntityNotFoundException, "") {
+			log.Printf("[WARN] Glue Connection (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("error reading Glue Connection (%s): %s", d.Id(), err)
+	}
+
+	connection := output.Connection
+	if connection == nil {
+		log.Printf("[WARN] Glue Connection (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("catalog_id", catalogID)
+	if err := d.Set("connection_properties", aws.StringValueMap(connection.ConnectionProperties)); err != nil {
+		return fmt.Errorf("error setting connection_properties: %s", err)
+	}
+	d.Set("connection_type", connection.ConnectionType)
+	d.Set("description", connection.Description)
+	if err := d.Set("match_criteria", flattenStringList(connection.MatchCriteria)); err != nil {
+		return fmt.Errorf("error setting match_criteria: %s", err)
+	}
+	d.Set("name", connection.Name)
+	if err := d.Set("physical_connection_requirements", flattenGluePhysicalConnectionRequirements(connection.PhysicalConnectionRequirements)); err != nil {
+		return fmt.Errorf("error setting physical_connection_requirements: %s", err)
+	}
+
+	return nil
+}
+
+func resourceAwsGlueConnectionUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).glueconn
+
+	catalogID, connectionName, err := decodeGlueConnectionID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	input := &glue.UpdateConnectionInput{
+		CatalogId:       aws.String(catalogID),
+		ConnectionInput: expandGlueConnectionInput(d),
+		Name:            aws.String(connectionName),
+	}
+
+	log.Printf("[DEBUG] Updating Glue Connection: %s", input)
+	_, err = conn.UpdateConnection(input)
+	if err != nil {
+		return fmt.Errorf("error updating Glue Connection (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceAwsGlueConnectionDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).glueconn
+
+	catalogID, connectionName, err := decodeGlueConnectionID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] Deleting Glue Connection: %s", d.Id())
+	err = deleteGlueConnection(conn, catalogID, connectionName)
+	if err != nil {
+		return fmt.Errorf("error deleting Glue Connection (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func decodeGlueConnectionID(id string) (string, string, error) {
+	idParts := strings.Split(id, ":")
+	if len(idParts) != 2 {
+		return "", "", fmt.Errorf("expected ID in format CATALOG-ID:NAME, provided: %s", id)
+	}
+	return idParts[0], idParts[1], nil
+}
+
+func deleteGlueConnection(conn *glue.Glue, catalogID, connectionName string) error {
+	input := &glue.DeleteConnectionInput{
+		CatalogId:      aws.String(catalogID),
+		ConnectionName: aws.String(connectionName),
+	}
+
+	_, err := conn.DeleteConnection(input)
+	if err != nil {
+		if isAWSErr(err, glue.ErrCodeEntityNotFoundException, "") {
+			return nil
+		}
+		return err
+	}
+
+	return nil
+}
+
+func expandGlueConnectionInput(d *schema.ResourceData) *glue.ConnectionInput {
+	connectionProperties := make(map[string]string)
+	for k, v := range d.Get("connection_properties").(map[string]interface{}) {
+		connectionProperties[k] = v.(string)
+	}
+
+	connectionInput := &glue.ConnectionInput{
+		ConnectionProperties: aws.StringMap(connectionProperties),
+		ConnectionType:       aws.String(d.Get("connection_type").(string)),
+		Name:                 aws.String(d.Get("name").(string)),
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		connectionInput.Description = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("match_criteria"); ok {
+		connectionInput.MatchCriteria = expandStringList(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("physical_connection_requirements"); ok {
+		physicalConnectionRequirementsList := v.([]interface{})
+		physicalConnectionRequirementsMap := physicalConnectionRequirementsList[0].(map[string]interface{})
+		connectionInput.PhysicalConnectionRequirements = expandGluePhysicalConnectionRequirements(physicalConnectionRequirementsMap)
+	}
+
+	return connectionInput
+}
+
+func expandGluePhysicalConnectionRequirements(m map[string]interface{}) *glue.PhysicalConnectionRequirements {
+	physicalConnectionRequirements := &glue.PhysicalConnectionRequirements{}
+
+	if v, ok := m["security_group_id_list"]; ok {
+		physicalConnectionRequirements.SecurityGroupIdList = expandStringList(v.([]interface{}))
+	}
+
+	if v, ok := m["subnet_id"]; ok {
+		physicalConnectionRequirements.SubnetId = aws.String(v.(string))
+	}
+
+	return physicalConnectionRequirements
+}
+
+func flattenGluePhysicalConnectionRequirements(physicalConnectionRequirements *glue.PhysicalConnectionRequirements) []map[string]interface{} {
+	if physicalConnectionRequirements == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"security_group_id_list": flattenStringList(physicalConnectionRequirements.SecurityGroupIdList),
+		"subnet_id":              aws.StringValue(physicalConnectionRequirements.SubnetId),
+	}
+
+	return []map[string]interface{}{m}
+}

--- a/aws/resource_aws_glue_connection_test.go
+++ b/aws/resource_aws_glue_connection_test.go
@@ -1,0 +1,444 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/glue"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_glue_connection", &resource.Sweeper{
+		Name: "aws_glue_connection",
+		F:    testSweepGlueConnections,
+	})
+}
+
+func testSweepGlueConnections(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).glueconn
+	catalogID := client.(*AWSClient).accountid
+
+	prefixes := []string{
+		"tf-acc-test-",
+	}
+
+	input := &glue.GetConnectionsInput{
+		CatalogId: aws.String(catalogID),
+	}
+	err = conn.GetConnectionsPages(input, func(page *glue.GetConnectionsOutput, lastPage bool) bool {
+		if len(page.ConnectionList) == 0 {
+			log.Printf("[INFO] No Glue Connections to sweep")
+			return false
+		}
+		for _, connection := range page.ConnectionList {
+			skip := true
+			name := connection.Name
+			for _, prefix := range prefixes {
+				if strings.HasPrefix(*name, prefix) {
+					skip = false
+					break
+				}
+			}
+			if skip {
+				log.Printf("[INFO] Skipping Glue Connection: %s", *name)
+				continue
+			}
+
+			log.Printf("[INFO] Deleting Glue Connection: %s", *name)
+			err := deleteGlueConnection(conn, catalogID, *name)
+			if err != nil {
+				log.Printf("[ERROR] Failed to delete Glue Connection %s: %s", *name, err)
+			}
+		}
+		return !lastPage
+	})
+	if err != nil {
+		return fmt.Errorf("Error retrieving Glue Connections: %s", err)
+	}
+
+	return nil
+}
+
+func TestAccAWSGlueConnection_Basic(t *testing.T) {
+	var connection glue.Connection
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "aws_glue_connection.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueConnectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGlueConnectionConfig_Required(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueConnectionExists(resourceName, &connection),
+					resource.TestCheckResourceAttr(resourceName, "connection_properties.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "connection_properties.JDBC_CONNECTION_URL", "jdbc:mysql://terraformacctesting.com/testdatabase"),
+					resource.TestCheckResourceAttr(resourceName, "connection_properties.PASSWORD", "testpassword"),
+					resource.TestCheckResourceAttr(resourceName, "connection_properties.USERNAME", "testusername"),
+					resource.TestCheckResourceAttr(resourceName, "match_criteria.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "physical_connection_requirements.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSGlueConnection_Description(t *testing.T) {
+	var connection glue.Connection
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "aws_glue_connection.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueConnectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGlueConnectionConfig_Description(rName, "First Description"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueConnectionExists(resourceName, &connection),
+					resource.TestCheckResourceAttr(resourceName, "description", "First Description"),
+				),
+			},
+			{
+				Config: testAccAWSGlueConnectionConfig_Description(rName, "Second Description"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueConnectionExists(resourceName, &connection),
+					resource.TestCheckResourceAttr(resourceName, "description", "Second Description"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSGlueConnection_MatchCriteria(t *testing.T) {
+	var connection glue.Connection
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "aws_glue_connection.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueConnectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGlueConnectionConfig_MatchCriteria_First(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueConnectionExists(resourceName, &connection),
+					resource.TestCheckResourceAttr(resourceName, "match_criteria.#", "4"),
+					resource.TestCheckResourceAttr(resourceName, "match_criteria.0", "criteria1"),
+					resource.TestCheckResourceAttr(resourceName, "match_criteria.1", "criteria2"),
+					resource.TestCheckResourceAttr(resourceName, "match_criteria.2", "criteria3"),
+					resource.TestCheckResourceAttr(resourceName, "match_criteria.3", "criteria4"),
+				),
+			},
+			{
+				Config: testAccAWSGlueConnectionConfig_MatchCriteria_Second(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueConnectionExists(resourceName, &connection),
+					resource.TestCheckResourceAttr(resourceName, "match_criteria.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "match_criteria.0", "criteria1"),
+				),
+			},
+			{
+				Config: testAccAWSGlueConnectionConfig_MatchCriteria_Third(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueConnectionExists(resourceName, &connection),
+					resource.TestCheckResourceAttr(resourceName, "match_criteria.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "match_criteria.0", "criteria2"),
+					resource.TestCheckResourceAttr(resourceName, "match_criteria.1", "criteria3"),
+					resource.TestCheckResourceAttr(resourceName, "match_criteria.2", "criteria4"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSGlueConnection_PhysicalConnectionRequirements(t *testing.T) {
+	var connection glue.Connection
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "aws_glue_connection.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueConnectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGlueConnectionConfig_PhysicalConnectionRequirements(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueConnectionExists(resourceName, &connection),
+					resource.TestCheckResourceAttr(resourceName, "connection_properties.%", "3"),
+					resource.TestCheckResourceAttrSet(resourceName, "connection_properties.JDBC_CONNECTION_URL"),
+					resource.TestCheckResourceAttrSet(resourceName, "connection_properties.PASSWORD"),
+					resource.TestCheckResourceAttrSet(resourceName, "connection_properties.USERNAME"),
+					resource.TestCheckResourceAttr(resourceName, "match_criteria.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "physical_connection_requirements.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "physical_connection_requirements.0.security_group_id_list.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "physical_connection_requirements.0.subnet_id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSGlueConnectionExists(resourceName string, connection *glue.Connection) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Glue Connection ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).glueconn
+		catalogID, connectionName, err := decodeGlueConnectionID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		output, err := conn.GetConnection(&glue.GetConnectionInput{
+			CatalogId: aws.String(catalogID),
+			Name:      aws.String(connectionName),
+		})
+		if err != nil {
+			return err
+		}
+
+		if output.Connection == nil {
+			return fmt.Errorf("Glue Connection (%s) not found", rs.Primary.ID)
+		}
+
+		if aws.StringValue(output.Connection.Name) == connectionName {
+			*connection = *output.Connection
+			return nil
+		}
+
+		return fmt.Errorf("Glue Connection (%s) not found", rs.Primary.ID)
+	}
+}
+
+func testAccCheckAWSGlueConnectionDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_glue_connection" {
+			continue
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).glueconn
+		catalogID, connectionName, err := decodeGlueConnectionID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		output, err := conn.GetConnection(&glue.GetConnectionInput{
+			CatalogId: aws.String(catalogID),
+			Name:      aws.String(connectionName),
+		})
+
+		if err != nil {
+			if isAWSErr(err, glue.ErrCodeEntityNotFoundException, "") {
+				return nil
+			}
+
+		}
+
+		connection := output.Connection
+		if connection != nil && aws.StringValue(connection.Name) == connectionName {
+			return fmt.Errorf("Glue Connection %s still exists", rs.Primary.ID)
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func testAccAWSGlueConnectionConfig_Description(rName, description string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_connection" "test" {
+  connection_properties = {
+    JDBC_CONNECTION_URL = "jdbc:mysql://terraformacctesting.com/testdatabase"
+    PASSWORD            = "testpassword"
+    USERNAME            = "testusername"
+  }
+
+  description = "%[1]s"
+  name        = "%[2]s"
+}
+`, description, rName)
+}
+
+func testAccAWSGlueConnectionConfig_MatchCriteria_First(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_connection" "test" {
+  connection_properties = {
+    JDBC_CONNECTION_URL = "jdbc:mysql://terraformacctesting.com/testdatabase"
+    PASSWORD            = "testpassword"
+    USERNAME            = "testusername"
+  }
+
+  match_criteria = ["criteria1", "criteria2", "criteria3", "criteria4"]
+  name           = "%s"
+}
+`, rName)
+}
+
+func testAccAWSGlueConnectionConfig_MatchCriteria_Second(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_connection" "test" {
+  connection_properties = {
+    JDBC_CONNECTION_URL = "jdbc:mysql://terraformacctesting.com/testdatabase"
+    PASSWORD            = "testpassword"
+    USERNAME            = "testusername"
+  }
+
+  match_criteria = ["criteria1"]
+  name           = "%s"
+}
+`, rName)
+}
+
+func testAccAWSGlueConnectionConfig_MatchCriteria_Third(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_connection" "test" {
+  connection_properties = {
+    JDBC_CONNECTION_URL = "jdbc:mysql://terraformacctesting.com/testdatabase"
+    PASSWORD            = "testpassword"
+    USERNAME            = "testusername"
+  }
+
+  match_criteria = ["criteria2", "criteria3", "criteria4"]
+  name           = "%s"
+}
+`, rName)
+}
+
+func testAccAWSGlueConnectionConfig_PhysicalConnectionRequirements(rName string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    Name = "terraform-testacc-glue-connection-base"
+  }
+}
+
+resource "aws_security_group" "test" {
+  name   = "%[1]s"
+  vpc_id = "${aws_vpc.test.id}"
+
+  ingress {
+    from_port = 1
+    protocol  = "tcp"
+    self      = true
+    to_port   = 65535
+  }
+}
+
+resource "aws_subnet" "test" {
+  count = 2
+
+  availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
+  cidr_block        = "10.0.${count.index}.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
+
+  tags {
+    Name = "terraform-testacc-glue-connection-base"
+  }
+}
+
+resource "aws_db_subnet_group" "test" {
+  name       = "%[1]s"
+  subnet_ids = ["${aws_subnet.test.0.id}", "${aws_subnet.test.1.id}"]
+}
+
+resource "aws_rds_cluster" "test" {
+  cluster_identifier              = "%[1]s"
+  database_name                   = "gluedatabase"
+  db_cluster_parameter_group_name = "default.aurora-mysql5.7"
+  db_subnet_group_name            = "${aws_db_subnet_group.test.name}"
+  engine                          = "aurora-mysql"
+  master_password                 = "gluepassword"
+  master_username                 = "glueusername"
+  skip_final_snapshot             = true
+  vpc_security_group_ids          = ["${aws_security_group.test.id}"]
+}
+
+resource "aws_rds_cluster_instance" "test" {
+  cluster_identifier = "${aws_rds_cluster.test.id}"
+  engine             = "aurora-mysql"
+  identifier         = "%[1]s"
+  instance_class     = "db.t2.medium"
+}
+
+resource "aws_glue_connection" "test" {
+  connection_properties = {
+    JDBC_CONNECTION_URL = "jdbc:mysql://${aws_rds_cluster.test.endpoint}/${aws_rds_cluster.test.database_name}"
+    PASSWORD            = "${aws_rds_cluster.test.master_password}"
+    USERNAME            = "${aws_rds_cluster.test.master_username}"
+  }
+
+  name = "%[1]s"
+
+  physical_connection_requirements {
+    security_group_id_list = ["${aws_security_group.test.id}"]
+    subnet_id              = "${aws_subnet.test.0.id}"
+  }
+}
+`, rName)
+}
+
+func testAccAWSGlueConnectionConfig_Required(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_connection" "test" {
+  connection_properties = {
+    JDBC_CONNECTION_URL = "jdbc:mysql://terraformacctesting.com/testdatabase"
+    PASSWORD            = "testpassword"
+    USERNAME            = "testusername"
+  }
+
+  name = "%s"
+}
+`, rName)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1044,6 +1044,9 @@
                         <li<%= sidebar_current("docs-aws-resource-glue-catalog-database") %>>
                             <a href="/docs/providers/aws/r/glue_catalog_database.html">aws_glue_catalog_database</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-resource-glue-connection") %>>
+                            <a href="/docs/providers/aws/r/glue_connection.html">aws_glue_connection</a>
+                        </li>
                     </ul>
                  </li>
 

--- a/website/docs/r/glue_connection.html.markdown
+++ b/website/docs/r/glue_connection.html.markdown
@@ -1,0 +1,79 @@
+---
+layout: "aws"
+page_title: "AWS: aws_glue_connection"
+sidebar_current: "docs-aws-resource-glue-connection"
+description: |-
+  Provides an Glue Connection resource.
+---
+
+# aws_glue_connection
+
+Provides a Glue Connection resource.
+
+## Example Usage
+
+### Non-VPC Connection
+
+```hcl
+resource "aws_glue_connection" "example" {
+  connection_properties = {
+    JDBC_CONNECTION_URL = "jdbc:mysql://example.com/exampledatabase"
+    PASSWORD            = "examplepassword"
+    USERNAME            = "exampleusername"
+  }
+
+  name = "example"
+}
+```
+
+### VPC Connection
+
+For more information, see the [AWS Documentation](https://docs.aws.amazon.com/glue/latest/dg/populate-add-connection.html#connection-JDBC-VPC).
+
+```hcl
+resource "aws_glue_connection" "example" {
+  connection_properties = {
+    JDBC_CONNECTION_URL = "jdbc:mysql://${aws_rds_cluster.example.endpoint}/exampledatabase"
+    PASSWORD            = "examplepassword"
+    USERNAME            = "exampleusername"
+  }
+
+  name = "example"
+
+  physical_connection_requirements {
+    security_group_id_list = ["${aws_security_group.example.id}"]
+    subnet_id              = "${aws_subnet.example.id}"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `catalog_id` – (Optional) The ID of the Data Catalog in which to create the connection. If none is supplied, the AWS account ID is used by default.
+* `connection_properties` – (Required) A map of key-value pairs used as parameters for this connection.
+* `connection_type` – (Optional) The type of the connection. Defaults to `JBDC`.
+* `description` – (Optional) Description of the connection.
+* `match_criteria` – (Optional) A list of criteria that can be used in selecting this connection.
+* `name` – (Required) The name of the connection.
+* `physical_connection_requirements` - (Optional) A map of physical connection requirements, such as VPC and SecurityGroup. Defined below.
+
+### physical_connection_requirements
+
+* `security_group_id_list` - (Optional) The security group ID list used by the connection.
+* `subnet_id` - (Optional) The subnet ID used by the connection.
+
+## Attributes Reference
+
+The following additional attributes are exported:
+
+* `id` - Catalog ID and name of the connection
+
+## Import
+
+Glue Connections can be imported using the `CATALOG-ID` (AWS account ID if not custom) and `NAME`, e.g.
+
+```
+$ terraform import aws_glue_connection.MyConnection 123456789012:MyConnection
+```


### PR DESCRIPTION
Closes #3874 

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSGlueConnection'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSGlueConnection -timeout 120m
=== RUN   TestAccAWSGlueConnection_Basic
--- PASS: TestAccAWSGlueConnection_Basic (12.92s)
=== RUN   TestAccAWSGlueConnection_Description
--- PASS: TestAccAWSGlueConnection_Description (19.69s)
=== RUN   TestAccAWSGlueConnection_MatchCriteria
--- PASS: TestAccAWSGlueConnection_MatchCriteria (29.49s)
=== RUN   TestAccAWSGlueConnection_PhysicalConnectionRequirements
--- PASS: TestAccAWSGlueConnection_PhysicalConnectionRequirements (642.15s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	704.298s
```