### PR TITLE
Fix page header and the example code's indentation

### DIFF
--- a/website/docs/r/ssm_resource_data_sync.html.markdown
+++ b/website/docs/r/ssm_resource_data_sync.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides a SSM resource data sync.
 ---
 
-# aws_athena_database
+# aws_ssm_resource_data_sync
 
 Provides a SSM resource data sync.
 
@@ -47,10 +47,9 @@ resource "aws_s3_bucket_policy" "hoge" {
                 }
             }
         }
-      ]
-  }
-  EOF
+    ]
 }
+EOF
 
 resource "aws_ssm_resource_data_sync" "foo" {
   name = "foo"


### PR DESCRIPTION
Page header was showing the wrong resource name, probably forgotten after a copy&paste from another resource documentation.

The indentation in the example code was not right as it was affecting the highlighting.

There was an extra curly bracket in the example code.