### PR TITLE
aws db instance: displaying invalid parameter in error

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -908,7 +908,13 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			return nil
 		})
 		if err != nil {
+			if awsErr, ok := err.(awserr.Error); ok {
+				if awsErr.Code() == "InvalidParameterValue" {
+					return fmt.Errorf("Error creating DB Instance: %s, %+v", err, opts)
+				}
+			}
 			return fmt.Errorf("Error creating DB Instance: %s", err)
+
 		}
 	}
 


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #3626

Changes proposed in this pull request:

* if a`InvalidParameterValue` error is   returned  when creating DB resource, then opts sent to the requests are shown in the error

Output from acceptance testing:

None
```
