### PR TITLE
Update example stack_id to be consistent

### DIFF
--- a/website/docs/r/opsworks_application.html.markdown
+++ b/website/docs/r/opsworks_application.html.markdown
@@ -16,7 +16,7 @@ Provides an OpsWorks application resource.
 resource "aws_opsworks_application" "foo-app" {
   name        = "foobar application"
   short_name  = "foobar"
-  stack_id    = "${aws_opsworks_stack.stack.id}"
+  stack_id    = "${aws_opsworks_stack.main.id}"
   type        = "rails"
   description = "This is a Rails application"
 


### PR DESCRIPTION
Update example stack_id to be consistent with other opsworks examples (see `opsworks_custom_layer` and `aws_opsworks_stack`).

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->

Changes proposed in this pull request:

* Minor update to documenation for `aws_opsworks_application` resource.