### PR TITLE
New Data Source: aws_vpc_dhcp_options

### DIFF
--- a/aws/data_source_aws_vpc_dhcp_options.go
+++ b/aws/data_source_aws_vpc_dhcp_options.go
@@ -1,0 +1,111 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/validation"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsVpcDhcpOptions() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsVpcDhcpOptionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"dhcp_options_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+			"domain_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"domain_name_servers": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"netbios_name_servers": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"netbios_node_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ntp_servers": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"tags": tagsSchemaComputed(),
+		},
+	}
+}
+
+func dataSourceAwsVpcDhcpOptionsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+	dhcpOptionID := d.Get("dhcp_options_id").(string)
+
+	input := &ec2.DescribeDhcpOptionsInput{
+		DhcpOptionsIds: []*string{aws.String(dhcpOptionID)},
+	}
+
+	log.Printf("[DEBUG] Reading EC2 DHCP Options: %s", input)
+	output, err := conn.DescribeDhcpOptions(input)
+	if err != nil {
+		if isNoSuchDhcpOptionIDErr(err) {
+			return fmt.Errorf("EC2 DHCP Options %q not found", dhcpOptionID)
+		}
+		return fmt.Errorf("error reading EC2 DHCP Options: %s", err)
+	}
+
+	if len(output.DhcpOptions) == 0 {
+		return fmt.Errorf("EC2 DHCP Options %q not found", dhcpOptionID)
+	}
+
+	d.SetId(dhcpOptionID)
+
+	dhcpConfigurations := output.DhcpOptions[0].DhcpConfigurations
+
+	for _, dhcpConfiguration := range dhcpConfigurations {
+		key := aws.StringValue(dhcpConfiguration.Key)
+		tfKey := strings.Replace(key, "-", "_", -1)
+
+		if len(dhcpConfiguration.Values) == 0 {
+			continue
+		}
+
+		switch key {
+		case "domain-name":
+			d.Set(tfKey, aws.StringValue(dhcpConfiguration.Values[0].Value))
+		case "domain-name-servers":
+			if err := d.Set(tfKey, flattenEc2AttributeValues(dhcpConfiguration.Values)); err != nil {
+				return fmt.Errorf("error setting %s: %s", tfKey, err)
+			}
+		case "netbios-name-servers":
+			if err := d.Set(tfKey, flattenEc2AttributeValues(dhcpConfiguration.Values)); err != nil {
+				return fmt.Errorf("error setting %s: %s", tfKey, err)
+			}
+		case "netbios-node-type":
+			d.Set(tfKey, aws.StringValue(dhcpConfiguration.Values[0].Value))
+		case "ntp-servers":
+			if err := d.Set(tfKey, flattenEc2AttributeValues(dhcpConfiguration.Values)); err != nil {
+				return fmt.Errorf("error setting %s: %s", tfKey, err)
+			}
+		}
+	}
+
+	if err := d.Set("tags", d.Set("tags", tagsToMap(output.DhcpOptions[0].Tags))); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	return nil
+}

--- a/aws/data_source_aws_vpc_dhcp_options.go
+++ b/aws/data_source_aws_vpc_dhcp_options.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func dataSourceAwsVpcDhcpOptions() *schema.Resource {
@@ -18,10 +17,9 @@ func dataSourceAwsVpcDhcpOptions() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"dhcp_options_id": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.NoZeroValues,
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 			},
 			"domain_name": {
 				Type:     schema.TypeString,

--- a/aws/data_source_aws_vpc_dhcp_options.go
+++ b/aws/data_source_aws_vpc_dhcp_options.go
@@ -6,11 +6,10 @@ import (
 	"log"
 	"strings"
 
-	"github.com/hashicorp/terraform/helper/validation"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func dataSourceAwsVpcDhcpOptions() *schema.Resource {

--- a/aws/data_source_aws_vpc_dhcp_options_test.go
+++ b/aws/data_source_aws_vpc_dhcp_options_test.go
@@ -1,0 +1,53 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceAwsVpcDhcpOptions_basic(t *testing.T) {
+	resourceName := "aws_vpc_dhcp_options.test"
+	datasourceName := "data.aws_vpc_dhcp_options.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsVpcDhcpOptionsConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "domain_name", resourceName, "domain_name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "domain_name_servers.#", resourceName, "domain_name_servers.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "domain_name_servers.0", resourceName, "domain_name_servers.0"),
+					resource.TestCheckResourceAttrPair(datasourceName, "domain_name_servers.1", resourceName, "domain_name_servers.1"),
+					resource.TestCheckResourceAttrPair(datasourceName, "netbios_name_servers.#", resourceName, "netbios_name_servers.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "netbios_name_servers.0", resourceName, "netbios_name_servers.0"),
+					resource.TestCheckResourceAttrPair(datasourceName, "netbios_node_type", resourceName, "netbios_node_type"),
+					resource.TestCheckResourceAttrPair(datasourceName, "ntp_servers.#", resourceName, "ntp_servers.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "ntp_servers.0", resourceName, "ntp_servers.0"),
+					resource.TestCheckResourceAttrPair(datasourceName, "tags.%", resourceName, "tags.%"),
+					resource.TestCheckResourceAttrPair(datasourceName, "tags.Name", resourceName, "tags.Name"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceAwsVpcDhcpOptionsConfig = `
+resource "aws_vpc_dhcp_options" "test" {
+  domain_name          = "service.consul"
+  domain_name_servers  = ["127.0.0.1", "10.0.0.2"]
+  netbios_name_servers = ["127.0.0.1"]
+  netbios_node_type    = 2
+  ntp_servers          = ["127.0.0.1"]
+
+  tags {
+    Name = "tf-test-acc"
+  }
+}
+
+data "aws_vpc_dhcp_options" "test" {
+  dhcp_options_id = "${aws_vpc_dhcp_options.test.id}"
+}
+`

--- a/aws/data_source_aws_vpc_dhcp_options_test.go
+++ b/aws/data_source_aws_vpc_dhcp_options_test.go
@@ -1,8 +1,10 @@
 package aws
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
@@ -15,8 +17,9 @@ func TestAccDataSourceAwsVpcDhcpOptions_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAwsVpcDhcpOptionsConfig,
+				Config: testAccDataSourceAwsVpcDhcpOptionsConfig_DhcpOptionsID,
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "dhcp_options_id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(datasourceName, "domain_name", resourceName, "domain_name"),
 					resource.TestCheckResourceAttrPair(datasourceName, "domain_name_servers.#", resourceName, "domain_name_servers.#"),
 					resource.TestCheckResourceAttrPair(datasourceName, "domain_name_servers.0", resourceName, "domain_name_servers.0"),
@@ -34,7 +37,37 @@ func TestAccDataSourceAwsVpcDhcpOptions_basic(t *testing.T) {
 	})
 }
 
-const testAccDataSourceAwsVpcDhcpOptionsConfig = `
+func TestAccDataSourceAwsVpcDhcpOptions_Filter(t *testing.T) {
+	rInt := acctest.RandInt()
+	resourceName := "aws_vpc_dhcp_options.test"
+	datasourceName := "data.aws_vpc_dhcp_options.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsVpcDhcpOptionsConfig_Filter(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "dhcp_options_id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "domain_name", resourceName, "domain_name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "domain_name_servers.#", resourceName, "domain_name_servers.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "domain_name_servers.0", resourceName, "domain_name_servers.0"),
+					resource.TestCheckResourceAttrPair(datasourceName, "domain_name_servers.1", resourceName, "domain_name_servers.1"),
+					resource.TestCheckResourceAttrPair(datasourceName, "netbios_name_servers.#", resourceName, "netbios_name_servers.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "netbios_name_servers.0", resourceName, "netbios_name_servers.0"),
+					resource.TestCheckResourceAttrPair(datasourceName, "netbios_node_type", resourceName, "netbios_node_type"),
+					resource.TestCheckResourceAttrPair(datasourceName, "ntp_servers.#", resourceName, "ntp_servers.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "ntp_servers.0", resourceName, "ntp_servers.0"),
+					resource.TestCheckResourceAttrPair(datasourceName, "tags.%", resourceName, "tags.%"),
+					resource.TestCheckResourceAttrPair(datasourceName, "tags.Name", resourceName, "tags.Name"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceAwsVpcDhcpOptionsConfig_DhcpOptionsID = `
 resource "aws_vpc_dhcp_options" "test" {
   domain_name          = "service.consul"
   domain_name_servers  = ["127.0.0.1", "10.0.0.2"]
@@ -43,7 +76,7 @@ resource "aws_vpc_dhcp_options" "test" {
   ntp_servers          = ["127.0.0.1"]
 
   tags {
-    Name = "tf-test-acc"
+    Name = "tf-acc-test"
   }
 }
 
@@ -51,3 +84,31 @@ data "aws_vpc_dhcp_options" "test" {
   dhcp_options_id = "${aws_vpc_dhcp_options.test.id}"
 }
 `
+
+func testAccDataSourceAwsVpcDhcpOptionsConfig_Filter(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_vpc_dhcp_options" "test" {
+  domain_name          = "tf-acc-test-%d.example.com"
+  domain_name_servers  = ["127.0.0.1", "10.0.0.2"]
+  netbios_name_servers = ["127.0.0.1"]
+  netbios_node_type    = 2
+  ntp_servers          = ["127.0.0.1"]
+
+  tags {
+    Name = "tf-acc-test-%d"
+  }
+}
+
+data "aws_vpc_dhcp_options" "test" {
+  filter {
+    name   = "key"
+    values = ["domain-name"]
+  }
+
+  filter {
+    name   = "value"
+    values = ["${aws_vpc_dhcp_options.test.domain_name}"]
+  }
+}
+`, rInt, rInt)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -247,6 +247,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_vpcs":                             dataSourceAwsVpcs(),
 			"aws_security_group":                   dataSourceAwsSecurityGroup(),
 			"aws_vpc":                              dataSourceAwsVpc(),
+			"aws_vpc_dhcp_options":                 dataSourceAwsVpcDhcpOptions(),
 			"aws_vpc_endpoint":                     dataSourceAwsVpcEndpoint(),
 			"aws_vpc_endpoint_service":             dataSourceAwsVpcEndpointService(),
 			"aws_vpc_peering_connection":           dataSourceAwsVpcPeeringConnection(),

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -853,6 +853,14 @@ func flattenAttachment(a *ec2.NetworkInterfaceAttachment) map[string]interface{}
 	return att
 }
 
+func flattenEc2AttributeValues(l []*ec2.AttributeValue) []string {
+	values := make([]string, 0, len(l))
+	for _, v := range l {
+		values = append(values, aws.StringValue(v.Value))
+	}
+	return values
+}
+
 func flattenEc2NetworkInterfaceAssociation(a *ec2.NetworkInterfaceAssociation) []interface{} {
 	att := make(map[string]interface{})
 	if a.AllocationId != nil {

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -319,6 +319,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-vpc-x") %>>
                             <a href="/docs/providers/aws/d/vpc.html">aws_vpc</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-vpc-dhcp-options") %>>
+                            <a href="/docs/providers/aws/d/vpc_dhcp_options.html">aws_vpc_dhcp_options</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-vpc-endpoint-x") %>>
                             <a href="/docs/providers/aws/d/vpc_endpoint.html">aws_vpc_endpoint</a>
                         </li>

--- a/website/docs/d/vpc_dhcp_options.html.markdown
+++ b/website/docs/d/vpc_dhcp_options.html.markdown
@@ -12,20 +12,48 @@ Retrieve information about an EC2 DHCP Options configuration.
 
 ## Example Usage
 
+### Lookup by DHCP Options ID
+
 ```hcl
-data "aws_vpc_dhcp_options" "test" {
+data "aws_vpc_dhcp_options" "example" {
   dhcp_options_id = "dopts-12345678"
+}
+```
+
+### Lookup by Filter
+
+```hcl
+data "aws_vpc_dhcp_options" "example" {
+  filter {
+    name   = "key"
+    values = ["domain-name"]
+  }
+
+  filter {
+    name   = "value"
+    values = ["example.com"]
+  }
 }
 ```
 
 ## Argument Reference
 
-* `dhcp_options_id` - (Required) The EC2 DHCP Options ID.
+* `dhcp_options_id` - (Optional) The EC2 DHCP Options ID.
+* `filter` - (Optional) List of custom filters as described below.
+
+### filter
+
+For more information about filtering, see the [EC2 API documentation](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeDhcpOptions.html).
+
+* `name` - (Required) The name of the field to filter.
+* `values` - (Required) Set of values for filtering.
 
 ## Attributes Reference
 
+* `dhcp_options_id` - EC2 DHCP Options ID
 * `domain_name` - The suffix domain name to used when resolving non Fully Qualified Domain Names. e.g. the `search` value in the `/etc/resolv.conf` file.
 * `domain_name_servers` - List of name servers.
+* `id` - EC2 DHCP Options ID
 * `netbios_name_servers` - List of NETBIOS name servers.
 * `netbios_node_type` - The NetBIOS node type (1, 2, 4, or 8). For more information about these node types, see [RFC 2132](http://www.ietf.org/rfc/rfc2132.txt).
 * `ntp_servers` - List of NTP servers.

--- a/website/docs/d/vpc_dhcp_options.html.markdown
+++ b/website/docs/d/vpc_dhcp_options.html.markdown
@@ -1,0 +1,32 @@
+---
+layout: "aws"
+page_title: "AWS: aws_vpc_dhcp_options"
+sidebar_current: "docs-aws-datasource-vpc-dhcp-options"
+description: |-
+  Retrieve information about an EC2 DHCP Options configuration
+---
+
+# Data Source: aws_vpc_dhcp_options
+
+Retrieve information about an EC2 DHCP Options configuration.
+
+## Example Usage
+
+```hcl
+data "aws_vpc_dhcp_options" "test" {
+  dhcp_options_id = "dopts-12345678"
+}
+```
+
+## Argument Reference
+
+* `dhcp_options_id` - (Required) The EC2 DHCP Options ID.
+
+## Attributes Reference
+
+* `domain_name` - The suffix domain name to used when resolving non Fully Qualified Domain Names. e.g. the `search` value in the `/etc/resolv.conf` file.
+* `domain_name_servers` - List of name servers.
+* `netbios_name_servers` - List of NETBIOS name servers.
+* `netbios_node_type` - The NetBIOS node type (1, 2, 4, or 8). For more information about these node types, see [RFC 2132](http://www.ietf.org/rfc/rfc2132.txt).
+* `ntp_servers` - List of NTP servers.
+* `tags` - A mapping of tags assigned to the resource.


### PR DESCRIPTION
The existing resource and upstream API are unfortunately pluralized, so to reduce confusion, kept the pluralized naming for the data source as well.

Fixes #1395 

Changes proposed in this pull request:

* New Data Source: `aws_vpc_dhcp_options`

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsVpcDhcpOptions_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccDataSourceAwsVpcDhcpOptions_basic -timeout 120m
=== RUN   TestAccDataSourceAwsVpcDhcpOptions_basic
--- PASS: TestAccDataSourceAwsVpcDhcpOptions_basic (14.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	14.036s
```
