### PR TITLE
data-source/aws_autoscaling_groups: Use pagination function for DescribeTags filtering

### DIFF
--- a/aws/data_source_aws_autoscaling_groups.go
+++ b/aws/data_source_aws_autoscaling_groups.go
@@ -50,29 +50,29 @@ func dataSourceAwsAutoscalingGroupsRead(d *schema.ResourceData, meta interface{}
 	d.SetId(time.Now().UTC().String())
 
 	var raw []string
+	var err error
 
 	tf := d.Get("filter").(*schema.Set)
 	if tf.Len() > 0 {
-		out, err := conn.DescribeTags(&autoscaling.DescribeTagsInput{
+		input := &autoscaling.DescribeTagsInput{
 			Filters: expandAsgTagFilters(tf.List()),
-		})
-		if err != nil {
-			return err
 		}
-
-		raw = make([]string, len(out.Tags))
-		for i, v := range out.Tags {
-			raw[i] = *v.ResourceId
-		}
-	} else {
-		if err := conn.DescribeAutoScalingGroupsPages(&autoscaling.DescribeAutoScalingGroupsInput{}, func(resp *autoscaling.DescribeAutoScalingGroupsOutput, lastPage bool) bool {
-			for _, group := range resp.AutoScalingGroups {
-				raw = append(raw, *group.AutoScalingGroupName)
+		err = conn.DescribeTagsPages(input, func(resp *autoscaling.DescribeTagsOutput, lastPage bool) bool {
+			for _, v := range resp.Tags {
+				raw = append(raw, aws.StringValue(v.ResourceId))
 			}
-			return true
-		}); err != nil {
-			return fmt.Errorf("Error fetching Autoscaling Groups: %s", err)
-		}
+			return !lastPage
+		})
+	} else {
+		err = conn.DescribeAutoScalingGroupsPages(&autoscaling.DescribeAutoScalingGroupsInput{}, func(resp *autoscaling.DescribeAutoScalingGroupsOutput, lastPage bool) bool {
+			for _, group := range resp.AutoScalingGroups {
+				raw = append(raw, aws.StringValue(group.AutoScalingGroupName))
+			}
+			return !lastPage
+		})
+	}
+	if err != nil {
+		return fmt.Errorf("Error fetching Autoscaling Groups: %s", err)
 	}
 
 	sort.Strings(raw)


### PR DESCRIPTION
Fixes #4531

Changes proposed in this pull request:

* Use `DescribeTagsPages` function to properly handle results sets over 50 when using `filter` argument
* Minor consistency cleanup with non-filtered `DescribeAutoScalingGroupsPages` function

Output from acceptance testing:

```
1 test passed (all tests)
=== RUN   TestAccAWSAutoscalingGroups_basic
--- PASS: TestAccAWSAutoscalingGroups_basic (80.67s)
```
