### PR TITLE
Add aws_codebuild_webhook resource for creating GitHub webhooks for CodeBuild projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ENHANCEMENTS:
 
+* resource/aws_dms_endpoint: Support `s3` `engine_name` and add `s3_settings` argument [GH-1685] and [GH-4447]
 * resource/aws_lb_target_group: Add `proxy_protocol_v2` argument [GH-4365]
 * resource/aws_spot_fleet_request: Mark `spot_price` optional (defaults to on-demand price) [GH-4424]
 * resource/aws_spot_fleet_request: Add plan time validation for `valid_from` and `valid_until` arguments [GH-4463]

--- a/aws/resource_aws_codebuild_webhook.go
+++ b/aws/resource_aws_codebuild_webhook.go
@@ -18,6 +18,10 @@ func resourceAwsCodeBuildWebhook() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"branch_filter": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"url": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -30,13 +34,15 @@ func resourceAwsCodeBuildWebhookCreate(d *schema.ResourceData, meta interface{})
 	conn := meta.(*AWSClient).codebuildconn
 
 	resp, err := conn.CreateWebhook(&codebuild.CreateWebhookInput{
-		ProjectName: aws.String(d.Get("name").(string)),
+		ProjectName:  aws.String(d.Get("name").(string)),
+		BranchFilter: aws.String(d.Get("branch_filter").(string)),
 	})
 	if err != nil {
 		return err
 	}
 
 	d.SetId(d.Get("name").(string))
+	d.Set("branch_filter", d.Get("branch_filter").(string))
 	d.Set("url", resp.Webhook.Url)
 	return nil
 }

--- a/aws/resource_aws_codebuild_webhook_test.go
+++ b/aws/resource_aws_codebuild_webhook_test.go
@@ -70,7 +70,7 @@ func testAccCheckAwsCodeBuildWebhookExists(name string) resource.TestCheckFunc {
 }
 
 func testAccCodeBuildWebhookConfig_basic(rName string) string {
-	return fmt.Sprintf(testAccAWSCodeBuildProjectConfig_basic(rName) + `
+	return fmt.Sprintf(testAccAWSCodeBuildProjectConfig_basic(rName, "", "") + `
 resource "aws_codebuild_webhook" "test" {
   name = "${aws_codebuild_project.foo.name}"
 }

--- a/website/docs/r/codebuild_webhook.html.markdown
+++ b/website/docs/r/codebuild_webhook.html.markdown
@@ -35,6 +35,7 @@ resource "github_repository_webhook" "aws_codebuild" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the build project.
+* `branch_filter` - (Optional) A regular expression used to determine which branches get built. Default is all branches are built.
 
 ## Attributes Reference
 

--- a/website/docs/r/codebuild_webhook.html.markdown
+++ b/website/docs/r/codebuild_webhook.html.markdown
@@ -13,94 +13,20 @@ Provides a CodeBuild Webhook resource.
 ## Example Usage
 
 ```hcl
-resource "aws_iam_role" "codebuild_role" {
-  name = "codebuild-role-"
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "codebuild.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-EOF
+resource "aws_codebuild_webhook" "github" {
+  name = "${aws_codebuild_project.my_project.name}"
 }
 
-resource "aws_iam_policy" "codebuild_policy" {
-  name        = "codebuild-policy"
-  path        = "/service-role/"
-  description = "Policy used in trust relationship with CodeBuild"
+resource "github_repository_webhook" "aws_codebuild" {
+  repository = "${github_repository.repo.name}"
+  name       = "web"
 
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Resource": [
-        "*"
-      ],
-      "Action": [
-        "logs:CreateLogGroup",
-        "logs:CreateLogStream",
-        "logs:PutLogEvents"
-      ]
-    }
-  ]
-}
-POLICY
-}
-
-resource "aws_iam_policy_attachment" "codebuild_policy_attachment" {
-  name       = "codebuild-policy-attachment"
-  policy_arn = "${aws_iam_policy.codebuild_policy.arn}"
-  roles      = ["${aws_iam_role.codebuild_role.id}"]
-}
-
-resource "aws_codebuild_project" "foo" {
-  name         = "test-project"
-  description  = "test_codebuild_project"
-  build_timeout      = "5"
-  service_role = "${aws_iam_role.codebuild_role.arn}"
-
-  artifacts {
-    type = "NO_ARTIFACTS"
+  configuration {
+    url          = "${aws_codebuild_webhook.github.url}"
+    content_type = "json"
   }
 
-  environment {
-    compute_type = "BUILD_GENERAL1_SMALL"
-    image        = "2"
-    type         = "LINUX_CONTAINER"
-
-    environment_variable {
-      "name"  = "SOME_KEY1"
-      "value" = "SOME_VALUE1"
-    }
-
-    environment_variable {
-      "name"  = "SOME_KEY2"
-      "value" = "SOME_VALUE2"
-    }
-  }
-
-  source {
-    type     = "GITHUB"
-    location = "https://github.com/mitchellh/packer.git"
-  }
-
-  tags {
-    "Environment" = "Test"
-  }
-}
-
-resource "aws_codebuild_webhook" "foo" {
-  name = "${aws_codebuild_project.foo.name}"
+  events = ["pull_request", "push"]
 }
 ```
 

--- a/website/docs/r/codebuild_webhook.html.markdown
+++ b/website/docs/r/codebuild_webhook.html.markdown
@@ -10,23 +10,13 @@ description: |-
 
 Provides a CodeBuild Webhook resource.
 
+~> **Note:** The AWS account that Terraform uses to create this resource *must* have authorized CodeBuild to access GitHub's OAuth API. This is a manual step that must be done *before* creating webhooks with this resource. If OAuth is not configured, AWS will return an error similar to `ResourceNotFoundException: Could not find access token for server type github`.
+
 ## Example Usage
 
 ```hcl
 resource "aws_codebuild_webhook" "github" {
   name = "${aws_codebuild_project.my_project.name}"
-}
-
-resource "github_repository_webhook" "aws_codebuild" {
-  repository = "${github_repository.repo.name}"
-  name       = "web"
-
-  configuration {
-    url          = "${aws_codebuild_webhook.github.url}"
-    content_type = "json"
-  }
-
-  events = ["pull_request", "push"]
 }
 ```
 


### PR DESCRIPTION
Changes proposed in this pull request:

Introduces a resource called `aws_codebuild_webhook` that [creates GitHub webhook](https://docs.aws.amazon.com/codebuild/latest/APIReference/API_CreateWebhook.html#CodeBuild-CreateWebhook-request-branchFilter) for a CodeBuild project that has its source stored on GitHub.

This works builds on #2814 and adds branch filtering.

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAwsCodeBuildWebhook_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAwsCodeBuildWebhook_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAwsCodeBuildWebhook_basic
--- FAIL: TestAccAwsCodeBuildWebhook_basic (41.83s)
	testing.go:518: Step 0 error: Error applying: 1 error(s) occurred:
		
		* aws_codebuild_webhook.test: 1 error(s) occurred:
		
		* aws_codebuild_webhook.test: ResourceNotFoundException: Could not find access token for server type github
			status code: 400, request id: fe4a925b-523e-11e8-8f47-a9109ac40b1a
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	41.863s
make: *** [testacc] Error 1
```

The reason because this fails is because:

* The AWS user Terraform runs as must have already done an OAuth login with GitHub on an existing CodeBuild project.
* The GitHub user that the AWS user logs in as must have access to the GitHub repository listed in the `source`. 

I've tried to test this, but passing `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to tests appears to be ignored. Creating a webhook with the credentials I created works via the CLI, but not via the API call this resource makes.

How does one use their own AWS credentials when running `make test`?

**NOTE:** Once this passes, the upstream Terraform test environment will need to address this in order to run these tests. Alternatively, I could implement something like the [Heroku provider has](https://github.com/terraform-providers/terraform-provider-heroku/blob/master/heroku/resource_heroku_app_test.go#L214-L222) for skipping tests.