### PR TITLE
resource/aws_elasticache_cluster: Migrate from availability_zones TypeSet attribute to preferred_availability_zones TypeList attribute

### DIFF
--- a/aws/resource_aws_elasticache_cluster.go
+++ b/aws/resource_aws_elasticache_cluster.go
@@ -180,6 +180,9 @@ func resourceAwsElasticacheCluster() *schema.Resource {
 		ForceNew: true,
 	}
 
+	resourceSchema["availability_zones"].ConflictsWith = []string{"availability_zones"}
+	resourceSchema["availability_zones"].Deprecated = "Use `preferred_availability_zones` instead"
+
 	resourceSchema["configuration_endpoint"] = &schema.Schema{
 		Type:     schema.TypeString,
 		Computed: true,
@@ -213,6 +216,12 @@ func resourceAwsElasticacheCluster() *schema.Resource {
 				},
 			},
 		},
+	}
+
+	resourceSchema["preferred_availability_zones"] = &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Elem:     &schema.Schema{Type: schema.TypeString},
 	}
 
 	resourceSchema["replication_group_id"] = &schema.Schema{
@@ -400,10 +409,14 @@ func resourceAwsElasticacheClusterCreate(d *schema.ResourceData, meta interface{
 		req.PreferredAvailabilityZone = aws.String(v.(string))
 	}
 
-	preferred_azs := d.Get("availability_zones").(*schema.Set).List()
-	if len(preferred_azs) > 0 {
-		azs := expandStringList(preferred_azs)
-		req.PreferredAvailabilityZones = azs
+	if v, ok := d.GetOk("preferred_availability_zones"); ok && len(v.([]interface{})) > 0 {
+		req.PreferredAvailabilityZones = expandStringList(v.([]interface{}))
+	} else {
+		preferred_azs := d.Get("availability_zones").(*schema.Set).List()
+		if len(preferred_azs) > 0 {
+			azs := expandStringList(preferred_azs)
+			req.PreferredAvailabilityZones = azs
+		}
 	}
 
 	id, err := createElasticacheCacheCluster(conn, req)
@@ -589,6 +602,22 @@ func resourceAwsElasticacheClusterUpdate(d *schema.ResourceData, meta interface{
 			log.Printf("[INFO] Cluster %s is marked for Decreasing cache nodes from %d to %d", d.Id(), o, n)
 			nodesToRemove := getCacheNodesToRemove(d, o, o-n)
 			req.CacheNodeIdsToRemove = nodesToRemove
+		} else {
+			log.Printf("[INFO] Cluster %s is marked for increasing cache nodes from %d to %d", d.Id(), o, n)
+			// SDK documentation for NewAvailabilityZones states:
+			// The list of Availability Zones where the new Memcached cache nodes are created.
+			//
+			// This parameter is only valid when NumCacheNodes in the request is greater
+			// than the sum of the number of active cache nodes and the number of cache
+			// nodes pending creation (which may be zero). The number of Availability Zones
+			// supplied in this list must match the cache nodes being added in this request.
+			if v, ok := d.GetOk("preferred_availability_zones"); ok && len(v.([]interface{})) > 0 {
+				// Here we check the list length to prevent a potential panic :)
+				if len(v.([]interface{})) != n {
+					return fmt.Errorf("length of preferred_availability_zones (%d) must match num_cache_nodes (%d)", len(v.([]interface{})), n)
+				}
+				req.NewAvailabilityZones = expandStringList(v.([]interface{})[o:])
+			}
 		}
 
 		req.NumCacheNodes = aws.Int64(int64(d.Get("num_cache_nodes").(int)))

--- a/aws/resource_aws_elasticache_cluster.go
+++ b/aws/resource_aws_elasticache_cluster.go
@@ -180,7 +180,7 @@ func resourceAwsElasticacheCluster() *schema.Resource {
 		ForceNew: true,
 	}
 
-	resourceSchema["availability_zones"].ConflictsWith = []string{"availability_zones"}
+	resourceSchema["availability_zones"].ConflictsWith = []string{"preferred_availability_zones"}
 	resourceSchema["availability_zones"].Deprecated = "Use `preferred_availability_zones` instead"
 
 	resourceSchema["configuration_endpoint"] = &schema.Schema{

--- a/aws/resource_aws_elasticache_cluster_test.go
+++ b/aws/resource_aws_elasticache_cluster_test.go
@@ -245,12 +245,10 @@ func TestAccAWSElasticacheCluster_snapshotsWithUpdates(t *testing.T) {
 	})
 }
 
-func TestAccAWSElasticacheCluster_decreasingCacheNodes(t *testing.T) {
+func TestAccAWSElasticacheCluster_NumCacheNodes_Decrease(t *testing.T) {
 	var ec elasticache.CacheCluster
-
-	ri := acctest.RandInt()
-	preConfig := fmt.Sprintf(testAccAWSElasticacheClusterConfigDecreasingNodes, ri, ri, acctest.RandString(10))
-	postConfig := fmt.Sprintf(testAccAWSElasticacheClusterConfigDecreasingNodes_update, ri, ri, acctest.RandString(10))
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(8))
+	resourceName := "aws_elasticache_cluster.bar"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -258,22 +256,75 @@ func TestAccAWSElasticacheCluster_decreasingCacheNodes(t *testing.T) {
 		CheckDestroy: testAccCheckAWSElasticacheClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: preConfig,
+				Config: testAccAWSElasticacheClusterConfig_NumCacheNodes(rName, 3),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheSecurityGroupExists("aws_elasticache_security_group.bar"),
-					testAccCheckAWSElasticacheClusterExists("aws_elasticache_cluster.bar", &ec),
-					resource.TestCheckResourceAttr(
-						"aws_elasticache_cluster.bar", "num_cache_nodes", "3"),
+					testAccCheckAWSElasticacheClusterExists(resourceName, &ec),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_nodes", "3"),
 				),
 			},
-
 			{
-				Config: postConfig,
+				Config: testAccAWSElasticacheClusterConfig_NumCacheNodes(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheSecurityGroupExists("aws_elasticache_security_group.bar"),
-					testAccCheckAWSElasticacheClusterExists("aws_elasticache_cluster.bar", &ec),
-					resource.TestCheckResourceAttr(
-						"aws_elasticache_cluster.bar", "num_cache_nodes", "1"),
+					testAccCheckAWSElasticacheClusterExists(resourceName, &ec),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_nodes", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSElasticacheCluster_NumCacheNodes_Increase(t *testing.T) {
+	var ec elasticache.CacheCluster
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(8))
+	resourceName := "aws_elasticache_cluster.bar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSElasticacheClusterConfig_NumCacheNodes(rName, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheClusterExists(resourceName, &ec),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_nodes", "1"),
+				),
+			},
+			{
+				Config: testAccAWSElasticacheClusterConfig_NumCacheNodes(rName, 3),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheClusterExists(resourceName, &ec),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_nodes", "3"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSElasticacheCluster_NumCacheNodes_IncreaseWithPreferredAvailabilityZones(t *testing.T) {
+	var ec elasticache.CacheCluster
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(8))
+	resourceName := "aws_elasticache_cluster.bar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSElasticacheClusterConfig_NumCacheNodesWithPreferredAvailabilityZones(rName, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheClusterExists(resourceName, &ec),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_nodes", "1"),
+					resource.TestCheckResourceAttr(resourceName, "preferred_availability_zones.#", "1"),
+				),
+			},
+			{
+				Config: testAccAWSElasticacheClusterConfig_NumCacheNodesWithPreferredAvailabilityZones(rName, 3),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheClusterExists(resourceName, &ec),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_nodes", "3"),
+					resource.TestCheckResourceAttr(resourceName, "preferred_availability_zones.#", "3"),
 				),
 			},
 		},
@@ -963,70 +1014,39 @@ resource "aws_elasticache_cluster" "bar" {
 }
 `
 
-var testAccAWSElasticacheClusterConfigDecreasingNodes = `
-provider "aws" {
-	region = "us-east-1"
+func testAccAWSElasticacheClusterConfig_NumCacheNodes(rName string, numCacheNodes int) string {
+	return fmt.Sprintf(`
+resource "aws_elasticache_cluster" "bar" {
+  apply_immediately    = true
+  cluster_id           = "%s"
+  engine               = "memcached"
+  node_type            = "cache.m1.small"
+  num_cache_nodes      = %d
+  parameter_group_name = "default.memcached1.4"
 }
-resource "aws_security_group" "bar" {
-    name = "tf-test-security-group-%03d"
-    description = "tf-test-security-group-descr"
-    ingress {
-        from_port = -1
-        to_port = -1
-        protocol = "icmp"
-        cidr_blocks = ["0.0.0.0/0"]
-    }
+`, rName, numCacheNodes)
 }
 
-resource "aws_elasticache_security_group" "bar" {
-    name = "tf-test-security-group-%03d"
-    description = "tf-test-security-group-descr"
-    security_group_names = ["${aws_security_group.bar.name}"]
-}
+func testAccAWSElasticacheClusterConfig_NumCacheNodesWithPreferredAvailabilityZones(rName string, numCacheNodes int) string {
+	preferredAvailabilityZones := make([]string, numCacheNodes)
+	for i := range preferredAvailabilityZones {
+		preferredAvailabilityZones[i] = `"${data.aws_availability_zones.available.names[0]}"`
+	}
+
+	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {}
 
 resource "aws_elasticache_cluster" "bar" {
-    cluster_id = "tf-%s"
-    engine = "memcached"
-    node_type = "cache.m1.small"
-    num_cache_nodes = 3
-    port = 11211
-    parameter_group_name = "default.memcached1.4"
-    security_group_names = ["${aws_elasticache_security_group.bar.name}"]
+  apply_immediately            = true
+  cluster_id                   = "%s"
+  engine                       = "memcached"
+  node_type                    = "cache.m1.small"
+  num_cache_nodes              = %d
+  parameter_group_name         = "default.memcached1.4"
+  preferred_availability_zones = [%s]
 }
-`
-
-var testAccAWSElasticacheClusterConfigDecreasingNodes_update = `
-provider "aws" {
-	region = "us-east-1"
+`, rName, numCacheNodes, strings.Join(preferredAvailabilityZones, ","))
 }
-resource "aws_security_group" "bar" {
-    name = "tf-test-security-group-%03d"
-    description = "tf-test-security-group-descr"
-    ingress {
-        from_port = -1
-        to_port = -1
-        protocol = "icmp"
-        cidr_blocks = ["0.0.0.0/0"]
-    }
-}
-
-resource "aws_elasticache_security_group" "bar" {
-    name = "tf-test-security-group-%03d"
-    description = "tf-test-security-group-descr"
-    security_group_names = ["${aws_security_group.bar.name}"]
-}
-
-resource "aws_elasticache_cluster" "bar" {
-    cluster_id = "tf-%s"
-    engine = "memcached"
-    node_type = "cache.m1.small"
-    num_cache_nodes = 1
-    port = 11211
-    parameter_group_name = "default.memcached1.4"
-    security_group_names = ["${aws_elasticache_security_group.bar.name}"]
-    apply_immediately = true
-}
-`
 
 var testAccAWSElasticacheClusterInVPCConfig = fmt.Sprintf(`
 resource "aws_vpc" "foo" {

--- a/aws/resource_aws_elasticache_cluster_test.go
+++ b/aws/resource_aws_elasticache_cluster_test.go
@@ -1162,7 +1162,7 @@ resource "aws_elasticache_cluster" "bar" {
     security_group_ids = ["${aws_security_group.bar.id}"]
     parameter_group_name = "default.memcached1.4"
     az_mode = "cross-az"
-    availability_zones = [
+    preferred_availability_zones = [
         "us-west-2a",
         "us-west-2b"
     ]

--- a/website/docs/r/elasticache_cluster.html.markdown
+++ b/website/docs/r/elasticache_cluster.html.markdown
@@ -127,9 +127,11 @@ SNS topic to send ElastiCache notifications to. Example:
 
 * `az_mode` - (Optional, Memcached only) Specifies whether the nodes in this Memcached node group are created in a single Availability Zone or created across multiple Availability Zones in the cluster's region. Valid values for this parameter are `single-az` or `cross-az`, default is `single-az`. If you want to choose `cross-az`, `num_cache_nodes` must be greater than `1`
 
-* `availability_zone` - (Optional) The Availability Zone for the cache cluster. If you want to create cache nodes in multi-az, use `availability_zones`
+* `availability_zone` - (Optional) The Availability Zone for the cache cluster. If you want to create cache nodes in multi-az, use `preferred_availability_zones` instead. Default: System chosen Availability Zone.
 
-* `availability_zones` - (Optional, Memcached only) List of Availability Zones in which the cache nodes will be created. If you want to create cache nodes in single-az, use `availability_zone`
+* `availability_zones` - (*DEPRECATED*, Optional, Memcached only) Use `preferred_availability_zones` instead unless you want to create cache nodes in single-az, then use `availability_zone`. Set of Availability Zones in which the cache nodes will be created.
+
+* `preferred_availability_zones` - (Optional, Memcached only) A list of the Availability Zones in which cache nodes are created. If you are creating your cluster in an Amazon VPC you can only locate nodes in Availability Zones that are associated with the subnets in the selected subnet group. The number of Availability Zones listed must equal the value of `num_cache_nodes`. If you want all the nodes in the same Availability Zone, use `availability_zone` instead, or repeat the Availability Zone multiple times in the list. Default: System chosen Availability Zones. Detecting drift of existing node availability zone is not currently supported. Updating this argument by itself to migrate existing node availability zones is not currently supported and will show a perpetual difference.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource
 


### PR DESCRIPTION
Fixes #2658 
Fixes #374
Fixes #207 

Changes proposed in this pull request:

* Deprecate `availability_zones` (TypeSet) attribute in `aws_elasticache_cluster`
* Create `preferred_availability_zones` (TypeList) attribute in `aws_elasticache_cluster`
* Support `NewAvailabilityZones` parameter in `ModifyCacheCluster` when increasing `num_cache_nodes` with `preferred_availability_zones`
* Add acceptance test to cover increasing `num_cache_nodes` while utilizing `preferred_availability_zones`

We must create a new attribute because there is no way to migrate state from TypeSet to TypeList without breaking existing configurations, so we will allow an opt-in upgrade procedure and phase out the old attribute. I'm indifferent with the new attribute naming so suggestions welcome (we've used `ordered_X` for other migrations like this, but `preferred_` here does match the `CreateCacheCluster` parameter `PreferredAvailabilityZones`).

Output from acceptance testing:

```
20 tests passed (all tests)
=== RUN   TestAccAWSElasticacheCluster_ReplicationGroupID_InvalidAttributes
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_InvalidAttributes (3.51s)
=== RUN   TestAccAWSElasticacheCluster_NumCacheNodes_Redis_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Redis_Ec2Classic (3.58s)
=== RUN   TestAccAWSElasticacheCluster_AZMode_Memcached_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_AZMode_Memcached_Ec2Classic (443.83s)
=== RUN   TestAccAWSElasticacheCluster_AZMode_Redis_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_AZMode_Redis_Ec2Classic (493.62s)
=== RUN   TestAccAWSElasticacheCluster_SecurityGroup
--- PASS: TestAccAWSElasticacheCluster_SecurityGroup (529.19s)
=== RUN   TestAccAWSElasticacheCluster_Engine_Memcached_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_Engine_Memcached_Ec2Classic (535.47s)
=== RUN   TestAccAWSElasticacheCluster_Engine_Redis_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_Engine_Redis_Ec2Classic (546.33s)
=== RUN   TestAccAWSElasticacheCluster_Port_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_Port_Ec2Classic (556.38s)
=== RUN   TestAccAWSElasticacheCluster_vpc
--- PASS: TestAccAWSElasticacheCluster_vpc (829.40s)
=== RUN   TestAccAWSElasticacheCluster_multiAZInVpc
--- PASS: TestAccAWSElasticacheCluster_multiAZInVpc (848.69s)
=== RUN   TestAccAWSElasticacheCluster_NodeTypeResize_Redis_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_NodeTypeResize_Redis_Ec2Classic (891.39s)
=== RUN   TestAccAWSElasticacheCluster_NodeTypeResize_Memcached_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_NodeTypeResize_Memcached_Ec2Classic (938.32s)
=== RUN   TestAccAWSElasticacheCluster_NumCacheNodes_Decrease
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Decrease (1093.41s)
=== RUN   TestAccAWSElasticacheCluster_NumCacheNodes_IncreaseWithPreferredAvailabilityZones
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_IncreaseWithPreferredAvailabilityZones (1094.63s)
=== RUN   TestAccAWSElasticacheCluster_EngineVersion_Memcached_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_EngineVersion_Memcached_Ec2Classic (1107.33s)
=== RUN   TestAccAWSElasticacheCluster_ReplicationGroupID_SingleReplica_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_SingleReplica_Ec2Classic (1121.69s)
=== RUN   TestAccAWSElasticacheCluster_ReplicationGroupID_MultipleReplica_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_MultipleReplica_Ec2Classic (1122.54s)
=== RUN   TestAccAWSElasticacheCluster_EngineVersion_Redis_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_EngineVersion_Redis_Ec2Classic (1145.84s)
=== RUN   TestAccAWSElasticacheCluster_NumCacheNodes_Increase
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Increase (1174.01s)
=== RUN   TestAccAWSElasticacheCluster_snapshotsWithUpdates
--- PASS: TestAccAWSElasticacheCluster_snapshotsWithUpdates (2146.12s)
```
