### PR TITLE
add import for aws_eip_association

### DIFF
--- a/aws/resource_aws_eip_association.go
+++ b/aws/resource_aws_eip_association.go
@@ -18,6 +18,9 @@ func resourceAwsEipAssociation() *schema.Resource {
 		Create: resourceAwsEipAssociationCreate,
 		Read:   resourceAwsEipAssociationRead,
 		Delete: resourceAwsEipAssociationDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"allocation_id": &schema.Schema{

--- a/website/docs/r/eip_association.html.markdown
+++ b/website/docs/r/eip_association.html.markdown
@@ -68,3 +68,11 @@ address with an instance.
 * `network_interface_id` - As above
 * `private_ip_address` - As above
 * `public_ip` - As above
+
+## Import
+
+EIP Assocations can be imported using their association ID.
+
+```
+$ terraform import aws_eip_association.test eipassoc-ab12c345
+```


### PR DESCRIPTION
Fixes #4876

Changes proposed in this pull request:

* Add import to aws_eip_association

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSEIPAssociation_import'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSEIPAssociation_import -timeout 120m
=== RUN   TestAccAWSEIPAssociation_importInstance
--- PASS: TestAccAWSEIPAssociation_importInstance (243.58s)
=== RUN   TestAccAWSEIPAssociation_importNetworkInterface
--- PASS: TestAccAWSEIPAssociation_importNetworkInterface (39.74s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	283.357s
```
