### PR TITLE
resource/aws_db_event_subscription: Fix tag ARN handling

### DIFF
--- a/aws/resource_aws_db_event_subscription.go
+++ b/aws/resource_aws_db_event_subscription.go
@@ -6,10 +6,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/rds"
-
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -23,7 +20,16 @@ func resourceAwsDbEventSubscription() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: resourceAwsDbEventSubscriptionImport,
 		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(40 * time.Minute),
+			Delete: schema.DefaultTimeout(40 * time.Minute),
+			Update: schema.DefaultTimeout(40 * time.Minute),
+		},
 		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -67,7 +73,7 @@ func resourceAwsDbEventSubscription() *schema.Resource {
 }
 
 func resourceAwsDbEventSubscriptionCreate(d *schema.ResourceData, meta interface{}) error {
-	rdsconn := meta.(*AWSClient).rdsconn
+	conn := meta.(*AWSClient).rdsconn
 	name := d.Get("name").(string)
 	tags := tagsFromMapRDS(d.Get("tags").(map[string]interface{}))
 
@@ -95,9 +101,15 @@ func resourceAwsDbEventSubscriptionCreate(d *schema.ResourceData, meta interface
 
 	log.Println("[DEBUG] Create RDS Event Subscription:", request)
 
-	_, err := rdsconn.CreateEventSubscription(request)
-	if err != nil {
+	output, err := conn.CreateEventSubscription(request)
+	if err != nil || output.EventSubscription == nil {
 		return fmt.Errorf("Error creating RDS Event Subscription %s: %s", name, err)
+	}
+
+	d.SetId(aws.StringValue(output.EventSubscription.CustSubscriptionId))
+
+	if err := setTagsRDS(conn, d, aws.StringValue(output.EventSubscription.EventSubscriptionArn)); err != nil {
+		return fmt.Errorf("Error creating RDS Event Subscription (%s) tags: %s", d.Id(), err)
 	}
 
 	log.Println(
@@ -106,8 +118,8 @@ func resourceAwsDbEventSubscriptionCreate(d *schema.ResourceData, meta interface
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"creating"},
 		Target:     []string{"active"},
-		Refresh:    resourceAwsDbEventSubscriptionRefreshFunc(d, meta.(*AWSClient).rdsconn),
-		Timeout:    40 * time.Minute,
+		Refresh:    resourceAwsDbEventSubscriptionRefreshFunc(d.Id(), conn),
+		Timeout:    d.Timeout(schema.TimeoutCreate),
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second, // Wait 30 secs before starting
 	}
@@ -122,16 +134,19 @@ func resourceAwsDbEventSubscriptionCreate(d *schema.ResourceData, meta interface
 }
 
 func resourceAwsDbEventSubscriptionRead(d *schema.ResourceData, meta interface{}) error {
-	sub, err := resourceAwsDbEventSubscriptionRetrieve(d.Get("name").(string), meta.(*AWSClient).rdsconn)
+	conn := meta.(*AWSClient).rdsconn
+
+	sub, err := resourceAwsDbEventSubscriptionRetrieve(d.Get("name").(string), conn)
 	if err != nil {
 		return fmt.Errorf("Error retrieving RDS Event Subscription %s: %s", d.Id(), err)
 	}
 	if sub == nil {
+		log.Printf("[WARN] RDS Event Subscription (%s) not found - removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 
-	d.SetId(*sub.CustSubscriptionId)
+	d.Set("arn", sub.EventSubscriptionArn)
 	if err := d.Set("name", sub.CustSubscriptionId); err != nil {
 		return err
 	}
@@ -155,43 +170,34 @@ func resourceAwsDbEventSubscriptionRead(d *schema.ResourceData, meta interface{}
 	}
 
 	// list tags for resource
-	// set tags
-	conn := meta.(*AWSClient).rdsconn
-
-	arn := arn.ARN{
-		Partition: meta.(*AWSClient).partition,
-		Service:   "rds",
-		Region:    meta.(*AWSClient).region,
-		AccountID: d.Get("customer_aws_id").(string),
-		Resource:  fmt.Sprintf("subgrp:%s", d.Id()),
-	}.String()
 	resp, err := conn.ListTagsForResource(&rds.ListTagsForResourceInput{
-		ResourceName: aws.String(arn),
+		ResourceName: sub.EventSubscriptionArn,
 	})
 
 	if err != nil {
-		log.Printf("[DEBUG] Error retrieving tags for ARN: %s", arn)
+		log.Printf("[DEBUG] Error retrieving tags for ARN: %s", aws.StringValue(sub.EventSubscriptionArn))
 	}
 
 	var dt []*rds.Tag
 	if len(resp.TagList) > 0 {
 		dt = resp.TagList
 	}
-	d.Set("tags", tagsToMapRDS(dt))
+	if err := d.Set("tags", tagsToMapRDS(dt)); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
 
 	return nil
 }
 
-func resourceAwsDbEventSubscriptionRetrieve(
-	name string, rdsconn *rds.RDS) (*rds.EventSubscription, error) {
+func resourceAwsDbEventSubscriptionRetrieve(name string, conn *rds.RDS) (*rds.EventSubscription, error) {
 
 	request := &rds.DescribeEventSubscriptionsInput{
 		SubscriptionName: aws.String(name),
 	}
 
-	describeResp, err := rdsconn.DescribeEventSubscriptions(request)
+	describeResp, err := conn.DescribeEventSubscriptions(request)
 	if err != nil {
-		if rdserr, ok := err.(awserr.Error); ok && rdserr.Code() == "SubscriptionNotFound" {
+		if isAWSErr(err, rds.ErrCodeSubscriptionNotFoundFault, "") {
 			log.Printf("[WARN] No RDS Event Subscription by name (%s) found", name)
 			return nil, nil
 		}
@@ -206,7 +212,7 @@ func resourceAwsDbEventSubscriptionRetrieve(
 }
 
 func resourceAwsDbEventSubscriptionUpdate(d *schema.ResourceData, meta interface{}) error {
-	rdsconn := meta.(*AWSClient).rdsconn
+	conn := meta.(*AWSClient).rdsconn
 
 	d.Partial(true)
 	requestUpdate := false
@@ -243,7 +249,7 @@ func resourceAwsDbEventSubscriptionUpdate(d *schema.ResourceData, meta interface
 	log.Printf("[DEBUG] Send RDS Event Subscription modification request: %#v", requestUpdate)
 	if requestUpdate {
 		log.Printf("[DEBUG] RDS Event Subscription modification request: %#v", req)
-		_, err := rdsconn.ModifyEventSubscription(req)
+		_, err := conn.ModifyEventSubscription(req)
 		if err != nil {
 			return fmt.Errorf("Modifying RDS Event Subscription %s failed: %s", d.Id(), err)
 		}
@@ -254,8 +260,8 @@ func resourceAwsDbEventSubscriptionUpdate(d *schema.ResourceData, meta interface
 		stateConf := &resource.StateChangeConf{
 			Pending:    []string{"modifying"},
 			Target:     []string{"active"},
-			Refresh:    resourceAwsDbEventSubscriptionRefreshFunc(d, meta.(*AWSClient).rdsconn),
-			Timeout:    40 * time.Minute,
+			Refresh:    resourceAwsDbEventSubscriptionRefreshFunc(d.Id(), conn),
+			Timeout:    d.Timeout(schema.TimeoutUpdate),
 			MinTimeout: 10 * time.Second,
 			Delay:      30 * time.Second, // Wait 30 secs before starting
 		}
@@ -271,14 +277,7 @@ func resourceAwsDbEventSubscriptionUpdate(d *schema.ResourceData, meta interface
 		d.SetPartial("source_type")
 	}
 
-	arn := arn.ARN{
-		Partition: meta.(*AWSClient).partition,
-		Service:   "rds",
-		Region:    meta.(*AWSClient).region,
-		AccountID: d.Get("customer_aws_id").(string),
-		Resource:  fmt.Sprintf("subgrp:%s", d.Id()),
-	}.String()
-	if err := setTagsRDS(rdsconn, d, arn); err != nil {
+	if err := setTagsRDS(conn, d, d.Get("arn").(string)); err != nil {
 		return err
 	} else {
 		d.SetPartial("tags")
@@ -301,7 +300,7 @@ func resourceAwsDbEventSubscriptionUpdate(d *schema.ResourceData, meta interface
 		if len(remove) > 0 {
 			for _, removing := range remove {
 				log.Printf("[INFO] Removing %s as a Source Identifier from %q", *removing, d.Id())
-				_, err := rdsconn.RemoveSourceIdentifierFromSubscription(&rds.RemoveSourceIdentifierFromSubscriptionInput{
+				_, err := conn.RemoveSourceIdentifierFromSubscription(&rds.RemoveSourceIdentifierFromSubscriptionInput{
 					SourceIdentifier: removing,
 					SubscriptionName: aws.String(d.Id()),
 				})
@@ -314,7 +313,7 @@ func resourceAwsDbEventSubscriptionUpdate(d *schema.ResourceData, meta interface
 		if len(add) > 0 {
 			for _, adding := range add {
 				log.Printf("[INFO] Adding %s as a Source Identifier to %q", *adding, d.Id())
-				_, err := rdsconn.AddSourceIdentifierToSubscription(&rds.AddSourceIdentifierToSubscriptionInput{
+				_, err := conn.AddSourceIdentifierToSubscription(&rds.AddSourceIdentifierToSubscriptionInput{
 					SourceIdentifier: adding,
 					SubscriptionName: aws.String(d.Id()),
 				})
@@ -332,28 +331,23 @@ func resourceAwsDbEventSubscriptionUpdate(d *schema.ResourceData, meta interface
 }
 
 func resourceAwsDbEventSubscriptionDelete(d *schema.ResourceData, meta interface{}) error {
-	rdsconn := meta.(*AWSClient).rdsconn
+	conn := meta.(*AWSClient).rdsconn
 	deleteOpts := rds.DeleteEventSubscriptionInput{
 		SubscriptionName: aws.String(d.Id()),
 	}
 
-	if _, err := rdsconn.DeleteEventSubscription(&deleteOpts); err != nil {
-		rdserr, ok := err.(awserr.Error)
-		if !ok {
-			return fmt.Errorf("Error deleting RDS Event Subscription %s: %s", d.Id(), err)
+	if _, err := conn.DeleteEventSubscription(&deleteOpts); err != nil {
+		if isAWSErr(err, rds.ErrCodeSubscriptionNotFoundFault, "") {
+			return nil
 		}
-
-		if rdserr.Code() != "DBEventSubscriptionNotFoundFault" {
-			log.Printf("[WARN] RDS Event Subscription %s missing during delete", d.Id())
-			return fmt.Errorf("Error deleting RDS Event Subscription %s: %s", d.Id(), err)
-		}
+		return fmt.Errorf("Error deleting RDS Event Subscription %s: %s", d.Id(), err)
 	}
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"deleting"},
 		Target:     []string{},
-		Refresh:    resourceAwsDbEventSubscriptionRefreshFunc(d, meta.(*AWSClient).rdsconn),
-		Timeout:    40 * time.Minute,
+		Refresh:    resourceAwsDbEventSubscriptionRefreshFunc(d.Id(), conn),
+		Timeout:    d.Timeout(schema.TimeoutDelete),
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second, // Wait 30 secs before starting
 	}
@@ -364,12 +358,10 @@ func resourceAwsDbEventSubscriptionDelete(d *schema.ResourceData, meta interface
 	return err
 }
 
-func resourceAwsDbEventSubscriptionRefreshFunc(
-	d *schema.ResourceData,
-	rdsconn *rds.RDS) resource.StateRefreshFunc {
+func resourceAwsDbEventSubscriptionRefreshFunc(name string, conn *rds.RDS) resource.StateRefreshFunc {
 
 	return func() (interface{}, string, error) {
-		sub, err := resourceAwsDbEventSubscriptionRetrieve(d.Get("name").(string), rdsconn)
+		sub, err := resourceAwsDbEventSubscriptionRetrieve(name, conn)
 
 		if err != nil {
 			log.Printf("Error on retrieving DB Event Subscription when waiting: %s", err)
@@ -381,7 +373,7 @@ func resourceAwsDbEventSubscriptionRefreshFunc(
 		}
 
 		if sub.Status != nil {
-			log.Printf("[DEBUG] DB Event Subscription status for %s: %s", d.Id(), *sub.Status)
+			log.Printf("[DEBUG] DB Event Subscription status for %s: %s", name, *sub.Status)
 		}
 
 		return sub, *sub.Status, nil

--- a/aws/resource_aws_db_event_subscription_test.go
+++ b/aws/resource_aws_db_event_subscription_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -15,6 +16,7 @@ import (
 func TestAccAWSDBEventSubscription_basicUpdate(t *testing.T) {
 	var v rds.EventSubscription
 	rInt := acctest.RandInt()
+	rName := fmt.Sprintf("tf-acc-test-rds-event-subs-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -25,26 +27,22 @@ func TestAccAWSDBEventSubscription_basicUpdate(t *testing.T) {
 				Config: testAccAWSDBEventSubscriptionConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBEventSubscriptionExists("aws_db_event_subscription.bar", &v),
-					resource.TestCheckResourceAttr(
-						"aws_db_event_subscription.bar", "enabled", "true"),
-					resource.TestCheckResourceAttr(
-						"aws_db_event_subscription.bar", "source_type", "db-instance"),
-					resource.TestCheckResourceAttr(
-						"aws_db_event_subscription.bar", "name", fmt.Sprintf("tf-acc-test-rds-event-subs-%d", rInt)),
-					resource.TestCheckResourceAttr(
-						"aws_db_event_subscription.bar", "tags.Name", "name"),
+					resource.TestMatchResourceAttr("aws_db_event_subscription.bar", "arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:rds:[^:]+:[^:]+:es:%s$", rName))),
+					resource.TestCheckResourceAttr("aws_db_event_subscription.bar", "enabled", "true"),
+					resource.TestCheckResourceAttr("aws_db_event_subscription.bar", "source_type", "db-instance"),
+					resource.TestCheckResourceAttr("aws_db_event_subscription.bar", "name", rName),
+					resource.TestCheckResourceAttr("aws_db_event_subscription.bar", "tags.%", "1"),
+					resource.TestCheckResourceAttr("aws_db_event_subscription.bar", "tags.Name", "name"),
 				),
 			},
 			{
 				Config: testAccAWSDBEventSubscriptionConfigUpdate(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBEventSubscriptionExists("aws_db_event_subscription.bar", &v),
-					resource.TestCheckResourceAttr(
-						"aws_db_event_subscription.bar", "enabled", "false"),
-					resource.TestCheckResourceAttr(
-						"aws_db_event_subscription.bar", "source_type", "db-parameter-group"),
-					resource.TestCheckResourceAttr(
-						"aws_db_event_subscription.bar", "tags.Name", "new-name"),
+					resource.TestCheckResourceAttr("aws_db_event_subscription.bar", "enabled", "false"),
+					resource.TestCheckResourceAttr("aws_db_event_subscription.bar", "source_type", "db-parameter-group"),
+					resource.TestCheckResourceAttr("aws_db_event_subscription.bar", "tags.%", "1"),
+					resource.TestCheckResourceAttr("aws_db_event_subscription.bar", "tags.Name", "new-name"),
 				),
 			},
 		},

--- a/website/docs/r/db_event_subscription.html.markdown
+++ b/website/docs/r/db_event_subscription.html.markdown
@@ -61,6 +61,22 @@ The following arguments are supported:
 * `enabled` - (Optional) A boolean flag to enable/disable the subscription. Defaults to true.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
+## Attributes
+
+The following additional atttributes are provided:
+
+* `id` - The name of the RDS event notification subscription
+* `arn` - The Amazon Resource Name of the RDS event notification subscription
+* `customer_aws_id` - The AWS customer account associated with the RDS event notification subscription
+
+## Timeouts
+
+`aws_db_event_subscription` provides the following [Timeouts](/docs/configuration/resources.html#timeouts)
+configuration options:
+
+- `create` - (Default `40m`) How long to wait for a RDS event notification subscription to be ready.
+- `delete` - (Default `40m`) How long to wait for a RDS event notification subscription to be deleted.
+- `update` - (Default `40m`) How long to wait for a RDS event notification subscription to be updated.
 
 ## Import
 


### PR DESCRIPTION
Additional updates:
* Add arn attribute
* Support configurable timeouts
* Use `isAWSErr()`
* Skip returning an error when deleting a non-existent subscription

The regression occurred during #4053, which was merged in for release in v1.14.0 of the AWS provider.

Fixes #4138 and the following testing:

```
=== RUN   TestAccAWSDBEventSubscription_basicUpdate
--- FAIL: TestAccAWSDBEventSubscription_basicUpdate (168.94s)
    testing.go:518: Step 0 error: Check failed: Check 5/5 error: aws_db_event_subscription.bar: Attribute 'tags.Name' not found

=== RUN   TestAccAWSDBEventSubscription_categoryUpdate
--- FAIL: TestAccAWSDBEventSubscription_categoryUpdate (617.09s)
    testing.go:518: Step 0 error: After applying this step, the plan was not empty:
        
        DIFF:
        
        UPDATE: aws_db_event_subscription.bar
          tags.%:    "0" => "1"
          tags.Name: "" => "name"

=== RUN   TestAccAWSDBEventSubscription_importBasic
--- FAIL: TestAccAWSDBEventSubscription_importBasic (769.86s)
    testing.go:518: Step 0 error: After applying this step, the plan was not empty:
        
        DIFF:
        
        UPDATE: aws_db_event_subscription.bar
          tags.%:    "0" => "1"
          tags.Name: "" => "name"

=== RUN   TestAccAWSDBEventSubscription_withSourceIds
--- FAIL: TestAccAWSDBEventSubscription_withSourceIds (166.35s)
    testing.go:518: Step 0 error: After applying this step, the plan was not empty:
        
        DIFF:
        
        UPDATE: aws_db_event_subscription.bar
          tags.%:    "0" => "1"
          tags.Name: "" => "name"
```

```
4 tests passed (all tests)
=== RUN   TestAccAWSDBEventSubscription_importBasic
--- PASS: TestAccAWSDBEventSubscription_importBasic (750.01s)
=== RUN   TestAccAWSDBEventSubscription_withSourceIds
--- PASS: TestAccAWSDBEventSubscription_withSourceIds (755.63s)
=== RUN   TestAccAWSDBEventSubscription_basicUpdate
--- PASS: TestAccAWSDBEventSubscription_basicUpdate (1235.63s)
=== RUN   TestAccAWSDBEventSubscription_categoryUpdate
--- PASS: TestAccAWSDBEventSubscription_categoryUpdate (1235.67s)
```