### PR TITLE
Removed unneccesary s3_bucket_object tagging  error

### DIFF
--- a/aws/resource_aws_s3_bucket_object.go
+++ b/aws/resource_aws_s3_bucket_object.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
-	"github.com/mitchellh/go-homedir"
+	homedir "github.com/mitchellh/go-homedir"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -325,9 +325,10 @@ func resourceAwsS3BucketObjectRead(d *schema.ResourceData, meta interface{}) err
 				Key:    aws.String(key),
 			})
 		if err != nil {
-			return fmt.Errorf("Failed to get object tags (bucket: %s, key: %s): %s", bucket, key, err)
+			log.Printf("[DEBUG] Failed to get object tags (bucket: %s, key: %s): %s", bucket, key, err)
+		} else {
+			d.Set("tags", tagsToMapS3(tagResp.TagSet))
 		}
-		d.Set("tags", tagsToMapS3(tagResp.TagSet))
 	}
 
 	return nil


### PR DESCRIPTION
It is possible to put an object in an s3 bucket but not be able to read from it, if the person creating the object is in a different account than the one the s3 bucket exists in, and depending on the policy of the s3 bucket and so forth. In this particular case, the resource would create properly, but then fail on the last step of the resourceAwsS3BucketObjectRead() - there is an unnecessary error about not being able to read the tags, which doesn't even matter because the tag output was set earlier in resourceAwsS3BucketObjectPut(). I changed this to print a debug statement, and then continue as normal. This follows the behavior of the aws cli and makes sense from a user perspective.