### PR TITLE
Fix incorrect resource reference for acm certificate

### DIFF
--- a/website/docs/r/acm_certificate_validation.html.markdown
+++ b/website/docs/r/acm_certificate_validation.html.markdown
@@ -48,7 +48,7 @@ resource "aws_acm_certificate_validation" "cert" {
 
 resource "aws_lb_listener" "front_end" {
   # [...]
-  certificate_arn   = "${aws_acm_certificate_validation.cert.certificate_arn}"
+  certificate_arn   = "${aws_acm_certificate.cert.arn}"
 }
 ```
 


### PR DESCRIPTION
Changes proposed in this pull request:

* Change the documentation to specify the `aws_acm_certificate` resource rather than `aws_acm_certificate_validation`. The `aws_acm_certificate_validation` resource does not export the `arn` or `certificate_arn` attribute. 