### PR TITLE
aws_route_tables data source filtering

### DIFF
--- a/aws/data_source_aws_route_tables.go
+++ b/aws/data_source_aws_route_tables.go
@@ -15,6 +15,8 @@ func dataSourceAwsRouteTables() *schema.Resource {
 		Read: dataSourceAwsRouteTablesRead,
 		Schema: map[string]*schema.Schema{
 
+			"filter": ec2CustomFiltersSchema(),
+
 			"tags": tagsSchemaComputed(),
 
 			"vpc_id": {
@@ -47,6 +49,10 @@ func dataSourceAwsRouteTablesRead(d *schema.ResourceData, meta interface{}) erro
 
 	req.Filters = append(req.Filters, buildEC2TagFilterList(
 		tagsFromMap(d.Get("tags").(map[string]interface{})),
+	)...)
+
+	req.Filters = append(req.Filters, buildEC2CustomFilterList(
+		d.Get("filter").(*schema.Set),
 	)...)
 
 	log.Printf("[DEBUG] DescribeRouteTables %s\n", req)

--- a/aws/data_source_aws_route_tables_test.go
+++ b/aws/data_source_aws_route_tables_test.go
@@ -21,9 +21,10 @@ func TestAccDataSourceAwsRouteTables(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsRouteTablesConfigWithDataSource(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_route_tables.test", "ids.#", "4"),
-					resource.TestCheckResourceAttr("data.aws_route_tables.private", "ids.#", "2"),
+					resource.TestCheckResourceAttr("data.aws_route_tables.test", "ids.#", "5"),
+					resource.TestCheckResourceAttr("data.aws_route_tables.private", "ids.#", "3"),
 					resource.TestCheckResourceAttr("data.aws_route_tables.test2", "ids.#", "1"),
+					resource.TestCheckResourceAttr("data.aws_route_tables.filter_test", "ids.#", "2"),
 				),
 			},
 		},
@@ -54,6 +55,7 @@ resource "aws_route_table" "test_public_a" {
   tags {
     Name = "tf-acc-route-tables-data-source-public-a"
     Tier = "Public"
+    Component = "Frontend"
   }
 }
 
@@ -63,6 +65,7 @@ resource "aws_route_table" "test_private_a" {
   tags {
     Name = "tf-acc-route-tables-data-source-private-a"
     Tier = "Private"
+    Component = "Database"
   }
 }
 
@@ -72,6 +75,17 @@ resource "aws_route_table" "test_private_b" {
   tags {
     Name = "tf-acc-route-tables-data-source-private-b"
     Tier = "Private"
+    Component = "Backend-1"
+  }
+}
+
+resource "aws_route_table" "test_private_c" {
+  vpc_id            = "${aws_vpc.test.id}"
+
+  tags {
+    Name = "tf-acc-route-tables-data-source-private-c"
+    Tier = "Private"
+    Component = "Backend-2"
   }
 }
 
@@ -87,6 +101,15 @@ data "aws_route_tables" "private" {
   vpc_id = "${aws_vpc.test.id}"
   tags {
     Tier = "Private"
+  }
+}
+
+data "aws_route_tables" "filter_test" {
+  vpc_id = "${aws_vpc.test.id}"
+
+  filter {
+    name = "tag:Component"
+    values = ["Backend*"]
   }
 }
 `, rInt, rInt)
@@ -108,6 +131,7 @@ resource "aws_route_table" "test_public_a" {
   tags {
     Name = "tf-acc-route-tables-data-source-public-a"
     Tier = "Public"
+    Component = "Frontend"
   }
 }
 
@@ -117,6 +141,7 @@ resource "aws_route_table" "test_private_a" {
   tags {
     Name = "tf-acc-route-tables-data-source-private-a"
     Tier = "Private"
+    Component = "Database"
   }
 }
 
@@ -126,6 +151,17 @@ resource "aws_route_table" "test_private_b" {
   tags {
     Name = "tf-acc-route-tables-data-source-private-b"
     Tier = "Private"
+    Component = "Backend-1"
+  }
+}
+
+resource "aws_route_table" "test_private_c" {
+  vpc_id            = "${aws_vpc.test.id}"
+
+  tags {
+    Name = "tf-acc-route-tables-data-source-private-c"
+    Tier = "Private"
+    Component = "Backend-2"
   }
 }
 `, rInt)

--- a/website/docs/d/route_tables.html.markdown
+++ b/website/docs/d/route_tables.html.markdown
@@ -12,19 +12,25 @@ This resource can be useful for getting back a list of route table ids to be ref
 
 ## Example Usage
 
-The following adds a route for a particular cidr block to every route table
-in a specified vpc to use a particular vpc peering connection.
+The following adds a route for a particular cidr block to every (private
+kops) route table in a specified vpc to use a particular vpc peering
+connection.
 
 ```hcl
 
 data "aws_route_tables" "rts" {
   vpc_id = "${var.vpc_id}"
+
+  filter {
+    name   = "tag:kubernetes.io/kops/role"
+    values = ["private*"]
+  }
 }
 
 resource "aws_route" "r" {
-  count                  = "${length(data.aws_route_tables.rts.ids)}"
-  route_table_id         = "${data.aws_route_tables.rts.ids[count.index]}"
-  destination_cidr_block = "10.0.1.0/22"
+  count                     = "${length(data.aws_route_tables.rts.ids)}"
+  route_table_id            = "${data.aws_route_tables.rts.ids[count.index]}"
+  destination_cidr_block    = "10.0.1.0/22"
   vpc_peering_connection_id = "pcx-0e9a7a9ecd137dc54"
 }
 
@@ -32,10 +38,21 @@ resource "aws_route" "r" {
 
 ## Argument Reference
 
+* `filter` - (Optional) Custom filter block as described below.
+
 * `vpc_id` - (Optional) The VPC ID that you want to filter from.
 
 * `tags` - (Optional) A mapping of tags, each pair of which must exactly match
   a pair on the desired route tables.
+
+More complex filters can be expressed using one or more `filter` sub-blocks,
+which take the following arguments:
+
+* `name` - (Required) The name of the field to filter by, as defined by
+  [the underlying AWS API](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRouteTables.html).
+
+* `values` - (Required) Set of values that are accepted for the given field.
+  A Route Table will be selected if any one of the given values matches.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Change proposed in this pull request:

Add a `filter` argument to the `aws_route_tables` data source.

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsRouteTables'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccDataSourceAwsRouteTables -timeout 120m
=== RUN   TestAccDataSourceAwsRouteTables
--- PASS: TestAccDataSourceAwsRouteTables (36.45s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       36.467s
```
