### PR TITLE
Create aws_ecr_lifecycle_policy_document data source

### DIFF
--- a/aws/data_source_aws_ecr_lifecycle_policy_document.go
+++ b/aws/data_source_aws_ecr_lifecycle_policy_document.go
@@ -1,0 +1,245 @@
+package aws
+
+import (
+	"encoding/json"
+	"sort"
+	"strconv"
+
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+type ECRLifecyclePolicyDocument struct {
+	Id    string                    `json:",omitempty"`
+	Rules []*ECRLifecyclePolicyRule `json:"rules"`
+}
+
+type ECRLifecyclePolicyRule struct {
+	Priority    int                            `json:"rulePriority,omitempty"`
+	Description string                         `json:"description,omitempty"`
+	Selection   ECRLifecyclePolicySelectionSet `json:"selection,omitempty"`
+	Action      ECRLifecyclePolicyActionSet    `json:"action,omitempty"`
+}
+
+type ECRLifecyclePolicySelectionSet struct {
+	TagStatus     string      `json:"tagStatus,omitempty"`
+	TagPrefixList interface{} `json:"tagPrefixList,omitempty"`
+	CountType     string      `json:"countType,omitempty"`
+	CountUnit     string      `json:"countUnit,omitempty"`
+	CountNumber   int         `json:"countNumber,omitempty"`
+}
+
+type ECRLifecyclePolicyActionSet struct {
+	Type string `json:"type,omitempty"`
+}
+
+func (self *ECRLifecyclePolicyDocument) merge(newDoc *ECRLifecyclePolicyDocument) {
+	// adopt newDoc's Id
+	if len(newDoc.Id) > 0 {
+		self.Id = newDoc.Id
+	}
+
+	// merge in newDoc's statements, overwriting any existing Sids
+	var seen bool
+	for _, newRule := range newDoc.Rules {
+		seen = false
+		for _, existingRule := range self.Rules {
+			if existingRule.Priority == newRule.Priority {
+				panic("Unsupported merge of rules with the same rule priority")
+			}
+		}
+
+		if !seen {
+			self.Rules = append(self.Rules, newRule)
+		}
+	}
+}
+
+func dataSourceAwsEcrLifecyclePolicyDocument() *schema.Resource {
+
+	return &schema.Resource{
+		Read: dataSourceAwsEcrLifecyclePolicyDocumentRead,
+
+		Schema: map[string]*schema.Schema{
+			"source_json": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"rule": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"priority": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"selection": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"tag_status": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice([]string{"untagged", "tagged"}, false),
+									},
+									"tag_prefixes": &schema.Schema{
+										Type:     schema.TypeSet,
+										Optional: true,
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+										},
+									},
+									"count_type": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice([]string{"imageCountMoreThan", "sinceImagePushed"}, false),
+									},
+									"count_unit": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringInSlice([]string{"days"}, false),
+									},
+									"count_number": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+						"action": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"type": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice([]string{"expire"}, false),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"json": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsEcrLifecyclePolicyDocumentRead(d *schema.ResourceData, meta interface{}) error {
+	mergedDoc := &ECRLifecyclePolicyDocument{}
+
+	// populate mergedDoc directly with any source_json
+	if sourceJson, hasSourceJson := d.GetOk("source_json"); hasSourceJson {
+		if err := json.Unmarshal([]byte(sourceJson.(string)), mergedDoc); err != nil {
+			return err
+		}
+	}
+
+	// process the current document
+	doc := &ECRLifecyclePolicyDocument{}
+
+	var cfgRules = d.Get("rule").([]interface{})
+	rules := make([]*ECRLifecyclePolicyRule, len(cfgRules))
+	for i, ruleI := range cfgRules {
+		cfgRule := ruleI.(map[string]interface{})
+		rule := &ECRLifecyclePolicyRule{}
+
+		if priority, ok := cfgRule["priority"]; ok {
+			rule.Priority, _ = strconv.Atoi(priority.(string))
+		}
+
+		if description, ok := cfgRule["description"]; ok {
+			rule.Description = description.(string)
+		}
+
+		rule.Selection = ecrLifecyclePolicyMakeSelection(cfgRule["selection"].(*schema.Set).List())
+		rule.Action = ecrLifecyclePolicyMakeAction(cfgRule["action"].(*schema.Set).List())
+
+		rules[i] = rule
+	}
+
+	doc.Rules = rules
+
+	// merge our current document into mergedDoc
+	mergedDoc.merge(doc)
+
+	jsonDoc, err := json.MarshalIndent(mergedDoc, "", "  ")
+	if err != nil {
+		// should never happen if the above code is correct
+		return err
+	}
+	jsonString := string(jsonDoc)
+
+	d.Set("json", jsonString)
+	d.SetId(strconv.Itoa(hashcode.String(jsonString)))
+
+	return nil
+}
+
+func ecrLifecyclePolicyMakeSelection(in []interface{}) ECRLifecyclePolicySelectionSet {
+	if len(in) == 1 {
+		selection := in[0].(map[string]interface{})
+		out := &ECRLifecyclePolicySelectionSet{}
+
+		if tagStatus, ok := selection["tag_status"]; ok {
+			out.TagStatus = tagStatus.(string)
+		}
+
+		if tagPrefixList := selection["tag_prefixes"].(*schema.Set).List(); len(tagPrefixList) > 0 {
+			out.TagPrefixList = ecrLifecyclePolicyDecodeConfigStringList(tagPrefixList)
+		}
+
+		if countType, ok := selection["count_type"]; ok {
+			out.CountType = countType.(string)
+		}
+
+		if countUnit, ok := selection["count_unit"]; ok {
+			out.CountUnit = countUnit.(string)
+		}
+
+		if countNumber, ok := selection["count_number"]; ok {
+			out.CountNumber, _ = strconv.Atoi(countNumber.(string))
+		}
+
+		return *out
+	} else {
+		panic("Cannot specify more than one selection per rule")
+	}
+}
+
+func ecrLifecyclePolicyMakeAction(in []interface{}) ECRLifecyclePolicyActionSet {
+	if len(in) == 0 {
+		return ECRLifecyclePolicyActionSet{
+			Type: "expire",
+		}
+	} else if len(in) == 1 {
+		action := in[0].(map[string]interface{})
+
+		return ECRLifecyclePolicyActionSet{
+			Type: action["type"].(string),
+		}
+	} else {
+		panic("Cannot specify more than one action per rule")
+	}
+}
+
+func ecrLifecyclePolicyDecodeConfigStringList(lI []interface{}) interface{} {
+	ret := make([]string, len(lI))
+	for i, vI := range lI {
+		ret[i] = vI.(string)
+	}
+	sort.Sort(sort.Reverse(sort.StringSlice(ret)))
+	return ret
+}

--- a/aws/data_source_aws_ecr_lifecycle_policy_document_test.go
+++ b/aws/data_source_aws_ecr_lifecycle_policy_document_test.go
@@ -1,0 +1,190 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSDataSourceECRLifecyclePolicyDocument_basic(t *testing.T) {
+	// This really ought to be able to be a unit test rather than an
+	// acceptance test, but just instantiating the AWS provider requires
+	// some AWS API calls, and so this needs valid AWS credentials to work.
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSECRLifecyclePolicyDocumentConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckStateValue("data.aws_ecr_lifecycle_policy_document.test", "json",
+						testAccAWSECRLifecyclePolicyDocumentExpectedJSON,
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDataSourceECRLifecyclePolicyDocument_source(t *testing.T) {
+	// This really ought to be able to be a unit test rather than an
+	// acceptance test, but just instantiating the AWS provider requires
+	// some AWS API calls, and so this needs valid AWS credentials to work.
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSECRLifecyclePolicyDocumentSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckStateValue("data.aws_ecr_lifecycle_policy_document.test_source", "json",
+						testAccAWSECRLifecyclePolicyDocumentSourceExpectedJSON,
+					),
+				),
+			},
+			{
+				Config: testAccAWSECRLifecyclePolicyDocumentSourceBlankConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckStateValue("data.aws_ecr_lifecycle_policy_document.test_source_blank", "json",
+						testAccAWSECRLifecyclePolicyDocumentSourceBlankExpectedJSON,
+					),
+				),
+			},
+		},
+	})
+}
+
+var testAccAWSECRLifecyclePolicyDocumentConfig = `
+data "aws_ecr_lifecycle_policy_document" "test" {
+  rule {
+    priority = 1
+    description = "Expire images older than 14 days"
+
+    selection {
+      tag_status = "untagged"
+      count_type = "sinceImagePushed"
+      count_unit = "days"
+      count_number = 14
+    }
+  }
+}
+`
+
+var testAccAWSECRLifecyclePolicyDocumentExpectedJSON = `{
+  "rules": [
+    {
+      "rulePriority": 1,
+      "description": "Expire images older than 14 days",
+      "selection": {
+        "tagStatus": "untagged",
+        "countType": "sinceImagePushed",
+        "countUnit": "days",
+        "countNumber": 14
+      },
+      "action": {
+        "type": "expire"
+      }
+    }
+  ]
+}`
+
+var testAccAWSECRLifecyclePolicyDocumentSourceConfig = `
+data "aws_ecr_lifecycle_policy_document" "test" {
+  rule {
+    priority = 1
+    description = "Expire images older than 14 days"
+
+    selection {
+      tag_status = "untagged"
+      count_type = "sinceImagePushed"
+      count_unit = "days"
+      count_number = 14
+    }
+  }
+}
+
+data "aws_ecr_lifecycle_policy_document" "test_source" {
+  source_json = "${data.aws_ecr_lifecycle_policy_document.test.json}"
+
+  rule {
+    priority = 2
+    description = "Keep last 30 images"
+
+    selection {
+      tag_status = "tagged"
+      tag_prefixes = ["v"]
+      count_type = "imageCountMoreThan"
+      count_number = 30
+    }
+  }
+}
+`
+var testAccAWSECRLifecyclePolicyDocumentSourceExpectedJSON = `{
+  "rules": [
+    {
+      "rulePriority": 1,
+      "description": "Expire images older than 14 days",
+      "selection": {
+        "tagStatus": "untagged",
+        "countType": "sinceImagePushed",
+        "countUnit": "days",
+        "countNumber": 14
+      },
+      "action": {
+        "type": "expire"
+      }
+    },
+    {
+      "rulePriority": 2,
+      "description": "Keep last 30 images",
+      "selection": {
+        "tagStatus": "tagged",
+        "tagPrefixList": [
+          "v"
+        ],
+        "countType": "imageCountMoreThan",
+        "countNumber": 30
+      },
+      "action": {
+        "type": "expire"
+      }
+    }
+  ]
+}`
+
+var testAccAWSECRLifecyclePolicyDocumentSourceBlankConfig = `
+data "aws_ecr_lifecycle_policy_document" "test_source_blank" {
+  source_json = ""
+
+  rule {
+    priority = 2
+    description = "Keep last 30 images"
+
+    selection {
+      tag_status = "tagged"
+      tag_prefixes = ["v"]
+      count_type = "imageCountMoreThan"
+      count_number = 30
+    }
+  }
+}
+`
+var testAccAWSECRLifecyclePolicyDocumentSourceBlankExpectedJSON = `{
+  "rules": [
+    {
+      "rulePriority": 2,
+      "description": "Keep last 30 images",
+      "selection": {
+        "tagStatus": "tagged",
+        "tagPrefixList": [
+          "v"
+        ],
+        "countType": "imageCountMoreThan",
+        "countNumber": 30
+      },
+      "action": {
+        "type": "expire"
+      }
+    }
+  ]
+}`

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -207,6 +207,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_iam_instance_profile":             dataSourceAwsIAMInstanceProfile(),
 			"aws_iam_policy":                       dataSourceAwsIAMPolicy(),
 			"aws_iam_policy_document":              dataSourceAwsIamPolicyDocument(),
+			"aws_ecr_lifecycle_policy_document":    dataSourceAwsEcrLifecyclePolicyDocument(),
 			"aws_iam_role":                         dataSourceAwsIAMRole(),
 			"aws_iam_server_certificate":           dataSourceAwsIAMServerCertificate(),
 			"aws_iam_user":                         dataSourceAwsIAMUser(),

--- a/website/docs/d/ecr_lifecycle_policy_document.html.markdown
+++ b/website/docs/d/ecr_lifecycle_policy_document.html.markdown
@@ -1,0 +1,184 @@
+---
+layout: "aws"
+page_title: "AWS: aws_ecr_lifecycle_policy_document"
+sidebar_current: "docs-aws-datasource-ecr-lifecycle-policy-document"
+description: |-
+  Generates an ECR lifecycle policy document in JSON format
+---
+
+# Data Source: aws_ecr_lifecycle_policy_document
+
+Generates an ECR lifecycle policy document in JSON format.
+
+This is a data source which can be used to construct a JSON representation of
+an ECR lifecycle policy document, for use with `aws_ecr_lifecycle_policy`.
+
+```hcl
+data "aws_ecr_lifecycle_policy_document" "example" {
+  rule {
+    priority = 1
+    description = "Expire images older than 14 days"
+
+    selection {
+      tag_status = "untagged"
+      count_type = "sinceImagePushed"
+      count_unit = "days"
+      count_number = 14
+    }
+
+    action {
+      type = "expire"
+    }
+  }
+
+  rule {
+    priority = 2
+    description = "Keep last 30 images"
+
+    selection {
+      tag_status = "tagged"
+      tag_prefixes = ["v"]
+      count_type = "imageCountMoreThan"
+      count_number = 30
+    }
+
+    action {
+      type = "expire"
+    }
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "example" {
+  name   = "example_policy"
+  policy = "${data.aws_ecr_lifecycle_policy_document.example.json}"
+}
+```
+
+Using this data source to generate policy documents is *optional*. It is also
+valid to use literal JSON strings within your configuration, or to use the
+`file` interpolation function to read a raw JSON policy document from a file.
+
+## Argument Reference
+
+The following arguments are supported:
+
+
+
+## Attributes Reference
+
+The following attribute is exported:
+
+* `json` - The above arguments serialized as a standard JSON policy document.
+
+## Example with Source and Override
+
+Showing how you can use `source_json` and `override_json`
+
+```hcl
+data "aws_iam_policy_document" "source" {
+  statement {
+    actions   = ["ec2:*"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "SidToOverwrite"
+
+    actions   = ["s3:*"]
+    resources = ["*"]
+  }
+}
+
+data "aws_iam_policy_document" "source_json_example" {
+  source_json = "${data.aws_iam_policy_document.source.json}"
+
+  statement {
+    sid = "SidToOverwrite"
+
+    actions = ["s3:*"]
+
+    resources = [
+      "arn:aws:s3:::somebucket",
+      "arn:aws:s3:::somebucket/*",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "override" {
+  statement {
+    sid = "SidToOverwrite"
+
+    actions   = ["s3:*"]
+    resources = ["*"]
+  }
+}
+
+data "aws_iam_policy_document" "override_json_example" {
+  override_json = "${data.aws_iam_policy_document.override.json}"
+
+  statement {
+    actions   = ["ec2:*"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "SidToOverwrite"
+
+    actions = ["s3:*"]
+
+    resources = [
+      "arn:aws:s3:::somebucket",
+      "arn:aws:s3:::somebucket/*",
+    ]
+  }
+}
+```
+
+`data.aws_iam_policy_document.source_json_example.json` will evaluate to:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": "ec2:*",
+      "Resource": "*"
+    },
+    {
+      "Sid": "SidToOverwrite",
+      "Effect": "Allow",
+      "Action": "s3:*",
+      "Resource": [
+        "arn:aws:s3:::somebucket/*",
+        "arn:aws:s3:::somebucket"
+      ]
+    }
+  ]
+}
+```
+
+`data.aws_iam_policy_document.override_json_example.json` will evaluate to:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": "ec2:*",
+      "Resource": "*"
+    },
+    {
+      "Sid": "SidToOverwrite",
+      "Effect": "Allow",
+      "Action": "s3:*",
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+You can also combine `source_json` and `override_json` in the same document.


### PR DESCRIPTION
Hello,

I propose to add the `aws_ecr_lifecycle_policy_document` data source to ease ECR lifecyle policy writing and validation. It is greatly inspired by the `aws_iam_policy_document` data source.

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDataSourceECRLifecyclePolicyDocument'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSDataSourceECRLifecyclePolicyDocument -timeout 120m
=== RUN   TestAccAWSDataSourceECRLifecyclePolicyDocument_basic
--- PASS: TestAccAWSDataSourceECRLifecyclePolicyDocument_basic (15.22s)
=== RUN   TestAccAWSDataSourceECRLifecyclePolicyDocument_source
--- PASS: TestAccAWSDataSourceECRLifecyclePolicyDocument_source (23.35s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	(cached)
```
