### PR TITLE
ForceNew on Lambda alias name change

### DIFF
--- a/aws/resource_aws_lambda_alias.go
+++ b/aws/resource_aws_lambda_alias.go
@@ -34,6 +34,7 @@ func resourceAwsLambdaAlias() *schema.Resource {
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"arn": &schema.Schema{
 				Type:     schema.TypeString,


### PR DESCRIPTION
When updating a Lamda Alias, the API uses the `name` as the ID of the alias to update. When updating the `name` of `aws_lambda_alias`, we're sending the new `name` from the config, which isn't found, so Terraform errors. 

The next `plan` reads the new `name` from the config, and shows an addition to be made (not an update). Applying then creates a new alias, and orphans the old one.

91d8b16 is a regression test that will fail on the current `master` (84353e40d03ac9a66168ea07a9d4368c9e45189e)

Fixes #4090

