### PR TITLE
tests/resource/aws_s3_bucket_policy: Fix expected policy with data-source/aws_iam_policy_document wildcard handling

### DIFF
--- a/aws/resource_aws_s3_bucket_policy_test.go
+++ b/aws/resource_aws_s3_bucket_policy_test.go
@@ -21,7 +21,7 @@ func TestAccAWSS3BucketPolicy_basic(t *testing.T) {
 	"Statement": [{
 		"Sid": "",
 		"Effect": "Allow",
-		"Principal": "*",
+		"Principal": {"AWS":"*"},
 		"Action": "s3:*",
 		"Resource": ["arn:%s:s3:::%s/*","arn:%s:s3:::%s"]
 	}]
@@ -52,7 +52,7 @@ func TestAccAWSS3BucketPolicy_policyUpdate(t *testing.T) {
 	"Statement": [{
 		"Sid": "",
 		"Effect": "Allow",
-		"Principal": "*",
+		"Principal": {"AWS":"*"},
 		"Action": "s3:*",
 		"Resource": ["arn:%s:s3:::%s/*","arn:%s:s3:::%s"]
 	}]
@@ -63,7 +63,7 @@ func TestAccAWSS3BucketPolicy_policyUpdate(t *testing.T) {
 	"Statement":[{
 		"Sid": "",
 		"Effect": "Allow",
-		"Principal": "*",
+		"Principal": {"AWS":"*"},
 		"Action": ["s3:DeleteBucket", "s3:ListBucket", "s3:ListBucketVersions"],
 		"Resource": ["arn:%s:s3:::%s/*","arn:%s:s3:::%s"]
 	}]


### PR DESCRIPTION
Followup to #4248 

Changes proposed in this pull request:

* Adjust testing expected policy content for change in #4248 (details in CHANGELOG)

Previously:

```
=== RUN   TestAccAWSS3BucketPolicy_basic
--- FAIL: TestAccAWSS3BucketPolicy_basic (21.16s)
    testing.go:518: Step 0 error: Check failed: Check 2/2 error: Non-equivalent policy error:
        
        expected: {"Version":"2012-10-17","Statement":[{"Sid": "", "Effect":"Allow","Principal":"*","Action":"s3:*","Resource":["arn:aws:s3:::tf-test-bucket-4419237844750449962/*","arn:aws:s3:::tf-test-bucket-4419237844750449962"]}]}
        
             got: {"Version":"2012-10-17","Statement":[{"Sid":"","Effect":"Allow","Principal":{"AWS":"*"},"Action":"s3:*","Resource":["arn:aws:s3:::tf-test-bucket-4419237844750449962/*","arn:aws:s3:::tf-test-bucket-4419237844750449962"]}]}

=== RUN   TestAccAWSS3BucketPolicy_policyUpdate
--- FAIL: TestAccAWSS3BucketPolicy_policyUpdate (10.80s)
    testing.go:518: Step 0 error: Check failed: Check 2/2 error: Non-equivalent policy error:
        
        expected: {"Version":"2012-10-17","Statement":[{"Sid": "", "Effect":"Allow","Principal":"*","Action":"s3:*","Resource":["arn:aws:s3:::tf-test-bucket-7001005429761437413/*","arn:aws:s3:::tf-test-bucket-7001005429761437413"]}]}
        
             got: {"Version":"2012-10-17","Statement":[{"Sid":"","Effect":"Allow","Principal":{"AWS":"*"},"Action":"s3:*","Resource":["arn:aws:s3:::tf-test-bucket-7001005429761437413/*","arn:aws:s3:::tf-test-bucket-7001005429761437413"]}]}
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSS3BucketPolicy'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSS3BucketPolicy -timeout 120m
=== RUN   TestAccAWSS3BucketPolicy_basic
--- PASS: TestAccAWSS3BucketPolicy_basic (34.86s)
=== RUN   TestAccAWSS3BucketPolicy_policyUpdate
--- PASS: TestAccAWSS3BucketPolicy_policyUpdate (48.12s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	83.013s
```
