### PR TITLE
tests/resource/aws_launch_configuration: Replace rand.New() usage with acctest.RandInt()

### DIFF
--- a/aws/resource_aws_launch_configuration_test.go
+++ b/aws/resource_aws_launch_configuration_test.go
@@ -3,11 +3,9 @@ package aws
 import (
 	"fmt"
 	"log"
-	"math/rand"
 	"regexp"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
@@ -538,7 +536,7 @@ resource "aws_launch_configuration" "bar" {
     virtual_name = "ephemeral0"
   }
 }
-`, rand.New(rand.NewSource(time.Now().UnixNano())).Int())
+`, acctest.RandInt())
 }
 
 func testAccAWSLaunchConfigurationWithSpotPriceConfig() string {
@@ -549,7 +547,7 @@ resource "aws_launch_configuration" "bar" {
   instance_type = "t2.micro"
   spot_price = "0.01"
 }
-`, rand.New(rand.NewSource(time.Now().UnixNano())).Int())
+`, acctest.RandInt())
 }
 
 func testAccAWSLaunchConfigurationNoNameConfig() string {


### PR DESCRIPTION
Reference: #4625 

Changes proposed in this pull request:

* Use consistent upstream function for random integers in testing

Output from acceptance testing:

```
11 tests passed (all tests)
=== RUN   TestAccAWSLaunchConfiguration_importBasic
--- PASS: TestAccAWSLaunchConfiguration_importBasic (14.44s)
=== RUN   TestAccAWSLaunchConfiguration_ebs_noDevice
--- PASS: TestAccAWSLaunchConfiguration_ebs_noDevice (15.87s)
=== RUN   TestAccAWSLaunchConfiguration_withSpotPrice
--- PASS: TestAccAWSLaunchConfiguration_withSpotPrice (21.24s)
=== RUN   TestAccAWSLaunchConfiguration_withIAMProfile
--- PASS: TestAccAWSLaunchConfiguration_withIAMProfile (34.48s)
=== RUN   TestAccAWSLaunchConfiguration_basic
--- PASS: TestAccAWSLaunchConfiguration_basic (37.92s)
=== RUN   TestAccAWSLaunchConfiguration_updateRootBlockDevice
--- PASS: TestAccAWSLaunchConfiguration_updateRootBlockDevice (38.93s)
=== RUN   TestAccAWSLaunchConfiguration_withVpcClassicLink
--- PASS: TestAccAWSLaunchConfiguration_withVpcClassicLink (43.77s)
=== RUN   TestAccAWSLaunchConfiguration_updateEbsBlockDevices
--- PASS: TestAccAWSLaunchConfiguration_updateEbsBlockDevices (48.60s)
=== RUN   TestAccAWSLaunchConfiguration_withEncryption
--- PASS: TestAccAWSLaunchConfiguration_withEncryption (60.50s)
=== RUN   TestAccAWSLaunchConfiguration_withBlockDevices
--- PASS: TestAccAWSLaunchConfiguration_withBlockDevices (65.05s)
=== RUN   TestAccAWSLaunchConfiguration_userData
--- PASS: TestAccAWSLaunchConfiguration_userData (65.14s)
```
