### PR TITLE
Make EventSourceMapping.starting_position optional.

### DIFF
--- a/aws/resource_aws_lambda_event_source_mapping.go
+++ b/aws/resource_aws_lambda_event_source_mapping.go
@@ -35,7 +35,7 @@ func resourceAwsLambdaEventSourceMapping() *schema.Resource {
 			},
 			"starting_position": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 			"batch_size": {

--- a/aws/resource_aws_lambda_event_source_mapping.go
+++ b/aws/resource_aws_lambda_event_source_mapping.go
@@ -178,10 +178,8 @@ func resourceAwsLambdaEventSourceMappingDelete(d *schema.ResourceData, meta inte
 	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
 		_, err := conn.DeleteEventSourceMapping(params)
 		if err != nil {
-			if awserr, ok := err.(awserr.Error); ok {
-				if awserr.Code() == "ResourceInUseException" {
-					return resource.RetryableError(awserr)
-				}
+			if isAWSErr(err, lambda.ErrCodeResourceInUseException, "") {
+				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)
 		}
@@ -212,12 +210,10 @@ func resourceAwsLambdaEventSourceMappingUpdate(d *schema.ResourceData, meta inte
 	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
 		_, err := conn.UpdateEventSourceMapping(params)
 		if err != nil {
-			if awserr, ok := err.(awserr.Error); ok {
-				if awserr.Code() == "InvalidParameterValueException" ||
-					awserr.Code() == "ResourceInUseException" {
+			if isAWSErr(err, lambda.ErrCodeInvalidParameterValueException, "") ||
+				isAWSErr(err, lambda.ErrCodeResourceInUseException, "") {
 
-					return resource.RetryableError(awserr)
-				}
+				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)
 		}

--- a/aws/resource_aws_lambda_event_source_mapping.go
+++ b/aws/resource_aws_lambda_event_source_mapping.go
@@ -41,7 +41,6 @@ func resourceAwsLambdaEventSourceMapping() *schema.Resource {
 			"batch_size": {
 				Type:     schema.TypeInt,
 				Optional: true,
-				Default:  100,
 			},
 			"enabled": {
 				Type:     schema.TypeBool,
@@ -89,11 +88,14 @@ func resourceAwsLambdaEventSourceMappingCreate(d *schema.ResourceData, meta inte
 	params := &lambda.CreateEventSourceMappingInput{
 		EventSourceArn: aws.String(eventSourceArn),
 		FunctionName:   aws.String(functionName),
-		BatchSize:      aws.Int64(int64(d.Get("batch_size").(int))),
 		Enabled:        aws.Bool(d.Get("enabled").(bool)),
 	}
 
-	if startingPosition := d.Get("starting_position"); startingPosition != "" {
+	if batchSize, ok := d.GetOk("batch_size"); ok {
+		params.BatchSize = aws.Int64(int64(batchSize.(int)))
+	}
+
+	if startingPosition, ok := d.GetOk("starting_position"); ok {
 		params.StartingPosition = aws.String(startingPosition.(string))
 	}
 

--- a/aws/resource_aws_lambda_event_source_mapping_test.go
+++ b/aws/resource_aws_lambda_event_source_mapping_test.go
@@ -33,14 +33,14 @@ func TestAccAWSLambdaEventSourceMapping_basic(t *testing.T) {
 		CheckDestroy: testAccCheckLambdaEventSourceMappingDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLambdaEventSourceMappingConfig(roleName, policyName, attName, streamName, funcName, uFuncName),
+				Config: testAccAWSLambdaEventSourceMappingConfig_kinesis(roleName, policyName, attName, streamName, funcName, uFuncName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaEventSourceMappingExists("aws_lambda_event_source_mapping.lambda_event_source_mapping_test", &conf),
 					testAccCheckAWSLambdaEventSourceMappingAttributes(&conf),
 				),
 			},
 			{
-				Config: testAccAWSLambdaEventSourceMappingConfigUpdate(roleName, policyName, attName, streamName, funcName, uFuncName),
+				Config: testAccAWSLambdaEventSourceMappingConfigUpdate_kinesis(roleName, policyName, attName, streamName, funcName, uFuncName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaEventSourceMappingExists("aws_lambda_event_source_mapping.lambda_event_source_mapping_test", &conf),
 					resource.TestCheckResourceAttr("aws_lambda_event_source_mapping.lambda_event_source_mapping_test",
@@ -49,6 +49,52 @@ func TestAccAWSLambdaEventSourceMapping_basic(t *testing.T) {
 						"enabled", strconv.FormatBool(false)),
 					resource.TestMatchResourceAttr("aws_lambda_event_source_mapping.lambda_event_source_mapping_test",
 						"function_arn", uFuncArnRe),
+					resource.TestCheckResourceAttr("aws_lambda_event_source_mapping.lambda_event_source_mapping_test",
+						"starting_position", "TRIM_HORIZON"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSLambdaEventSourceMapping_sqsBasic(t *testing.T) {
+	var conf lambda.EventSourceMappingConfiguration
+
+	rString := acctest.RandString(8)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_sqs_basic_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_lambda_sqs_basic_%s", rString)
+	attName := fmt.Sprintf("tf_acc_att_lambda_sqs_basic_%s", rString)
+	streamName := fmt.Sprintf("tf_acc_stream_lambda_sqs_basic_%s", rString)
+	funcName := fmt.Sprintf("tf_acc_lambda_sqs_basic_%s", rString)
+	uFuncName := fmt.Sprintf("tf_acc_lambda_sqs_basic_updated_%s", rString)
+	uFuncArnRe := regexp.MustCompile(":" + uFuncName + "$")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLambdaEventSourceMappingDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLambdaEventSourceMappingConfig_sqs(roleName, policyName, attName, streamName, funcName, uFuncName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsLambdaEventSourceMappingExists("aws_lambda_event_source_mapping.lambda_event_source_mapping_test", &conf),
+					testAccCheckAWSLambdaEventSourceMappingAttributes(&conf),
+					resource.TestCheckNoResourceAttr("aws_lambda_event_source_mapping.lambda_event_source_mapping_test",
+						"starting_position"),
+				),
+			},
+			{
+				Config: testAccAWSLambdaEventSourceMappingConfigUpdate_sqs(roleName, policyName, attName, streamName, funcName, uFuncName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsLambdaEventSourceMappingExists("aws_lambda_event_source_mapping.lambda_event_source_mapping_test", &conf),
+					resource.TestCheckResourceAttr("aws_lambda_event_source_mapping.lambda_event_source_mapping_test",
+						"batch_size", strconv.Itoa(5)),
+					resource.TestCheckResourceAttr("aws_lambda_event_source_mapping.lambda_event_source_mapping_test",
+						"enabled", strconv.FormatBool(false)),
+					resource.TestMatchResourceAttr("aws_lambda_event_source_mapping.lambda_event_source_mapping_test",
+						"function_arn", uFuncArnRe),
+					resource.TestCheckNoResourceAttr("aws_lambda_event_source_mapping.lambda_event_source_mapping_test",
+						"starting_position"),
 				),
 			},
 		},
@@ -72,7 +118,7 @@ func TestAccAWSLambdaEventSourceMapping_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckLambdaEventSourceMappingDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLambdaEventSourceMappingConfig(roleName, policyName, attName, streamName, funcName, uFuncName),
+				Config: testAccAWSLambdaEventSourceMappingConfig_kinesis(roleName, policyName, attName, streamName, funcName, uFuncName),
 			},
 
 			{
@@ -102,7 +148,35 @@ func TestAccAWSLambdaEventSourceMapping_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckLambdaEventSourceMappingDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLambdaEventSourceMappingConfig(roleName, policyName, attName, streamName, funcName, uFuncName),
+				Config: testAccAWSLambdaEventSourceMappingConfig_kinesis(roleName, policyName, attName, streamName, funcName, uFuncName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsLambdaEventSourceMappingExists("aws_lambda_event_source_mapping.lambda_event_source_mapping_test", &conf),
+					testAccCheckAWSLambdaEventSourceMappingDisappears(&conf),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSLambdaEventSourceMapping_sqsDisappears(t *testing.T) {
+	var conf lambda.EventSourceMappingConfiguration
+
+	rString := acctest.RandString(8)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_sqs_import_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_lambda_sqs_import_%s", rString)
+	attName := fmt.Sprintf("tf_acc_att_lambda_sqs_import_%s", rString)
+	streamName := fmt.Sprintf("tf_acc_stream_lambda_sqs_import_%s", rString)
+	funcName := fmt.Sprintf("tf_acc_lambda_sqs_import_%s", rString)
+	uFuncName := fmt.Sprintf("tf_acc_lambda_sqs_import_updated_%s", rString)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLambdaEventSourceMappingDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLambdaEventSourceMappingConfig_sqs(roleName, policyName, attName, streamName, funcName, uFuncName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaEventSourceMappingExists("aws_lambda_event_source_mapping.lambda_event_source_mapping_test", &conf),
 					testAccCheckAWSLambdaEventSourceMappingDisappears(&conf),
@@ -117,32 +191,49 @@ func testAccCheckAWSLambdaEventSourceMappingDisappears(conf *lambda.EventSourceM
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).lambdaconn
 
-		params := &lambda.DeleteEventSourceMappingInput{
-			UUID: conf.UUID,
-		}
-
-		_, err := conn.DeleteEventSourceMapping(params)
-		if err != nil {
-			if err != nil {
-				return err
+		err := resource.Retry(10*time.Minute, func() *resource.RetryError {
+			params := &lambda.DeleteEventSourceMappingInput{
+				UUID: conf.UUID,
 			}
+			_, err := conn.DeleteEventSourceMapping(params)
+			if err != nil {
+				cgw, ok := err.(awserr.Error)
+				if ok {
+					if cgw.Code() == "ResourceNotFoundException" {
+						return nil
+					}
+
+					if cgw.Code() == "ResourceInUseException" {
+						return resource.RetryableError(fmt.Errorf(
+							"Waiting for Lambda Event Source Mapping to delete: %v", conf.UUID))
+					}
+				}
+				return resource.NonRetryableError(
+					fmt.Errorf("Error deleting Lambda Event Source Mapping: %s", err))
+			}
+
+			return nil
+		})
+
+		if err != nil {
+			return err
 		}
 
 		return resource.Retry(10*time.Minute, func() *resource.RetryError {
 			params := &lambda.GetEventSourceMappingInput{
 				UUID: conf.UUID,
 			}
-			_, err := conn.GetEventSourceMapping(params)
+			_, err = conn.GetEventSourceMapping(params)
 			if err != nil {
 				cgw, ok := err.(awserr.Error)
 				if ok && cgw.Code() == "ResourceNotFoundException" {
 					return nil
 				}
 				return resource.NonRetryableError(
-					fmt.Errorf("Error retrieving Lambda Event Source Mapping: %s", err))
+					fmt.Errorf("Error getting Lambda Event Source Mapping: %s", err))
 			}
 			return resource.RetryableError(fmt.Errorf(
-				"Waiting for Lambda Event Source Mapping: %v", conf.UUID))
+				"Waiting to get Lambda Event Source Mapping: %v", conf.UUID))
 		})
 	}
 }
@@ -209,7 +300,7 @@ func testAccCheckAWSLambdaEventSourceMappingAttributes(mapping *lambda.EventSour
 	}
 }
 
-func testAccAWSLambdaEventSourceMappingConfig(roleName, policyName, attName, streamName,
+func testAccAWSLambdaEventSourceMappingConfig_kinesis(roleName, policyName, attName, streamName,
 	funcName, uFuncName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "iam_for_lambda" {
@@ -234,7 +325,7 @@ EOF
 resource "aws_iam_policy" "policy_for_role" {
     name = "%s"
     path = "/"
-    description = "IAM policy for for Lamda event mapping testing"
+    description = "IAM policy for for Lambda event mapping testing"
     policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -288,17 +379,18 @@ resource "aws_lambda_function" "lambda_function_test_update" {
 }
 
 resource "aws_lambda_event_source_mapping" "lambda_event_source_mapping_test" {
-		batch_size = 100
-		event_source_arn = "${aws_kinesis_stream.kinesis_stream_test.arn}"
-		enabled = true
-		depends_on = ["aws_iam_policy_attachment.policy_attachment_for_role"]
-		function_name = "${aws_lambda_function.lambda_function_test_create.arn}"
-		starting_position = "TRIM_HORIZON"
+    batch_size = 100
+    event_source_arn = "${aws_kinesis_stream.kinesis_stream_test.arn}"
+    enabled = true
+    depends_on = ["aws_iam_policy_attachment.policy_attachment_for_role"]
+    function_name = "${aws_lambda_function.lambda_function_test_create.arn}"
+    starting_position = "TRIM_HORIZON"
 }`, roleName, policyName, attName, streamName, funcName, uFuncName)
 }
 
-func testAccAWSLambdaEventSourceMappingConfigUpdate(roleName, policyName, attName, streamName,
+func testAccAWSLambdaEventSourceMappingConfigUpdate_kinesis(roleName, policyName, attName, streamName,
 	funcName, uFuncName string) string {
+
 	return fmt.Sprintf(`
 resource "aws_iam_role" "iam_for_lambda" {
     name = "%s"
@@ -322,7 +414,7 @@ EOF
 resource "aws_iam_policy" "policy_for_role" {
     name = "%s"
     path = "/"
-    description = "IAM policy for for Lamda event mapping testing"
+    description = "IAM policy for for Lambda event mapping testing"
     policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -376,11 +468,166 @@ resource "aws_lambda_function" "lambda_function_test_update" {
 }
 
 resource "aws_lambda_event_source_mapping" "lambda_event_source_mapping_test" {
-		batch_size = 200
-		event_source_arn = "${aws_kinesis_stream.kinesis_stream_test.arn}"
-		enabled = false
-		depends_on = ["aws_iam_policy_attachment.policy_attachment_for_role"]
-		function_name = "${aws_lambda_function.lambda_function_test_update.arn}"
-		starting_position = "TRIM_HORIZON"
+    batch_size = 200
+    event_source_arn = "${aws_kinesis_stream.kinesis_stream_test.arn}"
+    enabled = false
+    depends_on = ["aws_iam_policy_attachment.policy_attachment_for_role"]
+    function_name = "${aws_lambda_function.lambda_function_test_update.arn}"
+    starting_position = "TRIM_HORIZON"
+}`, roleName, policyName, attName, streamName, funcName, uFuncName)
+}
+
+func testAccAWSLambdaEventSourceMappingConfig_sqs(roleName, policyName, attName, streamName,
+	funcName, uFuncName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "iam_for_lambda" {
+    name = "%s"
+    assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "policy_for_role" {
+    name = "%s"
+    path = "/"
+    description = "IAM policy for for Lambda event mapping testing"
+    policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+      {
+          "Effect": "Allow",
+          "Action": [
+            "sqs:*"
+          ],
+          "Resource": "*"
+      }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy_attachment" "policy_attachment_for_role" {
+    name = "%s"
+    roles = ["${aws_iam_role.iam_for_lambda.name}"]
+    policy_arn = "${aws_iam_policy.policy_for_role.arn}"
+}
+
+resource "aws_sqs_queue" "sqs_queue_test" {
+    name = "%s"
+}
+
+resource "aws_lambda_function" "lambda_function_test_create" {
+    filename = "test-fixtures/lambdatest.zip"
+    function_name = "%s"
+    role = "${aws_iam_role.iam_for_lambda.arn}"
+    handler = "exports.example"
+    runtime = "nodejs4.3"
+}
+
+resource "aws_lambda_function" "lambda_function_test_update" {
+    filename = "test-fixtures/lambdatest.zip"
+    function_name = "%s"
+    role = "${aws_iam_role.iam_for_lambda.arn}"
+    handler = "exports.example"
+    runtime = "nodejs4.3"
+}
+
+resource "aws_lambda_event_source_mapping" "lambda_event_source_mapping_test" {
+    batch_size = 10
+    event_source_arn = "${aws_sqs_queue.sqs_queue_test.arn}"
+    enabled = true
+    depends_on = ["aws_iam_policy_attachment.policy_attachment_for_role"]
+    function_name = "${aws_lambda_function.lambda_function_test_create.arn}"
+}`, roleName, policyName, attName, streamName, funcName, uFuncName)
+}
+
+func testAccAWSLambdaEventSourceMappingConfigUpdate_sqs(roleName, policyName, attName, streamName,
+	funcName, uFuncName string) string {
+
+	return fmt.Sprintf(`
+resource "aws_iam_role" "iam_for_lambda" {
+    name = "%s"
+    assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "policy_for_role" {
+    name = "%s"
+    path = "/"
+    description = "IAM policy for for Lambda event mapping testing"
+    policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+      {
+          "Effect": "Allow",
+          "Action": [
+            "sqs:*"
+          ],
+          "Resource": "*"
+      }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy_attachment" "policy_attachment_for_role" {
+    name = "%s"
+    roles = ["${aws_iam_role.iam_for_lambda.name}"]
+    policy_arn = "${aws_iam_policy.policy_for_role.arn}"
+}
+
+resource "aws_sqs_queue" "sqs_queue_test" {
+    name = "%s"
+}
+
+resource "aws_lambda_function" "lambda_function_test_create" {
+    filename = "test-fixtures/lambdatest.zip"
+    function_name = "%s"
+    role = "${aws_iam_role.iam_for_lambda.arn}"
+    handler = "exports.example"
+    runtime = "nodejs4.3"
+}
+
+resource "aws_lambda_function" "lambda_function_test_update" {
+    filename = "test-fixtures/lambdatest.zip"
+    function_name = "%s"
+    role = "${aws_iam_role.iam_for_lambda.arn}"
+    handler = "exports.example"
+    runtime = "nodejs4.3"
+}
+
+resource "aws_lambda_event_source_mapping" "lambda_event_source_mapping_test" {
+    batch_size = 5
+    event_source_arn = "${aws_sqs_queue.sqs_queue_test.arn}"
+    enabled = false
+    depends_on = ["aws_iam_policy_attachment.policy_attachment_for_role"]
+    function_name = "${aws_lambda_function.lambda_function_test_update.arn}"
 }`, roleName, policyName, attName, streamName, funcName, uFuncName)
 }

--- a/aws/resource_aws_lambda_event_source_mapping_test.go
+++ b/aws/resource_aws_lambda_event_source_mapping_test.go
@@ -71,7 +71,6 @@ func TestAccAWSLambdaEventSourceMapping_kinesis_removeBatchSize(t *testing.T) {
 	streamName := fmt.Sprintf("tf_acc_stream_lambda_esm_basic_%s", rString)
 	funcName := fmt.Sprintf("tf_acc_lambda_esm_basic_%s", rString)
 	uFuncName := fmt.Sprintf("tf_acc_lambda_esm_basic_updated_%s", rString)
-	uFuncArnRe := regexp.MustCompile(":" + uFuncName + "$")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/aws/resource_aws_lambda_event_source_mapping_test.go
+++ b/aws/resource_aws_lambda_event_source_mapping_test.go
@@ -325,7 +325,7 @@ EOF
 resource "aws_iam_policy" "policy_for_role" {
     name = "%s"
     path = "/"
-    description = "IAM policy for for Lambda event mapping testing"
+    description = "IAM policy for Lambda event mapping testing"
     policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -414,7 +414,7 @@ EOF
 resource "aws_iam_policy" "policy_for_role" {
     name = "%s"
     path = "/"
-    description = "IAM policy for for Lambda event mapping testing"
+    description = "IAM policy for Lambda event mapping testing"
     policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -502,7 +502,7 @@ EOF
 resource "aws_iam_policy" "policy_for_role" {
     name = "%s"
     path = "/"
-    description = "IAM policy for for Lambda event mapping testing"
+    description = "IAM policy for Lambda event mapping testing"
     policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -580,7 +580,7 @@ EOF
 resource "aws_iam_policy" "policy_for_role" {
     name = "%s"
     path = "/"
-    description = "IAM policy for for Lambda event mapping testing"
+    description = "IAM policy for Lambda event mapping testing"
     policy = <<EOF
 {
   "Version": "2012-10-17",

--- a/website/docs/r/lambda_event_source_mapping.html.markdown
+++ b/website/docs/r/lambda_event_source_mapping.html.markdown
@@ -3,12 +3,12 @@ layout: "aws"
 page_title: "AWS: aws_lambda_event_source_mapping"
 sidebar_current: "docs-aws-resource-lambda-event-source-mapping"
 description: |-
-  Provides a Lambda event source mapping. This allows Lambda functions to get events from Kinesis and DynamoDB.
+  Provides a Lambda event source mapping. This allows Lambda functions to get events from Kinesis, DynamoDB and SQS
 ---
 
 # aws_lambda_event_source_mapping
 
-Provides a Lambda event source mapping. This allows Lambda functions to get events from Kinesis and DynamoDB.
+Provides a Lambda event source mapping. This allows Lambda functions to get events from Kinesis, DynamoDB and SQS
 
 For information about Lambda and how to use it, see [What is AWS Lambda?][1]
 For information about event source mappings, see [CreateEventSourceMapping][2] in the API docs.
@@ -31,7 +31,7 @@ resource "aws_lambda_event_source_mapping" "event_source_mapping" {
 * `event_source_arn` - (Required) The event source ARN - can either be a Kinesis or DynamoDB stream.
 * `enabled` - (Optional) Determines if the mapping will be enabled on creation. Defaults to `true`.
 * `function_name` - (Required) The name or the ARN of the Lambda function that will be subscribing to events.
-* `starting_position` - (Required) The position in the stream where AWS Lambda should start reading. Can be one of either `TRIM_HORIZON` or `LATEST`.
+* `starting_position` - (Optional) The position in the stream where AWS Lambda should start reading. Must be one of either `TRIM_HORIZON` or `LATEST` if getting events from Kinesis or DynamoDB.  Must not be provided if getting events from SQS.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Amazon recently made it possible to have SQS events trigger Lambdas.  See: https://aws.amazon.com/blogs/aws/aws-lambda-adds-amazon-simple-queue-service-to-supported-event-sources/ for more details. 

As part of this they specifically utilize CreateSourceEventMapping to describe the mapping between SQS and Lambda: https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html

*However*, as part of this, they changed the StartingPosition message property from required to optional.  You can see that it was previous required here: https://web.archive.org/web/20171222204154/https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html

```
StartingPosition
    The position in the stream where Lambda starts reading. For valid values, see CreateEventSourceMapping in the AWS Lambda Developer Guide.
    Required: Yes
    Type: String
    Update requires: Replacement
```

But now is optional in the current set of docs:

```
StartingPosition
    The position in the stream where Lambda starts reading. For valid values, see CreateEventSourceMapping in the AWS Lambda Developer Guide.
    Required: No
    Type: String
    Update requires: Replacement
```

Unfortunately, this makes is (afaict) impossible to use terraform to configure this EventSourceMapping.  If i leave out the starting_position property, terraform complains with:

```
Plan apply failed:
Error creating Lambda event source mapping: ValidationException: 1 validation error detected: Value '' at 'startingPosition' failed to satisfy constraint: Member must satisfy enum value set: [LATEST, AT_TIMESTAMP, TRIM_HORIZON]
```

However, if i supply any of those, AWS itself errors out with:

```
Plan apply failed: 
Error creating Lambda event source mapping: InvalidParameterValueException: StartingPosition is not valid for SQS event sources.
```

This PR attempts to rectify things by making this property optional to match current AWS expectations.

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/5025


Output from acceptance testing:

```
cyrusn@matebunty ~/go/src/github.com/terraform-providers/terraform-provider-aws[pulumi-master ≡]> make testacc TESTARGS='-run=TestAccAWSAvailabilityZones'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSAvailabilityZones -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSAvailabilityZones_basic
--- PASS: TestAccAWSAvailabilityZones_basic (28.19s)
=== RUN   TestAccAWSAvailabilityZones_stateFilter
--- PASS: TestAccAWSAvailabilityZones_stateFilter (29.25s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	57.462s```
