### PR TITLE
adding '/*' to the example so it works

### DIFF
--- a/website/docs/r/elasticsearch_domain_policy.html.markdown
+++ b/website/docs/r/elasticsearch_domain_policy.html.markdown
@@ -32,7 +32,7 @@ resource "aws_elasticsearch_domain_policy" "main" {
             "Condition": {
                 "IpAddress": {"aws:SourceIp": "127.0.0.1/32"}
             },
-            "Resource": "${aws_elasticsearch_domain.example.arn}"
+            "Resource": "${aws_elasticsearch_domain.example.arn}/*"
         }
     ]
 }


### PR DESCRIPTION
Just a quick tweak to the policy so that it works.  Without the "/*" at the end of the resource, the example policy didn't work for me. 
