### PR TITLE
Update route53_query_log example

### DIFF
--- a/website/docs/r/route53_query_log.html.markdown
+++ b/website/docs/r/route53_query_log.html.markdown
@@ -53,6 +53,8 @@ data "aws_iam_policy_document" "route53-query-logging-policy" {
 }
 
 resource "aws_cloudwatch_log_resource_policy" "route53-query-logging-policy" {
+  provider = "aws.us-east-1"
+
   policy_document = "${data.aws_iam_policy_document.route53-query-logging-policy.json}"
   policy_name     = "route53-query-logging-policy"
 }


### PR DESCRIPTION
Having just used this resource to set up query logs in my accounts, I believe the CloudWatch Log resource policy needs to be created in the same region as the log group, so in the case of these query logs, it needs to be in `us-east-1` as well.