### PR TITLE
tests/resource/aws_db_instance: Replace rand.New() usage with acctest.RandInt()

### DIFF
--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"math/rand"
 	"os"
 	"regexp"
 	"strings"
@@ -167,7 +166,7 @@ func TestAccAWSDBInstance_kmsKey(t *testing.T) {
 	var v rds.DBInstance
 	keyRegex := regexp.MustCompile("^arn:aws:kms:")
 
-	ri := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	ri := acctest.RandInt()
 	config := fmt.Sprintf(testAccAWSDBInstanceConfigKmsKeyId, ri)
 
 	resource.Test(t, resource.TestCase{
@@ -270,7 +269,7 @@ func TestAccAWSDBInstance_replica(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccReplicaInstanceConfig(rand.New(rand.NewSource(time.Now().UnixNano())).Int()),
+				Config: testAccReplicaInstanceConfig(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists("aws_db_instance.bar", &s),
 					testAccCheckAWSDBInstanceExists("aws_db_instance.replica", &r),


### PR DESCRIPTION
Reference: #4625 

Changes proposed in this pull request:

* Use consistent upstream function for random integers in testing

Output from acceptance testing:

```
21 tests passed (all tests)
=== RUN   TestAccAWSDBInstance_basic
--- PASS: TestAccAWSDBInstance_basic (412.88s)
=== RUN   TestAccAWSDBInstance_importBasic
--- PASS: TestAccAWSDBInstance_importBasic (414.02s)
=== RUN   TestAccAWSDBInstance_ec2Classic
--- PASS: TestAccAWSDBInstance_ec2Classic (443.59s)
=== RUN   TestAccAWSDBInstance_diffSuppressInitialState
--- PASS: TestAccAWSDBInstance_diffSuppressInitialState (463.43s)
=== RUN   TestAccAWSDBInstance_generatedName
--- PASS: TestAccAWSDBInstance_generatedName (463.53s)
=== RUN   TestAccAWSDBInstance_MinorVersion
--- PASS: TestAccAWSDBInstance_MinorVersion (463.51s)
=== RUN   TestAccAWSDBInstance_namePrefix
--- PASS: TestAccAWSDBInstance_namePrefix (463.75s)
=== RUN   TestAccAWSDBInstance_iamAuth
--- PASS: TestAccAWSDBInstance_iamAuth (483.74s)
=== RUN   TestAccAWSDBInstance_cloudwatchLogsExportConfiguration
--- PASS: TestAccAWSDBInstance_cloudwatchLogsExportConfiguration (497.70s)
=== RUN   TestAccAWSDBInstance_optionGroup
--- PASS: TestAccAWSDBInstance_optionGroup (534.67s)
=== RUN   TestAccAWSDBInstance_separate_iops_update
--- PASS: TestAccAWSDBInstance_separate_iops_update (538.57s)
=== RUN   TestAccAWSDBInstance_kmsKey
--- PASS: TestAccAWSDBInstance_kmsKey (545.65s)
=== RUN   TestAccAWSDBInstance_portUpdate
--- PASS: TestAccAWSDBInstance_portUpdate (549.13s)
=== RUN   TestAccAWSDBInstance_noSnapshot
--- PASS: TestAccAWSDBInstance_noSnapshot (706.25s)
=== RUN   TestAccAWSDBInstance_s3
--- PASS: TestAccAWSDBInstance_s3 (768.56s)
=== RUN   TestAccAWSDBInstance_subnetGroup
--- PASS: TestAccAWSDBInstance_subnetGroup (779.15s)
=== RUN   TestAccAWSDBInstance_enhancedMonitoring
--- PASS: TestAccAWSDBInstance_enhancedMonitoring (809.00s)
=== RUN   TestAccAWSDBInstance_cloudwatchLogsExportConfigurationUpdate
--- PASS: TestAccAWSDBInstance_cloudwatchLogsExportConfigurationUpdate (533.22s)
=== RUN   TestAccAWSDBInstance_snapshot
--- PASS: TestAccAWSDBInstance_snapshot (947.76s)
=== RUN   TestAccAWSDBInstance_replica
--- PASS: TestAccAWSDBInstance_replica (1656.83s)
=== RUN   TestAccAWSDBInstance_MSSQL_TZ
--- PASS: TestAccAWSDBInstance_MSSQL_TZ (1658.84s)
```
