### PR TITLE
issue #4169 Allow dot in aws_vpn_connection tunnel preshared_key

### DIFF
--- a/aws/resource_aws_vpn_connection.go
+++ b/aws/resource_aws_vpn_connection.go
@@ -567,8 +567,8 @@ func validateVpnConnectionTunnelPreSharedKey(v interface{}, k string) (ws []stri
 		errors = append(errors, fmt.Errorf("%q cannot start with zero character", k))
 	}
 
-	if !regexp.MustCompile(`^[0-9a-zA-Z_]+$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf("%q can only contain alphanumeric and underscore characters", k))
+	if !regexp.MustCompile(`^[0-9a-zA-Z_.]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf("%q can only contain alphanumeric, periods(.) and underscores(_) characters", k))
 	}
 
 	return

--- a/aws/resource_aws_vpn_connection.go
+++ b/aws/resource_aws_vpn_connection.go
@@ -568,7 +568,7 @@ func validateVpnConnectionTunnelPreSharedKey(v interface{}, k string) (ws []stri
 	}
 
 	if !regexp.MustCompile(`^[0-9a-zA-Z_.]+$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf("%q can only contain alphanumeric, periods(.) and underscores(_) characters", k))
+		errors = append(errors, fmt.Errorf("%q can only contain alphanumeric, period and underscore characters", k))
 	}
 
 	return

--- a/aws/resource_aws_vpn_connection_test.go
+++ b/aws/resource_aws_vpn_connection_test.go
@@ -122,7 +122,7 @@ func TestAccAWSVpnConnection_tunnelOptions(t *testing.T) {
 			},
 			{
 				Config:      testAccAwsVpnConnectionConfigSingleTunnelOptions(rBgpAsn, "1234567!", "169.254.254.0/30"),
-				ExpectError: regexp.MustCompile(`can only contain alphanumeric and underscore characters`),
+				ExpectError: regexp.MustCompile(`can only contain alphanumeric, period and underscore characters`),
 			},
 
 			//Try actual building

--- a/website/docs/r/vpn_connection.html.markdown
+++ b/website/docs/r/vpn_connection.html.markdown
@@ -55,6 +55,7 @@ The following arguments are supported:
 * `tunnel2_inside_cidr` - (Optional) The CIDR block of the second IP addresses for the first VPN tunnel.
 * `tunnel1_preshared_key` - (Optional) The preshared key of the first VPN tunnel.
 * `tunnel2_preshared_key` - (Optional) The preshared key of the second VPN tunnel.
+~> **Note:** The preshared key must be between 8 and 64 characters in length and cannot start with zero(0). Allowed characters are alphanumeric characters, periods(.) and underscores(_).
 
 ## Attribute Reference
 


### PR DESCRIPTION

Fixes #4169 

Changes proposed in this pull request:

* Change 1
Allowed dot in preshared_key.
Refer: https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_VPN.html#VPNTunnels