### PR TITLE
New Resource: aws_glue_trigger

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -395,6 +395,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_glue_catalog_database":                    resourceAwsGlueCatalogDatabase(),
 			"aws_glue_connection":                          resourceAwsGlueConnection(),
 			"aws_glue_job":                                 resourceAwsGlueJob(),
+			"aws_glue_trigger":                             resourceAwsGlueTrigger(),
 			"aws_guardduty_detector":                       resourceAwsGuardDutyDetector(),
 			"aws_guardduty_ipset":                          resourceAwsGuardDutyIpset(),
 			"aws_guardduty_member":                         resourceAwsGuardDutyMember(),

--- a/aws/resource_aws_glue_trigger.go
+++ b/aws/resource_aws_glue_trigger.go
@@ -1,0 +1,457 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/glue"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func resourceAwsGlueTrigger() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsGlueTriggerCreate,
+		Read:   resourceAwsGlueTriggerRead,
+		Update: resourceAwsGlueTriggerUpdate,
+		Delete: resourceAwsGlueTriggerDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"actions": {
+				Type:     schema.TypeList,
+				Required: true,
+				MinItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"arguments": {
+							Type:     schema.TypeMap,
+							Optional: true,
+						},
+						"job_name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"timeout": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+			"predicate": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"conditions": {
+							Type:     schema.TypeList,
+							Required: true,
+							MinItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"job_name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"logical_operator": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Default:  glue.LogicalOperatorEquals,
+										ValidateFunc: validation.StringInSlice([]string{
+											glue.LogicalOperatorEquals,
+										}, false),
+									},
+									"state": {
+										Type:     schema.TypeString,
+										Required: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											glue.JobRunStateFailed,
+											glue.JobRunStateStopped,
+											glue.JobRunStateSucceeded,
+											glue.JobRunStateTimeout,
+										}, false),
+									},
+								},
+							},
+						},
+						"logical": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  glue.LogicalAnd,
+							ValidateFunc: validation.StringInSlice([]string{
+								glue.LogicalAnd,
+								glue.LogicalAny,
+							}, false),
+						},
+					},
+				},
+			},
+			"schedule": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					glue.TriggerTypeConditional,
+					glue.TriggerTypeOnDemand,
+					glue.TriggerTypeScheduled,
+				}, false),
+			},
+		},
+	}
+}
+
+func resourceAwsGlueTriggerCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).glueconn
+	name := d.Get("name").(string)
+	triggerType := d.Get("type").(string)
+
+	input := &glue.CreateTriggerInput{
+		Actions: expandGlueActions(d.Get("actions").([]interface{})),
+		Name:    aws.String(name),
+		Type:    aws.String(triggerType),
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		input.Description = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("predicate"); ok {
+		input.Predicate = expandGluePredicate(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("schedule"); ok {
+		input.Schedule = aws.String(v.(string))
+	}
+
+	if d.Get("enabled").(bool) && triggerType != glue.TriggerTypeOnDemand {
+		input.StartOnCreation = aws.Bool(true)
+	}
+
+	log.Printf("[DEBUG] Creating Glue Trigger: %s", input)
+	_, err := conn.CreateTrigger(input)
+	if err != nil {
+		return fmt.Errorf("error creating Glue Trigger (%s): %s", name, err)
+	}
+
+	d.SetId(name)
+
+	log.Printf("[DEBUG] Waiting for Glue Trigger (%s) to create", d.Id())
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{
+			glue.TriggerStateActivating,
+			glue.TriggerStateCreating,
+		},
+		Target: []string{
+			glue.TriggerStateActivated,
+			glue.TriggerStateCreated,
+		},
+		Refresh: resourceAwsGlueTriggerRefreshFunc(conn, d.Id()),
+		Timeout: d.Timeout(schema.TimeoutCreate),
+	}
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("error waiting for Glue Trigger (%s) to create", d.Id())
+	}
+
+	return resourceAwsGlueTriggerRead(d, meta)
+}
+
+func resourceAwsGlueTriggerRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).glueconn
+
+	input := &glue.GetTriggerInput{
+		Name: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Reading Glue Trigger: %s", input)
+	output, err := conn.GetTrigger(input)
+	if err != nil {
+		if isAWSErr(err, glue.ErrCodeEntityNotFoundException, "") {
+			log.Printf("[WARN] Glue Trigger (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("error reading Glue Trigger (%s): %s", d.Id(), err)
+	}
+
+	trigger := output.Trigger
+	if trigger == nil {
+		log.Printf("[WARN] Glue Trigger (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err := d.Set("actions", flattenGlueActions(trigger.Actions)); err != nil {
+		return fmt.Errorf("error setting actions: %s", err)
+	}
+
+	d.Set("description", trigger.Description)
+
+	if aws.StringValue(trigger.Type) == glue.TriggerTypeOnDemand {
+		d.Set("enabled", (aws.StringValue(trigger.State) == glue.TriggerStateCreated || aws.StringValue(trigger.State) == glue.TriggerStateCreating))
+	} else {
+		d.Set("enabled", (aws.StringValue(trigger.State) == glue.TriggerStateActivated || aws.StringValue(trigger.State) == glue.TriggerStateActivating))
+	}
+
+	if err := d.Set("predicate", flattenGluePredicate(trigger.Predicate)); err != nil {
+		return fmt.Errorf("error setting predicate: %s", err)
+	}
+
+	d.Set("name", trigger.Name)
+	d.Set("schedule", trigger.Schedule)
+	d.Set("type", trigger.Type)
+
+	return nil
+}
+
+func resourceAwsGlueTriggerUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).glueconn
+
+	if d.HasChange("actions") ||
+		d.HasChange("description") ||
+		d.HasChange("predicate") ||
+		d.HasChange("schedule") {
+		triggerUpdate := &glue.TriggerUpdate{
+			Actions: expandGlueActions(d.Get("actions").([]interface{})),
+		}
+
+		if v, ok := d.GetOk("description"); ok {
+			triggerUpdate.Description = aws.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("predicate"); ok {
+			triggerUpdate.Predicate = expandGluePredicate(v.([]interface{}))
+		}
+
+		if v, ok := d.GetOk("schedule"); ok {
+			triggerUpdate.Schedule = aws.String(v.(string))
+		}
+		input := &glue.UpdateTriggerInput{
+			Name:          aws.String(d.Id()),
+			TriggerUpdate: triggerUpdate,
+		}
+
+		log.Printf("[DEBUG] Updating Glue Trigger: %s", input)
+		_, err := conn.UpdateTrigger(input)
+		if err != nil {
+			return fmt.Errorf("error updating Glue Trigger (%s): %s", d.Id(), err)
+		}
+	}
+
+	if d.HasChange("enabled") {
+		if d.Get("enabled").(bool) {
+			input := &glue.StartTriggerInput{
+				Name: aws.String(d.Id()),
+			}
+
+			log.Printf("[DEBUG] Starting Glue Trigger: %s", input)
+			_, err := conn.StartTrigger(input)
+			if err != nil {
+				return fmt.Errorf("error starting Glue Trigger (%s): %s", d.Id(), err)
+			}
+		} else {
+			input := &glue.StopTriggerInput{
+				Name: aws.String(d.Id()),
+			}
+
+			log.Printf("[DEBUG] Stopping Glue Trigger: %s", input)
+			_, err := conn.StopTrigger(input)
+			if err != nil {
+				return fmt.Errorf("error stopping Glue Trigger (%s): %s", d.Id(), err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func resourceAwsGlueTriggerDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).glueconn
+
+	log.Printf("[DEBUG] Deleting Glue Trigger: %s", d.Id())
+	err := deleteGlueTrigger(conn, d.Id())
+	if err != nil {
+		return fmt.Errorf("error deleting Glue Trigger (%s): %s", d.Id(), err)
+	}
+
+	log.Printf("[DEBUG] Waiting for Glue Trigger (%s) to delete", d.Id())
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{glue.TriggerStateDeleting},
+		Target:  []string{""},
+		Refresh: resourceAwsGlueTriggerRefreshFunc(conn, d.Id()),
+		Timeout: d.Timeout(schema.TimeoutDelete),
+	}
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		if isAWSErr(err, glue.ErrCodeEntityNotFoundException, "") {
+			return nil
+		}
+		return fmt.Errorf("error waiting for Glue Trigger (%s) to delete", d.Id())
+	}
+
+	return nil
+}
+
+func resourceAwsGlueTriggerRefreshFunc(conn *glue.Glue, name string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := conn.GetTrigger(&glue.GetTriggerInput{
+			Name: aws.String(name),
+		})
+		if err != nil {
+			return output, "", err
+		}
+
+		if output.Trigger == nil {
+			return output, "", nil
+		}
+
+		return output, aws.StringValue(output.Trigger.State), nil
+	}
+}
+
+func deleteGlueTrigger(conn *glue.Glue, Name string) error {
+	input := &glue.DeleteTriggerInput{
+		Name: aws.String(Name),
+	}
+
+	_, err := conn.DeleteTrigger(input)
+	if err != nil {
+		if isAWSErr(err, glue.ErrCodeEntityNotFoundException, "") {
+			return nil
+		}
+		return err
+	}
+
+	return nil
+}
+
+func expandGlueActions(l []interface{}) []*glue.Action {
+	actions := []*glue.Action{}
+
+	for _, mRaw := range l {
+		m := mRaw.(map[string]interface{})
+
+		action := &glue.Action{
+			JobName: aws.String(m["job_name"].(string)),
+		}
+
+		argumentsMap := make(map[string]string)
+		for k, v := range m["arguments"].(map[string]interface{}) {
+			argumentsMap[k] = v.(string)
+		}
+		action.Arguments = aws.StringMap(argumentsMap)
+
+		if v, ok := m["timeout"]; ok && v.(int) > 0 {
+			action.Timeout = aws.Int64(int64(v.(int)))
+		}
+
+		actions = append(actions, action)
+	}
+
+	return actions
+}
+
+func expandGlueConditions(l []interface{}) []*glue.Condition {
+	conditions := []*glue.Condition{}
+
+	for _, mRaw := range l {
+		m := mRaw.(map[string]interface{})
+
+		condition := &glue.Condition{
+			JobName:         aws.String(m["job_name"].(string)),
+			LogicalOperator: aws.String(m["logical_operator"].(string)),
+			State:           aws.String(m["state"].(string)),
+		}
+
+		conditions = append(conditions, condition)
+	}
+
+	return conditions
+}
+
+func expandGluePredicate(l []interface{}) *glue.Predicate {
+	m := l[0].(map[string]interface{})
+
+	predicate := &glue.Predicate{
+		Conditions: expandGlueConditions(m["conditions"].([]interface{})),
+	}
+
+	if v, ok := m["logical"]; ok && v.(string) != "" {
+		predicate.Logical = aws.String(v.(string))
+	}
+
+	return predicate
+}
+
+func flattenGlueActions(actions []*glue.Action) []interface{} {
+	l := []interface{}{}
+
+	for _, action := range actions {
+		m := map[string]interface{}{
+			"arguments": aws.StringValueMap(action.Arguments),
+			"job_name":  aws.StringValue(action.JobName),
+			"timeout":   int(aws.Int64Value(action.Timeout)),
+		}
+		l = append(l, m)
+	}
+
+	return l
+}
+
+func flattenGlueConditions(conditions []*glue.Condition) []interface{} {
+	l := []interface{}{}
+
+	for _, condition := range conditions {
+		m := map[string]interface{}{
+			"job_name":         aws.StringValue(condition.JobName),
+			"logical_operator": aws.StringValue(condition.LogicalOperator),
+			"state":            aws.StringValue(condition.State),
+		}
+		l = append(l, m)
+	}
+
+	return l
+}
+
+func flattenGluePredicate(predicate *glue.Predicate) []map[string]interface{} {
+	if predicate == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"conditions": flattenGlueConditions(predicate.Conditions),
+		"logical":    aws.StringValue(predicate.Logical),
+	}
+
+	return []map[string]interface{}{m}
+}

--- a/aws/resource_aws_glue_trigger_test.go
+++ b/aws/resource_aws_glue_trigger_test.go
@@ -1,0 +1,416 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/glue"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_glue_trigger", &resource.Sweeper{
+		Name: "aws_glue_trigger",
+		F:    testSweepGlueTriggers,
+	})
+}
+
+func testSweepGlueTriggers(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).glueconn
+
+	prefixes := []string{
+		"tf-acc-test-",
+	}
+
+	input := &glue.GetTriggersInput{}
+	err = conn.GetTriggersPages(input, func(page *glue.GetTriggersOutput, lastPage bool) bool {
+		if len(page.Triggers) == 0 {
+			log.Printf("[INFO] No Glue Triggers to sweep")
+			return false
+		}
+		for _, trigger := range page.Triggers {
+			skip := true
+			name := aws.StringValue(trigger.Name)
+			for _, prefix := range prefixes {
+				if strings.HasPrefix(name, prefix) {
+					skip = false
+					break
+				}
+			}
+			if skip {
+				log.Printf("[INFO] Skipping Glue Trigger: %s", name)
+				continue
+			}
+
+			log.Printf("[INFO] Deleting Glue Trigger: %s", name)
+			err := deleteGlueJob(conn, name)
+			if err != nil {
+				log.Printf("[ERROR] Failed to delete Glue Trigger %s: %s", name, err)
+			}
+		}
+		return !lastPage
+	})
+	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Glue Trigger sweep for %s: %s", region, err)
+			return nil
+		}
+		return fmt.Errorf("Error retrieving Glue Triggers: %s", err)
+	}
+
+	return nil
+}
+
+func TestAccAWSGlueTrigger_Basic(t *testing.T) {
+	var trigger glue.Trigger
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "aws_glue_trigger.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueTriggerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGlueTriggerConfig_OnDemand(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueTriggerExists(resourceName, &trigger),
+					resource.TestCheckResourceAttr(resourceName, "actions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.job_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "predicate.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "schedule", ""),
+					resource.TestCheckResourceAttr(resourceName, "type", "ON_DEMAND"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSGlueTrigger_Description(t *testing.T) {
+	var trigger glue.Trigger
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "aws_glue_trigger.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueTriggerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGlueTriggerConfig_Description(rName, "description1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueTriggerExists(resourceName, &trigger),
+					resource.TestCheckResourceAttr(resourceName, "description", "description1"),
+				),
+			},
+			{
+				Config: testAccAWSGlueTriggerConfig_Description(rName, "description2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueTriggerExists(resourceName, &trigger),
+					resource.TestCheckResourceAttr(resourceName, "description", "description2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSGlueTrigger_Enabled(t *testing.T) {
+	var trigger glue.Trigger
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "aws_glue_trigger.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueTriggerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGlueTriggerConfig_Enabled(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueTriggerExists(resourceName, &trigger),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+				),
+			},
+			{
+				Config: testAccAWSGlueTriggerConfig_Enabled(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueTriggerExists(resourceName, &trigger),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
+				),
+			},
+			{
+				Config: testAccAWSGlueTriggerConfig_Enabled(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueTriggerExists(resourceName, &trigger),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSGlueTrigger_Predicate(t *testing.T) {
+	var trigger glue.Trigger
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "aws_glue_trigger.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueTriggerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGlueTriggerConfig_Predicate(rName, "SUCCEEDED"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueTriggerExists(resourceName, &trigger),
+					resource.TestCheckResourceAttr(resourceName, "predicate.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "predicate.0.conditions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "predicate.0.conditions.0.job_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "predicate.0.conditions.0.state", "SUCCEEDED"),
+					resource.TestCheckResourceAttr(resourceName, "type", "CONDITIONAL"),
+				),
+			},
+			{
+				Config: testAccAWSGlueTriggerConfig_Predicate(rName, "FAILED"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueTriggerExists(resourceName, &trigger),
+					resource.TestCheckResourceAttr(resourceName, "predicate.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "predicate.0.conditions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "predicate.0.conditions.0.job_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "predicate.0.conditions.0.state", "FAILED"),
+					resource.TestCheckResourceAttr(resourceName, "type", "CONDITIONAL"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSGlueTrigger_Schedule(t *testing.T) {
+	var trigger glue.Trigger
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "aws_glue_trigger.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueTriggerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGlueTriggerConfig_Schedule(rName, "cron(1 2 * * ? *)"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueTriggerExists(resourceName, &trigger),
+					resource.TestCheckResourceAttr(resourceName, "schedule", "cron(1 2 * * ? *)"),
+				),
+			},
+			{
+				Config: testAccAWSGlueTriggerConfig_Schedule(rName, "cron(2 3 * * ? *)"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueTriggerExists(resourceName, &trigger),
+					resource.TestCheckResourceAttr(resourceName, "schedule", "cron(2 3 * * ? *)"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSGlueTriggerExists(resourceName string, trigger *glue.Trigger) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Glue Trigger ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).glueconn
+
+		output, err := conn.GetTrigger(&glue.GetTriggerInput{
+			Name: aws.String(rs.Primary.ID),
+		})
+		if err != nil {
+			return err
+		}
+
+		if output.Trigger == nil {
+			return fmt.Errorf("Glue Trigger (%s) not found", rs.Primary.ID)
+		}
+
+		if aws.StringValue(output.Trigger.Name) == rs.Primary.ID {
+			*trigger = *output.Trigger
+			return nil
+		}
+
+		return fmt.Errorf("Glue Trigger (%s) not found", rs.Primary.ID)
+	}
+}
+
+func testAccCheckAWSGlueTriggerDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_glue_trigger" {
+			continue
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).glueconn
+
+		output, err := conn.GetTrigger(&glue.GetTriggerInput{
+			Name: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			if isAWSErr(err, glue.ErrCodeEntityNotFoundException, "") {
+				return nil
+			}
+
+		}
+
+		trigger := output.Trigger
+		if trigger != nil && aws.StringValue(trigger.Name) == rs.Primary.ID {
+			return fmt.Errorf("Glue Trigger %s still exists", rs.Primary.ID)
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func testAccAWSGlueTriggerConfig_Description(rName, description string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "aws_glue_trigger" "test" {
+  description = "%s"
+  name        = "%s"
+  type        = "ON_DEMAND"
+
+  actions {
+    job_name = "${aws_glue_job.test.name}"
+  }
+}
+`, testAccAWSGlueJobConfig_Required(rName), description, rName)
+}
+
+func testAccAWSGlueTriggerConfig_Enabled(rName string, enabled bool) string {
+	return fmt.Sprintf(`
+%s
+
+resource "aws_glue_trigger" "test" {
+  enabled  = %t
+  name     = "%s"
+  schedule = "cron(15 12 * * ? *)"
+  type     = "SCHEDULED"
+
+  actions {
+    job_name = "${aws_glue_job.test.name}"
+  }
+}
+`, testAccAWSGlueJobConfig_Required(rName), enabled, rName)
+}
+
+func testAccAWSGlueTriggerConfig_OnDemand(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "aws_glue_trigger" "test" {
+  name = "%s"
+  type = "ON_DEMAND"
+
+  actions {
+    job_name = "${aws_glue_job.test.name}"
+  }
+}
+`, testAccAWSGlueJobConfig_Required(rName), rName)
+}
+
+func testAccAWSGlueTriggerConfig_Predicate(rName, state string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "aws_glue_job" "test2" {
+  name     = "%s2"
+  role_arn = "${aws_iam_role.test.arn}"
+
+  command {
+    script_location = "testscriptlocation"
+  }
+
+  depends_on = ["aws_iam_role_policy_attachment.test"]
+}
+
+resource "aws_glue_trigger" "test" {
+  name     = "%s"
+  type     = "CONDITIONAL"
+
+  actions {
+    job_name = "${aws_glue_job.test2.name}"
+  }
+
+  predicate {
+    conditions {
+      job_name = "${aws_glue_job.test.name}"
+      state    = "%s"
+    }
+  }
+}
+`, testAccAWSGlueJobConfig_Required(rName), rName, rName, state)
+}
+
+func testAccAWSGlueTriggerConfig_Schedule(rName, schedule string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "aws_glue_trigger" "test" {
+  name     = "%s"
+  schedule = "%s"
+  type     = "SCHEDULED"
+
+  actions {
+    job_name = "${aws_glue_job.test.name}"
+  }
+}
+`, testAccAWSGlueJobConfig_Required(rName), rName, schedule)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1111,6 +1111,9 @@
                         <li<%= sidebar_current("docs-aws-resource-glue-job") %>>
                             <a href="/docs/providers/aws/r/glue_job.html">aws_glue_job</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-resource-glue-trigger") %>>
+                            <a href="/docs/providers/aws/r/glue_trigger.html">aws_glue_trigger</a>
+                        </li>
                     </ul>
                  </li>
 

--- a/website/docs/r/glue_trigger.html.markdown
+++ b/website/docs/r/glue_trigger.html.markdown
@@ -1,0 +1,112 @@
+---
+layout: "aws"
+page_title: "AWS: aws_glue_trigger"
+sidebar_current: "docs-aws-resource-glue-trigger"
+description: |-
+  Provides an Glue Trigger resource.
+---
+
+# aws_glue_trigger
+
+Provides a Glue Job resource.
+
+## Example Usage
+
+### Conditional Trigger
+
+```hcl
+resource "aws_glue_trigger" "example" {
+  name     = "example"
+  type     = "CONDITIONAL"
+
+  actions {
+    job_name = "${aws_glue_job.example1.name}"
+  }
+
+  predicate {
+    conditions {
+      job_name = "${aws_glue_job.example2.name}"
+      state    = "SUCCEEDED"
+    }
+  }
+}
+```
+
+### On-Demand Trigger
+
+```hcl
+resource "aws_glue_trigger" "example" {
+  name     = "example"
+  type     = "ON_DEMAND"
+
+  actions {
+    job_name = "${aws_glue_job.example.name}"
+  }
+}
+```
+
+### Scheduled Trigger
+
+```hcl
+resource "aws_glue_trigger" "example" {
+  name     = "example"
+  schedule = "cron(15 12 * * ? *)"
+  type     = "SCHEDULED"
+
+  actions {
+    job_name = "${aws_glue_job.example.name}"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `actions` – (Required) List of actions initiated by this trigger when it fires. Defined below.
+* `description` – (Optional) A description of the new trigger.
+* `enabled` – (Optional) Start the trigger. Defaults to `true`. Not valid to disable for `ON_DEMAND` type.
+* `name` – (Required) The name of the trigger.
+* `predicate` – (Optional) A predicate to specify when the new trigger should fire. Required when trigger type is `CONDITIONAL`. Defined below.
+* `schedule` – (Optional) A cron expression used to specify the schedule. [Time-Based Schedules for Jobs and Crawlers](https://docs.aws.amazon.com/glue/latest/dg/monitor-data-warehouse-schedule.html)
+* `type` – (Required) The type of trigger. Valid values are `CONDITIONAL`, `ON_DEMAND`, and `SCHEDULED`.
+
+### actions Argument Reference
+
+* `arguments` - (Optional) Arguments to be passed to the job. You can specify arguments here that your own job-execution script consumes, as well as arguments that AWS Glue itself consumes.
+* `job_name` - (Required) The name of a job to be executed.
+* `timeout` - (Optional) The job run timeout in minutes. It overrides the timeout value of the job.
+
+### predicate Argument Reference
+
+* `conditions` - (Required) A list of the conditions that determine when the trigger will fire. Defined below.
+* `logical` - (Optional) How to handle multiple conditions. Defaults to `AND`. Valid values are `AND` or `ANY`.
+
+#### conditions Argument Reference
+
+* `job_name` - (Required) The name of the job to watch.
+* `logical_operator` - (Optional) A logical operator. Defaults to `EQUALS`.
+* `state` - (Required) The condition state. Currently, the values supported are `SUCCEEDED`, `STOPPED`, `TIMEOUT` and `FAILED`.
+
+## Attributes Reference
+
+The following additional attributes are exported:
+
+* `id` - Trigger name
+
+## Timeouts
+
+`aws_glue_trigger` provides the following [Timeouts](/docs/configuration/resources.html#timeouts)
+configuration options:
+
+- `create` - (Default `5m`) How long to wait for a trigger to be created.
+- `delete` - (Default `5m`) How long to wait for a trigger to be deleted.
+
+
+## Import
+
+Glue Triggers can be imported using `name`, e.g.
+
+```
+$ terraform import aws_glue_trigger.MyTrigger Myrigger
+```


### PR DESCRIPTION
Closes #3882

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSGlueTrigger'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSGlueTrigger -timeout 120m
=== RUN   TestAccAWSGlueTrigger_Basic
--- PASS: TestAccAWSGlueTrigger_Basic (9.86s)
=== RUN   TestAccAWSGlueTrigger_Description
--- PASS: TestAccAWSGlueTrigger_Description (11.44s)
=== RUN   TestAccAWSGlueTrigger_Enabled
--- PASS: TestAccAWSGlueTrigger_Enabled (51.44s)
=== RUN   TestAccAWSGlueTrigger_Predicate
--- PASS: TestAccAWSGlueTrigger_Predicate (47.30s)
=== RUN   TestAccAWSGlueTrigger_Schedule
--- PASS: TestAccAWSGlueTrigger_Schedule (48.42s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	168.495s
```