### PR TITLE
issue #4881 plan report no changes after deleting encryption related configuration from "aws_ebs_volume"

### DIFF
--- a/aws/resource_aws_ebs_volume.go
+++ b/aws/resource_aws_ebs_volume.go
@@ -38,8 +38,8 @@ func resourceAwsEbsVolume() *schema.Resource {
 			"encrypted": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Computed: true,
 				ForceNew: true,
+				Default:  false,
 			},
 			"iops": {
 				Type:     schema.TypeInt,

--- a/website/docs/r/ebs_volume.html.markdown
+++ b/website/docs/r/ebs_volume.html.markdown
@@ -29,7 +29,7 @@ resource "aws_ebs_volume" "example" {
 The following arguments are supported:
 
 * `availability_zone` - (Required) The AZ where the EBS volume will exist.
-* `encrypted` - (Optional) If true, the disk will be encrypted.
+* `encrypted` - (Optional) If true, the disk will be encrypted. The Default value is false.
 * `iops` - (Optional) The amount of IOPS to provision for the disk.
 * `size` - (Optional) The size of the drive in GiBs.
 * `snapshot_id` (Optional) A snapshot to base the EBS volume off of.


### PR DESCRIPTION

Fixes #4881 

Output from acceptance testing:

```
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSEBSVolume'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAWSEBSVolume -timeout 120m
=== RUN   TestAccAWSEBSVolume_importBasic
--- PASS: TestAccAWSEBSVolume_importBasic (59.13s)
=== RUN   TestAccAWSEBSVolume_basic
--- PASS: TestAccAWSEBSVolume_basic (52.71s)
=== RUN   TestAccAWSEBSVolume_updateAttachedEbsVolume
--- PASS: TestAccAWSEBSVolume_updateAttachedEbsVolume (257.81s)
=== RUN   TestAccAWSEBSVolume_updateSize
--- PASS: TestAccAWSEBSVolume_updateSize (90.93s)
=== RUN   TestAccAWSEBSVolume_updateType
--- PASS: TestAccAWSEBSVolume_updateType (93.78s)
=== RUN   TestAccAWSEBSVolume_updateIops
--- PASS: TestAccAWSEBSVolume_updateIops (95.95s)
=== RUN   TestAccAWSEBSVolume_kmsKey
--- PASS: TestAccAWSEBSVolume_kmsKey (104.32s)
=== RUN   TestAccAWSEBSVolume_NoIops
--- PASS: TestAccAWSEBSVolume_NoIops (53.44s)
=== RUN   TestAccAWSEBSVolume_withTags
--- PASS: TestAccAWSEBSVolume_withTags (52.68s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	860.784s
...
```
