### PR TITLE
docs/vpc_peering_connection_options clarify vpc_peering_connection_id

### DIFF
--- a/website/docs/r/vpc_peering_options.html.markdown
+++ b/website/docs/r/vpc_peering_options.html.markdown
@@ -139,7 +139,7 @@ resource "aws_vpc_peering_connection_options" "accepter" {
 
 The following arguments are supported:
 
-* `vpc_peering_connection_id` - (Required) The ID of the requester VPC.
+* `vpc_peering_connection_id` - (Required) The ID of the requester VPC peering connection.
 * `accepter` (Optional) - An optional configuration block that allows for [VPC Peering Connection]
 (http://docs.aws.amazon.com/AmazonVPC/latest/PeeringGuide) options to be set for the VPC that accepts
 the peering connection (a maximum of one).


### PR DESCRIPTION
Changes proposed in this pull request:

* Small fix to the docs for `vpc_peering_connection_options` to fix/clarify that `vpc_peering_connection_id` is a VPC peering connection ID and not a VPC ID