### PR TITLE
Add ComputePlatform to aws_codedeploy_app

### DIFF
--- a/aws/resource_aws_codedeploy_app.go
+++ b/aws/resource_aws_codedeploy_app.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/codedeploy"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsCodeDeployApp() *schema.Resource {
@@ -26,6 +27,16 @@ func resourceAwsCodeDeployApp() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"compute_platform": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					codedeploy.ComputePlatformServer,
+					codedeploy.ComputePlatformLambda,
+				}, false),
+				Default: codedeploy.ComputePlatformServer,
+			},
+
 			// The unique ID is set by AWS on create.
 			"unique_id": &schema.Schema{
 				Type:     schema.TypeString,
@@ -40,10 +51,12 @@ func resourceAwsCodeDeployAppCreate(d *schema.ResourceData, meta interface{}) er
 	conn := meta.(*AWSClient).codedeployconn
 
 	application := d.Get("name").(string)
+	computePlatform := d.Get("compute_platform").(string)
 	log.Printf("[DEBUG] Creating CodeDeploy application %s", application)
 
 	resp, err := conn.CreateApplication(&codedeploy.CreateApplicationInput{
 		ApplicationName: aws.String(application),
+		ComputePlatform: aws.String(computePlatform),
 	})
 	if err != nil {
 		return err

--- a/aws/resource_aws_codedeploy_app.go
+++ b/aws/resource_aws_codedeploy_app.go
@@ -21,13 +21,13 @@ func resourceAwsCodeDeployApp() *schema.Resource {
 		Delete: resourceAwsCodeDeployAppDelete,
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"compute_platform": &schema.Schema{
+			"compute_platform": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ValidateFunc: validation.StringInSlice([]string{
@@ -38,7 +38,7 @@ func resourceAwsCodeDeployApp() *schema.Resource {
 			},
 
 			// The unique ID is set by AWS on create.
-			"unique_id": &schema.Schema{
+			"unique_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,

--- a/aws/resource_aws_codedeploy_app_test.go
+++ b/aws/resource_aws_codedeploy_app_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/codedeploy"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -27,6 +28,34 @@ func TestAccAWSCodeDeployApp_basic(t *testing.T) {
 				Config: testAccAWSCodeDeployAppModified,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeDeployAppExists("aws_codedeploy_app.foo"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeDeployApp_computePlatform(t *testing.T) {
+	rName := acctest.RandString(5)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeDeployAppDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSCodeDeployAppConfigComputePlatform(rName, "Server"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployAppExists("aws_codedeploy_app.foo"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_app.foo", "compute_platform", "Server"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSCodeDeployAppConfigComputePlatform(rName, "Lambda"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployAppExists("aws_codedeploy_app.foo"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_app.foo", "compute_platform", "Lambda"),
 				),
 			},
 		},
@@ -68,6 +97,14 @@ func testAccCheckAWSCodeDeployAppExists(name string) resource.TestCheckFunc {
 
 		return nil
 	}
+}
+
+func testAccAWSCodeDeployAppConfigComputePlatform(rName string, value string) string {
+	return fmt.Sprintf(`
+resource "aws_codedeploy_app" "foo" {
+	name = "test-codedeploy-app-%s"
+	compute_platform = "%s"
+}`, rName, value)
 }
 
 var testAccAWSCodeDeployApp = `

--- a/aws/resource_aws_codedeploy_app_test.go
+++ b/aws/resource_aws_codedeploy_app_test.go
@@ -21,6 +21,7 @@ func TestAccAWSCodeDeployApp_basic(t *testing.T) {
 			resource.TestStep{
 				Config: testAccAWSCodeDeployApp,
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aws_codedeploy_app.foo", "compute_platform", "Server"),
 					testAccCheckAWSCodeDeployAppExists("aws_codedeploy_app.foo"),
 				),
 			},

--- a/website/docs/r/codedeploy_app.html.markdown
+++ b/website/docs/r/codedeploy_app.html.markdown
@@ -23,7 +23,7 @@ resource "aws_codedeploy_app" "foo" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the application.
-* `compute_platform` - (Optional) The compute platform can either be `SERVER` or `LAMBDA`.
+* `compute_platform` - (Optional) The compute platform can either be `Server` or `Lambda`.
 
 ## Attribute Reference
 

--- a/website/docs/r/codedeploy_app.html.markdown
+++ b/website/docs/r/codedeploy_app.html.markdown
@@ -23,7 +23,7 @@ resource "aws_codedeploy_app" "foo" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the application.
-* `compute_platform` - (Optional) The compute platform can either be `Server` or `Lambda`.
+* `compute_platform` - (Optional) The compute platform can either be `Server` or `Lambda`. Default is `Server`.
 
 ## Attribute Reference
 

--- a/website/docs/r/codedeploy_app.html.markdown
+++ b/website/docs/r/codedeploy_app.html.markdown
@@ -23,6 +23,7 @@ resource "aws_codedeploy_app" "foo" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the application.
+* `compute_platform` - (Optional) The compute platform can either be `SERVER` or `LAMBDA`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
Fixes #3692

Changes proposed in this pull request:

* Add `ComputePlatform` to `CodeDeployApp`

Output from acceptance testing:

```
$ make testacc make testacc TESTARGS='-run=TestAccAWSCodeDeployApp'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSCodeDeployApp -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSCodeDeployApp_basic
--- PASS: TestAccAWSCodeDeployApp_basic (24.20s)
=== RUN   TestAccAWSCodeDeployApp_computePlatform
--- PASS: TestAccAWSCodeDeployApp_computePlatform (23.75s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       58.844s
``