### PR TITLE
Fix crash with multiple values in IAMPolicyStatementPrincipalSet.Identifiers

### DIFF
--- a/aws/data_source_aws_iam_policy_document_test.go
+++ b/aws/data_source_aws_iam_policy_document_test.go
@@ -296,7 +296,10 @@ data "aws_iam_policy_document" "test" {
         ]
         principals {
             type = "AWS"
-            identifiers = ["arn:blahblah:example"]
+            identifiers = [
+				"arn:blahblah:example",
+				"arn:blahblahblah:example",
+			]
         }
     }
 
@@ -376,7 +379,10 @@ var testAccAWSIAMPolicyDocumentSourceExpectedJSON = `{
         "arn:aws:s3:::foo/home/${aws:username}"
       ],
       "Principal": {
-        "AWS": "arn:blahblah:example"
+        "AWS": [
+          "arn:blahblahblah:example",
+          "arn:blahblah:example"
+        ]
       }
     },
     {


### PR DESCRIPTION
Fixes #4085

Added acceptance tests and code to handle multiple values for IAMPolicyStatementPrincipalSet.Identifiers