### PR TITLE
resource/aws_codedeploy_deployment_config: Force new resource for minimum_healthy_hosts updates

### DIFF
--- a/aws/resource_aws_codedeploy_deployment_config.go
+++ b/aws/resource_aws_codedeploy_deployment_config.go
@@ -34,6 +34,7 @@ func resourceAwsCodeDeployDeploymentConfig() *schema.Resource {
 						"type": {
 							Type:     schema.TypeString,
 							Required: true,
+							ForceNew: true,
 							ValidateFunc: validation.StringInSlice([]string{
 								codedeploy.MinimumHealthyHostsTypeHostCount,
 								codedeploy.MinimumHealthyHostsTypeFleetPercent,
@@ -42,6 +43,7 @@ func resourceAwsCodeDeployDeploymentConfig() *schema.Resource {
 						"value": {
 							Type:     schema.TypeInt,
 							Optional: true,
+							ForceNew: true,
 						},
 					},
 				},


### PR DESCRIPTION
Fixes: #4192

Previously (before schema changes):
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSCodeDeployDeploymentConfig'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCodeDeployDeploymentConfig -timeout 120m
=== RUN   TestAccAWSCodeDeployDeploymentConfig_fleetPercent
--- FAIL: TestAccAWSCodeDeployDeploymentConfig_fleetPercent (17.96s)
	testing.go:518: Step 1 error: Error applying: 1 error(s) occurred:

		* aws_codedeploy_deployment_config.foo: 1 error(s) occurred:

		* aws_codedeploy_deployment_config.foo: doesn't support update
=== RUN   TestAccAWSCodeDeployDeploymentConfig_hostCount
--- FAIL: TestAccAWSCodeDeployDeploymentConfig_hostCount (16.40s)
	testing.go:518: Step 1 error: Error applying: 1 error(s) occurred:

		* aws_codedeploy_deployment_config.foo: 1 error(s) occurred:

		* aws_codedeploy_deployment_config.foo: doesn't support update
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	34.395s
make: *** [testacc] Error 1
```

After:
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSCodeDeployDeploymentConfig'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCodeDeployDeploymentConfig -timeout 120m
=== RUN   TestAccAWSCodeDeployDeploymentConfig_fleetPercent
--- PASS: TestAccAWSCodeDeployDeploymentConfig_fleetPercent (20.99s)
=== RUN   TestAccAWSCodeDeployDeploymentConfig_hostCount
--- PASS: TestAccAWSCodeDeployDeploymentConfig_hostCount (22.23s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	43.259s
```