### PR TITLE
Fix description of 'name' for iam_policy_attachment

### DIFF
--- a/website/docs/r/iam_policy_attachment.html.markdown
+++ b/website/docs/r/iam_policy_attachment.html.markdown
@@ -44,7 +44,7 @@ resource "aws_iam_policy_attachment" "test-attach" {
 
 The following arguments are supported:
 
-* `name` 		(Required) - The name of the policy. This cannot be an empty string.
+* `name` 		(Required) - The name of the attachment. This cannot be an empty string.
 * `users`		(Optional) - The user(s) the policy should be applied to
 * `roles`		(Optional) - The role(s) the policy should be applied to
 * `groups`		(Optional) - The group(s) the policy should be applied to
@@ -55,4 +55,4 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The policy's ID.
-* `name` - The name of the policy.
+* `name` - The name of the attachment.


### PR DESCRIPTION
It's not the name of the policy, but rather the name given to the attachment itself.