### PR TITLE
resource/aws_iam_group_policy: Properly handle generated policy name updates

### DIFF
--- a/aws/resource_aws_iam_group_policy.go
+++ b/aws/resource_aws_iam_group_policy.go
@@ -102,7 +102,12 @@ func resourceAwsIamGroupPolicyRead(d *schema.ResourceData, meta interface{}) err
 	if err != nil {
 		return err
 	}
-	return d.Set("policy", policy)
+
+	d.Set("group", group)
+	d.Set("name", name)
+	d.Set("policy", policy)
+
+	return nil
 }
 
 func resourceAwsIamGroupPolicyDelete(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
Fixes #4377

After testing updates but before code changes:

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSIAMGroupPolicy_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSIAMGroupPolicy_ -timeout 120m
=== RUN   TestAccAWSIAMGroupPolicy_basic
--- PASS: TestAccAWSIAMGroupPolicy_basic (123.65s)
=== RUN   TestAccAWSIAMGroupPolicy_namePrefix
--- FAIL: TestAccAWSIAMGroupPolicy_namePrefix (66.59s)
	testing.go:518: Step 1 error: Check failed: Check 2/2 error: IAM Group Policy name did not match
	testing.go:579: Error destroying resource! WARNING: Dangling resources
		may exist. The full state and error is shown below.

		Error: Error applying: 1 error(s) occurred:

		* aws_iam_group.test (destroy): 1 error(s) occurred:

		* aws_iam_group.test: Error deleting IAM Group test_group_6453479404941257412: DeleteConflict: Cannot delete entity, must delete policies first.
			status code: 409, request id: 4197118c-4a18-11e8-a475-37a7836ae511

		State: aws_iam_group.test:
		  ID = test_group_6453479404941257412
		  provider = provider.aws
		  arn = arn:aws:iam::187416307283:group/test_group_6453479404941257412
		  name = test_group_6453479404941257412
		  path = /
		  unique_id = AGPAIVYQCFZDGLRBR3NXS
=== RUN   TestAccAWSIAMGroupPolicy_generatedName
--- FAIL: TestAccAWSIAMGroupPolicy_generatedName (101.27s)
	testing.go:518: Step 1 error: Check failed: Check 2/2 error: IAM Group Policy name did not match
	testing.go:579: Error destroying resource! WARNING: Dangling resources
		may exist. The full state and error is shown below.

		Error: Error applying: 1 error(s) occurred:

		* aws_iam_group.test (destroy): 1 error(s) occurred:

		* aws_iam_group.test: Error deleting IAM Group test_group_4300747935912896569: DeleteConflict: Cannot delete entity, must delete policies first.
			status code: 409, request id: 7df6644f-4a18-11e8-bf04-d919114d6f8f

		State: aws_iam_group.test:
		  ID = test_group_4300747935912896569
		  provider = provider.aws
		  arn = arn:aws:iam::187416307283:group/test_group_4300747935912896569
		  name = test_group_4300747935912896569
		  path = /
		  unique_id = AGPAJN2FJ6BIMRBYTKK2E
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	291.541s
make: *** [testacc] Error 1
```

After code changes:

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSIAMGroupPolicy_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSIAMGroupPolicy_ -timeout 120m
=== RUN   TestAccAWSIAMGroupPolicy_basic
--- PASS: TestAccAWSIAMGroupPolicy_basic (102.28s)
=== RUN   TestAccAWSIAMGroupPolicy_namePrefix
--- PASS: TestAccAWSIAMGroupPolicy_namePrefix (80.25s)
=== RUN   TestAccAWSIAMGroupPolicy_generatedName
--- PASS: TestAccAWSIAMGroupPolicy_generatedName (71.56s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	254.121s
```
