### PR TITLE
aws_sqs_queue - Added .fifo for FIFO queues with name_prefix

### DIFF
--- a/aws/resource_aws_sqs_queue.go
+++ b/aws/resource_aws_sqs_queue.go
@@ -134,15 +134,20 @@ func resourceAwsSqsQueueCreate(d *schema.ResourceData, meta interface{}) error {
 	sqsconn := meta.(*AWSClient).sqsconn
 
 	var name string
+
+	fq := d.Get("fifo_queue").(bool)
+
 	if v, ok := d.GetOk("name"); ok {
 		name = v.(string)
 	} else if v, ok := d.GetOk("name_prefix"); ok {
 		name = resource.PrefixedUniqueId(v.(string))
+		if fq {
+			name += ".fifo"
+		}
 	} else {
 		name = resource.UniqueId()
 	}
 
-	fq := d.Get("fifo_queue").(bool)
 	cbd := d.Get("content_based_deduplication").(bool)
 
 	if fq {


### PR DESCRIPTION
Fixes #4747

Output from acceptance testing:

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSSQSQueue_namePrefix -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSSQSQueue_namePrefix
--- PASS: TestAccAWSSQSQueue_namePrefix (21.24s)
=== RUN   TestAccAWSSQSQueue_namePrefix_fifo
--- PASS: TestAccAWSSQSQueue_namePrefix_fifo (21.35s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	42.631s
```
