### PR TITLE
 issue #4566 add new attribute dns_name in aws_redshift_cluster

### DIFF
--- a/aws/resource_aws_redshift_cluster.go
+++ b/aws/resource_aws_redshift_cluster.go
@@ -193,6 +193,12 @@ func resourceAwsRedshiftCluster() *schema.Resource {
 				Computed: true,
 			},
 
+			"dns_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
 			"cluster_public_key": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -567,6 +573,7 @@ func resourceAwsRedshiftClusterRead(d *schema.ResourceData, meta interface{}) er
 		if rsc.Endpoint.Port != nil {
 			endpoint = fmt.Sprintf("%s:%d", endpoint, *rsc.Endpoint.Port)
 		}
+		d.Set("dns_name", rsc.Endpoint.Address)
 		d.Set("port", rsc.Endpoint.Port)
 		d.Set("endpoint", endpoint)
 	}

--- a/aws/resource_aws_redshift_cluster.go
+++ b/aws/resource_aws_redshift_cluster.go
@@ -195,7 +195,6 @@ func resourceAwsRedshiftCluster() *schema.Resource {
 
 			"dns_name": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 

--- a/aws/resource_aws_redshift_cluster_test.go
+++ b/aws/resource_aws_redshift_cluster_test.go
@@ -120,7 +120,7 @@ func TestAccAWSRedshiftCluster_basic(t *testing.T) {
 						"aws_redshift_cluster.default", "cluster_type", "single-node"),
 					resource.TestCheckResourceAttr(
 						"aws_redshift_cluster.default", "publicly_accessible", "true"),
-					resource.TestMatchResourceAttr("aws_redshift_cluster.default", "address", regexp.MustCompile(fmt.Sprintf("^tf-redshift-cluster-%d.*\\.redshift\\..*", ri))),
+					resource.TestMatchResourceAttr("aws_redshift_cluster.default", "dns_name", regexp.MustCompile(fmt.Sprintf("^tf-redshift-cluster-%d.*\\.redshift\\..*", ri))),
 				),
 			},
 		},

--- a/aws/resource_aws_redshift_cluster_test.go
+++ b/aws/resource_aws_redshift_cluster_test.go
@@ -126,6 +126,32 @@ func TestAccAWSRedshiftCluster_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSRedshiftCluster_dnsName(t *testing.T) {
+	var v redshift.Cluster
+
+	ri := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	config := testAccAWSRedshiftClusterConfig_basic(ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRedshiftClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRedshiftClusterExists("aws_redshift_cluster.default", &v),
+					resource.TestCheckResourceAttr(
+						"aws_redshift_cluster.default", "cluster_type", "single-node"),
+					resource.TestCheckResourceAttr(
+						"aws_redshift_cluster.default", "publicly_accessible", "true"),
+					testAccCheckAWSRedshiftClusterDNSName(&v, ri),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSRedshiftCluster_withFinalSnapshot(t *testing.T) {
 	var v redshift.Cluster
 
@@ -626,6 +652,23 @@ func testAccCheckAWSRedshiftClusterMasterUsername(c *redshift.Cluster, value str
 		if *c.MasterUsername != value {
 			return fmt.Errorf("Expected cluster's MasterUsername: %q, given: %q", value, *c.MasterUsername)
 		}
+		return nil
+	}
+}
+
+func testAccCheckAWSRedshiftClusterDNSName(c *redshift.Cluster, rInt int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if c.Endpoint == nil {
+			return fmt.Errorf("Expected cluster Endpoint to be set, got nil")
+		}
+
+		//validate the cluster address
+		str := fmt.Sprintf("tf-redshift-cluster-%d.?[a-zA-Z0-9].*?.us-west-2.redshift.amazonaws.com", rInt)
+		re := regexp.MustCompile(str)
+		if !re.MatchString(*c.Endpoint.Address) {
+			return fmt.Errorf("Expected cluster DNS name, got %s", *c.Endpoint.Address)
+		}
+
 		return nil
 	}
 }

--- a/aws/resource_aws_redshift_cluster_test.go
+++ b/aws/resource_aws_redshift_cluster_test.go
@@ -104,7 +104,7 @@ func TestValidateRedshiftClusterDbName(t *testing.T) {
 func TestAccAWSRedshiftCluster_basic(t *testing.T) {
 	var v redshift.Cluster
 
-	ri := acctest.RandInt()
+	ri := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	config := testAccAWSRedshiftClusterConfig_basic(ri)
 
 	resource.Test(t, resource.TestCase{

--- a/website/docs/r/redshift_cluster.html.markdown
+++ b/website/docs/r/redshift_cluster.html.markdown
@@ -104,6 +104,7 @@ The following attributes are exported:
 * `encrypted` - Whether the data in the cluster is encrypted
 * `cluster_security_groups` - The security groups associated with the cluster
 * `vpc_security_group_ids` - The VPC security group Ids associated with the cluster
+* `dns_name` - The DNS name of the cluster
 * `port` - The Port the cluster responds on
 * `cluster_version` - The version of Redshift engine software
 * `cluster_parameter_group_name` - The name of the parameter group to be associated with this cluster


### PR DESCRIPTION

Fixes #4566 

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSRedshiftCluster_dnsName'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSRedshiftCluster_dnsName -timeout 120m
=== RUN   TestAccAWSRedshiftCluster_dnsName
--- PASS: TestAccAWSRedshiftCluster_dnsName (1258.35s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1258.385s

```
