### PR TITLE
[WIP] New Data Sources: aws_organizations_*

### DIFF
--- a/aws/data_source_aws_organizations_account.go
+++ b/aws/data_source_aws_organizations_account.go
@@ -1,0 +1,83 @@
+package aws
+
+import (
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/organizations"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsOrganizationsAccount() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsOrganizationsAccountRead,
+		Schema: map[string]*schema.Schema{
+			"account_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"joined_method": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"joined_timestamp": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"email": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"iam_user_access_to_billing": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"role_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsOrganizationsAccountRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).organizationsconn
+
+	accountID := d.Get("account_id").(string)
+	req := &organizations.DescribeAccountInput{
+		AccountId: aws.String(accountID),
+	}
+
+	log.Printf("[DEBUG] DescribeAccount %s\n", req)
+	resp, err := conn.DescribeAccount(req)
+	if err != nil {
+		return err
+	}
+
+	account := resp.Account
+
+	log.Printf("[DEBUG] DescribeAccountResponse %s\n", account)
+
+	d.SetId(*account.Id)
+	d.Set("account_id", account.Id)
+	d.Set("arn", account.Arn)
+	d.Set("email", account.Email)
+	d.Set("joined_method", account.JoinedMethod)
+	d.Set("joined_timestamp", account.JoinedTimestamp)
+	d.Set("name", account.Name)
+	d.Set("status", account.Status)
+
+	return nil
+}

--- a/aws/data_source_aws_organizations_account_ids.go
+++ b/aws/data_source_aws_organizations_account_ids.go
@@ -27,16 +27,16 @@ func dataSourceAwsOrganizationsAccountIDsRead(d *schema.ResourceData, meta inter
 
 	req := &organizations.ListAccountsInput{}
 
-	log.Printf("[DEBUG] ListAccounts %s\n", req)
-	resp, err := conn.ListAccounts(req)
-	if err != nil {
-		return err
-	}
-
 	accounts := make([]string, 0)
 
-	for _, account := range resp.Accounts {
-		accounts = append(accounts, *account.Id)
+	log.Printf("[DEBUG] ListAccounts %s\n", req)
+	if err := conn.ListAccountsPages(req, func(resp *organizations.ListAccountsOutput, lastPage bool) bool {
+		for _, account := range resp.Accounts {
+			accounts = append(accounts, *account.Id)
+		}
+		return true
+	}); err != nil {
+		return err
 	}
 
 	log.Printf("[DEBUG] ListAccountsResponse %s\n", accounts)

--- a/aws/data_source_aws_organizations_account_ids.go
+++ b/aws/data_source_aws_organizations_account_ids.go
@@ -1,0 +1,48 @@
+package aws
+
+import (
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/organizations"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsOrganizationsAccountIDs() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsOrganizationsAccountIDsRead,
+		Schema: map[string]*schema.Schema{
+
+			"ids": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceAwsOrganizationsAccountIDsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).organizationsconn
+
+	req := &organizations.ListAccountsInput{}
+
+	log.Printf("[DEBUG] ListAccounts %s\n", req)
+	resp, err := conn.ListAccounts(req)
+	if err != nil {
+		return err
+	}
+
+	accounts := make([]string, 0)
+
+	for _, account := range resp.Accounts {
+		accounts = append(accounts, *account.Id)
+	}
+
+	log.Printf("[DEBUG] ListAccountsResponse %s\n", accounts)
+
+	d.SetId(time.Now().UTC().String())
+	d.Set("ids", accounts)
+
+	return nil
+}

--- a/aws/data_source_aws_organizations_account_ids_test.go
+++ b/aws/data_source_aws_organizations_account_ids_test.go
@@ -1,0 +1,48 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataSourceAwsOrganizationsAccountIDs_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:             testAccDataSourceAwsOrganizationsAccountIDsConfig,
+				ExpectNonEmptyPlan: true,
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsOrganizationsAccountIDsCheck("data.aws_organizations_account_ids.test"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsOrganizationsAccountIDsCheck(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Can't find Account IDs data source: %s", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Account IDs data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+const testAccDataSourceAwsOrganizationsAccountIDsConfig = `
+resource "aws_organizations_organization" "test" {}
+
+data "aws_organizations_account_ids" "test" {
+  depends_on = ["aws_organizations_organization.test"]
+}
+`

--- a/aws/data_source_aws_organizations_account_test.go
+++ b/aws/data_source_aws_organizations_account_test.go
@@ -1,0 +1,52 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataSourceAwsOrganizationsAccount_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:             testAccDataSourceAwsOrganizationsAccountConfig,
+				ExpectNonEmptyPlan: true,
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsOrganizationsAccountCheck("data.aws_organizations_account.test"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsOrganizationsAccountCheck(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Can't find Account data source: %s", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Account data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+const testAccDataSourceAwsOrganizationsAccountConfig = `
+resource "aws_organizations_organization" "test" {}
+
+data "aws_organizations_account_ids" "test" {
+  depends_on = ["aws_organizations_organization.test"]
+}
+
+data "aws_organizations_account" "test" {
+  account_id = "${data.aws_organizations_account_ids.test.ids[0]}"
+}
+`

--- a/aws/data_source_aws_organizations_organization.go
+++ b/aws/data_source_aws_organizations_organization.go
@@ -1,0 +1,62 @@
+package aws
+
+import (
+	"log"
+
+	"github.com/aws/aws-sdk-go/service/organizations"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsOrganizationsOrganization() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsOrganizationsOrganizationRead,
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"master_account_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"master_account_email": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"master_account_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"feature_set": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsOrganizationsOrganizationRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).organizationsconn
+
+	req := &organizations.DescribeOrganizationInput{}
+
+	log.Printf("[DEBUG] Reading Organization: %s", req)
+	resp, err := conn.DescribeOrganization(req)
+	if err != nil {
+		return err
+	}
+
+	org := resp.Organization
+
+	d.SetId(*org.Id)
+	d.Set("arn", org.Arn)
+	d.Set("feature_set", org.FeatureSet)
+	d.Set("master_account_arn", org.MasterAccountArn)
+	d.Set("master_account_email", org.MasterAccountEmail)
+	d.Set("master_account_id", org.MasterAccountId)
+
+	log.Printf("[DEBUG] Reading Organization: %+v\n", org)
+
+	return nil
+}

--- a/aws/data_source_aws_organizations_organization_test.go
+++ b/aws/data_source_aws_organizations_organization_test.go
@@ -1,0 +1,55 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/organizations"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataSourceAwsOrganizationsOrganization_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:             testAccDataSourceAwsOrganizationsOrganizationConfig,
+				ExpectNonEmptyPlan: true,
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsOrganizationsOrganizationCheck("data.aws_organizations_organization.test"),
+					resource.TestCheckResourceAttr("data.aws_organizations_organization.test", "feature_set", organizations.OrganizationFeatureSetAll),
+					resource.TestCheckResourceAttrSet("data.aws_organizations_organization.test", "arn"),
+					resource.TestCheckResourceAttrSet("data.aws_organizations_organization.test", "feature_set"),
+					resource.TestCheckResourceAttrSet("data.aws_organizations_organization.test", "master_account_arn"),
+					resource.TestCheckResourceAttrSet("data.aws_organizations_organization.test", "master_account_email"),
+					resource.TestCheckResourceAttrSet("data.aws_organizations_organization.test", "master_account_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsOrganizationsOrganizationCheck(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Can't find Organization data source: %s", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Organization data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+const testAccDataSourceAwsOrganizationsOrganizationConfig = `
+resource "aws_organizations_organization" "test" {}
+
+data "aws_organizations_organization" "test" {
+  depends_on = ["aws_organizations_organization.test"]
+}
+`

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -223,6 +223,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_mq_broker":                        dataSourceAwsMqBroker(),
 			"aws_nat_gateway":                      dataSourceAwsNatGateway(),
 			"aws_network_interface":                dataSourceAwsNetworkInterface(),
+			"aws_organizations_account_ids":        dataSourceAwsOrganizationsAccountIDs(),
 			"aws_organizations_account":            dataSourceAwsOrganizationsAccount(),
 			"aws_organizations_organization":       dataSourceAwsOrganizationsOrganization(),
 			"aws_partition":                        dataSourceAwsPartition(),

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -223,6 +223,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_mq_broker":                        dataSourceAwsMqBroker(),
 			"aws_nat_gateway":                      dataSourceAwsNatGateway(),
 			"aws_network_interface":                dataSourceAwsNetworkInterface(),
+			"aws_organizations_organization":       dataSourceAwsOrganizationsOrganization(),
 			"aws_partition":                        dataSourceAwsPartition(),
 			"aws_prefix_list":                      dataSourceAwsPrefixList(),
 			"aws_rds_cluster":                      dataSourceAwsRdsCluster(),

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -223,6 +223,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_mq_broker":                        dataSourceAwsMqBroker(),
 			"aws_nat_gateway":                      dataSourceAwsNatGateway(),
 			"aws_network_interface":                dataSourceAwsNetworkInterface(),
+			"aws_organizations_account":            dataSourceAwsOrganizationsAccount(),
 			"aws_organizations_organization":       dataSourceAwsOrganizationsOrganization(),
 			"aws_partition":                        dataSourceAwsPartition(),
 			"aws_prefix_list":                      dataSourceAwsPrefixList(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -232,6 +232,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-mq-broker") %>>
                             <a href="/docs/providers/aws/d/mq_broker.html">aws_mq_broker</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-organizations_account") %>>
+                            <a href="/docs/providers/aws/d/organizations_account.html">aws_organizations_account</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-organizations_organization") %>>
                             <a href="/docs/providers/aws/d/organizations_organization.html">aws_organizations_organization</a>
                         </li>

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -232,6 +232,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-mq-broker") %>>
                             <a href="/docs/providers/aws/d/mq_broker.html">aws_mq_broker</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-organizations_organization") %>>
+                            <a href="/docs/providers/aws/d/organizations_organization.html">aws_organizations_organization</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-partition") %>>
                             <a href="/docs/providers/aws/d/partition.html">aws_partition</a>
                         </li>

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -232,6 +232,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-mq-broker") %>>
                             <a href="/docs/providers/aws/d/mq_broker.html">aws_mq_broker</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-organizations_account_ids") %>>
+                            <a href="/docs/providers/aws/d/organizations_account_ids.html">aws_organizations_account_ids</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-organizations_account") %>>
                             <a href="/docs/providers/aws/d/organizations_account.html">aws_organizations_account</a>
                         </li>

--- a/website/docs/d/organizations_account.html.markdown
+++ b/website/docs/d/organizations_account.html.markdown
@@ -1,0 +1,47 @@
+---
+layout: "aws"
+page_title: "AWS: aws_organizations_account"
+sidebar_current: "docs-aws-datasource-organizations_account"
+description: |-
+  Get information on an AWS Account in the joined AWS Organization.
+---
+
+# Data Source: aws_organizations_account
+
+Use this data source to get details on an AWS Account in the joined organization.
+
+~> **NOTE:** Account management must be done from the organization's master account.
+
+## Example Usage
+
+```hcl
+data "aws_caller_identity" "current" {}
+
+data "aws_organizations_account" "dev" {
+  account_id = "${data.aws_caller_identity.current.account_id}"
+}
+
+resource "aws_ssm_parameter" "accounts_dev_email" {
+  name  = "/terraform-example/accounts/dev/email"
+  type  = "String"
+  value = "${data.aws_organizations_account.dev.email}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `account_id` - (Required) The ID of the AWS Account
+
+## Attributes Reference
+
+`id` is set to the ID of the AWS Account. In addition, the following attributes
+are exported:
+
+* `arn` - The ARN for this account.
+* `email` - The email address associated with the AWS account.
+* `joined_method` - The method by which the account joined the organization.
+* `joined_timestamp` - The date the account became a part of the organization.
+* `name` - The friendly name of the account.
+* `status` - The status of the account in the organization.

--- a/website/docs/d/organizations_account_ids.html.markdown
+++ b/website/docs/d/organizations_account_ids.html.markdown
@@ -1,0 +1,40 @@
+---
+layout: "aws"
+page_title: "AWS: aws_organizations_account_ids"
+sidebar_current: "docs-aws-datasource-organizations_account_ids"
+description: |-
+  Provides a list of AWS Account IDs in the joined AWS Organization.
+---
+
+# Data Source: aws_organizations_account_ids
+
+Use this data source to get a list of AWS Account IDs in the joined organization.
+
+~> **NOTE:** Account management must be done from the organization's master account.
+
+## Example Usage
+
+```hcl
+data "aws_organizations_account_ids" "accounts" {}
+
+resource "aws_ami_copy" "example" {
+  name              = "terraform-example"
+  description       = "A copy of ami-f2d3638a"
+  source_ami_id     = "ami-f2d3638a"
+  source_ami_region = "us-west-2"
+}
+
+resource "aws_ami_launch_permission" "example1" {
+  count      = "${length(data.aws_organizations_account_ids.accounts.ids)}"
+  image_id   = "${aws_ami_copy.example.id}"
+  account_id = "${data.aws_organizations_account_ids.accounts.ids[count.index]}"
+}
+```
+
+## Argument Reference
+
+There are no arguments available for this data source.
+
+## Attributes Reference
+
+`ids` is set to the list of Account IDs

--- a/website/docs/d/organizations_organization.html.markdown
+++ b/website/docs/d/organizations_organization.html.markdown
@@ -1,0 +1,70 @@
+---
+layout: "aws"
+page_title: "AWS: aws_organizations_organization"
+sidebar_current: "docs-aws-datasource-organizations_organization"
+description: |-
+  Get information on the organization that the user's account belongs to.
+---
+
+# Data Source: aws_organizations_organization
+
+Use this data source to get details on the joined organization.
+
+~> **NOTE:** The AWS Account must be a member of an AWS Organization.
+
+## Example Usage
+
+```hcl
+data "aws_organizations_organization" "org" {}
+
+resource "aws_s3_bucket" "example" {
+  bucket = "my_tf_test_bucket"
+}
+
+data "aws_iam_policy_document" "bucket" {
+  statement {
+    actions = [
+      "s3:*",
+    ]
+
+    resources = ["arn:aws:s3:::${aws_s3_bucket.example.id}/*"]
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalOrgID"
+
+      values = [
+        "${data.aws_organizations_organization.org.id}",
+      ]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "example" {
+  bucket = "${aws_s3_bucket.example.id}"
+  policy = "${data.aws_iam_policy_document.bucket.json}"
+}
+```
+
+## Argument Reference
+
+There are no arguments available for this data source.
+
+## Attributes Reference
+
+`id` is set to the ID of the Organization. In addition, the following attributes
+are exported:
+
+* `arn` - ARN of the organization
+* `master_account_arn` - ARN of the master account
+* `master_account_email` - Email address of the master account
+* `master_account_id` - Identifier of the master account
+* `feature_set` - Specifies the functionality that currently is available to the
+  organization.If set to "ALL", then all features are enabled and policies can be
+  applied to accounts in the organization. If set to "CONSOLIDATED_BILLING", then
+  only consolidated billing functionality is available.


### PR DESCRIPTION
We have a need for a few data sources for AWS Organizations resources. The included data sources allow us to more easily share resources like S3 Buckets and AMIs across all AWS Accounts within our organization.

Changes proposed in this pull request:

* New Data Source: aws_organizations_organization
* New Data Source: aws_organizations_account_ids
* New Data Source: aws_organizations_account

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccDataSourceAwsOrganizations*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccDataSourceAwsOrganizations* -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccDataSourceAwsOrganizationsAccountIDs_basic
--- PASS: TestAccDataSourceAwsOrganizationsAccountIDs_basic (41.77s)
=== RUN   TestAccDataSourceAwsOrganizationsAccount_basic
--- PASS: TestAccDataSourceAwsOrganizationsAccount_basic (38.51s)
=== RUN   TestAccDataSourceAwsOrganizationsOrganization_basic
--- PASS: TestAccDataSourceAwsOrganizationsOrganization_basic (42.56s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	122.854s

```

WIP:

For the acceptance tests, I'm not sure of the best way to test features that
require an organization. I currently have the tests creating an organization, but
because I need to use `depends_on` in the tested data source, the plan check fails.
I'm currently working around this by ignoring the check (`ExpectNonEmptyPlan: true`).

Output when not ignoring the plan check:
```
=== RUN   TestAccDataSourceAwsOrganizationsAccount_basic
--- FAIL: TestAccDataSourceAwsOrganizationsAccount_basic (43.06s)
	testing.go:518: Step 0 error: After applying this step and refreshing, the plan was not empty:
		
		DIFF:
		
		CREATE: data.aws_organizations_account.test
		  account_id:                 "" => "<computed>"
		  arn:                        "" => "<computed>"
		  email:                      "" => "<computed>"
		  iam_user_access_to_billing: "" => "<computed>"
		  joined_method:              "" => "<computed>"
		  joined_timestamp:           "" => "<computed>"
		  name:                       "" => "<computed>"
		  role_name:                  "" => "<computed>"
		  status:                     "" => "<computed>"
		CREATE: data.aws_organizations_account_ids.test
		  ids.#: "" => "<computed>"
		
		STATE:
		
		aws_organizations_organization.test:
		  ...