### PR TITLE
Run deleteLingeringLambdaENIs when subnets are destroyed

### DIFF
--- a/aws/resource_aws_security_group.go
+++ b/aws/resource_aws_security_group.go
@@ -438,7 +438,7 @@ func resourceAwsSecurityGroupDelete(d *schema.ResourceData, meta interface{}) er
 
 	log.Printf("[DEBUG] Security Group destroy: %v", d.Id())
 
-	if err := deleteLingeringLambdaENIs(conn, d); err != nil {
+	if err := deleteLingeringLambdaENIs(conn, d, "group-id"); err != nil {
 		return fmt.Errorf("Failed to delete Lambda ENIs: %s", err)
 	}
 
@@ -1223,12 +1223,12 @@ func sgProtocolIntegers() map[string]int {
 
 // The AWS Lambda service creates ENIs behind the scenes and keeps these around for a while
 // which would prevent SGs attached to such ENIs from being destroyed
-func deleteLingeringLambdaENIs(conn *ec2.EC2, d *schema.ResourceData) error {
+func deleteLingeringLambdaENIs(conn *ec2.EC2, d *schema.ResourceData, filterName string) error {
 	// Here we carefully find the offenders
 	params := &ec2.DescribeNetworkInterfacesInput{
 		Filters: []*ec2.Filter{
 			{
-				Name:   aws.String("group-id"),
+				Name:   aws.String(filterName),
 				Values: []*string{aws.String(d.Id())},
 			},
 			{

--- a/aws/resource_aws_subnet.go
+++ b/aws/resource_aws_subnet.go
@@ -22,6 +22,11 @@ func resourceAwsSubnet() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
 		SchemaVersion: 1,
 		MigrateState:  resourceAwsSubnetMigrateState,
 
@@ -287,6 +292,11 @@ func resourceAwsSubnetDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
 	log.Printf("[INFO] Deleting subnet: %s", d.Id())
+
+	if err := deleteLingeringLambdaENIs(conn, d, "subnet-id"); err != nil {
+		return fmt.Errorf("Failed to delete Lambda ENIs: %s", err)
+	}
+
 	req := &ec2.DeleteSubnetInput{
 		SubnetId: aws.String(d.Id()),
 	}


### PR DESCRIPTION
The ENIs associated with lambda functions sometimes fail to delete. This applies the deleteLingeringLambdaENIs as well as the associated timeouts from resource_aws_security_group to resource_aws_subnet.

Fixes #829

Changes proposed in this pull request:

* Updates deleteLingeringLambdaENIs to accept a 3rd parameter that decides the filterName
* Runs deleteLingeringLambdaENIs in resource_aws_subnet when deleting.

Output from acceptance testing (pretty sure these are fine):
```
# make testacc TEST=./aws TESTARGS='-run=TestAccAWSSecurityGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSSecurityGroup -timeout 120m
=== RUN   TestAccAWSSecurityGroup_importBasic
--- PASS: TestAccAWSSecurityGroup_importBasic (89.95s)
=== RUN   TestAccAWSSecurityGroup_importIpv6
--- PASS: TestAccAWSSecurityGroup_importIpv6 (92.78s)
=== RUN   TestAccAWSSecurityGroup_importSelf
--- PASS: TestAccAWSSecurityGroup_importSelf (108.04s)
=== RUN   TestAccAWSSecurityGroup_importSourceSecurityGroup
--- PASS: TestAccAWSSecurityGroup_importSourceSecurityGroup (100.26s)
=== RUN   TestAccAWSSecurityGroup_importIPRangeAndSecurityGroupWithSameRules
--- PASS: TestAccAWSSecurityGroup_importIPRangeAndSecurityGroupWithSameRules (107.95s)
=== RUN   TestAccAWSSecurityGroup_importIPRangesWithSameRules
--- PASS: TestAccAWSSecurityGroup_importIPRangesWithSameRules (100.98s)
=== RUN   TestAccAWSSecurityGroup_importPrefixList
--- PASS: TestAccAWSSecurityGroup_importPrefixList (120.93s)
=== RUN   TestAccAWSSecurityGroupRule_Ingress_VPC
--- PASS: TestAccAWSSecurityGroupRule_Ingress_VPC (42.38s)
=== RUN   TestAccAWSSecurityGroupRule_Ingress_Protocol
--- PASS: TestAccAWSSecurityGroupRule_Ingress_Protocol (88.83s)
=== RUN   TestAccAWSSecurityGroupRule_Ingress_Ipv6
--- PASS: TestAccAWSSecurityGroupRule_Ingress_Ipv6 (90.27s)
=== RUN   TestAccAWSSecurityGroupRule_Ingress_Classic
--- PASS: TestAccAWSSecurityGroupRule_Ingress_Classic (9.35s)
=== RUN   TestAccAWSSecurityGroupRule_MultiIngress
--- PASS: TestAccAWSSecurityGroupRule_MultiIngress (49.70s)
=== RUN   TestAccAWSSecurityGroupRule_Egress
--- PASS: TestAccAWSSecurityGroupRule_Egress (44.19s)
=== RUN   TestAccAWSSecurityGroupRule_SelfReference
--- FAIL: TestAccAWSSecurityGroupRule_SelfReference (4.35s)
	testing.go:518: Step 0 error: Error applying: 1 error(s) occurred:

		* aws_vpc.main: 1 error(s) occurred:

		* aws_vpc.main: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
			status code: 400, request id: 931493d5-b7d9-479a-b5f0-6e3d98c94d40
=== RUN   TestAccAWSSecurityGroupRule_ExpectInvalidTypeError
--- PASS: TestAccAWSSecurityGroupRule_ExpectInvalidTypeError (1.72s)
=== RUN   TestAccAWSSecurityGroupRule_ExpectInvalidCIDR
--- PASS: TestAccAWSSecurityGroupRule_ExpectInvalidCIDR (2.12s)
=== RUN   TestAccAWSSecurityGroupRule_PartialMatching_basic
--- PASS: TestAccAWSSecurityGroupRule_PartialMatching_basic (100.69s)
=== RUN   TestAccAWSSecurityGroupRule_PartialMatching_Source
--- PASS: TestAccAWSSecurityGroupRule_PartialMatching_Source (103.81s)
=== RUN   TestAccAWSSecurityGroupRule_Issue5310
--- PASS: TestAccAWSSecurityGroupRule_Issue5310 (9.19s)
=== RUN   TestAccAWSSecurityGroupRule_Race
--- PASS: TestAccAWSSecurityGroupRule_Race (831.50s)
=== RUN   TestAccAWSSecurityGroupRule_SelfSource
--- PASS: TestAccAWSSecurityGroupRule_SelfSource (94.62s)
=== RUN   TestAccAWSSecurityGroupRule_PrefixListEgress
--- FAIL: TestAccAWSSecurityGroupRule_PrefixListEgress (61.86s)
	testing.go:518: Step 0 error: Error applying: 1 error(s) occurred:

		* aws_vpc_endpoint.s3-us-west-2: 1 error(s) occurred:

		* aws_vpc_endpoint.s3-us-west-2: Error creating VPC Endpoint: InvalidServiceName: The Vpc Endpoint Service 'com.amazonaws.us-west-2.s3' does not exist
			status code: 400, request id: 81e41d64-92ce-4fd2-85dc-c7860de72ea1
=== RUN   TestAccAWSSecurityGroupRule_IngressDescription
--- PASS: TestAccAWSSecurityGroupRule_IngressDescription (48.04s)
=== RUN   TestAccAWSSecurityGroupRule_EgressDescription
--- PASS: TestAccAWSSecurityGroupRule_EgressDescription (47.66s)
=== RUN   TestAccAWSSecurityGroupRule_IngressDescription_updates
--- PASS: TestAccAWSSecurityGroupRule_IngressDescription_updates (67.26s)
=== RUN   TestAccAWSSecurityGroupRule_EgressDescription_updates
--- PASS: TestAccAWSSecurityGroupRule_EgressDescription_updates (68.89s)
=== RUN   TestAccAWSSecurityGroupRule_MultiDescription
--- FAIL: TestAccAWSSecurityGroupRule_MultiDescription (89.37s)
	testing.go:518: Step 0 error: Error applying: 1 error(s) occurred:

		* aws_vpc_endpoint.s3-us-west-2: 1 error(s) occurred:

		* aws_vpc_endpoint.s3-us-west-2: Error creating VPC Endpoint: InvalidServiceName: The Vpc Endpoint Service 'com.amazonaws.us-west-2.s3' does not exist
			status code: 400, request id: ab4ce49a-3445-4566-aaf1-c8cd4cba1371
=== RUN   TestAccAWSSecurityGroup_basic
--- PASS: TestAccAWSSecurityGroup_basic (86.45s)
=== RUN   TestAccAWSSecurityGroup_ruleGathering
--- PASS: TestAccAWSSecurityGroup_ruleGathering (118.30s)
=== RUN   TestAccAWSSecurityGroup_forceRevokeRules_true
--- PASS: TestAccAWSSecurityGroup_forceRevokeRules_true (887.73s)
=== RUN   TestAccAWSSecurityGroup_forceRevokeRules_false
--- PASS: TestAccAWSSecurityGroup_forceRevokeRules_false (783.14s)
=== RUN   TestAccAWSSecurityGroup_basicRuleDescription
--- PASS: TestAccAWSSecurityGroup_basicRuleDescription (81.23s)
=== RUN   TestAccAWSSecurityGroup_ipv6
--- PASS: TestAccAWSSecurityGroup_ipv6 (83.40s)
=== RUN   TestAccAWSSecurityGroup_tagsCreatedFirst
--- PASS: TestAccAWSSecurityGroup_tagsCreatedFirst (61.21s)
=== RUN   TestAccAWSSecurityGroup_namePrefix
--- PASS: TestAccAWSSecurityGroup_namePrefix (10.21s)
=== RUN   TestAccAWSSecurityGroup_self
--- PASS: TestAccAWSSecurityGroup_self (88.52s)
=== RUN   TestAccAWSSecurityGroup_vpc
--- PASS: TestAccAWSSecurityGroup_vpc (81.29s)
=== RUN   TestAccAWSSecurityGroup_vpcNegOneIngress
--- PASS: TestAccAWSSecurityGroup_vpcNegOneIngress (82.01s)
=== RUN   TestAccAWSSecurityGroup_vpcProtoNumIngress
--- PASS: TestAccAWSSecurityGroup_vpcProtoNumIngress (80.03s)
=== RUN   TestAccAWSSecurityGroup_MultiIngress
--- PASS: TestAccAWSSecurityGroup_MultiIngress (104.81s)
=== RUN   TestAccAWSSecurityGroup_Change
--- PASS: TestAccAWSSecurityGroup_Change (150.91s)
=== RUN   TestAccAWSSecurityGroup_ChangeRuleDescription
--- PASS: TestAccAWSSecurityGroup_ChangeRuleDescription (214.98s)
=== RUN   TestAccAWSSecurityGroup_generatedName
--- PASS: TestAccAWSSecurityGroup_generatedName (80.88s)
=== RUN   TestAccAWSSecurityGroup_DefaultEgress_VPC
--- PASS: TestAccAWSSecurityGroup_DefaultEgress_VPC (77.23s)
=== RUN   TestAccAWSSecurityGroup_DefaultEgress_Classic
--- PASS: TestAccAWSSecurityGroup_DefaultEgress_Classic (9.00s)
=== RUN   TestAccAWSSecurityGroup_drift
--- PASS: TestAccAWSSecurityGroup_drift (35.87s)
=== RUN   TestAccAWSSecurityGroup_drift_complex
--- PASS: TestAccAWSSecurityGroup_drift_complex (102.27s)
=== RUN   TestAccAWSSecurityGroup_invalidCIDRBlock
--- PASS: TestAccAWSSecurityGroup_invalidCIDRBlock (2.52s)
=== RUN   TestAccAWSSecurityGroup_tags
--- PASS: TestAccAWSSecurityGroup_tags (130.70s)
=== RUN   TestAccAWSSecurityGroup_CIDRandGroups
--- PASS: TestAccAWSSecurityGroup_CIDRandGroups (99.24s)
=== RUN   TestAccAWSSecurityGroup_ingressWithCidrAndSGs
--- PASS: TestAccAWSSecurityGroup_ingressWithCidrAndSGs (102.83s)
=== RUN   TestAccAWSSecurityGroup_ingressWithCidrAndSGs_classic
--- FAIL: TestAccAWSSecurityGroup_ingressWithCidrAndSGs_classic (8.23s)
	testing.go:518: Step 0 error: Error applying: 1 error(s) occurred:

		* aws_security_group.web: 1 error(s) occurred:

		* aws_security_group.web: Error authorizing security group ingress rules: InvalidGroupId.Malformed: Invalid id: "tf_other_acc_tests" (expecting "sg-...")
			status code: 400, request id: 12945cfb-2a89-48b7-a6d5-fbda88c8fdfa
=== RUN   TestAccAWSSecurityGroup_egressWithPrefixList
--- PASS: TestAccAWSSecurityGroup_egressWithPrefixList (120.01s)
=== RUN   TestAccAWSSecurityGroup_emptyRuleDescription
--- PASS: TestAccAWSSecurityGroup_emptyRuleDescription (82.84s)
=== RUN   TestAccAWSSecurityGroup_ipv4andipv6Egress
--- PASS: TestAccAWSSecurityGroup_ipv4andipv6Egress (83.51s)
=== RUN   TestAccAWSSecurityGroup_failWithDiffMismatch
--- PASS: TestAccAWSSecurityGroup_failWithDiffMismatch (93.72s)
FAIL
exit status 1
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	6519.847s
GNUmakefile:20: recipe for target 'testacc' failed
make: *** [testacc] Error 1
```

```
# make testacc TEST=./aws TESTARGS='-run=TestAccAWSSubnet'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSSubnet -timeout 120m
=== RUN   TestAccAWSSubnet_importBasic
--- PASS: TestAccAWSSubnet_importBasic (74.87s)
=== RUN   TestAccAWSSubnet_basic
--- PASS: TestAccAWSSubnet_basic (83.91s)
=== RUN   TestAccAWSSubnet_ipv6
--- PASS: TestAccAWSSubnet_ipv6 (222.41s)
=== RUN   TestAccAWSSubnet_enableIpv6
--- PASS: TestAccAWSSubnet_enableIpv6 (139.01s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	520.265s
```