### PR TITLE
resource/vpc_dhcp_options: Update not found error message

### DIFF
--- a/aws/resource_aws_vpc_dhcp_options.go
+++ b/aws/resource_aws_vpc_dhcp_options.go
@@ -272,7 +272,7 @@ func resourceDHCPOptionsStateRefreshFunc(conn *ec2.EC2, id string) resource.Stat
 
 		resp, err := conn.DescribeDhcpOptions(DescribeDhcpOpts)
 		if err != nil {
-			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidDhcpOptionsID.NotFound" {
+			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidDhcpOptionID.NotFound" {
 				resp = nil
 			} else {
 				log.Printf("Error on DHCPOptionsStateRefresh: %s", err)

--- a/aws/resource_aws_vpc_dhcp_options.go
+++ b/aws/resource_aws_vpc_dhcp_options.go
@@ -147,17 +147,11 @@ func resourceAwsVpcDhcpOptionsRead(d *schema.ResourceData, meta interface{}) err
 
 	resp, err := conn.DescribeDhcpOptions(req)
 	if err != nil {
-		ec2err, ok := err.(awserr.Error)
-		if !ok {
-			return fmt.Errorf("Error retrieving DHCP Options: %s", err.Error())
-		}
-
-		if ec2err.Code() == "InvalidDhcpOptionID.NotFound" {
+		if isNoSuchDhcpOptionIDErr(err) {
 			log.Printf("[WARN] DHCP Options (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
-
 		return fmt.Errorf("Error retrieving DHCP Options: %s", err.Error())
 	}
 
@@ -212,7 +206,7 @@ func resourceAwsVpcDhcpOptionsDelete(d *schema.ResourceData, meta interface{}) e
 		}
 
 		switch ec2err.Code() {
-		case "InvalidDhcpOptionsID.NotFound":
+		case "InvalidDhcpOptionsID.NotFound", "InvalidDhcpOptionID.NotFound":
 			return nil
 		case "DependencyViolation":
 			// If it is a dependency violation, we want to disassociate
@@ -272,7 +266,7 @@ func resourceDHCPOptionsStateRefreshFunc(conn *ec2.EC2, id string) resource.Stat
 
 		resp, err := conn.DescribeDhcpOptions(DescribeDhcpOpts)
 		if err != nil {
-			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidDhcpOptionID.NotFound" {
+			if isNoSuchDhcpOptionIDErr(err) {
 				resp = nil
 			} else {
 				log.Printf("Error on DHCPOptionsStateRefresh: %s", err)
@@ -289,4 +283,8 @@ func resourceDHCPOptionsStateRefreshFunc(conn *ec2.EC2, id string) resource.Stat
 		dos := resp.DhcpOptions[0]
 		return dos, "created", nil
 	}
+}
+
+func isNoSuchDhcpOptionIDErr(err error) bool {
+	return isAWSErr(err, "InvalidDhcpOptionID.NotFound", "") || isAWSErr(err, "InvalidDhcpOptionsID.NotFound", "")
 }


### PR DESCRIPTION
AWS uses the error code "InvalidDhcpOptionID.NotFound" and not the plural version when calling DescribeDhcpOptions. The check for the plural version in DeleteDhcpOptions is correct as AWS returns a plural version on this call.

```2018-04-06T13:01:46.772Z [DEBUG] plugin.terraform-provider-aws_v1.5.2: 2018/04/06 13:01:46 [DEBUG] [aws-sdk-go] <?xml version="1.0" encoding="UTF-8"?>       
2018-04-06T13:01:46.772Z [DEBUG] plugin.terraform-provider-aws_v1.5.2: <Response><Errors><Error><Code>InvalidDhcpOptionID.NotFound</Code><Message>The dhcpOption ID 'id-removed' does not exist</Message></Error></Errors><RequestID>req-id-removed</RequestID></Response>                 
2018-04-06T13:01:46.772Z [DEBUG] plugin.terraform-provider-aws_v1.5.2: 2018/04/06 13:01:46 [DEBUG] [aws-sdk-go] DEBUG: Validate Response ec2/DescribeDhcpOptions failed, not retrying, error InvalidDhcpOptionID.NotFound: The dhcpOption ID 'id-removed' does not exist                   
2018-04-06T13:01:46.772Z [DEBUG] plugin.terraform-provider-aws_v1.5.2:  status code: 400, request id: req-id-removed          
2018-04-06T13:01:46.772Z [DEBUG] plugin.terraform-provider-aws_v1.5.2: 2018/04/06 13:01:46 Error on DHCPOptionsStateRefresh: InvalidDhcpOptionID.NotFound: The dhcpOption ID 'id-removed' does not exist                                                    
2018-04-06T13:01:46.772Z [DEBUG] plugin.terraform-provider-aws_v1.5.2:  status code: 400, request id: req-id-removed          
2018/04/06 13:01:46 [TRACE] root.primary: eval: *terraform.EvalWriteState                                                     
2018/04/06 13:01:46 [ERROR] root.primary: eval: *terraform.EvalApplyPost, err: 1 error(s) occurred:                           

* aws_vpc_dhcp_options.this: Error waiting for DHCP Options (id-removed) to become available: InvalidDhcpOptionID.NotFound: The dhcpOption ID 'id-removed' does not exist                    
        status code: 400, request id: req-id-removed           
2018/04/06 13:01:46 [ERROR] root.primary: eval: *terraform.EvalSequence, err: 1 error(s) occurred:                            

* aws_vpc_dhcp_options.this: Error waiting for DHCP Options (id-removed) to become available: InvalidDhcpOptionID.NotFound: The dhcpOption ID 'id-removed' does not exist                    
        status code: 400, request id: req-id-removed           
2018/04/06 13:01:46 [TRACE] [walkApply] Exiting eval tree: module.primary.aws_vpc_dhcp_options.this