### PR TITLE
resource/aws_dynamodb_table: Handle UnknownOperationException with DescribeContinuousBackups

### DIFF
--- a/aws/resource_aws_dynamodb_table.go
+++ b/aws/resource_aws_dynamodb_table.go
@@ -527,7 +527,7 @@ func resourceAwsDynamoDbTableRead(d *schema.ResourceData, meta interface{}) erro
 	pitrOut, err := conn.DescribeContinuousBackups(&dynamodb.DescribeContinuousBackupsInput{
 		TableName: aws.String(d.Id()),
 	})
-	if err != nil {
+	if err != nil && !isAWSErr(err, "UnknownOperationException", "") {
 		return err
 	}
 	d.Set("point_in_time_recovery", flattenDynamoDbPitr(pitrOut))

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -3697,15 +3697,19 @@ func flattenDynamoDbTtl(ttlDesc *dynamodb.TimeToLiveDescription) []interface{} {
 }
 
 func flattenDynamoDbPitr(pitrDesc *dynamodb.DescribeContinuousBackupsOutput) []interface{} {
-	m := map[string]interface{}{}
+	m := map[string]interface{}{
+		"enabled": false,
+	}
+
+	if pitrDesc == nil {
+		return []interface{}{m}
+	}
+
 	if pitrDesc.ContinuousBackupsDescription != nil {
 		pitr := pitrDesc.ContinuousBackupsDescription.PointInTimeRecoveryDescription
 		if pitr != nil {
 			m["enabled"] = (*pitr.PointInTimeRecoveryStatus == dynamodb.PointInTimeRecoveryStatusEnabled)
 		}
-	}
-	if len(m) > 0 {
-		return []interface{}{m}
 	}
 
 	return []interface{}{m}


### PR DESCRIPTION
Fixes #4567 

Changes proposed in this pull request:

* Ignore `UnknownOperationException` when calling the new `DescribeContinuousBackups` for point in time recovery that is not deployed in all AWS partitions - defaults to returning `enabled = false`

Output from acceptance testing:

```
21 tests passed (all tests)
=== RUN   TestAccAWSDynamoDbTable_importBasic
--- PASS: TestAccAWSDynamoDbTable_importBasic (43.57s)
=== RUN   TestAccAWSDynamoDbTable_basic
--- PASS: TestAccAWSDynamoDbTable_basic (112.61s)
=== RUN   TestAccAWSDynamoDbTableItem_rangeKey
--- PASS: TestAccAWSDynamoDbTableItem_rangeKey (112.81s)
=== RUN   TestAccAWSDynamoDbTableItem_withMultipleItems
--- PASS: TestAccAWSDynamoDbTableItem_withMultipleItems (112.83s)
=== RUN   TestAccAWSDynamoDbTable_streamSpecificationValidation
--- PASS: TestAccAWSDynamoDbTable_streamSpecificationValidation (1.59s)
=== RUN   TestAccAWSDynamoDbTableItem_update
--- PASS: TestAccAWSDynamoDbTableItem_update (117.31s)
=== RUN   TestAccAWSDynamoDbTableItem_updateWithRangeKey
--- PASS: TestAccAWSDynamoDbTableItem_updateWithRangeKey (117.52s)
=== RUN   TestAccAWSDynamoDbTable_importTimeToLive
--- PASS: TestAccAWSDynamoDbTable_importTimeToLive (123.36s)
=== RUN   TestAccAWSDynamoDbTableItem_basic
--- PASS: TestAccAWSDynamoDbTableItem_basic (143.02s)
=== RUN   TestAccAWSDynamoDbTable_importTags
--- PASS: TestAccAWSDynamoDbTable_importTags (153.83s)
=== RUN   TestAccAWSDynamoDbTable_attributeUpdateValidation
--- PASS: TestAccAWSDynamoDbTable_attributeUpdateValidation (2.31s)
=== RUN   TestAccAWSDynamoDbTable_tags
--- PASS: TestAccAWSDynamoDbTable_tags (51.41s)
=== RUN   TestAccAWSDynamoDbTable_streamSpecification
--- PASS: TestAccAWSDynamoDbTable_streamSpecification (129.47s)
=== RUN   TestAccAWSDynamoDbTable_ttl
--- PASS: TestAccAWSDynamoDbTable_ttl (138.01s)
=== RUN   TestAccAWSDynamoDbTable_gsiUpdateCapacity
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateCapacity (157.95s)
=== RUN   TestAccAWSDynamoDbTable_encryption
--- PASS: TestAccAWSDynamoDbTable_encryption (130.53s)
=== RUN   TestAccAWSDynamoDbTable_gsiUpdateNonKeyAttributes
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateNonKeyAttributes (189.45s)
=== RUN   TestAccAWSDynamoDbTable_extended
--- PASS: TestAccAWSDynamoDbTable_extended (309.64s)
=== RUN   TestAccAWSDynamoDbTable_enablePitr
--- PASS: TestAccAWSDynamoDbTable_enablePitr (327.44s)
=== RUN   TestAccAWSDynamoDbTable_attributeUpdate
--- PASS: TestAccAWSDynamoDbTable_attributeUpdate (466.19s)
=== RUN   TestAccAWSDynamoDbTable_gsiUpdateOtherAttributes
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateOtherAttributes (499.00s)
```
