### PR TITLE
r/aws_launch_template: Fix various bugs

### DIFF
--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -597,7 +597,7 @@ func getBlockDeviceMappings(m []*ec2.LaunchTemplateBlockDeviceMapping) []interfa
 				ebs["snapshot_id"] = aws.StringValue(v.Ebs.SnapshotId)
 			}
 
-			mapping["ebs"] = ebs
+			mapping["ebs"] = []interface{}{ebs}
 		}
 		s = append(s, mapping)
 	}

--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -882,16 +882,16 @@ func buildLaunchTemplateData(d *schema.ResourceData, meta interface{}) (*ec2.Req
 func readBlockDeviceMappingFromConfig(bdm map[string]interface{}) *ec2.LaunchTemplateBlockDeviceMappingRequest {
 	blockDeviceMapping := &ec2.LaunchTemplateBlockDeviceMappingRequest{}
 
-	if v := bdm["device_name"]; v != nil {
-		blockDeviceMapping.DeviceName = aws.String(v.(string))
+	if v := bdm["device_name"].(string); v != "" {
+		blockDeviceMapping.DeviceName = aws.String(v)
 	}
 
-	if v := bdm["no_device"]; v != nil {
-		blockDeviceMapping.NoDevice = aws.String(v.(string))
+	if v := bdm["no_device"].(string); v != "" {
+		blockDeviceMapping.NoDevice = aws.String(v)
 	}
 
-	if v := bdm["virtual_name"]; v != nil {
-		blockDeviceMapping.VirtualName = aws.String(v.(string))
+	if v := bdm["virtual_name"].(string); v != "" {
+		blockDeviceMapping.VirtualName = aws.String(v)
 	}
 
 	if v := bdm["ebs"]; len(v.([]interface{})) > 0 {
@@ -920,20 +920,20 @@ func readEbsBlockDeviceFromConfig(ebs map[string]interface{}) *ec2.LaunchTemplat
 		ebsDevice.Iops = aws.Int64(int64(v.(int)))
 	}
 
-	if v := ebs["kms_key_id"]; v != nil {
-		ebsDevice.KmsKeyId = aws.String(v.(string))
+	if v := ebs["kms_key_id"].(string); v != "" {
+		ebsDevice.KmsKeyId = aws.String(v)
 	}
 
-	if v := ebs["snapshot_id"]; v != nil {
-		ebsDevice.SnapshotId = aws.String(v.(string))
+	if v := ebs["snapshot_id"].(string); v != "" {
+		ebsDevice.SnapshotId = aws.String(v)
 	}
 
 	if v := ebs["volume_size"]; v != nil {
 		ebsDevice.VolumeSize = aws.Int64(int64(v.(int)))
 	}
 
-	if v := ebs["volume_type"]; v != nil {
-		ebsDevice.VolumeType = aws.String(v.(string))
+	if v := ebs["volume_type"].(string); v != "" {
+		ebsDevice.VolumeType = aws.String(v)
 	}
 
 	return ebsDevice

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1751,8 +1751,8 @@ func validateLaunchTemplateName(v interface{}, k string) (ws []string, errors []
 		errors = append(errors, fmt.Errorf("%q cannot be longer than 99 characters, name is limited to 125", k))
 	} else if !strings.HasSuffix(k, "prefix") && len(value) > 125 {
 		errors = append(errors, fmt.Errorf("%q cannot be longer than 125 characters", k))
-	} else if !regexp.MustCompile(`^[0-9a-zA-Z()./_]+$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf("%q can only alphanumeric characters and ()./_ symbols", k))
+	} else if !regexp.MustCompile(`^[0-9a-zA-Z()./_\-]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf("%q can only alphanumeric characters and ()./_- symbols", k))
 	}
 	return
 }

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -2537,7 +2537,6 @@ func TestValidateLaunchTemplateName(t *testing.T) {
 	invalidNames := []string{
 		"tf",
 		strings.Repeat("W", 126), // > 125
-		"invalid-",
 		"invalid*",
 		"invalid\name",
 		"inavalid&",

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -17,7 +17,17 @@ resource "aws_launch_template" "foo" {
   name = "foo"
 
   block_device_mappings {
-    device_name = "test"
+    # to change the type or size of the root volume, override the ami's root device name
+    # you can figure this out based on the ami id by running:
+    # aws ec2 describe-images --region us-west-2 --image-id ami-4e79ed36
+    device_name = "/dev/sda1"
+    ebs {
+      volume_size = 20
+    }
+  }
+
+  block_device_mappings {
+    device_name = "/dev/xvdb"
   }
 
   credit_specification {

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -10,8 +10,6 @@ description: |-
 
 Provides an EC2 launch template resource. Can be used to create instances or auto scaling groups.
 
--> **Note:** All arguments are optional except for either `name`, or `name_prefix`.
-
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
These three commits fixes the following errors:

- > Error: aws_launch_template.default: "name_prefix" can only alphanumeric characters and ()./_ symbols
- > * aws_launch_template.default: InvalidSnapshotID.Malformed: The snapshot ID '' is not valid. The expected format is snap-xxxxxxxx or snap-xxxxxxxxxxxxxxxxx.
  >  status code: 400, request id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
- > * aws_launch_template.default: block_device_mappings.0.ebs: '': source data must be an array or slice, got map

I am not sure if there are more things to fix for the middle one.. The problem is that empty strings were used when the properties were not defined (such as `snapshot_id`). I tried to find other places in the code that had similar conventions, and I just used the first one that worked for me.

I still haven't learned how to run the tests, so if anyone thinks there needs to be tests added, then please feel free to add them to this PR (edits from maintainers are allowed).