### PR TITLE
issue #4499 data source aws_ssm_parameter returns string for StringList type

### DIFF
--- a/aws/data_source_aws_ssm_parameter.go
+++ b/aws/data_source_aws_ssm_parameter.go
@@ -33,6 +33,12 @@ func dataSourceAwsSsmParameter() *schema.Resource {
 				Computed:  true,
 				Sensitive: true,
 			},
+			"value_list": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
+				Computed: true,
+			},
 			"with_decryption": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -80,6 +86,13 @@ func dataAwsSsmParameterRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("name", param.Name)
 	d.Set("type", param.Type)
 	d.Set("value", param.Value)
+
+	if aws.StringValue(param.Type) == "StringList" {
+		valueList := strings.Split(aws.StringValue(param.Value), ",")
+		if err := d.Set("value_list", valueList); err != nil {
+			return fmt.Errorf("Error setting value_list: %s", err)
+		}
+	}
 
 	return nil
 }

--- a/aws/data_source_aws_ssm_parameter.go
+++ b/aws/data_source_aws_ssm_parameter.go
@@ -33,12 +33,6 @@ func dataSourceAwsSsmParameter() *schema.Resource {
 				Computed:  true,
 				Sensitive: true,
 			},
-			"value_list": {
-				Type:     schema.TypeSet,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Optional: true,
-				Computed: true,
-			},
 			"with_decryption": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -82,17 +76,9 @@ func dataAwsSsmParameterRead(d *schema.ResourceData, meta interface{}) error {
 		Resource:  fmt.Sprintf("parameter/%s", strings.TrimPrefix(d.Id(), "/")),
 	}
 	d.Set("arn", arn.String())
-
 	d.Set("name", param.Name)
 	d.Set("type", param.Type)
 	d.Set("value", param.Value)
-
-	if aws.StringValue(param.Type) == "StringList" {
-		valueList := strings.Split(aws.StringValue(param.Value), ",")
-		if err := d.Set("value_list", valueList); err != nil {
-			return fmt.Errorf("Error setting value_list: %s", err)
-		}
-	}
 
 	return nil
 }

--- a/website/docs/d/ssm_parameter.html.markdown
+++ b/website/docs/d/ssm_parameter.html.markdown
@@ -19,6 +19,24 @@ data "aws_ssm_parameter" "foo" {
   name  = "foo"
 }
 ```
+To store a StringList parameter:
+
+```hcl
+resource "aws_ssm_parameter" "subnets" {
+  name      = "/my/subnets"
+  type      = "StringList"
+  overwrite = true
+  value     = "1.1.1.1,2.2.2.2"
+}
+
+data "aws_ssm_parameter" "subnets" {
+  name = "/my/subnets"
+}
+
+output "subnets_list" {
+  value = "${data.aws_ssm_parameter.subnets.value_list}"
+}
+```
 
 ~> **Note:** The unencrypted value of a SecureString will be stored in the raw state as plain-text.
 [Read more about sensitive data in state](/docs/state/sensitive-data.html).
@@ -37,3 +55,4 @@ In addition to all arguments above, the following attributes are exported:
 * `name` - (Required) The name of the parameter.
 * `type` - (Required) The type of the parameter. Valid types are `String`, `StringList` and `SecureString`.
 * `value` - (Required) The value of the parameter.
+* `value_list` - (Optional) It will provide value of the parameter in a list when `type` of the parameter is `StringList`.

--- a/website/docs/d/ssm_parameter.html.markdown
+++ b/website/docs/d/ssm_parameter.html.markdown
@@ -19,27 +19,13 @@ data "aws_ssm_parameter" "foo" {
   name  = "foo"
 }
 ```
-To store a StringList parameter:
-
-```hcl
-resource "aws_ssm_parameter" "subnets" {
-  name      = "/my/subnets"
-  type      = "StringList"
-  overwrite = true
-  value     = "1.1.1.1,2.2.2.2"
-}
-
-data "aws_ssm_parameter" "subnets" {
-  name = "/my/subnets"
-}
-
-output "subnets_list" {
-  value = "${data.aws_ssm_parameter.subnets.value_list}"
-}
-```
 
 ~> **Note:** The unencrypted value of a SecureString will be stored in the raw state as plain-text.
 [Read more about sensitive data in state](/docs/state/sensitive-data.html).
+
+
+~> **Note:** The data source is currently following the behavior of the [SSM API](https://docs.aws.amazon.com/sdk-for-go/api/service/ssm/#Parameter) to return a string value, regardless of parameter type. For type `StringList`, we can use [split()](https://www.terraform.io/docs/configuration/interpolation.html#split-delim-string-) built-in function to get values in a list. Example: `split(",", data.aws_ssm_parameter.subnets.value)`
+
 
 ## Argument Reference
 
@@ -55,4 +41,3 @@ In addition to all arguments above, the following attributes are exported:
 * `name` - (Required) The name of the parameter.
 * `type` - (Required) The type of the parameter. Valid types are `String`, `StringList` and `SecureString`.
 * `value` - (Required) The value of the parameter.
-* `value_list` - (Optional) It will provide value of the parameter in a list when `type` of the parameter is `StringList`.


### PR DESCRIPTION

Fixes #4499 

Changes proposed in this pull request:

* Change 1
Added the attribute value_list to return list of values if type is `StringList`