### PR TITLE
[WIP] Add an aws_organizations_account_ids data source

### DIFF
--- a/aws/data_source_aws_organizations_account_ids.go
+++ b/aws/data_source_aws_organizations_account_ids.go
@@ -1,0 +1,65 @@
+package aws
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/organizations"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsOrganizationsAccountIds() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsOrganizationAccountIdsRead,
+
+		Schema: map[string]*schema.Schema{
+			"parent_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"ids": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceAwsOrganizationAccountIdsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).organizationsconn
+
+	accountIds := make([]string, 0)
+
+	if parentId, ok := d.GetOk("parent_id"); ok {
+		input := &organizations.ListAccountsForParentInput{
+			ParentId: aws.String(parentId.(string)),
+		}
+		result, err := conn.ListAccountsForParent(input)
+
+		if err != nil {
+			return err
+		}
+
+		for _, account := range result.Accounts {
+			accountIds = append(accountIds, *account.Id)
+		}
+	} else {
+		input := &organizations.ListAccountsInput{}
+		result, err := conn.ListAccounts(input)
+
+		if err != nil {
+			return err
+		}
+
+		for _, account := range result.Accounts {
+			accountIds = append(accountIds, *account.Id)
+		}
+	}
+
+	d.SetId(time.Now().UTC().String())
+	d.Set("ids", accountIds)
+
+	return nil
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -219,6 +219,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_mq_broker":                        dataSourceAwsMqBroker(),
 			"aws_nat_gateway":                      dataSourceAwsNatGateway(),
 			"aws_network_interface":                dataSourceAwsNetworkInterface(),
+			"aws_organizations_account_ids":        dataSourceAwsOrganizationsAccountIds(),
 			"aws_partition":                        dataSourceAwsPartition(),
 			"aws_prefix_list":                      dataSourceAwsPrefixList(),
 			"aws_rds_cluster":                      dataSourceAwsRdsCluster(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -220,6 +220,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-mq-broker") %>>
                             <a href="/docs/providers/aws/d/mq_broker.html">aws_mq_broker</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-organizations-account-ids") %>>
+                            <a href="/docs/providers/aws/d/organizations_account_ids.html">aws_organizations_account_ids</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-partition") %>>
                             <a href="/docs/providers/aws/d/partition.html">aws_partition</a>
                         </li>

--- a/website/docs/d/organizations_account_ids.html.markdown
+++ b/website/docs/d/organizations_account_ids.html.markdown
@@ -1,0 +1,29 @@
+---
+layout: "aws"
+page_title: "AWS: aws_organizations_account_ids"
+sidebar_current: "docs-aws-datasource-organizations-account-ids"
+description: |-
+    Provides a list of Account IDs in an Organization or Organizational Unit.Use this data source to get a list of Account IDs in an Organization or Organizational Unit
+---
+
+# Data Source: aws_organizations_account_ids
+
+`aws_organizations_account_ids` provides a list of AccountIds in an [organization](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_org.html) or [organizational unit](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_ous.html).
+
+Will give an error if Organizations aren't enabled - see `aws_organizations_organization`.
+
+## Example Usage
+
+```hcl
+data "aws_organizations_account_ids" "master" {}
+```
+
+## Argument Reference
+
+* `parent_id` - (Optional) The ID for the [parent root](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_getting-started_concepts.html#root) or [organizational unit](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_getting-started_concepts.html#organizationalunit) whose accounts you want to list.  If you specify the root you get the list of all the accounts that are not in any organizational unit.  If you specify an organizational unit, you get a list of all the accounts in only that organizational unit, and not any child organizational units.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `ids` - is set to a list Account IDs.


### PR DESCRIPTION
Part of #571 

Corresponds to [ListAccounts](https://docs.aws.amazon.com/organizations/latest/APIReference/API_ListAccounts.html) and the [ListAccountsForParent](https://docs.aws.amazon.com/organizations/latest/APIReference/API_ListAccountsForParent.html) APIs.  Motivation here is to be able to write IAM policies that automatically allow things for all accounts in an Organization or Organizational Unit (e.g. allowing all accounts belonging to an Organization to write CloudTrail logs to the same S3 bucket) without needing to hardcode the Account Ids.

I have not written the tests for this yet because to do so I really need #4207 and #4229.  But I wanted to checkpoint my work and get feedback on what I already have.

I've tested it as follows:
```hcl
data "aws_organizations_account_ids" "me" {}

output "account_ids" {
  value = ["${data.aws_organizations_account_ids.me.ids}"]
}
```

Which resulted in the following output (actual account id obfuscated):
```
$ terraform apply
data.aws_organizations_account_ids.me: Refreshing state...

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

account_ids = [
    123456789012
]
```

With the root id:
```hcl
data "aws_organizations_account_ids" "me" { parent_id = "r-oi5p" }

output "account_ids" {
  value = ["${data.aws_organizations_account_ids.me.ids}"]
}
```

Which resulted in the following output (actual account id obfuscated):
```
$ terraform apply
data.aws_organizations_account_ids.me: Refreshing state...

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

account_ids = [
    123456789012
]
```

I then moved the account into an OU and tried it again with the root which resulted in the following output (actual account id obfuscated):
```
$ terraform apply
data.aws_organizations_account_ids.me: Refreshing state...

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

account_ids = []
```

And then finally with the OU id:
```hcl
data "aws_organizations_account_ids" "me" { parent_id = "ou-oi5p-mgp77s7y" }

output "account_ids" {
  value = ["${data.aws_organizations_account_ids.me.ids}"]
}
```

Which resulted in the following output (actual account id obfuscated):
```
$ terraform apply
data.aws_organizations_account_ids.me: Refreshing state...

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

account_ids = [
    123456789012
]
```

I intend to test with an account with many accounts in the Organization next week at work.