### PR TITLE
r/launch_template: set security groups in network interfaces

### DIFF
--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -90,6 +90,7 @@ func TestAccAWSLaunchTemplate_data(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resName, "key_name"),
 					resource.TestCheckResourceAttr(resName, "monitoring.#", "1"),
 					resource.TestCheckResourceAttr(resName, "network_interfaces.#", "1"),
+					resource.TestCheckResourceAttr(resName, "network_interfaces.0.security_groups.#", "1"),
 					resource.TestCheckResourceAttr(resName, "placement.#", "1"),
 					resource.TestCheckResourceAttrSet(resName, "ram_disk_id"),
 					resource.TestCheckResourceAttr(resName, "vpc_security_group_ids.#", "1"),
@@ -275,6 +276,7 @@ resource "aws_launch_template" "foo" {
   network_interfaces {
     associate_public_ip_address = true
     network_interface_id = "eni-123456ab"
+    security_groups = ["sg-1a23bc45"]
   }
 
   placement {


### PR DESCRIPTION
Addresses: https://github.com/terraform-providers/terraform-provider-aws/issues/4358

Sorry, I somehow completely forgot to set the `security_groups` attribute inside `network_interfaces`

```
TF_ACC=1 go test ./aws -v -run=TestAccAWSLaunchTemplate_ -timeout 120m
=== RUN   TestAccAWSLaunchTemplate_importBasic
--- PASS: TestAccAWSLaunchTemplate_importBasic (14.00s)
=== RUN   TestAccAWSLaunchTemplate_importData
--- PASS: TestAccAWSLaunchTemplate_importData (12.70s)
=== RUN   TestAccAWSLaunchTemplate_basic
--- PASS: TestAccAWSLaunchTemplate_basic (11.99s)
=== RUN   TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS (21.41s)
=== RUN   TestAccAWSLaunchTemplate_data
--- PASS: TestAccAWSLaunchTemplate_data (11.28s)
=== RUN   TestAccAWSLaunchTemplate_update
--- PASS: TestAccAWSLaunchTemplate_update (20.77s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	92.190s
```