### PR TITLE
aws route53 zone cnt fix

### DIFF
--- a/aws/resource_aws_route53_zone.go
+++ b/aws/resource_aws_route53_zone.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/satori/uuid"
+
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -89,7 +91,7 @@ func resourceAwsRoute53ZoneCreate(d *schema.ResourceData, meta interface{}) erro
 	req := &route53.CreateHostedZoneInput{
 		Name:             aws.String(d.Get("name").(string)),
 		HostedZoneConfig: &route53.HostedZoneConfig{Comment: aws.String(d.Get("comment").(string))},
-		CallerReference:  aws.String(d.Get("name").(string) + time.Now().Format(time.RFC3339Nano)),
+		CallerReference:  aws.String(uuid.NewV4().String()),
 	}
 	if v := d.Get("vpc_id"); v != "" {
 		req.VPC = &route53.VPC{

--- a/aws/resource_aws_route53_zone.go
+++ b/aws/resource_aws_route53_zone.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/satori/uuid"
-
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -91,7 +89,7 @@ func resourceAwsRoute53ZoneCreate(d *schema.ResourceData, meta interface{}) erro
 	req := &route53.CreateHostedZoneInput{
 		Name:             aws.String(d.Get("name").(string)),
 		HostedZoneConfig: &route53.HostedZoneConfig{Comment: aws.String(d.Get("comment").(string))},
-		CallerReference:  aws.String(uuid.NewV4().String()),
+		CallerReference:  aws.String(resource.UniqueId()),
 	}
 	if v := d.Get("vpc_id"); v != "" {
 		req.VPC = &route53.VPC{


### PR DESCRIPTION
Eliminate CallerReference collision.

Fixes #562

Changes proposed in this pull request:

* Use resource.UniqueId to generate CallerReference 


Output from acceptance testing:

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSRoute53Zone -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSRoute53Zone_importBasic
--- PASS: TestAccAWSRoute53Zone_importBasic (85.94s)
=== RUN   TestAccAWSRoute53ZoneAssociation_basic
--- PASS: TestAccAWSRoute53ZoneAssociation_basic (217.28s)
=== RUN   TestAccAWSRoute53ZoneAssociation_region
--- PASS: TestAccAWSRoute53ZoneAssociation_region (208.04s)
=== RUN   TestAccAWSRoute53Zone_basic
--- PASS: TestAccAWSRoute53Zone_basic (184.45s)
=== RUN   TestAccAWSRoute53Zone_forceDestroy
--- PASS: TestAccAWSRoute53Zone_forceDestroy (442.99s)
=== RUN   TestAccAWSRoute53Zone_updateComment
--- PASS: TestAccAWSRoute53Zone_updateComment (120.50s)
=== RUN   TestAccAWSRoute53Zone_private_basic
--- PASS: TestAccAWSRoute53Zone_private_basic (157.01s)
=== RUN   TestAccAWSRoute53Zone_private_region
--- PASS: TestAccAWSRoute53Zone_private_region (130.94s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1547.177s
```
