### PR TITLE
resource/aws_iam_service_linked_role: Support custom_suffix and description arguments

### DIFF
--- a/aws/resource_aws_iam_service_linked_role_test.go
+++ b/aws/resource_aws_iam_service_linked_role_test.go
@@ -2,15 +2,124 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_iam_service_linked_role", &resource.Sweeper{
+		Name: "aws_iam_service_linked_role",
+		F:    testSweepIamServiceLinkedRoles,
+	})
+}
+
+func testSweepIamServiceLinkedRoles(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).iamconn
+
+	input := &iam.ListRolesInput{
+		PathPrefix: aws.String("/aws-service-role/"),
+	}
+	customSuffixRegex := regexp.MustCompile(`_tf-acc-test-\d+$`)
+	err = conn.ListRolesPages(input, func(page *iam.ListRolesOutput, lastPage bool) bool {
+		if len(page.Roles) == 0 {
+			log.Printf("[INFO] No IAM Service Roles to sweep")
+			return true
+		}
+		for _, role := range page.Roles {
+			roleName := aws.StringValue(role.RoleName)
+
+			if !customSuffixRegex.MatchString(roleName) {
+				log.Printf("[INFO] Skipping IAM Service Role: %s", roleName)
+				continue
+			}
+
+			log.Printf("[INFO] Deleting IAM Service Role: %s", roleName)
+			deletionTaskID, err := deleteIamServiceLinkedRole(conn, roleName)
+			if err != nil {
+				log.Printf("[ERROR] Failed to delete IAM Service Role %s: %s", roleName, err)
+				continue
+			}
+			if deletionTaskID == "" {
+				continue
+			}
+
+			log.Printf("[INFO] Waiting for deletion of IAM Service Role: %s", roleName)
+			err = deleteIamServiceLinkedRoleWaiter(conn, deletionTaskID)
+			if err != nil {
+				log.Printf("[ERROR] Failed to wait for deletion of IAM Service Role %s: %s", roleName, err)
+			}
+		}
+		return !lastPage
+	})
+	if err != nil {
+		return fmt.Errorf("Error retrieving IAM Service Roles: %s", err)
+	}
+
+	return nil
+}
+
+func TestDecodeIamServiceLinkedRoleID(t *testing.T) {
+	var testCases = []struct {
+		Input        string
+		ServiceName  string
+		RoleName     string
+		CustomSuffix string
+		ErrCount     int
+	}{
+		{
+			Input:    "not-arn",
+			ErrCount: 1,
+		},
+		{
+			Input:    "arn:aws:iam::123456789012:role/not-service-linked-role",
+			ErrCount: 1,
+		},
+		{
+			Input:        "arn:aws:iam::123456789012:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling",
+			ServiceName:  "autoscaling.amazonaws.com",
+			RoleName:     "AWSServiceRoleForAutoScaling",
+			CustomSuffix: "",
+			ErrCount:     0,
+		},
+		{
+			Input:        "arn:aws:iam::123456789012:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling_custom-suffix",
+			ServiceName:  "autoscaling.amazonaws.com",
+			RoleName:     "AWSServiceRoleForAutoScaling_custom-suffix",
+			CustomSuffix: "custom-suffix",
+			ErrCount:     0,
+		},
+	}
+
+	for _, tc := range testCases {
+		serviceName, roleName, customSuffix, err := decodeIamServiceLinkedRoleID(tc.Input)
+		if tc.ErrCount == 0 && err != nil {
+			t.Fatalf("expected %q not to trigger an error, received: %s", tc.Input, err)
+		}
+		if tc.ErrCount > 0 && err == nil {
+			t.Fatalf("expected %q to trigger an error", tc.Input)
+		}
+		if serviceName != tc.ServiceName {
+			t.Fatalf("expected service name %q to be %q", serviceName, tc.ServiceName)
+		}
+		if roleName != tc.RoleName {
+			t.Fatalf("expected role name %q to be %q", roleName, tc.RoleName)
+		}
+		if customSuffix != tc.CustomSuffix {
+			t.Fatalf("expected custom suffix %q to be %q", customSuffix, tc.CustomSuffix)
+		}
+	}
+}
 
 func TestAccAWSIAMServiceLinkedRole_basic(t *testing.T) {
 	resourceName := "aws_iam_service_linked_role.test"
@@ -26,6 +135,22 @@ func TestAccAWSIAMServiceLinkedRole_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSIAMServiceLinkedRoleDestroy,
 		Steps: []resource.TestStep{
 			{
+				PreConfig: func() {
+					// Remove existing if possible
+					conn := testAccProvider.Meta().(*AWSClient).iamconn
+					deletionID, err := deleteIamServiceLinkedRole(conn, name)
+					if err != nil {
+						t.Fatalf("Error deleting service-linked role %s: %s", name, err)
+					}
+					if deletionID == "" {
+						return
+					}
+
+					err = deleteIamServiceLinkedRoleWaiter(conn, deletionID)
+					if err != nil {
+						t.Fatalf("Error waiting for role (%s) to be deleted: %s", name, err)
+					}
+				},
 				Config: testAccAWSIAMServiceLinkedRoleConfig(awsServiceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSIAMServiceLinkedRoleExists(resourceName),
@@ -46,6 +171,72 @@ func TestAccAWSIAMServiceLinkedRole_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSIAMServiceLinkedRole_CustomSuffix(t *testing.T) {
+	resourceName := "aws_iam_service_linked_role.test"
+	awsServiceName := "autoscaling.amazonaws.com"
+	customSuffix := acctest.RandomWithPrefix("tf-acc-test")
+	name := fmt.Sprintf("AWSServiceRoleForAutoScaling_%s", customSuffix)
+	path := fmt.Sprintf("/aws-service-role/%s/", awsServiceName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSIAMServiceLinkedRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSIAMServiceLinkedRoleConfig_CustomSuffix(awsServiceName, customSuffix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSIAMServiceLinkedRoleExists(resourceName),
+					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:iam::[^:]+:role%s%s$", path, name))),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSIAMServiceLinkedRole_Description(t *testing.T) {
+	resourceName := "aws_iam_service_linked_role.test"
+	awsServiceName := "autoscaling.amazonaws.com"
+	customSuffix := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSIAMServiceLinkedRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSIAMServiceLinkedRoleConfig_Description(awsServiceName, customSuffix, "description1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSIAMServiceLinkedRoleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "description", "description1"),
+				),
+			},
+			{
+				Config: testAccAWSIAMServiceLinkedRoleConfig_Description(awsServiceName, customSuffix, "description2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSIAMServiceLinkedRoleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "description", "description2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAWSIAMServiceLinkedRoleDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).iamconn
 
@@ -54,14 +245,16 @@ func testAccCheckAWSIAMServiceLinkedRoleDestroy(s *terraform.State) error {
 			continue
 		}
 
-		arnSplit := strings.Split(rs.Primary.ID, "/")
-		roleName := arnSplit[len(arnSplit)-1]
+		_, roleName, _, err := decodeIamServiceLinkedRoleID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
 
 		params := &iam.GetRoleInput{
 			RoleName: aws.String(roleName),
 		}
 
-		_, err := conn.GetRole(params)
+		_, err = conn.GetRole(params)
 
 		if err == nil {
 			return fmt.Errorf("Service-Linked Role still exists: %q", rs.Primary.ID)
@@ -84,14 +277,16 @@ func testAccCheckAWSIAMServiceLinkedRoleExists(n string) resource.TestCheckFunc 
 		}
 
 		conn := testAccProvider.Meta().(*AWSClient).iamconn
-		arnSplit := strings.Split(rs.Primary.ID, "/")
-		roleName := arnSplit[len(arnSplit)-1]
+		_, roleName, _, err := decodeIamServiceLinkedRoleID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
 
 		params := &iam.GetRoleInput{
 			RoleName: aws.String(roleName),
 		}
 
-		_, err := conn.GetRole(params)
+		_, err = conn.GetRole(params)
 
 		if err != nil {
 			if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
@@ -107,7 +302,26 @@ func testAccCheckAWSIAMServiceLinkedRoleExists(n string) resource.TestCheckFunc 
 func testAccAWSIAMServiceLinkedRoleConfig(awsServiceName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_service_linked_role" "test" {
-	aws_service_name = "%s"
+  aws_service_name = "%s"
 }
 `, awsServiceName)
+}
+
+func testAccAWSIAMServiceLinkedRoleConfig_CustomSuffix(awsServiceName, customSuffix string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_service_linked_role" "test" {
+  aws_service_name = "%s"
+  custom_suffix    = "%s"
+}
+`, awsServiceName, customSuffix)
+}
+
+func testAccAWSIAMServiceLinkedRoleConfig_Description(awsServiceName, customSuffix, description string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_service_linked_role" "test" {
+  aws_service_name = "%s"
+  custom_suffix    = "%s"
+  description      = "%s"
+}
+`, awsServiceName, customSuffix, description)
 }

--- a/website/docs/r/iam_service_linked_role.html.markdown
+++ b/website/docs/r/iam_service_linked_role.html.markdown
@@ -23,17 +23,19 @@ resource "aws_iam_service_linked_role" "elasticbeanstalk" {
 The following arguments are supported:
 
 * `aws_service_name` - (Required, Forces new resource) The AWS service to which this role is attached. You use a string similar to a URL but without the `http://` in front. For example: `elasticbeanstalk.amazonaws.com`. To find the full list of services that support service-linked roles, check [the docs](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_aws-services-that-work-with-iam.html).
+* `custom_suffix` - (Optional, forces new resource) Additional string appended to the role name.
+* `description` - (Optional) The description of the role.
 
 ## Attributes Reference
 
-The following attributes are exported:
+The following additional attributes are exported:
 
-* `name` - The name of the role.
-* `path` - The path of the role.
+* `id` - The Amazon Resource Name (ARN) of the role.
 * `arn` - The Amazon Resource Name (ARN) specifying the role.
 * `create_date` - The creation date of the IAM role.
+* `name` - The name of the role.
+* `path` - The path of the role.
 * `unique_id` - The stable and unique string identifying the role.
-* `description` - The description of the role.
 
 ## Import
 

--- a/website/docs/r/iam_service_linked_role.html.markdown
+++ b/website/docs/r/iam_service_linked_role.html.markdown
@@ -23,7 +23,7 @@ resource "aws_iam_service_linked_role" "elasticbeanstalk" {
 The following arguments are supported:
 
 * `aws_service_name` - (Required, Forces new resource) The AWS service to which this role is attached. You use a string similar to a URL but without the `http://` in front. For example: `elasticbeanstalk.amazonaws.com`. To find the full list of services that support service-linked roles, check [the docs](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_aws-services-that-work-with-iam.html).
-* `custom_suffix` - (Optional, forces new resource) Additional string appended to the role name.
+* `custom_suffix` - (Optional, forces new resource) Additional string appended to the role name. Not all AWS services support custom suffixes.
 * `description` - (Optional) The description of the role.
 
 ## Attributes Reference


### PR DESCRIPTION
Other goodies:
* Attempts to remove elasticbeanstalk service linked role before basic test (should handle our acceptance test suite better)
* Test sweeper for our custom suffix roles

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSIAMServiceLinkedRole'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSIAMServiceLinkedRole -timeout 120m
=== RUN   TestAccAWSIAMServiceLinkedRole_basic
--- PASS: TestAccAWSIAMServiceLinkedRole_basic (21.50s)
=== RUN   TestAccAWSIAMServiceLinkedRole_CustomSuffix
--- PASS: TestAccAWSIAMServiceLinkedRole_CustomSuffix (20.92s)
=== RUN   TestAccAWSIAMServiceLinkedRole_Description
--- PASS: TestAccAWSIAMServiceLinkedRole_Description (27.24s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	69.699s
```