### PR TITLE
tests/resource/aws_lb: Remove missing attribute from TestAccAWSLBBackwardsCompatibility

### DIFF
--- a/aws/resource_aws_lb_test.go
+++ b/aws/resource_aws_lb_test.go
@@ -158,7 +158,6 @@ func TestAccAWSLBBackwardsCompatibility(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_alb.lb_test", "tags.%", "1"),
 					resource.TestCheckResourceAttr("aws_alb.lb_test", "tags.Name", "TestAccAWSALB_basic"),
 					resource.TestCheckResourceAttr("aws_alb.lb_test", "enable_deletion_protection", "false"),
-					resource.TestCheckResourceAttr("aws_alb.lb_test", "enable_cross_zone_load_balancing", "false"),
 					resource.TestCheckResourceAttr("aws_alb.lb_test", "idle_timeout", "30"),
 					resource.TestCheckResourceAttr("aws_alb.lb_test", "ip_address_type", "ipv4"),
 					resource.TestCheckResourceAttr("aws_alb.lb_test", "load_balancer_type", "application"),


### PR DESCRIPTION
Missed this yesterday in #4032 😓  - the attribute should be missing as it is not applicable to application load balancers.

Previously:
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSLBBackwardsCompatibility'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSLBBackwardsCompatibility -timeout 120m
=== RUN   TestAccAWSLBBackwardsCompatibility
--- FAIL: TestAccAWSLBBackwardsCompatibility (212.66s)
	testing.go:518: Step 0 error: Check failed: 1 error(s) occurred:

		* Check 9/16 error: aws_alb.lb_test: Attribute 'enable_cross_zone_load_balancing' not found
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	212.707s
make: *** [testacc] Error 1
```

Now:
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSLBBackwardsCompatibility'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSLBBackwardsCompatibility -timeout 120m
=== RUN   TestAccAWSLBBackwardsCompatibility
--- PASS: TestAccAWSLBBackwardsCompatibility (191.09s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	191.136s
```