### PR TITLE
Update docs to append '/' to s3 arn for cloudtrail

### DIFF
--- a/website/docs/r/cloudtrail.html.markdown
+++ b/website/docs/r/cloudtrail.html.markdown
@@ -127,7 +127,9 @@ resource "aws_cloudtrail" "example" {
 
     data_resource {
       type   = "AWS::S3::Object"
-      values = ["${data.aws_s3_bucket.important-bucket.arn}"]
+      # Make sure to append a trailing '/' to your ARN if you want
+      # to monitor all objects in a bucket.
+      values = ["${data.aws_s3_bucket.important-bucket.arn}/"]
     }
   }
 }


### PR DESCRIPTION
Fixes #4043. If you want to monitor all objects in a bucket, you need to append a '/' to your ARN.