### PR TITLE
[WIP] Add import functionality to CodeBuild Project

### DIFF
--- a/aws/import_aws_codebuild_project_test.go
+++ b/aws/import_aws_codebuild_project_test.go
@@ -23,8 +23,6 @@ func TestAWSCodeBuildProject_importBasic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"force_destroy", "acl"},
 			},
 		},
 	})

--- a/aws/import_aws_codebuild_project_test.go
+++ b/aws/import_aws_codebuild_project_test.go
@@ -1,0 +1,31 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAWSCodeBuildProject_importBasic(t *testing.T) {
+	resourceName := "aws_codebuild_project.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeBuildProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodeBuildProjectConfig_basic(rName),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy", "acl"},
+			},
+		},
+	})
+}

--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -23,6 +23,9 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 		Read:   resourceAwsCodeBuildProjectRead,
 		Update: resourceAwsCodeBuildProjectUpdate,
 		Delete: resourceAwsCodeBuildProjectDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"artifacts": {

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -212,3 +212,11 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ARN of the CodeBuild project.
 * `badge_url` - The URL of the build badge when `badge_enabled` is enabled.
+
+## Import
+
+CodeBuild Project can be imported using the `name`, e.g.
+
+```
+$ terraform import aws_codebuild_project.name project-name
+```


### PR DESCRIPTION
Though I couldn't find any issue about this, I made this PR because I'm using CodeBuild frequently.
I'm not familliar with Golang very well, so please point out if something is wrong.

**Changes proposed in this pull request:**

* Add import functionality to CodeBuild Project

**Output from acceptance testing:**

```
$ make testacc TESTARGS='-run=TestAWSCodeBuildProject_importBasic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAWSCodeBuildProject_importBasic -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
q=== RUN   TestAWSCodeBuildProject_importBasic
--- PASS: TestAWSCodeBuildProject_importBasic (48.20s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       48.241s
```
