### PR TITLE
docs/resource/aws_lambda_function: Clarify s3_bucket must be in same region to match SDK documentation

### DIFF
--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -67,7 +67,7 @@ large files efficiently.
 ## Argument Reference
 
 * `filename` - (Optional) The path to the function's deployment package within the local filesystem. If defined, The `s3_`-prefixed options cannot be used.
-* `s3_bucket` - (Optional) The S3 bucket location containing the function's deployment package. Conflicts with `filename`.
+* `s3_bucket` - (Optional) The S3 bucket location containing the function's deployment package. Conflicts with `filename`. This bucket must reside in the same AWS region where you are creating the Lambda function.
 * `s3_key` - (Optional) The S3 key of an object containing the function's deployment package. Conflicts with `filename`.
 * `s3_object_version` - (Optional) The object version containing the function's deployment package. Conflicts with `filename`.
 * `function_name` - (Required) A unique name for your Lambda Function.


### PR DESCRIPTION
Closes #2540 as it is an API limitation and we will not break the provider's resource management in same region principal. Reference: https://docs.aws.amazon.com/sdk-for-go/api/service/lambda/#FunctionCode