### PR TITLE
resource/aws_elasticache_replication_group: Support number_cache_nodes updates

### DIFF
--- a/aws/resource_aws_elasticache_cluster.go
+++ b/aws/resource_aws_elasticache_cluster.go
@@ -406,31 +406,16 @@ func resourceAwsElasticacheClusterCreate(d *schema.ResourceData, meta interface{
 		req.PreferredAvailabilityZones = azs
 	}
 
-	resp, err := conn.CreateCacheCluster(req)
+	id, err := createElasticacheCacheCluster(conn, req)
 	if err != nil {
-		return fmt.Errorf("Error creating Elasticache: %s", err)
+		return fmt.Errorf("error creating Elasticache Cache Cluster: %s", err)
 	}
 
-	// Assign the cluster id as the resource ID
-	// Elasticache always retains the id in lower case, so we have to
-	// mimic that or else we won't be able to refresh a resource whose
-	// name contained uppercase characters.
-	d.SetId(strings.ToLower(*resp.CacheCluster.CacheClusterId))
+	d.SetId(id)
 
-	pending := []string{"creating", "modifying", "restoring", "snapshotting"}
-	stateConf := &resource.StateChangeConf{
-		Pending:    pending,
-		Target:     []string{"available"},
-		Refresh:    cacheClusterStateRefreshFunc(conn, d.Id(), "available", pending),
-		Timeout:    40 * time.Minute,
-		MinTimeout: 10 * time.Second,
-		Delay:      30 * time.Second,
-	}
-
-	log.Printf("[DEBUG] Waiting for state to become available: %v", d.Id())
-	_, sterr := stateConf.WaitForState()
-	if sterr != nil {
-		return fmt.Errorf("Error waiting for elasticache (%s) to be created: %s", d.Id(), sterr)
+	err = createElasticacheCacheClusterWaiter(conn, d.Id(), 40*time.Minute)
+	if err != nil {
+		return fmt.Errorf("error waiting for Elasticache Cache Cluster (%s) to be created: %s", d.Id(), err)
 	}
 
 	return resourceAwsElasticacheClusterRead(d, meta)
@@ -682,9 +667,16 @@ func (b byCacheNodeId) Less(i, j int) bool {
 func resourceAwsElasticacheClusterDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).elasticacheconn
 
-	err := deleteElasticacheCluster(d.Id(), 40*time.Minute, conn)
+	err := deleteElasticacheCacheCluster(conn, d.Id())
 	if err != nil {
-		return fmt.Errorf("error deleting Elasticache Cluster (%s): %s", d.Id(), err)
+		if isAWSErr(err, elasticache.ErrCodeCacheClusterNotFoundFault, "") {
+			return nil
+		}
+		return fmt.Errorf("error deleting Elasticache Cache Cluster (%s): %s", d.Id(), err)
+	}
+	err = deleteElasticacheCacheClusterWaiter(conn, d.Id(), 40*time.Minute)
+	if err != nil {
+		return fmt.Errorf("error waiting for Elasticache Cache Cluster (%s) to be deleted: %s", d.Id(), err)
 	}
 
 	return nil
@@ -761,13 +753,49 @@ func cacheClusterStateRefreshFunc(conn *elasticache.ElastiCache, clusterID, give
 	}
 }
 
-func deleteElasticacheCluster(clusterID string, timeout time.Duration, conn *elasticache.ElastiCache) error {
-	input := &elasticache.DeleteCacheClusterInput{
-		CacheClusterId: aws.String(clusterID),
+func createElasticacheCacheCluster(conn *elasticache.ElastiCache, input *elasticache.CreateCacheClusterInput) (string, error) {
+	log.Printf("[DEBUG] Creating Elasticache Cache Cluster: %s", input)
+	output, err := conn.CreateCacheCluster(input)
+	if err != nil {
+		return "", err
 	}
+	if output == nil || output.CacheCluster == nil {
+		return "", errors.New("missing cluster ID after creation")
+	}
+	// Elasticache always retains the id in lower case, so we have to
+	// mimic that or else we won't be able to refresh a resource whose
+	// name contained uppercase characters.
+	return strings.ToLower(aws.StringValue(output.CacheCluster.CacheClusterId)), nil
+}
+
+func createElasticacheCacheClusterWaiter(conn *elasticache.ElastiCache, cacheClusterID string, timeout time.Duration) error {
+	pending := []string{"creating", "modifying", "restoring", "snapshotting"}
+	stateConf := &resource.StateChangeConf{
+		Pending:    pending,
+		Target:     []string{"available"},
+		Refresh:    cacheClusterStateRefreshFunc(conn, cacheClusterID, "available", pending),
+		Timeout:    timeout,
+		MinTimeout: 10 * time.Second,
+		Delay:      30 * time.Second,
+	}
+
+	log.Printf("[DEBUG] Waiting for Elasticache Cache Cluster (%s) to be created", cacheClusterID)
+	_, err := stateConf.WaitForState()
+	return err
+}
+
+func deleteElasticacheCacheCluster(conn *elasticache.ElastiCache, cacheClusterID string) error {
+	input := &elasticache.DeleteCacheClusterInput{
+		CacheClusterId: aws.String(cacheClusterID),
+	}
+	log.Printf("[DEBUG] Deleting Elasticache Cache Cluster: %s", input)
 	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
 		_, err := conn.DeleteCacheCluster(input)
 		if err != nil {
+			// This will not be fixed by retrying
+			if isAWSErr(err, elasticache.ErrCodeInvalidCacheClusterStateFault, "serving as primary") {
+				return resource.NonRetryableError(err)
+			}
 			// The cluster may be just snapshotting, so we retry until it's ready for deletion
 			if isAWSErr(err, elasticache.ErrCodeInvalidCacheClusterStateFault, "") {
 				return resource.RetryableError(err)
@@ -776,20 +804,20 @@ func deleteElasticacheCluster(clusterID string, timeout time.Duration, conn *ela
 		}
 		return nil
 	})
-	if err != nil {
-		return err
-	}
+	return err
+}
 
-	log.Printf("[DEBUG] Waiting for deletion: %v", clusterID)
+func deleteElasticacheCacheClusterWaiter(conn *elasticache.ElastiCache, cacheClusterID string, timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"creating", "available", "deleting", "incompatible-parameters", "incompatible-network", "restore-failed", "snapshotting"},
 		Target:     []string{},
-		Refresh:    cacheClusterStateRefreshFunc(conn, clusterID, "", []string{}),
+		Refresh:    cacheClusterStateRefreshFunc(conn, cacheClusterID, "", []string{}),
 		Timeout:    timeout,
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second,
 	}
+	log.Printf("[DEBUG] Waiting for Elasticache Cache Cluster deletion: %v", cacheClusterID)
 
-	_, err = stateConf.WaitForState()
+	_, err := stateConf.WaitForState()
 	return err
 }

--- a/aws/resource_aws_elasticache_cluster.go
+++ b/aws/resource_aws_elasticache_cluster.go
@@ -413,7 +413,7 @@ func resourceAwsElasticacheClusterCreate(d *schema.ResourceData, meta interface{
 
 	d.SetId(id)
 
-	err = createElasticacheCacheClusterWaiter(conn, d.Id(), 40*time.Minute)
+	err = waitForCreateElasticacheCacheCluster(conn, d.Id(), 40*time.Minute)
 	if err != nil {
 		return fmt.Errorf("error waiting for Elasticache Cache Cluster (%s) to be created: %s", d.Id(), err)
 	}
@@ -674,7 +674,7 @@ func resourceAwsElasticacheClusterDelete(d *schema.ResourceData, meta interface{
 		}
 		return fmt.Errorf("error deleting Elasticache Cache Cluster (%s): %s", d.Id(), err)
 	}
-	err = deleteElasticacheCacheClusterWaiter(conn, d.Id(), 40*time.Minute)
+	err = waitForDeleteElasticacheCacheCluster(conn, d.Id(), 40*time.Minute)
 	if err != nil {
 		return fmt.Errorf("error waiting for Elasticache Cache Cluster (%s) to be deleted: %s", d.Id(), err)
 	}
@@ -768,7 +768,7 @@ func createElasticacheCacheCluster(conn *elasticache.ElastiCache, input *elastic
 	return strings.ToLower(aws.StringValue(output.CacheCluster.CacheClusterId)), nil
 }
 
-func createElasticacheCacheClusterWaiter(conn *elasticache.ElastiCache, cacheClusterID string, timeout time.Duration) error {
+func waitForCreateElasticacheCacheCluster(conn *elasticache.ElastiCache, cacheClusterID string, timeout time.Duration) error {
 	pending := []string{"creating", "modifying", "restoring", "snapshotting"}
 	stateConf := &resource.StateChangeConf{
 		Pending:    pending,
@@ -807,7 +807,7 @@ func deleteElasticacheCacheCluster(conn *elasticache.ElastiCache, cacheClusterID
 	return err
 }
 
-func deleteElasticacheCacheClusterWaiter(conn *elasticache.ElastiCache, cacheClusterID string, timeout time.Duration) error {
+func waitForDeleteElasticacheCacheCluster(conn *elasticache.ElastiCache, cacheClusterID string, timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"creating", "available", "deleting", "incompatible-parameters", "incompatible-network", "restore-failed", "snapshotting"},
 		Target:     []string{},

--- a/aws/resource_aws_elasticache_cluster_test.go
+++ b/aws/resource_aws_elasticache_cluster_test.go
@@ -62,9 +62,13 @@ func testSweepElasticacheClusters(region string) error {
 				continue
 			}
 			log.Printf("[INFO] Deleting Elasticache Cluster: %s", id)
-			err := deleteElasticacheCluster(id, 40*time.Minute, conn)
+			err := deleteElasticacheCacheCluster(conn, id)
 			if err != nil {
-				log.Printf("[ERROR] Failed to delete Elasticache Cluster (%s): %s", id, err)
+				log.Printf("[ERROR] Failed to delete Elasticache Cache Cluster (%s): %s", id, err)
+			}
+			err = deleteElasticacheCacheClusterWaiter(conn, id, 40*time.Minute)
+			if err != nil {
+				log.Printf("[ERROR] Failed waiting for Elasticache Cache Cluster (%s) to be deleted: %s", id, err)
 			}
 		}
 		return !isLast

--- a/aws/resource_aws_elasticache_cluster_test.go
+++ b/aws/resource_aws_elasticache_cluster_test.go
@@ -66,7 +66,7 @@ func testSweepElasticacheClusters(region string) error {
 			if err != nil {
 				log.Printf("[ERROR] Failed to delete Elasticache Cache Cluster (%s): %s", id, err)
 			}
-			err = deleteElasticacheCacheClusterWaiter(conn, id, 40*time.Minute)
+			err = waitForDeleteElasticacheCacheCluster(conn, id, 40*time.Minute)
 			if err != nil {
 				log.Printf("[ERROR] Failed waiting for Elasticache Cache Cluster (%s) to be deleted: %s", id, err)
 			}

--- a/aws/resource_aws_elasticache_replication_group.go
+++ b/aws/resource_aws_elasticache_replication_group.go
@@ -48,7 +48,6 @@ func resourceAwsElasticacheReplicationGroup() *schema.Resource {
 		Type:     schema.TypeInt,
 		Computed: true,
 		Optional: true,
-		ForceNew: true,
 	}
 
 	resourceSchema["primary_endpoint_address"] = &schema.Schema{
@@ -405,20 +404,169 @@ func resourceAwsElasticacheReplicationGroupUpdate(d *schema.ResourceData, meta i
 			return fmt.Errorf("error modifying Elasticache Replication Group shard configuration: %s", err)
 		}
 
-		pending := []string{"creating", "modifying", "snapshotting"}
-		stateConf := &resource.StateChangeConf{
-			Pending:    pending,
-			Target:     []string{"available"},
-			Refresh:    cacheReplicationGroupStateRefreshFunc(conn, d.Id(), "available", pending),
-			Timeout:    d.Timeout(schema.TimeoutUpdate),
-			MinTimeout: 10 * time.Second,
-			Delay:      30 * time.Second,
-		}
-
-		log.Printf("[DEBUG] Waiting for Elasticache Replication Group (%s) shard reconfiguration completion", d.Id())
-		_, err = stateConf.WaitForState()
+		err = modifyElasticacheReplicationGroupWaiter(conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
 			return fmt.Errorf("error waiting for Elasticache Replication Group (%s) shard reconfiguration completion: %s", d.Id(), err)
+		}
+	}
+
+	if d.HasChange("number_cache_clusters") {
+		o, n := d.GetChange("number_cache_clusters")
+		oldNumberCacheClusters := o.(int)
+		newNumberCacheClusters := n.(int)
+
+		// We will try to use similar naming to the console, which are 1 indexed: RGID-001 through RGID-006
+		var addClusterIDs, removeClusterIDs []string
+		for clusterID := oldNumberCacheClusters + 1; clusterID <= newNumberCacheClusters; clusterID++ {
+			addClusterIDs = append(addClusterIDs, fmt.Sprintf("%s-%03d", d.Id(), clusterID))
+		}
+		for clusterID := oldNumberCacheClusters; clusterID >= (newNumberCacheClusters + 1); clusterID-- {
+			removeClusterIDs = append(removeClusterIDs, fmt.Sprintf("%s-%03d", d.Id(), clusterID))
+		}
+
+		if len(addClusterIDs) > 0 {
+			// Kick off all the Cache Cluster creations
+			for _, cacheClusterID := range addClusterIDs {
+				input := &elasticache.CreateCacheClusterInput{
+					CacheClusterId:     aws.String(cacheClusterID),
+					ReplicationGroupId: aws.String(d.Id()),
+				}
+				_, err := createElasticacheCacheCluster(conn, input)
+				if err != nil {
+					// Future enhancement: we could retry creation with random ID on naming collision
+					// if isAWSErr(err, elasticache.ErrCodeCacheClusterAlreadyExistsFault, "") { ... }
+					return fmt.Errorf("error creating Elasticache Cache Cluster (adding replica): %s", err)
+				}
+			}
+
+			// Wait for all Cache Cluster creations
+			for _, cacheClusterID := range addClusterIDs {
+				err := createElasticacheCacheClusterWaiter(conn, cacheClusterID, d.Timeout(schema.TimeoutUpdate))
+				if err != nil {
+					return fmt.Errorf("error waiting for Elasticache Cache Cluster (%s) to be created (adding replica): %s", cacheClusterID, err)
+				}
+			}
+		}
+
+		if len(removeClusterIDs) > 0 {
+			// Cannot reassign primary cluster ID while automatic failover is enabled
+			// If we temporarily disable automatic failover, ensure we re-enable it
+			reEnableAutomaticFailover := false
+
+			// Kick off all the Cache Cluster deletions
+			for _, cacheClusterID := range removeClusterIDs {
+				err := deleteElasticacheCacheCluster(conn, cacheClusterID)
+				if err != nil {
+					// Future enhancement: we could retry deletion with random existing ID on missing name
+					// if isAWSErr(err, elasticache.ErrCodeCacheClusterNotFoundFault, "") { ... }
+					if !isAWSErr(err, elasticache.ErrCodeInvalidCacheClusterStateFault, "serving as primary") {
+						return fmt.Errorf("error deleting Elasticache Cache Cluster (%s) (removing replica): %s", cacheClusterID, err)
+					}
+
+					// Use Replication Group MemberClusters to find a new primary cache cluster ID
+					// that is not in removeClusterIDs
+					newPrimaryClusterID := ""
+
+					describeReplicationGroupInput := &elasticache.DescribeReplicationGroupsInput{
+						ReplicationGroupId: aws.String(d.Id()),
+					}
+					log.Printf("[DEBUG] Reading Elasticache Replication Group: %s", describeReplicationGroupInput)
+					output, err := conn.DescribeReplicationGroups(describeReplicationGroupInput)
+					if err != nil {
+						return fmt.Errorf("error reading Elasticache Replication Group (%s) to determine new primary: %s", d.Id(), err)
+					}
+					if output == nil || len(output.ReplicationGroups) == 0 || len(output.ReplicationGroups[0].MemberClusters) == 0 {
+						return fmt.Errorf("error reading Elasticache Replication Group (%s) to determine new primary: missing replication group information", d.Id())
+					}
+
+					for _, memberClusterPtr := range output.ReplicationGroups[0].MemberClusters {
+						memberCluster := aws.StringValue(memberClusterPtr)
+						memberClusterInRemoveClusterIDs := false
+						for _, removeClusterID := range removeClusterIDs {
+							if memberCluster == removeClusterID {
+								memberClusterInRemoveClusterIDs = true
+								break
+							}
+						}
+						if !memberClusterInRemoveClusterIDs {
+							newPrimaryClusterID = memberCluster
+							break
+						}
+					}
+					if newPrimaryClusterID == "" {
+						return fmt.Errorf("error reading Elasticache Replication Group (%s) to determine new primary: unable to assign new primary", d.Id())
+					}
+
+					// Disable automatic failover if enabled
+					// Must be applied previous to trying to set new primary
+					// InvalidReplicationGroupState: Cannot manually promote a new master cache cluster while autofailover is enabled
+					if aws.StringValue(output.ReplicationGroups[0].AutomaticFailover) == elasticache.AutomaticFailoverStatusEnabled {
+						// Be kind and rewind
+						if d.Get("automatic_failover_enabled").(bool) {
+							reEnableAutomaticFailover = true
+						}
+
+						modifyReplicationGroupInput := &elasticache.ModifyReplicationGroupInput{
+							ApplyImmediately:         aws.Bool(true),
+							AutomaticFailoverEnabled: aws.Bool(false),
+							ReplicationGroupId:       aws.String(d.Id()),
+						}
+						log.Printf("[DEBUG] Modifying Elasticache Replication Group: %s", modifyReplicationGroupInput)
+						_, err = conn.ModifyReplicationGroup(modifyReplicationGroupInput)
+						if err != nil {
+							return fmt.Errorf("error modifying Elasticache Replication Group (%s) to set new primary: %s", d.Id(), err)
+						}
+						err = modifyElasticacheReplicationGroupWaiter(conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
+						if err != nil {
+							return fmt.Errorf("error waiting for Elasticache Replication Group (%s) to be available: %s", d.Id(), err)
+						}
+					}
+
+					// Set new primary
+					modifyReplicationGroupInput := &elasticache.ModifyReplicationGroupInput{
+						ApplyImmediately:   aws.Bool(true),
+						PrimaryClusterId:   aws.String(newPrimaryClusterID),
+						ReplicationGroupId: aws.String(d.Id()),
+					}
+					log.Printf("[DEBUG] Modifying Elasticache Replication Group: %s", modifyReplicationGroupInput)
+					_, err = conn.ModifyReplicationGroup(modifyReplicationGroupInput)
+					if err != nil {
+						return fmt.Errorf("error modifying Elasticache Replication Group (%s) to set new primary: %s", d.Id(), err)
+					}
+					err = modifyElasticacheReplicationGroupWaiter(conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
+					if err != nil {
+						return fmt.Errorf("error waiting for Elasticache Replication Group (%s) to be available: %s", d.Id(), err)
+					}
+
+					// Finally retry deleting the cache cluster
+					err = deleteElasticacheCacheCluster(conn, cacheClusterID)
+					if err != nil {
+						return fmt.Errorf("error deleting Elasticache Cache Cluster (%s) (removing replica after setting new primary): %s", cacheClusterID, err)
+					}
+				}
+			}
+
+			// Wait for all Cache Cluster deletions
+			for _, cacheClusterID := range removeClusterIDs {
+				err := deleteElasticacheCacheClusterWaiter(conn, cacheClusterID, d.Timeout(schema.TimeoutUpdate))
+				if err != nil {
+					return fmt.Errorf("error waiting for Elasticache Cache Cluster (%s) to be deleted (removing replica): %s", cacheClusterID, err)
+				}
+			}
+
+			// Re-enable automatic failover if we needed to temporarily disable it
+			if reEnableAutomaticFailover {
+				input := &elasticache.ModifyReplicationGroupInput{
+					ApplyImmediately:         aws.Bool(true),
+					AutomaticFailoverEnabled: aws.Bool(true),
+					ReplicationGroupId:       aws.String(d.Id()),
+				}
+				log.Printf("[DEBUG] Modifying Elasticache Replication Group: %s", input)
+				_, err := conn.ModifyReplicationGroup(input)
+				if err != nil {
+					return fmt.Errorf("error modifying Elasticache Replication Group (%s) to re-enable automatic failover: %s", d.Id(), err)
+				}
+			}
 		}
 	}
 
@@ -501,23 +649,12 @@ func resourceAwsElasticacheReplicationGroupUpdate(d *schema.ResourceData, meta i
 	if requestUpdate {
 		_, err := conn.ModifyReplicationGroup(params)
 		if err != nil {
-			return fmt.Errorf("Error updating Elasticache replication group: %s", err)
+			return fmt.Errorf("error updating Elasticache Replication Group (%s): %s", d.Id(), err)
 		}
 
-		pending := []string{"creating", "modifying", "snapshotting"}
-		stateConf := &resource.StateChangeConf{
-			Pending:    pending,
-			Target:     []string{"available"},
-			Refresh:    cacheReplicationGroupStateRefreshFunc(conn, d.Id(), "available", pending),
-			Timeout:    d.Timeout(schema.TimeoutUpdate),
-			MinTimeout: 10 * time.Second,
-			Delay:      30 * time.Second,
-		}
-
-		log.Printf("[DEBUG] Waiting for state to become available: %v", d.Id())
-		_, sterr := stateConf.WaitForState()
-		if sterr != nil {
-			return fmt.Errorf("Error waiting for elasticache replication group (%s) to be created: %s", d.Id(), sterr)
+		err = modifyElasticacheReplicationGroupWaiter(conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			return fmt.Errorf("error waiting for Elasticache Replication Group (%s) to be updated: %s", d.Id(), err)
 		}
 	}
 	return resourceAwsElasticacheReplicationGroupRead(d, meta)
@@ -586,11 +723,23 @@ func deleteElasticacheReplicationGroup(replicationGroupID string, timeout time.D
 		ReplicationGroupId: aws.String(replicationGroupID),
 	}
 
-	_, err := conn.DeleteReplicationGroup(input)
-	if err != nil {
-		if isAWSErr(err, elasticache.ErrCodeReplicationGroupNotFoundFault, "") {
-			return nil
+	// 10 minutes should give any creating/deleting cache clusters or snapshots time to complete
+	err := resource.Retry(10*time.Minute, func() *resource.RetryError {
+		_, err := conn.DeleteReplicationGroup(input)
+		if err != nil {
+			if isAWSErr(err, elasticache.ErrCodeReplicationGroupNotFoundFault, "") {
+				return nil
+			}
+			// Cache Cluster is creating/deleting or Replication Group is snapshotting
+			// InvalidReplicationGroupState: Cache cluster tf-acc-test-uqhe-003 is not in a valid state to be deleted
+			if isAWSErr(err, elasticache.ErrCodeInvalidReplicationGroupStateFault, "") {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
 		}
+		return nil
+	})
+	if err != nil {
 		return err
 	}
 
@@ -625,6 +774,22 @@ func flattenElasticacheNodeGroupsToClusterMode(clusterEnabled bool, nodeGroups [
 	m["num_node_groups"] = len(nodeGroups)
 	m["replicas_per_node_group"] = (len(nodeGroups[0].NodeGroupMembers) - 1)
 	return []map[string]interface{}{m}
+}
+
+func modifyElasticacheReplicationGroupWaiter(conn *elasticache.ElastiCache, replicationGroupID string, timeout time.Duration) error {
+	pending := []string{"creating", "modifying", "snapshotting"}
+	stateConf := &resource.StateChangeConf{
+		Pending:    pending,
+		Target:     []string{"available"},
+		Refresh:    cacheReplicationGroupStateRefreshFunc(conn, replicationGroupID, "available", pending),
+		Timeout:    timeout,
+		MinTimeout: 10 * time.Second,
+		Delay:      30 * time.Second,
+	}
+
+	log.Printf("[DEBUG] Waiting for Elasticache Replication Group (%s) to become available", replicationGroupID)
+	_, err := stateConf.WaitForState()
+	return err
 }
 
 func validateAwsElastiCacheReplicationGroupEngine(v interface{}, k string) (ws []string, errors []error) {

--- a/aws/resource_aws_elasticache_replication_group.go
+++ b/aws/resource_aws_elasticache_replication_group.go
@@ -404,7 +404,7 @@ func resourceAwsElasticacheReplicationGroupUpdate(d *schema.ResourceData, meta i
 			return fmt.Errorf("error modifying Elasticache Replication Group shard configuration: %s", err)
 		}
 
-		err = modifyElasticacheReplicationGroupWaiter(conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
+		err = waitForModifyElasticacheReplicationGroup(conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
 			return fmt.Errorf("error waiting for Elasticache Replication Group (%s) shard reconfiguration completion: %s", d.Id(), err)
 		}
@@ -441,7 +441,7 @@ func resourceAwsElasticacheReplicationGroupUpdate(d *schema.ResourceData, meta i
 
 			// Wait for all Cache Cluster creations
 			for _, cacheClusterID := range addClusterIDs {
-				err := createElasticacheCacheClusterWaiter(conn, cacheClusterID, d.Timeout(schema.TimeoutUpdate))
+				err := waitForCreateElasticacheCacheCluster(conn, cacheClusterID, d.Timeout(schema.TimeoutUpdate))
 				if err != nil {
 					return fmt.Errorf("error waiting for Elasticache Cache Cluster (%s) to be created (adding replica): %s", cacheClusterID, err)
 				}
@@ -516,7 +516,7 @@ func resourceAwsElasticacheReplicationGroupUpdate(d *schema.ResourceData, meta i
 						if err != nil {
 							return fmt.Errorf("error modifying Elasticache Replication Group (%s) to set new primary: %s", d.Id(), err)
 						}
-						err = modifyElasticacheReplicationGroupWaiter(conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
+						err = waitForModifyElasticacheReplicationGroup(conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
 						if err != nil {
 							return fmt.Errorf("error waiting for Elasticache Replication Group (%s) to be available: %s", d.Id(), err)
 						}
@@ -533,7 +533,7 @@ func resourceAwsElasticacheReplicationGroupUpdate(d *schema.ResourceData, meta i
 					if err != nil {
 						return fmt.Errorf("error modifying Elasticache Replication Group (%s) to set new primary: %s", d.Id(), err)
 					}
-					err = modifyElasticacheReplicationGroupWaiter(conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
+					err = waitForModifyElasticacheReplicationGroup(conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
 					if err != nil {
 						return fmt.Errorf("error waiting for Elasticache Replication Group (%s) to be available: %s", d.Id(), err)
 					}
@@ -548,7 +548,7 @@ func resourceAwsElasticacheReplicationGroupUpdate(d *schema.ResourceData, meta i
 
 			// Wait for all Cache Cluster deletions
 			for _, cacheClusterID := range removeClusterIDs {
-				err := deleteElasticacheCacheClusterWaiter(conn, cacheClusterID, d.Timeout(schema.TimeoutUpdate))
+				err := waitForDeleteElasticacheCacheCluster(conn, cacheClusterID, d.Timeout(schema.TimeoutUpdate))
 				if err != nil {
 					return fmt.Errorf("error waiting for Elasticache Cache Cluster (%s) to be deleted (removing replica): %s", cacheClusterID, err)
 				}
@@ -652,7 +652,7 @@ func resourceAwsElasticacheReplicationGroupUpdate(d *schema.ResourceData, meta i
 			return fmt.Errorf("error updating Elasticache Replication Group (%s): %s", d.Id(), err)
 		}
 
-		err = modifyElasticacheReplicationGroupWaiter(conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
+		err = waitForModifyElasticacheReplicationGroup(conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
 			return fmt.Errorf("error waiting for Elasticache Replication Group (%s) to be updated: %s", d.Id(), err)
 		}
@@ -776,7 +776,7 @@ func flattenElasticacheNodeGroupsToClusterMode(clusterEnabled bool, nodeGroups [
 	return []map[string]interface{}{m}
 }
 
-func modifyElasticacheReplicationGroupWaiter(conn *elasticache.ElastiCache, replicationGroupID string, timeout time.Duration) error {
+func waitForModifyElasticacheReplicationGroup(conn *elasticache.ElastiCache, replicationGroupID string, timeout time.Duration) error {
 	pending := []string{"creating", "modifying", "snapshotting"}
 	stateConf := &resource.StateChangeConf{
 		Pending:    pending,

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -545,7 +545,7 @@ func TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFail
 					if _, err := conn.ModifyReplicationGroup(input); err != nil {
 						t.Fatalf("error setting new primary cache cluster: %s", err)
 					}
-					if err := modifyElasticacheReplicationGroupWaiter(conn, rName, 40*time.Minute); err != nil {
+					if err := waitForModifyElasticacheReplicationGroup(conn, rName, 40*time.Minute); err != nil {
 						t.Fatalf("error waiting for new primary cache cluster: %s", err)
 					}
 				},
@@ -593,7 +593,7 @@ func TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFail
 					if _, err := conn.ModifyReplicationGroup(input); err != nil {
 						t.Fatalf("error disabling automatic failover: %s", err)
 					}
-					if err := modifyElasticacheReplicationGroupWaiter(conn, rName, 40*time.Minute); err != nil {
+					if err := waitForModifyElasticacheReplicationGroup(conn, rName, 40*time.Minute); err != nil {
 						t.Fatalf("error waiting for disabling automatic failover: %s", err)
 					}
 
@@ -606,7 +606,7 @@ func TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFail
 					if _, err := conn.ModifyReplicationGroup(input); err != nil {
 						t.Fatalf("error setting new primary cache cluster: %s", err)
 					}
-					if err := modifyElasticacheReplicationGroupWaiter(conn, rName, 40*time.Minute); err != nil {
+					if err := waitForModifyElasticacheReplicationGroup(conn, rName, 40*time.Minute); err != nil {
 						t.Fatalf("error waiting for new primary cache cluster: %s", err)
 					}
 
@@ -619,7 +619,7 @@ func TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFail
 					if _, err := conn.ModifyReplicationGroup(input); err != nil {
 						t.Fatalf("error enabled automatic failover: %s", err)
 					}
-					if err := modifyElasticacheReplicationGroupWaiter(conn, rName, 40*time.Minute); err != nil {
+					if err := waitForModifyElasticacheReplicationGroup(conn, rName, 40*time.Minute); err != nil {
 						t.Fatalf("error waiting for enabled automatic failover: %s", err)
 					}
 				},

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -477,6 +477,163 @@ func TestAccAWSElasticacheReplicationGroup_enableAtRestEncryption(t *testing.T) 
 	})
 }
 
+func TestAccAWSElasticacheReplicationGroup_NumberCacheClusters(t *testing.T) {
+	var replicationGroup elasticache.ReplicationGroup
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(4))
+	resourceName := "aws_elasticache_replication_group.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheReplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSElasticacheReplicationGroupConfig_NumberCacheClusters(rName, 2, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &replicationGroup),
+					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "2"),
+				),
+			},
+			{
+				Config: testAccAWSElasticacheReplicationGroupConfig_NumberCacheClusters(rName, 4, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &replicationGroup),
+					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "4"),
+				),
+			},
+			{
+				Config: testAccAWSElasticacheReplicationGroupConfig_NumberCacheClusters(rName, 2, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &replicationGroup),
+					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverDisabled(t *testing.T) {
+	var replicationGroup elasticache.ReplicationGroup
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(4))
+	resourceName := "aws_elasticache_replication_group.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheReplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSElasticacheReplicationGroupConfig_NumberCacheClusters(rName, 3, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &replicationGroup),
+					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "3"),
+				),
+			},
+			{
+				PreConfig: func() {
+					// Simulate failover so primary is on node we are trying to delete
+					conn := testAccProvider.Meta().(*AWSClient).elasticacheconn
+					input := &elasticache.ModifyReplicationGroupInput{
+						ApplyImmediately:   aws.Bool(true),
+						PrimaryClusterId:   aws.String(fmt.Sprintf("%s-003", rName)),
+						ReplicationGroupId: aws.String(rName),
+					}
+					if _, err := conn.ModifyReplicationGroup(input); err != nil {
+						t.Fatalf("error setting new primary cache cluster: %s", err)
+					}
+					if err := modifyElasticacheReplicationGroupWaiter(conn, rName, 40*time.Minute); err != nil {
+						t.Fatalf("error waiting for new primary cache cluster: %s", err)
+					}
+				},
+				Config: testAccAWSElasticacheReplicationGroupConfig_NumberCacheClusters(rName, 2, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &replicationGroup),
+					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverEnabled(t *testing.T) {
+	var replicationGroup elasticache.ReplicationGroup
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(4))
+	resourceName := "aws_elasticache_replication_group.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheReplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSElasticacheReplicationGroupConfig_NumberCacheClusters(rName, 3, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &replicationGroup),
+					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "3"),
+				),
+			},
+			{
+				PreConfig: func() {
+					// Simulate failover so primary is on node we are trying to delete
+					conn := testAccProvider.Meta().(*AWSClient).elasticacheconn
+					var input *elasticache.ModifyReplicationGroupInput
+
+					// Must disable automatic failover first
+					input = &elasticache.ModifyReplicationGroupInput{
+						ApplyImmediately:         aws.Bool(true),
+						AutomaticFailoverEnabled: aws.Bool(false),
+						ReplicationGroupId:       aws.String(rName),
+					}
+					if _, err := conn.ModifyReplicationGroup(input); err != nil {
+						t.Fatalf("error disabling automatic failover: %s", err)
+					}
+					if err := modifyElasticacheReplicationGroupWaiter(conn, rName, 40*time.Minute); err != nil {
+						t.Fatalf("error waiting for disabling automatic failover: %s", err)
+					}
+
+					// Failover
+					input = &elasticache.ModifyReplicationGroupInput{
+						ApplyImmediately:   aws.Bool(true),
+						PrimaryClusterId:   aws.String(fmt.Sprintf("%s-003", rName)),
+						ReplicationGroupId: aws.String(rName),
+					}
+					if _, err := conn.ModifyReplicationGroup(input); err != nil {
+						t.Fatalf("error setting new primary cache cluster: %s", err)
+					}
+					if err := modifyElasticacheReplicationGroupWaiter(conn, rName, 40*time.Minute); err != nil {
+						t.Fatalf("error waiting for new primary cache cluster: %s", err)
+					}
+
+					// Re-enable automatic failover like nothing ever happened
+					input = &elasticache.ModifyReplicationGroupInput{
+						ApplyImmediately:         aws.Bool(true),
+						AutomaticFailoverEnabled: aws.Bool(true),
+						ReplicationGroupId:       aws.String(rName),
+					}
+					if _, err := conn.ModifyReplicationGroup(input); err != nil {
+						t.Fatalf("error enabled automatic failover: %s", err)
+					}
+					if err := modifyElasticacheReplicationGroupWaiter(conn, rName, 40*time.Minute); err != nil {
+						t.Fatalf("error waiting for enabled automatic failover: %s", err)
+					}
+				},
+				Config: testAccAWSElasticacheReplicationGroupConfig_NumberCacheClusters(rName, 2, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &replicationGroup),
+					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "2"),
+				),
+			},
+		},
+	})
+}
+
 func TestResourceAWSElastiCacheReplicationGroupIdValidation(t *testing.T) {
 	cases := []struct {
 		Value    string
@@ -1248,4 +1405,44 @@ resource "aws_elasticache_replication_group" "bar" {
   auth_token = "%s"
 }
 `, rInt, rInt, rString10, rString16)
+}
+
+func testAccAWSElasticacheReplicationGroupConfig_NumberCacheClusters(rName string, numberCacheClusters int, autoFailover bool) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc" "test" {
+  cidr_block = "192.168.0.0/16"
+  tags {
+      Name = "terraform-testacc-elasticache-replication-group-number-cache-clusters"
+  }
+}
+
+resource "aws_subnet" "test" {
+  count = 2
+
+  availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
+  cidr_block        = "192.168.${count.index}.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
+
+  tags {
+    Name = "tf-acc-elasticache-replication-group-number-cache-clusters"
+  }
+}
+
+resource "aws_elasticache_subnet_group" "test" {
+  name       = "%[1]s"
+  subnet_ids = ["${aws_subnet.test.*.id}"]
+}
+
+resource "aws_elasticache_replication_group" "test" {
+  # InvalidParameterCombination: Automatic failover is not supported for T1 and T2 cache node types.
+  automatic_failover_enabled    = %[2]t
+  node_type                     = "cache.m3.medium"
+  number_cache_clusters         = %[3]d
+  parameter_group_name          = "default.redis3.2"
+  replication_group_id          = "%[1]s"
+  replication_group_description = "Terraform Acceptance Testing - number_cache_clusters"
+  subnet_group_name             = "${aws_elasticache_subnet_group.test.name}"
+}`, rName, autoFailover, numberCacheClusters)
 }

--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -31,7 +31,10 @@ resource "aws_elasticache_replication_group" "example" {
 }
 ```
 
-Additional read replicas can be added or removed with the [`aws_elasticache_cluster` resource](/docs/providers/aws/r/elasticache_cluster.html) and its `replication_group_id` attribute. In this situation, you will need to utilize the [lifecycle configuration block](/docs/configuration/resources.html) with `ignore_changes` to prevent replication group recreation.
+You have two options for adjusting the number of replicas:
+
+* Adjusting `number_cache_clusters` directly. This will attempt to automatically add or remove replicas, but provides no granular control (e.g. preferred availability zone, cache cluster ID) for the added or removed replicas. This also currently expects cache cluster IDs in the form of `replication_group_id-00#`.
+* Otherwise for fine grained control of the underlying cache clusters, they can be added or removed with the [`aws_elasticache_cluster` resource](/docs/providers/aws/r/elasticache_cluster.html) and its `replication_group_id` attribute. In this situation, you will need to utilize the [lifecycle configuration block](/docs/configuration/resources.html) with `ignore_changes` to prevent perpetual differences during Terraform plan with the `number_cache_cluster` attribute.
 
 ```hcl
 resource "aws_elasticache_replication_group" "example" {
@@ -89,8 +92,7 @@ The following arguments are supported:
 
 * `replication_group_id` – (Required) The replication group identifier. This parameter is stored as a lowercase string.
 * `replication_group_description` – (Required) A user-created description for the replication group.
-* `number_cache_clusters` - (Required) The number of cache clusters this replication group will have.
- If Multi-AZ is enabled , the value of this parameter must be at least 2. Changing this number will force a new resource
+* `number_cache_clusters` - (Required for Cluster Mode Disabled) The number of cache clusters (primary and replicas) this replication group will have. If Multi-AZ is enabled, the value of this parameter must be at least 2. Updates will occur before other modifications.
 * `node_type` - (Required) The compute and memory capacity of the nodes in the node group.
 * `automatic_failover_enabled` - (Optional) Specifies whether a read-only replica will be automatically promoted to read/write primary if the existing primary fails. If true, Multi-AZ is enabled for this replication group. If false, Multi-AZ is disabled for this replication group. Must be enabled for Redis (cluster mode enabled) replication groups. Defaults to `false`.
 * `auto_minor_version_upgrade` - (Optional) Specifies whether a minor engine upgrades will be applied automatically to the underlying Cache Cluster instances during the maintenance window. Defaults to `true`.
@@ -146,7 +148,7 @@ configuration options:
 
 * `create` - (Default `60m`) How long to wait for a replication group to be created.
 * `delete` - (Default `40m`) How long to wait for a replication group to be deleted.
-* `update` - (Default `40m`) How long to wait for replication group settings to be updated. This is also separately used for online resize operation completion, if necessary.
+* `update` - (Default `40m`) How long to wait for replication group settings to be updated. This is also separately used for adding/removing replicas and online resize operation completion, if necessary.
 
 ## Import
 


### PR DESCRIPTION
Fixes #236 

Changes proposed in this pull request:

* Allow updates to `number_cache_nodes` argument
  * Try to stay consistent with console naming
  * Automatically handle failover if attempting to delete primary
* Document scaling usage as compared to previously available option of using `aws_elasticache_cluster` resource

Output from acceptance testing (test failure unrelated):

```
Tests failed: 1 (1 new), passed: 36
=== RUN   TestAccAWSElasticacheCluster_ReplicationGroupID_InvalidAttributes
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_InvalidAttributes (3.45s)
=== RUN   TestAccAWSElasticacheCluster_NumCacheNodes_Redis_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Redis_Ec2Classic (3.62s)
=== RUN   TestAccAWSElasticacheCluster_AZMode_Memcached_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_AZMode_Memcached_Ec2Classic (434.56s)
=== RUN   TestAccAWSElasticacheCluster_AZMode_Redis_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_AZMode_Redis_Ec2Classic (482.56s)
=== RUN   TestAccAWSElasticacheCluster_Engine_Memcached_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_Engine_Memcached_Ec2Classic (504.61s)
=== RUN   TestAccAWSElasticacheCluster_Engine_Redis_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_Engine_Redis_Ec2Classic (525.53s)
=== RUN   TestAccAWSElasticacheCluster_Port_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_Port_Ec2Classic (630.12s)
=== RUN   TestAccAWSElasticacheCluster_vpc
--- PASS: TestAccAWSElasticacheCluster_vpc (687.58s)
=== RUN   TestAccAWSElasticacheCluster_SecurityGroup
--- PASS: TestAccAWSElasticacheCluster_SecurityGroup (725.70s)
=== RUN   TestAccAWSElasticacheReplicationGroup_Uppercase
--- PASS: TestAccAWSElasticacheReplicationGroup_Uppercase (743.46s)
=== RUN   TestAccAWSElasticacheCluster_NodeTypeResize_Redis_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_NodeTypeResize_Redis_Ec2Classic (772.43s)
=== RUN   TestAccAWSElasticacheReplicationGroup_clusteringAndCacheNodesCausesError
--- PASS: TestAccAWSElasticacheReplicationGroup_clusteringAndCacheNodesCausesError (6.32s)
=== RUN   TestAccAWSElasticacheCluster_multiAZInVpc
--- FAIL: TestAccAWSElasticacheCluster_multiAZInVpc (806.66s)
=== RUN   TestAccAWSElasticacheCluster_NodeTypeResize_Memcached_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_NodeTypeResize_Memcached_Ec2Classic (918.11s)
=== RUN   TestAccAWSElasticacheReplicationGroup_importBasic
--- PASS: TestAccAWSElasticacheReplicationGroup_importBasic (979.19s)
=== RUN   TestAccAWSElasticacheReplicationGroup_updateDescription
--- PASS: TestAccAWSElasticacheReplicationGroup_updateDescription (1017.31s)
=== RUN   TestAccAWSElasticacheCluster_EngineVersion_Memcached_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_EngineVersion_Memcached_Ec2Classic (1111.13s)
=== RUN   TestAccAWSElasticacheCluster_ReplicationGroupID_SingleReplica_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_SingleReplica_Ec2Classic (1119.90s)
=== RUN   TestAccAWSElasticacheCluster_ReplicationGroupID_MultipleReplica_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_MultipleReplica_Ec2Classic (1125.24s)
=== RUN   TestAccAWSElasticacheCluster_decreasingCacheNodes
--- PASS: TestAccAWSElasticacheCluster_decreasingCacheNodes (1156.84s)
=== RUN   TestAccAWSElasticacheCluster_snapshotsWithUpdates
--- PASS: TestAccAWSElasticacheCluster_snapshotsWithUpdates (1165.91s)
=== RUN   TestAccAWSElasticacheCluster_EngineVersion_Redis_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_EngineVersion_Redis_Ec2Classic (1177.59s)
=== RUN   TestAccAWSElasticacheReplicationGroup_vpc
--- PASS: TestAccAWSElasticacheReplicationGroup_vpc (777.64s)
=== RUN   TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow
--- PASS: TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow (1113.64s)
=== RUN   TestAccAWSElasticacheReplicationGroup_enableAtRestEncryption
--- PASS: TestAccAWSElasticacheReplicationGroup_enableAtRestEncryption (656.60s)
=== RUN   TestAccAWSElasticacheReplicationGroup_enableAuthTokenTransitEncryption
--- PASS: TestAccAWSElasticacheReplicationGroup_enableAuthTokenTransitEncryption (948.65s)
=== RUN   TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2
--- PASS: TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2 (1070.61s)
=== RUN   TestAccAWSElasticacheReplicationGroup_multiAzInVpc
--- PASS: TestAccAWSElasticacheReplicationGroup_multiAzInVpc (1312.61s)
=== RUN   TestAccAWSElasticacheReplicationGroup_ClusterMode_Basic
--- PASS: TestAccAWSElasticacheReplicationGroup_ClusterMode_Basic (1242.81s)
=== RUN   TestAccAWSElasticacheReplicationGroup_enableSnapshotting
--- PASS: TestAccAWSElasticacheReplicationGroup_enableSnapshotting (1238.68s)
=== RUN   TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverDisabled
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverDisabled (1391.20s)
=== RUN   TestAccAWSElasticacheReplicationGroup_NumberCacheClusters
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters (1589.91s)
=== RUN   TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverEnabled
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverEnabled (1803.12s)
=== RUN   TestAccAWSElasticacheReplicationGroup_updateParameterGroup
--- PASS: TestAccAWSElasticacheReplicationGroup_updateParameterGroup (2565.36s)
=== RUN   TestAccAWSElasticacheReplicationGroup_basic
--- PASS: TestAccAWSElasticacheReplicationGroup_basic (3108.46s)
=== RUN   TestAccAWSElasticacheReplicationGroup_ClusterMode_NumNodeGroups
--- PASS: TestAccAWSElasticacheReplicationGroup_ClusterMode_NumNodeGroups (3990.56s)
=== RUN   TestAccAWSElasticacheReplicationGroup_updateNodeSize
--- PASS: TestAccAWSElasticacheReplicationGroup_updateNodeSize (4280.50s)
```
