### PR TITLE
resource/cloudfront_distribution: Added ordered cache behaviors

### DIFF
--- a/aws/cloudfront_distribution_configuration_structure.go
+++ b/aws/cloudfront_distribution_configuration_structure.go
@@ -42,7 +42,6 @@ func (p StringPtrSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 // Used by the aws_cloudfront_distribution Create and Update functions.
 func expandDistributionConfig(d *schema.ResourceData) *cloudfront.DistributionConfig {
 	distributionConfig := &cloudfront.DistributionConfig{
-		CacheBehaviors:       expandCacheBehaviors(d.Get("cache_behavior").(*schema.Set)),
 		CustomErrorResponses: expandCustomErrorResponses(d.Get("custom_error_response").(*schema.Set)),
 		DefaultCacheBehavior: expandDefaultCacheBehavior(d.Get("default_cache_behavior").(*schema.Set).List()[0].(map[string]interface{})),
 		Enabled:              aws.Bool(d.Get("enabled").(bool)),
@@ -50,6 +49,11 @@ func expandDistributionConfig(d *schema.ResourceData) *cloudfront.DistributionCo
 		HttpVersion:          aws.String(d.Get("http_version").(string)),
 		Origins:              expandOrigins(d.Get("origin").(*schema.Set)),
 		PriceClass:           aws.String(d.Get("price_class").(string)),
+	}
+	if v, ok := d.GetOk("ordered_cache_behavior"); ok {
+		distributionConfig.CacheBehaviors = expandCacheBehaviors(v.([]interface{}))
+	} else {
+		distributionConfig.CacheBehaviors = expandCacheBehaviorsDeprecated(d.Get("cache_behavior").(*schema.Set))
 	}
 	// This sets CallerReference if it's still pending computation (ie: new resource)
 	if v, ok := d.GetOk("caller_reference"); ok == false {
@@ -140,7 +144,12 @@ func flattenDistributionConfig(d *schema.ResourceData, distributionConfig *cloud
 		}
 	}
 	if distributionConfig.CacheBehaviors != nil {
-		err = d.Set("cache_behavior", flattenCacheBehaviors(distributionConfig.CacheBehaviors))
+		if _, ok := d.GetOk("ordered_cache_behavior"); ok {
+			err = d.Set("ordered_cache_behavior", flattenCacheBehaviors(distributionConfig.CacheBehaviors))
+		} else {
+			err = d.Set("cache_behavior", flattenCacheBehaviorsDeprecated(distributionConfig.CacheBehaviors))
+		}
+
 		if err != nil {
 			return err
 		}
@@ -178,7 +187,7 @@ func flattenDistributionConfig(d *schema.ResourceData, distributionConfig *cloud
 }
 
 func expandDefaultCacheBehavior(m map[string]interface{}) *cloudfront.DefaultCacheBehavior {
-	cb := expandCacheBehavior(m)
+	cb := expandCacheBehaviorDeprecated(m)
 	var dcb cloudfront.DefaultCacheBehavior
 
 	simpleCopyStruct(cb, &dcb)
@@ -190,7 +199,7 @@ func flattenDefaultCacheBehavior(dcb *cloudfront.DefaultCacheBehavior) *schema.S
 	var cb cloudfront.CacheBehavior
 
 	simpleCopyStruct(dcb, &cb)
-	m = flattenCacheBehavior(&cb)
+	m = flattenCacheBehaviorDeprecated(&cb)
 	return schema.NewSet(defaultCacheBehaviorHash, []interface{}{m})
 }
 
@@ -246,10 +255,31 @@ func defaultCacheBehaviorHash(v interface{}) int {
 	return hashcode.String(buf.String())
 }
 
-func expandCacheBehaviors(s *schema.Set) *cloudfront.CacheBehaviors {
+func expandCacheBehaviorsDeprecated(s *schema.Set) *cloudfront.CacheBehaviors {
 	var qty int64
 	var items []*cloudfront.CacheBehavior
 	for _, v := range s.List() {
+		items = append(items, expandCacheBehaviorDeprecated(v.(map[string]interface{})))
+		qty++
+	}
+	return &cloudfront.CacheBehaviors{
+		Quantity: aws.Int64(qty),
+		Items:    items,
+	}
+}
+
+func flattenCacheBehaviorsDeprecated(cbs *cloudfront.CacheBehaviors) *schema.Set {
+	s := []interface{}{}
+	for _, v := range cbs.Items {
+		s = append(s, flattenCacheBehaviorDeprecated(v))
+	}
+	return schema.NewSet(cacheBehaviorHash, s)
+}
+
+func expandCacheBehaviors(lst []interface{}) *cloudfront.CacheBehaviors {
+	var qty int64
+	var items []*cloudfront.CacheBehavior
+	for _, v := range lst {
 		items = append(items, expandCacheBehavior(v.(map[string]interface{})))
 		qty++
 	}
@@ -259,12 +289,50 @@ func expandCacheBehaviors(s *schema.Set) *cloudfront.CacheBehaviors {
 	}
 }
 
-func flattenCacheBehaviors(cbs *cloudfront.CacheBehaviors) *schema.Set {
-	s := []interface{}{}
+func flattenCacheBehaviors(cbs *cloudfront.CacheBehaviors) []interface{} {
+	lst := []interface{}{}
 	for _, v := range cbs.Items {
-		s = append(s, flattenCacheBehavior(v))
+		lst = append(lst, flattenCacheBehavior(v))
 	}
-	return schema.NewSet(cacheBehaviorHash, s)
+	return lst
+}
+
+// Deprecated.
+func expandCacheBehaviorDeprecated(m map[string]interface{}) *cloudfront.CacheBehavior {
+	cb := &cloudfront.CacheBehavior{
+		Compress:               aws.Bool(m["compress"].(bool)),
+		FieldLevelEncryptionId: aws.String(m["field_level_encryption_id"].(string)),
+		ViewerProtocolPolicy:   aws.String(m["viewer_protocol_policy"].(string)),
+		TargetOriginId:         aws.String(m["target_origin_id"].(string)),
+		ForwardedValues:        expandForwardedValues(m["forwarded_values"].(*schema.Set).List()[0].(map[string]interface{})),
+		DefaultTTL:             aws.Int64(int64(m["default_ttl"].(int))),
+		MaxTTL:                 aws.Int64(int64(m["max_ttl"].(int))),
+		MinTTL:                 aws.Int64(int64(m["min_ttl"].(int))),
+	}
+
+	if v, ok := m["trusted_signers"]; ok {
+		cb.TrustedSigners = expandTrustedSigners(v.([]interface{}))
+	} else {
+		cb.TrustedSigners = expandTrustedSigners([]interface{}{})
+	}
+
+	if v, ok := m["lambda_function_association"]; ok {
+		cb.LambdaFunctionAssociations = expandLambdaFunctionAssociations(v.(*schema.Set).List())
+	}
+
+	if v, ok := m["smooth_streaming"]; ok {
+		cb.SmoothStreaming = aws.Bool(v.(bool))
+	}
+	if v, ok := m["allowed_methods"]; ok {
+		cb.AllowedMethods = expandAllowedMethodsDeprecated(v.([]interface{}))
+	}
+	if v, ok := m["cached_methods"]; ok {
+		cb.AllowedMethods.CachedMethods = expandCachedMethodsDeprecated(v.([]interface{}))
+	}
+	if v, ok := m["path_pattern"]; ok {
+		cb.PathPattern = aws.String(v.(string))
+	}
+	return cb
 }
 
 func expandCacheBehavior(m map[string]interface{}) *cloudfront.CacheBehavior {
@@ -293,15 +361,52 @@ func expandCacheBehavior(m map[string]interface{}) *cloudfront.CacheBehavior {
 		cb.SmoothStreaming = aws.Bool(v.(bool))
 	}
 	if v, ok := m["allowed_methods"]; ok {
-		cb.AllowedMethods = expandAllowedMethods(v.([]interface{}))
+		cb.AllowedMethods = expandAllowedMethods(v.(*schema.Set))
 	}
 	if v, ok := m["cached_methods"]; ok {
-		cb.AllowedMethods.CachedMethods = expandCachedMethods(v.([]interface{}))
+		cb.AllowedMethods.CachedMethods = expandCachedMethods(v.(*schema.Set))
 	}
 	if v, ok := m["path_pattern"]; ok {
 		cb.PathPattern = aws.String(v.(string))
 	}
 	return cb
+}
+
+func flattenCacheBehaviorDeprecated(cb *cloudfront.CacheBehavior) map[string]interface{} {
+	m := make(map[string]interface{})
+
+	m["compress"] = *cb.Compress
+	m["field_level_encryption_id"] = aws.StringValue(cb.FieldLevelEncryptionId)
+	m["viewer_protocol_policy"] = *cb.ViewerProtocolPolicy
+	m["target_origin_id"] = *cb.TargetOriginId
+	m["forwarded_values"] = schema.NewSet(forwardedValuesHash, []interface{}{flattenForwardedValues(cb.ForwardedValues)})
+	m["min_ttl"] = int(*cb.MinTTL)
+
+	if len(cb.TrustedSigners.Items) > 0 {
+		m["trusted_signers"] = flattenTrustedSigners(cb.TrustedSigners)
+	}
+	if len(cb.LambdaFunctionAssociations.Items) > 0 {
+		m["lambda_function_association"] = flattenLambdaFunctionAssociations(cb.LambdaFunctionAssociations)
+	}
+	if cb.MaxTTL != nil {
+		m["max_ttl"] = int(*cb.MaxTTL)
+	}
+	if cb.SmoothStreaming != nil {
+		m["smooth_streaming"] = *cb.SmoothStreaming
+	}
+	if cb.DefaultTTL != nil {
+		m["default_ttl"] = int(*cb.DefaultTTL)
+	}
+	if cb.AllowedMethods != nil {
+		m["allowed_methods"] = flattenAllowedMethodsDeprecated(cb.AllowedMethods)
+	}
+	if cb.AllowedMethods.CachedMethods != nil {
+		m["cached_methods"] = flattenCachedMethodsDeprecated(cb.AllowedMethods.CachedMethods)
+	}
+	if cb.PathPattern != nil {
+		m["path_pattern"] = *cb.PathPattern
+	}
+	return m
 }
 
 func flattenCacheBehavior(cb *cloudfront.CacheBehavior) map[string]interface{} {
@@ -597,28 +702,56 @@ func flattenCookieNames(cn *cloudfront.CookieNames) []interface{} {
 	return []interface{}{}
 }
 
-func expandAllowedMethods(s []interface{}) *cloudfront.AllowedMethods {
+func expandAllowedMethods(s *schema.Set) *cloudfront.AllowedMethods {
+	return &cloudfront.AllowedMethods{
+		Quantity: aws.Int64(int64(s.Len())),
+		Items:    expandStringList(s.List()),
+	}
+}
+
+func flattenAllowedMethods(am *cloudfront.AllowedMethods) *schema.Set {
+	if am.Items != nil {
+		return schema.NewSet(schema.HashString, flattenStringList(am.Items))
+	}
+	return nil
+}
+
+func expandAllowedMethodsDeprecated(s []interface{}) *cloudfront.AllowedMethods {
 	return &cloudfront.AllowedMethods{
 		Quantity: aws.Int64(int64(len(s))),
 		Items:    expandStringList(s),
 	}
 }
 
-func flattenAllowedMethods(am *cloudfront.AllowedMethods) []interface{} {
+func flattenAllowedMethodsDeprecated(am *cloudfront.AllowedMethods) []interface{} {
 	if am.Items != nil {
 		return flattenStringList(am.Items)
 	}
 	return []interface{}{}
 }
 
-func expandCachedMethods(s []interface{}) *cloudfront.CachedMethods {
+func expandCachedMethods(s *schema.Set) *cloudfront.CachedMethods {
+	return &cloudfront.CachedMethods{
+		Quantity: aws.Int64(int64(s.Len())),
+		Items:    expandStringList(s.List()),
+	}
+}
+
+func flattenCachedMethods(cm *cloudfront.CachedMethods) *schema.Set {
+	if cm.Items != nil {
+		return schema.NewSet(schema.HashString, flattenStringList(cm.Items))
+	}
+	return nil
+}
+
+func expandCachedMethodsDeprecated(s []interface{}) *cloudfront.CachedMethods {
 	return &cloudfront.CachedMethods{
 		Quantity: aws.Int64(int64(len(s))),
 		Items:    expandStringList(s),
 	}
 }
 
-func flattenCachedMethods(cm *cloudfront.CachedMethods) []interface{} {
+func flattenCachedMethodsDeprecated(cm *cloudfront.CachedMethods) []interface{} {
 	if cm.Items != nil {
 		return flattenStringList(cm.Items)
 	}

--- a/aws/cloudfront_distribution_configuration_structure_test.go
+++ b/aws/cloudfront_distribution_configuration_structure_test.go
@@ -290,10 +290,10 @@ func TestCloudFrontStructure_expandDefaultCacheBehavior(t *testing.T) {
 		t.Fatalf("Expected LambdaFunctionAssociations to be 2, got %v", *dcb.LambdaFunctionAssociations.Quantity)
 	}
 	if reflect.DeepEqual(dcb.AllowedMethods.Items, expandStringList(allowedMethodsConf())) != true {
-		t.Fatalf("Expected TrustedSigners.Items to be %v, got %v", allowedMethodsConf(), dcb.AllowedMethods.Items)
+		t.Fatalf("Expected AllowedMethods.Items to be %v, got %v", allowedMethodsConf(), dcb.AllowedMethods.Items)
 	}
 	if reflect.DeepEqual(dcb.AllowedMethods.CachedMethods.Items, expandStringList(cachedMethodsConf())) != true {
-		t.Fatalf("Expected TrustedSigners.Items to be %v, got %v", cachedMethodsConf(), dcb.AllowedMethods.CachedMethods.Items)
+		t.Fatalf("Expected AllowedMethods.CachedMethods.Items to be %v, got %v", cachedMethodsConf(), dcb.AllowedMethods.CachedMethods.Items)
 	}
 }
 
@@ -310,7 +310,7 @@ func TestCloudFrontStructure_flattenDefaultCacheBehavior(t *testing.T) {
 
 func TestCloudFrontStructure_expandCacheBehavior(t *testing.T) {
 	data := cacheBehaviorConf1()
-	cb := expandCacheBehavior(data)
+	cb := expandCacheBehaviorDeprecated(data)
 	if *cb.Compress != true {
 		t.Fatalf("Expected Compress to be true, got %v", *cb.Compress)
 	}
@@ -354,8 +354,8 @@ func TestCloudFrontStructure_expandCacheBehavior(t *testing.T) {
 
 func TestCloudFrontStructure_flattenCacheBehavior(t *testing.T) {
 	in := cacheBehaviorConf1()
-	cb := expandCacheBehavior(in)
-	out := flattenCacheBehavior(cb)
+	cb := expandCacheBehaviorDeprecated(in)
+	out := flattenCacheBehaviorDeprecated(cb)
 	var diff *schema.Set
 	if out["compress"] != true {
 		t.Fatalf("Expected out[compress] to be true, got %v", out["compress"])
@@ -413,7 +413,7 @@ func TestCloudFrontStructure_flattenCacheBehavior(t *testing.T) {
 
 func TestCloudFrontStructure_expandCacheBehaviors(t *testing.T) {
 	data := cacheBehaviorsConf()
-	cbs := expandCacheBehaviors(data)
+	cbs := expandCacheBehaviorsDeprecated(data)
 	if *cbs.Quantity != 2 {
 		t.Fatalf("Expected Quantity to be 2, got %v", *cbs.Quantity)
 	}
@@ -424,8 +424,8 @@ func TestCloudFrontStructure_expandCacheBehaviors(t *testing.T) {
 
 func TestCloudFrontStructure_flattenCacheBehaviors(t *testing.T) {
 	in := cacheBehaviorsConf()
-	cbs := expandCacheBehaviors(in)
-	out := flattenCacheBehaviors(cbs)
+	cbs := expandCacheBehaviorsDeprecated(in)
+	out := flattenCacheBehaviorsDeprecated(cbs)
 	diff := in.Difference(out)
 
 	if len(diff.List()) > 0 {
@@ -628,7 +628,7 @@ func TestCloudFrontStructure_flattenCookieNames(t *testing.T) {
 
 func TestCloudFrontStructure_expandAllowedMethods(t *testing.T) {
 	data := allowedMethodsConf()
-	am := expandAllowedMethods(data)
+	am := expandAllowedMethodsDeprecated(data)
 	if *am.Quantity != 7 {
 		t.Fatalf("Expected Quantity to be 7, got %v", *am.Quantity)
 	}
@@ -639,8 +639,8 @@ func TestCloudFrontStructure_expandAllowedMethods(t *testing.T) {
 
 func TestCloudFrontStructure_flattenAllowedMethods(t *testing.T) {
 	in := allowedMethodsConf()
-	am := expandAllowedMethods(in)
-	out := flattenAllowedMethods(am)
+	am := expandAllowedMethodsDeprecated(in)
+	out := flattenAllowedMethodsDeprecated(am)
 
 	if reflect.DeepEqual(in, out) != true {
 		t.Fatalf("Expected out to be %v, got %v", in, out)
@@ -649,7 +649,7 @@ func TestCloudFrontStructure_flattenAllowedMethods(t *testing.T) {
 
 func TestCloudFrontStructure_expandCachedMethods(t *testing.T) {
 	data := cachedMethodsConf()
-	cm := expandCachedMethods(data)
+	cm := expandCachedMethodsDeprecated(data)
 	if *cm.Quantity != 3 {
 		t.Fatalf("Expected Quantity to be 3, got %v", *cm.Quantity)
 	}
@@ -660,8 +660,8 @@ func TestCloudFrontStructure_expandCachedMethods(t *testing.T) {
 
 func TestCloudFrontStructure_flattenCachedMethods(t *testing.T) {
 	in := cachedMethodsConf()
-	cm := expandCachedMethods(in)
-	out := flattenCachedMethods(cm)
+	cm := expandCachedMethodsDeprecated(in)
+	out := flattenCachedMethodsDeprecated(cm)
 
 	if reflect.DeepEqual(in, out) != true {
 		t.Fatalf("Expected out to be %v, got %v", in, out)

--- a/aws/resource_aws_cloudfront_distribution.go
+++ b/aws/resource_aws_cloudfront_distribution.go
@@ -36,9 +36,11 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 				Set:      aliasesHash,
 			},
 			"cache_behavior": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Set:      cacheBehaviorHash,
+				Type:          schema.TypeSet,
+				Optional:      true,
+				Set:           cacheBehaviorHash,
+				ConflictsWith: []string{"ordered_cache_behavior"},
+				Deprecated:    "Use `ordered_cache_behavior` instead",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"allowed_methods": {
@@ -48,6 +50,131 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 						},
 						"cached_methods": {
 							Type:     schema.TypeList,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"compress": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+						"default_ttl": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  86400,
+						},
+						"field_level_encryption_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"forwarded_values": {
+							Type:     schema.TypeSet,
+							Required: true,
+							Set:      forwardedValuesHash,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"cookies": {
+										Type:     schema.TypeSet,
+										Required: true,
+										Set:      cookiePreferenceHash,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"forward": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+												"whitelisted_names": {
+													Type:     schema.TypeList,
+													Optional: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+											},
+										},
+									},
+									"headers": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"query_string": {
+										Type:     schema.TypeBool,
+										Required: true,
+									},
+									"query_string_cache_keys": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+						"lambda_function_association": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							MaxItems: 4,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"event_type": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"lambda_arn": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+							Set: lambdaFunctionAssociationHash,
+						},
+						"max_ttl": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  31536000,
+						},
+						"min_ttl": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  0,
+						},
+						"path_pattern": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"smooth_streaming": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"target_origin_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"trusted_signers": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"viewer_protocol_policy": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"ordered_cache_behavior": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				ConflictsWith: []string{"cache_behavior"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"allowed_methods": {
+							Type:     schema.TypeSet,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"cached_methods": {
+							Type:     schema.TypeSet,
 							Required: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},


### PR DESCRIPTION
## Description

This allows configuring CloudFront cache behavior precedence.
This is an alternative approach to https://github.com/terraform-providers/terraform-provider-aws/pull/1269 and heavily inspired by it.

While the other PR is a breaking change and thus does not allow a quick merge, this approach introduces a new attribute called `ordered_cache_behavior`, deprecating `cache_behavior`.
This work is backward-compatible as it keeps the old behaviour and adds a new one, mainly benefiting from new methods. The previous methods are marked and named as `XXXDeprecated`.

It also fixes the sub-options `allowed_methods` and `cached_methods` which were lists whereas it should have been set.

Alternative & better names for the new attribute are welcomed :)

Sidenote: panic when running tests after 2hours, main tests + ordered cache behaviors are passing but might be a good idea to run a TC test.

## Related issues
https://github.com/terraform-providers/terraform-provider-aws/issues/188
https://github.com/terraform-providers/terraform-provider-aws/pull/1269

## Test

```
$ TF_LOG=DEBUG TF_LOG_PATH=terraform.log make testacc TEST=./aws TESTARGS='-run=TestAccAWSCloudFrontDistribution_'                    
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCloudFrontDistribution_ -timeout 120m
=== RUN   TestAccAWSCloudFrontDistribution_importBasic
--- PASS: TestAccAWSCloudFrontDistribution_importBasic (1247.34s)
=== RUN   TestAccAWSCloudFrontDistribution_S3Origin
--- PASS: TestAccAWSCloudFrontDistribution_S3Origin (1323.08s)
=== RUN   TestAccAWSCloudFrontDistribution_S3OriginWithTags
--- PASS: TestAccAWSCloudFrontDistribution_S3OriginWithTags (1382.72s)
=== RUN   TestAccAWSCloudFrontDistribution_customOrigin
--- PASS: TestAccAWSCloudFrontDistribution_customOrigin (1373.03s)
=== RUN   TestAccAWSCloudFrontDistribution_multiOrigin
--- PASS: TestAccAWSCloudFrontDistribution_multiOrigin (1042.85s)
=== RUN   TestAccAWSCloudFrontDistribution_orderedCacheBehavior
--- PASS: TestAccAWSCloudFrontDistribution_orderedCacheBehavior (798.87s)
=== RUN   TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName (2.29s)
=== RUN   TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID (2.01s)
=== RUN   TestAccAWSCloudFrontDistribution_noOptionalItemsConfig
panic: test timed out after 2h0m0s
```