### PR TITLE
Fixed a typo in acm_certificate_validation.html

### DIFF
--- a/website/docs/r/acm_certificate_validation.html.markdown
+++ b/website/docs/r/acm_certificate_validation.html.markdown
@@ -11,7 +11,7 @@ description: |-
 This resource represents a successful validation of an ACM certificate in concert
 with other resources.
 
-Most commonly, this resource is used to together with [`aws_route53_record`](route53_record.html) and
+Most commonly, this resource is used together with [`aws_route53_record`](route53_record.html) and
 [`aws_acm_certificate`](acm_certificate.html) to request a DNS validated certificate,
 deploy the required validation records and wait for validation to complete.
 


### PR DESCRIPTION
I think the "to" in "this resource is used to together" is just a typo and should be removed.
