### PR TITLE
fix example

### DIFF
--- a/website/docs/r/cognito_identity_provider.html.markdown
+++ b/website/docs/r/cognito_identity_provider.html.markdown
@@ -20,7 +20,7 @@ resource "aws_cognito_user_pool" "example" {
 
 resource "aws_cognito_identity_provider" "example_provider" {
   user_pool_id  = "${aws_cognito_user_pool.example.id}"
-  provider_name = "example_name"
+  provider_name = "Google"
   provider_type = "Google"
 
   provider_details {


### PR DESCRIPTION
`provider_name = "example_name"` gave me an error.


according to
https://github.com/aws/aws-sdk-go/blob/master/service/cognitoidentityprovider/api.go#L19928
provider_name are Facebook, Google, or Login with Amazon

`provider_name = "Google"` works for me. 