### PR TITLE
Add import instructions to default VPC

### DIFF
--- a/website/docs/r/default_vpc.html.markdown
+++ b/website/docs/r/default_vpc.html.markdown
@@ -74,3 +74,11 @@ block with a /56 prefix length for the VPC was assigned
 
 
 [1]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/vpc-classiclink.html
+
+## Import
+
+Default VPCs can be imported using the `vpc id`, e.g.
+
+```
+$ terraform import aws_default_vpc.default vpc-a01106c2
+```


### PR DESCRIPTION
Almost identical to [the way non-default VPCs work](https://www.terraform.io/docs/providers/aws/r/vpc.html#import), but documented here too for completeness.

I checked first that this works with the latest version of Terraform and the AWS provider.