### PR TITLE
aws_rds_cluster is not setting engine_version for aurora postgres

### DIFF
--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -460,6 +460,10 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 			createOpts.DBClusterParameterGroupName = aws.String(attr.(string))
 		}
 
+		if attr, ok := d.GetOk("engine_version"); ok {
+			createOpts.EngineVersion = aws.String(attr.(string))
+		}
+
 		if attr := d.Get("vpc_security_group_ids").(*schema.Set); attr.Len() > 0 {
 			createOpts.VpcSecurityGroupIds = expandStringList(attr.List())
 		}


### PR DESCRIPTION
aurora for postgres added support for postgres 9.6.6 version in addition to 9.6.3 (default).

Attempt to set version 9.6.6 revealed that engine_version parameter was not added to all code paths in original enhancement.  