### PR TITLE
fix yaml headers

### DIFF
--- a/website/docs/d/batch_job_queue.html.markdown
+++ b/website/docs/d/batch_job_queue.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "aws"
-page_title: "AWS: aws_batch_job_queue
-sidebar_current: "docs-aws-datasource-batch-job-queue
+page_title: "AWS: aws_batch_job_queue"
+sidebar_current: "docs-aws-datasource-batch-job-queue"
 description: |-
     Provides details about a batch job queue
 ---

--- a/website/docs/r/db_event_subscription.html.markdown
+++ b/website/docs/r/db_event_subscription.html.markdown
@@ -2,6 +2,8 @@
 layout: "aws"
 page_title: "AWS: aws_db_event_subscription"
 sidebar_current: "docs-aws-resource-db-event-subscription"
+description: |-
+  Provides a DB event subscription resource.
 ---
 
 # aws_db_event_subscription

--- a/website/docs/r/db_option_group.html.markdown
+++ b/website/docs/r/db_option_group.html.markdown
@@ -2,6 +2,8 @@
 layout: "aws"
 page_title: "AWS: aws_db_option_group"
 sidebar_current: "docs-aws-resource-db-option-group"
+description: |-
+  Provides an RDS DB option group resource.
 ---
 
 # aws_db_option_group

--- a/website/docs/r/db_parameter_group.html.markdown
+++ b/website/docs/r/db_parameter_group.html.markdown
@@ -2,6 +2,8 @@
 layout: "aws"
 page_title: "AWS: aws_db_parameter_group"
 sidebar_current: "docs-aws-resource-db-parameter-group"
+description: |-
+  Provides an RDS DB parameter group resource.
 ---
 
 # aws_db_parameter_group

--- a/website/docs/r/elasticache_parameter_group.html.markdown
+++ b/website/docs/r/elasticache_parameter_group.html.markdown
@@ -2,6 +2,8 @@
 layout: "aws"
 page_title: "AWS: aws_elasticache_parameter_group"
 sidebar_current: "docs-aws-resource-elasticache-parameter-group"
+description: |-
+  Provides an ElastiCache parameter group resource.
 ---
 
 # aws_elasticache_parameter_group

--- a/website/docs/r/rds_cluster_parameter_group.markdown
+++ b/website/docs/r/rds_cluster_parameter_group.markdown
@@ -2,6 +2,8 @@
 layout: "aws"
 page_title: "AWS: aws_rds_cluster_parameter_group"
 sidebar_current: "docs-aws-resource-rds-cluster-parameter-group"
+description: |-
+  Provides an RDS DB cluster parameter group resource.
 ---
 
 # aws_rds_cluster_parameter_group

--- a/website/docs/r/redshift_cluster.html.markdown
+++ b/website/docs/r/redshift_cluster.html.markdown
@@ -2,6 +2,8 @@
 layout: "aws"
 page_title: "AWS: aws_redshift_cluster"
 sidebar_current: "docs-aws-resource-redshift-cluster"
+description: |-
+  Provides a Redshift Cluster resource.
 ---
 
 # aws_redshift_cluster

--- a/website/docs/r/redshift_parameter_group.html.markdown
+++ b/website/docs/r/redshift_parameter_group.html.markdown
@@ -2,6 +2,8 @@
 layout: "aws"
 page_title: "AWS: aws_redshift_parameter_group"
 sidebar_current: "docs-aws-resource-redshift-parameter-group"
+description: |-
+  Provides a Redshift Cluster parameter group resource.
 ---
 
 # aws_redshift_parameter_group


### PR DESCRIPTION
Some of the yaml headers that are included in the documentation `.markdown` files were not correct (missing fileds/quotes).