### PR TITLE
An empty metric_interval_lower_bound is treated as negative infinity

### DIFF
--- a/website/docs/r/appautoscaling_policy.html.markdown
+++ b/website/docs/r/appautoscaling_policy.html.markdown
@@ -154,7 +154,7 @@ The following arguments are supported:
   }
   ```
 
-  * `metric_interval_lower_bound` - (Optional) The lower bound for the difference between the alarm threshold and the CloudWatch metric. Without a value, AWS will treat this bound as infinity.
+  * `metric_interval_lower_bound` - (Optional) The lower bound for the difference between the alarm threshold and the CloudWatch metric. Without a value, AWS will treat this bound as negative infinity.
   * `metric_interval_upper_bound` - (Optional) The upper bound for the difference between the alarm threshold and the CloudWatch metric. Without a value, AWS will treat this bound as infinity. The upper bound must be greater than the lower bound.
   * `scaling_adjustment` - (Required) The number of members by which to scale, when the adjustment bounds are breached. A positive value scales up. A negative value scales down.
 


### PR DESCRIPTION
As mentioned in https://github.com/terraform-providers/terraform-provider-aws/issues/3088 and https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_StepAdjustment.html#API_StepAdjustment_Contents a null value for 'metric_interval_lower_bound' is treated as _negative_ infinity.

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #3088