### PR TITLE
Update RDS engine versions in example to latest supported

### DIFF
--- a/examples/rds/variables.tf
+++ b/examples/rds/variables.tf
@@ -17,8 +17,8 @@ variable "engine_version" {
   description = "Engine version"
 
   default = {
-    mysql    = "5.6.22"
-    postgres = "9.4.1"
+    mysql    = "5.7.21"
+    postgres = "9.6.8"
   }
 }
 


### PR DESCRIPTION
Pretty minor - just updated the db engine versions in the RDS example to the latest from:

- https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts
- https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_MySQL.html#MySQL.Concepts.VersionMgmt

I copied the example and discovered that `9.4.1` was no longer supported:
```
* aws_db_instance.grafana_db: Error creating DB Instance: InvalidParameterCombination: Cannot find version 9.4.1 for postgres
	status code: 400, request id: d5b6025c-1714-47be-8196-51da21fddf96
```