### PR TITLE
tests/resource/aws_cognito_user_pool: Add sweeper

### DIFF
--- a/aws/resource_aws_cognito_user_pool_test.go
+++ b/aws/resource_aws_cognito_user_pool_test.go
@@ -3,7 +3,9 @@ package aws
 import (
 	"errors"
 	"fmt"
+	"log"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -13,6 +15,64 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_cognito_user_pool", &resource.Sweeper{
+		Name: "aws_cognito_user_pool",
+		F:    testSweepCognitoUserPools,
+	})
+}
+
+func testSweepCognitoUserPools(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("Error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).cognitoidpconn
+
+	input := &cognitoidentityprovider.ListUserPoolsInput{
+		MaxResults: aws.Int64(int64(50)),
+	}
+
+	for {
+		output, err := conn.ListUserPools(input)
+		if err != nil {
+			if testSweepSkipSweepError(err) {
+				log.Printf("[WARN] Skipping Cognito User Pool sweep for %s: %s", region, err)
+				return nil
+			}
+			return fmt.Errorf("Error retrieving Cognito User Pools: %s", err)
+		}
+
+		if len(output.UserPools) == 0 {
+			log.Print("[DEBUG] No Cognito User Pools to sweep")
+			return nil
+		}
+
+		for _, userPool := range output.UserPools {
+			name := aws.StringValue(userPool.Name)
+
+			if !strings.HasPrefix(name, "tf_acc_") {
+				continue
+			}
+
+			log.Printf("[INFO] Deleting Cognito User Pool %s", name)
+			_, err := conn.DeleteUserPool(&cognitoidentityprovider.DeleteUserPoolInput{
+				UserPoolId: userPool.Id,
+			})
+			if err != nil {
+				return fmt.Errorf("Error deleting Cognito User Pool %s: %s", name, err)
+			}
+		}
+
+		if output.NextToken == nil {
+			break
+		}
+		input.NextToken = output.NextToken
+	}
+
+	return nil
+}
 
 func TestAccAWSCognitoUserPool_basic(t *testing.T) {
 	name := acctest.RandString(5)


### PR DESCRIPTION
Changes proposed in this pull request:

* Add test sweeper for `aws_cognito_user_pool` resource

Currently receiving (for a bunch of the Cognito User Pool related tests):

```
=== RUN   TestAccAWSCognitoUserPool_basic
--- FAIL: TestAccAWSCognitoUserPool_basic (5.26s)
    testing.go:518: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_cognito_user_pool.pool: 1 error(s) occurred:
        
        * aws_cognito_user_pool.pool: Error creating Cognito User Pool: LimitExceededException: The limit for user pools is: 60.
            status code: 400, request id: 555d70ef-5a5f-11e8-9109-23736d1cb70e
```

Output from acceptance testing:

```
$ aws cognito-idp list-user-pools --max-results 60 | jq '.UserPools | length'
60

$ make sweep SWEEPARGS='-sweep-run=aws_cognito_user_pool'
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./... -v -sweep=us-east-1,us-west-2 -sweep-run=aws_cognito_user_pool
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
2018/05/18 09:19:57 [DEBUG] Running Sweepers for region (us-east-1):
2018/05/18 09:19:57 [INFO] Building AWS region structure
2018/05/18 09:19:57 [INFO] Building AWS auth structure
2018/05/18 09:19:57 [INFO] Setting AWS metadata API timeout to 100ms
2018/05/18 09:19:58 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2018/05/18 09:19:58 [INFO] AWS Auth provider used: "EnvProvider"
2018/05/18 09:19:58 [INFO] Initializing DeviceFarm SDK connection
2018/05/18 09:19:58 [DEBUG] Trying to get account ID via iam:GetUser
2018/05/18 09:20:00 [DEBUG] No Cognito User Pools to sweep
2018/05/18 09:20:00 Sweeper Tests ran:
	- aws_cognito_user_pool
2018/05/18 09:20:00 [DEBUG] Running Sweepers for region (us-west-2):
2018/05/18 09:20:00 [INFO] Building AWS region structure
2018/05/18 09:20:00 [INFO] Building AWS auth structure
2018/05/18 09:20:00 [INFO] Setting AWS metadata API timeout to 100ms
2018/05/18 09:20:00 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2018/05/18 09:20:00 [INFO] AWS Auth provider used: "EnvProvider"
2018/05/18 09:20:00 [INFO] Initializing DeviceFarm SDK connection
2018/05/18 09:20:00 [DEBUG] Trying to get account ID via iam:GetUser
2018/05/18 09:20:01 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_npjtj47
2018/05/18 09:20:02 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_y1pnbar
2018/05/18 09:20:03 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_b98wx37
2018/05/18 09:20:03 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_igmnyoy
2018/05/18 09:20:04 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_kop0myi
2018/05/18 09:20:05 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_y1pnbar
2018/05/18 09:20:05 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_qzqy2yc
2018/05/18 09:20:06 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_wri0hgx
2018/05/18 09:20:07 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_kop0myi
2018/05/18 09:20:07 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_igmnyoy
2018/05/18 09:20:08 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_yvc7bvj
2018/05/18 09:20:08 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_gs91hyn
2018/05/18 09:20:09 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_cwy64oi
2018/05/18 09:20:10 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_2mx0nhj
2018/05/18 09:20:11 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_6tgrnce
2018/05/18 09:20:11 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_x1zg4qn
2018/05/18 09:20:12 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_6tgrnce
2018/05/18 09:20:13 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_b98wx37
2018/05/18 09:20:14 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_cwy64oi
2018/05/18 09:20:14 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_ui1g86q
2018/05/18 09:20:15 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_pkar9um
2018/05/18 09:20:15 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_zfymjcl
2018/05/18 09:20:16 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_xd6jq0n
2018/05/18 09:20:17 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_ui1g86q
2018/05/18 09:20:17 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_pkar9um
2018/05/18 09:20:18 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_2mx0nhj
2018/05/18 09:20:18 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_f1znnif
2018/05/18 09:20:19 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_ya1svjr
2018/05/18 09:20:20 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_xmv7ihk
2018/05/18 09:20:20 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_72rurab
2018/05/18 09:20:21 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_fu870cs
2018/05/18 09:20:21 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_qzqy2yc
2018/05/18 09:20:22 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_xmv7ihk
2018/05/18 09:20:23 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_jvutvmh
2018/05/18 09:20:23 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_scgb1o3
2018/05/18 09:20:24 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_jvutvmh
2018/05/18 09:20:24 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_wri0hgx
2018/05/18 09:20:25 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_yitnaiu
2018/05/18 09:20:26 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_scgb1o3
2018/05/18 09:20:26 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_gawuoup
2018/05/18 09:20:27 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_6tgrnce
2018/05/18 09:20:27 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_ya1svjr
2018/05/18 09:20:28 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_gawuoup
2018/05/18 09:20:29 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_f1znnif
2018/05/18 09:20:29 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_yvc7bvj
2018/05/18 09:20:30 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_xd6jq0n
2018/05/18 09:20:31 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_72rurab
2018/05/18 09:20:31 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_f1znnif
2018/05/18 09:20:32 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_x1zg4qn
2018/05/18 09:20:33 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_zfymjcl
2018/05/18 09:20:34 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_w9jtlbo
2018/05/18 09:20:34 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_gs91hyn
2018/05/18 09:20:35 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_yitnaiu
2018/05/18 09:20:36 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_w9jtlbo
2018/05/18 09:20:36 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_npjtj47
2018/05/18 09:20:37 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_fu870cs
2018/05/18 09:20:38 [INFO] Deleting Cognito User Pool tf_acc_ds_cognito_user_pools_pkar9um
2018/05/18 09:20:38 Sweeper Tests ran:
	- aws_cognito_user_pool
ok  	github.com/terraform-providers/terraform-provider-aws/aws	41.341s

$ aws cognito-idp list-user-pools --max-results 60 | jq '.UserPools | length'
4
```
