### PR TITLE
Adds support for PRIVATE endpoint type for aws_api_gateway_rest_api

### DIFF
--- a/aws/resource_aws_api_gateway_rest_api.go
+++ b/aws/resource_aws_api_gateway_rest_api.go
@@ -98,6 +98,7 @@ func resourceAwsApiGatewayRestApi() *schema.Resource {
 								ValidateFunc: validation.StringInSlice([]string{
 									apigateway.EndpointTypeEdge,
 									apigateway.EndpointTypeRegional,
+									apigateway.EndpointTypePrivate,
 								}, false),
 							},
 						},

--- a/aws/resource_aws_api_gateway_rest_api_test.go
+++ b/aws/resource_aws_api_gateway_rest_api_test.go
@@ -203,6 +203,24 @@ func TestAccAWSAPIGatewayRestApi_EndpointConfiguration(t *testing.T) {
 			},
 		},
 	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayRestAPIDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayRestAPIConfig_EndpointConfiguration(rName, "PRIVATE"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayRestAPIExists("aws_api_gateway_rest_api.test", &restApi),
+					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "endpoint_configuration.#", "1"),
+					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "endpoint_configuration.0.types.#", "1"),
+					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "endpoint_configuration.0.types.0", "PRIVATE"),
+				),
+			},
+		},
+	})
+
 }
 
 func TestAccAWSAPIGatewayRestApi_api_key_source(t *testing.T) {

--- a/website/docs/r/api_gateway_rest_api.html.markdown
+++ b/website/docs/r/api_gateway_rest_api.html.markdown
@@ -59,7 +59,7 @@ __Note__: If the `body` argument is provided, the OpenAPI specification will be 
 
 ### endpoint_configuration
 
-* `types` - (Required) A list of endpoint types. This resource currently only supports managing a single value. Valid values: `EDGE` or `REGIONAL`. If unspecified, defaults to `EDGE`. Must be declared as `REGIONAL` in non-Commercial partitions. Refer to the [documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/create-regional-api.html) for more information on the difference between edge-optimized and regional APIs.
+* `types` - (Required) A list of endpoint types. This resource currently only supports managing a single value. Valid values: `EDGE`, `REGIONAL` or `PRIVATE`. If unspecified, defaults to `EDGE`. Must be declared as `REGIONAL` in non-Commercial partitions. Refer to the [documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/create-regional-api.html) for more information on the difference between edge-optimized and regional APIs.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Changes proposed in this pull request:

* Adds support for private API Gateways[1]

[1] https://aws.amazon.com/blogs/compute/introducing-amazon-api-gateway-private-endpoints/

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAPIGatewayRestApi_EndpointConfiguration'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSAPIGatewayRestApi_EndpointConfiguration -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSAPIGatewayRestApi_EndpointConfiguration
--- PASS: TestAccAWSAPIGatewayRestApi_EndpointConfiguration (136.90s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	136.921s
...
```

#### Comments
My Golang knowledge is vey limited, but instead of asking for this feature, I thought I could do it myself and contribute. The change is quite simple, yet I'm not sure the acceptance test I added is correct. Please tell me if not.
I built and tested it and it works.