### PR TITLE
EKS Getting Started Guide: Include aws_availability_zones data source in sample configuration

### DIFF
--- a/website/docs/guides/eks-getting-started.html.md
+++ b/website/docs/guides/eks-getting-started.html.md
@@ -124,6 +124,10 @@ gateway, and setup the subnet routing to route external traffic through the
 internet gateway:
 
 ```hcl
+# This data source is included for ease of sample architecture deployment
+# and can be swapped out as necessary.
+data "aws_availability_zones" "available" {}
+
 resource "aws_vpc" "demo" {
   cidr_block = "10.0.0.0/16"
 


### PR DESCRIPTION
Changes proposed in this pull request:

* Fixes a missing configuration reference: `Error: resource 'aws_subnet.demo' config: unknown resource 'data.aws_availability_zones.available' referenced in variable data.aws_availability_zones.available.names`

Output from acceptance testing: N/A
