### PR TITLE
Adding codebuild.EnvironmentTypeWindowsContainer as valid type for aw…

### DIFF
--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -157,6 +157,7 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 							Required: true,
 							ValidateFunc: validation.StringInSlice([]string{
 								codebuild.EnvironmentTypeLinuxContainer,
+								codebuild.EnvironmentTypeWindowsContainer,
 							}, false),
 						},
 						"privileged_mode": {

--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -418,6 +418,32 @@ func TestAccAWSCodeBuildProject_VpcConfig(t *testing.T) {
 	})
 }
 
+func TestAccAWSCodeBuildProject_WindowsContainer(t *testing.T) {
+	var project codebuild.Project
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_codebuild_project.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeBuildProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodeBuildProjectConfig_WindowsContainer(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
+					resource.TestCheckResourceAttr(resourceName, "environment.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "environment.3935046469.compute_type", "BUILD_GENERAL1_MEDIUM"),
+					resource.TestCheckResourceAttr(resourceName, "environment.3935046469.environment_variable.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "environment.3935046469.image", "2"),
+					resource.TestCheckResourceAttr(resourceName, "environment.3935046469.privileged_mode", "false"),
+					resource.TestCheckResourceAttr(resourceName, "environment.3935046469.type", "WINDOWS_CONTAINER"),
+				),
+			},
+		},
+	})
+}
+
 func TestAWSCodeBuildProject_nameValidation(t *testing.T) {
 	cases := []struct {
 		Value    string
@@ -911,4 +937,28 @@ resource "aws_codebuild_project" "test" {
   }
 }
 `, subnetCount, rName)
+}
+
+func testAccAWSCodeBuildProjectConfig_WindowsContainer(rName string) string {
+	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+resource "aws_codebuild_project" "test" {
+  name         = "%s"
+  service_role = "${aws_iam_role.test.arn}"
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type = "BUILD_GENERAL1_MEDIUM"
+    image        = "2"
+    type         = "WINDOWS_CONTAINER"
+  }
+
+  source {
+    location = "%s"
+    type     = "GITHUB"
+  }
+}
+`, rName, testAccAWSCodeBuildGitHubSourceLocationFromEnv())
 }


### PR DESCRIPTION
…s_codepipeline_project/environment/type. Fixes #4940

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #4940

Changes proposed in this pull request:

* Adds `codebuild.EnvironmentTypeWindowsContainer` as a valid type for the aws_codebuild_project environment/type property.

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSCodeBuildProject'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSCodeBuildProject -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSCodeBuildProject_basic
--- PASS: TestAccAWSCodeBuildProject_basic (32.15s)
=== RUN   TestAccAWSCodeBuildProject_BadgeEnabled
--- PASS: TestAccAWSCodeBuildProject_BadgeEnabled (30.96s)
=== RUN   TestAccAWSCodeBuildProject_BuildTimeout
--- PASS: TestAccAWSCodeBuildProject_BuildTimeout (47.82s)
=== RUN   TestAccAWSCodeBuildProject_Cache
--- PASS: TestAccAWSCodeBuildProject_Cache (75.70s)
=== RUN   TestAccAWSCodeBuildProject_Description
--- PASS: TestAccAWSCodeBuildProject_Description (45.53s)
=== RUN   TestAccAWSCodeBuildProject_EncryptionKey
--- PASS: TestAccAWSCodeBuildProject_EncryptionKey (55.91s)
=== RUN   TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type (46.50s)
=== RUN   TestAccAWSCodeBuildProject_Source_Auth
--- PASS: TestAccAWSCodeBuildProject_Source_Auth (27.05s)
=== RUN   TestAccAWSCodeBuildProject_Source_GitCloneDepth
--- PASS: TestAccAWSCodeBuildProject_Source_GitCloneDepth (44.63s)
=== RUN   TestAccAWSCodeBuildProject_Source_InsecureSSL
--- PASS: TestAccAWSCodeBuildProject_Source_InsecureSSL (45.24s)
=== RUN   TestAccAWSCodeBuildProject_Tags
--- PASS: TestAccAWSCodeBuildProject_Tags (45.08s)
=== RUN   TestAccAWSCodeBuildProject_VpcConfig
--- PASS: TestAccAWSCodeBuildProject_VpcConfig (54.92s)
=== RUN   TestAccAWSCodeBuildProject_WindowsContainer
--- PASS: TestAccAWSCodeBuildProject_WindowsContainer (25.87s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	577.404s
```