### PR TITLE
DMS Endpoint: Update doc as kms_key_arn is now mandatory for mongodb

### DIFF
--- a/website/docs/r/dms_endpoint.html.markdown
+++ b/website/docs/r/dms_endpoint.html.markdown
@@ -55,7 +55,7 @@ The following arguments are supported:
 * `endpoint_type` - (Required) The type of endpoint. Can be one of `source | target`.
 * `engine_name` - (Required) The type of engine for the endpoint. Can be one of `mysql | oracle | postgres | mariadb | aurora | redshift | sybase | sqlserver | dynamodb | mongodb | s3 | azuredb`.
 * `extra_connection_attributes` - (Optional) Additional attributes associated with the connection. For available attributes see [Using Extra Connection Attributes with AWS Database Migration Service](http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Introduction.ConnectionAttributes.html).
-* `kms_key_arn` - (Optional) The Amazon Resource Name (ARN) for the KMS key that will be used to encrypt the connection parameters. If you do not specify a value for `kms_key_arn`, then AWS DMS will use your default encryption key. AWS KMS creates the default encryption key for your AWS account. Your AWS account has a different default encryption key for each AWS region.
+* `kms_key_arn` - (Required when `engine_name` is `mongodb`, optional otherwise) The Amazon Resource Name (ARN) for the KMS key that will be used to encrypt the connection parameters. If you do not specify a value for `kms_key_arn`, then AWS DMS will use your default encryption key. AWS KMS creates the default encryption key for your AWS account. Your AWS account has a different default encryption key for each AWS region.
 * `password` - (Optional) The password to be used to login to the endpoint database.
 * `port` - (Optional) The port used by the endpoint database.
 * `server_name` - (Optional) The host name of the server.


### PR DESCRIPTION
Changes proposed in this pull request:

* Update the documentation where `kms_key_arn` is either required or optional depending on the type of engine selected (required when `mongodb` is selected)
* See [this PR](https://github.com/terraform-providers/terraform-provider-aws/pull/4559) for more details

Output from acceptance testing:

No code changes in this PR