### PR TITLE
Added Parameter Store support for CodeBuild environmental variables

### DIFF
--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -137,7 +137,7 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 									},
 									"type": {
 										Type:     schema.TypeString,
-										Required: false,
+										Optional: true,
 										Default:  codebuild.EnvironmentVariableTypePlaintext,
 										ValidateFunc: validation.StringInSlice([]string{
 											codebuild.EnvironmentVariableTypeParameterStore,

--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -135,6 +135,15 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 										Type:     schema.TypeString,
 										Required: true,
 									},
+									"type": {
+										Type:     schema.TypeString,
+										Required: false,
+										Default:  codebuild.EnvironmentVariableTypePlaintext,
+										ValidateFunc: validation.StringInSlice([]string{
+											codebuild.EnvironmentVariableTypeParameterStore,
+											codebuild.EnvironmentVariableTypePlaintext,
+										}, false),
+									},
 								},
 							},
 						},

--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -370,7 +370,7 @@ resource "aws_codebuild_project" "foo" {
     environment_variable = {
       "name"  = "SOME_KEY"
       "value" = "SOME_VALUE"
-      "type" = "PARAMETER_STORE"
+      "type"  = "PLAINTEXT"
     }
   }
 
@@ -456,7 +456,7 @@ resource "aws_codebuild_project" "foo" {
     environment_variable = {
       "name"  = "SOME_OTHERKEY"
       "value" = "SOME_OTHERVALUE"
-      "type" = "PLAINTEXT"
+      "type"  = "PARAMETER_STORE"
     }
   }
 
@@ -638,6 +638,7 @@ resource "aws_codebuild_project" "foo" {
     environment_variable = {
       "name"  = "SOME_OTHERKEY"
       "value" = "SOME_OTHERVALUE"
+      "type"  = "PLAINTEXT"
     }
   }
 

--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -370,6 +370,7 @@ resource "aws_codebuild_project" "foo" {
     environment_variable = {
       "name"  = "SOME_KEY"
       "value" = "SOME_VALUE"
+      "type" = "PARAMETER_STORE"
     }
   }
 
@@ -455,6 +456,7 @@ resource "aws_codebuild_project" "foo" {
     environment_variable = {
       "name"  = "SOME_OTHERKEY"
       "value" = "SOME_OTHERVALUE"
+      "type" = "PLAINTEXT"
     }
   }
 

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -91,11 +91,13 @@ resource "aws_codebuild_project" "foo" {
     environment_variable {
       "name"  = "SOME_KEY1"
       "value" = "SOME_VALUE1"
+      "type"  = "PARAMETER_STORE"
     }
 
     environment_variable {
       "name"  = "SOME_KEY2"
       "value" = "SOME_VALUE2"
+      "type"  = "PLAINTEXT"
     }
   }
 
@@ -165,7 +167,8 @@ The following arguments are supported:
 `environment_variable` supports the following:
 
 * `name` - (Required) The environment variable's name or key.
-* `value` - (Required) The environment variable's value.
+* `value` - (Required) The environment variable's value. If `type` is set to `PARAMETER_STORE` this should be the name of the Parameter.
+* `type` - (Optional) Valid values for this parameter are: `PLAINTEXT` or `PARAMETER_STORE`. Defaults to `PLAINTEXT`.
 
 `source` supports the following:
 


### PR DESCRIPTION
Updated the `aws_codebuild_project` resource to allow an `environmental_variable` block to accept a plaintext variable or a reference to a EC2 Systems Manager Parameter Store object. This fixes the current issue of having to manually use the AWS Console to add variables to your CodeBuild project if you want to keep the value in a Parameter Store in EC2.

The `type` option defaults to `PLAINTEXT` to prevent a breaking change.

See:
- https://docs.aws.amazon.com/codebuild/latest/APIReference/API_EnvironmentVariable.html
- https://github.com/aws/aws-sdk-go/blob/master/service/codebuild/api.go#L4603