### PR TITLE
[WIP] Add policy attribute to aws_api_gateway_rest_api

### DIFF
--- a/aws/resource_aws_api_gateway_rest_api.go
+++ b/aws/resource_aws_api_gateway_rest_api.go
@@ -36,7 +36,7 @@ func resourceAwsApiGatewayRestApi() *schema.Resource {
 				Type:             schema.TypeString,
 				Computed:         true,
 				Optional:         true,
-				ValidateFunc:     validateIAMPolicyJson,
+				ValidateFunc:     validateJsonString,
 				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
 			},
 
@@ -166,6 +166,7 @@ func resourceAwsApiGatewayRestApiRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("name", api.Name)
 	d.Set("description", api.Description)
 	d.Set("policy", api.Policy)
+
 	d.Set("binary_media_types", api.BinaryMediaTypes)
 	if api.MinimumCompressionSize == nil {
 		d.Set("minimum_compression_size", -1)

--- a/aws/resource_aws_api_gateway_rest_api.go
+++ b/aws/resource_aws_api_gateway_rest_api.go
@@ -34,7 +34,6 @@ func resourceAwsApiGatewayRestApi() *schema.Resource {
 
 			"policy": {
 				Type:             schema.TypeString,
-				Computed:         true,
 				Optional:         true,
 				ValidateFunc:     validateJsonString,
 				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,

--- a/aws/resource_aws_api_gateway_rest_api_test.go
+++ b/aws/resource_aws_api_gateway_rest_api_test.go
@@ -92,7 +92,6 @@ func TestAccAWSAPIGatewayRestApi_basic(t *testing.T) {
 					testAccCheckAWSAPIGatewayRestAPINameAttribute(&conf, "bar"),
 					testAccCheckAWSAPIGatewayRestAPIMinimumCompressionSizeAttribute(&conf, 0),
 					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "name", "bar"),
-					// resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "policy", "{\\\"Version\\\":\\\"2012-10-17\\\",\\\"Statement\\\":[{\\\"Effect\\\":\\\"Allow\\\",\\\"Principal\\\":{\\\"AWS\\\":\\\"*\\\"},\\\"Action\\\":\\\"execute-api:Invoke\\\",\\\"Resource\\\":\\\"*\\\"}]}"),
 					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "description", ""),
 					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "minimum_compression_size", "0"),
 					resource.TestCheckResourceAttrSet("aws_api_gateway_rest_api.test", "created_date"),

--- a/aws/resource_aws_api_gateway_rest_api_test.go
+++ b/aws/resource_aws_api_gateway_rest_api_test.go
@@ -304,20 +304,7 @@ const testAccAWSAPIGatewayRestAPIUpdateConfig = `
 resource "aws_api_gateway_rest_api" "test" {
   name = "test"
   description = "test",
-  policy = = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "ec2:Describe*"
-      ],
-      "Effect": "Allow",
-      "Resource": "*"
-    }
-  ]
-}
-EOF
+  policy = "{}"
   binary_media_types = ["application/octet-stream"]
   minimum_compression_size = 10485760
 }

--- a/aws/resource_aws_api_gateway_rest_api_test.go
+++ b/aws/resource_aws_api_gateway_rest_api_test.go
@@ -92,7 +92,7 @@ func TestAccAWSAPIGatewayRestApi_basic(t *testing.T) {
 					testAccCheckAWSAPIGatewayRestAPINameAttribute(&conf, "bar"),
 					testAccCheckAWSAPIGatewayRestAPIMinimumCompressionSizeAttribute(&conf, 0),
 					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "name", "bar"),
-					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "policy", "{\\\"Version\\\":\\\"2012-10-17\\\",\\\"Statement\\\":[{\\\"Effect\\\":\\\"Allow\\\",\\\"Principal\\\":{\\\"AWS\\\":\\\"arn:aws:iam::717754130149:user\\/dev-encryption-service-emr-user\\\"},\\\"Action\\\":\\\"execute-api:Invoke\\\",\\\"Resource\\\":\\\"arn:aws:execute-api:us-west-2:717754130149:wwo2hqsydh\\/*\\/POST\\/v1\\/encryption-service\\/password\\/change\\\"}]}"),
+					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "policy", "{\\\"Version\\\":\\\"2012-10-17\\\",\\\"Statement\\\":[{\\\"Effect\\\":\\\"Allow\\\",\\\"Principal\\\":{\\\"AWS\\\":\\\"*\\\"},\\\"Action\\\":\\\"execute-api:Invoke\\\",\\\"Resource\\\":\\\"*\\\"}]}"),
 					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "description", ""),
 					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "minimum_compression_size", "0"),
 					resource.TestCheckResourceAttrSet("aws_api_gateway_rest_api.test", "created_date"),
@@ -313,10 +313,10 @@ resource "aws_api_gateway_rest_api" "test" {
         {
             "Effect": "Allow",
             "Principal": {
-                "AWS": "arn:aws:iam::717754130149:user/dev-encryption-service-emr-user"
+                "AWS": "*"
             },
             "Action": "execute-api:Invoke",
-            "Resource": "arn:aws:execute-api:us-west-2:717754130149:wwo2hqsydh/*/POST/v1/encryption-service/password/change"
+            "Resource": "*"
         }
     ]
 }

--- a/aws/resource_aws_api_gateway_rest_api_test.go
+++ b/aws/resource_aws_api_gateway_rest_api_test.go
@@ -93,6 +93,7 @@ func TestAccAWSAPIGatewayRestApi_basic(t *testing.T) {
 					testAccCheckAWSAPIGatewayRestAPIMinimumCompressionSizeAttribute(&conf, 0),
 					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "name", "bar"),
 					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "description", ""),
+					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "policy", ""),
 					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "minimum_compression_size", "0"),
 					resource.TestCheckResourceAttrSet("aws_api_gateway_rest_api.test", "created_date"),
 					resource.TestCheckNoResourceAttr("aws_api_gateway_rest_api.test", "binary_media_types"),
@@ -108,6 +109,7 @@ func TestAccAWSAPIGatewayRestApi_basic(t *testing.T) {
 					testAccCheckAWSAPIGatewayRestAPIMinimumCompressionSizeAttribute(&conf, 10485760),
 					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "name", "test"),
 					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "description", "test"),
+					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "policy", "test"),
 					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "minimum_compression_size", "10485760"),
 					resource.TestCheckResourceAttrSet("aws_api_gateway_rest_api.test", "created_date"),
 					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "binary_media_types.#", "1"),
@@ -301,7 +303,21 @@ resource "aws_api_gateway_rest_api" "test" {
 const testAccAWSAPIGatewayRestAPIUpdateConfig = `
 resource "aws_api_gateway_rest_api" "test" {
   name = "test"
-  description = "test"
+  description = "test",
+  policy = = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:Describe*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
   binary_media_types = ["application/octet-stream"]
   minimum_compression_size = 10485760
 }

--- a/aws/resource_aws_api_gateway_rest_api_test.go
+++ b/aws/resource_aws_api_gateway_rest_api_test.go
@@ -92,8 +92,8 @@ func TestAccAWSAPIGatewayRestApi_basic(t *testing.T) {
 					testAccCheckAWSAPIGatewayRestAPINameAttribute(&conf, "bar"),
 					testAccCheckAWSAPIGatewayRestAPIMinimumCompressionSizeAttribute(&conf, 0),
 					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "name", "bar"),
+					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "policy", "{\\\"Version\\\":\\\"2012-10-17\\\",\\\"Statement\\\":[{\\\"Effect\\\":\\\"Allow\\\",\\\"Principal\\\":{\\\"AWS\\\":\\\"arn:aws:iam::717754130149:user\\/dev-encryption-service-emr-user\\\"},\\\"Action\\\":\\\"execute-api:Invoke\\\",\\\"Resource\\\":\\\"arn:aws:execute-api:us-west-2:717754130149:wwo2hqsydh\\/*\\/POST\\/v1\\/encryption-service\\/password\\/change\\\"}]}"),
 					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "description", ""),
-					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "policy", ""),
 					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "minimum_compression_size", "0"),
 					resource.TestCheckResourceAttrSet("aws_api_gateway_rest_api.test", "created_date"),
 					resource.TestCheckNoResourceAttr("aws_api_gateway_rest_api.test", "binary_media_types"),
@@ -109,7 +109,6 @@ func TestAccAWSAPIGatewayRestApi_basic(t *testing.T) {
 					testAccCheckAWSAPIGatewayRestAPIMinimumCompressionSizeAttribute(&conf, 10485760),
 					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "name", "test"),
 					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "description", "test"),
-					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "policy", "test"),
 					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "minimum_compression_size", "10485760"),
 					resource.TestCheckResourceAttrSet("aws_api_gateway_rest_api.test", "created_date"),
 					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "binary_media_types.#", "1"),
@@ -168,6 +167,16 @@ func testAccCheckAWSAPIGatewayRestAPINameAttribute(conf *apigateway.RestApi, nam
 	return func(s *terraform.State) error {
 		if *conf.Name != name {
 			return fmt.Errorf("Wrong Name: %q", *conf.Name)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSAPIGatewayRestAPIPolicyAttribute(conf *apigateway.RestApi, policy string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if *conf.Policy != policy {
+			return fmt.Errorf("Wrong Policy: %q", *conf.Policy)
 		}
 
 		return nil
@@ -297,6 +306,21 @@ const testAccAWSAPIGatewayRestAPIConfig = `
 resource "aws_api_gateway_rest_api" "test" {
   name = "bar"
   minimum_compression_size = 0
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::717754130149:user/dev-encryption-service-emr-user"
+            },
+            "Action": "execute-api:Invoke",
+            "Resource": "arn:aws:execute-api:us-west-2:717754130149:wwo2hqsydh/*/POST/v1/encryption-service/password/change"
+        }
+    ]
+}
+EOF
 }
 `
 
@@ -304,7 +328,6 @@ const testAccAWSAPIGatewayRestAPIUpdateConfig = `
 resource "aws_api_gateway_rest_api" "test" {
   name = "test"
   description = "test",
-  policy = "{}"
   binary_media_types = ["application/octet-stream"]
   minimum_compression_size = 10485760
 }

--- a/aws/resource_aws_api_gateway_rest_api_test.go
+++ b/aws/resource_aws_api_gateway_rest_api_test.go
@@ -92,7 +92,7 @@ func TestAccAWSAPIGatewayRestApi_basic(t *testing.T) {
 					testAccCheckAWSAPIGatewayRestAPINameAttribute(&conf, "bar"),
 					testAccCheckAWSAPIGatewayRestAPIMinimumCompressionSizeAttribute(&conf, 0),
 					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "name", "bar"),
-					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "policy", "{\\\"Version\\\":\\\"2012-10-17\\\",\\\"Statement\\\":[{\\\"Effect\\\":\\\"Allow\\\",\\\"Principal\\\":{\\\"AWS\\\":\\\"*\\\"},\\\"Action\\\":\\\"execute-api:Invoke\\\",\\\"Resource\\\":\\\"*\\\"}]}"),
+					// resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "policy", "{\\\"Version\\\":\\\"2012-10-17\\\",\\\"Statement\\\":[{\\\"Effect\\\":\\\"Allow\\\",\\\"Principal\\\":{\\\"AWS\\\":\\\"*\\\"},\\\"Action\\\":\\\"execute-api:Invoke\\\",\\\"Resource\\\":\\\"*\\\"}]}"),
 					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "description", ""),
 					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "minimum_compression_size", "0"),
 					resource.TestCheckResourceAttrSet("aws_api_gateway_rest_api.test", "created_date"),
@@ -122,6 +122,24 @@ func TestAccAWSAPIGatewayRestApi_basic(t *testing.T) {
 					testAccCheckAWSAPIGatewayRestAPIExists("aws_api_gateway_rest_api.test", &conf),
 					testAccCheckAWSAPIGatewayRestAPIMinimumCompressionSizeAttributeIsNil(&conf),
 					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "minimum_compression_size", "-1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayRestApi_policy(t *testing.T) {
+	expectedPolicyText := fmt.Sprintf(`{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"execute-api:Invoke","Resource":"*"}]}`)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayRestAPIDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayRestAPIConfigWithPolicy,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "policy", expectedPolicyText),
 				),
 			},
 		},
@@ -306,6 +324,13 @@ const testAccAWSAPIGatewayRestAPIConfig = `
 resource "aws_api_gateway_rest_api" "test" {
   name = "bar"
   minimum_compression_size = 0
+}
+`
+
+const testAccAWSAPIGatewayRestAPIConfigWithPolicy = `
+resource "aws_api_gateway_rest_api" "test" {
+  name = "bar"
+  minimum_compression_size = 0
   policy = <<EOF
 {
     "Version": "2012-10-17",
@@ -327,7 +352,7 @@ EOF
 const testAccAWSAPIGatewayRestAPIUpdateConfig = `
 resource "aws_api_gateway_rest_api" "test" {
   name = "test"
-  description = "test",
+  description = "test"
   binary_media_types = ["application/octet-stream"]
   minimum_compression_size = 10485760
 }

--- a/aws/resource_aws_api_gateway_rest_api_test.go
+++ b/aws/resource_aws_api_gateway_rest_api_test.go
@@ -128,8 +128,8 @@ func TestAccAWSAPIGatewayRestApi_basic(t *testing.T) {
 }
 
 func TestAccAWSAPIGatewayRestApi_policy(t *testing.T) {
-	expectedPolicyText := fmt.Sprintf(`{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"execute-api:Invoke","Resource":"*"}]}`)
-
+	expectedPolicyText := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"execute-api:Invoke","Resource":"*"}]}`
+	expectedUpdatePolicyText := `{"Version":"2012-10-17","Statement":[{"Effect":"Deny","Principal":{"AWS":"*"},"Action":"execute-api:Invoke","Resource":"*"}]}`
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -139,6 +139,18 @@ func TestAccAWSAPIGatewayRestApi_policy(t *testing.T) {
 				Config: testAccAWSAPIGatewayRestAPIConfigWithPolicy,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "policy", expectedPolicyText),
+				),
+			},
+			{
+				Config: testAccAWSAPIGatewayRestAPIConfigUpdatePolicy,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "policy", expectedUpdatePolicyText),
+				),
+			},
+			{
+				Config: testAccAWSAPIGatewayRestAPIConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "policy", ""),
 				),
 			},
 		},
@@ -326,6 +338,28 @@ resource "aws_api_gateway_rest_api" "test" {
     "Statement": [
         {
             "Effect": "Allow",
+            "Principal": {
+                "AWS": "*"
+            },
+            "Action": "execute-api:Invoke",
+            "Resource": "*"
+        }
+    ]
+}
+EOF
+}
+`
+
+const testAccAWSAPIGatewayRestAPIConfigUpdatePolicy = `
+resource "aws_api_gateway_rest_api" "test" {
+  name = "bar"
+  minimum_compression_size = 0
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Deny",
             "Principal": {
                 "AWS": "*"
             },

--- a/aws/resource_aws_api_gateway_rest_api_test.go
+++ b/aws/resource_aws_api_gateway_rest_api_test.go
@@ -190,16 +190,6 @@ func testAccCheckAWSAPIGatewayRestAPINameAttribute(conf *apigateway.RestApi, nam
 	}
 }
 
-func testAccCheckAWSAPIGatewayRestAPIPolicyAttribute(conf *apigateway.RestApi, policy string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if *conf.Policy != policy {
-			return fmt.Errorf("Wrong Policy: %q", *conf.Policy)
-		}
-
-		return nil
-	}
-}
-
 func testAccCheckAWSAPIGatewayRestAPIDescriptionAttribute(conf *apigateway.RestApi, description string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if *conf.Description != description {

--- a/website/docs/r/api_gateway_rest_api.html.markdown
+++ b/website/docs/r/api_gateway_rest_api.html.markdown
@@ -28,6 +28,7 @@ The following arguments are supported:
 * `binary_media_types` - (Optional) The list of binary media types supported by the RestApi. By default, the RestApi supports only UTF-8-encoded text payloads.
 * `minimum_compression_size` - (Optional) Minimum response size to compress for the REST API. Integer between -1 and 10485760 (10MB). Setting a value greater than -1 will enable compression, -1 disables compression (default).
 * `body` - (Optional) An OpenAPI specification that defines the set of routes and integrations to create as part of the REST API.
+* `policy` - (Optional) JSON formatted policy document that controls access to the API Gateway
 
 __Note__: If the `body` argument is provided, the OpenAPI specification will be used to configure the resources, methods and integrations for the Rest API. If this argument is provided, the following resources should not be managed as separate ones, as updates may cause manual resource updates to be overwritten:
 


### PR DESCRIPTION
Fixes #4171. 
Adds a `policy` attribute to the `aws_api_gateway_rest_api` resource. 

The `policy` attribute is currently being applied, however on every subsequent `terraform plan`, its requesting to update the attribute in place. I assume this is due to how I am setting the policy in `resourceAwsApiGatewayRestApiRead` causing one version to be escaped, and one not. 

Is there a standard for escaping -> unescaping JSON policies correctly? Sorry if it's obvious, I'm new to Go :)

Failing Test: 
```
--- FAIL: TestAccAWSAPIGatewayRestApi_policy (9.53s)
	testing.go:518: Step 0 error: Check failed: Check 1/1 error: aws_api_gateway_rest_api.test: Attribute 'policy' expected "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Action\":\"execute-api:Invoke\",\"Resource\":\"*\"}]}", got "{\\\"Version\\\":\\\"2012-10-17\\\",\\\"Statement\\\":[{\\\"Effect\\\":\\\"Allow\\\",\\\"Principal\\\":{\\\"AWS\\\":\\\"*\\\"},\\\"Action\\\":\\\"execute-api:Invoke\\\",\\\"Resource\\\":\\\"*\\\"}]}"
```
`terraform plan` ran after apply. 
``` 
rwittman$ $GOPATH/bin/terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

aws_api_gateway_rest_api.test_gateway: Refreshing state... (ID: hj4o1slwk2)

------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  ~ aws_api_gateway_rest_api.test_gateway
      policy: "{\\\"Version\\\":\\\"2012-10-17\\\",\\\"Statement\\\":[{\\\"Effect\\\":\\\"Allow\\\",\\\"Principal\\\":{\\\"AWS\\\":\\\"arn:aws:iam::717754130149:user\\/dev-encryption-service-emr-user\\\"},\\\"Action\\\":\\\"execute-api:Invoke\\\",\\\"Resource\\\":\\\"arn:aws:execute-api:us-west-2:717754130149:wwo2hqsydh\\/*\\/POST\\/v1\\/encryption-service\\/password\\/change\\\"}]}" => "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Effect\": \"Allow\",\n      \"Principal\": {\n        \"AWS\": \"arn:aws:iam::717754130149:user/dev-encryption-service-emr-user\"\n      },\n      \"Action\": \"execute-api:Invoke\",\n      \"Resource\": \"arn:aws:execute-api:us-west-2:717754130149:wwo2hqsydh/*/POST/v1/encryption-service/password/change\"\n    }\n  ]\n}\n"


Plan: 0 to add, 1 to change, 0 to destroy.
```
