### PR TITLE
resource/aws_kinesis_firehose_delivery_stream: Support Redshift processing_configuration

### DIFF
--- a/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -254,6 +254,7 @@ func flattenFirehoseRedshiftConfiguration(description *firehose.RedshiftDestinat
 		"cloudwatch_logging_options": flattenCloudwatchLoggingOptions(description.CloudWatchLoggingOptions),
 		"cluster_jdbcurl":            aws.StringValue(description.ClusterJDBCURL),
 		"password":                   configuredPassword,
+		"processing_configuration":   flattenProcessingConfiguration(description.ProcessingConfiguration, aws.StringValue(description.RoleARN)),
 		"role_arn":                   aws.StringValue(description.RoleARN),
 		"s3_backup_configuration":    flattenFirehoseS3Configuration(description.S3BackupDescription),
 		"s3_backup_mode":             aws.StringValue(description.S3BackupMode),
@@ -589,6 +590,8 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 							Required:  true,
 							Sensitive: true,
 						},
+
+						"processing_configuration": processingConfigurationSchema(),
 
 						"role_arn": {
 							Type:     schema.TypeString,
@@ -1129,6 +1132,9 @@ func createRedshiftConfig(d *schema.ResourceData, s3Config *firehose.S3Destinati
 	if _, ok := redshift["cloudwatch_logging_options"]; ok {
 		configuration.CloudWatchLoggingOptions = extractCloudWatchLoggingConfiguration(redshift)
 	}
+	if _, ok := redshift["processing_configuration"]; ok {
+		configuration.ProcessingConfiguration = extractProcessingConfiguration(redshift)
+	}
 	if s3BackupMode, ok := redshift["s3_backup_mode"]; ok {
 		configuration.S3BackupMode = aws.String(s3BackupMode.(string))
 		configuration.S3BackupConfiguration = expandS3BackupConfig(d.Get("redshift_configuration").([]interface{})[0].(map[string]interface{}))
@@ -1158,6 +1164,9 @@ func updateRedshiftConfig(d *schema.ResourceData, s3Update *firehose.S3Destinati
 
 	if _, ok := redshift["cloudwatch_logging_options"]; ok {
 		configuration.CloudWatchLoggingOptions = extractCloudWatchLoggingConfiguration(redshift)
+	}
+	if _, ok := redshift["processing_configuration"]; ok {
+		configuration.ProcessingConfiguration = extractProcessingConfiguration(redshift)
 	}
 	if s3BackupMode, ok := redshift["s3_backup_mode"]; ok {
 		configuration.S3BackupMode = aws.String(s3BackupMode.(string))

--- a/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
@@ -1203,7 +1203,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
     copy_options = "GZIP"
     data_table_columns = "test-col"
     processing_configuration = [{
-      enabled = "false",
+      enabled = false,
       processors = [{
         type = "Lambda"
         parameters = [{

--- a/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
@@ -290,16 +290,35 @@ func TestAccAWSKinesisFirehoseDeliveryStream_RedshiftConfigUpdates(t *testing.T)
 	var stream firehose.DeliveryStreamDescription
 
 	ri := acctest.RandInt()
+	rString := acctest.RandString(8)
+	funcName := fmt.Sprintf("aws_kinesis_firehose_delivery_stream_test_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_%s", rString)
 	preConfig := fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_RedshiftBasic,
 		ri, ri, ri, ri, ri)
-	postConfig := fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_RedshiftUpdates,
-		ri, ri, ri, ri, ri)
+	postConfig := testAccFirehoseAWSLambdaConfigBasic(funcName, policyName, roleName) +
+		fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_RedshiftUpdates,
+			ri, ri, ri, ri, ri)
 
 	updatedRedshiftConfig := &firehose.RedshiftDestinationDescription{
 		CopyCommand: &firehose.CopyCommand{
 			CopyOptions: aws.String("GZIP"),
 		},
 		S3BackupMode: aws.String("Enabled"),
+		ProcessingConfiguration: &firehose.ProcessingConfiguration{
+			Enabled: aws.Bool(true),
+			Processors: []*firehose.Processor{
+				&firehose.Processor{
+					Type: aws.String("Lambda"),
+					Parameters: []*firehose.ProcessorParameter{
+						&firehose.ProcessorParameter{
+							ParameterName:  aws.String("LambdaArn"),
+							ParameterValue: aws.String("valueNotTested"),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -558,7 +577,7 @@ func testAccCheckAWSKinesisFirehoseDeliveryStreamAttributes(stream *firehose.Del
 				r := redshiftConfig.(*firehose.RedshiftDestinationDescription)
 				// Range over the Stream Destinations, looking for the matching Redshift
 				// destination
-				var matchCopyOptions, matchS3BackupMode bool
+				var matchCopyOptions, matchS3BackupMode, processingConfigMatch bool
 				for _, d := range stream.Destinations {
 					if d.RedshiftDestinationDescription != nil {
 						if *d.RedshiftDestinationDescription.CopyCommand.CopyOptions == *r.CopyCommand.CopyOptions {
@@ -567,10 +586,16 @@ func testAccCheckAWSKinesisFirehoseDeliveryStreamAttributes(stream *firehose.Del
 						if *d.RedshiftDestinationDescription.S3BackupMode == *r.S3BackupMode {
 							matchS3BackupMode = true
 						}
+						if r.ProcessingConfiguration != nil && d.RedshiftDestinationDescription.ProcessingConfiguration != nil {
+							processingConfigMatch = len(r.ProcessingConfiguration.Processors) == len(d.RedshiftDestinationDescription.ProcessingConfiguration.Processors)
+						}
 					}
 				}
 				if !matchCopyOptions || !matchS3BackupMode {
 					return fmt.Errorf("Mismatch Redshift CopyOptions or S3BackupMode, expected: %s, got: %s", r, stream.Destinations)
+				}
+				if !processingConfigMatch {
+					return fmt.Errorf("Mismatch Redshift ProcessingConfiguration.Processors count, expected: %s, got: %s", r, stream.Destinations)
 				}
 			}
 
@@ -1177,6 +1202,16 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
     data_table_name = "test-table"
     copy_options = "GZIP"
     data_table_columns = "test-col"
+    processing_configuration = [{
+      enabled = "false",
+      processors = [{
+        type = "Lambda"
+        parameters = [{
+          parameter_name = "LambdaArn"
+          parameter_value = "${aws_lambda_function.lambda_function_test.arn}:$LATEST"
+        }]
+      }]
+    }]
   }
 }`
 

--- a/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
+++ b/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
@@ -302,6 +302,7 @@ The `redshift_configuration` object supports the following:
 * `copy_options` - (Optional) Copy options for copying the data from the s3 intermediate bucket into redshift, for example to change the default delimiter. For valid values, see the [AWS documentation](http://docs.aws.amazon.com/firehose/latest/APIReference/API_CopyCommand.html)
 * `data_table_columns` - (Optional) The data table columns that will be targeted by the copy command.
 * `cloudwatch_logging_options` - (Optional) The CloudWatch Logging Options for the delivery stream. More details are given below
+* `processing_configuration` - (Optional) The data processing configuration.  More details are given below.
 
 The `elasticsearch_configuration` object supports the following:
 


### PR DESCRIPTION
Closes #513 

Test failure is a known issue.
```
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidParameterName
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidParameterName (1.53s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidProcessorType
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidProcessorType (1.95s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_missingProcessingConfiguration
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_missingProcessingConfiguration (97.07s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_s3KinesisStreamSource
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3KinesisStreamSource (102.50s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3Updates
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3Updates (103.84s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3basic
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3basic (107.25s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_importBasic
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_importBasic (108.98s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_s3basic
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basic (109.01s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3KmsKeyArn
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3KmsKeyArn (125.83s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_s3ConfigUpdates
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3ConfigUpdates (183.52s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_s3WithCloudwatchLogging
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3WithCloudwatchLogging (229.20s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_SplunkConfigUpdates
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_SplunkConfigUpdates (262.68s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_RedshiftConfigUpdates
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_RedshiftConfigUpdates (1058.01s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigUpdates
--- FAIL: TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigUpdates (1273.59s)
    testing.go:518: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_kinesis_firehose_delivery_stream.test_stream_es: 1 error(s) occurred:
        
        * aws_kinesis_firehose_delivery_stream.test_stream_es: error creating Kinesis Firehose Delivery Stream: InvalidArgumentException: Delivery Role is not authorized to describe the Elasticsearch domain: arn:aws:es:us-west-2:*******:domain/es-test-8013883722251758873.
            status code: 400, request id: 4c708fc7-432b-11e8-9cb3-a9462fe68d6e
```