### PR TITLE
New Data Source: cognito_user_pools

### DIFF
--- a/aws/data_source_aws_cognito_user_pools.go
+++ b/aws/data_source_aws_cognito_user_pools.go
@@ -1,0 +1,77 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsCognitoUserPools() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsCognitoUserPoolsRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"ids": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceAwsCognitoUserPoolsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cognitoidpconn
+	name := d.Get("name").(string)
+	var ids []string
+
+	pools, err := getAllCognitoUserPools(conn)
+	if err != nil {
+		return fmt.Errorf("Error listing cognito user pools: %s", err)
+	}
+	for _, pool := range pools {
+		if name == aws.StringValue(pool.Name) {
+			ids = append(ids, aws.StringValue(pool.Id))
+		}
+	}
+
+	if len(ids) == 0 {
+		return fmt.Errorf("No cognito user pool found with name: %s", name)
+	}
+
+	d.SetId(name)
+	d.Set("ids", ids)
+	return nil
+}
+
+func getAllCognitoUserPools(conn *cognitoidentityprovider.CognitoIdentityProvider) ([]*cognitoidentityprovider.UserPoolDescriptionType, error) {
+	var pools []*cognitoidentityprovider.UserPoolDescriptionType
+	var nextToken string
+
+	for {
+		input := &cognitoidentityprovider.ListUserPoolsInput{
+			// MaxResults Valid Range: Minimum value of 1. Maximum value of 60
+			MaxResults: aws.Int64(int64(60)),
+		}
+		if nextToken != "" {
+			input.NextToken = aws.String(nextToken)
+		}
+		out, err := conn.ListUserPools(input)
+		if err != nil {
+			return pools, err
+		}
+		pools = append(pools, out.UserPools...)
+
+		if out.NextToken == nil {
+			break
+		}
+		nextToken = aws.StringValue(out.NextToken)
+	}
+
+	return pools, nil
+}

--- a/aws/data_source_aws_cognito_user_pools_test.go
+++ b/aws/data_source_aws_cognito_user_pools_test.go
@@ -1,0 +1,51 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceAwsCognitoUserPools_basic(t *testing.T) {
+	rName := fmt.Sprintf("tf_acc_ds_cognito_user_pools_%s", acctest.RandString(7))
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsCognitoUserPoolsConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_cognito_user_pools.selected", "ids.#", "3"),
+				),
+			},
+			{
+				Config:      testAccDataSourceAwsCognitoUserPoolsConfig_notFound(rName),
+				ExpectError: regexp.MustCompile(`No cognito user pool found with name:`),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsCognitoUserPoolsConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cognito_user_pool" "main" {
+	count = 3
+	name  = "%s"
+}
+
+data "aws_cognito_user_pools" "selected" {
+	name = "${aws_cognito_user_pool.main.*.name[0]}"
+}
+`, rName)
+}
+
+func testAccDataSourceAwsCognitoUserPoolsConfig_notFound(rName string) string {
+	return fmt.Sprintf(`
+data "aws_cognito_user_pools" "selected" {
+	name = "%s-not-found"
+}
+`, rName)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -173,6 +173,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_cloudformation_stack":             dataSourceAwsCloudFormationStack(),
 			"aws_cloudtrail_service_account":       dataSourceAwsCloudTrailServiceAccount(),
 			"aws_cloudwatch_log_group":             dataSourceAwsCloudwatchLogGroup(),
+			"aws_cognito_user_pools":               dataSourceAwsCognitoUserPools(),
 			"aws_db_instance":                      dataSourceAwsDbInstance(),
 			"aws_db_snapshot":                      dataSourceAwsDbSnapshot(),
 			"aws_dynamodb_table":                   dataSourceAwsDynamoDbTable(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -73,6 +73,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-cloudwatch-log-group") %>>
                             <a href="/docs/providers/aws/d/cloudwatch_log_group.html">aws_cloudwatch_log_group</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-cognito-user-pools") %>>
+                            <a href="/docs/providers/aws/d/cognito_user_pools.html">aws_cognito_user_pools</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-db-instance") %>>
                             <a href="/docs/providers/aws/d/db_instance.html">aws_db_instance</a>
                         </li>

--- a/website/docs/d/cognito_user_pools.markdown
+++ b/website/docs/d/cognito_user_pools.markdown
@@ -1,0 +1,39 @@
+---
+layout: "aws"
+page_title: "AWS: aws_cognito_user_pools"
+sidebar_current: "docs-aws-cognito-user-pools"
+description: |-
+  Get list of cognito user pools.
+---
+
+# Data Source: aws_cognito_user_pools
+
+Use this data source to get a list of cognito user pools.
+
+## Example Usage
+
+```hcl
+data "aws_api_gateway_rest_api" "selected" {
+  name = "${var.api_gateway_name}"
+}
+
+data "aws_cognito_user_pools" "selected" {
+  name = "${var.cognito_user_pool_name}"
+}
+
+resource "aws_api_gateway_authorizer" "cognito" {
+  name = "cognito"
+  type = "COGNITO_USER_POOLS"
+  rest_api_id = "${data.aws_api_gateway_rest_api.selected.id}"
+  provider_arns = ["${data.aws_cognito_user_pools.selected.ids}"]
+}
+```
+
+## Argument Reference
+
+* `name` - (required) Name of the cognito user pools. Name is not a unique attribute for cognito user pool, so multiple pools might be returned with given name.
+
+
+## Attributes Reference
+
+* `ids` - The list of cognito user pool ids.


### PR DESCRIPTION
Complete missing part between cognito user pools and api gateway authorizer.

There is no option to filter cognito user pools, so a simple loop is used to match given name.

```
⎇  make fmt; and echo > aws/debug.log ; and make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsCognitoUserPoolIds_basic'
gofmt -w $(find . -name '*.go' |grep -v vendor)
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccDataSourceAwsCognitoUserPoolIds_basic -timeout 120m
=== RUN   TestAccDataSourceAwsCognitoUserPoolIds_basic
--- PASS: TestAccDataSourceAwsCognitoUserPoolIds_basic (18.81s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	18.858s
```