### PR TITLE
AWS: Create composite resource 'aws_iam_policy_with_attachment'

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -426,6 +426,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_iam_instance_profile":                     resourceAwsIamInstanceProfile(),
 			"aws_iam_openid_connect_provider":              resourceAwsIamOpenIDConnectProvider(),
 			"aws_iam_policy":                               resourceAwsIamPolicy(),
+			"aws_iam_policy_with_attachment":               resourceAwsIamPolicyWithAttachment(),
 			"aws_iam_policy_attachment":                    resourceAwsIamPolicyAttachment(),
 			"aws_iam_role_policy_attachment":               resourceAwsIamRolePolicyAttachment(),
 			"aws_iam_role_policy":                          resourceAwsIamRolePolicy(),

--- a/aws/resource_aws_iam_user_policy_attachment.go
+++ b/aws/resource_aws_iam_user_policy_attachment.go
@@ -89,9 +89,13 @@ func resourceAwsIamUserPolicyAttachmentRead(d *schema.ResourceData, meta interfa
 }
 
 func resourceAwsIamUserPolicyAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*AWSClient).iamconn
 	user := d.Get("user").(string)
-	arn := d.Get("policy_arn").(string)
+	return resourceAwsIamUserPolicyAttachmentDeleter(d, "policy_arn", user, meta)
+}
+
+func resourceAwsIamUserPolicyAttachmentDeleter(d *schema.ResourceData, arnKey string, user string, meta interface{}) error {
+	conn := meta.(*AWSClient).iamconn
+	arn := d.Get(arnKey).(string)
 
 	err := detachPolicyFromUser(conn, user, arn)
 	if err != nil {


### PR DESCRIPTION
Changes proposed in this pull request:

* I want to create a composite aws resource type 'aws_iam_policy_with_attachment' that creates a policy together with the attachment.

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSIAMPolicyWithAttachment'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSIAMPolicyWithAttachment -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSIAMPolicyWithAttachment
--- PASS: TestAccAWSIAMPolicyWithAttachment (30.22s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	(cached)
```
