### PR TITLE
eks: Additional fixes to Getting Started Guide and example configuration from preview to GA release

### DIFF
--- a/examples/eks-getting-started/eks-worker-nodes.tf
+++ b/examples/eks-getting-started/eks-worker-nodes.tf
@@ -36,6 +36,11 @@ resource "aws_iam_role_policy_attachment" "demo-node-AmazonEKS_CNI_Policy" {
   role       = "${aws_iam_role.demo-node.name}"
 }
 
+resource "aws_iam_role_policy_attachment" "demo-node-AmazonEC2ContainerRegistryReadOnly" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = "${aws_iam_role.demo-node.name}"
+}
+
 resource "aws_iam_instance_profile" "demo-node" {
   name = "terraform-eks-demo"
   role = "${aws_iam_role.demo-node.name}"
@@ -91,6 +96,11 @@ data "aws_ami" "eks-worker" {
   owners      = ["602401143452"] # Amazon
 }
 
+# EKS currently documents this required userdata for EKS worker nodes to
+# properly configure Kubernetes applications on the EC2 instance.
+# We utilize a Terraform local here to simplify Base64 encoding this
+# information into the AutoScaling Launch Configuration.
+# More information: https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-06-05/amazon-eks-nodegroup.yaml
 locals {
   demo-node-userdata = <<USERDATA
 #!/bin/bash -xe
@@ -100,12 +110,15 @@ CA_CERTIFICATE_FILE_PATH=$CA_CERTIFICATE_DIRECTORY/ca.crt
 mkdir -p $CA_CERTIFICATE_DIRECTORY
 echo "${aws_eks_cluster.demo.certificate_authority.0.data}" | base64 -d >  $CA_CERTIFICATE_FILE_PATH
 INTERNAL_IP=$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)
-sed -i s,MASTER_ENDPOINT,${aws_eks_cluster.demo.master_endpoint},g /var/lib/kubelet/kubeconfig
+sed -i s,MASTER_ENDPOINT,${aws_eks_cluster.demo.endpoint},g /var/lib/kubelet/kubeconfig
 sed -i s,CLUSTER_NAME,${var.cluster-name},g /var/lib/kubelet/kubeconfig
-sed -i s,MASTER_ENDPOINT,${aws_eks_cluster.demo.master_endpoint},g /etc/systemd/system/kubelet.service
-sed -i s,MASTER_ENDPOINT,${aws_eks_cluster.demo.master_endpoint},g /etc/systemd/system/kube-proxy.service
+sed -i s,REGION,${data.aws_region.current.name},g /etc/systemd/system/kubelet.service
+sed -i s,MAX_PODS,20,g /etc/systemd/system/kubelet.service
+sed -i s,MASTER_ENDPOINT,${aws_eks_cluster.demo.endpoint},g /etc/systemd/system/kubelet.service
 sed -i s,INTERNAL_IP,$INTERNAL_IP,g /etc/systemd/system/kubelet.service
-sed -i s,INTERNAL_IP,$INTERNAL_IP,g /etc/systemd/system/kube-proxy.service
+DNS_CLUSTER_IP=10.100.0.10
+if [[ $INTERNAL_IP == 10.* ]] ; then DNS_CLUSTER_IP=172.20.0.10; fi
+sed -i s,DNS_CLUSTER_IP,$DNS_CLUSTER_IP,g /etc/systemd/system/kubelet.service
 sed -i s,CERTIFICATE_AUTHORITY_FILE,$CA_CERTIFICATE_FILE_PATH,g /var/lib/kubelet/kubeconfig
 sed -i s,CLIENT_CA_FILE,$CA_CERTIFICATE_FILE_PATH,g  /etc/systemd/system/kubelet.service
 systemctl daemon-reload

--- a/examples/eks-getting-started/outputs.tf
+++ b/examples/eks-getting-started/outputs.tf
@@ -10,7 +10,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: aws-auth
-  namespace: default
+  namespace: kube-system
 data:
   mapRoles: |
     - rolearn: ${aws_iam_role.demo-node.arn}
@@ -18,7 +18,6 @@ data:
       groups:
         - system:bootstrappers
         - system:nodes
-        - system:node-proxier
 CONFIGMAPAWSAUTH
 
   kubeconfig = <<KUBECONFIG

--- a/examples/eks-getting-started/providers.tf
+++ b/examples/eks-getting-started/providers.tf
@@ -6,8 +6,10 @@ provider "aws" {
   region = "us-west-2"
 }
 
-# Using this data source allows the configuration to be
+# Using these data sources allows the configuration to be
 # generic for any region.
+data "aws_region" "current" {}
+
 data "aws_availability_zones" "available" {}
 
 # Not required: currently used in conjuction with using

--- a/website/docs/guides/eks-getting-started.html.md
+++ b/website/docs/guides/eks-getting-started.html.md
@@ -377,6 +377,11 @@ resource "aws_iam_role_policy_attachment" "demo-node-AmazonEKS_CNI_Policy" {
   role       = "${aws_iam_role.demo-node.name}"
 }
 
+resource "aws_iam_role_policy_attachment" "demo-node-AmazonEC2ContainerRegistryReadOnly" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = "${aws_iam_role.demo-node.name}"
+}
+
 resource "aws_iam_instance_profile" "demo-node" {
   name = "terraform-eks-demo"
   role = "${aws_iam_role.demo-node.name}"
@@ -473,10 +478,15 @@ Next, lets create an AutoScaling Launch Configuration that uses all our
 prerequisite resources to define how to create EC2 instances using them.
 
 ```hcl
+# This data source is included for ease of sample architecture deployment
+# and can be swapped out as necessary.
+data "aws_region" "current" {}
+
 # EKS currently documents this required userdata for EKS worker nodes to
 # properly configure Kubernetes applications on the EC2 instance.
 # We utilize a Terraform local here to simplify Base64 encoding this
 # information into the AutoScaling Launch Configuration.
+# More information: https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-06-05/amazon-eks-nodegroup.yaml
 locals {
   demo-node-userdata = <<USERDATA
 #!/bin/bash -xe
@@ -488,10 +498,13 @@ echo "${aws_eks_cluster.demo.certificate_authority.0.data}" | base64 -d >  $CA_C
 INTERNAL_IP=$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)
 sed -i s,MASTER_ENDPOINT,${aws_eks_cluster.demo.endpoint},g /var/lib/kubelet/kubeconfig
 sed -i s,CLUSTER_NAME,${var.cluster-name},g /var/lib/kubelet/kubeconfig
+sed -i s,REGION,${data.aws_region.current.name},g /etc/systemd/system/kubelet.service
+sed -i s,MAX_PODS,20,g /etc/systemd/system/kubelet.service
 sed -i s,MASTER_ENDPOINT,${aws_eks_cluster.demo.endpoint},g /etc/systemd/system/kubelet.service
-sed -i s,MASTER_ENDPOINT,${aws_eks_cluster.demo.endpoint},g /etc/systemd/system/kube-proxy.service
 sed -i s,INTERNAL_IP,$INTERNAL_IP,g /etc/systemd/system/kubelet.service
-sed -i s,INTERNAL_IP,$INTERNAL_IP,g /etc/systemd/system/kube-proxy.service
+DNS_CLUSTER_IP=10.100.0.10
+if [[ $INTERNAL_IP == 10.* ]] ; then DNS_CLUSTER_IP=172.20.0.10; fi
+sed -i s,DNS_CLUSTER_IP,$DNS_CLUSTER_IP,g /etc/systemd/system/kubelet.service
 sed -i s,CERTIFICATE_AUTHORITY_FILE,$CA_CERTIFICATE_FILE_PATH,g /var/lib/kubelet/kubeconfig
 sed -i s,CLIENT_CA_FILE,$CA_CERTIFICATE_FILE_PATH,g  /etc/systemd/system/kubelet.service
 systemctl daemon-reload
@@ -570,7 +583,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: aws-auth
-  namespace: default
+  namespace: kube-system
 data:
   mapRoles: |
     - rolearn: ${aws_iam_role.demo-node.arn}
@@ -578,7 +591,6 @@ data:
       groups:
         - system:bootstrappers
         - system:nodes
-        - system:node-proxier
 CONFIGMAPAWSAUTH
 }
 


### PR DESCRIPTION
Changes proposed in this pull request:

* Various updates to EKS Getting Started Guide and EKS example configuration relating to changes from EKS preview to GA release

Verified nodes properly connect to EKS cluster now using the guide:

```
kubectl get nodes
NAME                                       STATUS    ROLES     AGE       VERSION
ip-10-0-0-199.us-west-2.compute.internal   Ready     <none>    24s       v1.10.3
ip-10-0-1-77.us-west-2.compute.internal    Ready     <none>    26s       v1.10.3
```