### PR TITLE
resource/aws_waf_ipset: Support resource import

### DIFF
--- a/aws/resource_aws_waf_ipset.go
+++ b/aws/resource_aws_waf_ipset.go
@@ -17,6 +17,9 @@ func resourceAwsWafIPSet() *schema.Resource {
 		Read:   resourceAwsWafIPSetRead,
 		Update: resourceAwsWafIPSetUpdate,
 		Delete: resourceAwsWafIPSetDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/aws/resource_aws_waf_ipset_test.go
+++ b/aws/resource_aws_waf_ipset_test.go
@@ -38,6 +38,11 @@ func TestAccAWSWafIPSet_basic(t *testing.T) {
 						regexp.MustCompile(`^arn:[\w-]+:waf::\d{12}:ipset/.+$`)),
 				),
 			},
+			{
+				ResourceName:      "aws_waf_ipset.ipset",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/website/docs/r/waf_ipset.html.markdown
+++ b/website/docs/r/waf_ipset.html.markdown
@@ -45,11 +45,17 @@ The following arguments are supported:
 * `value` - (Required) An IPv4 or IPv6 address specified via CIDR notation.
 	e.g. `192.0.2.44/32` or `1111:0000:0000:0000:0000:0000:0000:0000/64`
 
-## Remarks
-
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the WAF IPSet.
 * `arn` - The ARN of the WAF IPSet.
+
+## Import
+
+WAF IPSets can be imported using their ID, e.g.
+
+```
+$ terraform import aws_waf_ipset.example a1b2c3d4-d5f6-7777-8888-9999aaaabbbbcccc
+```


### PR DESCRIPTION
Closes #4279

Changes proposed in this pull request:

* Support resource import via ID

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSWafIPSet'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSWafIPSet -timeout 120m
=== RUN   TestAccAWSWafIPSet_basic
--- PASS: TestAccAWSWafIPSet_basic (12.31s)
=== RUN   TestAccAWSWafIPSet_disappears
--- PASS: TestAccAWSWafIPSet_disappears (9.10s)
=== RUN   TestAccAWSWafIPSet_changeNameForceNew
--- PASS: TestAccAWSWafIPSet_changeNameForceNew (18.14s)
=== RUN   TestAccAWSWafIPSet_changeDescriptors
--- PASS: TestAccAWSWafIPSet_changeDescriptors (17.64s)
=== RUN   TestAccAWSWafIPSet_noDescriptors
--- PASS: TestAccAWSWafIPSet_noDescriptors (8.38s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	65.613s
```
