### PR TITLE
Make sure route53 records really exist after creation and add support for all ASCII characters

### DIFF
--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -20,8 +20,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/route53"
 )
 
-var r53NoRecordsFound = errors.New("No matching Hosted Zone found")
-var r53NoHostedZoneFound = errors.New("No matching records found")
+var r53NoRecordsFound = errors.New("No matching records found")
+var r53NoHostedZoneFound = errors.New("No matching Hosted Zone found")
 var r53ValidRecordTypes = regexp.MustCompile("^(A|AAAA|CAA|CNAME|MX|NAPTR|NS|PTR|SOA|SPF|SRV|TXT)$")
 
 func resourceAwsRoute53Record() *schema.Resource {

--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -374,7 +374,8 @@ func resourceAwsRoute53RecordUpdate(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	return resourceAwsRoute53RecordRead(d, meta)
+	_, err = findRecord(d, meta)
+	return err
 }
 
 func resourceAwsRoute53RecordCreate(d *schema.ResourceData, meta interface{}) error {
@@ -451,7 +452,8 @@ func resourceAwsRoute53RecordCreate(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	return resourceAwsRoute53RecordRead(d, meta)
+	_, err = findRecord(d, meta)
+	return err
 }
 
 func changeRoute53RecordSet(conn *route53.Route53, input *route53.ChangeResourceRecordSetsInput) (interface{}, error) {

--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -632,27 +632,49 @@ func findRecord(d *schema.ResourceData, meta interface{}) (*route53.ResourceReco
 	log.Printf("[DEBUG] Expanded record name: %s", en)
 	d.Set("fqdn", en)
 
+	recordName := FQDN(strings.ToLower(en))
+	recordType := d.Get("type").(string)
+	recordSetIdentifier := d.Get("set_identifier")
+
+	// If this isn't a Weighted, Latency, Geo, or Failover resource with
+	// a SetIdentifier we only need to look at the first record in the response since there can be
+	// only one
+	maxItems := "1"
+	if recordSetIdentifier != "" {
+		maxItems = "100"
+	}
+
 	lopts := &route53.ListResourceRecordSetsInput{
 		HostedZoneId:    aws.String(cleanZoneID(zone)),
-		StartRecordName: aws.String(en),
-		StartRecordType: aws.String(d.Get("type").(string)),
+		StartRecordName: aws.String(recordName),
+		StartRecordType: aws.String(recordType),
+		MaxItems:        aws.String(maxItems),
 	}
 
 	log.Printf("[DEBUG] List resource records sets for zone: %s, opts: %s",
 		zone, lopts)
 
 	var record *route53.ResourceRecordSet
+
+	// We need to loop over all records starting from the record we are looking for because
+	// Weighted, Latency, Geo, and Failover resource record sets have a special option
+	// called SetIdentifier which allows multiple entries with the same name and type but
+	// a different SetIdentifier
+	// For all other records we are setting the maxItems to 1 so that we don't return extra
+	// unneeded records
 	err = conn.ListResourceRecordSetsPages(lopts, func(resp *route53.ListResourceRecordSetsOutput, lastPage bool) bool {
 		for _, recordSet := range resp.ResourceRecordSets {
-			name := cleanRecordName(*recordSet.Name)
-			if FQDN(strings.ToLower(name)) != FQDN(strings.ToLower(*lopts.StartRecordName)) {
-				continue
-			}
-			if strings.ToUpper(*recordSet.Type) != strings.ToUpper(*lopts.StartRecordType) {
-				continue
-			}
 
-			if recordSet.SetIdentifier != nil && *recordSet.SetIdentifier != d.Get("set_identifier") {
+			responseName := strings.ToLower(cleanRecordName(*recordSet.Name))
+			responseType := strings.ToUpper(*recordSet.Type)
+
+			if recordName != responseName {
+				continue
+			}
+			if recordType != responseType {
+				continue
+			}
+			if recordSet.SetIdentifier != nil && *recordSet.SetIdentifier != recordSetIdentifier {
 				continue
 			}
 

--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -907,16 +908,17 @@ func FQDN(name string) string {
 	}
 }
 
-// Route 53 stores the "*" wildcard indicator as ASCII 42 and returns the
-// octal equivalent, "\\052". Here we look for that, and convert back to "*"
-// as needed.
+// Route 53 stores certain characters with the octal equivalent in ASCII format.
+// This function converts all of these characters back into the original character
+// E.g. "*" is stored as "\\052" and "@" as "\\100"
+
 func cleanRecordName(name string) string {
 	str := name
-	if strings.HasPrefix(name, "\\052") {
-		str = strings.Replace(name, "\\052", "*", 1)
-		log.Printf("[DEBUG] Replacing octal \\052 for * in: %s", name)
+	s, err := strconv.Unquote(`"` + str + `"`)
+	if err != nil {
+		return str
 	}
-	return str
+	return s
 }
 
 // Check if the current record name contains the zone suffix.

--- a/aws/resource_aws_route53_record_test.go
+++ b/aws/resource_aws_route53_record_test.go
@@ -22,6 +22,8 @@ func TestCleanRecordName(t *testing.T) {
 	}{
 		{"www.nonexample.com", "www.nonexample.com"},
 		{"\\052.nonexample.com", "*.nonexample.com"},
+		{"\\100.nonexample.com", "@.nonexample.com"},
+		{"\\043.nonexample.com", "#.nonexample.com"},
 		{"nonexample.com", "nonexample.com"},
 	}
 


### PR DESCRIPTION
In #3579 we found some weird behaviour where records starting with `@` were always showing up as a change for every `terrafrom apply`. The weird part about this was that the record was being created correctly and not showing up in state. In https://github.com/terraform-providers/terraform-provider-aws/issues/3579#issuecomment-369590392 @bflad pointed out that `@` doesn't need to be used with AWS and they actually give you a warning when you try to use it inside the AWS console. With this answer I was happy and able to move these `@` records to the apex domain and move on with my life. However I was still very curious why the records weren't showing up in state properly. 

Fast forward a few days and I submitted a job to move the values of the `@` records to the apex domains for each zone. It worked! However a little while later someone reported an unrelated DNS record was no longer resolving. I had only just recently moved all of our production DNS into terraform so I was worried that the automation for deploying changes had accidentally deleted something. In https://github.com/terraform-providers/terraform-provider-aws/issues/3579#issuecomment-380064285 you can see more detail about what actually happened. 

Luckily all DNS changes are now automated by a jenkins job running terraform. Looking at the Route53 logs I could see that the unrelated record was removed exactly when terraform was removing the `@` record. Another terraform run fixed things up and added the record back but I felt that I needed to figure out what happened. Luckily I was able to reproduce this locally however I still hadn't explained why it only happened for 1 of the 3 zones which had `@` records.

# Findings

## How did a random record get deleted?

I figured out very quickly that this was only happening for zones which had more than 100 records (the default maxItems per page for the AWS api). I noticed this when I tried to reproduce it with a limited dataset and couldn't trigger the issue. So my focus shifted to the code which was looping of the paginated results from AWS.

The root cause was the line https://github.com/terraform-providers/terraform-provider-aws/blob/c77020f539eed9d3f1dab36c2d2d5a624ed3007b/aws/resource_aws_route53_record.go#L646

So the current record in the response was being compared to the `*lopts.StartRecordName`. Which for the first page of results was the correct record. However if the first result didn't match for some reason (In my case because `@.domain.com` != `\\100.domain.com` it would continue looping until it got to the next page. At this stage `*lopts.StartRecordName` now was set to the first result in the second page of results and then the record matched perfectly!

So this bug would only be triggered if the record being deleted didn't match with how AWS returned the record, and if there were more than 100 records in the zone. 

P.S. I tried to write an acceptance test for this behaviour but with my other fixes I now can't trigger a scenario where terraform can create a record it can't find. 

## Why didn't terraform give an error that it couldn't find the record after creating it?

The above wouldn't have been possible if terraform had correctly detected that it couldn't read the record it had created. When creating and updating records the final line is https://github.com/terraform-providers/terraform-provider-aws/blob/c77020f539eed9d3f1dab36c2d2d5a624ed3007b/aws/resource_aws_route53_record.go#L454

Since this function is also used for checking if a record exists or not it silently will drop the record and remove it from state if the record doesn't exist.

https://github.com/terraform-providers/terraform-provider-aws/blob/c77020f539eed9d3f1dab36c2d2d5a624ed3007b/aws/resource_aws_route53_record.go#L520-L530

So what was happening is terraform was trying to create `@.domain.com`, after successfully creating it then called `resourceAwsRoute53RecordRead` which didn't return an error so Terraform didn't give an error. 

# Other improvements

## Maxitems

My first reaction when seeing the looping over the first 100 results was....why? I then discovered the reason and added it as an inline comment so nobody else gets confused in the future. I have now optimised this to only return a single result if we know that there can be only one match. This saves terraform needing to pull in 100 resources everytime it wants to check if a single record exists. 

## Escaped ASCII characters

AWS supports a lot more special characters apart from `*` and `@` which I have now added support for. You can see a full list at the [Route53 Domain Name Format](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DomainNameFormat.html) docs. I decided to just convert all of them instead of trying to maintain a list of supported characters. If a user does somehow pick a character that doesn't convert correctly they will now correctly receive an error when terraform tries to read back the record after creating it. 