### PR TITLE
typo fix: 'access' -> 'acces'

### DIFF
--- a/aws/resource_aws_iam_access_key.go
+++ b/aws/resource_aws_iam_access_key.go
@@ -122,7 +122,7 @@ func resourceAwsIamAccessKeyRead(d *schema.ResourceData, meta interface{}) error
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error reading IAM acces key: %s", err)
+		return fmt.Errorf("Error reading IAM access key: %s", err)
 	}
 
 	for _, key := range getResp.AccessKeyMetadata {


### PR DESCRIPTION
This is an obvious typo fix, so I'm ditching the standard template process. Makes `grep` better and perfectionists happier.