### PR TITLE
Fixed an example for acm_certificate_validation

### DIFF
--- a/website/docs/r/acm_certificate_validation.html.markdown
+++ b/website/docs/r/acm_certificate_validation.html.markdown
@@ -36,7 +36,7 @@ data "aws_route53_zone" "zone" {
 resource "aws_route53_record" "cert_validation" {
   name = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_name}"
   type = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_type}"
-  zone_id = "${data.aws_route53_zone.zone.id}"
+  zone_id = "${aws_route53_zone.zone.id}"
   records = ["${aws_acm_certificate.cert.domain_validation_options.0.resource_record_value}"]
   ttl = 60
 }


### PR DESCRIPTION
Changes proposed in this pull request:

* In the example for acm_certificate_validation, zone_id in aws_route53_record.cert_validation was incorrectly a data attribute.

Output from acceptance testing:
N/A
