### PR TITLE
resource/aws_cloudfront_distribution: Add cache_behavior field_level_encryption_id attribute

### DIFF
--- a/aws/cloudfront_distribution_configuration_structure.go
+++ b/aws/cloudfront_distribution_configuration_structure.go
@@ -204,6 +204,9 @@ func defaultCacheBehaviorHash(v interface{}) int {
 	buf.WriteString(fmt.Sprintf("%s-", m["target_origin_id"].(string)))
 	buf.WriteString(fmt.Sprintf("%d-", forwardedValuesHash(m["forwarded_values"].(*schema.Set).List()[0].(map[string]interface{}))))
 	buf.WriteString(fmt.Sprintf("%d-", m["min_ttl"].(int)))
+	if d, ok := m["field_level_encryption_id"]; ok && d.(string) != "" {
+		buf.WriteString(fmt.Sprintf("%s-", d.(string)))
+	}
 	if d, ok := m["trusted_signers"]; ok {
 		for _, e := range sortInterfaceSlice(d.([]interface{})) {
 			buf.WriteString(fmt.Sprintf("%s-", e.(string)))
@@ -266,13 +269,14 @@ func flattenCacheBehaviors(cbs *cloudfront.CacheBehaviors) *schema.Set {
 
 func expandCacheBehavior(m map[string]interface{}) *cloudfront.CacheBehavior {
 	cb := &cloudfront.CacheBehavior{
-		Compress:             aws.Bool(m["compress"].(bool)),
-		ViewerProtocolPolicy: aws.String(m["viewer_protocol_policy"].(string)),
-		TargetOriginId:       aws.String(m["target_origin_id"].(string)),
-		ForwardedValues:      expandForwardedValues(m["forwarded_values"].(*schema.Set).List()[0].(map[string]interface{})),
-		DefaultTTL:           aws.Int64(int64(m["default_ttl"].(int))),
-		MaxTTL:               aws.Int64(int64(m["max_ttl"].(int))),
-		MinTTL:               aws.Int64(int64(m["min_ttl"].(int))),
+		Compress:               aws.Bool(m["compress"].(bool)),
+		FieldLevelEncryptionId: aws.String(m["field_level_encryption_id"].(string)),
+		ViewerProtocolPolicy:   aws.String(m["viewer_protocol_policy"].(string)),
+		TargetOriginId:         aws.String(m["target_origin_id"].(string)),
+		ForwardedValues:        expandForwardedValues(m["forwarded_values"].(*schema.Set).List()[0].(map[string]interface{})),
+		DefaultTTL:             aws.Int64(int64(m["default_ttl"].(int))),
+		MaxTTL:                 aws.Int64(int64(m["max_ttl"].(int))),
+		MinTTL:                 aws.Int64(int64(m["min_ttl"].(int))),
 	}
 
 	if v, ok := m["trusted_signers"]; ok {
@@ -304,6 +308,7 @@ func flattenCacheBehavior(cb *cloudfront.CacheBehavior) map[string]interface{} {
 	m := make(map[string]interface{})
 
 	m["compress"] = *cb.Compress
+	m["field_level_encryption_id"] = aws.StringValue(cb.FieldLevelEncryptionId)
 	m["viewer_protocol_policy"] = *cb.ViewerProtocolPolicy
 	m["target_origin_id"] = *cb.TargetOriginId
 	m["forwarded_values"] = schema.NewSet(forwardedValuesHash, []interface{}{flattenForwardedValues(cb.ForwardedValues)})
@@ -346,6 +351,9 @@ func cacheBehaviorHash(v interface{}) int {
 	buf.WriteString(fmt.Sprintf("%s-", m["target_origin_id"].(string)))
 	buf.WriteString(fmt.Sprintf("%d-", forwardedValuesHash(m["forwarded_values"].(*schema.Set).List()[0].(map[string]interface{}))))
 	buf.WriteString(fmt.Sprintf("%d-", m["min_ttl"].(int)))
+	if d, ok := m["field_level_encryption_id"]; ok && d.(string) != "" {
+		buf.WriteString(fmt.Sprintf("%s-", d.(string)))
+	}
 	if d, ok := m["trusted_signers"]; ok {
 		for _, e := range sortInterfaceSlice(d.([]interface{})) {
 			buf.WriteString(fmt.Sprintf("%s-", e.(string)))

--- a/aws/cloudfront_distribution_configuration_structure_test.go
+++ b/aws/cloudfront_distribution_configuration_structure_test.go
@@ -23,6 +23,7 @@ func defaultCacheBehaviorConf() map[string]interface{} {
 		"allowed_methods":             allowedMethodsConf(),
 		"cached_methods":              cachedMethodsConf(),
 		"compress":                    true,
+		"field_level_encryption_id":   "",
 	}
 }
 

--- a/aws/resource_aws_cloudfront_distribution.go
+++ b/aws/resource_aws_cloudfront_distribution.go
@@ -61,6 +61,10 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 							Optional: true,
 							Default:  86400,
 						},
+						"field_level_encryption_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 						"forwarded_values": {
 							Type:     schema.TypeSet,
 							Required: true,
@@ -211,6 +215,10 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 							Type:     schema.TypeInt,
 							Optional: true,
 							Default:  86400,
+						},
+						"field_level_encryption_id": {
+							Type:     schema.TypeString,
+							Optional: true,
 						},
 						"forwarded_values": {
 							Type:     schema.TypeSet,

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -172,6 +172,8 @@ of several sub-resources - these resources are laid out below.
     in the absence of an `Cache-Control max-age` or `Expires` header. Defaults to
     1 day.
 
+  * `field_level_encryption_id` (Optional) - Field level encryption configuration ID
+
   * `forwarded_values` (Required) - The [forwarded values configuration](#forwarded-values-arguments) that specifies how CloudFront
     handles query strings, cookies and headers (maximum one).
 


### PR DESCRIPTION
Fixes #4091 and unblocks v1.14.0 release. I have created a followup issue associated with the new field level encryption configuration resource to properly test this new attribute: #4101

Tests
```
11 tests passed (all tests)
=== RUN   TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName (1.53s)
=== RUN   TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID (1.55s)
=== RUN   TestAccAWSCloudFrontDistribution_importBasic
--- PASS: TestAccAWSCloudFrontDistribution_importBasic (1356.52s)
=== RUN   TestAccAWSCloudFrontDistribution_noOptionalItemsConfig
--- PASS: TestAccAWSCloudFrontDistribution_noOptionalItemsConfig (1360.24s)
=== RUN   TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig
--- PASS: TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig (1360.97s)
=== RUN   TestAccAWSCloudFrontDistribution_S3Origin
--- PASS: TestAccAWSCloudFrontDistribution_S3Origin (1361.33s)
=== RUN   TestAccAWSCloudFrontDistribution_multiOrigin
--- PASS: TestAccAWSCloudFrontDistribution_multiOrigin (1362.51s)
=== RUN   TestAccAWSCloudFrontDistribution_customOrigin
--- PASS: TestAccAWSCloudFrontDistribution_customOrigin (1362.54s)
=== RUN   TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig
--- PASS: TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig (1362.91s)
=== RUN   TestAccAWSCloudFrontDistribution_HTTP11Config
--- PASS: TestAccAWSCloudFrontDistribution_HTTP11Config (1363.86s)
=== RUN   TestAccAWSCloudFrontDistribution_S3OriginWithTags
--- PASS: TestAccAWSCloudFrontDistribution_S3OriginWithTags (1364.49s)
```