### PR TITLE
resource/aws_iam_user: Retry user login profile deletion on EntityTemporarilyUnmodifiable

### DIFF
--- a/aws/resource_aws_iam_user.go
+++ b/aws/resource_aws_iam_user.go
@@ -4,11 +4,13 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
 
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -218,13 +220,24 @@ func resourceAwsIamUserDelete(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 
-		_, err = iamconn.DeleteLoginProfile(&iam.DeleteLoginProfileInput{
-			UserName: aws.String(d.Id()),
-		})
-		if err != nil {
-			if iamerr, ok := err.(awserr.Error); !ok || iamerr.Code() != "NoSuchEntity" {
-				return fmt.Errorf("Error deleting Account Login Profile: %s", err)
+		err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+			_, err = iamconn.DeleteLoginProfile(&iam.DeleteLoginProfileInput{
+				UserName: aws.String(d.Id()),
+			})
+			if err != nil {
+				if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
+					return nil
+				}
+				// EntityTemporarilyUnmodifiable: Login Profile for User XXX cannot be modified while login profile is being created.
+				if isAWSErr(err, iam.ErrCodeEntityTemporarilyUnmodifiableException, "") {
+					return resource.RetryableError(err)
+				}
 			}
+			return nil
+		})
+
+		if err != nil {
+			return fmt.Errorf("Error deleting Account Login Profile: %s", err)
 		}
 	}
 

--- a/aws/resource_aws_iam_user.go
+++ b/aws/resource_aws_iam_user.go
@@ -232,6 +232,7 @@ func resourceAwsIamUserDelete(d *schema.ResourceData, meta interface{}) error {
 				if isAWSErr(err, iam.ErrCodeEntityTemporarilyUnmodifiableException, "") {
 					return resource.RetryableError(err)
 				}
+				return resource.NonRetryableError(err)
 			}
 			return nil
 		})

--- a/aws/resource_aws_iam_user_login_profile_test.go
+++ b/aws/resource_aws_iam_user_login_profile_test.go
@@ -228,7 +228,11 @@ func testDecryptPasswordAndTest(nProfile, nAccessKey, key string) resource.TestC
 				NewPassword: aws.String(generateIAMPassword(20)),
 			})
 			if err != nil {
-				if awserr, ok := err.(awserr.Error); ok && awserr.Code() == "InvalidClientTokenId" {
+				// EntityTemporarilyUnmodifiable: Login Profile for User XXX cannot be modified while login profile is being created.
+				if isAWSErr(err, iam.ErrCodeEntityTemporarilyUnmodifiableException, "") {
+					return resource.RetryableError(err)
+				}
+				if isAWSErr(err, "InvalidClientTokenId", "") {
 					return resource.RetryableError(err)
 				}
 


### PR DESCRIPTION
Fix for flakey tests:

```
=== RUN   TestAccAWSUserLoginProfile_basic
--- FAIL: TestAccAWSUserLoginProfile_basic (18.43s)
    testing.go:518: Step 0 error: Check failed: Check 2/2 error: Error changing decrypted password: EntityTemporarilyUnmodifiable: Login Profile for User test-user-4147537163883902538 cannot be modified while login profile is being created.
            status code: 409, request id: f8bd8d09-3c8c-11e8-bc50-d37153ae8ac5

=== RUN   TestAccAWSUserLoginProfile_keybase
--- FAIL: TestAccAWSUserLoginProfile_keybase (11.70s)
    testing.go:579: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Error applying: 1 error(s) occurred:
        
        * aws_iam_user.user (destroy): 1 error(s) occurred:
        
        * aws_iam_user.user: Error deleting Account Login Profile: EntityTemporarilyUnmodifiable: Login Profile for User test-user-6024721623225702403 cannot be modified while login profile is being created.
            status code: 409, request id: b845803c-3cc0-11e8-81f2-395966b82e3f

=== RUN   TestAccAWSUserLoginProfile_PasswordLength
--- FAIL: TestAccAWSUserLoginProfile_PasswordLength (11.42s)
    testing.go:579: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Error applying: 1 error(s) occurred:
        
        * aws_iam_user.user (destroy): 1 error(s) occurred:
        
        * aws_iam_user.user: Error deleting Account Login Profile: EntityTemporarilyUnmodifiable: Login Profile for User test-user-9159356937389943695 cannot be modified while login profile is being created.
            status code: 409, request id: b81ac762-3cc0-11e8-b6b6-17d7b8ab932d
```

```
12 tests passed (all tests)
=== RUN   TestAccAWSUser_importBasic
--- PASS: TestAccAWSUser_importBasic (10.51s)
=== RUN   TestAccAWSUserLoginProfile_notAKey
--- PASS: TestAccAWSUserLoginProfile_notAKey (11.99s)
=== RUN   TestAccAWSUserLoginProfile_keybaseDoesntExist
--- PASS: TestAccAWSUserLoginProfile_keybaseDoesntExist (12.21s)
=== RUN   TestAccAWSUserSSHKey_basic
--- PASS: TestAccAWSUserSSHKey_basic (13.94s)
=== RUN   TestAccAWSUserLoginProfile_PasswordLength
--- PASS: TestAccAWSUserLoginProfile_PasswordLength (15.49s)
=== RUN   TestAccAWSUser_nameChange
--- PASS: TestAccAWSUser_nameChange (16.97s)
=== RUN   TestAccAWSUserLoginProfile_keybase
--- PASS: TestAccAWSUserLoginProfile_keybase (17.95s)
=== RUN   TestAccAWSUser_basic
--- PASS: TestAccAWSUser_basic (18.08s)
=== RUN   TestAccAWSUser_pathChange
--- PASS: TestAccAWSUser_pathChange (19.61s)
=== RUN   TestAccAWSUserSSHKey_pemEncoding
--- PASS: TestAccAWSUserSSHKey_pemEncoding (21.14s)
=== RUN   TestAccAWSUserLoginProfile_basic
--- PASS: TestAccAWSUserLoginProfile_basic (24.14s)
=== RUN   TestAccAWSUserPolicyAttachment_basic
--- PASS: TestAccAWSUserPolicyAttachment_basic (25.30s)
```