### PR TITLE
AWS Glue database table

### DIFF
--- a/aws/import_aws_glue_catalog_table_test.go
+++ b/aws/import_aws_glue_catalog_table_test.go
@@ -1,0 +1,34 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/aws/aws-sdk-go/service/glue"
+	"github.com/aws/aws-sdk-go/aws"
+	"fmt"
+)
+
+func TestAccAWSGlueCatalogTable_importBasic(t *testing.T) {
+	resourceName := "aws_glue_catalog_table.test"
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGlueTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlueCatalogTable_full(rInt, "A test table from terraform"),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+

--- a/aws/import_aws_glue_catalog_table_test.go
+++ b/aws/import_aws_glue_catalog_table_test.go
@@ -5,10 +5,6 @@ import (
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
-	"github.com/aws/aws-sdk-go/service/glue"
-	"github.com/aws/aws-sdk-go/aws"
-	"fmt"
 )
 
 func TestAccAWSGlueCatalogTable_importBasic(t *testing.T) {
@@ -31,4 +27,3 @@ func TestAccAWSGlueCatalogTable_importBasic(t *testing.T) {
 		},
 	})
 }
-

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -393,6 +393,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_glue_catalog_database":                    resourceAwsGlueCatalogDatabase(),
 			"aws_glue_connection":                          resourceAwsGlueConnection(),
 			"aws_glue_job":                                 resourceAwsGlueJob(),
+			"aws_glue_catalog_table":                       resourceAwsGlueCatalogTable(),
 			"aws_guardduty_detector":                       resourceAwsGuardDutyDetector(),
 			"aws_guardduty_ipset":                          resourceAwsGuardDutyIpset(),
 			"aws_guardduty_member":                         resourceAwsGuardDutyMember(),

--- a/aws/resource_aws_glue_catalog_table.go
+++ b/aws/resource_aws_glue_catalog_table.go
@@ -1,7 +1,12 @@
 package aws
 
 import (
+	"fmt"
+	"log"
 	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/glue"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -11,18 +16,78 @@ func resourceAwsGlueCatalogTable() *schema.Resource {
 		Read:   resourceAwsGlueCatalogTableRead,
 		Update: resourceAwsGlueCatalogTableUpdate,
 		Delete: resourceAwsGlueCatalogTableDelete,
-		Exists: resourceAwsGlueCatalogTableExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
 
 		Schema: map[string]*schema.Schema{
-			"name": {
+			"catalog_id": {
 				Type:     schema.TypeString,
 				ForceNew: true,
 				Required: true,
 			},
-			...
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"database_name": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"owner": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"retention": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"storage_descriptor": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     schema.TypeString,
+			},
+			"partition_keys": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"comment": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"view_original_text": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"view_expanded_text": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"table_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"parameters": {
+				Type:     schema.TypeMap,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -30,4 +95,163 @@ func resourceAwsGlueCatalogTable() *schema.Resource {
 func readAwsGlueTableID(id string) (catalogID string, dbName string, name string) {
 	idParts := strings.Split(id, ":")
 	return idParts[0], idParts[1], idParts[2]
+}
+
+func resourceAwsGlueCatalogTableCreate(t *schema.ResourceData, meta interface{}) error {
+	glueconn := meta.(*AWSClient).glueconn
+	catalogID := createAwsGlueCatalogID(t, meta.(*AWSClient).accountid)
+	dbName := t.Get("database_name").(string)
+	name := t.Get("name").(string)
+
+	input := &glue.CreateTableInput{
+		CatalogId:    aws.String(catalogID),
+		DatabaseName: aws.String(dbName),
+		TableInput:   expandGlueTableInput(t),
+	}
+
+	_, err := glueconn.CreateTable(input)
+	if err != nil {
+		return fmt.Errorf("Error creating Catalog Table: %s", err)
+	}
+
+	t.SetId(fmt.Sprintf("%s:%s:%s", catalogID, dbName, name))
+
+	return resourceAwsGlueCatalogTableRead(t, meta)
+}
+
+func resourceAwsGlueCatalogTableUpdate(t *schema.ResourceData, meta interface{}) error {
+	glueconn := meta.(*AWSClient).glueconn
+
+	catalogID, dbName, _ := readAwsGlueTableID(t.Id())
+
+	updateTableInput := &glue.UpdateTableInput{
+		CatalogId:    aws.String(catalogID),
+		DatabaseName: aws.String(dbName),
+		TableInput:   expandGlueTableInput(t),
+	}
+
+	if t.HasChange("table_input") {
+		if _, err := glueconn.UpdateTable(updateTableInput); err != nil {
+			return fmt.Errorf("Error updating Glue Catalog Table: %s", err)
+		}
+	}
+
+	return nil
+}
+
+func resourceAwsGlueCatalogTableRead(t *schema.ResourceData, meta interface{}) error {
+	glueconn := meta.(*AWSClient).glueconn
+
+	catalogID, dbName, name := readAwsGlueTableID(t.Id())
+
+	input := &glue.GetTableInput{
+		CatalogId:    aws.String(catalogID),
+		DatabaseName: aws.String(dbName),
+		Name:         aws.String(name),
+	}
+
+	out, err := glueconn.GetTable(input)
+	if err != nil {
+
+		if isAWSErr(err, glue.ErrCodeEntityNotFoundException, "") {
+			log.Printf("[WARN] Glue Catalog Table (%s) not found, removing from state", t.Id())
+			t.SetId("")
+		}
+
+		return fmt.Errorf("Error reading Glue Catalog Table: %s", err)
+	}
+
+	t.Set("name", out.Table.Name)
+	t.Set("catalog_id", catalogID)
+	t.Set("description", out.Table.Description)
+
+	return nil
+}
+
+func resourceAwsGlueCatalogTableDelete(t *schema.ResourceData, meta interface{}) error {
+	glueconn := meta.(*AWSClient).glueconn
+	catalogID, dbName, name := readAwsGlueTableID(t.Id())
+
+	log.Printf("[DEBUG] Glue Catalog Table: %s:%s:%s", catalogID, dbName, name)
+	_, err := glueconn.DeleteTable(&glue.DeleteTableInput{
+		CatalogId:    aws.String(catalogID),
+		Name:         aws.String(name),
+		DatabaseName: aws.String(dbName),
+	})
+	if err != nil {
+		return fmt.Errorf("Error deleting Glue Catalog Table: %s", err.Error())
+	}
+	return nil
+}
+
+func expandGlueTableInput(t *schema.ResourceData) *glue.TableInput {
+	tableInput := &glue.TableInput{
+		Name: aws.String(t.Get("name").(string)),
+	}
+
+	if v, ok := t.GetOk("description"); ok {
+		tableInput.Description = aws.String(v.(string))
+	}
+
+	if v, ok := t.GetOk("owner"); ok {
+		tableInput.Owner = aws.String(v.(string))
+	}
+
+	if v, ok := t.GetOk("retention"); ok {
+		tableInput.Retention = aws.Int64(v.(int64))
+	}
+
+	if v, ok := t.GetOk("storage_descriptor"); ok {
+		tableInput.StorageDescriptor = expandGlueStorageDescriptor(v.(map[string]interface{}))
+	}
+
+	if v, ok := t.GetOk("partition_keys"); ok {
+		columns := expandGlueColumns(v.(map[string]schema.ResourceData))
+		tableInput.PartitionKeys = columns
+	}
+
+	if v, ok := t.GetOk("view_original_text"); ok {
+		tableInput.Owner = aws.String(v.(string))
+	}
+
+	if v, ok := t.GetOk("view_expanded_text"); ok {
+		tableInput.Owner = aws.String(v.(string))
+	}
+
+	if v, ok := t.GetOk("table_type"); ok {
+		tableInput.Owner = aws.String(v.(string))
+	}
+
+	if v, ok := t.GetOk("parameters"); ok {
+		tableInput.Parameters = aws.StringMap(v.(map[string]string))
+	}
+
+	return tableInput
+}
+
+func expandGlueStorageDescriptor(s map[string]interface{}) *glue.StorageDescriptor {
+	storageDescriptor := &glue.StorageDescriptor{}
+
+	return storageDescriptor
+}
+
+func expandGlueColumns(columns map[string]schema.ResourceData) []*glue.Column {
+	columnSlice := []*glue.Column{}
+	for _, element := range columns {
+		column := &glue.Column{
+			Name: aws.String(element.Get("name").(string)),
+		}
+
+		if v, ok := element.GetOk("comment"); ok {
+			column.Comment = aws.String(v.(string))
+		}
+
+		if v, ok := element.GetOk("type"); ok {
+			column.Type = aws.String(v.(string))
+		}
+
+		columnSlice = append(columnSlice, column)
+	}
+
+	return columnSlice
 }

--- a/aws/resource_aws_glue_catalog_table.go
+++ b/aws/resource_aws_glue_catalog_table.go
@@ -8,6 +8,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/glue"
 	"github.com/hashicorp/terraform/helper/schema"
+
+	"github.com/fatih/structs"
 )
 
 func resourceAwsGlueCatalogTable() *schema.Resource {
@@ -49,62 +51,127 @@ func resourceAwsGlueCatalogTable() *schema.Resource {
 				Optional: true,
 			},
 			"storage_descriptor": {
-				Type:     schema.TypeMap,
+				Type:     schema.TypeList,
 				Optional: true,
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						//"columns": {
-						//	Type:     schema.TypeString,
-						//	Required: true,
-						//},
-						//"location": {
-						//	Type:     schema.TypeString,
-						//	Optional: true,
-						//},
-						//"input_format": {
-						//	Type:     schema.TypeString,
-						//	Optional: true,
-						//},
-						//"output_format": {
-						//	Type:     schema.TypeString,
-						//	Optional: true,
-						//},
-						//"compressed": {
-						//	Type:     schema.TypeBool,
-						//	Optional: true,
-						//},
-						//"number_of_buckets": {
-						//	Type:     schema.TypeInt,
-						//	Optional: true,
-						//},
-						//"ser_de_info": {
-						//	Type:     schema.TypeString,
-						//	Optional: true,
-						//},
+						"columns": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"comment": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"location": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"input_format": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"output_format": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"compressed": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"number_of_buckets": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"ser_de_info": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"parameters": {
+										Type:     schema.TypeMap,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"serialization_library": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
 						"bucket_columns": {
 							Type:     schema.TypeList,
 							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"sort_columns": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"column": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"sort_order": {
+										Type:     schema.TypeInt,
+										Required: true,
+									},
+								},
 							},
 						},
-						//"sort_columns": {
-						//	Type:     schema.TypeString,
-						//	Optional: true,
-						//},
-						//"parameters": {
-						//	Type:     schema.TypeMap,
-						//	Optional: true,
-						//	Elem:     schema.TypeString,
-						//},
-						//"skewed_info": {
-						//	Type:     schema.TypeString,
-						//	Optional: true,
-						//},
-						//"stored_as_sub_directories": {
-						//	Type:     schema.TypeBool,
-						//	Optional: true,
-						//},
+						"parameters": {
+							Type:     schema.TypeMap,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"skewed_info": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"skewed_column_names": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"skewed_column_value_location_maps": {
+										Type:     schema.TypeMap,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"skewed_column_values": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+						"stored_as_sub_directories": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
 					},
 				},
 			},
@@ -143,6 +210,7 @@ func resourceAwsGlueCatalogTable() *schema.Resource {
 			"parameters": {
 				Type:     schema.TypeMap,
 				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}
@@ -186,13 +254,11 @@ func resourceAwsGlueCatalogTableUpdate(t *schema.ResourceData, meta interface{})
 		TableInput:   expandGlueTableInput(t),
 	}
 
-	if t.HasChange("table_input") {
-		if _, err := glueconn.UpdateTable(updateTableInput); err != nil {
-			return fmt.Errorf("Error updating Glue Catalog Table: %s", err)
-		}
+	if _, err := glueconn.UpdateTable(updateTableInput); err != nil {
+		return fmt.Errorf("Error updating Glue Catalog Table: %s", err)
 	}
 
-	return nil
+	return resourceAwsGlueCatalogTableRead(t, meta)
 }
 
 func resourceAwsGlueCatalogTableRead(t *schema.ResourceData, meta interface{}) error {
@@ -223,7 +289,11 @@ func resourceAwsGlueCatalogTableRead(t *schema.ResourceData, meta interface{}) e
 	t.Set("description", out.Table.Description)
 	t.Set("owner", out.Table.Owner)
 	t.Set("retention", out.Table.Retention)
-	t.Set("storage_descriptor", out.Table.StorageDescriptor)
+
+	if out.Table.StorageDescriptor != nil {
+		t.Set("storage_descriptor", flattenStorageDescriptor(out.Table.StorageDescriptor))
+	}
+
 	t.Set("partition_keys", out.Table.PartitionKeys)
 	t.Set("view_original_text", out.Table.ViewOriginalText)
 	t.Set("view_expanded_text", out.Table.ViewExpandedText)
@@ -263,102 +333,124 @@ func expandGlueTableInput(t *schema.ResourceData) *glue.TableInput {
 	}
 
 	if v, ok := t.GetOk("retention"); ok {
-		tableInput.Retention = aws.Int64(v.(int64))
+		tableInput.Retention = aws.Int64(int64(v.(int)))
 	}
 
 	if v, ok := t.GetOk("storage_descriptor"); ok {
-		tableInput.StorageDescriptor = expandGlueStorageDescriptor(v.(*schema.ResourceData))
+		for _, elem := range v.([]interface{}) {
+			tableInput.StorageDescriptor = expandGlueStorageDescriptor(elem.(map[string]interface{}))
+		}
 	}
 
 	if v, ok := t.GetOk("partition_keys"); ok {
-		columns := expandGlueColumns(v.([]*schema.ResourceData))
+		columns := expandGlueColumns(v.([]interface{}))
 		tableInput.PartitionKeys = columns
 	}
 
 	if v, ok := t.GetOk("view_original_text"); ok {
-		tableInput.Owner = aws.String(v.(string))
+		tableInput.ViewOriginalText = aws.String(v.(string))
 	}
 
 	if v, ok := t.GetOk("view_expanded_text"); ok {
-		tableInput.Owner = aws.String(v.(string))
+		tableInput.ViewExpandedText = aws.String(v.(string))
 	}
 
 	if v, ok := t.GetOk("table_type"); ok {
-		tableInput.Owner = aws.String(v.(string))
+		tableInput.TableType = aws.String(v.(string))
 	}
 
 	if v, ok := t.GetOk("parameters"); ok {
-		tableInput.Parameters = aws.StringMap(v.(map[string]string))
+		paramsMap := map[string]string{}
+		for key, value := range v.(map[string]interface{}) {
+			paramsMap[key] = value.(string)
+		}
+		tableInput.Parameters = aws.StringMap(paramsMap)
 	}
 
 	return tableInput
 }
 
-func expandGlueStorageDescriptor(s *schema.ResourceData) *glue.StorageDescriptor {
+func expandGlueStorageDescriptor(s map[string]interface{}) *glue.StorageDescriptor {
 	storageDescriptor := &glue.StorageDescriptor{}
 
-	if v, ok := s.GetOk("columns"); ok {
-		columns := expandGlueColumns(v.([]*schema.ResourceData))
+	if v, ok := s["columns"]; ok {
+		columns := expandGlueColumns(v.([]interface{}))
 		storageDescriptor.Columns = columns
 	}
 
-	if v, ok := s.GetOk("location"); ok {
+	if v, ok := s["location"]; ok {
 		storageDescriptor.Location = aws.String(v.(string))
 	}
 
-	if v, ok := s.GetOk("input_format"); ok {
+	if v, ok := s["input_format"]; ok {
 		storageDescriptor.InputFormat = aws.String(v.(string))
 	}
 
-	if v, ok := s.GetOk("output_format"); ok {
+	if v, ok := s["output_format"]; ok {
 		storageDescriptor.OutputFormat = aws.String(v.(string))
 	}
 
-	if v, ok := s.GetOk("compressed"); ok {
+	if v, ok := s["compressed"]; ok {
 		storageDescriptor.Compressed = aws.Bool(v.(bool))
 	}
 
-	if v, ok := s.GetOk("number_of_buckets"); ok {
-		storageDescriptor.NumberOfBuckets = aws.Int64(v.(int64))
+	if v, ok := s["number_of_buckets"]; ok {
+		storageDescriptor.NumberOfBuckets = aws.Int64(int64(v.(int)))
 	}
 
-	if _, ok := s.GetOk("ser_de_info"); ok { // todo
-		ser_de_info := &glue.SerDeInfo{}
-		storageDescriptor.SerdeInfo = ser_de_info
+	if v, ok := s["ser_de_info"]; ok {
+		for _, elem := range v.([]interface{}) {
+			storageDescriptor.SerdeInfo = expandSerDeInfo(elem.(map[string]interface{}))
+		}
 	}
 
-	if v, ok := s.GetOk("bucket_columns"); ok {
-		storageDescriptor.BucketColumns = aws.StringSlice(v.([]string))
+	if v, ok := s["bucket_columns"]; ok {
+		bucketColumns := make([]string, len(v.([]interface{})))
+		for i, item := range v.([]interface{}) {
+			bucketColumns[i] = fmt.Sprint(item)
+		}
+		storageDescriptor.BucketColumns = aws.StringSlice(bucketColumns)
 	}
 
-	if _, ok := s.GetOk("sort_colums"); ok { // todo
-		sort_columns := []*glue.Order{}
-		storageDescriptor.SortColumns = sort_columns
+	if v, ok := s["sort_colums"]; ok {
+		storageDescriptor.SortColumns = expandSortColumns(v.([]interface{}))
 	}
 
-	if v, ok := s.GetOk("parameters"); ok {
-		storageDescriptor.Parameters = aws.StringMap(v.(map[string]string))
+	if v, ok := s["skewed_info"]; ok {
+		for _, elem := range v.([]interface{}) {
+			storageDescriptor.SkewedInfo = expandSkewedInfo(elem.(map[string]interface{}))
+		}
 	}
 
-	if v, ok := s.GetOk("stored_as_sub_directories"); ok {
+	if v, ok := s["parameters"]; ok {
+		paramsMap := map[string]string{}
+		for key, value := range v.(map[string]interface{}) {
+			paramsMap[key] = value.(string)
+		}
+		storageDescriptor.Parameters = aws.StringMap(paramsMap)
+	}
+
+	if v, ok := s["stored_as_sub_directories"]; ok {
 		storageDescriptor.StoredAsSubDirectories = aws.Bool(v.(bool))
 	}
 
 	return storageDescriptor
 }
 
-func expandGlueColumns(columns []*schema.ResourceData) []*glue.Column {
+func expandGlueColumns(columns []interface{}) []*glue.Column {
 	columnSlice := []*glue.Column{}
 	for _, element := range columns {
+		elementMap := element.(map[string]interface{})
+
 		column := &glue.Column{
-			Name: aws.String(element.Get("name").(string)),
+			Name: aws.String(elementMap["name"].(string)),
 		}
 
-		if v, ok := element.GetOk("comment"); ok {
+		if v, ok := elementMap["comment"]; ok {
 			column.Comment = aws.String(v.(string))
 		}
 
-		if v, ok := element.GetOk("type"); ok {
+		if v, ok := elementMap["type"]; ok {
 			column.Type = aws.String(v.(string))
 		}
 
@@ -366,4 +458,81 @@ func expandGlueColumns(columns []*schema.ResourceData) []*glue.Column {
 	}
 
 	return columnSlice
+}
+
+func expandSerDeInfo(s map[string]interface{}) *glue.SerDeInfo {
+	serDeInfo := &glue.SerDeInfo{}
+
+	if v, ok := s["name"]; ok {
+		serDeInfo.Name = aws.String(v.(string))
+	}
+
+	if v, ok := s["parameters"]; ok {
+		paramsMap := map[string]string{}
+		for key, value := range v.(map[string]interface{}) {
+			paramsMap[key] = value.(string)
+		}
+		serDeInfo.Parameters = aws.StringMap(paramsMap)
+	}
+
+	if v, ok := s["serialization_library"]; ok {
+		serDeInfo.SerializationLibrary = aws.String(v.(string))
+	}
+
+	return serDeInfo
+}
+
+func expandSortColumns(columns []interface{}) []*glue.Order {
+	orderSlice := []*glue.Order{}
+	for _, element := range columns {
+		elementMap := element.(map[string]interface{})
+
+		order := &glue.Order{
+			Column: aws.String(elementMap["column"].(string)),
+		}
+
+		if v, ok := elementMap["sort_order"]; ok {
+			order.SortOrder = aws.Int64(int64(v.(int)))
+		}
+
+		orderSlice = append(orderSlice, order)
+	}
+
+	return orderSlice
+}
+
+func expandSkewedInfo(s map[string]interface{}) *glue.SkewedInfo {
+	skewedInfo := &glue.SkewedInfo{}
+
+	if v, ok := s["skewed_column_names"]; ok {
+		columnsSlice := make([]string, len(v.([]interface{})))
+		for i, item := range v.([]interface{}) {
+			columnsSlice[i] = fmt.Sprint(item)
+		}
+		skewedInfo.SkewedColumnNames = aws.StringSlice(columnsSlice)
+	}
+
+	if v, ok := s["skewed_column_value_location_maps"]; ok {
+		typeMap := map[string]string{}
+		for key, value := range v.(map[string]interface{}) {
+			typeMap[key] = value.(string)
+		}
+		skewedInfo.SkewedColumnValueLocationMaps = aws.StringMap(typeMap)
+	}
+
+	if v, ok := s["skewed_column_values"]; ok {
+		columnsSlice := make([]string, len(v.([]interface{})))
+		for i, item := range v.([]interface{}) {
+			columnsSlice[i] = fmt.Sprint(item)
+		}
+		skewedInfo.SkewedColumnValues = aws.StringSlice(columnsSlice)
+	}
+
+	return skewedInfo
+}
+
+func flattenStorageDescriptor(s *glue.StorageDescriptor) []map[string]interface{} {
+	storageDescriptors := make([]map[string]interface{}, 1)
+	storageDescriptors[0] = structs.Map(s)
+	return storageDescriptors
 }

--- a/aws/resource_aws_glue_catalog_table.go
+++ b/aws/resource_aws_glue_catalog_table.go
@@ -1,0 +1,33 @@
+package aws
+
+import (
+	"strings"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsGlueCatalogTable() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsGlueCatalogTableCreate,
+		Read:   resourceAwsGlueCatalogTableRead,
+		Update: resourceAwsGlueCatalogTableUpdate,
+		Delete: resourceAwsGlueCatalogTableDelete,
+		Exists: resourceAwsGlueCatalogTableExists,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			...
+		},
+	}
+}
+
+func readAwsGlueTableID(id string) (catalogID string, dbName string, name string) {
+	idParts := strings.Split(id, ":")
+	return idParts[0], idParts[1], idParts[2]
+}

--- a/aws/resource_aws_glue_catalog_table_test.go
+++ b/aws/resource_aws_glue_catalog_table_test.go
@@ -12,7 +12,95 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestAccAWSGlueCatalogTable_basic(t *testing.T) {
+	rInt := acctest.RandInt()
+	tableName := "aws_glue_catalog_table.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGlueTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:  testAccGlueCatalogTable_basic(rInt),
+				Destroy: false,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGlueCatalogTableExists("aws_glue_catalog_table.test"),
+					resource.TestCheckResourceAttr(
+						"aws_glue_catalog_table.test",
+						"name",
+						fmt.Sprintf("my_test_catalog_table_%d", rInt),
+					),
+					resource.TestCheckResourceAttr(
+						tableName,
+						"database_name",
+						fmt.Sprintf("my_test_catalog_database_%d", rInt),
+					),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSGlueCatalogTable_full(t *testing.T) {
+	rInt := acctest.RandInt()
+	description := "A test table from terraform"
+	tableName := "aws_glue_catalog_table.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGlueTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:  testAccGlueCatalogTable_full(rInt, description),
+				Destroy: false,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGlueCatalogTableExists(tableName),
+					resource.TestCheckResourceAttr(tableName, "name", fmt.Sprintf("my_test_catalog_table_%d", rInt)),
+					resource.TestCheckResourceAttr(tableName, "database_name", fmt.Sprintf("my_test_catalog_database_%d", rInt)),
+					resource.TestCheckResourceAttr(tableName, "description", description),
+					resource.TestCheckResourceAttr(tableName, "owner", "my_owner"),
+					resource.TestCheckResourceAttr(tableName, "retention", "1"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.0.name", "my_column_1"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.0.type", "int"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.0.comment", "my_column1_comment"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.1.name", "my_column_2"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.1.type", "string"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.1.comment", "my_column2_comment"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.location", "my_location"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.input_format", "SequenceFileInputFormat"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.output_format", "SequenceFileInputFormat"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.compressed", "false"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.number_of_buckets", "1"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.ser_de_info.0.name", "ser_de_name"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.ser_de_info.0.parameters.param1", "param_val_1"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.ser_de_info.0.serialization_library", "org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.bucket_columns.0", "bucket_column_1"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.sort_columns.0.column", "my_column_1"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.sort_columns.0.sort_order", "1"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.parameters.param1", "param1_val"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.skewed_info.0.skewed_column_names.0", "my_column_1"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.skewed_info.0.skewed_column_value_location_maps.my_column_1", "my_column_1_val_loc_map"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.skewed_info.0.skewed_column_values.0", "skewed_val_1"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.stored_as_sub_directories", "false"),
+					resource.TestCheckResourceAttr(tableName, "partition_keys.0.name", "my_column_1"),
+					resource.TestCheckResourceAttr(tableName, "partition_keys.0.type", "int"),
+					resource.TestCheckResourceAttr(tableName, "partition_keys.0.comment", "my_column_1_comment"),
+					resource.TestCheckResourceAttr(tableName, "partition_keys.1.name", "my_column_2"),
+					resource.TestCheckResourceAttr(tableName, "partition_keys.1.type", "string"),
+					resource.TestCheckResourceAttr(tableName, "partition_keys.1.comment", "my_column_2_comment"),
+					resource.TestCheckResourceAttr(tableName, "view_original_text", "view_original_text_1"),
+					resource.TestCheckResourceAttr(tableName, "view_expanded_text", "view_expanded_text_1"),
+					resource.TestCheckResourceAttr(tableName, "table_type", "VIRTUAL_VIEW"),
+					resource.TestCheckResourceAttr(tableName, "parameters.param1", "param1_val"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSGlueCatalogTable_update_addValues(t *testing.T) {
 	rInt := acctest.RandInt()
 	description := "A test table from terraform"
 	tableName := "aws_glue_catalog_table.test"
@@ -81,6 +169,114 @@ func TestAccAWSGlueCatalogTable_full(t *testing.T) {
 					resource.TestCheckResourceAttr(tableName, "view_expanded_text", "view_expanded_text_1"),
 					resource.TestCheckResourceAttr(tableName, "table_type", "VIRTUAL_VIEW"),
 					resource.TestCheckResourceAttr(tableName, "parameters.param1", "param1_val"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSGlueCatalogTable_update_replaceValues(t *testing.T) {
+	rInt := acctest.RandInt()
+	description := "A test table from terraform"
+	tableName := "aws_glue_catalog_table.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGlueTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:  testAccGlueCatalogTable_full(rInt, description),
+				Destroy: false,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGlueCatalogTableExists(tableName),
+					resource.TestCheckResourceAttr(tableName, "name", fmt.Sprintf("my_test_catalog_table_%d", rInt)),
+					resource.TestCheckResourceAttr(tableName, "database_name", fmt.Sprintf("my_test_catalog_database_%d", rInt)),
+					resource.TestCheckResourceAttr(tableName, "description", description),
+					resource.TestCheckResourceAttr(tableName, "owner", "my_owner"),
+					resource.TestCheckResourceAttr(tableName, "retention", "1"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.0.name", "my_column_1"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.0.type", "int"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.0.comment", "my_column1_comment"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.1.name", "my_column_2"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.1.type", "string"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.1.comment", "my_column2_comment"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.location", "my_location"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.input_format", "SequenceFileInputFormat"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.output_format", "SequenceFileInputFormat"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.compressed", "false"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.number_of_buckets", "1"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.ser_de_info.0.name", "ser_de_name"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.ser_de_info.0.parameters.param1", "param_val_1"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.ser_de_info.0.serialization_library", "org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.bucket_columns.0", "bucket_column_1"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.sort_columns.0.column", "my_column_1"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.sort_columns.0.sort_order", "1"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.parameters.param1", "param1_val"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.skewed_info.0.skewed_column_names.0", "my_column_1"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.skewed_info.0.skewed_column_value_location_maps.my_column_1", "my_column_1_val_loc_map"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.skewed_info.0.skewed_column_values.0", "skewed_val_1"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.stored_as_sub_directories", "false"),
+					resource.TestCheckResourceAttr(tableName, "partition_keys.0.name", "my_column_1"),
+					resource.TestCheckResourceAttr(tableName, "partition_keys.0.type", "int"),
+					resource.TestCheckResourceAttr(tableName, "partition_keys.0.comment", "my_column_1_comment"),
+					resource.TestCheckResourceAttr(tableName, "partition_keys.1.name", "my_column_2"),
+					resource.TestCheckResourceAttr(tableName, "partition_keys.1.type", "string"),
+					resource.TestCheckResourceAttr(tableName, "partition_keys.1.comment", "my_column_2_comment"),
+					resource.TestCheckResourceAttr(tableName, "view_original_text", "view_original_text_1"),
+					resource.TestCheckResourceAttr(tableName, "view_expanded_text", "view_expanded_text_1"),
+					resource.TestCheckResourceAttr(tableName, "table_type", "VIRTUAL_VIEW"),
+					resource.TestCheckResourceAttr(tableName, "parameters.param1", "param1_val"),
+				),
+			},
+			{
+				Config:  testAccGlueCatalogTable_full_replacedValues(rInt),
+				Destroy: false,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGlueCatalogTableExists(tableName),
+					resource.TestCheckResourceAttr(tableName, "name", fmt.Sprintf("my_test_catalog_table_%d", rInt)),
+					resource.TestCheckResourceAttr(tableName, "database_name", fmt.Sprintf("my_test_catalog_database_%d", rInt)),
+					resource.TestCheckResourceAttr(tableName, "description", "A test table from terraform2"),
+					resource.TestCheckResourceAttr(tableName, "owner", "my_owner2"),
+					resource.TestCheckResourceAttr(tableName, "retention", "2"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.0.name", "my_column_12"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.0.type", "date"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.0.comment", "my_column1_comment2"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.1.name", "my_column_22"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.1.type", "timestamp"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.1.comment", "my_column2_comment2"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.location", "my_location2"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.input_format", "TextInputFormat"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.output_format", "TextInputFormat"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.compressed", "true"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.number_of_buckets", "12"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.ser_de_info.0.name", "ser_de_name2"),
+					resource.TestCheckNoResourceAttr(tableName, "storage_descriptor.0.ser_de_info.0.parameters.param1"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.ser_de_info.0.parameters.param2", "param_val_12"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.ser_de_info.0.serialization_library", "org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe2"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.bucket_columns.0", "bucket_column_12"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.bucket_columns.1", "bucket_column_2"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.sort_columns.0.column", "my_column_12"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.sort_columns.0.sort_order", "0"),
+					resource.TestCheckNoResourceAttr(tableName, "storage_descriptor.0.parameters.param1"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.parameters.param12", "param1_val2"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.skewed_info.0.skewed_column_names.0", "my_column_12"),
+					resource.TestCheckNoResourceAttr(tableName, "storage_descriptor.0.skewed_info.0.skewed_column_value_location_maps.my_column_1"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.skewed_info.0.skewed_column_value_location_maps.my_column_12", "my_column_1_val_loc_map2"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.skewed_info.0.skewed_column_values.0", "skewed_val_12"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.skewed_info.0.skewed_column_values.1", "skewed_val_2"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.stored_as_sub_directories", "true"),
+					resource.TestCheckResourceAttr(tableName, "partition_keys.0.name", "my_column_12"),
+					resource.TestCheckResourceAttr(tableName, "partition_keys.0.type", "date"),
+					resource.TestCheckResourceAttr(tableName, "partition_keys.0.comment", "my_column_1_comment2"),
+					resource.TestCheckResourceAttr(tableName, "partition_keys.1.name", "my_column_22"),
+					resource.TestCheckResourceAttr(tableName, "partition_keys.1.type", "timestamp"),
+					resource.TestCheckResourceAttr(tableName, "partition_keys.1.comment", "my_column_2_comment2"),
+					resource.TestCheckResourceAttr(tableName, "view_original_text", "view_original_text_12"),
+					resource.TestCheckResourceAttr(tableName, "view_expanded_text", "view_expanded_text_12"),
+					resource.TestCheckResourceAttr(tableName, "table_type", "EXTERNAL_TABLE"),
+					//resource.TestCheckResourceAttr(tableName, "parameters.param1", "param1_val"),
+					resource.TestCheckResourceAttr(tableName, "parameters.param2", "param1_val2"),
 				),
 			},
 		},
@@ -180,6 +376,92 @@ resource "aws_glue_catalog_table" "test" {
   }
 }
 `, rInt, rInt, desc)
+}
+
+func testAccGlueCatalogTable_full_replacedValues(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = "my_test_catalog_database_%d"
+}
+
+resource "aws_glue_catalog_table" "test" {
+  name = "my_test_catalog_table_%d"
+  database_name = "${aws_glue_catalog_database.test.name}"
+  description = "A test table from terraform2"
+  owner = "my_owner2"
+  retention = 2
+  storage_descriptor {
+    columns = [
+     {
+       name = "my_column_12"
+       type = "date"
+       comment = "my_column1_comment2"
+     },
+     {
+       name = "my_column_22"
+       type = "timestamp"
+       comment = "my_column2_comment2"
+     }
+    ]
+	location = "my_location2"
+	input_format = "TextInputFormat"
+	output_format = "TextInputFormat"
+	compressed = true
+	number_of_buckets = 12
+	ser_de_info {
+      name = "ser_de_name2"
+      parameters {
+        param2 = "param_val_12"
+      }
+      serialization_library = "org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe2"
+	}
+	bucket_columns = [
+      "bucket_column_12",
+      "bucket_column_2"
+	]
+	sort_columns = [
+      {
+        column = "my_column_12"
+        sort_order = 0
+      }
+	]
+	parameters {
+      param12 = "param1_val2"
+	}
+	skewed_info {
+      skewed_column_names = [
+        "my_column_12"
+      ]
+      skewed_column_value_location_maps {
+        my_column_12 = "my_column_1_val_loc_map2"
+      }
+      skewed_column_values = [
+        "skewed_val_12",
+		"skewed_val_2"
+      ]
+	}
+	stored_as_sub_directories = true
+  }
+  partition_keys = [
+    {
+      name = "my_column_12"
+      type = "date"
+      comment = "my_column_1_comment2"
+    },
+    {
+      name = "my_column_22"
+      type = "timestamp"
+      comment = "my_column_2_comment2"
+    }
+  ]
+  view_original_text = "view_original_text_12"
+  view_expanded_text = "view_expanded_text_12"
+  table_type = "EXTERNAL_TABLE"
+  parameters {
+  	param2 = "param1_val2"
+  }
+}
+`, rInt, rInt)
 }
 
 func testAccCheckGlueTableDestroy(s *terraform.State) error {

--- a/aws/resource_aws_glue_catalog_table_test.go
+++ b/aws/resource_aws_glue_catalog_table_test.go
@@ -1,13 +1,15 @@
 package aws
 
 import (
+	"fmt"
 	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/glue"
+
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
-	"fmt"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/aws/aws-sdk-go/service/glue"
-	"github.com/aws/aws-sdk-go/aws"
 )
 
 func TestAccAWSGlueCatalogTable_full(t *testing.T) {

--- a/aws/resource_aws_glue_catalog_table_test.go
+++ b/aws/resource_aws_glue_catalog_table_test.go
@@ -1,0 +1,41 @@
+package aws
+
+import (
+	"testing"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"fmt"
+)
+
+func TestAccAWSGlueCatalogTable_full(t *testing.T) {
+	rInt := acctest.RandInt()
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGlueTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:  testAccGlueCatalogTable_basic(rInt),
+				Destroy: false,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGlueCatalogTableExists("aws_glue_catalog_table.test"),
+					resource.TestCheckResourceAttr(
+						"aws_glue_catalog_table.test",
+						"name",
+						fmt.Sprintf("my_test_catalog_table_%d", rInt),
+					),
+					resource.TestCheckResourceAttr(
+						"aws_glue_catalog_table.test",
+						"description",
+						"",
+					),
+					resource.TestCheckResourceAttr(
+						"aws_glue_catalog_table.test",
+						"owner",
+						"",
+					),
+				),
+			},
+		},
+	})
+}

--- a/aws/resource_aws_glue_catalog_table_test.go
+++ b/aws/resource_aws_glue_catalog_table_test.go
@@ -5,6 +5,9 @@ import (
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"fmt"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/aws/aws-sdk-go/service/glue"
+	"github.com/aws/aws-sdk-go/aws"
 )
 
 func TestAccAWSGlueCatalogTable_full(t *testing.T) {
@@ -26,6 +29,11 @@ func TestAccAWSGlueCatalogTable_full(t *testing.T) {
 					),
 					resource.TestCheckResourceAttr(
 						"aws_glue_catalog_table.test",
+						"database",
+						fmt.Sprintf("my_test_catalog_database_%d", rInt),
+					),
+					resource.TestCheckResourceAttr(
+						"aws_glue_catalog_table.test",
 						"description",
 						"",
 					),
@@ -38,4 +46,117 @@ func TestAccAWSGlueCatalogTable_full(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccGlueCatalogTable_basic(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = "my_test_catalog_database_%d"
+}
+
+resource "aws_glue_catalog_table" "test" {
+  name     = "my_test_table_%d"
+  database = "${aws_glue_catalog_database.test.name}"
+}
+`, rInt, rInt)
+}
+
+func testAccGlueCatalogTable_full(rInt int, desc string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = "my_test_catalog_database_%d"
+}
+# @TODO Fill out parameters from https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-tables.html#aws-glue-api-catalog-tables-StorageDescriptor
+resource "aws_glue_catalog_table" "test" {
+  name = "my_test_table_%d"
+  database = "${aws_glue_catalog_database.test.name}"
+  description = "%s"
+  owner = "my_owner"
+  retetention = "%s",
+  storage {
+    location = "my_location"
+    columns = [{
+      name = "my_column_1"
+      type = "int"
+      comment = "my_column_comment"
+    },{
+      name = "my_column_1"
+      type = "string"
+      comment = "my_column_comment"
+    }]
+    ...
+  }
+  partition_keys = [{
+    name = "my_column_1"
+    type = "int"
+    comment = "my_column_comment"
+  }]
+  ...
+}
+`, rInt, rInt, rInt, desc)
+}
+
+func testAccCheckGlueTableDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).glueconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_glue_catalog_table" {
+			continue
+		}
+
+		catalogId, dbName, tableName := readAwsGlueTableID(rs.Primary.ID)
+
+		input := &glue.GetTableInput{
+			DatabaseName: aws.String(dbName),
+			CatalogId:    aws.String(catalogId),
+			Name:         aws.String(tableName),
+		}
+		if _, err := conn.GetTable(input); err != nil {
+			//Verify the error is what we want
+			if isAWSErr(err, glue.ErrCodeEntityNotFoundException, "") {
+				continue
+			}
+
+			return err
+		}
+		return fmt.Errorf("still exists")
+	}
+	return nil
+}
+
+func testAccCheckGlueCatalogTableExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		catalogId, dbName, tableName := readAwsGlueTableID(rs.Primary.ID)
+
+		glueconn := testAccProvider.Meta().(*AWSClient).glueconn
+		out, err := glueconn.GetTable(&glue.GetTableInput{
+			CatalogId:    aws.String(catalogId),
+			DatabaseName: aws.String(dbName),
+			Name:         aws.String(tableName),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if out.Table == nil {
+			return fmt.Errorf("No Glue Database Found")
+		}
+
+		if *out.Table.Name != dbName {
+			return fmt.Errorf("Glue Database Mismatch - existing: %q, state: %q",
+				*out.Table.Name, tableName)
+		}
+
+		return nil
+	}
 }

--- a/aws/resource_aws_glue_catalog_table_test.go
+++ b/aws/resource_aws_glue_catalog_table_test.go
@@ -15,6 +15,7 @@ import (
 func TestAccAWSGlueCatalogTable_full(t *testing.T) {
 	rInt := acctest.RandInt()
 	description := "A test table from terraform"
+	tableName := "aws_glue_catalog_table.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -32,7 +33,7 @@ func TestAccAWSGlueCatalogTable_full(t *testing.T) {
 						fmt.Sprintf("my_test_catalog_table_%d", rInt),
 					),
 					resource.TestCheckResourceAttr(
-						"aws_glue_catalog_table.test",
+						tableName,
 						"database_name",
 						fmt.Sprintf("my_test_catalog_database_%d", rInt),
 					),
@@ -42,17 +43,44 @@ func TestAccAWSGlueCatalogTable_full(t *testing.T) {
 				Config:  testAccGlueCatalogTable_full(rInt, description),
 				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGlueCatalogTableExists("aws_glue_catalog_table.test"),
-					resource.TestCheckResourceAttr(
-						"aws_glue_catalog_table.test",
-						"name",
-						fmt.Sprintf("my_test_catalog_table_%d", rInt),
-					),
-					resource.TestCheckResourceAttr(
-						"aws_glue_catalog_table.test",
-						"database_name",
-						fmt.Sprintf("my_test_catalog_database_%d", rInt),
-					),
+					testAccCheckGlueCatalogTableExists(tableName),
+					resource.TestCheckResourceAttr(tableName, "name", fmt.Sprintf("my_test_catalog_table_%d", rInt)),
+					resource.TestCheckResourceAttr(tableName, "database_name", fmt.Sprintf("my_test_catalog_database_%d", rInt)),
+					resource.TestCheckResourceAttr(tableName, "description", description),
+					resource.TestCheckResourceAttr(tableName, "owner", "my_owner"),
+					resource.TestCheckResourceAttr(tableName, "retention", "1"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.0.name", "my_column_1"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.0.type", "int"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.0.comment", "my_column1_comment"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.1.name", "my_column_2"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.1.type", "string"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.columns.1.comment", "my_column2_comment"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.location", "my_location"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.input_format", "SequenceFileInputFormat"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.output_format", "SequenceFileInputFormat"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.compressed", "false"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.number_of_buckets", "1"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.ser_de_info.0.name", "ser_de_name"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.ser_de_info.0.parameters.param1", "param_val_1"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.ser_de_info.0.serialization_library", "org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.bucket_columns.0", "bucket_column_1"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.sort_columns.0.column", "my_column_1"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.sort_columns.0.sort_order", "1"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.parameters.param1", "param1_val"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.skewed_info.0.skewed_column_names.0", "my_column_1"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.skewed_info.0.skewed_column_value_location_maps.my_column_1", "my_column_1_val_loc_map"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.skewed_info.0.skewed_column_values.0", "skewed_val_1"),
+					resource.TestCheckResourceAttr(tableName, "storage_descriptor.0.stored_as_sub_directories", "false"),
+					resource.TestCheckResourceAttr(tableName, "partition_keys.0.name", "my_column_1"),
+					resource.TestCheckResourceAttr(tableName, "partition_keys.0.type", "int"),
+					resource.TestCheckResourceAttr(tableName, "partition_keys.0.comment", "my_column_1_comment"),
+					resource.TestCheckResourceAttr(tableName, "partition_keys.1.name", "my_column_2"),
+					resource.TestCheckResourceAttr(tableName, "partition_keys.1.type", "string"),
+					resource.TestCheckResourceAttr(tableName, "partition_keys.1.comment", "my_column_2_comment"),
+					resource.TestCheckResourceAttr(tableName, "view_original_text", "view_original_text_1"),
+					resource.TestCheckResourceAttr(tableName, "view_expanded_text", "view_expanded_text_1"),
+					resource.TestCheckResourceAttr(tableName, "table_type", "VIRTUAL_VIEW"),
+					resource.TestCheckResourceAttr(tableName, "parameters.param1", "param1_val"),
 				),
 			},
 		},
@@ -79,49 +107,47 @@ resource "aws_glue_catalog_database" "test" {
 }
 
 resource "aws_glue_catalog_table" "test" {
-  name = "my_test_table_%d"
+  name = "my_test_catalog_table_%d"
   database_name = "${aws_glue_catalog_database.test.name}"
   description = "%s"
   owner = "my_owner"
   retention = 1
   storage_descriptor {
-    /* columns = [
-      {
-        name = "my_column_1"
-        type = "int"
-        comment = "my_column1_comment"
-      },
-      {
-        name = "my_column_2"
-        type = "string"
-        comment = "my_column2_comment"
-      }
-    ] */
+    columns = [
+     {
+       name = "my_column_1"
+       type = "int"
+       comment = "my_column1_comment"
+     },
+     {
+       name = "my_column_2"
+       type = "string"
+       comment = "my_column2_comment"
+     }
+    ]
 	location = "my_location"
 	input_format = "SequenceFileInputFormat"
 	output_format = "SequenceFileInputFormat"
 	compressed = false
 	number_of_buckets = 1
-	/* ser_de_info {
+	ser_de_info {
       name = "ser_de_name"
       parameters {
         param1 = "param_val_1"
       }
       serialization_library = "org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe"
-	} */
-	bucket_columns = [
-      "bucket_column_1",
-	]
-	/* sort_columns = [
+	}
+	bucket_columns = ["bucket_column_1"]
+	sort_columns = [
       {
         column = "my_column_1"
         sort_order = 1
       }
-	] */
+	]
 	parameters {
       param1 = "param1_val"
 	}
-	/* skewed_info {
+	skewed_info {
       skewed_column_names = [
         "my_column_1"
       ]
@@ -131,19 +157,19 @@ resource "aws_glue_catalog_table" "test" {
       skewed_column_values = [
         "skewed_val_1"
       ]
-	} */
+	}
 	stored_as_sub_directories = false
   }
   partition_keys = [
     {
       name = "my_column_1"
       type = "int"
-      comment = "my_column1_comment"
+      comment = "my_column_1_comment"
     },
     {
       name = "my_column_2"
       type = "string"
-      comment = "my_column2_comment"
+      comment = "my_column_2_comment"
     }
   ]
   view_original_text = "view_original_text_1"

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1099,6 +1099,9 @@
                         <li<%= sidebar_current("docs-aws-resource-glue-job") %>>
                             <a href="/docs/providers/aws/r/glue_job.html">aws_glue_job</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-resource-glue-catalog-table") %>>
+                            <a href="/docs/providers/aws/r/glue_catalog_table.html">aws_glue_catalog_table</a>
+                        </li>
                     </ul>
                  </li>
 

--- a/website/docs/r/glue_catalog_table.html.markdown
+++ b/website/docs/r/glue_catalog_table.html.markdown
@@ -1,0 +1,76 @@
+---
+layout: "aws"
+page_title: "AWS: aws_glue_catalog_table"
+sidebar_current: "docs-aws-resource-glue-catalog-table"
+description: |-
+  Provides a Glue Catalog Table.
+---
+
+# aws_glue_catalog_table
+
+Provides a Glue Catalog Table Resource. You can refer to the [Glue Developer Guide](http://docs.aws.amazon.com/glue/latest/dg/populate-data-catalog.html) for a full explanation of the Glue Data Catalog functionality.
+
+## Example Usage
+
+```hcl
+resource "aws_glue_catalog_table" "aws_glue_catalog_table" {
+  name = "MyCatalogTable"
+  database_name = "MyCatalogDatabase"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name of the table. For Hive compatibility, this must be entirely lowercase.
+* `database_name` - (Required) Name of the metadata database where the table metadata resides. For Hive compatibility, this must be all lowercase.
+* `catalog_id` - (Optional) ID of the Glue Catalog and database to create the table in. If omitted, this defaults to the AWS Account ID plus the database name.
+* `description` - (Optional) Description of the table.
+* `owner` - (Optional) Owner of the table.
+* `retention` - (Optional) Retention time for this table.
+* `storage_descriptor` - (Optional) A [storage descriptor](#storage_descriptor) object containing information about the physical storage of this table. You can refer to the [Glue Developer Guide](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-tables.html#aws-glue-api-catalog-tables-StorageDescriptor) for a full explanation of this object.
+* `partition_keys` - (Optional) A list of columns by which the table is partitioned. Only primitive types are supported as partition keys.
+* `view_original_text` - (Optional) If the table is a view, the original text of the view; otherwise null.
+* `view_expanded_text` - (Optional) If the table is a view, the expanded text of the view; otherwise null.
+* `table_type` - (Optional) The type of this table (EXTERNAL_TABLE, VIRTUAL_VIEW, etc.).
+* `parameters` - (Optional) Properties associated with this table, as a list of key-value pairs.
+
+##### storage_descriptor
+
+* `columns` - (Optional) A list of the [Columns](#column) in the table.
+* `location` - (Optional) The physical location of the table. By default this takes the form of the warehouse location, followed by the database location in the warehouse, followed by the table name.
+* `input_format` - (Optional) The input format: SequenceFileInputFormat (binary), or TextInputFormat, or a custom format.
+* `output_format` - (Optional) The output format: SequenceFileOutputFormat (binary), or IgnoreKeyTextOutputFormat, or a custom format.
+* `compressed` - (Optional) True if the data in the table is compressed, or False if not.
+* `number_of_buckets` - (Optional) Must be specified if the table contains any dimension columns.
+* `ser_de_info` - (Optional) [Serialization/deserialization (SerDe)](#ser_de_info) information.
+* `bucket_columns` - (Optional) A list of reducer grouping columns, clustering columns, and bucketing columns in the table.
+* `sort_columns` - (Optional) A list of [Order](#sort_column) objects specifying the sort order of each bucket in the table.
+* `parameters` - (Optional) User-supplied properties in key-value form.
+* `skewed_info` - (Optional) Information about values that appear very frequently in a column (skewed values).
+* `stored_as_sub_directories` - (Optional) True if the table data is stored in subdirectories, or False if not.
+
+##### column
+
+* `name` - (Required) The name of the Column.
+* `type` - (Optional) The datatype of data in the Column.
+* `comment` - (Optional) Free-form text comment.
+
+##### ser_de_info
+
+* `name` - (Optional) Name of the SerDe.
+* `parameters` - (Optional) Usually the class that implements the SerDe. An example is: org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe.
+* `serialization_library` - (Optional) A list of initialization parameters for the SerDe, in key-value form.
+
+##### sort_column
+
+* `column` - (Required) The name of the column.
+* `sort_order` - (Required) Indicates that the column is sorted in ascending order (== 1), or in descending order (==0).
+
+##### skewed_info
+
+* `skewed_column_names` - (Optional) A list of names of columns that contain skewed values.
+* `skewed_column_value_location_maps` - (Optional) A list of values that appear so frequently as to be considered skewed.
+* `skewed_column_values` - (Optional) A mapping of skewed values to the columns that contain them.
+


### PR DESCRIPTION
Fixes #3880

Apologies in advance for any dodgy Go or terraform. I'm a newcomer to both.

Test output:
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSGlueCatalogTable_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSGlueCatalogTable_ -timeout 120m
=== RUN   TestAccAWSGlueCatalogTable_importBasic
--- PASS: TestAccAWSGlueCatalogTable_importBasic (27.41s)
=== RUN   TestAccAWSGlueCatalogTable_basic
--- PASS: TestAccAWSGlueCatalogTable_basic (25.35s)
=== RUN   TestAccAWSGlueCatalogTable_full
--- PASS: TestAccAWSGlueCatalogTable_full (25.13s)
=== RUN   TestAccAWSGlueCatalogTable_update_addValues
--- PASS: TestAccAWSGlueCatalogTable_update_addValues (42.97s)
=== RUN   TestAccAWSGlueCatalogTable_update_replaceValues
--- PASS: TestAccAWSGlueCatalogTable_update_replaceValues (43.20s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws      164.100s
```