### PR TITLE
Handle empty strings in s3 cors settings.

### DIFF
--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -1259,8 +1259,9 @@ func resourceAwsS3BucketCorsUpdate(s3conn *s3.S3, d *schema.ResourceData) error 
 				} else {
 					vMap := make([]*string, len(v.([]interface{})))
 					for i, vv := range v.([]interface{}) {
-						str := vv.(string)
-						vMap[i] = aws.String(str)
+						if str, ok := vv.(string); ok {
+							vMap[i] = aws.String(str)
+						}
 					}
 					switch k {
 					case "allowed_headers":

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -587,6 +587,32 @@ func TestAccAWSS3Bucket_Cors(t *testing.T) {
 			},
 		},
 	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSS3BucketConfigWithCORSEmptyOrigin(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					testAccCheckAWSS3BucketCors(
+						"aws_s3_bucket.bucket",
+						[]*s3.CORSRule{
+							{
+								AllowedHeaders: []*string{aws.String("*")},
+								AllowedMethods: []*string{aws.String("PUT"), aws.String("POST")},
+								AllowedOrigins: []*string{aws.String("")},
+								ExposeHeaders:  []*string{aws.String("x-amz-server-side-encryption"), aws.String("ETag")},
+								MaxAgeSeconds:  aws.Int64(3000),
+							},
+						},
+					),
+				),
+			},
+		},
+	})
 }
 
 func TestAccAWSS3Bucket_Logging(t *testing.T) {
@@ -1657,6 +1683,22 @@ resource "aws_s3_bucket" "bucket" {
 			allowed_headers = ["*"]
 			allowed_methods = ["PUT","POST"]
 			allowed_origins = ["https://www.example.com"]
+			expose_headers = ["x-amz-server-side-encryption","ETag"]
+			max_age_seconds = 3000
+	}
+}
+`, randInt)
+}
+
+func testAccAWSS3BucketConfigWithCORSEmptyOrigin(randInt int) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "bucket" {
+	bucket = "tf-test-bucket-%d"
+	acl = "public-read"
+	cors_rule {
+			allowed_headers = ["*"]
+			allowed_methods = ["PUT","POST"]
+			allowed_origins = [""]
 			expose_headers = ["x-amz-server-side-encryption","ETag"]
 			max_age_seconds = 3000
 	}


### PR DESCRIPTION
[Fixes #4258]

Changes proposed in this pull request:

* Check that `interface{}` can be cast to `string` in cors settings
* Add regression test

Output from acceptance testing:

```
± time TF_ACC=1 go test ./... -run TestAccAWSS3Bucket_Cors -v
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSS3Bucket_Cors
--- PASS: TestAccAWSS3Bucket_Cors (83.88s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       83.932s
```