### PR TITLE
tests/resource/aws_elasticache_cluster: Remove now extraneous plan-time validation checks for node_type

### DIFF
--- a/aws/resource_aws_elasticache_cluster_test.go
+++ b/aws/resource_aws_elasticache_cluster_test.go
@@ -478,18 +478,6 @@ func TestAccAWSElasticacheCluster_NodeTypeResize_Memcached_Ec2Classic(t *testing
 		CheckDestroy: testAccCheckAWSElasticacheClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccAWSElasticacheClusterConfig_NodeType_Memcached_Ec2Classic(rName, "cache.t2.micro"),
-				ExpectError: regexp.MustCompile(`node_type "cache.t2.micro" can only be created in a VPC`),
-			},
-			{
-				Config:      testAccAWSElasticacheClusterConfig_NodeType_Memcached_Ec2Classic(rName, "cache.t2.small"),
-				ExpectError: regexp.MustCompile(`node_type "cache.t2.small" can only be created in a VPC`),
-			},
-			{
-				Config:      testAccAWSElasticacheClusterConfig_NodeType_Memcached_Ec2Classic(rName, "cache.t2.medium"),
-				ExpectError: regexp.MustCompile(`node_type "cache.t2.medium" can only be created in a VPC`),
-			},
-			{
 				Config: testAccAWSElasticacheClusterConfig_NodeType_Memcached_Ec2Classic(rName, "cache.m3.medium"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheClusterExists(resourceName, &pre),
@@ -522,18 +510,6 @@ func TestAccAWSElasticacheCluster_NodeTypeResize_Redis_Ec2Classic(t *testing.T) 
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSElasticacheClusterDestroy,
 		Steps: []resource.TestStep{
-			{
-				Config:      testAccAWSElasticacheClusterConfig_NodeType_Redis_Ec2Classic(rName, "cache.t2.micro"),
-				ExpectError: regexp.MustCompile(`node_type "cache.t2.micro" can only be created in a VPC`),
-			},
-			{
-				Config:      testAccAWSElasticacheClusterConfig_NodeType_Redis_Ec2Classic(rName, "cache.t2.small"),
-				ExpectError: regexp.MustCompile(`node_type "cache.t2.small" can only be created in a VPC`),
-			},
-			{
-				Config:      testAccAWSElasticacheClusterConfig_NodeType_Redis_Ec2Classic(rName, "cache.t2.medium"),
-				ExpectError: regexp.MustCompile(`node_type "cache.t2.medium" can only be created in a VPC`),
-			},
 			{
 				Config: testAccAWSElasticacheClusterConfig_NodeType_Redis_Ec2Classic(rName, "cache.m3.medium"),
 				Check: resource.ComposeTestCheckFunc(


### PR DESCRIPTION
The code adjustment (#4333) went into the v1.16.0 last minute yesterday -- this PR fixes up the testing from that troublesome validation being removed.

This is to fix these in daily acceptance testing:

```
=== RUN   TestAccAWSElasticacheCluster_NodeTypeResize_Memcached_Ec2Classic
--- FAIL: TestAccAWSElasticacheCluster_NodeTypeResize_Memcached_Ec2Classic (3.98s)
    testing.go:511: Step 0, expected error:
        
        Error applying: 1 error(s) occurred:
        
        * aws_elasticache_cluster.bar: 1 error(s) occurred:
        
        * aws_elasticache_cluster.bar: Error creating Elasticache: InvalidParameterCombination: Instance type cache.t2.micro can only be created in a VPC.
            status code: 400, request id: a13cbe93-491a-11e8-bcdc-0591db82b7f0
        
        To match:
        
        node_type "cache.t2.micro" can only be created in a VPC

=== RUN   TestAccAWSElasticacheCluster_NodeTypeResize_Redis_Ec2Classic
--- FAIL: TestAccAWSElasticacheCluster_NodeTypeResize_Redis_Ec2Classic (4.23s)
    testing.go:511: Step 0, expected error:
        
        Error applying: 1 error(s) occurred:
        
        * aws_elasticache_cluster.bar: 1 error(s) occurred:
        
        * aws_elasticache_cluster.bar: Error creating Elasticache: InvalidParameterCombination: Instance type cache.t2.micro can only be created in a VPC.
            status code: 400, request id: a13e44d3-491a-11e8-a91b-d344dde8a2b5
        
        To match:
        
        node_type "cache.t2.micro" can only be created in a VPC
```

Testing
```
18 tests passed (all tests)
=== RUN   TestAccAWSElasticacheCluster_ReplicationGroupID_InvalidAttributes
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_InvalidAttributes (3.18s)
=== RUN   TestAccAWSElasticacheCluster_NumCacheNodes_Redis_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Redis_Ec2Classic (3.43s)
=== RUN   TestAccAWSElasticacheCluster_AZMode_Memcached_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_AZMode_Memcached_Ec2Classic (442.96s)
=== RUN   TestAccAWSElasticacheCluster_AZMode_Redis_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_AZMode_Redis_Ec2Classic (461.20s)
=== RUN   TestAccAWSElasticacheCluster_Port_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_Port_Ec2Classic (503.93s)
=== RUN   TestAccAWSElasticacheCluster_SecurityGroup
--- PASS: TestAccAWSElasticacheCluster_SecurityGroup (529.69s)
=== RUN   TestAccAWSElasticacheCluster_NodeTypeResize_Redis_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_NodeTypeResize_Redis_Ec2Classic (736.29s)
=== RUN   TestAccAWSElasticacheCluster_Engine_Redis_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_Engine_Redis_Ec2Classic (773.47s)
=== RUN   TestAccAWSElasticacheCluster_vpc
--- PASS: TestAccAWSElasticacheCluster_vpc (809.31s)
=== RUN   TestAccAWSElasticacheCluster_Engine_Memcached_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_Engine_Memcached_Ec2Classic (814.83s)
=== RUN   TestAccAWSElasticacheCluster_NodeTypeResize_Memcached_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_NodeTypeResize_Memcached_Ec2Classic (905.95s)
=== RUN   TestAccAWSElasticacheCluster_ReplicationGroupID_SingleReplica_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_SingleReplica_Ec2Classic (1088.30s)
=== RUN   TestAccAWSElasticacheCluster_multiAZInVpc
--- PASS: TestAccAWSElasticacheCluster_multiAZInVpc (1102.29s)
=== RUN   TestAccAWSElasticacheCluster_ReplicationGroupID_MultipleReplica_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_MultipleReplica_Ec2Classic (1141.16s)
=== RUN   TestAccAWSElasticacheCluster_EngineVersion_Memcached_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_EngineVersion_Memcached_Ec2Classic (1235.17s)
=== RUN   TestAccAWSElasticacheCluster_EngineVersion_Redis_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_EngineVersion_Redis_Ec2Classic (1299.49s)
=== RUN   TestAccAWSElasticacheCluster_decreasingCacheNodes
--- PASS: TestAccAWSElasticacheCluster_decreasingCacheNodes (1362.81s)
=== RUN   TestAccAWSElasticacheCluster_snapshotsWithUpdates
--- PASS: TestAccAWSElasticacheCluster_snapshotsWithUpdates (1601.71s)
```