### PR TITLE
resource/aws_glue_job: Add timeout argument

### DIFF
--- a/aws/resource_aws_glue_job.go
+++ b/aws/resource_aws_glue_job.go
@@ -90,6 +90,11 @@ func resourceAwsGlueJob() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validateArn,
 			},
+			"timeout": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  2880,
+			},
 		},
 	}
 }
@@ -102,6 +107,7 @@ func resourceAwsGlueJobCreate(d *schema.ResourceData, meta interface{}) error {
 		Command: expandGlueJobCommand(d.Get("command").([]interface{})),
 		Name:    aws.String(name),
 		Role:    aws.String(d.Get("role_arn").(string)),
+		Timeout: aws.Int64(int64(d.Get("timeout").(int))),
 	}
 
 	if v, ok := d.GetOk("allocated_capacity"); ok {
@@ -187,6 +193,7 @@ func resourceAwsGlueJobRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("max_retries", int(aws.Int64Value(job.MaxRetries)))
 	d.Set("name", job.Name)
 	d.Set("role_arn", job.Role)
+	d.Set("timeout", int(aws.Int64Value(job.Timeout)))
 
 	return nil
 }
@@ -197,6 +204,7 @@ func resourceAwsGlueJobUpdate(d *schema.ResourceData, meta interface{}) error {
 	jobUpdate := &glue.JobUpdate{
 		Command: expandGlueJobCommand(d.Get("command").([]interface{})),
 		Role:    aws.String(d.Get("role_arn").(string)),
+		Timeout: aws.Int64(int64(d.Get("timeout").(int))),
 	}
 
 	if v, ok := d.GetOk("allocated_capacity"); ok {

--- a/website/docs/r/glue_job.html.markdown
+++ b/website/docs/r/glue_job.html.markdown
@@ -55,6 +55,7 @@ The following arguments are supported:
 * `max_retries` – (Optional) The maximum number of times to retry this job if it fails.
 * `name` – (Required) The name you assign to this job. It must be unique in your account.
 * `role` – (Required) The ARN of the IAM role associated with this job.
+* `timeout` – (Optional) The job timeout in minutes. The default is 2880 minutes (48 hours).
 
 ### command Argument Reference
 


### PR DESCRIPTION
Closes #4332 

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSGlueJob'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSGlueJob -timeout 120m
=== RUN   TestAccAWSGlueJob_Basic
--- PASS: TestAccAWSGlueJob_Basic (14.25s)
=== RUN   TestAccAWSGlueJob_AllocatedCapacity
--- PASS: TestAccAWSGlueJob_AllocatedCapacity (21.51s)
=== RUN   TestAccAWSGlueJob_Command
--- PASS: TestAccAWSGlueJob_Command (21.32s)
=== RUN   TestAccAWSGlueJob_DefaultArguments
--- PASS: TestAccAWSGlueJob_DefaultArguments (21.88s)
=== RUN   TestAccAWSGlueJob_Description
--- PASS: TestAccAWSGlueJob_Description (20.10s)
=== RUN   TestAccAWSGlueJob_ExecutionProperty
--- PASS: TestAccAWSGlueJob_ExecutionProperty (21.57s)
=== RUN   TestAccAWSGlueJob_MaxRetries
--- PASS: TestAccAWSGlueJob_MaxRetries (20.74s)
=== RUN   TestAccAWSGlueJob_Timeout
--- PASS: TestAccAWSGlueJob_Timeout (21.92s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	163.323s
```