### PR TITLE
Add endpoint attribute to cognito_user_pool

### DIFF
--- a/aws/resource_aws_cognito_user_pool.go
+++ b/aws/resource_aws_cognito_user_pool.go
@@ -163,6 +163,11 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 				ValidateFunc: validateCognitoUserPoolEmailVerificationMessage,
 			},
 
+			"endpoint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"lambda_config": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -655,6 +660,7 @@ func resourceAwsCognitoUserPoolRead(d *schema.ResourceData, meta interface{}) er
 		Resource:  fmt.Sprintf("userpool/%s", d.Id()),
 	}
 	d.Set("arn", arn.String())
+	d.Set("endpoint", fmt.Sprintf("cognito-idp.%s.amazonaws.com/%s", meta.(*AWSClient).region, d.Id()))
 	d.Set("auto_verified_attributes", flattenStringList(resp.UserPool.AutoVerifiedAttributes))
 
 	if resp.UserPool.EmailVerificationSubject != nil {

--- a/aws/resource_aws_cognito_user_pool_test.go
+++ b/aws/resource_aws_cognito_user_pool_test.go
@@ -88,6 +88,8 @@ func TestAccAWSCognitoUserPool_basic(t *testing.T) {
 					testAccCheckAWSCognitoUserPoolExists("aws_cognito_user_pool.pool"),
 					resource.TestMatchResourceAttr("aws_cognito_user_pool.pool", "arn",
 						regexp.MustCompile("^arn:aws:cognito-idp:[^:]+:[0-9]{12}:userpool/[\\w-]+_[0-9a-zA-Z]+$")),
+					resource.TestMatchResourceAttr("aws_cognito_user_pool.pool", "endpoint",
+						regexp.MustCompile("^cognito-idp\\.[^.]+\\.amazonaws.com/[\\w-]+_[0-9a-zA-Z]+$")),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "name", "terraform-test-pool-"+name),
 					resource.TestCheckResourceAttrSet("aws_cognito_user_pool.pool", "creation_date"),
 					resource.TestCheckResourceAttrSet("aws_cognito_user_pool.pool", "last_modified_date"),

--- a/website/docs/r/cognito_user_pool.markdown
+++ b/website/docs/r/cognito_user_pool.markdown
@@ -126,6 +126,7 @@ The following additional attributes are exported:
 
 * `id` - The id of the user pool.
 * `arn` - The ARN of the user pool.
+* `endpoint` - The endpoint name of the user pool.
 * `creation_date` - The date the user pool was created.
 * `last_modified_date` - The date the user pool was last modified.
 


### PR DESCRIPTION
Cognito User Pools have a provider/issuer/endpoint name (I can't find a consistent name for this) of the format cognito-idp.<region>.amazonaws.com/<YOUR_USER_POOL_ID>. This name is used by various clients (as the token issuer, and to form the URL to retrieve the JWKs), and for configuring the user pool as an identity provider in a Cognito Identity Pool.

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #4700

Changes proposed in this pull request:

* Adds `endpoint` attribute to `cognito_user_pool`

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCognitoUserPool_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCognitoUserPool_basic -timeout 120m
=== RUN   TestAccAWSCognitoUserPool_basic
--- PASS: TestAccAWSCognitoUserPool_basic (14.82s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	25.618s
```
