### PR TITLE
resource/aws_cognito_user_pool: Trim custom: prefix of developer_only_attribute = false schema attributes

### DIFF
--- a/aws/resource_aws_cognito_user_pool_test.go
+++ b/aws/resource_aws_cognito_user_pool_test.go
@@ -403,7 +403,7 @@ func TestAccAWSCognitoUserPool_withSchemaAttributes(t *testing.T) {
 			{
 				Config: testAccAWSCognitoUserPoolConfig_withSchemaAttributesUpdated(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.#", "2"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.#", "3"),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2078884933.attribute_data_type", "String"),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2078884933.developer_only_attribute", "false"),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2078884933.mutable", "false"),
@@ -422,6 +422,15 @@ func TestAccAWSCognitoUserPool_withSchemaAttributes(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2718111653.number_attribute_constraints.0.max_value", "6"),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2718111653.required", "false"),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2718111653.string_attribute_constraints.#", "0"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2753746449.attribute_data_type", "Number"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2753746449.developer_only_attribute", "false"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2753746449.mutable", "true"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2753746449.name", "mynondevnumber"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2753746449.number_attribute_constraints.#", "1"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2753746449.number_attribute_constraints.0.min_value", "2"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2753746449.number_attribute_constraints.0.max_value", "6"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2753746449.required", "false"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "schema.2753746449.string_attribute_constraints.#", "0"),
 				),
 			},
 			{
@@ -909,6 +918,19 @@ resource "aws_cognito_user_pool" "main" {
     developer_only_attribute = true
     mutable                  = true
     name                     = "mynumber"
+    required                 = false
+
+    number_attribute_constraints {
+      min_value = 2
+      max_value = 6
+    }
+  }
+
+  schema {
+    attribute_data_type      = "Number"
+    developer_only_attribute = false
+    mutable                  = true
+    name                     = "mynondevnumber"
     required                 = false
 
     number_attribute_constraints {

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -3022,7 +3022,7 @@ func flattenCognitoUserPoolSchema(configuredAttributes, inputs []*cognitoidentit
 			"attribute_data_type":      aws.StringValue(input.AttributeDataType),
 			"developer_only_attribute": aws.BoolValue(input.DeveloperOnlyAttribute),
 			"mutable":                  aws.BoolValue(input.Mutable),
-			"name":                     strings.TrimPrefix(aws.StringValue(input.Name), "dev:custom:"),
+			"name":                     strings.TrimPrefix(strings.TrimPrefix(aws.StringValue(input.Name), "dev:"), "custom:"),
 			"required":                 aws.BoolValue(input.Required),
 		}
 


### PR DESCRIPTION
Closes #4036 

Previously before code change:
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSCognitoUserPool_withSchemaAttributes'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCognitoUserPool_withSchemaAttributes -timeout 120m
=== RUN   TestAccAWSCognitoUserPool_withSchemaAttributes
--- FAIL: TestAccAWSCognitoUserPool_withSchemaAttributes (21.38s)
	testing.go:518: Step 1 error: After applying this step, the plan was not empty:

		DIFF:

		DESTROY/CREATE: aws_cognito_user_pool.main
		  admin_create_user_config.#:                                  "1" => "<computed>"
		  arn:                                                         "arn:aws:cognito-idp:us-west-2:187416307283:userpool/us-west-2_b79eqbrrp" => "<computed>"
		  creation_date:                                               "2018-04-04T15:24:46Z" => "<computed>"
		  email_verification_message:                                  "" => "<computed>"
		  email_verification_subject:                                  "" => "<computed>"
		  lambda_config.#:                                             "0" => "<computed>"
		  last_modified_date:                                          "2018-04-04T15:24:46Z" => "<computed>"
		  mfa_configuration:                                           "OFF" => "OFF"
		  name:                                                        "1laln" => "1laln"
		  password_policy.#:                                           "1" => "<computed>"
		  schema.#:                                                    "3" => "3"
		  schema.2078884933.attribute_data_type:                       "String" => "String"
		  schema.2078884933.developer_only_attribute:                  "false" => "false"
		  schema.2078884933.mutable:                                   "false" => "false"
		  schema.2078884933.name:                                      "email" => "email"
		  schema.2078884933.number_attribute_constraints.#:            "0" => "0"
		  schema.2078884933.required:                                  "true" => "true"
		  schema.2078884933.string_attribute_constraints.#:            "1" => "1"
		  schema.2078884933.string_attribute_constraints.0.max_length: "15" => "15"
		  schema.2078884933.string_attribute_constraints.0.min_length: "7" => "7"
		  schema.2410726534.attribute_data_type:                       "Number" => "" (forces new resource)
		  schema.2410726534.developer_only_attribute:                  "false" => "false"
		  schema.2410726534.mutable:                                   "true" => "false" (forces new resource)
		  schema.2410726534.name:                                      "custom:mynondevnumber" => "" (forces new resource)
		  schema.2410726534.number_attribute_constraints.#:            "1" => "0" (forces new resource)
		  schema.2410726534.number_attribute_constraints.0.max_value:  "6" => "" (forces new resource)
		  schema.2410726534.number_attribute_constraints.0.min_value:  "2" => "" (forces new resource)
		  schema.2410726534.required:                                  "false" => "false"
		  schema.2410726534.string_attribute_constraints.#:            "0" => "0"
		  schema.2718111653.attribute_data_type:                       "Number" => "Number"
		  schema.2718111653.developer_only_attribute:                  "true" => "true"
		  schema.2718111653.mutable:                                   "true" => "true"
		  schema.2718111653.name:                                      "mynumber" => "mynumber"
		  schema.2718111653.number_attribute_constraints.#:            "1" => "1"
		  schema.2718111653.number_attribute_constraints.0.max_value:  "6" => "6"
		  schema.2718111653.number_attribute_constraints.0.min_value:  "2" => "2"
		  schema.2718111653.required:                                  "false" => "false"
		  schema.2718111653.string_attribute_constraints.#:            "0" => "0"
		  schema.2753746449.attribute_data_type:                       "" => "Number" (forces new resource)
		  schema.2753746449.developer_only_attribute:                  "" => "false" (forces new resource)
		  schema.2753746449.mutable:                                   "" => "true" (forces new resource)
		  schema.2753746449.name:                                      "" => "mynondevnumber" (forces new resource)
		  schema.2753746449.number_attribute_constraints.#:            "" => "1" (forces new resource)
		  schema.2753746449.number_attribute_constraints.0.max_value:  "" => "6" (forces new resource)
		  schema.2753746449.number_attribute_constraints.0.min_value:  "" => "2" (forces new resource)
		  schema.2753746449.required:                                  "" => "false" (forces new resource)
		  schema.2753746449.string_attribute_constraints.#:            "" => "0"
		  verification_message_template.#:                             "1" => "<computed>"
```

After code change:
```
19 tests passed (all tests)
=== RUN   TestAccAWSCognitoUserPoolClient_allFields
--- PASS: TestAccAWSCognitoUserPoolClient_allFields (10.88s)
=== RUN   TestAccAWSCognitoUserPool_importBasic
--- PASS: TestAccAWSCognitoUserPool_importBasic (13.97s)
=== RUN   TestAccAWSCognitoUserPool_withEmailVerificationMessage
--- PASS: TestAccAWSCognitoUserPool_withEmailVerificationMessage (24.21s)
=== RUN   TestAccAWSCognitoUserPoolClient_basic
--- PASS: TestAccAWSCognitoUserPoolClient_basic (29.33s)
=== RUN   TestAccAWSCognitoUserPool_withSmsVerificationMessage
--- PASS: TestAccAWSCognitoUserPool_withSmsVerificationMessage (29.84s)
=== RUN   TestAccAWSCognitoUserPoolDomain_import
--- PASS: TestAccAWSCognitoUserPoolDomain_import (30.71s)
=== RUN   TestAccAWSCognitoUserPool_withSmsConfiguration
--- PASS: TestAccAWSCognitoUserPool_withSmsConfiguration (32.50s)
=== RUN   TestAccAWSCognitoUserPool_withTags
--- PASS: TestAccAWSCognitoUserPool_withTags (33.41s)
=== RUN   TestAccAWSCognitoUserPool_withEmailConfiguration
--- PASS: TestAccAWSCognitoUserPool_withEmailConfiguration (33.65s)
=== RUN   TestAccAWSCognitoUserPool_basic
--- PASS: TestAccAWSCognitoUserPool_basic (36.77s)
=== RUN   TestAccAWSCognitoUserPool_withDeviceConfiguration
--- PASS: TestAccAWSCognitoUserPool_withDeviceConfiguration (37.25s)
=== RUN   TestAccAWSCognitoUserPool_withVerificationMessageTemplate
--- PASS: TestAccAWSCognitoUserPool_withVerificationMessageTemplate (37.49s)
=== RUN   TestAccAWSCognitoUserPool_withAliasAttributes
--- PASS: TestAccAWSCognitoUserPool_withAliasAttributes (37.47s)
=== RUN   TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration
--- PASS: TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration (40.29s)
=== RUN   TestAccAWSCognitoUserPoolDomain_basic
--- PASS: TestAccAWSCognitoUserPoolDomain_basic (40.40s)
=== RUN   TestAccAWSCognitoUserPool_withSchemaAttributes
--- PASS: TestAccAWSCognitoUserPool_withSchemaAttributes (40.65s)
=== RUN   TestAccAWSCognitoUserPool_withPasswordPolicy
--- PASS: TestAccAWSCognitoUserPool_withPasswordPolicy (44.58s)
=== RUN   TestAccAWSCognitoUserPool_withLambdaConfig
--- PASS: TestAccAWSCognitoUserPool_withLambdaConfig (45.25s)
=== RUN   TestAccAWSCognitoUserPool_withSmsConfigurationUpdated
--- PASS: TestAccAWSCognitoUserPool_withSmsConfigurationUpdated (63.51s)
```