### PR TITLE
provider: Remove extraneous d.SetId() calls during resource deletion

### DIFF
--- a/aws/resource_aws_acm_certificate.go
+++ b/aws/resource_aws_acm_certificate.go
@@ -251,6 +251,5 @@ func resourceAwsAcmCertificateDelete(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Error deleting certificate: %s", err)
 	}
 
-	d.SetId("")
 	return nil
 }

--- a/aws/resource_aws_acm_certificate_validation.go
+++ b/aws/resource_aws_acm_certificate_validation.go
@@ -160,6 +160,5 @@ func resourceAwsAcmCertificateValidationRead(d *schema.ResourceData, meta interf
 
 func resourceAwsAcmCertificateValidationDelete(d *schema.ResourceData, meta interface{}) error {
 	// No need to do anything, certificate will be deleted when acm_certificate is deleted
-	d.SetId("")
 	return nil
 }

--- a/aws/resource_aws_ami.go
+++ b/aws/resource_aws_ami.go
@@ -307,8 +307,6 @@ func resourceAwsAmiDelete(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	// No error, ami was deleted successfully
-	d.SetId("")
 	return nil
 }
 

--- a/aws/resource_aws_api_gateway_account.go
+++ b/aws/resource_aws_api_gateway_account.go
@@ -122,6 +122,5 @@ func resourceAwsApiGatewayAccountUpdate(d *schema.ResourceData, meta interface{}
 
 func resourceAwsApiGatewayAccountDelete(d *schema.ResourceData, meta interface{}) error {
 	// There is no API for "deleting" account or resetting it to "default" settings
-	d.SetId("")
 	return nil
 }

--- a/aws/resource_aws_appautoscaling_policy.go
+++ b/aws/resource_aws_appautoscaling_policy.go
@@ -349,7 +349,6 @@ func resourceAwsAppautoscalingPolicyDelete(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("Failed to delete autoscaling policy: %s", err)
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/aws/resource_aws_appautoscaling_scheduled_action.go
+++ b/aws/resource_aws_appautoscaling_scheduled_action.go
@@ -184,11 +184,10 @@ func resourceAwsAppautoscalingScheduledActionDelete(d *schema.ResourceData, meta
 	if err != nil {
 		if isAWSErr(err, applicationautoscaling.ErrCodeObjectNotFoundException, "") {
 			log.Printf("[WARN] Application Autoscaling Scheduled Action (%s) already gone, removing from state", d.Id())
-			d.SetId("")
 			return nil
 		}
 		return err
 	}
-	d.SetId("")
+
 	return nil
 }

--- a/aws/resource_aws_appautoscaling_target.go
+++ b/aws/resource_aws_appautoscaling_target.go
@@ -130,7 +130,6 @@ func resourceAwsAppautoscalingTargetDelete(d *schema.ResourceData, meta interfac
 	}
 	if t == nil {
 		log.Printf("[INFO] Application AutoScaling Target %q not found", d.Id())
-		d.SetId("")
 		return nil
 	}
 

--- a/aws/resource_aws_autoscaling_group.go
+++ b/aws/resource_aws_autoscaling_group.go
@@ -821,7 +821,6 @@ func resourceAwsAutoscalingGroupDelete(d *schema.ResourceData, meta interface{})
 	}
 	if g == nil {
 		log.Printf("[WARN] Autoscaling Group (%s) not found, removing from state", d.Id())
-		d.SetId("")
 		return nil
 	}
 	if len(g.Instances) > 0 || *g.DesiredCapacity > 0 {

--- a/aws/resource_aws_autoscaling_lifecycle_hook.go
+++ b/aws/resource_aws_autoscaling_lifecycle_hook.go
@@ -131,7 +131,6 @@ func resourceAwsAutoscalingLifecycleHookDelete(d *schema.ResourceData, meta inte
 		return errwrap.Wrapf("Autoscaling Lifecycle Hook: {{err}}", err)
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/aws/resource_aws_autoscaling_policy.go
+++ b/aws/resource_aws_autoscaling_policy.go
@@ -273,7 +273,6 @@ func resourceAwsAutoscalingPolicyDelete(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("Autoscaling Scaling Policy: %s ", err)
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/aws/resource_aws_batch_job_definition.go
+++ b/aws/resource_aws_batch_job_definition.go
@@ -165,7 +165,7 @@ func resourceAwsBatchJobDefinitionDelete(d *schema.ResourceData, meta interface{
 	if err != nil {
 		return fmt.Errorf("%s %q", err, arn)
 	}
-	d.SetId("")
+
 	return nil
 }
 

--- a/aws/resource_aws_cloudformation_stack.go
+++ b/aws/resource_aws_cloudformation_stack.go
@@ -559,8 +559,6 @@ func resourceAwsCloudFormationStackDelete(d *schema.ResourceData, meta interface
 
 	log.Printf("[DEBUG] CloudFormation stack %q has been deleted", d.Id())
 
-	d.SetId("")
-
 	return nil
 }
 

--- a/aws/resource_aws_cloudfront_distribution.go
+++ b/aws/resource_aws_cloudfront_distribution.go
@@ -733,7 +733,6 @@ func resourceAwsCloudFrontDistributionRead(d *schema.ResourceData, meta interfac
 		return err
 	}
 	// Update other attributes outside of DistributionConfig
-	d.SetId(*resp.Distribution.Id)
 	err = d.Set("active_trusted_signers", flattenActiveTrustedSigners(resp.Distribution.ActiveTrustedSigners))
 	if err != nil {
 		return err
@@ -794,7 +793,6 @@ func resourceAwsCloudFrontDistributionDelete(d *schema.ResourceData, meta interf
 	// skip delete if retain_on_delete is enabled
 	if d.Get("retain_on_delete").(bool) {
 		log.Printf("[WARN] Removing CloudFront Distribution ID %q with `retain_on_delete` set. Please delete this distribution manually.", d.Id())
-		d.SetId("")
 		return nil
 	}
 
@@ -825,8 +823,6 @@ func resourceAwsCloudFrontDistributionDelete(d *schema.ResourceData, meta interf
 		return fmt.Errorf("CloudFront Distribution %s cannot be deleted: %s", d.Id(), err)
 	}
 
-	// Done
-	d.SetId("")
 	return nil
 }
 

--- a/aws/resource_aws_cloudfront_origin_access_identity.go
+++ b/aws/resource_aws_cloudfront_origin_access_identity.go
@@ -119,8 +119,6 @@ func resourceAwsCloudFrontOriginAccessIdentityDelete(d *schema.ResourceData, met
 		return err
 	}
 
-	// Done
-	d.SetId("")
 	return nil
 }
 

--- a/aws/resource_aws_cloudwatch_dashboard.go
+++ b/aws/resource_aws_cloudwatch_dashboard.go
@@ -102,15 +102,12 @@ func resourceAwsCloudWatchDashboardDelete(d *schema.ResourceData, meta interface
 
 	if _, err := conn.DeleteDashboards(&params); err != nil {
 		if isCloudWatchDashboardNotFoundErr(err) {
-			log.Printf("[WARN] CloudWatch Dashboard %s is already gone", d.Id())
-			d.SetId("")
 			return nil
 		}
 		return fmt.Errorf("Error deleting CloudWatch Dashboard: %s", err)
 	}
 	log.Printf("[INFO] CloudWatch Dashboard %s deleted", d.Id())
 
-	d.SetId("")
 	return nil
 }
 

--- a/aws/resource_aws_cloudwatch_event_rule.go
+++ b/aws/resource_aws_cloudwatch_event_rule.go
@@ -223,8 +223,6 @@ func resourceAwsCloudWatchEventRuleDelete(d *schema.ResourceData, meta interface
 	}
 	log.Println("[INFO] CloudWatch Event Rule deleted")
 
-	d.SetId("")
-
 	return nil
 }
 

--- a/aws/resource_aws_cloudwatch_event_target.go
+++ b/aws/resource_aws_cloudwatch_event_target.go
@@ -346,8 +346,6 @@ func resourceAwsCloudWatchEventTargetDelete(d *schema.ResourceData, meta interfa
 	}
 	log.Println("[INFO] CloudWatch Event Target deleted")
 
-	d.SetId("")
-
 	return nil
 }
 

--- a/aws/resource_aws_cloudwatch_log_destination.go
+++ b/aws/resource_aws_cloudwatch_log_destination.go
@@ -121,7 +121,7 @@ func resourceAwsCloudWatchLogDestinationDelete(d *schema.ResourceData, meta inte
 	if err != nil {
 		return fmt.Errorf("Error deleting Destination with name %s", name)
 	}
-	d.SetId("")
+
 	return nil
 }
 

--- a/aws/resource_aws_cloudwatch_log_destination_policy.go
+++ b/aws/resource_aws_cloudwatch_log_destination_policy.go
@@ -83,6 +83,5 @@ func resourceAwsCloudWatchLogDestinationPolicyRead(d *schema.ResourceData, meta 
 }
 
 func resourceAwsCloudWatchLogDestinationPolicyDelete(d *schema.ResourceData, meta interface{}) error {
-	d.SetId("")
 	return nil
 }

--- a/aws/resource_aws_cloudwatch_log_group.go
+++ b/aws/resource_aws_cloudwatch_log_group.go
@@ -267,8 +267,6 @@ func resourceAwsCloudWatchLogGroupDelete(d *schema.ResourceData, meta interface{
 	}
 	log.Println("[INFO] CloudWatch Log Group deleted")
 
-	d.SetId("")
-
 	return nil
 }
 

--- a/aws/resource_aws_cloudwatch_log_metric_filter.go
+++ b/aws/resource_aws_cloudwatch_log_metric_filter.go
@@ -189,7 +189,5 @@ func resourceAwsCloudWatchLogMetricFilterDelete(d *schema.ResourceData, meta int
 	}
 	log.Println("[INFO] CloudWatch Log Metric Filter deleted")
 
-	d.SetId("")
-
 	return nil
 }

--- a/aws/resource_aws_cloudwatch_log_subscription_filter.go
+++ b/aws/resource_aws_cloudwatch_log_subscription_filter.go
@@ -180,7 +180,7 @@ func resourceAwsCloudwatchLogSubscriptionFilterDelete(d *schema.ResourceData, me
 		return fmt.Errorf(
 			"Error deleting Subscription Filter from log group: %s with name filter name %s: %+v", log_group_name, name, err)
 	}
-	d.SetId("")
+
 	return nil
 }
 

--- a/aws/resource_aws_cloudwatch_metric_alarm.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm.go
@@ -224,7 +224,6 @@ func resourceAwsCloudWatchMetricAlarmDelete(d *schema.ResourceData, meta interfa
 	}
 	log.Println("[INFO] CloudWatch Metric Alarm deleted")
 
-	d.SetId("")
 	return nil
 }
 

--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -642,8 +642,6 @@ func resourceAwsCodeBuildProjectDelete(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
-	d.SetId("")
-
 	return nil
 }
 

--- a/aws/resource_aws_codedeploy_app.go
+++ b/aws/resource_aws_codedeploy_app.go
@@ -110,7 +110,6 @@ func resourceAwsCodeDeployAppDelete(d *schema.ResourceData, meta interface{}) er
 	})
 	if err != nil {
 		if cderr, ok := err.(awserr.Error); ok && cderr.Code() == "InvalidApplicationNameException" {
-			d.SetId("")
 			return nil
 		} else {
 			log.Printf("[ERROR] Error deleting CodeDeploy application: %s", err)

--- a/aws/resource_aws_codedeploy_deployment_group.go
+++ b/aws/resource_aws_codedeploy_deployment_group.go
@@ -655,8 +655,6 @@ func resourceAwsCodeDeployDeploymentGroupDelete(d *schema.ResourceData, meta int
 		return err
 	}
 
-	d.SetId("")
-
 	return nil
 }
 

--- a/aws/resource_aws_codepipeline.go
+++ b/aws/resource_aws_codepipeline.go
@@ -488,7 +488,5 @@ func resourceAwsCodePipelineDelete(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 
-	d.SetId("")
-
 	return nil
 }

--- a/aws/resource_aws_config_config_rule.go
+++ b/aws/resource_aws_config_config_rule.go
@@ -295,7 +295,6 @@ func resourceAwsConfigConfigRuleDelete(d *schema.ResourceData, meta interface{})
 
 	log.Printf("[DEBUG] AWS Config config rule %q deleted", name)
 
-	d.SetId("")
 	return nil
 }
 

--- a/aws/resource_aws_config_configuration_recorder.go
+++ b/aws/resource_aws_config_configuration_recorder.go
@@ -144,6 +144,5 @@ func resourceAwsConfigConfigurationRecorderDelete(d *schema.ResourceData, meta i
 		return fmt.Errorf("Deleting Configuration Recorder failed: %s", err)
 	}
 
-	d.SetId("")
 	return nil
 }

--- a/aws/resource_aws_config_configuration_recorder_status.go
+++ b/aws/resource_aws_config_configuration_recorder_status.go
@@ -117,6 +117,5 @@ func resourceAwsConfigConfigurationRecorderStatusDelete(d *schema.ResourceData, 
 		return fmt.Errorf("Stopping Configuration Recorder failed: %s", err)
 	}
 
-	d.SetId("")
 	return nil
 }

--- a/aws/resource_aws_config_delivery_channel.go
+++ b/aws/resource_aws_config_delivery_channel.go
@@ -178,6 +178,5 @@ func resourceAwsConfigDeliveryChannelDelete(d *schema.ResourceData, meta interfa
 		return fmt.Errorf("Unable to delete delivery channel: %s", err)
 	}
 
-	d.SetId("")
 	return nil
 }

--- a/aws/resource_aws_customer_gateway.go
+++ b/aws/resource_aws_customer_gateway.go
@@ -236,7 +236,6 @@ func resourceAwsCustomerGatewayDelete(d *schema.ResourceData, meta interface{}) 
 	})
 	if err != nil {
 		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidCustomerGatewayID.NotFound" {
-			d.SetId("")
 			return nil
 		} else {
 			log.Printf("[ERROR] Error deleting CustomerGateway: %s", err)

--- a/aws/resource_aws_dax_cluster.go
+++ b/aws/resource_aws_dax_cluster.go
@@ -485,8 +485,6 @@ func resourceAwsDaxClusterDelete(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Error waiting for DAX (%s) to delete: %s", d.Id(), sterr)
 	}
 
-	d.SetId("")
-
 	return nil
 }
 

--- a/aws/resource_aws_default_network_acl.go
+++ b/aws/resource_aws_default_network_acl.go
@@ -243,7 +243,6 @@ func resourceAwsDefaultNetworkAclUpdate(d *schema.ResourceData, meta interface{}
 
 func resourceAwsDefaultNetworkAclDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[WARN] Cannot destroy Default Network ACL. Terraform will remove this resource from the state file, however resources may remain.")
-	d.SetId("")
 	return nil
 }
 

--- a/aws/resource_aws_default_route_table.go
+++ b/aws/resource_aws_default_route_table.go
@@ -155,7 +155,6 @@ func resourceAwsDefaultRouteTableRead(d *schema.ResourceData, meta interface{}) 
 
 func resourceAwsDefaultRouteTableDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[WARN] Cannot destroy Default Route Table. Terraform will remove this resource from the state file, however resources may remain.")
-	d.SetId("")
 	return nil
 }
 

--- a/aws/resource_aws_default_security_group.go
+++ b/aws/resource_aws_default_security_group.go
@@ -101,7 +101,6 @@ func resourceAwsDefaultSecurityGroupCreate(d *schema.ResourceData, meta interfac
 
 func resourceAwsDefaultSecurityGroupDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[WARN] Cannot destroy Default Security Group. Terraform will remove this resource from the state file, however resources may remain.")
-	d.SetId("")
 	return nil
 }
 

--- a/aws/resource_aws_default_vpc.go
+++ b/aws/resource_aws_default_vpc.go
@@ -61,6 +61,5 @@ func resourceAwsDefaultVpcCreate(d *schema.ResourceData, meta interface{}) error
 
 func resourceAwsDefaultVpcDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[WARN] Cannot destroy Default VPC. Terraform will remove this resource from the state file, however resources may remain.")
-	d.SetId("")
 	return nil
 }

--- a/aws/resource_aws_default_vpc_dhcp_options.go
+++ b/aws/resource_aws_default_vpc_dhcp_options.go
@@ -85,6 +85,5 @@ func resourceAwsDefaultVpcDhcpOptionsCreate(d *schema.ResourceData, meta interfa
 
 func resourceAwsDefaultVpcDhcpOptionsDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[WARN] Cannot destroy Default DHCP Options Set. Terraform will remove this resource from the state file, however resources may remain.")
-	d.SetId("")
 	return nil
 }

--- a/aws/resource_aws_dms_replication_task.go
+++ b/aws/resource_aws_dms_replication_task.go
@@ -258,7 +258,6 @@ func resourceAwsDmsReplicationTaskDelete(d *schema.ResourceData, meta interface{
 	if err != nil {
 		if dmserr, ok := err.(awserr.Error); ok && dmserr.Code() == "ResourceNotFoundFault" {
 			log.Printf("[DEBUG] DMS Replication Task %q Not Found", d.Id())
-			d.SetId("")
 			return nil
 		}
 		return err

--- a/aws/resource_aws_ecr_lifecycle_policy.go
+++ b/aws/resource_aws_ecr_lifecycle_policy.go
@@ -91,11 +91,9 @@ func resourceAwsEcrLifecyclePolicyDelete(d *schema.ResourceData, meta interface{
 	_, err := conn.DeleteLifecyclePolicy(input)
 	if err != nil {
 		if isAWSErr(err, ecr.ErrCodeRepositoryNotFoundException, "") {
-			d.SetId("")
 			return nil
 		}
 		if isAWSErr(err, ecr.ErrCodeLifecyclePolicyNotFoundException, "") {
-			d.SetId("")
 			return nil
 		}
 		return err

--- a/aws/resource_aws_ecr_repository.go
+++ b/aws/resource_aws_ecr_repository.go
@@ -113,7 +113,6 @@ func resourceAwsEcrRepositoryDelete(d *schema.ResourceData, meta interface{}) er
 	})
 	if err != nil {
 		if ecrerr, ok := err.(awserr.Error); ok && ecrerr.Code() == "RepositoryNotFoundException" {
-			d.SetId("")
 			return nil
 		}
 		return err
@@ -145,7 +144,6 @@ func resourceAwsEcrRepositoryDelete(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	d.SetId("")
 	log.Printf("[DEBUG] repository %q deleted.", d.Get("name").(string))
 
 	return nil

--- a/aws/resource_aws_ecr_repository_policy.go
+++ b/aws/resource_aws_ecr_repository_policy.go
@@ -153,7 +153,6 @@ func resourceAwsEcrRepositoryPolicyDelete(d *schema.ResourceData, meta interface
 		if ecrerr, ok := err.(awserr.Error); ok {
 			switch ecrerr.Code() {
 			case "RepositoryNotFoundException", "RepositoryPolicyNotFoundException":
-				d.SetId("")
 				return nil
 			default:
 				return err

--- a/aws/resource_aws_ecs_service.go
+++ b/aws/resource_aws_ecs_service.go
@@ -743,7 +743,6 @@ func resourceAwsEcsServiceDelete(d *schema.ResourceData, meta interface{}) error
 	if err != nil {
 		if isAWSErr(err, ecs.ErrCodeServiceNotFoundException, "") {
 			log.Printf("[DEBUG] Removing ECS Service from state, %q is already gone", d.Id())
-			d.SetId("")
 			return nil
 		}
 		return err
@@ -751,7 +750,6 @@ func resourceAwsEcsServiceDelete(d *schema.ResourceData, meta interface{}) error
 
 	if len(resp.Services) == 0 {
 		log.Printf("[DEBUG] Removing ECS Service from state, %q is already gone", d.Id())
-		d.SetId("")
 		return nil
 	}
 

--- a/aws/resource_aws_elastic_beanstalk_application_version.go
+++ b/aws/resource_aws_elastic_beanstalk_application_version.go
@@ -153,14 +153,12 @@ func resourceAwsElasticBeanstalkApplicationVersionDelete(d *schema.ResourceData,
 		if awserr, ok := err.(awserr.Error); ok {
 			// application version is pending delete, or no longer exists.
 			if awserr.Code() == "InvalidParameterValue" {
-				d.SetId("")
 				return nil
 			}
 		}
 		return err
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/aws/resource_aws_elasticache_parameter_group.go
+++ b/aws/resource_aws_elasticache_parameter_group.go
@@ -231,7 +231,6 @@ func resourceAwsElasticacheParameterGroupDelete(d *schema.ResourceData, meta int
 		if err != nil {
 			awsErr, ok := err.(awserr.Error)
 			if ok && awsErr.Code() == "CacheParameterGroupNotFoundFault" {
-				d.SetId("")
 				return nil
 			}
 			if ok && awsErr.Code() == "InvalidCacheParameterGroupState" {

--- a/aws/resource_aws_elasticsearch_domain_policy.go
+++ b/aws/resource_aws_elasticsearch_domain_policy.go
@@ -122,6 +122,5 @@ func resourceAwsElasticSearchDomainPolicyDelete(d *schema.ResourceData, meta int
 		return err
 	}
 
-	d.SetId("")
 	return nil
 }

--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -835,7 +835,6 @@ func resourceAwsEMRClusterDelete(d *schema.ResourceData, meta interface{}) error
 		log.Printf("[ERR] Error waiting for EMR Cluster (%s) Instances to drain", d.Id())
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/aws/resource_aws_emr_security_configuration.go
+++ b/aws/resource_aws_emr_security_configuration.go
@@ -106,12 +106,10 @@ func resourceAwsEmrSecurityConfigurationDelete(d *schema.ResourceData, meta inte
 	})
 	if err != nil {
 		if isAWSErr(err, "InvalidRequestException", "does not exist") {
-			d.SetId("")
 			return nil
 		}
 		return err
 	}
-	d.SetId("")
 
 	return nil
 }

--- a/aws/resource_aws_iam_account_alias.go
+++ b/aws/resource_aws_iam_account_alias.go
@@ -88,7 +88,5 @@ func resourceAwsIamAccountAliasDelete(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("Error deleting account alias with name '%s': %s", account_alias, err)
 	}
 
-	d.SetId("")
-
 	return nil
 }

--- a/aws/resource_aws_iam_account_password_policy.go
+++ b/aws/resource_aws_iam_account_password_policy.go
@@ -161,7 +161,6 @@ func resourceAwsIamAccountPasswordPolicyDelete(d *schema.ResourceData, meta inte
 	if _, err := iamconn.DeleteAccountPasswordPolicy(input); err != nil {
 		return fmt.Errorf("Error deleting IAM Password Policy: %s", err)
 	}
-	d.SetId("")
 	log.Println("[DEBUG] Deleted IAM account password policy")
 
 	return nil

--- a/aws/resource_aws_iam_instance_profile.go
+++ b/aws/resource_aws_iam_instance_profile.go
@@ -295,7 +295,7 @@ func resourceAwsIamInstanceProfileDelete(d *schema.ResourceData, meta interface{
 	if err != nil {
 		return fmt.Errorf("Error deleting IAM instance profile %s: %s", d.Id(), err)
 	}
-	d.SetId("")
+
 	return nil
 }
 

--- a/aws/resource_aws_iam_server_certificate.go
+++ b/aws/resource_aws_iam_server_certificate.go
@@ -173,8 +173,6 @@ func resourceAwsIAMServerCertificateDelete(d *schema.ResourceData, meta interfac
 					return resource.RetryableError(err)
 				}
 				if awsErr.Code() == "NoSuchEntity" {
-					log.Printf("[WARN] IAM Server Certificate (%s) not found, removing from state", d.Id())
-					d.SetId("")
 					return nil
 				}
 			}
@@ -187,7 +185,6 @@ func resourceAwsIAMServerCertificateDelete(d *schema.ResourceData, meta interfac
 		return err
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/aws/resource_aws_inspector_resource_group.go
+++ b/aws/resource_aws_inspector_resource_group.go
@@ -69,8 +69,5 @@ func resourceAwsInspectorResourceGroupRead(d *schema.ResourceData, meta interfac
 }
 
 func resourceAwsInspectorResourceGroupDelete(d *schema.ResourceData, meta interface{}) error {
-	d.Set("arn", "")
-	d.SetId("")
-
 	return nil
 }

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -1143,7 +1143,6 @@ func resourceAwsInstanceDelete(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -1608,7 +1608,6 @@ func resourceAwsKinesisFirehoseDeliveryStreamDelete(d *schema.ResourceData, meta
 			sn, err)
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/aws/resource_aws_kinesis_stream.go
+++ b/aws/resource_aws_kinesis_stream.go
@@ -229,7 +229,6 @@ func resourceAwsKinesisStreamDelete(d *schema.ResourceData, meta interface{}) er
 			sn, err)
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/aws/resource_aws_kms_alias.go
+++ b/aws/resource_aws_kms_alias.go
@@ -166,7 +166,7 @@ func resourceAwsKmsAliasDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] KMS Alias: (%s) deleted.", d.Id())
-	d.SetId("")
+
 	return nil
 }
 

--- a/aws/resource_aws_kms_key.go
+++ b/aws/resource_aws_kms_key.go
@@ -473,6 +473,6 @@ func resourceAwsKmsKeyDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] KMS Key %s deactivated.", keyId)
-	d.SetId("")
+
 	return nil
 }

--- a/aws/resource_aws_lambda_alias.go
+++ b/aws/resource_aws_lambda_alias.go
@@ -119,8 +119,6 @@ func resourceAwsLambdaAliasDelete(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Error deleting Lambda alias: %s", err)
 	}
 
-	d.SetId("")
-
 	return nil
 }
 

--- a/aws/resource_aws_lambda_event_source_mapping.go
+++ b/aws/resource_aws_lambda_event_source_mapping.go
@@ -175,8 +175,6 @@ func resourceAwsLambdaEventSourceMappingDelete(d *schema.ResourceData, meta inte
 		return fmt.Errorf("Error deleting Lambda event source mapping: %s", err)
 	}
 
-	d.SetId("")
-
 	return nil
 }
 

--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -595,8 +595,6 @@ func resourceAwsLambdaFunctionDelete(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Error deleting Lambda Function: %s", err)
 	}
 
-	d.SetId("")
-
 	return nil
 }
 

--- a/aws/resource_aws_lambda_permission.go
+++ b/aws/resource_aws_lambda_permission.go
@@ -340,7 +340,6 @@ func resourceAwsLambdaPermissionDelete(d *schema.ResourceData, meta interface{})
 	}
 
 	log.Printf("[DEBUG] Lambda permission with ID %q removed", d.Id())
-	d.SetId("")
 
 	return nil
 }

--- a/aws/resource_aws_lb_target_group_attachment.go
+++ b/aws/resource_aws_lb_target_group_attachment.go
@@ -104,8 +104,6 @@ func resourceAwsLbAttachmentDelete(d *schema.ResourceData, meta interface{}) err
 		return errwrap.Wrapf("Error deregistering Targets: {{err}}", err)
 	}
 
-	d.SetId("")
-
 	return nil
 }
 

--- a/aws/resource_aws_lightsail_instance.go
+++ b/aws/resource_aws_lightsail_instance.go
@@ -230,7 +230,6 @@ func resourceAwsLightsailInstanceDelete(d *schema.ResourceData, meta interface{}
 			d.Id(), err)
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/aws/resource_aws_lightsail_key_pair.go
+++ b/aws/resource_aws_lightsail_key_pair.go
@@ -220,6 +220,5 @@ func resourceAwsLightsailKeyPairDelete(d *schema.ResourceData, meta interface{})
 			d.Id(), err)
 	}
 
-	d.SetId("")
 	return nil
 }

--- a/aws/resource_aws_load_balancer_backend_server_policy.go
+++ b/aws/resource_aws_load_balancer_backend_server_policy.go
@@ -128,7 +128,6 @@ func resourceAwsLoadBalancerBackendServerPoliciesDelete(d *schema.ResourceData, 
 		return fmt.Errorf("Error setting LoadBalancerPoliciesForBackendServer: %s", err)
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/aws/resource_aws_load_balancer_listener_policy.go
+++ b/aws/resource_aws_load_balancer_listener_policy.go
@@ -128,7 +128,6 @@ func resourceAwsLoadBalancerListenerPoliciesDelete(d *schema.ResourceData, meta 
 		return fmt.Errorf("Error setting LoadBalancerPoliciesOfListener: %s", err)
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/aws/resource_aws_load_balancer_policy.go
+++ b/aws/resource_aws_load_balancer_policy.go
@@ -205,7 +205,6 @@ func resourceAwsLoadBalancerPolicyDelete(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error deleting Load Balancer Policy %s: %s", d.Id(), err)
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/aws/resource_aws_media_store_container.go
+++ b/aws/resource_aws_media_store_container.go
@@ -95,7 +95,6 @@ func resourceAwsMediaStoreContainerDelete(d *schema.ResourceData, meta interface
 	_, err := conn.DeleteContainer(input)
 	if err != nil {
 		if isAWSErr(err, mediastore.ErrCodeContainerNotFoundException, "") {
-			d.SetId("")
 			return nil
 		}
 		return err
@@ -118,7 +117,6 @@ func resourceAwsMediaStoreContainerDelete(d *schema.ResourceData, meta interface
 		return err
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/aws/resource_aws_network_interface_sg_attachment.go
+++ b/aws/resource_aws_network_interface_sg_attachment.go
@@ -116,7 +116,6 @@ func resourceAwsNetworkInterfaceSGAttachmentDelete(d *schema.ResourceData, meta 
 		return err
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/aws/resource_aws_opsworks_instance.go
+++ b/aws/resource_aws_opsworks_instance.go
@@ -859,7 +859,6 @@ func resourceAwsOpsworksInstanceDelete(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/aws/resource_aws_placement_group.go
+++ b/aws/resource_aws_placement_group.go
@@ -148,6 +148,5 @@ func resourceAwsPlacementGroupDelete(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	d.SetId("")
 	return nil
 }

--- a/aws/resource_aws_proxy_protocol_policy.go
+++ b/aws/resource_aws_proxy_protocol_policy.go
@@ -166,8 +166,6 @@ func resourceAwsProxyProtocolPolicyDelete(d *schema.ResourceData, meta interface
 	resp, err := elbconn.DescribeLoadBalancers(req)
 	if err != nil {
 		if isLoadBalancerNotFound(err) {
-			// The ELB is gone now, so just remove it from the state
-			d.SetId("")
 			return nil
 		}
 		return fmt.Errorf("Error retrieving ELB attributes: %s", err)

--- a/aws/resource_aws_route.go
+++ b/aws/resource_aws_route.go
@@ -425,7 +425,6 @@ func resourceAwsRouteDelete(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -701,8 +701,6 @@ func resourceAwsRoute53RecordDelete(d *schema.ResourceData, meta interface{}) er
 	if err != nil {
 		switch err {
 		case r53NoHostedZoneFound, r53NoRecordsFound:
-			log.Printf("[DEBUG] %s for: %s, removing from state file", err, d.Id())
-			d.SetId("")
 			return nil
 		default:
 			return err

--- a/aws/resource_aws_route53_zone.go
+++ b/aws/resource_aws_route53_zone.go
@@ -277,8 +277,6 @@ func resourceAwsRoute53ZoneDelete(d *schema.ResourceData, meta interface{}) erro
 	_, err := r53.DeleteHostedZone(&route53.DeleteHostedZoneInput{Id: aws.String(d.Id())})
 	if err != nil {
 		if r53err, ok := err.(awserr.Error); ok && r53err.Code() == "NoSuchHostedZone" {
-			log.Printf("[DEBUG] No matching Route 53 Zone found for: %s, removing from state file", d.Id())
-			d.SetId("")
 			return nil
 		}
 		return err

--- a/aws/resource_aws_s3_bucket_metric.go
+++ b/aws/resource_aws_s3_bucket_metric.go
@@ -109,14 +109,11 @@ func resourceAwsS3BucketMetricDelete(d *schema.ResourceData, meta interface{}) e
 	_, err = conn.DeleteBucketMetricsConfiguration(input)
 	if err != nil {
 		if isAWSErr(err, s3.ErrCodeNoSuchBucket, "") || isAWSErr(err, "NoSuchConfiguration", "The specified configuration does not exist.") {
-			log.Printf("[WARN] %s S3 bucket metrics configuration not found, removing from state.", d.Id())
-			d.SetId("")
 			return nil
 		}
 		return fmt.Errorf("Error deleting S3 metric configuration: %s", err)
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/aws/resource_aws_s3_bucket_notification.go
+++ b/aws/resource_aws_s3_bucket_notification.go
@@ -346,8 +346,6 @@ func resourceAwsS3BucketNotificationDelete(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("Error deleting S3 notification configuration: %s", err)
 	}
 
-	d.SetId("")
-
 	return nil
 }
 

--- a/aws/resource_aws_security_group_rule.go
+++ b/aws/resource_aws_security_group_rule.go
@@ -354,8 +354,6 @@ func resourceAwsSecurityGroupRuleDelete(d *schema.ResourceData, meta interface{}
 		}
 	}
 
-	d.SetId("")
-
 	return nil
 }
 

--- a/aws/resource_aws_service_discovery_private_dns_namespace.go
+++ b/aws/resource_aws_service_discovery_private_dns_namespace.go
@@ -127,6 +127,5 @@ func resourceAwsServiceDiscoveryPrivateDnsNamespaceDelete(d *schema.ResourceData
 		return err
 	}
 
-	d.SetId("")
 	return nil
 }

--- a/aws/resource_aws_service_discovery_public_dns_namespace.go
+++ b/aws/resource_aws_service_discovery_public_dns_namespace.go
@@ -126,7 +126,6 @@ func resourceAwsServiceDiscoveryPublicDnsNamespaceDelete(d *schema.ResourceData,
 		return err
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/aws/resource_aws_simpledb_domain.go
+++ b/aws/resource_aws_simpledb_domain.go
@@ -79,6 +79,5 @@ func resourceAwsSimpleDBDomainDelete(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Delete SimpleDB Domain failed: %s", err)
 	}
 
-	d.SetId("")
 	return nil
 }

--- a/aws/resource_aws_ssm_document.go
+++ b/aws/resource_aws_ssm_document.go
@@ -347,8 +347,6 @@ func resourceAwsSsmDocumentDelete(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	d.SetId("")
-
 	return nil
 }
 

--- a/aws/resource_aws_ssm_parameter.go
+++ b/aws/resource_aws_ssm_parameter.go
@@ -167,7 +167,6 @@ func resourceAwsSsmParameterDelete(d *schema.ResourceData, meta interface{}) err
 	if err != nil {
 		return err
 	}
-	d.SetId("")
 
 	return nil
 }

--- a/aws/resource_aws_volume_attachment.go
+++ b/aws/resource_aws_volume_attachment.go
@@ -213,8 +213,6 @@ func resourceAwsVolumeAttachmentDelete(d *schema.ResourceData, meta interface{})
 	conn := meta.(*AWSClient).ec2conn
 
 	if _, ok := d.GetOk("skip_destroy"); ok {
-		log.Printf("[INFO] Found skip_destroy to be true, removing attachment %q from state", d.Id())
-		d.SetId("")
 		return nil
 	}
 
@@ -250,7 +248,7 @@ func resourceAwsVolumeAttachmentDelete(d *schema.ResourceData, meta interface{})
 			"Error waiting for Volume (%s) to detach from Instance: %s",
 			vID, iID)
 	}
-	d.SetId("")
+
 	return nil
 }
 

--- a/aws/resource_aws_vpc_dhcp_options_association.go
+++ b/aws/resource_aws_vpc_dhcp_options_association.go
@@ -94,6 +94,5 @@ func resourceAwsVpcDhcpOptionsAssociationDelete(d *schema.ResourceData, meta int
 		return err
 	}
 
-	d.SetId("")
 	return nil
 }

--- a/aws/resource_aws_vpc_peering_connection_accepter.go
+++ b/aws/resource_aws_vpc_peering_connection_accepter.go
@@ -69,6 +69,5 @@ func resourceAwsVPCPeeringAccepterCreate(d *schema.ResourceData, meta interface{
 
 func resourceAwsVPCPeeringAccepterDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[WARN] Will not delete VPC peering connection. Terraform will remove this resource from the state file, however resources may remain.")
-	d.SetId("")
 	return nil
 }

--- a/aws/resource_aws_vpn_connection.go
+++ b/aws/resource_aws_vpn_connection.go
@@ -461,7 +461,6 @@ func resourceAwsVpnConnectionDelete(d *schema.ResourceData, meta interface{}) er
 	})
 	if err != nil {
 		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidVpnConnectionID.NotFound" {
-			d.SetId("")
 			return nil
 		} else {
 			log.Printf("[ERROR] Error deleting VPN connection: %s", err)

--- a/aws/resource_aws_vpn_connection_route.go
+++ b/aws/resource_aws_vpn_connection_route.go
@@ -106,7 +106,6 @@ func resourceAwsVpnConnectionRouteDelete(d *schema.ResourceData, meta interface{
 	})
 	if err != nil {
 		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidVpnConnectionID.NotFound" {
-			d.SetId("")
 			return nil
 		}
 		log.Printf("[ERROR] Error deleting VPN connection route: %s", err)

--- a/aws/resource_aws_vpn_gateway_attachment.go
+++ b/aws/resource_aws_vpn_gateway_attachment.go
@@ -131,14 +131,8 @@ func resourceAwsVpnGatewayAttachmentDelete(d *schema.ResourceData, meta interfac
 		if ok {
 			switch awsErr.Code() {
 			case "InvalidVPNGatewayID.NotFound":
-				log.Printf("[WARN] VPN Gateway %q not found.", vgwId)
-				d.SetId("")
 				return nil
 			case "InvalidVpnGatewayAttachment.NotFound":
-				log.Printf(
-					"[WARN] VPN Gateway %q attachment to VPC %q not found.",
-					vgwId, vpcId)
-				d.SetId("")
 				return nil
 			}
 		}
@@ -163,7 +157,6 @@ func resourceAwsVpnGatewayAttachmentDelete(d *schema.ResourceData, meta interfac
 	}
 	log.Printf("[DEBUG] VPN Gateway %q detached from VPC %q.", vgwId, vpcId)
 
-	d.SetId("")
 	return nil
 }
 

--- a/aws/resource_aws_vpn_gateway_route_propagation.go
+++ b/aws/resource_aws_vpn_gateway_route_propagation.go
@@ -64,7 +64,6 @@ func resourceAwsVpnGatewayRoutePropagationDisable(d *schema.ResourceData, meta i
 		return fmt.Errorf("error disabling VGW propagation: %s", err)
 	}
 
-	d.SetId("")
 	return nil
 }
 


### PR DESCRIPTION
Fixes #4191 except for 3 thornier cases:

```
[resource.aws_autoscaling_policy] [tfprovlint001] /Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_autoscaling_policy.go:385:11: DeleteFunc should not call (*github.com/hashicorp/terraform/helper/schema.ResourceData).SetId
[resource.aws_cloudfront_distribution] [tfprovlint001] /Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_cloudfront_distribution.go:723:11: DeleteFunc should not call (*github.com/hashicorp/terraform/helper/schema.ResourceData).SetId
[resource.aws_eip] [tfprovlint001] /Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_eip.go:221:10: DeleteFunc should not call (*github.com/hashicorp/terraform/helper/schema.ResourceData).SetId
```