### PR TITLE
Deps: Bump aws-sdk-go@v1.13.54

### DIFF
--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.13.51"
+const SDKVersion = "1.13.54"

--- a/vendor/github.com/aws/aws-sdk-go/service/cloudformation/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/cloudformation/api.go
@@ -3618,7 +3618,8 @@ func (c *CloudFormation) UpdateStackSetRequest(input *UpdateStackSetInput) (req 
 
 // UpdateStackSet API operation for AWS CloudFormation.
 //
-// Updates the stack set and all associated stack instances.
+// Updates the stack set, and associated stack instances in the specified accounts
+// and regions.
 //
 // Even if the stack set operation created by updating the stack set fails (completely
 // or partially, below or above a specified failure tolerance), the stack set
@@ -3649,6 +3650,9 @@ func (c *CloudFormation) UpdateStackSetRequest(input *UpdateStackSetInput) (req 
 //
 //   * ErrCodeInvalidOperationException "InvalidOperationException"
 //   The specified operation isn't valid.
+//
+//   * ErrCodeStackInstanceNotFoundException "StackInstanceNotFoundException"
+//   The specified stack instance doesn't exist.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/cloudformation-2010-05-15/UpdateStackSet
 func (c *CloudFormation) UpdateStackSet(input *UpdateStackSetInput) (*UpdateStackSetOutput, error) {
@@ -5130,8 +5134,8 @@ type CreateStackSetInput struct {
 	//
 	// Specify an IAM role only if you are using customized administrator roles
 	// to control which users or groups can manage specific stack sets within the
-	// same administrator account. For more information, see Define Permissions
-	// for Multiple Administrators (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-prereqs.html)
+	// same administrator account. For more information, see Prerequisites: Granting
+	// Permissions for Stack Set Operations (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-prereqs.html)
 	// in the AWS CloudFormation User Guide.
 	AdministrationRoleARN *string `min:"20" type:"string"`
 
@@ -5183,6 +5187,14 @@ type CreateStackSetInput struct {
 	// A description of the stack set. You can use the description to identify the
 	// stack set's purpose or other important information.
 	Description *string `min:"1" type:"string"`
+
+	// The name of the IAM execution role to use to create the stack set. If you
+	// do not specify an execution role, AWS CloudFormation uses the AWSCloudFormationStackSetExecutionRole
+	// role for the stack set operation.
+	//
+	// Specify an IAM role only if you are using customized execution roles to control
+	// which stack resources users and groups can include in their stack sets.
+	ExecutionRoleName *string `min:"1" type:"string"`
 
 	// The input parameters for the stack set template.
 	Parameters []*Parameter `type:"list"`
@@ -5248,6 +5260,9 @@ func (s *CreateStackSetInput) Validate() error {
 	if s.Description != nil && len(*s.Description) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("Description", 1))
 	}
+	if s.ExecutionRoleName != nil && len(*s.ExecutionRoleName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ExecutionRoleName", 1))
+	}
 	if s.StackSetName == nil {
 		invalidParams.Add(request.NewErrParamRequired("StackSetName"))
 	}
@@ -5295,6 +5310,12 @@ func (s *CreateStackSetInput) SetClientRequestToken(v string) *CreateStackSetInp
 // SetDescription sets the Description field's value.
 func (s *CreateStackSetInput) SetDescription(v string) *CreateStackSetInput {
 	s.Description = &v
+	return s
+}
+
+// SetExecutionRoleName sets the ExecutionRoleName field's value.
+func (s *CreateStackSetInput) SetExecutionRoleName(v string) *CreateStackSetInput {
+	s.ExecutionRoleName = &v
 	return s
 }
 
@@ -9765,7 +9786,7 @@ type StackSet struct {
 	//
 	// Use customized administrator roles to control which users or groups can manage
 	// specific stack sets within the same administrator account. For more information,
-	// see Define Permissions for Multiple Administrators (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-prereqs.html)
+	// see Prerequisites: Granting Permissions for Stack Set Operations (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-prereqs.html)
 	// in the AWS CloudFormation User Guide.
 	AdministrationRoleARN *string `min:"20" type:"string"`
 
@@ -9779,6 +9800,12 @@ type StackSet struct {
 	// A description of the stack set that you specify when the stack set is created
 	// or updated.
 	Description *string `min:"1" type:"string"`
+
+	// The name of the IAM execution role used to create or update the stack set.
+	//
+	// Use customized execution roles to control which stack resources users and
+	// groups can include in their stack sets.
+	ExecutionRoleName *string `min:"1" type:"string"`
 
 	// A list of input parameters for a stack set.
 	Parameters []*Parameter `type:"list"`
@@ -9829,6 +9856,12 @@ func (s *StackSet) SetCapabilities(v []*string) *StackSet {
 // SetDescription sets the Description field's value.
 func (s *StackSet) SetDescription(v string) *StackSet {
 	s.Description = &v
+	return s
+}
+
+// SetExecutionRoleName sets the ExecutionRoleName field's value.
+func (s *StackSet) SetExecutionRoleName(v string) *StackSet {
+	s.ExecutionRoleName = &v
 	return s
 }
 
@@ -9905,6 +9938,12 @@ type StackSetOperation struct {
 	// set operation was successful, or even attempted, in each account or region.
 	EndTimestamp *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
+	// The name of the IAM execution role used to create or update the stack set.
+	//
+	// Use customized execution roles to control which stack resources users and
+	// groups can include in their stack sets.
+	ExecutionRoleName *string `min:"1" type:"string"`
+
 	// The unique ID of a stack set operation.
 	OperationId *string `min:"1" type:"string"`
 
@@ -9973,6 +10012,12 @@ func (s *StackSetOperation) SetCreationTimestamp(v time.Time) *StackSetOperation
 // SetEndTimestamp sets the EndTimestamp field's value.
 func (s *StackSetOperation) SetEndTimestamp(v time.Time) *StackSetOperation {
 	s.EndTimestamp = &v
+	return s
+}
+
+// SetExecutionRoleName sets the ExecutionRoleName field's value.
+func (s *StackSetOperation) SetExecutionRoleName(v string) *StackSetOperation {
+	s.ExecutionRoleName = &v
 	return s
 }
 
@@ -11168,6 +11213,23 @@ func (s *UpdateStackOutput) SetStackId(v string) *UpdateStackOutput {
 type UpdateStackSetInput struct {
 	_ struct{} `type:"structure"`
 
+	// The accounts in which to update associated stack instances. If you specify
+	// accounts, you must also specify the regions in which to update stack set
+	// instances.
+	//
+	// To update all the stack instances associated with this stack set, do not
+	// specify the Accounts or Regions properties.
+	//
+	// If the stack set update includes changes to the template (that is, if the
+	// TemplateBody or TemplateURL properties are specified), or the Parameters
+	// property, AWS CloudFormation marks all stack instances with a status of OUTDATED
+	// prior to updating the stack instances in the specified accounts and regions.
+	// If the stack set update does not include changes to the template or parameters,
+	// AWS CloudFormation updates the stack instances in the specified accounts
+	// and regions, while leaving all other stack instances with their existing
+	// stack instance status.
+	Accounts []*string `type:"list"`
+
 	// The Amazon Resource Number (ARN) of the IAM role to use to update this stack
 	// set.
 	//
@@ -11223,6 +11285,20 @@ type UpdateStackSetInput struct {
 	// A brief description of updates that you are making.
 	Description *string `min:"1" type:"string"`
 
+	// The name of the IAM execution role to use to update the stack set. If you
+	// do not specify an execution role, AWS CloudFormation uses the AWSCloudFormationStackSetExecutionRole
+	// role for the stack set operation.
+	//
+	// Specify an IAM role only if you are using customized execution roles to control
+	// which stack resources users and groups can include in their stack sets.
+	//
+	// If you specify a customized execution role, AWS CloudFormation uses that
+	// role to update the stack. If you do not specify a customized execution role,
+	// AWS CloudFormation performs the update using the role previously associated
+	// with the stack set, so long as you have permissions to perform operations
+	// on the stack set.
+	ExecutionRoleName *string `min:"1" type:"string"`
+
 	// The unique ID for this stack set operation.
 	//
 	// The operation ID also functions as an idempotency token, to ensure that AWS
@@ -11241,6 +11317,22 @@ type UpdateStackSetInput struct {
 
 	// A list of input parameters for the stack set template.
 	Parameters []*Parameter `type:"list"`
+
+	// The regions in which to update associated stack instances. If you specify
+	// regions, you must also specify accounts in which to update stack set instances.
+	//
+	// To update all the stack instances associated with this stack set, do not
+	// specify the Accounts or Regions properties.
+	//
+	// If the stack set update includes changes to the template (that is, if the
+	// TemplateBody or TemplateURL properties are specified), or the Parameters
+	// property, AWS CloudFormation marks all stack instances with a status of OUTDATED
+	// prior to updating the stack instances in the specified accounts and regions.
+	// If the stack set update does not include changes to the template or parameters,
+	// AWS CloudFormation updates the stack instances in the specified accounts
+	// and regions, while leaving all other stack instances with their existing
+	// stack instance status.
+	Regions []*string `type:"list"`
 
 	// The name or unique ID of the stack set that you want to update.
 	//
@@ -11321,6 +11413,9 @@ func (s *UpdateStackSetInput) Validate() error {
 	if s.Description != nil && len(*s.Description) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("Description", 1))
 	}
+	if s.ExecutionRoleName != nil && len(*s.ExecutionRoleName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ExecutionRoleName", 1))
+	}
 	if s.OperationId != nil && len(*s.OperationId) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("OperationId", 1))
 	}
@@ -11355,6 +11450,12 @@ func (s *UpdateStackSetInput) Validate() error {
 	return nil
 }
 
+// SetAccounts sets the Accounts field's value.
+func (s *UpdateStackSetInput) SetAccounts(v []*string) *UpdateStackSetInput {
+	s.Accounts = v
+	return s
+}
+
 // SetAdministrationRoleARN sets the AdministrationRoleARN field's value.
 func (s *UpdateStackSetInput) SetAdministrationRoleARN(v string) *UpdateStackSetInput {
 	s.AdministrationRoleARN = &v
@@ -11373,6 +11474,12 @@ func (s *UpdateStackSetInput) SetDescription(v string) *UpdateStackSetInput {
 	return s
 }
 
+// SetExecutionRoleName sets the ExecutionRoleName field's value.
+func (s *UpdateStackSetInput) SetExecutionRoleName(v string) *UpdateStackSetInput {
+	s.ExecutionRoleName = &v
+	return s
+}
+
 // SetOperationId sets the OperationId field's value.
 func (s *UpdateStackSetInput) SetOperationId(v string) *UpdateStackSetInput {
 	s.OperationId = &v
@@ -11388,6 +11495,12 @@ func (s *UpdateStackSetInput) SetOperationPreferences(v *StackSetOperationPrefer
 // SetParameters sets the Parameters field's value.
 func (s *UpdateStackSetInput) SetParameters(v []*Parameter) *UpdateStackSetInput {
 	s.Parameters = v
+	return s
+}
+
+// SetRegions sets the Regions field's value.
+func (s *UpdateStackSetInput) SetRegions(v []*string) *UpdateStackSetInput {
+	s.Regions = v
 	return s
 }
 

--- a/vendor/github.com/aws/aws-sdk-go/service/inspector/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/inspector/api.go
@@ -182,6 +182,10 @@ func (c *Inspector) CreateAssessmentTargetRequest(input *CreateAssessmentTargetI
 //   The request was rejected because it referenced an entity that does not exist.
 //   The error code describes the entity.
 //
+//   * ErrCodeInvalidCrossAccountRoleException "InvalidCrossAccountRoleException"
+//   Amazon Inspector cannot assume the cross-account role that it needs to list
+//   your EC2 instances during the assessment run.
+//
 // See also, https://docs.aws.amazon.com/goto/WebAPI/inspector-2016-02-16/CreateAssessmentTarget
 func (c *Inspector) CreateAssessmentTarget(input *CreateAssessmentTargetInput) (*CreateAssessmentTargetOutput, error) {
 	req, out := c.CreateAssessmentTargetRequest(input)
@@ -4278,9 +4282,7 @@ type AssessmentTarget struct {
 
 	// The ARN that specifies the resource group that is associated with the assessment
 	// target.
-	//
-	// ResourceGroupArn is a required field
-	ResourceGroupArn *string `locationName:"resourceGroupArn" min:"1" type:"string" required:"true"`
+	ResourceGroupArn *string `locationName:"resourceGroupArn" min:"1" type:"string"`
 
 	// The time at which UpdateAssessmentTarget is called.
 	//
@@ -4692,9 +4694,7 @@ type CreateAssessmentTargetInput struct {
 
 	// The ARN that specifies the resource group that is used to create the assessment
 	// target.
-	//
-	// ResourceGroupArn is a required field
-	ResourceGroupArn *string `locationName:"resourceGroupArn" min:"1" type:"string" required:"true"`
+	ResourceGroupArn *string `locationName:"resourceGroupArn" min:"1" type:"string"`
 }
 
 // String returns the string representation
@@ -4715,9 +4715,6 @@ func (s *CreateAssessmentTargetInput) Validate() error {
 	}
 	if s.AssessmentTargetName != nil && len(*s.AssessmentTargetName) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("AssessmentTargetName", 1))
-	}
-	if s.ResourceGroupArn == nil {
-		invalidParams.Add(request.NewErrParamRequired("ResourceGroupArn"))
 	}
 	if s.ResourceGroupArn != nil && len(*s.ResourceGroupArn) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("ResourceGroupArn", 1))
@@ -8203,9 +8200,7 @@ type UpdateAssessmentTargetInput struct {
 
 	// The ARN of the resource group that is used to specify the new resource group
 	// to associate with the assessment target.
-	//
-	// ResourceGroupArn is a required field
-	ResourceGroupArn *string `locationName:"resourceGroupArn" min:"1" type:"string" required:"true"`
+	ResourceGroupArn *string `locationName:"resourceGroupArn" min:"1" type:"string"`
 }
 
 // String returns the string representation
@@ -8232,9 +8227,6 @@ func (s *UpdateAssessmentTargetInput) Validate() error {
 	}
 	if s.AssessmentTargetName != nil && len(*s.AssessmentTargetName) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("AssessmentTargetName", 1))
-	}
-	if s.ResourceGroupArn == nil {
-		invalidParams.Add(request.NewErrParamRequired("ResourceGroupArn"))
 	}
 	if s.ResourceGroupArn != nil && len(*s.ResourceGroupArn) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("ResourceGroupArn", 1))

--- a/vendor/github.com/aws/aws-sdk-go/service/iot/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/iot/api.go
@@ -266,7 +266,7 @@ func (c *IoT) AssociateTargetsWithJobRequest(input *AssociateTargetsWithJobInput
 //   The specified resource does not exist.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   The number of attached entities exceeds the limit.
+//   A limit has been exceeded.
 //
 //   * ErrCodeThrottlingException "ThrottlingException"
 //   The rate exceeds the limit.
@@ -368,7 +368,7 @@ func (c *IoT) AttachPolicyRequest(input *AttachPolicyInput) (req *request.Reques
 //   An unexpected error has occurred.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   The number of attached entities exceeds the limit.
+//   A limit has been exceeded.
 //
 func (c *IoT) AttachPolicy(input *AttachPolicyInput) (*AttachPolicyOutput, error) {
 	req, out := c.AttachPolicyRequest(input)
@@ -470,7 +470,7 @@ func (c *IoT) AttachPrincipalPolicyRequest(input *AttachPrincipalPolicyInput) (r
 //   An unexpected error has occurred.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   The number of attached entities exceeds the limit.
+//   A limit has been exceeded.
 //
 func (c *IoT) AttachPrincipalPolicy(input *AttachPrincipalPolicyInput) (*AttachPrincipalPolicyOutput, error) {
 	req, out := c.AttachPrincipalPolicyRequest(input)
@@ -925,7 +925,7 @@ func (c *IoT) CreateAuthorizerRequest(input *CreateAuthorizerInput) (req *reques
 //   The request is not valid.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   The number of attached entities exceeds the limit.
+//   A limit has been exceeded.
 //
 //   * ErrCodeThrottlingException "ThrottlingException"
 //   The rate exceeds the limit.
@@ -1151,7 +1151,7 @@ func (c *IoT) CreateJobRequest(input *CreateJobInput) (req *request.Request, out
 //   The resource already exists.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   The number of attached entities exceeds the limit.
+//   A limit has been exceeded.
 //
 //   * ErrCodeThrottlingException "ThrottlingException"
 //   The rate exceeds the limit.
@@ -1627,7 +1627,7 @@ func (c *IoT) CreateRoleAliasRequest(input *CreateRoleAliasInput) (req *request.
 //   The request is not valid.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   The number of attached entities exceeds the limit.
+//   A limit has been exceeded.
 //
 //   * ErrCodeThrottlingException "ThrottlingException"
 //   The rate exceeds the limit.
@@ -2411,6 +2411,202 @@ func (c *IoT) DeleteCertificate(input *DeleteCertificateInput) (*DeleteCertifica
 // for more information on using Contexts.
 func (c *IoT) DeleteCertificateWithContext(ctx aws.Context, input *DeleteCertificateInput, opts ...request.Option) (*DeleteCertificateOutput, error) {
 	req, out := c.DeleteCertificateRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDeleteJob = "DeleteJob"
+
+// DeleteJobRequest generates a "aws/request.Request" representing the
+// client's request for the DeleteJob operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DeleteJob for more information on using the DeleteJob
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DeleteJobRequest method.
+//    req, resp := client.DeleteJobRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) DeleteJobRequest(input *DeleteJobInput) (req *request.Request, output *DeleteJobOutput) {
+	op := &request.Operation{
+		Name:       opDeleteJob,
+		HTTPMethod: "DELETE",
+		HTTPPath:   "/jobs/{jobId}",
+	}
+
+	if input == nil {
+		input = &DeleteJobInput{}
+	}
+
+	output = &DeleteJobOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restjson.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// DeleteJob API operation for AWS IoT.
+//
+// Deletes a job and its related job executions.
+//
+// Deleting a job may take time, depending on the number of job executions created
+// for the job and various other factors. While the job is being deleted, the
+// status of the job will be shown as "DELETION_IN_PROGRESS". Attempting to
+// delete or cancel a job whose status is already "DELETION_IN_PROGRESS" will
+// result in an error.
+//
+// Only 10 jobs may have status "DELETION_IN_PROGRESS" at the same time, or
+// a LimitExceededException will occur.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation DeleteJob for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeInvalidStateTransitionException "InvalidStateTransitionException"
+//   An attempt was made to change to an invalid state, for example by deleting
+//   a job or a job execution which is "IN_PROGRESS" without setting the force
+//   parameter.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   A limit has been exceeded.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+func (c *IoT) DeleteJob(input *DeleteJobInput) (*DeleteJobOutput, error) {
+	req, out := c.DeleteJobRequest(input)
+	return out, req.Send()
+}
+
+// DeleteJobWithContext is the same as DeleteJob with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeleteJob for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) DeleteJobWithContext(ctx aws.Context, input *DeleteJobInput, opts ...request.Option) (*DeleteJobOutput, error) {
+	req, out := c.DeleteJobRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDeleteJobExecution = "DeleteJobExecution"
+
+// DeleteJobExecutionRequest generates a "aws/request.Request" representing the
+// client's request for the DeleteJobExecution operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DeleteJobExecution for more information on using the DeleteJobExecution
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DeleteJobExecutionRequest method.
+//    req, resp := client.DeleteJobExecutionRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *IoT) DeleteJobExecutionRequest(input *DeleteJobExecutionInput) (req *request.Request, output *DeleteJobExecutionOutput) {
+	op := &request.Operation{
+		Name:       opDeleteJobExecution,
+		HTTPMethod: "DELETE",
+		HTTPPath:   "/things/{thingName}/jobs/{jobId}/executionNumber/{executionNumber}",
+	}
+
+	if input == nil {
+		input = &DeleteJobExecutionInput{}
+	}
+
+	output = &DeleteJobExecutionOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restjson.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// DeleteJobExecution API operation for AWS IoT.
+//
+// Deletes a job execution.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS IoT's
+// API operation DeleteJobExecution for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   The request is not valid.
+//
+//   * ErrCodeInvalidStateTransitionException "InvalidStateTransitionException"
+//   An attempt was made to change to an invalid state, for example by deleting
+//   a job or a job execution which is "IN_PROGRESS" without setting the force
+//   parameter.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource does not exist.
+//
+//   * ErrCodeThrottlingException "ThrottlingException"
+//   The rate exceeds the limit.
+//
+//   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
+//   The service is temporarily unavailable.
+//
+func (c *IoT) DeleteJobExecution(input *DeleteJobExecutionInput) (*DeleteJobExecutionOutput, error) {
+	req, out := c.DeleteJobExecutionRequest(input)
+	return out, req.Send()
+}
+
+// DeleteJobExecutionWithContext is the same as DeleteJobExecution with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeleteJobExecution for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *IoT) DeleteJobExecutionWithContext(ctx aws.Context, input *DeleteJobExecutionInput, opts ...request.Option) (*DeleteJobExecutionOutput, error) {
+	req, out := c.DeleteJobExecutionRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -4923,7 +5119,7 @@ func (c *IoT) DetachPolicyRequest(input *DetachPolicyInput) (req *request.Reques
 //   An unexpected error has occurred.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   The number of attached entities exceeds the limit.
+//   A limit has been exceeded.
 //
 func (c *IoT) DetachPolicy(input *DetachPolicyInput) (*DetachPolicyOutput, error) {
 	req, out := c.DetachPolicyRequest(input)
@@ -5380,7 +5576,7 @@ func (c *IoT) GetEffectivePoliciesRequest(input *GetEffectivePoliciesInput) (req
 //   An unexpected error has occurred.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   The number of attached entities exceeds the limit.
+//   A limit has been exceeded.
 //
 func (c *IoT) GetEffectivePolicies(input *GetEffectivePoliciesInput) (*GetEffectivePoliciesOutput, error) {
 	req, out := c.GetEffectivePoliciesRequest(input)
@@ -6258,7 +6454,7 @@ func (c *IoT) ListAttachedPoliciesRequest(input *ListAttachedPoliciesInput) (req
 //   An unexpected error has occurred.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   The number of attached entities exceeds the limit.
+//   A limit has been exceeded.
 //
 func (c *IoT) ListAttachedPolicies(input *ListAttachedPoliciesInput) (*ListAttachedPoliciesOutput, error) {
 	req, out := c.ListAttachedPoliciesRequest(input)
@@ -7868,7 +8064,7 @@ func (c *IoT) ListTargetsForPolicyRequest(input *ListTargetsForPolicyInput) (req
 //   An unexpected error has occurred.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   The number of attached entities exceeds the limit.
+//   A limit has been exceeded.
 //
 func (c *IoT) ListTargetsForPolicy(input *ListTargetsForPolicyInput) (*ListTargetsForPolicyOutput, error) {
 	req, out := c.ListTargetsForPolicyRequest(input)
@@ -8818,7 +9014,7 @@ func (c *IoT) RegisterCACertificateRequest(input *RegisterCACertificateInput) (r
 //   The rate exceeds the limit.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   The number of attached entities exceeds the limit.
+//   A limit has been exceeded.
 //
 //   * ErrCodeUnauthorizedException "UnauthorizedException"
 //   You are not authorized to perform this operation.
@@ -10118,7 +10314,7 @@ func (c *IoT) TestAuthorizationRequest(input *TestAuthorizationInput) (req *requ
 //   An unexpected error has occurred.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   The number of attached entities exceeds the limit.
+//   A limit has been exceeded.
 //
 func (c *IoT) TestAuthorization(input *TestAuthorizationInput) (*TestAuthorizationOutput, error) {
 	req, out := c.TestAuthorizationRequest(input)
@@ -10403,7 +10599,7 @@ func (c *IoT) UpdateAuthorizerRequest(input *UpdateAuthorizerInput) (req *reques
 //   The request is not valid.
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
-//   The number of attached entities exceeds the limit.
+//   A limit has been exceeded.
 //
 //   * ErrCodeThrottlingException "ThrottlingException"
 //   The rate exceeds the limit.
@@ -14876,6 +15072,187 @@ func (s DeleteCertificateOutput) GoString() string {
 	return s.String()
 }
 
+type DeleteJobExecutionInput struct {
+	_ struct{} `type:"structure"`
+
+	// The ID of the job execution to be deleted. The executionNumber refers to
+	// the execution of a particular job on a particular device.
+	//
+	// Note that once a job execution is deleted, the executionNumber may be reused
+	// by IoT, so be sure you get and use the correct value here.
+	//
+	// ExecutionNumber is a required field
+	ExecutionNumber *int64 `location:"uri" locationName:"executionNumber" type:"long" required:"true"`
+
+	// (Optional) When true, you can delete a job execution which is "IN_PROGRESS".
+	// Otherwise, you can only delete a job execution which is in a terminal state
+	// ("SUCCEEDED", "FAILED", "REJECTED", "REMOVED" or "CANCELED") or an exception
+	// will occur. The default is false.
+	//
+	// Deleting a job execution which is "IN_PROGRESS", will cause the device to
+	// be unable to access job information or update the job execution status. Use
+	// caution and ensure that the device is able to recover to a valid state.
+	Force *bool `location:"querystring" locationName:"force" type:"boolean"`
+
+	// The ID of the job whose execution on a particular device will be deleted.
+	//
+	// JobId is a required field
+	JobId *string `location:"uri" locationName:"jobId" min:"1" type:"string" required:"true"`
+
+	// The name of the thing whose job execution will be deleted.
+	//
+	// ThingName is a required field
+	ThingName *string `location:"uri" locationName:"thingName" min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DeleteJobExecutionInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteJobExecutionInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteJobExecutionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteJobExecutionInput"}
+	if s.ExecutionNumber == nil {
+		invalidParams.Add(request.NewErrParamRequired("ExecutionNumber"))
+	}
+	if s.JobId == nil {
+		invalidParams.Add(request.NewErrParamRequired("JobId"))
+	}
+	if s.JobId != nil && len(*s.JobId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("JobId", 1))
+	}
+	if s.ThingName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ThingName"))
+	}
+	if s.ThingName != nil && len(*s.ThingName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ThingName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetExecutionNumber sets the ExecutionNumber field's value.
+func (s *DeleteJobExecutionInput) SetExecutionNumber(v int64) *DeleteJobExecutionInput {
+	s.ExecutionNumber = &v
+	return s
+}
+
+// SetForce sets the Force field's value.
+func (s *DeleteJobExecutionInput) SetForce(v bool) *DeleteJobExecutionInput {
+	s.Force = &v
+	return s
+}
+
+// SetJobId sets the JobId field's value.
+func (s *DeleteJobExecutionInput) SetJobId(v string) *DeleteJobExecutionInput {
+	s.JobId = &v
+	return s
+}
+
+// SetThingName sets the ThingName field's value.
+func (s *DeleteJobExecutionInput) SetThingName(v string) *DeleteJobExecutionInput {
+	s.ThingName = &v
+	return s
+}
+
+type DeleteJobExecutionOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteJobExecutionOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteJobExecutionOutput) GoString() string {
+	return s.String()
+}
+
+type DeleteJobInput struct {
+	_ struct{} `type:"structure"`
+
+	// (Optional) When true, you can delete a job which is "IN_PROGRESS". Otherwise,
+	// you can only delete a job which is in a terminal state ("COMPLETED" or "CANCELED")
+	// or an exception will occur. The default is false.
+	//
+	// Deleting a job which is "IN_PROGRESS", will cause a device which is executing
+	// the job to be unable to access job information or update the job execution
+	// status. Use caution and ensure that each device executing a job which is
+	// deleted is able to recover to a valid state.
+	Force *bool `location:"querystring" locationName:"force" type:"boolean"`
+
+	// The ID of the job to be deleted.
+	//
+	// After a job deletion is completed, you may reuse this jobId when you create
+	// a new job. However, this is not recommended, and you must ensure that your
+	// devices are not using the jobId to refer to the deleted job.
+	//
+	// JobId is a required field
+	JobId *string `location:"uri" locationName:"jobId" min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DeleteJobInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteJobInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteJobInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteJobInput"}
+	if s.JobId == nil {
+		invalidParams.Add(request.NewErrParamRequired("JobId"))
+	}
+	if s.JobId != nil && len(*s.JobId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("JobId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetForce sets the Force field's value.
+func (s *DeleteJobInput) SetForce(v bool) *DeleteJobInput {
+	s.Force = &v
+	return s
+}
+
+// SetJobId sets the JobId field's value.
+func (s *DeleteJobInput) SetJobId(v string) *DeleteJobInput {
+	s.JobId = &v
+	return s
+}
+
+type DeleteJobOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteJobOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteJobOutput) GoString() string {
+	return s.String()
+}
+
 type DeleteOTAUpdateInput struct {
 	_ struct{} `type:"structure"`
 
@@ -18410,7 +18787,7 @@ func (s *ImplicitDeny) SetPolicies(v []*Policy) *ImplicitDeny {
 	return s
 }
 
-// Sends message data to an AWS IoT Analytics channel.
+// Sends messge data to an AWS IoT Analytics channel.
 type IotAnalyticsAction struct {
 	_ struct{} `type:"structure"`
 
@@ -18421,8 +18798,8 @@ type IotAnalyticsAction struct {
 	// The name of the IoT Analytics channel to which message data will be sent.
 	ChannelName *string `locationName:"channelName" type:"string"`
 
-	// The ARN of the role which has a policy that grants IoT permission to send
-	// message data via IoT Analytics (iotanalytics:BatchPutMessage).
+	// The ARN of the role which has a policy that grants IoT Analytics permission
+	// to send message data via IoT Analytics (iotanalytics:BatchPutMessage).
 	RoleArn *string `locationName:"roleArn" type:"string"`
 }
 

--- a/vendor/github.com/aws/aws-sdk-go/service/iot/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/iot/errors.go
@@ -73,10 +73,18 @@ const (
 	// The response is invalid.
 	ErrCodeInvalidResponseException = "InvalidResponseException"
 
+	// ErrCodeInvalidStateTransitionException for service response error code
+	// "InvalidStateTransitionException".
+	//
+	// An attempt was made to change to an invalid state, for example by deleting
+	// a job or a job execution which is "IN_PROGRESS" without setting the force
+	// parameter.
+	ErrCodeInvalidStateTransitionException = "InvalidStateTransitionException"
+
 	// ErrCodeLimitExceededException for service response error code
 	// "LimitExceededException".
 	//
-	// The number of attached entities exceeds the limit.
+	// A limit has been exceeded.
 	ErrCodeLimitExceededException = "LimitExceededException"
 
 	// ErrCodeMalformedPolicyException for service response error code

--- a/vendor/github.com/aws/aws-sdk-go/service/ses/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ses/api.go
@@ -246,7 +246,7 @@ func (c *SES) CreateConfigurationSetEventDestinationRequest(input *CreateConfigu
 // Creates a configuration set event destination.
 //
 // When you create or update an event destination, you must provide one, and
-// only one, destination. The destination can be Amazon CloudWatch, Amazon Kinesis
+// only one, destination. The destination can be CloudWatch, Amazon Kinesis
 // Firehose, or Amazon Simple Notification Service (Amazon SNS).
 //
 // An event destination is the AWS service to which Amazon SES publishes the
@@ -357,9 +357,8 @@ func (c *SES) CreateConfigurationSetTrackingOptionsRequest(input *CreateConfigur
 //
 // By default, images and links used for tracking open and click events are
 // hosted on domains operated by Amazon SES. You can configure a subdomain of
-// your own to handle these events. For information about using configuration
-// sets, see Configuring Custom Domains to Handle Open and Click Tracking (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/configure-custom-open-click-domains.html)
-// in the Amazon SES Developer Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/Welcome.html).
+// your own to handle these events. For information about using custom domains,
+// see the Amazon SES Developer Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/configure-custom-open-click-domains.html).
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -455,7 +454,7 @@ func (c *SES) CreateCustomVerificationEmailTemplateRequest(input *CreateCustomVe
 // Creates a new custom verification email template.
 //
 // For more information about custom verification email templates, see Using
-// Custom Verification Email Templates (https://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html)
+// Custom Verification Email Templates (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html)
 // in the Amazon SES Developer Guide.
 //
 // You can execute this operation no more than once per second.
@@ -855,8 +854,8 @@ func (c *SES) CreateTemplateRequest(input *CreateTemplateInput) (req *request.Re
 //   Indicates that a resource could not be created because of a naming conflict.
 //
 //   * ErrCodeInvalidTemplateException "InvalidTemplate"
-//   Indicates that a template could not be created because it contained invalid
-//   JSON.
+//   Indicates that the template that you specified could not be rendered. This
+//   issue may occur when a template refers to a partial that does not exist.
 //
 //   * ErrCodeLimitExceededException "LimitExceeded"
 //   Indicates that a resource could not be created because of service limits.
@@ -1103,9 +1102,8 @@ func (c *SES) DeleteConfigurationSetTrackingOptionsRequest(input *DeleteConfigur
 //
 // By default, images and links used for tracking open and click events are
 // hosted on domains operated by Amazon SES. You can configure a subdomain of
-// your own to handle these events. For information about using configuration
-// sets, see Configuring Custom Domains to Handle Open and Click Tracking (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/configure-custom-open-click-domains.html)
-// in the Amazon SES Developer Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/Welcome.html).
+// your own to handle these events. For information about using custom domains,
+// see the Amazon SES Developer Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/configure-custom-open-click-domains.html).
 //
 // Deleting this kind of association will result in emails sent using the specified
 // configuration set to capture open and click events using the standard, Amazon
@@ -1196,7 +1194,7 @@ func (c *SES) DeleteCustomVerificationEmailTemplateRequest(input *DeleteCustomVe
 // Deletes an existing custom verification email template.
 //
 // For more information about custom verification email templates, see Using
-// Custom Verification Email Templates (https://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html)
+// Custom Verification Email Templates (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html)
 // in the Amazon SES Developer Guide.
 //
 // You can execute this operation no more than once per second.
@@ -2170,7 +2168,8 @@ func (c *SES) GetAccountSendingEnabledRequest(input *GetAccountSendingEnabledInp
 
 // GetAccountSendingEnabled API operation for Amazon Simple Email Service.
 //
-// Returns the email sending status of the Amazon SES account.
+// Returns the email sending status of the Amazon SES account for the current
+// region.
 //
 // You can execute this operation no more than once per second.
 //
@@ -2250,7 +2249,7 @@ func (c *SES) GetCustomVerificationEmailTemplateRequest(input *GetCustomVerifica
 // specify.
 //
 // For more information about custom verification email templates, see Using
-// Custom Verification Email Templates (https://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html)
+// Custom Verification Email Templates (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html)
 // in the Amazon SES Developer Guide.
 //
 // You can execute this operation no more than once per second.
@@ -2844,7 +2843,7 @@ func (c *SES) GetSendStatisticsRequest(input *GetSendStatisticsInput) (req *requ
 
 // GetSendStatistics API operation for Amazon Simple Email Service.
 //
-// Provides sending statistics for the Amazon SES account. The result is a list
+// Provides sending statistics for the current AWS Region. The result is a list
 // of data points, representing the last two weeks of sending activity. Each
 // data point in the list contains statistics for a 15-minute period of time.
 //
@@ -3006,8 +3005,8 @@ func (c *SES) ListConfigurationSetsRequest(input *ListConfigurationSetsInput) (r
 // ListConfigurationSets API operation for Amazon Simple Email Service.
 //
 // Provides a list of the configuration sets associated with your Amazon SES
-// account. For information about using configuration sets, see Monitoring Your
-// Amazon SES Sending Activity (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html)
+// account in the current AWS Region. For information about using configuration
+// sets, see Monitoring Your Amazon SES Sending Activity (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html)
 // in the Amazon SES Developer Guide.
 //
 // You can execute this operation no more than once per second. This operation
@@ -3095,10 +3094,11 @@ func (c *SES) ListCustomVerificationEmailTemplatesRequest(input *ListCustomVerif
 
 // ListCustomVerificationEmailTemplates API operation for Amazon Simple Email Service.
 //
-// Lists the existing custom verification email templates for your account.
+// Lists the existing custom verification email templates for your account in
+// the current AWS Region.
 //
 // For more information about custom verification email templates, see Using
-// Custom Verification Email Templates (https://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html)
+// Custom Verification Email Templates (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html)
 // in the Amazon SES Developer Guide.
 //
 // You can execute this operation no more than once per second.
@@ -3232,7 +3232,8 @@ func (c *SES) ListIdentitiesRequest(input *ListIdentitiesInput) (req *request.Re
 // ListIdentities API operation for Amazon Simple Email Service.
 //
 // Returns a list containing all of the identities (email addresses and domains)
-// for your AWS account, regardless of verification status.
+// for your AWS account in the current AWS Region, regardless of verification
+// status.
 //
 // You can execute this operation no more than once per second.
 //
@@ -3443,7 +3444,8 @@ func (c *SES) ListReceiptFiltersRequest(input *ListReceiptFiltersInput) (req *re
 
 // ListReceiptFilters API operation for Amazon Simple Email Service.
 //
-// Lists the IP address filters associated with your AWS account.
+// Lists the IP address filters associated with your AWS account in the current
+// AWS Region.
 //
 // For information about managing IP address filters, see the Amazon SES Developer
 // Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-managing-ip-filters.html).
@@ -3522,10 +3524,10 @@ func (c *SES) ListReceiptRuleSetsRequest(input *ListReceiptRuleSetsInput) (req *
 
 // ListReceiptRuleSets API operation for Amazon Simple Email Service.
 //
-// Lists the receipt rule sets that exist under your AWS account. If there are
-// additional receipt rule sets to be retrieved, you will receive a NextToken
-// that you can provide to the next call to ListReceiptRuleSets to retrieve
-// the additional entries.
+// Lists the receipt rule sets that exist under your AWS account in the current
+// AWS Region. If there are additional receipt rule sets to be retrieved, you
+// will receive a NextToken that you can provide to the next call to ListReceiptRuleSets
+// to retrieve the additional entries.
 //
 // For information about managing receipt rule sets, see the Amazon SES Developer
 // Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-managing-receipt-rule-sets.html).
@@ -3604,7 +3606,8 @@ func (c *SES) ListTemplatesRequest(input *ListTemplatesInput) (req *request.Requ
 
 // ListTemplates API operation for Amazon Simple Email Service.
 //
-// Lists the email templates present in your Amazon SES account.
+// Lists the email templates present in your Amazon SES account in the current
+// AWS Region.
 //
 // You can execute this operation no more than once per second.
 //
@@ -4156,12 +4159,13 @@ func (c *SES) SendCustomVerificationEmailRequest(input *SendCustomVerificationEm
 // SendCustomVerificationEmail API operation for Amazon Simple Email Service.
 //
 // Adds an email address to the list of identities for your Amazon SES account
-// and attempts to verify it. As a result of executing this operation, a customized
-// verification email is sent to the specified address.
+// in the current AWS Region and attempts to verify it. As a result of executing
+// this operation, a customized verification email is sent to the specified
+// address.
 //
 // To use this operation, you must first create a custom verification email
 // template. For more information about creating and using custom verification
-// email templates, see Using Custom Verification Email Templates (https://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html)
+// email templates, see Using Custom Verification Email Templates (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html)
 // in the Amazon SES Developer Guide.
 //
 // You can execute this operation no more than once per second.
@@ -4594,6 +4598,17 @@ func (c *SES) SendTemplatedEmailRequest(input *SendTemplatedEmailInput) (req *re
 //    not in the format UserName@[SubDomain.]Domain.TopLevelDomain), the entire
 //    message will be rejected, even if the message contains other recipients
 //    that are valid.
+//
+// If your call to the SendTemplatedEmail operation includes all of the required
+// parameters, Amazon SES accepts it and returns a Message ID. However, if Amazon
+// SES can't render the email because the template contains errors, it doesn't
+// send the email. Additionally, because it already accepted the message, Amazon
+// SES doesn't return a message stating that it was unable to send the email.
+//
+// For these reasons, we highly recommend that you set up Amazon SES to send
+// you notifications when Rendering Failure events occur. For more information,
+// see Sending Personalized Email Using the Amazon SES API (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-personalized-email-api.html)
+// in the Amazon Simple Email Service Developer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -5389,10 +5404,11 @@ func (c *SES) UpdateAccountSendingEnabledRequest(input *UpdateAccountSendingEnab
 
 // UpdateAccountSendingEnabled API operation for Amazon Simple Email Service.
 //
-// Enables or disables email sending across your entire Amazon SES account.
-// You can use this operation in conjunction with Amazon CloudWatch alarms to
-// temporarily pause email sending across your Amazon SES account when reputation
-// metrics (such as your bounce on complaint rate) reach certain thresholds.
+// Enables or disables email sending across your entire Amazon SES account in
+// the current AWS Region. You can use this operation in conjunction with Amazon
+// CloudWatch alarms to temporarily pause email sending across your Amazon SES
+// account in a given AWS Region when reputation metrics (such as your bounce
+// or complaint rates) reach certain thresholds.
 //
 // You can execute this operation no more than once per second.
 //
@@ -5576,10 +5592,10 @@ func (c *SES) UpdateConfigurationSetReputationMetricsEnabledRequest(input *Updat
 // UpdateConfigurationSetReputationMetricsEnabled API operation for Amazon Simple Email Service.
 //
 // Enables or disables the publishing of reputation metrics for emails sent
-// using a specific configuration set. Reputation metrics include bounce and
-// complaint rates. These metrics are published to Amazon CloudWatch. By using
-// Amazon CloudWatch, you can create alarms when bounce or complaint rates exceed
-// a certain threshold.
+// using a specific configuration set in a given AWS Region. Reputation metrics
+// include bounce and complaint rates. These metrics are published to Amazon
+// CloudWatch. By using CloudWatch, you can create alarms when bounce or complaint
+// rates exceed certain thresholds.
 //
 // You can execute this operation no more than once per second.
 //
@@ -5663,10 +5679,10 @@ func (c *SES) UpdateConfigurationSetSendingEnabledRequest(input *UpdateConfigura
 // UpdateConfigurationSetSendingEnabled API operation for Amazon Simple Email Service.
 //
 // Enables or disables email sending for messages sent using a specific configuration
-// set. You can use this operation in conjunction with Amazon CloudWatch alarms
-// to temporarily pause email sending for a configuration set when the reputation
-// metrics for that configuration set (such as your bounce on complaint rate)
-// reach certain thresholds.
+// set in a given AWS Region. You can use this operation in conjunction with
+// Amazon CloudWatch alarms to temporarily pause email sending for a configuration
+// set when the reputation metrics for that configuration set (such as your
+// bounce on complaint rate) exceed certain thresholds.
 //
 // You can execute this operation no more than once per second.
 //
@@ -5752,9 +5768,8 @@ func (c *SES) UpdateConfigurationSetTrackingOptionsRequest(input *UpdateConfigur
 //
 // By default, images and links used for tracking open and click events are
 // hosted on domains operated by Amazon SES. You can configure a subdomain of
-// your own to handle these events. For information about using configuration
-// sets, see Configuring Custom Domains to Handle Open and Click Tracking (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/configure-custom-open-click-domains.html)
-// in the Amazon SES Developer Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/Welcome.html).
+// your own to handle these events. For information about using custom domains,
+// see the Amazon SES Developer Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/configure-custom-open-click-domains.html).
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -5849,7 +5864,7 @@ func (c *SES) UpdateCustomVerificationEmailTemplateRequest(input *UpdateCustomVe
 // Updates an existing custom verification email template.
 //
 // For more information about custom verification email templates, see Using
-// Custom Verification Email Templates (https://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html)
+// Custom Verification Email Templates (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html)
 // in the Amazon SES Developer Guide.
 //
 // You can execute this operation no more than once per second.
@@ -6067,8 +6082,8 @@ func (c *SES) UpdateTemplateRequest(input *UpdateTemplateInput) (req *request.Re
 //   SES account.
 //
 //   * ErrCodeInvalidTemplateException "InvalidTemplate"
-//   Indicates that a template could not be created because it contained invalid
-//   JSON.
+//   Indicates that the template that you specified could not be rendered. This
+//   issue may occur when a template refers to a partial that does not exist.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/email-2010-12-01/UpdateTemplate
 func (c *SES) UpdateTemplate(input *UpdateTemplateInput) (*UpdateTemplateOutput, error) {
@@ -6224,9 +6239,9 @@ func (c *SES) VerifyDomainIdentityRequest(input *VerifyDomainIdentityInput) (req
 
 // VerifyDomainIdentity API operation for Amazon Simple Email Service.
 //
-// Adds a domain to the list of identities for your Amazon SES account and attempts
-// to verify it. For more information about verifying domains, see Verifying
-// Email Addresses and Domains (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-addresses-and-domains.html)
+// Adds a domain to the list of identities for your Amazon SES account in the
+// current AWS Region and attempts to verify it. For more information about
+// verifying domains, see Verifying Email Addresses and Domains (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-addresses-and-domains.html)
 // in the Amazon SES Developer Guide.
 //
 // You can execute this operation no more than once per second.
@@ -6380,8 +6395,8 @@ func (c *SES) VerifyEmailIdentityRequest(input *VerifyEmailIdentityInput) (req *
 // VerifyEmailIdentity API operation for Amazon Simple Email Service.
 //
 // Adds an email address to the list of identities for your Amazon SES account
-// and attempts to verify it. As a result of executing this operation, a verification
-// email is sent to the specified address.
+// in the current AWS region and attempts to verify it. As a result of executing
+// this operation, a verification email is sent to the specified address.
 //
 // You can execute this operation no more than once per second.
 //
@@ -7348,8 +7363,8 @@ type CreateConfigurationSetTrackingOptionsInput struct {
 	// emails.
 	//
 	// For more information, see Configuring Custom Domains to Handle Open and Click
-	// Tracking (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/configure-custom-open-click-domains.html)
-	// in the Amazon SES Developer Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/Welcome.html).
+	// Tracking (ses/latest/DeveloperGuide/configure-custom-open-click-domains.html)
+	// in the Amazon SES Developer Guide.
 	//
 	// TrackingOptions is a required field
 	TrackingOptions *TrackingOptions `type:"structure" required:"true"`
@@ -9094,12 +9109,12 @@ func (s GetAccountSendingEnabledInput) GoString() string {
 }
 
 // Represents a request to return the email sending status for your Amazon SES
-// account.
+// account in the current AWS Region.
 type GetAccountSendingEnabledOutput struct {
 	_ struct{} `type:"structure"`
 
 	// Describes whether email sending is enabled or disabled for your Amazon SES
-	// account.
+	// account in the current AWS Region.
 	Enabled *bool `type:"boolean"`
 }
 
@@ -10237,7 +10252,7 @@ func (s *ListConfigurationSetsOutput) SetNextToken(v string) *ListConfigurationS
 // for your account.
 //
 // For more information about custom verification email templates, see Using
-// Custom Verification Email Templates (https://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html)
+// Custom Verification Email Templates (ses/latest/DeveloperGuide/custom-verification-emails.html)
 // in the Amazon SES Developer Guide.
 type ListCustomVerificationEmailTemplatesInput struct {
 	_ struct{} `type:"structure"`
@@ -11088,7 +11103,7 @@ type ReceiptAction struct {
 	StopAction *StopAction `type:"structure"`
 
 	// Calls Amazon WorkMail and, optionally, publishes a notification to Amazon
-	// SNS.
+	// Amazon SNS.
 	WorkmailAction *WorkmailAction `type:"structure"`
 }
 
@@ -11787,10 +11802,10 @@ type S3Action struct {
 	// using Amazon S3 server-side encryption. This means that you must use the
 	// Amazon S3 encryption client to decrypt the email after retrieving it from
 	// Amazon S3, as the service has no access to use your AWS KMS keys for decryption.
-	// This encryption client is currently available with the AWS Java SDK (http://aws.amazon.com/sdk-for-java/)
-	// and AWS Ruby SDK (http://aws.amazon.com/sdk-for-ruby/) only. For more information
-	// about client-side encryption using AWS KMS master keys, see the Amazon S3
-	// Developer Guide (AmazonS3/latest/dev/UsingClientSideEncryption.html).
+	// This encryption client is currently available with the AWS SDK for Java (http://aws.amazon.com/sdk-for-java/)
+	// and AWS SDK for Ruby (http://aws.amazon.com/sdk-for-ruby/) only. For more
+	// information about client-side encryption using AWS KMS master keys, see the
+	// Amazon S3 Developer Guide (http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingClientSideEncryption.html).
 	KmsKeyArn *string `type:"string"`
 
 	// The key prefix of the Amazon S3 bucket. The key prefix is similar to a directory
@@ -13935,8 +13950,8 @@ func (s *TestRenderTemplateOutput) SetRenderedTemplate(v string) *TestRenderTemp
 // emails.
 //
 // For more information, see Configuring Custom Domains to Handle Open and Click
-// Tracking (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/configure-custom-open-click-domains.html)
-// in the Amazon SES Developer Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/Welcome.html).
+// Tracking (ses/latest/DeveloperGuide/configure-custom-open-click-domains.html)
+// in the Amazon SES Developer Guide.
 type TrackingOptions struct {
 	_ struct{} `type:"structure"`
 
@@ -13967,7 +13982,7 @@ type UpdateAccountSendingEnabledInput struct {
 	_ struct{} `type:"structure"`
 
 	// Describes whether email sending is enabled or disabled for your Amazon SES
-	// account.
+	// account in the current AWS Region.
 	Enabled *bool `type:"boolean"`
 }
 
@@ -14231,8 +14246,8 @@ type UpdateConfigurationSetTrackingOptionsInput struct {
 	// emails.
 	//
 	// For more information, see Configuring Custom Domains to Handle Open and Click
-	// Tracking (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/configure-custom-open-click-domains.html)
-	// in the Amazon SES Developer Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/Welcome.html).
+	// Tracking (ses/latest/DeveloperGuide/configure-custom-open-click-domains.html)
+	// in the Amazon SES Developer Guide.
 	//
 	// TrackingOptions is a required field
 	TrackingOptions *TrackingOptions `type:"structure" required:"true"`

--- a/vendor/github.com/aws/aws-sdk-go/service/ses/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ses/doc.go
@@ -3,9 +3,10 @@
 // Package ses provides the client and types for making API
 // requests to Amazon Simple Email Service.
 //
-// This is the API Reference for Amazon Simple Email Service (https://aws.amazon.com/ses/)
-// (Amazon SES). This documentation is intended to be used in conjunction with
-// the Amazon SES Developer Guide (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/Welcome.html).
+// This document contains reference information for the Amazon Simple Email
+// Service (https://aws.amazon.com/ses/) (Amazon SES) API, version 2010-12-01.
+// This document is best used in conjunction with the Amazon SES Developer Guide
+// (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/Welcome.html).
 //
 // For a list of Amazon SES endpoints to use in service requests, see Regions
 // and Amazon SES (http://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html)

--- a/vendor/github.com/aws/aws-sdk-go/service/ses/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ses/errors.go
@@ -158,8 +158,8 @@ const (
 	// ErrCodeInvalidTemplateException for service response error code
 	// "InvalidTemplate".
 	//
-	// Indicates that a template could not be created because it contained invalid
-	// JSON.
+	// Indicates that the template that you specified could not be rendered. This
+	// issue may occur when a template refers to a partial that does not exist.
 	ErrCodeInvalidTemplateException = "InvalidTemplate"
 
 	// ErrCodeInvalidTrackingOptionsException for service response error code

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -39,916 +39,916 @@
 			"revisionTime": "2017-07-27T15:54:43Z"
 		},
 		{
-			"checksumSHA1": "+rg8/+FTaz2LcwSnPt/qh4MXeQ0=",
+			"checksumSHA1": "Qyx5QR0lF06blWbcpkR97E54pd0=",
 			"path": "github.com/aws/aws-sdk-go/aws",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "DtuTqKH29YnLjrIJkRYX0HQtXY0=",
 			"path": "github.com/aws/aws-sdk-go/aws/arn",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "Y9W+4GimK4Fuxq+vyIskVYFRnX4=",
 			"path": "github.com/aws/aws-sdk-go/aws/awserr",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "yyYr41HZ1Aq0hWc3J5ijXwYEcac=",
 			"path": "github.com/aws/aws-sdk-go/aws/awsutil",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "hicPtITUionsA+dgs1SpsZUkQu4=",
 			"path": "github.com/aws/aws-sdk-go/aws/client",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "ieAJ+Cvp/PKv1LpUEnUXpc3OI6E=",
 			"path": "github.com/aws/aws-sdk-go/aws/client/metadata",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "vVSUnICaD9IaBQisCfw0n8zLwig=",
 			"path": "github.com/aws/aws-sdk-go/aws/corehandlers",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "Y+cPwQL0dZMyqp3wI+KJWmA9KQ8=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "u3GOAJLmdvbuNUeUEcZSEAOeL/0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "NUJUTWlc1sV8b7WjfiYc4JZbXl0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/endpointcreds",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "JEYqmF83O5n5bHkupAzA6STm0no=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "HogDW/Wu6ZKTDrQ2HSzG8/vj9Ag=",
 			"path": "github.com/aws/aws-sdk-go/aws/defaults",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "pDnK93CqjQ4ROSW8Y/RuHXjv52M=",
 			"path": "github.com/aws/aws-sdk-go/aws/ec2metadata",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "HyynTJ+UU7h0vv85x18zxc9h8C8=",
 			"path": "github.com/aws/aws-sdk-go/aws/endpoints",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "CntJM8T3dRgC0e1i66CIbP8uCSY=",
 			"path": "github.com/aws/aws-sdk-go/aws/request",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "J66FLqo++F1PXLUU8XQqYaageSc=",
 			"path": "github.com/aws/aws-sdk-go/aws/session",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "BqDC+Sxo3hrC6WYvwx1U4OObaT4=",
 			"path": "github.com/aws/aws-sdk-go/aws/signer/v4",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "wjxQlU1PYxrDRFoL1Vek8Wch7jk=",
 			"path": "github.com/aws/aws-sdk-go/internal/sdkio",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "MYLldFRnsZh21TfCkgkXCT3maPU=",
 			"path": "github.com/aws/aws-sdk-go/internal/sdkrand",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "04ypv4x12l4q0TksA1zEVsmgpvw=",
 			"path": "github.com/aws/aws-sdk-go/internal/shareddefaults",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "NStHCXEvYqG72GknZyv1jaKaeH0=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "GQuRJY72iGQrufDqIaB50zG27u0=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/ec2query",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "yHfT5DTbeCLs4NE2Rgnqrhe15ls=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/json/jsonutil",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "R00RL5jJXRYq1iiK1+PGvMfvXyM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/jsonrpc",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "SBBVYdLcocjdPzMWgDuR8vcOfDQ=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "9V1PvtFQ9MObZTc3sa86WcuOtOU=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "pkeoOfZpHRvFG/AOZeTf0lwtsFg=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/rest",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "Rpu8KBtHZgvhkwHxUfaky+qW+G4=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restjson",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "ODo+ko8D6unAxZuN1jGzMcN4QCc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restxml",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "6zosteWJqUGM9+t9dkANQymMA9s=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "F6mth+G7dXN1GI+nktaGo8Lx8aE=",
 			"path": "github.com/aws/aws-sdk-go/private/signer/v2",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "yqQRtxoLmiwe3lUvTx81hxfy+S0=",
 			"path": "github.com/aws/aws-sdk-go/service/acm",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "WliJXTogdly9qe5xEV6Fn2zklcs=",
 			"path": "github.com/aws/aws-sdk-go/service/acmpca",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "rQmpNRto8bpB17qNubhGzRh/Aj8=",
 			"path": "github.com/aws/aws-sdk-go/service/apigateway",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "7o1gMXoE8cemDzkZFUrQknQS4Yo=",
 			"path": "github.com/aws/aws-sdk-go/service/applicationautoscaling",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "DtAllf3BfE0Z5JOhcdYHQnv1jnY=",
 			"path": "github.com/aws/aws-sdk-go/service/appsync",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "YlKOG1eZClZYmcRwJQO+LfEQrVY=",
 			"path": "github.com/aws/aws-sdk-go/service/athena",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "58ARAtV4EKAIv5zpieVjvJMFjO0=",
 			"path": "github.com/aws/aws-sdk-go/service/autoscaling",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "s6of5mfMFZtYy6BRo/tIafylOUc=",
 			"path": "github.com/aws/aws-sdk-go/service/batch",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "ToedYe8j0Uiv9NkIIu48SWTjexU=",
 			"path": "github.com/aws/aws-sdk-go/service/budgets",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "AQGPL+fXjjKhBmyb37QAG05R/Qw=",
 			"path": "github.com/aws/aws-sdk-go/service/cloud9",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
-			"checksumSHA1": "NU6AqUCd5TOrxaqFdWmo8l2oeOI=",
+			"checksumSHA1": "nw4K5HhToQ/12OVV14F3z5JCmkA=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudformation",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "hCz5z7QQz1416cCjbhjGjvbrdpY=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudfront",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "8PdtKqSEcLQ1V0Gnl2FAHJoOQy0=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudhsmv2",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "kM7Fxkb1OdCiOOmTlRIadqnsdt0=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudsearch",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "pKJec2iJiKDSY5UKmLSeYxLxucg=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudtrail",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "BD7EvXghMHMw52wtxISIhpJ4CTk=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatch",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "6Q9ZHEAsu92jsFOCwJAI+SjYYAk=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchevents",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "YNl9xTPOb1SFVmwXDtmwzyGsx8U=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "AuLMjGF8UT3fgzn+KmaIrS3mG8g=",
 			"path": "github.com/aws/aws-sdk-go/service/codebuild",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "4KiQdvEfpTf2g+UF2rWlLg/kgok=",
 			"path": "github.com/aws/aws-sdk-go/service/codecommit",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "MMGpZlc46/MCYfjGeFzzQPtwuWY=",
 			"path": "github.com/aws/aws-sdk-go/service/codedeploy",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "5uQsnuE2bMWQ2ypmll1rzXyNqPw=",
 			"path": "github.com/aws/aws-sdk-go/service/codepipeline",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "cx2wG4c6Q5gSTsAU6D/UZMQN/Kg=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentity",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "UY9xJ9mOYNblY3XDCSyJX/reKHg=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentityprovider",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "uRxL2y+YAmNYyKu8LgpfZJQ180g=",
 			"path": "github.com/aws/aws-sdk-go/service/configservice",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "FEUIC6EG3tPnTuvmIsV4b3r9D+k=",
 			"path": "github.com/aws/aws-sdk-go/service/databasemigrationservice",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "I5sSvXLvlj9Ppv0HCbFXdN4tqn4=",
 			"path": "github.com/aws/aws-sdk-go/service/dax",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "/Wa2paWfntnF+4pRSsgMffedplE=",
 			"path": "github.com/aws/aws-sdk-go/service/devicefarm",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "hurqUivjVxLHaXEd2oS8JrwMGQs=",
 			"path": "github.com/aws/aws-sdk-go/service/directconnect",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "zxX7V0AIU1x2yX5Uyd9RMe0C3ok=",
 			"path": "github.com/aws/aws-sdk-go/service/directoryservice",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "mJR+NQiCTZGMy+eaCzbP4sEnX6w=",
 			"path": "github.com/aws/aws-sdk-go/service/dynamodb",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "iGwAmpiDSU/XizPBrB+sqdOgrzw=",
 			"path": "github.com/aws/aws-sdk-go/service/ec2",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "V3D5pDdtXS0yVShpS/fOqFGxCrA=",
 			"path": "github.com/aws/aws-sdk-go/service/ecr",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
-			"checksumSHA1": "7igFr0esmtcs9V0F9iMs2k5uNDI=",
+			"checksumSHA1": "9T22yyMdTlrDohUxSg6Tv2Gne1Y=",
 			"path": "github.com/aws/aws-sdk-go/service/ecs",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "PQnfXJ0ZQIIMiqUUFs4bkUPHqnc=",
 			"path": "github.com/aws/aws-sdk-go/service/efs",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "pZoO4JKc/TJACuq1n9IHuhovD4k=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticache",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "Z2ql82q2CJ3AXQ/Wi+3jhkpXmt0=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticbeanstalk",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "mPE8FtH4eBfXADHlCh6WE3b7Lvk=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticsearchservice",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "JpvcQ+tc0yz2WZ0ne6zzxlbfscI=",
 			"path": "github.com/aws/aws-sdk-go/service/elastictranscoder",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "MgdGxbP8vjCkzkj1ukmU5Uqh3UA=",
 			"path": "github.com/aws/aws-sdk-go/service/elb",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "hgqHUngsP+NPjkZVqevXuioHnkE=",
 			"path": "github.com/aws/aws-sdk-go/service/elbv2",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "OQuas8ovzB34Yb2bCMBDsu8teu4=",
 			"path": "github.com/aws/aws-sdk-go/service/emr",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "ACpOdHZr9nuPF1y/GSDiHTZd4GQ=",
 			"path": "github.com/aws/aws-sdk-go/service/firehose",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "4DYLn0HnMhZvXXgx6VjbS/V0srA=",
 			"path": "github.com/aws/aws-sdk-go/service/fms",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "/cpOFocraRx5nL1OB0ux2KDKytk=",
 			"path": "github.com/aws/aws-sdk-go/service/gamelift",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "pOhtcgvfgH3qPUiqZrBgpawiu8I=",
 			"path": "github.com/aws/aws-sdk-go/service/glacier",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "2bqJtsfs1LDLLhczU/SNtmvkjcw=",
 			"path": "github.com/aws/aws-sdk-go/service/glue",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "yMGyjJHSsK+Mb+SbNxGIcXhl67o=",
 			"path": "github.com/aws/aws-sdk-go/service/guardduty",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "DHrIPXQ0QzjE+Hnfwk0INR4rUkU=",
 			"path": "github.com/aws/aws-sdk-go/service/iam",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
-			"checksumSHA1": "pvrqgHDeZ3gAHIiZyZfwXOi9GD4=",
+			"checksumSHA1": "ROZF4+oTzVYUocMVFoTboiDSV8k=",
 			"path": "github.com/aws/aws-sdk-go/service/inspector",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
-			"checksumSHA1": "lKGIKcPcMErM1NJdXBsHLic1E8w=",
+			"checksumSHA1": "fVHxe423/cpyx1KiGEWJ8bvF3Es=",
 			"path": "github.com/aws/aws-sdk-go/service/iot",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "zdG3e3bdyNaBuApO06pygeSJsJ4=",
 			"path": "github.com/aws/aws-sdk-go/service/kinesis",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "zmOo5EeLSGFEuIBiRQsVd4+SBJ0=",
 			"path": "github.com/aws/aws-sdk-go/service/kms",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "nlvFlqVKHyuyYHG88H3Yt/OA1e0=",
 			"path": "github.com/aws/aws-sdk-go/service/lambda",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "AO97b1GChOs2geiFc//6YcpVfX8=",
 			"path": "github.com/aws/aws-sdk-go/service/lexmodelbuildingservice",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "jyxQ6TEdSl9/j7qC0LCkVMSXkog=",
 			"path": "github.com/aws/aws-sdk-go/service/lightsail",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "lKyAXJ4S6uXuSR1/pQ9gCGHYSLI=",
 			"path": "github.com/aws/aws-sdk-go/service/mediaconvert",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "NVSUO8GRtIWDm7IexnBSmQWvBh8=",
 			"path": "github.com/aws/aws-sdk-go/service/medialive",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "ETmB3lf15r4sn18bB9ilBQVXto4=",
 			"path": "github.com/aws/aws-sdk-go/service/mediapackage",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "I1sxeu8aJOiM3a5/tnJya8blE3A=",
 			"path": "github.com/aws/aws-sdk-go/service/mediastore",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "AnipOpUAJroLkoknx4xacrO0qSA=",
 			"path": "github.com/aws/aws-sdk-go/service/mediastoredata",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "lAweYYdjcZ6acj6oI3HI9hX3eIQ=",
 			"path": "github.com/aws/aws-sdk-go/service/mq",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "X/WdGuHGMxRCvufmQxstVjdbFT4=",
 			"path": "github.com/aws/aws-sdk-go/service/opsworks",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "or6cG9Dd37+THnVOUyZBXvuIcFs=",
 			"path": "github.com/aws/aws-sdk-go/service/organizations",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "0NGBJyXbKYwa+5iOOaDLkhV11OQ=",
 			"path": "github.com/aws/aws-sdk-go/service/rds",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "kapXC7OZ1fnkZ3N6p19+WUafn40=",
 			"path": "github.com/aws/aws-sdk-go/service/redshift",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "Hi/sxx81pqe+fI5VrS5+UK2DsDU=",
 			"path": "github.com/aws/aws-sdk-go/service/route53",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "KidzwXO5VKKI9zIuTAUsuF7KxIM=",
 			"path": "github.com/aws/aws-sdk-go/service/s3",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "OUQpREA6ZLi/zTX4vZc56+ZoZLI=",
 			"path": "github.com/aws/aws-sdk-go/service/sagemaker",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "GTjPShDHZ0hNWS1xsh44ux4jSp8=",
 			"path": "github.com/aws/aws-sdk-go/service/secretsmanager",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "NoPuCAL/h2IdumibRRFOfABpKGc=",
 			"path": "github.com/aws/aws-sdk-go/service/servicecatalog",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "NLj37wyUZIo8/Rp3zp+LDfr878M=",
 			"path": "github.com/aws/aws-sdk-go/service/servicediscovery",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
-			"checksumSHA1": "nXAp7K8BCFvsaSdorGV7swBEQgA=",
+			"checksumSHA1": "WHXx9dFnTQJzH68cv8LHCw17Qis=",
 			"path": "github.com/aws/aws-sdk-go/service/ses",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "q4qCE/5OiBJA1k8P0jQRx9UhKvs=",
 			"path": "github.com/aws/aws-sdk-go/service/sfn",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "hAIPfcEcdc8xJ7MseIufmssdE/s=",
 			"path": "github.com/aws/aws-sdk-go/service/simpledb",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "1Fin0tclPDC/+rL7V06GrzXaMXI=",
 			"path": "github.com/aws/aws-sdk-go/service/sns",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "T8ABBS2aS6yRTD6w3kjpgFLe/Zw=",
 			"path": "github.com/aws/aws-sdk-go/service/sqs",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "q5ApQXXApBOPXOYOLDOetdC4MNw=",
 			"path": "github.com/aws/aws-sdk-go/service/ssm",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "llx3DydC0nTbF0cZoYUjO9P1eZw=",
 			"path": "github.com/aws/aws-sdk-go/service/sts",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "i1yLjEKjcDxm0rakhcaDuAcQb7I=",
 			"path": "github.com/aws/aws-sdk-go/service/swf",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "Mf9nXjY0+Lq5RxEGEIYCYL8u+Kc=",
 			"path": "github.com/aws/aws-sdk-go/service/waf",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "iRNs3RoLjrzcBsPrSynhbEqY/4s=",
 			"path": "github.com/aws/aws-sdk-go/service/wafregional",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "LzD/Yb1Xzc4OPKZZadOGV2fpQto=",
 			"path": "github.com/aws/aws-sdk-go/service/workspaces",
-			"revision": "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443",
-			"revisionTime": "2018-05-17T21:48:00Z",
-			"version": "v1.13.51",
-			"versionExact": "v1.13.51"
+			"revision": "fad131ddc707880428615dc8bc1587b55fb46d74",
+			"revisionTime": "2018-05-22T22:16:27Z",
+			"version": "v1.13.54",
+			"versionExact": "v1.13.54"
 		},
 		{
 			"checksumSHA1": "usT4LCSQItkFvFOQT7cBlkCuGaE=",


### PR DESCRIPTION
Changes proposed in this pull request:

* `govendor fetch github.com/aws/aws-sdk-go/...@v1.13.54`

To support ECS service discovery for services that use host or bridged network mode.
