### PR TITLE
Adding additional note to kms_key_arn attribute

### DIFF
--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -82,7 +82,7 @@ large files efficiently.
 * `publish` - (Optional) Whether to publish creation/change as new Lambda Function Version. Defaults to `false`.
 * `vpc_config` - (Optional) Provide this to allow your function to access your VPC. Fields documented below. See [Lambda in VPC][7]
 * `environment` - (Optional) The Lambda environment's configuration settings. Fields documented below.
-* `kms_key_arn` - (Optional) The ARN for the KMS encryption key.
+* `kms_key_arn` - (Optional) The ARN for the KMS encryption key. If used without optional `environment` attribute, may lead to resource not creating.
 * `source_code_hash` - (Optional) Used to trigger updates. Must be set to a base64-encoded SHA256 hash of the package file specified with either `filename` or `s3_key`. The usual way to set this is `${base64sha256(file("file.zip"))}`, where "file.zip" is the local filename of the lambda function source archive.
 * `tags` - (Optional) A mapping of tags to assign to the object.
 


### PR DESCRIPTION
I ran into an issue that if you include the ksm_key_arn without adding something for it to actually encrypt (such as ENV vars) the resource will silently fail to build during the plan phase and will instead throw an error if the resource is used as a variable in another declaration. I propose the documentation be updated to help save people hours of confusion.

the offending error returned because of this issue is:

```
aws_lambda_event_source_mapping.my_mapping: Resource 'aws_lambda_function.my_function' not found for variable 'a
ws_lambda_function.my_function'