### PR TITLE
New Resource: aws_glue_classifier

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -393,6 +393,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_gamelift_fleet":                           resourceAwsGameliftFleet(),
 			"aws_glacier_vault":                            resourceAwsGlacierVault(),
 			"aws_glue_catalog_database":                    resourceAwsGlueCatalogDatabase(),
+			"aws_glue_classifier":                          resourceAwsGlueClassifier(),
 			"aws_glue_connection":                          resourceAwsGlueConnection(),
 			"aws_glue_job":                                 resourceAwsGlueJob(),
 			"aws_guardduty_detector":                       resourceAwsGuardDutyDetector(),

--- a/aws/resource_aws_glue_classifier.go
+++ b/aws/resource_aws_glue_classifier.go
@@ -1,0 +1,348 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/glue"
+	"github.com/hashicorp/terraform/helper/customdiff"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func resourceAwsGlueClassifier() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsGlueClassifierCreate,
+		Read:   resourceAwsGlueClassifierRead,
+		Update: resourceAwsGlueClassifierUpdate,
+		Delete: resourceAwsGlueClassifierDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		CustomizeDiff: customdiff.Sequence(
+			func(diff *schema.ResourceDiff, v interface{}) error {
+				// ForceNew when changing classifier type
+				// InvalidInputException: UpdateClassifierRequest can't change the type of the classifier
+				if diff.HasChange("grok_classifier") && diff.HasChange("json_classifier") {
+					diff.ForceNew("grok_classifier")
+					diff.ForceNew("json_classifier")
+				}
+				if diff.HasChange("grok_classifier") && diff.HasChange("xml_classifier") {
+					diff.ForceNew("grok_classifier")
+					diff.ForceNew("xml_classifier")
+				}
+				if diff.HasChange("json_classifier") && diff.HasChange("xml_classifier") {
+					diff.ForceNew("json_classifier")
+					diff.ForceNew("xml_classifier")
+				}
+				return nil
+			},
+		),
+
+		Schema: map[string]*schema.Schema{
+			"grok_classifier": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				MaxItems:      1,
+				ConflictsWith: []string{"json_classifier", "xml_classifier"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"classification": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"custom_patterns": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringLenBetween(0, 16000),
+						},
+						"grok_pattern": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringLenBetween(1, 2048),
+						},
+					},
+				},
+			},
+			"json_classifier": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				MaxItems:      1,
+				ConflictsWith: []string{"grok_classifier", "xml_classifier"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"json_path": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 255),
+			},
+			"xml_classifier": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				MaxItems:      1,
+				ConflictsWith: []string{"grok_classifier", "json_classifier"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"classification": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"row_tag": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsGlueClassifierCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).glueconn
+	name := d.Get("name").(string)
+
+	input := &glue.CreateClassifierInput{}
+
+	if v, ok := d.GetOk("grok_classifier"); ok {
+		m := v.([]interface{})[0].(map[string]interface{})
+		input.GrokClassifier = expandGlueGrokClassifierCreate(name, m)
+	}
+
+	if v, ok := d.GetOk("json_classifier"); ok {
+		m := v.([]interface{})[0].(map[string]interface{})
+		input.JsonClassifier = expandGlueJsonClassifierCreate(name, m)
+	}
+
+	if v, ok := d.GetOk("xml_classifier"); ok {
+		m := v.([]interface{})[0].(map[string]interface{})
+		input.XMLClassifier = expandGlueXmlClassifierCreate(name, m)
+	}
+
+	log.Printf("[DEBUG] Creating Glue Classifier: %s", input)
+	_, err := conn.CreateClassifier(input)
+	if err != nil {
+		return fmt.Errorf("error creating Glue Classifier (%s): %s", name, err)
+	}
+
+	d.SetId(name)
+
+	return resourceAwsGlueClassifierRead(d, meta)
+}
+
+func resourceAwsGlueClassifierRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).glueconn
+
+	input := &glue.GetClassifierInput{
+		Name: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Reading Glue Classifier: %s", input)
+	output, err := conn.GetClassifier(input)
+	if err != nil {
+		if isAWSErr(err, glue.ErrCodeEntityNotFoundException, "") {
+			log.Printf("[WARN] Glue Classifier (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("error reading Glue Classifier (%s): %s", d.Id(), err)
+	}
+
+	classifier := output.Classifier
+	if classifier == nil {
+		log.Printf("[WARN] Glue Classifier (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err := d.Set("grok_classifier", flattenGlueGrokClassifier(classifier.GrokClassifier)); err != nil {
+		return fmt.Errorf("error setting match_criteria: %s", err)
+	}
+
+	if err := d.Set("json_classifier", flattenGlueJsonClassifier(classifier.JsonClassifier)); err != nil {
+		return fmt.Errorf("error setting json_classifier: %s", err)
+	}
+
+	d.Set("name", d.Id())
+
+	if err := d.Set("xml_classifier", flattenGlueXmlClassifier(classifier.XMLClassifier)); err != nil {
+		return fmt.Errorf("error setting xml_classifier: %s", err)
+	}
+
+	return nil
+}
+
+func resourceAwsGlueClassifierUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).glueconn
+
+	input := &glue.UpdateClassifierInput{}
+
+	if v, ok := d.GetOk("grok_classifier"); ok {
+		m := v.([]interface{})[0].(map[string]interface{})
+		input.GrokClassifier = expandGlueGrokClassifierUpdate(d.Id(), m)
+	}
+
+	if v, ok := d.GetOk("json_classifier"); ok {
+		m := v.([]interface{})[0].(map[string]interface{})
+		input.JsonClassifier = expandGlueJsonClassifierUpdate(d.Id(), m)
+	}
+
+	if v, ok := d.GetOk("xml_classifier"); ok {
+		m := v.([]interface{})[0].(map[string]interface{})
+		input.XMLClassifier = expandGlueXmlClassifierUpdate(d.Id(), m)
+	}
+
+	log.Printf("[DEBUG] Updating Glue Classifier: %s", input)
+	_, err := conn.UpdateClassifier(input)
+	if err != nil {
+		return fmt.Errorf("error updating Glue Classifier (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceAwsGlueClassifierDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).glueconn
+
+	log.Printf("[DEBUG] Deleting Glue Classifier: %s", d.Id())
+	err := deleteGlueClassifier(conn, d.Id())
+	if err != nil {
+		return fmt.Errorf("error deleting Glue Classifier (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func deleteGlueClassifier(conn *glue.Glue, name string) error {
+	input := &glue.DeleteClassifierInput{
+		Name: aws.String(name),
+	}
+
+	_, err := conn.DeleteClassifier(input)
+	if err != nil {
+		if isAWSErr(err, glue.ErrCodeEntityNotFoundException, "") {
+			return nil
+		}
+		return err
+	}
+
+	return nil
+}
+
+func expandGlueGrokClassifierCreate(name string, m map[string]interface{}) *glue.CreateGrokClassifierRequest {
+	grokClassifier := &glue.CreateGrokClassifierRequest{
+		Classification: aws.String(m["classification"].(string)),
+		GrokPattern:    aws.String(m["grok_pattern"].(string)),
+		Name:           aws.String(name),
+	}
+
+	if v, ok := m["custom_patterns"]; ok && v.(string) != "" {
+		grokClassifier.CustomPatterns = aws.String(v.(string))
+	}
+
+	return grokClassifier
+}
+
+func expandGlueGrokClassifierUpdate(name string, m map[string]interface{}) *glue.UpdateGrokClassifierRequest {
+	grokClassifier := &glue.UpdateGrokClassifierRequest{
+		Classification: aws.String(m["classification"].(string)),
+		GrokPattern:    aws.String(m["grok_pattern"].(string)),
+		Name:           aws.String(name),
+	}
+
+	if v, ok := m["custom_patterns"]; ok && v.(string) != "" {
+		grokClassifier.CustomPatterns = aws.String(v.(string))
+	}
+
+	return grokClassifier
+}
+
+func expandGlueJsonClassifierCreate(name string, m map[string]interface{}) *glue.CreateJsonClassifierRequest {
+	jsonClassifier := &glue.CreateJsonClassifierRequest{
+		JsonPath: aws.String(m["json_path"].(string)),
+		Name:     aws.String(name),
+	}
+
+	return jsonClassifier
+}
+
+func expandGlueJsonClassifierUpdate(name string, m map[string]interface{}) *glue.UpdateJsonClassifierRequest {
+	jsonClassifier := &glue.UpdateJsonClassifierRequest{
+		JsonPath: aws.String(m["json_path"].(string)),
+		Name:     aws.String(name),
+	}
+
+	return jsonClassifier
+}
+
+func expandGlueXmlClassifierCreate(name string, m map[string]interface{}) *glue.CreateXMLClassifierRequest {
+	xmlClassifier := &glue.CreateXMLClassifierRequest{
+		Classification: aws.String(m["classification"].(string)),
+		Name:           aws.String(name),
+		RowTag:         aws.String(m["row_tag"].(string)),
+	}
+
+	return xmlClassifier
+}
+
+func expandGlueXmlClassifierUpdate(name string, m map[string]interface{}) *glue.UpdateXMLClassifierRequest {
+	xmlClassifier := &glue.UpdateXMLClassifierRequest{
+		Classification: aws.String(m["classification"].(string)),
+		Name:           aws.String(name),
+		RowTag:         aws.String(m["row_tag"].(string)),
+	}
+
+	if v, ok := m["row_tag"]; ok && v.(string) != "" {
+		xmlClassifier.RowTag = aws.String(v.(string))
+	}
+
+	return xmlClassifier
+}
+
+func flattenGlueGrokClassifier(grokClassifier *glue.GrokClassifier) []map[string]interface{} {
+	if grokClassifier == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"classification":  aws.StringValue(grokClassifier.Classification),
+		"custom_patterns": aws.StringValue(grokClassifier.CustomPatterns),
+		"grok_pattern":    aws.StringValue(grokClassifier.GrokPattern),
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func flattenGlueJsonClassifier(jsonClassifier *glue.JsonClassifier) []map[string]interface{} {
+	if jsonClassifier == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"json_path": aws.StringValue(jsonClassifier.JsonPath),
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func flattenGlueXmlClassifier(xmlClassifier *glue.XMLClassifier) []map[string]interface{} {
+	if xmlClassifier == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"classification": aws.StringValue(xmlClassifier.Classification),
+		"row_tag":        aws.StringValue(xmlClassifier.RowTag),
+	}
+
+	return []map[string]interface{}{m}
+}

--- a/aws/resource_aws_glue_classifier_test.go
+++ b/aws/resource_aws_glue_classifier_test.go
@@ -1,0 +1,437 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/glue"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_glue_classifier", &resource.Sweeper{
+		Name: "aws_glue_classifier",
+		F:    testSweepGlueClassifiers,
+	})
+}
+
+func testSweepGlueClassifiers(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).glueconn
+
+	prefixes := []string{
+		"tf-acc-test-",
+	}
+
+	input := &glue.GetClassifiersInput{}
+	err = conn.GetClassifiersPages(input, func(page *glue.GetClassifiersOutput, lastPage bool) bool {
+		if len(page.Classifiers) == 0 {
+			log.Printf("[INFO] No Glue Classifiers to sweep")
+			return false
+		}
+		for _, classifier := range page.Classifiers {
+			skip := true
+
+			var name string
+			if classifier.GrokClassifier != nil {
+				name = aws.StringValue(classifier.GrokClassifier.Name)
+			} else if classifier.JsonClassifier != nil {
+				name = aws.StringValue(classifier.JsonClassifier.Name)
+			} else if classifier.XMLClassifier != nil {
+				name = aws.StringValue(classifier.XMLClassifier.Name)
+			}
+			if name == "" {
+				log.Printf("[WARN] Unable to determine Glue Classifier name: %#v", classifier)
+				continue
+			}
+
+			for _, prefix := range prefixes {
+				if strings.HasPrefix(name, prefix) {
+					skip = false
+					break
+				}
+			}
+			if skip {
+				log.Printf("[INFO] Skipping Glue Classifier: %s", name)
+				continue
+			}
+
+			log.Printf("[INFO] Deleting Glue Classifier: %s", name)
+			err := deleteGlueClassifier(conn, name)
+			if err != nil {
+				log.Printf("[ERROR] Failed to delete Glue Classifier %s: %s", name, err)
+			}
+		}
+		return !lastPage
+	})
+	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Glue Classifier sweep for %s: %s", region, err)
+			return nil
+		}
+		return fmt.Errorf("Error retrieving Glue Classifiers: %s", err)
+	}
+
+	return nil
+}
+
+func TestAccAWSGlueClassifier_GrokClassifier(t *testing.T) {
+	var classifier glue.Classifier
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_glue_classifier.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueClassifierDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGlueClassifierConfig_GrokClassifier(rName, "classification1", "pattern1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueClassifierExists(resourceName, &classifier),
+					resource.TestCheckResourceAttr(resourceName, "grok_classifier.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "grok_classifier.0.classification", "classification1"),
+					resource.TestCheckResourceAttr(resourceName, "grok_classifier.0.custom_patterns", ""),
+					resource.TestCheckResourceAttr(resourceName, "grok_classifier.0.grok_pattern", "pattern1"),
+					resource.TestCheckResourceAttr(resourceName, "json_classifier.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "xml_classifier.#", "0"),
+				),
+			},
+			{
+				Config: testAccAWSGlueClassifierConfig_GrokClassifier(rName, "classification2", "pattern2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueClassifierExists(resourceName, &classifier),
+					resource.TestCheckResourceAttr(resourceName, "grok_classifier.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "grok_classifier.0.classification", "classification2"),
+					resource.TestCheckResourceAttr(resourceName, "grok_classifier.0.custom_patterns", ""),
+					resource.TestCheckResourceAttr(resourceName, "grok_classifier.0.grok_pattern", "pattern2"),
+					resource.TestCheckResourceAttr(resourceName, "json_classifier.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "xml_classifier.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSGlueClassifier_GrokClassifier_CustomPatterns(t *testing.T) {
+	var classifier glue.Classifier
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_glue_classifier.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueClassifierDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGlueClassifierConfig_GrokClassifier_CustomPatterns(rName, "custompattern1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueClassifierExists(resourceName, &classifier),
+					resource.TestCheckResourceAttr(resourceName, "grok_classifier.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "grok_classifier.0.classification", "classification"),
+					resource.TestCheckResourceAttr(resourceName, "grok_classifier.0.custom_patterns", "custompattern1"),
+					resource.TestCheckResourceAttr(resourceName, "grok_classifier.0.grok_pattern", "pattern"),
+					resource.TestCheckResourceAttr(resourceName, "json_classifier.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "xml_classifier.#", "0"),
+				),
+			},
+			{
+				Config: testAccAWSGlueClassifierConfig_GrokClassifier_CustomPatterns(rName, "custompattern2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueClassifierExists(resourceName, &classifier),
+					resource.TestCheckResourceAttr(resourceName, "grok_classifier.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "grok_classifier.0.classification", "classification"),
+					resource.TestCheckResourceAttr(resourceName, "grok_classifier.0.custom_patterns", "custompattern2"),
+					resource.TestCheckResourceAttr(resourceName, "grok_classifier.0.grok_pattern", "pattern"),
+					resource.TestCheckResourceAttr(resourceName, "json_classifier.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "xml_classifier.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSGlueClassifier_JsonClassifier(t *testing.T) {
+	var classifier glue.Classifier
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_glue_classifier.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueClassifierDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGlueClassifierConfig_JsonClassifier(rName, "jsonpath1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueClassifierExists(resourceName, &classifier),
+					resource.TestCheckResourceAttr(resourceName, "grok_classifier.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "json_classifier.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "json_classifier.0.json_path", "jsonpath1"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "xml_classifier.#", "0"),
+				),
+			},
+			{
+				Config: testAccAWSGlueClassifierConfig_JsonClassifier(rName, "jsonpath2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueClassifierExists(resourceName, &classifier),
+					resource.TestCheckResourceAttr(resourceName, "grok_classifier.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "json_classifier.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "json_classifier.0.json_path", "jsonpath2"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "xml_classifier.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSGlueClassifier_TypeChange(t *testing.T) {
+	var classifier glue.Classifier
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_glue_classifier.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueClassifierDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGlueClassifierConfig_GrokClassifier(rName, "classification1", "pattern1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueClassifierExists(resourceName, &classifier),
+					resource.TestCheckResourceAttr(resourceName, "grok_classifier.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "grok_classifier.0.classification", "classification1"),
+					resource.TestCheckResourceAttr(resourceName, "grok_classifier.0.custom_patterns", ""),
+					resource.TestCheckResourceAttr(resourceName, "grok_classifier.0.grok_pattern", "pattern1"),
+					resource.TestCheckResourceAttr(resourceName, "json_classifier.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "xml_classifier.#", "0"),
+				),
+			},
+			{
+				Config: testAccAWSGlueClassifierConfig_JsonClassifier(rName, "jsonpath1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueClassifierExists(resourceName, &classifier),
+					resource.TestCheckResourceAttr(resourceName, "grok_classifier.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "json_classifier.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "json_classifier.0.json_path", "jsonpath1"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "xml_classifier.#", "0"),
+				),
+			},
+			{
+				Config: testAccAWSGlueClassifierConfig_XmlClassifier(rName, "classification1", "rowtag1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueClassifierExists(resourceName, &classifier),
+					resource.TestCheckResourceAttr(resourceName, "grok_classifier.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "json_classifier.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "xml_classifier.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "xml_classifier.0.classification", "classification1"),
+					resource.TestCheckResourceAttr(resourceName, "xml_classifier.0.row_tag", "rowtag1"),
+				),
+			},
+			{
+				Config: testAccAWSGlueClassifierConfig_GrokClassifier(rName, "classification1", "pattern1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueClassifierExists(resourceName, &classifier),
+					resource.TestCheckResourceAttr(resourceName, "grok_classifier.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "grok_classifier.0.classification", "classification1"),
+					resource.TestCheckResourceAttr(resourceName, "grok_classifier.0.custom_patterns", ""),
+					resource.TestCheckResourceAttr(resourceName, "grok_classifier.0.grok_pattern", "pattern1"),
+					resource.TestCheckResourceAttr(resourceName, "json_classifier.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "xml_classifier.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSGlueClassifier_XmlClassifier(t *testing.T) {
+	var classifier glue.Classifier
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_glue_classifier.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueClassifierDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGlueClassifierConfig_XmlClassifier(rName, "classification1", "rowtag1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueClassifierExists(resourceName, &classifier),
+					resource.TestCheckResourceAttr(resourceName, "grok_classifier.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "json_classifier.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "xml_classifier.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "xml_classifier.0.classification", "classification1"),
+					resource.TestCheckResourceAttr(resourceName, "xml_classifier.0.row_tag", "rowtag1"),
+				),
+			},
+			{
+				Config: testAccAWSGlueClassifierConfig_XmlClassifier(rName, "classification2", "rowtag2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueClassifierExists(resourceName, &classifier),
+					resource.TestCheckResourceAttr(resourceName, "grok_classifier.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "json_classifier.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "xml_classifier.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "xml_classifier.0.classification", "classification2"),
+					resource.TestCheckResourceAttr(resourceName, "xml_classifier.0.row_tag", "rowtag2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSGlueClassifierExists(resourceName string, classifier *glue.Classifier) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Glue Classifier ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).glueconn
+
+		output, err := conn.GetClassifier(&glue.GetClassifierInput{
+			Name: aws.String(rs.Primary.ID),
+		})
+		if err != nil {
+			return err
+		}
+
+		if output.Classifier == nil {
+			return fmt.Errorf("Glue Classifier (%s) not found", rs.Primary.ID)
+		}
+
+		*classifier = *output.Classifier
+		return nil
+	}
+}
+
+func testAccCheckAWSGlueClassifierDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_glue_classifier" {
+			continue
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).glueconn
+
+		output, err := conn.GetClassifier(&glue.GetClassifierInput{
+			Name: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			if isAWSErr(err, glue.ErrCodeEntityNotFoundException, "") {
+				return nil
+			}
+
+		}
+
+		classifier := output.Classifier
+		if classifier != nil {
+			return fmt.Errorf("Glue Classifier %s still exists", rs.Primary.ID)
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func testAccAWSGlueClassifierConfig_GrokClassifier(rName, classification, grokPattern string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_classifier" "test" {
+  name = "%s"
+
+  grok_classifier {
+    classification = "%s"
+    grok_pattern   = "%s"
+  }
+}
+`, rName, classification, grokPattern)
+}
+
+func testAccAWSGlueClassifierConfig_GrokClassifier_CustomPatterns(rName, customPatterns string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_classifier" "test" {
+  name = "%s"
+
+  grok_classifier {
+    classification  = "classification"
+    custom_patterns = "%s"
+    grok_pattern    = "pattern"
+  }
+}
+`, rName, customPatterns)
+}
+
+func testAccAWSGlueClassifierConfig_JsonClassifier(rName, jsonPath string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_classifier" "test" {
+  name = "%s"
+
+  json_classifier {
+    json_path = "%s"
+  }
+}
+`, rName, jsonPath)
+}
+
+func testAccAWSGlueClassifierConfig_XmlClassifier(rName, classification, rowTag string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_classifier" "test" {
+  name = "%s"
+
+  xml_classifier {
+    classification  = "%s"
+    row_tag         = "%s"
+  }
+}
+`, rName, classification, rowTag)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1105,6 +1105,9 @@
                         <li<%= sidebar_current("docs-aws-resource-glue-catalog-database") %>>
                             <a href="/docs/providers/aws/r/glue_catalog_database.html">aws_glue_catalog_database</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-resource-glue-classifier") %>>
+                            <a href="/docs/providers/aws/r/glue_classifier.html">aws_glue_classifier</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-resource-glue-connection") %>>
                             <a href="/docs/providers/aws/r/glue_connection.html">aws_glue_connection</a>
                         </li>

--- a/website/docs/r/glue_classifier.html.markdown
+++ b/website/docs/r/glue_classifier.html.markdown
@@ -1,0 +1,91 @@
+---
+layout: "aws"
+page_title: "AWS: aws_glue_classifier"
+sidebar_current: "docs-aws-resource-glue-classifier"
+description: |-
+  Provides an Glue Classifier resource.
+---
+
+# aws_glue_classifier
+
+Provides a Glue Classifier resource.
+
+~> **NOTE:** It is only valid to create one type of classifier (grok, JSON, or XML). Changing classifier types will recreate the classifier.
+
+## Example Usage
+
+### Grok Classifier
+
+```hcl
+resource "aws_glue_classifier" "example" {
+  name = "example"
+
+  grok_classifier {
+    classification = "example"
+    grok_pattern   = "example"
+  }
+}
+```
+
+### JSON Classifier
+
+```hcl
+resource "aws_glue_classifier" "example" {
+  name = "example"
+
+  json_classifier {
+    json_path = "example"
+  }
+}
+```
+
+### XML Classifier
+
+```hcl
+resource "aws_glue_classifier" "example" {
+  name = "example"
+
+  xml_classifier {
+    classification = "example"
+    row_tag        = "example"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `grok_classifier` – (Optional) A classifier that uses grok patterns. Defined below.
+* `json_classifier` – (Optional) A classifier for JSON content. Defined below.
+* `name` – (Required) The name of the classifier.
+* `xml_classifier` – (Optional) A classifier for XML content. Defined below.
+
+### grok_classifier
+
+* `classification` - (Required) An identifier of the data format that the classifier matches, such as Twitter, JSON, Omniture logs, Amazon CloudWatch Logs, and so on.
+* `custom_patterns` - (Optional) Custom grok patterns used by this classifier.
+* `grok_pattern` - (Required) The grok pattern used by this classifier.
+
+### json_classifier
+
+* `json_path` - (Required) A `JsonPath` string defining the JSON data for the classifier to classify. AWS Glue supports a subset of `JsonPath`, as described in [Writing JsonPath Custom Classifiers](https://docs.aws.amazon.com/glue/latest/dg/custom-classifier.html#custom-classifier-json).
+
+### xml_classifier
+
+* `classification` - (Required) An identifier of the data format that the classifier matches.
+* `row_tag` - (Required) The XML tag designating the element that contains each record in an XML document being parsed. Note that this cannot identify a self-closing element (closed by `/>`). An empty row element that contains only attributes can be parsed as long as it ends with a closing tag (for example, `<row item_a="A" item_b="B"></row>` is okay, but `<row item_a="A" item_b="B" />` is not).
+
+## Attributes Reference
+
+The following additional attributes are exported:
+
+* `id` - Name of the classifier
+
+## Import
+
+Glue Classifiers can be imported using their name, e.g.
+
+```
+$ terraform import aws_glue_classifier.MyClassifier MyClassifier
+```


### PR DESCRIPTION
Closes #3873

Changes proposed in this pull request:

* New Resource: `aws_glue_classifier`

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSGlueClassifier'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSGlueClassifier -timeout 120m
=== RUN   TestAccAWSGlueClassifier_GrokClassifier
--- PASS: TestAccAWSGlueClassifier_GrokClassifier (19.72s)
=== RUN   TestAccAWSGlueClassifier_GrokClassifier_CustomPatterns
--- PASS: TestAccAWSGlueClassifier_GrokClassifier_CustomPatterns (19.01s)
=== RUN   TestAccAWSGlueClassifier_JsonClassifier
--- PASS: TestAccAWSGlueClassifier_JsonClassifier (19.38s)
=== RUN   TestAccAWSGlueClassifier_TypeChange
--- PASS: TestAccAWSGlueClassifier_TypeChange (34.42s)
=== RUN   TestAccAWSGlueClassifier_XmlClassifier
--- PASS: TestAccAWSGlueClassifier_XmlClassifier (20.50s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	113.062s
```
