### PR TITLE
aws_instance: Bypass UnsupportedOperation errors with DescribeInstanceCreditSpecifications

### DIFF
--- a/aws/data_source_aws_instance.go
+++ b/aws/data_source_aws_instance.go
@@ -407,7 +407,7 @@ func instanceDescriptionAttributes(d *schema.ResourceData, instance *ec2.Instanc
 	}
 	{
 		creditSpecifications, err := getCreditSpecifications(conn, d.Id())
-		if err != nil {
+		if err != nil && !isAWSErr(err, "UnsupportedOperation", "") {
 			return err
 		}
 		if err := d.Set("credit_specification", creditSpecifications); err != nil {

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -807,7 +807,7 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	{
 		creditSpecifications, err := getCreditSpecifications(conn, d.Id())
-		if err != nil {
+		if err != nil && !isAWSErr(err, "UnsupportedOperation", "") {
 			return err
 		}
 		if err := d.Set("credit_specification", creditSpecifications); err != nil {
@@ -1899,10 +1899,10 @@ func getCreditSpecifications(conn *ec2.EC2, instanceId string) ([]map[string]int
 		InstanceIds: []*string{aws.String(instanceId)},
 	})
 	if err != nil {
-		return nil, err
+		return creditSpecifications, err
 	}
-	if attr.InstanceCreditSpecifications != nil {
-		creditSpecification["cpu_credits"] = *attr.InstanceCreditSpecifications[0].CpuCredits
+	if len(attr.InstanceCreditSpecifications) > 0 {
+		creditSpecification["cpu_credits"] = aws.StringValue(attr.InstanceCreditSpecifications[0].CpuCredits)
 		creditSpecifications = append(creditSpecifications, creditSpecification)
 	}
 


### PR DESCRIPTION
Fixes #4359 

Also prevent possible panics if `DescribeInstanceCreditSpecificationsOutput.InstanceCreditSpecifications` is zero element slice or `CpuCredits` is `nil`

Test failure unrelated
```
Tests failed: 1 (1 new), passed: 68
=== RUN   TestAccAWSInstanceDataSource_tags
--- PASS: TestAccAWSInstanceDataSource_tags (150.89s)
=== RUN   TestAccAWSInstanceDataSource_SecurityGroups
--- PASS: TestAccAWSInstanceDataSource_SecurityGroups (154.00s)
=== RUN   TestAWSInstanceMigrateState
--- PASS: TestAWSInstanceMigrateState (0.00s)
=== RUN   TestAWSInstanceMigrateState_empty
--- PASS: TestAWSInstanceMigrateState_empty (0.00s)
=== RUN   TestAccAWSInstanceDataSource_keyPair
--- PASS: TestAccAWSInstanceDataSource_keyPair (161.66s)
=== RUN   TestAccAWSInstanceDataSource_gp2IopsDevice
--- PASS: TestAccAWSInstanceDataSource_gp2IopsDevice (188.25s)
=== RUN   TestAccAWSInstanceDataSource_basic
--- PASS: TestAccAWSInstanceDataSource_basic (191.64s)
=== RUN   TestAccAWSInstance_importBasic
--- PASS: TestAccAWSInstance_importBasic (223.67s)
=== RUN   TestAccAWSInstance_importInDefaultVpcBySgName
--- PASS: TestAccAWSInstance_importInDefaultVpcBySgName (228.95s)
=== RUN   TestAccAWSInstance_importInEc2Classic
--- PASS: TestAccAWSInstance_importInEc2Classic (99.17s)
=== RUN   TestAccAWSInstanceDataSource_VPC
--- PASS: TestAccAWSInstanceDataSource_VPC (274.44s)
=== RUN   TestAccAWSInstance_importInDefaultVpcBySgId
--- PASS: TestAccAWSInstance_importInDefaultVpcBySgId (293.00s)
=== RUN   TestAccAWSInstance_userDataBase64
--- PASS: TestAccAWSInstance_userDataBase64 (187.47s)
=== RUN   TestAccAWSInstanceDataSource_creditSpecification
--- PASS: TestAccAWSInstanceDataSource_creditSpecification (377.32s)
=== RUN   TestAccAWSInstance_noAMIEphemeralDevices
--- PASS: TestAccAWSInstance_noAMIEphemeralDevices (133.60s)
=== RUN   TestAccAWSInstanceDataSource_rootInstanceStore
--- PASS: TestAccAWSInstanceDataSource_rootInstanceStore (411.48s)
=== RUN   TestAccAWSInstance_GP2IopsDevice
--- PASS: TestAccAWSInstance_GP2IopsDevice (246.17s)
=== RUN   TestAccAWSInstance_basic
--- PASS: TestAccAWSInstance_basic (286.79s)
=== RUN   TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError
--- PASS: TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError (39.82s)
=== RUN   TestAccAWSInstanceDataSource_VPCSecurityGroups
--- PASS: TestAccAWSInstanceDataSource_VPCSecurityGroups (464.47s)
=== RUN   TestAccAWSInstance_blockDevices
--- PASS: TestAccAWSInstance_blockDevices (262.82s)
=== RUN   TestAccAWSInstance_vpc
--- PASS: TestAccAWSInstance_vpc (152.16s)
=== RUN   TestAccAWSInstanceDataSource_blockDevices
--- PASS: TestAccAWSInstanceDataSource_blockDevices (509.37s)
=== RUN   TestAccAWSInstance_rootInstanceStore
--- PASS: TestAccAWSInstance_rootInstanceStore (318.17s)
=== RUN   TestAccAWSInstance_GP2WithIopsValue
--- PASS: TestAccAWSInstance_GP2WithIopsValue (396.63s)
=== RUN   TestAccAWSInstanceDataSource_AzUserData
--- PASS: TestAccAWSInstanceDataSource_AzUserData (588.30s)
=== RUN   TestAccAWSInstanceDataSource_privateIP
--- PASS: TestAccAWSInstanceDataSource_privateIP (645.80s)
=== RUN   TestAccAWSInstance_ipv6_supportAddressCountWithIpv4
--- PASS: TestAccAWSInstance_ipv6_supportAddressCountWithIpv4 (238.53s)
=== RUN   TestAccAWSInstance_disableApiTermination
--- PASS: TestAccAWSInstance_disableApiTermination (402.30s)
=== RUN   TestAccAWSInstance_volumeTagsComputed
--- PASS: TestAccAWSInstance_volumeTagsComputed (178.44s)
=== RUN   TestAccAWSInstance_placementGroup
--- PASS: TestAccAWSInstance_placementGroup (377.60s)
=== RUN   TestAccAWSInstance_tags
--- PASS: TestAccAWSInstance_tags (259.99s)
=== RUN   TestAccAWSInstance_ipv6_supportAddressCount
--- PASS: TestAccAWSInstance_ipv6_supportAddressCount (379.07s)
=== RUN   TestAccAWSInstance_instanceProfileChange
--- PASS: TestAccAWSInstance_instanceProfileChange (193.05s)
=== RUN   TestAccAWSInstancesDataSource_tags
--- PASS: TestAccAWSInstancesDataSource_tags (858.51s)
=== RUN   TestAccAWSInstancesDataSource_basic
--- PASS: TestAccAWSInstancesDataSource_basic (878.38s)
=== RUN   TestAccAWSInstance_volumeTags
--- PASS: TestAccAWSInstance_volumeTags (377.65s)
=== RUN   TestAccAWSInstance_keyPairCheck
--- PASS: TestAccAWSInstance_keyPairCheck (210.05s)
=== RUN   TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck
--- PASS: TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck (127.02s)
=== RUN   TestAccAWSInstanceDataSource_getPasswordData_falseToTrue
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_falseToTrue (914.82s)
=== RUN   TestAccAWSInstance_associatePublicIPAndPrivateIP
--- PASS: TestAccAWSInstance_associatePublicIPAndPrivateIP (249.90s)
=== RUN   TestAccAWSInstance_withIamInstanceProfile
--- PASS: TestAccAWSInstance_withIamInstanceProfile (349.22s)
=== RUN   TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups
--- PASS: TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups (480.69s)
=== RUN   TestAccAWSInstance_rootBlockDeviceMismatch
--- PASS: TestAccAWSInstance_rootBlockDeviceMismatch (222.82s)
=== RUN   TestAccAWSInstance_sourceDestCheck
--- PASS: TestAccAWSInstance_sourceDestCheck (719.49s)
=== RUN   TestAccAWSInstance_primaryNetworkInterface
--- PASS: TestAccAWSInstance_primaryNetworkInterface (277.64s)
=== RUN   TestAccAWSInstanceDataSource_getPasswordData_trueToFalse
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_trueToFalse (1069.59s)
=== RUN   TestAccAWSInstance_associatePublic_defaultPublic
--- PASS: TestAccAWSInstance_associatePublic_defaultPublic (188.89s)
=== RUN   TestAccAWSInstance_changeInstanceType
--- PASS: TestAccAWSInstance_changeInstanceType (378.61s)
=== RUN   TestAccAWSInstance_creditSpecification_standardCpuCredits
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits (189.22s)
=== RUN   TestAccAWSInstance_associatePublic_explicitPublic
--- PASS: TestAccAWSInstance_associatePublic_explicitPublic (340.80s)
=== RUN   TestAccAWSInstance_associatePublic_explicitPrivate
--- PASS: TestAccAWSInstance_associatePublic_explicitPrivate (354.03s)
=== RUN   TestAccAWSInstance_privateIP
--- PASS: TestAccAWSInstance_privateIP (626.32s)
=== RUN   TestAccAWSInstance_associatePublic_overridePublic
--- PASS: TestAccAWSInstance_associatePublic_overridePublic (351.66s)
=== RUN   TestAccAWSInstance_forceNewAndTagsDrift
--- PASS: TestAccAWSInstance_forceNewAndTagsDrift (536.68s)
=== RUN   TestAccAWSInstance_addSecondaryInterface
--- PASS: TestAccAWSInstance_addSecondaryInterface (451.55s)
=== RUN   TestAccAWSInstance_creditSpecification_updateCpuCredits
--- PASS: TestAccAWSInstance_creditSpecification_updateCpuCredits (232.43s)
=== RUN   TestAccAWSInstance_creditSpecification_unspecifiedDefaultsToStandard
--- PASS: TestAccAWSInstance_creditSpecification_unspecifiedDefaultsToStandard (334.03s)
=== RUN   TestAccAWSInstanceDataSource_PlacementGroup
--- PASS: TestAccAWSInstanceDataSource_PlacementGroup (1340.90s)
=== RUN   TestAccAWSInstance_creditSpecification_removalReturnsStandard
--- PASS: TestAccAWSInstance_creditSpecification_removalReturnsStandard (211.97s)
=== RUN   TestAccAWSInstance_associatePublic_overridePrivate
--- PASS: TestAccAWSInstance_associatePublic_overridePrivate (420.65s)
=== RUN   TestAccAWSInstance_creditSpecification_unlimitedCpuCredits
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits (307.62s)
=== RUN   TestAccAWSInstance_multipleRegions
--- PASS: TestAccAWSInstance_multipleRegions (987.82s)
=== RUN   TestAccAWSInstance_associatePublic_defaultPrivate
--- PASS: TestAccAWSInstance_associatePublic_defaultPrivate (551.65s)
=== RUN   TestAccAWSInstance_NetworkInstanceSecurityGroups
--- PASS: TestAccAWSInstance_NetworkInstanceSecurityGroups (1020.38s)
=== RUN   TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs
--- PASS: TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs (1034.24s)
=== RUN   TestAccAWSInstance_getPasswordData_trueToFalse
--- PASS: TestAccAWSInstance_getPasswordData_trueToFalse (694.24s)
=== RUN   TestAccAWSInstance_addSecurityGroupNetworkInterface
--- PASS: TestAccAWSInstance_addSecurityGroupNetworkInterface (804.20s)
=== RUN   TestAccAWSInstance_getPasswordData_falseToTrue
--- FAIL: TestAccAWSInstance_getPasswordData_falseToTrue (1578.00s)
    testing.go:518: Step 1 error: Error applying: 1 error(s) occurred:
        
        * aws_instance.foo: 1 error(s) occurred:
        
        * aws_instance.foo: Password data is blank for instance ID: i-026811c32d7309f68
```