### PR TITLE
Deps: Bump aws-sdk-go@v1.14.5 for ECS schedulingStrategy

### DIFF
--- a/vendor/github.com/aws/aws-sdk-go/aws/credentials/credentials.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/credentials/credentials.go
@@ -178,7 +178,8 @@ func (e *Expiry) IsExpired() bool {
 type Credentials struct {
 	creds        Value
 	forceRefresh bool
-	m            sync.Mutex
+
+	m sync.RWMutex
 
 	provider Provider
 }
@@ -201,6 +202,17 @@ func NewCredentials(provider Provider) *Credentials {
 // If Credentials.Expire() was called the credentials Value will be force
 // expired, and the next call to Get() will cause them to be refreshed.
 func (c *Credentials) Get() (Value, error) {
+	// Check the cached credentials first with just the read lock.
+	c.m.RLock()
+	if !c.isExpired() {
+		creds := c.creds
+		c.m.RUnlock()
+		return creds, nil
+	}
+	c.m.RUnlock()
+
+	// Credentials are expired need to retrieve the credentials taking the full
+	// lock.
 	c.m.Lock()
 	defer c.m.Unlock()
 
@@ -234,8 +246,8 @@ func (c *Credentials) Expire() {
 // If the Credentials were forced to be expired with Expire() this will
 // reflect that override.
 func (c *Credentials) IsExpired() bool {
-	c.m.Lock()
-	defer c.m.Unlock()
+	c.m.RLock()
+	defer c.m.RUnlock()
 
 	return c.isExpired()
 }

--- a/vendor/github.com/aws/aws-sdk-go/aws/request/request.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/request/request.go
@@ -370,9 +370,9 @@ func (r *Request) Build() error {
 	return r.Error
 }
 
-// Sign will sign the request returning error if errors are encountered.
+// Sign will sign the request, returning error if errors are encountered.
 //
-// Send will build the request prior to signing. All Sign Handlers will
+// Sign will build the request prior to signing. All Sign Handlers will
 // be executed in the order they were set.
 func (r *Request) Sign() error {
 	r.Build()
@@ -442,7 +442,7 @@ func (r *Request) GetBody() io.ReadSeeker {
 	return r.safeBody
 }
 
-// Send will send the request returning error if errors are encountered.
+// Send will send the request, returning error if errors are encountered.
 //
 // Send will sign the request prior to sending. All Send Handlers will
 // be executed in the order they were set.

--- a/vendor/github.com/aws/aws-sdk-go/aws/request/request_1_7.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/request/request_1_7.go
@@ -21,7 +21,7 @@ func (noBody) WriteTo(io.Writer) (int64, error) { return 0, nil }
 var NoBody = noBody{}
 
 // ResetBody rewinds the request body back to its starting position, and
-// set's the HTTP Request body reference. When the body is read prior
+// sets the HTTP Request body reference. When the body is read prior
 // to being sent in the HTTP request it will need to be rewound.
 //
 // ResetBody will automatically be called by the SDK's build handler, but if

--- a/vendor/github.com/aws/aws-sdk-go/aws/request/request_1_8.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/request/request_1_8.go
@@ -11,7 +11,7 @@ import (
 var NoBody = http.NoBody
 
 // ResetBody rewinds the request body back to its starting position, and
-// set's the HTTP Request body reference. When the body is read prior
+// sets the HTTP Request body reference. When the body is read prior
 // to being sent in the HTTP request it will need to be rewound.
 //
 // ResetBody will automatically be called by the SDK's build handler, but if

--- a/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/v4.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/v4.go
@@ -135,6 +135,7 @@ var requiredSignedHeaders = rules{
 			"X-Amz-Server-Side-Encryption-Customer-Key-Md5":               struct{}{},
 			"X-Amz-Storage-Class":                                         struct{}{},
 			"X-Amz-Website-Redirect-Location":                             struct{}{},
+			"X-Amz-Content-Sha256":                                        struct{}{},
 		},
 	},
 	patterns{"X-Amz-Meta-"},
@@ -671,8 +672,15 @@ func (ctx *signingCtx) buildSignature() {
 func (ctx *signingCtx) buildBodyDigest() error {
 	hash := ctx.Request.Header.Get("X-Amz-Content-Sha256")
 	if hash == "" {
-		if ctx.unsignedPayload || (ctx.isPresign && ctx.ServiceName == "s3") {
+		includeSHA256Header := ctx.unsignedPayload ||
+			ctx.ServiceName == "s3" ||
+			ctx.ServiceName == "glacier"
+
+		s3Presign := ctx.isPresign && ctx.ServiceName == "s3"
+
+		if ctx.unsignedPayload || s3Presign {
 			hash = "UNSIGNED-PAYLOAD"
+			includeSHA256Header = !s3Presign
 		} else if ctx.Body == nil {
 			hash = emptyStringSHA256
 		} else {
@@ -681,7 +689,8 @@ func (ctx *signingCtx) buildBodyDigest() error {
 			}
 			hash = hex.EncodeToString(makeSha256Reader(ctx.Body))
 		}
-		if ctx.unsignedPayload || ctx.ServiceName == "s3" || ctx.ServiceName == "glacier" {
+
+		if includeSHA256Header {
 			ctx.Request.Header.Set("X-Amz-Content-Sha256", hash)
 		}
 	}

--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.14.1"
+const SDKVersion = "1.14.5"

--- a/vendor/github.com/aws/aws-sdk-go/service/devicefarm/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/devicefarm/api.go
@@ -7105,6 +7105,9 @@ type CreateRemoteAccessSessionConfiguration struct {
 
 	// The billing method for the remote access session.
 	BillingMethod *string `locationName:"billingMethod" type:"string" enum:"BillingMethod"`
+
+	// An array of Amazon Resource Names (ARNs) included in the VPC endpoint configuration.
+	VpceConfigurationArns []*string `locationName:"vpceConfigurationArns" type:"list"`
 }
 
 // String returns the string representation
@@ -7120,6 +7123,12 @@ func (s CreateRemoteAccessSessionConfiguration) GoString() string {
 // SetBillingMethod sets the BillingMethod field's value.
 func (s *CreateRemoteAccessSessionConfiguration) SetBillingMethod(v string) *CreateRemoteAccessSessionConfiguration {
 	s.BillingMethod = &v
+	return s
+}
+
+// SetVpceConfigurationArns sets the VpceConfigurationArns field's value.
+func (s *CreateRemoteAccessSessionConfiguration) SetVpceConfigurationArns(v []*string) *CreateRemoteAccessSessionConfiguration {
+	s.VpceConfigurationArns = v
 	return s
 }
 

--- a/vendor/github.com/aws/aws-sdk-go/service/medialive/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/medialive/api.go
@@ -64,9 +64,9 @@ func (c *MediaLive) CreateChannelRequest(input *CreateChannelInput) (req *reques
 // API operation CreateChannel for usage and error information.
 //
 // Returned Error Codes:
-//   * ErrCodeUnprocessableEntityException "UnprocessableEntityException"
-//
 //   * ErrCodeBadRequestException "BadRequestException"
+//
+//   * ErrCodeUnprocessableEntityException "UnprocessableEntityException"
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
 //
@@ -1492,9 +1492,9 @@ func (c *MediaLive) UpdateChannelRequest(input *UpdateChannelInput) (req *reques
 // API operation UpdateChannel for usage and error information.
 //
 // Returned Error Codes:
-//   * ErrCodeUnprocessableEntityException "UnprocessableEntityException"
-//
 //   * ErrCodeBadRequestException "BadRequestException"
+//
+//   * ErrCodeUnprocessableEntityException "UnprocessableEntityException"
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
 //
@@ -3625,6 +3625,9 @@ type Channel struct {
 
 	InputSpecification *InputSpecification `locationName:"inputSpecification" type:"structure"`
 
+	// The log level being written to CloudWatch Logs.
+	LogLevel *string `locationName:"logLevel" type:"string" enum:"LogLevel"`
+
 	// The name of the channel. (user-mutable)
 	Name *string `locationName:"name" type:"string"`
 
@@ -3686,6 +3689,12 @@ func (s *Channel) SetInputAttachments(v []*InputAttachment) *Channel {
 // SetInputSpecification sets the InputSpecification field's value.
 func (s *Channel) SetInputSpecification(v *InputSpecification) *Channel {
 	s.InputSpecification = v
+	return s
+}
+
+// SetLogLevel sets the LogLevel field's value.
+func (s *Channel) SetLogLevel(v string) *Channel {
+	s.LogLevel = &v
 	return s
 }
 
@@ -3758,6 +3767,9 @@ type ChannelSummary struct {
 
 	InputSpecification *InputSpecification `locationName:"inputSpecification" type:"structure"`
 
+	// The log level being written to CloudWatch Logs.
+	LogLevel *string `locationName:"logLevel" type:"string" enum:"LogLevel"`
+
 	// The name of the channel. (user-mutable)
 	Name *string `locationName:"name" type:"string"`
 
@@ -3816,6 +3828,12 @@ func (s *ChannelSummary) SetInputSpecification(v *InputSpecification) *ChannelSu
 	return s
 }
 
+// SetLogLevel sets the LogLevel field's value.
+func (s *ChannelSummary) SetLogLevel(v string) *ChannelSummary {
+	s.LogLevel = &v
+	return s
+}
+
 // SetName sets the Name field's value.
 func (s *ChannelSummary) SetName(v string) *ChannelSummary {
 	s.Name = &v
@@ -3850,6 +3868,8 @@ type CreateChannelInput struct {
 	InputAttachments []*InputAttachment `locationName:"inputAttachments" type:"list"`
 
 	InputSpecification *InputSpecification `locationName:"inputSpecification" type:"structure"`
+
+	LogLevel *string `locationName:"logLevel" type:"string" enum:"LogLevel"`
 
 	Name *string `locationName:"name" type:"string"`
 
@@ -3916,6 +3936,12 @@ func (s *CreateChannelInput) SetInputAttachments(v []*InputAttachment) *CreateCh
 // SetInputSpecification sets the InputSpecification field's value.
 func (s *CreateChannelInput) SetInputSpecification(v *InputSpecification) *CreateChannelInput {
 	s.InputSpecification = v
+	return s
+}
+
+// SetLogLevel sets the LogLevel field's value.
+func (s *CreateChannelInput) SetLogLevel(v string) *CreateChannelInput {
+	s.LogLevel = &v
 	return s
 }
 
@@ -4147,6 +4173,8 @@ type DeleteChannelOutput struct {
 
 	InputSpecification *InputSpecification `locationName:"inputSpecification" type:"structure"`
 
+	LogLevel *string `locationName:"logLevel" type:"string" enum:"LogLevel"`
+
 	Name *string `locationName:"name" type:"string"`
 
 	PipelinesRunningCount *int64 `locationName:"pipelinesRunningCount" type:"integer"`
@@ -4205,6 +4233,12 @@ func (s *DeleteChannelOutput) SetInputAttachments(v []*InputAttachment) *DeleteC
 // SetInputSpecification sets the InputSpecification field's value.
 func (s *DeleteChannelOutput) SetInputSpecification(v *InputSpecification) *DeleteChannelOutput {
 	s.InputSpecification = v
+	return s
+}
+
+// SetLogLevel sets the LogLevel field's value.
+func (s *DeleteChannelOutput) SetLogLevel(v string) *DeleteChannelOutput {
+	s.LogLevel = &v
 	return s
 }
 
@@ -4385,6 +4419,8 @@ type DescribeChannelOutput struct {
 
 	InputSpecification *InputSpecification `locationName:"inputSpecification" type:"structure"`
 
+	LogLevel *string `locationName:"logLevel" type:"string" enum:"LogLevel"`
+
 	Name *string `locationName:"name" type:"string"`
 
 	PipelinesRunningCount *int64 `locationName:"pipelinesRunningCount" type:"integer"`
@@ -4443,6 +4479,12 @@ func (s *DescribeChannelOutput) SetInputAttachments(v []*InputAttachment) *Descr
 // SetInputSpecification sets the InputSpecification field's value.
 func (s *DescribeChannelOutput) SetInputSpecification(v *InputSpecification) *DescribeChannelOutput {
 	s.InputSpecification = v
+	return s
+}
+
+// SetLogLevel sets the LogLevel field's value.
+func (s *DescribeChannelOutput) SetLogLevel(v string) *DescribeChannelOutput {
+	s.LogLevel = &v
 	return s
 }
 
@@ -10208,6 +10250,8 @@ type StartChannelOutput struct {
 
 	InputSpecification *InputSpecification `locationName:"inputSpecification" type:"structure"`
 
+	LogLevel *string `locationName:"logLevel" type:"string" enum:"LogLevel"`
+
 	Name *string `locationName:"name" type:"string"`
 
 	PipelinesRunningCount *int64 `locationName:"pipelinesRunningCount" type:"integer"`
@@ -10269,6 +10313,12 @@ func (s *StartChannelOutput) SetInputSpecification(v *InputSpecification) *Start
 	return s
 }
 
+// SetLogLevel sets the LogLevel field's value.
+func (s *StartChannelOutput) SetLogLevel(v string) *StartChannelOutput {
+	s.LogLevel = &v
+	return s
+}
+
 // SetName sets the Name field's value.
 func (s *StartChannelOutput) SetName(v string) *StartChannelOutput {
 	s.Name = &v
@@ -10297,7 +10347,9 @@ type StaticKeySettings struct {
 	_ struct{} `type:"structure"`
 
 	// The URL of the license server used for protecting content.
-	KeyProviderServer *InputLocation `locationName:"keyProviderServer" type:"structure"`
+	//
+	// KeyProviderServer is a required field
+	KeyProviderServer *InputLocation `locationName:"keyProviderServer" type:"structure" required:"true"`
 
 	// Static key value as a 32 character hexadecimal string.
 	//
@@ -10318,6 +10370,9 @@ func (s StaticKeySettings) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *StaticKeySettings) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "StaticKeySettings"}
+	if s.KeyProviderServer == nil {
+		invalidParams.Add(request.NewErrParamRequired("KeyProviderServer"))
+	}
 	if s.StaticKeyValue == nil {
 		invalidParams.Add(request.NewErrParamRequired("StaticKeyValue"))
 	}
@@ -10401,6 +10456,8 @@ type StopChannelOutput struct {
 
 	InputSpecification *InputSpecification `locationName:"inputSpecification" type:"structure"`
 
+	LogLevel *string `locationName:"logLevel" type:"string" enum:"LogLevel"`
+
 	Name *string `locationName:"name" type:"string"`
 
 	PipelinesRunningCount *int64 `locationName:"pipelinesRunningCount" type:"integer"`
@@ -10459,6 +10516,12 @@ func (s *StopChannelOutput) SetInputAttachments(v []*InputAttachment) *StopChann
 // SetInputSpecification sets the InputSpecification field's value.
 func (s *StopChannelOutput) SetInputSpecification(v *InputSpecification) *StopChannelOutput {
 	s.InputSpecification = v
+	return s
+}
+
+// SetLogLevel sets the LogLevel field's value.
+func (s *StopChannelOutput) SetLogLevel(v string) *StopChannelOutput {
+	s.LogLevel = &v
 	return s
 }
 
@@ -10788,6 +10851,8 @@ type UpdateChannelInput struct {
 
 	InputSpecification *InputSpecification `locationName:"inputSpecification" type:"structure"`
 
+	LogLevel *string `locationName:"logLevel" type:"string" enum:"LogLevel"`
+
 	Name *string `locationName:"name" type:"string"`
 
 	RoleArn *string `locationName:"roleArn" type:"string"`
@@ -10858,6 +10923,12 @@ func (s *UpdateChannelInput) SetInputAttachments(v []*InputAttachment) *UpdateCh
 // SetInputSpecification sets the InputSpecification field's value.
 func (s *UpdateChannelInput) SetInputSpecification(v *InputSpecification) *UpdateChannelInput {
 	s.InputSpecification = v
+	return s
+}
+
+// SetLogLevel sets the LogLevel field's value.
+func (s *UpdateChannelInput) SetLogLevel(v string) *UpdateChannelInput {
+	s.LogLevel = &v
 	return s
 }
 
@@ -12601,6 +12672,23 @@ const (
 
 	// InputTypeUrlPull is a InputType enum value
 	InputTypeUrlPull = "URL_PULL"
+)
+
+const (
+	// LogLevelError is a LogLevel enum value
+	LogLevelError = "ERROR"
+
+	// LogLevelWarning is a LogLevel enum value
+	LogLevelWarning = "WARNING"
+
+	// LogLevelInfo is a LogLevel enum value
+	LogLevelInfo = "INFO"
+
+	// LogLevelDebug is a LogLevel enum value
+	LogLevelDebug = "DEBUG"
+
+	// LogLevelDisabled is a LogLevel enum value
+	LogLevelDisabled = "DISABLED"
 )
 
 const (

--- a/vendor/github.com/aws/aws-sdk-go/service/rds/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/rds/api.go
@@ -12480,9 +12480,11 @@ type CreateDBInstanceInput struct {
 
 	// The version number of the database engine to use.
 	//
-	// The following are the database engines and major and minor versions that
-	// are available with Amazon RDS. Not every database engine is available for
-	// every AWS Region.
+	// For a list of valid engine versions, call DescribeDBEngineVersions.
+	//
+	// The following are the database engines and links to information about the
+	// major and minor versions that are available with Amazon RDS. Not every database
+	// engine is available for every AWS Region.
 	//
 	// Amazon Aurora
 	//
@@ -12491,98 +12493,28 @@ type CreateDBInstanceInput struct {
 	//
 	// MariaDB
 	//
-	//    * 10.2.12 (supported in all AWS Regions)
+	// See MariaDB on Amazon RDS Versions (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_MariaDB.html#MariaDB.Concepts.VersionMgmt)
+	// in the Amazon RDS User Guide.
 	//
-	//    * 10.2.11 (supported in all AWS Regions)
+	// Microsoft SQL Server
 	//
-	// 10.1.31 (supported in all AWS Regions)
-	//
-	//    * 10.1.26 (supported in all AWS Regions)
-	//
-	//    * 10.1.23 (supported in all AWS Regions)
-	//
-	//    * 10.1.19 (supported in all AWS Regions)
-	//
-	//    * 10.1.14 (supported in all AWS Regions except us-east-2)
-	//
-	//    * 10.0.34 (supported in all AWS Regions)
-	//
-	//    * 10.0.32 (supported in all AWS Regions)
-	//
-	//    * 10.0.31 (supported in all AWS Regions)
-	//
-	//    * 10.0.28 (supported in all AWS Regions)
-	//
-	//    * 10.0.24 (supported in all AWS Regions)
-	//
-	//    * 10.0.17 (supported in all AWS Regions except us-east-2, ca-central-1,
-	//    eu-west-2)
-	//
-	// Microsoft SQL Server 2017
-	//
-	//    * 14.00.1000.169.v1 (supported for all editions, and all AWS Regions)
-	//
-	// Microsoft SQL Server 2016
-	//
-	//    * 13.00.4451.0.v1 (supported for all editions, and all AWS Regions)
-	//
-	//    * 13.00.4422.0.v1 (supported for all editions, and all AWS Regions)
-	//
-	//    * 13.00.2164.0.v1 (supported for all editions, and all AWS Regions)
-	//
-	// Microsoft SQL Server 2014
-	//
-	//    * 12.00.5546.0.v1 (supported for all editions, and all AWS Regions)
-	//
-	//    * 12.00.5000.0.v1 (supported for all editions, and all AWS Regions)
-	//
-	//    * 12.00.4422.0.v1 (supported for all editions except Enterprise Edition,
-	//    and all AWS Regions except ca-central-1 and eu-west-2)
-	//
-	// Microsoft SQL Server 2012
-	//
-	//    * 11.00.6594.0.v1 (supported for all editions, and all AWS Regions)
-	//
-	//    * 11.00.6020.0.v1 (supported for all editions, and all AWS Regions)
-	//
-	//    * 11.00.5058.0.v1 (supported for all editions, and all AWS Regions except
-	//    us-east-2, ca-central-1, and eu-west-2)
-	//
-	//    * 11.00.2100.60.v1 (supported for all editions, and all AWS Regions except
-	//    us-east-2, ca-central-1, and eu-west-2)
-	//
-	// Microsoft SQL Server 2008 R2
-	//
-	//    * 10.50.6529.0.v1 (supported for all editions, and all AWS Regions except
-	//    us-east-2, ca-central-1, and eu-west-2)
-	//
-	//    * 10.50.6000.34.v1 (supported for all editions, and all AWS Regions except
-	//    us-east-2, ca-central-1, and eu-west-2)
-	//
-	//    * 10.50.2789.0.v1 (supported for all editions, and all AWS Regions except
-	//    us-east-2, ca-central-1, and eu-west-2)
+	// See Version and Feature Support on Amazon RDS (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_SQLServer.html#SQLServer.Concepts.General.FeatureSupport)
+	// in the Amazon RDS User Guide.
 	//
 	// MySQL
 	//
-	//    * 5.7.21 (supported in all AWS regions)
+	// See MySQL on Amazon RDS Versions (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_MySQL.html#MySQL.Concepts.VersionMgmt)
+	// in the Amazon RDS User Guide.
 	//
-	//    * 5.7.19 (supported in all AWS regions)
+	// Oracle
 	//
-	//    * 5.7.17 (supported in all AWS regions)
+	// See Oracle Database Engine Release Notes (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.Oracle.PatchComposition.html)
+	// in the Amazon RDS User Guide.
 	//
-	//    * 5.7.16 (supported in all AWS regions)
+	// PostgreSQL
 	//
-	// 5.6.39(supported in all AWS Regions)
-	//
-	// 5.6.37(supported in all AWS Regions)
-	//
-	// 5.6.35(supported in all AWS Regions)
-	//
-	// 5.6.34(supported in all AWS Regions)
-	//
-	// 5.6.29(supported in all AWS Regions)
-	//
-	// 5.6.27
+	// See Supported PostgreSQL Database Versions (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.DBVersions)
+	// in the Amazon RDS User Guide.
 	EngineVersion *string `type:"string"`
 
 	// The amount of Provisioned IOPS (input/output operations per second) to be
@@ -22237,7 +22169,7 @@ type ModifyDBClusterInput struct {
 	// this parameter results in an outage. The change is applied during the next
 	// maintenance window unless the ApplyImmediately parameter is set to true.
 	//
-	// For a list of valid engine versions, see CreateDBInstance, or call DescribeDBEngineVersions.
+	// For a list of valid engine versions, see CreateDBCluster, or call DescribeDBEngineVersions.
 	EngineVersion *string `type:"string"`
 
 	// The new password for the master database user. This password can contain
@@ -22860,7 +22792,8 @@ type ModifyDBInstanceInput struct {
 	// new engine version must be specified. The new DB parameter group can be the
 	// default for that DB parameter group family.
 	//
-	// For a list of valid engine versions, see CreateDBInstance.
+	// For information about valid engine versions, see CreateDBInstance, or call
+	// DescribeDBEngineVersions.
 	EngineVersion *string `type:"string"`
 
 	// The new Provisioned IOPS (I/O operations per second) value for the RDS instance.
@@ -27907,7 +27840,8 @@ type RestoreDBInstanceFromS3Input struct {
 	Engine *string `type:"string" required:"true"`
 
 	// The version number of the database engine to use. Choose the latest minor
-	// version of your database engine as specified in CreateDBInstance.
+	// version of your database engine. For information about engine versions, see
+	// CreateDBInstance, or call DescribeDBEngineVersions.
 	EngineVersion *string `type:"string"`
 
 	// The amount of Provisioned IOPS (input/output operations per second) to allocate

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -39,956 +39,956 @@
 			"revisionTime": "2017-07-27T15:54:43Z"
 		},
 		{
-			"checksumSHA1": "jd5M/MrEpUoJT8nAh4h63J7gKso=",
+			"checksumSHA1": "SB/35IBzZHtqDgGUK90D2Qo0DQs=",
 			"path": "github.com/aws/aws-sdk-go/aws",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "DtuTqKH29YnLjrIJkRYX0HQtXY0=",
 			"path": "github.com/aws/aws-sdk-go/aws/arn",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "Y9W+4GimK4Fuxq+vyIskVYFRnX4=",
 			"path": "github.com/aws/aws-sdk-go/aws/awserr",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "yyYr41HZ1Aq0hWc3J5ijXwYEcac=",
 			"path": "github.com/aws/aws-sdk-go/aws/awsutil",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "hicPtITUionsA+dgs1SpsZUkQu4=",
 			"path": "github.com/aws/aws-sdk-go/aws/client",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "uEJU4I6dTKaraQKvrljlYKUZwoc=",
 			"path": "github.com/aws/aws-sdk-go/aws/client/metadata",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "vVSUnICaD9IaBQisCfw0n8zLwig=",
 			"path": "github.com/aws/aws-sdk-go/aws/corehandlers",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
-			"checksumSHA1": "Y+cPwQL0dZMyqp3wI+KJWmA9KQ8=",
+			"checksumSHA1": "925zPp8gtaXi2gkWrgZ1gAA003A=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "u3GOAJLmdvbuNUeUEcZSEAOeL/0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "NUJUTWlc1sV8b7WjfiYc4JZbXl0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/endpointcreds",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "JEYqmF83O5n5bHkupAzA6STm0no=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "W4R+WW4t2Ty5mbKypFoATk3tqTA=",
 			"path": "github.com/aws/aws-sdk-go/aws/csm",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "HogDW/Wu6ZKTDrQ2HSzG8/vj9Ag=",
 			"path": "github.com/aws/aws-sdk-go/aws/defaults",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "pDnK93CqjQ4ROSW8Y/RuHXjv52M=",
 			"path": "github.com/aws/aws-sdk-go/aws/ec2metadata",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "grMynvpfyTKuULQ6KFTZqQFA76M=",
 			"path": "github.com/aws/aws-sdk-go/aws/endpoints",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
-			"checksumSHA1": "bZRS4Sp4uAL5INdU2oFIaM2az1Y=",
+			"checksumSHA1": "CYLheDSqXftEAmmdj+tTiT+83Ko=",
 			"path": "github.com/aws/aws-sdk-go/aws/request",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "+d8hhT6Ih+DsRpkF44pvw+IkI7w=",
 			"path": "github.com/aws/aws-sdk-go/aws/session",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
-			"checksumSHA1": "BqDC+Sxo3hrC6WYvwx1U4OObaT4=",
+			"checksumSHA1": "u3cA2IiD36A+VnFIH7XtGjYk2NU=",
 			"path": "github.com/aws/aws-sdk-go/aws/signer/v4",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "wjxQlU1PYxrDRFoL1Vek8Wch7jk=",
 			"path": "github.com/aws/aws-sdk-go/internal/sdkio",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "MYLldFRnsZh21TfCkgkXCT3maPU=",
 			"path": "github.com/aws/aws-sdk-go/internal/sdkrand",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "04ypv4x12l4q0TksA1zEVsmgpvw=",
 			"path": "github.com/aws/aws-sdk-go/internal/shareddefaults",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "Ij9RP5HrBWBYYb3/LEMHNNZXH9g=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "GQuRJY72iGQrufDqIaB50zG27u0=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/ec2query",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "2ywNMWQ3qxbz/dzuuOC/42xXzWM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/eventstream",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "/JJPEdYxSgTTDqUDTAaSJQSKNn0=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/eventstream/eventstreamapi",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "yHfT5DTbeCLs4NE2Rgnqrhe15ls=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/json/jsonutil",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "R00RL5jJXRYq1iiK1+PGvMfvXyM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/jsonrpc",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "SBBVYdLcocjdPzMWgDuR8vcOfDQ=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "9V1PvtFQ9MObZTc3sa86WcuOtOU=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "/2Ppb4vP/H+B3cM7bOOEeA7Z0iY=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/rest",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "Rpu8KBtHZgvhkwHxUfaky+qW+G4=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restjson",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "ODo+ko8D6unAxZuN1jGzMcN4QCc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restxml",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "6zosteWJqUGM9+t9dkANQymMA9s=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "F6mth+G7dXN1GI+nktaGo8Lx8aE=",
 			"path": "github.com/aws/aws-sdk-go/private/signer/v2",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "icNLLSAexjtbkVyi/mEoowKn7TM=",
 			"path": "github.com/aws/aws-sdk-go/service/acm",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "HplIlQpFWtaMwe0olJfmoo3sJcc=",
 			"path": "github.com/aws/aws-sdk-go/service/acmpca",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "gheZFdV5PcyzQmYa59dFyS/BYRE=",
 			"path": "github.com/aws/aws-sdk-go/service/apigateway",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "WueKFMAZM7iPJSihPp/0Mry3b5w=",
 			"path": "github.com/aws/aws-sdk-go/service/applicationautoscaling",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "nzUGe3sO4xxtH83cw7rBZq9lyiI=",
 			"path": "github.com/aws/aws-sdk-go/service/appsync",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "dN8v1XcKbVAkfnw+MuQhbip9jTw=",
 			"path": "github.com/aws/aws-sdk-go/service/athena",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "AnXBeqOKS0ad/OmaN9QlFCgSdeY=",
 			"path": "github.com/aws/aws-sdk-go/service/autoscaling",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "z0/DLuHQZzChNvLzUInKV+Lev/k=",
 			"path": "github.com/aws/aws-sdk-go/service/batch",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "s+CV8CfnX7YJLG0zcAa+gvTrq9g=",
 			"path": "github.com/aws/aws-sdk-go/service/budgets",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "yZLZ2ku9xdQHGbOmWBAqUQFtpg0=",
 			"path": "github.com/aws/aws-sdk-go/service/cloud9",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "lKIc8G2LzbdDilnsUdPFzXpIZN0=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudformation",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "qGchJkU7EOQ6+Sw97pYZ5jNdemE=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudfront",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "Cw8nuWo0kgac7Ospu6pcPiWGLP8=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudhsmv2",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "UpLN7n+Gh5GH4MQxaAz8rv8jJXg=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudsearch",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "TI5seh5lq95G6sAl8zvjPAYbPrE=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudtrail",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "N4DxAf2obzkWyhZXi6sjzvrvfkE=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatch",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "k8qFGvgSm7+IxvsBwubScOheA5I=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchevents",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "gyc9YgSiM3BUm0xq2bq6wAjIye4=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "nRCAv4j8pK6Yo0Cct1sO6UqtUsc=",
 			"path": "github.com/aws/aws-sdk-go/service/codebuild",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "PkFtAdj1+DkwlDynYcA0qk0Ie1Q=",
 			"path": "github.com/aws/aws-sdk-go/service/codecommit",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "jNdpbNmmirlluTWU9FFUIOcOtOw=",
 			"path": "github.com/aws/aws-sdk-go/service/codedeploy",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "hrxEpIJA4pw/QIvsQGRA5ie8u3Q=",
 			"path": "github.com/aws/aws-sdk-go/service/codepipeline",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "VICTgoxfIUQDmEPzz/x+vNAVWdU=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentity",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "SsvLlbsC9ivlJ8HNE4/EpFXlJSE=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentityprovider",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "OHN5BEcmi7CJIlx+6Uze+aMA49s=",
 			"path": "github.com/aws/aws-sdk-go/service/configservice",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "5tc1cqGB2fQvgbm5Dy2xRkw5hAU=",
 			"path": "github.com/aws/aws-sdk-go/service/databasemigrationservice",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "NzIc6fQDS/r7cPiS+mymXIwAZ2o=",
 			"path": "github.com/aws/aws-sdk-go/service/dax",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
-			"checksumSHA1": "uuqJ5z51az/x5eeyMTJByCSK9oo=",
+			"checksumSHA1": "o0nYsx8mGrJEAVhwJIfxnRDb93I=",
 			"path": "github.com/aws/aws-sdk-go/service/devicefarm",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "txT38J2l/2IRxx0zBfLgo6wfsCk=",
 			"path": "github.com/aws/aws-sdk-go/service/directconnect",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "yp4/e0fwfubFFvVwf5fjCq8+g8A=",
 			"path": "github.com/aws/aws-sdk-go/service/directoryservice",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "84L48NhMSrhczhlhgJWwZ/IV3R0=",
 			"path": "github.com/aws/aws-sdk-go/service/dynamodb",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "cuffkFl2LN+J/n8KG7pi3DL4+W0=",
 			"path": "github.com/aws/aws-sdk-go/service/ec2",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "IVYXmukn+rPCj0Sq/VEdnXIbams=",
 			"path": "github.com/aws/aws-sdk-go/service/ecr",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
-			"checksumSHA1": "5v6Vm7xP2EmyuYhMULE35V+rwxc=",
+			"checksumSHA1": "xQUSLO+otgiCywMlVCyeCitD644=",
 			"path": "github.com/aws/aws-sdk-go/service/ecs",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "65m8IegeLtRStO3Vlsk1n1xjctk=",
 			"path": "github.com/aws/aws-sdk-go/service/efs",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "b94Lg6Cd3RFRKfKBrOVpjkrVh/Y=",
 			"path": "github.com/aws/aws-sdk-go/service/eks",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "z9BRP3NdNqas2z81TySw2dujS3A=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticache",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "wVSdzCjBAE3enZXGlQqQhwe1t84=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticbeanstalk",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "iGNKg4PFBRfB6DX3TMv6K2sP7QQ=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticsearchservice",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "XSffwdsnhaFywzoP2yxkjPaJf1Y=",
 			"path": "github.com/aws/aws-sdk-go/service/elastictranscoder",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "dRf+FPPbJm74GqF3BDbaoaf5KbM=",
 			"path": "github.com/aws/aws-sdk-go/service/elb",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "tnBLz+je0qxfYTfOWqZVyzCVajI=",
 			"path": "github.com/aws/aws-sdk-go/service/elbv2",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "F0m/QORHlxssOUE3bksmZTrpyzM=",
 			"path": "github.com/aws/aws-sdk-go/service/emr",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "0XG6jo3rddARKG79z5ryqB3Zb7M=",
 			"path": "github.com/aws/aws-sdk-go/service/firehose",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "l1UuSbyIJYSLB/dE/RLjHHr6+g0=",
 			"path": "github.com/aws/aws-sdk-go/service/fms",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "MWYtV542JKbmzC0WqmklCp8u34g=",
 			"path": "github.com/aws/aws-sdk-go/service/gamelift",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "lHpe5oh6xF3tATbJ0hA8YwpZqP4=",
 			"path": "github.com/aws/aws-sdk-go/service/glacier",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "yxQpD1A+3Vxe3IKGX/Jwve0tkJ0=",
 			"path": "github.com/aws/aws-sdk-go/service/glue",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "amSxqxRb2nDFXm9vPasvG24C904=",
 			"path": "github.com/aws/aws-sdk-go/service/guardduty",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "2fW5rVTwFXBjEsV8TfQNdibLQQM=",
 			"path": "github.com/aws/aws-sdk-go/service/iam",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "ArB4JBn8TxkODaCzg3o7JaCe1TA=",
 			"path": "github.com/aws/aws-sdk-go/service/inspector",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "Pj10knRcMdJvMk8PonY3QEaXhOc=",
 			"path": "github.com/aws/aws-sdk-go/service/iot",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "vJCPPvHq0jmGC1GEf4SrsjUHRxk=",
 			"path": "github.com/aws/aws-sdk-go/service/kinesis",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "ARppTdal/LnCl/FXh28Ii31GQMs=",
 			"path": "github.com/aws/aws-sdk-go/service/kms",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "3EVmOU4ALB/2+lxV+y8eFmCGvb4=",
 			"path": "github.com/aws/aws-sdk-go/service/lambda",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "wrEpYDyNKpsXNsPoV2r/q6VnLzM=",
 			"path": "github.com/aws/aws-sdk-go/service/lexmodelbuildingservice",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "4/xr/6I0+oOyOcpN2HbIr31OVxc=",
 			"path": "github.com/aws/aws-sdk-go/service/lightsail",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "wcU0JF5+gkSK0B4tt7tltDC1fmw=",
 			"path": "github.com/aws/aws-sdk-go/service/mediaconvert",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
-			"checksumSHA1": "4NwpxCnTyKCH7TBmMOtySrpNOt8=",
+			"checksumSHA1": "59WNio3jETOsju0fKep+jLiudck=",
 			"path": "github.com/aws/aws-sdk-go/service/medialive",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "C0IVbo/IIqtwjN9FzBP2xuN9tVE=",
 			"path": "github.com/aws/aws-sdk-go/service/mediapackage",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "t/R/0xU0mufuVqFm7eupnGJHEMY=",
 			"path": "github.com/aws/aws-sdk-go/service/mediastore",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "JblylaVkaXAJpDarZTfOoqEOzPA=",
 			"path": "github.com/aws/aws-sdk-go/service/mediastoredata",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "u0iow8ORt9b268lcJAVCVPbOIww=",
 			"path": "github.com/aws/aws-sdk-go/service/mq",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "1MgcJOzhM8dpb8ioMiYKZUusUR8=",
 			"path": "github.com/aws/aws-sdk-go/service/neptune",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "3fL2AHxNGt5Zneao0L0rPWicP+A=",
 			"path": "github.com/aws/aws-sdk-go/service/opsworks",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "8+Ut2yZlstbgm65CRwoJvDenGZY=",
 			"path": "github.com/aws/aws-sdk-go/service/organizations",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
-			"checksumSHA1": "YWHpuQygA/9YhQ42HGr8tvTlPr0=",
+			"checksumSHA1": "QGUC3zDm5lKE+RYZsqvG4QAl53g=",
 			"path": "github.com/aws/aws-sdk-go/service/rds",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "W5RS2LpTpmZcg5Zx/XZ4dC337Ts=",
 			"path": "github.com/aws/aws-sdk-go/service/redshift",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "lFXM8XpT1dzK+5hazyEY2zgrqAk=",
 			"path": "github.com/aws/aws-sdk-go/service/route53",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "YmZtX0SKULpSeWWtmq15Etnxdj4=",
 			"path": "github.com/aws/aws-sdk-go/service/s3",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "9yFRAnN7WYBGrqhuTiG9de9czaM=",
 			"path": "github.com/aws/aws-sdk-go/service/sagemaker",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "EOrj5kAayRQsGyiROCSn7dTdTHo=",
 			"path": "github.com/aws/aws-sdk-go/service/secretsmanager",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "PVO2BA9vUNGnBLc4MXdlDKBZwv8=",
 			"path": "github.com/aws/aws-sdk-go/service/servicecatalog",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "/kV4ehPl3wDXCpz5bKBvetJzX+I=",
 			"path": "github.com/aws/aws-sdk-go/service/servicediscovery",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "pP0jHii9PCvEsmrmgnFzgU2b3xA=",
 			"path": "github.com/aws/aws-sdk-go/service/ses",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "yrnNkOvlN6kG8KfO+NZ5fZA5hew=",
 			"path": "github.com/aws/aws-sdk-go/service/sfn",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "FxyGpQxZZj95K+HmtFtkJZEXi5E=",
 			"path": "github.com/aws/aws-sdk-go/service/simpledb",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "sEeC7D4grNggaKxWcofBQX/HyAw=",
 			"path": "github.com/aws/aws-sdk-go/service/sns",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "c7VBBFkctgWKeIbnwuuKmYpzocQ=",
 			"path": "github.com/aws/aws-sdk-go/service/sqs",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "P6qcqRs7eQQoUBXR/GtNaOLtJUc=",
 			"path": "github.com/aws/aws-sdk-go/service/ssm",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "8oXVUCBenZzaXkvkfx5H7hDEpnY=",
 			"path": "github.com/aws/aws-sdk-go/service/sts",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "Wy0MZEERBJE4cKOzIX3LW/cV2CU=",
 			"path": "github.com/aws/aws-sdk-go/service/swf",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "b8m3sDM8RBL16Su60vWEVLbYGvA=",
 			"path": "github.com/aws/aws-sdk-go/service/waf",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "kaO7lKAVw7wdfBF9qW6WhaBKBMQ=",
 			"path": "github.com/aws/aws-sdk-go/service/wafregional",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "QQEtSKxzvK3pYO4S0+JjtsJypmw=",
 			"path": "github.com/aws/aws-sdk-go/service/workspaces",
-			"revision": "47309c012812d9e9c488a54313e5cdfa7479df93",
-			"revisionTime": "2018-06-05T23:03:32Z",
-			"version": "v1.14.1",
-			"versionExact": "v1.14.1"
+			"revision": "4bdf3e6f6926903b8ca6b0d2b93bbdddcf6af219",
+			"revisionTime": "2018-06-12T21:46:25Z",
+			"version": "v1.14.5",
+			"versionExact": "v1.14.5"
 		},
 		{
 			"checksumSHA1": "usT4LCSQItkFvFOQT7cBlkCuGaE=",


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Dependency of #4820

Changes proposed in this pull request:

* update aws-sdk-go to [1.14.5](https://github.com/aws/aws-sdk-go/releases/tag/v1.14.5) to support ECS schedulingStrategy

Output from acceptance testing: Handled via daily acceptance testing
