### PR TITLE
resource/aws_lb: suppress diff for attributes incorrect lb types

### DIFF
--- a/aws/resource_aws_lb.go
+++ b/aws/resource_aws_lb.go
@@ -122,25 +122,29 @@ func resourceAwsLb() *schema.Resource {
 			},
 
 			"access_logs": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
+				Type:             schema.TypeList,
+				Optional:         true,
+				Computed:         true,
+				MaxItems:         1,
+				DiffSuppressFunc: suppressIfLBType("network"),
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"bucket": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:             schema.TypeString,
+							Required:         true,
+							DiffSuppressFunc: suppressIfLBType("network"),
 						},
 						"prefix": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
+							Type:             schema.TypeString,
+							Optional:         true,
+							Computed:         true,
+							DiffSuppressFunc: suppressIfLBType("network"),
 						},
 						"enabled": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Computed: true,
+							Type:             schema.TypeBool,
+							Optional:         true,
+							Computed:         true,
+							DiffSuppressFunc: suppressIfLBType("network"),
 						},
 					},
 				},
@@ -153,21 +157,24 @@ func resourceAwsLb() *schema.Resource {
 			},
 
 			"idle_timeout": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  60,
+				Type:             schema.TypeInt,
+				Optional:         true,
+				Default:          60,
+				DiffSuppressFunc: suppressIfLBType("network"),
 			},
 
 			"enable_cross_zone_load_balancing": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
+				Type:             schema.TypeBool,
+				Optional:         true,
+				Default:          false,
+				DiffSuppressFunc: suppressIfLBType("application"),
 			},
 
 			"enable_http2": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
+				Type:             schema.TypeBool,
+				Optional:         true,
+				Default:          true,
+				DiffSuppressFunc: suppressIfLBType("network"),
 			},
 
 			"ip_address_type": {
@@ -193,6 +200,12 @@ func resourceAwsLb() *schema.Resource {
 
 			"tags": tagsSchema(),
 		},
+	}
+}
+
+func suppressIfLBType(t string) schema.SchemaDiffSuppressFunc {
+	return func(k string, old string, new string, d *schema.ResourceData) bool {
+		return d.Get("load_balancer_type").(string) == t
 	}
 }
 


### PR DESCRIPTION
Fix #4011 

We recently added support for all elbv2 load balancer attributes. Some attributes can only be applied to application load balancers and some only for network load balancers. Even though the code is correct and we would never attempt to set an attribute that didn't apply to a network load balancer (or vice versa), the shared nature of the schema for this resource (and it's defaults) would show values in the state plan even if it did not make sense for the type.

This PR will suppress the diff for the respective attributes and load balancer types. Please let me know if unit tests are required, I have pasted a capture of `terraform plan` to confirm the attribute are hidden based on type.

network.tf:
```
resource "aws_lb" "my-lb" {
  name_prefix        = "my-lb"
  load_balancer_type = "network"
}
```
terraform plan:
```
Terraform will perform the following actions:

  + aws_lb.my-lb
      id:                               <computed>
      arn:                              <computed>
      arn_suffix:                       <computed>
      dns_name:                         <computed>
      enable_cross_zone_load_balancing: "false"
      enable_deletion_protection:       "false"
      internal:                         <computed>
      ip_address_type:                  <computed>
      load_balancer_type:               "network"
      name:                             <computed>
      name_prefix:                      "my-lb"
      security_groups.#:                <computed>
      subnet_mapping.#:                 <computed>
      subnets.#:                        <computed>
      vpc_id:                           <computed>
      zone_id:                          <computed>
```
application.tf:
```
resource "aws_lb" "my-lb" {
  name_prefix        = "my-lb"
  load_balancer_type = "application"
}
```
terraform apply:
```
+ aws_lb.my-lb
      id:                         <computed>
      access_logs.#:              <computed>
      arn:                        <computed>
      arn_suffix:                 <computed>
      dns_name:                   <computed>
      enable_deletion_protection: "false"
      enable_http2:               "true"
      idle_timeout:               "60"
      internal:                   <computed>
      ip_address_type:            <computed>
      load_balancer_type:         "application"
      name:                       <computed>
      name_prefix:                "my-lb"
      security_groups.#:          <computed>
      subnet_mapping.#:           <computed>
      subnets.#:                  <computed>
      vpc_id:                     <computed>
      zone_id:                    <computed>
```