### PR TITLE
tests/aws_lb_listener: Replace rand.New() usage with acctest.RandInt()

### DIFF
--- a/aws/data_source_aws_lb_listener_test.go
+++ b/aws/data_source_aws_lb_listener_test.go
@@ -2,9 +2,7 @@ package aws
 
 import (
 	"fmt"
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -476,5 +474,5 @@ data "aws_lb_listener" "front_end" {
 data "aws_lb_listener" "from_lb_and_port" {
   load_balancer_arn = "${aws_lb.alb_test.arn}"
   port              = "${aws_lb_listener.front_end.port}"
-}`, lbName, targetGroupName, rand.New(rand.NewSource(time.Now().UnixNano())).Int())
+}`, lbName, targetGroupName, acctest.RandInt())
 }

--- a/aws/resource_aws_lb_listener_test.go
+++ b/aws/resource_aws_lb_listener_test.go
@@ -3,9 +3,7 @@ package aws
 import (
 	"errors"
 	"fmt"
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elbv2"
@@ -488,5 +486,5 @@ resource "tls_self_signed_cert" "example" {
     "server_auth",
   ]
 }
-`, lbName, targetGroupName, rand.New(rand.NewSource(time.Now().UnixNano())).Int())
+`, lbName, targetGroupName, acctest.RandInt())
 }


### PR DESCRIPTION
Reference: #4625 

Changes proposed in this pull request:

* Use consistent upstream function for random integers in testing

Output from acceptance testing:

```
12 tests passed (all tests)
=== RUN   TestAccAWSLBListenerRule_multipleConditionThrowsError
--- PASS: TestAccAWSLBListenerRule_multipleConditionThrowsError (1.72s)
=== RUN   TestAccAWSLBListenerRuleBackwardsCompatibility
--- PASS: TestAccAWSLBListenerRuleBackwardsCompatibility (222.19s)
=== RUN   TestAccAWSLBListenerBackwardsCompatibility
--- PASS: TestAccAWSLBListenerBackwardsCompatibility (226.13s)
=== RUN   TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew
--- PASS: TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew (252.06s)
=== RUN   TestAccDataSourceAWSLBListener_basic
--- PASS: TestAccDataSourceAWSLBListener_basic (255.22s)
=== RUN   TestAccAWSLBListener_https
--- PASS: TestAccAWSLBListener_https (278.08s)
=== RUN   TestAccDataSourceAWSLBListenerBackwardsCompatibility
--- PASS: TestAccDataSourceAWSLBListenerBackwardsCompatibility (279.69s)
=== RUN   TestAccDataSourceAWSLBListener_https
--- PASS: TestAccDataSourceAWSLBListener_https (291.89s)
=== RUN   TestAccAWSLBListenerRule_basic
--- PASS: TestAccAWSLBListenerRule_basic (293.18s)
=== RUN   TestAccAWSLBListener_basic
--- PASS: TestAccAWSLBListener_basic (298.93s)
=== RUN   TestAccAWSLBListenerRule_updateRulePriority
--- PASS: TestAccAWSLBListenerRule_updateRulePriority (342.21s)
=== RUN   TestAccAWSLBListenerRule_priority
--- PASS: TestAccAWSLBListenerRule_priority (397.64s)
```
