### PR TITLE
r/ecs_service: modify TestAccAWSEcsService_withLaunchTypeFargate

### DIFF
--- a/aws/resource_aws_ecs_service_test.go
+++ b/aws/resource_aws_ecs_service_test.go
@@ -544,13 +544,6 @@ func TestAccAWSEcsService_withLaunchTypeFargate(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_ecs_service.main", "network_configuration.0.subnets.#", "2"),
 				),
 			},
-		},
-	})
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
-		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSEcsServiceWithLaunchTypeFargate(sg1Name, sg2Name, clusterName, tdName, svcName, "true"),
 				Check: resource.ComposeTestCheckFunc(
@@ -558,13 +551,6 @@ func TestAccAWSEcsService_withLaunchTypeFargate(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_ecs_service.main", "network_configuration.0.assign_public_ip", "true"),
 				),
 			},
-		},
-	})
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
-		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSEcsServiceWithLaunchTypeFargate(sg1Name, sg2Name, clusterName, tdName, svcName, "false"),
 				Check: resource.ComposeTestCheckFunc(


### PR DESCRIPTION
## Before
```
=== RUN   TestAccAWSEcsService_withLaunchTypeFargate
--- FAIL: TestAccAWSEcsService_withLaunchTypeFargate (510.55s)
	testing.go:518: Step 0 error: After applying this step, the plan was not empty:
		
		DIFF:
		
		UPDATE: aws_security_group.allow_all_b
		  ingress.#:                             "0" => "1"
		  ingress.2269895920.cidr_blocks.#:      "0" => "1"
		  ingress.2269895920.cidr_blocks.0:      "" => "10.10.0.0/16"
		  ingress.2269895920.description:        "" => ""
		  ingress.2269895920.from_port:          "" => "80"
		  ingress.2269895920.ipv6_cidr_blocks.#: "0" => "0"
		  ingress.2269895920.protocol:           "" => "tcp"
		  ingress.2269895920.security_groups.#:  "0" => "0"
		  ingress.2269895920.self:               "" => "false"
		  ingress.2269895920.to_port:            "" => "8000"
		
		STATE:
		
		aws_ecs_cluster.main:
		  ID = arn:aws:ecs:us-east-1:481473273857:cluster/tf-acc-cluster-svc-w-ltf-gy77qbah
		  provider = provider.aws
		  arn = arn:aws:ecs:us-east-1:481473273857:cluster/tf-acc-cluster-svc-w-ltf-gy77qbah
		  name = tf-acc-cluster-svc-w-ltf-gy77qbah
		aws_ecs_service.main:
		  ID = arn:aws:ecs:us-east-1:481473273857:service/tf-acc-svc-w-ltf-gy77qbah
		  provider = provider.aws
		  cluster = arn:aws:ecs:us-east-1:481473273857:cluster/tf-acc-cluster-svc-w-ltf-gy77qbah
		  deployment_maximum_percent = 200
		  deployment_minimum_healthy_percent = 100
		  desired_count = 1
		  health_check_grace_period_seconds = 0
		  iam_role = aws-service-role
		  launch_type = FARGATE
		  load_balancer.# = 0
		  name = tf-acc-svc-w-ltf-gy77qbah
		  network_configuration.# = 1
		  network_configuration.0.assign_public_ip = true
		  network_configuration.0.security_groups.# = 2
		  network_configuration.0.security_groups.2328280639 = sg-cbe8d382
		  network_configuration.0.security_groups.372139329 = sg-49eed500
		  network_configuration.0.subnets.# = 2
		  network_configuration.0.subnets.4057621718 = subnet-002bc42e
		  network_configuration.0.subnets.4073193208 = subnet-2694256c
		  ordered_placement_strategy.# = 0
		  placement_constraints.# = 0
		  service_registries.# = 0
		  task_definition = arn:aws:ecs:us-east-1:481473273857:task-definition/tf-acc-td-svc-w-ltf-gy77qbah:2
		
		  Dependencies:
		    aws_ecs_cluster.main
		    aws_ecs_task_definition.mongo
		    aws_security_group.allow_all_a
		    aws_security_group.allow_all_b
		    aws_subnet.main.*
		aws_ecs_task_definition.mongo:
		  ID = tf-acc-td-svc-w-ltf-gy77qbah
		  provider = provider.aws
		  arn = arn:aws:ecs:us-east-1:481473273857:task-definition/tf-acc-td-svc-w-ltf-gy77qbah:2
		  container_definitions = [{"cpu":256,"environment":[],"essential":true,"image":"mongo:latest","memory":512,"mountPoints":[],"name":"mongodb","portMappings":[],"volumesFrom":[]}]
		  cpu = 256
		  execution_role_arn = 
		  family = tf-acc-td-svc-w-ltf-gy77qbah
		  memory = 512
		  network_mode = awsvpc
		  placement_constraints.# = 0
		  requires_compatibilities.# = 1
		  requires_compatibilities.3072437307 = FARGATE
		  revision = 2
		  task_role_arn = 
		  volume.# = 0
		aws_security_group.allow_all_a:
		  ID = sg-49eed500
		  provider = provider.aws
		  arn = arn:aws:ec2:us-east-1:481473273857:security-group/sg-49eed500
		  description = Allow all inbound traffic
		  egress.# = 0
		  ingress.# = 1
		  ingress.2269895920.cidr_blocks.# = 1
		  ingress.2269895920.cidr_blocks.0 = 10.10.0.0/16
		  ingress.2269895920.description = 
		  ingress.2269895920.from_port = 80
		  ingress.2269895920.ipv6_cidr_blocks.# = 0
		  ingress.2269895920.protocol = tcp
		  ingress.2269895920.security_groups.# = 0
		  ingress.2269895920.self = false
		  ingress.2269895920.to_port = 8000
		  name = tf-acc-sg-1-svc-w-ltf-gy77qbah
		  owner_id = 481473273857
		  revoke_rules_on_delete = false
		  tags.% = 0
		  vpc_id = vpc-d31047a8
		
		  Dependencies:
		    aws_vpc.main
		aws_security_group.allow_all_b:
		  ID = sg-cbe8d382
		  provider = provider.aws
		  arn = arn:aws:ec2:us-east-1:481473273857:security-group/sg-cbe8d382
		  description = Allow all inbound traffic
		  egress.# = 0
		  ingress.# = 0
		  name = tf-acc-sg-2-svc-w-ltf-gy77qbah
		  owner_id = 481473273857
		  revoke_rules_on_delete = false
		  tags.% = 0
		  vpc_id = vpc-d31047a8
		
		  Dependencies:
		    aws_vpc.main
		aws_subnet.main.0:
		  ID = subnet-002bc42e
		  provider = provider.aws
		  assign_ipv6_address_on_creation = false
		  availability_zone = us-east-1a
		  cidr_block = 10.10.0.0/24
		  map_public_ip_on_launch = false
		  tags.% = 1
		  tags.Name = tf-acc-ecs-service-with-launch-type-fargate
		  vpc_id = vpc-d31047a8
		
		  Dependencies:
		    aws_vpc.main
		    data.aws_availability_zones.available
		aws_subnet.main.1:
		  ID = subnet-2694256c
		  provider = provider.aws
		  assign_ipv6_address_on_creation = false
		  availability_zone = us-east-1b
		  cidr_block = 10.10.1.0/24
		  map_public_ip_on_launch = false
		  tags.% = 1
		  tags.Name = tf-acc-ecs-service-with-launch-type-fargate
		  vpc_id = vpc-d31047a8
		
		  Dependencies:
		    aws_vpc.main
		    data.aws_availability_zones.available
		aws_vpc.main:
		  ID = vpc-d31047a8
		  provider = provider.aws
		  assign_generated_ipv6_cidr_block = false
		  cidr_block = 10.10.0.0/16
		  default_network_acl_id = acl-914ce4eb
		  default_route_table_id = rtb-d61b29aa
		  default_security_group_id = sg-17e9d25e
		  dhcp_options_id = dopt-c679a6a0
		  enable_classiclink = false
		  enable_classiclink_dns_support = false
		  enable_dns_hostnames = false
		  enable_dns_support = true
		  instance_tenancy = default
		  main_route_table_id = rtb-d61b29aa
		  tags.% = 1
		  tags.Name = terraform-testacc-ecs-service-with-launch-type-fargate
		data.aws_availability_zones.available:
		  ID = 2018-04-30 01:50:15.96365987 +0000 UTC
		  provider = provider.aws
		  names.# = 6
		  names.0 = us-east-1a
		  names.1 = us-east-1b
		  names.2 = us-east-1c
		  names.3 = us-east-1d
		  names.4 = us-east-1e
		  names.5 = us-east-1f
```
## After
```
TF_ACC=1 go test ./aws -v -run=TestAccAWSEcsService_withLaunchTypeFargate -timeout 120m
=== RUN   TestAccAWSEcsService_withLaunchTypeFargate
--- PASS: TestAccAWSEcsService_withLaunchTypeFargate (243.28s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	243.318s
```