### PR TITLE
resource/aws_codebuild_project: Properly handle setting cache type NO_CACHE

### DIFF
--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -87,34 +87,49 @@ func TestAccAWSCodeBuildProject_cache(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCodeBuildProjectDestroy,
 		Steps: []resource.TestStep{
 			{
+				Config:      testAccAWSCodeBuildProjectConfig_cache(name, testAccAWSCodeBuildProjectConfig_cacheConfig("S3", "")),
+				ExpectError: regexp.MustCompile(`cache location is required when cache type is "S3"`),
+			},
+			{
+				Config: testAccAWSCodeBuildProjectConfig_cache(name, testAccAWSCodeBuildProjectConfig_cacheConfig("NO_CACHE", "")),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeBuildProjectExists("aws_codebuild_project.foo"),
+					resource.TestCheckResourceAttr("aws_codebuild_project.foo", "cache.#", "1"),
+					resource.TestCheckResourceAttr("aws_codebuild_project.foo", "cache.0.type", "NO_CACHE"),
+				),
+			},
+			{
 				Config: testAccAWSCodeBuildProjectConfig_cache(name, ""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeBuildProjectExists("aws_codebuild_project.foo"),
-					resource.TestCheckNoResourceAttr("aws_codebuild_project.foo", "cache"),
+					resource.TestCheckResourceAttr("aws_codebuild_project.foo", "cache.#", "1"),
+					resource.TestCheckResourceAttr("aws_codebuild_project.foo", "cache.0.type", "NO_CACHE"),
 				),
 			},
 			{
 				Config: testAccAWSCodeBuildProjectConfig_cache(name, testAccAWSCodeBuildProjectConfig_cacheConfig("S3", "some-bucket")),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeBuildProjectExists("aws_codebuild_project.foo"),
+					resource.TestCheckResourceAttr("aws_codebuild_project.foo", "cache.#", "1"),
 					resource.TestCheckResourceAttr("aws_codebuild_project.foo", "cache.0.type", "S3"),
-					resource.TestCheckResourceAttrSet("aws_codebuild_project.foo", "cache.0.location"),
+					resource.TestCheckResourceAttr("aws_codebuild_project.foo", "cache.0.location", "some-bucket"),
 				),
 			},
 			{
 				Config: testAccAWSCodeBuildProjectConfig_cache(name, testAccAWSCodeBuildProjectConfig_cacheConfig("S3", "some-new-bucket")),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeBuildProjectExists("aws_codebuild_project.foo"),
+					resource.TestCheckResourceAttr("aws_codebuild_project.foo", "cache.#", "1"),
 					resource.TestCheckResourceAttr("aws_codebuild_project.foo", "cache.0.type", "S3"),
-					resource.TestCheckResourceAttrSet("aws_codebuild_project.foo", "cache.0.location"),
+					resource.TestCheckResourceAttr("aws_codebuild_project.foo", "cache.0.location", "some-new-bucket"),
 				),
 			},
 			{
 				Config: testAccAWSCodeBuildProjectConfig_cache(name, ""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeBuildProjectExists("aws_codebuild_project.foo"),
-					resource.TestCheckResourceAttr("aws_codebuild_project.foo", "cache.0.type", "S3"),
-					resource.TestCheckResourceAttrSet("aws_codebuild_project.foo", "cache.0.location"),
+					resource.TestCheckResourceAttr("aws_codebuild_project.foo", "cache.#", "1"),
+					resource.TestCheckResourceAttr("aws_codebuild_project.foo", "cache.0.type", "NO_CACHE"),
 				),
 			},
 		},

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -151,8 +151,8 @@ The following arguments are supported:
 
 `cache` supports the following:
 
-* `type` - (Required) The type of storage that will be used for the AWS CodeBuild project cache. The only valid value is `S3`.
-* `location` - (Required) The location where the AWS CodeBuild project stores cached resources. This value must be a valid S3 bucket name/prefix.
+* `type` - (Optional) The type of storage that will be used for the AWS CodeBuild project cache. Valid values: `NO_CACHE` and `S3`. Defaults to `NO_CACHE`.
+* `location` - (Required when cache type is not `NO_CACHE`) The location where the AWS CodeBuild project stores cached resources. For type `S3` the value must be a valid S3 bucket name/prefix.
 
 `environment` supports the following:
 


### PR DESCRIPTION
Removes the initial workaround from #2860 to keep backwards compatibility with `Computed: true` on the `cache` attribute.

Closes #4113 

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSCodeBuildProject'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCodeBuildProject -timeout 120m
=== RUN   TestAccAWSCodeBuildProject_basic
--- PASS: TestAccAWSCodeBuildProject_basic (22.21s)
=== RUN   TestAccAWSCodeBuildProject_vpc
--- PASS: TestAccAWSCodeBuildProject_vpc (54.93s)
=== RUN   TestAccAWSCodeBuildProject_cache
--- PASS: TestAccAWSCodeBuildProject_cache (61.97s)
=== RUN   TestAccAWSCodeBuildProject_sourceAuth
--- PASS: TestAccAWSCodeBuildProject_sourceAuth (21.89s)
=== RUN   TestAccAWSCodeBuildProject_default_build_timeout
--- PASS: TestAccAWSCodeBuildProject_default_build_timeout (29.48s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	190.521s
```