### PR TITLE
Set subnet_mapping element attributes to ForceNew

### DIFF
--- a/aws/resource_aws_lb.go
+++ b/aws/resource_aws_lb.go
@@ -103,10 +103,12 @@ func resourceAwsLb() *schema.Resource {
 						"subnet_id": {
 							Type:     schema.TypeString,
 							Required: true,
+							ForceNew: true,
 						},
 						"allocation_id": {
 							Type:     schema.TypeString,
 							Optional: true,
+							ForceNew: true,
 						},
 					},
 				},


### PR DESCRIPTION
The way `diffSet` in Terraform works on `Resource`, the `ForceNew` property
on the Set has no effect unless `ForceNew` is also set on the resource's
attributes.

Without `ForceNew` on these attributes, changing `subnet_mappings` just
silently does nothing.