### PR TITLE
Don't update disable_api_termination on new resource

### DIFF
--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -1067,7 +1067,7 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	if d.HasChange("disable_api_termination") {
+	if d.HasChange("disable_api_termination") && !d.IsNewResource() {
 		_, err := conn.ModifyInstanceAttribute(&ec2.ModifyInstanceAttributeInput{
 			InstanceId: aws.String(d.Id()),
 			DisableApiTermination: &ec2.AttributeBooleanValue{


### PR DESCRIPTION
Similar to #4897 Terraform performs an unnecessary ModifyInstanceAttribute call when specifying disable_api_termination on a new ec2 instance.

Fixes #4939