### PR TITLE
Fixes an issue where the `cname_prefix` attribute isn't correctly read in region China

### DIFF
--- a/aws/resource_aws_elastic_beanstalk_environment.go
+++ b/aws/resource_aws_elastic_beanstalk_environment.go
@@ -584,7 +584,7 @@ func resourceAwsElasticBeanstalkEnvironmentRead(d *schema.ResourceData, meta int
 	}
 
 	if env.CNAME != nil {
-		beanstalkCnamePrefixRegexp := regexp.MustCompile(`(^[^.]+)(.\w{2}-\w{4,9}-\d)?.elasticbeanstalk.com$`)
+		beanstalkCnamePrefixRegexp := regexp.MustCompile(`(^[^.]+)(.\w{2}-\w{4,9}-\d)?.(elasticbeanstalk.com|eb.amazonaws.com.cn)$`)
 		var cnamePrefix string
 		cnamePrefixMatch := beanstalkCnamePrefixRegexp.FindStringSubmatch(*env.CNAME)
 


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes an issue where the `cname_prefix` attribute isn't correctly read China regions.

Basically as extension of a previous [issue](https://github.com/hashicorp/terraform/pull/6653).
Elastic Beanstalk has a different domain name in China regions, which ends with `eb.amazonaws.com.cn` rather than the usual `elasticbeanstalk.com` [(reference)](http://docs.amazonaws.cn/en_us/aws/latest/userguide/beanstalk.html), so `cname_prefix` cannot be correctly read.

Changes proposed in this pull request:

* Adapt the regex expression to match `cname` in `resource_aws_elastic_beanstalk_environment.go` to be able to take `cname` in domain `eb.amazonaws.com.cn`.

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAvailabilityZones'

...
```
