### PR TITLE
Ensure desired_vcpus is set before including it in update

### DIFF
--- a/aws/resource_aws_batch_compute_environment.go
+++ b/aws/resource_aws_batch_compute_environment.go
@@ -346,7 +346,9 @@ func resourceAwsBatchComputeEnvironmentUpdate(d *schema.ResourceData, meta inter
 		}
 		computeResource := computeResources[0].(map[string]interface{})
 
-		input.ComputeResources.DesiredvCpus = aws.Int64(int64(computeResource["desired_vcpus"].(int)))
+		if v, ok := computeResource["desired_vcpus"]; ok {
+			input.ComputeResources.DesiredvCpus = aws.Int64(int64(v.(int)))
+		}
 		input.ComputeResources.MaxvCpus = aws.Int64(int64(computeResource["max_vcpus"].(int)))
 		input.ComputeResources.MinvCpus = aws.Int64(int64(computeResource["min_vcpus"].(int)))
 	}

--- a/aws/resource_aws_batch_compute_environment.go
+++ b/aws/resource_aws_batch_compute_environment.go
@@ -346,9 +346,7 @@ func resourceAwsBatchComputeEnvironmentUpdate(d *schema.ResourceData, meta inter
 		}
 		computeResource := computeResources[0].(map[string]interface{})
 
-		if v, ok := computeResource["desired_vcpus"]; ok {
-			input.ComputeResources.DesiredvCpus = aws.Int64(int64(v.(int)))
-		}
+		input.ComputeResources.DesiredvCpus = aws.Int64(int64(computeResource["desired_vcpus"].(int)))
 		input.ComputeResources.MaxvCpus = aws.Int64(int64(computeResource["max_vcpus"].(int)))
 		input.ComputeResources.MinvCpus = aws.Int64(int64(computeResource["min_vcpus"].(int)))
 	}


### PR DESCRIPTION
Fixes #4671 #4788 

When updating an AWS Batch compute environment, do not specify `DesiredvCpus` in the call to `UpdateComputeEnvironment` unless `desired_vcpus` is set.

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSBatchComputeEnvironment_createEc2'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSBatchComputeEnvironment_createEc2 -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSBatchComputeEnvironment_createEc2
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2 (49.55s)
=== RUN   TestAccAWSBatchComputeEnvironment_createEc2WithTags
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2WithTags (46.84s)
=== RUN   TestAccAWSBatchComputeEnvironment_createEc2WithoutComputeResources
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2WithoutComputeResources (21.39s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       117.838s
```
