### PR TITLE
resource/security_group: fix rule gathering with description included

### DIFF
--- a/aws/resource_aws_security_group.go
+++ b/aws/resource_aws_security_group.go
@@ -590,122 +590,83 @@ func resourceAwsSecurityGroupRuleHash(v interface{}) int {
 func resourceAwsSecurityGroupIPPermGather(groupId string, permissions []*ec2.IpPermission, ownerId *string) []map[string]interface{} {
 	ruleMap := make(map[string]map[string]interface{})
 	for _, perm := range permissions {
-		var fromPort, toPort int64
-		if v := perm.FromPort; v != nil {
-			fromPort = *v
-		}
-		if v := perm.ToPort; v != nil {
-			toPort = *v
-		}
-
-		k := fmt.Sprintf("%s-%d-%d", *perm.IpProtocol, fromPort, toPort)
-		m, ok := ruleMap[k]
-		if !ok {
-			m = make(map[string]interface{})
-			ruleMap[k] = m
-		}
-
-		m["from_port"] = fromPort
-		m["to_port"] = toPort
-		m["protocol"] = *perm.IpProtocol
-
-		var description string
-
 		if len(perm.IpRanges) > 0 {
-			raw, ok := m["cidr_blocks"]
-			if !ok {
-				raw = make([]string, 0, len(perm.IpRanges))
-			}
-			list := raw.([]string)
-
 			for _, ip := range perm.IpRanges {
-				list = append(list, *ip.CidrIp)
-
 				desc := aws.StringValue(ip.Description)
-				if desc != "" {
-					description = desc
-				}
-			}
 
-			m["cidr_blocks"] = list
+				rule := initSecurityGroupRule(ruleMap, perm, desc)
+
+				raw, ok := rule["cidr_blocks"]
+				if !ok {
+					raw = make([]string, 0)
+				}
+				list := raw.([]string)
+
+				rule["cidr_blocks"] = append(list, *ip.CidrIp)
+			}
 		}
 
 		if len(perm.Ipv6Ranges) > 0 {
-			raw, ok := m["ipv6_cidr_blocks"]
-			if !ok {
-				raw = make([]string, 0, len(perm.Ipv6Ranges))
-			}
-			list := raw.([]string)
-
 			for _, ip := range perm.Ipv6Ranges {
-				list = append(list, *ip.CidrIpv6)
-
 				desc := aws.StringValue(ip.Description)
-				if desc != "" {
-					description = desc
-				}
-			}
 
-			m["ipv6_cidr_blocks"] = list
+				rule := initSecurityGroupRule(ruleMap, perm, desc)
+
+				raw, ok := rule["ipv6_cidr_blocks"]
+				if !ok {
+					raw = make([]string, 0)
+				}
+				list := raw.([]string)
+
+				rule["ipv6_cidr_blocks"] = append(list, *ip.CidrIpv6)
+			}
 		}
 
 		if len(perm.PrefixListIds) > 0 {
-			raw, ok := m["prefix_list_ids"]
-			if !ok {
-				raw = make([]string, 0, len(perm.PrefixListIds))
-			}
-			list := raw.([]string)
-
 			for _, pl := range perm.PrefixListIds {
-				list = append(list, *pl.PrefixListId)
-
 				desc := aws.StringValue(pl.Description)
-				if desc != "" {
-					description = desc
-				}
-			}
 
-			m["prefix_list_ids"] = list
+				rule := initSecurityGroupRule(ruleMap, perm, desc)
+
+				raw, ok := rule["prefix_list_ids"]
+				if !ok {
+					raw = make([]string, 0)
+				}
+				list := raw.([]string)
+
+				rule["prefix_list_ids"] = append(list, *pl.PrefixListId)
+			}
 		}
 
 		groups := flattenSecurityGroups(perm.UserIdGroupPairs, ownerId)
-		for i, g := range groups {
-			if *g.GroupId == groupId {
-				groups[i], groups = groups[len(groups)-1], groups[:len(groups)-1]
-				m["self"] = true
-
-				desc := aws.StringValue(g.Description)
-				if desc != "" {
-					description = desc
-				}
-			}
-		}
-
 		if len(groups) > 0 {
-			raw, ok := m["security_groups"]
-			if !ok {
-				raw = schema.NewSet(schema.HashString, nil)
-			}
-			list := raw.(*schema.Set)
-
 			for _, g := range groups {
+				desc := aws.StringValue(g.Description)
+
+				rule := initSecurityGroupRule(ruleMap, perm, desc)
+
+				if *g.GroupId == groupId {
+					rule["self"] = true
+					continue
+				}
+
+				raw, ok := rule["security_groups"]
+				if !ok {
+					raw = schema.NewSet(schema.HashString, nil)
+				}
+				list := raw.(*schema.Set)
+
 				if g.GroupName != nil {
 					list.Add(*g.GroupName)
 				} else {
 					list.Add(*g.GroupId)
 				}
-
-				desc := aws.StringValue(g.Description)
-				if desc != "" {
-					description = desc
-				}
+				rule["security_groups"] = list
 			}
-
-			m["security_groups"] = list
 		}
 
-		m["description"] = description
 	}
+
 	rules := make([]map[string]interface{}, 0, len(ruleMap))
 	for _, m := range ruleMap {
 		rules = append(rules, m)
@@ -1338,4 +1299,28 @@ func networkInterfaceAttachedRefreshFunc(conn *ec2.EC2, id string) resource.Stat
 		log.Printf("[DEBUG] ENI %s has attachment state %s", id, hasAttachment)
 		return eni, hasAttachment, nil
 	}
+}
+
+func initSecurityGroupRule(ruleMap map[string]map[string]interface{}, perm *ec2.IpPermission, desc string) map[string]interface{} {
+	var fromPort, toPort int64
+	if v := perm.FromPort; v != nil {
+		fromPort = *v
+	}
+	if v := perm.ToPort; v != nil {
+		toPort = *v
+	}
+	k := fmt.Sprintf("%s-%d-%d-%s", *perm.IpProtocol, fromPort, toPort, desc)
+	rule, ok := ruleMap[k]
+	if !ok {
+		rule = make(map[string]interface{})
+		ruleMap[k] = rule
+	}
+	rule["protocol"] = *perm.IpProtocol
+	rule["from_port"] = fromPort
+	rule["to_port"] = toPort
+	if desc != "" {
+		rule["description"] = desc
+	}
+
+	return rule
 }

--- a/aws/resource_aws_security_group_test.go
+++ b/aws/resource_aws_security_group_test.go
@@ -386,6 +386,8 @@ func TestAccAWSSecurityGroup_ruleGathering(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSecurityGroupExists("aws_security_group.test", &group),
 					resource.TestCheckResourceAttr("aws_security_group.test", "name", sgName),
+					resource.TestCheckResourceAttr("aws_security_group.test", "egress.#", "3"),
+					resource.TestCheckResourceAttr("aws_security_group.test", "ingress.#", "5"),
 				),
 			},
 		},
@@ -2832,6 +2834,8 @@ resource "aws_security_group" "egress" {
 `
 
 const testAccAWSSecurityGroupConfigPrefixListEgress = `
+data "aws_region" "current" {}
+
 resource "aws_vpc" "tf_sg_prefix_list_egress_test" {
     cidr_block = "10.0.0.0/16"
     tags {
@@ -2843,9 +2847,9 @@ resource "aws_route_table" "default" {
     vpc_id = "${aws_vpc.tf_sg_prefix_list_egress_test.id}"
 }
 
-resource "aws_vpc_endpoint" "s3-us-west-2" {
+resource "aws_vpc_endpoint" "test" {
   	vpc_id = "${aws_vpc.tf_sg_prefix_list_egress_test.id}"
-  	service_name = "com.amazonaws.us-west-2.s3"
+  	service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
   	route_table_ids = ["${aws_route_table.default.id}"]
   	policy = <<POLICY
 {
@@ -2872,7 +2876,7 @@ resource "aws_security_group" "egress" {
       protocol = "-1"
       from_port = 0
       to_port = 0
-      prefix_list_ids = ["${aws_vpc_endpoint.s3-us-west-2.prefix_list_id}"]
+      prefix_list_ids = ["${aws_vpc_endpoint.test.prefix_list_id}"]
     }
 }
 `


### PR DESCRIPTION
fix #2018 
fix #2069 
fix #2379 
fix #2879 
fix #3139
fix #3202
fix #3204
fix #3261 
fix #3346
fix #4346
fix #4410 

There have been a few issues regarding rules with the same `protocol`, `from_port` and `to_port` but different `description`. The last `description` will eventually override previous ones and next `plan` shows changes to apply.

One simple example could be:
```
resource "aws_vpc" "test" {
  cidr_block = "10.0.0.0/16"

  tags {
    Name = "tf-test"
  }
}

resource "aws_security_group" "test" {
  name        = "tf-test"
  vpc_id      = "${aws_vpc.test.id}"

  ingress {
    protocol         = "tcp"
    from_port        = 80
    to_port          = 80
    ipv6_cidr_blocks = ["0.0.0.0/0"]
    description      = "ingress from all ipv4"
  }

  ingress {
    protocol         = "tcp"
    from_port        = 80
    to_port          = 80
    ipv6_cidr_blocks = ["::/0"]
    description      = "ingress from all ipv6"
  }
}
```
