### PR TITLE
New Resource: aws_neptune_cluster_parameter_group

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -625,6 +625,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_batch_job_definition":                     resourceAwsBatchJobDefinition(),
 			"aws_batch_job_queue":                          resourceAwsBatchJobQueue(),
 			"aws_neptune_subnet_group":                     resourceAwsNeptuneSubnetGroup(),
+			"aws_neptune_cluster_parameter_group":          resourceAwsNeptuneClusterParameterGroup(),
 
 			// ALBs are actually LBs because they can be type `network` or `application`
 			// To avoid regressions, we will add a new resource for each and they both point

--- a/aws/resource_aws_neptune_cluster_parameter_group.go
+++ b/aws/resource_aws_neptune_cluster_parameter_group.go
@@ -1,0 +1,254 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/neptune"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+const neptuneClusterParameterGroupMaxParamsBulkEdit = 20
+
+func resourceAwsNeptuneClusterParameterGroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsNeptuneClusterParameterGroupCreate,
+		Read:   resourceAwsNeptuneClusterParameterGroupRead,
+		Update: resourceAwsNeptuneClusterParameterGroupUpdate,
+		Delete: resourceAwsNeptuneClusterParameterGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name_prefix"},
+				ValidateFunc:  validateNeptuneParamGroupName,
+			},
+			"name_prefix": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validateNeptuneParamGroupNamePrefix,
+			},
+			"family": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "Managed by Terraform",
+			},
+			"parameter": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"apply_method": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  neptune.ApplyMethodPendingReboot,
+							ValidateFunc: validation.StringInSlice([]string{
+								neptune.ApplyMethodImmediate,
+								neptune.ApplyMethodPendingReboot,
+							}, false),
+						},
+					},
+				},
+			},
+
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceAwsNeptuneClusterParameterGroupCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).neptuneconn
+	tags := tagsFromMapNeptune(d.Get("tags").(map[string]interface{}))
+
+	var groupName string
+	if v, ok := d.GetOk("name"); ok {
+		groupName = v.(string)
+	} else if v, ok := d.GetOk("name_prefix"); ok {
+		groupName = resource.PrefixedUniqueId(v.(string))
+	} else {
+		groupName = resource.UniqueId()
+	}
+
+	createOpts := neptune.CreateDBClusterParameterGroupInput{
+		DBClusterParameterGroupName: aws.String(groupName),
+		DBParameterGroupFamily:      aws.String(d.Get("family").(string)),
+		Description:                 aws.String(d.Get("description").(string)),
+		Tags:                        tags,
+	}
+
+	log.Printf("[DEBUG] Create Neptune Cluster Parameter Group: %#v", createOpts)
+	_, err := conn.CreateDBClusterParameterGroup(&createOpts)
+	if err != nil {
+		return fmt.Errorf("Error creating Neptune Cluster Parameter Group: %s", err)
+	}
+
+	d.SetId(aws.StringValue(createOpts.DBClusterParameterGroupName))
+	log.Printf("[INFO] Neptune Cluster Parameter Group ID: %s", d.Id())
+
+	return resourceAwsNeptuneClusterParameterGroupUpdate(d, meta)
+}
+
+func resourceAwsNeptuneClusterParameterGroupRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).neptuneconn
+
+	describeOpts := neptune.DescribeDBClusterParameterGroupsInput{
+		DBClusterParameterGroupName: aws.String(d.Id()),
+	}
+
+	describeResp, err := conn.DescribeDBClusterParameterGroups(&describeOpts)
+	if err != nil {
+		if isAWSErr(err, neptune.ErrCodeDBParameterGroupNotFoundFault, "") {
+			log.Printf("[WARN] Neptune Cluster Parameter Group (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+
+		return err
+	}
+
+	if len(describeResp.DBClusterParameterGroups) != 1 ||
+		aws.StringValue(describeResp.DBClusterParameterGroups[0].DBClusterParameterGroupName) != d.Id() {
+		return fmt.Errorf("Unable to find Cluster Parameter Group: %#v", describeResp.DBClusterParameterGroups)
+	}
+
+	d.Set("name", describeResp.DBClusterParameterGroups[0].DBClusterParameterGroupName)
+	d.Set("family", describeResp.DBClusterParameterGroups[0].DBParameterGroupFamily)
+	d.Set("description", describeResp.DBClusterParameterGroups[0].Description)
+	arn := aws.StringValue(describeResp.DBClusterParameterGroups[0].DBClusterParameterGroupArn)
+	d.Set("arn", arn)
+
+	// Only include user customized parameters as there's hundreds of system/default ones
+	describeParametersOpts := neptune.DescribeDBClusterParametersInput{
+		DBClusterParameterGroupName: aws.String(d.Id()),
+		Source: aws.String("user"),
+	}
+
+	describeParametersResp, err := conn.DescribeDBClusterParameters(&describeParametersOpts)
+	if err != nil {
+		return err
+	}
+
+	if err := d.Set("parameter", flattenNeptuneParameters(describeParametersResp.Parameters)); err != nil {
+		return fmt.Errorf("error setting neptune parameter: %s", err)
+	}
+
+	resp, err := conn.ListTagsForResource(&neptune.ListTagsForResourceInput{
+		ResourceName: aws.String(arn),
+	})
+	if err != nil {
+		log.Printf("[DEBUG] Error retrieving tags for ARN: %s", arn)
+	}
+
+	d.Set("tags", tagsToMapNeptune(resp.TagList))
+
+	return nil
+}
+
+func resourceAwsNeptuneClusterParameterGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).neptuneconn
+
+	d.Partial(true)
+
+	if d.HasChange("parameter") {
+		o, n := d.GetChange("parameter")
+		if o == nil {
+			o = new(schema.Set)
+		}
+		if n == nil {
+			n = new(schema.Set)
+		}
+
+		os := o.(*schema.Set)
+		ns := n.(*schema.Set)
+
+		parameters, err := expandNeptuneParameters(ns.Difference(os).List())
+		if err != nil {
+			return err
+		}
+
+		if len(parameters) > 0 {
+			// We can only modify 20 parameters at a time, so walk them until
+			// we've got them all.
+			for parameters != nil {
+				paramsToModify := make([]*neptune.Parameter, 0)
+				if len(parameters) <= neptuneClusterParameterGroupMaxParamsBulkEdit {
+					paramsToModify, parameters = parameters[:], nil
+				} else {
+					paramsToModify, parameters = parameters[:neptuneClusterParameterGroupMaxParamsBulkEdit], parameters[neptuneClusterParameterGroupMaxParamsBulkEdit:]
+				}
+				parameterGroupName := d.Get("name").(string)
+				modifyOpts := neptune.ModifyDBClusterParameterGroupInput{
+					DBClusterParameterGroupName: aws.String(parameterGroupName),
+					Parameters:                  paramsToModify,
+				}
+
+				log.Printf("[DEBUG] Modify Neptune Cluster Parameter Group: %s", modifyOpts)
+				_, err = conn.ModifyDBClusterParameterGroup(&modifyOpts)
+				if err != nil {
+					return fmt.Errorf("Error modifying Neptune Cluster Parameter Group: %s", err)
+				}
+			}
+			d.SetPartial("parameter")
+		}
+	}
+
+	arn := d.Get("arn").(string)
+	if err := setTagsNeptune(conn, d, arn); err != nil {
+		return err
+	} else {
+		d.SetPartial("tags")
+	}
+
+	d.Partial(false)
+
+	return resourceAwsNeptuneClusterParameterGroupRead(d, meta)
+}
+
+func resourceAwsNeptuneClusterParameterGroupDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).neptuneconn
+
+	input := neptune.DeleteDBClusterParameterGroupInput{
+		DBClusterParameterGroupName: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Deleting Neptune Cluster Parameter Group: %s", d.Id())
+	_, err := conn.DeleteDBClusterParameterGroup(&input)
+	if err != nil {
+		if isAWSErr(err, neptune.ErrCodeDBParameterGroupNotFoundFault, "") {
+			return nil
+		}
+		return fmt.Errorf("error deleting Neptune Cluster Parameter Group (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_neptune_cluster_parameter_group_test.go
+++ b/aws/resource_aws_neptune_cluster_parameter_group_test.go
@@ -1,0 +1,229 @@
+package aws
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/neptune"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSNeptuneClusterParameterGroup_basic(t *testing.T) {
+	var v neptune.DBClusterParameterGroup
+
+	parameterGroupName := fmt.Sprintf("cluster-parameter-group-test-terraform-%d", acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSNeptuneClusterParameterGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSNeptuneClusterParameterGroupConfig(parameterGroupName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSNeptuneClusterParameterGroupExists("aws_neptune_cluster_parameter_group.bar", &v),
+					testAccCheckAWSNeptuneClusterParameterGroupAttributes(&v, parameterGroupName),
+					resource.TestCheckResourceAttr(
+						"aws_neptune_cluster_parameter_group.bar", "name", parameterGroupName),
+					resource.TestCheckResourceAttr(
+						"aws_neptune_cluster_parameter_group.bar", "family", "neptune1"),
+					resource.TestCheckResourceAttr(
+						"aws_neptune_cluster_parameter_group.bar", "description", "Test cluster parameter group for terraform"),
+					resource.TestCheckResourceAttr("aws_neptune_cluster_parameter_group.bar", "parameter.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_neptune_cluster_parameter_group.bar", "tags.%", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSNeptuneClusterParameterGroup_namePrefix(t *testing.T) {
+	var v neptune.DBClusterParameterGroup
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSNeptuneClusterParameterGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSNeptuneClusterParameterGroupConfig_namePrefix,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSNeptuneClusterParameterGroupExists("aws_neptune_cluster_parameter_group.test", &v),
+					resource.TestMatchResourceAttr(
+						"aws_neptune_cluster_parameter_group.test", "name", regexp.MustCompile("^tf-test-")),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSNeptuneClusterParameterGroup_generatedName(t *testing.T) {
+	var v neptune.DBClusterParameterGroup
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSNeptuneClusterParameterGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSNeptuneClusterParameterGroupConfig_generatedName,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSNeptuneClusterParameterGroupExists("aws_neptune_cluster_parameter_group.test", &v),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSNeptuneClusterParameterGroup_withoutParameter(t *testing.T) {
+	var v neptune.DBClusterParameterGroup
+
+	parameterGroupName := fmt.Sprintf("cluster-parameter-group-test-tf-%d", acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSNeptuneClusterParameterGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSNeptuneClusterParameterGroupOnlyConfig(parameterGroupName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSNeptuneClusterParameterGroupExists("aws_neptune_cluster_parameter_group.bar", &v),
+					testAccCheckAWSNeptuneClusterParameterGroupAttributes(&v, parameterGroupName),
+					resource.TestCheckResourceAttr(
+						"aws_neptune_cluster_parameter_group.bar", "name", parameterGroupName),
+					resource.TestCheckResourceAttr(
+						"aws_neptune_cluster_parameter_group.bar", "family", "neptune1"),
+					resource.TestCheckResourceAttr(
+						"aws_neptune_cluster_parameter_group.bar", "description", "Managed by Terraform"),
+					resource.TestCheckResourceAttr("aws_neptune_cluster_parameter_group.bar", "parameter.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSNeptuneClusterParameterGroupDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).neptuneconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_neptune_cluster_parameter_group" {
+			continue
+		}
+
+		resp, err := conn.DescribeDBClusterParameterGroups(
+			&neptune.DescribeDBClusterParameterGroupsInput{
+				DBClusterParameterGroupName: aws.String(rs.Primary.ID),
+			})
+
+		if err == nil {
+			if len(resp.DBClusterParameterGroups) != 0 &&
+				aws.StringValue(resp.DBClusterParameterGroups[0].DBClusterParameterGroupName) == rs.Primary.ID {
+				return errors.New("Neptune Cluster Parameter Group still exists")
+			}
+		}
+
+		if err != nil {
+			if isAWSErr(err, neptune.ErrCodeDBParameterGroupNotFoundFault, "") {
+				return nil
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAWSNeptuneClusterParameterGroupAttributes(v *neptune.DBClusterParameterGroup, name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		if *v.DBClusterParameterGroupName != name {
+			return fmt.Errorf("bad name: %#v expected: %v", *v.DBClusterParameterGroupName, name)
+		}
+
+		if *v.DBParameterGroupFamily != "neptune1" {
+			return fmt.Errorf("bad family: %#v", *v.DBParameterGroupFamily)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSNeptuneClusterParameterGroupExists(n string, v *neptune.DBClusterParameterGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("No Neptune Cluster Parameter Group ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).neptuneconn
+
+		opts := neptune.DescribeDBClusterParameterGroupsInput{
+			DBClusterParameterGroupName: aws.String(rs.Primary.ID),
+		}
+
+		resp, err := conn.DescribeDBClusterParameterGroups(&opts)
+
+		if err != nil {
+			return err
+		}
+
+		if len(resp.DBClusterParameterGroups) != 1 ||
+			aws.StringValue(resp.DBClusterParameterGroups[0].DBClusterParameterGroupName) != rs.Primary.ID {
+			return errors.New("Neptune Cluster Parameter Group not found")
+		}
+
+		*v = *resp.DBClusterParameterGroups[0]
+
+		return nil
+	}
+}
+
+func testAccAWSNeptuneClusterParameterGroupConfig(name string) string {
+	return fmt.Sprintf(`
+resource "aws_neptune_cluster_parameter_group" "bar" {
+  name        = "%s"
+  family      = "neptune1"
+  description = "Test cluster parameter group for terraform"
+
+  parameter {
+    name  = "neptune_enable_audit_log"
+    value = 1
+  }
+
+  tags {
+    foo = "bar"
+  }
+}
+`, name)
+}
+
+func testAccAWSNeptuneClusterParameterGroupOnlyConfig(name string) string {
+	return fmt.Sprintf(`resource "aws_neptune_cluster_parameter_group" "bar" {
+  name        = "%s"
+  family      = "neptune1"
+  description = "Managed by Terraform"
+}`, name)
+}
+
+const testAccAWSNeptuneClusterParameterGroupConfig_namePrefix = `
+resource "aws_neptune_cluster_parameter_group" "test" {
+  name_prefix = "tf-test-"
+  family = "neptune1"
+}
+`
+const testAccAWSNeptuneClusterParameterGroupConfig_generatedName = `
+resource "aws_neptune_cluster_parameter_group" "test" {
+  family = "neptune1"
+}
+`

--- a/aws/resource_aws_neptune_cluster_parameter_group_test.go
+++ b/aws/resource_aws_neptune_cluster_parameter_group_test.go
@@ -212,7 +212,6 @@ func testAccAWSNeptuneClusterParameterGroupOnlyConfig(name string) string {
 	return fmt.Sprintf(`resource "aws_neptune_cluster_parameter_group" "bar" {
   name        = "%s"
   family      = "neptune1"
-  description = "Managed by Terraform"
 }`, name)
 }
 

--- a/aws/resource_aws_neptune_cluster_parameter_group_test.go
+++ b/aws/resource_aws_neptune_cluster_parameter_group_test.go
@@ -37,6 +37,8 @@ func TestAccAWSNeptuneClusterParameterGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_neptune_cluster_parameter_group.bar", "parameter.#", "1"),
 					resource.TestCheckResourceAttr(
 						"aws_neptune_cluster_parameter_group.bar", "tags.%", "1"),
+					resource.TestMatchResourceAttr(
+						"aws_neptune_cluster_parameter_group.bar", "arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:rds:[^:]+:\\d{12}:cluster-pg:%s", parameterGroupName))),
 				),
 			},
 		},

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1816,3 +1816,50 @@ func validateLaunchTemplateId(v interface{}, k string) (ws []string, errors []er
 	}
 	return
 }
+
+func validateNeptuneParamGroupName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only lowercase alphanumeric characters and hyphens allowed in %q", k))
+	}
+	if !regexp.MustCompile(`^[a-z]`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"first character of %q must be a letter", k))
+	}
+	if regexp.MustCompile(`--`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot contain two consecutive hyphens", k))
+	}
+	if regexp.MustCompile(`-$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot end with a hyphen", k))
+	}
+	if len(value) > 255 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be greater than 255 characters", k))
+	}
+	return
+}
+
+func validateNeptuneParamGroupNamePrefix(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only lowercase alphanumeric characters and hyphens allowed in %q", k))
+	}
+	if !regexp.MustCompile(`^[a-z]`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"first character of %q must be a letter", k))
+	}
+	if regexp.MustCompile(`--`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot contain two consecutive hyphens", k))
+	}
+	prefixMaxLength := 255 - resource.UniqueIDSuffixLength
+	if len(value) > prefixMaxLength {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be greater than %d characters", k, prefixMaxLength))
+	}
+	return
+}

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -2646,3 +2646,91 @@ func TestValidateLaunchTemplateId(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateNeptuneParamGroupName(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "tEsting123",
+			ErrCount: 1,
+		},
+		{
+			Value:    "testing123!",
+			ErrCount: 1,
+		},
+		{
+			Value:    "1testing123",
+			ErrCount: 1,
+		},
+		{
+			Value:    "testing--123",
+			ErrCount: 1,
+		},
+		{
+			Value:    "testing_123",
+			ErrCount: 1,
+		},
+		{
+			Value:    "testing123-",
+			ErrCount: 1,
+		},
+		{
+			Value:    randomString(256),
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateNeptuneParamGroupName(tc.Value, "aws_neptune_cluster_parameter_group_name")
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected the Neptune Parameter Group Name to trigger a validation error")
+		}
+	}
+}
+
+func TestValidateNeptuneParamGroupNamePrefix(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "tEsting123",
+			ErrCount: 1,
+		},
+		{
+			Value:    "testing123!",
+			ErrCount: 1,
+		},
+		{
+			Value:    "1testing123",
+			ErrCount: 1,
+		},
+		{
+			Value:    "testing--123",
+			ErrCount: 1,
+		},
+		{
+			Value:    "testing_123",
+			ErrCount: 1,
+		},
+		{
+			Value:    "testing123-",
+			ErrCount: 1,
+		},
+		{
+			Value:    randomString(256),
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateNeptuneParamGroupNamePrefix(tc.Value, "aws_neptune_cluster_parameter_group_name")
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected the Neptune Parameter Group Name to trigger a validation error")
+		}
+	}
+}

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -2686,7 +2686,7 @@ func TestValidateNeptuneParamGroupName(t *testing.T) {
 		_, errors := validateNeptuneParamGroupName(tc.Value, "aws_neptune_cluster_parameter_group_name")
 
 		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected the Neptune Parameter Group Name to trigger a validation error")
+			t.Fatalf("Expected the Neptune Parameter Group Name to trigger a validation error for %q", tc.Value)
 		}
 	}
 }
@@ -2717,10 +2717,6 @@ func TestValidateNeptuneParamGroupNamePrefix(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    "testing123-",
-			ErrCount: 1,
-		},
-		{
 			Value:    randomString(256),
 			ErrCount: 1,
 		},
@@ -2730,7 +2726,7 @@ func TestValidateNeptuneParamGroupNamePrefix(t *testing.T) {
 		_, errors := validateNeptuneParamGroupNamePrefix(tc.Value, "aws_neptune_cluster_parameter_group_name")
 
 		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected the Neptune Parameter Group Name to trigger a validation error")
+			t.Fatalf("Expected the Neptune Parameter Group Name to trigger a validation error for %q", tc.Value)
 		}
 	}
 }

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1625,6 +1625,10 @@
                             <a href="/docs/providers/aws/r/neptune_subnet_group.html">aws_neptune_subnet_group</a>
                         </li>
 
+                         <li<%= sidebar_current("docs-aws-resource-neptune-cluster-parameter-group") %>>
+                            <a href="/docs/providers/aws/r/neptune_cluster_parameter_group.html">aws_neptune_cluster_parameter_group</a>
+                        </li>
+
                     </ul>
                 </li>
 
@@ -1647,16 +1651,6 @@
                   <li<%= sidebar_current("docs-aws-resource-redshift-subnet-group") %>>
                     <a href="/docs/providers/aws/r/redshift_subnet_group.html">aws_redshift_subnet_group</a>
                   </li>
-                 <li<%= sidebar_current("docs-aws-resource-neptune") %>>
-                    <a href="#">Neptune Resources</a>
-                    <ul class="nav nav-visible">
-
-                        <li<%= sidebar_current("docs-aws-resource-aws-neptune-parameter-group") %>>
-                            <a href="/docs/providers/aws/r/neptune_parameter_group.html">aws_neptune_parameter_group</a>
-                        </li>
-
-                    </ul>
-                </li>
 
                 </ul>
               </li>

--- a/website/docs/r/neptune_cluster_parameter_group.html.markdown
+++ b/website/docs/r/neptune_cluster_parameter_group.html.markdown
@@ -1,0 +1,59 @@
+---
+layout: "aws"
+page_title: "AWS: aws_neptune_cluster_parameter_group"
+sidebar_current: "docs-aws-resource-aws-neptune-cluster-parameter-group"
+description: |-
+  Manages a Neptune Cluster Parameter Group
+---
+
+# aws_neptune_cluster_parameter_group
+
+Manages a Neptune Cluster Parameter Group
+
+## Example Usage
+
+```hcl
+resource "aws_neptune_cluster_parameter_group" "example" {
+  family = "neptune1"
+  name   = "example"
+  description = "neptune cluster parameter group"
+
+  parameter {
+    name         = "neptune_enable_audit_log"
+    value        = 1
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Optional, Forces new resource) The name of the neptune cluster parameter group. If omitted, Terraform will assign a random, unique name.
+* `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
+* `family` - (Required) The family of the neptune cluster parameter group.
+* `description` - (Optional) The description of the neptune cluster parameter group. Defaults to "Managed by Terraform".
+* `parameter` - (Optional) A list of neptune parameters to apply.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
+Parameter blocks support the following:
+
+* `name` - (Required) The name of the neptune parameter.
+* `value` - (Required) The value of the neptune parameter.
+* `apply_method` - (Optional) Valid values are `immediate` and `pending-reboot`. Defaults to `pending-reboot`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The neptune cluster parameter group name.
+* `arn` - The ARN of the neptune cluster parameter group.
+
+
+## Import
+
+Neptune Cluster Parameter Groups can be imported using the `name`, e.g.
+
+```
+$ terraform import aws_neptune_cluster_parameter_group.cluster_pg production-pg-1
+```


### PR DESCRIPTION
Reference #4713 

Changes proposed in this pull request:

* Change 1
added new resource neptune cluster parameter group

```
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSNeptuneClusterParameterGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAWSNeptuneClusterParameterGroup -timeout 120m
=== RUN   TestAccAWSNeptuneClusterParameterGroup_basic
--- PASS: TestAccAWSNeptuneClusterParameterGroup_basic (50.01s)
=== RUN   TestAccAWSNeptuneClusterParameterGroup_namePrefix
--- PASS: TestAccAWSNeptuneClusterParameterGroup_namePrefix (44.31s)
=== RUN   TestAccAWSNeptuneClusterParameterGroup_generatedName
--- PASS: TestAccAWSNeptuneClusterParameterGroup_generatedName (46.43s)
=== RUN   TestAccAWSNeptuneClusterParameterGroup_withoutParameter
--- PASS: TestAccAWSNeptuneClusterParameterGroup_withoutParameter (46.04s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	186.824s
...
```
