### PR TITLE
r/ecs_service: Added ordered placement strategy

### DIFF
--- a/aws/resource_aws_ecs_service_test.go
+++ b/aws/resource_aws_ecs_service_test.go
@@ -862,7 +862,7 @@ resource "aws_ecs_service" "mongo" {
 func testAccAWSEcsServiceWithMultiPlacementStrategy(clusterName, tdName, svcName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "default" {
-	name = "%s"
+  name = "%s"
 }
 
 resource "aws_ecs_task_definition" "mongo" {
@@ -886,12 +886,12 @@ resource "aws_ecs_service" "mongo" {
   task_definition = "${aws_ecs_task_definition.mongo.arn}"
   desired_count = 1
   ordered_placement_strategy {
-	  type = "binpack"
-	  field = "memory"
+    type = "binpack"
+    field = "memory"
   }
-	ordered_placement_strategy {
-	  field = "host"
-	  type = "spread"
+  ordered_placement_strategy {
+    field = "host"
+    type = "spread"
   }
 }
 `, clusterName, tdName, svcName)

--- a/aws/resource_aws_ecs_service_test.go
+++ b/aws/resource_aws_ecs_service_test.go
@@ -457,14 +457,27 @@ func TestAccAWSEcsService_withPlacementStrategy(t *testing.T) {
 				Config: testAccAWSEcsService(clusterName, tdName, svcName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsServiceExists("aws_ecs_service.mongo", &service),
-					resource.TestCheckResourceAttr("aws_ecs_service.mongo", "placement_strategy.#", "0"),
+					resource.TestCheckResourceAttr("aws_ecs_service.mongo", "ordered_placement_strategy.#", "0"),
 				),
 			},
 			{
 				Config: testAccAWSEcsServiceWithPlacementStrategy(clusterName, tdName, svcName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsServiceExists("aws_ecs_service.mongo", &service),
-					resource.TestCheckResourceAttr("aws_ecs_service.mongo", "placement_strategy.#", "1"),
+					resource.TestCheckResourceAttr("aws_ecs_service.mongo", "ordered_placement_strategy.#", "1"),
+					resource.TestCheckResourceAttr("aws_ecs_service.mongo", "ordered_placement_strategy.0.type", "binpack"),
+					resource.TestCheckResourceAttr("aws_ecs_service.mongo", "ordered_placement_strategy.0.field", "memory"),
+				),
+			},
+			{
+				Config: testAccAWSEcsServiceWithMultiPlacementStrategy(clusterName, tdName, svcName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcsServiceExists("aws_ecs_service.mongo", &service),
+					resource.TestCheckResourceAttr("aws_ecs_service.mongo", "ordered_placement_strategy.#", "2"),
+					resource.TestCheckResourceAttr("aws_ecs_service.mongo", "ordered_placement_strategy.0.type", "binpack"),
+					resource.TestCheckResourceAttr("aws_ecs_service.mongo", "ordered_placement_strategy.0.field", "memory"),
+					resource.TestCheckResourceAttr("aws_ecs_service.mongo", "ordered_placement_strategy.1.type", "spread"),
+					resource.TestCheckResourceAttr("aws_ecs_service.mongo", "ordered_placement_strategy.1.field", "instanceId"),
 				),
 			},
 		},
@@ -838,9 +851,47 @@ resource "aws_ecs_service" "mongo" {
   cluster = "${aws_ecs_cluster.default.id}"
   task_definition = "${aws_ecs_task_definition.mongo.arn}"
   desired_count = 1
-  placement_strategy {
+  ordered_placement_strategy {
     type = "binpack"
     field = "memory"
+  }
+}
+`, clusterName, tdName, svcName)
+}
+
+func testAccAWSEcsServiceWithMultiPlacementStrategy(clusterName, tdName, svcName string) string {
+	return fmt.Sprintf(`
+resource "aws_ecs_cluster" "default" {
+	name = "%s"
+}
+
+resource "aws_ecs_task_definition" "mongo" {
+  family = "%s"
+  container_definitions = <<DEFINITION
+[
+  {
+    "cpu": 128,
+    "essential": true,
+    "image": "mongo:latest",
+    "memory": 128,
+    "name": "mongodb"
+  }
+]
+DEFINITION
+}
+
+resource "aws_ecs_service" "mongo" {
+  name = "%s"
+  cluster = "${aws_ecs_cluster.default.id}"
+  task_definition = "${aws_ecs_task_definition.mongo.arn}"
+  desired_count = 1
+  ordered_placement_strategy {
+	  type = "binpack"
+	  field = "memory"
+  }
+	ordered_placement_strategy {
+	  field = "host"
+	  type = "spread"
   }
 }
 `, clusterName, tdName, svcName)

--- a/website/docs/r/ecs_service.html.markdown
+++ b/website/docs/r/ecs_service.html.markdown
@@ -25,7 +25,7 @@ resource "aws_ecs_service" "mongo" {
   iam_role        = "${aws_iam_role.foo.arn}"
   depends_on      = ["aws_iam_role_policy.foo"]
 
-  placement_strategy {
+  ordered_placement_strategy {
     type  = "binpack"
     field = "cpu"
   }
@@ -73,9 +73,8 @@ The following arguments are supported:
 * `iam_role` - (Optional) The ARN of IAM role that allows your Amazon ECS container agent to make calls to your load balancer on your behalf. This parameter is only required if you are using a load balancer with your service.
 * `deployment_maximum_percent` - (Optional) The upper limit (as a percentage of the service's desiredCount) of the number of running tasks that can be running in a service during a deployment.
 * `deployment_minimum_healthy_percent` - (Optional) The lower limit (as a percentage of the service's desiredCount) of the number of running tasks that must remain running and healthy in a service during a deployment.
-* `placement_strategy` - (Optional) Service level strategy rules that are taken
-into consideration during task placement. The maximum number of
-`placement_strategy` blocks is `5`. Defined below.
+* `placement_strategy` - (Optional) **Deprecated**, use `ordered_placement_strategy` instead.
+* `ordered_placement_strategy` - (Optional) Service level strategy rules that are taken into consideration during task placement. List from top to bottom in order of precedence. The maximum number of `placement_strategy` blocks is `5`. Defined below.
 * `health_check_grace_period_seconds` - (Optional) Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 1800. Only valid for services configured to use load balancers.
 * `load_balancer` - (Optional) A load balancer block. Load balancers documented below.
 * `placement_constraints` - (Optional) rules that are taken into consideration during task placement. Maximum number of
@@ -92,9 +91,9 @@ Load balancers support the following:
 * `container_name` - (Required) The name of the container to associate with the load balancer (as it appears in a container definition).
 * `container_port` - (Required) The port on the container to associate with the load balancer.
 
-## placement_strategy
+## ordered_placement_strategy
 
-`placement_strategy` supports the following:
+`ordered_placement_strategy` supports the following:
 
 * `type` - (Required) The type of placement strategy. Must be one of: `binpack`, `random`, or `spread`
 * `field` - (Optional) For the `spread` placement strategy, valid values are instanceId (or host,


### PR DESCRIPTION
Related: #1476 
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSEcsService*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSEcsService* -timeout 120m
=== RUN   TestAccAWSEcsService_withARN
--- PASS: TestAccAWSEcsService_withARN (90.39s)
=== RUN   TestAccAWSEcsService_basicImport
--- PASS: TestAccAWSEcsService_basicImport (69.87s)
=== RUN   TestAccAWSEcsService_withUnnormalizedPlacementStrategy
--- PASS: TestAccAWSEcsService_withUnnormalizedPlacementStrategy (57.94s)
=== RUN   TestAccAWSEcsService_withFamilyAndRevision
--- PASS: TestAccAWSEcsService_withFamilyAndRevision (70.74s)
=== RUN   TestAccAWSEcsService_withRenamedCluster
--- PASS: TestAccAWSEcsService_withRenamedCluster (99.11s)
=== RUN   TestAccAWSEcsService_healthCheckGracePeriodSeconds
--- PASS: TestAccAWSEcsService_healthCheckGracePeriodSeconds (356.86s)
=== RUN   TestAccAWSEcsService_withIamRole
--- PASS: TestAccAWSEcsService_withIamRole (137.31s)
=== RUN   TestAccAWSEcsService_withDeploymentValues
--- PASS: TestAccAWSEcsService_withDeploymentValues (46.42s)
=== RUN   TestAccAWSEcsService_withLbChanges
--- PASS: TestAccAWSEcsService_withLbChanges (228.93s)
=== RUN   TestAccAWSEcsService_withEcsClusterName
--- PASS: TestAccAWSEcsService_withEcsClusterName (49.66s)
=== RUN   TestAccAWSEcsService_withAlb
--- PASS: TestAccAWSEcsService_withAlb (303.50s)
=== RUN   TestAccAWSEcsService_withPlacementStrategy
--- PASS: TestAccAWSEcsService_withPlacementStrategy (136.09s)
=== RUN   TestAccAWSEcsService_withPlacementConstraints
--- PASS: TestAccAWSEcsService_withPlacementConstraints (56.23s)
=== RUN   TestAccAWSEcsService_withPlacementConstraints_emptyExpression
--- PASS: TestAccAWSEcsService_withPlacementConstraints_emptyExpression (62.02s)
=== RUN   TestAccAWSEcsService_withLaunchTypeFargate
--- FAIL: TestAccAWSEcsService_withLaunchTypeFargate (510.55s)
	testing.go:518: Step 0 error: After applying this step, the plan was not empty:
		
		DIFF:
		
		UPDATE: aws_security_group.allow_all_b
		  ingress.#:                             "0" => "1"
		  ingress.2269895920.cidr_blocks.#:      "0" => "1"
		  ingress.2269895920.cidr_blocks.0:      "" => "10.10.0.0/16"
		  ingress.2269895920.description:        "" => ""
		  ingress.2269895920.from_port:          "" => "80"
		  ingress.2269895920.ipv6_cidr_blocks.#: "0" => "0"
		  ingress.2269895920.protocol:           "" => "tcp"
		  ingress.2269895920.security_groups.#:  "0" => "0"
		  ingress.2269895920.self:               "" => "false"
		  ingress.2269895920.to_port:            "" => "8000"
		
		STATE:
		
		aws_ecs_cluster.main:
		  ID = arn:aws:ecs:us-east-1:481473273857:cluster/tf-acc-cluster-svc-w-ltf-gy77qbah
		  provider = provider.aws
		  arn = arn:aws:ecs:us-east-1:481473273857:cluster/tf-acc-cluster-svc-w-ltf-gy77qbah
		  name = tf-acc-cluster-svc-w-ltf-gy77qbah
		aws_ecs_service.main:
		  ID = arn:aws:ecs:us-east-1:481473273857:service/tf-acc-svc-w-ltf-gy77qbah
		  provider = provider.aws
		  cluster = arn:aws:ecs:us-east-1:481473273857:cluster/tf-acc-cluster-svc-w-ltf-gy77qbah
		  deployment_maximum_percent = 200
		  deployment_minimum_healthy_percent = 100
		  desired_count = 1
		  health_check_grace_period_seconds = 0
		  iam_role = aws-service-role
		  launch_type = FARGATE
		  load_balancer.# = 0
		  name = tf-acc-svc-w-ltf-gy77qbah
		  network_configuration.# = 1
		  network_configuration.0.assign_public_ip = true
		  network_configuration.0.security_groups.# = 2
		  network_configuration.0.security_groups.2328280639 = sg-cbe8d382
		  network_configuration.0.security_groups.372139329 = sg-49eed500
		  network_configuration.0.subnets.# = 2
		  network_configuration.0.subnets.4057621718 = subnet-002bc42e
		  network_configuration.0.subnets.4073193208 = subnet-2694256c
		  ordered_placement_strategy.# = 0
		  placement_constraints.# = 0
		  service_registries.# = 0
		  task_definition = arn:aws:ecs:us-east-1:481473273857:task-definition/tf-acc-td-svc-w-ltf-gy77qbah:2
		
		  Dependencies:
		    aws_ecs_cluster.main
		    aws_ecs_task_definition.mongo
		    aws_security_group.allow_all_a
		    aws_security_group.allow_all_b
		    aws_subnet.main.*
		aws_ecs_task_definition.mongo:
		  ID = tf-acc-td-svc-w-ltf-gy77qbah
		  provider = provider.aws
		  arn = arn:aws:ecs:us-east-1:481473273857:task-definition/tf-acc-td-svc-w-ltf-gy77qbah:2
		  container_definitions = [{"cpu":256,"environment":[],"essential":true,"image":"mongo:latest","memory":512,"mountPoints":[],"name":"mongodb","portMappings":[],"volumesFrom":[]}]
		  cpu = 256
		  execution_role_arn = 
		  family = tf-acc-td-svc-w-ltf-gy77qbah
		  memory = 512
		  network_mode = awsvpc
		  placement_constraints.# = 0
		  requires_compatibilities.# = 1
		  requires_compatibilities.3072437307 = FARGATE
		  revision = 2
		  task_role_arn = 
		  volume.# = 0
		aws_security_group.allow_all_a:
		  ID = sg-49eed500
		  provider = provider.aws
		  arn = arn:aws:ec2:us-east-1:481473273857:security-group/sg-49eed500
		  description = Allow all inbound traffic
		  egress.# = 0
		  ingress.# = 1
		  ingress.2269895920.cidr_blocks.# = 1
		  ingress.2269895920.cidr_blocks.0 = 10.10.0.0/16
		  ingress.2269895920.description = 
		  ingress.2269895920.from_port = 80
		  ingress.2269895920.ipv6_cidr_blocks.# = 0
		  ingress.2269895920.protocol = tcp
		  ingress.2269895920.security_groups.# = 0
		  ingress.2269895920.self = false
		  ingress.2269895920.to_port = 8000
		  name = tf-acc-sg-1-svc-w-ltf-gy77qbah
		  owner_id = 481473273857
		  revoke_rules_on_delete = false
		  tags.% = 0
		  vpc_id = vpc-d31047a8
		
		  Dependencies:
		    aws_vpc.main
		aws_security_group.allow_all_b:
		  ID = sg-cbe8d382
		  provider = provider.aws
		  arn = arn:aws:ec2:us-east-1:481473273857:security-group/sg-cbe8d382
		  description = Allow all inbound traffic
		  egress.# = 0
		  ingress.# = 0
		  name = tf-acc-sg-2-svc-w-ltf-gy77qbah
		  owner_id = 481473273857
		  revoke_rules_on_delete = false
		  tags.% = 0
		  vpc_id = vpc-d31047a8
		
		  Dependencies:
		    aws_vpc.main
		aws_subnet.main.0:
		  ID = subnet-002bc42e
		  provider = provider.aws
		  assign_ipv6_address_on_creation = false
		  availability_zone = us-east-1a
		  cidr_block = 10.10.0.0/24
		  map_public_ip_on_launch = false
		  tags.% = 1
		  tags.Name = tf-acc-ecs-service-with-launch-type-fargate
		  vpc_id = vpc-d31047a8
		
		  Dependencies:
		    aws_vpc.main
		    data.aws_availability_zones.available
		aws_subnet.main.1:
		  ID = subnet-2694256c
		  provider = provider.aws
		  assign_ipv6_address_on_creation = false
		  availability_zone = us-east-1b
		  cidr_block = 10.10.1.0/24
		  map_public_ip_on_launch = false
		  tags.% = 1
		  tags.Name = tf-acc-ecs-service-with-launch-type-fargate
		  vpc_id = vpc-d31047a8
		
		  Dependencies:
		    aws_vpc.main
		    data.aws_availability_zones.available
		aws_vpc.main:
		  ID = vpc-d31047a8
		  provider = provider.aws
		  assign_generated_ipv6_cidr_block = false
		  cidr_block = 10.10.0.0/16
		  default_network_acl_id = acl-914ce4eb
		  default_route_table_id = rtb-d61b29aa
		  default_security_group_id = sg-17e9d25e
		  dhcp_options_id = dopt-c679a6a0
		  enable_classiclink = false
		  enable_classiclink_dns_support = false
		  enable_dns_hostnames = false
		  enable_dns_support = true
		  instance_tenancy = default
		  main_route_table_id = rtb-d61b29aa
		  tags.% = 1
		  tags.Name = terraform-testacc-ecs-service-with-launch-type-fargate
		data.aws_availability_zones.available:
		  ID = 2018-04-30 01:50:15.96365987 +0000 UTC
		  provider = provider.aws
		  names.# = 6
		  names.0 = us-east-1a
		  names.1 = us-east-1b
		  names.2 = us-east-1c
		  names.3 = us-east-1d
		  names.4 = us-east-1e
		  names.5 = us-east-1f
=== RUN   TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration
--- PASS: TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration (186.37s)
=== RUN   TestAccAWSEcsService_withServiceRegistries
--- PASS: TestAccAWSEcsService_withServiceRegistries (128.50s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	2590.537s
make: *** [testacc] Error 1
```

`TestAccAWSEcsService_withLaunchTypeFargate` isn't associated with this change.