### PR TITLE
resource/aws_cognito_user_pool_client: Prevent panic with updating refresh_token_validity

### DIFF
--- a/aws/resource_aws_cognito_user_pool_client.go
+++ b/aws/resource_aws_cognito_user_pool_client.go
@@ -283,7 +283,7 @@ func resourceAwsCognitoUserPoolClientUpdate(d *schema.ResourceData, meta interfa
 	}
 
 	if d.HasChange("refresh_token_validity") {
-		params.RefreshTokenValidity = aws.Int64(d.Get("refresh_token_validity").(int64))
+		params.RefreshTokenValidity = aws.Int64(int64(d.Get("refresh_token_validity").(int)))
 	}
 
 	if d.HasChange("allowed_oauth_flows") {


### PR DESCRIPTION
Fixes #4848

Changes proposed in this pull request:

* Fix `refresh_token_validity` interface conversion during update function

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCognitoUserPoolClient'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCognitoUserPoolClient -timeout 120m
=== RUN   TestAccAWSCognitoUserPoolClient_basic
--- PASS: TestAccAWSCognitoUserPoolClient_basic (15.82s)
=== RUN   TestAccAWSCognitoUserPoolClient_importBasic
--- PASS: TestAccAWSCognitoUserPoolClient_importBasic (31.85s)
=== RUN   TestAccAWSCognitoUserPoolClient_RefreshTokenValidity
--- PASS: TestAccAWSCognitoUserPoolClient_RefreshTokenValidity (24.85s)
=== RUN   TestAccAWSCognitoUserPoolClient_allFields
--- PASS: TestAccAWSCognitoUserPoolClient_allFields (13.82s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	86.376s
```
