### PR TITLE
Raise an error when failing to retrieve RDS instance tags

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -1035,7 +1035,7 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	})
 
 	if err != nil {
-		log.Printf("[DEBUG] Error retrieving tags for ARN: %s", arn)
+		return fmt.Errorf("Error retrieving tags for ARN: %s", arn)
 	}
 
 	var dt []*rds.Tag


### PR DESCRIPTION
Just logging the error means that if the user is unable to call the ListTagsForResource API endpoint then they will see a diff showing that they need to add the tags each time.
Instead it's better to actually error instead of hiding this from the user (unless they happen to check the logs).

Closes https://github.com/terraform-providers/terraform-provider-aws/issues/345

See extended discussion in the original issue: https://github.com/hashicorp/terraform/issues/9821

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #345

Changes proposed in this pull request:

* Error instead of just logging when user is unable to call ListTagsForResource.

