### PR TITLE
r/aws_kms_grant: Add Support for Referencing CMK by ARN

### DIFF
--- a/aws/resource_aws_kms_grant.go
+++ b/aws/resource_aws_kms_grant.go
@@ -520,11 +520,24 @@ func flattenKmsGrantConstraints(constraint *kms.GrantConstraints) *schema.Set {
 }
 
 func decodeKmsGrantId(id string) (string, string, error) {
-	parts := strings.Split(id, ":")
-	if len(parts) != 2 {
-		return "", "", fmt.Errorf("unexpected format of ID (%q), expected KeyID:GrantID", id)
+	if strings.HasPrefix(id, "arn:aws:kms") {
+		arn_parts := strings.Split(id, "/")
+		if len(arn_parts) != 2 {
+			return "", "", fmt.Errorf("unexpected format of ARN (%q), expected KeyID:GrantID", id)
+		}
+		arn_prefix := arn_parts[0]
+		parts := strings.Split(arn_parts[1], ":")
+		if len(parts) != 2 {
+			return "", "", fmt.Errorf("unexpected format of ID (%q), expected KeyID:GrantID", id)
+		}
+		return fmt.Sprintf("%s/%s", arn_prefix, parts[0]), parts[1], nil
+	} else {
+		parts := strings.Split(id, ":")
+		if len(parts) != 2 {
+			return "", "", fmt.Errorf("unexpected format of ID (%q), expected KeyID:GrantID", id)
+		}
+		return parts[0], parts[1], nil
 	}
-	return parts[0], parts[1], nil
 }
 
 // Custom error, so we don't have to rely on

--- a/website/docs/r/kms_grant.html.markdown
+++ b/website/docs/r/kms_grant.html.markdown
@@ -53,7 +53,7 @@ resource "aws_kms_grant" "a" {
 The following arguments are supported:
 
 * `name` - (Optional, Forces new resources) A friendly name for identifying the grant.
-* `key_id` - (Required, Forces new resources) The unique identifier for the customer master key (CMK) that the grant applies to.
+* `key_id` - (Required, Forces new resources) The unique identifier for the customer master key (CMK) that the grant applies to. Specify the key ID or the Amazon Resource Name (ARN) of the CMK. To specify a CMK in a different AWS account, you must use the key ARN.
 * `grantee_principal` - (Required, Forces new resources) The principal that is given permission to perform the operations that the grant permits in ARN format. Note that due to eventual consistency issues around IAM principals, terraform's state may not always be refreshed to reflect what is true in AWS.
 * `operations` - (Required, Forces new resources) A list of operations that the grant permits. The permitted values are: `Decrypt, Encrypt, GenerateDataKey, GenerateDataKeyWithoutPlaintext, ReEncryptFrom, ReEncryptTo, CreateGrant, RetireGrant, DescribeKey`
 * `retiree_principal` - (Optional, Forces new resources) The principal that is given permission to retire the grant by using RetireGrant operation in ARN format. Note that due to eventual consistency issues around IAM principals, terraform's state may not always be refreshed to reflect what is true in AWS.


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #4141

Changes proposed in this pull request:

* Add Support for Referencing CMK by ARN which includes CMKs in a different AWS accounts

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAWSKmsGrant_*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAWSKmsGrant_* -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAWSKmsGrant_Basic
--- PASS: TestAWSKmsGrant_Basic (102.16s)
=== RUN   TestAWSKmsGrant_withConstraints
--- PASS: TestAWSKmsGrant_withConstraints (143.80s)
=== RUN   TestAWSKmsGrant_withRetiringPrincipal
--- PASS: TestAWSKmsGrant_withRetiringPrincipal (89.55s)
=== RUN   TestAWSKmsGrant_bare
--- PASS: TestAWSKmsGrant_bare (94.40s)
=== RUN   TestAWSKmsGrant_ARN
--- PASS: TestAWSKmsGrant_ARN (90.32s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	520.244s
```
