### PR TITLE
Change gofmt arguments backquotes to xargs

### DIFF
--- a/scripts/gofmtcheck.sh
+++ b/scripts/gofmtcheck.sh
@@ -2,7 +2,7 @@
 
 # Check gofmt
 echo "==> Checking that code complies with gofmt requirements..."
-gofmt_files=$(gofmt -l `find . -name '*.go' | grep -v vendor`)
+gofmt_files=$(find . -name '*.go' | grep -v vendor | xargs gofmt -l)
 if [[ -n ${gofmt_files} ]]; then
     echo 'gofmt needs running on the following files:'
     echo "${gofmt_files}"


### PR DESCRIPTION
Changes proposed in this pull request:

* This resolves error `Argument list too long` caused by gofmt

I have tested building terraform-provider-aws with msys2 on windows. Then I got the error "gofmt: Argument list too long". This is caused by file counts is larger than `ARG_MAX` defined by using OS.
