### PR TITLE
Add import to aws_iam_role_policy_attachment

### DIFF
--- a/aws/import_aws_iam_role_policy_attachment.go
+++ b/aws/import_aws_iam_role_policy_attachment.go
@@ -1,0 +1,38 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsIamRolePolicyAttachmentImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	conn := meta.(*AWSClient).iamconn
+	roleName := d.Id()
+
+	resp, err := conn.ListAttachedRolePolicies(&iam.ListAttachedRolePoliciesInput{
+		RoleName: aws.String(roleName),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	results := []*schema.ResourceData{}
+
+	for _, policy := range resp.AttachedPolicies {
+		id := fmt.Sprintf("%s-%s", roleName, *policy.PolicyArn)
+
+		attachment := resourceAwsIamRolePolicyAttachment()
+		ad := attachment.Data(nil)
+		ad.SetId(id)
+		ad.SetType("aws_iam_role_policy_attachment")
+		ad.Set("role", roleName)
+		ad.Set("policy_arn", policy.PolicyArn)
+
+		results = append(results, ad)
+	}
+
+	return results, nil
+}

--- a/aws/import_aws_iam_role_policy_attachment_test.go
+++ b/aws/import_aws_iam_role_policy_attachment_test.go
@@ -1,13 +1,14 @@
 package aws
 
 import (
-	"testing"
-
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
+	"testing"
 )
 
 func TestAccAwsIamRolePolicyAttachmentImport(t *testing.T) {
 	resourceName := "aws_iam_role_policy_attachment.test-attach"
+	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -15,7 +16,7 @@ func TestAccAwsIamRolePolicyAttachmentImport(t *testing.T) {
 		CheckDestroy: testAccCheckAWSRolePolicyAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSRolePolicyAttachConfig,
+				Config: testAccAWSRolePolicyAttachConfig(rInt),
 			},
 			{
 				ResourceName:      resourceName,

--- a/aws/import_aws_iam_role_policy_attachment_test.go
+++ b/aws/import_aws_iam_role_policy_attachment_test.go
@@ -1,0 +1,28 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAwsIamRolePolicyAttachmentImport(t *testing.T) {
+	resourceName := "aws_iam_role_policy_attachment.test-attach"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRolePolicyAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRolePolicyAttachConfig,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateId:     "test-role",
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/aws/resource_aws_iam_role_policy_attachment.go
+++ b/aws/resource_aws_iam_role_policy_attachment.go
@@ -7,7 +7,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
-	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -16,6 +15,9 @@ func resourceAwsIamRolePolicyAttachment() *schema.Resource {
 		Create: resourceAwsIamRolePolicyAttachmentCreate,
 		Read:   resourceAwsIamRolePolicyAttachmentRead,
 		Delete: resourceAwsIamRolePolicyAttachmentDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceAwsIamRolePolicyAttachmentImport,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"role": &schema.Schema{
@@ -43,7 +45,7 @@ func resourceAwsIamRolePolicyAttachmentCreate(d *schema.ResourceData, meta inter
 		return fmt.Errorf("[WARN] Error attaching policy %s to IAM Role %s: %v", arn, role, err)
 	}
 
-	d.SetId(resource.PrefixedUniqueId(fmt.Sprintf("%s-", role)))
+	d.SetId(fmt.Sprintf("%s-%s", role, arn))
 	return resourceAwsIamRolePolicyAttachmentRead(d, meta)
 }
 

--- a/website/docs/r/iam_policy_attachment.html.markdown
+++ b/website/docs/r/iam_policy_attachment.html.markdown
@@ -58,3 +58,11 @@ The following attributes are exported:
 
 * `id` - The policy's ID.
 * `name` - The name of the attachment.
+
+## Import
+
+IAM role policy attachments can be imported using the `name` of the role. This will import all role policy attachments associated with the role.
+
+```
+$ terraform import aws_iam_role_policy_attachment.test-attach test-role
+```


### PR DESCRIPTION
Fixes #544
Based on @jzbruno https://github.com/hashicorp/terraform/pull/12101 

Changes proposed in this pull request:

* Add import functionality to role_policy_attachment

Output from acceptance testing:

```
make testacc TESTARGS='-run=TestAccAwsIamRolePolicyAttachmentImport'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAwsIamRolePolicyAttachmentImport -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAwsIamRolePolicyAttachmentImport
--- PASS: TestAccAwsIamRolePolicyAttachmentImport (39.39s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	39.450s
```

The test is not very robust, I had to have an empty "test-role" in my AWS account to get it to pass. Would appreciate some help on that front.