### PR TITLE
resource/api_gateway_vpc_link: support import

### DIFF
--- a/aws/resource_aws_api_gateway_vpc_link.go
+++ b/aws/resource_aws_api_gateway_vpc_link.go
@@ -17,6 +17,9 @@ func resourceAwsApiGatewayVpcLink() *schema.Resource {
 		Read:   resourceAwsApiGatewayVpcLinkRead,
 		Update: resourceAwsApiGatewayVpcLinkUpdate,
 		Delete: resourceAwsApiGatewayVpcLinkDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/aws/resource_aws_api_gateway_vpc_link_test.go
+++ b/aws/resource_aws_api_gateway_vpc_link_test.go
@@ -40,6 +40,26 @@ func TestAccAWSAPIGatewayVpcLink_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSAPIGatewayVpcLink_importBasic(t *testing.T) {
+	rName := acctest.RandString(5)
+	resourceName := "aws_api_gateway_vpc_link.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAPIGatewayVpcLinkConfig(rName),
+			},
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAwsAPIGatewayVpcLinkDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).apigateway
 

--- a/website/docs/r/api_gateway_vpc_link.html.markdown
+++ b/website/docs/r/api_gateway_vpc_link.html.markdown
@@ -43,3 +43,11 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The identifier of the VpcLink.
+
+## Import
+
+API Gateway VPC Link can be imported using the `id`, e.g.
+
+```
+$ terraform import aws_api_gateway_vpc_link.example <vpc_link_id>
+```


### PR DESCRIPTION
fix #3893 

```
⎇  make fmt; and echo > aws/debug.log ; and make testacc TEST=./aws TESTARGS='-run=TestAccAWSAPIGatewayVpcLink_importBasic'
gofmt -w $(find . -name '*.go' |grep -v vendor)
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSAPIGatewayVpcLink_importBasic -timeout 120m
=== RUN   TestAccAWSAPIGatewayVpcLink_importBasic
--- PASS: TestAccAWSAPIGatewayVpcLink_importBasic (794.67s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	794.728s
```