### PR TITLE
docs/resource/aws_ssm_association: Prefer targets InstanceIds over instance_id for schema version 2.0+

### DIFF
--- a/website/docs/r/ssm_association.html.markdown
+++ b/website/docs/r/ssm_association.html.markdown
@@ -60,7 +60,10 @@ DOC
 
 resource "aws_ssm_association" "foo" {
   name        = "test_document_association-%s"
-  instance_id = "${aws_instance.foo.id}"
+  targets {
+    key    = "InstanceIds"
+    values = "${aws_instance.foo.id}"
+  }
 }
 ```
 
@@ -71,7 +74,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the SSM document to apply.
 * `association_name` - (Optional) The descriptive name for the association.
 * `document_version` - (Optional) The document version you want to associate with the target(s). Can be a specific version or the default version.
-* `instance_id` - (Optional) The instance ID to apply an SSM document to.
+* `instance_id` - (Optional) The instance ID to apply an SSM document to. Use `targets` with key `InstanceIds` for document schema versions 2.0 and above.
 * `output_location` - (Optional) An output location block. Output Location is documented below.
 * `parameters` - (Optional) A block of arbitrary string parameters to pass to the SSM document.
 * `schedule_expression` - (Optional) A cron expression when the association will be applied to the target(s).

--- a/website/docs/r/ssm_association.html.markdown
+++ b/website/docs/r/ssm_association.html.markdown
@@ -13,56 +13,12 @@ Associates an SSM Document to an instance or EC2 tag.
 ## Example Usage
 
 ```hcl
-resource "aws_security_group" "tf_test_foo" {
-  name        = "tf_test_foo"
-  description = "foo"
+resource "aws_ssm_association" "example" {
+  name = "${aws_ssm_document.example.name}"
 
-  ingress {
-    protocol    = "icmp"
-    from_port   = -1
-    to_port     = -1
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-}
-
-resource "aws_instance" "foo" {
-  # eu-west-1
-  ami               = "ami-f77ac884"
-  availability_zone = "eu-west-1a"
-  instance_type     = "t2.small"
-  security_groups   = ["${aws_security_group.tf_test_foo.name}"]
-}
-
-resource "aws_ssm_document" "foo_document" {
-  name          = "test_document_association-%s"
-  document_type = "Command"
-
-  content = <<DOC
-  {
-    "schemaVersion": "1.2",
-    "description": "Check ip configuration of a Linux instance.",
-    "parameters": {
-
-    },
-    "runtimeConfig": {
-      "aws:runShellScript": {
-        "properties": [
-          {
-            "id": "0.aws:runShellScript",
-            "runCommand": ["ifconfig"]
-          }
-        ]
-      }
-    }
-  }
-DOC
-}
-
-resource "aws_ssm_association" "foo" {
-  name        = "test_document_association-%s"
   targets {
     key    = "InstanceIds"
-    values = "${aws_instance.foo.id}"
+    values = "${aws_instance.example.id}"
   }
 }
 ```


### PR DESCRIPTION
Closes #2840 by switching the example from `instance_id` to `targets` and adding note about schema version 2.0+ in `instance_id` argument.