### PR TITLE
docs/resource/aws_autoscaling_*: Use resource references for RDS examples

### DIFF
--- a/website/docs/r/appautoscaling_policy.html.markdown
+++ b/website/docs/r/appautoscaling_policy.html.markdown
@@ -95,16 +95,16 @@ resource "aws_ecs_service" "ecs_service" {
 resource "aws_appautoscaling_target" "replicas" {
   service_namespace  = "rds"
   scalable_dimension = "rds:cluster:ReadReplicaCount"
-  resource_id        = "cluster:aurora-cluster-id"
+  resource_id        = "cluster:${aws_rds_cluster.example.id}"
   min_capacity       = 1
   max_capacity       = 15
 }
 
 resource "aws_appautoscaling_policy" "replicas" {
   name               = "cpu-auto-scaling"
-  service_namespace  = "rds"
-  scalable_dimension = "rds:cluster:ReadReplicaCount"
-  resource_id        = "cluster:aurora-cluster-id"
+  service_namespace  = "${aws_appautoscaling_target.replicas.service_namespace}"
+  scalable_dimension = "${aws_appautoscaling_target.replicas.scalable_dimension}"
+  resource_id        = "${aws_appautoscaling_target.replicas.resource_id}"
   policy_type        = "TargetTrackingScaling"
 
   target_tracking_scaling_policy_configuration {
@@ -115,8 +115,6 @@ resource "aws_appautoscaling_policy" "replicas" {
     scale_in_cooldown = 300
     scale_out_cooldown = 300
   }
-
-  depends_on = ["aws_appautoscaling_target.replicas"]
 }
 ```
 

--- a/website/docs/r/appautoscaling_target.html.markdown
+++ b/website/docs/r/appautoscaling_target.html.markdown
@@ -57,7 +57,7 @@ resource "aws_appautoscaling_target" "ecs_target" {
 resource "aws_appautoscaling_target" "replicas" {
   service_namespace  = "rds"
   scalable_dimension = "rds:cluster:ReadReplicaCount"
-  resource_id        = "cluster:aurora-cluster-id"
+  resource_id        = "cluster:${aws_rds_cluster.example.id}"
   min_capacity       = 1
   max_capacity       = 15
 }


### PR DESCRIPTION
Followup to #4087 