### PR TITLE
Improve handling of security group updates

### DIFF
--- a/aws/resource_aws_security_group.go
+++ b/aws/resource_aws_security_group.go
@@ -688,14 +688,14 @@ func resourceAwsSecurityGroupUpdateRules(
 			n = new(schema.Set)
 		}
 
-		os := o.(*schema.Set)
-		ns := n.(*schema.Set)
+		os := expandRules(o.(*schema.Set))
+		ns := expandRules(n.(*schema.Set))
 
-		remove, err := expandIPPerms(group, os.Difference(ns).List())
+		remove, err := expandIPPerms(group, collapseRules(ruleset, os.Difference(ns).List()))
 		if err != nil {
 			return err
 		}
-		add, err := expandIPPerms(group, ns.Difference(os).List())
+		add, err := expandIPPerms(group, collapseRules(ruleset, ns.Difference(os).List()))
 		if err != nil {
 			return err
 		}
@@ -1141,6 +1141,118 @@ func matchRules(rType string, local []interface{}, remote []map[string]interface
 	}
 
 	return saves
+}
+
+func collapseRules(ruleset string, rules []interface{}) []interface{} {
+
+	var keys_to_collapse = []string{"cidr_blocks", "ipv6_cidr_blocks", "prefix_list_ids", "security_groups"}
+
+	collapsed := make(map[string]map[string]interface{})
+
+	for _, rule := range rules {
+		r := rule.(map[string]interface{})
+
+		ruleHash := idCollapseHash(ruleset, r["protocol"].(string), int64(r["to_port"].(int)), int64(r["from_port"].(int)), r["description"].(string))
+
+		if _, ok := collapsed[ruleHash]; ok {
+			if v, ok := r["self"]; ok && v.(bool) {
+				collapsed[ruleHash]["self"] = r["self"]
+			}
+		} else {
+			collapsed[ruleHash] = r
+			continue
+		}
+
+		for _, key := range keys_to_collapse {
+			if _, ok := r[key]; ok {
+				if _, ok := collapsed[ruleHash][key]; ok {
+					if key == "security_groups" {
+						collapsed[ruleHash][key] = collapsed[ruleHash][key].(*schema.Set).Union(r[key].(*schema.Set))
+					} else {
+						collapsed[ruleHash][key] = append(collapsed[ruleHash][key].([]interface{}), r[key].([]interface{})...)
+					}
+				} else {
+					collapsed[ruleHash][key] = r[key]
+				}
+			}
+		}
+	}
+
+	values := make([]interface{}, 0, len(collapsed))
+	for _, val := range collapsed {
+		values = append(values, val)
+	}
+	return values
+}
+
+func copyRule(src map[string]interface{}, self bool, k string, v interface{}) map[string]interface{} {
+	var keys_to_copy = []string{"description", "from_port", "to_port", "protocol"}
+
+	dst := make(map[string]interface{})
+	for _, key := range keys_to_copy {
+		if val, ok := src[key]; ok {
+			dst[key] = val
+		}
+	}
+	if k != "" {
+		dst[k] = v
+	}
+	if _, ok := src["self"]; ok {
+		dst["self"] = self
+	}
+	return dst
+}
+
+func expandRules(rules *schema.Set) *schema.Set {
+	var keys_to_expand = []string{"cidr_blocks", "ipv6_cidr_blocks", "prefix_list_ids", "security_groups"}
+
+	normalized := schema.NewSet(resourceAwsSecurityGroupRuleHash, nil)
+
+	for _, rawRule := range rules.List() {
+		rule := rawRule.(map[string]interface{})
+
+		if v, ok := rule["self"]; ok && v.(bool) {
+			new_rule := copyRule(rule, true, "", nil)
+			normalized.Add(new_rule)
+		}
+		for _, key := range keys_to_expand {
+			item, exists := rule[key]
+			if exists {
+				var list []interface{}
+				if key == "security_groups" {
+					list = item.(*schema.Set).List()
+				} else {
+					list = item.([]interface{})
+				}
+				for _, v := range list {
+					var new_rule map[string]interface{}
+					if key == "security_groups" {
+						new_v := schema.NewSet(schema.HashString, nil)
+						new_v.Add(v)
+						new_rule = copyRule(rule, false, key, new_v)
+					} else {
+						new_v := make([]interface{}, 0)
+						new_v = append(new_v, v)
+						new_rule = copyRule(rule, false, key, new_v)
+					}
+					normalized.Add(new_rule)
+				}
+			}
+		}
+	}
+
+	return normalized
+}
+
+func idCollapseHash(rType, protocol string, toPort, fromPort int64, description string) string {
+	var buf bytes.Buffer
+	buf.WriteString(fmt.Sprintf("%s-", rType))
+	buf.WriteString(fmt.Sprintf("%d-", toPort))
+	buf.WriteString(fmt.Sprintf("%d-", fromPort))
+	buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(protocol)))
+	buf.WriteString(fmt.Sprintf("%s-", description))
+
+	return fmt.Sprintf("rule-%d", hashcode.String(buf.String()))
 }
 
 // Creates a unique hash for the type, ports, and protocol, used as a key in

--- a/aws/resource_aws_security_group.go
+++ b/aws/resource_aws_security_group.go
@@ -688,14 +688,14 @@ func resourceAwsSecurityGroupUpdateRules(
 			n = new(schema.Set)
 		}
 
-		os := expandRules(o.(*schema.Set))
-		ns := expandRules(n.(*schema.Set))
+		os := resourceAwsSecurityGroupExpandRules(o.(*schema.Set))
+		ns := resourceAwsSecurityGroupExpandRules(n.(*schema.Set))
 
-		remove, err := expandIPPerms(group, collapseRules(ruleset, os.Difference(ns).List()))
+		remove, err := expandIPPerms(group, resourceAwsSecurityGroupCollapseRules(ruleset, os.Difference(ns).List()))
 		if err != nil {
 			return err
 		}
-		add, err := expandIPPerms(group, collapseRules(ruleset, ns.Difference(os).List()))
+		add, err := expandIPPerms(group, resourceAwsSecurityGroupCollapseRules(ruleset, ns.Difference(os).List()))
 		if err != nil {
 			return err
 		}
@@ -1143,7 +1143,34 @@ func matchRules(rType string, local []interface{}, remote []map[string]interface
 	return saves
 }
 
-func collapseRules(ruleset string, rules []interface{}) []interface{} {
+// Duplicate ingress/egress block structure and fill out all
+// the required fields
+func resourceAwsSecurityGroupCopyRule(src map[string]interface{}, self bool, k string, v interface{}) map[string]interface{} {
+	var keys_to_copy = []string{"description", "from_port", "to_port", "protocol"}
+
+	dst := make(map[string]interface{})
+	for _, key := range keys_to_copy {
+		if val, ok := src[key]; ok {
+			dst[key] = val
+		}
+	}
+	if k != "" {
+		dst[k] = v
+	}
+	if _, ok := src["self"]; ok {
+		dst["self"] = self
+	}
+	return dst
+}
+
+// Given a set of SG rules (ingress/egress blocks), this function
+// will group the rules by from_port/to_port/protocol/description
+// tuples. This is inverse operation of
+// resourceAwsSecurityGroupExpandRules()
+//
+// For more detail, see comments for
+// resourceAwsSecurityGroupExpandRules()
+func resourceAwsSecurityGroupCollapseRules(ruleset string, rules []interface{}) []interface{} {
 
 	var keys_to_collapse = []string{"cidr_blocks", "ipv6_cidr_blocks", "prefix_list_ids", "security_groups"}
 
@@ -1185,25 +1212,53 @@ func collapseRules(ruleset string, rules []interface{}) []interface{} {
 	return values
 }
 
-func copyRule(src map[string]interface{}, self bool, k string, v interface{}) map[string]interface{} {
-	var keys_to_copy = []string{"description", "from_port", "to_port", "protocol"}
-
-	dst := make(map[string]interface{})
-	for _, key := range keys_to_copy {
-		if val, ok := src[key]; ok {
-			dst[key] = val
-		}
-	}
-	if k != "" {
-		dst[k] = v
-	}
-	if _, ok := src["self"]; ok {
-		dst["self"] = self
-	}
-	return dst
-}
-
-func expandRules(rules *schema.Set) *schema.Set {
+// resourceAwsSecurityGroupExpandRules works in pair with
+// resourceAwsSecurityGroupCollapseRules and is used as a
+// workaround for the problem explained in
+// https://github.com/terraform-providers/terraform-provider-aws/pull/4726
+//
+// This function converts every ingress/egress block that
+// contains multiple rules to multiple blocks with only one
+// rule. Doing a Difference operation on such a normalized
+// set helps to avoid unnecessary removal of unchanged
+// rules during the Apply step.
+//
+// For example, in terraform syntax, the following block:
+//
+// ingress {
+//   from_port = 80
+//   to_port = 80
+//   protocol = "tcp"
+//   cidr_blocks = [
+//     "192.168.0.1/32",
+//     "192.168.0.2/32",
+//   ]
+// }
+//
+// will be converted to the two blocks below:
+//
+// ingress {
+//   from_port = 80
+//   to_port = 80
+//   protocol = "tcp"
+//   cidr_blocks = [ "192.168.0.1/32" ]
+// }
+//
+// ingress {
+//   from_port = 80
+//   to_port = 80
+//   protocol = "tcp"
+//   cidr_blocks = [ "192.168.0.2/32" ]
+// }
+//
+// Then the Difference operation is executed on the new set
+// to find which rules got modified, and the resulting set
+// is then passed to resourceAwsSecurityGroupCollapseRules
+// to convert the "diff" back to a more compact form for
+// execution. Such compact form helps reduce the number of
+// API calls.
+//
+func resourceAwsSecurityGroupExpandRules(rules *schema.Set) *schema.Set {
 	var keys_to_expand = []string{"cidr_blocks", "ipv6_cidr_blocks", "prefix_list_ids", "security_groups"}
 
 	normalized := schema.NewSet(resourceAwsSecurityGroupRuleHash, nil)
@@ -1212,7 +1267,7 @@ func expandRules(rules *schema.Set) *schema.Set {
 		rule := rawRule.(map[string]interface{})
 
 		if v, ok := rule["self"]; ok && v.(bool) {
-			new_rule := copyRule(rule, true, "", nil)
+			new_rule := resourceAwsSecurityGroupCopyRule(rule, true, "", nil)
 			normalized.Add(new_rule)
 		}
 		for _, key := range keys_to_expand {
@@ -1229,11 +1284,11 @@ func expandRules(rules *schema.Set) *schema.Set {
 					if key == "security_groups" {
 						new_v := schema.NewSet(schema.HashString, nil)
 						new_v.Add(v)
-						new_rule = copyRule(rule, false, key, new_v)
+						new_rule = resourceAwsSecurityGroupCopyRule(rule, false, key, new_v)
 					} else {
 						new_v := make([]interface{}, 0)
 						new_v = append(new_v, v)
-						new_rule = copyRule(rule, false, key, new_v)
+						new_rule = resourceAwsSecurityGroupCopyRule(rule, false, key, new_v)
 					}
 					normalized.Add(new_rule)
 				}
@@ -1244,6 +1299,8 @@ func expandRules(rules *schema.Set) *schema.Set {
 	return normalized
 }
 
+// Convert type-to_port-from_port-protocol-description tuple
+// to a hash to use as a key in Set.
 func idCollapseHash(rType, protocol string, toPort, fromPort int64, description string) string {
 	var buf bytes.Buffer
 	buf.WriteString(fmt.Sprintf("%s-", rType))

--- a/aws/resource_aws_security_group_test.go
+++ b/aws/resource_aws_security_group_test.go
@@ -1700,6 +1700,13 @@ func testAccCheckAWSSecurityGroupAttributesChanged(group *ec2.SecurityGroup) res
 				group.IpPermissions[0], group.IpPermissions[1]
 		}
 
+		if len(group.IpPermissions[1].IpRanges) > 1 {
+			if *group.IpPermissions[1].IpRanges[0].CidrIp != "0.0.0.0/0" {
+				group.IpPermissions[1].IpRanges[0], group.IpPermissions[1].IpRanges[1] =
+					group.IpPermissions[1].IpRanges[1], group.IpPermissions[1].IpRanges[0]
+			}
+		}
+
 		if !reflect.DeepEqual(group.IpPermissions, p) {
 			return fmt.Errorf(
 				"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
@@ -1761,6 +1768,304 @@ func TestAccAWSSecurityGroup_failWithDiffMismatch(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccAWSSecurityGroup_ruleLimitExceededAppend(t *testing.T) {
+	var group ec2.SecurityGroup
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			// create a valid SG just under the limit
+			{
+				Config: testAccAWSSecurityGroupConfigRuleLimit(0, 50),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSecurityGroupExists("aws_security_group.test", &group),
+					testAccCheckAWSSecurityGroupRuleCount(&group, 0, 50),
+				),
+			},
+			// append a rule to step over the limit
+			{
+				Config:      testAccAWSSecurityGroupConfigRuleLimit(0, 51),
+				ExpectError: regexp.MustCompile("RulesPerSecurityGroupLimitExceeded"),
+			},
+			{
+				PreConfig: func() {
+					// should have the 50 original rules still
+					err := testSecurityGroupRuleCount(*group.GroupId, 0, 50)
+					if err != nil {
+						t.Fatalf("PreConfig check failed: %s", err)
+					}
+				},
+				// running the original config again now should restore the rules
+				Config: testAccAWSSecurityGroupConfigRuleLimit(0, 50),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSecurityGroupExists("aws_security_group.test", &group),
+					testAccCheckAWSSecurityGroupRuleCount(&group, 0, 50),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSecurityGroup_ruleLimitCidrBlockExceededAppend(t *testing.T) {
+	t.Skip(
+		"currently AWS does not offer the ability to update the CIDR blocks " +
+			"you must revoke the entire rule per the docs and re-authorize a new " +
+			"rule, if this changes it's worth revisiting this test to avoid all CIDR " +
+			"blocks being revoked and the the authorize failing",
+	)
+
+	var group ec2.SecurityGroup
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			// create a valid SG just under the limit
+			{
+				Config: testAccAWSSecurityGroupConfigCidrBlockRuleLimit(0, 50),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSecurityGroupExists("aws_security_group.test", &group),
+					testAccCheckAWSSecurityGroupRuleCount(&group, 0, 1),
+				),
+			},
+			// append a rule to step over the limit
+			{
+				Config:      testAccAWSSecurityGroupConfigCidrBlockRuleLimit(0, 51),
+				ExpectError: regexp.MustCompile("RulesPerSecurityGroupLimitExceeded"),
+			},
+			{
+				PreConfig: func() {
+					// should have the 50 original cidr blocks still in 1 rule
+					err := testSecurityGroupRuleCount(*group.GroupId, 0, 1)
+					if err != nil {
+						t.Fatalf("PreConfig check failed: %s", err)
+					}
+
+					id := *group.GroupId
+
+					conn := testAccProvider.Meta().(*AWSClient).ec2conn
+					req := &ec2.DescribeSecurityGroupsInput{
+						GroupIds: []*string{aws.String(id)},
+					}
+					resp, err := conn.DescribeSecurityGroups(req)
+					if err != nil {
+						t.Fatalf("PreConfig check failed: %s", err)
+					}
+
+					var match *ec2.SecurityGroup
+					if len(resp.SecurityGroups) > 0 && *resp.SecurityGroups[0].GroupId == id {
+						match = resp.SecurityGroups[0]
+					}
+
+					if match == nil {
+						t.Fatalf("PreConfig check failed: security group %s not found", id)
+					}
+
+					if cidrCount := len(match.IpPermissionsEgress[0].IpRanges); cidrCount != 50 {
+						t.Fatalf("PreConfig check failed: rule does not have 50 previous IP ranges, has %d", cidrCount)
+					}
+				},
+				// running the original config again now should restore the rules
+				Config: testAccAWSSecurityGroupConfigCidrBlockRuleLimit(0, 50),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSecurityGroupExists("aws_security_group.test", &group),
+					testAccCheckAWSSecurityGroupRuleCount(&group, 0, 1),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSecurityGroup_ruleLimitExceededPrepend(t *testing.T) {
+	var group ec2.SecurityGroup
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			// create a valid SG just under the limit
+			{
+				Config: testAccAWSSecurityGroupConfigRuleLimit(0, 50),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSecurityGroupExists("aws_security_group.test", &group),
+					testAccCheckAWSSecurityGroupRuleCount(&group, 0, 50),
+				),
+			},
+			// prepend a rule to step over the limit
+			{
+				Config:      testAccAWSSecurityGroupConfigRuleLimit(1, 51),
+				ExpectError: regexp.MustCompile("RulesPerSecurityGroupLimitExceeded"),
+			},
+			{
+				PreConfig: func() {
+					// should have the 49 original rules still (50 - 1 because of the shift)
+					err := testSecurityGroupRuleCount(*group.GroupId, 0, 49)
+					if err != nil {
+						t.Fatalf("PreConfig check failed: %s", err)
+					}
+				},
+				// running the original config again now should restore the rules
+				Config: testAccAWSSecurityGroupConfigRuleLimit(0, 50),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSecurityGroupExists("aws_security_group.test", &group),
+					testAccCheckAWSSecurityGroupRuleCount(&group, 0, 50),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSecurityGroup_ruleLimitExceededAllNew(t *testing.T) {
+	var group ec2.SecurityGroup
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			// create a valid SG just under the limit
+			{
+				Config: testAccAWSSecurityGroupConfigRuleLimit(0, 50),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSecurityGroupExists("aws_security_group.test", &group),
+					testAccCheckAWSSecurityGroupRuleCount(&group, 0, 50),
+				),
+			},
+			// add a rule to step over the limit with entirely new rules
+			{
+				Config:      testAccAWSSecurityGroupConfigRuleLimit(100, 51),
+				ExpectError: regexp.MustCompile("RulesPerSecurityGroupLimitExceeded"),
+			},
+			{
+				// all the rules should have been revoked and the add failed
+				PreConfig: func() {
+					err := testSecurityGroupRuleCount(*group.GroupId, 0, 0)
+					if err != nil {
+						t.Fatalf("PreConfig check failed: %s", err)
+					}
+				},
+				// running the original config again now should restore the rules
+				Config: testAccAWSSecurityGroupConfigRuleLimit(0, 50),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSecurityGroupExists("aws_security_group.test", &group),
+					testAccCheckAWSSecurityGroupRuleCount(&group, 0, 50),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSSecurityGroupRuleCount(group *ec2.SecurityGroup, expectedIngressCount, expectedEgressCount int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		id := *group.GroupId
+		return testSecurityGroupRuleCount(id, expectedIngressCount, expectedEgressCount)
+	}
+}
+
+func testSecurityGroupRuleCount(id string, expectedIngressCount, expectedEgressCount int) error {
+	conn := testAccProvider.Meta().(*AWSClient).ec2conn
+	req := &ec2.DescribeSecurityGroupsInput{
+		GroupIds: []*string{aws.String(id)},
+	}
+	resp, err := conn.DescribeSecurityGroups(req)
+	if err != nil {
+		return err
+	}
+
+	var group *ec2.SecurityGroup
+	if len(resp.SecurityGroups) > 0 && *resp.SecurityGroups[0].GroupId == id {
+		group = resp.SecurityGroups[0]
+	}
+
+	if group == nil {
+		return fmt.Errorf("Security group %s not found", id)
+	}
+
+	if actual := len(group.IpPermissions); actual != expectedIngressCount {
+		return fmt.Errorf("Security group ingress rule count %d does not match %d", actual, expectedIngressCount)
+	}
+
+	if actual := len(group.IpPermissionsEgress); actual != expectedEgressCount {
+		return fmt.Errorf("Security group egress rule count %d does not match %d", actual, expectedEgressCount)
+	}
+
+	return nil
+}
+
+func testAccAWSSecurityGroupConfigRuleLimit(egressStartIndex, egressRulesCount int) string {
+	c := `
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+  tags {
+    Name = "terraform-testacc-security-group-rule-limit"
+  }
+}
+
+resource "aws_security_group" "test" {
+  name = "terraform_acceptance_test_rule_limit"
+  description = "Used in the terraform acceptance tests"
+  vpc_id = "${aws_vpc.test.id}"
+
+	tags {
+    Name = "tf-acc-test"
+  }
+
+	// egress rules to exhaust the limit
+`
+
+	for i := egressStartIndex; i < egressRulesCount+egressStartIndex; i++ {
+		c += fmt.Sprintf(`
+  egress {
+		protocol = "tcp"
+		from_port = "${80 + %[1]d}"
+		to_port = "${80 + %[1]d}"
+		cidr_blocks = ["${cidrhost("10.1.0.0/16", %[1]d)}/32"]
+	}
+`, i)
+	}
+
+	c += "\n}"
+
+	return c
+}
+
+func testAccAWSSecurityGroupConfigCidrBlockRuleLimit(egressStartIndex, egressRulesCount int) string {
+	c := `
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+  tags {
+    Name = "terraform-testacc-security-group-rule-limit"
+  }
+}
+
+resource "aws_security_group" "test" {
+  name = "terraform_acceptance_test_rule_limit"
+  description = "Used in the terraform acceptance tests"
+  vpc_id = "${aws_vpc.test.id}"
+
+	tags {
+    Name = "tf-acc-test"
+  }
+
+	// egress rules to exhaust the limit
+	egress {
+		protocol = "tcp"
+		from_port = "80"
+		to_port = "80"
+		cidr_blocks = [
+`
+
+	for i := egressStartIndex; i < egressRulesCount+egressStartIndex; i++ {
+		c += fmt.Sprintf(`
+		"${cidrhost("10.1.0.0/16", %[1]d)}/32",
+`, i)
+	}
+
+	c += "\n\t\t]\n\t}\n}"
+
+	return c
 }
 
 const testAccAWSSecurityGroupConfigEmptyRuleDescription = `


### PR DESCRIPTION
Currently, when any single rule is added or removed to/from a security group, Terraform revokes and re-authorizes all the rules in the given ingress/egress block. This leads to a couple of undesirable effects:

1. Rules that didn't change are always removed and re-added back on apply, causing temporary packet loss, and potentially - outage.
2. Due to EC2 API specifics, if any single rule in the given ingress/egress block cannot be authorized due to an error (e.g. wrong netmask, non-existent security group, etc), no rules are added at all after revoke, and the security group may be left blank causing permanent packet loss, outage, and manual intervention is then required to recover.

This patch improves the way security groups are updated so that only rules that actually changed are authorized/revoked, which avoids unnecessary revocation of entire ingress/egress blocks and reduces the possibility of an outage.

Note: this PR also integrates tests from #4665

Output from acceptance testing:

```
$ TESTARGS="-cover -run 'TestAccAWSSecurityGroup'" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -cover -run 'TestAccAWSSecurityGroup' -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]


=== RUN   TestAccAWSSecurityGroup_importBasic
--- PASS: TestAccAWSSecurityGroup_importBasic (22.21s)
=== RUN   TestAccAWSSecurityGroup_importIpv6
--- PASS: TestAccAWSSecurityGroup_importIpv6 (21.14s)
=== RUN   TestAccAWSSecurityGroup_importSelf
--- PASS: TestAccAWSSecurityGroup_importSelf (22.72s)
=== RUN   TestAccAWSSecurityGroup_importSourceSecurityGroup
--- PASS: TestAccAWSSecurityGroup_importSourceSecurityGroup (23.17s)
=== RUN   TestAccAWSSecurityGroup_importIPRangeAndSecurityGroupWithSameRules
--- PASS: TestAccAWSSecurityGroup_importIPRangeAndSecurityGroupWithSameRules (24.81s)
=== RUN   TestAccAWSSecurityGroup_importIPRangesWithSameRules
--- PASS: TestAccAWSSecurityGroup_importIPRangesWithSameRules (23.03s)
=== RUN   TestAccAWSSecurityGroup_importPrefixList
--- PASS: TestAccAWSSecurityGroup_importPrefixList (35.47s)
=== RUN   TestAccAWSSecurityGroupRule_Ingress_VPC
--- PASS: TestAccAWSSecurityGroupRule_Ingress_VPC (15.55s)
=== RUN   TestAccAWSSecurityGroupRule_Ingress_Protocol
--- PASS: TestAccAWSSecurityGroupRule_Ingress_Protocol (21.22s)
=== RUN   TestAccAWSSecurityGroupRule_Ingress_Ipv6
--- PASS: TestAccAWSSecurityGroupRule_Ingress_Ipv6 (20.75s)
=== RUN   TestAccAWSSecurityGroupRule_Ingress_Classic
--- PASS: TestAccAWSSecurityGroupRule_Ingress_Classic (19.88s)
=== RUN   TestAccAWSSecurityGroupRule_MultiIngress
--- PASS: TestAccAWSSecurityGroupRule_MultiIngress (16.64s)
=== RUN   TestAccAWSSecurityGroupRule_Egress
--- PASS: TestAccAWSSecurityGroupRule_Egress (14.34s)
=== RUN   TestAccAWSSecurityGroupRule_SelfReference
--- PASS: TestAccAWSSecurityGroupRule_SelfReference (21.03s)
=== RUN   TestAccAWSSecurityGroupRule_ExpectInvalidTypeError
--- PASS: TestAccAWSSecurityGroupRule_ExpectInvalidTypeError (1.23s)
=== RUN   TestAccAWSSecurityGroupRule_ExpectInvalidCIDR
--- PASS: TestAccAWSSecurityGroupRule_ExpectInvalidCIDR (1.21s)
=== RUN   TestAccAWSSecurityGroupRule_PartialMatching_basic
--- PASS: TestAccAWSSecurityGroupRule_PartialMatching_basic (22.02s)
=== RUN   TestAccAWSSecurityGroupRule_PartialMatching_Source
--- PASS: TestAccAWSSecurityGroupRule_PartialMatching_Source (23.74s)
=== RUN   TestAccAWSSecurityGroupRule_Issue5310
--- PASS: TestAccAWSSecurityGroupRule_Issue5310 (19.37s)
=== RUN   TestAccAWSSecurityGroupRule_Race
--- PASS: TestAccAWSSecurityGroupRule_Race (163.82s)
=== RUN   TestAccAWSSecurityGroupRule_SelfSource
--- PASS: TestAccAWSSecurityGroupRule_SelfSource (21.97s)
=== RUN   TestAccAWSSecurityGroupRule_PrefixListEgress
--- PASS: TestAccAWSSecurityGroupRule_PrefixListEgress (33.66s)
=== RUN   TestAccAWSSecurityGroupRule_IngressDescription
--- PASS: TestAccAWSSecurityGroupRule_IngressDescription (15.37s)
=== RUN   TestAccAWSSecurityGroupRule_EgressDescription
--- PASS: TestAccAWSSecurityGroupRule_EgressDescription (13.97s)
=== RUN   TestAccAWSSecurityGroupRule_IngressDescription_updates
--- PASS: TestAccAWSSecurityGroupRule_IngressDescription_updates (23.61s)
=== RUN   TestAccAWSSecurityGroupRule_EgressDescription_updates
--- PASS: TestAccAWSSecurityGroupRule_EgressDescription_updates (23.65s)
=== RUN   TestAccAWSSecurityGroupRule_MultiDescription
--- PASS: TestAccAWSSecurityGroupRule_MultiDescription (52.96s)
=== RUN   TestAccAWSSecurityGroup_basic
--- PASS: TestAccAWSSecurityGroup_basic (19.89s)
=== RUN   TestAccAWSSecurityGroup_ruleGathering
--- PASS: TestAccAWSSecurityGroup_ruleGathering (36.80s)
=== RUN   TestAccAWSSecurityGroup_forceRevokeRules_true
--- PASS: TestAccAWSSecurityGroup_forceRevokeRules_true (674.39s)
=== RUN   TestAccAWSSecurityGroup_forceRevokeRules_false
--- PASS: TestAccAWSSecurityGroup_forceRevokeRules_false (648.45s)
=== RUN   TestAccAWSSecurityGroup_basicRuleDescription
--- PASS: TestAccAWSSecurityGroup_basicRuleDescription (20.92s)
=== RUN   TestAccAWSSecurityGroup_ipv6
--- PASS: TestAccAWSSecurityGroup_ipv6 (20.48s)
=== RUN   TestAccAWSSecurityGroup_tagsCreatedFirst
--- PASS: TestAccAWSSecurityGroup_tagsCreatedFirst (14.83s)
=== RUN   TestAccAWSSecurityGroup_namePrefix
--- PASS: TestAccAWSSecurityGroup_namePrefix (15.21s)
=== RUN   TestAccAWSSecurityGroup_self
--- PASS: TestAccAWSSecurityGroup_self (20.41s)
=== RUN   TestAccAWSSecurityGroup_vpc
--- PASS: TestAccAWSSecurityGroup_vpc (19.97s)
=== RUN   TestAccAWSSecurityGroup_vpcNegOneIngress
--- PASS: TestAccAWSSecurityGroup_vpcNegOneIngress (18.89s)
=== RUN   TestAccAWSSecurityGroup_vpcProtoNumIngress
--- PASS: TestAccAWSSecurityGroup_vpcProtoNumIngress (18.18s)
=== RUN   TestAccAWSSecurityGroup_MultiIngress
--- PASS: TestAccAWSSecurityGroup_MultiIngress (22.82s)
=== RUN   TestAccAWSSecurityGroup_Change
--- PASS: TestAccAWSSecurityGroup_Change (33.88s)
=== RUN   TestAccAWSSecurityGroup_ChangeRuleDescription
--- PASS: TestAccAWSSecurityGroup_ChangeRuleDescription (50.46s)
=== RUN   TestAccAWSSecurityGroup_generatedName
--- PASS: TestAccAWSSecurityGroup_generatedName (20.49s)
=== RUN   TestAccAWSSecurityGroup_DefaultEgress_VPC
--- PASS: TestAccAWSSecurityGroup_DefaultEgress_VPC (19.35s)
=== RUN   TestAccAWSSecurityGroup_DefaultEgress_Classic
--- PASS: TestAccAWSSecurityGroup_DefaultEgress_Classic (14.97s)
=== RUN   TestAccAWSSecurityGroup_drift
--- PASS: TestAccAWSSecurityGroup_drift (14.52s)
=== RUN   TestAccAWSSecurityGroup_drift_complex
--- PASS: TestAccAWSSecurityGroup_drift_complex (22.90s)
=== RUN   TestAccAWSSecurityGroup_invalidCIDRBlock
--- PASS: TestAccAWSSecurityGroup_invalidCIDRBlock (1.28s)
=== RUN   TestAccAWSSecurityGroup_tags
--- PASS: TestAccAWSSecurityGroup_tags (31.39s)
=== RUN   TestAccAWSSecurityGroup_CIDRandGroups
--- PASS: TestAccAWSSecurityGroup_CIDRandGroups (23.19s)
=== RUN   TestAccAWSSecurityGroup_ingressWithCidrAndSGs
--- PASS: TestAccAWSSecurityGroup_ingressWithCidrAndSGs (22.40s)
=== RUN   TestAccAWSSecurityGroup_ingressWithCidrAndSGs_classic
--- PASS: TestAccAWSSecurityGroup_ingressWithCidrAndSGs_classic (20.97s)
=== RUN   TestAccAWSSecurityGroup_egressWithPrefixList
--- PASS: TestAccAWSSecurityGroup_egressWithPrefixList (37.33s)
=== RUN   TestAccAWSSecurityGroup_emptyRuleDescription
--- PASS: TestAccAWSSecurityGroup_emptyRuleDescription (21.23s)
=== RUN   TestAccAWSSecurityGroup_ipv4andipv6Egress
--- PASS: TestAccAWSSecurityGroup_ipv4andipv6Egress (21.34s)
=== RUN   TestAccAWSSecurityGroup_failWithDiffMismatch
--- PASS: TestAccAWSSecurityGroup_failWithDiffMismatch (22.22s)
=== RUN   TestAccAWSSecurityGroup_ruleLimitExceededAppend
--- PASS: TestAccAWSSecurityGroup_ruleLimitExceededAppend (36.09s)
=== RUN   TestAccAWSSecurityGroup_ruleLimitCidrBlockExceededAppend
--- SKIP: TestAccAWSSecurityGroup_ruleLimitCidrBlockExceededAppend (0.00s)
	resource_aws_security_group_test.go:1710: currently AWS does not offer the ability to update the CIDR blocks you must revoke the entire rule per the docs and re-authorize a new rule, if this changes it's worth revisiting this test to avoid all CIDR blocks being revoked and the the authorize failing
=== RUN   TestAccAWSSecurityGroup_ruleLimitExceededPrepend
--- PASS: TestAccAWSSecurityGroup_ruleLimitExceededPrepend (39.89s)
=== RUN   TestAccAWSSecurityGroup_ruleLimitExceededAllNew
--- PASS: TestAccAWSSecurityGroup_ruleLimitExceededAllNew (40.89s)
PASS
coverage: 4.6% of statements
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2764.994s	coverage: 4.6% of statements
```

@paultyng 