### PR TITLE
New Resource: r/aws_config_authorization

### DIFF
--- a/aws/import_aws_config_authorization_test.go
+++ b/aws/import_aws_config_authorization_test.go
@@ -1,0 +1,30 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccConfigAuthorization_import(t *testing.T) {
+	resourceName := "aws_config_authorization.example"
+	rString := acctest.RandStringFromCharSet(12, "0123456789")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckConfigAuthorizationDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccConfigAuthorizationConfig_basic(rString),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -303,6 +303,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_cloudwatch_log_resource_policy":           resourceAwsCloudWatchLogResourcePolicy(),
 			"aws_cloudwatch_log_stream":                    resourceAwsCloudWatchLogStream(),
 			"aws_cloudwatch_log_subscription_filter":       resourceAwsCloudwatchLogSubscriptionFilter(),
+			"aws_config_authorization":                     resourceAwsConfigAuthorization(),
 			"aws_config_config_rule":                       resourceAwsConfigConfigRule(),
 			"aws_config_configuration_recorder":            resourceAwsConfigConfigurationRecorder(),
 			"aws_config_configuration_recorder_status":     resourceAwsConfigConfigurationRecorderStatus(),

--- a/aws/resource_aws_config_authorization.go
+++ b/aws/resource_aws_config_authorization.go
@@ -1,0 +1,123 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/configservice"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsConfigAuthorization() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsConfigAuthorizationPut,
+		Read:   resourceAwsConfigAuthorizationRead,
+		Delete: resourceAwsConfigAuthorizationDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"account_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateAwsAccountId,
+			},
+			"region": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAwsConfigAuthorizationPut(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).configconn
+
+	accountId := d.Get("account_id").(string)
+	region := d.Get("region").(string)
+
+	req := &configservice.PutAggregationAuthorizationInput{
+		AuthorizedAccountId: aws.String(accountId),
+		AuthorizedAwsRegion: aws.String(region),
+	}
+
+	_, err := conn.PutAggregationAuthorization(req)
+	if err != nil {
+		return fmt.Errorf("Error creating authorization: %s", err)
+	}
+
+	d.SetId(fmt.Sprintf("%s:%s", accountId, region))
+	return resourceAwsConfigAuthorizationRead(d, meta)
+}
+
+func resourceAwsConfigAuthorizationRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).configconn
+
+	accountId, region, err := resourceAwsConfigAuthorizationParseID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	d.Set("account_id", accountId)
+	d.Set("region", region)
+
+	res, err := conn.DescribeAggregationAuthorizations(&configservice.DescribeAggregationAuthorizationsInput{})
+	if err != nil {
+		return fmt.Errorf("Error retrieving list of authorizations: %s", err)
+	}
+
+	// Check for existing authorization
+	for _, auth := range res.AggregationAuthorizations {
+		if accountId == *auth.AuthorizedAccountId && region == *auth.AuthorizedAwsRegion {
+			d.Set("arn", auth.AggregationAuthorizationArn)
+			return nil
+		}
+	}
+
+	log.Printf("[WARN] Authorization not found, removing from state: %s", d.Id())
+	d.SetId("")
+	return nil
+}
+
+func resourceAwsConfigAuthorizationDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).configconn
+
+	accountId, region, err := resourceAwsConfigAuthorizationParseID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	req := &configservice.DeleteAggregationAuthorizationInput{
+		AuthorizedAccountId: aws.String(accountId),
+		AuthorizedAwsRegion: aws.String(region),
+	}
+
+	_, err = conn.DeleteAggregationAuthorization(req)
+	if err != nil {
+		return fmt.Errorf("Error deleting authorization: %s", err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourceAwsConfigAuthorizationParseID(id string) (string, string, error) {
+	idParts := strings.Split(id, ":")
+	if len(idParts) != 2 {
+		return "", "", fmt.Errorf("Please make sure the ID is in the form account_id:region (i.e. 123456789012:us-east-1")
+	}
+	accountId := idParts[0]
+	region := idParts[1]
+	return accountId, region, nil
+}

--- a/aws/resource_aws_config_authorization_test.go
+++ b/aws/resource_aws_config_authorization_test.go
@@ -1,0 +1,102 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/configservice"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_config_authorization", &resource.Sweeper{
+		Name: "aws_config_authorization",
+		F:    testSweepConfigAuthorizations,
+	})
+}
+
+func testSweepConfigAuthorizations(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("Error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).configconn
+
+	resp, err := conn.DescribeAggregationAuthorizations(&configservice.DescribeAggregationAuthorizationsInput{})
+	if err != nil {
+		return fmt.Errorf("Error retrieving config authorizations: %s", err)
+	}
+
+	if len(resp.AggregationAuthorizations) == 0 {
+		log.Print("[DEBUG] No config authorizations to sweep")
+		return nil
+	}
+
+	log.Printf("[INFO] Found %d config authorizations", len(resp.AggregationAuthorizations))
+
+	for _, auth := range resp.AggregationAuthorizations {
+		log.Printf("[INFO] Deleting config authorization %s", *auth.AggregationAuthorizationArn)
+		_, err := conn.DeleteAggregationAuthorization(&configservice.DeleteAggregationAuthorizationInput{
+			AuthorizedAccountId: auth.AuthorizedAccountId,
+			AuthorizedAwsRegion: auth.AuthorizedAwsRegion,
+		})
+		if err != nil {
+			return fmt.Errorf("Error deleting config authorization %s: %s", *auth.AggregationAuthorizationArn, err)
+		}
+	}
+
+	return nil
+}
+
+func TestAccConfigAuthorization_basic(t *testing.T) {
+	rString := acctest.RandStringFromCharSet(12, "0123456789")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckConfigAuthorizationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigAuthorizationConfig_basic(rString),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aws_config_authorization.example", "account_id", rString),
+					resource.TestCheckResourceAttr("aws_config_authorization.example", "region", "eu-west-1"),
+					resource.TestMatchResourceAttr("aws_config_authorization.example", "arn", regexp.MustCompile("^arn:aws:config:[\\w-]+:\\d{12}:aggregation-authorization/\\d{12}/[\\w-]+$")),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckConfigAuthorizationDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).configconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_config_authorization" {
+			continue
+		}
+
+		resp, err := conn.DescribeAggregationAuthorizations(&configservice.DescribeAggregationAuthorizationsInput{})
+
+		if err == nil {
+			if len(resp.AggregationAuthorizations) != 0 &&
+				*resp.AggregationAuthorizations[0].AuthorizedAccountId == rs.Primary.Attributes["account_id"] {
+				return fmt.Errorf("Config authorization still exists: %s", rs.Primary.Attributes["account_id"])
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccConfigAuthorizationConfig_basic(rString string) string {
+	return fmt.Sprintf(`
+resource "aws_config_authorization" "example" {
+  account_id = "%s" # Required
+  region = "eu-west-1"    # Required
+}`, rString)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -583,6 +583,9 @@
                 <li<%= sidebar_current("docs-aws-resource-config") %>>
                     <a href="#">Config Resources</a>
                     <ul class="nav nav-visible">
+                        <li<%= sidebar_current("docs-aws-resource-config-authorization") %>>
+                            <a href="/docs/providers/aws/r/config_authorization.html">aws_config_authorization</a>
+                        </li>
 
                         <li<%= sidebar_current("docs-aws-resource-config-config-rule") %>>
                             <a href="/docs/providers/aws/r/config_config_rule.html">aws_config_config_rule</a>

--- a/website/docs/r/config_authorization.markdown
+++ b/website/docs/r/config_authorization.markdown
@@ -1,0 +1,41 @@
+---
+layout: "aws"
+page_title: "AWS: aws_config_authorization"
+sidebar_current: "docs-aws-resource-config-authorization"
+description: |-
+  Provides an AWS Config Authorization.
+---
+
+# aws_config_authorization
+
+Provides an AWS Config Authorization
+
+## Example Usage
+
+```hcl
+resource "aws_config_authorization" "example" {
+  account_id = "123456789012" # Required
+  region     = "eu-west-2"    # Required
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `account_id` - (Required) Account ID
+* `region` - (Required) Region
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `arn` - The ARN of the authorization
+
+## Import
+
+Config authorizations can be imported using `account_id:region`, e.g.
+
+```
+$ terraform import aws_config_authorization.example 123456789012:us-east-1
+```


### PR DESCRIPTION
Partially implements #4067 

New Resources:

* `aws_config_authorization`

```
$ AWS_PROFILE=personal make testacc TESTARGS='-run=TestAccConfigAuthorization'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccConfigAuthorization -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccConfigAuthorization_import
--- PASS: TestAccConfigAuthorization_import (24.76s)
=== RUN   TestAccConfigAuthorization_basic
--- PASS: TestAccConfigAuthorization_basic (21.88s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	46.688s
```