### PR TITLE
data-source/aws_iam_role: Add max_session_duration attribute

### DIFF
--- a/aws/data_source_aws_iam_role.go
+++ b/aws/data_source_aws_iam_role.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -51,6 +52,10 @@ func dataSourceAwsIAMRole() *schema.Resource {
 			},
 			"create_date": {
 				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"max_session_duration": {
+				Type:     schema.TypeInt,
 				Computed: true,
 			},
 		},


### PR DESCRIPTION
New `max_session_duration` attribute was added in master to the `aws_iam_role` resource but not the data source:

```
=== RUN   TestAccAWSDataSourceIAMRole_basic
--- FAIL: TestAccAWSDataSourceIAMRole_basic (6.81s)
    testing.go:518: Step 0 error: Error applying: 1 error(s) occurred:
        
        * data.aws_iam_role.test: data.aws_iam_role.test: Invalid address to set: []string{"max_session_duration"}
    testing.go:579: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Error refreshing: 1 error(s) occurred:
        
        * data.aws_iam_role.test: 1 error(s) occurred:
        
        * data.aws_iam_role.test: data.aws_iam_role.test: Invalid address to set: []string{"max_session_duration"}
        
        State: <nil>
FAIL
```

Now:

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSDataSourceIAMRole_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSDataSourceIAMRole_basic -timeout 120m
=== RUN   TestAccAWSDataSourceIAMRole_basic
--- PASS: TestAccAWSDataSourceIAMRole_basic (11.83s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	11.877s
```