### PR TITLE
Add tag group support for codedeploy-deployment-group

### DIFF
--- a/aws/resource_aws_codedeploy_deployment_group.go
+++ b/aws/resource_aws_codedeploy_deployment_group.go
@@ -245,6 +245,40 @@ func resourceAwsCodeDeployDeploymentGroup() *schema.Resource {
 				ValidateFunc: validateMaxLength(100),
 			},
 
+			"ec2_tag_set": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ec2_tag_filter": &schema.Schema{
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": &schema.Schema{
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+
+									"type": &schema.Schema{
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validateTagFilters,
+									},
+
+									"value": &schema.Schema{
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+							Set: resourceAwsCodeDeployTagFilterHash,
+						},
+					},
+				},
+				Set: resourceAwsCodeDeployTagSetHash,
+			},
+
 			"ec2_tag_filter": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -367,9 +401,12 @@ func resourceAwsCodeDeployDeploymentGroupCreate(d *schema.ResourceData, meta int
 		input.OnPremisesInstanceTagFilters = onPremFilters
 	}
 
+	if attr, ok := d.GetOk("ec2_tag_set"); ok {
+		input.Ec2TagSet = buildEC2TagSet(attr.(*schema.Set).List())
+	}
+
 	if attr, ok := d.GetOk("ec2_tag_filter"); ok {
-		ec2TagFilters := buildEC2TagFilters(attr.(*schema.Set).List())
-		input.Ec2TagFilters = ec2TagFilters
+		input.Ec2TagFilters = buildEC2TagFilters(attr.(*schema.Set).List())
 	}
 
 	if attr, ok := d.GetOk("trigger_configuration"); ok {
@@ -460,6 +497,10 @@ func resourceAwsCodeDeployDeploymentGroupRead(d *schema.ResourceData, meta inter
 		return err
 	}
 
+	if err := d.Set("ec2_tag_set", ec2TagSetToMap(resp.DeploymentGroupInfo.Ec2TagSet)); err != nil {
+		return err
+	}
+
 	if err := d.Set("ec2_tag_filter", ec2TagFiltersToMap(resp.DeploymentGroupInfo.Ec2TagFilters)); err != nil {
 		return err
 	}
@@ -525,6 +566,12 @@ func resourceAwsCodeDeployDeploymentGroupUpdate(d *schema.ResourceData, meta int
 		_, n := d.GetChange("on_premises_instance_tag_filter")
 		onPremFilters := buildOnPremTagFilters(n.(*schema.Set).List())
 		input.OnPremisesInstanceTagFilters = onPremFilters
+	}
+
+	if d.HasChange("ec2_tag_set") {
+		_, n := d.GetChange("ec2_tag_set")
+		ec2TagSet := buildEC2TagSet(n.(*schema.Set).List())
+		input.Ec2TagSet = ec2TagSet
 	}
 
 	if d.HasChange("ec2_tag_filter") {
@@ -653,6 +700,18 @@ func buildEC2TagFilters(configured []interface{}) []*codedeploy.EC2TagFilter {
 	}
 
 	return filters
+}
+
+// buildEC2TagSet converts raw schema lists into a codedeploy.EC2TagSet.
+func buildEC2TagSet(configured []interface{}) *codedeploy.EC2TagSet {
+	filterSets := make([][]*codedeploy.EC2TagFilter, 0)
+	for _, raw := range configured {
+		m := raw.(map[string]interface{})
+		rawFilters := m["ec2_tag_filter"].(*schema.Set)
+		filters := buildEC2TagFilters(rawFilters.List())
+		filterSets = append(filterSets, filters)
+	}
+	return &codedeploy.EC2TagSet{Ec2TagSetList: filterSets}
 }
 
 // buildTriggerConfigs converts a raw schema list into a list of
@@ -846,11 +905,11 @@ func expandBlueGreenDeploymentConfig(list []interface{}) *codedeploy.BlueGreenDe
 	return blueGreenDeploymentConfig
 }
 
-// ec2TagFiltersToMap converts lists of tag filters into a []map[string]string.
-func ec2TagFiltersToMap(list []*codedeploy.EC2TagFilter) []map[string]string {
-	result := make([]map[string]string, 0, len(list))
+// ec2TagFiltersToMap converts lists of tag filters into a []map[string]interface{}.
+func ec2TagFiltersToMap(list []*codedeploy.EC2TagFilter) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(list))
 	for _, tf := range list {
-		l := make(map[string]string)
+		l := make(map[string]interface{})
 		if tf.Key != nil && *tf.Key != "" {
 			l["key"] = *tf.Key
 		}
@@ -880,6 +939,28 @@ func onPremisesTagFiltersToMap(list []*codedeploy.TagFilter) []map[string]string
 			l["type"] = *tf.Type
 		}
 		result = append(result, l)
+	}
+	return result
+}
+
+// ec2TagSetToMap converts lists of tag filters into a [][]map[string]string.
+func ec2TagSetToMap(tagSet *codedeploy.EC2TagSet) []map[string]interface{} {
+	var result []map[string]interface{}
+	if tagSet == nil {
+		result = make([]map[string]interface{}, 0)
+	} else {
+		result = make([]map[string]interface{}, 0, len(tagSet.Ec2TagSetList))
+		for _, filterSet := range tagSet.Ec2TagSetList {
+			filters := ec2TagFiltersToMap(filterSet)
+			filtersAsIntfSlice := make([]interface{}, 0, len(filters))
+			for _, item := range filters {
+				filtersAsIntfSlice = append(filtersAsIntfSlice, item)
+			}
+			tagFilters := map[string]interface{}{
+				"ec2_tag_filter": schema.NewSet(resourceAwsCodeDeployTagFilterHash, filtersAsIntfSlice),
+			}
+			result = append(result, tagFilters)
+		}
 	}
 	return result
 }
@@ -1065,6 +1146,19 @@ func resourceAwsCodeDeployTagFilterHash(v interface{}) int {
 	}
 
 	return hashcode.String(buf.String())
+}
+
+func resourceAwsCodeDeployTagSetHash(v interface{}) int {
+	tagSetMap := v.(map[string]interface{})
+	filterSet := tagSetMap["ec2_tag_filter"]
+	filterSetSlice := filterSet.(*schema.Set).List()
+
+	var x uint64
+	x = 1
+	for i, filter := range filterSetSlice {
+		x = ((x << 7) | (x >> (64 - 7))) ^ uint64(i) ^ uint64(resourceAwsCodeDeployTagFilterHash(filter))
+	}
+	return int(x)
 }
 
 func resourceAwsCodeDeployTriggerConfigHash(v interface{}) int {

--- a/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -28,7 +28,7 @@ func TestAccAWSCodeDeployDeploymentGroup_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSCodeDeployDeploymentGroup(rName),
+				Config: testAccAWSCodeDeployDeploymentGroup(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo", &group),
 					resource.TestCheckResourceAttr(
@@ -41,6 +41,8 @@ func TestAccAWSCodeDeployDeploymentGroup_basic(t *testing.T) {
 						"aws_codedeploy_deployment_group.foo", "service_role_arn",
 						regexp.MustCompile("arn:aws:iam::[0-9]{12}:role/foo_role_.*")),
 
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "ec2_tag_set.#", "0"),
 					resource.TestCheckResourceAttr(
 						"aws_codedeploy_deployment_group.foo", "ec2_tag_filter.#", "1"),
 					resource.TestCheckResourceAttr(
@@ -59,7 +61,7 @@ func TestAccAWSCodeDeployDeploymentGroup_basic(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccAWSCodeDeployDeploymentGroupModified(rName),
+				Config: testAccAWSCodeDeployDeploymentGroupModified(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo", &group),
 					resource.TestCheckResourceAttr(
@@ -73,6 +75,8 @@ func TestAccAWSCodeDeployDeploymentGroup_basic(t *testing.T) {
 						regexp.MustCompile("arn:aws:iam::[0-9]{12}:role/bar_role_.*")),
 
 					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "ec2_tag_set.#", "0"),
+					resource.TestCheckResourceAttr(
 						"aws_codedeploy_deployment_group.foo", "ec2_tag_filter.#", "1"),
 					resource.TestCheckResourceAttr(
 						"aws_codedeploy_deployment_group.foo", "ec2_tag_filter.2369538975.key", "filterkey"),
@@ -80,6 +84,90 @@ func TestAccAWSCodeDeployDeploymentGroup_basic(t *testing.T) {
 						"aws_codedeploy_deployment_group.foo", "ec2_tag_filter.2369538975.type", "KEY_AND_VALUE"),
 					resource.TestCheckResourceAttr(
 						"aws_codedeploy_deployment_group.foo", "ec2_tag_filter.2369538975.value", "anotherfiltervalue"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "alarm_configuration.#", "0"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "auto_rollback_configuration.#", "0"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "trigger_configuration.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeDeployDeploymentGroup_basic_tagSet(t *testing.T) {
+	var group codedeploy.DeploymentGroupInfo
+
+	rName := acctest.RandString(5)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSCodeDeployDeploymentGroup(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "app_name", "foo_app_"+rName),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "deployment_group_name", "foo_"+rName),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "deployment_config_name", "CodeDeployDefault.OneAtATime"),
+					resource.TestMatchResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "service_role_arn",
+						regexp.MustCompile("arn:aws:iam::[0-9]{12}:role/foo_role_.*")),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "ec2_tag_set.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "ec2_tag_set.2916377593.ec2_tag_filter.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "ec2_tag_set.2916377593.ec2_tag_filter.2916377465.key", "filterkey"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "ec2_tag_set.2916377593.ec2_tag_filter.2916377465.type", "KEY_AND_VALUE"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "ec2_tag_set.2916377593.ec2_tag_filter.2916377465.value", "filtervalue"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "ec2_tag_filter.#", "0"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "alarm_configuration.#", "0"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "auto_rollback_configuration.#", "0"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "trigger_configuration.#", "0"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSCodeDeployDeploymentGroupModified(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "app_name", "foo_app_"+rName),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "deployment_group_name", "bar_"+rName),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "deployment_config_name", "CodeDeployDefault.OneAtATime"),
+					resource.TestMatchResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "service_role_arn",
+						regexp.MustCompile("arn:aws:iam::[0-9]{12}:role/bar_role_.*")),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "ec2_tag_set.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "ec2_tag_set.2369538847.ec2_tag_filter.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "ec2_tag_set.2369538847.ec2_tag_filter.2369538975.key", "filterkey"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "ec2_tag_set.2369538847.ec2_tag_filter.2369538975.type", "KEY_AND_VALUE"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "ec2_tag_set.2369538847.ec2_tag_filter.2369538975.value", "anotherfiltervalue"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo", "ec2_tag_filter.#", "0"),
 
 					resource.TestCheckResourceAttr(
 						"aws_codedeploy_deployment_group.foo", "alarm_configuration.#", "0"),
@@ -138,7 +226,7 @@ func TestAccAWSCodeDeployDeploymentGroup_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSCodeDeployDeploymentGroup(rName),
+				Config: testAccAWSCodeDeployDeploymentGroup(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo", &group),
 					testAccAWSCodeDeployDeploymentGroupDisappears(&group),
@@ -1786,7 +1874,26 @@ func testAccCheckAWSCodeDeployDeploymentGroupExists(name string, group *codedepl
 	}
 }
 
-func testAccAWSCodeDeployDeploymentGroup(rName string) string {
+func testAccAWSCodeDeployDeploymentGroup(rName string, tagGroup bool) string {
+	var tagGroupOrFilter string
+	if tagGroup {
+		tagGroupOrFilter = `ec2_tag_set {
+    ec2_tag_filter {
+      key = "filterkey"
+      type = "KEY_AND_VALUE"
+      value = "filtervalue"
+    }
+  }
+`
+	} else {
+		tagGroupOrFilter = `ec2_tag_filter {
+    key = "filterkey"
+    type = "KEY_AND_VALUE"
+    value = "filtervalue"
+  }
+`
+	}
+
 	return fmt.Sprintf(`
 resource "aws_codedeploy_app" "foo_app" {
   name = "foo_app_%s"
@@ -1845,15 +1952,30 @@ resource "aws_codedeploy_deployment_group" "foo" {
   app_name = "${aws_codedeploy_app.foo_app.name}"
   deployment_group_name = "foo_%s"
   service_role_arn = "${aws_iam_role.foo_role.arn}"
-  ec2_tag_filter {
-    key = "filterkey"
-    type = "KEY_AND_VALUE"
-    value = "filtervalue"
-  }
-}`, rName, rName, rName, rName)
+  %s
+}`, rName, rName, rName, rName, tagGroupOrFilter)
 }
 
-func testAccAWSCodeDeployDeploymentGroupModified(rName string) string {
+func testAccAWSCodeDeployDeploymentGroupModified(rName string, tagGroup bool) string {
+	var tagGroupOrFilter string
+	if tagGroup {
+		tagGroupOrFilter = `ec2_tag_set {
+    ec2_tag_filter {
+      key = "filterkey"
+      type = "KEY_AND_VALUE"
+      value = "anotherfiltervalue"
+    }
+  }
+`
+	} else {
+		tagGroupOrFilter = `ec2_tag_filter {
+    key = "filterkey"
+    type = "KEY_AND_VALUE"
+    value = "anotherfiltervalue"
+  }
+`
+	}
+
 	return fmt.Sprintf(`
 resource "aws_codedeploy_app" "foo_app" {
   name = "foo_app_%s"
@@ -1912,12 +2034,8 @@ resource "aws_codedeploy_deployment_group" "foo" {
   app_name = "${aws_codedeploy_app.foo_app.name}"
   deployment_group_name = "bar_%s"
   service_role_arn = "${aws_iam_role.bar_role.arn}"
-  ec2_tag_filter {
-    key = "filterkey"
-    type = "KEY_AND_VALUE"
-    value = "anotherfiltervalue"
-  }
-}`, rName, rName, rName, rName)
+  %s
+}`, rName, rName, rName, rName, tagGroupOrFilter)
 }
 
 func testAccAWSCodeDeployDeploymentGroupOnPremiseTags(rName string) string {

--- a/website/docs/r/codedeploy_deployment_group.html.markdown
+++ b/website/docs/r/codedeploy_deployment_group.html.markdown
@@ -77,10 +77,18 @@ resource "aws_codedeploy_deployment_group" "example" {
   deployment_group_name = "example-group"
   service_role_arn      = "${aws_iam_role.example.arn}"
 
-  ec2_tag_filter {
-    key   = "filterkey"
-    type  = "KEY_AND_VALUE"
-    value = "filtervalue"
+  ec2_tag_set {
+    ec2_tag_filter {
+      key   = "filterkey1"
+      type  = "KEY_AND_VALUE"
+      value = "filtervalue"
+    }
+
+    ec2_tag_filter {
+      key   = "filterkey2"
+      type  = "KEY_AND_VALUE"
+      value = "filtervalue"
+    }
   }
 
   trigger_configuration {
@@ -150,7 +158,8 @@ The following arguments are supported:
 * `service_role_arn` - (Required) The service role ARN that allows deployments.
 * `autoscaling_groups` - (Optional) Autoscaling groups associated with the deployment group.
 * `deployment_config_name` - (Optional) The name of the group's deployment config. The default is "CodeDeployDefault.OneAtATime".
-* `ec2_tag_filter` - (Optional) Tag filters associated with the group. See the AWS docs for details.
+* `ec2_tag_filter` - (Optional) Tag filters associated with the deployment group. See the AWS docs for details.
+* `ec2_tag_set` - (Optional) Sets of Tag filters associated with the deployment group, which are referred to as *tag groups* in the document.  See the AWS docs for details.
 * `on_premises_instance_tag_filter` - (Optional) On premise tag filters associated with the group. See the AWS docs for details.
 * `trigger_configuration` - (Optional) Trigger Configurations for the deployment group (documented below).
 * `auto_rollback_configuration` - (Optional) The automatic rollback configuration associated with the deployment group (documented below).
@@ -165,6 +174,13 @@ Both `ec2_tag_filter` and `on_premises_tag_filter` support the following:
 * `key` - (Optional) The key of the tag filter.
 * `type` - (Optional) The type of the tag filter, either `KEY_ONLY`, `VALUE_ONLY`, or `KEY_AND_VALUE`.
 * `value` - (Optional) The value of the tag filter.
+
+Multiple occurrences of `ec2_tag_filter` are allowed, where any instance that matches to at least one of the tag filters is selected.
+
+
+### Tag Groups
+You can form a tag group by putting a set of tag filters into `ec2_tag_set`. If multiple tag groups are specified, any instance that matches to at least one tag filter of every tag group is selected.
+
 
 ### Trigger Configuration
 Add triggers to a Deployment Group to receive notifications about events related to deployments or instances in the group. Notifications are sent to subscribers of the **SNS** topic associated with the trigger. _CodeDeploy must have permission to publish to the topic from this deployment group_. `trigger_configuration` supports the following:


### PR DESCRIPTION
This patch implements #2073 (#2930) .
