### PR TITLE
resource/aws_dms_endpoint: Handle mongodb KmsKeyId and fix S3 test

### DIFF
--- a/aws/resource_aws_dms_endpoint.go
+++ b/aws/resource_aws_dms_endpoint.go
@@ -244,6 +244,7 @@ func resourceAwsDmsEndpointCreate(d *schema.ResourceData, meta interface{}) erro
 			ServerName:   aws.String(d.Get("server_name").(string)),
 			Port:         aws.Int64(int64(d.Get("port").(int))),
 			DatabaseName: aws.String(d.Get("database_name").(string)),
+			KmsKeyId:     aws.String(d.Get("kms_key_arn").(string)),
 
 			AuthType:          aws.String(d.Get("mongodb_settings.0.auth_type").(string)),
 			AuthMechanism:     aws.String(d.Get("mongodb_settings.0.auth_mechanism").(string)),
@@ -422,6 +423,7 @@ func resourceAwsDmsEndpointUpdate(d *schema.ResourceData, meta interface{}) erro
 				ServerName:   aws.String(d.Get("server_name").(string)),
 				Port:         aws.Int64(int64(d.Get("port").(int))),
 				DatabaseName: aws.String(d.Get("database_name").(string)),
+				KmsKeyId:     aws.String(d.Get("kms_key_arn").(string)),
 
 				AuthType:          aws.String(d.Get("mongodb_settings.0.auth_type").(string)),
 				AuthMechanism:     aws.String(d.Get("mongodb_settings.0.auth_mechanism").(string)),
@@ -549,9 +551,9 @@ func resourceAwsDmsEndpointSetState(d *schema.ResourceData, endpoint *dms.Endpoi
 		d.Set("port", endpoint.Port)
 		d.Set("server_name", endpoint.ServerName)
 		d.Set("username", endpoint.Username)
-		d.Set("kms_key_arn", endpoint.KmsKeyId)
 	}
 
+	d.Set("kms_key_arn", endpoint.KmsKeyId)
 	d.Set("ssl_mode", endpoint.SslMode)
 
 	return nil


### PR DESCRIPTION
Changes proposed in this pull request:

* Allow specifying `kms_key_arn` through to MongoDB KmsKeyId parameter
* Fix S3 test to properly specify initial bucket name

Previously:

```
=== RUN   TestAccAwsDmsEndpointMongoDb
--- FAIL: TestAccAwsDmsEndpointMongoDb (5.89s)
    testing.go:518: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_dms_endpoint.dms_endpoint: 1 error(s) occurred:
        
        * aws_dms_endpoint.dms_endpoint: InvalidParameterValueException: The parameter KMS key must be provided and must not be blank.
            status code: 400, request id: 25b3ab2d-58d5-11e8-9b63-49426c21117b

=== RUN   TestAccAwsDmsEndpointS3
--- FAIL: TestAccAwsDmsEndpointS3 (7.98s)
    testing.go:518: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_dms_endpoint.dms_endpoint: 1 error(s) occurred:
        
        * aws_dms_endpoint.dms_endpoint: InvalidParameterValueException: The parameter BucketName must be provided and must not be blank.
            status code: 400, request id: 1ff4dfc2-58d5-11e8-bb69-75d02d3449ce
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAwsDmsEndpoint'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAwsDmsEndpoint -timeout 120m
=== RUN   TestAccAwsDmsEndpointBasic
--- PASS: TestAccAwsDmsEndpointBasic (46.33s)
=== RUN   TestAccAwsDmsEndpointS3
--- PASS: TestAccAwsDmsEndpointS3 (59.54s)
=== RUN   TestAccAwsDmsEndpointDynamoDb
--- PASS: TestAccAwsDmsEndpointDynamoDb (52.82s)
=== RUN   TestAccAwsDmsEndpointMongoDb
--- PASS: TestAccAwsDmsEndpointMongoDb (48.04s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	206.774s
```
