### PR TITLE
tests/resource/aws_elasticache_security_group: Add sweeper

### DIFF
--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -158,5 +158,10 @@ func testSweepSkipSweepError(err error) bool {
 	if isAWSErr(err, "UnsupportedOperation", "") {
 		return true
 	}
+	// Ignore more unsupported API calls
+	// InvalidParameterValue: Use of cache security groups is not permitted in this API version for your account.
+	if isAWSErr(err, "InvalidParameterValue", "not permitted in this API version for your account") {
+		return true
+	}
 	return false
 }


### PR DESCRIPTION
Fixes:

```
--- FAIL: TestAccAWSElasticacheReplicationGroup_enableSnapshotting (8.73s)
    testing.go:518: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_elasticache_security_group.bar: 1 error(s) occurred:
        
        * aws_elasticache_security_group.bar: Error creating CacheSecurityGroup: QuotaExceeded.CacheSecurityGroup: You have already reached your quota of 50 cache security groups in this region. If you need more, please visit the Support Center and open a Service Limit Increase case.
            status code: 400, request id: 417bc182-5426-11e8-a427-159fba20a9f4
```

Changes proposed in this pull request:

* Add test sweeper for `aws_elasticache_security_group` resource

Output from acceptance testing:

```
$ make sweep SWEEPARGS='-sweep-run=aws_elasticache_security_group'
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./... -v -sweep=us-west-2,us-east-1 -sweep-run=aws_elasticache_security_group
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
2018/05/10 13:51:10 [DEBUG] Running Sweepers for region (us-east-1):
...
2018/05/10 13:51:21 [INFO] Deleting Elasticache Cache Security Group: tf-test-security-group-yna8mkhmou
2018/05/10 13:51:21 Sweeper Tests ran:
	- aws_elasticache_cluster
	- aws_elasticache_security_group
	- aws_elasticache_replication_group
ok  	github.com/terraform-providers/terraform-provider-aws/aws	11.191s
```
