### PR TITLE
resource/aws_elb: Return any errors when updating listeners

### DIFF
--- a/aws/resource_aws_elb.go
+++ b/aws/resource_aws_elb.go
@@ -473,7 +473,10 @@ func resourceAwsElbUpdate(d *schema.ResourceData, meta interface{}) error {
 		ns := n.(*schema.Set)
 
 		remove, _ := expandListeners(os.Difference(ns).List())
-		add, _ := expandListeners(ns.Difference(os).List())
+		add, err := expandListeners(ns.Difference(os).List())
+		if err != nil {
+			return err
+		}
 
 		if len(remove) > 0 {
 			ports := make([]*int64, 0, len(remove))

--- a/aws/resource_aws_elb_test.go
+++ b/aws/resource_aws_elb_test.go
@@ -369,9 +369,11 @@ func TestAccAWSELB_tags(t *testing.T) {
 	})
 }
 
-func TestAccAWSELB_iam_server_cert(t *testing.T) {
+func TestAccAWSELB_Listener_SSLCertificateID_IAMServerCertificate(t *testing.T) {
 	var conf elb.LoadBalancerDescription
-	// var td elb.TagDescription
+	rName := fmt.Sprintf("tf-acctest-%s", acctest.RandString(10))
+	resourceName := "aws_elb.bar"
+
 	testCheck := func(*terraform.State) error {
 		if len(conf.ListenerDescriptions) != 1 {
 			return fmt.Errorf(
@@ -380,19 +382,26 @@ func TestAccAWSELB_iam_server_cert(t *testing.T) {
 		}
 		return nil
 	}
+
 	resource.Test(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_elb.bar",
-		Providers:     testAccProvidersWithTLS,
-		CheckDestroy:  testAccCheckAWSELBDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProvidersWithTLS,
+		CheckDestroy: testAccCheckAWSELBDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccELBIAMServerCertConfig(
-					fmt.Sprintf("tf-acctest-%s", acctest.RandString(10))),
+				Config:      testAccELBConfig_Listener_IAMServerCertificate(rName, "tcp"),
+				ExpectError: regexp.MustCompile(`ssl_certificate_id may be set only when protocol is 'https' or 'ssl'`),
+			},
+			{
+				Config: testAccELBConfig_Listener_IAMServerCertificate(rName, "https"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSELBExists("aws_elb.bar", &conf),
+					testAccCheckAWSELBExists(resourceName, &conf),
 					testCheck,
 				),
+			},
+			{
+				Config:      testAccELBConfig_Listener_IAMServerCertificate_AddInvalidListener(rName),
+				ExpectError: regexp.MustCompile(`ssl_certificate_id may be set only when protocol is 'https' or 'ssl'`),
 			},
 		},
 	})
@@ -1624,33 +1633,63 @@ resource "aws_security_group" "bar" {
 }
 `
 
-func testAccELBIAMServerCertConfig(certName string) string {
+func testAccELBConfig_Listener_IAMServerCertificate(certName, lbProtocol string) string {
 	return fmt.Sprintf(`
-%s 
+data "aws_availability_zones" "available" {}
+
+%[1]s
 
 resource "aws_iam_server_certificate" "test_cert" {
-  name = "%s"
+  name             = "%[2]s"
   certificate_body = "${tls_self_signed_cert.example.cert_pem}"
   private_key      = "${tls_private_key.example.private_key_pem}"
 }
 
 resource "aws_elb" "bar" {
-  availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  availability_zones = ["${data.aws_availability_zones.available.names[0]}"]
 
   listener {
-    instance_port = 8000
-    instance_protocol = "https"
-    lb_port = 80
-    // Protocol should be case insensitive
-    lb_protocol = "HttPs"
+    instance_port      = 443
+    instance_protocol  = "%[3]s"
+    lb_port            = 443
+    lb_protocol        = "%[3]s"
+    ssl_certificate_id = "${aws_iam_server_certificate.test_cert.arn}"
+  }
+}
+`, testAccTLSServerCert, certName, lbProtocol)
+}
+
+func testAccELBConfig_Listener_IAMServerCertificate_AddInvalidListener(certName string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {}
+
+%[1]s
+
+resource "aws_iam_server_certificate" "test_cert" {
+  name             = "%[2]s"
+  certificate_body = "${tls_self_signed_cert.example.cert_pem}"
+  private_key      = "${tls_private_key.example.private_key_pem}"
+}
+
+resource "aws_elb" "bar" {
+  availability_zones = ["${data.aws_availability_zones.available.names[0]}"]
+
+  listener {
+    instance_port      = 443
+    instance_protocol  = "https"
+    lb_port            = 443
+    lb_protocol        = "https"
     ssl_certificate_id = "${aws_iam_server_certificate.test_cert.arn}"
   }
 
-	tags {
-		bar = "baz"
-	}
-
-  cross_zone_load_balancing = true
+  # lb_protocol tcp and ssl_certificate_id is not valid
+  listener {
+    instance_port      = 8443
+    instance_protocol  = "tcp"
+    lb_port            = 8443
+    lb_protocol        = "tcp"
+    ssl_certificate_id = "${aws_iam_server_certificate.test_cert.arn}"
+  }
 }
 `, testAccTLSServerCert, certName)
 }


### PR DESCRIPTION
Closes #3785 

Previously, it was ignoring any errors from `expandListeners` and subsequently skipping the addition of invalid listeners:

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSELB_Listener_SSLCertificateID_IAMServerCertificate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSELB_Listener_SSLCertificateID_IAMServerCertificate -timeout 120m
=== RUN   TestAccAWSELB_Listener_SSLCertificateID_IAMServerCertificate
--- FAIL: TestAccAWSELB_Listener_SSLCertificateID_IAMServerCertificate (40.41s)
	testing.go:511: Step 2, expected error:

		After applying this step, the plan was not empty:

		DIFF:

		UPDATE: aws_elb.bar
		  listener.#:                             "1" => "2"
		  listener.1105221442.instance_port:      "443" => "443"
		  listener.1105221442.instance_protocol:  "https" => "https"
		  listener.1105221442.lb_port:            "443" => "443"
		  listener.1105221442.lb_protocol:        "https" => "https"
		  listener.1105221442.ssl_certificate_id: "arn:aws:iam::187416307283:server-certificate/tf-acctest-x09yfu0gci" => "arn:aws:iam::187416307283:server-certificate/tf-acctest-x09yfu0gci"
		  listener.3527251857.instance_port:      "" => "8443"
		  listener.3527251857.instance_protocol:  "" => "tcp"
		  listener.3527251857.lb_port:            "" => "8443"
		  listener.3527251857.lb_protocol:        "" => "tcp"
		  listener.3527251857.ssl_certificate_id: "" => "arn:aws:iam::187416307283:server-certificate/tf-acctest-x09yfu0gci"

...

		To match:

		ssl_certificate_id may be set only when protocol is 'https' or 'ssl'


FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	40.441s
make: *** [testacc] Error 1
```

Now passes:

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSELB_Listener_SSLCertificateID_IAMServerCertificate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSELB_Listener_SSLCertificateID_IAMServerCertificate -timeout 120m
=== RUN   TestAccAWSELB_Listener_SSLCertificateID_IAMServerCertificate
--- PASS: TestAccAWSELB_Listener_SSLCertificateID_IAMServerCertificate (40.59s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	40.623s
```