### PR TITLE
Add support for AWS Batch job definition timeout

### DIFF
--- a/aws/resource_aws_batch_job_definition.go
+++ b/aws/resource_aws_batch_job_definition.go
@@ -50,8 +50,9 @@ func resourceAwsBatchJobDefinition() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"attempts": {
-							Type:     schema.TypeInt,
-							Required: true,
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(1, 10),
 						},
 					},
 				},
@@ -65,7 +66,7 @@ func resourceAwsBatchJobDefinition() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"attempt_duration_seconds": {
 							Type:         schema.TypeInt,
-							Required:     true,
+							Optional:     true,
 							ValidateFunc: validation.IntAtLeast(60),
 						},
 					},

--- a/aws/resource_aws_batch_job_definition.go
+++ b/aws/resource_aws_batch_job_definition.go
@@ -223,15 +223,19 @@ func expandJobDefinitionParameters(params map[string]interface{}) map[string]*st
 }
 
 func expandJobDefinitionRetryStrategy(item []interface{}) *batch.RetryStrategy {
+	retryStrategy := &batch.RetryStrategy{}
 	data := item[0].(map[string]interface{})
-	return &batch.RetryStrategy{
-		Attempts: aws.Int64(int64(data["attempts"].(int))),
+
+	if v, ok := data["attempts"].(int); ok && v > 0 && v <= 10 {
+		retryStrategy.Attempts = aws.Int64(int64(v))
 	}
+
+	return retryStrategy
 }
 
 func flattenBatchRetryStrategy(item *batch.RetryStrategy) []map[string]interface{} {
 	data := []map[string]interface{}{}
-	if item != nil {
+	if item != nil && item.Attempts != nil {
 		data = append(data, map[string]interface{}{
 			"attempts": int(aws.Int64Value(item.Attempts)),
 		})
@@ -240,15 +244,19 @@ func flattenBatchRetryStrategy(item *batch.RetryStrategy) []map[string]interface
 }
 
 func expandJobDefinitionTimeout(item []interface{}) *batch.JobTimeout {
+	timeout := &batch.JobTimeout{}
 	data := item[0].(map[string]interface{})
-	return &batch.JobTimeout{
-		AttemptDurationSeconds: aws.Int64(int64(data["attempt_duration_seconds"].(int))),
+
+	if v, ok := data["attempt_duration_seconds"].(int); ok && v >= 60 {
+		timeout.AttemptDurationSeconds = aws.Int64(int64(v))
 	}
+
+	return timeout
 }
 
 func flattenBatchJobTimeout(item *batch.JobTimeout) []map[string]interface{} {
 	data := []map[string]interface{}{}
-	if item != nil {
+	if item != nil && item.AttemptDurationSeconds != nil {
 		data = append(data, map[string]interface{}{
 			"attempt_duration_seconds": int(aws.Int64Value(item.AttemptDurationSeconds)),
 		})

--- a/aws/resource_aws_batch_job_definition.go
+++ b/aws/resource_aws_batch_job_definition.go
@@ -232,7 +232,7 @@ func flattenBatchRetryStrategy(item *batch.RetryStrategy) []map[string]interface
 	data := []map[string]interface{}{}
 	if item != nil {
 		data = append(data, map[string]interface{}{
-			"attempts": item.Attempts,
+			"attempts": int(aws.Int64Value(item.Attempts)),
 		})
 	}
 	return data
@@ -249,7 +249,7 @@ func flattenBatchJobTimeout(item *batch.JobTimeout) []map[string]interface{} {
 	data := []map[string]interface{}{}
 	if item != nil {
 		data = append(data, map[string]interface{}{
-			"attempt_duration_seconds": item.AttemptDurationSeconds,
+			"attempt_duration_seconds": int(aws.Int64Value(item.AttemptDurationSeconds)),
 		})
 	}
 	return data

--- a/aws/resource_aws_batch_job_definition.go
+++ b/aws/resource_aws_batch_job_definition.go
@@ -64,8 +64,9 @@ func resourceAwsBatchJobDefinition() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"attempt_duration_seconds": {
-							Type:     schema.TypeInt,
-							Required: true,
+							Type:         schema.TypeInt,
+							Required:     true,
+							ValidateFunc: validation.IntAtLeast(60),
 						},
 					},
 				},

--- a/aws/resource_aws_batch_job_definition.go
+++ b/aws/resource_aws_batch_job_definition.go
@@ -141,8 +141,15 @@ func resourceAwsBatchJobDefinitionRead(d *schema.ResourceData, meta interface{})
 	d.Set("arn", job.JobDefinitionArn)
 	d.Set("container_properties", job.ContainerProperties)
 	d.Set("parameters", aws.StringValueMap(job.Parameters))
-	d.Set("retry_strategy", flattenRetryStrategy(job.RetryStrategy))
-	d.Set("timeout", flattenTimeout(job.Timeout))
+
+	if err := d.Set("retry_strategy", flattenBatchRetryStrategy(job.RetryStrategy)); err != nil {
+		return fmt.Errorf("error setting retry_strategy: %s", err)
+	}
+
+	if err := d.Set("timeout", flattenBatchJobTimeout(job.Timeout)); err != nil {
+		return fmt.Errorf("error setting timeout: %s", err)
+	}
+
 	d.Set("revision", job.Revision)
 	d.Set("type", job.Type)
 	return nil
@@ -221,7 +228,7 @@ func expandJobDefinitionRetryStrategy(item []interface{}) *batch.RetryStrategy {
 	}
 }
 
-func flattenRetryStrategy(item *batch.RetryStrategy) []map[string]interface{} {
+func flattenBatchRetryStrategy(item *batch.RetryStrategy) []map[string]interface{} {
 	data := []map[string]interface{}{}
 	if item != nil {
 		data = append(data, map[string]interface{}{
@@ -238,7 +245,7 @@ func expandJobDefinitionTimeout(item []interface{}) *batch.JobTimeout {
 	}
 }
 
-func flattenTimeout(item *batch.JobTimeout) []map[string]interface{} {
+func flattenBatchJobTimeout(item *batch.JobTimeout) []map[string]interface{} {
 	data := []map[string]interface{}{}
 	if item != nil {
 		data = append(data, map[string]interface{}{

--- a/aws/resource_aws_batch_job_definition_test.go
+++ b/aws/resource_aws_batch_job_definition_test.go
@@ -24,6 +24,9 @@ func TestAccAWSBatchJobDefinition_basic(t *testing.T) {
 		RetryStrategy: &batch.RetryStrategy{
 			Attempts: aws.Int64(int64(1)),
 		},
+		Timeout: &batch.JobTimeout{
+			AttemptDurationSeconds: aws.Int64(int64(60)),
+		},
 		ContainerProperties: &batch.ContainerProperties{
 			Command: []*string{aws.String("ls"), aws.String("-la")},
 			Environment: []*batch.KeyValuePair{
@@ -184,6 +187,9 @@ resource "aws_batch_job_definition" "test" {
 	}
 	retry_strategy = {
 		attempts = 1
+	}
+	timeout = {
+		attempt_duration_seconds = 60
 	}
 	container_properties = <<CONTAINER_PROPERTIES
 {

--- a/website/docs/r/batch_job_definition.html.markdown
+++ b/website/docs/r/batch_job_definition.html.markdown
@@ -69,13 +69,13 @@ The following arguments are supported:
 
 `retry_strategy` supports the following:
 
-* `attempts` - (Required) The number of times to move a job to the `RUNNABLE` status. You may specify between `1` and `10` attempts.
+* `attempts` - (Optional) The number of times to move a job to the `RUNNABLE` status. You may specify between `1` and `10` attempts.
 
 ## timeout
 
 `timeout` supports the following:
 
-* `attempt_duration_seconds` - (Required) The time duration in seconds after which AWS Batch terminates your jobs if they have not finished. The minimum value for the timeout is `60` seconds.
+* `attempt_duration_seconds` - (Optional) The time duration in seconds after which AWS Batch terminates your jobs if they have not finished. The minimum value for the timeout is `60` seconds.
 
 ## Attribute Reference
 

--- a/website/docs/r/batch_job_definition.html.markdown
+++ b/website/docs/r/batch_job_definition.html.markdown
@@ -62,6 +62,7 @@ The following arguments are supported:
 * `parameters` - (Optional) Specifies the parameter substitution placeholders to set in the job definition.
 * `retry_strategy` - (Optional) Specifies the retry strategy to use for failed jobs that are submitted with this job definition.
     Maximum number of `retry_strategy` is `1`.  Defined below.
+* `timeout` - (Optional) Specifies the timeout for jobs so that if a job runs longer, AWS Batch terminates the job. Maximum number of `timeout` is `1`. Defined below.
 * `type` - (Required) The type of job definition.  Must be `container`
 
 ## retry_strategy
@@ -69,6 +70,12 @@ The following arguments are supported:
 `retry_strategy` supports the following:
 
 * `attempts` - (Required) The number of times to move a job to the `RUNNABLE` status. You may specify between `1` and `10` attempts.
+
+## timeout
+
+`timeout` supports the following:
+
+* `attempt_duration_seconds` - (Required) The time duration in seconds after which AWS Batch terminates your jobs if they have not finished. The minimum value for the timeout is `60` seconds.
 
 ## Attribute Reference
 


### PR DESCRIPTION
Update the existing `aws_batch_job_definition` resource so that it supports the newly added timeout feature. The timeout configuration is supplied through a `timeout` block inside `aws_batch_job_definition` with a single `attempt_duration_seconds` attribute.

This was tested via `make test` and by building a `terraform-provider-aws` binary. The binary was used with an existing Terraform project after `timeout {}` blocks were added to the existing `aws_batch_job_definition` resources.

Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/4186

See:

- https://docs.aws.amazon.com/sdk-for-go/api/service/batch/#RegisterJobDefinitionInput
- https://docs.aws.amazon.com/batch/latest/userguide/job_definition_parameters.html#timeout