### PR TITLE
Resource aws_route53_zone - count fix

### DIFF
--- a/aws/resource_aws_route53_zone.go
+++ b/aws/resource_aws_route53_zone.go
@@ -89,7 +89,7 @@ func resourceAwsRoute53ZoneCreate(d *schema.ResourceData, meta interface{}) erro
 	req := &route53.CreateHostedZoneInput{
 		Name:             aws.String(d.Get("name").(string)),
 		HostedZoneConfig: &route53.HostedZoneConfig{Comment: aws.String(d.Get("comment").(string))},
-		CallerReference:  aws.String(time.Now().Format(time.RFC3339Nano)),
+		CallerReference:  aws.String(d.Get("name").(string) + time.Now().Format(time.RFC3339Nano)),
 	}
 	if v := d.Get("vpc_id"); v != "" {
 		req.VPC = &route53.VPC{


### PR DESCRIPTION
This PR solves #562.

Add domain name to caller reference to avoid generate non-unique id.
Add test with count parameter in aws_route53_zone resource.

## Test results:
```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSRoute53Zone_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSRoute53Zone_basic
--- PASS: TestAccAWSRoute53Zone_basic (167.43s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	167.460s
```

## Manual tests:

Before:
```
* aws_route53_zone.test[2]: 1 error(s) occurred:

* aws_route53_zone.test.2: HostedZoneAlreadyExists: A hosted zone has already been created with the specified caller reference.
	status code: 409, request id: cd51d304-4882-11e8-9b8e-4dcc7a507192
```
After:

```
Apply complete! Resources: 10 added, 0 changed, 0 destroyed.
```