### PR TITLE
aws_ses_receipt_rule fails when kms_key_arn is not specified

### DIFF
--- a/aws/resource_aws_ses_receipt_rule.go
+++ b/aws/resource_aws_ses_receipt_rule.go
@@ -683,9 +683,15 @@ func buildReceiptRule(d *schema.ResourceData, meta interface{}) *ses.ReceiptRule
 			elem := element.(map[string]interface{})
 
 			s3Action := &ses.S3Action{
-				BucketName:      aws.String(elem["bucket_name"].(string)),
-				KmsKeyArn:       aws.String(elem["kms_key_arn"].(string)),
-				ObjectKeyPrefix: aws.String(elem["object_key_prefix"].(string)),
+				BucketName: aws.String(elem["bucket_name"].(string)),
+			}
+
+			if elem["kms_key_arn"] != "" {
+				s3Action.KmsKeyArn = aws.String(elem["kms_key_arn"].(string))
+			}
+
+			if elem["object_key_prefix"] != "" {
+				s3Action.ObjectKeyPrefix = aws.String(elem["object_key_prefix"].(string))
 			}
 
 			if elem["topic_arn"] != "" {

--- a/aws/resource_aws_ses_receipt_rule_test.go
+++ b/aws/resource_aws_ses_receipt_rule_test.go
@@ -268,7 +268,7 @@ resource "aws_ses_receipt_rule_set" "test" {
 }
 
 resource "aws_s3_bucket" "emails" {
-    bucket = "ses-terraform-emails"
+    bucket = "ses-terraform-emails-%d"
     acl = "public-read-write"
     force_destroy = "true"
 }
@@ -286,7 +286,7 @@ resource "aws_ses_receipt_rule" "basic" {
     	position = 1
   	}
 }
-`, srrsRandomInt)
+`, srrsRandomInt, srrsRandomInt)
 
 var testAccAWSSESReceiptRuleOrderConfig = fmt.Sprintf(`
 resource "aws_ses_receipt_rule_set" "test" {

--- a/aws/resource_aws_ses_receipt_rule_test.go
+++ b/aws/resource_aws_ses_receipt_rule_test.go
@@ -31,6 +31,24 @@ func TestAccAWSSESReceiptRule_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSSESReceiptRule_s3Action(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSESReceiptRuleDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSSESReceiptRuleS3ActionConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsSESReceiptRuleExists("aws_ses_receipt_rule.basic"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSSESReceiptRule_order(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -241,6 +259,32 @@ resource "aws_ses_receipt_rule" "basic" {
     enabled = true
     scan_enabled = true
     tls_policy = "Require"
+}
+`, srrsRandomInt)
+
+var testAccAWSSESReceiptRuleS3ActionConfig = fmt.Sprintf(`
+resource "aws_ses_receipt_rule_set" "test" {
+    rule_set_name = "test-me-%d"
+}
+
+resource "aws_s3_bucket" "emails" {
+    bucket = "ses-terraform-emails"
+    acl = "public-read-write"
+    force_destroy = "true"
+}
+
+resource "aws_ses_receipt_rule" "basic" {
+    name = "basic"
+    rule_set_name = "${aws_ses_receipt_rule_set.test.rule_set_name}"
+    recipients = ["test@example.com"]
+    enabled = true
+    scan_enabled = true
+    tls_policy = "Require"
+
+    s3_action {
+    	bucket_name = "${aws_s3_bucket.emails.id}"
+    	position = 1
+  	}
 }
 `, srrsRandomInt)
 


### PR DESCRIPTION

Fixes #4963 & #4906 
Output from acceptance testing:

```
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSSESReceiptRule'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAWSSESReceiptRule -timeout 120m
=== RUN   TestAccAWSSESReceiptRuleSet_importBasic
--- PASS: TestAccAWSSESReceiptRuleSet_importBasic (39.21s)
=== RUN   TestAccAWSSESReceiptRuleSet_basic
--- PASS: TestAccAWSSESReceiptRuleSet_basic (34.15s)
=== RUN   TestAccAWSSESReceiptRule_basic
--- PASS: TestAccAWSSESReceiptRule_basic (41.63s)
=== RUN   TestAccAWSSESReceiptRule_order
--- PASS: TestAccAWSSESReceiptRule_order (49.81s)
=== RUN   TestAccAWSSESReceiptRule_actions
--- PASS: TestAccAWSSESReceiptRule_actions (76.14s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	240.982s
...
```
