### PR TITLE
Add badge_enabled and badge_url attributes to aws_codebuild_project.

### DIFF
--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -72,6 +72,11 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"badge_url": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"cache": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -546,7 +551,8 @@ func resourceAwsCodeBuildProjectRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	d.Set("description", project.Description)
-	d.Set("badge_enabled", project.BadgeEnabled)
+	d.Set("badge_enabled", project.Badge.BadgeEnabled)
+	d.Set("badge_url", project.Badge.BadgeRequestUrl)
 	d.Set("encryption_key", project.EncryptionKey)
 	d.Set("name", project.Name)
 	d.Set("service_role", project.ServiceRole)
@@ -600,7 +606,7 @@ func resourceAwsCodeBuildProjectUpdate(d *schema.ResourceData, meta interface{})
 	}
 
 	if d.HasChange("badge_enabled") {
-		params.BadgeEnabled = aws.String(d.Get("badge_enabled").(bool))
+		params.BadgeEnabled = aws.Bool(d.Get("badge_enabled").(bool))
 	}
 
 	if d.HasChange("encryption_key") {

--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -67,6 +67,11 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 				},
 				Set: resourceAwsCodeBuildProjectArtifactsHash,
 			},
+			"badge_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"cache": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -298,6 +303,10 @@ func resourceAwsCodeBuildProjectCreate(d *schema.ResourceData, meta interface{})
 
 	if v, ok := d.GetOk("description"); ok {
 		params.Description = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("badge_enabled"); ok {
+		params.BadgeEnabled = aws.Bool(v.(bool))
 	}
 
 	if v, ok := d.GetOk("encryption_key"); ok {
@@ -537,6 +546,7 @@ func resourceAwsCodeBuildProjectRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	d.Set("description", project.Description)
+	d.Set("badge_enabled", project.BadgeEnabled)
 	d.Set("encryption_key", project.EncryptionKey)
 	d.Set("name", project.Name)
 	d.Set("service_role", project.ServiceRole)
@@ -587,6 +597,10 @@ func resourceAwsCodeBuildProjectUpdate(d *schema.ResourceData, meta interface{})
 
 	if d.HasChange("description") {
 		params.Description = aws.String(d.Get("description").(string))
+	}
+
+	if d.HasChange("badge_enabled") {
+		params.BadgeEnabled = aws.String(d.Get("badge_enabled").(bool))
 	}
 
 	if d.HasChange("encryption_key") {

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -130,6 +130,7 @@ The following arguments are supported:
 
 * `name` - (Required) The projects name.
 * `description` - (Optional) A short description of the project.
+* `build_enabled` - (Optional) If set to `true`, enable a public status badge for the project. The badge's public URL is exported as `badge_url`. Defaults to `false`.
 * `encryption_key` - (Optional) The AWS Key Management Service (AWS KMS) customer master key (CMK) to be used for encrypting the build project's build output artifacts.
 * `service_role` - (Optional) The Amazon Resource Name (ARN) of the AWS Identity and Access Management (IAM) role that enables AWS CodeBuild to interact with dependent AWS services on behalf of the AWS account.
 * `build_timeout` - (Optional) How long in minutes, from 5 to 480 (8 hours), for AWS CodeBuild to wait until timing out any related build that does not get marked as completed. The default is 60 minutes.
@@ -191,6 +192,7 @@ The following attributes are exported:
 
 * `id` - The ARN of the CodeBuild project.
 * `description` - A short description of the project.
+* `badge_url` - The public URL of the status badge for the project.
 * `encryption_key` - The AWS Key Management Service (AWS KMS) customer master key (CMK) that was used for encrypting the build project's build output artifacts.
 * `name` - The projects name.
 * `service_role` - The ARN of the IAM service role.

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -130,7 +130,7 @@ The following arguments are supported:
 
 * `name` - (Required) The projects name.
 * `description` - (Optional) A short description of the project.
-* `build_enabled` - (Optional) If set to `true`, enable a public status badge for the project. The badge's public URL is exported as `badge_url`. Defaults to `false`.
+* `badge_enabled` - (Optional) If set to `true`, enable a public status badge for the project. The badge's public URL is exported as `badge_url`. Defaults to `false`.
 * `encryption_key` - (Optional) The AWS Key Management Service (AWS KMS) customer master key (CMK) to be used for encrypting the build project's build output artifacts.
 * `service_role` - (Optional) The Amazon Resource Name (ARN) of the AWS Identity and Access Management (IAM) role that enables AWS CodeBuild to interact with dependent AWS services on behalf of the AWS account.
 * `build_timeout` - (Optional) How long in minutes, from 5 to 480 (8 hours), for AWS CodeBuild to wait until timing out any related build that does not get marked as completed. The default is 60 minutes.


### PR DESCRIPTION
Changes proposed in this pull request:

Adds a `badge_enabled` boolean option to `aws_codebuild_project` to support the [`badgeEnabled`](https://docs.aws.amazon.com/codebuild/latest/APIReference/API_CreateProject.html#CodeBuild-CreateProject-request-badgeEnabled) attribute that the AWS API now exposes. 

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSCodeBuildProject_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSCodeBuildProject_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSCodeBuildProject_basic
--- PASS: TestAccAWSCodeBuildProject_basic (47.66s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	47.706s
```
