### PR TITLE
removing optional schema reference

### DIFF
--- a/aws/resource_aws_api_gateway_account.go
+++ b/aws/resource_aws_api_gateway_account.go
@@ -22,21 +22,21 @@ func resourceAwsApiGatewayAccount() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"cloudwatch_role_arn": &schema.Schema{
+			"cloudwatch_role_arn": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"throttle_settings": &schema.Schema{
+			"throttle_settings": {
 				Type:     schema.TypeList,
 				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"burst_limit": &schema.Schema{
+						"burst_limit": {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
-						"rate_limit": &schema.Schema{
+						"rate_limit": {
 							Type:     schema.TypeFloat,
 							Computed: true,
 						},

--- a/aws/resource_aws_api_gateway_api_key.go
+++ b/aws/resource_aws_api_gateway_api_key.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/apigateway"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -98,7 +97,7 @@ func resourceAwsApiGatewayApiKeyCreate(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error creating API Gateway: %s", err)
 	}
 
-	d.SetId(*apiKey.Id)
+	d.SetId(aws.StringValue(apiKey.Id))
 
 	return resourceAwsApiGatewayApiKeyRead(d, meta)
 }
@@ -112,7 +111,7 @@ func resourceAwsApiGatewayApiKeyRead(d *schema.ResourceData, meta interface{}) e
 		IncludeValue: aws.Bool(true),
 	})
 	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NotFoundException" {
+		if isAWSErr(err, apigateway.ErrCodeNotFoundException, "") {
 			log.Printf("[WARN] API Gateway API Key (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
@@ -195,8 +194,10 @@ func resourceAwsApiGatewayApiKeyDelete(d *schema.ResourceData, meta interface{})
 			return nil
 		}
 
-		if apigatewayErr, ok := err.(awserr.Error); ok && apigatewayErr.Code() == "NotFoundException" {
-			return nil
+		if err != nil {
+			if isAWSErr(err, apigateway.ErrCodeNotFoundException, "") {
+				return nil
+			}
 		}
 
 		return resource.NonRetryableError(err)


### PR DESCRIPTION
Output from acceptance testing:

```
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSAPIGatewayApiKey_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAWSAPIGatewayApiKey_basic -timeout 120m
=== RUN   TestAccAWSAPIGatewayApiKey_basic
--- PASS: TestAccAWSAPIGatewayApiKey_basic (65.46s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	65.501s

$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSAPIGatewayAccount_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAWSAPIGatewayAccount_basic -timeout 120m
=== RUN   TestAccAWSAPIGatewayAccount_basic
--- PASS: TestAccAWSAPIGatewayAccount_basic (157.51s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	157.549s
...
```
