### PR TITLE
aws_eks_cluster: Ensure arn is available as an attribute

### DIFF
--- a/aws/data_source_aws_eks_cluster.go
+++ b/aws/data_source_aws_eks_cluster.go
@@ -15,6 +15,10 @@ func dataSourceAwsEksCluster() *schema.Resource {
 		Read: dataSourceAwsEksClusterRead,
 
 		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"certificate_authority": {
 				Type:     schema.TypeList,
 				MaxItems: 1,

--- a/aws/data_source_aws_eks_cluster_test.go
+++ b/aws/data_source_aws_eks_cluster_test.go
@@ -21,6 +21,7 @@ func TestAccAWSEksClusterDataSource_basic(t *testing.T) {
 			{
 				Config: testAccAWSEksClusterDataSourceConfig_Basic(rName),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceResourceName, "arn"),
 					resource.TestCheckResourceAttr(dataSourceResourceName, "certificate_authority.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "certificate_authority.0.data", dataSourceResourceName, "certificate_authority.0.data"),
 					resource.TestCheckResourceAttrPair(resourceName, "created_at", dataSourceResourceName, "created_at"),

--- a/aws/resource_aws_eks_cluster.go
+++ b/aws/resource_aws_eks_cluster.go
@@ -28,6 +28,10 @@ func resourceAwsEksCluster() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"certificate_authority": {
 				Type:     schema.TypeList,
 				MaxItems: 1,

--- a/aws/resource_aws_eks_cluster_test.go
+++ b/aws/resource_aws_eks_cluster_test.go
@@ -86,6 +86,7 @@ func TestAccAWSEksCluster_basic(t *testing.T) {
 				Config: testAccAWSEksClusterConfig_Required(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEksClusterExists(resourceName, &cluster),
+					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:eks:[^:]+:[^:]+:cluster/%s$", rName))),
 					resource.TestCheckResourceAttr(resourceName, "certificate_authority.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "certificate_authority.0.data"),
 					resource.TestMatchResourceAttr(resourceName, "endpoint", regexp.MustCompile(`^https://`)),


### PR DESCRIPTION
The addition of the `Arn` attribute from the API was an addition that occurred between EKS preview and GA. While I added the `d.Set()` for it, unfortunately I missed the testing for the new attribute which would have caught this.

Fixes #4764 

Changes proposed in this pull request:

* Add `arn` attribute to schema and properly acceptance test the new attribute in the `aws_eks_cluster` resource and data source

Output from acceptance testing:

```
Pending in TeamCity
```
