### PR TITLE
New Resource: aws_s3_bucket_inventory

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -559,6 +559,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_s3_bucket_object":                             resourceAwsS3BucketObject(),
 			"aws_s3_bucket_notification":                       resourceAwsS3BucketNotification(),
 			"aws_s3_bucket_metric":                             resourceAwsS3BucketMetric(),
+			"aws_s3_bucket_inventory":                          resourceAwsS3BucketInventory(),
 			"aws_security_group":                               resourceAwsSecurityGroup(),
 			"aws_network_interface_sg_attachment":              resourceAwsNetworkInterfaceSGAttachment(),
 			"aws_default_security_group":                       resourceAwsDefaultSecurityGroup(),

--- a/aws/resource_aws_s3_bucket_inventory.go
+++ b/aws/resource_aws_s3_bucket_inventory.go
@@ -1,0 +1,451 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func resourceAwsS3BucketInventory() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsS3BucketInventoryPut,
+		Read:   resourceAwsS3BucketInventoryRead,
+		Update: resourceAwsS3BucketInventoryPut,
+		Delete: resourceAwsS3BucketInventoryDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"bucket": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateMaxLength(64),
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Default:  true,
+				Optional: true,
+			},
+			"filter": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"prefix": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"destination": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				MinItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"bucket": {
+							Type:     schema.TypeList,
+							Required: true,
+							MaxItems: 1,
+							MinItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"format": {
+										Type:     schema.TypeString,
+										Required: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											s3.InventoryFormatCsv,
+											s3.InventoryFormatOrc,
+										}, false),
+									},
+									"bucket_arn": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validateArn,
+									},
+									"account_id": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"prefix": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"encryption": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"sse_kms": &schema.Schema{
+													Type:          schema.TypeList,
+													Optional:      true,
+													MaxItems:      1,
+													ConflictsWith: []string{"destination.0.bucket.0.encryption.0.sse_s3"},
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"key_id": {
+																Type:         schema.TypeString,
+																Required:     true,
+																ValidateFunc: validateArn,
+															},
+														},
+													},
+												},
+												"sse_s3": &schema.Schema{
+													Type:          schema.TypeList,
+													Optional:      true,
+													MaxItems:      1,
+													ConflictsWith: []string{"destination.0.bucket.0.encryption.0.sse_kms"},
+													Elem: &schema.Resource{
+														// No options currently; just existence of "sse_s3".
+														Schema: map[string]*schema.Schema{},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"schedule": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				MinItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"frequency": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								s3.InventoryFrequencyDaily,
+								s3.InventoryFrequencyWeekly,
+							}, false),
+						},
+					},
+				},
+			},
+			// TODO: Is there a sensible default for this?
+			"included_object_versions": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					s3.InventoryIncludedObjectVersionsCurrent,
+					s3.InventoryIncludedObjectVersionsAll,
+				}, false),
+			},
+			"optional_fields": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					ValidateFunc: validation.StringInSlice([]string{
+						s3.InventoryOptionalFieldSize,
+						s3.InventoryOptionalFieldLastModifiedDate,
+						s3.InventoryOptionalFieldStorageClass,
+						s3.InventoryOptionalFieldEtag,
+						s3.InventoryOptionalFieldIsMultipartUploaded,
+						s3.InventoryOptionalFieldReplicationStatus,
+						s3.InventoryOptionalFieldEncryptionStatus,
+					}, false),
+				},
+				Set: schema.HashString,
+			},
+		},
+	}
+}
+
+func resourceAwsS3BucketInventoryPut(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).s3conn
+	bucket := d.Get("bucket").(string)
+	name := d.Get("name").(string)
+
+	inventoryConfiguration := &s3.InventoryConfiguration{
+		Id:        aws.String(name),
+		IsEnabled: aws.Bool(d.Get("enabled").(bool)),
+	}
+
+	if v, ok := d.GetOk("included_object_versions"); ok {
+		inventoryConfiguration.IncludedObjectVersions = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("optional_fields"); ok {
+		inventoryConfiguration.OptionalFields = expandStringList(v.(*schema.Set).List())
+	}
+
+	if v, ok := d.GetOk("schedule"); ok {
+		scheduleList := v.([]interface{})
+		scheduleMap := scheduleList[0].(map[string]interface{})
+		inventoryConfiguration.Schedule = &s3.InventorySchedule{
+			Frequency: aws.String(scheduleMap["frequency"].(string)),
+		}
+	}
+
+	if v, ok := d.GetOk("filter"); ok {
+		filterList := v.([]interface{})
+		filterMap := filterList[0].(map[string]interface{})
+		inventoryConfiguration.Filter = expandS3InventoryFilter(filterMap)
+	}
+
+	if v, ok := d.GetOk("destination"); ok {
+		destinationList := v.([]interface{})
+		destinationMap := destinationList[0].(map[string]interface{})
+		bucketList := destinationMap["bucket"].([]interface{})
+		bucketMap := bucketList[0].(map[string]interface{})
+
+		inventoryConfiguration.Destination = &s3.InventoryDestination{
+			S3BucketDestination: expandS3InventoryS3BucketDestination(bucketMap),
+		}
+	}
+
+	input := &s3.PutBucketInventoryConfigurationInput{
+		Bucket: aws.String(bucket),
+		Id:     aws.String(name),
+		InventoryConfiguration: inventoryConfiguration,
+	}
+
+	log.Printf("[DEBUG] Putting S3 bucket inventory configuration: %s", input)
+	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+		_, err := conn.PutBucketInventoryConfiguration(input)
+		if err != nil {
+			if isAWSErr(err, s3.ErrCodeNoSuchBucket, "") {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("Error putting S3 bucket inventory configuration: %s", err)
+	}
+
+	d.SetId(fmt.Sprintf("%s:%s", bucket, name))
+
+	return resourceAwsS3BucketInventoryRead(d, meta)
+}
+
+func resourceAwsS3BucketInventoryDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).s3conn
+
+	bucket, name, err := resourceAwsS3BucketInventoryParseID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	input := &s3.DeleteBucketInventoryConfigurationInput{
+		Bucket: aws.String(bucket),
+		Id:     aws.String(name),
+	}
+
+	log.Printf("[DEBUG] Deleting S3 bucket inventory configuration: %s", input)
+	_, err = conn.DeleteBucketInventoryConfiguration(input)
+	if err != nil {
+		if isAWSErr(err, s3.ErrCodeNoSuchBucket, "") || isAWSErr(err, "NoSuchConfiguration", "The specified configuration does not exist.") {
+			return nil
+		}
+		return fmt.Errorf("Error deleting S3 bucket inventory configuration: %s", err)
+	}
+
+	return nil
+}
+
+func resourceAwsS3BucketInventoryRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).s3conn
+
+	bucket, name, err := resourceAwsS3BucketInventoryParseID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	d.Set("bucket", bucket)
+	d.Set("name", name)
+
+	input := &s3.GetBucketInventoryConfigurationInput{
+		Bucket: aws.String(bucket),
+		Id:     aws.String(name),
+	}
+
+	log.Printf("[DEBUG] Reading S3 bucket inventory configuration: %s", input)
+	output, err := conn.GetBucketInventoryConfiguration(input)
+	if err != nil {
+		if isAWSErr(err, s3.ErrCodeNoSuchBucket, "") || isAWSErr(err, "NoSuchConfiguration", "The specified configuration does not exist.") {
+			log.Printf("[WARN] %s S3 bucket inventory configuration not found, removing from state.", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	d.Set("enabled", aws.BoolValue(output.InventoryConfiguration.IsEnabled))
+	d.Set("included_object_versions", aws.StringValue(output.InventoryConfiguration.IncludedObjectVersions))
+
+	if err := d.Set("optional_fields", flattenStringList(output.InventoryConfiguration.OptionalFields)); err != nil {
+		return fmt.Errorf("error setting optional_fields: %s", err)
+	}
+
+	if err := d.Set("filter", flattenS3InventoryFilter(output.InventoryConfiguration.Filter)); err != nil {
+		return fmt.Errorf("error setting filter: %s", err)
+	}
+
+	if err := d.Set("schedule", flattenS3InventorySchedule(output.InventoryConfiguration.Schedule)); err != nil {
+		return fmt.Errorf("error setting schedule: %s", err)
+	}
+
+	if output.InventoryConfiguration.Destination != nil {
+		destination := map[string]interface{}{
+			"bucket": flattenS3InventoryS3BucketDestination(output.InventoryConfiguration.Destination.S3BucketDestination),
+		}
+
+		if err := d.Set("destination", []map[string]interface{}{destination}); err != nil {
+			return fmt.Errorf("error setting destination: %s", err)
+		}
+	}
+
+	return nil
+}
+
+func expandS3InventoryFilter(m map[string]interface{}) *s3.InventoryFilter {
+	v, ok := m["prefix"]
+	if !ok {
+		return nil
+	}
+	return &s3.InventoryFilter{
+		Prefix: aws.String(v.(string)),
+	}
+}
+
+func flattenS3InventoryFilter(filter *s3.InventoryFilter) []map[string]interface{} {
+	if filter == nil {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, 1)
+
+	m := make(map[string]interface{}, 0)
+	if filter.Prefix != nil {
+		m["prefix"] = aws.StringValue(filter.Prefix)
+	}
+
+	result = append(result, m)
+
+	return result
+}
+
+func flattenS3InventorySchedule(schedule *s3.InventorySchedule) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, 1)
+
+	m := make(map[string]interface{}, 1)
+	m["frequency"] = aws.StringValue(schedule.Frequency)
+
+	result = append(result, m)
+
+	return result
+}
+
+func expandS3InventoryS3BucketDestination(m map[string]interface{}) *s3.InventoryS3BucketDestination {
+	destination := &s3.InventoryS3BucketDestination{
+		Format: aws.String(m["format"].(string)),
+		Bucket: aws.String(m["bucket_arn"].(string)),
+	}
+
+	if v, ok := m["account_id"]; ok && v.(string) != "" {
+		destination.AccountId = aws.String(v.(string))
+	}
+
+	if v, ok := m["prefix"]; ok && v.(string) != "" {
+		destination.Prefix = aws.String(v.(string))
+	}
+
+	if v, ok := m["encryption"].([]interface{}); ok && len(v) > 0 {
+		encryptionMap := v[0].(map[string]interface{})
+
+		encryption := &s3.InventoryEncryption{}
+
+		for k, v := range encryptionMap {
+			data := v.([]interface{})
+
+			if len(data) == 0 {
+				continue
+			}
+
+			switch k {
+			case "sse_kms":
+				m := data[0].(map[string]interface{})
+				encryption.SSEKMS = &s3.SSEKMS{
+					KeyId: aws.String(m["key_id"].(string)),
+				}
+			case "sse_s3":
+				encryption.SSES3 = &s3.SSES3{}
+			}
+		}
+
+		destination.Encryption = encryption
+	}
+
+	return destination
+}
+
+func flattenS3InventoryS3BucketDestination(destination *s3.InventoryS3BucketDestination) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, 1)
+
+	m := map[string]interface{}{
+		"format":     aws.StringValue(destination.Format),
+		"bucket_arn": aws.StringValue(destination.Bucket),
+	}
+
+	if destination.AccountId != nil {
+		m["account_id"] = aws.StringValue(destination.AccountId)
+	}
+	if destination.Prefix != nil {
+		m["prefix"] = aws.StringValue(destination.Prefix)
+	}
+
+	if destination.Encryption != nil {
+		encryption := make(map[string]interface{}, 1)
+		if destination.Encryption.SSES3 != nil {
+			encryption["sse_s3"] = []map[string]interface{}{{}}
+		} else if destination.Encryption.SSEKMS != nil {
+			encryption["sse_kms"] = []map[string]interface{}{
+				{
+					"key_id": aws.StringValue(destination.Encryption.SSEKMS.KeyId),
+				},
+			}
+		}
+		m["encryption"] = []map[string]interface{}{encryption}
+	}
+
+	result = append(result, m)
+
+	return result
+}
+
+func resourceAwsS3BucketInventoryParseID(id string) (string, string, error) {
+	idParts := strings.Split(id, ":")
+	if len(idParts) != 2 {
+		return "", "", fmt.Errorf("please make sure the ID is in the form BUCKET:NAME (i.e. my-bucket:EntireBucket")
+	}
+	bucket := idParts[0]
+	name := idParts[1]
+	return bucket, name, nil
+}

--- a/aws/resource_aws_s3_bucket_inventory_test.go
+++ b/aws/resource_aws_s3_bucket_inventory_test.go
@@ -1,0 +1,296 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSS3BucketInventory_basic(t *testing.T) {
+	var conf s3.InventoryConfiguration
+	rString := acctest.RandString(8)
+	resourceName := "aws_s3_bucket_inventory.test"
+
+	bucketName := fmt.Sprintf("tf-acc-bucket-inventory-%s", rString)
+	inventoryName := t.Name()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketInventoryDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSS3BucketInventoryConfig(bucketName, inventoryName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketInventoryConfigExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "bucket", bucketName),
+					resource.TestCheckNoResourceAttr(resourceName, "filter"),
+					resource.TestCheckResourceAttr(resourceName, "name", inventoryName),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "included_object_versions", "All"),
+
+					resource.TestCheckResourceAttr(resourceName, "optional_fields.#", "2"),
+
+					resource.TestCheckResourceAttr(resourceName, "schedule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "schedule.0.frequency", "Weekly"),
+
+					resource.TestCheckResourceAttr(resourceName, "destination.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "destination.0.bucket.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "destination.0.bucket.0.bucket_arn", "arn:aws:s3:::"+bucketName),
+					resource.TestCheckResourceAttrSet(resourceName, "destination.0.bucket.0.account_id"),
+					resource.TestCheckResourceAttr(resourceName, "destination.0.bucket.0.format", "ORC"),
+					resource.TestCheckResourceAttr(resourceName, "destination.0.bucket.0.prefix", "inventory"),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSS3BucketInventory_encryptWithSSES3(t *testing.T) {
+	var conf s3.InventoryConfiguration
+	rString := acctest.RandString(8)
+	resourceName := "aws_s3_bucket_inventory.test"
+
+	bucketName := fmt.Sprintf("tf-acc-bucket-inventory-%s", rString)
+	inventoryName := t.Name()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketInventoryDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSS3BucketInventoryConfigEncryptWithSSES3(bucketName, inventoryName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketInventoryConfigExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "destination.0.bucket.0.encryption.0.sse_s3.#", "1"),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSS3BucketInventory_encryptWithSSEKMS(t *testing.T) {
+	var conf s3.InventoryConfiguration
+	rString := acctest.RandString(8)
+	resourceName := "aws_s3_bucket_inventory.test"
+
+	bucketName := fmt.Sprintf("tf-acc-bucket-inventory-%s", rString)
+	inventoryName := t.Name()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketInventoryDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSS3BucketInventoryConfigEncryptWithSSEKMS(bucketName, inventoryName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketInventoryConfigExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "destination.0.bucket.0.encryption.0.sse_kms.#", "1"),
+					resource.TestMatchResourceAttr(resourceName, "destination.0.bucket.0.encryption.0.sse_kms.0.key_id", regexp.MustCompile("^arn:aws:kms:")),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSS3BucketInventoryConfigExists(n string, res *s3.InventoryConfiguration) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No S3 bucket inventory configuration ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).s3conn
+		bucket, name, err := resourceAwsS3BucketInventoryParseID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		input := &s3.GetBucketInventoryConfigurationInput{
+			Bucket: aws.String(bucket),
+			Id:     aws.String(name),
+		}
+		log.Printf("[DEBUG] Reading S3 bucket inventory configuration: %s", input)
+		output, err := conn.GetBucketInventoryConfiguration(input)
+		if err != nil {
+			return err
+		}
+
+		*res = *output.InventoryConfiguration
+
+		return nil
+	}
+}
+
+func testAccCheckAWSS3BucketInventoryDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).s3conn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_s3_bucket_inventory" {
+			continue
+		}
+
+		bucket, name, err := resourceAwsS3BucketInventoryParseID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+			input := &s3.GetBucketInventoryConfigurationInput{
+				Bucket: aws.String(bucket),
+				Id:     aws.String(name),
+			}
+			log.Printf("[DEBUG] Reading S3 bucket inventory configuration: %s", input)
+			output, err := conn.GetBucketInventoryConfiguration(input)
+			if err != nil {
+				if isAWSErr(err, s3.ErrCodeNoSuchBucket, "") || isAWSErr(err, "NoSuchConfiguration", "The specified configuration does not exist.") {
+					return nil
+				}
+				return resource.NonRetryableError(err)
+			}
+			if output.InventoryConfiguration != nil {
+				return resource.RetryableError(fmt.Errorf("S3 bucket inventory configuration exists: %v", output))
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func testAccAWSS3BucketInventoryConfigBucket(name string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "bucket" {
+  bucket = "%s"
+  acl    = "private"
+}
+`, name)
+}
+
+func testAccAWSS3BucketInventoryConfig(bucketName, inventoryName string) string {
+	return fmt.Sprintf(`
+%s
+data "aws_caller_identity" "current" {}
+
+resource "aws_s3_bucket_inventory" "test" {
+  bucket = "${aws_s3_bucket.bucket.id}"
+  name   = "%s"
+
+  included_object_versions = "All"
+
+  optional_fields = [
+    "Size",
+    "LastModifiedDate",
+  ]
+
+  filter {
+    prefix = "documents/"
+  }
+
+  schedule {
+    frequency = "Weekly"
+  }
+
+  destination {
+    bucket {
+      format = "ORC"
+      bucket_arn = "${aws_s3_bucket.bucket.arn}"
+      account_id = "${data.aws_caller_identity.current.account_id}"
+      prefix = "inventory"
+    }
+  }
+}
+`, testAccAWSS3BucketMetricsConfigBucket(bucketName), inventoryName)
+}
+
+func testAccAWSS3BucketInventoryConfigEncryptWithSSES3(bucketName, inventoryName string) string {
+	return fmt.Sprintf(`
+%s
+resource "aws_s3_bucket_inventory" "test" {
+  bucket = "${aws_s3_bucket.bucket.id}"
+  name   = "%s"
+
+  included_object_versions = "Current"
+
+  schedule {
+    frequency = "Daily"
+  }
+
+  destination {
+    bucket {
+      format = "CSV"
+      bucket_arn = "${aws_s3_bucket.bucket.arn}"
+
+      encryption {
+        sse_s3 {}
+      }
+    }
+  }
+}
+`, testAccAWSS3BucketMetricsConfigBucket(bucketName), inventoryName)
+}
+
+func testAccAWSS3BucketInventoryConfigEncryptWithSSEKMS(bucketName, inventoryName string) string {
+	return fmt.Sprintf(`
+%s
+resource "aws_kms_key" "inventory" {
+  description             = "Terraform acc test S3 inventory SSE-KMS encryption: %s"
+  deletion_window_in_days = 7
+}
+
+resource "aws_s3_bucket_inventory" "test" {
+  bucket = "${aws_s3_bucket.bucket.id}"
+  name   = "%s"
+
+  included_object_versions = "Current"
+
+  schedule {
+    frequency = "Daily"
+  }
+
+  destination {
+    bucket {
+      format = "ORC"
+      bucket_arn = "${aws_s3_bucket.bucket.arn}"
+
+      encryption {
+        sse_kms {
+          key_id = "${aws_kms_key.inventory.arn}"
+        }
+      }
+    }
+  }
+}
+`, testAccAWSS3BucketMetricsConfigBucket(bucketName), bucketName, inventoryName)
+}

--- a/aws/resource_aws_s3_bucket_inventory_test.go
+++ b/aws/resource_aws_s3_bucket_inventory_test.go
@@ -60,6 +60,8 @@ func TestAccAWSS3BucketInventory_basic(t *testing.T) {
 }
 
 func TestAccAWSS3BucketInventory_encryptWithSSES3(t *testing.T) {
+	t.Skip("SSE-S3 is not supported by the SDK.")
+
 	var conf s3.InventoryConfiguration
 	rString := acctest.RandString(8)
 	resourceName := "aws_s3_bucket_inventory.test"

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1861,6 +1861,10 @@
                             <a href="/docs/providers/aws/r/s3_bucket.html">aws_s3_bucket</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-s3-bucket-inventory") %>>
+                            <a href="/docs/providers/aws/r/s3_bucket_metric.html">aws_s3_bucket_inventory</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-aws-resource-s3-bucket-metric") %>>
                             <a href="/docs/providers/aws/r/s3_bucket_metric.html">aws_s3_bucket_metric</a>
                         </li>

--- a/website/docs/r/s3_bucket_inventory.html.markdown
+++ b/website/docs/r/s3_bucket_inventory.html.markdown
@@ -111,6 +111,8 @@ The `bucket` configuration supports the following:
 
 The `encryption` configuration supports the following:
 
+~> **NOTE:** `sse_s3` is currently unsupported.
+
 * `sse_kms` - (Optional) Specifies to use server-side encryption with AWS KMS-managed keys to encrypt the inventory file (documented below).
 * `sse_s3` - (Optional) Specifies to use server-side encryption with Amazon S3-managed keys (SSE-S3) to encrypt the inventory file.
 

--- a/website/docs/r/s3_bucket_inventory.html.markdown
+++ b/website/docs/r/s3_bucket_inventory.html.markdown
@@ -1,0 +1,127 @@
+---
+layout: "aws"
+page_title: "AWS: aws_s3_bucket_inventory"
+sidebar_current: "docs-aws-resource-s3-bucket-inventory"
+description: |-
+  Provides a S3 bucket inventory configuration resource.
+---
+
+# aws_s3_bucket_inventory
+
+Provides a S3 bucket [inventory configuration](https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-inventory.html) resource.
+
+## Example Usage
+
+### Add inventory configuration
+
+```hcl
+resource "aws_s3_bucket" "test" {
+  bucket = "my-tf-test-bucket"
+}
+
+resource "aws_s3_bucket" "inventory" {
+  bucket = "my-tf-inventory-bucket"
+}
+
+resource "aws_s3_bucket_inventory" "test" {
+  bucket = "${aws_s3_bucket.test.id}"
+  name   = "EntireBucketDaily"
+
+  included_object_versions = "All"
+
+  schedule {
+    frequency = "Daily"
+  }
+
+  destination {
+    bucket {
+      format = "ORC"
+      bucket_arn = "${aws_s3_bucket.inventory.arn}"
+    }
+}
+```
+
+### Add inventory configuration with S3 bucket object prefix
+
+```hcl
+resource "aws_s3_bucket" "test" {
+  bucket = "my-tf-test-bucket"
+}
+
+resource "aws_s3_bucket" "inventory" {
+  bucket = "my-tf-inventory-bucket"
+}
+
+resource "aws_s3_bucket_inventory" "test-prefix" {
+  bucket = "${aws_s3_bucket.test.id}"
+  name   = "DocumentsWeekly"
+
+  included_object_versions = "Weekly"
+
+  schedule {
+    frequency = "Daily"
+  }
+
+  filter {
+    prefix = "documents/"
+  }
+
+  destination {
+    bucket {
+      format = "ORC"
+      bucket = "${aws_s3_bucket.inventory.arn}"
+      prefix = "inventory"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `bucket` - (Required) The name of the bucket to put inventory configuration.
+* `name` - (Required) Unique identifier of the inventory configuration for the bucket.
+* `included_object_versions` - (Required) Object filtering that accepts a prefix (documented below). Can be `All` or `Current`.
+* `schedule` - (Required) Contains the frequency for generating inventory results (documented below).
+* `destination` - (Required) Destination bucket where inventory list files are written (documented below).
+* `enabled` - (Optional, Default: true) Specifies whether the inventory is enabled or disabled.
+* `filter` - (Optional) Object filtering that accepts a prefix (documented below).
+* `optional_fields` - (Optional) Contains the optional fields that are included in the inventory results.
+
+The `filter` configuration supports the following:
+
+* `prefix` - (Optional) Object prefix for filtering (singular).
+
+The `schedule` configuration supports the following:
+
+* `frequency` - (Required) Specifies how frequently inventory results are produced. Can be `Daily` or `Weekly`.
+
+The `destination` configuration supports the following:
+
+* `bucket` - (Required) The S3 bucket configuration where inventory results are published (documented below).
+
+The `bucket` configuration supports the following:
+
+* `bucket_arn` - (Required) The Amazon S3 bucket ARN of the destination.
+* `format` - (Required) Specifies the output format of the inventory results. Can be `CSV` or [`ORC`](https://orc.apache.org/).
+* `account_id` - (Optional) The ID of the account that owns the destination bucket. Recommended to be set to prevent problems if the destination bucket ownership changes.
+* `prefix` - (Optional) The prefix that is prepended to all inventory results.
+* `encryption` - (Optional) Contains the type of server-side encryption to use to encrypt the inventory (documented below).
+
+The `encryption` configuration supports the following:
+
+* `sse_kms` - (Optional) Specifies to use server-side encryption with AWS KMS-managed keys to encrypt the inventory file (documented below).
+* `sse_s3` - (Optional) Specifies to use server-side encryption with Amazon S3-managed keys (SSE-S3) to encrypt the inventory file.
+
+The `sse_kms` configuration supports the following:
+
+* `kms_id` - (Required) The ARN of the KMS customer master key (CMK) used to encrypt the inventory file.
+
+## Import
+
+S3 bucket inventory configurations can be imported using `bucket:inventory`, e.g.
+
+```
+$ terraform import aws_s3_bucket_inventory.my-bucket-entire-bucket my-bucket:EntireBucket
+```


### PR DESCRIPTION
Fixes #532

Changes proposed in this pull request:

* Introduces a new resource for managing [Amazon S3 Inventory](https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-inventory.html#storage-inventory-kms-key-policy).

Output from acceptance testing:

```
$ make testacc TESTARGS='-run TestAccAWSS3BucketInventory'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run TestAccAWSS3BucketInventory -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSS3BucketInventory_basic
--- PASS: TestAccAWSS3BucketInventory_basic (63.01s)
=== RUN   TestAccAWSS3BucketInventory_encryptWithSSES3
--- FAIL: TestAccAWSS3BucketInventory_encryptWithSSES3 (41.02s)
	testing.go:518: Step 0 error: Error applying: 1 error(s) occurred:
		
		* aws_s3_bucket_inventory.test: 1 error(s) occurred:
		
		* aws_s3_bucket_inventory.test: Error putting S3 bucket inventory configuration: MalformedXML: The XML you provided was not well-formed or did not validate against our published schema
			status code: 400, request id: 41C41887B3D56896, host id: ArmdzLF7RPfvH/UNpgddZ86+XmR6OLB+icTo6OkPiHe+k1vyz9vNS5TJ61KBC3VB2taNf+Lk8Pw=
=== RUN   TestAccAWSS3BucketInventory_encryptWithSSEKMS
--- PASS: TestAccAWSS3BucketInventory_encryptWithSSEKMS (99.58s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	203.657s
make: *** [testacc] Error 1
```

Pending:

- [x] Limitation in the AWS SDK prevents creating of resources with SSE-S3 encryption. See: https://github.com/aws/aws-sdk-go/issues/2015. **Note:** Resources with this enabled will fail to be imported or created until the underlying issue is resolved.