### PR TITLE
tests: Bypass missing endpoints and UnsupportedOperation for sweepers

### DIFF
--- a/aws/import_aws_lambda_function_test.go
+++ b/aws/import_aws_lambda_function_test.go
@@ -28,6 +28,10 @@ func testSweepLambdaFunctions(region string) error {
 
 	resp, err := lambdaconn.ListFunctions(&lambda.ListFunctionsInput{})
 	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Lambda Function sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("Error retrieving Lambda functions: %s", err)
 	}
 

--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -146,3 +146,17 @@ func testAccCheckWithProviders(f func(*terraform.State, *schema.Provider) error,
 		return nil
 	}
 }
+
+// Check sweeper API call error for reasons to skip sweeping
+// These include missing API endpoints and unsupported API calls
+func testSweepSkipSweepError(err error) bool {
+	// Ignore missing API endpoints
+	if isAWSErr(err, "RequestError", "send request failed") {
+		return true
+	}
+	// Ignore unsupported API calls
+	if isAWSErr(err, "UnsupportedOperation", "") {
+		return true
+	}
+	return false
+}

--- a/aws/resource_aws_api_gateway_rest_api_test.go
+++ b/aws/resource_aws_api_gateway_rest_api_test.go
@@ -71,6 +71,10 @@ func testSweepAPIGatewayRestApis(region string) error {
 		return !lastPage
 	})
 	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping API Gateway REST API sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("Error retrieving API Gateway REST APIs: %s", err)
 	}
 

--- a/aws/resource_aws_autoscaling_group_test.go
+++ b/aws/resource_aws_autoscaling_group_test.go
@@ -36,6 +36,10 @@ func testSweepAutoscalingGroups(region string) error {
 
 	resp, err := conn.DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{})
 	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping AutoScaling Group sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("Error retrieving AutoScaling Groups in Sweeper: %s", err)
 	}
 

--- a/aws/resource_aws_batch_compute_environment_test.go
+++ b/aws/resource_aws_batch_compute_environment_test.go
@@ -38,6 +38,10 @@ func testSweepBatchComputeEnvironments(region string) error {
 
 	out, err := conn.DescribeComputeEnvironments(&batch.DescribeComputeEnvironmentsInput{})
 	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Batch Compute Environment sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("Error retrieving Batch Compute Environments: %s", err)
 	}
 	for _, computeEnvironment := range out.ComputeEnvironments {

--- a/aws/resource_aws_batch_job_queue_test.go
+++ b/aws/resource_aws_batch_job_queue_test.go
@@ -34,6 +34,10 @@ func testSweepBatchJobQueues(region string) error {
 
 	out, err := conn.DescribeJobQueues(&batch.DescribeJobQueuesInput{})
 	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Batch Job Queue sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("Error retrieving Batch Job Queues: %s", err)
 	}
 	for _, jobQueue := range out.JobQueues {

--- a/aws/resource_aws_cloudfront_distribution_test.go
+++ b/aws/resource_aws_cloudfront_distribution_test.go
@@ -40,6 +40,10 @@ func testSweepCloudFrontDistributions(region string) error {
 		return !lastPage
 	})
 	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping CloudFront Distribution sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("Error listing CloudFront Distributions: %s", err)
 	}
 

--- a/aws/resource_aws_dax_cluster_test.go
+++ b/aws/resource_aws_dax_cluster_test.go
@@ -30,6 +30,12 @@ func testSweepDAXClusters(region string) error {
 
 	resp, err := conn.DescribeClusters(&dax.DescribeClustersInput{})
 	if err != nil {
+		// GovCloud (with no DAX support) has an endpoint that responds with:
+		// InvalidParameterValueException: Access Denied to API Version: DAX_V3
+		if testSweepSkipSweepError(err) || isAWSErr(err, "InvalidParameterValueException", "Access Denied to API Version: DAX_V3") {
+			log.Printf("[WARN] Skipping DAX Cluster sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("Error retrieving DAX clusters: %s", err)
 	}
 

--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -74,6 +74,10 @@ func testSweepDbInstances(region string) error {
 		return !lastPage
 	})
 	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping RDS DB Instance sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("Error retrieving DB instances: %s", err)
 	}
 

--- a/aws/resource_aws_db_option_group_test.go
+++ b/aws/resource_aws_db_option_group_test.go
@@ -35,6 +35,10 @@ func testSweepDbOptionGroups(region string) error {
 	opts := rds.DescribeOptionGroupsInput{}
 	resp, err := conn.DescribeOptionGroups(&opts)
 	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping RDS DB Option Group sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("error describing DB Option Groups in Sweeper: %s", err)
 	}
 

--- a/aws/resource_aws_dynamodb_table_test.go
+++ b/aws/resource_aws_dynamodb_table_test.go
@@ -54,6 +54,10 @@ func testSweepDynamoDbTables(region string) error {
 		return !lastPage
 	})
 	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping DynamoDB Table sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("Error retrieving DynamoDB Tables: %s", err)
 	}
 

--- a/aws/resource_aws_elastic_beanstalk_application_test.go
+++ b/aws/resource_aws_elastic_beanstalk_application_test.go
@@ -32,6 +32,10 @@ func testSweepBeanstalkApplications(region string) error {
 
 	resp, err := beanstalkconn.DescribeApplications(&elasticbeanstalk.DescribeApplicationsInput{})
 	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Elastic Beanstalk Application sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("Error retrieving beanstalk application: %s", err)
 	}
 

--- a/aws/resource_aws_elastic_beanstalk_environment_test.go
+++ b/aws/resource_aws_elastic_beanstalk_environment_test.go
@@ -38,6 +38,10 @@ func testSweepBeanstalkEnvironments(region string) error {
 	})
 
 	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Elastic Beanstalk Environment sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("Error retrieving beanstalk environment: %s", err)
 	}
 

--- a/aws/resource_aws_elasticache_cluster_test.go
+++ b/aws/resource_aws_elasticache_cluster_test.go
@@ -42,7 +42,7 @@ func testSweepElasticacheClusters(region string) error {
 		"tf-acc-test-",
 	}
 
-	return conn.DescribeCacheClustersPages(&elasticache.DescribeCacheClustersInput{}, func(page *elasticache.DescribeCacheClustersOutput, isLast bool) bool {
+	err = conn.DescribeCacheClustersPages(&elasticache.DescribeCacheClustersInput{}, func(page *elasticache.DescribeCacheClustersOutput, isLast bool) bool {
 		if len(page.CacheClusters) == 0 {
 			log.Print("[DEBUG] No Elasticache Replicaton Groups to sweep")
 			return false
@@ -69,6 +69,14 @@ func testSweepElasticacheClusters(region string) error {
 		}
 		return !isLast
 	})
+	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Elasticache Cluster sweep for %s: %s", region, err)
+			return nil
+		}
+		return fmt.Errorf("Error retrieving Elasticache Clusters: %s", err)
+	}
+	return nil
 }
 
 func TestAccAWSElasticacheCluster_Engine_Memcached_Ec2Classic(t *testing.T) {

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -36,7 +36,7 @@ func testSweepElasticacheReplicationGroups(region string) error {
 		"tf-acc-test-",
 	}
 
-	return conn.DescribeReplicationGroupsPages(&elasticache.DescribeReplicationGroupsInput{}, func(page *elasticache.DescribeReplicationGroupsOutput, isLast bool) bool {
+	err = conn.DescribeReplicationGroupsPages(&elasticache.DescribeReplicationGroupsInput{}, func(page *elasticache.DescribeReplicationGroupsOutput, isLast bool) bool {
 		if len(page.ReplicationGroups) == 0 {
 			log.Print("[DEBUG] No Elasticache Replicaton Groups to sweep")
 			return false
@@ -63,6 +63,14 @@ func testSweepElasticacheReplicationGroups(region string) error {
 		}
 		return !isLast
 	})
+	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Elasticache Replication Group sweep for %s: %s", region, err)
+			return nil
+		}
+		return fmt.Errorf("Error retrieving Elasticache Replication Groups: %s", err)
+	}
+	return nil
 }
 
 func TestAccAWSElasticacheReplicationGroup_basic(t *testing.T) {

--- a/aws/resource_aws_elasticsearch_domain_test.go
+++ b/aws/resource_aws_elasticsearch_domain_test.go
@@ -36,6 +36,10 @@ func testSweepElasticSearchDomains(region string) error {
 
 	out, err := conn.ListDomainNames(&elasticsearch.ListDomainNamesInput{})
 	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Elasticsearch Domain sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("Error retrieving Elasticsearch Domains: %s", err)
 	}
 	for _, domain := range out.DomainNames {

--- a/aws/resource_aws_elb_test.go
+++ b/aws/resource_aws_elb_test.go
@@ -37,7 +37,7 @@ func testSweepELBs(region string) error {
 		"test-elb-",
 	}
 
-	return conn.DescribeLoadBalancersPages(&elb.DescribeLoadBalancersInput{}, func(out *elb.DescribeLoadBalancersOutput, isLast bool) bool {
+	err = conn.DescribeLoadBalancersPages(&elb.DescribeLoadBalancersInput{}, func(out *elb.DescribeLoadBalancersOutput, isLast bool) bool {
 		if len(out.LoadBalancerDescriptions) == 0 {
 			log.Println("[INFO] No ELBs found for sweeping")
 			return false
@@ -71,6 +71,14 @@ func testSweepELBs(region string) error {
 		}
 		return !isLast
 	})
+	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping ELB sweep for %s: %s", region, err)
+			return nil
+		}
+		return fmt.Errorf("Error retrieving ELBs: %s", err)
+	}
+	return nil
 }
 
 func TestAccAWSELB_basic(t *testing.T) {

--- a/aws/resource_aws_gamelift_alias_test.go
+++ b/aws/resource_aws_gamelift_alias_test.go
@@ -55,6 +55,10 @@ func testSweepGameliftAliases(region string) error {
 		return nil
 	})
 	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Gamelift Alias sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("Error listing Gamelift Aliases: %s", err)
 	}
 

--- a/aws/resource_aws_gamelift_build_test.go
+++ b/aws/resource_aws_gamelift_build_test.go
@@ -31,6 +31,10 @@ func testSweepGameliftBuilds(region string) error {
 
 	resp, err := conn.ListBuilds(&gamelift.ListBuildsInput{})
 	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Gamelife Build sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("Error listing Gamelift Builds: %s", err)
 	}
 

--- a/aws/resource_aws_glue_connection_test.go
+++ b/aws/resource_aws_glue_connection_test.go
@@ -63,6 +63,10 @@ func testSweepGlueConnections(region string) error {
 		return !lastPage
 	})
 	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Glue Connection sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("Error retrieving Glue Connections: %s", err)
 	}
 

--- a/aws/resource_aws_glue_job_test.go
+++ b/aws/resource_aws_glue_job_test.go
@@ -61,6 +61,10 @@ func testSweepGlueJobs(region string) error {
 		return !lastPage
 	})
 	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Glue Job sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("Error retrieving Glue Jobs: %s", err)
 	}
 

--- a/aws/resource_aws_iam_server_certificate_test.go
+++ b/aws/resource_aws_iam_server_certificate_test.go
@@ -58,6 +58,10 @@ func testSweepIamServerCertificates(region string) error {
 		return !lastPage
 	})
 	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping IAM Server Certificate sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("Error retrieving IAM Server Certificates: %s", err)
 	}
 

--- a/aws/resource_aws_iam_service_linked_role_test.go
+++ b/aws/resource_aws_iam_service_linked_role_test.go
@@ -63,6 +63,10 @@ func testSweepIamServiceLinkedRoles(region string) error {
 		return !lastPage
 	})
 	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping IAM Service Role sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("Error retrieving IAM Service Roles: %s", err)
 	}
 

--- a/aws/resource_aws_internet_gateway_test.go
+++ b/aws/resource_aws_internet_gateway_test.go
@@ -38,6 +38,10 @@ func testSweepInternetGateways(region string) error {
 	}
 	resp, err := conn.DescribeInternetGateways(req)
 	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Internet Gateway sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("Error describing Internet Gateways: %s", err)
 	}
 

--- a/aws/resource_aws_key_pair_test.go
+++ b/aws/resource_aws_key_pair_test.go
@@ -38,6 +38,10 @@ func testSweepKeyPairs(region string) error {
 		},
 	})
 	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping EC2 Key Pair sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("Error describing key pairs in Sweeper: %s", err)
 	}
 

--- a/aws/resource_aws_kms_key_test.go
+++ b/aws/resource_aws_kms_key_test.go
@@ -70,6 +70,10 @@ func testSweepKmsKeys(region string) error {
 		return !lastPage
 	})
 	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping KMS Key sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("Error describing KMS keys: %s", err)
 	}
 

--- a/aws/resource_aws_launch_configuration_test.go
+++ b/aws/resource_aws_launch_configuration_test.go
@@ -34,6 +34,10 @@ func testSweepLaunchConfigurations(region string) error {
 
 	resp, err := autoscalingconn.DescribeLaunchConfigurations(&autoscaling.DescribeLaunchConfigurationsInput{})
 	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping AutoScaling Launch Configuration sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("Error retrieving launch configuration: %s", err)
 	}
 

--- a/aws/resource_aws_mq_broker_test.go
+++ b/aws/resource_aws_mq_broker_test.go
@@ -81,6 +81,10 @@ func testSweepMqBrokers(region string) error {
 		MaxResults: aws.Int64(100),
 	})
 	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping MQ Broker sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("Error listing MQ brokers: %s", err)
 	}
 

--- a/aws/resource_aws_nat_gateway_test.go
+++ b/aws/resource_aws_nat_gateway_test.go
@@ -39,6 +39,10 @@ func testSweepNatGateways(region string) error {
 	}
 	resp, err := conn.DescribeNatGateways(req)
 	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping EC2 NAT Gateway sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("Error describing NAT Gateways: %s", err)
 	}
 

--- a/aws/resource_aws_network_acl_test.go
+++ b/aws/resource_aws_network_acl_test.go
@@ -38,6 +38,10 @@ func testSweepNetworkAcls(region string) error {
 	}
 	resp, err := conn.DescribeNetworkAcls(req)
 	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping EC2 Network ACL sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("Error describing Network ACLs: %s", err)
 	}
 

--- a/aws/resource_aws_redshift_cluster_test.go
+++ b/aws/resource_aws_redshift_cluster_test.go
@@ -31,7 +31,7 @@ func testSweepRedshiftClusters(region string) error {
 	}
 	conn := client.(*AWSClient).redshiftconn
 
-	return conn.DescribeClustersPages(&redshift.DescribeClustersInput{}, func(resp *redshift.DescribeClustersOutput, isLast bool) bool {
+	err = conn.DescribeClustersPages(&redshift.DescribeClustersInput{}, func(resp *redshift.DescribeClustersOutput, isLast bool) bool {
 		if len(resp.Clusters) == 0 {
 			log.Print("[DEBUG] No Redshift clusters to sweep")
 			return false
@@ -55,6 +55,14 @@ func testSweepRedshiftClusters(region string) error {
 		}
 		return !isLast
 	})
+	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Redshift Cluster sweep for %s: %s", region, err)
+			return nil
+		}
+		return fmt.Errorf("Error retrieving Redshift Clusters: %s", err)
+	}
+	return nil
 }
 
 func TestValidateRedshiftClusterDbName(t *testing.T) {

--- a/aws/resource_aws_secretsmanager_secret_test.go
+++ b/aws/resource_aws_secretsmanager_secret_test.go
@@ -28,7 +28,7 @@ func testSweepSecretsManagerSecrets(region string) error {
 	}
 	conn := client.(*AWSClient).secretsmanagerconn
 
-	return conn.ListSecretsPages(&secretsmanager.ListSecretsInput{}, func(page *secretsmanager.ListSecretsOutput, isLast bool) bool {
+	err = conn.ListSecretsPages(&secretsmanager.ListSecretsInput{}, func(page *secretsmanager.ListSecretsOutput, isLast bool) bool {
 		if len(page.SecretList) == 0 {
 			log.Print("[DEBUG] No Secrets Manager Secrets to sweep")
 			return true
@@ -57,6 +57,14 @@ func testSweepSecretsManagerSecrets(region string) error {
 
 		return !isLast
 	})
+	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Secrets Manager Secret sweep for %s: %s", region, err)
+			return nil
+		}
+		return fmt.Errorf("Error retrieving Secrets Manager Secrets: %s", err)
+	}
+	return nil
 }
 
 func TestAccAwsSecretsManagerSecret_Basic(t *testing.T) {

--- a/aws/resource_aws_security_group_test.go
+++ b/aws/resource_aws_security_group_test.go
@@ -41,6 +41,13 @@ func testSweepSecurityGroups(region string) error {
 		},
 	}
 	resp, err := conn.DescribeSecurityGroups(req)
+	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping EC2 Security Group sweep for %s: %s", region, err)
+			return nil
+		}
+		return fmt.Errorf("Error retrieving EC2 Security Groups: %s", err)
+	}
 
 	if len(resp.SecurityGroups) == 0 {
 		log.Print("[DEBUG] No aws security groups to sweep")

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -28,7 +28,7 @@ func testSweepSpotFleetRequests(region string) error {
 	}
 	conn := client.(*AWSClient).ec2conn
 
-	return conn.DescribeSpotFleetRequestsPages(&ec2.DescribeSpotFleetRequestsInput{}, func(page *ec2.DescribeSpotFleetRequestsOutput, isLast bool) bool {
+	err = conn.DescribeSpotFleetRequestsPages(&ec2.DescribeSpotFleetRequestsInput{}, func(page *ec2.DescribeSpotFleetRequestsOutput, isLast bool) bool {
 		if len(page.SpotFleetRequestConfigs) == 0 {
 			log.Print("[DEBUG] No Spot Fleet Requests to sweep")
 			return false
@@ -45,6 +45,14 @@ func testSweepSpotFleetRequests(region string) error {
 		}
 		return !isLast
 	})
+	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping EC2 Spot Fleet Requests sweep for %s: %s", region, err)
+			return nil
+		}
+		return fmt.Errorf("Error retrieving EC2 Spot Fleet Requests: %s", err)
+	}
+	return nil
 }
 
 func TestAccAWSSpotFleetRequest_associatePublicIpAddress(t *testing.T) {

--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -55,6 +55,10 @@ func testSweepSubnets(region string) error {
 	}
 	resp, err := conn.DescribeSubnets(req)
 	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping EC2 Subnet sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("Error describing subnets: %s", err)
 	}
 

--- a/aws/resource_aws_vpc_test.go
+++ b/aws/resource_aws_vpc_test.go
@@ -47,6 +47,10 @@ func testSweepVPCs(region string) error {
 	}
 	resp, err := conn.DescribeVpcs(req)
 	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping EC2 VPC sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("Error describing vpcs: %s", err)
 	}
 

--- a/aws/resource_aws_vpn_gateway_test.go
+++ b/aws/resource_aws_vpn_gateway_test.go
@@ -40,6 +40,10 @@ func testSweepVPNGateways(region string) error {
 	}
 	resp, err := conn.DescribeVpnGateways(req)
 	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping EC2 VPN Gateway sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("Error describing VPN Gateways: %s", err)
 	}
 

--- a/aws/resource_aws_waf_regex_match_set_test.go
+++ b/aws/resource_aws_waf_regex_match_set_test.go
@@ -30,6 +30,10 @@ func testSweepWafRegexMatchSet(region string) error {
 	req := &waf.ListRegexMatchSetsInput{}
 	resp, err := conn.ListRegexMatchSets(req)
 	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping WAF Regex Match Set sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("Error describing WAF Regex Match Sets: %s", err)
 	}
 

--- a/aws/resource_aws_waf_rule_group_test.go
+++ b/aws/resource_aws_waf_rule_group_test.go
@@ -31,6 +31,10 @@ func testSweepWafRuleGroups(region string) error {
 	req := &waf.ListRuleGroupsInput{}
 	resp, err := conn.ListRuleGroups(req)
 	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping WAF Rule Group sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("Error describing WAF Rule Groups: %s", err)
 	}
 

--- a/aws/resource_aws_wafregional_regex_match_set_test.go
+++ b/aws/resource_aws_wafregional_regex_match_set_test.go
@@ -31,6 +31,10 @@ func testSweepWafRegionalRegexMatchSet(region string) error {
 	req := &waf.ListRegexMatchSetsInput{}
 	resp, err := conn.ListRegexMatchSets(req)
 	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping WAF Regional Regex Match Set sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("Error describing WAF Regional Regex Match Sets: %s", err)
 	}
 

--- a/aws/resource_aws_wafregional_rule_group_test.go
+++ b/aws/resource_aws_wafregional_rule_group_test.go
@@ -31,6 +31,10 @@ func testSweepWafRegionalRuleGroups(region string) error {
 	req := &waf.ListRuleGroupsInput{}
 	resp, err := conn.ListRuleGroups(req)
 	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping WAF Regional Rule Group sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("Error describing WAF Regional Rule Groups: %s", err)
 	}
 


### PR DESCRIPTION
This will allow them to run in regions and partitions that do not support all services.

e.g. GovCloud

```
make sweep SWEEP='us-gov-west-1'
...
2018/05/03 19:53:29 Sweeper Tests ran:
	- aws_gamelift_fleet
	- aws_elb
	- aws_secretsmanager_secret
	- aws_internet_gateway
	- aws_subnet
	- aws_elasticache_replication_group
	- aws_network_acl
	- aws_elasticsearch_domain
	- aws_wafregional_rule_group
	- aws_wafregional_regex_match_set
	- aws_gamelift_alias
	- aws_iam_service_linked_role
	- aws_redshift_cluster
	- aws_security_group
	- aws_elasticache_cluster
	- aws_spot_fleet_request
	- aws_db_instance
	- aws_api_gateway_rest_api
	- aws_dynamodb_table
	- aws_db_option_group
	- aws_vpn_gateway
	- aws_cloudfront_distribution
	- aws_glue_connection
	- aws_key_pair
	- aws_lambda_function
	- aws_nat_gateway
	- aws_gamelift_build
	- aws_launch_configuration
	- aws_batch_job_queue
	- aws_waf_regex_match_set
	- aws_mq_broker
	- aws_glue_job
	- aws_autoscaling_group
	- aws_beanstalk_environment
	- aws_batch_compute_environment
	- aws_beanstalk_application
	- aws_kms_key
	- aws_vpc
	- aws_waf_rule_group
	- aws_iam_server_certificate
	- aws_dax_cluster
ok  	github.com/terraform-providers/terraform-provider-aws/aws	541.615s
```