### PR TITLE
tests/resource/aws_cloudwatch_event_rule: Add sweeper

### DIFF
--- a/aws/resource_aws_cloudwatch_event_rule_test.go
+++ b/aws/resource_aws_cloudwatch_event_rule_test.go
@@ -2,7 +2,9 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -11,6 +13,62 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_cloudwatch_event_rule", &resource.Sweeper{
+		Name: "aws_cloudwatch_event_rule",
+		F:    testSweepCloudWatchEventRules,
+	})
+}
+
+func testSweepCloudWatchEventRules(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("Error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).cloudwatcheventsconn
+
+	input := &events.ListRulesInput{}
+
+	for {
+		output, err := conn.ListRules(input)
+		if err != nil {
+			if testSweepSkipSweepError(err) {
+				log.Printf("[WARN] Skipping CloudWatch Event Rule sweep for %s: %s", region, err)
+				return nil
+			}
+			return fmt.Errorf("Error retrieving CloudWatch Event Rules: %s", err)
+		}
+
+		if len(output.Rules) == 0 {
+			log.Print("[DEBUG] No CloudWatch Event Rules to sweep")
+			return nil
+		}
+
+		for _, rule := range output.Rules {
+			name := aws.StringValue(rule.Name)
+
+			if !strings.HasPrefix(name, "tf") {
+				continue
+			}
+
+			log.Printf("[INFO] Deleting CloudWatch Event Rule %s", name)
+			_, err := conn.DeleteRule(&events.DeleteRuleInput{
+				Name: aws.String(name),
+			})
+			if err != nil {
+				return fmt.Errorf("Error deleting CloudWatch Event Rule %s: %s", name, err)
+			}
+		}
+
+		if output.NextToken == nil {
+			break
+		}
+		input.NextToken = output.NextToken
+	}
+
+	return nil
+}
 
 func TestAccAWSCloudWatchEventRule_basic(t *testing.T) {
 	var rule events.DescribeRuleOutput


### PR DESCRIPTION
We were leaving some dangling rules. Let's be kind and rewind. ♻️ 

Changes proposed in this pull request:

* New sweeper for `aws_cloudwatch_event_rule` resource

Output from acceptance testing:

```
$ aws events list-rules | jq '.Rules | length'
21

$ make sweep SWEEPARGS='-sweep-run=aws_cloudwatch_event_rule'
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./... -v -sweep=us-east-1,us-west-2 -sweep-run=aws_cloudwatch_event_rule
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
2018/05/17 21:38:46 [DEBUG] Running Sweepers for region (us-east-1):
2018/05/17 21:38:46 [INFO] Building AWS region structure
2018/05/17 21:38:46 [INFO] Building AWS auth structure
2018/05/17 21:38:46 [INFO] Setting AWS metadata API timeout to 100ms
2018/05/17 21:38:46 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2018/05/17 21:38:46 [INFO] AWS Auth provider used: "EnvProvider"
2018/05/17 21:38:46 [INFO] Initializing DeviceFarm SDK connection
2018/05/17 21:38:47 [DEBUG] Trying to get account ID via iam:GetUser
2018/05/17 21:38:49 [DEBUG] No CloudWatch Event Rules to sweep
2018/05/17 21:38:49 Sweeper Tests ran:
	- aws_cloudwatch_event_rule
2018/05/17 21:38:49 [DEBUG] Running Sweepers for region (us-west-2):
2018/05/17 21:38:49 [INFO] Building AWS region structure
2018/05/17 21:38:49 [INFO] Building AWS auth structure
2018/05/17 21:38:49 [INFO] Setting AWS metadata API timeout to 100ms
2018/05/17 21:38:50 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2018/05/17 21:38:50 [INFO] AWS Auth provider used: "EnvProvider"
2018/05/17 21:38:50 [INFO] Initializing DeviceFarm SDK connection
2018/05/17 21:38:51 [DEBUG] Trying to get account ID via iam:GetUser
2018/05/17 21:38:52 [WARN] Unable to get supported EC2 platforms: RequestLimitExceeded: Request limit exceeded.
	status code: 503, request id: df439e3e-3776-47c7-9a25-5ecfd8b1f3ca
2018/05/17 21:38:52 [INFO] Deleting CloudWatch Event Rule tf-acc-cw-event-rule-prefix-20180426162323934100000002
2018/05/17 21:38:52 [INFO] Deleting CloudWatch Event Rule tf-acc-cw-event-rule-prefix-20180426162514120400000002
2018/05/17 21:38:53 [INFO] Deleting CloudWatch Event Rule tf-acc-cw-event-rule-prefix-20180427053026579200000002
2018/05/17 21:38:54 [INFO] Deleting CloudWatch Event Rule tf-acc-cw-event-rule-prefix-20180428060328552200000002
2018/05/17 21:38:54 [INFO] Deleting CloudWatch Event Rule tf-acc-cw-event-rule-prefix-20180429060519520300000002
2018/05/17 21:38:55 [INFO] Deleting CloudWatch Event Rule tf-acc-cw-event-rule-prefix-20180501053203121800000002
2018/05/17 21:38:55 [INFO] Deleting CloudWatch Event Rule tf-acc-cw-event-rule-prefix-20180502053210453100000002
2018/05/17 21:38:55 [INFO] Deleting CloudWatch Event Rule tf-acc-cw-event-rule-prefix-20180503060601159900000002
2018/05/17 21:38:56 [INFO] Deleting CloudWatch Event Rule tf-acc-cw-event-rule-prefix-20180504063840134000000002
2018/05/17 21:38:56 [INFO] Deleting CloudWatch Event Rule tf-acc-cw-event-rule-prefix-20180505054500305900000002
2018/05/17 21:38:56 [INFO] Deleting CloudWatch Event Rule tf-acc-cw-event-rule-prefix-20180506060233773100000002
2018/05/17 21:38:57 [INFO] Deleting CloudWatch Event Rule tf-acc-cw-event-rule-prefix-20180508053138002100000002
2018/05/17 21:38:57 [INFO] Deleting CloudWatch Event Rule tf-acc-cw-event-rule-prefix-20180509053336875600000002
2018/05/17 21:38:57 [INFO] Deleting CloudWatch Event Rule tf-acc-cw-event-rule-prefix-20180510064223367500000002
2018/05/17 21:38:58 [INFO] Deleting CloudWatch Event Rule tf-acc-cw-event-rule-prefix-20180512060518989300000002
2018/05/17 21:38:58 [INFO] Deleting CloudWatch Event Rule tf-acc-cw-event-rule-prefix-20180514053257185000000002
2018/05/17 21:38:58 [INFO] Deleting CloudWatch Event Rule tf-acc-cw-event-rule-prefix-20180515054306224300000002
2018/05/17 21:38:59 [INFO] Deleting CloudWatch Event Rule tf-acc-cw-event-rule-prefix-20180516062014304000000002
2018/05/17 21:38:59 [INFO] Deleting CloudWatch Event Rule tf-acc-cw-event-rule-prefix-20180517053608965300000002
2018/05/17 21:38:59 [INFO] Deleting CloudWatch Event Rule tf_ecs_target-8891489586102447075
2018/05/17 21:39:00 [INFO] Deleting CloudWatch Event Rule tf_ssm_Document-1998416028163312674
2018/05/17 21:39:00 Sweeper Tests ran:
	- aws_cloudwatch_event_rule
ok  	github.com/terraform-providers/terraform-provider-aws/aws	14.435s

$ aws events list-rules | jq '.Rules | length'
0
```
