### PR TITLE
docs/resource/lambda_permission: Fix cloudwatch example

### DIFF
--- a/website/docs/r/lambda_permission.html.markdown
+++ b/website/docs/r/lambda_permission.html.markdown
@@ -19,7 +19,6 @@ resource "aws_lambda_permission" "allow_cloudwatch" {
   action         = "lambda:InvokeFunction"
   function_name  = "${aws_lambda_function.test_lambda.function_name}"
   principal      = "events.amazonaws.com"
-  source_account = "111122223333"
   source_arn     = "arn:aws:events:eu-west-1:111122223333:rule/RunDaily"
   qualifier      = "${aws_lambda_alias.test_alias.name}"
 }


### PR DESCRIPTION
source_account isn't valid for a CloudWatch Lambda Permission and
prevents CloudWatch from invoking the function as decribed at the
bottom of https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/CWE_Troubleshooting.html#LAMfunctionNotInvoked