### PR TITLE
Fix aws_organizations_policy documentation link

### DIFF
--- a/website/docs/r/organizations_policy.html.markdown
+++ b/website/docs/r/organizations_policy.html.markdown
@@ -33,7 +33,7 @@ CONTENT
 
 The following arguments are supported:
 
-* `content` - (Required) The policy content to add to the new policy. For example, if you create a [service control policy (SCP)](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scp.html), this string must be JSON text that specifies the permissions that admins in attached accounts can delegate to their users, groups, and roles. For more information about the SCP syntax, see the [Service Control Policy Syntax documentation]((https://docs.aws.amazon.com/organizations/latest/userguide/orgs_reference_scp-syntax.html).
+* `content` - (Required) The policy content to add to the new policy. For example, if you create a [service control policy (SCP)](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scp.html), this string must be JSON text that specifies the permissions that admins in attached accounts can delegate to their users, groups, and roles. For more information about the SCP syntax, see the [Service Control Policy Syntax documentation](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_reference_scp-syntax.html).
 * `name` - (Required) The friendly name to assign to the policy.
 * `description` - (Optional) A description to assign to the policy.
 * `type` - (Optional) The type of policy to create. Currently, the only valid value is `SERVICE_CONTROL_POLICY` (SCP).


### PR DESCRIPTION
Remove excess '(' in link to fix syntax

Changes proposed in this pull request:

* Fix syntax for external link in resource Documentation

Reasoning for docs update:

* Fixes badly formated link at https://www.terraform.io/docs/providers/aws/r/organizations_policy.html

Relevant Terraform version:

* Unrelated to Terraform version.