### PR TITLE
Issue #4266 add Type attribute in aws_spot_fleet_request

### DIFF
--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -319,6 +319,12 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validateRFC3339TimeString,
 			},
+			"fleet_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "maintain",
+				ForceNew: true,
+			},
 			"spot_request_state": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -600,6 +606,7 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 		TerminateInstancesWithExpiration: aws.Bool(d.Get("terminate_instances_with_expiration").(bool)),
 		ReplaceUnhealthyInstances:        aws.Bool(d.Get("replace_unhealthy_instances").(bool)),
 		InstanceInterruptionBehavior:     aws.String(d.Get("instance_interruption_behaviour").(string)),
+		Type: aws.String(d.Get("fleet_type").(string)),
 	}
 
 	if v, ok := d.GetOk("excess_capacity_termination_policy"); ok {
@@ -906,6 +913,7 @@ func resourceAwsSpotFleetRequestRead(d *schema.ResourceData, meta interface{}) e
 
 	d.Set("replace_unhealthy_instances", config.ReplaceUnhealthyInstances)
 	d.Set("instance_interruption_behaviour", config.InstanceInterruptionBehavior)
+	d.Set("fleet_type", config.Type)
 	d.Set("launch_specification", launchSpecsToSet(config.LaunchSpecifications, conn))
 
 	return nil

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -322,8 +322,12 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 			"fleet_type": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "maintain",
+				Default:  ec2.FleetTypeMaintain,
 				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					ec2.FleetTypeMaintain,
+					ec2.FleetTypeRequest,
+				}, false),
 			},
 			"spot_request_state": {
 				Type:     schema.TypeString,

--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -118,6 +118,8 @@ lowestPrice.
 * `instance_interruption_behaviour` - (Optional) Indicates whether a Spot
   instance stops or terminates when it is interrupted. Default is
   `terminate`.
+* `fleet_type` - (Optional) The type of fleet request. Indicates whether the Spot Fleet only requests the target
+  capacity or also attempts to maintain it. Default is `maintain`.
 * `valid_until` - (Optional) The end date and time of the request, in UTC [RFC3339](https://tools.ietf.org/html/rfc3339#section-5.8) format(for example, YYYY-MM-DDTHH:MM:SSZ). At this point, no new Spot instance requests are placed or enabled to fulfill the request. Defaults to 24 hours.
 * `valid_from` - (Optional) The start date and time of the request, in UTC [RFC3339](https://tools.ietf.org/html/rfc3339#section-5.8) format(for example, YYYY-MM-DDTHH:MM:SSZ). The default is to start fulfilling the request immediately.
 * `load_balancers` (Optional) A list of elastic load balancer names to add to the Spot fleet.


### PR DESCRIPTION

Fixes #4266

Changes proposed in this pull request:

* Change 1
added Type attribute in aws_spot_fleet_request

Output from acceptance testing:

```
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSSpotFleetRequest_fleetType'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAWSSpotFleetRequest_fleetType -timeout 120m
=== RUN   TestAccAWSSpotFleetRequest_fleetType
--- PASS: TestAccAWSSpotFleetRequest_fleetType (379.63s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	379.677s
...
```
