### PR TITLE
fix: update us-east-1 S3 bucket naming validations

### DIFF
--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -902,68 +902,6 @@ func TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError(t *testing.T)
 	})
 }
 
-func TestAWSS3BucketName(t *testing.T) {
-	validDnsNames := []string{
-		"foobar",
-		"foo.bar",
-		"foo.bar.baz",
-		"1234",
-		"foo-bar",
-		strings.Repeat("x", 63),
-	}
-
-	for _, v := range validDnsNames {
-		if err := validateS3BucketName(v, "us-west-2"); err != nil {
-			t.Fatalf("%q should be a valid S3 bucket name", v)
-		}
-	}
-
-	invalidDnsNames := []string{
-		"foo..bar",
-		"Foo.Bar",
-		"192.168.0.1",
-		"127.0.0.1",
-		".foo",
-		"bar.",
-		"foo_bar",
-		strings.Repeat("x", 64),
-	}
-
-	for _, v := range invalidDnsNames {
-		if err := validateS3BucketName(v, "us-west-2"); err == nil {
-			t.Fatalf("%q should not be a valid S3 bucket name", v)
-		}
-	}
-
-	validEastNames := []string{
-		"foobar",
-		"foo_bar",
-		"127.0.0.1",
-		"foo..bar",
-		"foo_bar_baz",
-		"foo.bar.baz",
-		"Foo.Bar",
-		strings.Repeat("x", 255),
-	}
-
-	for _, v := range validEastNames {
-		if err := validateS3BucketName(v, "us-east-1"); err != nil {
-			t.Fatalf("%q should be a valid S3 bucket name", v)
-		}
-	}
-
-	invalidEastNames := []string{
-		"foo;bar",
-		strings.Repeat("x", 256),
-	}
-
-	for _, v := range invalidEastNames {
-		if err := validateS3BucketName(v, "us-east-1"); err == nil {
-			t.Fatalf("%q should not be a valid S3 bucket name", v)
-		}
-	}
-}
-
 func testAccCheckAWSS3BucketDestroy(s *terraform.State) error {
 	return testAccCheckAWSS3BucketDestroyWithProvider(s, testAccProvider)
 }

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -530,6 +530,31 @@ func validateLogGroupNamePrefix(v interface{}, k string) (ws []string, errors []
 	return
 }
 
+func validateS3BucketName(v interface{}, k string) (ws []string, errors []error) {
+	// https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html#bucketnamingrules
+
+	value := v.(string)
+	if (len(value) < 3) || (len(value) > 63) {
+		errors = append(errors, fmt.Errorf("%q must contain from 3 to 63 characters", k))
+	}
+	if !regexp.MustCompile(`^[0-9a-z-.]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf("only lowercase alphanumeric characters and hyphens allowed in %q", value))
+	}
+	if regexp.MustCompile(`^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf("%q must not be formatted as an IP address", value))
+	}
+	if strings.HasPrefix(value, `.`) {
+		errors = append(errors, fmt.Errorf("%q cannot start with a period", value))
+	}
+	if strings.HasSuffix(value, `.`) {
+		errors = append(errors, fmt.Errorf("%q cannot end with a period", value))
+	}
+	if strings.Contains(value, `..`) {
+		errors = append(errors, fmt.Errorf("%q can be only one period between labels", value))
+	}
+	return
+}
+
 func validateS3BucketLifecycleTimestamp(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	_, err := time.Parse(time.RFC3339, fmt.Sprintf("%sT00:00:00Z", value))

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -522,6 +522,42 @@ func TestValidateLogGroupNamePrefix(t *testing.T) {
 	}
 }
 
+func TestValidateS3BucketName(t *testing.T) {
+	validDnsNames := []string{
+		"foobar",
+		"foo.bar",
+		"foo.bar.baz",
+		"1234",
+		"foo-bar",
+		strings.Repeat("x", 63),
+	}
+
+	for _, v := range validDnsNames {
+		_, errors := validateS3BucketName(v, "bucket")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid S3 bucket name: %q", v, errors)
+		}
+	}
+
+	invalidDnsNames := []string{
+		"foo..bar",
+		"Foo.Bar",
+		"192.168.0.1",
+		"127.0.0.1",
+		".foo",
+		"bar.",
+		"foo_bar",
+		strings.Repeat("x", 64),
+	}
+
+	for _, v := range invalidDnsNames {
+		_, errors := validateS3BucketName(v, "bucket")
+		if len(errors) == 0 {
+			t.Fatalf("%q should not be a valid S3 bucket name", v)
+		}
+	}
+}
+
 func TestValidateS3BucketLifecycleTimestamp(t *testing.T) {
 	validDates := []string{
 		"2016-01-01",


### PR DESCRIPTION
Since March 1, 2018 AWS applies the same naming conventions for all
regions. [0] This means that the special validation for us-east-1 is obsolete.

This enabled refactoring the validation to a normal schema validator which has
the benefit of plan-time validation.

[[0](https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html#bucketnamingrules)](https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html#bucketnamingrules)