### PR TITLE
fix example documentation for aws_db_snapshot db reference and defaul…

### DIFF
--- a/website/docs/d/db_snapshot.html.markdown
+++ b/website/docs/d/db_snapshot.html.markdown
@@ -28,14 +28,14 @@ resource "aws_db_instance" "prod" {
 }
 
 data "aws_db_snapshot" "latest_prod_snapshot" {
-  db_instance_identifier = "${aws_db_instance.prod.identifier}"
+  db_instance_identifier = "${aws_db_instance.prod.id}"
   most_recent = true
 }
 
 # Use the latest production snapshot to create a dev instance.
 resource "aws_db_instance" "dev" {
   instance_class      = "db.t2.micro"
-  name                = "mydb-dev"
+  name                = "mydbdev"
   snapshot_identifier = "${data.aws_db_snapshot.latest_prod_snapshot.id}"
   lifecycle {
     ignore_changes = ["snapshot_identifier"]
@@ -54,15 +54,15 @@ recent Snapshot.
 
 * `db_snapshot_identifier` - (Optional) Returns information on a specific snapshot_id.
 
-* `snapshot_type` - (Optional) The type of snapshots to be returned. If you don't specify a SnapshotType 
-value, then both automated and manual snapshots are returned. Shared and public DB snapshots are not 
+* `snapshot_type` - (Optional) The type of snapshots to be returned. If you don't specify a SnapshotType
+value, then both automated and manual snapshots are returned. Shared and public DB snapshots are not
 included in the returned results by default. Possible values are, `automated`, `manual`, `shared` and `public`.
 
-* `include_shared` - (Optional) Set this value to true to include shared manual DB snapshots from other 
-AWS accounts that this AWS account has been given permission to copy or restore, otherwise set this value to false. 
+* `include_shared` - (Optional) Set this value to true to include shared manual DB snapshots from other
+AWS accounts that this AWS account has been given permission to copy or restore, otherwise set this value to false.
 The default is `false`.
 
-* `include_public` - (Optional) Set this value to true to include manual DB snapshots that are public and can be 
+* `include_public` - (Optional) Set this value to true to include manual DB snapshots that are public and can be
 copied or restored by any AWS account, otherwise set this value to false. The default is `false`.
 
 


### PR DESCRIPTION
 **Reasoning for docs update:** 
Provide example that compatible with MySql RDS instance engine which doesn't support dash in the database name. 
Correcting aws_db_instance exported attribute `id` .

**Relevant Terraform version:** 
Tested with latest stable versions: 
- Terraform v0.11.5
- provider.aws v1.14.1