### PR TITLE
New Resource: aws_ses_domain_identity_verification

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -482,6 +482,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_route_table_association":                  resourceAwsRouteTableAssociation(),
 			"aws_ses_active_receipt_rule_set":              resourceAwsSesActiveReceiptRuleSet(),
 			"aws_ses_domain_identity":                      resourceAwsSesDomainIdentity(),
+			"aws_ses_domain_identity_verification":         resourceAwsSesDomainIdentityVerification(),
 			"aws_ses_domain_dkim":                          resourceAwsSesDomainDkim(),
 			"aws_ses_domain_mail_from":                     resourceAwsSesDomainMailFrom(),
 			"aws_ses_receipt_filter":                       resourceAwsSesReceiptFilter(),

--- a/aws/resource_aws_ses_domain_identity_verification.go
+++ b/aws/resource_aws_ses_domain_identity_verification.go
@@ -1,0 +1,117 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/ses"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsSesDomainIdentityVerification() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsSesDomainIdentityVerificationCreate,
+		Read:   resourceAwsSesDomainIdentityVerificationRead,
+		Delete: resourceAwsSesDomainIdentityVerificationDelete,
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"domain": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(45 * time.Minute),
+		},
+	}
+}
+
+func getAttributes(conn *ses.SES, domainName string) (*ses.IdentityVerificationAttributes, error) {
+	input := &ses.GetIdentityVerificationAttributesInput{
+		Identities: []*string{
+			aws.String(domainName),
+		},
+	}
+
+	response, err := conn.GetIdentityVerificationAttributes(input)
+	if err != nil {
+		return nil, fmt.Errorf("Error getting identity verification attributes: %s", err)
+	}
+
+	return response.VerificationAttributes[domainName], nil
+}
+
+func resourceAwsSesDomainIdentityVerificationCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sesConn
+	domainName := strings.TrimSuffix(d.Get("domain").(string), ".")
+	return resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		att, err := getAttributes(conn, domainName)
+		if err != nil {
+			return resource.NonRetryableError(fmt.Errorf("Error getting identity validation attributes: %s", err))
+		}
+
+		if att == nil {
+			return resource.NonRetryableError(fmt.Errorf("SES Domain Identity %s not found in AWS", domainName))
+		}
+
+		if *att.VerificationStatus != "Success" {
+			return resource.RetryableError(fmt.Errorf("Expected domain verification Success, but was in state %s", *att.VerificationStatus))
+		}
+
+		log.Printf("[INFO] Domain verification successful for %s", domainName)
+		d.SetId(domainName)
+		return resource.NonRetryableError(resourceAwsSesDomainIdentityVerificationRead(d, meta))
+	})
+}
+
+func resourceAwsSesDomainIdentityVerificationRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sesConn
+
+	domainName := d.Id()
+	d.Set("domain", domainName)
+
+	att, err := getAttributes(conn, domainName)
+	if err != nil {
+		log.Printf("[WARN] Error fetching identity verification attrubtes for %s: %s", d.Id(), err)
+		return err
+	}
+
+	if att == nil {
+		log.Printf("[WARN] Domain not listed in response when fetching verification attributes for %s", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if *att.VerificationStatus != "Success" {
+		log.Printf("[WARN] Expected domain verification Success, but was %s, tainting validation", *att.VerificationStatus)
+		d.SetId("")
+		return nil
+	}
+
+	arn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Service:   "ses",
+		Region:    meta.(*AWSClient).region,
+		AccountID: meta.(*AWSClient).accountid,
+		Resource:  fmt.Sprintf("identity/%s", d.Id()),
+	}.String()
+	d.Set("arn", arn)
+
+	return nil
+}
+
+func resourceAwsSesDomainIdentityVerificationDelete(d *schema.ResourceData, meta interface{}) error {
+	// No need to do anything, domain identity will be deleted when aws_ses_domain_identity is deleted
+	d.SetId("")
+	return nil
+}

--- a/aws/resource_aws_ses_domain_identity_verification.go
+++ b/aws/resource_aws_ses_domain_identity_verification.go
@@ -36,7 +36,7 @@ func resourceAwsSesDomainIdentityVerification() *schema.Resource {
 	}
 }
 
-func getAttributes(conn *ses.SES, domainName string) (*ses.IdentityVerificationAttributes, error) {
+func getAwsSesIdentityVerificationAttributes(conn *ses.SES, domainName string) (*ses.IdentityVerificationAttributes, error) {
 	input := &ses.GetIdentityVerificationAttributesInput{
 		Identities: []*string{
 			aws.String(domainName),
@@ -55,9 +55,9 @@ func resourceAwsSesDomainIdentityVerificationCreate(d *schema.ResourceData, meta
 	conn := meta.(*AWSClient).sesConn
 	domainName := strings.TrimSuffix(d.Get("domain").(string), ".")
 	return resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
-		att, err := getAttributes(conn, domainName)
+		att, err := getAwsSesIdentityVerificationAttributes(conn, domainName)
 		if err != nil {
-			return resource.NonRetryableError(fmt.Errorf("Error getting identity validation attributes: %s", err))
+			return resource.NonRetryableError(fmt.Errorf("Error getting identity verification attributes: %s", err))
 		}
 
 		if att == nil {
@@ -80,7 +80,7 @@ func resourceAwsSesDomainIdentityVerificationRead(d *schema.ResourceData, meta i
 	domainName := d.Id()
 	d.Set("domain", domainName)
 
-	att, err := getAttributes(conn, domainName)
+	att, err := getAwsSesIdentityVerificationAttributes(conn, domainName)
 	if err != nil {
 		log.Printf("[WARN] Error fetching identity verification attrubtes for %s: %s", d.Id(), err)
 		return err
@@ -93,7 +93,7 @@ func resourceAwsSesDomainIdentityVerificationRead(d *schema.ResourceData, meta i
 	}
 
 	if *att.VerificationStatus != "Success" {
-		log.Printf("[WARN] Expected domain verification Success, but was %s, tainting validation", *att.VerificationStatus)
+		log.Printf("[WARN] Expected domain verification Success, but was %s, tainting verification", *att.VerificationStatus)
 		d.SetId("")
 		return nil
 	}

--- a/aws/resource_aws_ses_domain_identity_verification_test.go
+++ b/aws/resource_aws_ses_domain_identity_verification_test.go
@@ -1,0 +1,176 @@
+package aws
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/ses"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func testAccAwsSesDomainIdentityDomainFromEnv(t *testing.T) string {
+	rootDomain := os.Getenv("SES_DOMAIN_IDENTITY_ROOT_DOMAIN")
+	if rootDomain == "" {
+		t.Skip(
+			"Environment variable SES_DOMAIN_IDENTITY_ROOT_DOMAIN is not set. " +
+				"For DNS verification requests, this domain must be publicly " +
+				"accessible and configurable via Route53 during the testing. ")
+	}
+	return rootDomain
+}
+
+func TestAccAwsSesDomainIdentityVerification_basic(t *testing.T) {
+	rootDomain := testAccAwsSesDomainIdentityDomainFromEnv(t)
+	domain := fmt.Sprintf("tf-acc-%d.%s", acctest.RandInt(), rootDomain)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsSESDomainIdentityDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsSesDomainIdentityVerification_basic(rootDomain, domain),
+				Check:  testAccCheckAwsSesDomainIdentityVerificationPassed("aws_ses_domain_identity_verification.test"),
+			},
+		},
+	})
+}
+
+func TestAccAwsSesDomainIdentityVerification_timeout(t *testing.T) {
+	domain := fmt.Sprintf(
+		"%s.terraformtesting.com",
+		acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsSESDomainIdentityDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAwsSesDomainIdentityVerification_timeout(domain),
+				ExpectError: regexp.MustCompile("Expected domain verification Success, but was in state Pending"),
+			},
+		},
+	})
+}
+
+func TestAccAwsSesDomainIdentityVerification_nonexistent(t *testing.T) {
+	domain := fmt.Sprintf(
+		"%s.terraformtesting.com",
+		acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsSESDomainIdentityDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAwsSesDomainIdentityVerification_nonexistent(domain),
+				ExpectError: regexp.MustCompile(fmt.Sprintf("SES Domain Identity %s not found in AWS", domain)),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsSesDomainIdentityVerificationPassed(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("SES Domain Identity not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("SES Domain Identity name not set")
+		}
+
+		domain := rs.Primary.ID
+		awsClient := testAccProvider.Meta().(*AWSClient)
+		conn := awsClient.sesConn
+
+		params := &ses.GetIdentityVerificationAttributesInput{
+			Identities: []*string{
+				aws.String(domain),
+			},
+		}
+
+		response, err := conn.GetIdentityVerificationAttributes(params)
+		if err != nil {
+			return err
+		}
+
+		if response.VerificationAttributes[domain] == nil {
+			return fmt.Errorf("SES Domain Identity %s not found in AWS", domain)
+		}
+
+		if *response.VerificationAttributes[domain].VerificationStatus != "Success" {
+			return fmt.Errorf("SES Domain Identity %s not successfully verified.", domain)
+		}
+
+		expected := arn.ARN{
+			AccountID: awsClient.accountid,
+			Partition: awsClient.partition,
+			Region:    awsClient.region,
+			Resource:  fmt.Sprintf("identity/%s", domain),
+			Service:   "ses",
+		}
+
+		if rs.Primary.Attributes["arn"] != expected.String() {
+			return fmt.Errorf("Incorrect ARN: expected %q, got %q", expected, rs.Primary.Attributes["arn"])
+		}
+
+		return nil
+	}
+}
+
+func testAccAwsSesDomainIdentityVerification_basic(rootDomain string, domain string) string {
+	return fmt.Sprintf(`
+resource "aws_route53_zone" "zone" {
+	name = "%s."
+}
+
+resource "aws_ses_domain_identity" "test" {
+	domain = "%s"
+}
+
+resource "aws_route53_record" "domain_identity_verification" {
+	zone_id = "${aws_route53_zone.zone.zone_id}"
+	name = "_amazonses.${aws_ses_domain_identity.test.id}"
+	type = "TXT"
+	ttl = "600"
+	records = ["${aws_ses_domain_identity.test.verification_token}"]
+}
+
+resource "aws_ses_domain_identity_verification" "test" {
+	domain = "${aws_ses_domain_identity.test.id}"
+}
+`, rootDomain, domain)
+}
+
+func testAccAwsSesDomainIdentityVerification_timeout(domain string) string {
+	return fmt.Sprintf(`
+resource "aws_ses_domain_identity" "test" {
+	domain = "%s"
+}
+
+resource "aws_ses_domain_identity_verification" "test" {
+	domain = "${aws_ses_domain_identity.test.id}"
+	timeouts {
+		create = "5s"
+	}
+}
+`, domain)
+}
+
+func testAccAwsSesDomainIdentityVerification_nonexistent(domain string) string {
+	return fmt.Sprintf(`
+resource "aws_ses_domain_identity_verification" "test" {
+	domain = "%s"
+}
+`, domain)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1652,6 +1652,10 @@
                             <a href="/docs/providers/aws/r/ses_domain_identity.html">aws_ses_domain_identity</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-ses-domain-identity-verification") %>>
+                            <a href="/docs/providers/aws/r/ses_domain_identity_verification.html">aws_ses_domain_identity_verification</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-aws-resource-ses-domain-dkim") %>>
                             <a href="/docs/providers/aws/r/ses_domain_dkim.html">aws_ses_domain_dkim</a>
                         </li>

--- a/website/docs/r/ses_domain_identity_verification.html.markdown
+++ b/website/docs/r/ses_domain_identity_verification.html.markdown
@@ -1,0 +1,57 @@
+---
+layout: "aws"
+page_title: "AWS: ses_domain_identity_verification"
+sidebar_current: "docs-aws-resource-ses-domain-identity-verification"
+description: |-
+  Waits for and checks successful verification of an SES domain identity.
+---
+
+# aws_ses_domain_identity_verification
+
+Represents a successful verification of an SES domain identity.
+
+Most commonly, this resource is used together with [`aws_route53_record`](route53_record.html) and
+[`aws_ses_domain_identity`](ses_domain_identity.html) to request an SES domain identity,
+deploy the required DNS verification records, and wait for verification to complete.
+
+~> **WARNING:** This resource implements a part of the verification workflow. It does not represent a real-world entity in AWS, therefore changing or deleting this resource on its own has no immediate effect.
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domain` - (Required) The domain name of the SES domain identity to verify.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The domain name of the domain identity.
+* `arn` - The ARN of the domain identity.
+
+## Timeouts
+
+`acm_ses_domain_identity_verification` provides the following [Timeouts](/docs/configuration/resources.html#timeouts)
+configuration options:
+
+- `create` - (Default `45m`) How long to wait for a domain identity to be verified.
+
+## Example Usage
+
+```hcl
+resource "aws_ses_domain_identity" "example" {
+  domain = "example.com"
+}
+
+resource "aws_route53_record" "example_amazonses_verification_record" {
+  zone_id = "ABCDEFGHIJ123"
+  name    = "_amazonses.example.com"
+  type    = "TXT"
+  ttl     = "600"
+  records = ["${aws_ses_domain_identity.example.verification_token}"]
+}
+
+resource "aws_ses_domain_identity_verification" "example_verification" {
+  domain = "${aws_ses_domain_identity.example.id}"
+}
+```


### PR DESCRIPTION
# Description

This PR introduces a new resource that ensures a domain identity in SES has passed verification. This can be used to create SES domain identities in a fully automated fashion as described in the documentation updates. This resource is quite similar to `aws_acm_certificate_validation`.

Since this requires modification of records in Route 53 corresponding to a real domain, a new environment variable `SES_DOMAIN_IDENTITY_ROOT_DOMAIN` has been introduced for the acceptance tests to specify the domain against which the records should be created. If the environment variable is not specified the acceptance test will be skipped with a warning. The basic acceptance test relies on propagation of DNS records, so it can take quite a while to complete.

# Test Results

```
TF_ACC=1 go test ./aws -v -run=TestAccAwsSesDomainIdentityVerification_ -timeout 120m
=== RUN   TestAccAwsSesDomainIdentityVerification_basic
--- PASS: TestAccAwsSesDomainIdentityVerification_basic (550.43s)
=== RUN   TestAccAwsSesDomainIdentityVerification_timeout
--- PASS: TestAccAwsSesDomainIdentityVerification_timeout (12.41s)
=== RUN   TestAccAwsSesDomainIdentityVerification_nonexistent
--- PASS: TestAccAwsSesDomainIdentityVerification_nonexistent (3.71s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       566.569s
```

I built the documentation and it looks good to me.