### PR TITLE
New Resource: r/aws_config_aggregator

### DIFF
--- a/aws/import_aws_config_aggregator_test.go
+++ b/aws/import_aws_config_aggregator_test.go
@@ -1,0 +1,30 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccConfigAggregator_import(t *testing.T) {
+	resourceName := "aws_config_aggregator.example"
+	rString := acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckConfigAggregatorDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccConfigAggregatorConfig_account(rString),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -303,6 +303,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_cloudwatch_log_resource_policy":           resourceAwsCloudWatchLogResourcePolicy(),
 			"aws_cloudwatch_log_stream":                    resourceAwsCloudWatchLogStream(),
 			"aws_cloudwatch_log_subscription_filter":       resourceAwsCloudwatchLogSubscriptionFilter(),
+			"aws_config_aggregator":                        resourceAwsConfigAggregator(),
 			"aws_config_config_rule":                       resourceAwsConfigConfigRule(),
 			"aws_config_configuration_recorder":            resourceAwsConfigConfigurationRecorder(),
 			"aws_config_configuration_recorder_status":     resourceAwsConfigConfigurationRecorderStatus(),

--- a/aws/resource_aws_config_aggregator.go
+++ b/aws/resource_aws_config_aggregator.go
@@ -1,0 +1,193 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/configservice"
+
+	"github.com/hashicorp/terraform/helper/customdiff"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsConfigAggregator() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsConfigAggregatorPut,
+		Read:   resourceAwsConfigAggregatorRead,
+		Update: resourceAwsConfigAggregatorPut,
+		Delete: resourceAwsConfigAggregatorDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		CustomizeDiff: customdiff.Sequence(
+			customdiff.ForceNewIfChange("account_aggregation_source", func(old, new, meta interface{}) bool {
+				return len(old.([]interface{})) == 0 && len(new.([]interface{})) > 0
+			}),
+			customdiff.ForceNewIfChange("organization_aggregation_source", func(old, new, meta interface{}) bool {
+				return len(old.([]interface{})) == 0 && len(new.([]interface{})) > 0
+			}),
+		),
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateMaxLength(256),
+			},
+			"account_aggregation_source": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				MaxItems:      1,
+				ConflictsWith: []string{"organization_aggregation_source"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"account_ids": {
+							Type:     schema.TypeList,
+							Required: true,
+							MinItems: 1,
+							Elem: &schema.Schema{
+								Type:         schema.TypeString,
+								ValidateFunc: validateAwsAccountId,
+							},
+						},
+						"all_regions": {
+							Type:     schema.TypeBool,
+							Default:  false,
+							Optional: true,
+						},
+						"regions": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MinItems: 1,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			},
+			"organization_aggregation_source": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				MaxItems:      1,
+				ConflictsWith: []string{"account_aggregation_source"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"all_regions": {
+							Type:     schema.TypeBool,
+							Default:  false,
+							Optional: true,
+						},
+						"regions": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MinItems: 1,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"role_arn": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateArn,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsConfigAggregatorPut(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).configconn
+
+	name := d.Get("name").(string)
+
+	req := &configservice.PutConfigurationAggregatorInput{
+		ConfigurationAggregatorName: aws.String(name),
+	}
+
+	account_aggregation_sources := d.Get("account_aggregation_source").([]interface{})
+	if len(account_aggregation_sources) > 0 {
+		req.AccountAggregationSources = expandConfigAccountAggregationSources(account_aggregation_sources)
+	}
+
+	organization_aggregation_sources := d.Get("organization_aggregation_source").([]interface{})
+	if len(organization_aggregation_sources) > 0 {
+		req.OrganizationAggregationSource = expandConfigOrganizationAggregationSource(organization_aggregation_sources[0].(map[string]interface{}))
+	}
+
+	_, err := conn.PutConfigurationAggregator(req)
+	if err != nil {
+		return fmt.Errorf("Error creating aggregator: %s", err)
+	}
+
+	d.SetId(strings.ToLower(name))
+
+	return resourceAwsConfigAggregatorRead(d, meta)
+}
+
+func resourceAwsConfigAggregatorRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).configconn
+	req := &configservice.DescribeConfigurationAggregatorsInput{
+		ConfigurationAggregatorNames: []*string{aws.String(d.Id())},
+	}
+
+	res, err := conn.DescribeConfigurationAggregators(req)
+	if err != nil {
+		if isAWSErr(err, configservice.ErrCodeNoSuchConfigurationAggregatorException, "") {
+			log.Printf("[WARN] No such configuration aggregator (%s), removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	if len(res.ConfigurationAggregators) == 0 {
+		log.Printf("[WARN] No aggregators returned (%s), removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	aggregator := res.ConfigurationAggregators[0]
+	d.Set("arn", aggregator.ConfigurationAggregatorArn)
+	d.Set("name", aggregator.ConfigurationAggregatorName)
+
+	if aggregator.AccountAggregationSources != nil {
+		d.Set("account_aggregation_source", flattenConfigAccountAggregationSources(aggregator.AccountAggregationSources))
+	} else {
+		d.Set("account_aggregation_source", nil)
+	}
+
+	if aggregator.OrganizationAggregationSource != nil {
+		d.Set("organization_aggregation_source", flattenConfigOrganizationAggregationSource(aggregator.OrganizationAggregationSource))
+	} else {
+		d.Set("organization_aggregation_source", nil)
+	}
+
+	return nil
+}
+
+func resourceAwsConfigAggregatorDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).configconn
+
+	req := &configservice.DeleteConfigurationAggregatorInput{
+		ConfigurationAggregatorName: aws.String(d.Id()),
+	}
+	_, err := conn.DeleteConfigurationAggregator(req)
+	if err != nil {
+		return err
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/aws/resource_aws_config_aggregator_test.go
+++ b/aws/resource_aws_config_aggregator_test.go
@@ -1,0 +1,257 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/configservice"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_config_aggregator", &resource.Sweeper{
+		Name: "aws_config_aggregator",
+		F:    testSweepConfigAggregators,
+	})
+}
+
+func testSweepConfigAggregators(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("Error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).configconn
+
+	resp, err := conn.DescribeConfigurationAggregators(&configservice.DescribeConfigurationAggregatorsInput{})
+	if err != nil {
+		return fmt.Errorf("Error retrieving config aggregators: %s", err)
+	}
+
+	if len(resp.ConfigurationAggregators) == 0 {
+		log.Print("[DEBUG] No config aggregators to sweep")
+		return nil
+	}
+
+	log.Printf("[INFO] Found %d config aggregators", len(resp.ConfigurationAggregators))
+
+	for _, agg := range resp.ConfigurationAggregators {
+		if !strings.HasPrefix(*agg.ConfigurationAggregatorName, "tf-") {
+			continue
+		}
+
+		log.Printf("[INFO] Deleting config aggregator %s", *agg.ConfigurationAggregatorName)
+		_, err := conn.DeleteConfigurationAggregator(&configservice.DeleteConfigurationAggregatorInput{
+			ConfigurationAggregatorName: agg.ConfigurationAggregatorName,
+		})
+
+		if err != nil {
+			return fmt.Errorf("Error deleting config aggregator %s: %s", *agg.ConfigurationAggregatorName, err)
+		}
+	}
+
+	return nil
+}
+
+func TestAccConfigAggregator_account(t *testing.T) {
+	var ca configservice.ConfigurationAggregator
+	rString := acctest.RandString(10)
+	expectedName := fmt.Sprintf("tf-%s", rString)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckConfigAggregatorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigAggregatorConfig_account(rString),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfigAggregatorExists("aws_config_aggregator.example", &ca),
+					testAccCheckConfigAggregatorName("aws_config_aggregator.example", expectedName, &ca),
+					resource.TestCheckResourceAttr("aws_config_aggregator.example", "name", expectedName),
+					resource.TestCheckResourceAttr("aws_config_aggregator.example", "account_aggregation_source.#", "1"),
+					resource.TestCheckResourceAttr("aws_config_aggregator.example", "account_aggregation_source.0.account_ids.#", "1"),
+					resource.TestMatchResourceAttr("aws_config_aggregator.example", "account_aggregation_source.0.account_ids.0", regexp.MustCompile("^\\d{12}$")),
+					resource.TestCheckResourceAttr("aws_config_aggregator.example", "account_aggregation_source.0.regions.#", "1"),
+					resource.TestCheckResourceAttr("aws_config_aggregator.example", "account_aggregation_source.0.regions.0", "us-west-2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigAggregator_organization(t *testing.T) {
+	var ca configservice.ConfigurationAggregator
+	rString := acctest.RandString(10)
+	expectedName := fmt.Sprintf("tf-%s", rString)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckConfigAggregatorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigAggregatorConfig_organization(rString),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfigAggregatorExists("aws_config_aggregator.example", &ca),
+					testAccCheckConfigAggregatorName("aws_config_aggregator.example", expectedName, &ca),
+					resource.TestCheckResourceAttr("aws_config_aggregator.example", "name", expectedName),
+					resource.TestCheckResourceAttr("aws_config_aggregator.example", "organization_aggregation_source.#", "1"),
+					resource.TestMatchResourceAttr("aws_config_aggregator.example", "organization_aggregation_source.0.role_arn", regexp.MustCompile("^arn:aws:iam::\\d+:role/")),
+					resource.TestCheckResourceAttr("aws_config_aggregator.example", "organization_aggregation_source.0.all_regions", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigAggregator_switch(t *testing.T) {
+	rString := acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckConfigAggregatorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigAggregatorConfig_account(rString),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aws_config_aggregator.example", "account_aggregation_source.#", "1"),
+					resource.TestCheckResourceAttr("aws_config_aggregator.example", "organization_aggregation_source.#", "0"),
+				),
+			},
+			{
+				Config: testAccConfigAggregatorConfig_organization(rString),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aws_config_aggregator.example", "account_aggregation_source.#", "0"),
+					resource.TestCheckResourceAttr("aws_config_aggregator.example", "organization_aggregation_source.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckConfigAggregatorName(n, desired string, obj *configservice.ConfigurationAggregator) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		if rs.Primary.Attributes["name"] != *obj.ConfigurationAggregatorName {
+			return fmt.Errorf("Expected name: %q, given: %q", desired, *obj.ConfigurationAggregatorName)
+		}
+		return nil
+	}
+}
+
+func testAccCheckConfigAggregatorExists(n string, obj *configservice.ConfigurationAggregator) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not Found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No config aggregator ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).configconn
+		out, err := conn.DescribeConfigurationAggregators(&configservice.DescribeConfigurationAggregatorsInput{
+			ConfigurationAggregatorNames: []*string{aws.String(rs.Primary.Attributes["name"])},
+		})
+		if err != nil {
+			return fmt.Errorf("Failed to describe config aggregator: %s", err)
+		}
+		if len(out.ConfigurationAggregators) < 1 {
+			return fmt.Errorf("No config aggregator found when describing %q", rs.Primary.Attributes["name"])
+		}
+
+		ca := out.ConfigurationAggregators[0]
+		*obj = *ca
+
+		return nil
+	}
+}
+
+func testAccCheckConfigAggregatorDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).configconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_config_aggregator" {
+			continue
+		}
+
+		resp, err := conn.DescribeConfigurationAggregators(&configservice.DescribeConfigurationAggregatorsInput{
+			ConfigurationAggregatorNames: []*string{aws.String(rs.Primary.Attributes["name"])},
+		})
+
+		if err == nil {
+			if len(resp.ConfigurationAggregators) != 0 &&
+				*resp.ConfigurationAggregators[0].ConfigurationAggregatorName == rs.Primary.Attributes["name"] {
+				return fmt.Errorf("config aggregator still exists: %s", rs.Primary.Attributes["name"])
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccConfigAggregatorConfig_account(rString string) string {
+	return fmt.Sprintf(`
+resource "aws_config_aggregator" "example" {
+  name = "tf-%s"
+
+  account_aggregation_source {
+    account_ids = ["${data.aws_caller_identity.current.account_id}"]
+    regions     = ["us-west-2"]
+  }
+}
+
+data "aws_caller_identity" "current" {}
+`, rString)
+}
+
+func testAccConfigAggregatorConfig_organization(rString string) string {
+	return fmt.Sprintf(`
+resource "aws_config_aggregator" "example" {
+  depends_on = ["aws_iam_role_policy_attachment.example"]
+
+  name = "tf-%s"
+
+  organization_aggregation_source {
+    all_regions = true
+    role_arn    = "${aws_iam_role.example.arn}"
+  }
+}
+
+resource "aws_iam_role" "example" {
+  name = "tf-%s"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "config.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "example" {
+  role       = "${aws_iam_role.example.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSConfigRoleForOrganizations"
+}
+`, rString, rString)
+}

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -1908,6 +1908,70 @@ func flattenPolicyAttributes(list []*elb.PolicyAttributeDescription) []interface
 	return attributes
 }
 
+func expandConfigAccountAggregationSources(configured []interface{}) []*configservice.AccountAggregationSource {
+	var results []*configservice.AccountAggregationSource
+	for _, item := range configured {
+		detail := item.(map[string]interface{})
+		source := configservice.AccountAggregationSource{
+			AllAwsRegions: aws.Bool(detail["all_regions"].(bool)),
+		}
+
+		if v, ok := detail["account_ids"]; ok {
+			accountIDs := v.([]interface{})
+			if len(accountIDs) > 0 {
+				source.AccountIds = expandStringList(accountIDs)
+			}
+		}
+
+		if v, ok := detail["regions"]; ok {
+			regions := v.([]interface{})
+			if len(regions) > 0 {
+				source.AwsRegions = expandStringList(regions)
+			}
+		}
+
+		results = append(results, &source)
+	}
+	return results
+}
+
+func expandConfigOrganizationAggregationSource(configured map[string]interface{}) *configservice.OrganizationAggregationSource {
+	source := configservice.OrganizationAggregationSource{
+		AllAwsRegions: aws.Bool(configured["all_regions"].(bool)),
+		RoleArn:       aws.String(configured["role_arn"].(string)),
+	}
+
+	if v, ok := configured["regions"]; ok {
+		regions := v.([]interface{})
+		if len(regions) > 0 {
+			source.AwsRegions = expandStringList(regions)
+		}
+	}
+
+	return &source
+}
+
+func flattenConfigAccountAggregationSources(sources []*configservice.AccountAggregationSource) []interface{} {
+	source := sources[0]
+	var result []interface{}
+	m := make(map[string]interface{})
+	m["account_ids"] = flattenStringList(source.AccountIds)
+	m["all_regions"] = *source.AllAwsRegions
+	m["regions"] = flattenStringList(source.AwsRegions)
+	result = append(result, m)
+	return result
+}
+
+func flattenConfigOrganizationAggregationSource(source *configservice.OrganizationAggregationSource) []interface{} {
+	var result []interface{}
+	m := make(map[string]interface{})
+	m["all_regions"] = *source.AllAwsRegions
+	m["regions"] = flattenStringList(source.AwsRegions)
+	m["role_arn"] = *source.RoleArn
+	result = append(result, m)
+	return result
+}
+
 func flattenConfigRuleSource(source *configservice.Source) []interface{} {
 	var result []interface{}
 	m := make(map[string]interface{})

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -584,6 +584,10 @@
                     <a href="#">Config Resources</a>
                     <ul class="nav nav-visible">
 
+                        <li<%= sidebar_current("docs-aws-resource-config-aggregator") %>>
+                            <a href="/docs/providers/aws/r/config_aggregator.html">aws_config_aggregator</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-aws-resource-config-config-rule") %>>
                             <a href="/docs/providers/aws/r/config_config_rule.html">aws_config_config_rule</a>
                         </li>

--- a/website/docs/r/config_aggregator.markdown
+++ b/website/docs/r/config_aggregator.markdown
@@ -1,0 +1,104 @@
+---
+layout: "aws"
+page_title: "AWS: aws_config_aggregator"
+sidebar_current: "docs-aws-resource-config-aws_config_aggregator"
+description: |-
+  Provides an AWS Config Aggregator.
+---
+
+# aws_config_aggregator
+
+Provides an AWS Config Aggregator
+
+## Example Usage
+
+```hcl
+resource "aws_config_aggregator" "account" {
+  name = "example" # Required
+
+  account_aggregation_source {
+    account_ids = ["123456789012"] # Required
+    regions     = ["us-west-2"]    # Optional
+  }
+}
+```
+
+```hcl
+resource "aws_config_aggregator" "organization" {
+  depends_on = ["aws_iam_role_policy_attachment.organization"]
+
+  name = "example" # Required
+
+  organization_aggregation_source {
+    all_regions = true                               # Optional
+    role_arn    = "${aws_iam_role.organization.arn}" # Required
+  }
+}
+
+resource "aws_iam_role" "organization" {
+  name = "example"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "config.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "organization" {
+  role       = "${aws_iam_role.organization.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSConfigRoleForOrganizations"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the configuration aggregator.
+* `account_aggregation_source` - (Optional) The account(s) to aggregate config data from as documented below.
+* `organization_aggregation_source` - (Optional) The organization to aggregate config data from as documented below.
+
+Either `account_aggregation_source` or `organization_aggregation_source` must be specified.
+
+### `account_aggregation_source`
+
+* `account_ids` - (Required) List of 12-digit account IDs of the account(s) being aggregated.
+* `all_regions` - (Optional) If true, aggregate existing AWS Config regions and future regions.
+* `regions` - (Optional) List of source regions being aggregated.
+
+Either `regions` or `all_regions` (as true) must be specified.
+
+### `organization_aggregation_source`
+
+~> **Note:** If your source type is an organization, you must be signed in to the master account and all features must be enabled in your organization. AWS Config calls EnableAwsServiceAccess API to enable integration between AWS Config and AWS Organizations.
+
+* `all_regions` - (Optional) If true, aggregate existing AWS Config regions and future regions.
+* `regions` - (Optional) List of source regions being aggregated.
+* `role_arn` - (Required) ARN of the IAM role used to retreive AWS Organization details associated with the aggregator account.
+
+Either `regions` or `all_regions` (as true) must be specified.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `arn` - The ARN of the aggregator
+
+## Import
+
+Aggregators can be imported using the name, e.g.
+
+```
+$ terraform import aws_config_aggregator.example foo
+```


### PR DESCRIPTION
Partially implements #4067 

New Resources: 

* `aws_config_aggregator`

```
$ make testacc TESTARGS='-run=TestAccConfigAggregator'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccConfigAggregator -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccConfigAggregator_import
--- PASS: TestAccConfigAggregator_import (25.42s)
=== RUN   TestAccConfigAggregator_account
--- PASS: TestAccConfigAggregator_account (28.26s)
=== RUN   TestAccConfigAggregator_organization
--- PASS: TestAccConfigAggregator_organization (28.64s)
=== RUN   TestAccConfigAggregator_switch
--- PASS: TestAccConfigAggregator_switch (44.97s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	127.344s
```