### PR TITLE
Updating S3 CORS planning when CORS is deleted via API or console.

### DIFF
--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -728,6 +728,11 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 		if err := d.Set("cors_rule", rules); err != nil {
 			return err
 		}
+	} else {
+		log.Printf("[DEBUG] S3 bucket: %s, read CORS: %v", d.Id(), cors)
+		if err := d.Set("cors_rule", make([]map[string]interface{}, 0)); err != nil {
+			return err
+		}
 	}
 
 	// Read the website configuration


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #4849 

Changes proposed in this pull request:

* Set 'cors_rules' to an empty list as needed if CORs is missing from bucket

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSS3Bucket_Cors'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSS3Bucket_Cors -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSS3Bucket_Cors
--- PASS: TestAccAWSS3Bucket_Cors (114.62s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       114.670s
```
