### PR TITLE
provider: Lower retry threshold for DNS resolution failures

### DIFF
--- a/aws/awserr.go
+++ b/aws/awserr.go
@@ -8,11 +8,27 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
+// Returns true if the error matches all these conditions:
+//  * err is of type awserr.Error
+//  * Error.Code() matches code
+//  * Error.Message() contains message
 func isAWSErr(err error, code string, message string) bool {
 	if err, ok := err.(awserr.Error); ok {
 		return err.Code() == code && strings.Contains(err.Message(), message)
 	}
 	return false
+}
+
+// Returns true if the error matches all these conditions:
+//  * err is of type awserr.Error
+//  * Error.Code() matches code
+//  * Error.Message() contains message
+//  * Error.OrigErr() contains origErrMessage
+func isAWSErrExtended(err error, code string, message string, origErrMessage string) bool {
+	if !isAWSErr(err, code, message) {
+		return false
+	}
+	return strings.Contains(err.(awserr.Error).OrigErr().Error(), origErrMessage)
 }
 
 func retryOnAwsCode(code string, f func() (interface{}, error)) (interface{}, error) {

--- a/aws/config.go
+++ b/aws/config.go
@@ -351,6 +351,26 @@ func (c *Config) Client() (interface{}, error) {
 		sess = sess.Copy(&aws.Config{MaxRetries: aws.Int(c.MaxRetries)})
 	}
 
+	// Generally, we want to configure a lower retry theshold for networking issues
+	// as the session retry threshold is very high by default and can mask permanent
+	// networking failures, such as a non-existent service endpoint.
+	// MaxRetries will override this logic if it has a lower retry threshold.
+	// NOTE: This logic can be fooled by other request errors raising the retry count
+	//       before any networking error occurs
+	sess.Handlers.Retry.PushBack(func(r *request.Request) {
+		// We currently depend on the DefaultRetryer exponential backoff here.
+		// ~10 retries gives a fair backoff of a few seconds.
+		if r.RetryCount < 9 {
+			return
+		}
+		// RequestError: send request failed
+		// caused by: Post https://FQDN/: dial tcp: lookup FQDN: no such host
+		if isAWSErrExtended(r.Error, "RequestError", "send request failed", "no such host") {
+			log.Printf("[WARN] Disabling retries after next request due to networking issue")
+			r.Retryable = aws.Bool(false)
+		}
+	})
+
 	// This restriction should only be used for Route53 sessions.
 	// Other resources that have restrictions should allow the API to fail, rather
 	// than Terraform abstracting the region for the user. This can lead to breaking


### PR DESCRIPTION
Add a session-wide retry handler that will lower the retry threshold when attempting to contact endpoints that do not exist or if there is a reasonably long DNS resolution issue.

Closes #4457
Closes #3760
Reference #1756
Reference #1354

Previously, the `MaxRetries` default of 25 would mean this RequestError for "no such host" could take upwards of 30 minutes to reveal (I gave up below):

```
export AWS_DEFAULT_REGION=eu-central-1
make testacc TEST=./aws TESTARGS='-run=TestAccAWSServiceDiscoveryPrivateDnsNamespace_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSServiceDiscoveryPrivateDnsNamespace_basic -timeout 120m
=== RUN   TestAccAWSServiceDiscoveryPrivateDnsNamespace_basic
^CFAIL	github.com/terraform-providers/terraform-provider-aws/aws	1559.376s
make: *** [testacc] Error 1
```

Now it will return in a reasonable timeframe:

```
export AWS_DEFAULT_REGION=eu-central-1
make testacc TEST=./aws TESTARGS='-run=TestAccAWSServiceDiscoveryPrivateDnsNamespace_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSServiceDiscoveryPrivateDnsNamespace_basic -timeout 120m
=== RUN   TestAccAWSServiceDiscoveryPrivateDnsNamespace_basic
--- FAIL: TestAccAWSServiceDiscoveryPrivateDnsNamespace_basic (38.19s)
	testing.go:518: Step 0 error: Error applying: 1 error(s) occurred:

		* aws_service_discovery_private_dns_namespace.test: 1 error(s) occurred:

		* aws_service_discovery_private_dns_namespace.test: RequestError: send request failed
		caused by: Post https://servicediscovery.eu-central-1.amazonaws.com/: dial tcp: lookup servicediscovery.eu-central-1.amazonaws.com: no such host
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	38.230s
make: *** [testacc] Error 1
```

#3760 case:

```
export AWS_DEFAULT_REGION=eu-central-1
make testacc TEST=./aws TESTARGS='-run=TestAccAWSSESConfigurationSet_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSSESConfigurationSet_basic -timeout 120m
=== RUN   TestAccAWSSESConfigurationSet_basic
--- FAIL: TestAccAWSSESConfigurationSet_basic (27.44s)
	testing.go:518: Step 0 error: Error applying: 1 error(s) occurred:

		* aws_ses_configuration_set.test: 1 error(s) occurred:

		* aws_ses_configuration_set.test: Error creating SES configuration set: RequestError: send request failed
		caused by: Post https://email.eu-central-1.amazonaws.com/: dial tcp: lookup email.eu-central-1.amazonaws.com: no such host
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	27.485s
make: *** [testacc] Error 1
```

#1756 case:

```
export AWS_DEFAULT_REGION=ap-southeast-1
make testacc TEST=./aws TESTARGS='-run=TestAccAWSEFSFileSystem_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSEFSFileSystem_basic -timeout 120m
=== RUN   TestAccAWSEFSFileSystem_basic
--- FAIL: TestAccAWSEFSFileSystem_basic (27.54s)
	testing.go:518: Step 0 error: Error applying: 1 error(s) occurred:

		* aws_efs_file_system.foo: 1 error(s) occurred:

		* aws_efs_file_system.foo: Error creating EFS file system: RequestError: send request failed
		caused by: Post https://elasticfilesystem.ap-southeast-1.amazonaws.com/2015-02-01/file-systems: dial tcp: lookup elasticfilesystem.ap-southeast-1.amazonaws.com: no such host
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	27.580s
make: *** [testacc] Error 1
```
