### PR TITLE
ForceNew OpsWorks Stack on ChefVersion Change

### DIFF
--- a/aws/resource_aws_opsworks_stack.go
+++ b/aws/resource_aws_opsworks_stack.go
@@ -77,6 +77,7 @@ func resourceAwsOpsworksStack() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "11.10",
+				ForceNew: true
 			},
 
 			"manage_berkshelf": {


### PR DESCRIPTION
Hi there 👋 

I've only worked in Golang a few times in my life, and I only recently started using Terraform at my workplace for managing our servers...but I realized that my OpsWorks stack can't be changed to the newer version right now.

From AWS Management Console, it looks like a new resource is required to make changes to the Chef version.

<img width="639" alt="tfopsworksinvalid" src="https://user-images.githubusercontent.com/3521186/39073652-1e16ecd8-44b4-11e8-9ce2-e1945658320d.png">
<img width="589" alt="opsworkscheflocked" src="https://user-images.githubusercontent.com/3521186/39073700-44c6963a-44b4-11e8-8547-6876b1d827eb.png">