### PR TITLE
resource/aws_neptune_parameter_group: Support tags argument and arn attribute

### DIFF
--- a/aws/resource_aws_neptune_parameter_group_test.go
+++ b/aws/resource_aws_neptune_parameter_group_test.go
@@ -242,12 +242,12 @@ func testAccAWSNeptuneParameterGroupConfig_Parameter(rName, pName, pValue, pAppl
 	return fmt.Sprintf(`
 resource "aws_neptune_parameter_group" "test" {
   family = "neptune1"
-  name   = "%s"
+  name   = %q
 
   parameter {
-    apply_method = "%s"
-    name         = "%s"
-    value        = "%s"
+    apply_method = %q
+    name         = %q
+    value        = %q
   }
 }`, rName, pApplyMethod, pName, pValue)
 }
@@ -255,9 +255,9 @@ resource "aws_neptune_parameter_group" "test" {
 func testAccAWSNeptuneParameterGroupConfig_Description(rName, description string) string {
 	return fmt.Sprintf(`
 resource "aws_neptune_parameter_group" "test" {
-  description = "%s"
+  description = %q
   family      = "neptune1"
-  name        = "%s"
+  name        = %q
 }`, description, rName)
 }
 
@@ -265,7 +265,7 @@ func testAccAWSNeptuneParameterGroupConfig_Required(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_neptune_parameter_group" "test" {
   family = "neptune1"
-  name   = "%s"
+  name   = %q
 }`, rName)
 }
 
@@ -273,10 +273,10 @@ func testAccAWSNeptuneParameterGroupConfig_Tags_SingleTag(name, tKey, tValue str
 	return fmt.Sprintf(`
 resource "aws_neptune_parameter_group" "test" {
   family = "neptune1"
-  name   = "%s"
+  name   = %q
 
   tags {
-    %s = "%s"
+    %s = %q
   }
 }
 `, name, tKey, tValue)
@@ -286,11 +286,11 @@ func testAccAWSNeptuneParameterGroupConfig_Tags_MultipleTags(name, tKey1, tValue
 	return fmt.Sprintf(`
 resource "aws_neptune_parameter_group" "test" {
   family = "neptune1"
-  name   = "%s"
+  name   = %q
 
   tags {
-    %s = "%s"
-    %s = "%s"
+    %s = %q
+    %s = %q
   }
 }
 `, name, tKey1, tValue1, tKey2, tValue2)

--- a/website/docs/r/neptune_parameter_group.html.markdown
+++ b/website/docs/r/neptune_parameter_group.html.markdown
@@ -32,6 +32,7 @@ The following arguments are supported:
 * `family` - (Required) The family of the Neptune parameter group.
 * `description` - (Optional) The description of the Neptune parameter group. Defaults to "Managed by Terraform".
 * `parameter` - (Optional) A list of Neptune parameters to apply.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 Parameter blocks support the following:
 
@@ -45,6 +46,7 @@ Parameter blocks support the following:
 The following attributes are exported:
 
 * `id` - The Neptune parameter group name.
+* `arn` - The Neptune parameter group Amazon Resource Name (ARN).
 
 ## Import
 


### PR DESCRIPTION
Reference: #4713 

Changes proposed in this pull request:

* Add `arn` attribute to `aws_neptune_parameter_group` resource
* Add `tags` argument to `aws_neptune_parameter_group` resource

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSNeptuneParameterGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSNeptuneParameterGroup -timeout 120m
=== RUN   TestAccAWSNeptuneParameterGroup_basic
--- PASS: TestAccAWSNeptuneParameterGroup_basic (15.80s)
=== RUN   TestAccAWSNeptuneParameterGroup_Description
--- PASS: TestAccAWSNeptuneParameterGroup_Description (14.66s)
=== RUN   TestAccAWSNeptuneParameterGroup_Parameter
--- PASS: TestAccAWSNeptuneParameterGroup_Parameter (27.16s)
=== RUN   TestAccAWSNeptuneParameterGroup_Tags
--- PASS: TestAccAWSNeptuneParameterGroup_Tags (34.85s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	92.509s
```
