### PR TITLE
r/aws_instance: Add support for launch template

### DIFF
--- a/aws/structure.go
+++ b/aws/structure.go
@@ -4582,6 +4582,35 @@ func expandLaunchTemplateSpecification(specs []interface{}) (*autoscaling.Launch
 	return result, nil
 }
 
+func expandEc2LaunchTemplateSpecification(specs []interface{}) (*ec2.LaunchTemplateSpecification, error) {
+	if len(specs) < 1 {
+		return nil, nil
+	}
+
+	spec := specs[0].(map[string]interface{})
+
+	idValue, idOk := spec["id"]
+	nameValue, nameOk := spec["name"]
+
+	if idValue == "" && nameValue == "" {
+		return nil, fmt.Errorf("One of `id` or `name` must be set for `launch_template`")
+	}
+
+	result := &ec2.LaunchTemplateSpecification{}
+
+	if idOk && idValue != "" {
+		result.LaunchTemplateId = aws.String(idValue.(string))
+	} else if nameOk && nameValue != "" {
+		result.LaunchTemplateName = aws.String(nameValue.(string))
+	}
+
+	if v, ok := spec["version"]; ok && v != "" {
+		result.Version = aws.String(v.(string))
+	}
+
+	return result, nil
+}
+
 func flattenLaunchTemplateSpecification(lt *autoscaling.LaunchTemplateSpecification) []map[string]interface{} {
 	if lt == nil {
 		return []map[string]interface{}{}

--- a/aws/tags.go
+++ b/aws/tags.go
@@ -490,3 +490,28 @@ func ec2TagSpecificationsFromMap(m map[string]interface{}, t string) []*ec2.TagS
 		},
 	}
 }
+
+// getInstanceTagValue returns instance tag value by name
+func getInstanceTagValue(conn *ec2.EC2, instanceId string, tagKey string) (*string, error) {
+	tagsResp, err := conn.DescribeTags(&ec2.DescribeTagsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("resource-id"),
+				Values: []*string{aws.String(instanceId)},
+			},
+			{
+				Name:   aws.String("key"),
+				Values: []*string{aws.String(tagKey)},
+			},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(tagsResp.Tags) != 1 {
+		return nil, nil
+	}
+
+	return tagsResp.Tags[0].Value, nil
+}

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -50,7 +50,7 @@ resource "aws_instance" "web" {
 
 The following arguments are supported:
 
-* `ami` - (Required) The AMI to use for the instance.
+* `ami` - (Optional) The AMI to use for the instance. Must be set here or in Launch Template.
 * `availability_zone` - (Optional) The AZ to start the instance in.
 * `placement_group` - (Optional) The Placement Group to start the instance in.
 * `tenancy` - (Optional) The tenancy of the instance (if the instance is running in a VPC). An instance with a tenancy of dedicated runs on single-tenant hardware. The host tenancy is not supported for the import-instance command.
@@ -73,9 +73,11 @@ The following arguments are supported:
 instance. Amazon defaults this to `stop` for EBS-backed instances and
 `terminate` for instance-store instances. Cannot be set on instance-store
 instances. See [Shutdown Behavior](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingInstanceInitiatedShutdownBehavior) for more information.
-* `instance_type` - (Required) The type of instance to start. Updates to this field will trigger a stop/start of the EC2 instance.
+* `instance_type` - (Optional) The type of instance to start. Can be set here or
+  in Launch Template. If type is not set here or in provided `launch_template` instance type will
+  default to `m1.small`. Updates to this field will trigger a stop/start of the EC2
+  instance.
 * `key_name` - (Optional) The key name of the Key Pair to use for the instance; which can be managed using [the `aws_key_pair` resource](key_pair.html).
-
 * `get_password_data` - (Optional) If true, wait for password data to become available and retrieve it. Useful for getting the administrator password for instances running Microsoft Windows. The password data is exported to the `password_data` attribute. See [GetPasswordData](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_GetPasswordData.html) for more information.
 * `monitoring` - (Optional) If true, the launched EC2 instance will have detailed monitoring enabled. (Available since v0.6.0)
 * `security_groups` - (Optional, EC2-Classic and default VPC only) A list of security group names (EC2-Classic) or IDs (default VPC) to associate with.
@@ -105,6 +107,8 @@ instances. See [Shutdown Behavior](https://docs.aws.amazon.com/AWSEC2/latest/Use
   "Instance Store") volumes on the instance. See [Block Devices](#block-devices) below for details.
 * `network_interface` - (Optional) Customize network interfaces to be attached at instance boot time. See [Network Interfaces](#network-interfaces) below for more details.
 * `credit_specification` - (Optional) Customize the credit specification of the instance. See [Credit Specification](#credit-specification) below for more details.
+* `launch_template` - (Optional) Launch template specification to use to launch instances.
+  See [Launch Template Specification](#launch-template-specification) below for more details.
 
 ### Timeouts
 
@@ -237,6 +241,19 @@ resource "aws_instance" "foo" {
   }
 }
 ```
+
+### Launch Template Specification
+
+-> **Note:** Launch Template parameters will be used only once during instance creation. If you want to update existing instance you need to change parameters
+directly. Updating Launch Template specification will force new instance.
+
+Any other instance parameters that you specify will override the same parameters in the launch template.
+
+The `launch_template` block supports the following:
+
+* `id` - The ID of the launch template. Conflicts with `name`.
+* `name` - The name of the launch template. Conflicts with `id`.
+* `version` - Template version. Can be version number, `$Latest` or `$Default`. (Default: `$Default`).
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fixes #4264

Changes proposed in this pull request:

* Add support for launch template in instance resource

Output from acceptance testing:

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSInstance_LaunchTemplate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSInstance_LaunchTemplate -timeout 120m
=== RUN   TestAccAWSInstance_LaunchTemplate
--- PASS: TestAccAWSInstance_LaunchTemplate (430.43s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	430.769s
```

A couple of notes:
1. Template is used only once when instance is created, so later it should be possible to change instance parameters via direct attributes.
2. Using template and overriding root volume device should check template ami and use its device.
3. We can get launch template details only from instance tags
4. I did not want to implement complicated logic of whether changes in template should force instance recreation or not, so any change to template version or id/name will force new instance.
5. But if `$Default` or `$Latest` switch to a version that is actually the same, this will not force recreation.


Maybe there is a better way to do this CustomDiff?
