### PR TITLE
updating URI reference in the aws_api_gateway_integration block

### DIFF
--- a/website/docs/guides/serverless-with-aws-lambda-and-api-gateway.html.md
+++ b/website/docs/guides/serverless-with-aws-lambda-and-api-gateway.html.md
@@ -319,7 +319,7 @@ resource "aws_api_gateway_integration" "lambda" {
 
   integration_http_method = "POST"
   type                    = "AWS_PROXY"
-  uri                     = "${aws_lambda_function.main.invoke_arn}"
+  uri                     = "${aws_lambda_function.example.invoke_arn}"
 }
 ```
 


### PR DESCRIPTION
When following the guide here the URI reference for the aws_api_gateway_integration block incorrectly references:

uri                     = "${aws_lambda_function.main.invoke_arn}"

instead of:

uri                     = "${aws_lambda_function.example.invoke_arn}"


Thank you!