### PR TITLE
resource/aws_eks_cluster: allow referencing arn attribute

### DIFF
--- a/aws/data_source_aws_eks_cluster.go
+++ b/aws/data_source_aws_eks_cluster.go
@@ -42,6 +42,10 @@ func dataSourceAwsEksCluster() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.NoZeroValues,
 			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"role_arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -106,6 +110,7 @@ func dataSourceAwsEksClusterRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("created_at", aws.TimeValue(cluster.CreatedAt).String())
 	d.Set("endpoint", cluster.Endpoint)
 	d.Set("name", cluster.Name)
+	d.Set("arn", cluster.Arn)
 	d.Set("role_arn", cluster.RoleArn)
 	d.Set("version", cluster.Version)
 

--- a/aws/data_source_aws_eks_cluster_test.go
+++ b/aws/data_source_aws_eks_cluster_test.go
@@ -25,6 +25,7 @@ func TestAccAWSEksClusterDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "certificate_authority.0.data", dataSourceResourceName, "certificate_authority.0.data"),
 					resource.TestCheckResourceAttrPair(resourceName, "created_at", dataSourceResourceName, "created_at"),
 					resource.TestCheckResourceAttrPair(resourceName, "endpoint", dataSourceResourceName, "endpoint"),
+					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceResourceName, "arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "role_arn", dataSourceResourceName, "role_arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "version", dataSourceResourceName, "version"),
 					resource.TestCheckResourceAttr(dataSourceResourceName, "vpc_config.#", "1"),

--- a/aws/resource_aws_eks_cluster.go
+++ b/aws/resource_aws_eks_cluster.go
@@ -49,6 +49,10 @@ func resourceAwsEksCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -191,6 +195,7 @@ func resourceAwsEksClusterRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("created_at", aws.TimeValue(cluster.CreatedAt).String())
 	d.Set("endpoint", cluster.Endpoint)
 	d.Set("name", cluster.Name)
+	d.Set("arn", cluster.Arn)
 	d.Set("role_arn", cluster.RoleArn)
 	d.Set("version", cluster.Version)
 

--- a/aws/resource_aws_eks_cluster_test.go
+++ b/aws/resource_aws_eks_cluster_test.go
@@ -90,6 +90,8 @@ func TestAccAWSEksCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "certificate_authority.0.data"),
 					resource.TestMatchResourceAttr(resourceName, "endpoint", regexp.MustCompile(`^https://`)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(
+						"^arn:aws:eks:[^:]+:[0-9]+:cluster/"+rName+"$")),
 					resource.TestMatchResourceAttr(resourceName, "role_arn", regexp.MustCompile(fmt.Sprintf("%s$", rName))),
 					resource.TestMatchResourceAttr(resourceName, "version", regexp.MustCompile(`^\d+\.\d+$`)),
 					resource.TestCheckResourceAttr(resourceName, "vpc_config.#", "1"),


### PR DESCRIPTION
Fixes #4764

Changes proposed in this pull request:

* expose `arn` in resource `aws_eks_cluster` 
* expose `arn` in data `aws_eks_cluster` 

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSEksCluster_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSEksCluster_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSEksCluster_basic
--- PASS: TestAccAWSEksCluster_basic (785.40s)
PASS
ok  	github.com/terraform-providers/terraform-prov
...
```
