### PR TITLE
Data source does not fail if hosted zone not found.

### DIFF
--- a/aws/data_source_aws_route53_zone.go
+++ b/aws/data_source_aws_route53_zone.go
@@ -158,7 +158,7 @@ func dataSourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) erro
 		}
 	}
 	if hostedZoneFound == nil {
-		return fmt.Errorf("no matching Route53Zone found")
+		return nil
 	}
 
 	idHostedZone := cleanZoneID(*hostedZoneFound.Id)


### PR DESCRIPTION
We are hoping to use the aws route53 hosted zone data source conditionally on the presence of a requested name. Given the zone does not exist, then create the resource. While this works when the zone does exist, it fails when it does not with `no matching Route53Zone found`. We hoped to use the data sources similarly across the IaaSes after being able to do this conditional logic with the (azure dns zone](https://github.com/terraform-providers/terraform-provider-azurerm/blob/master/azurerm/data_source_dns_zone.go#L53-L56).

Changes proposed in this pull request:

* Return nil instead of failing when the hosted zone name is not found.

Output from acceptance testing:

```
--- PASS: TestAccDataSourceAwsRoute53Zone (78.70s)
PASS
```
