### PR TITLE
Adding KMS support for ebs_block_devices for `aws_instance`

### DIFF
--- a/aws/data_source_aws_instance.go
+++ b/aws/data_source_aws_instance.go
@@ -163,6 +163,11 @@ func dataSourceAwsInstance() *schema.Resource {
 							Computed: true,
 						},
 
+						"kms_key_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
 						"iops": {
 							Type:     schema.TypeInt,
 							Computed: true,

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -308,6 +308,12 @@ func resourceAwsInstance() *schema.Resource {
 							ForceNew: true,
 						},
 
+						"kms_key_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+
 						"iops": {
 							Type:             schema.TypeInt,
 							Optional:         true,
@@ -1279,6 +1285,9 @@ func readBlockDevicesFromInstance(instance *ec2.Instance, conn *ec2.EC2) (map[st
 			if vol.Encrypted != nil {
 				bd["encrypted"] = *vol.Encrypted
 			}
+			if vol.KmsKeyId != nil {
+				bd["kms_key_id"] = *vol.KmsKeyId
+			}
 			if vol.SnapshotId != nil {
 				bd["snapshot_id"] = *vol.SnapshotId
 			}
@@ -1437,6 +1446,10 @@ func readBlockDeviceMappingsFromConfig(
 
 			if v, ok := bd["encrypted"].(bool); ok && v {
 				ebs.Encrypted = aws.Bool(v)
+			}
+
+			if v, ok := bd["kms_key_id"].(string); ok && v != "" {
+				ebs.KmsKeyId = aws.String(v)
 			}
 
 			if v, ok := bd["volume_size"].(int); ok && v != 0 {

--- a/website/docs/d/instance.html.markdown
+++ b/website/docs/d/instance.html.markdown
@@ -63,6 +63,7 @@ interpolation.
   * `delete_on_termination` - If the EBS volume will be deleted on termination.
   * `device_name` - The physical name of the device.
   * `encrypted` - If the EBS volume is encrypted.
+  * `kms_key_id` - If the EBS volume is encrypted with a CMK KMS
   * `iops` - `0` If the EBS volume is not a provisioned IOPS image, otherwise the supported IOPS count.
   * `snapshot_id` - The ID of the snapshot.
   * `volume_size` - The size of the volume, in GiB.

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -137,6 +137,7 @@ Each `ebs_block_device` supports the following:
 * `encrypted` - (Optional) Enables [EBS
   encryption](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html)
   on the volume (Default: `false`). Cannot be used with `snapshot_id`.
+* `kms_key_id` - (Optional) Uses a CMK KMS key for encrypting the EBS block device. Either the      KMS key arn or the alias name can be used.
 
 Modifying any `ebs_block_device` currently requires resource replacement.
 


### PR DESCRIPTION
Signed-off-by: Noel Georgi <18496730+frezbo@users.noreply.github.com>

refers: https://github.com/terraform-providers/terraform-provider-aws/issues/657


I would like to know how to add test case's for this, should I create a KMS key before and use that. This needs to be added back to launch configs, opsworks instances etc.

I would also love to run acceptance testing, but the hard coded regions and values makes it difficult. (I use gov-cloud  regions). Will it be possible in the future to read a config file that has these details and if not present fall back to the hardcoded values. A sample config file  we use for testing with chef projects:
```
export VPC_ID="<redacted>"
export SUBNET_ID="<redacted>"
export SG_ID="<redacted>"
export SSH_KEY="<redacted>"
export IAM_PROFILE="<redacted>"
export TAGS_OWNER="<redacted>"
export TAGS_ENVIRONMENT="<redacted>"
export TAGS_PROJECT="redacted"
export TAGS_EXPIRY=$(date -d +10days +%Y-%m-%d)
export SSH_KEY_PATH="<redacted>"
export PUBLIC_IP=true
``` 
@hashibot 