### PR TITLE
DMS Endpoint: Specify MongoDB connection info in the top-level namespace

### DIFF
--- a/aws/resource_aws_dms_endpoint.go
+++ b/aws/resource_aws_dms_endpoint.go
@@ -253,6 +253,13 @@ func resourceAwsDmsEndpointCreate(d *schema.ResourceData, meta interface{}) erro
 			DocsToInvestigate: aws.String(d.Get("mongodb_settings.0.docs_to_investigate").(string)),
 			AuthSource:        aws.String(d.Get("mongodb_settings.0.auth_source").(string)),
 		}
+
+		// Set connection info in top-level namespace as well
+		request.Username = aws.String(d.Get("username").(string))
+		request.Password = aws.String(d.Get("password").(string))
+		request.ServerName = aws.String(d.Get("server_name").(string))
+		request.Port = aws.Int64(int64(d.Get("port").(int)))
+		request.DatabaseName = aws.String(d.Get("database_name").(string))
 	case "s3":
 		request.S3Settings = &dms.S3Settings{
 			ServiceAccessRoleArn:    aws.String(d.Get("s3_settings.0.service_access_role_arn").(string)),
@@ -433,6 +440,14 @@ func resourceAwsDmsEndpointUpdate(d *schema.ResourceData, meta interface{}) erro
 				AuthSource:        aws.String(d.Get("mongodb_settings.0.auth_source").(string)),
 			}
 			request.EngineName = aws.String(d.Get("engine_name").(string)) // Must be included (should be 'mongodb')
+
+			// Update connection info in top-level namespace as well
+			request.Username = aws.String(d.Get("username").(string))
+			request.Password = aws.String(d.Get("password").(string))
+			request.ServerName = aws.String(d.Get("server_name").(string))
+			request.Port = aws.Int64(int64(d.Get("port").(int)))
+			request.DatabaseName = aws.String(d.Get("database_name").(string))
+
 			hasChanges = true
 		}
 	case "s3":


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #4635

Changes proposed in this pull request:

* MongoDB connection info (server name, port, username, passport and database name) are now specified in the top-level namespace as well as in the nested `mongodb_settings` settings. Otherwise it would not be able to test the connection as explained in the issue above.
* Running
```
# Trigger a connection test
$ aws dms test-connection --replication-instance-arn <replication-instance-arn> --endpoint-arn <endpoint-arn>
# Retrieve the most recent connection test result
$ aws dms describe-connections
```
will now return
```
{
    "Connections": [
        {
            "ReplicationInstanceArn": "..."
            "EndpointArn": "..."
            "Status": "successful",
            "EndpointIdentifier": "..."
            "ReplicationInstanceIdentifier": "..."
        },
        ...
    ]
}
```

Output from acceptance testing (unchanged and still passes):

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAwsDmsEndpointMongoDb'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAwsDmsEndpointMongoDb -timeout 120m
=== RUN   TestAccAwsDmsEndpointMongoDb
--- PASS: TestAccAwsDmsEndpointMongoDb (74.04s)
PASS
ok     github.com/terraform-providers/terraform-provider-aws/aws      74.053s
```
