### PR TITLE
r/aws_vpn_gateway_attachment: Correct error code for missing VPN gateway

### DIFF
--- a/aws/resource_aws_vpn_gateway_attachment.go
+++ b/aws/resource_aws_vpn_gateway_attachment.go
@@ -85,7 +85,7 @@ func resourceAwsVpnGatewayAttachmentRead(d *schema.ResourceData, meta interface{
 
 	if err != nil {
 		awsErr, ok := err.(awserr.Error)
-		if ok && awsErr.Code() == "InvalidVPNGatewayID.NotFound" {
+		if ok && awsErr.Code() == "InvalidVpnGatewayID.NotFound" {
 			log.Printf("[WARN] VPN Gateway %q not found.", vgwId)
 			d.SetId("")
 			return nil
@@ -130,7 +130,7 @@ func resourceAwsVpnGatewayAttachmentDelete(d *schema.ResourceData, meta interfac
 		awsErr, ok := err.(awserr.Error)
 		if ok {
 			switch awsErr.Code() {
-			case "InvalidVPNGatewayID.NotFound":
+			case "InvalidVpnGatewayID.NotFound":
 				return nil
 			case "InvalidVpnGatewayAttachment.NotFound":
 				return nil
@@ -176,7 +176,7 @@ func vpnGatewayAttachmentStateRefresh(conn *ec2.EC2, vpcId, vgwId string) resour
 			awsErr, ok := err.(awserr.Error)
 			if ok {
 				switch awsErr.Code() {
-				case "InvalidVPNGatewayID.NotFound":
+				case "InvalidVpnGatewayID.NotFound":
 					fallthrough
 				case "InvalidVpnGatewayAttachment.NotFound":
 					return nil, "", nil


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/4894.

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSVpnGatewayAttachment_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAWSVpnGatewayAttachment_ -timeout 120m
=== RUN   TestAccAWSVpnGatewayAttachment_basic
--- PASS: TestAccAWSVpnGatewayAttachment_basic (69.07s)
=== RUN   TestAccAWSVpnGatewayAttachment_deleted
--- PASS: TestAccAWSVpnGatewayAttachment_deleted (85.40s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	168.410s
```
