### PR TITLE
resource/aws_glue_job: Remove allocated_capacity and max_concurrent_runs upper plan time validation limits

### DIFF
--- a/aws/resource_aws_glue_job.go
+++ b/aws/resource_aws_glue_job.go
@@ -25,7 +25,7 @@ func resourceAwsGlueJob() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Default:      10,
-				ValidateFunc: validation.IntBetween(2, 100),
+				ValidateFunc: validation.IntAtLeast(2),
 			},
 			"command": {
 				Type:     schema.TypeList,
@@ -69,7 +69,7 @@ func resourceAwsGlueJob() *schema.Resource {
 							Type:         schema.TypeInt,
 							Optional:     true,
 							Default:      1,
-							ValidateFunc: validation.IntBetween(1, 3),
+							ValidateFunc: validation.IntAtLeast(1),
 						},
 					},
 				},

--- a/aws/resource_aws_glue_job_test.go
+++ b/aws/resource_aws_glue_job_test.go
@@ -115,11 +115,7 @@ func TestAccAWSGlueJob_AllocatedCapacity(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAWSGlueJobConfig_AllocatedCapacity(rName, 1),
-				ExpectError: regexp.MustCompile(`expected allocated_capacity to be in the range`),
-			},
-			{
-				Config:      testAccAWSGlueJobConfig_AllocatedCapacity(rName, 101),
-				ExpectError: regexp.MustCompile(`expected allocated_capacity to be in the range`),
+				ExpectError: regexp.MustCompile(`expected allocated_capacity to be at least`),
 			},
 			{
 				Config: testAccAWSGlueJobConfig_AllocatedCapacity(rName, 2),
@@ -129,10 +125,10 @@ func TestAccAWSGlueJob_AllocatedCapacity(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSGlueJobConfig_AllocatedCapacity(rName, 100),
+				Config: testAccAWSGlueJobConfig_AllocatedCapacity(rName, 3),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSGlueJobExists(resourceName, &job),
-					resource.TestCheckResourceAttr(resourceName, "allocated_capacity", "100"),
+					resource.TestCheckResourceAttr(resourceName, "allocated_capacity", "3"),
 				),
 			},
 			{
@@ -265,11 +261,7 @@ func TestAccAWSGlueJob_ExecutionProperty(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAWSGlueJobConfig_ExecutionProperty(rName, 0),
-				ExpectError: regexp.MustCompile(`expected execution_property.0.max_concurrent_runs to be in the range`),
-			},
-			{
-				Config:      testAccAWSGlueJobConfig_ExecutionProperty(rName, 4),
-				ExpectError: regexp.MustCompile(`expected execution_property.0.max_concurrent_runs to be in the range`),
+				ExpectError: regexp.MustCompile(`expected execution_property.0.max_concurrent_runs to be at least`),
 			},
 			{
 				Config: testAccAWSGlueJobConfig_ExecutionProperty(rName, 1),

--- a/website/docs/r/glue_job.html.markdown
+++ b/website/docs/r/glue_job.html.markdown
@@ -46,7 +46,7 @@ resource "aws_glue_job" "example" {
 
 The following arguments are supported:
 
-* `allocated_capacity` – (Optional) The number of AWS Glue data processing units (DPUs) to allocate to this Job. From 2 to 100 DPUs can be allocated; the default is 10. A DPU is a relative measure of processing power that consists of 4 vCPUs of compute capacity and 16 GB of memory.
+* `allocated_capacity` – (Optional) The number of AWS Glue data processing units (DPUs) to allocate to this Job. At least 2 DPUs need to be allocated; the default is 10. A DPU is a relative measure of processing power that consists of 4 vCPUs of compute capacity and 16 GB of memory.
 * `command` – (Required) The command of the job. Defined below.
 * `connections` – (Optional) The list of connections used for this job.
 * `default_arguments` – (Optional) The map of default arguments for this job. You can specify arguments here that your own job-execution script consumes, as well as arguments that AWS Glue itself consumes. For information about how to specify and consume your own Job arguments, see the [Calling AWS Glue APIs in Python](http://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-python-calling.html) topic in the developer guide. For information about the key-value pairs that AWS Glue consumes to set up your job, see the [Special Parameters Used by AWS Glue](http://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-python-glue-arguments.html) topic in the developer guide.


### PR DESCRIPTION
As correctly pointed out, these limits can be increased.

Closes #4331 

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSGlueJob'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSGlueJob -timeout 120m
=== RUN   TestAccAWSGlueJob_Basic
--- PASS: TestAccAWSGlueJob_Basic (39.39s)
=== RUN   TestAccAWSGlueJob_AllocatedCapacity
--- PASS: TestAccAWSGlueJob_AllocatedCapacity (33.50s)
=== RUN   TestAccAWSGlueJob_Command
--- PASS: TestAccAWSGlueJob_Command (81.33s)
=== RUN   TestAccAWSGlueJob_DefaultArguments
--- PASS: TestAccAWSGlueJob_DefaultArguments (21.49s)
=== RUN   TestAccAWSGlueJob_Description
--- PASS: TestAccAWSGlueJob_Description (22.92s)
=== RUN   TestAccAWSGlueJob_ExecutionProperty
--- PASS: TestAccAWSGlueJob_ExecutionProperty (21.05s)
=== RUN   TestAccAWSGlueJob_MaxRetries
--- PASS: TestAccAWSGlueJob_MaxRetries (21.81s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	241.541s
```