### PR TITLE
resource/aws_service_discovery_service: Support HealthCheckCustomConfig

### DIFF
--- a/aws/resource_aws_service_discovery_service_test.go
+++ b/aws/resource_aws_service_discovery_service_test.go
@@ -19,9 +19,10 @@ func TestAccAWSServiceDiscoveryService_private(t *testing.T) {
 		CheckDestroy: testAccCheckAwsServiceDiscoveryServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceDiscoveryServiceConfig_private(rName),
+				Config: testAccServiceDiscoveryServiceConfig_private(rName, 5),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsServiceDiscoveryServiceExists("aws_service_discovery_service.test"),
+					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "health_check_custom_config.0.failure_threshold", "5"),
 					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "dns_config.0.dns_records.#", "1"),
 					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "dns_config.0.dns_records.0.type", "A"),
 					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "dns_config.0.dns_records.0.ttl", "5"),
@@ -30,7 +31,7 @@ func TestAccAWSServiceDiscoveryService_private(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccServiceDiscoveryServiceConfig_private_update(rName),
+				Config: testAccServiceDiscoveryServiceConfig_private_update(rName, 5),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsServiceDiscoveryServiceExists("aws_service_discovery_service.test"),
 					resource.TestCheckResourceAttr("aws_service_discovery_service.test", "dns_config.0.dns_records.#", "2"),
@@ -86,7 +87,7 @@ func TestAccAWSServiceDiscoveryService_import(t *testing.T) {
 		CheckDestroy: testAccCheckAwsServiceDiscoveryServiceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccServiceDiscoveryServiceConfig_private(acctest.RandString(5)),
+				Config: testAccServiceDiscoveryServiceConfig_private(acctest.RandString(5), 5),
 			},
 
 			resource.TestStep{
@@ -143,7 +144,7 @@ func testAccCheckAwsServiceDiscoveryServiceExists(name string) resource.TestChec
 	}
 }
 
-func testAccServiceDiscoveryServiceConfig_private(rName string) string {
+func testAccServiceDiscoveryServiceConfig_private(rName string, th int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -167,11 +168,14 @@ resource "aws_service_discovery_service" "test" {
       type = "A"
     }
   }
+  health_check_custom_config {
+    failure_threshold = %d
+  }
 }
-`, rName, rName)
+`, rName, rName, th)
 }
 
-func testAccServiceDiscoveryServiceConfig_private_update(rName string) string {
+func testAccServiceDiscoveryServiceConfig_private_update(rName string, th int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -200,8 +204,11 @@ resource "aws_service_discovery_service" "test" {
     }
     routing_policy = "MULTIVALUE"
   }
+  health_check_custom_config {
+    failure_threshold = %d
+  }
 }
-`, rName, rName)
+`, rName, rName, th)
 }
 
 func testAccServiceDiscoveryServiceConfig_public(rName string, th int, path string) string {

--- a/website/docs/r/service_discovery_service.html.markdown
+++ b/website/docs/r/service_discovery_service.html.markdown
@@ -33,6 +33,10 @@ resource "aws_service_discovery_service" "example" {
     }
     routing_policy = "MULTIVALUE"
   }
+
+  health_check_custom_config {
+    failure_threshold = 1
+  }
 }
 ```
 
@@ -67,6 +71,7 @@ The following arguments are supported:
 * `description` - (Optional) The description of the service.
 * `dns_config` - (Required) A complex type that contains information about the resource record sets that you want Amazon Route 53 to create when you register an instance.
 * `health_check_config` - (Optional) A complex type that contains settings for an optional health check. Only for Public DNS namespaces.
+* `health_check_custom_config` - (Optional, ForceNew) A complex type that contains settings for ECS managed health checks.
 
 ### dns_config
 
@@ -90,6 +95,12 @@ The following arguments are supported:
 * `failure_threshold` - (Optional) The number of consecutive health checks. Maximum value of 10.
 * `resource_path` - (Optional) An array that contains one DnsRecord object for each resource record set.
 * `type` - (Optional, ForceNew) An array that contains one DnsRecord object for each resource record set.
+
+### health_check_custom_config
+
+The following arguments are supported:
+
+* `failure_threshold` - (Optional, ForceNew) The number of 30-second intervals that you want service discovery to wait before it changes the health status of a service instance.  Maximum value of 10.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Adds HealthCheckCustomConfig support.

Setting HealcheckCustomConfig / Threshold to 1 is currently required for AWS Service Discovery to work properly.

Closes #4082 