### PR TITLE
resource/aws_emr_cluster: Prevent crash with missing StateChangeReason

### DIFF
--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -1390,7 +1390,7 @@ func resourceAwsEMRClusterStateRefreshFunc(d *schema.ResourceData, meta interfac
 			if reason == nil {
 				return resp.Cluster, state, fmt.Errorf("%s: reason code and message not provided", state)
 			}
-			return resp.Cluster, state, fmt.Errorf("%s: %s", aws.StringValue(reason.Code), aws.StringValue(reason.Message))
+			return resp.Cluster, state, fmt.Errorf("%s: %s: %s", state, aws.StringValue(reason.Code), aws.StringValue(reason.Message))
 		}
 
 		return resp.Cluster, state, nil

--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -1374,23 +1374,25 @@ func resourceAwsEMRClusterStateRefreshFunc(d *schema.ResourceData, meta interfac
 			return nil, "", err
 		}
 
-		emrc := resp.Cluster
-
-		if emrc == nil {
+		if resp.Cluster == nil {
 			return 42, "destroyed", nil
 		}
 
-		if resp.Cluster.Status != nil {
-			log.Printf("[DEBUG] EMR Cluster status (%s): %s", d.Id(), *resp.Cluster.Status)
+		if resp.Cluster.Status == nil {
+			return resp.Cluster, "", fmt.Errorf("cluster status not provided")
 		}
 
-		status := emrc.Status
-		if *status.State == "TERMINATING" || *status.State == "TERMINATED_WITH_ERRORS" {
-			reason := *status.StateChangeReason
-			return emrc, *status.State, fmt.Errorf("%s: %s",
-				*reason.Code, *reason.Message)
+		state := aws.StringValue(resp.Cluster.Status.State)
+		log.Printf("[DEBUG] EMR Cluster status (%s): %s", d.Id(), state)
+
+		if state == emr.ClusterStateTerminating || state == emr.ClusterStateTerminatedWithErrors {
+			reason := resp.Cluster.Status.StateChangeReason
+			if reason == nil {
+				return resp.Cluster, state, fmt.Errorf("%s: reason code and message not provided", state)
+			}
+			return resp.Cluster, state, fmt.Errorf("%s: %s", aws.StringValue(reason.Code), aws.StringValue(reason.Message))
 		}
 
-		return emrc, *status.State, nil
+		return resp.Cluster, state, nil
 	}
 }


### PR DESCRIPTION
Fixes #4164 

Tests
```
13 tests passed (all tests)
=== RUN   TestAccAWSEMRCluster_bootstrap_ordering
--- PASS: TestAccAWSEMRCluster_bootstrap_ordering (469.33s)
=== RUN   TestAccAWSEMRCluster_terminationProtected
--- PASS: TestAccAWSEMRCluster_terminationProtected (475.55s)
=== RUN   TestAccAWSEMRCluster_security_config
--- PASS: TestAccAWSEMRCluster_security_config (486.26s)
=== RUN   TestAccAWSEMRCluster_Step_Multiple
--- PASS: TestAccAWSEMRCluster_Step_Multiple (491.98s)
=== RUN   TestAccAWSEMRCluster_Kerberos_ClusterDedicatedKdc
--- PASS: TestAccAWSEMRCluster_Kerberos_ClusterDedicatedKdc (499.33s)
=== RUN   TestAccAWSEMRCluster_basic
--- PASS: TestAccAWSEMRCluster_basic (527.11s)
=== RUN   TestAccAWSEMRCluster_Step_Basic
--- PASS: TestAccAWSEMRCluster_Step_Basic (586.03s)
=== RUN   TestAccAWSEMRCluster_instance_group
--- PASS: TestAccAWSEMRCluster_instance_group (619.21s)
=== RUN   TestAccAWSEMRCluster_custom_ami_id
--- PASS: TestAccAWSEMRCluster_custom_ami_id (639.96s)
=== RUN   TestAccAWSEMRCluster_s3Logging
--- PASS: TestAccAWSEMRCluster_s3Logging (651.75s)
=== RUN   TestAccAWSEMRCluster_visibleToAllUsers
--- PASS: TestAccAWSEMRCluster_visibleToAllUsers (871.67s)
=== RUN   TestAccAWSEMRCluster_tags
--- PASS: TestAccAWSEMRCluster_tags (948.41s)
=== RUN   TestAccAWSEMRCluster_root_volume_size
--- PASS: TestAccAWSEMRCluster_root_volume_size (989.54s)
```