### PR TITLE
Ensure IPv6 CIDR block is assigned to default VPC

### DIFF
--- a/aws/resource_aws_default_vpc.go
+++ b/aws/resource_aws_default_vpc.go
@@ -28,6 +28,7 @@ func resourceAwsDefaultVpc() *schema.Resource {
 	// assign_generated_ipv6_cidr_block is a computed value for Default VPCs
 	dvpc.Schema["assign_generated_ipv6_cidr_block"] = &schema.Schema{
 		Type:     schema.TypeBool,
+		Optional: true,
 		Computed: true,
 	}
 
@@ -36,31 +37,28 @@ func resourceAwsDefaultVpc() *schema.Resource {
 
 func resourceAwsDefaultVpcCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
-	req := &ec2.DescribeVpcsInput{
-		Filters: []*ec2.Filter{
-			{
-				Name:   aws.String("isDefault"),
-				Values: aws.StringSlice([]string{"true"}),
-			},
-		},
-	}
 
+	req := &ec2.DescribeVpcsInput{}
+	req.Filters = buildEC2AttributeFilterList(
+		map[string]string{
+			"isDefault": "true",
+		},
+	)
+
+	log.Printf("[DEBUG] Reading Default VPC: %s", req)
 	resp, err := conn.DescribeVpcs(req)
 	if err != nil {
 		return err
 	}
-
 	if resp.Vpcs == nil || len(resp.Vpcs) == 0 {
 		return fmt.Errorf("No default VPC found in this region.")
 	}
 
 	d.SetId(aws.StringValue(resp.Vpcs[0].VpcId))
-
 	return resourceAwsVpcUpdate(d, meta)
 }
 
 func resourceAwsDefaultVpcDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[WARN] Cannot destroy Default VPC. Terraform will remove this resource from the state file, however resources may remain.")
-	d.SetId("")
 	return nil
 }

--- a/aws/resource_aws_default_vpc_test.go
+++ b/aws/resource_aws_default_vpc_test.go
@@ -26,13 +26,50 @@ func TestAccAWSDefaultVpc_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_default_vpc.foo", "tags.%", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_default_vpc.foo", "tags.Name", "Default VPC"),
-					resource.TestCheckNoResourceAttr(
-						"aws_default_vpc.foo", "assign_generated_ipv6_cidr_block"),
-					resource.TestCheckNoResourceAttr(
-						"aws_default_vpc.foo", "ipv6_association_id"),
-					resource.TestCheckNoResourceAttr(
-						"aws_default_vpc.foo", "ipv6_cidr_block"),
+						"aws_default_vpc.foo", "tags.Name", "terraform-testacc-default-vpc"),
+					// For backwards compatability the assign_generated_ipv6_cidr_block attribute has no default value
+					// for a region's default VPC. The assumption here is that IPv6 is not enabled.
+					testAccCheckVpcIpv6(&vpc, false),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDefaultVpc_enableIpv6(t *testing.T) {
+	var vpc ec2.Vpc
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDefaultVpcDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDefaultVpcConfigIpv6Enabled,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVpcExists("aws_default_vpc.foo", &vpc),
+					testAccCheckVpcCidr(&vpc, "172.31.0.0/16"),
+					resource.TestCheckResourceAttr(
+						"aws_default_vpc.foo", "cidr_block", "172.31.0.0/16"),
+					resource.TestCheckResourceAttr(
+						"aws_default_vpc.foo", "tags.%", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_default_vpc.foo", "tags.Name", "terraform-testacc-default-vpc-ipv6"),
+					testAccCheckVpcIpv6(&vpc, true),
+				),
+			},
+			{
+				Config: testAccAWSDefaultVpcConfigIpv6Disabled,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVpcExists("aws_default_vpc.foo", &vpc),
+					testAccCheckVpcCidr(&vpc, "172.31.0.0/16"),
+					resource.TestCheckResourceAttr(
+						"aws_default_vpc.foo", "assign_generated_ipv6_cidr_block", "false"),
+					resource.TestCheckResourceAttr(
+						"aws_default_vpc.foo", "ipv6_association_id", ""),
+					resource.TestCheckResourceAttr(
+						"aws_default_vpc.foo", "ipv6_cidr_block", ""),
+					testAccCheckVpcIpv6(&vpc, false),
 				),
 			},
 		},
@@ -45,13 +82,27 @@ func testAccCheckAWSDefaultVpcDestroy(s *terraform.State) error {
 }
 
 const testAccAWSDefaultVpcConfigBasic = `
-provider "aws" {
-    region = "us-west-2"
-}
-
 resource "aws_default_vpc" "foo" {
-	tags {
-		Name = "Default VPC"
-	}
+  tags {
+    Name = "terraform-testacc-default-vpc"
+  }
+}
+`
+
+const testAccAWSDefaultVpcConfigIpv6Enabled = `
+resource "aws_default_vpc" "foo" {
+  assign_generated_ipv6_cidr_block = true
+  tags {
+    Name = "terraform-testacc-default-vpc-ipv6"
+  }
+}
+`
+
+const testAccAWSDefaultVpcConfigIpv6Disabled = `
+resource "aws_default_vpc" "foo" {
+  assign_generated_ipv6_cidr_block = false
+  tags {
+    Name = "terraform-testacc-default-vpc-ipv6"
+  }
 }
 `

--- a/website/docs/r/default_vpc.html.markdown
+++ b/website/docs/r/default_vpc.html.markdown
@@ -17,7 +17,7 @@ using it. Please read this document in its entirety before using this resource.
 
 The `aws_default_vpc` behaves differently from normal resources, in that
 Terraform does not _create_ this resource, but instead "adopts" it
-into management. 
+into management.
 
 ## Example Usage
 
@@ -33,15 +33,18 @@ resource "aws_default_vpc" "default" {
 
 ## Argument Reference
 
-The arguments of an `aws_default_vpc` differ slightly from `aws_vpc` 
-resources. Namely, the `cidr_block`, `instance_tenancy` and `assign_generated_ipv6_cidr_block`
-arguments are computed. The following arguments are still supported: 
+The arguments of an `aws_default_vpc` differ slightly from `aws_vpc`
+resources. Namely, the `cidr_block` and `instance_tenancy` arguments are computed.
+The following arguments are still supported:
 
 * `enable_dns_support` - (Optional) A boolean flag to enable/disable DNS support in the VPC. Defaults true.
 * `enable_dns_hostnames` - (Optional) A boolean flag to enable/disable DNS hostnames in the VPC. Defaults false.
-* `enable_classiclink` - (Optional) A boolean flag to enable/disable ClassicLink 
+* `enable_classiclink` - (Optional) A boolean flag to enable/disable ClassicLink
   for the VPC. Only valid in regions and accounts that support EC2 Classic.
   See the [ClassicLink documentation][1] for more information. Defaults false.
+* `assign_generated_ipv6_cidr_block` - (Optional) Requests an Amazon-provided IPv6 CIDR
+block with a /56 prefix length for the VPC. You cannot specify the range of IP addresses, or
+the size of the CIDR block.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ### Removing `aws_default_vpc` from your configuration
@@ -61,7 +64,7 @@ The following attributes are exported:
 * `enable_dns_support` - Whether or not the VPC has DNS support
 * `enable_dns_hostnames` - Whether or not the VPC has DNS hostname support
 * `enable_classiclink` - Whether or not the VPC has Classiclink enabled
-* `assign_generated_ipv6_cidr_block` - Whether or not an Amazon-provided IPv6 CIDR 
+* `assign_generated_ipv6_cidr_block` - Whether or not an Amazon-provided IPv6 CIDR
 block with a /56 prefix length for the VPC was assigned
 * `main_route_table_id` - The ID of the main route table associated with
      this VPC. Note that you can change a VPC's main route table by using an


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/4290.

Acceptance tests:

```
make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSDefaultVpc_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAWSDefaultVpc_ -timeout 120m
=== RUN   TestAccAWSDefaultVpc_basic
--- PASS: TestAccAWSDefaultVpc_basic (23.73s)
=== RUN   TestAccAWSDefaultVpc_enableIpv6
--- PASS: TestAccAWSDefaultVpc_enableIpv6 (44.30s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	68.043s
```

```
make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSVpc_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAWSVpc_ -timeout 120m
=== RUN   TestAccAWSVpc_coreMismatchedDiffs
--- PASS: TestAccAWSVpc_coreMismatchedDiffs (24.83s)
=== RUN   TestAccAWSVpc_importBasic
--- PASS: TestAccAWSVpc_importBasic (29.81s)
=== RUN   TestAccAWSVpc_basic
--- PASS: TestAccAWSVpc_basic (24.59s)
=== RUN   TestAccAWSVpc_enableIpv6
--- PASS: TestAccAWSVpc_enableIpv6 (67.12s)
=== RUN   TestAccAWSVpc_dedicatedTenancy
--- PASS: TestAccAWSVpc_dedicatedTenancy (25.02s)
=== RUN   TestAccAWSVpc_tags
--- PASS: TestAccAWSVpc_tags (45.89s)
=== RUN   TestAccAWSVpc_update
--- PASS: TestAccAWSVpc_update (44.48s)
=== RUN   TestAccAWSVpc_bothDnsOptionsSet
--- PASS: TestAccAWSVpc_bothDnsOptionsSet (27.52s)
=== RUN   TestAccAWSVpc_DisabledDnsSupport
--- PASS: TestAccAWSVpc_DisabledDnsSupport (24.00s)
=== RUN   TestAccAWSVpc_classiclinkOptionSet
--- PASS: TestAccAWSVpc_classiclinkOptionSet (24.82s)
=== RUN   TestAccAWSVpc_classiclinkDnsSupportOptionSet
--- PASS: TestAccAWSVpc_classiclinkDnsSupportOptionSet (25.57s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	363.655s
```