### PR TITLE
Resource - Neptune: aws_neptune_parameter_group

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -71,6 +71,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/lightsail"
 	"github.com/aws/aws-sdk-go/service/mediastore"
 	"github.com/aws/aws-sdk-go/service/mq"
+	"github.com/aws/aws-sdk-go/service/neptune"
 	"github.com/aws/aws-sdk-go/service/opsworks"
 	"github.com/aws/aws-sdk-go/service/organizations"
 	"github.com/aws/aws-sdk-go/service/rds"
@@ -226,6 +227,7 @@ type AWSClient struct {
 	appsyncconn           *appsync.AppSync
 	lexmodelconn          *lexmodelbuildingservice.LexModelBuildingService
 	budgetconn            *budgets.Budgets
+	neptuneconn           *neptune.Neptune
 }
 
 func (c *AWSClient) S3() *s3.S3 {
@@ -494,6 +496,7 @@ func (c *Config) Client() (interface{}, error) {
 	client.lexmodelconn = lexmodelbuildingservice.New(sess)
 	client.lightsailconn = lightsail.New(sess)
 	client.mqconn = mq.New(sess)
+	client.neptuneconn = neptune.New(sess)
 	client.opsworksconn = opsworks.New(sess)
 	client.organizationsconn = organizations.New(sess)
 	client.r53conn = route53.New(r53Sess)

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -474,6 +474,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_nat_gateway":                              resourceAwsNatGateway(),
 			"aws_network_acl":                              resourceAwsNetworkAcl(),
 			"aws_default_network_acl":                      resourceAwsDefaultNetworkAcl(),
+			"aws_neptune_parameter_group":                  resourceAwsNeptuneParameterGroup(),
 			"aws_network_acl_rule":                         resourceAwsNetworkAclRule(),
 			"aws_network_interface":                        resourceAwsNetworkInterface(),
 			"aws_network_interface_attachment":             resourceAwsNetworkInterfaceAttachment(),

--- a/aws/resource_aws_neptune_parameter_group.go
+++ b/aws/resource_aws_neptune_parameter_group.go
@@ -126,6 +126,10 @@ func resourceAwsNeptuneParameterGroupRead(d *schema.ResourceData, meta interface
 		return err
 	}
 
+	if describeResp == nil {
+		return fmt.Errorf("Unable to get Describe Response for Neptune Parameter Group (%s)", d.Id())
+	}
+
 	if len(describeResp.DBParameterGroups) != 1 ||
 		*describeResp.DBParameterGroups[0].DBParameterGroupName != d.Id() {
 		return fmt.Errorf("Unable to find Parameter Group: %#v", describeResp.DBParameterGroups)

--- a/aws/resource_aws_neptune_parameter_group.go
+++ b/aws/resource_aws_neptune_parameter_group.go
@@ -1,0 +1,266 @@
+package aws
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/neptune"
+)
+
+func resourceAwsNeptuneParameterGroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsNeptuneParameterGroupCreate,
+		Read:   resourceAwsNeptuneParameterGroupRead,
+		Update: resourceAwsNeptuneParameterGroupUpdate,
+		Delete: resourceAwsNeptuneParameterGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+				StateFunc: func(val interface{}) string {
+					return strings.ToLower(val.(string))
+				},
+			},
+			"family": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "Managed by Terraform",
+			},
+			"parameter": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"apply_method": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "immediate",
+							// this parameter is not actually state, but a
+							// meta-parameter describing how the RDS API call
+							// to modify the parameter group should be made.
+							// Future reads of the resource from AWS don't tell
+							// us what we used for apply_method previously, so
+							// by squashing state to an empty string we avoid
+							// needing to do an update for every future run.
+							StateFunc: func(interface{}) string { return "" },
+						},
+					},
+				},
+				Set: resourceAwsNeptuneParameterHash,
+			},
+		},
+	}
+}
+
+func resourceAwsNeptuneParameterGroupCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).neptuneconn
+
+	createOpts := neptune.CreateDBParameterGroupInput{
+		DBParameterGroupName:   aws.String(d.Get("name").(string)),
+		DBParameterGroupFamily: aws.String(d.Get("family").(string)),
+		Description:            aws.String(d.Get("description").(string)),
+	}
+
+	log.Printf("[DEBUG] Create Neptune Parameter Group: %#v", createOpts)
+	resp, err := conn.CreateDBParameterGroup(&createOpts)
+	if err != nil {
+		return fmt.Errorf("Error creating Cache Parameter Group: %s", err)
+	}
+
+	d.Partial(true)
+	d.SetPartial("name")
+	d.SetPartial("family")
+	d.SetPartial("description")
+	d.Partial(false)
+
+	d.SetId(*resp.DBParameterGroup.DBParameterGroupName)
+	log.Printf("[INFO] Neptune Parameter Group ID: %s", d.Id())
+
+	return resourceAwsNeptuneParameterGroupUpdate(d, meta)
+}
+
+func resourceAwsNeptuneParameterGroupRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).neptuneconn
+
+	describeOpts := neptune.DescribeDBParameterGroupsInput{
+		DBParameterGroupName: aws.String(d.Id()),
+	}
+
+	describeResp, err := conn.DescribeDBParameterGroups(&describeOpts)
+	if err != nil {
+		return err
+	}
+
+	if len(describeResp.DBParameterGroups) != 1 ||
+		*describeResp.DBParameterGroups[0].DBParameterGroupName != d.Id() {
+		return fmt.Errorf("Unable to find Parameter Group: %#v", describeResp.DBParameterGroups)
+	}
+
+	d.Set("name", describeResp.DBParameterGroups[0].DBParameterGroupName)
+	d.Set("family", describeResp.DBParameterGroups[0].DBParameterGroupFamily)
+	d.Set("description", describeResp.DBParameterGroups[0].Description)
+
+	// Only include user customized parameters as there's hundreds of system/default ones
+	describeParametersOpts := neptune.DescribeDBParametersInput{
+		DBParameterGroupName: aws.String(d.Id()),
+		Source:               aws.String("user"),
+	}
+
+	describeParametersResp, err := conn.DescribeDBParameters(&describeParametersOpts)
+	if err != nil {
+		return err
+	}
+
+	d.Set("parameter", flattenNeptuneParameters(describeParametersResp.Parameters))
+
+	return nil
+}
+
+func resourceAwsNeptuneParameterGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).neptuneconn
+
+	d.Partial(true)
+
+	if d.HasChange("parameter") {
+		o, n := d.GetChange("parameter")
+		if o == nil {
+			o = new(schema.Set)
+		}
+		if n == nil {
+			n = new(schema.Set)
+		}
+
+		os := o.(*schema.Set)
+		ns := n.(*schema.Set)
+
+		toRemove, err := expandNeptuneParameters(os.Difference(ns).List())
+		if err != nil {
+			return err
+		}
+
+		log.Printf("[DEBUG] Parameters to remove: %#v", toRemove)
+
+		toAdd, err := expandNeptuneParameters(ns.Difference(os).List())
+		if err != nil {
+			return err
+		}
+
+		log.Printf("[DEBUG] Parameters to add: %#v", toAdd)
+
+		// We can only modify 20 parameters at a time, so walk them until
+		// we've got them all.
+		maxParams := 20
+
+		for len(toRemove) > 0 {
+			paramsToModify := make([]*neptune.Parameter, 0)
+			if len(toRemove) <= maxParams {
+				paramsToModify, toRemove = toRemove[:], nil
+			} else {
+				paramsToModify, toRemove = toRemove[:maxParams], toRemove[maxParams:]
+			}
+			resetOpts := neptune.ResetDBParameterGroupInput{
+				DBParameterGroupName: aws.String(d.Get("name").(string)),
+				Parameters:           paramsToModify,
+			}
+
+			log.Printf("[DEBUG] Reset Neptune Parameter Group: %s", resetOpts)
+			err := resource.Retry(30*time.Second, func() *resource.RetryError {
+				_, err = conn.ResetDBParameterGroup(&resetOpts)
+				if err != nil {
+					if isAWSErr(err, "InvalidDBParameterGroupState", " has pending changes") {
+						return resource.RetryableError(err)
+					}
+					return resource.NonRetryableError(err)
+				}
+				return nil
+			})
+			if err != nil {
+				return fmt.Errorf("Error resetting Neptune Parameter Group: %s", err)
+			}
+		}
+
+		for len(toAdd) > 0 {
+			paramsToModify := make([]*neptune.Parameter, 0)
+			if len(toAdd) <= maxParams {
+				paramsToModify, toAdd = toAdd[:], nil
+			} else {
+				paramsToModify, toAdd = toAdd[:maxParams], toAdd[maxParams:]
+			}
+			modifyOpts := neptune.ModifyDBParameterGroupInput{
+				DBParameterGroupName: aws.String(d.Get("name").(string)),
+				Parameters:           paramsToModify,
+			}
+
+			log.Printf("[DEBUG] Modify Neptune Parameter Group: %s", modifyOpts)
+			_, err = conn.ModifyDBParameterGroup(&modifyOpts)
+			if err != nil {
+				return fmt.Errorf("Error modifying Neptune Parameter Group: %s", err)
+			}
+		}
+
+		d.SetPartial("parameter")
+	}
+
+	d.Partial(false)
+
+	return resourceAwsNeptuneParameterGroupRead(d, meta)
+}
+
+func resourceAwsNeptuneParameterGroupDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).neptuneconn
+
+	return resource.Retry(3*time.Minute, func() *resource.RetryError {
+		deleteOpts := neptune.DeleteDBParameterGroupInput{
+			DBParameterGroupName: aws.String(d.Id()),
+		}
+		_, err := conn.DeleteDBParameterGroup(&deleteOpts)
+		if err != nil {
+			awsErr, ok := err.(awserr.Error)
+			if ok && awsErr.Code() == "DBParameterGroupNotFound" {
+				return nil
+			}
+			if ok && awsErr.Code() == "InvalidDBParameterGroupState" {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+}
+
+func resourceAwsNeptuneParameterHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
+	// Store the value as a lower case string, to match how we store them in flattenParameters
+	buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(m["value"].(string))))
+
+	return hashcode.String(buf.String())
+}

--- a/aws/resource_aws_neptune_parameter_group.go
+++ b/aws/resource_aws_neptune_parameter_group.go
@@ -15,6 +15,10 @@ import (
 	"github.com/aws/aws-sdk-go/service/neptune"
 )
 
+// We can only modify 20 parameters at a time, so walk them until
+// we've got them all.
+const maxParams = 20
+
 func resourceAwsNeptuneParameterGroup() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsNeptuneParameterGroupCreate,
@@ -179,10 +183,6 @@ func resourceAwsNeptuneParameterGroupUpdate(d *schema.ResourceData, meta interfa
 		}
 
 		log.Printf("[DEBUG] Parameters to add: %#v", toAdd)
-
-		// We can only modify 20 parameters at a time, so walk them until
-		// we've got them all.
-		maxParams := 20
 
 		for len(toRemove) > 0 {
 			paramsToModify := make([]*neptune.Parameter, 0)

--- a/aws/resource_aws_neptune_parameter_group.go
+++ b/aws/resource_aws_neptune_parameter_group.go
@@ -91,7 +91,7 @@ func resourceAwsNeptuneParameterGroupCreate(d *schema.ResourceData, meta interfa
 	log.Printf("[DEBUG] Create Neptune Parameter Group: %#v", createOpts)
 	resp, err := conn.CreateDBParameterGroup(&createOpts)
 	if err != nil {
-		return fmt.Errorf("Error creating Cache Parameter Group: %s", err)
+		return fmt.Errorf("Error creating Neptune Parameter Group: %s", err)
 	}
 
 	d.Partial(true)

--- a/aws/resource_aws_neptune_parameter_group.go
+++ b/aws/resource_aws_neptune_parameter_group.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/neptune"
 )
 
@@ -249,11 +248,10 @@ func resourceAwsNeptuneParameterGroupDelete(d *schema.ResourceData, meta interfa
 		}
 		_, err := conn.DeleteDBParameterGroup(&deleteOpts)
 		if err != nil {
-			awsErr, ok := err.(awserr.Error)
-			if ok && awsErr.Code() == "DBParameterGroupNotFound" {
+			if isAWSErr(err, neptune.ErrCodeDBParameterGroupNotFoundFault, "") {
 				return nil
 			}
-			if ok && awsErr.Code() == "InvalidDBParameterGroupState" {
+			if isAWSErr(err, neptune.ErrCodeInvalidDBParameterGroupStateFault, "") {
 				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)

--- a/aws/resource_aws_neptune_parameter_group.go
+++ b/aws/resource_aws_neptune_parameter_group.go
@@ -26,7 +26,7 @@ func resourceAwsNeptuneParameterGroup() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				ForceNew: true,
 				Required: true,
@@ -34,31 +34,31 @@ func resourceAwsNeptuneParameterGroup() *schema.Resource {
 					return strings.ToLower(val.(string))
 				},
 			},
-			"family": &schema.Schema{
+			"family": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 				Default:  "Managed by Terraform",
 			},
-			"parameter": &schema.Schema{
+			"parameter": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"name": &schema.Schema{
+						"name": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
-						"value": &schema.Schema{
+						"value": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
-						"apply_method": &schema.Schema{
+						"apply_method": {
 							Type:     schema.TypeString,
 							Optional: true,
 							Default:  "immediate",

--- a/aws/resource_aws_neptune_parameter_group_test.go
+++ b/aws/resource_aws_neptune_parameter_group_test.go
@@ -1,0 +1,218 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/neptune"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSNeptuneParameterGroup_basic(t *testing.T) {
+	var v neptune.DBParameterGroup
+	rName := fmt.Sprintf("parameter-group-test-terraform-%d", acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSNeptuneParameterGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSNeptuneParameterGroupConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSNeptuneParameterGroupExists("aws_neptune_parameter_group.bar", &v),
+					testAccCheckAWSNeptuneParameterGroupAttributes(&v, rName),
+					resource.TestCheckResourceAttr(
+						"aws_neptune_parameter_group.bar", "name", rName),
+					resource.TestCheckResourceAttr(
+						"aws_neptune_parameter_group.bar", "family", "neptune1"),
+					resource.TestCheckResourceAttr(
+						"aws_neptune_parameter_group.bar", "description", "Managed by Terraform"),
+					resource.TestCheckResourceAttr(
+						"aws_neptune_parameter_group.bar", "parameter.562386247.name", "neptune_query_timeout"),
+					resource.TestCheckResourceAttr(
+						"aws_neptune_parameter_group.bar", "parameter.562386247.value", "25"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSNeptuneParameterGroup_only(t *testing.T) {
+	var v neptune.DBParameterGroup
+	rName := fmt.Sprintf("parameter-group-test-terraform-%d", acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSNeptuneParameterGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSNeptuneParameterGroupOnlyConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSNeptuneParameterGroupExists("aws_neptune_parameter_group.bar", &v),
+					testAccCheckAWSNeptuneParameterGroupAttributes(&v, rName),
+					resource.TestCheckResourceAttr(
+						"aws_neptune_parameter_group.bar", "name", rName),
+					resource.TestCheckResourceAttr(
+						"aws_neptune_parameter_group.bar", "family", "neptune1"),
+				),
+			},
+		},
+	})
+}
+
+// Regression for https://github.com/terraform-providers/terraform-provider-aws/issues/116
+func TestAccAWSNeptuneParameterGroup_removeParam(t *testing.T) {
+	var v neptune.DBParameterGroup
+	rName := fmt.Sprintf("parameter-group-test-terraform-%d", acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSNeptuneParameterGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSNeptuneParameterGroupConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSNeptuneParameterGroupExists("aws_neptune_parameter_group.bar", &v),
+					testAccCheckAWSNeptuneParameterGroupAttributes(&v, rName),
+					resource.TestCheckResourceAttr(
+						"aws_neptune_parameter_group.bar", "name", rName),
+					resource.TestCheckResourceAttr(
+						"aws_neptune_parameter_group.bar", "family", "neptune1"),
+					resource.TestCheckResourceAttr(
+						"aws_neptune_parameter_group.bar", "parameter.562386247.name", "neptune_query_timeout"),
+					resource.TestCheckResourceAttr(
+						"aws_neptune_parameter_group.bar", "parameter.562386247.value", "25"),
+				),
+			},
+			{
+				Config: testAccAWSNeptuneParameterGroupOnlyConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSNeptuneParameterGroupExists("aws_neptune_parameter_group.bar", &v),
+					testAccCheckAWSNeptuneParameterGroupAttributes(&v, rName),
+					resource.TestCheckResourceAttr(
+						"aws_neptune_parameter_group.bar", "name", rName),
+					resource.TestCheckResourceAttr(
+						"aws_neptune_parameter_group.bar", "family", "neptune1"),
+
+					resource.TestCheckNoResourceAttr(
+						"aws_neptune_parameter_group.bar", "parameter.562386247.name"),
+					resource.TestCheckNoResourceAttr(
+						"aws_neptune_parameter_group.bar", "parameter.562386247.value"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSNeptuneParameterGroupDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).neptuneconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_neptune_parameter_group" {
+			continue
+		}
+
+		// Try to find the Group
+		resp, err := conn.DescribeDBParameterGroups(
+			&neptune.DescribeDBParameterGroupsInput{
+				DBParameterGroupName: aws.String(rs.Primary.ID),
+			})
+
+		if err == nil {
+			if len(resp.DBParameterGroups) != 0 &&
+				*resp.DBParameterGroups[0].DBParameterGroupName == rs.Primary.ID {
+				return fmt.Errorf("DB Parameter Group still exists")
+			}
+		}
+
+		// Verify the error
+		newerr, ok := err.(awserr.Error)
+		if !ok {
+			return err
+		}
+		if newerr.Code() != "DBParameterGroupNotFound" {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAWSNeptuneParameterGroupAttributes(v *neptune.DBParameterGroup, rName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		if *v.DBParameterGroupName != rName {
+			return fmt.Errorf("bad name: %#v", v.DBParameterGroupName)
+		}
+
+		if *v.DBParameterGroupFamily != "neptune1" {
+			return fmt.Errorf("bad family: %#v", v.DBParameterGroupFamily)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSNeptuneParameterGroupExists(n string, v *neptune.DBParameterGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Neptune Parameter Group ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).neptuneconn
+
+		opts := neptune.DescribeDBParameterGroupsInput{
+			DBParameterGroupName: aws.String(rs.Primary.ID),
+		}
+
+		resp, err := conn.DescribeDBParameterGroups(&opts)
+
+		if err != nil {
+			return err
+		}
+
+		if len(resp.DBParameterGroups) != 1 ||
+			*resp.DBParameterGroups[0].DBParameterGroupName != rs.Primary.ID {
+			return fmt.Errorf("Neptune Parameter Group not found")
+		}
+
+		*v = *resp.DBParameterGroups[0]
+
+		return nil
+	}
+}
+
+func testAccAWSNeptuneParameterGroupConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_neptune_parameter_group" "bar" {
+	name = "%s"
+	family = "neptune1"
+	parameter {
+	  name = "neptune_query_timeout"
+	  value = "25"
+          apply_method = "pending-reboot"
+
+	}
+}`, rName)
+}
+
+func testAccAWSNeptuneParameterGroupOnlyConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_neptune_parameter_group" "bar" {
+	name = "%s"
+	family = "neptune1"
+	description = "Test parameter group for terraform"
+}`, rName)
+}

--- a/aws/resource_aws_neptune_parameter_group_test.go
+++ b/aws/resource_aws_neptune_parameter_group_test.go
@@ -32,11 +32,17 @@ func TestAccAWSNeptuneParameterGroup_basic(t *testing.T) {
 						"aws_neptune_parameter_group.bar", "family", "neptune1"),
 					resource.TestCheckResourceAttr(
 						"aws_neptune_parameter_group.bar", "description", "Managed by Terraform"),
+					resource.TestCheckResourceAttr("aws_neptune_parameter_group.bar", "parameter.562386247", "1"),
 					resource.TestCheckResourceAttr(
 						"aws_neptune_parameter_group.bar", "parameter.562386247.name", "neptune_query_timeout"),
 					resource.TestCheckResourceAttr(
 						"aws_neptune_parameter_group.bar", "parameter.562386247.value", "25"),
 				),
+			},
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/aws/resource_aws_neptune_parameter_group_test.go
+++ b/aws/resource_aws_neptune_parameter_group_test.go
@@ -32,7 +32,7 @@ func TestAccAWSNeptuneParameterGroup_basic(t *testing.T) {
 						"aws_neptune_parameter_group.bar", "family", "neptune1"),
 					resource.TestCheckResourceAttr(
 						"aws_neptune_parameter_group.bar", "description", "Managed by Terraform"),
-					resource.TestCheckResourceAttr("aws_neptune_parameter_group.bar", "parameter.562386247", "1"),
+					resource.TestCheckResourceAttr("aws_neptune_parameter_group.bar", "parameter.#", "1"),
 					resource.TestCheckResourceAttr(
 						"aws_neptune_parameter_group.bar", "parameter.562386247.name", "neptune_query_timeout"),
 					resource.TestCheckResourceAttr(
@@ -40,7 +40,7 @@ func TestAccAWSNeptuneParameterGroup_basic(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				ResourceName:      rName,
+				ResourceName:      "aws_neptune_parameter_group.bar",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},

--- a/aws/resource_aws_neptune_parameter_group_test.go
+++ b/aws/resource_aws_neptune_parameter_group_test.go
@@ -40,7 +40,7 @@ func TestAccAWSNeptuneParameterGroup_basic(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				ResourceName:      resourceName,
+				ResourceName:      rName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -769,9 +769,9 @@ func flattenNeptuneParameters(list []*neptune.Parameter) []map[string]interface{
 	for _, i := range list {
 		if i.ParameterValue != nil {
 			result = append(result, map[string]interface{}{
-				"name":         strings.ToLower(*i.ParameterName),
-				"value":        *i.ParameterValue,
-				"apply_method": strings.ToLower(*i.ApplyMethod),
+				"name":         strings.ToLower(aws.StringValue(i.ParameterName)),
+				"value":        aws.StringValue(i.ParameterValue),
+				"apply_method": strings.ToLower(aws.StringValue(i.ParameterName)),
 			})
 		}
 	}

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -32,6 +32,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/kinesis"
 	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/aws/aws-sdk-go/service/mq"
+	"github.com/aws/aws-sdk-go/service/neptune"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/redshift"
 	"github.com/aws/aws-sdk-go/service/route53"
@@ -399,6 +400,28 @@ func expandElastiCacheParameters(configured []interface{}) ([]*elasticache.Param
 	return parameters, nil
 }
 
+// Takes the result of flatmap.Expand for an array of parameters and
+// returns Parameter API compatible objects
+func expandNeptuneParameters(configured []interface{}) ([]*neptune.Parameter, error) {
+	parameters := make([]*neptune.Parameter, 0, len(configured))
+
+	// Loop over our configured parameters and create
+	// an array of aws-sdk-go compatible objects
+	for _, pRaw := range configured {
+		data := pRaw.(map[string]interface{})
+
+		p := &neptune.Parameter{
+			ApplyMethod:    aws.String(data["apply_method"].(string)),
+			ParameterName:  aws.String(data["name"].(string)),
+			ParameterValue: aws.String(data["value"].(string)),
+		}
+
+		parameters = append(parameters, p)
+	}
+
+	return parameters, nil
+}
+
 // Flattens an access log into something that flatmap.Flatten() can handle
 func flattenAccessLog(l *elb.AccessLog) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0, 1)
@@ -734,6 +757,21 @@ func flattenElastiCacheParameters(list []*elasticache.Parameter) []map[string]in
 			result = append(result, map[string]interface{}{
 				"name":  strings.ToLower(*i.ParameterName),
 				"value": *i.ParameterValue,
+			})
+		}
+	}
+	return result
+}
+
+// Flattens an array of Parameters into a []map[string]interface{}
+func flattenNeptuneParameters(list []*neptune.Parameter) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(list))
+	for _, i := range list {
+		if i.ParameterValue != nil {
+			result = append(result, map[string]interface{}{
+				"name":         strings.ToLower(*i.ParameterName),
+				"value":        *i.ParameterValue,
+				"apply_method": strings.ToLower(*i.ApplyMethod),
 			})
 		}
 	}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1589,6 +1589,16 @@
                   <li<%= sidebar_current("docs-aws-resource-redshift-subnet-group") %>>
                     <a href="/docs/providers/aws/r/redshift_subnet_group.html">aws_redshift_subnet_group</a>
                   </li>
+                 <li<%= sidebar_current("docs-aws-resource-neptune") %>>
+                    <a href="#">Neptune Resources</a>
+                    <ul class="nav nav-visible">
+
+                        <li<%= sidebar_current("docs-aws-resource-aws-neptune-parameter-group") %>>
+                            <a href="/docs/providers/aws/r/neptune_parameter_group.html">aws_neptune_parameter_group</a>
+                        </li>
+
+                    </ul>
+                </li>
 
                 </ul>
               </li>

--- a/website/docs/r/neptune_parameter_group.html.markdown
+++ b/website/docs/r/neptune_parameter_group.html.markdown
@@ -1,0 +1,65 @@
+---
+layout: "aws"
+page_title: "AWS: aws_neptune_parameter_group"
+sidebar_current: "docs-aws-resource-aws-neptune-parameter-group"
+description: |-
+   Provides an Neptune parameter group resource.
+---
+
+# aws_neptune_parameter_group
+
+ Creates a parameter group for AWS Neptune
+
+## Example Usage
+
+```hcl
+resource "aws_neptune_parameter_group" "bar" {
+	name = "my_group"
+	family = "neptune1"
+	description = "Test parameter group for terraform"
+}
+```
+
+```hcl
+resource "aws_neptune_parameter_group" "bar" {
+	name = "my_group"
+	family = "neptune1"
+	description = "Test parameter group for terraform"
+	
+	parameter {
+	  name = "neptune_query_timeout"
+      apply_method = "pending-reboot"
+	  value = "25"
+	}
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, Forces new resource) The name of the Neptune parameter group.
+* `family` - (Required) The family of the Neptune parameter group.
+* `description` - (Optional) The description of the Neptune parameter group. Defaults to "Managed by Terraform".
+* `parameter` - (Optional) A list of Neptune parameters to apply.
+* `tags`  - (Optional) A mapping of tags to assign to the resource.
+
+Parameter blocks support the following:
+
+* `name`  - (Required) The name of the Neptune parameter.
+* `value` - (Required) The value of the Neptune parameter.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The dbNeptune parameter group name.
+
+## Import
+
+Neptune Parameter groups can be imported using the `name`, e.g.
+
+```
+$ terraform import aws_neptune_parameter_group.some_pg some-pg
+```

--- a/website/docs/r/neptune_parameter_group.html.markdown
+++ b/website/docs/r/neptune_parameter_group.html.markdown
@@ -22,15 +22,14 @@ resource "aws_neptune_parameter_group" "bar" {
 
 ```hcl
 resource "aws_neptune_parameter_group" "bar" {
-	name = "my_group"
-	family = "neptune1"
-	description = "Test parameter group for terraform"
-	
-	parameter {
-	  name = "neptune_query_timeout"
+    name = "my_group"
+    family = "neptune1"
+    description = "Test parameter group for terraform"
+    parameter {
+      name = "neptune_query_timeout"
       apply_method = "pending-reboot"
-	  value = "25"
-	}
+      value = "25"
+    }
 }
 ```
 


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Reference: #4713

Changes proposed in this pull request:

* adding a new resource `aws_neptune_parameter_group` as a first step to address #4713

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSNeptuneParameterGroup_basic'
=== RUN   TestAccAWSNeptuneParameterGroup_basic
--- PASS: TestAccAWSNeptuneParameterGroup_basic

$ make testacc TESTARGS='-run=TestAccAWSNeptuneParameterGroup_removeParam'
=== RUN   TestAccAWSNeptuneParameterGroup_removeParam
--- PASS: TestAccAWSNeptuneParameterGroup_removeParam

$ make testacc TESTARGS='-run=TestAccAWSNeptuneParameterGroup_only'
=== RUN   TestAccAWSNeptuneParameterGroup_only
--- PASS: TestAccAWSNeptuneParameterGroup_only
```
