### PR TITLE
docs/resource/aws_db_option_group: Add AWS documentation links for engine options and IAM role example

### DIFF
--- a/website/docs/r/db_option_group.html.markdown
+++ b/website/docs/r/db_option_group.html.markdown
@@ -8,12 +8,16 @@ description: |-
 
 # aws_db_option_group
 
-Provides an RDS DB option group resource.
+Provides an RDS DB option group resource. Documentation of the available options for various RDS engines can be found at:
+* [MariaDB Options](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.MariaDB.Options.html)
+* [Microsoft SQL Server Options](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.SQLServer.Options.html)
+* [MySQL Options](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.MySQL.Options.html)
+* [Oracle Options](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.Oracle.Options.html)
 
 ## Example Usage
 
 ```hcl
-resource "aws_db_option_group" "bar" {
+resource "aws_db_option_group" "example" {
   name                     = "option-group-test-terraform"
   option_group_description = "Terraform Option Group"
   engine_name              = "sqlserver-ee"
@@ -25,6 +29,15 @@ resource "aws_db_option_group" "bar" {
     option_settings {
       name  = "TIME_ZONE"
       value = "UTC"
+    }
+  }
+
+  option {
+    option_name = "SQLSERVER_BACKUP_RESTORE"
+
+    option_settings {
+      name  = "IAM_ROLE_ARN"
+      value = "${aws_iam_role.example.arn}"
     }
   }
 
@@ -69,7 +82,6 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The db option group name.
 * `arn` - The ARN of the db option group.
 
-<a id="timeouts"></a>
 ## Timeouts
 
 `aws_db_option_group` provides the following


### PR DESCRIPTION
Fixes #238

Changes proposed in this pull request:

* Link to AWS documentation for each available engine
* Add IAM role option to example

Output from acceptance testing: N/A
