### PR TITLE
docs: Add RDS Cluster and Instance Parameter Group links to available parameters

### DIFF
--- a/website/docs/r/db_parameter_group.html.markdown
+++ b/website/docs/r/db_parameter_group.html.markdown
@@ -8,7 +8,12 @@ description: |-
 
 # aws_db_parameter_group
 
-Provides an RDS DB parameter group resource.
+Provides an RDS DB parameter group resource .Documentation of the available parameters for various RDS engines can be found at:
+* [Aurora MySQL Parameters](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AuroraMySQL.Reference.html)
+* [Aurora PostgreSQL Parameters](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AuroraPostgreSQL.Reference.html)
+* [MariaDB Parameters](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.MariaDB.Parameters.html)
+* [Oracle Parameters](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ModifyInstance.Oracle.html#USER_ModifyInstance.Oracle.sqlnet)
+* [PostgreSQL Parameters](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.PostgreSQL.CommonDBATasks.html#Appendix.PostgreSQL.CommonDBATasks.Parameters)
 
 ## Example Usage
 

--- a/website/docs/r/rds_cluster_parameter_group.markdown
+++ b/website/docs/r/rds_cluster_parameter_group.markdown
@@ -8,7 +8,9 @@ description: |-
 
 # aws_rds_cluster_parameter_group
 
-Provides an RDS DB cluster parameter group resource.
+Provides an RDS DB cluster parameter group resource. Documentation of the available parameters for various Aurora engines can be found at:
+* [Aurora MySQL Parameters](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AuroraMySQL.Reference.html)
+* [Aurora PostgreSQL Parameters](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AuroraPostgreSQL.Reference.html)
 
 ## Example Usage
 


### PR DESCRIPTION
Closes #1598

Changes proposed in this pull request:

* Add Aurora parameter documentation links to `aws_rds_cluster_parameter_group` resource documentation
* Add Aurora, MariaDB, Oracle, and PostgreSQL parameter documentation links to `aws_db_parameter_group` resource documentation

Output from acceptance testing: N/A
