### PR TITLE
docs/resource/aws_rds_cluster: backtrack_window is only valid for aurora (Aurora MySQL 5.6) engine currently

### DIFF
--- a/website/docs/r/rds_cluster.html.markdown
+++ b/website/docs/r/rds_cluster.html.markdown
@@ -94,7 +94,7 @@ The following arguments are supported:
 * `skip_final_snapshot` - (Optional) Determines whether a final DB snapshot is created before the DB cluster is deleted. If true is specified, no DB snapshot is created. If false is specified, a DB snapshot is created before the DB cluster is deleted, using the value from `final_snapshot_identifier`. Default is `false`.
 * `availability_zones` - (Optional) A list of EC2 Availability Zones that
   instances in the DB cluster can be created in
-* `backtrack_window` - (Optional) The target backtrack window, in seconds. Only available for `aurora` or `aurora-mysql` engines. To disable backtracking, set this value to `0`. Defaults to `0`. Must be between `0` and `259200` (72 hours)
+* `backtrack_window` - (Optional) The target backtrack window, in seconds. Only available for `aurora` engine currently. To disable backtracking, set this value to `0`. Defaults to `0`. Must be between `0` and `259200` (72 hours)
 * `backup_retention_period` - (Optional) The days to retain backups for. Default `1`
 * `preferred_backup_window` - (Optional) The daily time range during which automated backups are created if automated backups are enabled using the BackupRetentionPeriod parameter.Time in UTC
 Default: A 30-minute window selected at random from an 8-hour block of time per region. e.g. 04:00-09:00


### PR DESCRIPTION
Fixes #4640 

Changes proposed in this pull request:

* According to the [RDS documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AuroraMySQL.Managing.Backtrack.html), backtrack is only available for the `aurora` engine (Aurora MySQL 5.6) and not `aurora-mysql` engine (Aurora MySQL 5.7)

> Backtracking is only supported for Aurora MySQL 5.6. It is not supported for Aurora MySQL 5.7. Because of this limitation, you can't restore a snapshot of an Aurora MySQL 5.6 DB cluster with Backtrack enabled to Aurora MySQL 5.7, and you can't perform point-in-time recovery on an Aurora MySQL 5.6 DB cluster with Backtrack enabled to restore the DB cluster to Aurora MySQL 5.7.

Output from acceptance testing: N/A
