### PR TITLE
New Data Source: aws_dx_gateway

### DIFF
--- a/aws/data_source_aws_dx_gateway.go
+++ b/aws/data_source_aws_dx_gateway.go
@@ -1,0 +1,66 @@
+package aws
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/directconnect"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsDxGateway() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsDxGatewayRead,
+
+		Schema: map[string]*schema.Schema{
+			"amazon_side_asn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsDxGatewayRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).dxconn
+	name := d.Get("name").(string)
+
+	gateways := make([]*directconnect.Gateway, 0)
+	// DescribeDirectConnectGatewaysInput does not have a name parameter for filtering
+	input := &directconnect.DescribeDirectConnectGatewaysInput{}
+	for {
+		output, err := conn.DescribeDirectConnectGateways(input)
+		if err != nil {
+			return fmt.Errorf("error reading Direct Connect Gateway: %s", err)
+		}
+		for _, gateway := range output.DirectConnectGateways {
+			if aws.StringValue(gateway.DirectConnectGatewayName) == name {
+				gateways = append(gateways, gateway)
+			}
+		}
+		if output.NextToken == nil {
+			break
+		}
+		input.NextToken = output.NextToken
+	}
+
+	if len(gateways) == 0 {
+		return fmt.Errorf("Direct Connect Gateway not found for name: %s", name)
+	}
+
+	if len(gateways) > 1 {
+		return fmt.Errorf("Multiple Direct Connect Gateways found for name: %s", name)
+	}
+
+	gateway := gateways[0]
+
+	d.SetId(aws.StringValue(gateway.DirectConnectGatewayId))
+	d.Set("amazon_side_asn", strconv.FormatInt(aws.Int64Value(gateway.AmazonSideAsn), 10))
+
+	return nil
+}

--- a/aws/data_source_aws_dx_gateway_test.go
+++ b/aws/data_source_aws_dx_gateway_test.go
@@ -1,0 +1,58 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceAwsDxGateway_Basic(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_dx_gateway.test"
+	datasourceName := "data.aws_dx_gateway.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataSourceAwsDxGatewayConfig_NonExistent,
+				ExpectError: regexp.MustCompile(`Direct Connect Gateway not found`),
+			},
+			{
+				Config: testAccDataSourceAwsDxGatewayConfig_Name(rName, randIntRange(64512, 65534)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "amazon_side_asn", resourceName, "amazon_side_asn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsDxGatewayConfig_Name(rName string, rBgpAsn int) string {
+	return fmt.Sprintf(`
+resource "aws_dx_gateway" "wrong" {
+  amazon_side_asn = "%d"
+  name            = "%s-wrong"
+}
+resource "aws_dx_gateway" "test" {
+  amazon_side_asn = "%d"
+  name            = "%s"
+}
+
+data "aws_dx_gateway" "test" {
+  name = "${aws_dx_gateway.test.name}"
+}
+`, rBgpAsn+1, rName, rBgpAsn, rName)
+}
+
+const testAccDataSourceAwsDxGatewayConfig_NonExistent = `
+data "aws_dx_gateway" "test" {
+  name = "tf-acc-test-does-not-exist"
+}
+`

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -182,6 +182,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_codecommit_repository":            dataSourceAwsCodeCommitRepository(),
 			"aws_db_instance":                      dataSourceAwsDbInstance(),
 			"aws_db_snapshot":                      dataSourceAwsDbSnapshot(),
+			"aws_dx_gateway":                       dataSourceAwsDxGateway(),
 			"aws_dynamodb_table":                   dataSourceAwsDynamoDbTable(),
 			"aws_ebs_snapshot":                     dataSourceAwsEbsSnapshot(),
 			"aws_ebs_snapshot_ids":                 dataSourceAwsEbsSnapshotIds(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -115,6 +115,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-db-snapshot") %>>
                           <a href="/docs/providers/aws/d/db_snapshot.html">aws_db_snapshot</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-dx-gateway") %>>
+                          <a href="/docs/providers/aws/d/dx_gateway.html">aws_dx_gateway</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-dynamodb-table") %>>
                           <a href="/docs/providers/aws/d/dynamodb_table.html">aws_dynamodb_table</a>
                         </li>

--- a/website/docs/d/dx_gateway.html.markdown
+++ b/website/docs/d/dx_gateway.html.markdown
@@ -1,0 +1,28 @@
+---
+layout: "aws"
+page_title: "AWS: aws_dx_gateway"
+sidebar_current: "docs-aws-datasource-dx-gateway"
+description: |-
+  Retrieve information about a Direct Connect Gateway
+---
+
+# Data Source: aws_dx_gateway
+
+Retrieve information about a Direct Connect Gateway.
+
+## Example Usage
+
+```hcl
+data "aws_dx_gateway" "example" {
+  name = "example"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The name of the gateway to retrieve.
+
+## Attributes Reference
+
+* `amazon_side_asn` - The ASN on the Amazon side of the connection.
+* `id` - The ID of the gateway.


### PR DESCRIPTION
Closes #4983

Changes proposed in this pull request:

* New data source: `aws_dx_gateway`

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsDxGateway_Basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccDataSourceAwsDxGateway_Basic -timeout 120m
=== RUN   TestAccDataSourceAwsDxGateway_Basic
--- PASS: TestAccDataSourceAwsDxGateway_Basic (35.88s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	35.921s
```
