### PR TITLE
Use ipv4 helper subdomain to get correct IP for EKS demo

### DIFF
--- a/examples/eks-getting-started/workstation-external-ip.tf
+++ b/examples/eks-getting-started/workstation-external-ip.tf
@@ -9,7 +9,7 @@
 #
 
 data "http" "workstation-external-ip" {
-  url = "http://icanhazip.com"
+  url = "http://ipv4.icanhazip.com"
 }
 
 # Override with variable or hardcoded value if necessary


### PR DESCRIPTION
Fixes #4778 by calling ipv4 helper subdomain in "EKS getting started guide" 

Kudos to @danielhartnell.