### PR TITLE
d/aws_vpc_endpoint_service: GovCloud doesn't respect the VPC Endpoint Service service names filter

### DIFF
--- a/aws/data_source_aws_vpc_endpoint_service.go
+++ b/aws/data_source_aws_vpc_endpoint_service.go
@@ -86,20 +86,28 @@ func dataSourceAwsVpcEndpointServiceRead(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error fetching VPC Endpoint Services: %s", err)
 	}
 
-	if resp == nil || len(resp.ServiceNames) == 0 {
+	if resp == nil || (len(resp.ServiceNames) == 0 && len(resp.ServiceDetails) == 0) {
 		return fmt.Errorf("no matching VPC Endpoint Service found")
-	}
-
-	if len(resp.ServiceNames) > 1 {
-		return fmt.Errorf("multiple VPC Endpoint Services matched; use additional constraints to reduce matches to a single VPC Endpoint Service")
 	}
 
 	// Note: AWS Commercial now returns a response with `ServiceNames` and
 	// `ServiceDetails`, but GovCloud responses only include `ServiceNames`
 	if len(resp.ServiceDetails) == 0 {
-		d.SetId(strconv.Itoa(hashcode.String(*resp.ServiceNames[0])))
-		d.Set("service_name", resp.ServiceNames[0])
-		return nil
+		// GovCloud doesn't respect the filter.
+		names := aws.StringValueSlice(resp.ServiceNames)
+		for _, name := range names {
+			if name == serviceName {
+				d.SetId(strconv.Itoa(hashcode.String(name)))
+				d.Set("service_name", name)
+				return nil
+			}
+		}
+
+		return fmt.Errorf("no matching VPC Endpoint Service found")
+	}
+
+	if len(resp.ServiceDetails) > 1 {
+		return fmt.Errorf("multiple VPC Endpoint Services matched; use additional constraints to reduce matches to a single VPC Endpoint Service")
 	}
 
 	sd := resp.ServiceDetails[0]


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/4398.

Restore the original response filtering code for GovCloud.

Acceptance tests (not in GovCloud):

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccDataSourceAwsVpcEndpointService_gateway'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccDataSourceAwsVpcEndpointService_gateway -timeout 120m
=== RUN   TestAccDataSourceAwsVpcEndpointService_gateway
--- PASS: TestAccDataSourceAwsVpcEndpointService_gateway (14.71s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	14.727s
```

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccDataSourceAwsVpcEndpointService_interface'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccDataSourceAwsVpcEndpointService_interface -timeout 120m
=== RUN   TestAccDataSourceAwsVpcEndpointService_interface
--- PASS: TestAccDataSourceAwsVpcEndpointService_interface (14.17s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	14.185s
```
