### PR TITLE
tests/resource/aws_cloudfront_distribution: Replace rand.New() usage with acctest.RandInt()

### DIFF
--- a/aws/resource_aws_cloudfront_distribution_test.go
+++ b/aws/resource_aws_cloudfront_distribution_test.go
@@ -3,11 +3,9 @@ package aws
 import (
 	"fmt"
 	"log"
-	"math/rand"
 	"os"
 	"regexp"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudfront"
@@ -685,7 +683,7 @@ resource "aws_cloudfront_distribution" "custom_distribution" {
 	}
 	%s
 }
-`, rand.New(rand.NewSource(time.Now().UnixNano())).Int(), logBucket, testAccAWSCloudFrontDistributionRetainConfig())
+`, acctest.RandInt(), logBucket, testAccAWSCloudFrontDistributionRetainConfig())
 
 var testAccAWSCloudFrontDistributionMultiOriginConfig = fmt.Sprintf(`
 variable rand_id {
@@ -789,7 +787,7 @@ resource "aws_cloudfront_distribution" "multi_origin_distribution" {
 	}
 	%s
 }
-`, rand.New(rand.NewSource(time.Now().UnixNano())).Int(), originBucket, logBucket, testAccAWSCloudFrontDistributionRetainConfig())
+`, acctest.RandInt(), originBucket, logBucket, testAccAWSCloudFrontDistributionRetainConfig())
 
 var testAccAWSCloudFrontDistributionNoCustomErroResponseInfo = fmt.Sprintf(`
 variable rand_id {
@@ -840,7 +838,7 @@ resource "aws_cloudfront_distribution" "no_custom_error_responses" {
 	}
 	%s
 }
-`, rand.New(rand.NewSource(time.Now().UnixNano())).Int(), testAccAWSCloudFrontDistributionRetainConfig())
+`, acctest.RandInt(), testAccAWSCloudFrontDistributionRetainConfig())
 
 var testAccAWSCloudFrontDistributionNoOptionalItemsConfig = fmt.Sprintf(`
 variable rand_id {
@@ -883,7 +881,7 @@ resource "aws_cloudfront_distribution" "no_optional_items" {
 	}
 	%s
 }
-`, rand.New(rand.NewSource(time.Now().UnixNano())).Int(), testAccAWSCloudFrontDistributionRetainConfig())
+`, acctest.RandInt(), testAccAWSCloudFrontDistributionRetainConfig())
 
 var testAccAWSCloudFrontDistributionConfig_Origin_EmptyDomainName = fmt.Sprintf(`
 resource "aws_cloudfront_distribution" "Origin_EmptyDomainName" {
@@ -1009,7 +1007,7 @@ resource "aws_cloudfront_distribution" "http_1_1" {
 	}
 	%s
 }
-`, rand.New(rand.NewSource(time.Now().UnixNano())).Int(), testAccAWSCloudFrontDistributionRetainConfig())
+`, acctest.RandInt(), testAccAWSCloudFrontDistributionRetainConfig())
 
 var testAccAWSCloudFrontDistributionIsIPV6EnabledConfig = fmt.Sprintf(`
 variable rand_id {
@@ -1058,7 +1056,7 @@ resource "aws_cloudfront_distribution" "is_ipv6_enabled" {
 	}
 	%s
 }
-`, rand.New(rand.NewSource(time.Now().UnixNano())).Int(), testAccAWSCloudFrontDistributionRetainConfig())
+`, acctest.RandInt(), testAccAWSCloudFrontDistributionRetainConfig())
 
 var testAccAWSCloudFrontDistributionOrderedCacheBehavior = fmt.Sprintf(`
 variable rand_id {
@@ -1139,4 +1137,4 @@ resource "aws_cloudfront_distribution" "main" {
 	}
 	%s
 }
-`, rand.New(rand.NewSource(time.Now().UnixNano())).Int(), testAccAWSCloudFrontDistributionRetainConfig())
+`, acctest.RandInt(), testAccAWSCloudFrontDistributionRetainConfig())


### PR DESCRIPTION
Reference: #4625 

Changes proposed in this pull request:

* Use consistent upstream function for random integers in testing

Output from acceptance testing:

```
12 tests passed (all tests)
=== RUN   TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID (1.78s)
=== RUN   TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName (1.83s)
=== RUN   TestAccAWSCloudFrontDistribution_HTTP11Config
--- PASS: TestAccAWSCloudFrontDistribution_HTTP11Config (744.97s)
=== RUN   TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig
--- PASS: TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig (746.09s)
=== RUN   TestAccAWSCloudFrontDistribution_multiOrigin
--- PASS: TestAccAWSCloudFrontDistribution_multiOrigin (746.39s)
=== RUN   TestAccAWSCloudFrontDistribution_S3OriginWithTags
--- PASS: TestAccAWSCloudFrontDistribution_S3OriginWithTags (750.05s)
=== RUN   TestAccAWSCloudFrontDistribution_noOptionalItemsConfig
--- PASS: TestAccAWSCloudFrontDistribution_noOptionalItemsConfig (750.34s)
=== RUN   TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig
--- PASS: TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig (750.40s)
=== RUN   TestAccAWSCloudFrontDistribution_customOrigin
--- PASS: TestAccAWSCloudFrontDistribution_customOrigin (750.46s)
=== RUN   TestAccAWSCloudFrontDistribution_importBasic
--- PASS: TestAccAWSCloudFrontDistribution_importBasic (753.06s)
=== RUN   TestAccAWSCloudFrontDistribution_orderedCacheBehavior
--- PASS: TestAccAWSCloudFrontDistribution_orderedCacheBehavior (753.57s)
=== RUN   TestAccAWSCloudFrontDistribution_S3Origin
--- PASS: TestAccAWSCloudFrontDistribution_S3Origin (754.89s)
```
