### PR TITLE
Add support for Azure SQL as a DMS endpoint

### DIFF
--- a/aws/resource_aws_dms_endpoint.go
+++ b/aws/resource_aws_dms_endpoint.go
@@ -74,6 +74,7 @@ func resourceAwsDmsEndpoint() *schema.Resource {
 					"sqlserver",
 					"mongodb",
 					"s3",
+					"azuredb",
 				}, false),
 			},
 			"extra_connection_attributes": {

--- a/website/docs/r/dms_endpoint.html.markdown
+++ b/website/docs/r/dms_endpoint.html.markdown
@@ -53,7 +53,7 @@ The following arguments are supported:
     - Must not contain two consecutive hyphens
 
 * `endpoint_type` - (Required) The type of endpoint. Can be one of `source | target`.
-* `engine_name` - (Required) The type of engine for the endpoint. Can be one of `mysql | oracle | postgres | mariadb | aurora | redshift | sybase | sqlserver | dynamodb | mongodb`.
+* `engine_name` - (Required) The type of engine for the endpoint. Can be one of `mysql | oracle | postgres | mariadb | aurora | redshift | sybase | sqlserver | dynamodb | mongodb | azuredb`.
 * `extra_connection_attributes` - (Optional) Additional attributes associated with the connection. For available attributes see [Using Extra Connection Attributes with AWS Database Migration Service](http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Introduction.ConnectionAttributes.html).
 * `kms_key_arn` - (Optional) The Amazon Resource Name (ARN) for the KMS key that will be used to encrypt the connection parameters. If you do not specify a value for `kms_key_arn`, then AWS DMS will use your default encryption key. AWS KMS creates the default encryption key for your AWS account. Your AWS account has a different default encryption key for each AWS region.
 * `password` - (Optional) The password to be used to login to the endpoint database.


### PR DESCRIPTION
Changes proposed in this pull request:

* `azuredb` added to the list of engines supported in DMS
* Documentation updated accordingly

Please see `aws dms create-endpoint help`, in particular its `engine-name` flag. No additional acceptance tests were added as it only depends on top-level attributes that are already present.

Thanks so much for reviewing.