### PR TITLE
r/aws_budgets_budget: Add support for notifications

### DIFF
--- a/aws/resource_aws_budgets_budget.go
+++ b/aws/resource_aws_budgets_budget.go
@@ -205,7 +205,7 @@ func resourceAwsBudgetsBudgetCreate(d *schema.ResourceData, meta interface{}) er
 		budget.BudgetName = aws.String(resource.UniqueId())
 	}
 
-	client := meta.(*AWSClient).budgetconn
+	conn := meta.(*AWSClient).budgetconn
 	var accountID string
 	if v, ok := d.GetOk("account_id"); ok {
 		accountID = v.(string)
@@ -213,7 +213,7 @@ func resourceAwsBudgetsBudgetCreate(d *schema.ResourceData, meta interface{}) er
 		accountID = meta.(*AWSClient).accountid
 	}
 
-	_, err = client.CreateBudget(&budgets.CreateBudgetInput{
+	_, err = conn.CreateBudget(&budgets.CreateBudgetInput{
 		AccountId: aws.String(accountID),
 		Budget:    budget,
 	})
@@ -236,14 +236,14 @@ func resourceAwsBudgetsBudgetCreate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceAwsBudgetsBudgetNotificationsCreate(notifications []*budgets.Notification, subscribers [][]*budgets.Subscriber, budgetName string, accountID string, meta interface{}) error {
-	client := meta.(*AWSClient).budgetconn
+	conn := meta.(*AWSClient).budgetconn
 
 	for i, notification := range notifications {
 		subscribers := subscribers[i]
 		if len(subscribers) == 0 {
 			return fmt.Errorf("Notification must have at least one subscriber!")
 		}
-		_, err := client.CreateNotification(&budgets.CreateNotificationInput{
+		_, err := conn.CreateNotification(&budgets.CreateNotificationInput{
 			BudgetName:   aws.String(budgetName),
 			AccountId:    aws.String(accountID),
 			Notification: notification,
@@ -302,8 +302,8 @@ func resourceAwsBudgetsBudgetRead(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	client := meta.(*AWSClient).budgetconn
-	describeBudgetOutput, err := client.DescribeBudget(&budgets.DescribeBudgetInput{
+	conn := meta.(*AWSClient).budgetconn
+	describeBudgetOutput, err := conn.DescribeBudget(&budgets.DescribeBudgetInput{
 		BudgetName: aws.String(budgetName),
 		AccountId:  aws.String(accountID),
 	})
@@ -353,11 +353,11 @@ func resourceAwsBudgetsBudgetRead(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceAwsBudgetsBudgetNotificationRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*AWSClient).budgetconn
+	conn := meta.(*AWSClient).budgetconn
 
 	accountID, budgetName, err := decodeBudgetsBudgetID(d.Id())
 
-	describeNotificationsForBudgetOutput, err := client.DescribeNotificationsForBudget(&budgets.DescribeNotificationsForBudgetInput{
+	describeNotificationsForBudgetOutput, err := conn.DescribeNotificationsForBudget(&budgets.DescribeNotificationsForBudgetInput{
 		BudgetName: aws.String(budgetName),
 		AccountId:  aws.String(accountID),
 	})
@@ -376,7 +376,7 @@ func resourceAwsBudgetsBudgetNotificationRead(d *schema.ResourceData, meta inter
 		notification["threshold"] = *notificationOutput.Threshold
 		notification["notification_type"] = *notificationOutput.NotificationType
 
-		subscribersOutput, err := client.DescribeSubscribersForNotification(&budgets.DescribeSubscribersForNotificationInput{
+		subscribersOutput, err := conn.DescribeSubscribersForNotification(&budgets.DescribeSubscribersForNotificationInput{
 			BudgetName:   aws.String(budgetName),
 			AccountId:    aws.String(accountID),
 			Notification: notificationOutput,
@@ -426,13 +426,13 @@ func resourceAwsBudgetsBudgetUpdate(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	client := meta.(*AWSClient).budgetconn
+	conn := meta.(*AWSClient).budgetconn
 	budget, err := expandBudgetsBudgetUnmarshal(d)
 	if err != nil {
 		return fmt.Errorf("could not create budget: %v", err)
 	}
 
-	_, err = client.UpdateBudget(&budgets.UpdateBudgetInput{
+	_, err = conn.UpdateBudget(&budgets.UpdateBudgetInput{
 		AccountId: aws.String(accountID),
 		NewBudget: budget,
 	})
@@ -449,7 +449,7 @@ func resourceAwsBudgetsBudgetUpdate(d *schema.ResourceData, meta interface{}) er
 	return resourceAwsBudgetsBudgetRead(d, meta)
 }
 func resourceAwsBudgetsBudgetNotificationsUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*AWSClient).budgetconn
+	conn := meta.(*AWSClient).budgetconn
 	accountID, budgetName, err := decodeBudgetsBudgetID(d.Id())
 
 	if err != nil {
@@ -471,7 +471,7 @@ func resourceAwsBudgetsBudgetNotificationsUpdate(d *schema.ResourceData, meta in
 				Notification: notification,
 			}
 
-			_, err := client.DeleteNotification(input)
+			_, err := conn.DeleteNotification(input)
 
 			if err != nil {
 				return fmt.Errorf("error deleting Budget (%s) Notification: %s", d.Id(), err)
@@ -494,8 +494,8 @@ func resourceAwsBudgetsBudgetDelete(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	client := meta.(*AWSClient).budgetconn
-	_, err = client.DeleteBudget(&budgets.DeleteBudgetInput{
+	conn := meta.(*AWSClient).budgetconn
+	_, err = conn.DeleteBudget(&budgets.DeleteBudgetInput{
 		BudgetName: aws.String(budgetName),
 		AccountId:  aws.String(accountID),
 	})

--- a/aws/resource_aws_budgets_budget.go
+++ b/aws/resource_aws_budgets_budget.go
@@ -276,15 +276,15 @@ func expandBudgetNotificationsUnmarshal(notificationsRaw []interface{}) ([]*budg
 			NotificationType:   aws.String(notificationType),
 		}
 
-		emailSubscribers := expandSubscribers(notificationRaw["subscriber_email_addresses"], budgets.SubscriptionTypeEmail)
-		snsSubscribers := expandSubscribers(notificationRaw["subscriber_sns_topic_arns"], budgets.SubscriptionTypeSns)
+		emailSubscribers := expandBudgetSubscribers(notificationRaw["subscriber_email_addresses"], budgets.SubscriptionTypeEmail)
+		snsSubscribers := expandBudgetSubscribers(notificationRaw["subscriber_sns_topic_arns"], budgets.SubscriptionTypeSns)
 
 		subscribersForNotifications[i] = append(emailSubscribers, snsSubscribers...)
 	}
 	return notifications, subscribersForNotifications
 }
 
-func expandSubscribers(rawList interface{}, subscriptionType string) []*budgets.Subscriber {
+func expandBudgetSubscribers(rawList interface{}, subscriptionType string) []*budgets.Subscriber {
 	result := make([]*budgets.Subscriber, 0)
 	addrs := expandStringSet(rawList.(*schema.Set))
 	for _, addr := range addrs {

--- a/aws/resource_aws_budgets_budget.go
+++ b/aws/resource_aws_budgets_budget.go
@@ -371,10 +371,10 @@ func resourceAwsBudgetsBudgetNotificationRead(d *schema.ResourceData, meta inter
 	for _, notificationOutput := range describeNotificationsForBudgetOutput.Notifications {
 		setNotificationDefaults(notificationOutput)
 		notification := make(map[string]interface{})
-		notification["comparison_operator"] = *notificationOutput.ComparisonOperator
-		notification["threshold_type"] = *notificationOutput.ThresholdType
-		notification["threshold"] = *notificationOutput.Threshold
-		notification["notification_type"] = *notificationOutput.NotificationType
+		notification["comparison_operator"] = aws.StringValue(notificationOutput.ComparisonOperator)
+		notification["threshold_type"] = aws.StringValue(notificationOutput.ThresholdType)
+		notification["threshold"] = aws.Float64Value(notificationOutput.Threshold)
+		notification["notification_type"] = aws.StringValue(notificationOutput.NotificationType)
 
 		subscribersOutput, err := conn.DescribeSubscribersForNotification(&budgets.DescribeSubscribersForNotificationInput{
 			BudgetName:   aws.String(budgetName),

--- a/aws/resource_aws_budgets_budget.go
+++ b/aws/resource_aws_budgets_budget.go
@@ -357,6 +357,10 @@ func resourceAwsBudgetsBudgetNotificationRead(d *schema.ResourceData, meta inter
 
 	accountID, budgetName, err := decodeBudgetsBudgetID(d.Id())
 
+	if err != nil {
+		return fmt.Errorf("error decoding Budget (%s) ID: %s", d.Id(), err)
+	}
+
 	describeNotificationsForBudgetOutput, err := conn.DescribeNotificationsForBudget(&budgets.DescribeNotificationsForBudgetInput{
 		BudgetName: aws.String(budgetName),
 		AccountId:  aws.String(accountID),

--- a/aws/resource_aws_budgets_budget.go
+++ b/aws/resource_aws_budgets_budget.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/budgets"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsBudgetsBudget() *schema.Resource {
@@ -138,6 +139,11 @@ func resourceAwsBudgetsBudget() *schema.Resource {
 						"comparison_operator": {
 							Type:     schema.TypeString,
 							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								budgets.ComparisonOperatorEqualTo,
+								budgets.ComparisonOperatorGreaterThan,
+								budgets.ComparisonOperatorLessThan,
+							}, false),
 						},
 						"threshold": {
 							Type:     schema.TypeFloat,
@@ -146,10 +152,18 @@ func resourceAwsBudgetsBudget() *schema.Resource {
 						"threshold_type": {
 							Type:     schema.TypeString,
 							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								budgets.ThresholdTypeAbsoluteValue,
+								budgets.ThresholdTypePercentage,
+							}, false),
 						},
 						"notification_type": {
 							Type:     schema.TypeString,
 							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								budgets.NotificationTypeActual,
+								budgets.NotificationTypeForecasted,
+							}, false),
 						},
 						"subscriber_email_addresses": {
 							Type:     schema.TypeSet,

--- a/website/docs/r/budgets_budget.html.markdown
+++ b/website/docs/r/budgets_budget.html.markdown
@@ -25,6 +25,14 @@ resource "aws_budgets_budget" "ec2" {
   cost_filters = {
     Service = "Amazon Elastic Compute Cloud - Compute"
   }
+
+  notification {
+    comparison_operator = "GREATER_THAN"
+    threshold = 100
+    threshold_type = "PERCENTAGE"
+    notification_type = "FORECASTED"
+    subscriber_email_addresses = ["test@example.com"]
+  }
 }
 ```
 
@@ -68,6 +76,7 @@ The following arguments are supported:
 * `time_period_end` - (Optional) The end of the time period covered by the budget. There are no restrictions on the end date. Format: `2017-01-01_12:00`.
 * `time_period_start` - (Required) The start of the time period covered by the budget. The start date must come before the end date. Format: `2017-01-01_12:00`.
 * `time_unit` - (Required) The length of time until a budget resets the actual and forecasted spend. Valid values: `MONTHLY`, `QUARTERLY`, `ANNUALLY`.
+* `notification` - (Optional) Object containing [Budget Notifications](#BudgetNotification). Can be used multiple times to define more than one budget notification
 
 ## Attributes Reference
 
@@ -113,6 +122,18 @@ Valid keys for `cost_filters` parameter vary depending on the `budget_type` valu
   * `TagKeyValue`
 
 Refer to [AWS CostFilter documentation](http://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/data-type-filter.html) for further detail.
+
+### BudgetNotification
+
+Valid keys for `notification` parameter.
+
+* `comparison_operator` - (Required) Comparison operator to use to evaluate the condition. Can be `LESS_THAN`, `EQUAL_TO` or `GREATER_THAN`.
+* `threshold` - (Required) Threshold when the notification should be sent.
+* `threshold_type` - (Required) What kind of threshold is defined. Can be `PERCENTAGE` OR `ABSOLUTE_VALUE`.
+* `notification_type` - (Required) What kind of budget value to notify on. Can be `ACTUAL` or `FORECASTED`
+* `subscriber_email_addresses` - (Optional) E-Mail addresses to notify. Either this or `subscriber_sns_topic_arns` is required.
+* `subscriber_sns_topic_arns` - (Optional) SNS topics to notify. Either this or `subscriber_email_addresses` is required.
+
 
 ## Import
 


### PR DESCRIPTION

#1879 introduced a basic aws_budgets_budget resource. 

This PR adds support for budget notifications via E-Mail or SNS. 

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSBudgetsBudget'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSBudgetsBudget -timeout 120m
=== RUN   TestAccAWSBudgetsBudget_basic
--- PASS: TestAccAWSBudgetsBudget_basic (124.06s)
=== RUN   TestAccAWSBudgetsBudget_prefix
--- PASS: TestAccAWSBudgetsBudget_prefix (108.59s)
=== RUN   TestAccAWSBudgetsBudget_notification
--- PASS: TestAccAWSBudgetsBudget_notification (385.83s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	618.530s
```