### PR TITLE
tests/resource/aws_ecs_task_definition: Randomize IAM role and task definition family names

### DIFF
--- a/aws/data_source_aws_ecs_task_definition_test.go
+++ b/aws/data_source_aws_ecs_task_definition_test.go
@@ -1,35 +1,39 @@
 package aws
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccAWSEcsDataSource_ecsTaskDefinition(t *testing.T) {
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckAwsEcsTaskDefinitionDataSourceConfig,
+				Config: testAccCheckAwsEcsTaskDefinitionDataSourceConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr("data.aws_ecs_task_definition.mongo", "id", regexp.MustCompile("^arn:aws:ecs:us-west-2:[0-9]{12}:task-definition/mongodb:[1-9][0-9]*$")),
-					resource.TestCheckResourceAttr("data.aws_ecs_task_definition.mongo", "family", "mongodb"),
+					resource.TestCheckResourceAttr("data.aws_ecs_task_definition.mongo", "family", rName),
 					resource.TestCheckResourceAttr("data.aws_ecs_task_definition.mongo", "network_mode", "bridge"),
 					resource.TestMatchResourceAttr("data.aws_ecs_task_definition.mongo", "revision", regexp.MustCompile("^[1-9][0-9]*$")),
 					resource.TestCheckResourceAttr("data.aws_ecs_task_definition.mongo", "status", "ACTIVE"),
-					resource.TestMatchResourceAttr("data.aws_ecs_task_definition.mongo", "task_role_arn", regexp.MustCompile("^arn:aws:iam::[0-9]{12}:role/mongo_role$")),
+					resource.TestMatchResourceAttr("data.aws_ecs_task_definition.mongo", "task_role_arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:iam::[^:]+:role/%s$", rName))),
 				),
 			},
 		},
 	})
 }
 
-const testAccCheckAwsEcsTaskDefinitionDataSourceConfig = `
+func testAccCheckAwsEcsTaskDefinitionDataSourceConfig(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_iam_role" "mongo_role" {
-    name = "mongo_role"
+    name = "%[1]s"
     assume_role_policy = <<POLICY
 {
   "Version": "2012-10-17",
@@ -48,7 +52,7 @@ POLICY
 }
 
 resource "aws_ecs_task_definition" "mongo" {
-  family = "mongodb"
+  family = "%[1]s"
   task_role_arn = "${aws_iam_role.mongo_role.arn}"
   network_mode = "bridge"
   container_definitions = <<DEFINITION
@@ -72,4 +76,5 @@ DEFINITION
 data "aws_ecs_task_definition" "mongo" {
   task_definition = "${aws_ecs_task_definition.mongo.family}"
 }
-`
+`, rName)
+}


### PR DESCRIPTION
Previously:
```
=== RUN   TestAccAWSEcsDataSource_ecsTaskDefinition
--- FAIL: TestAccAWSEcsDataSource_ecsTaskDefinition (8.93s)
    testing.go:518: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_iam_role.mongo_role: 1 error(s) occurred:
        
        * aws_iam_role.mongo_role: Error creating IAM Role mongo_role: EntityAlreadyExists: Role with name mongo_role already exists.
            status code: 409, request id: c6830246-384a-11e8-8ee2-43ceebacef8c
```

Now:
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSEcsDataSource_ecsTaskDefinition'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSEcsDataSource_ecsTaskDefinition -timeout 120m
=== RUN   TestAccAWSEcsDataSource_ecsTaskDefinition
--- PASS: TestAccAWSEcsDataSource_ecsTaskDefinition (14.48s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	14.520s
```