### PR TITLE
resource/aws_launch_template: Validate tag_specifications and link to AWS docs

### DIFF
--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -388,6 +388,10 @@ func resourceAwsLaunchTemplate() *schema.Resource {
 						"resource_type": {
 							Type:     schema.TypeString,
 							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"instance",
+								"volume",
+							}, false),
 						},
 						"tags": tagsSchema(),
 					},

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -232,11 +232,11 @@ The `placement` block supports the following:
 
 ### Tags
 
-The tags to apply to the resources during launch. You can tag instances and volumes.
+The tags to apply to the resources during launch. You can tag instances and volumes. More information can be found in the [EC2 API documentation](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_LaunchTemplateTagSpecificationRequest.html).
 
 Each `tag_specifications` block supports the following:
 
-* `resource_type` - The type of resource to tag.
+* `resource_type` - The type of resource to tag. Valid values are `instance` and `volume`.
 * `tags` - A mapping of tags to assign to the resource.
 
 


### PR DESCRIPTION
Closes #4649 

Changes proposed in this pull request:

* Add plan time validation for tag_specifications `resource_type`
* Provide valid values and add link to AWS EC2 API documentation on the matter

Output from acceptance testing:

```
Pending in TeamCity
```
