### PR TITLE
resource/aws_kinesis_firehose_delivery_stream: Support data_format_conversion_configuration

### DIFF
--- a/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -387,10 +387,9 @@ func flattenFirehoseOpenXJsonSerDe(oxjsd *firehose.OpenXJsonSerDe) []map[string]
 	// API omits default values
 	// Return defaults that are not type zero values to prevent extraneous difference
 
+	m["case_insensitive"] = true
 	if oxjsd.CaseInsensitive != nil {
 		m["case_insensitive"] = aws.BoolValue(oxjsd.CaseInsensitive)
-	} else {
-		m["case_insensitive"] = true
 	}
 
 	return []map[string]interface{}{m}
@@ -435,46 +434,39 @@ func flattenFirehoseOrcSerDe(osd *firehose.OrcSerDe) []map[string]interface{} {
 	// API omits default values
 	// Return defaults that are not type zero values to prevent extraneous difference
 
+	m["block_size_bytes"] = 268435456
 	if osd.BlockSizeBytes != nil {
 		m["block_size_bytes"] = int(aws.Int64Value(osd.BlockSizeBytes))
-	} else {
-		m["block_size_bytes"] = 268435456
 	}
 
+	m["bloom_filter_false_positive_probability"] = 0.05
 	if osd.BloomFilterFalsePositiveProbability != nil {
 		m["bloom_filter_false_positive_probability"] = aws.Float64Value(osd.BloomFilterFalsePositiveProbability)
-	} else {
-		m["bloom_filter_false_positive_probability"] = 0.05
 	}
 
+	m["compression"] = firehose.OrcCompressionSnappy
 	if osd.Compression != nil {
 		m["compression"] = aws.StringValue(osd.Compression)
-	} else {
-		m["compression"] = firehose.OrcCompressionSnappy
 	}
 
+	m["format_version"] = firehose.OrcFormatVersionV012
 	if osd.FormatVersion != nil {
 		m["format_version"] = aws.StringValue(osd.FormatVersion)
-	} else {
-		m["format_version"] = firehose.OrcFormatVersionV012
 	}
 
+	m["padding_tolerance"] = 0.05
 	if osd.PaddingTolerance != nil {
 		m["padding_tolerance"] = aws.Float64Value(osd.PaddingTolerance)
-	} else {
-		m["padding_tolerance"] = 0.05
 	}
 
+	m["row_index_stride"] = 10000
 	if osd.RowIndexStride != nil {
 		m["row_index_stride"] = int(aws.Int64Value(osd.RowIndexStride))
-	} else {
-		m["row_index_stride"] = 10000
 	}
 
+	m["stripe_size_bytes"] = 67108864
 	if osd.StripeSizeBytes != nil {
 		m["stripe_size_bytes"] = int(aws.Int64Value(osd.StripeSizeBytes))
-	} else {
-		m["stripe_size_bytes"] = 67108864
 	}
 
 	return []map[string]interface{}{m}
@@ -493,28 +485,24 @@ func flattenFirehoseParquetSerDe(psd *firehose.ParquetSerDe) []map[string]interf
 	// API omits default values
 	// Return defaults that are not type zero values to prevent extraneous difference
 
+	m["block_size_bytes"] = 268435456
 	if psd.BlockSizeBytes != nil {
 		m["block_size_bytes"] = int(aws.Int64Value(psd.BlockSizeBytes))
-	} else {
-		m["block_size_bytes"] = 268435456
 	}
 
+	m["compression"] = firehose.ParquetCompressionSnappy
 	if psd.Compression != nil {
 		m["compression"] = aws.StringValue(psd.Compression)
-	} else {
-		m["compression"] = firehose.ParquetCompressionSnappy
 	}
 
+	m["page_size_bytes"] = 1048576
 	if psd.PageSizeBytes != nil {
 		m["page_size_bytes"] = int(aws.Int64Value(psd.PageSizeBytes))
-	} else {
-		m["page_size_bytes"] = 1048576
 	}
 
+	m["writer_version"] = firehose.ParquetWriterVersionV1
 	if psd.WriterVersion != nil {
 		m["writer_version"] = aws.StringValue(psd.WriterVersion)
-	} else {
-		m["writer_version"] = firehose.ParquetWriterVersionV1
 	}
 
 	return []map[string]interface{}{m}

--- a/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -759,9 +759,10 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 													Elem: &schema.Resource{
 														Schema: map[string]*schema.Schema{
 															"hive_json_ser_de": {
-																Type:     schema.TypeList,
-																Optional: true,
-																MaxItems: 1,
+																Type:          schema.TypeList,
+																Optional:      true,
+																MaxItems:      1,
+																ConflictsWith: []string{"extended_s3_configuration.0.data_format_conversion_configuration.0.input_format_configuration.0.deserializer.0.open_x_json_ser_de"},
 																Elem: &schema.Resource{
 																	Schema: map[string]*schema.Schema{
 																		"timestamp_formats": {
@@ -773,9 +774,10 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 																},
 															},
 															"open_x_json_ser_de": {
-																Type:     schema.TypeList,
-																Optional: true,
-																MaxItems: 1,
+																Type:          schema.TypeList,
+																Optional:      true,
+																MaxItems:      1,
+																ConflictsWith: []string{"extended_s3_configuration.0.data_format_conversion_configuration.0.input_format_configuration.0.deserializer.0.hive_json_ser_de"},
 																Elem: &schema.Resource{
 																	Schema: map[string]*schema.Schema{
 																		"case_insensitive": {
@@ -815,9 +817,10 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 													Elem: &schema.Resource{
 														Schema: map[string]*schema.Schema{
 															"orc_ser_de": {
-																Type:     schema.TypeList,
-																Optional: true,
-																MaxItems: 1,
+																Type:          schema.TypeList,
+																Optional:      true,
+																MaxItems:      1,
+																ConflictsWith: []string{"extended_s3_configuration.0.data_format_conversion_configuration.0.output_format_configuration.0.serializer.0.parquet_ser_de"},
 																Elem: &schema.Resource{
 																	Schema: map[string]*schema.Schema{
 																		"block_size_bytes": {
@@ -890,9 +893,10 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 																},
 															},
 															"parquet_ser_de": {
-																Type:     schema.TypeList,
-																Optional: true,
-																MaxItems: 1,
+																Type:          schema.TypeList,
+																Optional:      true,
+																MaxItems:      1,
+																ConflictsWith: []string{"extended_s3_configuration.0.data_format_conversion_configuration.0.output_format_configuration.0.serializer.0.orc_ser_de"},
 																Elem: &schema.Resource{
 																	Schema: map[string]*schema.Schema{
 																		"block_size_bytes": {

--- a/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -7,14 +7,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/terraform/helper/validation"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/firehose"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func cloudWatchLoggingOptionsSchema() *schema.Schema {
@@ -838,13 +837,6 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 																			Optional: true,
 																			// 256 MiB
 																			Default: 268435456,
-																			// // API sometimes omits default value
-																			// DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-																			// 	if old == "" && new == "268435456" {
-																			// 		return true
-																			// 	}
-																			// 	return false
-																			// },
 																			// 64 MiB
 																			ValidateFunc: validation.IntAtLeast(67108864),
 																		},
@@ -857,13 +849,6 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 																			Type:     schema.TypeFloat,
 																			Optional: true,
 																			Default:  0.05,
-																			// // API sometimes omits default value
-																			// DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-																			// 	if old == "" && new == "0.05" {
-																			// 		return true
-																			// 	}
-																			// 	return false
-																			// },
 																		},
 																		"compression": {
 																			Type:     schema.TypeString,
@@ -898,25 +883,11 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 																			Type:     schema.TypeFloat,
 																			Optional: true,
 																			Default:  0.05,
-																			// // API sometimes omits default value
-																			// DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-																			// 	if old == "" && new == "0.05" {
-																			// 		return true
-																			// 	}
-																			// 	return false
-																			// },
 																		},
 																		"row_index_stride": {
-																			Type:     schema.TypeInt,
-																			Optional: true,
-																			Default:  10000,
-																			// // API sometimes omits default value
-																			// DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-																			// 	if old == "" && new == "10000" {
-																			// 		return true
-																			// 	}
-																			// 	return false
-																			// },
+																			Type:         schema.TypeInt,
+																			Optional:     true,
+																			Default:      10000,
 																			ValidateFunc: validation.IntAtLeast(1000),
 																		},
 																		"stripe_size_bytes": {
@@ -924,13 +895,6 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 																			Optional: true,
 																			// 64 MiB
 																			Default: 67108864,
-																			// // API sometimes omits default value
-																			// DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-																			// 	if old == "" && new == "67108864" {
-																			// 		return true
-																			// 	}
-																			// 	return false
-																			// },
 																			// 8 MiB
 																			ValidateFunc: validation.IntAtLeast(8388608),
 																		},
@@ -948,13 +912,6 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 																			Optional: true,
 																			// 256 MiB
 																			Default: 268435456,
-																			// // API sometimes omits default value
-																			// DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-																			// 	if old == "268435456" && new == "" {
-																			// 		return true
-																			// 	}
-																			// 	return false
-																			// },
 																			// 64 MiB
 																			ValidateFunc: validation.IntAtLeast(67108864),
 																		},
@@ -983,13 +940,6 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 																			Optional: true,
 																			// 1 MiB
 																			Default: 1048576,
-																			// // API sometimes omits default value
-																			// DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-																			// 	if old == "1048576" && new == "" {
-																			// 		return true
-																			// 	}
-																			// 	return false
-																			// },
 																			// 64 KiB
 																			ValidateFunc: validation.IntAtLeast(65536),
 																		},

--- a/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform/helper/validation"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/firehose"
@@ -223,14 +225,15 @@ func flattenFirehoseExtendedS3Configuration(description *firehose.ExtendedS3Dest
 	}
 
 	m := map[string]interface{}{
-		"bucket_arn":                 aws.StringValue(description.BucketARN),
-		"cloudwatch_logging_options": flattenCloudwatchLoggingOptions(description.CloudWatchLoggingOptions),
-		"compression_format":         aws.StringValue(description.CompressionFormat),
-		"prefix":                     aws.StringValue(description.Prefix),
-		"processing_configuration":   flattenProcessingConfiguration(description.ProcessingConfiguration, aws.StringValue(description.RoleARN)),
-		"role_arn":                   aws.StringValue(description.RoleARN),
-		"s3_backup_configuration":    flattenFirehoseS3Configuration(description.S3BackupDescription),
-		"s3_backup_mode":             aws.StringValue(description.S3BackupMode),
+		"bucket_arn":                           aws.StringValue(description.BucketARN),
+		"cloudwatch_logging_options":           flattenCloudwatchLoggingOptions(description.CloudWatchLoggingOptions),
+		"compression_format":                   aws.StringValue(description.CompressionFormat),
+		"data_format_conversion_configuration": flattenFirehoseDataFormatConversionConfiguration(description.DataFormatConversionConfiguration),
+		"prefix":                   aws.StringValue(description.Prefix),
+		"processing_configuration": flattenProcessingConfiguration(description.ProcessingConfiguration, aws.StringValue(description.RoleARN)),
+		"role_arn":                 aws.StringValue(description.RoleARN),
+		"s3_backup_configuration":  flattenFirehoseS3Configuration(description.S3BackupDescription),
+		"s3_backup_mode":           aws.StringValue(description.S3BackupMode),
 	}
 
 	if description.BufferingHints != nil {
@@ -315,6 +318,221 @@ func flattenFirehoseS3Configuration(description *firehose.S3DestinationDescripti
 
 	if description.EncryptionConfiguration != nil && description.EncryptionConfiguration.KMSEncryptionConfig != nil {
 		m["kms_key_arn"] = aws.StringValue(description.EncryptionConfiguration.KMSEncryptionConfig.AWSKMSKeyARN)
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func flattenFirehoseDataFormatConversionConfiguration(dfcc *firehose.DataFormatConversionConfiguration) []map[string]interface{} {
+	if dfcc == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"enabled":                     aws.BoolValue(dfcc.Enabled),
+		"input_format_configuration":  flattenFirehoseInputFormatConfiguration(dfcc.InputFormatConfiguration),
+		"output_format_configuration": flattenFirehoseOutputFormatConfiguration(dfcc.OutputFormatConfiguration),
+		"schema_configuration":        flattenFirehoseSchemaConfiguration(dfcc.SchemaConfiguration),
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func flattenFirehoseInputFormatConfiguration(ifc *firehose.InputFormatConfiguration) []map[string]interface{} {
+	if ifc == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"deserializer": flattenFirehoseDeserializer(ifc.Deserializer),
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func flattenFirehoseDeserializer(deserializer *firehose.Deserializer) []map[string]interface{} {
+	if deserializer == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"hive_json_ser_de":   flattenFirehoseHiveJsonSerDe(deserializer.HiveJsonSerDe),
+		"open_x_json_ser_de": flattenFirehoseOpenXJsonSerDe(deserializer.OpenXJsonSerDe),
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func flattenFirehoseHiveJsonSerDe(hjsd *firehose.HiveJsonSerDe) []map[string]interface{} {
+	if hjsd == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"timestamp_formats": flattenStringList(hjsd.TimestampFormats),
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func flattenFirehoseOpenXJsonSerDe(oxjsd *firehose.OpenXJsonSerDe) []map[string]interface{} {
+	if oxjsd == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"column_to_json_key_mappings":              aws.StringValueMap(oxjsd.ColumnToJsonKeyMappings),
+		"convert_dots_in_json_keys_to_underscores": aws.BoolValue(oxjsd.ConvertDotsInJsonKeysToUnderscores),
+	}
+
+	// API omits default values
+	// Return defaults that are not type zero values to prevent extraneous difference
+
+	if oxjsd.CaseInsensitive != nil {
+		m["case_insensitive"] = aws.BoolValue(oxjsd.CaseInsensitive)
+	} else {
+		m["case_insensitive"] = true
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func flattenFirehoseOutputFormatConfiguration(ofc *firehose.OutputFormatConfiguration) []map[string]interface{} {
+	if ofc == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"serializer": flattenFirehoseSerializer(ofc.Serializer),
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func flattenFirehoseSerializer(serializer *firehose.Serializer) []map[string]interface{} {
+	if serializer == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"orc_ser_de":     flattenFirehoseOrcSerDe(serializer.OrcSerDe),
+		"parquet_ser_de": flattenFirehoseParquetSerDe(serializer.ParquetSerDe),
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func flattenFirehoseOrcSerDe(osd *firehose.OrcSerDe) []map[string]interface{} {
+	if osd == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"bloom_filter_columns":     aws.StringValueSlice(osd.BloomFilterColumns),
+		"dictionary_key_threshold": aws.Float64Value(osd.DictionaryKeyThreshold),
+		"enable_padding":           aws.BoolValue(osd.EnablePadding),
+	}
+
+	// API omits default values
+	// Return defaults that are not type zero values to prevent extraneous difference
+
+	if osd.BlockSizeBytes != nil {
+		m["block_size_bytes"] = int(aws.Int64Value(osd.BlockSizeBytes))
+	} else {
+		m["block_size_bytes"] = 268435456
+	}
+
+	if osd.BloomFilterFalsePositiveProbability != nil {
+		m["bloom_filter_false_positive_probability"] = aws.Float64Value(osd.BloomFilterFalsePositiveProbability)
+	} else {
+		m["bloom_filter_false_positive_probability"] = 0.05
+	}
+
+	if osd.Compression != nil {
+		m["compression"] = aws.StringValue(osd.Compression)
+	} else {
+		m["compression"] = firehose.OrcCompressionSnappy
+	}
+
+	if osd.FormatVersion != nil {
+		m["format_version"] = aws.StringValue(osd.FormatVersion)
+	} else {
+		m["format_version"] = firehose.OrcFormatVersionV012
+	}
+
+	if osd.PaddingTolerance != nil {
+		m["padding_tolerance"] = aws.Float64Value(osd.PaddingTolerance)
+	} else {
+		m["padding_tolerance"] = 0.05
+	}
+
+	if osd.RowIndexStride != nil {
+		m["row_index_stride"] = int(aws.Int64Value(osd.RowIndexStride))
+	} else {
+		m["row_index_stride"] = 10000
+	}
+
+	if osd.StripeSizeBytes != nil {
+		m["stripe_size_bytes"] = int(aws.Int64Value(osd.StripeSizeBytes))
+	} else {
+		m["stripe_size_bytes"] = 67108864
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func flattenFirehoseParquetSerDe(psd *firehose.ParquetSerDe) []map[string]interface{} {
+	if psd == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"enable_dictionary_compression": aws.BoolValue(psd.EnableDictionaryCompression),
+		"max_padding_bytes":             int(aws.Int64Value(psd.MaxPaddingBytes)),
+	}
+
+	// API omits default values
+	// Return defaults that are not type zero values to prevent extraneous difference
+
+	if psd.BlockSizeBytes != nil {
+		m["block_size_bytes"] = int(aws.Int64Value(psd.BlockSizeBytes))
+	} else {
+		m["block_size_bytes"] = 268435456
+	}
+
+	if psd.Compression != nil {
+		m["compression"] = aws.StringValue(psd.Compression)
+	} else {
+		m["compression"] = firehose.ParquetCompressionSnappy
+	}
+
+	if psd.PageSizeBytes != nil {
+		m["page_size_bytes"] = int(aws.Int64Value(psd.PageSizeBytes))
+	} else {
+		m["page_size_bytes"] = 1048576
+	}
+
+	if psd.WriterVersion != nil {
+		m["writer_version"] = aws.StringValue(psd.WriterVersion)
+	} else {
+		m["writer_version"] = firehose.ParquetWriterVersionV1
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func flattenFirehoseSchemaConfiguration(sc *firehose.SchemaConfiguration) []map[string]interface{} {
+	if sc == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"catalog_id":    aws.StringValue(sc.CatalogId),
+		"database_name": aws.StringValue(sc.DatabaseName),
+		"region":        aws.StringValue(sc.Region),
+		"role_arn":      aws.StringValue(sc.RoleARN),
+		"table_name":    aws.StringValue(sc.TableName),
+		"version_id":    aws.StringValue(sc.VersionId),
 	}
 
 	return []map[string]interface{}{m}
@@ -528,6 +746,309 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							Default:  "UNCOMPRESSED",
+						},
+
+						"data_format_conversion_configuration": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Default:  true,
+									},
+									"input_format_configuration": {
+										Type:     schema.TypeList,
+										Required: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"deserializer": {
+													Type:     schema.TypeList,
+													Required: true,
+													MaxItems: 1,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"hive_json_ser_de": {
+																Type:     schema.TypeList,
+																Optional: true,
+																MaxItems: 1,
+																Elem: &schema.Resource{
+																	Schema: map[string]*schema.Schema{
+																		"timestamp_formats": {
+																			Type:     schema.TypeList,
+																			Optional: true,
+																			Elem:     &schema.Schema{Type: schema.TypeString},
+																		},
+																	},
+																},
+															},
+															"open_x_json_ser_de": {
+																Type:     schema.TypeList,
+																Optional: true,
+																MaxItems: 1,
+																Elem: &schema.Resource{
+																	Schema: map[string]*schema.Schema{
+																		"case_insensitive": {
+																			Type:     schema.TypeBool,
+																			Optional: true,
+																			Default:  true,
+																		},
+																		"column_to_json_key_mappings": {
+																			Type:     schema.TypeMap,
+																			Optional: true,
+																			Elem:     &schema.Schema{Type: schema.TypeString},
+																		},
+																		"convert_dots_in_json_keys_to_underscores": {
+																			Type:     schema.TypeBool,
+																			Optional: true,
+																			Default:  false,
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+									"output_format_configuration": {
+										Type:     schema.TypeList,
+										Required: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"serializer": {
+													Type:     schema.TypeList,
+													Required: true,
+													MaxItems: 1,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"orc_ser_de": {
+																Type:     schema.TypeList,
+																Optional: true,
+																MaxItems: 1,
+																Elem: &schema.Resource{
+																	Schema: map[string]*schema.Schema{
+																		"block_size_bytes": {
+																			Type:     schema.TypeInt,
+																			Optional: true,
+																			// 256 MiB
+																			Default: 268435456,
+																			// // API sometimes omits default value
+																			// DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+																			// 	if old == "" && new == "268435456" {
+																			// 		return true
+																			// 	}
+																			// 	return false
+																			// },
+																			// 64 MiB
+																			ValidateFunc: validation.IntAtLeast(67108864),
+																		},
+																		"bloom_filter_columns": {
+																			Type:     schema.TypeList,
+																			Optional: true,
+																			Elem:     &schema.Schema{Type: schema.TypeString},
+																		},
+																		"bloom_filter_false_positive_probability": {
+																			Type:     schema.TypeFloat,
+																			Optional: true,
+																			Default:  0.05,
+																			// // API sometimes omits default value
+																			// DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+																			// 	if old == "" && new == "0.05" {
+																			// 		return true
+																			// 	}
+																			// 	return false
+																			// },
+																		},
+																		"compression": {
+																			Type:     schema.TypeString,
+																			Optional: true,
+																			Default:  firehose.OrcCompressionSnappy,
+																			ValidateFunc: validation.StringInSlice([]string{
+																				firehose.OrcCompressionNone,
+																				firehose.OrcCompressionSnappy,
+																				firehose.OrcCompressionZlib,
+																			}, false),
+																		},
+																		"dictionary_key_threshold": {
+																			Type:     schema.TypeFloat,
+																			Optional: true,
+																			Default:  0.0,
+																		},
+																		"enable_padding": {
+																			Type:     schema.TypeBool,
+																			Optional: true,
+																			Default:  false,
+																		},
+																		"format_version": {
+																			Type:     schema.TypeString,
+																			Optional: true,
+																			Default:  firehose.OrcFormatVersionV012,
+																			ValidateFunc: validation.StringInSlice([]string{
+																				firehose.OrcFormatVersionV011,
+																				firehose.OrcFormatVersionV012,
+																			}, false),
+																		},
+																		"padding_tolerance": {
+																			Type:     schema.TypeFloat,
+																			Optional: true,
+																			Default:  0.05,
+																			// // API sometimes omits default value
+																			// DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+																			// 	if old == "" && new == "0.05" {
+																			// 		return true
+																			// 	}
+																			// 	return false
+																			// },
+																		},
+																		"row_index_stride": {
+																			Type:     schema.TypeInt,
+																			Optional: true,
+																			Default:  10000,
+																			// // API sometimes omits default value
+																			// DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+																			// 	if old == "" && new == "10000" {
+																			// 		return true
+																			// 	}
+																			// 	return false
+																			// },
+																			ValidateFunc: validation.IntAtLeast(1000),
+																		},
+																		"stripe_size_bytes": {
+																			Type:     schema.TypeInt,
+																			Optional: true,
+																			// 64 MiB
+																			Default: 67108864,
+																			// // API sometimes omits default value
+																			// DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+																			// 	if old == "" && new == "67108864" {
+																			// 		return true
+																			// 	}
+																			// 	return false
+																			// },
+																			// 8 MiB
+																			ValidateFunc: validation.IntAtLeast(8388608),
+																		},
+																	},
+																},
+															},
+															"parquet_ser_de": {
+																Type:     schema.TypeList,
+																Optional: true,
+																MaxItems: 1,
+																Elem: &schema.Resource{
+																	Schema: map[string]*schema.Schema{
+																		"block_size_bytes": {
+																			Type:     schema.TypeInt,
+																			Optional: true,
+																			// 256 MiB
+																			Default: 268435456,
+																			// // API sometimes omits default value
+																			// DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+																			// 	if old == "268435456" && new == "" {
+																			// 		return true
+																			// 	}
+																			// 	return false
+																			// },
+																			// 64 MiB
+																			ValidateFunc: validation.IntAtLeast(67108864),
+																		},
+																		"compression": {
+																			Type:     schema.TypeString,
+																			Optional: true,
+																			Default:  firehose.ParquetCompressionSnappy,
+																			ValidateFunc: validation.StringInSlice([]string{
+																				firehose.ParquetCompressionGzip,
+																				firehose.ParquetCompressionSnappy,
+																				firehose.ParquetCompressionUncompressed,
+																			}, false),
+																		},
+																		"enable_dictionary_compression": {
+																			Type:     schema.TypeBool,
+																			Optional: true,
+																			Default:  false,
+																		},
+																		"max_padding_bytes": {
+																			Type:     schema.TypeInt,
+																			Optional: true,
+																			Default:  0,
+																		},
+																		"page_size_bytes": {
+																			Type:     schema.TypeInt,
+																			Optional: true,
+																			// 1 MiB
+																			Default: 1048576,
+																			// // API sometimes omits default value
+																			// DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+																			// 	if old == "1048576" && new == "" {
+																			// 		return true
+																			// 	}
+																			// 	return false
+																			// },
+																			// 64 KiB
+																			ValidateFunc: validation.IntAtLeast(65536),
+																		},
+																		"writer_version": {
+																			Type:     schema.TypeString,
+																			Optional: true,
+																			Default:  firehose.ParquetWriterVersionV1,
+																			ValidateFunc: validation.StringInSlice([]string{
+																				firehose.ParquetWriterVersionV1,
+																				firehose.ParquetWriterVersionV2,
+																			}, false),
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+									"schema_configuration": {
+										Type:     schema.TypeList,
+										Required: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"catalog_id": {
+													Type:     schema.TypeString,
+													Optional: true,
+													Computed: true,
+												},
+												"database_name": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"region": {
+													Type:     schema.TypeString,
+													Optional: true,
+													Computed: true,
+												},
+												"role_arn": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"table_name": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"version_id": {
+													Type:     schema.TypeString,
+													Optional: true,
+													Default:  "LATEST",
+												},
+											},
+										},
+									},
+								},
+							},
 						},
 
 						"kms_key_arn": {
@@ -914,9 +1435,10 @@ func createExtendedS3Config(d *schema.ResourceData) *firehose.ExtendedS3Destinat
 			IntervalInSeconds: aws.Int64(int64(s3["buffer_interval"].(int))),
 			SizeInMBs:         aws.Int64(int64(s3["buffer_size"].(int))),
 		},
-		Prefix:                  extractPrefixConfiguration(s3),
-		CompressionFormat:       aws.String(s3["compression_format"].(string)),
-		EncryptionConfiguration: extractEncryptionConfiguration(s3),
+		Prefix:                            extractPrefixConfiguration(s3),
+		CompressionFormat:                 aws.String(s3["compression_format"].(string)),
+		DataFormatConversionConfiguration: expandFirehoseDataFormatConversionConfiguration(s3["data_format_conversion_configuration"].([]interface{})),
+		EncryptionConfiguration:           extractEncryptionConfiguration(s3),
 	}
 
 	if _, ok := s3["processing_configuration"]; ok {
@@ -996,11 +1518,12 @@ func updateExtendedS3Config(d *schema.ResourceData) *firehose.ExtendedS3Destinat
 			IntervalInSeconds: aws.Int64((int64)(s3["buffer_interval"].(int))),
 			SizeInMBs:         aws.Int64((int64)(s3["buffer_size"].(int))),
 		},
-		Prefix:                   extractPrefixConfiguration(s3),
-		CompressionFormat:        aws.String(s3["compression_format"].(string)),
-		EncryptionConfiguration:  extractEncryptionConfiguration(s3),
-		CloudWatchLoggingOptions: extractCloudWatchLoggingConfiguration(s3),
-		ProcessingConfiguration:  extractProcessingConfiguration(s3),
+		Prefix:                            extractPrefixConfiguration(s3),
+		CompressionFormat:                 aws.String(s3["compression_format"].(string)),
+		EncryptionConfiguration:           extractEncryptionConfiguration(s3),
+		DataFormatConversionConfiguration: expandFirehoseDataFormatConversionConfiguration(s3["data_format_conversion_configuration"].([]interface{})),
+		CloudWatchLoggingOptions:          extractCloudWatchLoggingConfiguration(s3),
+		ProcessingConfiguration:           extractProcessingConfiguration(s3),
 	}
 
 	if _, ok := s3["cloudwatch_logging_options"]; ok {
@@ -1013,6 +1536,180 @@ func updateExtendedS3Config(d *schema.ResourceData) *firehose.ExtendedS3Destinat
 	}
 
 	return configuration
+}
+
+func expandFirehoseDataFormatConversionConfiguration(l []interface{}) *firehose.DataFormatConversionConfiguration {
+	if len(l) == 0 {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	return &firehose.DataFormatConversionConfiguration{
+		Enabled:                   aws.Bool(m["enabled"].(bool)),
+		InputFormatConfiguration:  expandFirehoseInputFormatConfiguration(m["input_format_configuration"].([]interface{})),
+		OutputFormatConfiguration: expandFirehoseOutputFormatConfiguration(m["output_format_configuration"].([]interface{})),
+		SchemaConfiguration:       expandFirehoseSchemaConfiguration(m["schema_configuration"].([]interface{})),
+	}
+}
+
+func expandFirehoseInputFormatConfiguration(l []interface{}) *firehose.InputFormatConfiguration {
+	if len(l) == 0 {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	return &firehose.InputFormatConfiguration{
+		Deserializer: expandFirehoseDeserializer(m["deserializer"].([]interface{})),
+	}
+}
+
+func expandFirehoseDeserializer(l []interface{}) *firehose.Deserializer {
+	if len(l) == 0 {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	return &firehose.Deserializer{
+		HiveJsonSerDe:  expandFirehoseHiveJsonSerDe(m["hive_json_ser_de"].([]interface{})),
+		OpenXJsonSerDe: expandFirehoseOpenXJsonSerDe(m["open_x_json_ser_de"].([]interface{})),
+	}
+}
+
+func expandFirehoseHiveJsonSerDe(l []interface{}) *firehose.HiveJsonSerDe {
+	if len(l) == 0 {
+		return nil
+	}
+
+	if l[0] == nil {
+		return &firehose.HiveJsonSerDe{}
+	}
+
+	m := l[0].(map[string]interface{})
+
+	return &firehose.HiveJsonSerDe{
+		TimestampFormats: expandStringList(m["timestamp_formats"].([]interface{})),
+	}
+}
+
+func expandFirehoseOpenXJsonSerDe(l []interface{}) *firehose.OpenXJsonSerDe {
+	if len(l) == 0 {
+		return nil
+	}
+
+	if l[0] == nil {
+		return &firehose.OpenXJsonSerDe{}
+	}
+
+	m := l[0].(map[string]interface{})
+
+	return &firehose.OpenXJsonSerDe{
+		CaseInsensitive:                    aws.Bool(m["case_insensitive"].(bool)),
+		ColumnToJsonKeyMappings:            stringMapToPointers(m["column_to_json_key_mappings"].(map[string]interface{})),
+		ConvertDotsInJsonKeysToUnderscores: aws.Bool(m["convert_dots_in_json_keys_to_underscores"].(bool)),
+	}
+}
+
+func expandFirehoseOutputFormatConfiguration(l []interface{}) *firehose.OutputFormatConfiguration {
+	if len(l) == 0 {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	return &firehose.OutputFormatConfiguration{
+		Serializer: expandFirehoseSerializer(m["serializer"].([]interface{})),
+	}
+}
+
+func expandFirehoseSerializer(l []interface{}) *firehose.Serializer {
+	if len(l) == 0 {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	return &firehose.Serializer{
+		OrcSerDe:     expandFirehoseOrcSerDe(m["orc_ser_de"].([]interface{})),
+		ParquetSerDe: expandFirehoseParquetSerDe(m["parquet_ser_de"].([]interface{})),
+	}
+}
+
+func expandFirehoseOrcSerDe(l []interface{}) *firehose.OrcSerDe {
+	if len(l) == 0 {
+		return nil
+	}
+
+	if l[0] == nil {
+		return &firehose.OrcSerDe{}
+	}
+
+	m := l[0].(map[string]interface{})
+
+	orcSerDe := &firehose.OrcSerDe{
+		BlockSizeBytes:                      aws.Int64(int64(m["block_size_bytes"].(int))),
+		BloomFilterFalsePositiveProbability: aws.Float64(m["bloom_filter_false_positive_probability"].(float64)),
+		Compression:                         aws.String(m["compression"].(string)),
+		DictionaryKeyThreshold:              aws.Float64(m["dictionary_key_threshold"].(float64)),
+		EnablePadding:                       aws.Bool(m["enable_padding"].(bool)),
+		FormatVersion:                       aws.String(m["format_version"].(string)),
+		PaddingTolerance:                    aws.Float64(m["padding_tolerance"].(float64)),
+		RowIndexStride:                      aws.Int64(int64(m["row_index_stride"].(int))),
+		StripeSizeBytes:                     aws.Int64(int64(m["stripe_size_bytes"].(int))),
+	}
+
+	if v, ok := m["bloom_filter_columns"].([]interface{}); ok && len(v) > 0 {
+		orcSerDe.BloomFilterColumns = expandStringList(v)
+	}
+
+	return orcSerDe
+}
+
+func expandFirehoseParquetSerDe(l []interface{}) *firehose.ParquetSerDe {
+	if len(l) == 0 {
+		return nil
+	}
+
+	if l[0] == nil {
+		return &firehose.ParquetSerDe{}
+	}
+
+	m := l[0].(map[string]interface{})
+
+	return &firehose.ParquetSerDe{
+		BlockSizeBytes:              aws.Int64(int64(m["block_size_bytes"].(int))),
+		Compression:                 aws.String(m["compression"].(string)),
+		EnableDictionaryCompression: aws.Bool(m["enable_dictionary_compression"].(bool)),
+		MaxPaddingBytes:             aws.Int64(int64(m["max_padding_bytes"].(int))),
+		PageSizeBytes:               aws.Int64(int64(m["page_size_bytes"].(int))),
+		WriterVersion:               aws.String(m["writer_version"].(string)),
+	}
+}
+
+func expandFirehoseSchemaConfiguration(l []interface{}) *firehose.SchemaConfiguration {
+	if len(l) == 0 {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	config := &firehose.SchemaConfiguration{
+		DatabaseName: aws.String(m["database_name"].(string)),
+		RoleARN:      aws.String(m["role_arn"].(string)),
+		TableName:    aws.String(m["table_name"].(string)),
+		VersionId:    aws.String(m["version_id"].(string)),
+	}
+
+	if v, ok := m["catalog_id"].(string); ok && v != "" {
+		config.CatalogId = aws.String(v)
+	}
+	if v, ok := m["region"].(string); ok && v != "" {
+		config.Region = aws.String(v)
+	}
+
+	return config
 }
 
 func extractProcessingConfiguration(s3 map[string]interface{}) *firehose.ProcessingConfiguration {

--- a/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -966,7 +966,7 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 												},
 												"database_name": {
 													Type:     schema.TypeString,
-													Optional: true,
+													Required: true,
 												},
 												"region": {
 													Type:     schema.TypeString,
@@ -975,11 +975,11 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 												},
 												"role_arn": {
 													Type:     schema.TypeString,
-													Optional: true,
+													Required: true,
 												},
 												"table_name": {
 													Type:     schema.TypeString,
-													Optional: true,
+													Required: true,
 												},
 												"version_id": {
 													Type:     schema.TypeString,

--- a/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
@@ -185,6 +185,43 @@ func TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConf
 	})
 }
 
+func TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Deserializer_Update(t *testing.T) {
+	var stream firehose.DeliveryStreamDescription
+	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_kinesis_firehose_delivery_stream.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKinesisFirehoseDeliveryStreamDestroy_ExtendedS3,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKinesisFirehoseDeliveryStreamConfig_ExtendedS3_DataFormatConversionConfiguration_HiveJsonSerDe_Empty(rName, rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisFirehoseDeliveryStreamExists(resourceName, &stream),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.0.data_format_conversion_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.0.data_format_conversion_configuration.0.input_format_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.0.data_format_conversion_configuration.0.input_format_configuration.0.deserializer.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.0.data_format_conversion_configuration.0.input_format_configuration.0.deserializer.0.hive_json_ser_de.#", "1"),
+				),
+			},
+			{
+				Config: testAccKinesisFirehoseDeliveryStreamConfig_ExtendedS3_DataFormatConversionConfiguration_OpenXJsonSerDe_Empty(rName, rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisFirehoseDeliveryStreamExists(resourceName, &stream),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.0.data_format_conversion_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.0.data_format_conversion_configuration.0.input_format_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.0.data_format_conversion_configuration.0.input_format_configuration.0.deserializer.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.0.data_format_conversion_configuration.0.input_format_configuration.0.deserializer.0.open_x_json_ser_de.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_HiveJsonSerDe_Empty(t *testing.T) {
 	var stream firehose.DeliveryStreamDescription
 	rInt := acctest.RandInt()
@@ -304,6 +341,43 @@ func TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConf
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Serializer_Update(t *testing.T) {
+	var stream firehose.DeliveryStreamDescription
+	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_kinesis_firehose_delivery_stream.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKinesisFirehoseDeliveryStreamDestroy_ExtendedS3,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKinesisFirehoseDeliveryStreamConfig_ExtendedS3_DataFormatConversionConfiguration_OrcSerDe_Empty(rName, rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisFirehoseDeliveryStreamExists(resourceName, &stream),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.0.data_format_conversion_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.0.data_format_conversion_configuration.0.output_format_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.0.data_format_conversion_configuration.0.output_format_configuration.0.serializer.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.0.data_format_conversion_configuration.0.output_format_configuration.0.serializer.0.orc_ser_de.#", "1"),
+				),
+			},
+			{
+				Config: testAccKinesisFirehoseDeliveryStreamConfig_ExtendedS3_DataFormatConversionConfiguration_ParquetSerDe_Empty(rName, rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisFirehoseDeliveryStreamExists(resourceName, &stream),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.0.data_format_conversion_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.0.data_format_conversion_configuration.0.output_format_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.0.data_format_conversion_configuration.0.output_format_configuration.0.serializer.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.0.data_format_conversion_configuration.0.output_format_configuration.0.serializer.0.parquet_ser_de.#", "1"),
+				),
 			},
 		},
 	})

--- a/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
@@ -147,6 +147,168 @@ func TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Enabled(t *testing.T) {
+	var stream firehose.DeliveryStreamDescription
+	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_kinesis_firehose_delivery_stream.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKinesisFirehoseDeliveryStreamDestroy_ExtendedS3,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKinesisFirehoseDeliveryStreamConfig_ExtendedS3_DataFormatConversionConfiguration_Enabled(rName, rInt, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisFirehoseDeliveryStreamExists(resourceName, &stream),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.0.data_format_conversion_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.0.data_format_conversion_configuration.0.enabled", "false"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccKinesisFirehoseDeliveryStreamConfig_ExtendedS3_DataFormatConversionConfiguration_Enabled(rName, rInt, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisFirehoseDeliveryStreamExists(resourceName, &stream),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.0.data_format_conversion_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.0.data_format_conversion_configuration.0.enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_HiveJsonSerDe_Empty(t *testing.T) {
+	var stream firehose.DeliveryStreamDescription
+	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_kinesis_firehose_delivery_stream.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKinesisFirehoseDeliveryStreamDestroy_ExtendedS3,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKinesisFirehoseDeliveryStreamConfig_ExtendedS3_DataFormatConversionConfiguration_HiveJsonSerDe_Empty(rName, rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisFirehoseDeliveryStreamExists(resourceName, &stream),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.0.data_format_conversion_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.0.data_format_conversion_configuration.0.input_format_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.0.data_format_conversion_configuration.0.input_format_configuration.0.deserializer.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.0.data_format_conversion_configuration.0.input_format_configuration.0.deserializer.0.hive_json_ser_de.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OpenXJsonSerDe_Empty(t *testing.T) {
+	var stream firehose.DeliveryStreamDescription
+	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_kinesis_firehose_delivery_stream.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKinesisFirehoseDeliveryStreamDestroy_ExtendedS3,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKinesisFirehoseDeliveryStreamConfig_ExtendedS3_DataFormatConversionConfiguration_OpenXJsonSerDe_Empty(rName, rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisFirehoseDeliveryStreamExists(resourceName, &stream),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.0.data_format_conversion_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.0.data_format_conversion_configuration.0.input_format_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.0.data_format_conversion_configuration.0.input_format_configuration.0.deserializer.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.0.data_format_conversion_configuration.0.input_format_configuration.0.deserializer.0.open_x_json_ser_de.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OrcSerDe_Empty(t *testing.T) {
+	var stream firehose.DeliveryStreamDescription
+	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_kinesis_firehose_delivery_stream.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKinesisFirehoseDeliveryStreamDestroy_ExtendedS3,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKinesisFirehoseDeliveryStreamConfig_ExtendedS3_DataFormatConversionConfiguration_OrcSerDe_Empty(rName, rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisFirehoseDeliveryStreamExists(resourceName, &stream),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.0.data_format_conversion_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.0.data_format_conversion_configuration.0.output_format_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.0.data_format_conversion_configuration.0.output_format_configuration.0.serializer.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.0.data_format_conversion_configuration.0.output_format_configuration.0.serializer.0.orc_ser_de.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_ParquetSerDe_Empty(t *testing.T) {
+	var stream firehose.DeliveryStreamDescription
+	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_kinesis_firehose_delivery_stream.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKinesisFirehoseDeliveryStreamDestroy_ExtendedS3,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKinesisFirehoseDeliveryStreamConfig_ExtendedS3_DataFormatConversionConfiguration_ParquetSerDe_Empty(rName, rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisFirehoseDeliveryStreamExists(resourceName, &stream),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.0.data_format_conversion_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.0.data_format_conversion_configuration.0.output_format_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.0.data_format_conversion_configuration.0.output_format_configuration.0.serializer.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extended_s3_configuration.0.data_format_conversion_configuration.0.output_format_configuration.0.serializer.0.parquet_ser_de.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3KmsKeyArn(t *testing.T) {
 	rString := acctest.RandString(8)
 	funcName := fmt.Sprintf("aws_kinesis_firehose_delivery_stream_test_%s", rString)
@@ -824,6 +986,16 @@ resource "aws_iam_role_policy" "firehose" {
         "arn:aws:s3:::${aws_s3_bucket.bucket.id}",
         "arn:aws:s3:::${aws_s3_bucket.bucket.id}/*"
       ]
+    },
+    {
+      "Sid": "GlueAccess",
+      "Effect": "Allow",
+      "Action": [
+        "glue:GetTableVersions"
+      ],
+      "Resource": [
+        "*"
+      ]
     }
   ]
 }
@@ -1046,6 +1218,278 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
   }
 }
 `
+
+func testAccKinesisFirehoseDeliveryStreamConfig_ExtendedS3_DataFormatConversionConfiguration_Enabled(rName string, rInt int, enabled bool) string {
+	return fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamBaseConfig, rInt, rInt, rInt) + fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = "%s"
+}
+
+resource "aws_glue_catalog_table" "test" {
+  database_name = "${aws_glue_catalog_database.test.name}"
+  name          = "%s"
+
+  storage_descriptor {
+    columns {
+      name = "test"
+      type = "string"
+    }
+  }
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "test" {
+  destination = "extended_s3"
+  name        = "%s"
+
+  extended_s3_configuration {
+    bucket_arn  = "${aws_s3_bucket.bucket.arn}"
+    # InvalidArgumentException: BufferingHints.SizeInMBs must be at least 64 when data format conversion is enabled.
+    buffer_size = 128
+    role_arn    = "${aws_iam_role.firehose.arn}"
+
+    data_format_conversion_configuration {
+      enabled = %t
+
+      input_format_configuration {
+        deserializer {
+          hive_json_ser_de {} # we have to pick one
+        }
+      }
+
+      output_format_configuration {
+        serializer {
+          orc_ser_de {} # we have to pick one
+        }
+      }
+
+      schema_configuration {
+        database_name = "${aws_glue_catalog_table.test.database_name}"
+        role_arn      = "${aws_iam_role.firehose.arn}"
+        table_name    = "${aws_glue_catalog_table.test.name}"
+      }
+    }
+  }
+
+  depends_on = ["aws_iam_role_policy.firehose"]
+}
+`, rName, rName, rName, enabled)
+}
+
+func testAccKinesisFirehoseDeliveryStreamConfig_ExtendedS3_DataFormatConversionConfiguration_HiveJsonSerDe_Empty(rName string, rInt int) string {
+	return fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamBaseConfig, rInt, rInt, rInt) + fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = "%s"
+}
+
+resource "aws_glue_catalog_table" "test" {
+  database_name = "${aws_glue_catalog_database.test.name}"
+  name          = "%s"
+
+  storage_descriptor {
+    columns {
+      name = "test"
+      type = "string"
+    }
+  }
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "test" {
+  destination = "extended_s3"
+  name        = "%s"
+
+  extended_s3_configuration {
+    bucket_arn  = "${aws_s3_bucket.bucket.arn}"
+    # InvalidArgumentException: BufferingHints.SizeInMBs must be at least 64 when data format conversion is enabled.
+    buffer_size = 128
+    role_arn    = "${aws_iam_role.firehose.arn}"
+
+    data_format_conversion_configuration {
+      input_format_configuration {
+        deserializer {
+          hive_json_ser_de {}
+        }
+      }
+
+      output_format_configuration {
+        serializer {
+          orc_ser_de {} # we have to pick one
+        }
+      }
+
+      schema_configuration {
+        database_name = "${aws_glue_catalog_table.test.database_name}"
+        role_arn      = "${aws_iam_role.firehose.arn}"
+        table_name    = "${aws_glue_catalog_table.test.name}"
+      }
+    }
+  }
+
+  depends_on = ["aws_iam_role_policy.firehose"]
+}
+`, rName, rName, rName)
+}
+
+func testAccKinesisFirehoseDeliveryStreamConfig_ExtendedS3_DataFormatConversionConfiguration_OpenXJsonSerDe_Empty(rName string, rInt int) string {
+	return fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamBaseConfig, rInt, rInt, rInt) + fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = "%s"
+}
+
+resource "aws_glue_catalog_table" "test" {
+  database_name = "${aws_glue_catalog_database.test.name}"
+  name          = "%s"
+
+  storage_descriptor {
+    columns {
+      name = "test"
+      type = "string"
+    }
+  }
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "test" {
+  destination = "extended_s3"
+  name        = "%s"
+
+  extended_s3_configuration {
+    bucket_arn  = "${aws_s3_bucket.bucket.arn}"
+    # InvalidArgumentException: BufferingHints.SizeInMBs must be at least 64 when data format conversion is enabled.
+    buffer_size = 128
+    role_arn    = "${aws_iam_role.firehose.arn}"
+
+    data_format_conversion_configuration {
+      input_format_configuration {
+        deserializer {
+          open_x_json_ser_de {}
+        }
+      }
+
+      output_format_configuration {
+        serializer {
+          orc_ser_de {} # we have to pick one
+        }
+      }
+
+      schema_configuration {
+        database_name = "${aws_glue_catalog_table.test.database_name}"
+        role_arn      = "${aws_iam_role.firehose.arn}"
+        table_name    = "${aws_glue_catalog_table.test.name}"
+      }
+    }
+  }
+
+  depends_on = ["aws_iam_role_policy.firehose"]
+}
+`, rName, rName, rName)
+}
+
+func testAccKinesisFirehoseDeliveryStreamConfig_ExtendedS3_DataFormatConversionConfiguration_OrcSerDe_Empty(rName string, rInt int) string {
+	return fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamBaseConfig, rInt, rInt, rInt) + fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = "%s"
+}
+
+resource "aws_glue_catalog_table" "test" {
+  database_name = "${aws_glue_catalog_database.test.name}"
+  name          = "%s"
+
+  storage_descriptor {
+    columns {
+      name = "test"
+      type = "string"
+    }
+  }
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "test" {
+  destination = "extended_s3"
+  name        = "%s"
+
+  extended_s3_configuration {
+    bucket_arn  = "${aws_s3_bucket.bucket.arn}"
+    # InvalidArgumentException: BufferingHints.SizeInMBs must be at least 64 when data format conversion is enabled.
+    buffer_size = 128
+    role_arn    = "${aws_iam_role.firehose.arn}"
+
+    data_format_conversion_configuration {
+      input_format_configuration {
+        deserializer {
+          hive_json_ser_de {} # we have to pick one
+        }
+      }
+
+      output_format_configuration {
+        serializer {
+          orc_ser_de {}
+        }
+      }
+
+      schema_configuration {
+        database_name = "${aws_glue_catalog_table.test.database_name}"
+        role_arn      = "${aws_iam_role.firehose.arn}"
+        table_name    = "${aws_glue_catalog_table.test.name}"
+      }
+    }
+  }
+
+  depends_on = ["aws_iam_role_policy.firehose"]
+}
+`, rName, rName, rName)
+}
+
+func testAccKinesisFirehoseDeliveryStreamConfig_ExtendedS3_DataFormatConversionConfiguration_ParquetSerDe_Empty(rName string, rInt int) string {
+	return fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamBaseConfig, rInt, rInt, rInt) + fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = "%s"
+}
+
+resource "aws_glue_catalog_table" "test" {
+  database_name = "${aws_glue_catalog_database.test.name}"
+  name          = "%s"
+
+  storage_descriptor {
+    columns {
+      name = "test"
+      type = "string"
+    }
+  }
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "test" {
+  destination = "extended_s3"
+  name        = "%s"
+
+  extended_s3_configuration {
+    bucket_arn  = "${aws_s3_bucket.bucket.arn}"
+    # InvalidArgumentException: BufferingHints.SizeInMBs must be at least 64 when data format conversion is enabled.
+    buffer_size = 128
+    role_arn    = "${aws_iam_role.firehose.arn}"
+
+    data_format_conversion_configuration {
+      input_format_configuration {
+        deserializer {
+          hive_json_ser_de {} # we have to pick one
+        }
+      }
+
+      output_format_configuration {
+        serializer {
+          parquet_ser_de {}
+        }
+      }
+
+      schema_configuration {
+        database_name = "${aws_glue_catalog_table.test.database_name}"
+        role_arn      = "${aws_iam_role.firehose.arn}"
+        table_name    = "${aws_glue_catalog_table.test.name}"
+      }
+    }
+  }
+
+  depends_on = ["aws_iam_role_policy.firehose"]
+}
+`, rName, rName, rName)
+}
 
 var testAccKinesisFirehoseDeliveryStreamConfig_extendedS3KmsKeyArn = testAccKinesisFirehoseDeliveryStreamBaseConfig + `
 resource "aws_kms_key" "test" {

--- a/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
+++ b/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
@@ -384,10 +384,10 @@ resource "aws_kinesis_firehose_delivery_stream" "example" {
 }
 ```
 
-* `enabled` - (Optional) Defaults to `true`. Set it to `false` if you want to disable format conversion while preserving the configuration details.
 * `input_format_configuration` - (Required) Nested argument that specifies the deserializer that you want Kinesis Data Firehose to use to convert the format of your data from JSON. More details below.
 * `output_format_configuration` - (Required) Nested argument that specifies the serializer that you want Kinesis Data Firehose to use to convert the format of your data to the Parquet or ORC format. More details below.
 * `schema_configuration` - (Required) Nested argument that specifies the AWS Glue Data Catalog table that contains the column information. More details below.
+* `enabled` - (Optional) Defaults to `true`. Set it to `false` if you want to disable format conversion while preserving the configuration details.
 
 #### input_format_configuration
 
@@ -445,11 +445,11 @@ resource "aws_kinesis_firehose_delivery_stream" "example" {
 
 #### schema_configuration
 
+* `database_name` - (Required) Specifies the name of the AWS Glue database that contains the schema for the output data.
+* `role_arn` - (Required) The role that Kinesis Data Firehose can use to access AWS Glue. This role must be in the same account you use for Kinesis Data Firehose. Cross-account roles aren't allowed.
+* `table_name` - (Required) Specifies the AWS Glue table that contains the column information that constitutes your data schema.
 * `catalog_id` - (Optional) The ID of the AWS Glue Data Catalog. If you don't supply this, the AWS account ID is used by default.
-* `database_name` - (Optional) Specifies the name of the AWS Glue database that contains the schema for the output data.
 * `region` - (Optional) If you don't specify an AWS Region, the default is the current region.
-* `role_arn` - (Optional) The role that Kinesis Data Firehose can use to access AWS Glue. This role must be in the same account you use for Kinesis Data Firehose. Cross-account roles aren't allowed.
-* `table_name` - (Optional) Specifies the AWS Glue table that contains the column information that constitutes your data schema.
 * `version_id` - (Optional) Specifies the table version for the output data schema. Defaults to `LATEST`.
 
 ## Attributes Reference

--- a/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
+++ b/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
@@ -285,6 +285,7 @@ be used.
 
 The `extended_s3_configuration` object supports the same fields from `s3_configuration` as well as the following:
 
+* `data_format_conversion_configuration` - (Optional) Nested argument for the serializer, deserializer, and schema for converting data from the JSON format to the Parquet or ORC format before writing it to Amazon S3. More details given below.
 * `processing_configuration` - (Optional) The data processing configuration.  More details are given below.
 * `s3_backup_mode` - (Optional) The Amazon S3 backup mode.  Valid values are `Disabled` and `Enabled`.  Default value is `Disabled`.
 * `s3_backup_configuration` - (Optional) The configuration for backup in Amazon S3. Required if `s3_backup_mode` is `Enabled`. Supports the same fields as `s3_configuration` object.
@@ -348,6 +349,108 @@ The `parameters` array objects support the following:
 
 * `parameter_name` - (Required) Parameter name. Valid Values: `LambdaArn`, `NumberOfRetries`, `RoleArn`, `BufferSizeInMBs`, `BufferIntervalInSeconds`
 * `parameter_value` - (Required) Parameter value. Must be between 1 and 512 length (inclusive). When providing a Lambda ARN, you should specify the resource version as well.
+
+### data_format_conversion_configuration
+
+Example:
+
+```hcl
+resource "aws_kinesis_firehose_delivery_stream" "example" {
+  # ... other configuration ...
+  extended_s3_configuration {
+    # Must be at least 64
+    buffer_size = 128
+    # ... other configuration ...
+    data_format_conversion_configuration {
+      input_format_configuration {
+        deserializer {
+          hive_json_ser_de {}
+        }
+      }
+
+      output_format_configuration {
+        serializer {
+          orc_ser_de {}
+        }
+      }
+
+      schema_configuration {
+        database_name = "${aws_glue_catalog_table.example.database_name}"
+        role_arn      = "${aws_iam_role.example.arn}"
+        table_name    = "${aws_glue_catalog_table.example.name}"
+      }
+    }
+  }
+}
+```
+
+* `enabled` - (Optional) Defaults to `true`. Set it to `false` if you want to disable format conversion while preserving the configuration details.
+* `input_format_configuration` - (Required) Nested argument that specifies the deserializer that you want Kinesis Data Firehose to use to convert the format of your data from JSON. More details below.
+* `output_format_configuration` - (Required) Nested argument that specifies the serializer that you want Kinesis Data Firehose to use to convert the format of your data to the Parquet or ORC format. More details below.
+* `schema_configuration` - (Required) Nested argument that specifies the AWS Glue Data Catalog table that contains the column information. More details below.
+
+#### input_format_configuration
+
+* `deserializer` - (Required) Nested argument that specifies which deserializer to use. You can choose either the Apache Hive JSON SerDe or the OpenX JSON SerDe. More details below.
+
+##### deserializer
+
+~> **NOTE:** One of the deserializers must be configured. If no nested configuration needs to occur simply declare as `XXX_json_ser_de = []` or `XXX_json_ser_de {}`.
+
+* `hive_json_ser_de` - (Optional) Nested argument that specifies the native Hive / HCatalog JsonSerDe. More details below.
+* `open_x_json_ser_de` - (Optional) Nested argument that specifies the OpenX SerDe. More details below.
+
+###### hive_json_ser_de
+
+* `timestamp_formats` - (Optional) A list of how you want Kinesis Data Firehose to parse the date and time stamps that may be present in your input data JSON. To specify these format strings, follow the pattern syntax of JodaTime's DateTimeFormat format strings. For more information, see [Class DateTimeFormat](https://www.joda.org/joda-time/apidocs/org/joda/time/format/DateTimeFormat.html). You can also use the special value millis to parse time stamps in epoch milliseconds. If you don't specify a format, Kinesis Data Firehose uses java.sql.Timestamp::valueOf by default.
+
+###### open_x_json_ser_de
+
+* `case_insensitive` - (Optional) When set to true, which is the default, Kinesis Data Firehose converts JSON keys to lowercase before deserializing them.
+* `column_to_json_key_mappings` - (Optional) A map of column names to JSON keys that aren't identical to the column names. This is useful when the JSON contains keys that are Hive keywords. For example, timestamp is a Hive keyword. If you have a JSON key named timestamp, set this parameter to `{ ts = "timestamp" }` to map this key to a column named ts.
+* `convert_dots_in_json_keys_to_underscores` - (Optional) When set to `true`, specifies that the names of the keys include dots and that you want Kinesis Data Firehose to replace them with underscores. This is useful because Apache Hive does not allow dots in column names. For example, if the JSON contains a key whose name is "a.b", you can define the column name to be "a_b" when using this option. Defaults to `false`.
+
+#### output_format_configuration
+
+* `serializer` - (Required) Nested argument that specifies which serializer to use. You can choose either the ORC SerDe or the Parquet SerDe. More details below.
+
+##### serializer
+
+~> **NOTE:** One of the serializers must be configured. If no nested configuration needs to occur simply declare as `XXX_ser_de = []` or `XXX_ser_de {}`.
+
+* `orc_ser_de` - (Optional) Nested argument that specifies converting data to the ORC format before storing it in Amazon S3. For more information, see [Apache ORC](https://orc.apache.org/docs/). More details below.
+* `parquet_ser_de` - (Optional) Nested argument that specifies converting data to the Parquet format before storing it in Amazon S3. For more information, see [Apache Parquet](https://parquet.apache.org/documentation/latest/). More details below.
+
+###### orc_ser_de
+
+* `block_size_bytes` - (Optional) The Hadoop Distributed File System (HDFS) block size. This is useful if you intend to copy the data from Amazon S3 to HDFS before querying. The default is 256 MiB and the minimum is 64 MiB. Kinesis Data Firehose uses this value for padding calculations.
+* `bloom_filter_columns` - (Optional) A list of column names for which you want Kinesis Data Firehose to create bloom filters.
+* `bloom_filter_false_positive_probability` - (Optional) The Bloom filter false positive probability (FPP). The lower the FPP, the bigger the Bloom filter. The default value is `0.05`, the minimum is `0`, and the maximum is `1`.
+* `compression` - (Optional) The compression code to use over data blocks. The default is `SNAPPY`.
+* `dictionary_key_threshold` - (Optional) A float that represents the fraction of the total number of non-null rows. To turn off dictionary encoding, set this fraction to a number that is less than the number of distinct keys in a dictionary. To always use dictionary encoding, set this threshold to `1`.
+* `enable_padding` - (Optional) Set this to `true` to indicate that you want stripes to be padded to the HDFS block boundaries. This is useful if you intend to copy the data from Amazon S3 to HDFS before querying. The default is `false`.
+* `format_version` - (Optional) The version of the file to write. The possible values are `V0_11` and `V0_12`. The default is `V0_12`.
+* `padding_tolerance` - (Optional) A float between 0 and 1 that defines the tolerance for block padding as a decimal fraction of stripe size. The default value is `0.05`, which means 5 percent of stripe size. For the default values of 64 MiB ORC stripes and 256 MiB HDFS blocks, the default block padding tolerance of 5 percent reserves a maximum of 3.2 MiB for padding within the 256 MiB block. In such a case, if the available size within the block is more than 3.2 MiB, a new, smaller stripe is inserted to fit within that space. This ensures that no stripe crosses block boundaries and causes remote reads within a node-local task. Kinesis Data Firehose ignores this parameter when `enable_padding` is `false`.
+* `row_index_stride` - (Optional) The number of rows between index entries. The default is `10000` and the minimum is `1000`.
+* `stripe_size_bytes` - (Optional) The number of bytes in each stripe. The default is 64 MiB and the minimum is 8 MiB.
+
+###### parquet_ser_de
+
+* `block_size_bytes` - (Optional) The Hadoop Distributed File System (HDFS) block size. This is useful if you intend to copy the data from Amazon S3 to HDFS before querying. The default is 256 MiB and the minimum is 64 MiB. Kinesis Data Firehose uses this value for padding calculations.
+* `compression` - (Optional) The compression code to use over data blocks. The possible values are `UNCOMPRESSED`, `SNAPPY`, and `GZIP`, with the default being `SNAPPY`. Use `SNAPPY` for higher decompression speed. Use `GZIP` if the compression ratio is more important than speed.
+* `enable_dictionary_compression` - (Optional) Indicates whether to enable dictionary compression.
+* `max_padding_bytes` - (Optional) The maximum amount of padding to apply. This is useful if you intend to copy the data from Amazon S3 to HDFS before querying. The default is `0`.
+* `page_size_bytes` - (Optional) The Parquet page size. Column chunks are divided into pages. A page is conceptually an indivisible unit (in terms of compression and encoding). The minimum value is 64 KiB and the default is 1 MiB.
+* `writer_version` - (Optional) Indicates the version of row format to output. The possible values are `V1` and `V2`. The default is `V1`.
+
+#### schema_configuration
+
+* `catalog_id` - (Optional) The ID of the AWS Glue Data Catalog. If you don't supply this, the AWS account ID is used by default.
+* `database_name` - (Optional) Specifies the name of the AWS Glue database that contains the schema for the output data.
+* `region` - (Optional) If you don't specify an AWS Region, the default is the current region.
+* `role_arn` - (Optional) The role that Kinesis Data Firehose can use to access AWS Glue. This role must be in the same account you use for Kinesis Data Firehose. Cross-account roles aren't allowed.
+* `table_name` - (Optional) Specifies the AWS Glue table that contains the column information that constitutes your data schema.
+* `version_id` - (Optional) Specifies the table version for the output data schema. Defaults to `LATEST`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Closes #4510

Changes proposed in this pull request:

* Add extended S3 destination `data_format_conversion_configuration` and sub-arguments

References:

* https://docs.aws.amazon.com/firehose/latest/dev/record-format-conversion.html
* https://docs.aws.amazon.com/firehose/latest/APIReference/API_DataFormatConversionConfiguration.html

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration -timeout 120m
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Enabled
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Enabled (136.24s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_HiveJsonSerDe_Empty
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_HiveJsonSerDe_Empty (122.24s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OpenXJsonSerDe_Empty
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OpenXJsonSerDe_Empty (111.75s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OrcSerDe_Empty
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OrcSerDe_Empty (125.72s)
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_ParquetSerDe_Empty
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_ParquetSerDe_Empty (122.14s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	618.134s
```
