### PR TITLE
docs/resource/aws_secretsmanager_secret_version: Provide example key-value pair usage

### DIFF
--- a/website/docs/r/secretsmanager_secret_version.html.markdown
+++ b/website/docs/r/secretsmanager_secret_version.html.markdown
@@ -14,10 +14,34 @@ Provides a resource to manage AWS Secrets Manager secret version including its s
 
 ## Example Usage
 
+### Simple String Value
+
 ```hcl
 resource "aws_secretsmanager_secret_version" "example" {
   secret_id     = "${aws_secretsmanager_secret.example.id}"
   secret_string = "example-string-to-protect"
+}
+```
+
+### Key-Value Pairs
+
+Secrets Manager also accepts key-value pairs in JSON.
+
+```hcl
+# The map here can come from other supported configurations
+# like locals, resource attribute, map() built-in, etc.
+variable "example" {
+  default = {
+    key1 = "value1"
+    key2 = "value2"
+  }
+
+  type = "map"
+}
+
+resource "aws_secretsmanager_secret_version" "example" {
+  secret_id     = "${aws_secretsmanager_secret.example.id}"
+  secret_string = "${jsonencode(var.example)}"
 }
 ```
 


### PR DESCRIPTION
Reference #4611

Changes proposed in this pull request:

* Add example key-value pair usage

Output from acceptance testing: N/A