### PR TITLE
Issue #4785: New Datasource aws_codecommit_repository

### DIFF
--- a/aws/data_source_aws_codecommit_repository.go
+++ b/aws/data_source_aws_codecommit_repository.go
@@ -57,10 +57,14 @@ func dataSourceAwsCodeCommitRepositoryRead(d *schema.ResourceData, meta interfac
 		if isAWSErr(err, codecommit.ErrCodeRepositoryDoesNotExistException, "") {
 			log.Printf("[WARN] CodeCommit Repository (%s) not found, removing from state", d.Id())
 			d.SetId("")
-			return nil
+			return fmt.Errorf("Resource codecommit repository not found for %s", repositoryName)
 		} else {
 			return fmt.Errorf("Error reading CodeCommit Repository: %s", err.Error())
 		}
+	}
+
+	if out.RepositoryMetadata == nil {
+		return fmt.Errorf("no matches found for repository name: %s", repositoryName)
 	}
 
 	d.SetId(aws.StringValue(out.RepositoryMetadata.RepositoryName))

--- a/aws/data_source_aws_codecommit_repository.go
+++ b/aws/data_source_aws_codecommit_repository.go
@@ -1,0 +1,74 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/codecommit"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsCodeCommitRepository() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsCodeCommitRepositoryRead,
+
+		Schema: map[string]*schema.Schema{
+			"repository_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateMaxLength(100),
+			},
+
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"repository_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"clone_url_http": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"clone_url_ssh": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsCodeCommitRepositoryRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).codecommitconn
+
+	repositoryName := d.Get("repository_name").(string)
+	input := &codecommit.GetRepositoryInput{
+		RepositoryName: aws.String(repositoryName),
+	}
+
+	out, err := conn.GetRepository(input)
+	if err != nil {
+		if isAWSErr(err, codecommit.ErrCodeRepositoryDoesNotExistException, "") {
+			log.Printf("[WARN] CodeCommit Repository (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		} else {
+			return fmt.Errorf("Error reading CodeCommit Repository: %s", err.Error())
+		}
+	}
+
+	d.SetId(aws.StringValue(out.RepositoryMetadata.RepositoryName))
+	d.Set("arn", out.RepositoryMetadata.Arn)
+	d.Set("clone_url_http", out.RepositoryMetadata.CloneUrlHttp)
+	d.Set("clone_url_ssh", out.RepositoryMetadata.CloneUrlSsh)
+	d.Set("repository_name", out.RepositoryMetadata.RepositoryName)
+	d.Set("repository_id", out.RepositoryMetadata.RepositoryId)
+
+	return nil
+}

--- a/aws/data_source_aws_codecommit_repository_test.go
+++ b/aws/data_source_aws_codecommit_repository_test.go
@@ -1,0 +1,45 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSCodeCommitRepositoryDataSource_basic(t *testing.T) {
+	rName := fmt.Sprintf("tf-acctest-%d", acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAwsCodeCommitRepositoryDataSourceConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_codecommit_repository.default", "repository_name", rName),
+					resource.TestMatchResourceAttr("data.aws_codecommit_repository.default", "arn",
+						regexp.MustCompile(fmt.Sprintf("^arn:aws:codecommit:[^:]+:\\d{12}:%s", rName))),
+					resource.TestMatchResourceAttr("data.aws_codecommit_repository.default", "clone_url_http",
+						regexp.MustCompile(fmt.Sprintf("^https://git-codecommit.[^:]+.amazonaws.com/v1/repos/%s", rName))),
+					resource.TestMatchResourceAttr("data.aws_codecommit_repository.default", "clone_url_ssh",
+						regexp.MustCompile(fmt.Sprintf("^ssh://git-codecommit.[^:]+.amazonaws.com/v1/repos/%s", rName))),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsCodeCommitRepositoryDataSourceConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_codecommit_repository" "default" {
+  repository_name = "%s"
+}
+
+data "aws_codecommit_repository" "default" {
+  repository_name = "${aws_codecommit_repository.default.repository_name}"
+}
+`, rName)
+}

--- a/aws/data_source_aws_codecommit_repository_test.go
+++ b/aws/data_source_aws_codecommit_repository_test.go
@@ -19,7 +19,8 @@ func TestAccAWSCodeCommitRepositoryDataSource_basic(t *testing.T) {
 			{
 				Config: testAccCheckAwsCodeCommitRepositoryDataSourceConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_codecommit_repository.default", "repository_name", rName),
+					resource.TestCheckResourceAttrPair("data.aws_codecommit_repository.default", "repository_name",
+						"aws_codecommit_repository.default", "repository_name"),
 					resource.TestMatchResourceAttr("data.aws_codecommit_repository.default", "arn",
 						regexp.MustCompile(fmt.Sprintf("^arn:aws:codecommit:[^:]+:\\d{12}:%s", rName))),
 					resource.TestMatchResourceAttr("data.aws_codecommit_repository.default", "clone_url_http",

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -179,6 +179,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_cloudtrail_service_account":       dataSourceAwsCloudTrailServiceAccount(),
 			"aws_cloudwatch_log_group":             dataSourceAwsCloudwatchLogGroup(),
 			"aws_cognito_user_pools":               dataSourceAwsCognitoUserPools(),
+			"aws_codecommit_repository":            dataSourceAwsCodeCommitRepository(),
 			"aws_db_instance":                      dataSourceAwsDbInstance(),
 			"aws_db_snapshot":                      dataSourceAwsDbSnapshot(),
 			"aws_dynamodb_table":                   dataSourceAwsDynamoDbTable(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -103,6 +103,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-cloudwatch-log-group") %>>
                             <a href="/docs/providers/aws/d/cloudwatch_log_group.html">aws_cloudwatch_log_group</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-codecommit-repository") %>>
+                            <a href="/docs/providers/aws/d/codecommit_repository.html">aws_cloudwatch_log_group</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-cognito-user-pools") %>>
                             <a href="/docs/providers/aws/d/cognito_user_pools.html">aws_cognito_user_pools</a>
                         </li>

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -104,7 +104,7 @@
                             <a href="/docs/providers/aws/d/cloudwatch_log_group.html">aws_cloudwatch_log_group</a>
                         </li>
                         <li<%= sidebar_current("docs-aws-datasource-codecommit-repository") %>>
-                            <a href="/docs/providers/aws/d/codecommit_repository.html">aws_cloudwatch_log_group</a>
+                            <a href="/docs/providers/aws/d/codecommit_repository.html">aws_codecommit_repository</a>
                         </li>
                         <li<%= sidebar_current("docs-aws-datasource-cognito-user-pools") %>>
                             <a href="/docs/providers/aws/d/cognito_user_pools.html">aws_cognito_user_pools</a>

--- a/website/docs/d/codecommit_repository.html.markdown
+++ b/website/docs/d/codecommit_repository.html.markdown
@@ -1,0 +1,34 @@
+---
+layout: "aws"
+page_title: "AWS: aws_codecommit_repository"
+sidebar_current: "docs-aws-datasource-codecommit-repository"
+description: |-
+  Provides details about CodeCommit Repository.
+---
+
+# Data Source: aws_codecommit_repository
+
+The CodeCommit Repository data source allows the ARN, Repository ID, Repository URL for HTTP and Repository URL for SSH to be retrieved for an CodeCommit repository.
+
+## Example Usage
+
+```hcl
+data "aws_codecommit_repository" "test" {
+  repository_name = "MyTestRepository"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `repository_name` - (Required) The name for the repository. This needs to be less than 100 characters.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `repository_id` - The ID of the repository
+* `arn` - The ARN of the repository
+* `clone_url_http` - The URL to use for cloning the repository over HTTPS.
+* `clone_url_ssh` - The URL to use for cloning the repository over SSH.


### PR DESCRIPTION

Fixes #4785 

Output from acceptance testing:

```
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSCodeCommitRepositoryDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAWSCodeCommitRepositoryDataSource_basic -timeout 120m
=== RUN   TestAccAWSCodeCommitRepositoryDataSource_basic
--- PASS: TestAccAWSCodeCommitRepositoryDataSource_basic (49.71s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	49.751s
...
```
