### PR TITLE
r/aws_launch_template: Add tags support

### DIFF
--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -398,6 +398,8 @@ func resourceAwsLaunchTemplate() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -470,6 +472,7 @@ func resourceAwsLaunchTemplateRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("name", lt.LaunchTemplateName)
 	d.Set("latest_version", lt.LatestVersionNumber)
 	d.Set("default_version", lt.DefaultVersionNumber)
+	d.Set("tags", tagsToMap(lt.Tags))
 
 	version := strconv.Itoa(int(*lt.LatestVersionNumber))
 	dltv, err := conn.DescribeLaunchTemplateVersions(&ec2.DescribeLaunchTemplateVersionsInput{
@@ -555,6 +558,16 @@ func resourceAwsLaunchTemplateUpdate(d *schema.ResourceData, meta interface{}) e
 			return createErr
 		}
 	}
+
+	d.Partial(true)
+
+	if err := setTags(conn, d); err != nil {
+		return err
+	} else {
+		d.SetPartial("tags")
+	}
+
+	d.Partial(false)
 
 	return resourceAwsLaunchTemplateRead(d, meta)
 }

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -132,6 +132,35 @@ func TestAccAWSLaunchTemplate_update(t *testing.T) {
 	})
 }
 
+func TestAccAWSLaunchTemplate_tags(t *testing.T) {
+	var template ec2.LaunchTemplate
+	resName := "aws_launch_template.foo"
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLaunchTemplateConfig_basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchTemplateExists(resName, &template),
+					testAccCheckTags(&template.Tags, "foo", "bar"),
+				),
+			},
+			{
+				Config: testAccAWSLaunchTemplateConfig_tagsUpdate(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchTemplateExists(resName, &template),
+					testAccCheckTags(&template.Tags, "foo", ""),
+					testAccCheckTags(&template.Tags, "bar", "baz"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSLaunchTemplateExists(n string, t *ec2.LaunchTemplate) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -194,6 +223,10 @@ func testAccAWSLaunchTemplateConfig_basic(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_launch_template" "foo" {
   name = "foo_%d"
+
+  tags {
+    foo = "bar"
+  }
 }
 `, rInt)
 }
@@ -292,6 +325,18 @@ resource "aws_launch_template" "foo" {
     tags {
       Name = "test"
     }
+  }
+}
+`, rInt)
+}
+
+func testAccAWSLaunchTemplateConfig_tagsUpdate(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_launch_template" "foo" {
+  name = "foo_%d"
+
+  tags {
+    bar = "baz"
   }
 }
 `, rInt)

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -113,6 +113,7 @@ The following arguments are supported:
   `vpc_security_group_ids` instead.
 * `vpc_security_group_ids` - A list of security group IDs to associate with.
 * `tag_specifications` - The tags to apply to the resources during launch. See [Tags](#tags) below for more details.
+* `tags` - (Optional) A mapping of tags to assign to the launch template.
 * `user_data` - The Base64-encoded user data to provide when launching the instance.
 
 ### Block devices


### PR DESCRIPTION
Changes proposed in this pull request:

* Add support for tags for launch template

Output from acceptance testing:

```
$ TF_ACC=1 go test ./aws -v -run=TestAccAWSLaunchTemplate_* -timeout 120m
=== RUN   TestAccAWSLaunchTemplate_importBasic
--- PASS: TestAccAWSLaunchTemplate_importBasic (30.51s)
=== RUN   TestAccAWSLaunchTemplate_importData
--- PASS: TestAccAWSLaunchTemplate_importData (28.56s)
=== RUN   TestAccAWSLaunchTemplate_basic
--- PASS: TestAccAWSLaunchTemplate_basic (27.29s)
=== RUN   TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS (32.73s)
=== RUN   TestAccAWSLaunchTemplate_data
--- PASS: TestAccAWSLaunchTemplate_data (25.15s)
=== RUN   TestAccAWSLaunchTemplate_update
--- PASS: TestAccAWSLaunchTemplate_update (47.64s)
=== RUN   TestAccAWSLaunchTemplate_tags
--- PASS: TestAccAWSLaunchTemplate_tags (48.08s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	240.016s
```
