### PR TITLE
Fix force new behavior for aws_batch_job_definition timeout

### DIFF
--- a/aws/resource_aws_batch_job_definition.go
+++ b/aws/resource_aws_batch_job_definition.go
@@ -67,6 +67,7 @@ func resourceAwsBatchJobDefinition() *schema.Resource {
 						"attempt_duration_seconds": {
 							Type:         schema.TypeInt,
 							Optional:     true,
+							ForceNew:     true,
 							ValidateFunc: validation.IntAtLeast(60),
 						},
 					},


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/4696

Changes proposed in this pull request:

When the `timeout.attempt_duration_seconds` attribute of the `aws_batch_job_definition` is modified, ensure that a new resource is created vs. update-in-place (update-in-place is not support for this resource).

* Add `ForceNew` to `aws_batch_job_definition.timeout.attempt_duration_seconds`
