### PR TITLE
r/ecs_service: support bridge and host network mode for service registry

### DIFF
--- a/aws/resource_aws_ecs_service.go
+++ b/aws/resource_aws_ecs_service.go
@@ -249,6 +249,15 @@ func resourceAwsEcsService() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"container_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"container_port": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(0, 65536),
+						},
 						"port": {
 							Type:         schema.TypeInt,
 							Optional:     true,
@@ -369,6 +378,12 @@ func resourceAwsEcsServiceCreate(d *schema.ResourceData, meta interface{}) error
 			}
 			if port, ok := raw["port"].(int); ok && port != 0 {
 				sr.Port = aws.Int64(int64(port))
+			}
+			if raw, ok := raw["container_port"].(int); ok && raw != 0 {
+				sr.ContainerPort = aws.Int64(int64(raw))
+			}
+			if raw, ok := raw["container_name"].(string); ok && raw != "" {
+				sr.ContainerName = aws.String(raw)
 			}
 
 			srs = append(srs, sr)
@@ -673,6 +688,12 @@ func flattenServiceRegistries(srs []*ecs.ServiceRegistry) []map[string]interface
 		}
 		if sr.Port != nil {
 			c["port"] = int(aws.Int64Value(sr.Port))
+		}
+		if sr.ContainerPort != nil {
+			c["container_port"] = int(aws.Int64Value(sr.ContainerPort))
+		}
+		if sr.ContainerName != nil {
+			c["container_name"] = aws.StringValue(sr.ContainerName)
 		}
 		results = append(results, c)
 	}

--- a/aws/resource_aws_ecs_service_test.go
+++ b/aws/resource_aws_ecs_service_test.go
@@ -650,6 +650,30 @@ func TestAccAWSEcsService_withServiceRegistries(t *testing.T) {
 	})
 }
 
+func TestAccAWSEcsService_withServiceRegistries_container(t *testing.T) {
+	var service ecs.Service
+	rString := acctest.RandString(8)
+
+	clusterName := fmt.Sprintf("tf-acc-cluster-svc-w-ups-%s", rString)
+	tdName := fmt.Sprintf("tf-acc-td-svc-w-ups-%s", rString)
+	svcName := fmt.Sprintf("tf-acc-svc-w-ups-%s", rString)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEcsService_withServiceRegistries_container(rString, clusterName, tdName, svcName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcsServiceExists("aws_ecs_service.test", &service),
+					resource.TestCheckResourceAttr("aws_ecs_service.test", "service_registries.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSEcsServiceDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).ecsconn
 
@@ -1842,6 +1866,91 @@ resource "aws_ecs_service" "test" {
   network_configuration {
     security_groups = ["${aws_security_group.test.id}"]
     subnets = ["${aws_subnet.test.*.id}"]
+  }
+}
+`, rName, rName, rName, clusterName, tdName, svcName)
+}
+
+func testAccAWSEcsService_withServiceRegistries_container(rName, clusterName, tdName, svcName string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "test" {}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "test" {
+  count = 2
+  cidr_block = "${cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)}"
+  availability_zone = "${data.aws_availability_zones.test.names[count.index]}"
+  vpc_id = "${aws_vpc.test.id}"
+}
+
+resource "aws_security_group" "test" {
+  name        = "tf-acc-sg-%s"
+  vpc_id      = "${aws_vpc.test.id}"
+
+  ingress {
+    protocol = "-1"
+    from_port = 0
+    to_port = 0
+    cidr_blocks = ["${aws_vpc.test.cidr_block}"]
+  }
+}
+
+resource "aws_service_discovery_private_dns_namespace" "test" {
+  name = "tf-acc-sd-%s.terraform.local"
+  description = "test"
+  vpc = "${aws_vpc.test.id}"
+}
+
+resource "aws_service_discovery_service" "test" {
+  name = "tf-acc-sd-%s"
+  dns_config {
+    namespace_id = "${aws_service_discovery_private_dns_namespace.test.id}"
+    dns_records {
+      ttl = 5
+      type = "SRV"
+    }
+  }
+}
+
+resource "aws_ecs_cluster" "test" {
+  name = "%s"
+}
+
+resource "aws_ecs_task_definition" "test" {
+  family = "%s"
+  network_mode = "bridge"
+  container_definitions = <<DEFINITION
+[
+  {
+    "cpu": 128,
+    "essential": true,
+    "image": "mongo:latest",
+    "memory": 128,
+    "name": "mongodb",
+    "portMappings": [
+    {
+      "hostPort": 0,
+      "protocol": "tcp",
+      "containerPort": 27017
+    }
+    ]
+  }
+]
+DEFINITION
+}
+
+resource "aws_ecs_service" "test" {
+  name = "%s"
+  cluster = "${aws_ecs_cluster.test.id}"
+  task_definition = "${aws_ecs_task_definition.test.arn}"
+  desired_count = 1
+  service_registries {
+    container_name = "mongodb"
+    container_port = 27017
+    registry_arn = "${aws_service_discovery_service.test.arn}"
   }
 }
 `, rName, rName, rName, clusterName, tdName, svcName)

--- a/website/docs/r/ecs_service.html.markdown
+++ b/website/docs/r/ecs_service.html.markdown
@@ -130,6 +130,8 @@ For more information, see [Task Networking](https://docs.aws.amazon.com/AmazonEC
 
 * `registry_arn` - (Required) The ARN of the Service Registry. The currently supported service registry is Amazon Route 53 Auto Naming Service(`aws_service_discovery_service`). For more information, see [Service](https://docs.aws.amazon.com/Route53/latest/APIReference/API_autonaming_Service.html)
 * `port` - (Optional) The port value used if your Service Discovery service specified an SRV record.
+* `container_port` - (Optional) The port value, already specified in the task definition, to be used for your service discovery service.
+* `container_name` - (Optional) The container name value, already specified in the task definition, to be used for your service discovery service.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Changes proposed in this pull request:

* Update service registry

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSEcsService_withServiceRegistries*'
TF_ACC=1 go test ./aws -v -run=TestAccAWSEcsService_withServiceRegistries* -timeout 120m
=== RUN   TestAccAWSEcsService_withServiceRegistries
--- PASS: TestAccAWSEcsService_withServiceRegistries (311.05s)
=== RUN   TestAccAWSEcsService_withServiceRegistries_container
--- PASS: TestAccAWSEcsService_withServiceRegistries_container (165.10s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	165.138s
```
