### PR TITLE
Fix force new behavior for aws_batch_job_definition attempts

### DIFF
--- a/aws/resource_aws_batch_job_definition.go
+++ b/aws/resource_aws_batch_job_definition.go
@@ -52,6 +52,7 @@ func resourceAwsBatchJobDefinition() *schema.Resource {
 						"attempts": {
 							Type:         schema.TypeInt,
 							Optional:     true,
+							ForceNew:     true,
 							ValidateFunc: validation.IntBetween(1, 10),
 						},
 					},


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-aws/pull/4697#pullrequestreview-124368089

When the `retry_strategy.attempts` attribute of the
`aws_batch_job_definition` is modified, ensure that a new resource is
created vs. update-in-place.

* Add `ForceNew` to `aws_batch_job_definition.retry_strategy.attempts`