### PR TITLE
4701 aws_service_discovery_private_dns_namespace name length limit

### DIFF
--- a/aws/resource_aws_service_discovery_private_dns_namespace_test.go
+++ b/aws/resource_aws_service_discovery_private_dns_namespace_test.go
@@ -29,6 +29,24 @@ func TestAccAWSServiceDiscoveryPrivateDnsNamespace_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSServiceDiscoveryPrivateDnsNamespace_longname(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsServiceDiscoveryPrivateDnsNamespaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceDiscoveryPrivateDnsNamespaceConfig(acctest.RandString(8) + "." + acctest.RandString(8) + "." + acctest.RandString(8) + "." + acctest.RandString(8)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceDiscoveryPrivateDnsNamespaceExists("aws_service_discovery_private_dns_namespace.test"),
+					resource.TestCheckResourceAttrSet("aws_service_discovery_private_dns_namespace.test", "arn"),
+					resource.TestCheckResourceAttrSet("aws_service_discovery_private_dns_namespace.test", "hosted_zone"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAwsServiceDiscoveryPrivateDnsNamespaceDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).sdconn
 


### PR DESCRIPTION
Fixes #4701 aws_service_discovery_private_dns_namespace

Changes proposed in this pull request:

* use a hash of the name if its length exceeds 32 characters

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSServiceDiscoveryPrivateDnsNamespace'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSServiceDiscoveryPrivateDnsNamespace -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSServiceDiscoveryPrivateDnsNamespace_basic
--- PASS: TestAccAWSServiceDiscoveryPrivateDnsNamespace_basic (21.61s)
=== RUN   TestAccAWSServiceDiscoveryPrivateDnsNamespace_longname
--- PASS: TestAccAWSServiceDiscoveryPrivateDnsNamespace_longname (20.86s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	42.513s
```
