### PR TITLE
issue #4658 update validation_method attribute schema in aws_acm_certificate

### DIFF
--- a/aws/resource_aws_acm_certificate.go
+++ b/aws/resource_aws_acm_certificate.go
@@ -35,7 +35,7 @@ func resourceAwsAcmCertificate() *schema.Resource {
 			},
 			"validation_method": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 			"arn": {

--- a/website/docs/r/acm_certificate.html.markdown
+++ b/website/docs/r/acm_certificate.html.markdown
@@ -41,7 +41,7 @@ The following arguments are supported:
 
 * `domain_name` - (Required) A domain name for which the certificate should be issued
 * `subject_alternative_names` - (Optional) A list of domains that should be SANs in the issued certificate
-* `validation_method` - (Required) Which method to use for validation. `DNS` or `EMAIL` are valid, `NONE` can be used for certificates that were imported into ACM and then into Terraform.
+* `validation_method` - (Optional) Which method to use for validation. `DNS` or `EMAIL` are valid, `NONE` can be used for certificates that were imported into ACM and then into Terraform.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference


### PR DESCRIPTION

Fixes #4658 

Changes proposed in this pull request:

* Change 1
change the validation_method attribute as optional.
https://docs.aws.amazon.com/acm/latest/APIReference/API_RequestCertificate.html
