### PR TITLE
resource/aws_launch_configuration: Add support for ebs_block_device.*.no_device

### DIFF
--- a/aws/resource_aws_launch_configuration.go
+++ b/aws/resource_aws_launch_configuration.go
@@ -346,7 +346,10 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 			bd := v.(map[string]interface{})
 			ebs := &autoscaling.Ebs{}
 
-			if v, ok := bd["no_device"].(bool); !ok && v {
+			var noDevice *bool
+			if v, ok := bd["no_device"].(bool); ok && v {
+				noDevice = aws.Bool(v)
+			} else {
 				ebs.DeleteOnTermination = aws.Bool(bd["delete_on_termination"].(bool))
 			}
 
@@ -376,8 +379,8 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 
 			blockDevices = append(blockDevices, &autoscaling.BlockDeviceMapping{
 				DeviceName: aws.String(bd["device_name"].(string)),
-				NoDevice:   aws.Bool(bd["no_device"].(bool)),
 				Ebs:        ebs,
+				NoDevice:   noDevice,
 			})
 		}
 	}
@@ -589,11 +592,33 @@ func readBlockDevicesFromLaunchConfiguration(d *schema.ResourceData, lc *autosca
 		var blank string
 		rootDeviceName = &blank
 	}
+
+	// Collect existing configured devices, so we can check
+	// existing value of delete_on_termination below
+	existingEbsBlockDevices := make(map[string]map[string]interface{}, 0)
+	if v, ok := d.GetOk("ebs_block_device"); ok {
+		ebsBlocks := v.(*schema.Set)
+		for _, ebd := range ebsBlocks.List() {
+			m := ebd.(map[string]interface{})
+			deviceName := m["device_name"].(string)
+			existingEbsBlockDevices[deviceName] = m
+		}
+	}
+
 	for _, bdm := range lc.BlockDeviceMappings {
 		bd := make(map[string]interface{})
-		if bdm.Ebs != nil && bdm.Ebs.DeleteOnTermination != nil {
+
+		if bdm.NoDevice != nil {
+			// Keep existing value in place to avoid spurious diff
+			deleteOnTermination := true
+			if device, ok := existingEbsBlockDevices[*bdm.DeviceName]; ok {
+				deleteOnTermination = device["delete_on_termination"].(bool)
+			}
+			bd["delete_on_termination"] = deleteOnTermination
+		} else if bdm.Ebs != nil && bdm.Ebs.DeleteOnTermination != nil {
 			bd["delete_on_termination"] = *bdm.Ebs.DeleteOnTermination
 		}
+
 		if bdm.Ebs != nil && bdm.Ebs.VolumeSize != nil {
 			bd["volume_size"] = *bdm.Ebs.VolumeSize
 		}
@@ -619,6 +644,9 @@ func readBlockDevicesFromLaunchConfiguration(d *schema.ResourceData, lc *autosca
 			} else {
 				if bdm.Ebs != nil && bdm.Ebs.SnapshotId != nil {
 					bd["snapshot_id"] = *bdm.Ebs.SnapshotId
+				}
+				if bdm.NoDevice != nil {
+					bd["no_device"] = *bdm.NoDevice
 				}
 				blockDevices["ebs"] = append(blockDevices["ebs"].([]map[string]interface{}), bd)
 			}

--- a/aws/resource_aws_launch_configuration.go
+++ b/aws/resource_aws_launch_configuration.go
@@ -158,6 +158,12 @@ func resourceAwsLaunchConfiguration() *schema.Resource {
 							ForceNew: true,
 						},
 
+						"no_device": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							ForceNew: true,
+						},
+
 						"iops": {
 							Type:     schema.TypeInt,
 							Optional: true,
@@ -338,8 +344,10 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 		vL := v.(*schema.Set).List()
 		for _, v := range vL {
 			bd := v.(map[string]interface{})
-			ebs := &autoscaling.Ebs{
-				DeleteOnTermination: aws.Bool(bd["delete_on_termination"].(bool)),
+			ebs := &autoscaling.Ebs{}
+
+			if v, ok := bd["no_device"].(bool); !ok && v {
+				ebs.DeleteOnTermination = aws.Bool(bd["delete_on_termination"].(bool))
 			}
 
 			if v, ok := bd["snapshot_id"].(string); ok && v != "" {
@@ -368,6 +376,7 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 
 			blockDevices = append(blockDevices, &autoscaling.BlockDeviceMapping{
 				DeviceName: aws.String(bd["device_name"].(string)),
+				NoDevice:   aws.Bool(bd["no_device"].(bool)),
 				Ebs:        ebs,
 			})
 		}

--- a/aws/resource_aws_launch_configuration_test.go
+++ b/aws/resource_aws_launch_configuration_test.go
@@ -281,7 +281,7 @@ func TestAccAWSLaunchConfiguration_updateEbsBlockDevices(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSLaunchConfigurationExists("aws_launch_configuration.baz", &conf),
 					resource.TestCheckResourceAttr(
-						"aws_launch_configuration.baz", "ebs_block_device.2764618555.volume_size", "9"),
+						"aws_launch_configuration.baz", "ebs_block_device.1393547169.volume_size", "9"),
 				),
 			},
 			{
@@ -289,7 +289,29 @@ func TestAccAWSLaunchConfiguration_updateEbsBlockDevices(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSLaunchConfigurationExists("aws_launch_configuration.baz", &conf),
 					resource.TestCheckResourceAttr(
-						"aws_launch_configuration.baz", "ebs_block_device.3859927736.volume_size", "10"),
+						"aws_launch_configuration.baz", "ebs_block_device.4131155854.volume_size", "10"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSLaunchConfiguration_ebs_noDevice(t *testing.T) {
+	var conf autoscaling.LaunchConfiguration
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLaunchConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLaunchConfigurationConfigEbsNoDevice(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchConfigurationExists("aws_launch_configuration.bar", &conf),
+					resource.TestCheckResourceAttr("aws_launch_configuration.bar", "ebs_block_device.#", "1"),
+					resource.TestCheckResourceAttr("aws_launch_configuration.bar", "ebs_block_device.3099842682.device_name", "/dev/sda2"),
+					resource.TestCheckResourceAttr("aws_launch_configuration.bar", "ebs_block_device.3099842682.no_device", "true"),
 				),
 			},
 		},
@@ -605,6 +627,29 @@ resource "aws_launch_configuration" "bar" {
 	image_id             = "ami-5189a661"
 	instance_type        = "t2.nano"
 	iam_instance_profile = "${aws_iam_instance_profile.profile.name}"
+}
+`, rInt)
+}
+
+func testAccAWSLaunchConfigurationConfigEbsNoDevice(rInt int) string {
+	return fmt.Sprintf(`
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/ebs/ubuntu-precise-12.04-i386-server-*"]
+  }
+  owners = ["099720109477"] # Canonical
+}
+
+resource "aws_launch_configuration" "bar" {
+  name_prefix = "tf-acc-test-%d"
+  image_id = "${data.aws_ami.ubuntu.id}"
+  instance_type = "m1.small"
+  ebs_block_device {
+    device_name = "/dev/sda2"
+    no_device = true
+  }
 }
 `, rInt)
 }


### PR DESCRIPTION
Closes #2132

Original commit & authorship is retained (as usually) - thanks @maxfortune for the initial work.

As described in the commit message I added an acceptance test and reflected the new field in `Read()` so that drifts are detected as user would normally expect.

------

I played with multiple different solutions before eventually choosing this one. While it may not look ideal (due to awkward workaround for `delete_on_termination`), the other ones I considered had more annoying downsides. Here's a complete list of solutions I decided to stash:

 - Big refactoring the whole schema to reflect the API more accurately (i.e. replacing `ebs_block_device`, `ephemeral_block_device` & `root_block_device` with `block_device_mapping` and nested `ebs` field).
   - This seemed to be a good idea until I read the [reasoning](https://github.com/hashicorp/terraform/pull/1045#issue-29954782) behind the current "abstracted" schema. While some reasons (about ephemeral devices not being available in API) don't necessarily apply here in the context of Launch Configuration I still think that keeping device-related schemas across resources (EC2 instance, spot instance, AMI, ...) consistent is important for the UX.
 - Small refactoring of the `ebs_block_device` schema to make all `Ebs` fields actually optional (i.e. nest fields like `delete_on_termination` under new `ebs` field) and never conflict with `NoDevice`.
   - I realized that migration to the new schema is very difficult. We'd have to suppress drift detection for either the new or old (deprecated) fields because of how Set index for `ebs_block_device` is computed - it has no way of knowing whether a value comes explicitly from config or is just computed (new `ebs` block in this case).
 - Removing `Default: true` from `delete_on_termination` and forcing the user to be explicit.
   - I realized that this would probably make it less convenient for some users (since default [API](https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_Ebs.html) & [CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig-blockdev-template.html#cfn-as-launchconfig-blockdev-template-deleteonterm) behaviour is `delete_on_termination = true`) and it would also force us to introduce a breaking change as state migration has no way of knowing whether `"delete_on_termination": "true"` in state comes from an explicit config or just reflects default value. Making the field `Computed` wasn't very sound idea either because we'd loose the ability to detect drifts (from default `delete_on_termination = true`).
