### PR TITLE
Spotfleet Launch Template and On-Demand Capacity Support

### DIFF
--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -1148,7 +1148,7 @@ func resourceAwsSpotFleetRequestRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("fleet_type", config.Type)
 	d.Set("launch_specification", launchSpecsToSet(config.LaunchSpecifications, conn))
 
-	if config.LaunchTemplateConfigs[0] != nil {
+	if len(config.LaunchTemplateConfigs) > 0 {
 		d.Set("launch_template_configs.0.launch_template_specification.0", flattenFleetLaunchTemplateSpecification(config.LaunchTemplateConfigs[0].LaunchTemplateSpecification))
 		d.Set("launch_template_configs.0.overrides", setLaunchTemplateOverrides(config.LaunchTemplateConfigs[0].Overrides))
 	} else {
@@ -1469,7 +1469,7 @@ func deleteSpotFleetRequest(spotFleetRequestID string, terminateInstances bool, 
 				log.Printf("[DEBUG] Active instance count is %d for Spot Fleet Request (%s), but instances have terminated, removing", len(resp.ActiveInstances), spotFleetRequestID)
 				return nil
 			} else {
-				log.Printf("[DEBUG] Active instance count is %d for Spot Fleet Request (%s), and %d instances are still running", len(resp.ActiveInstances), spotFleetRequestID, len(iresp.Reservations))
+				log.Printf("[DEBUG] Active instance count is %d for Spot Fleet Request (%s), and at least 1 instance is still running", len(resp.ActiveInstances), spotFleetRequestID)
 			}
 		}
 

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -279,6 +279,7 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 			"launch_template_configs": {
 				Type:          schema.TypeSet,
 				Optional:      true,
+				ForceNew:      true,
 				ConflictsWith: []string{"launch_specification"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -292,6 +293,7 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 										Type:          schema.TypeString,
 										Optional:      true,
 										Computed:      true,
+										ForceNew:      true,
 										ConflictsWith: []string{"launch_template_configs.0.launch_template_specification.0.name"},
 										ValidateFunc:  validateLaunchTemplateId,
 									},
@@ -299,12 +301,15 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 										Type:          schema.TypeString,
 										Optional:      true,
 										Computed:      true,
+										ForceNew:      true,
 										ConflictsWith: []string{"launch_template_configs.0.launch_template_specification.0.id"},
 										ValidateFunc:  validateLaunchTemplateName,
 									},
 									"version": {
 										Type:         schema.TypeString,
 										Optional:     true,
+										Computed:     true,
+										ForceNew:     true,
 										ValidateFunc: validation.StringLenBetween(1, 255),
 									},
 								},
@@ -313,35 +318,45 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 						"overrides": {
 							Type:     schema.TypeSet,
 							Optional: true,
+							ForceNew: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"availability_zone": {
 										Type:     schema.TypeString,
 										Optional: true,
+										ForceNew: true,
 										//ValidateFunc:  validateLaunchTemplateId,
 									},
 									"instance_type": {
 										Type:     schema.TypeString,
 										Optional: true,
+										ForceNew: true,
 										//ValidateFunc:  validateLaunchTemplateName,
 									},
 									"spot_price": {
 										Type:     schema.TypeString,
 										Optional: true,
+										Computed: true,
+										ForceNew: true,
 										//ValidateFunc: validation.StringLenBetween(1, 255),
 									},
 									"subnet_id": {
 										Type:     schema.TypeString,
 										Optional: true,
+										Computed: true,
+										ForceNew: true,
 										//ValidateFunc: validation.StringLenBetween(1, 255),
 									},
 									"weighted_capacity": {
 										Type:     schema.TypeFloat,
 										Optional: true,
+										Computed: true,
+										ForceNew: true,
 										//ValidateFunc: validation.StringLenBetween(1, 255),
 									},
 								},
 							},
+							Set: hashLaunchTemplateOverrides,
 						},
 					},
 				},
@@ -688,7 +703,6 @@ func buildAwsSpotFleetLaunchSpecifications(
 func buildLaunchTemplateConfigs(d *schema.ResourceData, meta interface{}) ([]*ec2.LaunchTemplateConfig, error) {
 	launch_template_cfgs := d.Get("launch_template_configs").(*schema.Set).List()
 	cfgs := make([]*ec2.LaunchTemplateConfig, len(launch_template_cfgs))
-	log.Printf("[DEBUG] cfgs: %#v", cfgs)
 
 	for _, launch_template_cfg := range launch_template_cfgs {
 
@@ -698,16 +712,11 @@ func buildLaunchTemplateConfigs(d *schema.ResourceData, meta interface{}) ([]*ec
 
 		//launch template spec
 		if v, ok := ltc_map["launch_template_specification"]; ok {
-			//panic: interface conversion: interface {} is []interface {}, not *schema.Set
 			vL := v.([]interface{})
-			//vL := v.(*schema.Set).List()
-			//log.Printf("[DEBUG] vL(672): %#v", vL)
-			//for _, v := range vL {
-			//panic: interface conversion: interface {} is []interface {}, not map[string]interface {}
 			lts := vL[0].(map[string]interface{})
-			log.Printf("[DEBUG] lts(676): %#v", vL)
+
 			flts := &ec2.FleetLaunchTemplateSpecification{}
-			log.Printf("[DEBUG] flts(678): %#v", flts)
+
 			if v, ok := lts["id"].(string); ok && v != "" {
 				flts.LaunchTemplateId = aws.String(v)
 			}
@@ -719,15 +728,13 @@ func buildLaunchTemplateConfigs(d *schema.ResourceData, meta interface{}) ([]*ec
 			if v, ok := lts["version"].(string); ok && v != "" {
 				flts.Version = aws.String(v)
 			}
-			log.Printf("[DEBUG] flts(691): %#v", flts)
 
 			ltc.LaunchTemplateSpecification = flts
-			//}
+
 		}
 
-		//now the overrides
 		overrides := make([]*ec2.LaunchTemplateOverrides, 0)
-		// for each override
+
 		if v, ok := ltc_map["overrides"]; ok {
 			vL := v.(*schema.Set).List()
 			for _, v := range vL {
@@ -1142,12 +1149,46 @@ func resourceAwsSpotFleetRequestRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("launch_specification", launchSpecsToSet(config.LaunchSpecifications, conn))
 
 	if config.LaunchTemplateConfigs[0] != nil {
-		d.Set("launch_template_configs.0.launch_template_specification.0.id", flattenFleetLaunchTemplateSpecification(config.LaunchTemplateConfigs[0].LaunchTemplateSpecification))
+		d.Set("launch_template_configs.0.launch_template_specification.0", flattenFleetLaunchTemplateSpecification(config.LaunchTemplateConfigs[0].LaunchTemplateSpecification))
+		d.Set("launch_template_configs.0.overrides", setLaunchTemplateOverrides(config.LaunchTemplateConfigs[0].Overrides))
 	} else {
-		d.Set("launch_template_configs.0.launch_template_specification.0.id", nil)
+		d.Set("launch_template_configs.0.launch_template_specification.0", nil)
 	}
 
 	return nil
+}
+
+func setLaunchTemplateOverrides(overrides []*ec2.LaunchTemplateOverrides) *schema.Set {
+	overrideSet := &schema.Set{F: hashLaunchTemplateOverrides}
+	for _, override := range overrides {
+		overrideSet.Add(overrideToMap(override))
+	}
+	return overrideSet
+}
+
+func overrideToMap(override *ec2.LaunchTemplateOverrides) map[string]interface{} {
+	m := make(map[string]interface{})
+
+	if override.AvailabilityZone != nil {
+		m["availability_zone"] = aws.StringValue(override.AvailabilityZone)
+	}
+	if override.InstanceType != nil {
+		m["instance_type"] = aws.StringValue(override.InstanceType)
+	}
+
+	if override.SpotPrice != nil {
+		m["spot_price"] = aws.StringValue(override.SpotPrice)
+	}
+
+	if override.SubnetId != nil {
+		m["subnet_id"] = aws.StringValue(override.SubnetId)
+	}
+
+	if override.WeightedCapacity != nil {
+		m["weighted_capacity"] = aws.Float64Value(override.WeightedCapacity) //strconv.FormatFloat(*override.WeightedCapacity, 'f', 0, 64)
+	}
+
+	return m
 }
 
 func launchSpecsToSet(launchSpecs []*ec2.SpotFleetLaunchSpecification, conn *ec2.EC2) *schema.Set {
@@ -1400,6 +1441,7 @@ func deleteSpotFleetRequest(spotFleetRequestID string, terminateInstances bool, 
 		return nil
 	}
 
+	// On-Demand capacity instances are never delisted as "active" in spot fleet even once terminated, so we now need logic to check that they are gone.
 	return resource.Retry(timeout, func() *resource.RetryError {
 		resp, err := conn.DescribeSpotFleetInstances(&ec2.DescribeSpotFleetInstancesInput{
 			SpotFleetRequestId: aws.String(spotFleetRequestID),
@@ -1411,6 +1453,24 @@ func deleteSpotFleetRequest(spotFleetRequestID string, terminateInstances bool, 
 		if len(resp.ActiveInstances) == 0 {
 			log.Printf("[DEBUG] Active instance count is 0 for Spot Fleet Request (%s), removing", spotFleetRequestID)
 			return nil
+		} else {
+			instances := []*string{}
+			for _, instMap := range resp.ActiveInstances {
+				instances = append(instances, aws.String(*instMap.InstanceId))
+			}
+			iresp, err := conn.DescribeInstances(&ec2.DescribeInstancesInput{
+				InstanceIds: instances,
+			})
+			if err != nil {
+				return resource.RetryableError(
+					fmt.Errorf("Error while trying to determine fleet status for fleet (%s): %s", spotFleetRequestID, err))
+			}
+			if len(iresp.Reservations) == 0 {
+				log.Printf("[DEBUG] Active instance count is %d for Spot Fleet Request (%s), but instances have terminated, removing", len(resp.ActiveInstances), spotFleetRequestID)
+				return nil
+			} else {
+				log.Printf("[DEBUG] Active instance count is %d for Spot Fleet Request (%s), and %d instances are still running", len(resp.ActiveInstances), spotFleetRequestID, len(iresp.Reservations))
+			}
 		}
 
 		log.Printf("[DEBUG] Active instance count in Spot Fleet Request (%s): %d", spotFleetRequestID, len(resp.ActiveInstances))
@@ -1445,6 +1505,27 @@ func hashLaunchSpecification(v interface{}) int {
 	}
 	buf.WriteString(fmt.Sprintf("%s-", m["instance_type"].(string)))
 	buf.WriteString(fmt.Sprintf("%s-", m["spot_price"].(string)))
+	return hashcode.String(buf.String())
+}
+
+func hashLaunchTemplateOverrides(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	if m["availability_zone"] != nil {
+		buf.WriteString(fmt.Sprintf("%s-", m["availability_zone"].(string)))
+	}
+	if m["subnet_id"] != nil {
+		buf.WriteString(fmt.Sprintf("%s-", m["subnet_id"].(string)))
+	}
+	if m["spot_price"] != nil {
+		buf.WriteString(fmt.Sprintf("%s-", m["spot_price"].(string)))
+	}
+	if m["instance_type"] != nil {
+		buf.WriteString(fmt.Sprintf("%s-", m["instance_type"].(string)))
+	}
+	if m["weighted_capacity"] != nil {
+		buf.WriteString(fmt.Sprintf("%f-", m["weighted_capacity"].(float64)))
+	}
 	return hashcode.String(buf.String())
 }
 

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -1461,9 +1461,9 @@ func deleteSpotFleetRequest(spotFleetRequestID string, terminateInstances bool, 
 			if len(iresp.Reservations) == 0 {
 				log.Printf("[DEBUG] Active instance count is %d for Spot Fleet Request (%s), but instances have terminated, removing", len(resp.ActiveInstances), spotFleetRequestID)
 				return nil
-			} else {
-				log.Printf("[DEBUG] Active instance count is %d for Spot Fleet Request (%s), and at least 1 instance is still running", len(resp.ActiveInstances), spotFleetRequestID)
 			}
+
+			log.Printf("[DEBUG] Active instance count is %d for Spot Fleet Request (%s), and at least 1 instance is still running", len(resp.ActiveInstances), spotFleetRequestID)
 		}
 
 		log.Printf("[DEBUG] Active instance count in Spot Fleet Request (%s): %d", spotFleetRequestID, len(resp.ActiveInstances))

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -325,34 +325,29 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 										Type:     schema.TypeString,
 										Optional: true,
 										ForceNew: true,
-										//ValidateFunc:  validateLaunchTemplateId,
 									},
 									"instance_type": {
 										Type:     schema.TypeString,
 										Optional: true,
 										ForceNew: true,
-										//ValidateFunc:  validateLaunchTemplateName,
 									},
 									"spot_price": {
 										Type:     schema.TypeString,
 										Optional: true,
 										Computed: true,
 										ForceNew: true,
-										//ValidateFunc: validation.StringLenBetween(1, 255),
 									},
 									"subnet_id": {
 										Type:     schema.TypeString,
 										Optional: true,
 										Computed: true,
 										ForceNew: true,
-										//ValidateFunc: validation.StringLenBetween(1, 255),
 									},
 									"weighted_capacity": {
 										Type:     schema.TypeFloat,
 										Optional: true,
 										Computed: true,
 										ForceNew: true,
-										//ValidateFunc: validation.StringLenBetween(1, 255),
 									},
 								},
 							},
@@ -361,7 +356,8 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 					},
 				},
 			},
-			// Everything on a spot fleet is ForceNew except target_capacity
+			// Everything on a spot fleet is ForceNew except target_capacity and excess_capacity_termination_policy,
+			// see https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#ModifySpotFleetRequestInput
 			"target_capacity": {
 				Type:     schema.TypeInt,
 				Required: true,
@@ -371,7 +367,7 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 				Type:          schema.TypeInt,
 				ConflictsWith: []string{"launch_specification"},
 				Optional:      true,
-				ForceNew:      false,
+				ForceNew:      true,
 			},
 			"allocation_strategy": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -904,6 +904,8 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 				if awsErr.Code() == "InvalidSpotFleetRequestConfig" {
 					switch {
 					case strings.Contains(awsErr.Message(), "LaunchTemplateSpecification"):
+						// AWS is letting us know that the Launch Template has been specified in some invalid way.
+						// No point in retrying as the template needs to be corrected.
 						return resource.NonRetryableError(err)
 					case strings.Contains(awsErr.Message(), "IamFleetRole"):
 						// IAM is eventually consistent :/

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -914,10 +914,6 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 					default:
 						return resource.NonRetryableError(err)
 					}
-
-					// Assuming this doesn't work; we can get the same error code for reasons other than a lack of IAM consistency:
-					//return resource.RetryableError(
-					//	fmt.Errorf("[WARN] Error creating Spot fleet request, retrying: %s", err))
 				}
 			}
 			return resource.NonRetryableError(err)

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -758,7 +758,7 @@ func buildLaunchTemplateConfigs(d *schema.ResourceData, meta interface{}) ([]*ec
 				}
 
 				if v, ok := ors["weighted_capacity"].(float64); ok && v > 0 {
-					lto.WeightedCapacity = aws.Float64(float64(v))
+					lto.WeightedCapacity = aws.Float64(v)
 				}
 
 				overrides = append(overrides, lto)

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -450,6 +450,9 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 				Set:      schema.HashString,
 			},
 		},
+		// A launch template can be created with an id or a name, but once created will have both even though we specify only one.
+		// If either changes, this makes sure the other (which was specified) will register as changed in order to correctly determine diffs.
+		// This was taken from the original implementation of launch templates in resource_aws_autoscaling_group.go
 		CustomizeDiff: customdiff.Sequence(
 			customdiff.ComputedIf("launch_template_configs.0.launch_template_specification.0.id", func(diff *schema.ResourceDiff, meta interface{}) bool {
 				return diff.HasChange("launch_template_configs.0.launch_template_specification.0.name")

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -780,7 +780,7 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 	_, launchTemplateConfigsOk := d.GetOk("launch_template_configs")
 
 	if !launchSpecificationOk && !launchTemplateConfigsOk {
-		return fmt.Errorf("One of `launch_specification` or `launch_template` must be set for an a fleet request")
+		return fmt.Errorf("One of `launch_specification` or `launch_template` must be set for a fleet request")
 	}
 
 	// http://docs.aws.amazon.com/sdk-for-go/api/service/ec2.html#type-SpotFleetRequestConfigData
@@ -804,16 +804,12 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 		spotFleetConfig.LaunchSpecifications = launch_specs
 	}
 
-	// Need to suppport multiples
 	if launchTemplateConfigsOk {
-		// launch_template_cfg, err := buildLaunchTemplateConfig(d, meta)
-		// if err != nil {
-		// 	return err
-		// }
-		spotFleetConfig.LaunchTemplateConfigs, err = buildLaunchTemplateConfigs(d, meta)
+		launch_templates, err := buildLaunchTemplateConfigs(d, meta)
 		if err != nil {
 			return err
 		}
+		spotFleetConfig.LaunchTemplateConfigs = launch_templates
 	}
 
 	if v, ok := d.GetOk("on_demand_target_capacity"); ok {

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -1144,12 +1144,12 @@ func resourceAwsSpotFleetRequestRead(d *schema.ResourceData, meta interface{}) e
 func setLaunchTemplateOverrides(overrides []*ec2.LaunchTemplateOverrides) *schema.Set {
 	overrideSet := &schema.Set{F: hashLaunchTemplateOverrides}
 	for _, override := range overrides {
-		overrideSet.Add(overrideToMap(override))
+		overrideSet.Add(flattenSpotFleetRequestLaunchTemplateOverrides(override))
 	}
 	return overrideSet
 }
 
-func overrideToMap(override *ec2.LaunchTemplateOverrides) map[string]interface{} {
+func flattenSpotFleetRequestLaunchTemplateOverrides(override *ec2.LaunchTemplateOverrides) map[string]interface{} {
 	m := make(map[string]interface{})
 
 	if override.AvailabilityZone != nil {

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -693,7 +693,7 @@ func buildAwsSpotFleetLaunchSpecifications(
 	return specs, nil
 }
 
-func buildLaunchTemplateConfigs(d *schema.ResourceData, meta interface{}) ([]*ec2.LaunchTemplateConfig, error) {
+func buildLaunchTemplateConfigs(d *schema.ResourceData) ([]*ec2.LaunchTemplateConfig, error) {
 	launch_template_cfgs := d.Get("launch_template_configs").(*schema.Set).List()
 	cfgs := make([]*ec2.LaunchTemplateConfig, len(launch_template_cfgs))
 
@@ -799,7 +799,7 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 	}
 
 	if launchTemplateConfigsOk {
-		launch_templates, err := buildLaunchTemplateConfigs(d, meta)
+		launch_templates, err := buildLaunchTemplateConfigs(d)
 		if err != nil {
 			return err
 		}

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -1168,7 +1168,7 @@ func flattenSpotFleetRequestLaunchTemplateOverrides(override *ec2.LaunchTemplate
 	}
 
 	if override.WeightedCapacity != nil {
-		m["weighted_capacity"] = aws.Float64Value(override.WeightedCapacity) //strconv.FormatFloat(*override.WeightedCapacity, 'f', 0, 64)
+		m["weighted_capacity"] = aws.Float64Value(override.WeightedCapacity)
 	}
 
 	return m

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -715,7 +715,7 @@ func testAccCheckAWSSpotFleetRequest_IamInstanceProfileArn(
 			return fmt.Errorf("Expected IamInstanceProfile to be set, got nil")
 		}
 		//Validate the string whether it is ARN
-		re := regexp.MustCompile("arn:aws:iam::\\d{12}:instance-profile/?[a-zA-Z0-9+=,.@-_].*")
+		re := regexp.MustCompile(`arn:aws:iam::\d{12}:instance-profile/?[a-zA-Z0-9+=,.@-_].*`)
 		if !re.MatchString(*profile.Arn) {
 			return fmt.Errorf("Expected IamInstanceProfile input as ARN, got %s", *profile.Arn)
 		}

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -1120,29 +1120,6 @@ func TestAccAWSSpotFleetRequest_WithELBs(t *testing.T) {
 	})
 }
 
-func testAccCheckAWSSpotFleetRequest_IamInstanceProfileArn(
-	sfr *ec2.SpotFleetRequestConfig) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if len(sfr.SpotFleetRequestConfig.LaunchSpecifications) == 0 {
-			return errors.New("Missing launch specification")
-		}
-
-		spec := *sfr.SpotFleetRequestConfig.LaunchSpecifications[0]
-
-		profile := spec.IamInstanceProfile
-		if profile == nil {
-			return fmt.Errorf("Expected IamInstanceProfile to be set, got nil")
-		}
-		//Validate the string whether it is ARN
-		re := regexp.MustCompile(`arn:aws:iam::\d{12}:instance-profile/?[a-zA-Z0-9+=,.@-_].*`)
-		if !re.MatchString(*profile.Arn) {
-			return fmt.Errorf("Expected IamInstanceProfile input as ARN, got %s", *profile.Arn)
-		}
-
-		return nil
-	}
-}
-
 func TestAccAWSSpotFleetRequest_WithTargetGroups(t *testing.T) {
 	var sfr ec2.SpotFleetRequestConfig
 	rName := acctest.RandString(10)

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -227,8 +227,6 @@ func TestAccAWSSpotFleetRequest_launchTemplateToLaunchSpec(t *testing.T) {
                         "aws_spot_fleet_request.foo", "spot_price", "0.005"),
                     resource.TestCheckResourceAttr(
                         "aws_spot_fleet_request.foo", "launch_specification.#", "1"),
-                    // resource.TestCheckResourceAttr(
-                    //  "aws_spot_fleet_request.foo", "launch_template_configs.#", "0"),
                     testAccCheckAWSSpotFleetRequestConfigRecreated(t, &before, &after),
                 ),
             },
@@ -257,8 +255,6 @@ func TestAccAWSSpotFleetRequest_launchSpecToLaunchTemplate(t *testing.T) {
                         "aws_spot_fleet_request.foo", "spot_price", "0.005"),
                     resource.TestCheckResourceAttr(
                         "aws_spot_fleet_request.foo", "launch_specification.#", "1"),
-                    // resource.TestCheckResourceAttr(
-                    //  "aws_spot_fleet_request.foo", "launch_template_configs.#", "0"),
                 ),
             },
             {

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -114,40 +114,6 @@ func TestAccAWSSpotFleetRequest_launchTemplate(t *testing.T) {
     })
 }
 
-//On-Demand capacity requires launch template defined spot fleet, so can't test without it.
-func TestAccAWSSpotFleetRequest_launchTemplateWithOnDemandCapacity(t *testing.T) {
-    var sfr ec2.SpotFleetRequestConfig
-    rName := acctest.RandString(10)
-    rInt := acctest.RandInt()
-
-    resource.ParallelTest(t, resource.TestCase{
-        PreCheck:     func() { testAccPreCheck(t) },
-        Providers:    testAccProviders,
-        CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
-        Steps: []resource.TestStep{
-            {
-                Config: testAccAWSSpotFleetRequestLaunchTemplateConfigWithOnDemandCapacity(rName, rInt),
-                Check: resource.ComposeAggregateTestCheckFunc(
-                    testAccCheckAWSSpotFleetRequestExists(
-                        "aws_spot_fleet_request.foo", &sfr),
-                    resource.TestCheckResourceAttr(
-                        "aws_spot_fleet_request.foo", "spot_request_state", "active"),
-                    resource.TestCheckResourceAttr(
-                        "aws_spot_fleet_request.foo", "launch_specification.#", "0"),
-                    resource.TestCheckResourceAttr(
-                        "aws_spot_fleet_request.foo", "launch_template_configs.#", "1"),
-                    resource.TestCheckResourceAttr(
-                        "aws_spot_fleet_request.foo", "launch_template_configs.4018047529.launch_template_specification.#", "1"),
-                    resource.TestCheckResourceAttr(
-                        "aws_spot_fleet_request.foo", "launch_template_configs.4018047529.overrides.#", "0"),
-                    resource.TestCheckResourceAttr(
-                        "aws_spot_fleet_request.foo", "on_demand_target_capacity", "2"),
-                ),
-            },
-        },
-    })
-}
-
 func TestAccAWSSpotFleetRequest_launchTemplateWithOverrides(t *testing.T) {
     var sfr ec2.SpotFleetRequestConfig
     rName := acctest.RandString(10)
@@ -1296,6 +1262,7 @@ resource "aws_spot_fleet_request" "foo" {
 `, rName, rInt, rInt, rName)
 }
 
+<<<<<<< HEAD
 func testAccAWSSpotFleetRequestLaunchTemplateConfigWithOnDemandCapacity(rName string, rInt int) string {
     return fmt.Sprintf(`
 resource "aws_key_pair" "debugging" {
@@ -1382,6 +1349,8 @@ resource "aws_spot_fleet_request" "foo" {
 `, rName, rInt, rInt, rName)
 }
 
+=======
+>>>>>>> removed on-demand spot instance feature due to moving to a different PR
 func testAccAWSSpotFleetRequestLaunchTemplateConfigWithOverrides(rName string, rInt int) string {
     return fmt.Sprintf(`
 resource "aws_key_pair" "debugging" {

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -1,766 +1,1096 @@
 package aws
 
 import (
-	"errors"
-	"fmt"
-	"log"
-	"regexp"
-	"testing"
-	"time"
+    "errors"
+    "fmt"
+    "log"
+    "regexp"
+    "testing"
+    "time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/hashicorp/terraform/helper/acctest"
-	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
+    "github.com/aws/aws-sdk-go/aws"
+    "github.com/aws/aws-sdk-go/service/ec2"
+    "github.com/hashicorp/terraform/helper/acctest"
+    "github.com/hashicorp/terraform/helper/resource"
+    "github.com/hashicorp/terraform/terraform"
 )
 
 func init() {
-	resource.AddTestSweepers("aws_spot_fleet_request", &resource.Sweeper{
-		Name: "aws_spot_fleet_request",
-		F:    testSweepSpotFleetRequests,
-	})
+    resource.AddTestSweepers("aws_spot_fleet_request", &resource.Sweeper{
+        Name: "aws_spot_fleet_request",
+        F:    testSweepSpotFleetRequests,
+    })
 }
 
 func testSweepSpotFleetRequests(region string) error {
-	client, err := sharedClientForRegion(region)
-	if err != nil {
-		return fmt.Errorf("error getting client: %s", err)
-	}
-	conn := client.(*AWSClient).ec2conn
+    client, err := sharedClientForRegion(region)
+    if err != nil {
+        return fmt.Errorf("error getting client: %s", err)
+    }
+    conn := client.(*AWSClient).ec2conn
 
-	err = conn.DescribeSpotFleetRequestsPages(&ec2.DescribeSpotFleetRequestsInput{}, func(page *ec2.DescribeSpotFleetRequestsOutput, isLast bool) bool {
-		if len(page.SpotFleetRequestConfigs) == 0 {
-			log.Print("[DEBUG] No Spot Fleet Requests to sweep")
-			return false
-		}
+    err = conn.DescribeSpotFleetRequestsPages(&ec2.DescribeSpotFleetRequestsInput{}, func(page *ec2.DescribeSpotFleetRequestsOutput, isLast bool) bool {
+        if len(page.SpotFleetRequestConfigs) == 0 {
+            log.Print("[DEBUG] No Spot Fleet Requests to sweep")
+            return false
+        }
 
-		for _, config := range page.SpotFleetRequestConfigs {
-			id := aws.StringValue(config.SpotFleetRequestId)
+        for _, config := range page.SpotFleetRequestConfigs {
+            id := aws.StringValue(config.SpotFleetRequestId)
 
-			log.Printf("[INFO] Deleting Spot Fleet Request: %s", id)
-			err := deleteSpotFleetRequest(id, true, 5*time.Minute, conn)
-			if err != nil {
-				log.Printf("[ERROR] Failed to delete Spot Fleet Request (%s): %s", id, err)
-			}
-		}
-		return !isLast
-	})
-	if err != nil {
-		if testSweepSkipSweepError(err) {
-			log.Printf("[WARN] Skipping EC2 Spot Fleet Requests sweep for %s: %s", region, err)
-			return nil
-		}
-		return fmt.Errorf("Error retrieving EC2 Spot Fleet Requests: %s", err)
-	}
-	return nil
+            log.Printf("[INFO] Deleting Spot Fleet Request: %s", id)
+            err := deleteSpotFleetRequest(id, true, 5*time.Minute, conn)
+            if err != nil {
+                log.Printf("[ERROR] Failed to delete Spot Fleet Request (%s): %s", id, err)
+            }
+        }
+        return !isLast
+    })
+    if err != nil {
+        if testSweepSkipSweepError(err) {
+            log.Printf("[WARN] Skipping EC2 Spot Fleet Requests sweep for %s: %s", region, err)
+            return nil
+        }
+        return fmt.Errorf("Error retrieving EC2 Spot Fleet Requests: %s", err)
+    }
+    return nil
 }
 
 func TestAccAWSSpotFleetRequest_associatePublicIpAddress(t *testing.T) {
-	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+    var sfr ec2.SpotFleetRequestConfig
+    rName := acctest.RandString(10)
+    rInt := acctest.RandInt()
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSpotFleetRequestConfigAssociatePublicIpAddress(rName, rInt),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.24370212.associate_public_ip_address", "true"),
-				),
-			},
-		},
-	})
+    resource.ParallelTest(t, resource.TestCase{
+        PreCheck:     func() { testAccPreCheck(t) },
+        Providers:    testAccProviders,
+        CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccAWSSpotFleetRequestConfigAssociatePublicIpAddress(rName, rInt),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    testAccCheckAWSSpotFleetRequestExists(
+                        "aws_spot_fleet_request.foo", &sfr),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_request_state", "active"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.#", "1"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.24370212.associate_public_ip_address", "true"),
+                ),
+            },
+        },
+    })
+}
+
+func TestAccAWSSpotFleetRequest_launchTemplate(t *testing.T) {
+    var sfr ec2.SpotFleetRequestConfig
+    rName := acctest.RandString(10)
+    rInt := acctest.RandInt()
+
+    resource.ParallelTest(t, resource.TestCase{
+        PreCheck:     func() { testAccPreCheck(t) },
+        Providers:    testAccProviders,
+        CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccAWSSpotFleetRequestLaunchTemplateConfig(rName, rInt),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    testAccCheckAWSSpotFleetRequestExists(
+                        "aws_spot_fleet_request.foo", &sfr),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_request_state", "active"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.#", "0"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_template_configs.#", "1"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_template_configs.4018047529.launch_template_specification.#", "1"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_template_configs.4018047529.overrides.#", "0"),
+                ),
+            },
+        },
+    })
+}
+
+//On-Demand capacity requires launch template defined spot fleet, so can't test without it.
+func TestAccAWSSpotFleetRequest_launchTemplateWithOnDemandCapacity(t *testing.T) {
+    var sfr ec2.SpotFleetRequestConfig
+    rName := acctest.RandString(10)
+    rInt := acctest.RandInt()
+
+    resource.ParallelTest(t, resource.TestCase{
+        PreCheck:     func() { testAccPreCheck(t) },
+        Providers:    testAccProviders,
+        CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccAWSSpotFleetRequestLaunchTemplateConfigWithOnDemandCapacity(rName, rInt),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    testAccCheckAWSSpotFleetRequestExists(
+                        "aws_spot_fleet_request.foo", &sfr),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_request_state", "active"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.#", "0"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_template_configs.#", "1"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_template_configs.4018047529.launch_template_specification.#", "1"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_template_configs.4018047529.overrides.#", "0"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "on_demand_target_capacity", "2"),
+                ),
+            },
+        },
+    })
+}
+
+func TestAccAWSSpotFleetRequest_launchTemplateWithOverrides(t *testing.T) {
+    var sfr ec2.SpotFleetRequestConfig
+    rName := acctest.RandString(10)
+    rInt := acctest.RandInt()
+
+    resource.ParallelTest(t, resource.TestCase{
+        PreCheck:     func() { testAccPreCheck(t) },
+        Providers:    testAccProviders,
+        CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccAWSSpotFleetRequestLaunchTemplateConfigWithOverrides(rName, rInt),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    testAccCheckAWSSpotFleetRequestExists(
+                        "aws_spot_fleet_request.foo", &sfr),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_request_state", "active"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.#", "0"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_template_configs.#", "1"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_template_configs.3492852471.launch_template_specification.#", "1"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_template_configs.3492852471.overrides.#", "2"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_template_configs.3492852471.overrides.#", "2"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_template_configs.3492852471.overrides.3113255372.instance_type", "t1.micro"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_template_configs.3492852471.overrides.3113255372.weighted_capacity", "2"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_template_configs.3492852471.overrides.1994766569.instance_type", "m3.medium"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_template_configs.3492852471.overrides.1994766569.spot_price", "0.26"),
+                ),
+            },
+        },
+    })
+}
+
+func TestAccAWSSpotFleetRequest_launchTemplateToLaunchSpec(t *testing.T) {
+    var before, after ec2.SpotFleetRequestConfig
+    rName := acctest.RandString(10)
+    rInt := acctest.RandInt()
+
+    resource.Test(t, resource.TestCase{
+        PreCheck:     func() { testAccPreCheck(t) },
+        Providers:    testAccProviders,
+        CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccAWSSpotFleetRequestLaunchTemplateConfig(rName, rInt),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    testAccCheckAWSSpotFleetRequestExists(
+                        "aws_spot_fleet_request.foo", &before),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_request_state", "active"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.#", "0"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_template_configs.#", "1"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_template_configs.4018047529.launch_template_specification.#", "1"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_template_configs.4018047529.overrides.#", "0"),
+                ),
+            },
+            {
+                Config: testAccAWSSpotFleetRequestConfig(rName, rInt),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    testAccCheckAWSSpotFleetRequestExists(
+                        "aws_spot_fleet_request.foo", &after),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_request_state", "active"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_price", "0.005"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.#", "1"),
+                    // resource.TestCheckResourceAttr(
+                    //  "aws_spot_fleet_request.foo", "launch_template_configs.#", "0"),
+                    testAccCheckAWSSpotFleetRequestConfigRecreated(t, &before, &after),
+                ),
+            },
+        },
+    })
+}
+
+func TestAccAWSSpotFleetRequest_launchSpecToLaunchTemplate(t *testing.T) {
+    var before, after ec2.SpotFleetRequestConfig
+    rName := acctest.RandString(10)
+    rInt := acctest.RandInt()
+
+    resource.Test(t, resource.TestCase{
+        PreCheck:     func() { testAccPreCheck(t) },
+        Providers:    testAccProviders,
+        CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccAWSSpotFleetRequestConfig(rName, rInt),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    testAccCheckAWSSpotFleetRequestExists(
+                        "aws_spot_fleet_request.foo", &before),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_request_state", "active"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_price", "0.005"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.#", "1"),
+                    // resource.TestCheckResourceAttr(
+                    //  "aws_spot_fleet_request.foo", "launch_template_configs.#", "0"),
+                ),
+            },
+            {
+                Config: testAccAWSSpotFleetRequestLaunchTemplateConfig(rName, rInt),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    testAccCheckAWSSpotFleetRequestExists(
+                        "aws_spot_fleet_request.foo", &after),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_request_state", "active"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.#", "0"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_template_configs.#", "1"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_template_configs.4018047529.launch_template_specification.#", "1"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_template_configs.4018047529.overrides.#", "0"),
+                    testAccCheckAWSSpotFleetRequestConfigRecreated(t, &before, &after),
+                ),
+            },
+        },
+    })
+}
+
+func testAccAWSSpotFleetRequestConfigFleetType(rName string, rInt int) string {
+    return fmt.Sprintf(`
+resource "aws_iam_policy" "test-policy" {
+  name = "test-policy-%d"
+  path = "/"
+  description = "Spot Fleet Request ACCTest Policy"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": [
+       "ec2:DescribeImages",
+       "ec2:DescribeSubnets",
+       "ec2:RequestSpotInstances",
+       "ec2:TerminateInstances",
+       "ec2:DescribeInstanceStatus",
+       "iam:PassRole"
+        ],
+    "Resource": ["*"]
+  }]
+}
+EOF
+}
+resource "aws_iam_policy_attachment" "test-attach" {
+    name = "test-attachment-%d"
+    roles = ["${aws_iam_role.test-role.name}"]
+    policy_arn = "${aws_iam_policy.test-policy.arn}"
+}
+resource "aws_iam_role" "test-role" {
+    name = "test-role-%s"
+    assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "spotfleet.amazonaws.com",
+          "ec2.amazonaws.com"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+resource "aws_spot_fleet_request" "foo" {
+    iam_fleet_role = "${aws_iam_role.test-role.arn}"
+    spot_price = "0.005"
+    target_capacity = 2
+    valid_until = "2019-11-04T20:44:20Z"
+    fleet_type = "request"
+    terminate_instances_with_expiration = true
+    wait_for_fulfillment = true
+    launch_specification {
+        instance_type = "m1.small"
+        ami = "ami-516b9131"
+    }
+    depends_on = ["aws_iam_policy_attachment.test-attach"]
+}
+`, rInt, rInt, rName)
+}
+
+func testAccAWSSpotFleetRequestConfigIamInstanceProfileArn(rName string, rInt int) string {
+    return fmt.Sprintf(`
+resource "aws_key_pair" "debugging" {
+  key_name = "tmp-key-%s"
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
+}
+resource "aws_iam_policy" "test-policy" {
+  name = "test-policy-%d"
+  path = "/"
+  description = "Spot Fleet Request ACCTest Policy"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": [
+       "ec2:DescribeImages",
+       "ec2:DescribeSubnets",
+       "ec2:RequestSpotInstances",
+       "ec2:TerminateInstances",
+       "ec2:DescribeInstanceStatus",
+       "iam:PassRole"
+        ],
+    "Resource": ["*"]
+  }]
+}
+EOF
+}
+resource "aws_iam_policy_attachment" "test-attach" {
+    name = "test-attachment-%d"
+    roles = ["${aws_iam_role.test-role.name}"]
+    policy_arn = "${aws_iam_policy.test-policy.arn}"
+}
+resource "aws_iam_role" "test-role" {
+    name = "test-role-%s"
+    assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "spotfleet.amazonaws.com",
+          "ec2.amazonaws.com"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+resource "aws_iam_role" "test-role1" {
+    name = "tf-test-role1-%s"
+    assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "spotfleet.amazonaws.com",
+          "ec2.amazonaws.com"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+resource "aws_iam_role_policy" "test-role-policy1" {
+  name = "tf-test-role-policy1-%s"
+  role = "${aws_iam_role.test-role1.name}"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Action": "*",
+    "Resource": "*"
+  }
+}
+EOF
+}
+resource "aws_iam_instance_profile" "test-iam-instance-profile1" {
+  name = "tf-test-profile1-%s"
+  role = "${aws_iam_role.test-role1.name}"
+}
+resource "aws_spot_fleet_request" "foo" {
+    iam_fleet_role = "${aws_iam_role.test-role.arn}"
+    spot_price = "0.005"
+    target_capacity = 2
+    valid_until = "2019-11-04T20:44:20Z"
+    terminate_instances_with_expiration = true
+    instance_interruption_behaviour = "stop"
+    wait_for_fulfillment = true
+    launch_specification {
+        instance_type = "m1.small"
+        ami = "ami-516b9131"
+        key_name = "${aws_key_pair.debugging.key_name}"
+        iam_instance_profile_arn = "${aws_iam_instance_profile.test-iam-instance-profile1.arn}"
+    }
+    depends_on = ["aws_iam_policy_attachment.test-attach"]
+}
+`, rName, rInt, rInt, rName, rName, rName, rName)
 }
 
 func TestAccAWSSpotFleetRequest_instanceInterruptionBehavior(t *testing.T) {
-	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+    var sfr ec2.SpotFleetRequestConfig
+    rName := acctest.RandString(10)
+    rInt := acctest.RandInt()
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSpotFleetRequestConfig(rName, rInt),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "instance_interruption_behaviour", "stop"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSSpotFleetRequest_fleetType(t *testing.T) {
-	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSpotFleetRequestConfigFleetType(rName, rInt),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "fleet_type", "request"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSSpotFleetRequest_iamInstanceProfileArn(t *testing.T) {
-	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSpotFleetRequestConfigIamInstanceProfileArn(rName, rInt),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					testAccCheckAWSSpotFleetRequest_IamInstanceProfileArn(&sfr),
-				),
-			},
-		},
-	})
+    resource.Test(t, resource.TestCase{
+        PreCheck:     func() { testAccPreCheck(t) },
+        Providers:    testAccProviders,
+        CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccAWSSpotFleetRequestConfig(rName, rInt),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    testAccCheckAWSSpotFleetRequestExists(
+                        "aws_spot_fleet_request.foo", &sfr),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_request_state", "active"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "instance_interruption_behaviour", "stop"),
+                ),
+            },
+        },
+    })
 }
 
 func TestAccAWSSpotFleetRequest_changePriceForcesNewRequest(t *testing.T) {
-	var before, after ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+    var before, after ec2.SpotFleetRequestConfig
+    rName := acctest.RandString(10)
+    rInt := acctest.RandInt()
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSpotFleetRequestConfig(rName, rInt),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &before),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_price", "0.005"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.#", "1"),
-				),
-			},
-			{
-				Config: testAccAWSSpotFleetRequestConfigChangeSpotBidPrice(rName, rInt),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &after),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_price", "0.01"),
-					testAccCheckAWSSpotFleetRequestConfigRecreated(t, &before, &after),
-				),
-			},
-		},
-	})
+    resource.ParallelTest(t, resource.TestCase{
+        PreCheck:     func() { testAccPreCheck(t) },
+        Providers:    testAccProviders,
+        CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccAWSSpotFleetRequestConfig(rName, rInt),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    testAccCheckAWSSpotFleetRequestExists(
+                        "aws_spot_fleet_request.foo", &before),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_request_state", "active"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_price", "0.005"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.#", "1"),
+                ),
+            },
+            {
+                Config: testAccAWSSpotFleetRequestConfigChangeSpotBidPrice(rName, rInt),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    testAccCheckAWSSpotFleetRequestExists(
+                        "aws_spot_fleet_request.foo", &after),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_request_state", "active"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.#", "1"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_price", "0.01"),
+                    testAccCheckAWSSpotFleetRequestConfigRecreated(t, &before, &after),
+                ),
+            },
+        },
+    })
 }
 
 func TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion(t *testing.T) {
-	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+    var sfr ec2.SpotFleetRequestConfig
+    rName := acctest.RandString(10)
+    rInt := acctest.RandInt()
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSpotFleetRequestConfig(rName, rInt),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.#", "1"),
-				),
-			},
-		},
-	})
+    resource.ParallelTest(t, resource.TestCase{
+        PreCheck:     func() { testAccPreCheck(t) },
+        Providers:    testAccProviders,
+        CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccAWSSpotFleetRequestConfig(rName, rInt),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    testAccCheckAWSSpotFleetRequestExists(
+                        "aws_spot_fleet_request.foo", &sfr),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_request_state", "active"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.#", "1"),
+                ),
+            },
+        },
+    })
 }
 
 func TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList(t *testing.T) {
-	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+    var sfr ec2.SpotFleetRequestConfig
+    rName := acctest.RandString(10)
+    rInt := acctest.RandInt()
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSpotFleetRequestConfigWithAzs(rName, rInt),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.#", "2"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.1991689378.availability_zone", "us-west-2a"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.19404370.availability_zone", "us-west-2b"),
-				),
-			},
-		},
-	})
+    resource.ParallelTest(t, resource.TestCase{
+        PreCheck:     func() { testAccPreCheck(t) },
+        Providers:    testAccProviders,
+        CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccAWSSpotFleetRequestConfigWithAzs(rName, rInt),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    testAccCheckAWSSpotFleetRequestExists(
+                        "aws_spot_fleet_request.foo", &sfr),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_request_state", "active"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.#", "2"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.1991689378.availability_zone", "us-west-2a"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.19404370.availability_zone", "us-west-2b"),
+                ),
+            },
+        },
+    })
 }
 
 func TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList(t *testing.T) {
-	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+    var sfr ec2.SpotFleetRequestConfig
+    rName := acctest.RandString(10)
+    rInt := acctest.RandInt()
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSpotFleetRequestConfigWithSubnet(rName, rInt),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.#", "2"),
-				),
-			},
-		},
-	})
+    resource.ParallelTest(t, resource.TestCase{
+        PreCheck:     func() { testAccPreCheck(t) },
+        Providers:    testAccProviders,
+        CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccAWSSpotFleetRequestConfigWithSubnet(rName, rInt),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    testAccCheckAWSSpotFleetRequestExists(
+                        "aws_spot_fleet_request.foo", &sfr),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_request_state", "active"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.#", "2"),
+                ),
+            },
+        },
+    })
 }
 
 func TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz(t *testing.T) {
-	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+    var sfr ec2.SpotFleetRequestConfig
+    rName := acctest.RandString(10)
+    rInt := acctest.RandInt()
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSpotFleetRequestConfigMultipleInstanceTypesinSameAz(rName, rInt),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.#", "2"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.1991689378.instance_type", "m1.small"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.1991689378.availability_zone", "us-west-2a"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.590403189.instance_type", "m3.large"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.590403189.availability_zone", "us-west-2a"),
-				),
-			},
-		},
-	})
+    resource.ParallelTest(t, resource.TestCase{
+        PreCheck:     func() { testAccPreCheck(t) },
+        Providers:    testAccProviders,
+        CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccAWSSpotFleetRequestConfigMultipleInstanceTypesinSameAz(rName, rInt),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    testAccCheckAWSSpotFleetRequestExists(
+                        "aws_spot_fleet_request.foo", &sfr),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_request_state", "active"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.#", "2"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.1991689378.instance_type", "m1.small"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.1991689378.availability_zone", "us-west-2a"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.590403189.instance_type", "m3.large"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.590403189.availability_zone", "us-west-2a"),
+                ),
+            },
+        },
+    })
 }
 
 func TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet(t *testing.T) {
-	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+    var sfr ec2.SpotFleetRequestConfig
+    rName := acctest.RandString(10)
+    rInt := acctest.RandInt()
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSpotFleetRequestConfigMultipleInstanceTypesinSameSubnet(rName, rInt),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.#", "2"),
-				),
-			},
-		},
-	})
+    resource.ParallelTest(t, resource.TestCase{
+        PreCheck:     func() { testAccPreCheck(t) },
+        Providers:    testAccProviders,
+        CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccAWSSpotFleetRequestConfigMultipleInstanceTypesinSameSubnet(rName, rInt),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    testAccCheckAWSSpotFleetRequestExists(
+                        "aws_spot_fleet_request.foo", &sfr),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_request_state", "active"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.#", "2"),
+                ),
+            },
+        },
+    })
 }
 
 func TestAccAWSSpotFleetRequest_overriddingSpotPrice(t *testing.T) {
-	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+    var sfr ec2.SpotFleetRequestConfig
+    rName := acctest.RandString(10)
+    rInt := acctest.RandInt()
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSpotFleetRequestConfigOverridingSpotPrice(rName, rInt),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_price", "0.035"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.#", "2"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.4143232216.spot_price", "0.01"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.4143232216.instance_type", "m3.large"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.1991689378.spot_price", ""), //there will not be a value here since it's not overriding
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.1991689378.instance_type", "m1.small"),
-				),
-			},
-		},
-	})
+    resource.ParallelTest(t, resource.TestCase{
+        PreCheck:     func() { testAccPreCheck(t) },
+        Providers:    testAccProviders,
+        CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccAWSSpotFleetRequestConfigOverridingSpotPrice(rName, rInt),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    testAccCheckAWSSpotFleetRequestExists(
+                        "aws_spot_fleet_request.foo", &sfr),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_request_state", "active"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_price", "0.035"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.#", "2"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.4143232216.spot_price", "0.01"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.4143232216.instance_type", "m3.large"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.1991689378.spot_price", ""), //there will not be a value here since it's not overriding
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.1991689378.instance_type", "m1.small"),
+                ),
+            },
+        },
+    })
 }
 
 func TestAccAWSSpotFleetRequest_withoutSpotPrice(t *testing.T) {
-	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+    var sfr ec2.SpotFleetRequestConfig
+    rName := acctest.RandString(10)
+    rInt := acctest.RandInt()
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSpotFleetRequestConfigWithoutSpotPrice(rName, rInt),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.#", "2"),
-				),
-			},
-		},
-	})
+    resource.ParallelTest(t, resource.TestCase{
+        PreCheck:     func() { testAccPreCheck(t) },
+        Providers:    testAccProviders,
+        CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccAWSSpotFleetRequestConfigWithoutSpotPrice(rName, rInt),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    testAccCheckAWSSpotFleetRequestExists(
+                        "aws_spot_fleet_request.foo", &sfr),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_request_state", "active"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.#", "2"),
+                ),
+            },
+        },
+    })
 }
 
 func TestAccAWSSpotFleetRequest_diversifiedAllocation(t *testing.T) {
-	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+    var sfr ec2.SpotFleetRequestConfig
+    rName := acctest.RandString(10)
+    rInt := acctest.RandInt()
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSpotFleetRequestConfigDiversifiedAllocation(rName, rInt),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.#", "3"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "allocation_strategy", "diversified"),
-				),
-			},
-		},
-	})
+    resource.ParallelTest(t, resource.TestCase{
+        PreCheck:     func() { testAccPreCheck(t) },
+        Providers:    testAccProviders,
+        CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccAWSSpotFleetRequestConfigDiversifiedAllocation(rName, rInt),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    testAccCheckAWSSpotFleetRequestExists(
+                        "aws_spot_fleet_request.foo", &sfr),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_request_state", "active"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.#", "3"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "allocation_strategy", "diversified"),
+                ),
+            },
+        },
+    })
 }
 
 func TestAccAWSSpotFleetRequest_multipleInstancePools(t *testing.T) {
-	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+    var sfr ec2.SpotFleetRequestConfig
+    rName := acctest.RandString(10)
+    rInt := acctest.RandInt()
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSpotFleetRequestConfigMultipleInstancePools(rName, rInt),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.#", "3"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "allocation_strategy", "lowestPrice"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "instance_pools_to_use_count", "2"),
-				),
-			},
-		},
-	})
+    resource.ParallelTest(t, resource.TestCase{
+        PreCheck:     func() { testAccPreCheck(t) },
+        Providers:    testAccProviders,
+        CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccAWSSpotFleetRequestConfigMultipleInstancePools(rName, rInt),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    testAccCheckAWSSpotFleetRequestExists(
+                        "aws_spot_fleet_request.foo", &sfr),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_request_state", "active"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.#", "3"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "allocation_strategy", "lowestPrice"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "instance_pools_to_use_count", "2"),
+                ),
+            },
+        },
+    })
 }
 
 func TestAccAWSSpotFleetRequest_withWeightedCapacity(t *testing.T) {
-	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+    var sfr ec2.SpotFleetRequestConfig
+    rName := acctest.RandString(10)
+    rInt := acctest.RandInt()
 
-	fulfillSleep := func() resource.TestCheckFunc {
-		// sleep so that EC2 can fuflill the request. We do this to guard against a
-		// regression and possible leak where we'll destroy the request and the
-		// associated IAM role before anything is actually provisioned and running,
-		// thus leaking when those newly started instances are attempted to be
-		// destroyed
-		// See https://github.com/hashicorp/terraform/pull/8938
-		return func(s *terraform.State) error {
-			log.Print("[DEBUG] Test: Sleep to allow EC2 to actually begin fulfilling TestAccAWSSpotFleetRequest_withWeightedCapacity request")
-			time.Sleep(1 * time.Minute)
-			return nil
-		}
-	}
+    fulfillSleep := func() resource.TestCheckFunc {
+        // sleep so that EC2 can fuflill the request. We do this to guard against a
+        // regression and possible leak where we'll destroy the request and the
+        // associated IAM role before anything is actually provisioned and running,
+        // thus leaking when those newly started instances are attempted to be
+        // destroyed
+        // See https://github.com/hashicorp/terraform/pull/8938
+        return func(s *terraform.State) error {
+            log.Print("[DEBUG] Test: Sleep to allow EC2 to actually begin fulfilling TestAccAWSSpotFleetRequest_withWeightedCapacity request")
+            time.Sleep(1 * time.Minute)
+            return nil
+        }
+    }
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSpotFleetRequestConfigWithWeightedCapacity(rName, rInt),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					fulfillSleep(),
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.#", "2"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.4120185872.weighted_capacity", "3"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.4120185872.instance_type", "r3.large"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.590403189.weighted_capacity", "6"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.590403189.instance_type", "m3.large"),
-				),
-			},
-		},
-	})
+    resource.ParallelTest(t, resource.TestCase{
+        PreCheck:     func() { testAccPreCheck(t) },
+        Providers:    testAccProviders,
+        CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccAWSSpotFleetRequestConfigWithWeightedCapacity(rName, rInt),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    fulfillSleep(),
+                    testAccCheckAWSSpotFleetRequestExists(
+                        "aws_spot_fleet_request.foo", &sfr),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_request_state", "active"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.#", "2"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.4120185872.weighted_capacity", "3"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.4120185872.instance_type", "r3.large"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.590403189.weighted_capacity", "6"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.590403189.instance_type", "m3.large"),
+                ),
+            },
+        },
+    })
 }
 
 func TestAccAWSSpotFleetRequest_withEBSDisk(t *testing.T) {
-	var config ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+    var config ec2.SpotFleetRequestConfig
+    rName := acctest.RandString(10)
+    rInt := acctest.RandInt()
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSpotFleetRequestEBSConfig(rName, rInt),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &config),
-					testAccCheckAWSSpotFleetRequest_EBSAttributes(
-						&config),
-				),
-			},
-		},
-	})
+    resource.ParallelTest(t, resource.TestCase{
+        PreCheck:     func() { testAccPreCheck(t) },
+        Providers:    testAccProviders,
+        CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccAWSSpotFleetRequestEBSConfig(rName, rInt),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    testAccCheckAWSSpotFleetRequestExists(
+                        "aws_spot_fleet_request.foo", &config),
+                    testAccCheckAWSSpotFleetRequest_EBSAttributes(
+                        &config),
+                ),
+            },
+        },
+    })
 }
 
 func TestAccAWSSpotFleetRequest_withTags(t *testing.T) {
-	var config ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+    var config ec2.SpotFleetRequestConfig
+    rName := acctest.RandString(10)
+    rInt := acctest.RandInt()
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSpotFleetRequestTagsConfig(rName, rInt),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists("aws_spot_fleet_request.foo", &config),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.24370212.tags.%", "2"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.24370212.tags.First", "TfAccTest"),
-					resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.24370212.tags.Second", "Terraform"),
-				),
-			},
-		},
-	})
+    resource.ParallelTest(t, resource.TestCase{
+        PreCheck:     func() { testAccPreCheck(t) },
+        Providers:    testAccProviders,
+        CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccAWSSpotFleetRequestTagsConfig(rName, rInt),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    testAccCheckAWSSpotFleetRequestExists("aws_spot_fleet_request.foo", &config),
+                    resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.24370212.tags.%", "2"),
+                    resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.24370212.tags.First", "TfAccTest"),
+                    resource.TestCheckResourceAttr("aws_spot_fleet_request.foo", "launch_specification.24370212.tags.Second", "Terraform"),
+                ),
+            },
+        },
+    })
 }
 
 func TestAccAWSSpotFleetRequest_placementTenancy(t *testing.T) {
-	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+    var sfr ec2.SpotFleetRequestConfig
+    rName := acctest.RandString(10)
+    rInt := acctest.RandInt()
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSpotFleetRequestTenancyConfig(rName, rInt),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					testAccCheckAWSSpotFleetRequest_PlacementAttributes(&sfr),
-				),
-			},
-		},
-	})
+    resource.ParallelTest(t, resource.TestCase{
+        PreCheck:     func() { testAccPreCheck(t) },
+        Providers:    testAccProviders,
+        CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccAWSSpotFleetRequestTenancyConfig(rName, rInt),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    testAccCheckAWSSpotFleetRequestExists(
+                        "aws_spot_fleet_request.foo", &sfr),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_request_state", "active"),
+                    testAccCheckAWSSpotFleetRequest_PlacementAttributes(&sfr),
+                ),
+            },
+        },
+    })
 }
 
 func testAccCheckAWSSpotFleetRequestConfigRecreated(t *testing.T,
-	before, after *ec2.SpotFleetRequestConfig) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if before.SpotFleetRequestId == after.SpotFleetRequestId {
-			t.Fatalf("Expected change of Spot Fleet Request IDs, but both were %v", before.SpotFleetRequestId)
-		}
-		return nil
-	}
+    before, after *ec2.SpotFleetRequestConfig) resource.TestCheckFunc {
+    return func(s *terraform.State) error {
+        if before.SpotFleetRequestId == after.SpotFleetRequestId {
+            t.Fatalf("Expected change of Spot Fleet Request IDs, but both were %v", before.SpotFleetRequestId)
+        }
+        return nil
+    }
 }
 
 func testAccCheckAWSSpotFleetRequestExists(
-	n string, sfr *ec2.SpotFleetRequestConfig) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
+    n string, sfr *ec2.SpotFleetRequestConfig) resource.TestCheckFunc {
+    return func(s *terraform.State) error {
+        rs, ok := s.RootModule().Resources[n]
+        if !ok {
+            return fmt.Errorf("Not found: %s", n)
+        }
 
-		if rs.Primary.ID == "" {
-			return errors.New("No Spot fleet request with that id exists")
-		}
+        if rs.Primary.ID == "" {
+            return errors.New("No Spot fleet request with that id exists")
+        }
 
-		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+        conn := testAccProvider.Meta().(*AWSClient).ec2conn
 
-		params := &ec2.DescribeSpotFleetRequestsInput{
-			SpotFleetRequestIds: []*string{&rs.Primary.ID},
-		}
-		resp, err := conn.DescribeSpotFleetRequests(params)
+        params := &ec2.DescribeSpotFleetRequestsInput{
+            SpotFleetRequestIds: []*string{&rs.Primary.ID},
+        }
+        resp, err := conn.DescribeSpotFleetRequests(params)
 
-		if err != nil {
-			return err
-		}
+        if err != nil {
+            return err
+        }
 
-		if v := len(resp.SpotFleetRequestConfigs); v != 1 {
-			return fmt.Errorf("Expected 1 request returned, got %d", v)
-		}
+        if v := len(resp.SpotFleetRequestConfigs); v != 1 {
+            return fmt.Errorf("Expected 1 request returned, got %d", v)
+        }
 
-		*sfr = *resp.SpotFleetRequestConfigs[0]
+        *sfr = *resp.SpotFleetRequestConfigs[0]
 
-		return nil
-	}
+        return nil
+    }
 }
 
 func testAccCheckAWSSpotFleetRequest_EBSAttributes(
-	sfr *ec2.SpotFleetRequestConfig) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if len(sfr.SpotFleetRequestConfig.LaunchSpecifications) == 0 {
-			return errors.New("Missing launch specification")
-		}
+    sfr *ec2.SpotFleetRequestConfig) resource.TestCheckFunc {
+    return func(s *terraform.State) error {
+        if len(sfr.SpotFleetRequestConfig.LaunchSpecifications) == 0 {
+            return errors.New("Missing launch specification")
+        }
 
-		spec := *sfr.SpotFleetRequestConfig.LaunchSpecifications[0]
+        spec := *sfr.SpotFleetRequestConfig.LaunchSpecifications[0]
 
-		ebs := spec.BlockDeviceMappings
-		if len(ebs) < 2 {
-			return fmt.Errorf("Expected %d block device mappings, got %d", 2, len(ebs))
-		}
+        ebs := spec.BlockDeviceMappings
+        if len(ebs) < 2 {
+            return fmt.Errorf("Expected %d block device mappings, got %d", 2, len(ebs))
+        }
 
-		if *ebs[0].DeviceName != "/dev/xvda" {
-			return fmt.Errorf("Expected device 0's name to be %s, got %s", "/dev/xvda", *ebs[0].DeviceName)
-		}
-		if *ebs[1].DeviceName != "/dev/xvdcz" {
-			return fmt.Errorf("Expected device 1's name to be %s, got %s", "/dev/xvdcz", *ebs[1].DeviceName)
-		}
+        if *ebs[0].DeviceName != "/dev/xvda" {
+            return fmt.Errorf("Expected device 0's name to be %s, got %s", "/dev/xvda", *ebs[0].DeviceName)
+        }
+        if *ebs[1].DeviceName != "/dev/xvdcz" {
+            return fmt.Errorf("Expected device 1's name to be %s, got %s", "/dev/xvdcz", *ebs[1].DeviceName)
+        }
 
-		return nil
-	}
+        return nil
+    }
 }
 
 func testAccCheckAWSSpotFleetRequest_PlacementAttributes(
-	sfr *ec2.SpotFleetRequestConfig) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if len(sfr.SpotFleetRequestConfig.LaunchSpecifications) == 0 {
-			return errors.New("Missing launch specification")
-		}
+    sfr *ec2.SpotFleetRequestConfig) resource.TestCheckFunc {
+    return func(s *terraform.State) error {
+        if len(sfr.SpotFleetRequestConfig.LaunchSpecifications) == 0 {
+            return errors.New("Missing launch specification")
+        }
 
-		spec := *sfr.SpotFleetRequestConfig.LaunchSpecifications[0]
+        spec := *sfr.SpotFleetRequestConfig.LaunchSpecifications[0]
 
-		placement := spec.Placement
-		if placement == nil {
-			return fmt.Errorf("Expected placement to be set, got nil")
-		}
-		if *placement.Tenancy != "dedicated" {
-			return fmt.Errorf("Expected placement tenancy to be %q, got %q", "dedicated", *placement.Tenancy)
-		}
+        placement := spec.Placement
+        if placement == nil {
+            return fmt.Errorf("Expected placement to be set, got nil")
+        }
+        if *placement.Tenancy != "dedicated" {
+            return fmt.Errorf("Expected placement tenancy to be %q, got %q", "dedicated", *placement.Tenancy)
+        }
 
-		return nil
-	}
+        return nil
+    }
 }
 
 func testAccCheckAWSSpotFleetRequestDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*AWSClient).ec2conn
+    conn := testAccProvider.Meta().(*AWSClient).ec2conn
 
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_spot_fleet_request" {
-			continue
-		}
+    for _, rs := range s.RootModule().Resources {
+        if rs.Type != "aws_spot_fleet_request" {
+            continue
+        }
 
-		_, err := conn.CancelSpotFleetRequests(&ec2.CancelSpotFleetRequestsInput{
-			SpotFleetRequestIds: []*string{aws.String(rs.Primary.ID)},
-			TerminateInstances:  aws.Bool(true),
-		})
+        _, err := conn.CancelSpotFleetRequests(&ec2.CancelSpotFleetRequestsInput{
+            SpotFleetRequestIds: []*string{aws.String(rs.Primary.ID)},
+            TerminateInstances:  aws.Bool(true),
+        })
 
-		if err != nil {
-			return fmt.Errorf("Error cancelling spot request (%s): %s", rs.Primary.ID, err)
-		}
-	}
+        if err != nil {
+            return fmt.Errorf("Error cancelling spot request (%s): %s", rs.Primary.ID, err)
+        }
+    }
 
-	return nil
+    return nil
 }
 
 func TestAccAWSSpotFleetRequest_WithELBs(t *testing.T) {
-	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+    var sfr ec2.SpotFleetRequestConfig
+    rName := acctest.RandString(10)
+    rInt := acctest.RandInt()
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSpotFleetRequestConfigWithELBs(rName, rInt),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "load_balancers.#", "1"),
-				),
-			},
-		},
-	})
+    resource.ParallelTest(t, resource.TestCase{
+        PreCheck:     func() { testAccPreCheck(t) },
+        Providers:    testAccProviders,
+        CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccAWSSpotFleetRequestConfigWithELBs(rName, rInt),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    testAccCheckAWSSpotFleetRequestExists(
+                        "aws_spot_fleet_request.foo", &sfr),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_request_state", "active"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.#", "1"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "load_balancers.#", "1"),
+                ),
+            },
+        },
+    })
 }
 
 func testAccCheckAWSSpotFleetRequest_IamInstanceProfileArn(
-	sfr *ec2.SpotFleetRequestConfig) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if len(sfr.SpotFleetRequestConfig.LaunchSpecifications) == 0 {
-			return errors.New("Missing launch specification")
-		}
+    sfr *ec2.SpotFleetRequestConfig) resource.TestCheckFunc {
+    return func(s *terraform.State) error {
+        if len(sfr.SpotFleetRequestConfig.LaunchSpecifications) == 0 {
+            return errors.New("Missing launch specification")
+        }
 
-		spec := *sfr.SpotFleetRequestConfig.LaunchSpecifications[0]
+        spec := *sfr.SpotFleetRequestConfig.LaunchSpecifications[0]
 
-		profile := spec.IamInstanceProfile
-		if profile == nil {
-			return fmt.Errorf("Expected IamInstanceProfile to be set, got nil")
-		}
-		//Validate the string whether it is ARN
-		re := regexp.MustCompile(`arn:aws:iam::\d{12}:instance-profile/?[a-zA-Z0-9+=,.@-_].*`)
-		if !re.MatchString(*profile.Arn) {
-			return fmt.Errorf("Expected IamInstanceProfile input as ARN, got %s", *profile.Arn)
-		}
+        profile := spec.IamInstanceProfile
+        if profile == nil {
+            return fmt.Errorf("Expected IamInstanceProfile to be set, got nil")
+        }
+        //Validate the string whether it is ARN
+        re := regexp.MustCompile(`arn:aws:iam::\d{12}:instance-profile/?[a-zA-Z0-9+=,.@-_].*`)
+        if !re.MatchString(*profile.Arn) {
+            return fmt.Errorf("Expected IamInstanceProfile input as ARN, got %s", *profile.Arn)
+        }
 
-		return nil
-	}
+        return nil
+    }
 }
 
 func TestAccAWSSpotFleetRequest_WithTargetGroups(t *testing.T) {
-	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+    var sfr ec2.SpotFleetRequestConfig
+    rName := acctest.RandString(10)
+    rInt := acctest.RandInt()
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSpotFleetRequestConfigWithTargetGroups(rName, rInt),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "target_group_arns.#", "1"),
-				),
-			},
-		},
-	})
+    resource.ParallelTest(t, resource.TestCase{
+        PreCheck:     func() { testAccPreCheck(t) },
+        Providers:    testAccProviders,
+        CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccAWSSpotFleetRequestConfigWithTargetGroups(rName, rInt),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    testAccCheckAWSSpotFleetRequestExists(
+                        "aws_spot_fleet_request.foo", &sfr),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_request_state", "active"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.#", "1"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "target_group_arns.#", "1"),
+                ),
+            },
+        },
+    })
 }
 
 func testAccAWSSpotFleetRequestConfigAssociatePublicIpAddress(rName string, rInt int) string {
-	return fmt.Sprintf(`
+    return fmt.Sprintf(`
 resource "aws_key_pair" "debugging" {
-	key_name = "tmp-key-%s"
-	public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
+    key_name = "tmp-key-%s"
+    public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 }
 
 resource "aws_iam_policy_attachment" "test-attach" {
@@ -804,15 +1134,15 @@ resource "aws_spot_fleet_request" "foo" {
         key_name = "${aws_key_pair.debugging.key_name}"
         associate_public_ip_address = true
     }
-	depends_on = ["aws_iam_policy_attachment.test-attach"]
+    depends_on = ["aws_iam_policy_attachment.test-attach"]
 }`, rName, rInt, rName)
 }
 
 func testAccAWSSpotFleetRequestConfig(rName string, rInt int) string {
-	return fmt.Sprintf(`
+    return fmt.Sprintf(`
 resource "aws_key_pair" "debugging" {
-	key_name = "tmp-key-%s"
-	public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
+    key_name = "tmp-key-%s"
+    public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 }
 
 resource "aws_iam_policy" "test-policy" {
@@ -884,81 +1214,11 @@ resource "aws_spot_fleet_request" "foo" {
 `, rName, rInt, rInt, rName)
 }
 
-func testAccAWSSpotFleetRequestConfigFleetType(rName string, rInt int) string {
-	return fmt.Sprintf(`
-resource "aws_iam_policy" "test-policy" {
-  name = "test-policy-%d"
-  path = "/"
-  description = "Spot Fleet Request ACCTest Policy"
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [{
-    "Effect": "Allow",
-    "Action": [
-       "ec2:DescribeImages",
-       "ec2:DescribeSubnets",
-       "ec2:RequestSpotInstances",
-       "ec2:TerminateInstances",
-       "ec2:DescribeInstanceStatus",
-       "iam:PassRole"
-        ],
-    "Resource": ["*"]
-  }]
-}
-EOF
-}
-
-resource "aws_iam_policy_attachment" "test-attach" {
-    name = "test-attachment-%d"
-    roles = ["${aws_iam_role.test-role.name}"]
-    policy_arn = "${aws_iam_policy.test-policy.arn}"
-}
-
-resource "aws_iam_role" "test-role" {
-    name = "test-role-%s"
-    assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": [
-          "spotfleet.amazonaws.com",
-          "ec2.amazonaws.com"
-        ]
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_spot_fleet_request" "foo" {
-    iam_fleet_role = "${aws_iam_role.test-role.arn}"
-    spot_price = "0.005"
-    target_capacity = 2
-    valid_until = "2019-11-04T20:44:20Z"
-    fleet_type = "request"
-    terminate_instances_with_expiration = true
-    wait_for_fulfillment = true
-    launch_specification {
-        instance_type = "m1.small"
-        ami = "ami-516b9131"
-    }
-    depends_on = ["aws_iam_policy_attachment.test-attach"]
-}
-`, rInt, rInt, rName)
-}
-
-func testAccAWSSpotFleetRequestConfigIamInstanceProfileArn(rName string, rInt int) string {
-	return fmt.Sprintf(`
+func testAccAWSSpotFleetRequestLaunchTemplateConfig(rName string, rInt int) string {
+    return fmt.Sprintf(`
 resource "aws_key_pair" "debugging" {
-	key_name = "tmp-key-%s"
-	public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
+    key_name = "tmp-key-%s"
+    public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 }
 
 resource "aws_iam_policy" "test-policy" {
@@ -1012,46 +1272,11 @@ resource "aws_iam_role" "test-role" {
 EOF
 }
 
-resource "aws_iam_role" "test-role1" {
-    name = "tf-test-role1-%s"
-    assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": [
-          "spotfleet.amazonaws.com",
-          "ec2.amazonaws.com"
-        ]
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_role_policy" "test-role-policy1" {
-	name = "tf-test-role-policy1-%s"
-	role = "${aws_iam_role.test-role1.name}"
-	policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": {
-    "Effect": "Allow",
-    "Action": "*",
-    "Resource": "*"
-  }
-}
-EOF
-}
-
-resource "aws_iam_instance_profile" "test-iam-instance-profile1" {
-	name = "tf-test-profile1-%s"
-	role = "${aws_iam_role.test-role1.name}"
+resource "aws_launch_template" "foo" {
+  name = "test-launch-template"
+  image_id = "ami-516b9131"
+  instance_type = "m1.small"
+  key_name = "${aws_key_pair.debugging.key_name}"
 }
 
 resource "aws_spot_fleet_request" "foo" {
@@ -1062,22 +1287,205 @@ resource "aws_spot_fleet_request" "foo" {
     terminate_instances_with_expiration = true
     instance_interruption_behaviour = "stop"
     wait_for_fulfillment = true
-    launch_specification {
-        instance_type = "m1.small"
-        ami = "ami-516b9131"
-        key_name = "${aws_key_pair.debugging.key_name}"
-        iam_instance_profile_arn = "${aws_iam_instance_profile.test-iam-instance-profile1.arn}"
+
+    launch_template_configs {
+      launch_template_specification {
+        name = "${aws_launch_template.foo.name}"
+        version = "${aws_launch_template.foo.latest_version}"
+      }
     }
+
     depends_on = ["aws_iam_policy_attachment.test-attach"]
 }
-`, rName, rInt, rInt, rName, rName, rName, rName)
+`, rName, rInt, rInt, rName)
+}
+
+func testAccAWSSpotFleetRequestLaunchTemplateConfigWithOnDemandCapacity(rName string, rInt int) string {
+    return fmt.Sprintf(`
+resource "aws_key_pair" "debugging" {
+    key_name = "tmp-key-%s"
+    public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
+}
+
+resource "aws_iam_policy" "test-policy" {
+  name = "test-policy-%d"
+  path = "/"
+  description = "Spot Fleet Request ACCTest Policy"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": [
+       "ec2:DescribeImages",
+       "ec2:DescribeSubnets",
+       "ec2:RequestSpotInstances",
+       "ec2:TerminateInstances",
+       "ec2:DescribeInstanceStatus",
+       "iam:PassRole"
+        ],
+    "Resource": ["*"]
+  }]
+}
+EOF
+}
+
+resource "aws_iam_policy_attachment" "test-attach" {
+    name = "test-attachment-%d"
+    roles = ["${aws_iam_role.test-role.name}"]
+    policy_arn = "${aws_iam_policy.test-policy.arn}"
+}
+
+resource "aws_iam_role" "test-role" {
+    name = "test-role-%s"
+    assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "spotfleet.amazonaws.com",
+          "ec2.amazonaws.com"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_launch_template" "foo" {
+  name = "test-launch-template"
+  image_id = "ami-516b9131"
+  instance_type = "m1.small"
+  key_name = "${aws_key_pair.debugging.key_name}"
+}
+
+resource "aws_spot_fleet_request" "foo" {
+    iam_fleet_role = "${aws_iam_role.test-role.arn}"
+    spot_price = "0.005"
+    target_capacity = 2
+    valid_until = "2019-11-04T20:44:20Z"
+    terminate_instances_with_expiration = true
+    wait_for_fulfillment = true
+    on_demand_target_capacity = 2
+
+    launch_template_configs {
+      launch_template_specification {
+        name = "${aws_launch_template.foo.name}"
+        version = "${aws_launch_template.foo.latest_version}"
+      }
+    }
+
+    depends_on = ["aws_iam_policy_attachment.test-attach"]
+}
+`, rName, rInt, rInt, rName)
+}
+
+func testAccAWSSpotFleetRequestLaunchTemplateConfigWithOverrides(rName string, rInt int) string {
+    return fmt.Sprintf(`
+resource "aws_key_pair" "debugging" {
+    key_name = "tmp-key-%s"
+    public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
+}
+
+resource "aws_iam_policy" "test-policy" {
+  name = "test-policy-%d"
+  path = "/"
+  description = "Spot Fleet Request ACCTest Policy"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": [
+       "ec2:DescribeImages",
+       "ec2:DescribeSubnets",
+       "ec2:RequestSpotInstances",
+       "ec2:TerminateInstances",
+       "ec2:DescribeInstanceStatus",
+       "iam:PassRole"
+        ],
+    "Resource": ["*"]
+  }]
+}
+EOF
+}
+
+resource "aws_iam_policy_attachment" "test-attach" {
+    name = "test-attachment-%d"
+    roles = ["${aws_iam_role.test-role.name}"]
+    policy_arn = "${aws_iam_policy.test-policy.arn}"
+}
+
+resource "aws_iam_role" "test-role" {
+    name = "test-role-%s"
+    assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "spotfleet.amazonaws.com",
+          "ec2.amazonaws.com"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_launch_template" "foo" {
+  name = "test-launch-template"
+  image_id = "ami-516b9131"
+  instance_type = "m1.small"
+  key_name = "${aws_key_pair.debugging.key_name}"
+}
+
+resource "aws_spot_fleet_request" "foo" {
+    iam_fleet_role = "${aws_iam_role.test-role.arn}"
+    spot_price = "0.005"
+    target_capacity = 2
+    valid_until = "2019-11-04T20:44:20Z"
+    terminate_instances_with_expiration = true
+    instance_interruption_behaviour = "stop"
+    wait_for_fulfillment = true
+
+    launch_template_configs {
+      launch_template_specification {
+        name = "${aws_launch_template.foo.name}"
+        version = "${aws_launch_template.foo.latest_version}"
+      }
+      overrides {
+        instance_type = "t1.micro"
+        weighted_capacity = "2"
+      }
+      overrides {
+        instance_type = "m3.medium"
+        spot_price = "0.26"
+      }
+
+    }
+
+    depends_on = ["aws_iam_policy_attachment.test-attach"]
+}
+`, rName, rInt, rInt, rName)
 }
 
 func testAccAWSSpotFleetRequestConfigChangeSpotBidPrice(rName string, rInt int) string {
-	return fmt.Sprintf(`
+    return fmt.Sprintf(`
 resource "aws_key_pair" "debugging" {
-	key_name = "tmp-key-%s"
-	public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
+    key_name = "tmp-key-%s"
+    public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 }
 
 resource "aws_iam_policy" "test-policy" {
@@ -1149,10 +1557,10 @@ resource "aws_spot_fleet_request" "foo" {
 }
 
 func testAccAWSSpotFleetRequestConfigWithAzs(rName string, rInt int) string {
-	return fmt.Sprintf(`
+    return fmt.Sprintf(`
 resource "aws_key_pair" "debugging" {
-	key_name = "tmp-key-%s"
-	public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
+    key_name = "tmp-key-%s"
+    public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 }
 
 resource "aws_iam_policy" "test-policy" {
@@ -1231,10 +1639,10 @@ resource "aws_spot_fleet_request" "foo" {
 }
 
 func testAccAWSSpotFleetRequestConfigWithSubnet(rName string, rInt int) string {
-	return fmt.Sprintf(`
+    return fmt.Sprintf(`
 resource "aws_key_pair" "debugging" {
-	key_name = "tmp-key-%s"
-	public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
+    key_name = "tmp-key-%s"
+    public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 }
 
 resource "aws_iam_policy" "test-policy" {
@@ -1338,10 +1746,10 @@ resource "aws_spot_fleet_request" "foo" {
 }
 
 func testAccAWSSpotFleetRequestConfigWithELBs(rName string, rInt int) string {
-	return fmt.Sprintf(`
+    return fmt.Sprintf(`
 resource "aws_key_pair" "debugging" {
-	key_name = "tmp-key-%s"
-	public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
+    key_name = "tmp-key-%s"
+    public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 }
 
 resource "aws_iam_policy" "test-policy" {
@@ -1450,10 +1858,10 @@ resource "aws_spot_fleet_request" "foo" {
 }
 
 func testAccAWSSpotFleetRequestConfigWithTargetGroups(rName string, rInt int) string {
-	return fmt.Sprintf(`
+    return fmt.Sprintf(`
 resource "aws_key_pair" "debugging" {
-	key_name = "tmp-key-%s"
-	public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
+    key_name = "tmp-key-%s"
+    public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 }
 
 resource "aws_iam_policy" "test-policy" {
@@ -1573,10 +1981,10 @@ resource "aws_spot_fleet_request" "foo" {
 }
 
 func testAccAWSSpotFleetRequestConfigMultipleInstanceTypesinSameAz(rName string, rInt int) string {
-	return fmt.Sprintf(`
+    return fmt.Sprintf(`
 resource "aws_key_pair" "debugging" {
-	key_name = "tmp-key-%s"
-	public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
+    key_name = "tmp-key-%s"
+    public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 }
 
 resource "aws_iam_policy" "test-policy" {
@@ -1655,10 +2063,10 @@ resource "aws_spot_fleet_request" "foo" {
 }
 
 func testAccAWSSpotFleetRequestConfigMultipleInstanceTypesinSameSubnet(rName string, rInt int) string {
-	return fmt.Sprintf(`
+    return fmt.Sprintf(`
 resource "aws_key_pair" "debugging" {
-	key_name = "tmp-key-%s"
-	public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
+    key_name = "tmp-key-%s"
+    public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 }
 
 resource "aws_iam_policy" "test-policy" {
@@ -1753,10 +2161,10 @@ resource "aws_spot_fleet_request" "foo" {
 }
 
 func testAccAWSSpotFleetRequestConfigOverridingSpotPrice(rName string, rInt int) string {
-	return fmt.Sprintf(`
+    return fmt.Sprintf(`
 resource "aws_key_pair" "debugging" {
-	key_name = "tmp-key-%s"
-	public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
+    key_name = "tmp-key-%s"
+    public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 }
 
 resource "aws_iam_policy" "test-policy" {
@@ -1836,10 +2244,10 @@ resource "aws_spot_fleet_request" "foo" {
 }
 
 func testAccAWSSpotFleetRequestConfigWithoutSpotPrice(rName string, rInt int) string {
-	return fmt.Sprintf(`
+    return fmt.Sprintf(`
 resource "aws_key_pair" "debugging" {
-	key_name = "tmp-key-%s"
-	public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
+    key_name = "tmp-key-%s"
+    public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 }
 
 resource "aws_iam_policy" "test-policy" {
@@ -1917,10 +2325,10 @@ resource "aws_spot_fleet_request" "foo" {
 }
 
 func testAccAWSSpotFleetRequestConfigMultipleInstancePools(rName string, rInt int) string {
-	return fmt.Sprintf(`
+    return fmt.Sprintf(`
 resource "aws_key_pair" "debugging" {
-	key_name = "tmp-key-%s"
-	public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
+    key_name = "tmp-key-%s"
+    public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 }
 
 resource "aws_iam_policy" "test-policy" {
@@ -2006,10 +2414,10 @@ resource "aws_spot_fleet_request" "foo" {
 }
 
 func testAccAWSSpotFleetRequestConfigDiversifiedAllocation(rName string, rInt int) string {
-	return fmt.Sprintf(`
+    return fmt.Sprintf(`
 resource "aws_key_pair" "debugging" {
-	key_name = "tmp-key-%s"
-	public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
+    key_name = "tmp-key-%s"
+    public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 }
 
 resource "aws_iam_policy" "test-policy" {
@@ -2095,10 +2503,10 @@ resource "aws_spot_fleet_request" "foo" {
 }
 
 func testAccAWSSpotFleetRequestConfigWithWeightedCapacity(rName string, rInt int) string {
-	return fmt.Sprintf(`
+    return fmt.Sprintf(`
 resource "aws_key_pair" "debugging" {
-	key_name = "tmp-key-%s"
-	public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
+    key_name = "tmp-key-%s"
+    public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 }
 
 resource "aws_iam_policy" "test-policy" {
@@ -2179,7 +2587,7 @@ resource "aws_spot_fleet_request" "foo" {
 }
 
 func testAccAWSSpotFleetRequestEBSConfig(rName string, rInt int) string {
-	return fmt.Sprintf(`
+    return fmt.Sprintf(`
 resource "aws_iam_policy" "test-policy" {
   name = "test-policy-%d"
   path = "/"
@@ -2242,16 +2650,16 @@ resource "aws_spot_fleet_request" "foo" {
         instance_type = "m1.small"
         ami = "ami-516b9131"
 
-	ebs_block_device {
+    ebs_block_device {
             device_name = "/dev/xvda"
-	    volume_type = "gp2"
-	    volume_size = "8"
+        volume_type = "gp2"
+        volume_size = "8"
         }
 
-	ebs_block_device {
+    ebs_block_device {
             device_name = "/dev/xvdcz"
-	    volume_type = "gp2"
-	    volume_size = "100"
+        volume_type = "gp2"
+        volume_size = "100"
         }
     }
     depends_on = ["aws_iam_policy_attachment.test-attach"]
@@ -2260,7 +2668,7 @@ resource "aws_spot_fleet_request" "foo" {
 }
 
 func testAccAWSSpotFleetRequestTagsConfig(rName string, rInt int) string {
-	return fmt.Sprintf(`
+    return fmt.Sprintf(`
 resource "aws_iam_policy" "test-policy" {
   name = "test-policy-%d"
   path = "/"
@@ -2333,10 +2741,10 @@ resource "aws_spot_fleet_request" "foo" {
 }
 
 func testAccAWSSpotFleetRequestTenancyConfig(rName string, rInt int) string {
-	return fmt.Sprintf(`
+    return fmt.Sprintf(`
 resource "aws_key_pair" "debugging" {
-	key_name = "tmp-key-%s"
-	public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
+    key_name = "tmp-key-%s"
+    public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 }
 
 resource "aws_iam_policy" "test-policy" {

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -114,6 +114,22 @@ func TestAccAWSSpotFleetRequest_launchTemplate(t *testing.T) {
     })
 }
 
+func TestAccAWSSpotFleetRequest_launchTemplateConflictLaunchSpecification(t *testing.T) {
+    rName := acctest.RandString(10)
+
+    resource.ParallelTest(t, resource.TestCase{
+        PreCheck:     func() { testAccPreCheck(t) },
+        Providers:    testAccProviders,
+        CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config:      testAccAWSSpotFleetRequestLaunchTemplateConflictLaunchSpecification(rName),
+                ExpectError: regexp.MustCompile(`"launch_template_configs": conflicts with launch_specification`),
+            },
+        },
+    })
+}
+
 func TestAccAWSSpotFleetRequest_launchTemplateWithOverrides(t *testing.T) {
     var sfr ec2.SpotFleetRequestConfig
     rName := acctest.RandString(10)
@@ -1262,43 +1278,8 @@ resource "aws_spot_fleet_request" "foo" {
 `, rName, rInt, rInt, rName)
 }
 
-<<<<<<< HEAD
-func testAccAWSSpotFleetRequestLaunchTemplateConfigWithOnDemandCapacity(rName string, rInt int) string {
+func testAccAWSSpotFleetRequestLaunchTemplateConflictLaunchSpecification(rName string) string {
     return fmt.Sprintf(`
-resource "aws_key_pair" "debugging" {
-    key_name = "tmp-key-%s"
-    public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
-}
-
-resource "aws_iam_policy" "test-policy" {
-  name = "test-policy-%d"
-  path = "/"
-  description = "Spot Fleet Request ACCTest Policy"
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [{
-    "Effect": "Allow",
-    "Action": [
-       "ec2:DescribeImages",
-       "ec2:DescribeSubnets",
-       "ec2:RequestSpotInstances",
-       "ec2:TerminateInstances",
-       "ec2:DescribeInstanceStatus",
-       "iam:PassRole"
-        ],
-    "Resource": ["*"]
-  }]
-}
-EOF
-}
-
-resource "aws_iam_policy_attachment" "test-attach" {
-    name = "test-attachment-%d"
-    roles = ["${aws_iam_role.test-role.name}"]
-    policy_arn = "${aws_iam_policy.test-policy.arn}"
-}
-
 resource "aws_iam_role" "test-role" {
     name = "test-role-%s"
     assume_role_policy = <<EOF
@@ -1322,35 +1303,39 @@ EOF
 }
 
 resource "aws_launch_template" "foo" {
-  name = "test-launch-template"
+  name = "test-launch-template-%s"
   image_id = "ami-516b9131"
   instance_type = "m1.small"
-  key_name = "${aws_key_pair.debugging.key_name}"
 }
 
 resource "aws_spot_fleet_request" "foo" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
     spot_price = "0.005"
     target_capacity = 2
-    valid_until = "2019-11-04T20:44:20Z"
-    terminate_instances_with_expiration = true
-    wait_for_fulfillment = true
-    on_demand_target_capacity = 2
 
     launch_template_configs {
       launch_template_specification {
         name = "${aws_launch_template.foo.name}"
         version = "${aws_launch_template.foo.latest_version}"
       }
+      overrides {
+        instance_type = "t1.micro"
+        weighted_capacity = "2"
+      }
+      overrides {
+        instance_type = "m3.medium"
+        spot_price = "0.26"
+      }
     }
 
-    depends_on = ["aws_iam_policy_attachment.test-attach"]
+    launch_specification {
+        instance_type = "m1.small"
+        ami = "ami-516b9131"
+    }
 }
-`, rName, rInt, rInt, rName)
+`, rName, rName)
 }
 
-=======
->>>>>>> removed on-demand spot instance feature due to moving to a different PR
 func testAccAWSSpotFleetRequestLaunchTemplateConfigWithOverrides(rName string, rInt int) string {
     return fmt.Sprintf(`
 resource "aws_key_pair" "debugging" {

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -83,6 +83,55 @@ func TestAccAWSSpotFleetRequest_associatePublicIpAddress(t *testing.T) {
     })
 }
 
+func TestAccAWSSpotFleetRequest_fleetType(t *testing.T) {
+	var sfr ec2.SpotFleetRequestConfig
+	rName := acctest.RandString(10)
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSpotFleetRequestConfigFleetType(rName, rInt),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSSpotFleetRequestExists(
+						"aws_spot_fleet_request.foo", &sfr),
+					resource.TestCheckResourceAttr(
+						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(
+						"aws_spot_fleet_request.foo", "fleet_type", "request"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSpotFleetRequest_iamInstanceProfileArn(t *testing.T) {
+	var sfr ec2.SpotFleetRequestConfig
+	rName := acctest.RandString(10)
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSpotFleetRequestConfigIamInstanceProfileArn(rName, rInt),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSSpotFleetRequestExists(
+						"aws_spot_fleet_request.foo", &sfr),
+					resource.TestCheckResourceAttr(
+						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
+					testAccCheckAWSSpotFleetRequest_IamInstanceProfileArn(&sfr),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSSpotFleetRequest_launchTemplate(t *testing.T) {
     var sfr ec2.SpotFleetRequestConfig
     rName := acctest.RandString(10)
@@ -128,6 +177,40 @@ func TestAccAWSSpotFleetRequest_launchTemplateConflictLaunchSpecification(t *tes
             },
         },
     })
+}
+
+//On-Demand capacity requires launch template defined spot fleet, so can't test without it.
+func TestAccAWSSpotFleetRequest_launchTemplateWithOnDemandCapacity(t *testing.T) {
+	var sfr ec2.SpotFleetRequestConfig
+	rName := acctest.RandString(10)
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSpotFleetRequestLaunchTemplateConfigWithOnDemandCapacity(rName, rInt),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSSpotFleetRequestExists(
+						"aws_spot_fleet_request.foo", &sfr),
+					resource.TestCheckResourceAttr(
+						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
+					resource.TestCheckResourceAttr(
+						"aws_spot_fleet_request.foo", "launch_specification.#", "0"),
+					resource.TestCheckResourceAttr(
+						"aws_spot_fleet_request.foo", "launch_template_configs.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_spot_fleet_request.foo", "launch_template_configs.4018047529.launch_template_specification.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_spot_fleet_request.foo", "launch_template_configs.4018047529.overrides.#", "0"),
+					resource.TestCheckResourceAttr(
+						"aws_spot_fleet_request.foo", "on_demand_target_capacity", "2"),
+				),
+			},
+		},
+	})
 }
 
 func TestAccAWSSpotFleetRequest_launchTemplateWithOverrides(t *testing.T) {
@@ -1334,6 +1417,92 @@ resource "aws_spot_fleet_request" "foo" {
     }
 }
 `, rName, rName)
+}
+
+func testAccAWSSpotFleetRequestLaunchTemplateConfigWithOnDemandCapacity(rName string, rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_key_pair" "debugging" {
+    key_name = "tmp-key-%s"
+    public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
+}
+
+resource "aws_iam_policy" "test-policy" {
+  name = "test-policy-%d"
+  path = "/"
+  description = "Spot Fleet Request ACCTest Policy"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": [
+       "ec2:DescribeImages",
+       "ec2:DescribeSubnets",
+       "ec2:RequestSpotInstances",
+       "ec2:TerminateInstances",
+       "ec2:DescribeInstanceStatus",
+       "iam:PassRole"
+        ],
+    "Resource": ["*"]
+  }]
+}
+EOF
+}
+
+resource "aws_iam_policy_attachment" "test-attach" {
+    name = "test-attachment-%d"
+    roles = ["${aws_iam_role.test-role.name}"]
+    policy_arn = "${aws_iam_policy.test-policy.arn}"
+}
+
+resource "aws_iam_role" "test-role" {
+    name = "test-role-%s"
+    assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "spotfleet.amazonaws.com",
+          "ec2.amazonaws.com"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_launch_template" "foo" {
+  name = "test-launch-template"
+  image_id = "ami-516b9131"
+  instance_type = "m1.small"
+  key_name = "${aws_key_pair.debugging.key_name}"
+}
+
+resource "aws_spot_fleet_request" "foo" {
+    iam_fleet_role = "${aws_iam_role.test-role.arn}"
+    spot_price = "0.005"
+    target_capacity = 2
+    valid_until = "2019-11-04T20:44:20Z"
+    terminate_instances_with_expiration = true
+    wait_for_fulfillment = true
+    on_demand_target_capacity = 2
+
+    launch_template_configs {
+      launch_template_specification {
+        name = "${aws_launch_template.foo.name}"
+        version = "${aws_launch_template.foo.latest_version}"
+      }
+    }
+
+    depends_on = ["aws_iam_policy_attachment.test-attach"]
+}
+`, rName, rInt, rInt, rName)
 }
 
 func testAccAWSSpotFleetRequestLaunchTemplateConfigWithOverrides(rName string, rInt int) string {

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -84,52 +84,52 @@ func TestAccAWSSpotFleetRequest_associatePublicIpAddress(t *testing.T) {
 }
 
 func TestAccAWSSpotFleetRequest_fleetType(t *testing.T) {
-	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+    var sfr ec2.SpotFleetRequestConfig
+    rName := acctest.RandString(10)
+    rInt := acctest.RandInt()
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSpotFleetRequestConfigFleetType(rName, rInt),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "fleet_type", "request"),
-				),
-			},
-		},
-	})
+    resource.ParallelTest(t, resource.TestCase{
+        PreCheck:     func() { testAccPreCheck(t) },
+        Providers:    testAccProviders,
+        CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccAWSSpotFleetRequestConfigFleetType(rName, rInt),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    testAccCheckAWSSpotFleetRequestExists(
+                        "aws_spot_fleet_request.foo", &sfr),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_request_state", "active"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "fleet_type", "request"),
+                ),
+            },
+        },
+    })
 }
 
 func TestAccAWSSpotFleetRequest_iamInstanceProfileArn(t *testing.T) {
-	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+    var sfr ec2.SpotFleetRequestConfig
+    rName := acctest.RandString(10)
+    rInt := acctest.RandInt()
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSpotFleetRequestConfigIamInstanceProfileArn(rName, rInt),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					testAccCheckAWSSpotFleetRequest_IamInstanceProfileArn(&sfr),
-				),
-			},
-		},
-	})
+    resource.ParallelTest(t, resource.TestCase{
+        PreCheck:     func() { testAccPreCheck(t) },
+        Providers:    testAccProviders,
+        CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccAWSSpotFleetRequestConfigIamInstanceProfileArn(rName, rInt),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    testAccCheckAWSSpotFleetRequestExists(
+                        "aws_spot_fleet_request.foo", &sfr),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_request_state", "active"),
+                    testAccCheckAWSSpotFleetRequest_IamInstanceProfileArn(&sfr),
+                ),
+            },
+        },
+    })
 }
 
 func TestAccAWSSpotFleetRequest_launchTemplate(t *testing.T) {
@@ -181,36 +181,36 @@ func TestAccAWSSpotFleetRequest_launchTemplateConflictLaunchSpecification(t *tes
 
 //On-Demand capacity requires launch template defined spot fleet, so can't test without it.
 func TestAccAWSSpotFleetRequest_launchTemplateWithOnDemandCapacity(t *testing.T) {
-	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+    var sfr ec2.SpotFleetRequestConfig
+    rName := acctest.RandString(10)
+    rInt := acctest.RandInt()
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSpotFleetRequestLaunchTemplateConfigWithOnDemandCapacity(rName, rInt),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSSpotFleetRequestExists(
-						"aws_spot_fleet_request.foo", &sfr),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.#", "0"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_template_configs.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_template_configs.4018047529.launch_template_specification.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_template_configs.4018047529.overrides.#", "0"),
-					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "on_demand_target_capacity", "2"),
-				),
-			},
-		},
-	})
+    resource.ParallelTest(t, resource.TestCase{
+        PreCheck:     func() { testAccPreCheck(t) },
+        Providers:    testAccProviders,
+        CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccAWSSpotFleetRequestLaunchTemplateConfigWithOnDemandCapacity(rName, rInt),
+                Check: resource.ComposeAggregateTestCheckFunc(
+                    testAccCheckAWSSpotFleetRequestExists(
+                        "aws_spot_fleet_request.foo", &sfr),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "spot_request_state", "active"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_specification.#", "0"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_template_configs.#", "1"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_template_configs.4018047529.launch_template_specification.#", "1"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "launch_template_configs.4018047529.overrides.#", "0"),
+                    resource.TestCheckResourceAttr(
+                        "aws_spot_fleet_request.foo", "on_demand_target_capacity", "2"),
+                ),
+            },
+        },
+    })
 }
 
 func TestAccAWSSpotFleetRequest_launchTemplateWithOverrides(t *testing.T) {
@@ -699,6 +699,29 @@ func TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz(t *testing.T) {
             },
         },
     })
+}
+
+func testAccCheckAWSSpotFleetRequest_IamInstanceProfileArn(
+    sfr *ec2.SpotFleetRequestConfig) resource.TestCheckFunc {
+    return func(s *terraform.State) error {
+        if len(sfr.SpotFleetRequestConfig.LaunchSpecifications) == 0 {
+            return errors.New("Missing launch specification")
+        }
+
+        spec := *sfr.SpotFleetRequestConfig.LaunchSpecifications[0]
+
+        profile := spec.IamInstanceProfile
+        if profile == nil {
+            return fmt.Errorf("Expected IamInstanceProfile to be set, got nil")
+        }
+        //Validate the string whether it is ARN
+        re := regexp.MustCompile("arn:aws:iam::\\d{12}:instance-profile/?[a-zA-Z0-9+=,.@-_].*")
+        if !re.MatchString(*profile.Arn) {
+            return fmt.Errorf("Expected IamInstanceProfile input as ARN, got %s", *profile.Arn)
+        }
+
+        return nil
+    }
 }
 
 func TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet(t *testing.T) {
@@ -1420,7 +1443,7 @@ resource "aws_spot_fleet_request" "foo" {
 }
 
 func testAccAWSSpotFleetRequestLaunchTemplateConfigWithOnDemandCapacity(rName string, rInt int) string {
-	return fmt.Sprintf(`
+    return fmt.Sprintf(`
 resource "aws_key_pair" "debugging" {
     key_name = "tmp-key-%s"
     public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -4599,6 +4599,31 @@ func flattenLaunchTemplateSpecification(lt *autoscaling.LaunchTemplateSpecificat
 	return result
 }
 
+func flattenFleetLaunchTemplateSpecification(flt *ec2.FleetLaunchTemplateSpecification) []map[string]interface{} {
+	attrs := map[string]interface{}{}
+	result := make([]map[string]interface{}, 0)
+
+	// unlike autoscaling.LaunchTemplateConfiguration, FleetLaunchTemplateSpecs only return what was set
+	if flt.LaunchTemplateId != nil {
+		attrs["id"] = *flt.LaunchTemplateId
+	}
+
+	if flt.LaunchTemplateName != nil {
+		attrs["name"] = *flt.LaunchTemplateName
+	}
+
+	// version is returned only if it was previously set
+	if flt.Version != nil {
+		attrs["version"] = *flt.Version
+	} else {
+		attrs["version"] = nil
+	}
+
+	result = append(result, attrs)
+
+	return result
+}
+
 func flattenVpcPeeringConnectionOptions(options *ec2.VpcPeeringConnectionOptionsDescription) []map[string]interface{} {
 	m := map[string]interface{}{}
 

--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -182,7 +182,7 @@ across different markets and instance types. Conflicts with `launch_template_con
 * `target_capacity` - The number of units to request. You can choose to set the
   target capacity in terms of instances or a performance characteristic that is
   important to your application workload, such as vCPUs, memory, or I/O.
-* `on_demand_target_capacity` - (Optional) Allows specification of a minimum value of the `target_capacity` to be filled by full price on-demand instance to ensure a minimum capacity of the fleet no matter spot instance availability. Not supported by `launch_specification`, must be used with `launch_template_configs`.
+* `on_demand_target_capacity` - (Optional) The number of full-price On-Demand units to request in addition to the spot instance capacity. Use this to guarantee a minimum capacity of the fleet even in the event that the spot requests cannot be filled. Capacity is defined in the same units as configured in target_capacity such as vCPUs, memory, or I/O. Not supported by launch_specification, must be used with launch_template_configs.
 * `allocation_strategy` - Indicates how to allocate the target capacity across
   the Spot pools specified by the Spot fleet request. The default is
   `lowestPrice`.
@@ -218,7 +218,7 @@ The `launch_template_configs` block supports the following:
 
 * `id` - The ID of the launch template. Conflicts with `name`.
 * `name` - The name of the launch template. Conflicts with `id`.
-* `version` - (Optional) Template version. Unlike the autoscaling equivalent, does not support `$Latest` or `$Default`, so use the launch_template resource's attribute, e.g. `"${aws_launch_template.foo.latest_version}"`. Wil use default version if omitted.
+* `version` - (Optional) Template version. Unlike the autoscaling equivalent, does not support `$Latest` or `$Default`, so use the launch_template resource's attribute, e.g. `"${aws_launch_template.foo.latest_version}"`. Will use default version if omitted.
 
     **Note:** The specified launch template can specify only a subset of the 
     inputs of [`aws_launch_template`](launch_template.html).  There are limitations on

--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -54,7 +54,7 @@ resource "aws_spot_fleet_request" "cheap_compute" {
 }
 ```
 
-Using launch templates:
+### Using launch templates:
 
 ```
 resource "aws_launch_template" "foo" {

--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -13,7 +13,7 @@ instances to be requested on the Spot market.
 
 ## Example Usage
 
-Using launch specifications:
+### Using launch specifications:
 
 ```hcl
 # Request a Spot fleet

--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -217,7 +217,7 @@ The `launch_template_configs` block supports the following:
 
 * `id` - The ID of the launch template. Conflicts with `name`.
 * `name` - The name of the launch template. Conflicts with `id`.
-* `version` - (Optional) Template version. Unlike the autoscaling equivalent, does not support `$Latest` or `$Default`, so use the launch_template resource's attribute, e.g. `"${aws_launch_template.foo.latest_version}"`. Will use default version if omitted.
+* `version` - (Optional) Template version. Unlike the autoscaling equivalent, does not support `$Latest` or `$Default`, so use the launch_template resource's attribute, e.g. `"${aws_launch_template.foo.latest_version}"`. It will use the default version if omitted.
 
     **Note:** The specified launch template can specify only a subset of the 
     inputs of [`aws_launch_template`](launch_template.html).  There are limitations on

--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -13,6 +13,8 @@ instances to be requested on the Spot market.
 
 ## Example Usage
 
+Using launch specifications:
+
 ```hcl
 # Request a Spot fleet
 resource "aws_spot_fleet_request" "cheap_compute" {
@@ -52,10 +54,41 @@ resource "aws_spot_fleet_request" "cheap_compute" {
 }
 ```
 
+Using launch templates:
+
+```
+resource "aws_launch_template" "foo" {
+  name = "test-launch-template"
+  image_id = "${var.ami}"
+  instance_type = "${var.instance_type}"
+  key_name = "${var.key_name}"
+  spot_price = "0.05"
+}
+
+resource "aws_spot_fleet_request" "foo" {
+  iam_fleet_role  = "arn:aws:iam::12345678:role/spot-fleet"
+  spot_price      = "0.005"
+  target_capacity = 2
+  valid_until     = "2019-11-04T20:44:20Z"
+
+  launch_template_configs {
+      launch_template_specification {
+        id = "${aws_launch_template.foo.id}"
+        version = "${aws_launch_template.foo.latest_version}"
+      }
+  }
+
+  depends_on = ["aws_iam_policy_attachment.test-attach"]
+}
+```
+
 ~> **NOTE:** Terraform does not support the functionality where multiple `subnet_id` or `availability_zone` parameters can be specified in the same
-launch configuration block. If you want to specify multiple values, then separate launch configuration blocks should be used:
+launch configuration block. If you want to specify multiple values, then separate launch configuration blocks should be used or launch template overrides should be configured, one per subnet:
 
 ```hcl
+#
+# Launch Specification Method
+#
 resource "aws_spot_fleet_request" "foo" {
   iam_fleet_role  = "arn:aws:iam::12345678:role/spot-fleet"
   spot_price      = "0.005"
@@ -78,6 +111,47 @@ resource "aws_spot_fleet_request" "foo" {
 
   depends_on = ["aws_iam_policy_attachment.test-attach"]
 }
+
+#
+# Launch Template Method
+#
+
+data "aws_subnet_ids" "example" {
+  vpc_id = "${var.vpc_id}"
+}
+
+resource "aws_launch_template" "foo" {
+  name = "test-launch-template"
+  image_id = "${var.ami}"
+  instance_type = "${var.instance_type}"
+  key_name = "${var.key_name}"
+  spot_price = "0.05"
+}
+
+resource "aws_spot_fleet_request" "foo" {
+  iam_fleet_role  = "arn:aws:iam::12345678:role/spot-fleet"
+  spot_price      = "0.005"
+  target_capacity = 2
+  valid_until     = "2019-11-04T20:44:20Z"
+
+  launch_template_configs {
+      launch_template_specification {
+        id = "${aws_launch_template.foo.id}"
+        version = "${aws_launch_template.foo.latest_version}"
+      }
+      overrides {
+        subnet_id = "${data.aws_subnets.example.ids[0]}"
+      }
+      overrides {
+        subnet_id = "${data.aws_subnets.example.ids[1]}"
+      }
+      overrides {
+        subnet_id = "${data.aws_subnets.example.ids[2]}"
+      }
+    }
+
+  depends_on = ["aws_iam_policy_attachment.test-attach"]
+}
 ```
 
 ## Argument Reference
@@ -90,9 +164,9 @@ Most of these arguments directly correspond to the
 CancelSpotFleetRequests or when the Spot fleet request expires, if you set
 terminateInstancesWithExpiration.
 * `replace_unhealthy_instances` - (Optional) Indicates whether Spot fleet should replace unhealthy instances. Default `false`.
-* `launch_specification` - Used to define the launch configuration of the
+* `launch_specification` - (Optional) Used to define the launch configuration of the
   spot-fleet request. Can be specified multiple times to define different bids
-across different markets and instance types.
+across different markets and instance types. Conflicts with `launch_template_configs`. At least one of `launch_specification` or `launch_template_configs` is required.
 
     **Note:** This takes in similar but not
     identical inputs as [`aws_instance`](instance.html).  There are limitations on
@@ -100,6 +174,7 @@ across different markets and instance types.
     [reference documentation](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_SpotFleetLaunchSpecification.html). Any normal [`aws_instance`](instance.html) parameter that corresponds to those inputs may be used and it have
     a additional parameter `iam_instance_profile_arn` takes `aws_iam_instance_profile` attribute `arn` as input.
 
+* `launch_template_configs` - (Optional) Launch template configuration block. See [Launch Template Configs](#launch-template-configs) below for more details. Conflicts with `launch_specification`. At least one of `launch_specification` or `launch_template_configs` is required.
 * `spot_price` - (Optional; Default: On-demand price) The maximum bid price per unit hour.
 * `wait_for_fulfillment` - (Optional; Default: false) If set, Terraform will
   wait for the Spot Request to be fulfilled, and will throw an error if the
@@ -107,6 +182,7 @@ across different markets and instance types.
 * `target_capacity` - The number of units to request. You can choose to set the
   target capacity in terms of instances or a performance characteristic that is
   important to your application workload, such as vCPUs, memory, or I/O.
+* `on_demand_target_capacity` - (Optional) Allows specification of a minimum value of the `target_capacity` to be filled by full price on-demand instance to ensure a minimum capacity of the fleet no matter spot instance availability. Not supported by `launch_specification`, must be used with `launch_template_configs`.
 * `allocation_strategy` - Indicates how to allocate the target capacity across
   the Spot pools specified by the Spot fleet request. The default is
   `lowestPrice`.
@@ -130,6 +206,33 @@ across different markets and instance types.
 * `load_balancers` (Optional) A list of elastic load balancer names to add to the Spot fleet.
 * `target_group_arns` (Optional) A list of `aws_alb_target_group` ARNs, for use with Application Load Balancing.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
+
+### Launch Template Configs
+
+The `launch_template_configs` block supports the following:
+
+* `launch_template_specification` - (Required) Launch template specification. See [Launch Template Specification](#launch-template-specification) below for more details.
+* `overrides` - (Optional) One or more overide configurations. See [Overrides](#overrides) below for more details. 
+
+### Launch Template Specification
+
+* `id` - The ID of the launch template. Conflicts with `name`.
+* `name` - The name of the launch template. Conflicts with `id`.
+* `version` - (Optional) Template version. Unlike the autoscaling equivalent, does not support `$Latest` or `$Default`, so use the launch_template resource's attribute, e.g. `"${aws_launch_template.foo.latest_version}"`. Wil use default version if omitted.
+
+    **Note:** The specified launch template can specify only a subset of the 
+    inputs of [`aws_launch_template`](launch_template.html).  There are limitations on
+    what you can specify as spot fleet does not support all the attributes that are supported by autoscaling groups. [AWS documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-launch-templates.html#launch-templates-spot-fleet) is currently sparse, but at least `instance_initiated_shutdown_behavior` is confirmed unsupported.
+
+### Overrides
+
+* `instance_type` - (Optional) The type of instance to request.
+* `availability_zone` - (Optional) The availability zone in which to place the request.
+* `spot_price` - (Optional) The maximum spot bid for this override request.
+* `weighted_capacity` - (Optional) The capacity added to the fleet by a fulfilled request.
+* `subnet_id` - (Optional) The subnet in which to launch the requested instance.
+
+  **Note:** Instead of statically defining these override blocks they can be passed in as a list of maps containing the above keys and their values. This allows dynamic, programmatic generation of overrides based on variable or environment data.
 
 ### Timeouts
 

--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -182,7 +182,6 @@ across different markets and instance types. Conflicts with `launch_template_con
 * `target_capacity` - The number of units to request. You can choose to set the
   target capacity in terms of instances or a performance characteristic that is
   important to your application workload, such as vCPUs, memory, or I/O.
-* `on_demand_target_capacity` - (Optional) The number of full-price On-Demand units to request in addition to the spot instance capacity. Use this to guarantee a minimum capacity of the fleet even in the event that the spot requests cannot be filled. Capacity is defined in the same units as configured in target_capacity such as vCPUs, memory, or I/O. Not supported by launch_specification, must be used with launch_template_configs.
 * `allocation_strategy` - Indicates how to allocate the target capacity across
   the Spot pools specified by the Spot fleet request. The default is
   `lowestPrice`.


### PR DESCRIPTION
Updates the spotfleet_request resource to support the new launch_template resource and on-demand capacity.

Changes proposed in this pull request:

* launch_template_configs

The new block looks like this, following the structure from the go sdk as closely as possible:
```hcl
launch_template_configs {
    launch_template_specification {
      id = "${aws_launch_template.ecs_instance.id}"
      version = "${aws_launch_template.ecs_instance.latest_version}"
    }
    overrides {
      instance_type = "t2.micro"
      spot_price = "0.05"
    }
  }
```

* on_demand_target_capacity

Allows specifying a minimum portion of capcity to be filled by on-demand instances.

Any other tips & suggestions are appreciated.

Output from acceptance testing:

```
=== RUN   TestAccAWSSpotFleetRequest_associatePublicIpAddress
--- PASS: TestAccAWSSpotFleetRequest_associatePublicIpAddress (298.31s)
=== RUN   TestAccAWSSpotFleetRequest_launchTemplate
--- PASS: TestAccAWSSpotFleetRequest_launchTemplate (385.74s)
=== RUN   TestAccAWSSpotFleetRequest_launchTemplateWithOnDemandCapacity
--- PASS: TestAccAWSSpotFleetRequest_launchTemplateWithOnDemandCapacity (118.89s)
=== RUN   TestAccAWSSpotFleetRequest_launchTemplateWithOverrides
--- PASS: TestAccAWSSpotFleetRequest_launchTemplateWithOverrides (258.26s)
=== RUN   TestAccAWSSpotFleetRequest_launchTemplateToLaunchSpec
--- PASS: TestAccAWSSpotFleetRequest_launchTemplateToLaunchSpec (637.84s)
=== RUN   TestAccAWSSpotFleetRequest_launchSpecToLaunchTemplate
--- PASS: TestAccAWSSpotFleetRequest_launchSpecToLaunchTemplate (521.70s)
=== RUN   TestAccAWSSpotFleetRequest_instanceInterruptionBehavior
--- PASS: TestAccAWSSpotFleetRequest_instanceInterruptionBehavior (325.34s)
=== RUN   TestAccAWSSpotFleetRequest_changePriceForcesNewRequest
--- PASS: TestAccAWSSpotFleetRequest_changePriceForcesNewRequest (635.60s)
=== RUN   TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion (325.68s)
=== RUN   TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList (352.56s)
=== RUN   TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList (262.74s)
=== RUN   TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz (318.36s)
=== RUN   TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet (333.31s)
=== RUN   TestAccAWSSpotFleetRequest_overriddingSpotPrice
--- PASS: TestAccAWSSpotFleetRequest_overriddingSpotPrice (391.70s)
=== RUN   TestAccAWSSpotFleetRequest_withoutSpotPrice
--- PASS: TestAccAWSSpotFleetRequest_withoutSpotPrice (385.29s)
=== RUN   TestAccAWSSpotFleetRequest_withWeightedCapacity
--- PASS: TestAccAWSSpotFleetRequest_withWeightedCapacity (326.93s)
=== RUN   TestAccAWSSpotFleetRequest_withEBSDisk
--- PASS: TestAccAWSSpotFleetRequest_withEBSDisk (311.59s)
=== RUN   TestAccAWSSpotFleetRequest_withTags
--- PASS: TestAccAWSSpotFleetRequest_withTags (325.39s)
=== RUN   TestAccAWSSpotFleetRequest_placementTenancy
--- PASS: TestAccAWSSpotFleetRequest_placementTenancy (107.13s)
=== RUN   TestAccAWSSpotFleetRequest_diversifiedAllocation
--- PASS: TestAccAWSSpotFleetRequest_diversifiedAllocation (363.19s)
=== RUN   TestAccAWSSpotFleetRequest_WithELBs
--- PASS: TestAccAWSSpotFleetRequest_WithELBs (350.88s)
=== RUN   TestAccAWSSpotFleetRequest_WithTargetGroups
--- PASS: TestAccAWSSpotFleetRequest_WithTargetGroups (443.07s)
```

The above was the full set of spot fleet resource tests.
Of the above tests, these are the new ones:

```
=== RUN   TestAccAWSSpotFleetRequest_launchTemplate
--- PASS: TestAccAWSSpotFleetRequest_launchTemplate (385.74s)
=== RUN   TestAccAWSSpotFleetRequest_launchTemplateWithOnDemandCapacity
--- PASS: TestAccAWSSpotFleetRequest_launchTemplateWithOnDemandCapacity (118.89s)
=== RUN   TestAccAWSSpotFleetRequest_launchTemplateWithOverrides
--- PASS: TestAccAWSSpotFleetRequest_launchTemplateWithOverrides (258.26s)
=== RUN   TestAccAWSSpotFleetRequest_launchTemplateToLaunchSpec
--- PASS: TestAccAWSSpotFleetRequest_launchTemplateToLaunchSpec (637.84s)
=== RUN   TestAccAWSSpotFleetRequest_launchSpecToLaunchTemplate
--- PASS: TestAccAWSSpotFleetRequest_launchSpecToLaunchTemplate (521.70s)
```