### PR TITLE
 Add support for MongoDB as a DMS source endpoint 

### DIFF
--- a/aws/resource_aws_dms_endpoint.go
+++ b/aws/resource_aws_dms_endpoint.go
@@ -215,9 +215,7 @@ func resourceAwsDmsEndpointRead(d *schema.ResourceData, meta interface{}) error 
 	if err != nil {
 		return err
 	}
-	d.Set("tags", dmsTagsToMap(tagsResp.TagList))
-
-	return nil
+	return d.Set("tags", dmsTagsToMap(tagsResp.TagList))
 }
 
 func resourceAwsDmsEndpointUpdate(d *schema.ResourceData, meta interface{}) error {
@@ -316,11 +314,7 @@ func resourceAwsDmsEndpointDelete(d *schema.ResourceData, meta interface{}) erro
 	log.Printf("[DEBUG] DMS delete endpoint: %#v", request)
 
 	_, err := conn.DeleteEndpoint(request)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func resourceAwsDmsEndpointSetState(d *schema.ResourceData, endpoint *dms.Endpoint) error {

--- a/aws/resource_aws_dms_endpoint_test.go
+++ b/aws/resource_aws_dms_endpoint_test.go
@@ -82,6 +82,49 @@ func TestAccAWSDmsEndpointDynamoDb(t *testing.T) {
 	})
 }
 
+func TestAccAWSDmsEndpointMongoDb(t *testing.T) {
+	resourceName := "aws_dms_endpoint.dms_endpoint"
+	randId := acctest.RandString(8) + "-mongodb"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: dmsEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: dmsEndpointMongoDbConfig(randId),
+				Check: resource.ComposeTestCheckFunc(
+					checkDmsEndpointExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "endpoint_arn"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+			{
+				Config: dmsEndpointMongoDbConfigUpdate(randId),
+				Check: resource.ComposeTestCheckFunc(
+					checkDmsEndpointExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "server_name", "tftest-new-server_name"),
+					resource.TestCheckResourceAttr(resourceName, "port", "27018"),
+					resource.TestCheckResourceAttr(resourceName, "username", "tftest-new-username"),
+					resource.TestCheckResourceAttr(resourceName, "password", "tftest-new-password"),
+					resource.TestCheckResourceAttr(resourceName, "database_name", "tftest-new-database_name"),
+					resource.TestCheckResourceAttr(resourceName, "ssl_mode", "require"),
+					resource.TestCheckResourceAttr(resourceName, "extra_connection_attributes", "key=value;"),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_settings.0.auth_mechanism", "SCRAM_SHA_1"),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_settings.0.nesting_level", "ONE"),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_settings.0.extract_doc_id", "true"),
+					resource.TestCheckResourceAttr(resourceName, "mongodb_settings.0.docs_to_investigate", "1001"),
+				),
+			},
+		},
+	})
+}
+
 func dmsEndpointDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_dms_endpoint" {
@@ -293,6 +336,64 @@ resource "aws_iam_role_policy" "dms_dynamodb_access" {
 ]
 }
 EOF
+}
+`, randId)
+}
+
+func dmsEndpointMongoDbConfig(randId string) string {
+	return fmt.Sprintf(`
+resource "aws_dms_endpoint" "dms_endpoint" {
+	endpoint_id = "tf-test-dms-endpoint-%[1]s"
+	endpoint_type = "source"
+	engine_name = "mongodb"
+	server_name = "tftest"
+	port = 27017
+	username = "tftest"
+	password = "tftest"
+	database_name = "tftest"
+	ssl_mode = "none"
+	extra_connection_attributes = ""
+	tags {
+		Name = "tf-test-dms-endpoint-%[1]s"
+		Update = "to-update"
+		Remove = "to-remove"
+	}
+	mongodb_settings {
+		auth_type = "PASSWORD"
+		auth_mechanism = "DEFAULT"
+		nesting_level = "NONE"
+		extract_doc_id = "false"
+		docs_to_investigate = "1000"
+		auth_source = "admin"
+	}
+}
+`, randId)
+}
+
+func dmsEndpointMongoDbConfigUpdate(randId string) string {
+	return fmt.Sprintf(`
+resource "aws_dms_endpoint" "dms_endpoint" {
+	endpoint_id = "tf-test-dms-endpoint-%[1]s"
+	endpoint_type = "source"
+	engine_name = "mongodb"
+	server_name = "tftest-new-server_name"
+	port = 27018
+	username = "tftest-new-username"
+	password = "tftest-new-password"
+	database_name = "tftest-new-database_name"
+	ssl_mode = "require"
+	extra_connection_attributes = "key=value;"
+	tags {
+		Name = "tf-test-dms-endpoint-%[1]s"
+		Update = "updated"
+		Add = "added"
+	}
+	mongodb_settings {
+		auth_mechanism = "SCRAM_SHA_1"
+		nesting_level = "ONE"
+		extract_doc_id = "true"
+		docs_to_investigate = "1001"
+	}
 }
 `, randId)
 }

--- a/website/docs/r/dms_endpoint.html.markdown
+++ b/website/docs/r/dms_endpoint.html.markdown
@@ -53,7 +53,7 @@ The following arguments are supported:
     - Must not contain two consecutive hyphens
 
 * `endpoint_type` - (Required) The type of endpoint. Can be one of `source | target`.
-* `engine_name` - (Required) The type of engine for the endpoint. Can be one of `mysql | oracle | postgres | mariadb | aurora | redshift | sybase | sqlserver | dynamodb`.
+* `engine_name` - (Required) The type of engine for the endpoint. Can be one of `mysql | oracle | postgres | mariadb | aurora | redshift | sybase | sqlserver | dynamodb | mongodb`.
 * `extra_connection_attributes` - (Optional) Additional attributes associated with the connection. For available attributes see [Using Extra Connection Attributes with AWS Database Migration Service](http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Introduction.ConnectionAttributes.html).
 * `kms_key_arn` - (Optional) The Amazon Resource Name (ARN) for the KMS key that will be used to encrypt the connection parameters. If you do not specify a value for `kms_key_arn`, then AWS DMS will use your default encryption key. AWS KMS creates the default encryption key for your AWS account. Your AWS account has a different default encryption key for each AWS region.
 * `password` - (Optional) The password to be used to login to the endpoint database.
@@ -62,7 +62,8 @@ The following arguments are supported:
 * `ssl_mode` - (Optional, Default: none) The SSL mode to use for the connection. Can be one of `none | require | verify-ca | verify-full`
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 * `username` - (Optional) The user name to be used to login to the endpoint database.
-* `service_access_role` (Optional) The Amazon Resource Name (ARN) used by the service access IAM role for dynamodb endpoints.
+* `service_access_role` - (Optional) The Amazon Resource Name (ARN) used by the service access IAM role for dynamodb endpoints.
+* `mongodb_settings` - (Optional) Settings for the source MongoDB endpoint. Available settings are `auth_type` (default: `PASSWORD`), `auth_mechanism` (default: `DEFAULT`), `nesting_level` (default: `NONE`), `extract_doc_id` (default: `false`), `docs_to_investigate` (default: `1000`) and `auth_source` (default: `admin`). For more details, see [Using MongoDB as a Source for AWS DMS](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MongoDB.html).
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR is to add support for MongoDB as a DMS source endpoint.

It re-uses some of the attributes from the top-level namespace (`server_name`, `port`, `username`, `password` and `database_name`), but it also introduces MongoDB-specific attributes under `mongodb_settings` closely mimicking the output of `aws dms create-endpoint --generate-cli-skeleton`.

```
{
    ...
    "Username": "",
    "Password": "",
    "ServerName": "",
    "Port": 0,
    "DatabaseName": "",
    ...
    "MongoDbSettings": {
        "Username": "",
        "Password": "",
        "ServerName": "",
        "Port": 0,
        "DatabaseName": "",
        "AuthType": "no",
        "AuthMechanism": "scram_sha_1",
        "NestingLevel": "one",
        "ExtractDocId": "",
        "DocsToInvestigate": "",
        "AuthSource": ""
    }
}
```

Example usage:
```
resource "aws_dms_endpoint" "dms_endpoint" {
	...
	endpoint_type = "source"
	engine_name = "mongodb"
	...
	server_name = "..."
	port = ...
	username = "..."
	password = "..."
	database_name = "..."
	...
	mongodb_settings {
		auth_type = "PASSWORD"
		auth_mechanism = "DEFAULT"
		nesting_level = "NONE"
		extract_doc_id = "false"
		docs_to_investigate = "1000"
		auth_source = "admin"
	}
}
```

Here's an acceptance test for the new endpoint support.

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDmsEndpointMongoDb'
```
```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSDmsEndpointMongoDb -timeout 120m
=== RUN   TestAccAWSDmsEndpointMongoDb
--- PASS: TestAccAWSDmsEndpointMongoDb (60.58s)
PASS
ok     github.com/microamp/terraform-provider-aws/aws 60.596s
```

Thanks. Please let me know if I missed anything. Still very new to Terraform. :)
