### PR TITLE
Added cloudwatch log group data source

### DIFF
--- a/aws/data_source_aws_cloudwatch_log_group.go
+++ b/aws/data_source_aws_cloudwatch_log_group.go
@@ -1,0 +1,63 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsCloudwatchLogGroup() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsCloudwatchLogGroupRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"creation_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsCloudwatchLogGroupRead(d *schema.ResourceData, meta interface{}) error {
+	name := aws.String(d.Get("name").(string))
+	conn := meta.(*AWSClient).cloudwatchlogsconn
+
+	input := &cloudwatchlogs.DescribeLogGroupsInput{
+		LogGroupNamePrefix: name,
+	}
+
+	resp, err := conn.DescribeLogGroups(input)
+	if err != nil {
+		return err
+	}
+
+	var logGroup *cloudwatchlogs.LogGroup
+
+	for _, lg := range resp.LogGroups {
+		if *lg.LogGroupName == *name {
+			logGroup = lg
+			break
+		}
+	}
+
+	if logGroup == nil {
+		return fmt.Errorf("No log group named %s found\n", *name)
+	}
+
+	d.SetId(*logGroup.LogGroupName)
+	d.Set("arn", logGroup.Arn)
+	d.Set("creation_time", logGroup.CreationTime)
+
+	return nil
+}

--- a/aws/data_source_aws_cloudwatch_log_group_test.go
+++ b/aws/data_source_aws_cloudwatch_log_group_test.go
@@ -1,0 +1,36 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSCloudwatchLogGroupDataSource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAWSCloudwatchLogGroupDataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_cloudwatch_log_group.test", "name", "Test"),
+					resource.TestCheckResourceAttrSet("data.aws_cloudwatch_log_group.test", "arn"),
+					resource.TestCheckResourceAttrSet("data.aws_cloudwatch_log_group.test", "creation_time"),
+				),
+			},
+		},
+	})
+	return
+}
+
+var testAccCheckAWSCloudwatchLogGroupDataSourceConfig = fmt.Sprintf(`
+resource aws_cloudwatch_log_group "test" {
+  name = "Test"
+}
+
+data aws_cloudwatch_log_group "test" {
+  name = "${aws_cloudwatch_log_group.test.name}"
+}
+`)

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -171,6 +171,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_canonical_user_id":                dataSourceAwsCanonicalUserId(),
 			"aws_cloudformation_stack":             dataSourceAwsCloudFormationStack(),
 			"aws_cloudtrail_service_account":       dataSourceAwsCloudTrailServiceAccount(),
+			"aws_cloudwatch_log_group":             dataSourceAwsCloudwatchLogGroup(),
 			"aws_db_instance":                      dataSourceAwsDbInstance(),
 			"aws_db_snapshot":                      dataSourceAwsDbSnapshot(),
 			"aws_dynamodb_table":                   dataSourceAwsDynamoDbTable(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -67,6 +67,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-cloudtrail-service-account") %>>
                             <a href="/docs/providers/aws/d/cloudtrail_service_account.html">aws_cloudtrail_service_account</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-cloudwatch-log-group") %>>
+                            <a href="/docs/providers/aws/d/cloudwatch_log_group.html">aws_cloudwatch_log_group</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-db-instance") %>>
                             <a href="/docs/providers/aws/d/db_instance.html">aws_db_instance</a>
                         </li>

--- a/website/docs/d/cloudwatch_log_group.html.markdown
+++ b/website/docs/d/cloudwatch_log_group.html.markdown
@@ -1,0 +1,32 @@
+---
+layout: "aws"
+page_title: "AWS: aws_cloudwatch_log_group"
+sidebar_current: "docs-aws-cloudwatch-log-group"
+description: |-
+  Get information on a Cloudwatch Log Group.
+---
+
+# Data Source: aws_cloudwatch_log_group
+
+Use this data source to get information about an AWS Cloudwatch Log Group
+
+## Example Usage
+
+```hcl
+data "aws_cloudwatch_log_group" "example" {
+  name = "MyImportantLogs"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Cloudwatch log group
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `arn` - The ARN of the Cloudwatch log group
+* `creation_time` - The creation time of the log group, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC.


### PR DESCRIPTION
Ref #3247

```
% aws-vault exec development -- make testacc TESTARGS="-run TestAccAWSCloudwatchLogGroupDataSource"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run TestAccAWSCloudwatchLogGroupDataSource -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSCloudwatchLogGroupDataSource
--- PASS: TestAccAWSCloudwatchLogGroupDataSource (73.74s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	73.781s
```