### PR TITLE
Document that the protocols available to a listener are determined by the load balancer type

### DIFF
--- a/website/docs/r/lb_listener.html.markdown
+++ b/website/docs/r/lb_listener.html.markdown
@@ -49,6 +49,8 @@ The following arguments are supported:
 * `certificate_arn` - (Optional) The ARN of the default SSL server certificate. Exactly one certificate is required if the protocol is HTTPS. For adding additional SSL certificates, see the [`aws_lb_listener_certificate` resource](/docs/providers/aws/r/lb_listener_certificate.html).
 * `default_action` - (Required) An Action block. Action blocks are documented below.
 
+~> **NOTE::** Please note that listeners that are attached to Application Load Balancers must use either `HTTP` or `HTTPS` protocols while listeners that are attached to Network Load Balancers must use the `TCP` protocol.
+
 Action Blocks (for `default_action`) support the following:
 
 * `target_group_arn` - (Required) The ARN of the Target Group to which to route traffic.


### PR DESCRIPTION
The docs don't make it particularly clear right now that 'TCP' protocol listeners are only available on Network Load Balancers and vice versa.

This isn't something we can catch at plan or even apply time so have to just rely on the AWS API telling the user that they can't use the wrong protocol for the wrong load balancer type.

Closes #4659.

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #4659

Changes proposed in this pull request:

* Adds a note in the lb_listener docs to explain which load balancer type each protocol can be used with.