### PR TITLE
Add 'tags' argument to DMS replication subnet group documentation

### DIFF
--- a/website/docs/r/dms_replication_subnet_group.html.markdown
+++ b/website/docs/r/dms_replication_subnet_group.html.markdown
@@ -21,6 +21,10 @@ resource "aws_dms_replication_subnet_group" "test" {
   subnet_ids = [
     "subnet-12345678",
   ]
+
+  tags {
+    Name = "test"
+  }
 }
 ```
 
@@ -35,6 +39,7 @@ The following arguments are supported:
     - Must not be "default".
 
 * `subnet_ids` - (Required) A list of the EC2 subnet IDs for the subnet group.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Changes proposed in this pull request:

* Add a missing argument (`tags`) to the existing documentation for `dms_replication_subnet_group`

Now it covers all arguments from `aws dms create-replication-subnet-group --generate-cli-skeleton`.
```
{
    "ReplicationSubnetGroupIdentifier": "",
    "ReplicationSubnetGroupDescription": "",
    "SubnetIds": [
        ""
    ],
    "Tags": [
        {
            "Key": "",
            "Value": ""
        }
    ]
}
```