### PR TITLE
docs/resource/autoscaling_group: Add note that Wait for ELB Capacity can now be used with ALBs

### DIFF
--- a/website/docs/r/autoscaling_group.html.markdown
+++ b/website/docs/r/autoscaling_group.html.markdown
@@ -300,7 +300,7 @@ Setting `wait_for_capacity_timeout` to `"0"` disables ASG Capacity waiting.
 #### Waiting for ELB Capacity
 
 The second mechanism is optional, and affects ASGs with attached ELBs specified
-via the `load_balancers` attribute.
+via the `load_balancers` attribute or with ALBs specified with `target_group_arns`.
 
 The `min_elb_capacity` parameter causes Terraform to wait for at least the
 requested number of instances to show up `"InService"` in all attached ELBs


### PR DESCRIPTION
This adds a note for the AWS resource `autoscaling_group` that Wait for ELB Capacity can now be used with ALBs.

**Reasoning for the change:** when reading the Terraform AWS provider documentation for Auto Scaling Groups it's not clear that you can use Wait for ELB Capacity (`min_elb_capacity`/`wait_for_elb_capacity`) with ALBs attached via `target_group_arns` (current documentation says this can only be used with ELBs attached via `load_balancers`). This was addressed via https://github.com/hashicorp/terraform/issues/8655 and https://github.com/hashicorp/terraform/pull/10243 (pre-split), and Wait for ELB Capacity can now be used with ALBs as well as classic ELBs.

**Relevant Terraform version:** from @vancluever on Terraform PR #10243 
> I think a few changes were missed around the time this was merged but it did for sure make it in. It should have been available in many versions of v0.8.x and v0.9.x pre-split, and now a standard part of the AWS standalone provider post the v0.10.x provider split.

