### PR TITLE
Drop not-working cloudtrail example

### DIFF
--- a/website/docs/r/cloudtrail.html.markdown
+++ b/website/docs/r/cloudtrail.html.markdown
@@ -18,15 +18,6 @@ Enable CloudTrail to capture all compatible management events in region.
 For capturing events from services like IAM, `include_global_service_events` must be enabled.
 
 ```hcl
-resource "aws_cloudtrail" "example" {
-  name                          = "basic-example"
-  include_global_service_events = false
-}
-```
-
-### Logging to S3
-
-```hcl
 resource "aws_cloudtrail" "foobar" {
   name                          = "tf-trail-foobar"
   s3_bucket_name                = "${aws_s3_bucket.foo.id}"


### PR DESCRIPTION
Logging to s3 is the only option for the cloudtrail resource. So the current basic example doesn't work, and incorrectly implies that it's possible to log to someplace other than s3. This patch drops the basic example and relabels the s3 example as basic, since that's the simplest working configuration.