### PR TITLE
tests/resource/aws_network_acl: Prevent crash in TestAccAWSNetworkAcl_SubnetChange

### DIFF
--- a/aws/resource_aws_network_acl_test.go
+++ b/aws/resource_aws_network_acl_test.go
@@ -275,6 +275,7 @@ func TestAccAWSNetworkAcl_OnlyEgressRules(t *testing.T) {
 }
 
 func TestAccAWSNetworkAcl_SubnetChange(t *testing.T) {
+	var networkAcl ec2.NetworkAcl
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -285,12 +286,14 @@ func TestAccAWSNetworkAcl_SubnetChange(t *testing.T) {
 			{
 				Config: testAccAWSNetworkAclSubnetConfig,
 				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSNetworkAclExists("aws_network_acl.bar", &networkAcl),
 					testAccCheckSubnetIsAssociatedWithAcl("aws_network_acl.bar", "aws_subnet.old"),
 				),
 			},
 			{
 				Config: testAccAWSNetworkAclSubnetConfigChange,
 				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSNetworkAclExists("aws_network_acl.bar", &networkAcl),
 					testAccCheckSubnetIsNotAssociatedWithAcl("aws_network_acl.bar", "aws_subnet.old"),
 					testAccCheckSubnetIsAssociatedWithAcl("aws_network_acl.bar", "aws_subnet.new"),
 				),
@@ -459,7 +462,7 @@ func testAccCheckAWSNetworkAclExists(n string, networkAcl *ec2.NetworkAcl) resou
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No Security Group is set")
+			return fmt.Errorf("No ID is set: %s", n)
 		}
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
 


### PR DESCRIPTION
Old and busted (occasionally):
```
=== RUN   TestAccAWSNetworkAcl_SubnetChange
--- FAIL: TestAccAWSNetworkAcl_SubnetChange (25.21s)

------- Stderr: -------
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
    panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x2507806]

goroutine 22 [running]:
testing.tRunner.func1(0xc4202bd3b0)
    /usr/local/go/src/testing/testing.go:711 +0x2d2
panic(0x2b65040, 0x5218270)
    /usr/local/go/src/runtime/panic.go:491 +0x283
github.com/terraform-providers/terraform-provider-aws/aws.testAccCheckSubnetIsAssociatedWithAcl.func1(0xc4208a42a0, 0xbbc15f, 0xc42094b620)
    /opt/teamcity-agent/work/6025502d125bbe5e/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_network_acl_test.go:506 +0x136
```

New hotness:
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSNetworkAcl_SubnetChange'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSNetworkAcl_SubnetChange -timeout 120m
=== RUN   TestAccAWSNetworkAcl_SubnetChange
--- PASS: TestAccAWSNetworkAcl_SubnetChange (53.40s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	53.441s
```