### PR TITLE
resource/aws_elasticache_replication_group: Increase default create timeout to 60 minutes

### DIFF
--- a/aws/resource_aws_elasticache_replication_group.go
+++ b/aws/resource_aws_elasticache_replication_group.go
@@ -125,7 +125,7 @@ func resourceAwsElasticacheReplicationGroup() *schema.Resource {
 		SchemaVersion: 1,
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(50 * time.Minute),
+			Create: schema.DefaultTimeout(60 * time.Minute),
 			Delete: schema.DefaultTimeout(40 * time.Minute),
 			Update: schema.DefaultTimeout(40 * time.Minute),
 		},

--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -144,7 +144,7 @@ The following attributes are exported:
 `aws_elasticache_replication_group` provides the following [Timeouts](/docs/configuration/resources.html#timeouts)
 configuration options:
 
-* `create` - (Default `50m`) How long to wait for a replication group to be created.
+* `create` - (Default `60m`) How long to wait for a replication group to be created.
 * `delete` - (Default `40m`) How long to wait for a replication group to be deleted.
 * `update` - (Default `40m`) How long to wait for replication group settings to be updated. This is also separately used for online resize operation completion, if necessary.
 


### PR DESCRIPTION
Acceptance testing for the win (has been happening quite often recently):

```
--- FAIL: TestAccAWSElasticacheReplicationGroup_basic (3010.93s)
    testing.go:518: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_elasticache_replication_group.bar: 1 error(s) occurred:
        
        * aws_elasticache_replication_group.bar: Error waiting for elasticache replication group (tf-2smc8n7sxc) to be created: timeout while waiting for state to become 'available' (last state: 'creating', timeout: 50m0s)

--- FAIL: TestAccAWSElasticacheReplicationGroup_importBasic (3010.99s)
    testing.go:518: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_elasticache_replication_group.bar: 1 error(s) occurred:
        
        * aws_elasticache_replication_group.bar: Error waiting for elasticache replication group (tf-dj9pzg9div) to be created: timeout while waiting for state to become 'available' (last state: 'creating', timeout: 50m0s)

```