### PR TITLE
codedeploy documentation update 

### DIFF
--- a/website/docs/r/codedeploy_deployment_group.html.markdown
+++ b/website/docs/r/codedeploy_deployment_group.html.markdown
@@ -33,46 +33,9 @@ resource "aws_iam_role" "example" {
 EOF
 }
 
-resource "aws_iam_role_policy" "example" {
-  name = "example-policy"
-  role = "${aws_iam_role.example.id}"
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "autoscaling:CompleteLifecycleAction",
-        "autoscaling:DeleteLifecycleHook",
-        "autoscaling:DescribeAutoScalingGroups",
-        "autoscaling:DescribeLifecycleHooks",
-        "autoscaling:PutLifecycleHook",
-        "autoscaling:RecordLifecycleActionHeartbeat",
-
-        "codedeploy:Batch*",
-        "codedeploy:Get*",
-        "codedeploy:List*",
-
-        "ec2:DescribeInstances",
-        "ec2:DescribeInstanceStatus",
-
-        "elasticloadbalancing:Describe*",
-        "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
-        "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
-        "elasticloadbalancing:RegisterTargets",
-        "elasticloadbalancing:DeregisterTargets",
-
-        "tag:GetTags",
-        "tag:GetResources",
-        "sns:Publish"
-      ],
-      "Resource": "*"
-    }
-  ]
-}
-EOF
+resource "aws_iam_role_policy_attachment" "AWSCodeDeployRole" {
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRole"
+  role       = "${aws_iam_role.example.name}"
 }
 
 resource "aws_codedeploy_app" "example" {

--- a/website/docs/r/codedeploy_deployment_group.html.markdown
+++ b/website/docs/r/codedeploy_deployment_group.html.markdown
@@ -50,9 +50,20 @@ resource "aws_iam_role_policy" "example" {
         "autoscaling:DescribeLifecycleHooks",
         "autoscaling:PutLifecycleHook",
         "autoscaling:RecordLifecycleActionHeartbeat",
-        "codedeploy:*",
+
+        "codedeploy:Batch*",
+        "codedeploy:Get*",
+        "codedeploy:List*",
+
         "ec2:DescribeInstances",
         "ec2:DescribeInstanceStatus",
+
+        "elasticloadbalancing:Describe*",
+        "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
+        "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
+        "elasticloadbalancing:RegisterTargets",
+        "elasticloadbalancing:DeregisterTargets",
+
         "tag:GetTags",
         "tag:GetResources",
         "sns:Publish"


### PR DESCRIPTION
This is just documentation update.

In case one uses *Load Balancers* with *codedeploy*, I added to the example the necessary IAM permissions for *codedeploy* to be able to add and remove machines from the *load balancer* (or target group, in case it's an *alb*)

This will save time from people googling around the meaning of

`com.amazonaws.services.simpleworkflow.flow.ActivityTaskFailedException: Role does not have correct permissions. role XXXXXXXX
 for activityId="5" of activityType={Name: ExecuteCentralizedCommandOnInstanceActivity.runCentralizedCommand,Version: 1.00}
]`
