### PR TITLE
Allow setting endpoint for autoscaling

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -125,6 +125,7 @@ type Config struct {
 	DeviceFarmEndpoint       string
 	Ec2Endpoint              string
 	EcsEndpoint              string
+	AutoscalingEndpoint      string
 	EcrEndpoint              string
 	EfsEndpoint              string
 	EsEndpoint               string
@@ -392,6 +393,7 @@ func (c *Config) Client() (interface{}, error) {
 	awsCwlSess := sess.Copy(&aws.Config{Endpoint: aws.String(c.CloudWatchLogsEndpoint)})
 	awsDynamoSess := sess.Copy(&aws.Config{Endpoint: aws.String(c.DynamoDBEndpoint)})
 	awsEc2Sess := sess.Copy(&aws.Config{Endpoint: aws.String(c.Ec2Endpoint)})
+	awsAutoscalingSess := sess.Copy(&aws.Config{Endpoint: aws.String(c.AutoscalingEndpoint)})
 	awsEcrSess := sess.Copy(&aws.Config{Endpoint: aws.String(c.EcrEndpoint)})
 	awsEcsSess := sess.Copy(&aws.Config{Endpoint: aws.String(c.EcsEndpoint)})
 	awsEfsSess := sess.Copy(&aws.Config{Endpoint: aws.String(c.EfsEndpoint)})
@@ -458,7 +460,7 @@ func (c *Config) Client() (interface{}, error) {
 	client.acmpcaconn = acmpca.New(sess)
 	client.apigateway = apigateway.New(awsApigatewaySess)
 	client.appautoscalingconn = applicationautoscaling.New(sess)
-	client.autoscalingconn = autoscaling.New(sess)
+	client.autoscalingconn = autoscaling.New(awsAutoscalingSess)
 	client.cloud9conn = cloud9.New(sess)
 	client.cfconn = cloudformation.New(awsCfSess)
 	client.cloudfrontconn = cloudfront.New(sess)

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -705,6 +705,8 @@ func init() {
 
 		"ec2_endpoint": "Use this to override the default endpoint URL constructed from the `region`.\n",
 
+		"autoscaling_endpoint": "Use this to override the default endpoint URL constructed from the `region`.\n",
+
 		"efs_endpoint": "Use this to override the default endpoint URL constructed from the `region`.\n",
 
 		"elb_endpoint": "Use this to override the default endpoint URL constructed from the `region`.\n",
@@ -812,6 +814,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		config.DeviceFarmEndpoint = endpoints["devicefarm"].(string)
 		config.DynamoDBEndpoint = endpoints["dynamodb"].(string)
 		config.Ec2Endpoint = endpoints["ec2"].(string)
+		config.AutoscalingEndpoint = endpoints["autoscaling"].(string)
 		config.EcrEndpoint = endpoints["ecr"].(string)
 		config.EcsEndpoint = endpoints["ecs"].(string)
 		config.EfsEndpoint = endpoints["efs"].(string)
@@ -947,6 +950,13 @@ func endpointsSchema() *schema.Schema {
 					Description: descriptions["ec2_endpoint"],
 				},
 
+				"autoscaling": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Default:     "",
+					Description: descriptions["autoscaling_endpoint"],
+				},
+
 				"ecr": {
 					Type:        schema.TypeString,
 					Optional:    true,
@@ -1058,6 +1068,7 @@ func endpointsToHash(v interface{}) int {
 	buf.WriteString(fmt.Sprintf("%s-", m["dynamodb"].(string)))
 	buf.WriteString(fmt.Sprintf("%s-", m["iam"].(string)))
 	buf.WriteString(fmt.Sprintf("%s-", m["ec2"].(string)))
+	buf.WriteString(fmt.Sprintf("%s-", m["autoscaling"].(string)))
 	buf.WriteString(fmt.Sprintf("%s-", m["efs"].(string)))
 	buf.WriteString(fmt.Sprintf("%s-", m["elb"].(string)))
 	buf.WriteString(fmt.Sprintf("%s-", m["kinesis"].(string)))

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -289,6 +289,10 @@ Nested `endpoints` block supports the following:
   URL constructed from the `region`. It's typically used to connect to
   custom EC2 endpoints.
 
+* `autoscaling` - (Optional) Use this to override the default endpoint
+  URL constructed from the `region`. It's typically used to connect to
+  custom Autoscaling endpoints.
+
 * `ecr` - (Optional) Use this to override the default endpoint
   URL constructed from the `region`. It's typically used to connect to
   custom ECR endpoints.


### PR DESCRIPTION
Adding support for setting user defined end-point
Fixes #4967 

Changes proposed in this pull request:

* provider.go
* config.go
* website/docs/index.html.markdown

