### PR TITLE
Allow 'map_public_ip_on_launch' to be changed on default subnet

### DIFF
--- a/aws/resource_aws_default_subnet.go
+++ b/aws/resource_aws_default_subnet.go
@@ -38,6 +38,7 @@ func resourceAwsDefaultSubnet() *schema.Resource {
 	// map_public_ip_on_launch is a computed value for Default Subnets
 	dsubnet.Schema["map_public_ip_on_launch"] = &schema.Schema{
 		Type:     schema.TypeBool,
+		Optional: true,
 		Computed: true,
 	}
 	// assign_ipv6_address_on_creation is a computed value for Default Subnets
@@ -51,35 +52,29 @@ func resourceAwsDefaultSubnet() *schema.Resource {
 
 func resourceAwsDefaultSubnetCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
-	req := &ec2.DescribeSubnetsInput{
-		Filters: []*ec2.Filter{
-			&ec2.Filter{
-				Name:   aws.String("availabilityZone"),
-				Values: aws.StringSlice([]string{d.Get("availability_zone").(string)}),
-			},
-			&ec2.Filter{
-				Name:   aws.String("defaultForAz"),
-				Values: aws.StringSlice([]string{"true"}),
-			},
-		},
-	}
 
+	req := &ec2.DescribeSubnetsInput{}
+	req.Filters = buildEC2AttributeFilterList(
+		map[string]string{
+			"availabilityZone": d.Get("availability_zone").(string),
+			"defaultForAz":     "true",
+		},
+	)
+
+	log.Printf("[DEBUG] Reading Default Subnet: %s", req)
 	resp, err := conn.DescribeSubnets(req)
 	if err != nil {
 		return err
 	}
-
 	if len(resp.Subnets) != 1 || resp.Subnets[0] == nil {
 		return fmt.Errorf("Default subnet not found")
 	}
 
 	d.SetId(aws.StringValue(resp.Subnets[0].SubnetId))
-
 	return resourceAwsSubnetUpdate(d, meta)
 }
 
 func resourceAwsDefaultSubnetDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[WARN] Cannot destroy Default Subnet. Terraform will remove this resource from the state file, however resources may remain.")
-	d.SetId("")
 	return nil
 }

--- a/aws/resource_aws_default_subnet_test.go
+++ b/aws/resource_aws_default_subnet_test.go
@@ -23,13 +23,55 @@ func TestAccAWSDefaultSubnet_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_default_subnet.foo", "availability_zone", "us-west-2a"),
 					resource.TestCheckResourceAttr(
+						"aws_default_subnet.foo", "assign_ipv6_address_on_creation", "false"),
+					resource.TestCheckResourceAttr(
+						"aws_default_subnet.foo", "tags.%", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_default_subnet.foo", "tags.Name", "terraform-testacc-default-subnet"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDefaultSubnet_publicIp(t *testing.T) {
+	var v ec2.Subnet
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDefaultSubnetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDefaultSubnetConfigPublicIp,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSubnetExists("aws_default_subnet.foo", &v),
+					resource.TestCheckResourceAttr(
+						"aws_default_subnet.foo", "availability_zone", "us-west-2a"),
+					resource.TestCheckResourceAttr(
 						"aws_default_subnet.foo", "map_public_ip_on_launch", "true"),
 					resource.TestCheckResourceAttr(
 						"aws_default_subnet.foo", "assign_ipv6_address_on_creation", "false"),
 					resource.TestCheckResourceAttr(
 						"aws_default_subnet.foo", "tags.%", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_default_subnet.foo", "tags.Name", "Default subnet for us-west-2a"),
+						"aws_default_subnet.foo", "tags.Name", "terraform-testacc-default-subnet"),
+				),
+			},
+			{
+				Config: testAccAWSDefaultSubnetConfigNoPublicIp,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSubnetExists("aws_default_subnet.foo", &v),
+					resource.TestCheckResourceAttr(
+						"aws_default_subnet.foo", "availability_zone", "us-west-2a"),
+					resource.TestCheckResourceAttr(
+						"aws_default_subnet.foo", "map_public_ip_on_launch", "false"),
+					resource.TestCheckResourceAttr(
+						"aws_default_subnet.foo", "assign_ipv6_address_on_creation", "false"),
+					resource.TestCheckResourceAttr(
+						"aws_default_subnet.foo", "tags.%", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_default_subnet.foo", "tags.Name", "terraform-testacc-default-subnet"),
 				),
 			},
 		},
@@ -42,14 +84,30 @@ func testAccCheckAWSDefaultSubnetDestroy(s *terraform.State) error {
 }
 
 const testAccAWSDefaultSubnetConfigBasic = `
-provider "aws" {
-    region = "us-west-2"
-}
-
 resource "aws_default_subnet" "foo" {
-	availability_zone = "us-west-2a"
-	tags {
-		Name = "Default subnet for us-west-2a"
-	}
+  availability_zone = "us-west-2a"
+  tags {
+    Name = "terraform-testacc-default-subnet"
+  }
+}
+`
+
+const testAccAWSDefaultSubnetConfigPublicIp = `
+resource "aws_default_subnet" "foo" {
+  availability_zone = "us-west-2a"
+  map_public_ip_on_launch = true
+  tags {
+    Name = "terraform-testacc-default-subnet"
+  }
+}
+`
+
+const testAccAWSDefaultSubnetConfigNoPublicIp = `
+resource "aws_default_subnet" "foo" {
+  availability_zone = "us-west-2a"
+  map_public_ip_on_launch = false
+  tags {
+    Name = "terraform-testacc-default-subnet"
+  }
 }
 `

--- a/website/docs/r/default_subnet.html.markdown
+++ b/website/docs/r/default_subnet.html.markdown
@@ -13,7 +13,7 @@ in the current region.
 
 The `aws_default_subnet` behaves differently from normal resources, in that
 Terraform does not _create_ this resource, but instead "adopts" it
-into management. 
+into management.
 
 ## Example Usage
 
@@ -33,9 +33,12 @@ resource "aws_default_subnet" "default_az1" {
 
 The arguments of an `aws_default_subnet` differ from `aws_subnet` resources.
 Namely, the `availability_zone` argument is required and the `vpc_id`, `cidr_block`, `ipv6_cidr_block`,
-`map_public_ip_on_launch` and `assign_ipv6_address_on_creation` arguments are computed.
-The following arguments are still supported: 
+and `assign_ipv6_address_on_creation` arguments are computed.
+The following arguments are still supported:
 
+* `map_public_ip_on_launch` -  (Optional) Specify true to indicate
+    that instances launched into the subnet should be assigned
+    a public IP address.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ### Removing `aws_default_subnet` from your configuration


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/4291.

Acceptance tests:

```
make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSDefaultSubnet_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAWSDefaultSubnet_ -timeout 120m
=== RUN   TestAccAWSDefaultSubnet_basic
--- PASS: TestAccAWSDefaultSubnet_basic (13.21s)
=== RUN   TestAccAWSDefaultSubnet_publicIp
--- PASS: TestAccAWSDefaultSubnet_publicIp (23.26s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	36.494s
```