### PR TITLE
data-source/iam_instance_profile: export attributes role_arn and role_name

### DIFF
--- a/aws/data_source_aws_iam_instance_profile.go
+++ b/aws/data_source_aws_iam_instance_profile.go
@@ -31,7 +31,15 @@ func dataSourceAwsIAMInstanceProfile() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"role_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"role_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"role_name": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -64,9 +72,11 @@ func dataSourceAwsIAMInstanceProfileRead(d *schema.ResourceData, meta interface{
 	d.Set("create_date", fmt.Sprintf("%v", instanceProfile.CreateDate))
 	d.Set("path", instanceProfile.Path)
 
-	for _, r := range instanceProfile.Roles {
-		d.Set("role_id", r.RoleId)
-	}
+	// it's guaranteed that instanceProfile.Roles exists and has one element
+	role := instanceProfile.Roles[0]
+	d.Set("role_arn", role.Arn)
+	d.Set("role_id", role.RoleId)
+	d.Set("role_name", role.RoleName)
 
 	return nil
 }

--- a/aws/data_source_aws_iam_instance_profile_test.go
+++ b/aws/data_source_aws_iam_instance_profile_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 func TestAccAWSDataSourceIAMInstanceProfile_basic(t *testing.T) {
-	roleName := fmt.Sprintf("test-datasource-user-%d", acctest.RandInt())
-	profileName := fmt.Sprintf("test-datasource-user-%d", acctest.RandInt())
+	roleName := fmt.Sprintf("tf-acc-ds-instance-profile-role-%d", acctest.RandInt())
+	profileName := fmt.Sprintf("tf-acc-ds-instance-profile-%d", acctest.RandInt())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -20,10 +20,19 @@ func TestAccAWSDataSourceIAMInstanceProfile_basic(t *testing.T) {
 			{
 				Config: testAccDatasourceAwsIamInstanceProfileConfig(roleName, profileName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.aws_iam_instance_profile.test", "role_id"),
+					resource.TestMatchResourceAttr(
+						"data.aws_iam_instance_profile.test",
+						"arn",
+						regexp.MustCompile("^arn:aws:iam::[0-9]{12}:instance-profile/testpath/"+profileName+"$"),
+					),
 					resource.TestCheckResourceAttr("data.aws_iam_instance_profile.test", "path", "/testpath/"),
-					resource.TestMatchResourceAttr("data.aws_iam_instance_profile.test", "arn",
-						regexp.MustCompile("^arn:aws:iam::[0-9]{12}:instance-profile/testpath/"+profileName+"$")),
+					resource.TestMatchResourceAttr(
+						"data.aws_iam_instance_profile.test",
+						"role_arn",
+						regexp.MustCompile("^arn:aws:iam::[0-9]{12}:role/"+roleName+"$"),
+					),
+					resource.TestCheckResourceAttrSet("data.aws_iam_instance_profile.test", "role_id"),
+					resource.TestCheckResourceAttr("data.aws_iam_instance_profile.test", "role_name", roleName),
 				),
 			},
 		},

--- a/website/docs/d/iam_instance_profile.html.markdown
+++ b/website/docs/d/iam_instance_profile.html.markdown
@@ -9,7 +9,7 @@ description: |-
 # Data Source: aws_iam_instance_profile
 
 This data source can be used to fetch information about a specific
-IAM instance profile. By using this data source, you can reference IAM 
+IAM instance profile. By using this data source, you can reference IAM
 instance profile properties without having to hard code ARNs as input.
 
 ## Example Usage
@@ -33,4 +33,8 @@ data "aws_iam_instance_profile" "example" {
 
 * `path` - The path to the instance profile.
 
+* `role_arn` - The role arn associated with this instance profile.
+
 * `role_id` - The role id associated with this instance profile.
+
+* `role_name` - The role name associated with this instance profile.


### PR DESCRIPTION
fix #4080 

As arn and name are most likely concerned when reading instance profile.

```
  make fmt; and echo > aws/debug.log ; and make testacc TEST=./aws TESTARGS='-run=TestAccAWSDataSourceIAMInstanceProfile_basic'
gofmt -w $(find . -name '*.go' |grep -v vendor)
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSDataSourceIAMInstanceProfile_basic -timeout 120m
=== RUN   TestAccAWSDataSourceIAMInstanceProfile_basic
--- PASS: TestAccAWSDataSourceIAMInstanceProfile_basic (41.35s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	41.413s
```