### PR TITLE
Allow Data Source for AWS instances to get instances that are in a state other than running

### DIFF
--- a/aws/data_source_aws_instances.go
+++ b/aws/data_source_aws_instances.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func dataSourceAwsInstances() *schema.Resource {
@@ -17,6 +18,21 @@ func dataSourceAwsInstances() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"filter":        dataSourceFiltersSchema(),
 			"instance_tags": tagsSchemaComputed(),
+			"instance_state_names": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					ValidateFunc: validation.StringInSlice([]string{
+						ec2.InstanceStateNamePending,
+						ec2.InstanceStateNameRunning,
+						ec2.InstanceStateNameShuttingDown,
+						ec2.InstanceStateNameStopped,
+						ec2.InstanceStateNameStopping,
+						ec2.InstanceStateNameTerminated,
+					}, false),
+				},
+			},
 
 			"ids": {
 				Type:     schema.TypeList,
@@ -47,20 +63,19 @@ func dataSourceAwsInstancesRead(d *schema.ResourceData, meta interface{}) error 
 		return fmt.Errorf("One of filters or instance_tags must be assigned")
 	}
 
+	instanceStateNames := []*string{aws.String(ec2.InstanceStateNameRunning)}
+	if v, ok := d.GetOk("instance_state_names"); ok && len(v.(*schema.Set).List()) > 0 {
+		instanceStateNames = expandStringSet(v.(*schema.Set))
+	}
 	params := &ec2.DescribeInstancesInput{
 		Filters: []*ec2.Filter{
 			&ec2.Filter{
-				Name: aws.String("instance-state-name"),
-				Values: []*string{
-					aws.String("running"),
-					aws.String("stopped"),
-					aws.String("stopping"),
-					aws.String("pending"),
-					aws.String("shutting-down"),
-				},
+				Name:   aws.String("instance-state-name"),
+				Values: instanceStateNames,
 			},
 		},
 	}
+
 	if filtersOk {
 		params.Filters = append(params.Filters,
 			buildAwsDataSourceFilters(filters.(*schema.Set))...)

--- a/aws/data_source_aws_instances.go
+++ b/aws/data_source_aws_instances.go
@@ -50,8 +50,14 @@ func dataSourceAwsInstancesRead(d *schema.ResourceData, meta interface{}) error 
 	params := &ec2.DescribeInstancesInput{
 		Filters: []*ec2.Filter{
 			&ec2.Filter{
-				Name:   aws.String("instance-state-name"),
-				Values: []*string{aws.String("running")},
+				Name: aws.String("instance-state-name"),
+				Values: []*string{
+					aws.String("running"),
+					aws.String("stopped"),
+					aws.String("stopping"),
+					aws.String("pending"),
+					aws.String("shutting-down"),
+				},
 			},
 		},
 	}

--- a/aws/data_source_aws_instances_test.go
+++ b/aws/data_source_aws_instances_test.go
@@ -43,6 +43,22 @@ func TestAccAWSInstancesDataSource_tags(t *testing.T) {
 	})
 }
 
+func TestAccAWSInstancesDataSource_instance_state_names(t *testing.T) {
+	rInt := acctest.RandInt()
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstancesDataSourceConfig_instance_state_names(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_instances.test", "ids.#", "2"),
+				),
+			},
+		},
+	})
+}
+
 const testAccInstancesDataSourceConfig_ids = `
 data "aws_ami" "ubuntu" {
   most_recent = true
@@ -110,6 +126,44 @@ data "aws_instances" "test" {
     Name = "${aws_instance.test.0.tags["Name"]}"
     TestSeed = "%[1]d"
   }
+}
+`, rInt)
+}
+
+func testAccInstancesDataSourceConfig_instance_state_names(rInt int) string {
+	return fmt.Sprintf(`
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
+resource "aws_instance" "test" {
+  count = 2
+  ami = "${data.aws_ami.ubuntu.id}"
+  instance_type = "t2.micro"
+  tags {
+    Name = "TfAccTest-HelloWorld"
+    TestSeed = "%[1]d"
+  }
+}
+
+data "aws_instances" "test" {
+  instance_tags {
+    Name = "*"
+  }
+  
+  instance_state_names = [ "pending", "running" ]
 }
 `, rInt)
 }

--- a/aws/data_source_aws_instances_test.go
+++ b/aws/data_source_aws_instances_test.go
@@ -160,7 +160,7 @@ resource "aws_instance" "test" {
 
 data "aws_instances" "test" {
   instance_tags {
-    Name = "*"
+    Name = "${aws_instance.test.0.tags["Name"]}"
   }
   
   instance_state_names = [ "pending", "running" ]

--- a/website/docs/d/instances.html.markdown
+++ b/website/docs/d/instances.html.markdown
@@ -47,7 +47,7 @@ resource "aws_eip" "test" {
 * `instance_tags` - (Optional) A mapping of tags, each pair of which must
 exactly match a pair on desired instances.
 
-* `instance_state_names` - (Optional) A list of instance states that should be applicable to the desired instances. The permitted values are: `pending, running, shutting-down, stopped, stopping, terminated`
+* `instance_state_names` - (Optional) A list of instance states that should be applicable to the desired instances. The permitted values are: `pending, running, shutting-down, stopped, stopping, terminated`. The default value is `running`.
 
 * `filter` - (Optional) One or more name/value pairs to use as filters. There are
 several valid keys, for a full reference, check out

--- a/website/docs/d/instances.html.markdown
+++ b/website/docs/d/instances.html.markdown
@@ -32,6 +32,8 @@ data "aws_instances" "test" {
     name   = "instance.group-id"
     values = ["sg-12345678"]
   }
+  
+  instance_state_names = [ "running", "stopped" ]
 }
 
 resource "aws_eip" "test" {
@@ -44,6 +46,8 @@ resource "aws_eip" "test" {
 
 * `instance_tags` - (Optional) A mapping of tags, each pair of which must
 exactly match a pair on desired instances.
+
+* `instance_state_names` - (Optional) A list of instance states that should be applicable to the desired instances. The permitted values are: `pending, running, shutting-down, stopped, stopping, terminated`
 
 * `filter` - (Optional) One or more name/value pairs to use as filters. There are
 several valid keys, for a full reference, check out


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #3339

Changes proposed in this pull request:

* Also fetch AWS instances that have an instance state other than running. The only state not taken into account is **terminated**.

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAvailabilityZones'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSAvailabilityZones -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSAvailabilityZones_basic
--- FAIL: TestAccAWSAvailabilityZones_basic (0.00s)
	provider_test.go:62: AWS_ACCESS_KEY_ID must be set for acceptance tests
=== RUN   TestAccAWSAvailabilityZones_stateFilter
--- FAIL: TestAccAWSAvailabilityZones_stateFilter (0.00s)
	provider_test.go:62: AWS_ACCESS_KEY_ID must be set for acceptance tests
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	0.045s
make: *** [testacc] Error 1
...
```
