### PR TITLE
docs/resource/aws_ses_event_destination: Add SNS destination example and clarify headers

### DIFF
--- a/website/docs/r/ses_event_destination.markdown
+++ b/website/docs/r/ses_event_destination.markdown
@@ -12,24 +12,12 @@ Provides an SES event destination
 
 ## Example Usage
 
+### CloudWatch Destination
+
 ```hcl
-# Add a firehose event destination to a configuration set
-resource "aws_ses_event_destination" "kinesis" {
-  name                   = "event-destination-kinesis"
-  configuration_set_name = "${aws_ses_configuration_set.test.name}"
-  enabled                = true
-  matching_types         = ["bounce", "send"]
-
-  kinesis_destination = {
-    stream_arn = "${aws_kinesis_firehose_delivery_stream.test_stream.arn}"
-    role_arn   = "${aws_iam_role.firehose_role.arn}"
-  }
-}
-
-# CloudWatch event destination
 resource "aws_ses_event_destination" "cloudwatch" {
   name                   = "event-destination-cloudwatch"
-  configuration_set_name = "${aws_ses_configuration_set.test.name}"
+  configuration_set_name = "${aws_ses_configuration_set.example.name}"
   enabled                = true
   matching_types         = ["bounce", "send"]
 
@@ -37,6 +25,37 @@ resource "aws_ses_event_destination" "cloudwatch" {
     default_value  = "default"
     dimension_name = "dimension"
     value_source   = "emailHeader"
+  }
+}
+```
+
+### Kinesis Destination
+
+```hcl
+resource "aws_ses_event_destination" "kinesis" {
+  name                   = "event-destination-kinesis"
+  configuration_set_name = "${aws_ses_configuration_set.example.name}"
+  enabled                = true
+  matching_types         = ["bounce", "send"]
+
+  kinesis_destination = {
+    stream_arn = "${aws_kinesis_firehose_delivery_stream.example.arn}"
+    role_arn   = "${aws_iam_role.example.arn}"
+  }
+}
+```
+
+### SNS Destination
+
+```hcl
+resource "aws_ses_event_destination" "sns" {
+  name                   = "event-destination-sns"
+  configuration_set_name = "${aws_ses_configuration_set.example.name}"
+  enabled                = true
+  matching_types         = ["bounce", "send"]
+
+  sns_destination {
+    topic_arn = "${aws_sns_topic.example.arn}"
   }
 }
 ```
@@ -55,18 +74,17 @@ The following arguments are supported:
 
 ~> **NOTE:** You can specify `"cloudwatch_destination"` or `"kinesis_destination"` but not both
 
-CloudWatch Destination requires the following:
+### cloudwatch_destination Argument Reference
 
 * `default_value` - (Required) The default value for the event
 * `dimension_name` - (Required) The name for the dimension
 * `value_source` - (Required) The source for the value. It can be either `"messageTag"` or `"emailHeader"`
 
-Kinesis Destination requires the following:
+### kinesis_destination Argument Reference
 
 * `stream_arn` - (Required) The ARN of the Kinesis Stream
 * `role_arn` - (Required) The ARN of the role that has permissions to access the Kinesis Stream
 
-SNS Topic requires the following:
+### sns_destination Argument Reference
 
 * `topic_arn` - (Required) The ARN of the SNS topic
-


### PR DESCRIPTION
Closes #4858 

Changes proposed in this pull request:

* Add SNS destination example
* Clarify headers
* Use `example` resource name in example resource references

Output from acceptance testing: N/A