### PR TITLE
d/aws_instance: add missing disable_api_termination attribute

### DIFF
--- a/aws/data_source_aws_instance.go
+++ b/aws/data_source_aws_instance.go
@@ -234,6 +234,10 @@ func dataSourceAwsInstance() *schema.Resource {
 					},
 				},
 			},
+			"disable_api_termination": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 		},
 	}
 }


### PR DESCRIPTION
@bflad The `disable_api_termination` attribute was missing from the data source as was noticed in https://github.com/terraform-providers/terraform-provider-aws/pull/2619