### PR TITLE
Documeting SNS topic delivery policy

### DIFF
--- a/website/docs/r/sns_topic.html.markdown
+++ b/website/docs/r/sns_topic.html.markdown
@@ -30,7 +30,7 @@ The following arguments are supported:
 * `name_prefix` - (Optional) The friendly name for the SNS topic. Conflicts with `name`.
 * `display_name` - (Optional) The display name for the SNS topic
 * `policy` - (Optional) The fully-formed AWS policy as JSON
-* `delivery_policy` - (Optional) The SNS delivery policy
+* `delivery_policy` - (Optional) The SNS delivery policy. More on [AWS documentation](https://docs.aws.amazon.com/sns/latest/dg/DeliveryPolicies.html)
 * `application_success_feedback_role_arn` - (Optional) The IAM role permitted to receive success feedback for this topic
 * `application_success_feedback_sample_rate` - (Optional) Percentage of success to sample
 * `application_failure_feedback_role_arn` - (Optional) IAM role for failure feedback
@@ -57,4 +57,31 @@ SNS Topics can be imported using the `topic arn`, e.g.
 
 ```
 $ terraform import aws_sns_topic.user_updates arn:aws:sns:us-west-2:0123456789012:my-topic
+```
+
+## Example with Delivery Policy
+
+``` hcl
+resource "aws_sns_topic" "user_updates" {
+  name = "user-updates-topic"
+  delivery_policy = <<EOF
+{
+  "http": {
+    "defaultHealthyRetryPolicy": {
+      "minDelayTarget": 20,
+      "maxDelayTarget": 20,
+      "numRetries": 3,
+      "numMaxDelayRetries": 0,
+      "numNoDelayRetries": 0,
+      "numMinDelayRetries": 0,
+      "backoffFunction": "linear"
+    },
+    "disableSubscriptionOverrides": false,
+    "defaultThrottlePolicy": {
+      "maxReceivesPerSecond": 1
+    }
+  }
+}
+EOF
+}
 ```

--- a/website/docs/r/sns_topic.html.markdown
+++ b/website/docs/r/sns_topic.html.markdown
@@ -18,6 +18,33 @@ resource "aws_sns_topic" "user_updates" {
 }
 ```
 
+## Example with Delivery Policy
+
+``` hcl
+resource "aws_sns_topic" "user_updates" {
+  name = "user-updates-topic"
+  delivery_policy = <<EOF
+{
+  "http": {
+    "defaultHealthyRetryPolicy": {
+      "minDelayTarget": 20,
+      "maxDelayTarget": 20,
+      "numRetries": 3,
+      "numMaxDelayRetries": 0,
+      "numNoDelayRetries": 0,
+      "numMinDelayRetries": 0,
+      "backoffFunction": "linear"
+    },
+    "disableSubscriptionOverrides": false,
+    "defaultThrottlePolicy": {
+      "maxReceivesPerSecond": 1
+    }
+  }
+}
+EOF
+}
+```
+
 ## Message Delivery Status Arguments
 
 The `<endpoint>_success_feedback_role_arn` and `<endpoint>_failure_feedback_role_arn` arguments are used to give Amazon SNS write access to use CloudWatch Logs on your behalf. The `<endpoint>_success_feedback_sample_rate` argument is for specifying the sample rate percentage (0-100) of successfully delivered messages. After you configure the  `<endpoint>_failure_feedback_role_arn` argument, then all failed message deliveries generate CloudWatch Logs.
@@ -57,31 +84,4 @@ SNS Topics can be imported using the `topic arn`, e.g.
 
 ```
 $ terraform import aws_sns_topic.user_updates arn:aws:sns:us-west-2:0123456789012:my-topic
-```
-
-## Example with Delivery Policy
-
-``` hcl
-resource "aws_sns_topic" "user_updates" {
-  name = "user-updates-topic"
-  delivery_policy = <<EOF
-{
-  "http": {
-    "defaultHealthyRetryPolicy": {
-      "minDelayTarget": 20,
-      "maxDelayTarget": 20,
-      "numRetries": 3,
-      "numMaxDelayRetries": 0,
-      "numNoDelayRetries": 0,
-      "numMinDelayRetries": 0,
-      "backoffFunction": "linear"
-    },
-    "disableSubscriptionOverrides": false,
-    "defaultThrottlePolicy": {
-      "maxReceivesPerSecond": 1
-    }
-  }
-}
-EOF
-}
 ```


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #2161

Changes proposed in this pull request:

* Adds example for SNS topic delivery argument for SNS topic resource
* Links to AWS documentation

Output from acceptance testing:


