### PR TITLE
fix documentation description of replica_kms_key_id

### DIFF
--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -418,7 +418,7 @@ The `destination` object supports the following:
 
 * `bucket` - (Required) The ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
 * `storage_class` - (Optional) The class of storage used to store the object.
-* `replica_kms_key_id` - (Optional) Destination KMS encryption key ID for SSE-KMS replication. Must be used in conjunction with
+* `replica_kms_key_id` - (Optional) Destination KMS encryption key ARN for SSE-KMS replication. Must be used in conjunction with
   `sse_kms_encrypted_objects` source selection criteria.
 
 The `source_selection_criteria` object supports the following:


### PR DESCRIPTION
This property requires the ARN, not the ID, ultimately the whole thing should be renamed.  you can see the AWS documentation here: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-encryptionconfiguration.html