### PR TITLE
fixes #4170

### DIFF
--- a/aws/resource_aws_ssm_patch_baseline.go
+++ b/aws/resource_aws_ssm_patch_baseline.go
@@ -24,6 +24,7 @@ var ssmPatchOSs = []string{
 	ssm.OperatingSystemAmazonLinux,
 	ssm.OperatingSystemUbuntu,
 	ssm.OperatingSystemRedhatEnterpriseLinux,
+	ssm.OperatingSystemCentos,
 }
 
 func resourceAwsSsmPatchBaseline() *schema.Resource {


### PR DESCRIPTION
This PR fixes the issue I've described a few days ago. For more information please refer to the issue [#4170](https://github.com/terraform-providers/terraform-provider-aws/issues/4170) itself

```
./terraform plan

Error: aws_ssm_patch_baseline.patch-baseline-centos: expected operating_system to be one of [WINDOWS AMAZON_LINUX UBUNTU REDHAT_ENTERPRISE_LINUX], got CENTOS
```