### PR TITLE
data-source/cognito_user_pools: add attribute of arns

### DIFF
--- a/aws/data_source_aws_cognito_user_pools_test.go
+++ b/aws/data_source_aws_cognito_user_pools_test.go
@@ -18,7 +18,8 @@ func TestAccDataSourceAwsCognitoUserPools_basic(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsCognitoUserPoolsConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_cognito_user_pools.selected", "ids.#", "3"),
+					resource.TestCheckResourceAttr("data.aws_cognito_user_pools.selected", "ids.#", "2"),
+					resource.TestCheckResourceAttr("data.aws_cognito_user_pools.selected", "arns.#", "2"),
 				),
 			},
 			{
@@ -32,7 +33,7 @@ func TestAccDataSourceAwsCognitoUserPools_basic(t *testing.T) {
 func testAccDataSourceAwsCognitoUserPoolsConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_cognito_user_pool" "main" {
-	count = 3
+	count = 2
 	name  = "%s"
 }
 

--- a/website/docs/d/cognito_user_pools.markdown
+++ b/website/docs/d/cognito_user_pools.markdown
@@ -25,7 +25,7 @@ resource "aws_api_gateway_authorizer" "cognito" {
   name = "cognito"
   type = "COGNITO_USER_POOLS"
   rest_api_id = "${data.aws_api_gateway_rest_api.selected.id}"
-  provider_arns = ["${data.aws_cognito_user_pools.selected.ids}"]
+  provider_arns = ["${data.aws_cognito_user_pools.selected.arns}"]
 }
 ```
 


### PR DESCRIPTION
This should have been in the first implement with #4212. I missed to check even though an example was provided to serve as api gateway authorizer. As it's not returned directly from aws api, arn is populated from id.