### PR TITLE
resource/aws_ssm_document: Support tagging

### DIFF
--- a/aws/resource_aws_ssm_document.go
+++ b/aws/resource_aws_ssm_document.go
@@ -141,6 +141,7 @@ func resourceAwsSsmDocument() *schema.Resource {
 					},
 				},
 			},
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -179,6 +180,10 @@ func resourceAwsSsmDocumentCreate(d *schema.ResourceData, meta interface{}) erro
 		}
 	} else {
 		log.Printf("[DEBUG] Not setting permissions for %q", d.Id())
+	}
+
+	if err := setTagsSSM(ssmconn, d, d.Id(), ssm.ResourceTypeForTaggingDocument); err != nil {
+		return fmt.Errorf("error setting SSM Document tags: %s", err)
 	}
 
 	return resourceAwsSsmDocumentRead(d, meta)
@@ -271,10 +276,26 @@ func resourceAwsSsmDocumentRead(d *schema.ResourceData, meta interface{}) error 
 		return err
 	}
 
+	tagList, err := ssmconn.ListTagsForResource(&ssm.ListTagsForResourceInput{
+		ResourceId:   aws.String(d.Id()),
+		ResourceType: aws.String(ssm.ResourceTypeForTaggingDocument),
+	})
+	if err != nil {
+		return fmt.Errorf("error listing SSM Document tags for %s: %s", d.Id(), err)
+	}
+	d.Set("tags", tagsToMapSSM(tagList.TagList))
+
 	return nil
 }
 
 func resourceAwsSsmDocumentUpdate(d *schema.ResourceData, meta interface{}) error {
+	ssmconn := meta.(*AWSClient).ssmconn
+
+	if d.HasChange("tags") {
+		if err := setTagsSSM(ssmconn, d, d.Id(), ssm.ResourceTypeForTaggingDocument); err != nil {
+			return fmt.Errorf("error setting SSM Document tags: %s", err)
+		}
+	}
 
 	if _, ok := d.GetOk("permissions"); ok {
 		if err := setDocumentPermissions(d, meta); err != nil {

--- a/aws/resource_aws_ssm_document_test.go
+++ b/aws/resource_aws_ssm_document_test.go
@@ -27,6 +27,7 @@ func TestAccAWSSSMDocument_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_ssm_document.foo", "document_format", "JSON"),
 					resource.TestMatchResourceAttr("aws_ssm_document.foo", "arn",
 						regexp.MustCompile(`^arn:aws:ssm:[a-z]{2}-[a-z]+-\d{1}:\d{12}:document/.*$`)),
+					resource.TestCheckResourceAttr("aws_ssm_document.foo", "tags.%", "0"),
 				),
 			},
 		},
@@ -178,6 +179,44 @@ mainSteps:
 					testAccCheckAWSSSMDocumentExists("aws_ssm_document.foo"),
 					resource.TestCheckResourceAttr("aws_ssm_document.foo", "content", content2+"\n"),
 					resource.TestCheckResourceAttr("aws_ssm_document.foo", "document_format", "YAML"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSSMDocument_Tags(t *testing.T) {
+	rName := acctest.RandString(10)
+	resourceName := "aws_ssm_document.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMDocumentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSSMDocumentConfig_Tags_Single(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMDocumentExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				Config: testAccAWSSSMDocumentConfig_Tags_Multiple(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMDocumentExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSSSMDocumentConfig_Tags_Single(rName, "key2", "value2updated"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMDocumentExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2updated"),
 				),
 			},
 		},
@@ -517,4 +556,71 @@ resource "aws_ssm_document" "foo" {
 DOC
 }
 `, rName, content)
+}
+
+func testAccAWSSSMDocumentConfig_Tags_Single(rName, key1, value1 string) string {
+	return fmt.Sprintf(`
+resource "aws_ssm_document" "foo" {
+  document_type = "Command"
+  name          = "test_document-%s"
+
+  content = <<DOC
+    {
+      "schemaVersion": "1.2",
+      "description": "Check ip configuration of a Linux instance.",
+      "parameters": {
+
+      },
+      "runtimeConfig": {
+        "aws:runShellScript": {
+          "properties": [
+            {
+              "id": "0.aws:runShellScript",
+              "runCommand": ["ifconfig"]
+            }
+          ]
+        }
+      }
+    }
+DOC
+
+  tags {
+    %s = %q
+  }
+}
+`, rName, key1, value1)
+}
+
+func testAccAWSSSMDocumentConfig_Tags_Multiple(rName, key1, value1, key2, value2 string) string {
+	return fmt.Sprintf(`
+resource "aws_ssm_document" "foo" {
+  document_type = "Command"
+  name          = "test_document-%s"
+
+  content = <<DOC
+    {
+      "schemaVersion": "1.2",
+      "description": "Check ip configuration of a Linux instance.",
+      "parameters": {
+
+      },
+      "runtimeConfig": {
+        "aws:runShellScript": {
+          "properties": [
+            {
+              "id": "0.aws:runShellScript",
+              "runCommand": ["ifconfig"]
+            }
+          ]
+        }
+      }
+    }
+DOC
+
+  tags {
+    %s = %q
+    %s = %q
+  }
+}
+`, rName, key1, value1, key2, value2)
 }

--- a/website/docs/r/ssm_document.html.markdown
+++ b/website/docs/r/ssm_document.html.markdown
@@ -52,6 +52,7 @@ The following arguments are supported:
 * `document_format` - (Optional, defaults to JSON) The format of the document. Valid document types include: `JSON` and `YAML`
 * `document_type` - (Required) The type of the document. Valid document types include: `Command`, `Policy` and `Automation`
 * `permissions` - (Optional) Additional Permissions to attach to the document. See [Permissions](#permissions) below for details.
+* `tags` - (Optional) A mapping of tags to assign to the object.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Closes #5015 

Changes proposed in this pull request:

* Add `tags` argument to `aws_ssm_document` resource

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSSSMDocument'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSSSMDocument -timeout 120m
=== RUN   TestAccAWSSSMDocument_basic
--- PASS: TestAccAWSSSMDocument_basic (13.75s)
=== RUN   TestAccAWSSSMDocument_update
--- PASS: TestAccAWSSSMDocument_update (23.39s)
=== RUN   TestAccAWSSSMDocument_permission
--- PASS: TestAccAWSSSMDocument_permission (13.44s)
=== RUN   TestAccAWSSSMDocument_params
--- PASS: TestAccAWSSSMDocument_params (14.05s)
=== RUN   TestAccAWSSSMDocument_automation
--- PASS: TestAccAWSSSMDocument_automation (21.79s)
=== RUN   TestAccAWSSSMDocument_DocumentFormat_YAML
--- PASS: TestAccAWSSSMDocument_DocumentFormat_YAML (23.35s)
=== RUN   TestAccAWSSSMDocument_Tags
--- PASS: TestAccAWSSSMDocument_Tags (30.42s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	140.224s
```
