### PR TITLE
website: Standalone website

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,6 +1,7 @@
 SWEEP?=us-east-1,us-west-2
 TEST?=./...
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
+WEBSITE_REPO="github.com/hashicorp/terraform-website"
 
 default: build
 
@@ -46,5 +47,12 @@ test-compile:
 	fi
 	go test -c $(TEST) $(TESTARGS)
 
-.PHONY: build sweep test testacc vet fmt fmtcheck errcheck vendor-status test-compile
+website:
+ifneq (,$(wildcard "$(GOPATH)/src/$WEBSITE_REPO"))
+	echo "$(WEBSITE_REPO) not found in your GOPATH (necessary for layouts and assets), get-ting..."
+	go get $WEBSITE_REPO
+endif
+	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=aws
+
+.PHONY: build sweep test testacc vet fmt fmtcheck errcheck vendor-status test-compile website
 


### PR DESCRIPTION
## How

```
$ make website
==> Starting website in Docker...
...
```

and voilà!

![screen shot 2018-04-09 at 09 27 19](https://user-images.githubusercontent.com/287584/38487493-41f2dd2c-3bd8-11e8-970a-e88c13c02123.png)

## Caveats

Any links outside of AWS provider (more or less obviously) will 404.

## Motivation

This is to make it possible to serve the provider part of docs without having to pull other 70+ providers as submodules into one giant repository.

It should lower the barrier for maintainers/contributors for checking rendered website before submitting PR or as part of review, which seems to be a thing not many people do since provider split 🙈 , which in turn leads to rendering errors, broken links etc. 💥 

I'm raising this PR to AWS provider first, but the idea is to add it to all other provider repos afterwards (just with different volume mounts).