### PR TITLE
Adds link to valid values for delivery_frequency

### DIFF
--- a/website/docs/r/config_delivery_channel.html.markdown
+++ b/website/docs/r/config_delivery_channel.html.markdown
@@ -87,8 +87,9 @@ The following arguments are supported:
 
 ### `snapshot_delivery_properties`
 
-* `delivery_frequency` - (Optional) - The frequency with which a AWS Config recurringly delivers configuration snapshots.
-	e.g. `One_Hour` or `Three_Hours`
+* `delivery_frequency` - (Optional) - The frequency with which AWS Config recurringly delivers configuration snapshots.
+	e.g. `One_Hour` or `Three_Hours`.
+	Valid values are listed [here](https://docs.aws.amazon.com/config/latest/APIReference/API_ConfigSnapshotDeliveryProperties.html#API_ConfigSnapshotDeliveryProperties_Contents).
 
 ## Attributes Reference
 


### PR DESCRIPTION
Links to valid values for config_delivery_channel resource's snapshot_delivery_properties.delivery_frequency argument.
I would also list the default, but I can't find it in AWS' documentation and it's not returned by the AWS API if not set.