### PR TITLE
Feature/add enabled cloudwatch logs exports param for DB Instances

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsDbInstance() *schema.Resource {
@@ -351,6 +352,21 @@ func resourceAwsDbInstance() *schema.Resource {
 				Computed: true,
 			},
 
+			"enabled_cloudwatch_logs_exports": {
+				Type:     schema.TypeList,
+				Computed: false,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					ValidateFunc: validation.StringInSlice([]string{
+						"audit",
+						"error",
+						"general",
+						"slowquery",
+					}, false),
+				},
+			},
+
 			"tags": tagsSchema(),
 		},
 	}
@@ -408,6 +424,10 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			opts.DBSubnetGroupName = aws.String(attr.(string))
 		}
 
+		if attr, ok := d.GetOk("enabled_cloudwatch_logs_exports"); ok && len(attr.([]interface{})) > 0 {
+			opts.EnableCloudwatchLogsExports = expandStringList(attr.([]interface{}))
+		}
+
 		if attr, ok := d.GetOk("kms_key_id"); ok {
 			opts.KmsKeyId = aws.String(attr.(string))
 			if arnParts := strings.Split(v.(string), ":"); len(arnParts) >= 4 {
@@ -460,6 +480,10 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 
 		if attr, ok := d.GetOk("db_subnet_group_name"); ok {
 			opts.DBSubnetGroupName = aws.String(attr.(string))
+		}
+
+		if attr, ok := d.GetOk("enabled_cloudwatch_logs_exports"); ok && len(attr.([]interface{})) > 0 {
+			opts.EnableCloudwatchLogsExports = expandStringList(attr.([]interface{}))
 		}
 
 		if attr, ok := d.GetOk("engine"); ok {
@@ -628,6 +652,10 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			opts.DBSubnetGroupName = aws.String(attr.(string))
 		}
 
+		if attr, ok := d.GetOk("enabled_cloudwatch_logs_exports"); ok && len(attr.([]interface{})) > 0 {
+			opts.EnableCloudwatchLogsExports = expandStringList(attr.([]interface{}))
+		}
+
 		if attr, ok := d.GetOk("iops"); ok {
 			opts.Iops = aws.Int64(int64(attr.(int)))
 		}
@@ -773,6 +801,10 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 
 	if v.MonitoringRoleArn != nil {
 		d.Set("monitoring_role_arn", v.MonitoringRoleArn)
+	}
+
+	if v.EnabledCloudwatchLogsExports != nil {
+		d.Set("enabled_cloudwatch_logs_exports", v.EnabledCloudwatchLogsExports)
 	}
 
 	// list tags for resource
@@ -1020,6 +1052,12 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 		requestUpdate = true
 	}
 
+	if d.HasChange("enabled_cloudwatch_logs_exports") && !d.IsNewResource() {
+		d.SetPartial("enabled_cloudwatch_logs_exports")
+		req.CloudwatchLogsExportConfiguration = buildCloudwatchLogsExportConfiguration(d)
+		requestUpdate = true
+	}
+
 	if d.HasChange("iam_database_authentication_enabled") {
 		req.EnableIAMDatabaseAuthentication = aws.Bool(d.Get("iam_database_authentication_enabled").(bool))
 		requestUpdate = true
@@ -1151,10 +1189,55 @@ func resourceAwsDbInstanceStateRefreshFunc(id string, conn *rds.RDS) resource.St
 	}
 }
 
+func buildRDSARN(identifier, partition, accountid, region string) (string, error) {
+	if partition == "" {
+		return "", fmt.Errorf("Unable to construct RDS ARN because of missing AWS partition")
+	}
+	if accountid == "" {
+		return "", fmt.Errorf("Unable to construct RDS ARN because of missing AWS Account ID")
+	}
+	arn := fmt.Sprintf("arn:%s:rds:%s:%s:db:%s", partition, region, accountid, identifier)
+	return arn, nil
+}
+
+func buildCloudwatchLogsExportConfiguration(d *schema.ResourceData) *rds.CloudwatchLogsExportConfiguration {
+
+	oraw, nraw := d.GetChange("enabled_cloudwatch_logs_exports")
+	o := oraw.([]interface{})
+	n := nraw.([]interface{})
+
+	create, disable := diffCloudwatchLogsExportConfiguration(o, n)
+
+	return &rds.CloudwatchLogsExportConfiguration{
+		EnableLogTypes:  expandStringList(create),
+		DisableLogTypes: expandStringList(disable),
+	}
+}
+
+func diffCloudwatchLogsExportConfiguration(old, new []interface{}) ([]interface{}, []interface{}) {
+	create := make([]interface{}, 0)
+	disable := make([]interface{}, 0)
+
+	for _, n := range new {
+		if _, contains := sliceContainsString(old, n.(string)); !contains {
+			create = append(create, n)
+		}
+	}
+
+	for _, o := range old {
+		if _, contains := sliceContainsString(new, o.(string)); !contains {
+			disable = append(disable, o)
+		}
+	}
+
+	return create, disable
+}
+
 // Database instance status: http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.DBInstance.Status.html
 var resourceAwsDbInstanceCreatePendingStates = []string{
 	"backing-up",
 	"configuring-enhanced-monitoring",
+	"configuring-log-exports",
 	"creating",
 	"maintenance",
 	"modifying",
@@ -1170,6 +1253,7 @@ var resourceAwsDbInstanceDeletePendingStates = []string{
 	"available",
 	"backing-up",
 	"configuring-enhanced-monitoring",
+	"configuring-log-exports",
 	"creating",
 	"deleting",
 	"incompatible-parameters",
@@ -1183,6 +1267,7 @@ var resourceAwsDbInstanceDeletePendingStates = []string{
 var resourceAwsDbInstanceUpdatePendingStates = []string{
 	"backing-up",
 	"configuring-enhanced-monitoring",
+	"configuring-log-exports",
 	"creating",
 	"maintenance",
 	"modifying",

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -87,6 +87,8 @@ Default is `false`.
 * `db_subnet_group_name` - (Optional) Name of DB subnet group. DB instance will
 be created in the VPC associated with the DB subnet group. If unspecified, will
 be created in the `default` VPC, or in EC2 Classic, if available.
+* `enabled_cloudwatch_logs_exports` - (Optional) Name list of enable log type for exporting to cloudwatch logs. If omitted, any logs will not be exported to cloudwatch logs.
+   Either of the following is supported: `audit`, `error`, `general`, `slowquery`.
 * `engine` - (Required unless a `snapshot_identifier` or `replicate_source_db`
 is provided) The database engine to use.
 * `engine_version` - (Optional) The engine version to use. If `auto_minor_version_upgrade`
@@ -135,9 +137,9 @@ logs, and it will be stored in the state file.
 accessible. Default is `false`.
 * `replicate_source_db` - (Optional) Specifies that this resource is a Replicate
 database, and to use this value as the source database. This correlates to the
-`identifier` of another Amazon RDS Database to replicate. Note that if you are 
+`identifier` of another Amazon RDS Database to replicate. Note that if you are
 creating a cross-region replica of an encrypted database you will also need to
-specify a `kms_key_id`. See [DB Instance Replication][1] and [Working with 
+specify a `kms_key_id`. See [DB Instance Replication][1] and [Working with
 PostgreSQL and MySQL Read Replicas](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html)
 for more information on using Replication.
 * `security_group_names` - (Optional/Deprecated) List of DB Security Groups to
@@ -151,9 +153,9 @@ is `false`.
 * `snapshot_identifier` - (Optional) Specifies whether or not to create this
 database from a snapshot. This correlates to the snapshot ID you'd find in the
 RDS console, e.g: rds:production-2015-06-26-06-05.
-* `storage_encrypted` - (Optional) Specifies whether the DB instance is 
-encrypted. Note that if you are creating a cross-region read replica this field 
-is ignored and you should instead declare `kms_key_id` with a valid ARN. The 
+* `storage_encrypted` - (Optional) Specifies whether the DB instance is
+encrypted. Note that if you are creating a cross-region read replica this field
+is ignored and you should instead declare `kms_key_id` with a valid ARN. The
 default is `false` if not specified.
 * `storage_type` - (Optional) One of "standard" (magnetic), "gp2" (general
 purpose SSD), or "io1" (provisioned IOPS SSD). The default is "io1" if `iops` is


### PR DESCRIPTION
# Description
This PR implementation a new param `enabled_cloudwatch_logs_exports` to `aws_db_instance` for managing [Exporting Cloudwatch logs Configuration](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AuroraMySQL.Integrating.CloudWatch.html).


# Test Results

```
$ TF_ACC=1 go test ./aws -v -run=TestAccAWSDBInstance_cloudwatchLogsExportConfiguration -timeout 120m
=== RUN   TestAccAWSDBInstance_cloudwatchLogsExportConfiguration
--- PASS: TestAccAWSDBInstance_cloudwatchLogsExportConfiguration (484.14s)
=== RUN   TestAccAWSDBInstance_cloudwatchLogsExportConfigurationUpdate
--- PASS: TestAccAWSDBInstance_cloudwatchLogsExportConfigurationUpdate (755.77s)
PASS
ok     	github.com/terraform-providers/terraform-provider-aws/aws      	1239.953s
```