### PR TITLE
resource/aws_cognito_user_group: Fix role_arn updates

### DIFF
--- a/aws/resource_aws_cognito_user_group.go
+++ b/aws/resource_aws_cognito_user_group.go
@@ -130,7 +130,7 @@ func resourceAwsCognitoUserGroupUpdate(d *schema.ResourceData, meta interface{})
 	}
 
 	if d.HasChange("role_arn") {
-		params.RoleArn = aws.String(d.Get("description").(string))
+		params.RoleArn = aws.String(d.Get("role_arn").(string))
 	}
 
 	log.Print("[DEBUG] Updating Cognito User Group")


### PR DESCRIPTION
Fixes #4236 

Previously (before code change):
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSCognitoUserGroup_RoleArn'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCognitoUserGroup_RoleArn -timeout 120m
=== RUN   TestAccAWSCognitoUserGroup_RoleArn
--- FAIL: TestAccAWSCognitoUserGroup_RoleArn (18.61s)
	testing.go:518: Step 1 error: Error applying: 1 error(s) occurred:

		* aws_cognito_user_group.main: 1 error(s) occurred:

		* aws_cognito_user_group.main: Error updating Cognito User Group: InvalidParameter: 1 validation error(s) found.
		- minimum field size of 20, UpdateGroupInput.RoleArn.

FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	18.650s
make: *** [testacc] Error 1
```

Now:
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSCognitoUserGroup_RoleArn'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCognitoUserGroup_RoleArn -timeout 120m
=== RUN   TestAccAWSCognitoUserGroup_RoleArn
--- PASS: TestAccAWSCognitoUserGroup_RoleArn (22.91s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	22.946s
```