### PR TITLE
Support password data on spot requests

### DIFF
--- a/aws/resource_aws_spot_instance_request.go
+++ b/aws/resource_aws_spot_instance_request.go
@@ -309,6 +309,17 @@ func readInstance(d *schema.ResourceData, meta interface{}) error {
 		if err := d.Set("ipv6_addresses", ipv6Addresses); err != nil {
 			log.Printf("[WARN] Error setting ipv6_addresses for AWS Spot Instance (%s): %s", d.Id(), err)
 		}
+
+		if d.Get("get_password_data").(bool) {
+			passwordData, err := getAwsEc2InstancePasswordData(*instance.InstanceId, conn)
+			if err != nil {
+				return err
+			}
+			d.Set("password_data", passwordData)
+		} else {
+			d.Set("get_password_data", false)
+			d.Set("password_data", nil)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
#2219 added support for retrieving the instance password data but this wasn't also added for spot requests so even though the same `get_password_data` attribute can be set (due to the spot request schema inheriting the instance schema), it doesn't work and returns an error if you try and read the `password_data` attribute.

This PR simply copies the same code from the original PR that read the password data and now works for me with a Windows spot request the same as a regular instance.