### PR TITLE
Update the AppSync DataSource types documentation

### DIFF
--- a/website/docs/r/appsync_datasource.html.markdown
+++ b/website/docs/r/appsync_datasource.html.markdown
@@ -88,7 +88,7 @@ The following arguments are supported:
 
 * `api_id` - (Required) The API ID for the GraphQL API for the DataSource.
 * `name` - (Required) A user-supplied name for the DataSource.
-* `type` - (Required) The type of the DataSource. Valid values: `AWS_LAMBDA`, `AMAZON_DYNAMODB` and `AMAZON_ELASTICSEARCH`
+* `type` - (Required) The type of the DataSource. Valid values: `AWS_LAMBDA`, `AMAZON_DYNAMODB` and `AMAZON_ELASTICSEARCH`, `NONE`.
 * `description` - (Optional) A description of the DataSource.
 * `service_role_arn` - (Optional) The IAM service role ARN for the data source.
 * `dynamodb_config` - (Optional) DynamoDB settings. See [below](#dynamodb_config)


### PR DESCRIPTION
As per [the SDK](https://github.com/terraform-providers/terraform-provider-aws/blob/master/vendor/github.com/aws/aws-sdk-go/service/appsync/api.go#L5812), it is possible to set the AppSync DataStore as `NONE`.
The [current code also allows it](https://github.com/terraform-providers/terraform-provider-aws/blob/master/aws/resource_aws_appsync_datasource.go#L45).