### PR TITLE
Add support for glue connection vpc availability zones (required currently)

### DIFF
--- a/aws/resource_aws_glue_connection.go
+++ b/aws/resource_aws_glue_connection.go
@@ -62,6 +62,10 @@ func resourceAwsGlueConnection() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"availability_zone": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 						"security_group_id_list": {
 							Type:     schema.TypeList,
 							Optional: true,
@@ -249,6 +253,10 @@ func expandGlueConnectionInput(d *schema.ResourceData) *glue.ConnectionInput {
 func expandGluePhysicalConnectionRequirements(m map[string]interface{}) *glue.PhysicalConnectionRequirements {
 	physicalConnectionRequirements := &glue.PhysicalConnectionRequirements{}
 
+	if v, ok := m["availability_zone"]; ok {
+		physicalConnectionRequirements.AvailabilityZone = aws.String(v.(string))
+	}
+
 	if v, ok := m["security_group_id_list"]; ok {
 		physicalConnectionRequirements.SecurityGroupIdList = expandStringList(v.([]interface{}))
 	}
@@ -266,6 +274,7 @@ func flattenGluePhysicalConnectionRequirements(physicalConnectionRequirements *g
 	}
 
 	m := map[string]interface{}{
+		"availability_zone":      aws.StringValue(physicalConnectionRequirements.AvailabilityZone),
 		"security_group_id_list": flattenStringList(physicalConnectionRequirements.SecurityGroupIdList),
 		"subnet_id":              aws.StringValue(physicalConnectionRequirements.SubnetId),
 	}

--- a/aws/resource_aws_glue_connection_test.go
+++ b/aws/resource_aws_glue_connection_test.go
@@ -426,6 +426,7 @@ resource "aws_glue_connection" "test" {
   name = "%[1]s"
 
   physical_connection_requirements {
+    availability_zone      = "${aws_availability_zones.available[0].id}"
     security_group_id_list = ["${aws_security_group.test.id}"]
     subnet_id              = "${aws_subnet.test.0.id}"
   }

--- a/website/docs/r/glue_connection.html.markdown
+++ b/website/docs/r/glue_connection.html.markdown
@@ -41,6 +41,7 @@ resource "aws_glue_connection" "example" {
   name = "example"
 
   physical_connection_requirements {
+    availability_zone      = "${aws_subnet.example.availability_zone}"
     security_group_id_list = ["${aws_security_group.example.id}"]
     subnet_id              = "${aws_subnet.example.id}"
   }
@@ -61,6 +62,7 @@ The following arguments are supported:
 
 ### physical_connection_requirements
 
+* `availability_zone` - (Optional) The availability zone of the connection. This field is redundant and implied by `subnet_id`, but is currently an api requirement.
 * `security_group_id_list` - (Optional) The security group ID list used by the connection.
 * `subnet_id` - (Optional) The subnet ID used by the connection.
 


### PR DESCRIPTION
Fixes #4762

Changes proposed in this pull request:

* Add support for `AvailabilityZone`, currently required by the PhysicalConnectionRequirements structure per [aws api `PhysicalConnectionRequirements` documentation](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-connections.html#aws-glue-api-catalog-connections-PhysicalConnectionRequirements)

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAvailabilityZones'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSAvailabilityZones -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSAvailabilityZones_basic
--- PASS: TestAccAWSAvailabilityZones_basic (15.28s)
=== RUN   TestAccAWSAvailabilityZones_stateFilter
--- PASS: TestAccAWSAvailabilityZones_stateFilter (14.73s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	30.022s
```
