### PR TITLE
Add support for enabling Point in time recovery (PITR) for DynamoDB tables

### DIFF
--- a/aws/resource_aws_dynamodb_table_test.go
+++ b/aws/resource_aws_dynamodb_table_test.go
@@ -379,6 +379,33 @@ func TestAccAWSDynamoDbTable_extended(t *testing.T) {
 	})
 }
 
+func TestAccAWSDynamoDbTable_enablePitr(t *testing.T) {
+	var conf dynamodb.DescribeTableOutput
+
+	rName := acctest.RandomWithPrefix("TerraformTestTable-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDynamoDbTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDynamoDbConfigInitialState(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInitialAWSDynamoDbTableExists("aws_dynamodb_table.basic-dynamodb-table", &conf),
+					testAccCheckInitialAWSDynamoDbTableConf("aws_dynamodb_table.basic-dynamodb-table"),
+				),
+			},
+			{
+				Config: testAccAWSDynamoDbConfig_backup(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDynamoDbTableHasBackup("aws_dynamodb_table.basic-dynamodb-table"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSDynamoDbTable_streamSpecification(t *testing.T) {
 	var conf dynamodb.DescribeTableOutput
 
@@ -937,6 +964,37 @@ func testAccCheckInitialAWSDynamoDbTableConf(n string) resource.TestCheckFunc {
 	}
 }
 
+func testAccCheckDynamoDbTableHasBackup(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No DynamoDB table name specified!")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).dynamodbconn
+
+		resp, err := conn.DescribeContinuousBackups(&dynamodb.DescribeContinuousBackupsInput{
+			TableName: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		pitr := resp.ContinuousBackupsDescription.PointInTimeRecoveryDescription
+		status := *pitr.PointInTimeRecoveryStatus
+		if status != dynamodb.PointInTimeRecoveryStatusEnabled {
+			return fmt.Errorf("Point in time backup had a status of %s rather than enabled", status)
+		}
+
+		return nil
+	}
+}
+
 func testAccCheckDynamoDbTableWasUpdated(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -1034,6 +1092,23 @@ resource "aws_dynamodb_table" "basic-dynamodb-table" {
     name = "TestTableHashKey"
     type = "S"
   }
+}
+`, rName)
+}
+
+func testAccAWSDynamoDbConfig_backup(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "basic-dynamodb-table" {
+  name = "%s"
+  read_capacity = 1
+  write_capacity = 1
+  hash_key = "TestTableHashKey"
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+  point_in_time_backup_enabled = true
 }
 `, rName)
 }

--- a/aws/resource_aws_dynamodb_table_test.go
+++ b/aws/resource_aws_dynamodb_table_test.go
@@ -399,7 +399,9 @@ func TestAccAWSDynamoDbTable_enablePitr(t *testing.T) {
 			{
 				Config: testAccAWSDynamoDbConfig_backup(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDynamoDbTableHasBackup("aws_dynamodb_table.basic-dynamodb-table"),
+					testAccCheckDynamoDbTableHasPointInTimeRecoveryEnabled("aws_dynamodb_table.basic-dynamodb-table"),
+					resource.TestCheckResourceAttr("aws_dynamodb_table.basic-dynamodb-table", "point_in_time_recovery.#", "1"),
+					resource.TestCheckResourceAttr("aws_dynamodb_table.basic-dynamodb-table", "point_in_time_recovery.0.enabled", "true"),
 				),
 			},
 		},
@@ -964,7 +966,7 @@ func testAccCheckInitialAWSDynamoDbTableConf(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckDynamoDbTableHasBackup(n string) resource.TestCheckFunc {
+func testAccCheckDynamoDbTableHasPointInTimeRecoveryEnabled(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -1108,7 +1110,9 @@ resource "aws_dynamodb_table" "basic-dynamodb-table" {
     name = "TestTableHashKey"
     type = "S"
   }
-  point_in_time_backup_enabled = true
+  point_in_time_recovery {
+    enabled = true
+  }
 }
 `, rName)
 }

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -3650,6 +3650,21 @@ func flattenDynamoDbTtl(ttlDesc *dynamodb.TimeToLiveDescription) []interface{} {
 	return []interface{}{}
 }
 
+func flattenDynamoDbPitr(pitrDesc *dynamodb.DescribeContinuousBackupsOutput) []interface{} {
+	m := map[string]interface{}{}
+	if pitrDesc.ContinuousBackupsDescription != nil {
+		pitr := pitrDesc.ContinuousBackupsDescription.PointInTimeRecoveryDescription
+		if pitr != nil {
+			m["enabled"] = (*pitr.PointInTimeRecoveryStatus == dynamodb.PointInTimeRecoveryStatusEnabled)
+		}
+	}
+	if len(m) > 0 {
+		return []interface{}{m}
+	}
+
+	return []interface{}{m}
+}
+
 func flattenAwsDynamoDbTableResource(d *schema.ResourceData, table *dynamodb.TableDescription) error {
 	d.Set("write_capacity", table.ProvisionedThroughput.WriteCapacityUnits)
 	d.Set("read_capacity", table.ProvisionedThroughput.ReadCapacityUnits)

--- a/website/docs/r/dynamodb_table.html.markdown
+++ b/website/docs/r/dynamodb_table.html.markdown
@@ -90,6 +90,7 @@ attributes, etc.
 * `stream_view_type` - (Optional) When an item in the table is modified, StreamViewType determines what information is written to the table's stream. Valid values are `KEYS_ONLY`, `NEW_IMAGE`, `OLD_IMAGE`, `NEW_AND_OLD_IMAGES`.
 * `server_side_encryption` - (Optional) Encrypt at rest options.
 * `tags` - (Optional) A map of tags to populate on the created table.
+* `point_in_time_backup_enabled` - (Optional) Indicates whether point-in-time recovery is enabled (true) or disabled (false) - note that it can take a while to enable for new tables.
 
 ### Timeouts
 

--- a/website/docs/r/dynamodb_table.html.markdown
+++ b/website/docs/r/dynamodb_table.html.markdown
@@ -90,7 +90,7 @@ attributes, etc.
 * `stream_view_type` - (Optional) When an item in the table is modified, StreamViewType determines what information is written to the table's stream. Valid values are `KEYS_ONLY`, `NEW_IMAGE`, `OLD_IMAGE`, `NEW_AND_OLD_IMAGES`.
 * `server_side_encryption` - (Optional) Encrypt at rest options.
 * `tags` - (Optional) A map of tags to populate on the created table.
-* `point_in_time_backup_enabled` - (Optional) Indicates whether point-in-time recovery is enabled (true) or disabled (false) - note that it can take a while to enable for new tables.
+* `point_in_time_recovery` - (Optional) Point-in-time recovery options.
 
 ### Timeouts
 
@@ -135,6 +135,10 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 #### `server_side_encryption`
 
 * `enabled` - (Required) Whether to enable encryption at rest. If the `server_side_encryption` block is not provided then this defaults to `false`.
+
+#### `point_in_time_recovery`
+
+* `enabled` - (Required) Whether to enable point-in-time recovery - note that it can take up to 10 minutes to enable for new tables. If the `point_in_time_recovery` block is not provided then this defaults to `false`.
 
 ### A note about attributes
 


### PR DESCRIPTION
Fixes #3927.

Note that it can take ~10 minutes for PITR to be enabled on newly created tables.

Also note that I've added `waitForDynamoDbBackupUpdateToBeCompleted` as the documentation implies that it's possible for `PointInTimeRecoveryStatus` to be `ENABLING` rather than just `ENABLED` or `DISABLED` (https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_PointInTimeRecoveryDescription.html).