### PR TITLE
Updated formatting on aws_autoscaling_group docs

### DIFF
--- a/website/docs/r/autoscaling_group.html.markdown
+++ b/website/docs/r/autoscaling_group.html.markdown
@@ -90,7 +90,7 @@ resource "aws_autoscaling_group" "bar" {
 ## Interpolated tags
 
 ```hcl
-variable extra_tags {
+variable "extra_tags" {
   default = [
     {
       key = "Foo"
@@ -196,7 +196,7 @@ Note that if you suspend either the `Launch` or `Terminate` process types, it ca
 * `protect_from_scale_in` (Optional) Allows setting instance protection. The
    autoscaling group will not select instances with this setting for terminination
    during scale in events.
-*  `service_linked_role_arn` (Optional) The ARN of the service-linked role that the ASG will use to call other AWS services
+* `service_linked_role_arn` (Optional) The ARN of the service-linked role that the ASG will use to call other AWS services
 
 Tags support the following:
 


### PR DESCRIPTION
Tiny update on formatting in the documentation.