### PR TITLE
resource/aws_kinesis_stream: Handle tag additions/removals of more than 10 tags

### DIFF
--- a/aws/tags_kinesis.go
+++ b/aws/tags_kinesis.go
@@ -24,34 +24,55 @@ func setTagsKinesis(conn *kinesis.Kinesis, d *schema.ResourceData) error {
 		// Set tags
 		if len(remove) > 0 {
 			log.Printf("[DEBUG] Removing tags: %#v", remove)
-			k := make([]*string, len(remove), len(remove))
-			for i, t := range remove {
-				k[i] = t.Key
-			}
 
-			_, err := conn.RemoveTagsFromStream(&kinesis.RemoveTagsFromStreamInput{
-				StreamName: aws.String(sn),
-				TagKeys:    k,
-			})
-			if err != nil {
-				return err
+			// Kinesis requires these operations be split into 10 tag batches
+			tagKeysBatchLimit := 10
+			tagKeysBatch := make([]*string, 0, tagKeysBatchLimit)
+			tagKeysBatches := make([][]*string, 0, len(remove)/tagKeysBatchLimit+1)
+			for _, tag := range remove {
+				if len(tagKeysBatch) == tagKeysBatchLimit {
+					tagKeysBatches = append(tagKeysBatches, tagKeysBatch)
+					tagKeysBatch = make([]*string, 0, tagKeysBatchLimit)
+				}
+				tagKeysBatch = append(tagKeysBatch, tag.Key)
+			}
+			tagKeysBatches = append(tagKeysBatches, tagKeysBatch)
+
+			for _, tagKeys := range tagKeysBatches {
+				_, err := conn.RemoveTagsFromStream(&kinesis.RemoveTagsFromStreamInput{
+					StreamName: aws.String(sn),
+					TagKeys:    tagKeys,
+				})
+				if err != nil {
+					return err
+				}
 			}
 		}
 
 		if len(create) > 0 {
-
 			log.Printf("[DEBUG] Creating tags: %#v", create)
-			t := make(map[string]*string)
-			for _, tag := range create {
-				t[*tag.Key] = tag.Value
-			}
 
-			_, err := conn.AddTagsToStream(&kinesis.AddTagsToStreamInput{
-				StreamName: aws.String(sn),
-				Tags:       t,
-			})
-			if err != nil {
-				return err
+			// Kinesis requires these operations be split into 10 tag batches
+			tagsBatchLimit := 10
+			tagsBatch := make(map[string]*string)
+			tagsBatches := make([]map[string]*string, 0, len(create)/tagsBatchLimit+1)
+			for _, tag := range create {
+				if len(tagsBatch) == tagsBatchLimit {
+					tagsBatches = append(tagsBatches, tagsBatch)
+					tagsBatch = make(map[string]*string)
+				}
+				tagsBatch[aws.StringValue(tag.Key)] = tag.Value
+			}
+			tagsBatches = append(tagsBatches, tagsBatch)
+
+			for _, tags := range tagsBatches {
+				_, err := conn.AddTagsToStream(&kinesis.AddTagsToStreamInput{
+					StreamName: aws.String(sn),
+					Tags:       tags,
+				})
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #4562

Changes proposed in this pull request:

* Batch tag additions into groups of 10 to match API requirement
* Batch tag removals into groups of 10 to match API requirement

Previously:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSKinesisStream_Tags'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSKinesisStream_Tags -timeout 120m
=== RUN   TestAccAWSKinesisStream_Tags
--- FAIL: TestAccAWSKinesisStream_Tags (26.75s)
	testing.go:518: Step 0 error: Error applying: 1 error(s) occurred:

		* aws_kinesis_stream.test: 1 error(s) occurred:

		* aws_kinesis_stream.test: ValidationException: 1 validation error detected: Value '{tag1=tag1value, tag20=tag20value, tag8=tag8value, tag10=tag10value, tag21=tag21value, tag9=tag9value, tag11=tag11value, tag6=tag6value, tag12=tag12value, tag7=tag7value, tag13=tag13value, tag4=tag4value, tag14=tag14value, tag5=tag5value, tag15=tag15value, tag2=tag2value, tag16=tag16value, tag3=tag3value, tag17=tag17value, tag18=tag18value, tag19=tag19value}' at 'tags' failed to satisfy constraint: Member must have length less than or equal to 10
			status code: 400, request id: dc1bc791-6394-fcfd-8f63-ce1bafcbaf0d
	testing.go:579: Error destroying resource! WARNING: Dangling resources
		may exist. The full state and error is shown below.

		Error: Error refreshing: 1 error(s) occurred:

		* aws_kinesis_stream.test: 1 error(s) occurred:

		* aws_kinesis_stream.test: aws_kinesis_stream.test: [WARN] Error reading Kinesis Stream: "1 validation error(s) found.", code: "InvalidParameter"

		State: <nil>
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	26.797s
make: *** [testacc] Error 1
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSKinesisStream_Tags'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSKinesisStream_Tags -timeout 120m
=== RUN   TestAccAWSKinesisStream_Tags
--- PASS: TestAccAWSKinesisStream_Tags (108.99s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	109.030s
```

Full run:

```
10 tests passed (all tests)
=== RUN   TestAccAWSKinesisStream_encryptionWithoutKmsKeyThrowsError
--- PASS: TestAccAWSKinesisStream_encryptionWithoutKmsKeyThrowsError (62.80s)
=== RUN   TestAccAWSKinesisStream_basic
--- PASS: TestAccAWSKinesisStream_basic (75.04s)
=== RUN   TestAccAWSKinesisStream_importBasic
--- PASS: TestAccAWSKinesisStream_importBasic (75.87s)
=== RUN   TestAccAWSKinesisStream_Tags
--- PASS: TestAccAWSKinesisStream_Tags (89.73s)
=== RUN   TestAccAWSKinesisStream_retentionPeriod
--- PASS: TestAccAWSKinesisStream_retentionPeriod (122.32s)
=== RUN   TestAccAWSKinesisStream_shardLevelMetrics
--- PASS: TestAccAWSKinesisStream_shardLevelMetrics (142.56s)
=== RUN   TestAccAWSKinesisStream_encryption
--- PASS: TestAccAWSKinesisStream_encryption (190.55s)
=== RUN   TestAccAWSKinesisStreamDataSource
--- PASS: TestAccAWSKinesisStreamDataSource (210.89s)
=== RUN   TestAccAWSKinesisStream_createMultipleConcurrentStreams
--- PASS: TestAccAWSKinesisStream_createMultipleConcurrentStreams (315.24s)
=== RUN   TestAccAWSKinesisStream_shardCount
--- PASS: TestAccAWSKinesisStream_shardCount (363.95s)
```
