### PR TITLE
Fixing s3 bucket domain name in non-commercial regions

### DIFF
--- a/aws/data_source_aws_s3_bucket.go
+++ b/aws/data_source_aws_s3_bucket.go
@@ -70,7 +70,14 @@ func dataSourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 		Resource:  bucket,
 	}.String()
 	d.Set("arn", arn)
-	d.Set("bucket_domain_name", bucketDomainName(bucket))
+
+	var awsRegion string
+	if region, ok := d.GetOk("region"); ok {
+		awsRegion = region.(string)
+	} else {
+		awsRegion = meta.(*AWSClient).region
+	}
+	d.Set("bucket_domain_name", bucketDomainName(bucket, awsRegion))
 
 	if err := bucketLocation(d, bucket, conn); err != nil {
 		return err

--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -654,7 +654,14 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("bucket", d.Id())
 	}
 
-	d.Set("bucket_domain_name", bucketDomainName(d.Get("bucket").(string)))
+	var awsRegion string
+	if region, ok := d.GetOk("region"); ok {
+		awsRegion = region.(string)
+	} else {
+		awsRegion = meta.(*AWSClient).region
+	}
+
+	d.Set("bucket_domain_name", bucketDomainName(d.Get("bucket").(string), awsRegion))
 
 	// Read the policy
 	if _, ok := d.GetOk("policy"); ok {
@@ -1437,8 +1444,8 @@ func websiteEndpoint(s3conn *s3.S3, d *schema.ResourceData) (*S3Website, error) 
 	return WebsiteEndpoint(bucket, region), nil
 }
 
-func bucketDomainName(bucket string) string {
-	return fmt.Sprintf("%s.s3.amazonaws.com", bucket)
+func bucketDomainName(bucket string, region string) string {
+	return fmt.Sprintf("%s.s3-%s.amazonaws.com", bucket, region)
 }
 
 func WebsiteEndpoint(bucket string, region string) *S3Website {


### PR DESCRIPTION

Changes proposed in this pull request:

* Fixing s3 bucket domain name in non-commercial regions

Output from acceptance testing:

```
terraform-provider-aws (aws:rean-gov-sd)(kc)(git:feature/fix-domain-output)*$ printenv AWS_DEFAULT_REGION
us-gov-west-1
terraform-provider-aws (aws:rean-gov-sd)(kc)(git:feature/fix-domain-output)*$ make testacc TESTARGS='-run=TestAccAWSS3Bucket_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSS3Bucket_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSS3Bucket_basic
--- PASS: TestAccAWSS3Bucket_basic (156.21s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	156.229s
terraform-provider-aws (aws:rean-gov-sd)(kc)(git:feature/fix-domain-output)*$ 

```

I have added tests to make sure it works in `govcloud` and `china` regions. This is my initial stab at golang. Thanks.