### PR TITLE
Add enabled_cloudwatch_logs_exports to rds cluster resource

### DIFF
--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -838,8 +838,8 @@ func flattenAwsRdsClusterResource(d *schema.ResourceData, meta interface{}, dbc 
 	d.Set("iam_database_authentication_enabled", dbc.IAMDatabaseAuthenticationEnabled)
 	d.Set("hosted_zone_id", dbc.HostedZoneId)
 
-	if dbc.EnabledCloudwatchLogsExports != nil {
-		d.Set("enabled_cloudwatch_logs_exports", dbc.EnabledCloudwatchLogsExports)
+	if err := d.Set("enabled_cloudwatch_logs_exports", flattenStringList(dbc.EnabledCloudwatchLogsExports)); err != nil {
+		return fmt.Errorf("error setting enabled_cloudwatch_logs_exports: %s", err)
 	}
 
 	var vpcg []string

--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -301,6 +301,21 @@ func resourceAwsRDSCluster() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"enabled_cloudwatch_logs_exports": {
+				Type:     schema.TypeList,
+				Computed: false,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					ValidateFunc: validation.StringInSlice([]string{
+						"audit",
+						"error",
+						"general",
+						"slowquery",
+					}, false),
+				},
+			},
+
 			"tags": tagsSchema(),
 		},
 	}
@@ -368,6 +383,10 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 
 		if attr, ok := d.GetOk("port"); ok {
 			opts.Port = aws.Int64(int64(attr.(int)))
+		}
+
+		if attr, ok := d.GetOk("enabled_cloudwatch_logs_exports"); ok && len(attr.([]interface{})) > 0 {
+			opts.EnableCloudwatchLogsExports = expandStringList(attr.([]interface{}))
 		}
 
 		// Check if any of the parameters that require a cluster modification after creation are set
@@ -489,6 +508,10 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 			createOpts.SourceRegion = aws.String(attr.(string))
 		}
 
+		if attr, ok := d.GetOk("enabled_cloudwatch_logs_exports"); ok && len(attr.([]interface{})) > 0 {
+			createOpts.EnableCloudwatchLogsExports = expandStringList(attr.([]interface{}))
+		}
+
 		log.Printf("[DEBUG] Create RDS Cluster as read replica: %s", createOpts)
 		var resp *rds.CreateDBClusterOutput
 		err := resource.Retry(1*time.Minute, func() *resource.RetryError {
@@ -582,6 +605,10 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 
 		if attr, ok := d.GetOk("iam_database_authentication_enabled"); ok {
 			createOpts.EnableIAMDatabaseAuthentication = aws.Bool(attr.(bool))
+		}
+
+		if attr, ok := d.GetOk("enabled_cloudwatch_logs_exports"); ok && len(attr.([]interface{})) > 0 {
+			createOpts.EnableCloudwatchLogsExports = expandStringList(attr.([]interface{}))
 		}
 
 		log.Printf("[DEBUG] RDS Cluster restore options: %s", createOpts)
@@ -681,6 +708,10 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 
 		if attr, ok := d.GetOk("iam_database_authentication_enabled"); ok {
 			createOpts.EnableIAMDatabaseAuthentication = aws.Bool(attr.(bool))
+		}
+
+		if attr, ok := d.GetOk("enabled_cloudwatch_logs_exports"); ok && len(attr.([]interface{})) > 0 {
+			createOpts.EnableCloudwatchLogsExports = expandStringList(attr.([]interface{}))
 		}
 
 		log.Printf("[DEBUG] RDS Cluster create options: %s", createOpts)
@@ -807,6 +838,10 @@ func flattenAwsRdsClusterResource(d *schema.ResourceData, meta interface{}, dbc 
 	d.Set("iam_database_authentication_enabled", dbc.IAMDatabaseAuthenticationEnabled)
 	d.Set("hosted_zone_id", dbc.HostedZoneId)
 
+	if dbc.EnabledCloudwatchLogsExports != nil {
+		d.Set("enabled_cloudwatch_logs_exports", dbc.EnabledCloudwatchLogsExports)
+	}
+
 	var vpcg []string
 	for _, g := range dbc.VpcSecurityGroups {
 		vpcg = append(vpcg, *g.VpcSecurityGroupId)
@@ -898,6 +933,12 @@ func resourceAwsRDSClusterUpdate(d *schema.ResourceData, meta interface{}) error
 
 	if d.HasChange("iam_database_authentication_enabled") {
 		req.EnableIAMDatabaseAuthentication = aws.Bool(d.Get("iam_database_authentication_enabled").(bool))
+		requestUpdate = true
+	}
+
+	if d.HasChange("enabled_cloudwatch_logs_exports") && !d.IsNewResource() {
+		d.SetPartial("enabled_cloudwatch_logs_exports")
+		req.CloudwatchLogsExportConfiguration = buildCloudwatchLogsExportConfiguration(d)
 		requestUpdate = true
 	}
 

--- a/aws/resource_aws_rds_cluster_test.go
+++ b/aws/resource_aws_rds_cluster_test.go
@@ -39,6 +39,10 @@ func TestAccAWSRDSCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "engine", "aurora"),
 					resource.TestCheckResourceAttrSet(resourceName, "engine_version"),
 					resource.TestCheckResourceAttrSet(resourceName, "hosted_zone_id"),
+					resource.TestCheckResourceAttr(resourceName,
+						"enabled_cloudwatch_logs_exports.0", "audit"),
+					resource.TestCheckResourceAttr(resourceName,
+						"enabled_cloudwatch_logs_exports.1", "error"),
 				),
 			},
 		},
@@ -204,6 +208,39 @@ func TestAccAWSRDSCluster_updateTags(t *testing.T) {
 					testAccCheckAWSClusterExists("aws_rds_cluster.default", &v),
 					resource.TestCheckResourceAttr(
 						"aws_rds_cluster.default", "tags.%", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSRDSCluster_updateCloudwatchLogsExports(t *testing.T) {
+	var v rds.DBCluster
+	ri := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSClusterConfig(ri),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSClusterExists("aws_rds_cluster.default", &v),
+					resource.TestCheckResourceAttr("aws_rds_cluster.default",
+						"enabled_cloudwatch_logs_exports.0", "audit"),
+					resource.TestCheckResourceAttr("aws_rds_cluster.default",
+						"enabled_cloudwatch_logs_exports.1", "error"),
+				),
+			},
+			{
+				Config: testAccAWSClusterConfigUpdatedCloudwatchLogsExports(ri),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSClusterExists("aws_rds_cluster.default", &v),
+					resource.TestCheckResourceAttr("aws_rds_cluster.default",
+						"enabled_cloudwatch_logs_exports.0", "error"),
+					resource.TestCheckResourceAttr("aws_rds_cluster.default",
+						"enabled_cloudwatch_logs_exports.1", "slowquery"),
 				),
 			},
 		},
@@ -571,6 +608,10 @@ resource "aws_rds_cluster" "default" {
   tags {
     Environment = "production"
   }
+  enabled_cloudwatch_logs_exports = [
+	"audit",
+	"error",
+  ]
 }`, n)
 }
 
@@ -633,7 +674,7 @@ func testAccAWSClusterConfig_s3Restore(bucketName string, bucketPrefix string, u
 	return fmt.Sprintf(`
 
 data "aws_region" "current" {}
-    
+
 resource "aws_s3_bucket" "xtrabackup" {
   bucket = "%s"
   region = "${data.aws_region.current.name}"
@@ -828,6 +869,23 @@ resource "aws_rds_cluster" "default" {
     Environment = "production"
     AnotherTag = "test"
   }
+}`, n)
+}
+
+func testAccAWSClusterConfigUpdatedCloudwatchLogsExports(n int) string {
+	return fmt.Sprintf(`
+resource "aws_rds_cluster" "default" {
+  cluster_identifier = "tf-aurora-cluster-%d"
+  availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
+  database_name = "mydb"
+  master_username = "foo"
+  master_password = "mustbeeightcharaters"
+  db_cluster_parameter_group_name = "default.aurora5.6"
+  skip_final_snapshot = true
+  enabled_cloudwatch_logs_exports = [
+    "error",
+    "slowquery"
+  ]
 }`, n)
 }
 

--- a/website/docs/r/rds_cluster.html.markdown
+++ b/website/docs/r/rds_cluster.html.markdown
@@ -116,6 +116,8 @@ Default: A 30-minute window selected at random from an 8-hour block of time per 
 * `engine` - (Optional) The name of the database engine to be used for this DB cluster. Defaults to `aurora`. Valid Values: aurora,aurora-mysql,aurora-postgresql
 * `engine_version` - (Optional) The database engine version.
 * `source_region` - (Optional) The source region for an encrypted replica DB cluster.
+* `enabled_cloudwatch_logs_exports` - (Optional) List of log types to export to cloudwatch. If omitted, no logs will be exported.
+   The following log types are supported: `audit`, `error`, `general`, `slowquery`.
 * `tags` - (Optional) A mapping of tags to assign to the DB cluster.
 
 ### S3 Import Options


### PR DESCRIPTION
Based on the implementation for the `db_instance` resource this is supposed to add the `enabled_cloudwatch_logs_exports` field to cluster resources as well.