### PR TITLE
Fix codebuild_webhook docs name -> project_name

### DIFF
--- a/website/docs/r/codebuild_webhook.html.markdown
+++ b/website/docs/r/codebuild_webhook.html.markdown
@@ -28,7 +28,7 @@ More information creating webhooks with GitHub Enterprise can be found in the [C
 
 ```hcl
 resource "aws_codebuild_webhook" "example" {
-  name = "${aws_codebuild_project.example.name}"
+  project_name = "${aws_codebuild_project.example.name}"
 }
 
 resource "github_repository_webhook" "example" {
@@ -50,7 +50,7 @@ resource "github_repository_webhook" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the build project.
+* `project_name` - (Required) The name of the build project.
 * `branch_filter` - (Optional) A regular expression used to determine which branches get built. Default is all branches are built.
 
 ## Attributes Reference


### PR DESCRIPTION
Looks like it was missed when adding the docs and changing the name to project_name in the PR feedback: https://github.com/terraform-providers/terraform-provider-aws/commit/9d5bb5ed10053542d18171aca243e4fba9f67238

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #4901 

Changes proposed in this pull request:

* Fixes docs to move `name` -> `project_name`