### PR TITLE
resource/aws_kinesis_stream: Fix missing encryption_type default

### DIFF
--- a/aws/resource_aws_kinesis_stream.go
+++ b/aws/resource_aws_kinesis_stream.go
@@ -455,7 +455,12 @@ func readKinesisStreamState(conn *kinesis.Kinesis, sn string) (*kinesisStreamSta
 		state.openShards = append(state.openShards, flattenShards(openShards(page.StreamDescription.Shards))...)
 		state.closedShards = append(state.closedShards, flattenShards(closedShards(page.StreamDescription.Shards))...)
 		state.shardLevelMetrics = flattenKinesisShardLevelMetrics(page.StreamDescription.EnhancedMonitoring)
-		state.encryptionType = aws.StringValue(page.StreamDescription.EncryptionType)
+		// EncryptionType can be nil in certain APIs, e.g. AWS China
+		if page.StreamDescription.EncryptionType != nil {
+			state.encryptionType = aws.StringValue(page.StreamDescription.EncryptionType)
+		} else {
+			state.encryptionType = kinesis.EncryptionTypeNone
+		}
 		state.keyId = aws.StringValue(page.StreamDescription.KeyId)
 		return !last
 	})


### PR DESCRIPTION
Fixes #3566

Changes proposed in this pull request:

* Ensure missing `EncryptionType` defaults to schema default

Output from acceptance testing:

```
9 tests passed (all tests)
=== RUN   TestAccAWSKinesisStream_basic
--- PASS: TestAccAWSKinesisStream_basic (75.17s)
=== RUN   TestAccAWSKinesisStream_importBasic
--- PASS: TestAccAWSKinesisStream_importBasic (76.07s)
=== RUN   TestAccAWSKinesisStream_encryptionWithoutKmsKeyThrowsError
--- PASS: TestAccAWSKinesisStream_encryptionWithoutKmsKeyThrowsError (85.20s)
=== RUN   TestAccAWSKinesisStream_retentionPeriod
--- PASS: TestAccAWSKinesisStream_retentionPeriod (122.05s)
=== RUN   TestAccAWSKinesisStream_shardLevelMetrics
--- PASS: TestAccAWSKinesisStream_shardLevelMetrics (142.56s)
=== RUN   TestAccAWSKinesisStream_shardCount
--- PASS: TestAccAWSKinesisStream_shardCount (158.50s)
=== RUN   TestAccAWSKinesisStream_encryption
--- PASS: TestAccAWSKinesisStream_encryption (190.56s)
=== RUN   TestAccAWSKinesisStreamDataSource
--- PASS: TestAccAWSKinesisStreamDataSource (227.80s)
=== RUN   TestAccAWSKinesisStream_createMultipleConcurrentStreams
--- PASS: TestAccAWSKinesisStream_createMultipleConcurrentStreams (286.10s)
```
