### PR TITLE
add create_date as an attribute to aws_iam_instance_profile resource

### DIFF
--- a/aws/resource_aws_iam_instance_profile.go
+++ b/aws/resource_aws_iam_instance_profile.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"regexp"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -305,6 +306,9 @@ func instanceProfileReadResult(d *schema.ResourceData, result *iam.InstanceProfi
 		return err
 	}
 	if err := d.Set("arn", result.Arn); err != nil {
+		return err
+	}
+	if err := d.Set("create_date", result.CreateDate.Format(time.RFC3339)); err != nil {
 		return err
 	}
 	if err := d.Set("path", result.Path); err != nil {


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #3527 

Changes proposed in this pull request:

* Add create_date as an attribute to aws_iam_instance_profile resource.  The documentation already states the attribute is available.

Acceptance testing not run.  Manually tested on an existing instance profile in my environment.
