### PR TITLE
[WIP] 3394 redshift node output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ NOTES:
 
 FEATURES:
 
+* **New Data Source:** `aws_arn` [GH-3996]
 * **New Data Source:** `aws_lambda_invocation` [GH-4222]
 * **New Resource:** `aws_sns_sms_preferences` [GH-3858]
 

--- a/aws/resource_aws_redshift_cluster.go
+++ b/aws/resource_aws_redshift_cluster.go
@@ -143,6 +143,14 @@ func resourceAwsRedshiftCluster() *schema.Resource {
 				Default:  1,
 			},
 
+			"cluster_node_ips": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+
 			"publicly_accessible": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -380,6 +388,10 @@ func resourceAwsRedshiftClusterCreate(d *schema.ResourceData, meta interface{}) 
 			restoreOpts.IamRoles = expandStringList(v.(*schema.Set).List())
 		}
 
+		if v := d.Get("vpc_security_group_ids").(*schema.Set); v.Len() > 0 {
+			restoreOpts.VpcSecurityGroupIds = expandStringList(v.List())
+		}
+
 		log.Printf("[DEBUG] Redshift Cluster restore cluster options: %s", restoreOpts)
 
 		resp, err := conn.RestoreFromClusterSnapshot(restoreOpts)
@@ -601,6 +613,16 @@ func resourceAwsRedshiftClusterRead(d *schema.ResourceData, meta interface{}) er
 	}
 	if err := d.Set("iam_roles", iamRoles); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving IAM Roles to state for Redshift Cluster (%s): %s", d.Id(), err)
+	}
+
+	if rsc.ClusterNodes != nil {
+		var nip []string
+		for _, i := range rsc.ClusterNodes {
+			if i.PrivateIPAddress != nil {
+				nip = append(nip, *i.PrivateIPAddress)
+			}
+		}
+		d.Set("cluster_node_ips", nip)
 	}
 
 	d.Set("cluster_public_key", rsc.ClusterPublicKey)

--- a/aws/resource_aws_redshift_cluster_test.go
+++ b/aws/resource_aws_redshift_cluster_test.go
@@ -173,6 +173,28 @@ func TestAccAWSRedshiftCluster_kmsKey(t *testing.T) {
 	})
 }
 
+func TestAccAWSRedshiftCluster_privateIps(t *testing.T) {
+	var v redshift.Cluster
+
+	ri := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	config := testAccAWSRedshiftClusterConfig_basic(ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRedshiftClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRedshiftClusterExists("aws_redshift_cluster.default", &v),
+					resource.TestCheckResourceAttrSet("aws_redshift_cluster.default", "cluster_node_ips"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSRedshiftCluster_enhancedVpcRoutingEnabled(t *testing.T) {
 	var v redshift.Cluster
 

--- a/website/docs/r/redshift_cluster.html.markdown
+++ b/website/docs/r/redshift_cluster.html.markdown
@@ -110,6 +110,7 @@ The following attributes are exported:
 * `cluster_subnet_group_name` - The name of a cluster subnet group to be associated with this cluster
 * `cluster_public_key` - The public key for the cluster
 * `cluster_revision_number` - The specific revision number of the database in the cluster
+* `cluster_node_ips` - The IPs associated with the cluster nodes
 
 ## Import
 


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #0000

Changes proposed in this pull request:

* Adds cluster node IPs

Current output from acceptance testing:

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSRedshiftCluster_privateIps -timeout 120m
=== RUN   TestAccAWSRedshiftCluster_privateIps
FAIL  github.com/terraform-providers/terraform-provider-aws/aws       746.561s
make: *** [testacc] Error 1
```

I believe that setting this resource attribute is not possible at creation as the AWS response does not include this information and it's required to obtain via a `describe-cluster --cluster-name {clusterName}`  command after the cluster has been created. 

Is there an established method of adding this kind of post-creation computed value to a resource elsewhere in this provider I can reference? 