### PR TITLE
added support for custom endpoint for SSM

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -136,6 +136,7 @@ type Config struct {
 	SnsEndpoint              string
 	SqsEndpoint              string
 	StsEndpoint              string
+	SsmEndpoint              string
 	Insecure                 bool
 
 	SkipCredsValidation     bool
@@ -400,6 +401,7 @@ func (c *Config) Client() (interface{}, error) {
 	awsSqsSess := sess.Copy(&aws.Config{Endpoint: aws.String(c.SqsEndpoint)})
 	awsStsSess := sess.Copy(&aws.Config{Endpoint: aws.String(c.StsEndpoint)})
 	awsDeviceFarmSess := sess.Copy(&aws.Config{Endpoint: aws.String(c.DeviceFarmEndpoint)})
+	awsSsmSess := sess.Copy(&aws.Config{Endpoint: aws.String(c.SsmEndpoint)})
 
 	log.Println("[INFO] Initializing DeviceFarm SDK connection")
 	client.devicefarmconn = devicefarm.New(awsDeviceFarmSess)
@@ -506,7 +508,7 @@ func (c *Config) Client() (interface{}, error) {
 	client.sfnconn = sfn.New(sess)
 	client.snsconn = sns.New(awsSnsSess)
 	client.sqsconn = sqs.New(awsSqsSess)
-	client.ssmconn = ssm.New(sess)
+	client.ssmconn = ssm.New(awsSsmSess)
 	client.wafconn = waf.New(sess)
 	client.wafregionalconn = wafregional.New(sess)
 	client.batchconn = batch.New(sess)

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -699,6 +699,8 @@ func init() {
 
 		"sqs_endpoint": "Use this to override the default endpoint URL constructed from the `region`.\n",
 
+		"ssm_endpoint": "Use this to override the default endpoint URL constructed from the `region`.\n",
+
 		"insecure": "Explicitly allow the provider to perform \"insecure\" SSL requests. If omitted," +
 			"default value is `false`",
 
@@ -804,6 +806,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		config.SnsEndpoint = endpoints["sns"].(string)
 		config.SqsEndpoint = endpoints["sqs"].(string)
 		config.StsEndpoint = endpoints["sts"].(string)
+		config.SsmEndpoint = endpoints["ssm"].(string)
 	}
 
 	if v, ok := d.GetOk("allowed_account_ids"); ok {
@@ -1002,6 +1005,12 @@ func endpointsSchema() *schema.Schema {
 					Optional:    true,
 					Default:     "",
 					Description: descriptions["sts_endpoint"],
+				},
+				"ssm": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Default:     "",
+					Description: descriptions["ssm_endpoint"],
 				},
 			},
 		},

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -343,6 +343,10 @@ Nested `endpoints` block supports the following:
   URL constructed from the `region`. It's typically used to connect to
   custom STS endpoints.
 
+* `ssm` - (Optional) Use this to override the default endpoint
+  URL constructed from the `region`. It's typically used to connect to
+  custom STS endpoints.
+
 ## Getting the Account ID
 
 If you use either `allowed_account_ids` or `forbidden_account_ids`,


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #0000

Changes proposed in this pull request:

* Added in support for configuring the SSM endpoint
* updated website docs

Output from acceptance testing:

```
=== RUN   TestProvider
--- PASS: TestProvider (0.06s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
...
```
