### PR TITLE
resource/aws_lb: Ensure `access_logs` is properly set into Terraform state

### DIFF
--- a/aws/resource_aws_lb_test.go
+++ b/aws/resource_aws_lb_test.go
@@ -584,6 +584,11 @@ func TestAccAWSLB_accesslogs(t *testing.T) {
 					resource.TestCheckResourceAttrSet("aws_lb.lb_test", "arn"),
 				),
 			},
+			{
+				ResourceName:      "aws_lb.lb_test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }


### PR DESCRIPTION
Fixes #2969

Changes proposed in this pull request:

* Ensure we check for errors when setting the non-scalar `access_logs` attribute
* Fix `access_logs.0.enabled` handling to set it properly to a `bool`
* Add import test for access logs configuration

Previously (after error checking but before bool fix):

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSLB_accesslogs'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSLB_accesslogs -timeout 120m
=== RUN   TestAccAWSLB_accesslogs
--- FAIL: TestAccAWSLB_accesslogs (230.91s)
	testing.go:518: Step 1 error: Error applying: 1 error(s) occurred:

		* aws_lb.lb_test: 1 error(s) occurred:

		* aws_lb.lb_test: error setting access_logs: access_logs.0.enabled: '' expected type 'bool', got unconvertible type 'string'
	testing.go:579: Error destroying resource! WARNING: Dangling resources
		may exist. The full state and error is shown below.

		Error: Error refreshing: 1 error(s) occurred:

		* aws_lb.lb_test: aws_lb.lb_test: error setting access_logs: access_logs.0.enabled: '' expected type 'bool', got unconvertible type 'string'

		State: <nil>
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	230.950s
make: *** [testacc] Error 1
```

Now:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSLB_accesslogs'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSLB_accesslogs -timeout 120m
=== RUN   TestAccAWSLB_accesslogs
--- PASS: TestAccAWSLB_accesslogs (337.84s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	337.881s
```

Full acceptance test run (failures unrelated):
```
=== RUN   TestAccAWSLBListenerRule_multipleConditionThrowsError
--- PASS: TestAccAWSLBListenerRule_multipleConditionThrowsError (2.53s)
=== RUN   TestAccAWSLBSSLNegotiationPolicy_basic
--- PASS: TestAccAWSLBSSLNegotiationPolicy_basic (52.10s)
=== RUN   TestAccAWSLBTargetGroup_basic
--- PASS: TestAccAWSLBTargetGroup_basic (78.56s)
=== RUN   TestAccAWSLBSSLNegotiationPolicy_missingLB
--- PASS: TestAccAWSLBSSLNegotiationPolicy_missingLB (81.75s)
=== RUN   TestAccAWSLBCookieStickinessPolicy_missingLB
--- PASS: TestAccAWSLBCookieStickinessPolicy_missingLB (92.13s)
=== RUN   TestAccAWSLBCookieStickinessPolicy_basic
--- PASS: TestAccAWSLBCookieStickinessPolicy_basic (115.48s)
=== RUN   TestAccAWSLBCookieStickinessPolicy_drift
--- PASS: TestAccAWSLBCookieStickinessPolicy_drift (132.38s)
=== RUN   TestAccAWSLBTargetGroup_networkLB_TargetGroupWithProxy
--- PASS: TestAccAWSLBTargetGroup_networkLB_TargetGroupWithProxy (142.52s)
=== RUN   TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck
--- PASS: TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck (158.33s)
=== RUN   TestAccAWSLBTargetGroup_generatedName
--- PASS: TestAccAWSLBTargetGroup_generatedName (80.20s)
=== RUN   TestAccAWSLBTargetGroupAttachment_withoutPort
--- PASS: TestAccAWSLBTargetGroupAttachment_withoutPort (213.77s)
=== RUN   TestAccAWSLBListenerRuleBackwardsCompatibility
--- FAIL: TestAccAWSLBListenerRuleBackwardsCompatibility (261.87s)
=== RUN   TestAccAWSLBTargetGroup_namePrefix
--- PASS: TestAccAWSLBTargetGroup_namePrefix (248.64s)
=== RUN   TestAccAWSLBTargetGroup_changePortForceNew
--- PASS: TestAccAWSLBTargetGroup_changePortForceNew (231.92s)
=== RUN   TestAccAWSLBListenerRule_basic
--- PASS: TestAccAWSLBListenerRule_basic (367.72s)
=== RUN   TestAccAWSLBTargetGroup_defaults_application
--- PASS: TestAccAWSLBTargetGroup_defaults_application (108.53s)
=== RUN   TestAccAWSLBTargetGroup_stickinessWithTCPEnabledShouldError
--- PASS: TestAccAWSLBTargetGroup_stickinessWithTCPEnabledShouldError (2.99s)
=== RUN   TestAccAWSLBTargetGroup_updateSticknessEnabled
--- PASS: TestAccAWSLBTargetGroup_updateSticknessEnabled (182.56s)
=== RUN   TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew
--- PASS: TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew (434.46s)
=== RUN   TestAccAWSLBTargetGroup_changeNameForceNew
--- PASS: TestAccAWSLBTargetGroup_changeNameForceNew (366.05s)
=== RUN   TestAccAWSLBTargetGroup_defaults_network
--- PASS: TestAccAWSLBTargetGroup_defaults_network (135.57s)
=== RUN   TestAccAWSLBTargetGroup_tags
--- PASS: TestAccAWSLBTargetGroup_tags (303.55s)
=== RUN   TestAccAWSLBTargetGroup_stickinessWithTCPDisabled
--- PASS: TestAccAWSLBTargetGroup_stickinessWithTCPDisabled (107.58s)
=== RUN   TestAccAWSLBTargetGroupAttachment_basic
--- PASS: TestAccAWSLBTargetGroupAttachment_basic (484.84s)
=== RUN   TestAccAWSLBTargetGroup_changeProtocolForceNew
--- PASS: TestAccAWSLBTargetGroup_changeProtocolForceNew (385.54s)
=== RUN   TestAccAWSLBTargetGroupAttachmentBackwardsCompatibility
--- PASS: TestAccAWSLBTargetGroupAttachmentBackwardsCompatibility (517.03s)
=== RUN   TestAccAWSLBTargetGroup_changeVpcForceNew
--- PASS: TestAccAWSLBTargetGroup_changeVpcForceNew (377.90s)
=== RUN   TestAccAWSLBListener_basic
--- PASS: TestAccAWSLBListener_basic (599.95s)
=== RUN   TestAccAWSLBListenerRule_updateRulePriority
--- PASS: TestAccAWSLBListenerRule_updateRulePriority (612.61s)
=== RUN   TestAccAWSLBListenerBackwardsCompatibility
--- PASS: TestAccAWSLBListenerBackwardsCompatibility (624.24s)
=== RUN   TestAccAWSLBListener_https
--- PASS: TestAccAWSLBListener_https (657.69s)
=== RUN   TestAccAWSLBTargetGroupBackwardsCompatibility
--- FAIL: TestAccAWSLBTargetGroupBackwardsCompatibility (656.56s)
=== RUN   TestAccAWSLB_basic
--- PASS: TestAccAWSLB_basic (376.86s)
=== RUN   TestAccAWSLB_namePrefix
--- PASS: TestAccAWSLB_namePrefix (293.68s)
=== RUN   TestAccAWSLBListenerRule_priority
--- FAIL: TestAccAWSLBListenerRule_priority (836.36s)
=== RUN   TestAccAWSLB_tags
--- PASS: TestAccAWSLB_tags (385.03s)
=== RUN   TestAccAWSLB_generatedName
--- PASS: TestAccAWSLB_generatedName (408.94s)
=== RUN   TestAccAWSLBBackwardsCompatibility
--- PASS: TestAccAWSLBBackwardsCompatibility (461.87s)
=== RUN   TestAccAWSLB_generatesNameForZeroValue
--- PASS: TestAccAWSLB_generatesNameForZeroValue (446.47s)
=== RUN   TestAccAWSLB_networkLoadbalancerBasic
--- PASS: TestAccAWSLB_networkLoadbalancerBasic (539.49s)
=== RUN   TestAccAWSLB_noSecurityGroup
--- PASS: TestAccAWSLB_noSecurityGroup (287.60s)
=== RUN   TestAccAWSLB_networkLoadbalancerEIP
--- PASS: TestAccAWSLB_networkLoadbalancerEIP (542.18s)
=== RUN   TestAccAWSLBTargetGroup_updateHealthCheck
--- PASS: TestAccAWSLBTargetGroup_updateHealthCheck (796.71s)
=== RUN   TestAccAWSLB_applicationLoadBalancer_updateHttp2
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateHttp2 (512.96s)
=== RUN   TestAccAWSLB_updatedIpAddressType
--- PASS: TestAccAWSLB_updatedIpAddressType (405.95s)
=== RUN   TestAccAWSLB_applicationLoadBalancer_updateDeletionProtection
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateDeletionProtection (525.12s)
=== RUN   TestAccAWSLB_updatedSecurityGroups
--- PASS: TestAccAWSLB_updatedSecurityGroups (565.59s)
=== RUN   TestAccAWSLB_updatedSubnets
--- PASS: TestAccAWSLB_updatedSubnets (499.07s)
=== RUN   TestAccAWSLB_networkLoadbalancer_updateCrossZone
--- PASS: TestAccAWSLB_networkLoadbalancer_updateCrossZone (629.87s)
=== RUN   TestAccAWSLB_networkLoadbalancer_subnet_change
--- PASS: TestAccAWSLB_networkLoadbalancer_subnet_change (424.45s)
=== RUN   TestAccAWSLB_accesslogs
--- PASS: TestAccAWSLB_accesslogs (495.86s)
=== RUN   TestAccAWSLBTargetGroup_networkLB_TargetGroup
--- PASS: TestAccAWSLBTargetGroup_networkLB_TargetGroup (1171.26s)
```