### PR TITLE
tests/resource/aws_elasticache_(cluster|replication_group): Only set parameter_group_name for tests requiring it

### DIFF
--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -230,8 +230,8 @@ func TestAccAWSElasticacheReplicationGroup_updateParameterGroup(t *testing.T) {
 				Config: testAccAWSElasticacheReplicationGroupConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
-					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "parameter_group_name", "default.redis3.2"),
+					resource.TestMatchResourceAttr(
+						"aws_elasticache_replication_group.bar", "parameter_group_name", regexp.MustCompile(`^default.redis.+`)),
 				),
 			},
 
@@ -783,7 +783,6 @@ resource "aws_elasticache_replication_group" "bar" {
     node_type = "cache.m1.small"
     number_cache_clusters = 2
     port = 6379
-    parameter_group_name = "default.redis3.2"
     security_group_names = ["${aws_elasticache_security_group.bar.name}"]
     apply_immediately = true
     auto_minor_version_upgrade = false
@@ -831,7 +830,6 @@ resource "aws_elasticache_replication_group" "bar" {
     node_type = "cache.m1.small"
     number_cache_clusters = 2
     port = 6379
-    parameter_group_name = "default.redis3.2"
     security_group_names = ["${aws_elasticache_security_group.bar.name}"]
     apply_immediately = true
     auto_minor_version_upgrade = false
@@ -865,7 +863,9 @@ resource "aws_elasticache_security_group" "bar" {
 
 resource "aws_elasticache_parameter_group" "bar" {
     name = "allkeys-lru-%d"
-    family = "redis3.2"
+    # We do not have a data source for "latest" Elasticache family
+    # so unfortunately we must hardcode this for now
+    family = "redis4.0"
 
     parameter {
         name = "maxmemory-policy"
@@ -913,7 +913,6 @@ resource "aws_elasticache_replication_group" "bar" {
     node_type = "cache.m1.small"
     number_cache_clusters = 2
     port = 6379
-    parameter_group_name = "default.redis3.2"
     security_group_names = ["${aws_elasticache_security_group.bar.name}"]
     apply_immediately = true
     auto_minor_version_upgrade = true
@@ -948,7 +947,6 @@ resource "aws_elasticache_replication_group" "bar" {
     node_type = "cache.m1.small"
     number_cache_clusters = 2
     port = 6379
-    parameter_group_name = "default.redis3.2"
     security_group_names = ["${aws_elasticache_security_group.bar.name}"]
     apply_immediately = true
     auto_minor_version_upgrade = true
@@ -985,7 +983,6 @@ resource "aws_elasticache_replication_group" "bar" {
     node_type = "cache.m1.medium"
     number_cache_clusters = 2
     port = 6379
-    parameter_group_name = "default.redis3.2"
     security_group_names = ["${aws_elasticache_security_group.bar.name}"]
     apply_immediately = true
 }`, rName, rName, rName)
@@ -1034,7 +1031,6 @@ resource "aws_elasticache_replication_group" "bar" {
     port = 6379
     subnet_group_name = "${aws_elasticache_subnet_group.bar.name}"
     security_group_ids = ["${aws_security_group.bar.id}"]
-    parameter_group_name = "default.redis3.2"
     availability_zones = ["us-west-2a"]
     auto_minor_version_upgrade = false
 }
@@ -1096,7 +1092,6 @@ resource "aws_elasticache_replication_group" "bar" {
     port = 6379
     subnet_group_name = "${aws_elasticache_subnet_group.bar.name}"
     security_group_ids = ["${aws_security_group.bar.id}"]
-    parameter_group_name = "default.redis3.2"
     availability_zones = ["us-west-2a","us-west-2b"]
     automatic_failover_enabled = true
     snapshot_window = "02:00-03:00"
@@ -1159,9 +1154,8 @@ resource "aws_elasticache_replication_group" "bar" {
     port = 6379
     subnet_group_name = "${aws_elasticache_subnet_group.bar.name}"
     security_group_ids = ["${aws_security_group.bar.id}"]
-    parameter_group_name = "default.redis3.2.cluster.on"
     availability_zones = ["us-west-2a","us-west-2b"]
-    automatic_failover_enabled = true
+    automatic_failover_enabled = false
     snapshot_window = "02:00-03:00"
     snapshot_retention_limit = 7
     engine_version = "3.2.4"
@@ -1224,7 +1218,6 @@ resource "aws_elasticache_replication_group" "bar" {
     port = 6379
     subnet_group_name = "${aws_elasticache_subnet_group.bar.name}"
     security_group_ids = ["${aws_security_group.bar.id}"]
-    parameter_group_name = "default.redis3.2.cluster.on"
     automatic_failover_enabled = true
     cluster_mode {
       replicas_per_node_group = 1
@@ -1289,7 +1282,6 @@ resource "aws_elasticache_replication_group" "bar" {
     port = 6379
     subnet_group_name = "${aws_elasticache_subnet_group.bar.name}"
     security_group_ids = ["${aws_security_group.bar.id}"]
-    parameter_group_name = "default.redis3.2.cluster.on"
     automatic_failover_enabled = true
     cluster_mode {
       num_node_groups         = %d
@@ -1440,7 +1432,6 @@ resource "aws_elasticache_replication_group" "test" {
   automatic_failover_enabled    = %[2]t
   node_type                     = "cache.m3.medium"
   number_cache_clusters         = %[3]d
-  parameter_group_name          = "default.redis3.2"
   replication_group_id          = "%[1]s"
   replication_group_description = "Terraform Acceptance Testing - number_cache_clusters"
   subnet_group_name             = "${aws_elasticache_subnet_group.test.name}"


### PR DESCRIPTION
This is to prevent these new acceptance testing errors since Redis 4.0 was released (and future ones of similar nature):

```
Error creating Elasticache Replication Group: InvalidParameterCombination: Expected a parameter group of family redis4.0 but found one of family redis3.2
```

Changes proposed in this pull request:

* Remove explicit `parameter_group_name` where possible
* Add explicit `aws_elasticache_cluster` resource test for setting `parameter_group_name` (`aws_elasticache_replication_group` already had one)

Output from acceptance testing (test failure unrelated):

```
Tests failed: 1, passed: 39
=== RUN   TestAccAWSElasticacheCluster_ReplicationGroupID_InvalidAttributes
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_InvalidAttributes (3.56s)
=== RUN   TestAccAWSElasticacheCluster_NumCacheNodes_Redis_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Redis_Ec2Classic (3.81s)
=== RUN   TestAccAWSElasticacheCluster_AZMode_Redis_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_AZMode_Redis_Ec2Classic (440.87s)
=== RUN   TestAccAWSElasticacheCluster_AZMode_Memcached_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_AZMode_Memcached_Ec2Classic (443.56s)
=== RUN   TestAccAWSElasticacheCluster_SecurityGroup
--- PASS: TestAccAWSElasticacheCluster_SecurityGroup (488.47s)
=== RUN   TestAccAWSElasticacheCluster_Engine_Memcached_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_Engine_Memcached_Ec2Classic (524.58s)
=== RUN   TestAccAWSElasticacheCluster_Engine_Redis_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_Engine_Redis_Ec2Classic (524.88s)
=== RUN   TestAccAWSElasticacheCluster_Port_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_Port_Ec2Classic (526.20s)
=== RUN   TestAccAWSElasticacheCluster_NodeTypeResize_Redis_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_NodeTypeResize_Redis_Ec2Classic (793.99s)
=== RUN   TestAccAWSElasticacheCluster_multiAZInVpc
--- PASS: TestAccAWSElasticacheCluster_multiAZInVpc (798.34s)
=== RUN   TestAccAWSElasticacheCluster_vpc
--- PASS: TestAccAWSElasticacheCluster_vpc (819.76s)
=== RUN   TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2
--- FAIL: TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2 (6.71s)
=== RUN   TestAccAWSElasticacheCluster_NodeTypeResize_Memcached_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_NodeTypeResize_Memcached_Ec2Classic (916.60s)
=== RUN   TestAccAWSElasticacheCluster_ParameterGroupName_Default
--- PASS: TestAccAWSElasticacheCluster_ParameterGroupName_Default (1057.92s)
=== RUN   TestAccAWSElasticacheReplicationGroup_clusteringAndCacheNodesCausesError
--- PASS: TestAccAWSElasticacheReplicationGroup_clusteringAndCacheNodesCausesError (8.23s)
=== RUN   TestAccAWSElasticacheReplicationGroup_importBasic
--- PASS: TestAccAWSElasticacheReplicationGroup_importBasic (1083.13s)
=== RUN   TestAccAWSElasticacheReplicationGroup_Uppercase
--- PASS: TestAccAWSElasticacheReplicationGroup_Uppercase (642.41s)
=== RUN   TestAccAWSElasticacheCluster_EngineVersion_Memcached_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_EngineVersion_Memcached_Ec2Classic (1113.31s)
=== RUN   TestAccAWSElasticacheCluster_ReplicationGroupID_MultipleReplica_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_MultipleReplica_Ec2Classic (1119.99s)
=== RUN   TestAccAWSElasticacheCluster_ReplicationGroupID_SingleReplica_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_SingleReplica_Ec2Classic (1121.25s)
=== RUN   TestAccAWSElasticacheCluster_snapshotsWithUpdates
--- PASS: TestAccAWSElasticacheCluster_snapshotsWithUpdates (1133.31s)
=== RUN   TestAccAWSElasticacheCluster_EngineVersion_Redis_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_EngineVersion_Redis_Ec2Classic (1176.47s)
=== RUN   TestAccAWSElasticacheCluster_NumCacheNodes_Increase
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Increase (1284.31s)
=== RUN   TestAccAWSElasticacheCluster_NumCacheNodes_Decrease
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Decrease (1385.52s)
=== RUN   TestAccAWSElasticacheCluster_NumCacheNodes_IncreaseWithPreferredAvailabilityZones
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_IncreaseWithPreferredAvailabilityZones (1396.11s)
=== RUN   TestAccAWSElasticacheReplicationGroup_basic
--- PASS: TestAccAWSElasticacheReplicationGroup_basic (965.88s)
=== RUN   TestAccAWSElasticacheReplicationGroup_updateDescription
--- PASS: TestAccAWSElasticacheReplicationGroup_updateDescription (1134.40s)
=== RUN   TestAccAWSElasticacheReplicationGroup_enableAuthTokenTransitEncryption
--- PASS: TestAccAWSElasticacheReplicationGroup_enableAuthTokenTransitEncryption (656.26s)
=== RUN   TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow
--- PASS: TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow (1247.03s)
=== RUN   TestAccAWSElasticacheReplicationGroup_vpc
--- PASS: TestAccAWSElasticacheReplicationGroup_vpc (1039.16s)
=== RUN   TestAccAWSElasticacheReplicationGroup_updateParameterGroup
--- PASS: TestAccAWSElasticacheReplicationGroup_updateParameterGroup (1395.24s)
=== RUN   TestAccAWSElasticacheReplicationGroup_ClusterMode_Basic
--- PASS: TestAccAWSElasticacheReplicationGroup_ClusterMode_Basic (1273.77s)
=== RUN   TestAccAWSElasticacheReplicationGroup_multiAzInVpc
--- PASS: TestAccAWSElasticacheReplicationGroup_multiAzInVpc (1423.73s)
=== RUN   TestAccAWSElasticacheReplicationGroup_enableAtRestEncryption
--- PASS: TestAccAWSElasticacheReplicationGroup_enableAtRestEncryption (1290.90s)
=== RUN   TestAccAWSElasticacheReplicationGroup_updateNodeSize
--- PASS: TestAccAWSElasticacheReplicationGroup_updateNodeSize (2198.01s)
=== RUN   TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverDisabled
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverDisabled (1702.61s)
=== RUN   TestAccAWSElasticacheReplicationGroup_enableSnapshotting
--- PASS: TestAccAWSElasticacheReplicationGroup_enableSnapshotting (1768.12s)
=== RUN   TestAccAWSElasticacheReplicationGroup_NumberCacheClusters
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters (1984.44s)
=== RUN   TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverEnabled
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverEnabled (2458.60s)
=== RUN   TestAccAWSElasticacheReplicationGroup_ClusterMode_NumNodeGroups
--- PASS: TestAccAWSElasticacheReplicationGroup_ClusterMode_NumNodeGroups (3923.39s)
```
