### PR TITLE
build: Set clone depth to 1 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ language: go
 go:
 - 1.9.1
 
+git:
+  depth: 1
+
 install:
 # This script is used by the Travis build to install a cookie for
 # go.googlesource.com so rate limits are higher when using `go get` to fetch


### PR DESCRIPTION
This pull request adds YAML to the Travis CI configuration such that the repository is cloned with a depth of 1 on build, shaving a reasonable percentage off the time spent cloning. While this is a small part of the overall CI process, ~6 seconds is not to sniffed at for a "one liner"!

```shell
$ time git clone terraform-providers/terraform-provider-aws
Cloning into 'terraform-provider-aws'...
remote: Counting objects: 55146, done.
remote: Compressing objects: 100% (20/20), done.
remote: Total 55146 (delta 9), reused 4 (delta 1), pack-reused 55125
Receiving objects: 100% (55146/55146), 39.73 MiB | 3.94 MiB/s, done.
Resolving deltas: 100% (34476/34476), done.
Checking out files: 100% (3886/3886), done.
/usr/local/bin/hub clone terraform-providers/terraform-provider-aws  4.41s user 1.84s system 42% cpu 14.724 total

$ time git clone --depth 1 terraform-providers/terraform-provider-aws
Cloning into 'terraform-provider-aws'...
remote: Counting objects: 4217, done.
remote: Compressing objects: 100% (3614/3614), done.
remote: Total 4217 (delta 918), reused 2475 (delta 500), pack-reused 0
Receiving objects: 100% (4217/4217), 9.22 MiB | 3.22 MiB/s, done.
Resolving deltas: 100% (918/918), done.
Checking out files: 100% (3886/3886), done.
/usr/local/bin/hub clone --depth 1 terraform-providers/terraform-provider-aws  0.91s user 0.99s system 21% cpu 8.941 total
```