### PR TITLE
r/aws_launch_template: some more fixes

### DIFF
--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -952,7 +952,7 @@ func readNetworkInterfacesFromConfig(ni map[string]interface{}) *ec2.LaunchTempl
 		networkInterface.Description = aws.String(v)
 	}
 
-	if v, ok := ni["device_index"].(int); ok && v != 0 {
+	if v, ok := ni["device_index"].(int); ok {
 		networkInterface.DeviceIndex = aws.Int64(int64(v))
 	}
 


### PR DESCRIPTION
The first fix is trivial: `device_index` can be 0. I don't know if it's even desirable to keep it optional, since the console defaults the value to 0 if you do not fill in the field. If you add multiple devices and leave the index empty, the console will also increment them automatically, i.e. "eth0", "eth1", etc. Maybe we should do the same? I haven't tried launching an instance with a network interface without an index, so if that breaks then this is probably desirable.

The second fix is very incomplete. The thing is that almost all of the boolean values are really optional, but terraform defaults them to false. There is no way to leave them undefined. So terraform is not able to fully configure those properties. I tried making it a string, that way we can have the values `""`, `"true"`, and `"false"`. But then we lose the ability to just use `true` or `false` without quotes in the terraform code, which is kind of confusing for users.

I first tried this to only set it if it was defined as either true or false, but it did not work.
```
if v, ok := ni["associate_public_ip_address"]; ok {
	networkInterface.AssociatePublicIpAddress = aws.Bool(v.(bool))
}
```

I tried to use `Default: nil` like this, but it did not work. Perhaps the schema could be enhanced to allow this to make the code above work?
```
"associate_public_ip_address": {
	Type:     schema.TypeBool,
	Optional: true,
	Default:  nil,
},
```

But it still defaulted to `false`.

I then tried this, which did work, but there must be a better way.

```
"associate_public_ip_address": {
	Type:     schema.TypeString,
	Optional: true,
	ValidateFunc: validation.StringInSlice([]string{
		"true",
		"false",
	}, false),
},
```

So this affects any property that can be true, false, or undefined ("Do not include in template"). See screenshot:
<img width="1657" alt="screen shot 2018-04-26 at 07 45 27" src="https://user-images.githubusercontent.com/1991151/39313293-7f3e24f6-4926-11e8-8a36-1409b2a77dfa.png">

I was going to fix the network interface security groups, but thankfully @kl4w opened his PR first which is much better than my fix. https://github.com/terraform-providers/terraform-provider-aws/pull/4364