### PR TITLE
tests/resource/aws_elb: Replace rand.New() usage with acctest.RandInt()

### DIFF
--- a/aws/resource_aws_elb_test.go
+++ b/aws/resource_aws_elb_test.go
@@ -126,8 +126,7 @@ func TestAccAWSELB_basic(t *testing.T) {
 func TestAccAWSELB_fullCharacterRange(t *testing.T) {
 	var conf elb.LoadBalancerDescription
 
-	lbName := fmt.Sprintf("Tf-%d",
-		rand.New(rand.NewSource(time.Now().UnixNano())).Int())
+	lbName := fmt.Sprintf("Tf-%d", acctest.RandInt())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },


### PR DESCRIPTION
Reference: #4625 

Changes proposed in this pull request:

* Use consistent upstream function for random integers in testing

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSELB_fullCharacterRange'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSELB_fullCharacterRange -timeout 120m
=== RUN   TestAccAWSELB_fullCharacterRange
--- PASS: TestAccAWSELB_fullCharacterRange (31.02s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	31.061s
```
