### PR TITLE
Adding documentation for SSM Command as a Cloudwatch event target

### DIFF
--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -124,7 +124,7 @@ DOC
 }
 
 resource "aws_cloudwatch_event_rule" "stop_instances" {
-  name                = "StopInstance
+  name                = "StopInstance"
   description         = "Stop instances nightly"
   schedule_expression = "cron(0 0 * * ? *)"
 }
@@ -148,7 +148,7 @@ resource "aws_cloudwatch_event_target" "stop_instances" {
 ```
 
 resource "aws_cloudwatch_event_rule" "stop_instances" {
-  name                = "StopInstance
+  name                = "StopInstance"
   description         = "Stop instances nightly"
   schedule_expression = "cron(0 0 * * ? *)"
 }

--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -54,6 +54,94 @@ resource "aws_kinesis_stream" "test_stream" {
 }
 ```
 
+## Example Run Command Usage
+```
+data "aws_iam_policy_document" "ssm_lifecycle_trust" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "ssm_lifecycle" {
+  statement {
+    effect    = "Allow"
+    actions   = ["ssm:SendCommand"]
+    resources = ["arn:aws:ec2:eu-west-1:1234567890:instance/*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "ec2:ResourceTag/TerminationSchedule"
+      values   = ["*"]
+    }
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["ssm:SendCommand"]
+    resources = ["${aws_ssm_document.stop_instance.arn}"]
+  }
+}
+
+resource "aws_iam_role" "ssm_lifecycle" {
+  name               = "SSMLifecycle"
+  assume_role_policy = "${data.aws_iam_policy_document.ssm_lifecycle_trust.json}"
+}
+
+resource "aws_iam_policy" "ssm_lifecycle" {
+  name   = "SSMLifecycle"
+  policy = "${data.aws_iam_policy_document.ssm_lifecycle.json}"
+}
+
+resource "aws_ssm_document" "stop_instance" {
+  name          = "stop_instance"
+  document_type = "Command"
+
+  content = <<DOC
+  {
+    "schemaVersion": "1.2",
+    "description": "Stop an instance",
+    "parameters": {
+
+    },
+    "runtimeConfig": {
+      "aws:runShellScript": {
+        "properties": [
+          {
+            "id": "0.aws:runShellScript",
+            "runCommand": ["halt"]
+          }
+        ]
+      }
+    }
+  }
+DOC
+}
+
+resource "aws_cloudwatch_event_rule" "stop_instances" {
+  name                = "StopInstance
+  description         = "Stop instances nightly"
+  schedule_expression = "cron(0 0 * * ? *)"
+}
+
+resource "aws_cloudwatch_event_target" "stop_instances" {
+  target_id = "StopInstance"
+  arn       = "${aws_ssm_document.stop_instance.arn}"
+  rule      = "${aws_cloudwatch_event_rule.stop_instances.name}"
+  role_arn  = "${aws_iam_role.ssm_lifecycle.arn}"
+
+  run_command_targets {
+    key    = "tag:TerminationSchedule"
+    values = ["midnight"]
+  }
+}
+
+```
+
 ## Argument Reference
 
 -> **Note:** `input` and `input_path` are mutually exclusive options.

--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -143,6 +143,31 @@ resource "aws_cloudwatch_event_target" "stop_instances" {
 
 ```
 
+## Example RunCommand Usage
+
+```
+
+resource "aws_cloudwatch_event_rule" "stop_instances" {
+  name                = "StopInstance
+  description         = "Stop instances nightly"
+  schedule_expression = "cron(0 0 * * ? *)"
+}
+
+resource "aws_cloudwatch_event_target" "stop_instances" {
+  target_id = "StopInstance"
+  arn       = "arn:aws:ssm:${var.aws_region}::document/AWS-RunShellScript"
+  input     = "{\"commands\":[\"halt\"]}"
+  rule      = "${aws_cloudwatch_event_rule.stop_instances.name}"
+  role_arn  = "${aws_iam_role.ssm_lifecycle.arn}"
+
+  run_command_targets {
+    key    = "tag:Terminate"
+    values = ["midnight"]
+  }
+}
+
+```
+
 ## Argument Reference
 
 -> **Note:** `input` and `input_path` are mutually exclusive options.

--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -54,7 +54,7 @@ resource "aws_kinesis_stream" "test_stream" {
 }
 ```
 
-## Example SSM RunCommand Usage
+## Example SSM Document Usage
 
 ```
 data "aws_iam_policy_document" "ssm_lifecycle_trust" {
@@ -76,7 +76,7 @@ data "aws_iam_policy_document" "ssm_lifecycle" {
 
     condition {
       test     = "StringEquals"
-      variable = "ec2:ResourceTag/TerminationSchedule"
+      variable = "ec2:ResourceTag/Terminate"
       values   = ["*"]
     }
   }
@@ -84,7 +84,7 @@ data "aws_iam_policy_document" "ssm_lifecycle" {
   statement {
     effect    = "Allow"
     actions   = ["ssm:SendCommand"]
-    resources = ["arn:aws:ssm:eu-west-1:*:document/AWS-RunShellScript"]
+    resources = ["${aws_ssm_document.stop_instance.arn}"]
   }
 }
 
@@ -98,6 +98,31 @@ resource "aws_iam_policy" "ssm_lifecycle" {
   policy = "${data.aws_iam_policy_document.ssm_lifecycle.json}"
 }
 
+resource "aws_ssm_document" "stop_instance" {
+  name          = "stop_instance"
+  document_type = "Command"
+
+  content = <<DOC
+  {
+    "schemaVersion": "1.2",
+    "description": "Stop an instance",
+    "parameters": {
+
+    },
+    "runtimeConfig": {
+      "aws:runShellScript": {
+        "properties": [
+          {
+            "id": "0.aws:runShellScript",
+            "runCommand": ["halt"]
+          }
+        ]
+      }
+    }
+  }
+DOC
+}
+
 resource "aws_cloudwatch_event_rule" "stop_instances" {
   name                = "StopInstance
   description         = "Stop instances nightly"
@@ -106,12 +131,12 @@ resource "aws_cloudwatch_event_rule" "stop_instances" {
 
 resource "aws_cloudwatch_event_target" "stop_instances" {
   target_id = "StopInstance"
-  arn       = "arn:aws:ssm:eu-west-1::document/AWS-RunShellScript"
+  arn       = "${aws_ssm_document.stop_instance.arn}"
   rule      = "${aws_cloudwatch_event_rule.stop_instances.name}"
   role_arn  = "${aws_iam_role.ssm_lifecycle.arn}"
 
   run_command_targets {
-    key    = "tag:TerminationSchedule"
+    key    = "tag:Terminate"
     values = ["midnight"]
   }
 }

--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -54,7 +54,8 @@ resource "aws_kinesis_stream" "test_stream" {
 }
 ```
 
-## Example Run Command Usage
+## Example SSM RunCommand Usage
+
 ```
 data "aws_iam_policy_document" "ssm_lifecycle_trust" {
   statement {
@@ -83,7 +84,7 @@ data "aws_iam_policy_document" "ssm_lifecycle" {
   statement {
     effect    = "Allow"
     actions   = ["ssm:SendCommand"]
-    resources = ["${aws_ssm_document.stop_instance.arn}"]
+    resources = ["arn:aws:ssm:eu-west-1:*:document/AWS-RunShellScript"]
   }
 }
 
@@ -97,31 +98,6 @@ resource "aws_iam_policy" "ssm_lifecycle" {
   policy = "${data.aws_iam_policy_document.ssm_lifecycle.json}"
 }
 
-resource "aws_ssm_document" "stop_instance" {
-  name          = "stop_instance"
-  document_type = "Command"
-
-  content = <<DOC
-  {
-    "schemaVersion": "1.2",
-    "description": "Stop an instance",
-    "parameters": {
-
-    },
-    "runtimeConfig": {
-      "aws:runShellScript": {
-        "properties": [
-          {
-            "id": "0.aws:runShellScript",
-            "runCommand": ["halt"]
-          }
-        ]
-      }
-    }
-  }
-DOC
-}
-
 resource "aws_cloudwatch_event_rule" "stop_instances" {
   name                = "StopInstance
   description         = "Stop instances nightly"
@@ -130,7 +106,7 @@ resource "aws_cloudwatch_event_rule" "stop_instances" {
 
 resource "aws_cloudwatch_event_target" "stop_instances" {
   target_id = "StopInstance"
-  arn       = "${aws_ssm_document.stop_instance.arn}"
+  arn       = "arn:aws:ssm:eu-west-1::document/AWS-RunShellScript"
   rule      = "${aws_cloudwatch_event_rule.stop_instances.name}"
   role_arn  = "${aws_iam_role.ssm_lifecycle.arn}"
 


### PR DESCRIPTION
This PR is adding documentation around using SSM RunCommand as a `cloudwatch_event_target`

[There is an open issue](https://github.com/terraform-providers/terraform-provider-aws/issues/3437) for it to become available but it is possible old as the work to add the functionality was available shortly after the date of the original issue