### PR TITLE
Force all database names to lower case

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -39,6 +39,13 @@ func resourceAwsDbInstance() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
+				StateFunc: func(v interface{}) string {
+					value := v.(string)
+					return strings.ToLower(value)
+				},
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return strings.ToLower(old) == strings.ToLower(new)
+				},
 			},
 
 			"arn": {
@@ -954,7 +961,7 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	d.Set("name", v.DBName)
+	d.Set("name", strings.ToLower(*v.DBName))
 	d.Set("identifier", v.DBInstanceIdentifier)
 	d.Set("resource_id", v.DbiResourceId)
 	d.Set("username", v.MasterUsername)

--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -122,6 +122,26 @@ func TestAccAWSDBInstance_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSDBInstance_nameDiffSuppress(t *testing.T) {
+	var v rds.DBInstance
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBInstanceConfig_nameDiffSuppress,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBInstanceExists("aws_db_instance.test", &v),
+					resource.TestCheckResourceAttr("aws_db_instance.test", "name", "lower"),
+					resource.TestCheckResourceAttr("aws_db_instance.test", "engine", "oracle-se"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSDBInstance_namePrefix(t *testing.T) {
 	var v rds.DBInstance
 
@@ -867,7 +887,7 @@ resource "aws_db_instance" "bar" {
 	engine = "MySQL"
 	engine_version = "5.6.35"
 	instance_class = "db.t2.micro"
-	name = "baz"
+	name = "Baz"
 	password = "barbarbarbar"
 	username = "foo"
 
@@ -881,6 +901,23 @@ resource "aws_db_instance" "bar" {
 	backup_retention_period = 0
 
 	parameter_group_name = "default.mysql5.6"
+
+	timeouts {
+		create = "30m"
+	}
+}`
+
+const testAccAWSDBInstanceConfig_nameDiffSuppress = `
+resource "aws_db_instance" "test" {
+	name = "lower"
+	allocated_storage = 10
+	engine = "oracle-se"
+	identifier_prefix = "tf-test-"
+	instance_class = "db.t2.micro"
+	password = "password"
+	username = "root"
+	publicly_accessible = true
+	skip_final_snapshot = true
 
 	timeouts {
 		create = "30m"


### PR DESCRIPTION
The Oracle DB engine at least uppercases the database name so if provided with 'foo' will return 'FOO'.

Previously this would then make the next plan show a change from 'FOO' -> 'foo' which required a recreation even though it wasn't actually changing anything.

Instead we now just turn everything into lowercasing and ignoring the casing diffs in case anyone was using uppercase characters at all which would then show a diff for them for no good reason.

I originally came across this when trying to reproduce https://github.com/terraform-providers/terraform-provider-aws/issues/84 and tested all of the engines and could only see a diff for Oracle (as @brandonstevens has also discovered since apparently).

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #84 

Changes proposed in this pull request:

* Ignores casing for all database names to prevent the AWS API mangling them for different version names and causing a diff loop.

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSDBInstance_nameDiffSuppress"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSDBInstance_nameDiffSuppress -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSDBInstance_nameDiffSuppress
--- PASS: TestAccAWSDBInstance_nameDiffSuppress (855.88s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	855.901s
$ make testacc TESTARGS="-run=TestAccAWSDBInstance_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSDBInstance_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSDBInstance_basic
--- PASS: TestAccAWSDBInstance_basic (450.39s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	450.417s
```
