### PR TITLE
Iot Endpoint Data Source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ BUG FIXES:
 * resource/aws_lambda_function: Only retry IAM eventual consistency errors for one minute [GH-3765]
 * resource/aws_ssm_association: Prevent AssociationDoesNotExist error [GH-3776]
 * resource/aws_vpc_endpoint: Prevent perpertual diff in non-standard partitions [GH-3317]
+* resource/aws_dynamodb_table: Update and validate attributes correctly [GH-3194]
 
 ## 1.11.0 (March 09, 2018)
 

--- a/aws/data_source_aws_iot_endpoint.go
+++ b/aws/data_source_aws_iot_endpoint.go
@@ -1,0 +1,37 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iot"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsIotEndpoint() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsIotEndpointRead,
+		Schema: map[string]*schema.Schema{
+			"endpoint_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsIotEndpointRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).iotconn
+	input := &iot.DescribeEndpointInput{}
+
+	output, err := conn.DescribeEndpoint(input)
+	if err != nil {
+		return fmt.Errorf("error while describing iot endpoint: %s", err)
+	}
+	endpointAddress := aws.StringValue(output.EndpointAddress)
+	d.SetId(endpointAddress)
+	if err := d.Set("endpoint_address", endpointAddress); err != nil {
+		return fmt.Errorf("error setting endpoint_address: %s", err)
+	}
+	return nil
+}

--- a/aws/data_source_aws_iot_endpoint_test.go
+++ b/aws/data_source_aws_iot_endpoint_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccAWSIotEndpoint(t *testing.T) {
+func TestAccAWSIotEndpointDataSource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -14,8 +14,8 @@ func TestAccAWSIotEndpoint(t *testing.T) {
 			resource.TestStep{
 				Config: testAccAWSIotEndpointConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("aws_iot_endpoint.example", "id"),
-					resource.TestCheckResourceAttrSet("aws_iot_endpoint.example", "endpoint_address"),
+					resource.TestCheckResourceAttrSet("data.aws_iot_endpoint.example", "id"),
+					resource.TestCheckResourceAttrSet("data.aws_iot_endpoint.example", "endpoint_address"),
 				),
 			},
 		},

--- a/aws/data_source_aws_iot_endpoint_test.go
+++ b/aws/data_source_aws_iot_endpoint_test.go
@@ -1,0 +1,27 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSIotEndpoint(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSIotEndpointConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("aws_iot_endpoint.example", "id"),
+					resource.TestCheckResourceAttrSet("aws_iot_endpoint.example", "endpoint_address"),
+				),
+			},
+		},
+	})
+}
+
+const testAccAWSIotEndpointConfig = `
+data "aws_iot_endpoint" "example" {}
+`

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -200,6 +200,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_iam_server_certificate":           dataSourceAwsIAMServerCertificate(),
 			"aws_iam_user":                         dataSourceAwsIAMUser(),
 			"aws_internet_gateway":                 dataSourceAwsInternetGateway(),
+			"aws_iot_endpoint":                     dataSourceAwsIotEndpoint(),
 			"aws_inspector_rules_packages":         dataSourceAwsInspectorRulesPackages(),
 			"aws_instance":                         dataSourceAwsInstance(),
 			"aws_instances":                        dataSourceAwsInstances(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -163,6 +163,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-internet-gateway") %>>
                           <a href="/docs/providers/aws/d/internet_gateway.html">aws_internet_gateway</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-iot-endpoint") %>>
+                          <a href="/docs/providers/aws/d/iot_endpoint.html">aws_iot_endpoint</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-ip_ranges") %>>
                             <a href="/docs/providers/aws/d/ip_ranges.html">aws_ip_ranges</a>
                         </li>

--- a/website/docs/d/iot_endpoint.html.markdown
+++ b/website/docs/d/iot_endpoint.html.markdown
@@ -1,0 +1,44 @@
+---
+layout: "aws"
+page_title: "AWS: aws_iot_endpoint"
+sidebar_current: "docs-aws-datasource-iot-endpoint"
+description: |-
+  Get the unique IoT endpoint
+---
+
+# Data Source: aws_iot_endpoint
+
+Returns a unique endpoint specific to the AWS account making the call.
+
+## Example Usage
+
+```hcl
+data "aws_iot_endpoint" "example" {}
+
+resource "kubernetes_pod" "agent" {
+  metadata {
+    name = "my-device"
+  }
+  spec {
+    container {
+      image = "gcr.io/my-project/image-name"
+      name  = "image-name"
+
+      env = [
+        {
+          name  = "IOT_ENDPOINT"
+          value = "${data.aws_iot_endpoint.example.endpoint_address}"
+        },
+      ]
+    }
+  }
+}
+```
+
+## Argument Reference
+
+N/A
+
+## Attributes Reference
+
+* `endpoint_address` - The endpoint. The format of the endpoint is as follows: identifier .iot.*region* .amazonaws.com.


### PR DESCRIPTION
The iot endpoint is unique per account and is needed for connecting things to the iot registry. By having a data source for the iot endpoint, now it is possible to configure your things as part of a regular terraform deployment.