### PR TITLE
Fix typo in serverless guide

### DIFF
--- a/website/docs/guides/serverless-with-aws-lambda-and-api-gateway.html.md
+++ b/website/docs/guides/serverless-with-aws-lambda-and-api-gateway.html.md
@@ -346,7 +346,7 @@ resource "aws_api_gateway_integration" "lambda_root" {
 
   integration_http_method = "POST"
   type                    = "AWS_PROXY"
-  uri                     = "${aws_lambda_function.main.invoke_arn}"
+  uri                     = "${aws_lambda_function.example.invoke_arn}"
 }
 ```
 


### PR DESCRIPTION
I was following the Serverless AWS Lambda guide [on the website](https://www.terraform.io/docs/providers/aws/guides/serverless-with-aws-lambda-and-api-gateway.html) and ran into this error during the API gateway configuration section:

```
Error: resource 'aws_api_gateway_integration.lambda_root' config:
 unknown resource 'aws_lambda_function.main' referenced in variable aws_lambda_function.main.invoke_arn
```

I got through the guide by changing `main` to `example`, which seems like the correct name for the AWS Lambda resource.
