### PR TITLE
tests/resource/aws_redshift_cluster: Replace rand.New() usage with acctest.RandInt()

### DIFF
--- a/aws/resource_aws_redshift_cluster_test.go
+++ b/aws/resource_aws_redshift_cluster_test.go
@@ -3,11 +3,9 @@ package aws
 import (
 	"fmt"
 	"log"
-	"math/rand"
 	"regexp"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -104,7 +102,7 @@ func TestValidateRedshiftClusterDbName(t *testing.T) {
 func TestAccAWSRedshiftCluster_basic(t *testing.T) {
 	var v redshift.Cluster
 
-	ri := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	ri := acctest.RandInt()
 	config := testAccAWSRedshiftClusterConfig_basic(ri)
 
 	resource.Test(t, resource.TestCase{
@@ -149,7 +147,7 @@ func TestAccAWSRedshiftCluster_withFinalSnapshot(t *testing.T) {
 func TestAccAWSRedshiftCluster_kmsKey(t *testing.T) {
 	var v redshift.Cluster
 
-	ri := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	ri := acctest.RandInt()
 	config := testAccAWSRedshiftClusterConfig_kmsKey(ri)
 	keyRegex := regexp.MustCompile("^arn:aws:([a-zA-Z0-9\\-])+:([a-z]{2}-[a-z]+-\\d{1})?:(\\d{12})?:(.*)$")
 
@@ -176,7 +174,7 @@ func TestAccAWSRedshiftCluster_kmsKey(t *testing.T) {
 func TestAccAWSRedshiftCluster_enhancedVpcRoutingEnabled(t *testing.T) {
 	var v redshift.Cluster
 
-	ri := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	ri := acctest.RandInt()
 	preConfig := testAccAWSRedshiftClusterConfig_enhancedVpcRoutingEnabled(ri)
 	postConfig := testAccAWSRedshiftClusterConfig_enhancedVpcRoutingDisabled(ri)
 
@@ -303,7 +301,7 @@ func TestAccAWSRedshiftCluster_snapshotCopy(t *testing.T) {
 func TestAccAWSRedshiftCluster_iamRoles(t *testing.T) {
 	var v redshift.Cluster
 
-	ri := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	ri := acctest.RandInt()
 	preConfig := testAccAWSRedshiftClusterConfig_iamRoles(ri)
 	postConfig := testAccAWSRedshiftClusterConfig_updateIamRoles(ri)
 
@@ -366,7 +364,7 @@ func TestAccAWSRedshiftCluster_publiclyAccessible(t *testing.T) {
 func TestAccAWSRedshiftCluster_updateNodeCount(t *testing.T) {
 	var v redshift.Cluster
 
-	ri := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	ri := acctest.RandInt()
 	preConfig := testAccAWSRedshiftClusterConfig_basic(ri)
 	postConfig := testAccAWSRedshiftClusterConfig_updateNodeCount(ri)
 
@@ -403,7 +401,7 @@ func TestAccAWSRedshiftCluster_updateNodeCount(t *testing.T) {
 func TestAccAWSRedshiftCluster_updateNodeType(t *testing.T) {
 	var v redshift.Cluster
 
-	ri := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	ri := acctest.RandInt()
 	preConfig := testAccAWSRedshiftClusterConfig_basic(ri)
 	postConfig := testAccAWSRedshiftClusterConfig_updateNodeType(ri)
 
@@ -440,7 +438,7 @@ func TestAccAWSRedshiftCluster_updateNodeType(t *testing.T) {
 func TestAccAWSRedshiftCluster_tags(t *testing.T) {
 	var v redshift.Cluster
 
-	ri := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	ri := acctest.RandInt()
 	preConfig := testAccAWSRedshiftClusterConfig_tags(ri)
 	postConfig := testAccAWSRedshiftClusterConfig_updatedTags(ri)
 
@@ -475,7 +473,7 @@ func TestAccAWSRedshiftCluster_tags(t *testing.T) {
 func TestAccAWSRedshiftCluster_forceNewUsername(t *testing.T) {
 	var first, second redshift.Cluster
 
-	ri := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	ri := acctest.RandInt()
 	preConfig := testAccAWSRedshiftClusterConfig_basic(ri)
 	postConfig := testAccAWSRedshiftClusterConfig_updatedUsername(ri)
 


### PR DESCRIPTION
Reference: #4625 

Changes proposed in this pull request:

* Use consistent upstream function for random integers in testing

Output from acceptance testing (test failures are flakey and unrelated to the cluster naming):

```
Tests failed: 3 (2 new), passed: 11
=== RUN   TestAccAWSRedshiftCluster_loggingEnabled
--- PASS: TestAccAWSRedshiftCluster_loggingEnabled (912.97s)
=== RUN   TestAccAWSRedshiftCluster_basic
--- PASS: TestAccAWSRedshiftCluster_basic (989.69s)
=== RUN   TestAccAWSRedshiftCluster_importBasic
--- PASS: TestAccAWSRedshiftCluster_importBasic (993.91s)
=== RUN   TestAccAWSRedshiftCluster_loggingEnabledDeprecated
--- PASS: TestAccAWSRedshiftCluster_loggingEnabledDeprecated (1045.99s)
=== RUN   TestAccAWSRedshiftCluster_snapshotCopy
--- PASS: TestAccAWSRedshiftCluster_snapshotCopy (1151.04s)
=== RUN   TestAccAWSRedshiftCluster_enhancedVpcRoutingEnabled
--- FAIL: TestAccAWSRedshiftCluster_enhancedVpcRoutingEnabled (1164.92s)
    testing.go:518: Step 1 error: Error applying: 1 error(s) occurred:
        
        * aws_redshift_cluster.default: 1 error(s) occurred:
        
        * aws_redshift_cluster.default: [WARN] Error modifying Redshift Cluster (tf-redshift-cluster-5463161918232322692): InvalidClusterState: The Cluster is being modified by a concurrent operation. Please check the Cluster's status and try again.
            status code: 400, request id: 67461dc2-5eb5-11e8-901f-2bf8c29e07dd
=== RUN   TestAccAWSRedshiftCluster_kmsKey
--- PASS: TestAccAWSRedshiftCluster_kmsKey (1171.02s)
=== RUN   TestAccAWSRedshiftCluster_tags
--- PASS: TestAccAWSRedshiftCluster_tags (1271.98s)
=== RUN   TestAccAWSRedshiftCluster_iamRoles
--- PASS: TestAccAWSRedshiftCluster_iamRoles (1302.24s)
=== RUN   TestAccAWSRedshiftCluster_publiclyAccessible
--- FAIL: TestAccAWSRedshiftCluster_publiclyAccessible (1309.10s)
    testing.go:518: Step 1 error: Error applying: 1 error(s) occurred:
        
        * aws_redshift_cluster.default: 1 error(s) occurred:
        
        * aws_redshift_cluster.default: [WARN] Error modifying Redshift Cluster (tf-redshift-cluster-498346818921158188): InvalidClusterState: The changes cannot be applied because the cluster is already pending other changes.
            status code: 400, request id: 75bf41da-5eb5-11e8-901f-2bf8c29e07dd
=== RUN   TestAccAWSRedshiftCluster_withFinalSnapshot
--- PASS: TestAccAWSRedshiftCluster_withFinalSnapshot (1486.96s)
=== RUN   TestAccAWSRedshiftCluster_forceNewUsername
--- PASS: TestAccAWSRedshiftCluster_forceNewUsername (2516.81s)
=== RUN   TestAccAWSRedshiftCluster_updateNodeType
--- PASS: TestAccAWSRedshiftCluster_updateNodeType (2913.23s)
=== RUN   TestAccAWSRedshiftCluster_updateNodeCount
--- FAIL: TestAccAWSRedshiftCluster_updateNodeCount (3646.02s)
    testing.go:518: Step 1 error: Error applying: 1 error(s) occurred:
        
        * aws_redshift_cluster.default: 1 error(s) occurred:
        
        * aws_redshift_cluster.default: [WARN] Error Modifying Redshift Cluster (tf-redshift-cluster-6365426482026716014): timeout while waiting for state to become 'available' (last state: 'resizing', timeout: 40m0s)
```
