### PR TITLE
resource/aws_iam_role: Suppress NoSuchEntity errors while detaching policies from role

### DIFF
--- a/aws/resource_aws_iam_role.go
+++ b/aws/resource_aws_iam_role.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"net/url"
 	"regexp"
 	"time"
@@ -317,7 +318,11 @@ func resourceAwsIamRoleDelete(d *schema.ResourceData, meta interface{}) error {
 					RoleName:  aws.String(d.Id()),
 				})
 				if err != nil {
-					return fmt.Errorf("Error deleting IAM Role %s: %s", d.Id(), err)
+					if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
+						log.Printf("[WARN] Role policy attachment (%s) was already removed from role (%s)", aws.StringValue(parn), d.Id())
+					} else {
+						return fmt.Errorf("Error deleting IAM Role %s: %s", d.Id(), err)
+					}
 				}
 			}
 		}
@@ -342,7 +347,11 @@ func resourceAwsIamRoleDelete(d *schema.ResourceData, meta interface{}) error {
 					RoleName:   aws.String(d.Id()),
 				})
 				if err != nil {
-					return fmt.Errorf("Error deleting inline policy of IAM Role %s: %s", d.Id(), err)
+					if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
+						log.Printf("[WARN] Inline role policy (%s) was already removed from role (%s)", aws.StringValue(pname), d.Id())
+					} else {
+						return fmt.Errorf("Error deleting inline policy of IAM Role %s: %s", d.Id(), err)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
`aws_iam_role` with `force_detach_policies = true` sometimes gets outdated list of attached policies from AWS. This happens when terraform is removing `aws_iam_role` right after removing `aws_iam_role_policy_attachment` resources.