### PR TITLE
New Resource: aws_guardduty_invite_accepter

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -475,6 +475,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_glue_security_configuration":                  resourceAwsGlueSecurityConfiguration(),
 			"aws_glue_trigger":                                 resourceAwsGlueTrigger(),
 			"aws_guardduty_detector":                           resourceAwsGuardDutyDetector(),
+			"aws_guardduty_invite_accepter":                    resourceAwsGuardDutyInviteAccepter(),
 			"aws_guardduty_ipset":                              resourceAwsGuardDutyIpset(),
 			"aws_guardduty_member":                             resourceAwsGuardDutyMember(),
 			"aws_guardduty_threatintelset":                     resourceAwsGuardDutyThreatintelset(),

--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -192,6 +192,16 @@ func testAccGetPartition() string {
 	return "aws"
 }
 
+func testAccAlternateAccountPreCheck(t *testing.T) {
+	if os.Getenv("AWS_ALTERNATE_PROFILE") == "" && os.Getenv("AWS_ALTERNATE_ACCESS_KEY_ID") == "" {
+		t.Fatal("AWS_ALTERNATE_ACCESS_KEY_ID or AWS_ALTERNATE_PROFILE must be set for acceptance tests")
+	}
+
+	if os.Getenv("AWS_ALTERNATE_ACCESS_KEY_ID") != "" && os.Getenv("AWS_ALTERNATE_SECRET_ACCESS_KEY") == "" {
+		t.Fatal("AWS_ALTERNATE_SECRET_ACCESS_KEY must be set for acceptance tests")
+	}
+}
+
 func testAccEC2ClassicPreCheck(t *testing.T) {
 	client := testAccProvider.Meta().(*AWSClient)
 	platforms := client.supportedplatforms
@@ -229,6 +239,17 @@ func testAccOrganizationsAccountPreCheck(t *testing.T) {
 		t.Fatalf("error describing AWS Organization: %s", err)
 	}
 	t.Skip("skipping tests; this AWS account must not be an existing member of an AWS Organization")
+}
+
+func testAccAlternateAccountProviderConfig() string {
+	return fmt.Sprintf(`
+provider "aws" {
+  access_key = %[1]q
+  alias      = "alternate"
+  profile    = %[2]q
+  secret_key = %[3]q
+}
+`, os.Getenv("AWS_ALTERNATE_ACCESS_KEY_ID"), os.Getenv("AWS_ALTERNATE_PROFILE"), os.Getenv("AWS_ALTERNATE_SECRET_ACCESS_KEY"))
 }
 
 func testAccAwsRegionProviderFunc(region string, providers *[]*schema.Provider) func() *schema.Provider {

--- a/aws/resource_aws_guardduty_invite_accepter.go
+++ b/aws/resource_aws_guardduty_invite_accepter.go
@@ -1,0 +1,158 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/guardduty"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsGuardDutyInviteAccepter() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsGuardDutyInviteAccepterCreate,
+		Read:   resourceAwsGuardDutyInviteAccepterRead,
+		Delete: resourceAwsGuardDutyInviteAccepterDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"detector_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"master_account_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateAwsAccountId,
+			},
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(1 * time.Minute),
+		},
+	}
+}
+
+func resourceAwsGuardDutyInviteAccepterCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).guarddutyconn
+
+	detectorID := d.Get("detector_id").(string)
+	invitationID := ""
+	masterAccountID := d.Get("master_account_id").(string)
+
+	listInvitationsInput := &guardduty.ListInvitationsInput{}
+
+	err := resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		log.Printf("[DEBUG] Listing GuardDuty Invitations: %s", listInvitationsInput)
+		err := conn.ListInvitationsPages(listInvitationsInput, func(page *guardduty.ListInvitationsOutput, lastPage bool) bool {
+			for _, invitation := range page.Invitations {
+				if aws.StringValue(invitation.AccountId) == masterAccountID {
+					invitationID = aws.StringValue(invitation.InvitationId)
+					return false
+				}
+			}
+			return !lastPage
+		})
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		if invitationID == "" {
+			return resource.RetryableError(fmt.Errorf("unable to find pending GuardDuty Invitation for detector ID (%s) from master account ID (%s)", detectorID, masterAccountID))
+		}
+
+		return nil
+	})
+
+	if isResourceTimeoutError(err) {
+		err = conn.ListInvitationsPages(listInvitationsInput, func(page *guardduty.ListInvitationsOutput, lastPage bool) bool {
+			for _, invitation := range page.Invitations {
+				if aws.StringValue(invitation.AccountId) == masterAccountID {
+					invitationID = aws.StringValue(invitation.InvitationId)
+					return false
+				}
+			}
+			return !lastPage
+		})
+	}
+
+	if err != nil {
+		return fmt.Errorf("error listing GuardDuty Invitations: %s", err)
+	}
+
+	acceptInvitationInput := &guardduty.AcceptInvitationInput{
+		DetectorId:   aws.String(detectorID),
+		InvitationId: aws.String(invitationID),
+		MasterId:     aws.String(masterAccountID),
+	}
+
+	log.Printf("[DEBUG] Accepting GuardDuty Invitation: %s", acceptInvitationInput)
+	_, err = conn.AcceptInvitation(acceptInvitationInput)
+
+	if err != nil {
+		return fmt.Errorf("error accepting GuardDuty Invitation (%s): %s", invitationID, err)
+	}
+
+	d.SetId(detectorID)
+
+	return resourceAwsGuardDutyInviteAccepterRead(d, meta)
+}
+
+func resourceAwsGuardDutyInviteAccepterRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).guarddutyconn
+
+	input := &guardduty.GetMasterAccountInput{
+		DetectorId: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Reading GuardDuty Master Account: %s", input)
+	output, err := conn.GetMasterAccount(input)
+
+	if isAWSErr(err, guardduty.ErrCodeBadRequestException, "The request is rejected because the input detectorId is not owned by the current account.") {
+		log.Printf("[WARN] GuardDuty Detector %q not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading GuardDuty Detector (%s) GuardDuty Master Account: %s", d.Id(), err)
+	}
+
+	if output == nil || output.Master == nil {
+		return fmt.Errorf("error reading GuardDuty Detector (%s) GuardDuty Master Account: empty response", d.Id())
+	}
+
+	d.Set("detector_id", d.Id())
+	d.Set("master_account_id", output.Master.AccountId)
+
+	return nil
+}
+
+func resourceAwsGuardDutyInviteAccepterDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).guarddutyconn
+
+	input := &guardduty.DisassociateFromMasterAccountInput{
+		DetectorId: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Disassociating GuardDuty Detector (%s) from GuardDuty Master Account: %s", d.Id(), input)
+	_, err := conn.DisassociateFromMasterAccount(input)
+
+	if isAWSErr(err, guardduty.ErrCodeBadRequestException, "The request is rejected because the input detectorId is not owned by the current account.") {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error disassociating GuardDuty Member Detector (%s) from GuardDuty Master Account: %s", d.Id(), err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_guardduty_invite_accepter_test.go
+++ b/aws/resource_aws_guardduty_invite_accepter_test.go
@@ -1,0 +1,135 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/guardduty"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func testAccAwsGuardDutyInviteAccepter_basic(t *testing.T) {
+	var providers []*schema.Provider
+	masterDetectorResourceName := "aws_guardduty_detector.master"
+	memberDetectorResourceName := "aws_guardduty_detector.member"
+	resourceName := "aws_guardduty_invite_accepter.test"
+	_, email := testAccAWSGuardDutyMemberFromEnv(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccAlternateAccountPreCheck(t)
+		},
+		ProviderFactories: testAccProviderFactories(&providers),
+		CheckDestroy:      testAccCheckAwsGuardDutyInviteAccepterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsGuardDutyInviteAccepterConfig_basic(email),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsGuardDutyInviteAccepterExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "detector_id", memberDetectorResourceName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "master_account_id", masterDetectorResourceName, "account_id"),
+				),
+			},
+			{
+				Config:            testAccAwsGuardDutyInviteAccepterConfig_basic(email),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAwsGuardDutyInviteAccepterDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).guarddutyconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_guardduty_invite_accepter" {
+			continue
+		}
+
+		input := &guardduty.GetMasterAccountInput{
+			DetectorId: aws.String(rs.Primary.ID),
+		}
+
+		output, err := conn.GetMasterAccount(input)
+
+		if isAWSErr(err, guardduty.ErrCodeBadRequestException, "The request is rejected because the input detectorId is not owned by the current account.") {
+			return nil
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if output == nil || output.Master == nil || aws.StringValue(output.Master.AccountId) != rs.Primary.Attributes["master_account_id"] {
+			continue
+		}
+
+		return fmt.Errorf("GuardDuty Detector (%s) still has GuardDuty Master Account ID (%s)", rs.Primary.ID, aws.StringValue(output.Master.AccountId))
+	}
+
+	return nil
+}
+
+func testAccCheckAwsGuardDutyInviteAccepterExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Resource (%s) has empty ID", resourceName)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).guarddutyconn
+
+		input := &guardduty.GetMasterAccountInput{
+			DetectorId: aws.String(rs.Primary.ID),
+		}
+
+		output, err := conn.GetMasterAccount(input)
+
+		if err != nil {
+			return err
+		}
+
+		if output == nil || output.Master == nil || aws.StringValue(output.Master.AccountId) == "" {
+			return fmt.Errorf("no master account found for: %s", resourceName)
+		}
+
+		return nil
+	}
+}
+
+func testAccAwsGuardDutyInviteAccepterConfig_basic(email string) string {
+	return testAccAlternateAccountProviderConfig() + fmt.Sprintf(`
+resource "aws_guardduty_detector" "master" {
+  provider = "aws.alternate"
+}
+
+resource "aws_guardduty_detector" "member" {}
+
+resource "aws_guardduty_member" "member" {
+  provider = "aws.alternate"
+
+  account_id                 = "${aws_guardduty_detector.member.account_id}"
+  detector_id                = "${aws_guardduty_detector.master.id}"
+  disable_email_notification = true
+  email                      = %q
+  invite                     = true
+}
+
+resource "aws_guardduty_invite_accepter" "test" {
+  depends_on = ["aws_guardduty_member.member"]
+
+  detector_id       = "${aws_guardduty_detector.member.id}"
+  master_account_id = "${aws_guardduty_detector.master.account_id}"
+}
+`, email)
+}

--- a/aws/resource_aws_guardduty_test.go
+++ b/aws/resource_aws_guardduty_test.go
@@ -11,6 +11,9 @@ func TestAccAWSGuardDuty(t *testing.T) {
 			"basic":  testAccAwsGuardDutyDetector_basic,
 			"import": testAccAwsGuardDutyDetector_import,
 		},
+		"InviteAccepter": {
+			"basic": testAccAwsGuardDutyInviteAccepter_basic,
+		},
 		"IPSet": {
 			"basic":  testAccAwsGuardDutyIpset_basic,
 			"import": testAccAwsGuardDutyIpset_import,

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1502,6 +1502,10 @@
                             <a href="/docs/providers/aws/r/guardduty_detector.html">aws_guardduty_detector</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-guardduty-invite-accepter") %>>
+                            <a href="/docs/providers/aws/r/guardduty_invite_accepter.html">aws_guardduty_invite_accepter</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-aws-resource-guardduty-ipset") %>>
                             <a href="/docs/providers/aws/r/guardduty_ipset.html">aws_guardduty_ipset</a>
                         </li>

--- a/website/docs/r/guardduty_invite_accepter.html.markdown
+++ b/website/docs/r/guardduty_invite_accepter.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The member GuardDuty detector ID and master AWS account ID
+* `id` - GuardDuty member detector ID
 
 ## Timeouts
 

--- a/website/docs/r/guardduty_invite_accepter.html.markdown
+++ b/website/docs/r/guardduty_invite_accepter.html.markdown
@@ -1,0 +1,64 @@
+---
+layout: "aws"
+page_title: "AWS: aws_guardduty_invite_accepter"
+sidebar_current: "docs-aws-resource-guardduty-invite-accepter"
+description: |-
+  Provides a resource to accept a pending GuardDuty invite on creation, ensure the detector has the correct master account on read, and disassociate with the master account upon removal.
+---
+
+# aws_guardduty_invite_accepter
+
+Provides a resource to accept a pending GuardDuty invite on creation, ensure the detector has the correct master account on read, and disassociate with the master account upon removal.
+
+## Example Usage
+
+```hcl
+resource "aws_guardduty_detector" "master" {}
+
+resource "aws_guardduty_detector" "member" {
+  provider = "aws.dev"
+}
+
+resource "aws_guardduty_member" "dev" {
+  account_id         = "${aws_guardduty_detector.member.account_id}"
+  detector_id        = "${aws_guardduty_detector.master.id}"
+  email              = "required@example.com"
+  invite             = true
+}
+
+resource "aws_guardduty_invite_accepter" "member" {
+  depends_on = ["aws_guardduty_member.dev"]
+  provider   = "aws.dev"
+
+  detector_id       = "${aws_guardduty_detector.member.id}"
+  master_account_id = "${aws_guardduty_detector.master.account_id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `detector_id` - (Required) The detector ID of the member GuardDuty account.
+* `master_account_id` - (Required) AWS account ID for master account.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The member GuardDuty detector ID and master AWS account ID
+
+## Timeouts
+
+`aws_guardduty_invite_accepter` provides the following [Timeouts](/docs/configuration/resources.html#timeouts)
+configuration options:
+
+- `create` - (Default `1m`) How long to wait for an invite to accept.
+
+## Import
+
+`aws_guardduty_invite_accepter` can be imported using the the member GuardDuty detector ID, e.g.
+
+```
+$ terraform import aws_guardduty_invite_accepter.member 00b00fd5aecc0ab60a708659477e9617
+```


### PR DESCRIPTION
Closes #2489 

Changes proposed in this pull request:

* Adds alternate AWS account handling in the provider acceptance testing framework
* Adds new resource for managing a GuardDuty member account invitation from a master account and disassociation from a master account

Output from acceptance testing:

```
    --- PASS: TestAccAWSGuardDuty/InviteAccepter (18.16s)
        --- PASS: TestAccAWSGuardDuty/InviteAccepter/basic (18.16s)
```
