### PR TITLE
Add support for EnableNonSecurity boolean to SSM patch baseline appoval rules

### DIFF
--- a/aws/resource_aws_ssm_patch_baseline.go
+++ b/aws/resource_aws_ssm_patch_baseline.go
@@ -81,6 +81,12 @@ func resourceAwsSsmPatchBaseline() *schema.Resource {
 							ValidateFunc: validation.StringInSlice(ssmPatchComplianceLevels, false),
 						},
 
+						"enable_non_security": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+
 						"patch_filter": {
 							Type:     schema.TypeList,
 							Required: true,
@@ -328,9 +334,10 @@ func expandAwsSsmPatchRuleGroup(d *schema.ResourceData) *ssm.PatchRuleGroup {
 		}
 
 		rule := &ssm.PatchRule{
-			ApproveAfterDays: aws.Int64(int64(rCfg["approve_after_days"].(int))),
-			PatchFilterGroup: filterGroup,
-			ComplianceLevel:  aws.String(rCfg["compliance_level"].(string)),
+			ApproveAfterDays:  aws.Int64(int64(rCfg["approve_after_days"].(int))),
+			PatchFilterGroup:  filterGroup,
+			ComplianceLevel:   aws.String(rCfg["compliance_level"].(string)),
+			EnableNonSecurity: aws.Bool(rCfg["enable_non_security"].(bool)),
 		}
 
 		rules = append(rules, rule)
@@ -352,6 +359,7 @@ func flattenAwsSsmPatchRuleGroup(group *ssm.PatchRuleGroup) []map[string]interfa
 		r := make(map[string]interface{})
 		r["approve_after_days"] = *rule.ApproveAfterDays
 		r["compliance_level"] = *rule.ComplianceLevel
+		r["enable_non_security"] = *rule.EnableNonSecurity
 		r["patch_filter"] = flattenAwsSsmPatchFilterGroup(rule.PatchFilterGroup)
 		result = append(result, r)
 	}

--- a/aws/resource_aws_ssm_patch_baseline_test.go
+++ b/aws/resource_aws_ssm_patch_baseline_test.go
@@ -84,6 +84,8 @@ func TestAccAWSSSMPatchBaselineWithOperatingSystem(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_ssm_patch_baseline.foo", "approval_rule.0.compliance_level", ssm.PatchComplianceLevelCritical),
 					resource.TestCheckResourceAttr(
+						"aws_ssm_patch_baseline.foo", "approval_rule.0.enable_non_security", "true"),
+					resource.TestCheckResourceAttr(
 						"aws_ssm_patch_baseline.foo", "operating_system", "AMAZON_LINUX"),
 				),
 			},
@@ -220,6 +222,7 @@ resource "aws_ssm_patch_baseline" "foo" {
   description = "Baseline containing all updates approved for production systems"
   approval_rule {
   	approve_after_days = 7
+	enable_non_security = true
   	compliance_level = "CRITICAL"
 
   	patch_filter {

--- a/website/docs/r/ssm_patch_baseline.html.markdown
+++ b/website/docs/r/ssm_patch_baseline.html.markdown
@@ -90,6 +90,7 @@ The `approval_rule` block supports:
 * `approve_after_days` - (Required) The number of days after the release date of each patch matched by the rule the patch is marked as approved in the patch baseline. Valid Range: 0 to 100.
 * `patch_filter` - (Required) The patch filter group that defines the criteria for the rule. Up to 4 patch filters can be specified per approval rule using Key/Value pairs. Valid Keys are `PRODUCT | CLASSIFICATION | MSRC_SEVERITY | PATCH_ID`.
 * `compliance_level` - (Optional) Defines the compliance level for patches approved by this rule. Valid compliance levels include the following: `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, `INFORMATIONAL`, `UNSPECIFIED`. The default value is `UNSPECIFIED`.
+* `enable_non_security` - (Optional) Boolean enabling the application of non-security updates. The default value is 'false'. Valid for Linux instances only.
 
 ## Attributes Reference
 


### PR DESCRIPTION

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->

Changes proposed in this pull request:

* Adds support for the EnableNonSecurity flag in an AWS SSM patch baseline approval rule

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSSSMPatchBaseline' 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSSSMPatchBaseline -timeout 120m
=== RUN   TestAccAWSSSMPatchBaseline_basic
--- PASS: TestAccAWSSSMPatchBaseline_basic (34.90s)
=== RUN   TestAccAWSSSMPatchBaselineWithOperatingSystem
--- PASS: TestAccAWSSSMPatchBaselineWithOperatingSystem (36.87s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	71.787s
...
```
