### PR TITLE
Lightsail instances are imported via their name not ARN

### DIFF
--- a/website/docs/r/lightsail_instance.html.markdown
+++ b/website/docs/r/lightsail_instance.html.markdown
@@ -85,8 +85,8 @@ The following attributes are exported in addition to the arguments listed above:
 
 ## Import
 
-Lightsail Instances can be imported using their ARN, e.g.
+Lightsail Instances can be imported using their name, e.g.
 
 ```
-$ terraform import aws_lightsail_instance.bar <arn>
+$ terraform import aws_lightsail_instance.gitlab_test 'custom gitlab'
 ```


### PR DESCRIPTION
The aws_lightsail_instance uses the 'ImportStatePassthrough' which uses the ID of the resource.
In this case the ID is the name of the Lightsail instance.

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #4847 