### PR TITLE
add new data source aws_api_gateway_rest_api

### DIFF
--- a/aws/data_source_aws_api_gateway_rest_api.go
+++ b/aws/data_source_aws_api_gateway_rest_api.go
@@ -1,0 +1,88 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/apigateway"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsApiGatewayRestApi() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsApiGatewayRestApiRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"root_resource_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsApiGatewayRestApiRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).apigateway
+	params := &apigateway.GetRestApisInput{}
+
+	target := d.Get("name")
+	var matchedApis []*apigateway.RestApi
+	log.Printf("[DEBUG] Reading API Gateway REST APIs: %s", params)
+	err := conn.GetRestApisPages(params, func(page *apigateway.GetRestApisOutput, lastPage bool) bool {
+		for _, api := range page.Items {
+			if *api.Name == target {
+				matchedApis = append(matchedApis, api)
+			}
+		}
+		return true
+	})
+	if err != nil {
+		return errwrap.Wrapf("error describing API Gateway REST APIs: {{err}}", err)
+	}
+
+	if len(matchedApis) == 0 {
+		return fmt.Errorf("no REST APIs with name %q found in this region", target)
+	}
+	if len(matchedApis) > 1 {
+		return fmt.Errorf("multiple REST APIs with name %q found in this region", target)
+	}
+
+	match := matchedApis[0]
+
+	d.SetId(*match.Id)
+
+	if err = dataSourceAwsApiGatewayRestApiRefreshResources(d, meta); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func dataSourceAwsApiGatewayRestApiRefreshResources(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).apigateway
+
+	resp, err := conn.GetResources(&apigateway.GetResourcesInput{
+		RestApiId: aws.String(d.Id()),
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, item := range resp.Items {
+		if *item.Path == "/" {
+			d.Set("root_resource_id", item.Id)
+			break
+		}
+	}
+
+	return nil
+}

--- a/aws/data_source_aws_api_gateway_rest_api_test.go
+++ b/aws/data_source_aws_api_gateway_rest_api_test.go
@@ -76,5 +76,5 @@ name        = "%s_wrong1"
 data "aws_api_gateway_rest_api" "by_name" {
 name = "${aws_api_gateway_rest_api.tf_test.name}"
 }
-`, r)
+`, r, r, r)
 }

--- a/aws/data_source_aws_api_gateway_rest_api_test.go
+++ b/aws/data_source_aws_api_gateway_rest_api_test.go
@@ -1,0 +1,80 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataSourceAwsApiGatewayRestApi(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDataSourceAwsApiGatewayRestApiConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsApiGatewayRestApiCheck("data.aws_api_gateway_rest_api.by_name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsApiGatewayRestApiCheck(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resources, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("root module has no resource called %s", name)
+		}
+
+		apiGatewayRestApiResources, ok := s.RootModule().Resources["aws_api_gateway_rest_api.tf_test"]
+		if !ok {
+			return fmt.Errorf("can't find aws_api_gateway_rest_api.tf_test in state")
+		}
+
+		attr := resources.Primary.Attributes
+
+		if attr["name"] != apiGatewayRestApiResources.Primary.Attributes["name"] {
+			return fmt.Errorf(
+				"name is %s; want %s",
+				attr["name"],
+				apiGatewayRestApiResources.Primary.Attributes["name"],
+			)
+		}
+
+		if attr["root_resource_id"] != apiGatewayRestApiResources.Primary.Attributes["root_resource_id"] {
+			return fmt.Errorf(
+				"root_resource_id is %s; want %s",
+				attr["root_resource_id"],
+				apiGatewayRestApiResources.Primary.Attributes["root_resource_id"],
+			)
+		}
+
+		return nil
+	}
+}
+
+const testAccDataSourceAwsApiGatewayRestApiConfig = `
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_api_gateway_rest_api" "tf_wrong1" {
+  name        = "wrong1"
+}
+
+resource "aws_api_gateway_rest_api" "tf_test" {
+  name        = "tf_test"
+}
+
+resource "aws_api_gateway_rest_api" "tf_wrong2" {
+  name        = "wrong2"
+}
+
+data "aws_api_gateway_rest_api" "by_name" {
+  name = "${aws_api_gateway_rest_api.tf_test.name}"
+}
+`

--- a/aws/data_source_aws_api_gateway_rest_api_test.go
+++ b/aws/data_source_aws_api_gateway_rest_api_test.go
@@ -4,17 +4,19 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccDataSourceAwsApiGatewayRestApi(t *testing.T) {
+	rName := acctest.RandString(8)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccDataSourceAwsApiGatewayRestApiConfig,
+				Config: testAccDataSourceAwsApiGatewayRestApiConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceAwsApiGatewayRestApiCheck("data.aws_api_gateway_rest_api.by_name"),
 				),
@@ -57,24 +59,22 @@ func testAccDataSourceAwsApiGatewayRestApiCheck(name string) resource.TestCheckF
 	}
 }
 
-const testAccDataSourceAwsApiGatewayRestApiConfig = `
-provider "aws" {
-  region = "us-west-2"
-}
-
+func testAccDataSourceAwsApiGatewayRestApiConfig(r string) string {
+	return fmt.Sprintf(`
 resource "aws_api_gateway_rest_api" "tf_wrong1" {
-  name        = "wrong1"
+name        = "%s_wrong1"
 }
 
 resource "aws_api_gateway_rest_api" "tf_test" {
-  name        = "tf_test"
+name        = "%s_correct"
 }
 
 resource "aws_api_gateway_rest_api" "tf_wrong2" {
-  name        = "wrong2"
+name        = "%s_wrong1"
 }
 
 data "aws_api_gateway_rest_api" "by_name" {
-  name = "${aws_api_gateway_rest_api.tf_test.name}"
+name = "${aws_api_gateway_rest_api.tf_test.name}"
 }
-`
+`, r)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -163,6 +163,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_acm_certificate":                  dataSourceAwsAcmCertificate(),
 			"aws_ami":                              dataSourceAwsAmi(),
 			"aws_ami_ids":                          dataSourceAwsAmiIds(),
+			"aws_api_gateway_rest_api":             dataSourceAwsApiGatewayRestApi(),
 			"aws_autoscaling_groups":               dataSourceAwsAutoscalingGroups(),
 			"aws_availability_zone":                dataSourceAwsAvailabilityZone(),
 			"aws_availability_zones":               dataSourceAwsAvailabilityZones(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -43,6 +43,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-ami-ids") %>>
                             <a href="/docs/providers/aws/d/ami_ids.html">aws_ami_ids</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws_api_gateway_rest_api") %>>
+                            <a href="/docs/providers/aws/d/api_gateway_rest_api.html">aws_api_gateway_rest_api</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-autoscaling-groups") %>>
                             <a href="/docs/providers/aws/d/autoscaling_groups.html">aws_autoscaling_groups</a>
                         </li>

--- a/website/docs/d/api_gateway_rest_api.html.markdown
+++ b/website/docs/d/api_gateway_rest_api.html.markdown
@@ -1,0 +1,32 @@
+---
+layout: "aws"
+page_title: "AWS: aws_api_gateway_rest_api"
+sidebar_current: "docs-aws_api_gateway_rest_api"
+description: |-
+  Get information on a API Gateway REST API
+---
+
+# Data Source: aws_api_gateway_rest_api
+
+Use this data source to get the id and root_resource_id of a REST API in
+API Gateway. To fetch the REST API you must provide a name to match against. 
+As there is no unique name constraint on REST APIs this data source will 
+error if there is more than one match.
+
+## Example Usage
+
+```hcl
+data "aws_api_gateway_rest_api" "my_rest_api" {
+  name = "my-rest-api"
+}
+```
+
+## Argument Reference
+
+ * `name` - (Required) The name of the REST API to look up. If no REST API is found with this name, an error will be returned. 
+ If multiple REST APIs are found with this name, an error will be returned.
+
+## Attributes Reference
+
+ * `id` - Set to the ID of the found REST API.
+ * `root_resource_id` - Set to the ID of the API Gateway Resource on the found REST API where the route matches '/'.


### PR DESCRIPTION
#4146
```
make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsApiGatewayRestApi'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccDataSourceAwsApiGatewayRestApi -timeout 120m
=== RUN   TestAccDataSourceAwsApiGatewayRestApi
--- PASS: TestAccDataSourceAwsApiGatewayRestApi (28.58s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       29.862s
```

I've had issues trying to get the terraform-website project working to check the docs locally - I think they're ok but would be good if someone could check.