### PR TITLE
Add ARN to cognito_identity_pool

### DIFF
--- a/aws/resource_aws_cognito_identity_pool.go
+++ b/aws/resource_aws_cognito_identity_pool.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/cognitoidentity"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -28,6 +29,11 @@ func resourceAwsCognitoIdentityPool() *schema.Resource {
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validateCognitoIdentityPoolName,
+			},
+
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 
 			"cognito_identity_providers": {
@@ -151,6 +157,14 @@ func resourceAwsCognitoIdentityPoolRead(d *schema.ResourceData, meta interface{}
 		return err
 	}
 
+	arn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Region:    meta.(*AWSClient).region,
+		Service:   "cognito-identity",
+		AccountID: meta.(*AWSClient).accountid,
+		Resource:  fmt.Sprintf("identitypool/%s", d.Id()),
+	}
+	d.Set("arn", arn.String())
 	d.Set("identity_pool_name", ip.IdentityPoolName)
 	d.Set("allow_unauthenticated_identities", ip.AllowUnauthenticatedIdentities)
 	d.Set("developer_provider_name", ip.DeveloperProviderName)

--- a/aws/resource_aws_cognito_identity_pool_test.go
+++ b/aws/resource_aws_cognito_identity_pool_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -27,6 +28,8 @@ func TestAccAWSCognitoIdentityPool_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoIdentityPoolExists("aws_cognito_identity_pool.main"),
 					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
+					resource.TestMatchResourceAttr("aws_cognito_identity_pool.main", "arn",
+						regexp.MustCompile("^arn:aws:cognito-identity:[^:]+:[0-9]{12}:identitypool/[^:]+:([0-9a-f]){8}-([0-9a-f]){4}-([0-9a-f]){4}-([0-9a-f]){4}-([0-9a-f]){12}$")),
 					resource.TestCheckResourceAttr("aws_cognito_identity_pool.main", "allow_unauthenticated_identities", "false"),
 				),
 			},

--- a/website/docs/r/cognito_identity_pool.markdown
+++ b/website/docs/r/cognito_identity_pool.markdown
@@ -68,6 +68,7 @@ backend and the Cognito service to communicate about the developer provider.
 In addition to the arguments, which are exported, the following attributes are exported:
 
 * `id` - An identity pool ID in the format REGION:GUID.
+* `arn` - The ARN of the identity pool.
 
 ## Import
 


### PR DESCRIPTION
Cognito Identity Pools, like most AWS resources, have an ARN in addition to their ID that is used by other AWS services as a reference.

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #4703

Changes proposed in this pull request:

* Add `arn` attribute to cognito_identity_pool

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCognitoIdentityPool_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCognitoIdentityPool_basic -timeout 120m
=== RUN   TestAccAWSCognitoIdentityPool_basic
--- PASS: TestAccAWSCognitoIdentityPool_basic (23.18s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	33.956s
```
