### PR TITLE
resource/aws_codecommit_repository: Suppress error when codecommit repository doesn't exists

### DIFF
--- a/aws/resource_aws_codecommit_repository.go
+++ b/aws/resource_aws_codecommit_repository.go
@@ -112,7 +112,13 @@ func resourceAwsCodeCommitRepositoryRead(d *schema.ResourceData, meta interface{
 
 	out, err := conn.GetRepository(input)
 	if err != nil {
-		return fmt.Errorf("Error reading CodeCommit Repository: %s", err.Error())
+		if isAWSErr(err, codecommit.ErrCodeRepositoryDoesNotExistException, "") {
+			log.Printf("[WARN] CodeCommit Repository (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		} else {
+			return fmt.Errorf("Error reading CodeCommit Repository: %s", err.Error())
+		}
 	}
 
 	d.Set("repository_id", out.RepositoryMetadata.RepositoryId)


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->

Changes proposed in this pull request:

* Suppress error when codecommit repository doesn't exists

Output from acceptance testing:

```
$ TF_ACC=1 go test ./aws -v -run=TestAccAWSCodeCommitRepository_* -timeout 120m
=== RUN   TestAccAWSCodeCommitRepository_importBasic
--- PASS: TestAccAWSCodeCommitRepository_importBasic (24.69s)
=== RUN   TestAccAWSCodeCommitRepository_basic
--- PASS: TestAccAWSCodeCommitRepository_basic (22.04s)
=== RUN   TestAccAWSCodeCommitRepository_withChanges
--- PASS: TestAccAWSCodeCommitRepository_withChanges (39.28s)
=== RUN   TestAccAWSCodeCommitRepository_create_default_branch
--- PASS: TestAccAWSCodeCommitRepository_create_default_branch (23.21s)
=== RUN   TestAccAWSCodeCommitRepository_create_and_update_default_branch
--- PASS: TestAccAWSCodeCommitRepository_create_and_update_default_branch (37.69s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	146.956s
```
