### PR TITLE
data-source/aws_rds_cluster: Prevent panic when CloudWatch logs are enabled

### DIFF
--- a/aws/data_source_aws_rds_cluster.go
+++ b/aws/data_source_aws_rds_cluster.go
@@ -58,6 +58,12 @@ func dataSourceAwsRdsCluster() *schema.Resource {
 				Computed: true,
 			},
 
+			"enabled_cloudwatch_logs_exports": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
 			"endpoint": {
 				Type:     schema.TypeString,
 				Computed: true,


### PR DESCRIPTION
Fixes #4922 

While I can add an acceptance test to cover this specific case, it does bring up an interesting point. This data source failure would only occur in a certain resource situation and was not caught by existing acceptance testing. Much like we can run into trouble if all acceptance testing doesn't run the `ImportStateVerify` check for all iterations of a resource, we can run into similar situations with data sources as well. Thoughts appreciated on future thinking about how to handle this better.

Changes proposed in this pull request:

* Add `enabled_cloudwatch_logs_exports` attribute to `aws_rds_cluster` data source to match resource

Output from acceptance testing:

```
1 test passed (all tests)
=== RUN   TestAccDataSourceAwsRdsCluster_basic
--- PASS: TestAccDataSourceAwsRdsCluster_basic (103.40s)
```
