### PR TITLE
 EmailMessageByLink should not be limited to 140 characters

### DIFF
--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1245,8 +1245,8 @@ func validateCognitoUserPoolTemplateEmailMessageByLink(v interface{}, k string) 
 		es = append(es, fmt.Errorf("%q cannot be less than 1 character", k))
 	}
 
-	if len(value) > 140 {
-		es = append(es, fmt.Errorf("%q cannot be longer than 140 characters", k))
+	if len(value) > 20000 {
+		es = append(es, fmt.Errorf("%q cannot be longer than 20000 characters", k))
 	}
 
 	if !regexp.MustCompile(`[\p{L}\p{M}\p{S}\p{N}\p{P}\s*]*\{##[\p{L}\p{M}\p{S}\p{N}\p{P}\s*]*##\}[\p{L}\p{M}\p{S}\p{N}\p{P}\s*]*`).MatchString(value) {


### PR DESCRIPTION
This fixes #4050.

Looks like this was caused by a copy-paste error.

Changed EmailMessageByLink's validation to use the same length as EmailMessage, as per AWS docs.