### PR TITLE
[WIP] AWS Glue database table

### DIFF
--- a/aws/import_aws_glue_catalog_table_test.go
+++ b/aws/import_aws_glue_catalog_table_test.go
@@ -1,0 +1,34 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/aws/aws-sdk-go/service/glue"
+	"github.com/aws/aws-sdk-go/aws"
+	"fmt"
+)
+
+func TestAccAWSGlueCatalogTable_importBasic(t *testing.T) {
+	resourceName := "aws_glue_catalog_table.test"
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGlueTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlueCatalogTable_full(rInt, "A test table from terraform"),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+

--- a/aws/import_aws_glue_catalog_table_test.go
+++ b/aws/import_aws_glue_catalog_table_test.go
@@ -5,10 +5,6 @@ import (
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
-	"github.com/aws/aws-sdk-go/service/glue"
-	"github.com/aws/aws-sdk-go/aws"
-	"fmt"
 )
 
 func TestAccAWSGlueCatalogTable_importBasic(t *testing.T) {
@@ -31,4 +27,3 @@ func TestAccAWSGlueCatalogTable_importBasic(t *testing.T) {
 		},
 	})
 }
-

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -380,6 +380,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_gamelift_fleet":                           resourceAwsGameliftFleet(),
 			"aws_glacier_vault":                            resourceAwsGlacierVault(),
 			"aws_glue_catalog_database":                    resourceAwsGlueCatalogDatabase(),
+			"aws_glue_catalog_table":                       resourceAwsGlueCatalogTable(),
 			"aws_guardduty_detector":                       resourceAwsGuardDutyDetector(),
 			"aws_guardduty_ipset":                          resourceAwsGuardDutyIpset(),
 			"aws_guardduty_member":                         resourceAwsGuardDutyMember(),

--- a/aws/resource_aws_glue_catalog_table.go
+++ b/aws/resource_aws_glue_catalog_table.go
@@ -1,7 +1,12 @@
 package aws
 
 import (
+	"fmt"
+	"log"
 	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/glue"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -11,18 +16,78 @@ func resourceAwsGlueCatalogTable() *schema.Resource {
 		Read:   resourceAwsGlueCatalogTableRead,
 		Update: resourceAwsGlueCatalogTableUpdate,
 		Delete: resourceAwsGlueCatalogTableDelete,
-		Exists: resourceAwsGlueCatalogTableExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
 
 		Schema: map[string]*schema.Schema{
-			"name": {
+			"catalog_id": {
 				Type:     schema.TypeString,
 				ForceNew: true,
 				Required: true,
 			},
-			...
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"database_name": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"owner": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"retention": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"storage_descriptor": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     schema.TypeString,
+			},
+			"partition_keys": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"comment": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"view_original_text": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"view_expanded_text": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"table_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"parameters": {
+				Type:     schema.TypeMap,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -30,4 +95,163 @@ func resourceAwsGlueCatalogTable() *schema.Resource {
 func readAwsGlueTableID(id string) (catalogID string, dbName string, name string) {
 	idParts := strings.Split(id, ":")
 	return idParts[0], idParts[1], idParts[2]
+}
+
+func resourceAwsGlueCatalogTableCreate(t *schema.ResourceData, meta interface{}) error {
+	glueconn := meta.(*AWSClient).glueconn
+	catalogID := createAwsGlueCatalogID(t, meta.(*AWSClient).accountid)
+	dbName := t.Get("database_name").(string)
+	name := t.Get("name").(string)
+
+	input := &glue.CreateTableInput{
+		CatalogId:    aws.String(catalogID),
+		DatabaseName: aws.String(dbName),
+		TableInput:   expandGlueTableInput(t),
+	}
+
+	_, err := glueconn.CreateTable(input)
+	if err != nil {
+		return fmt.Errorf("Error creating Catalog Table: %s", err)
+	}
+
+	t.SetId(fmt.Sprintf("%s:%s:%s", catalogID, dbName, name))
+
+	return resourceAwsGlueCatalogTableRead(t, meta)
+}
+
+func resourceAwsGlueCatalogTableUpdate(t *schema.ResourceData, meta interface{}) error {
+	glueconn := meta.(*AWSClient).glueconn
+
+	catalogID, dbName, _ := readAwsGlueTableID(t.Id())
+
+	updateTableInput := &glue.UpdateTableInput{
+		CatalogId:    aws.String(catalogID),
+		DatabaseName: aws.String(dbName),
+		TableInput:   expandGlueTableInput(t),
+	}
+
+	if t.HasChange("table_input") {
+		if _, err := glueconn.UpdateTable(updateTableInput); err != nil {
+			return fmt.Errorf("Error updating Glue Catalog Table: %s", err)
+		}
+	}
+
+	return nil
+}
+
+func resourceAwsGlueCatalogTableRead(t *schema.ResourceData, meta interface{}) error {
+	glueconn := meta.(*AWSClient).glueconn
+
+	catalogID, dbName, name := readAwsGlueTableID(t.Id())
+
+	input := &glue.GetTableInput{
+		CatalogId:    aws.String(catalogID),
+		DatabaseName: aws.String(dbName),
+		Name:         aws.String(name),
+	}
+
+	out, err := glueconn.GetTable(input)
+	if err != nil {
+
+		if isAWSErr(err, glue.ErrCodeEntityNotFoundException, "") {
+			log.Printf("[WARN] Glue Catalog Table (%s) not found, removing from state", t.Id())
+			t.SetId("")
+		}
+
+		return fmt.Errorf("Error reading Glue Catalog Table: %s", err)
+	}
+
+	t.Set("name", out.Table.Name)
+	t.Set("catalog_id", catalogID)
+	t.Set("description", out.Table.Description)
+
+	return nil
+}
+
+func resourceAwsGlueCatalogTableDelete(t *schema.ResourceData, meta interface{}) error {
+	glueconn := meta.(*AWSClient).glueconn
+	catalogID, dbName, name := readAwsGlueTableID(t.Id())
+
+	log.Printf("[DEBUG] Glue Catalog Table: %s:%s:%s", catalogID, dbName, name)
+	_, err := glueconn.DeleteTable(&glue.DeleteTableInput{
+		CatalogId:    aws.String(catalogID),
+		Name:         aws.String(name),
+		DatabaseName: aws.String(dbName),
+	})
+	if err != nil {
+		return fmt.Errorf("Error deleting Glue Catalog Table: %s", err.Error())
+	}
+	return nil
+}
+
+func expandGlueTableInput(t *schema.ResourceData) *glue.TableInput {
+	tableInput := &glue.TableInput{
+		Name: aws.String(t.Get("name").(string)),
+	}
+
+	if v, ok := t.GetOk("description"); ok {
+		tableInput.Description = aws.String(v.(string))
+	}
+
+	if v, ok := t.GetOk("owner"); ok {
+		tableInput.Owner = aws.String(v.(string))
+	}
+
+	if v, ok := t.GetOk("retention"); ok {
+		tableInput.Retention = aws.Int64(v.(int64))
+	}
+
+	if v, ok := t.GetOk("storage_descriptor"); ok {
+		tableInput.StorageDescriptor = expandGlueStorageDescriptor(v.(map[string]interface{}))
+	}
+
+	if v, ok := t.GetOk("partition_keys"); ok {
+		columns := expandGlueColumns(v.(map[string]schema.ResourceData))
+		tableInput.PartitionKeys = columns
+	}
+
+	if v, ok := t.GetOk("view_original_text"); ok {
+		tableInput.Owner = aws.String(v.(string))
+	}
+
+	if v, ok := t.GetOk("view_expanded_text"); ok {
+		tableInput.Owner = aws.String(v.(string))
+	}
+
+	if v, ok := t.GetOk("table_type"); ok {
+		tableInput.Owner = aws.String(v.(string))
+	}
+
+	if v, ok := t.GetOk("parameters"); ok {
+		tableInput.Parameters = aws.StringMap(v.(map[string]string))
+	}
+
+	return tableInput
+}
+
+func expandGlueStorageDescriptor(s map[string]interface{}) *glue.StorageDescriptor {
+	storageDescriptor := &glue.StorageDescriptor{}
+
+	return storageDescriptor
+}
+
+func expandGlueColumns(columns map[string]schema.ResourceData) []*glue.Column {
+	columnSlice := []*glue.Column{}
+	for _, element := range columns {
+		column := &glue.Column{
+			Name: aws.String(element.Get("name").(string)),
+		}
+
+		if v, ok := element.GetOk("comment"); ok {
+			column.Comment = aws.String(v.(string))
+		}
+
+		if v, ok := element.GetOk("type"); ok {
+			column.Type = aws.String(v.(string))
+		}
+
+		columnSlice = append(columnSlice, column)
+	}
+
+	return columnSlice
 }

--- a/aws/resource_aws_glue_catalog_table.go
+++ b/aws/resource_aws_glue_catalog_table.go
@@ -1,0 +1,33 @@
+package aws
+
+import (
+	"strings"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsGlueCatalogTable() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsGlueCatalogTableCreate,
+		Read:   resourceAwsGlueCatalogTableRead,
+		Update: resourceAwsGlueCatalogTableUpdate,
+		Delete: resourceAwsGlueCatalogTableDelete,
+		Exists: resourceAwsGlueCatalogTableExists,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			...
+		},
+	}
+}
+
+func readAwsGlueTableID(id string) (catalogID string, dbName string, name string) {
+	idParts := strings.Split(id, ":")
+	return idParts[0], idParts[1], idParts[2]
+}

--- a/aws/resource_aws_glue_catalog_table_test.go
+++ b/aws/resource_aws_glue_catalog_table_test.go
@@ -1,13 +1,15 @@
 package aws
 
 import (
+	"fmt"
 	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/glue"
+
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
-	"fmt"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/aws/aws-sdk-go/service/glue"
-	"github.com/aws/aws-sdk-go/aws"
 )
 
 func TestAccAWSGlueCatalogTable_full(t *testing.T) {

--- a/aws/resource_aws_glue_catalog_table_test.go
+++ b/aws/resource_aws_glue_catalog_table_test.go
@@ -1,0 +1,41 @@
+package aws
+
+import (
+	"testing"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"fmt"
+)
+
+func TestAccAWSGlueCatalogTable_full(t *testing.T) {
+	rInt := acctest.RandInt()
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGlueTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:  testAccGlueCatalogTable_basic(rInt),
+				Destroy: false,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGlueCatalogTableExists("aws_glue_catalog_table.test"),
+					resource.TestCheckResourceAttr(
+						"aws_glue_catalog_table.test",
+						"name",
+						fmt.Sprintf("my_test_catalog_table_%d", rInt),
+					),
+					resource.TestCheckResourceAttr(
+						"aws_glue_catalog_table.test",
+						"description",
+						"",
+					),
+					resource.TestCheckResourceAttr(
+						"aws_glue_catalog_table.test",
+						"owner",
+						"",
+					),
+				),
+			},
+		},
+	})
+}

--- a/aws/resource_aws_glue_catalog_table_test.go
+++ b/aws/resource_aws_glue_catalog_table_test.go
@@ -5,6 +5,9 @@ import (
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"fmt"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/aws/aws-sdk-go/service/glue"
+	"github.com/aws/aws-sdk-go/aws"
 )
 
 func TestAccAWSGlueCatalogTable_full(t *testing.T) {
@@ -26,6 +29,11 @@ func TestAccAWSGlueCatalogTable_full(t *testing.T) {
 					),
 					resource.TestCheckResourceAttr(
 						"aws_glue_catalog_table.test",
+						"database",
+						fmt.Sprintf("my_test_catalog_database_%d", rInt),
+					),
+					resource.TestCheckResourceAttr(
+						"aws_glue_catalog_table.test",
 						"description",
 						"",
 					),
@@ -38,4 +46,117 @@ func TestAccAWSGlueCatalogTable_full(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccGlueCatalogTable_basic(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = "my_test_catalog_database_%d"
+}
+
+resource "aws_glue_catalog_table" "test" {
+  name     = "my_test_table_%d"
+  database = "${aws_glue_catalog_database.test.name}"
+}
+`, rInt, rInt)
+}
+
+func testAccGlueCatalogTable_full(rInt int, desc string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = "my_test_catalog_database_%d"
+}
+# @TODO Fill out parameters from https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-tables.html#aws-glue-api-catalog-tables-StorageDescriptor
+resource "aws_glue_catalog_table" "test" {
+  name = "my_test_table_%d"
+  database = "${aws_glue_catalog_database.test.name}"
+  description = "%s"
+  owner = "my_owner"
+  retetention = "%s",
+  storage {
+    location = "my_location"
+    columns = [{
+      name = "my_column_1"
+      type = "int"
+      comment = "my_column_comment"
+    },{
+      name = "my_column_1"
+      type = "string"
+      comment = "my_column_comment"
+    }]
+    ...
+  }
+  partition_keys = [{
+    name = "my_column_1"
+    type = "int"
+    comment = "my_column_comment"
+  }]
+  ...
+}
+`, rInt, rInt, rInt, desc)
+}
+
+func testAccCheckGlueTableDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).glueconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_glue_catalog_table" {
+			continue
+		}
+
+		catalogId, dbName, tableName := readAwsGlueTableID(rs.Primary.ID)
+
+		input := &glue.GetTableInput{
+			DatabaseName: aws.String(dbName),
+			CatalogId:    aws.String(catalogId),
+			Name:         aws.String(tableName),
+		}
+		if _, err := conn.GetTable(input); err != nil {
+			//Verify the error is what we want
+			if isAWSErr(err, glue.ErrCodeEntityNotFoundException, "") {
+				continue
+			}
+
+			return err
+		}
+		return fmt.Errorf("still exists")
+	}
+	return nil
+}
+
+func testAccCheckGlueCatalogTableExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		catalogId, dbName, tableName := readAwsGlueTableID(rs.Primary.ID)
+
+		glueconn := testAccProvider.Meta().(*AWSClient).glueconn
+		out, err := glueconn.GetTable(&glue.GetTableInput{
+			CatalogId:    aws.String(catalogId),
+			DatabaseName: aws.String(dbName),
+			Name:         aws.String(tableName),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if out.Table == nil {
+			return fmt.Errorf("No Glue Database Found")
+		}
+
+		if *out.Table.Name != dbName {
+			return fmt.Errorf("Glue Database Mismatch - existing: %q, state: %q",
+				*out.Table.Name, tableName)
+		}
+
+		return nil
+	}
 }


### PR DESCRIPTION
Fixes #3880

Partly implements the `table` resource for `Glue`.

However, I'm coming up against an error in my tests with a list of strings config variable. I'm sure I'm missing something obvious as I'm new to Terraform and Go so any help would be greatly appreciated.

Schema definition:
```
"bucket_columns": {
    Type:     schema.TypeList,
    Optional: true,
    Elem: &schema.Schema{
        Type: schema.TypeString,
    },
},
```

Test Terraform config:
```
storage_descriptor {
    bucket_columns = [
        "bucket_column_1",
    ]
}
```

Error message:
```
testing.go:518: Step 0 error: config is invalid: aws_glue_catalog_table.test: storage_descriptor (bucket_columns): '' expected type 'string', got unconvertible type '[]interface {}'
```
