### PR TITLE
docs/data-source/aws_batch_job_queue: Fix header

### DIFF
--- a/website/docs/d/batch_job_queue.html.markdown
+++ b/website/docs/d/batch_job_queue.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "aws"
-page_title: "AWS: aws_batch_job_queue
-sidebar_current: "docs-aws-datasource-batch-job-queue
+page_title: "AWS: aws_batch_job_queue"
+sidebar_current: "docs-aws-datasource-batch-job-queue"
 description: |-
     Provides details about a batch job queue
 ---


### PR DESCRIPTION
Currently broken: https://www.terraform.io/docs/providers/aws/d/batch_job_queue.html

Will merge into `stable-website` after merge and release website again.